### PR TITLE
fix(governance): gate the comments — prose naming a file or repo that does not exist

### DIFF
--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -428,6 +428,25 @@ gates:
     run: |
       python3 .github/scripts/check-license-headers.py
 
+  # Comments are stripped by every OTHER guard here on purpose, so that code-about-code does
+  # not trip them (#2450). Nothing therefore checks the prose — and the prose is what a human
+  # acts on. Measured cost of that in two days: a Kafka ACL header claiming the broker ran
+  # `allow.everyone.if.no.acl.found=true` (it runs false; 13 outbox rows died), an
+  # application.yaml naming the wrong schema-registry host AND port, and a workflow comment
+  # scoping tokens to an archived repo. This gate checks only what the repo can FALSIFY: a
+  # repo-root-relative path that resolves nowhere, and a JiRaska/<slug> that is archived or
+  # 404. Two other candidate rules were measured and rejected — see the script header, which
+  # records why, because "we did not build it" is what a later reader cannot recover.
+  # Enforced from the start: origin/main was left at zero findings by this PR.
+  - id: stale-comment-references
+    name: "stale comment references — prose naming a missing file or dead repo (enforced)"
+    group: supplychain
+    mode: enforced
+    selftest: |
+      python3 .github/scripts/check-stale-comment-references.py --self-test
+    run: |
+      python3 .github/scripts/check-stale-comment-references.py --enforce
+
   - id: gh-repo-context-in-checkoutless-jobs
     name: "gh repo context in checkoutless jobs (issue #2841, enforced)"
     group: supplychain

--- a/.github/scripts/check-gate-script-registration.py
+++ b/.github/scripts/check-gate-script-registration.py
@@ -71,6 +71,7 @@ HELPERS: dict[str, str] = {}
 #
 # A bare PATH is deliberately not one of them. The first draft accepted `.github/scripts/<name>`
 # anywhere, and its own self-test caught that on `ci_producer: ".github/scripts/check-demo.py"` —
+# stale-ref-ok: check-demo.py is a self-test fixture name, deliberately not a real file.
 # a rules.yaml value naming a script, which is precisely the #3240 case where the name is written
 # down and nothing runs it. Accepting the path would have made this gate green about the very
 # defect it exists to find.

--- a/.github/scripts/check-stale-comment-references.py
+++ b/.github/scripts/check-stale-comment-references.py
@@ -1,0 +1,571 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+# See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+#
+# ============================================================================
+# STALE COMMENT REFERENCES — prose that names something the repo can prove is gone.
+#
+# WHY THIS EXISTS
+#   Comments are invisible to every other gate in this repo BY DESIGN. Guards over source
+#   text strip comments first, precisely so code-about-code does not trip them (#2450), and
+#   that is correct for those guards. The consequence is that nothing checks the prose —
+#   and the prose is what a human reads and acts on.
+#
+#   Measured instances of the resulting defect class, all within two days:
+#     * a Kafka ACL manifest header claimed the broker ran `allow.everyone.if.no.acl.found`
+#       = true. It runs false. The false claim is WHY nobody granted the ACLs, and 13 outbox
+#       rows went dead in production.
+#     * an application.yaml documented the schema registry as "service schema-registry:8081".
+#       The real Service is apicurio-registry.messaging on 8080 — wrong host AND wrong port.
+#     * a workflow comment told whoever provisions the tokens to scope them to a repo that
+#       had since been archived.
+#   CLAUDE.md already records the general form: "stale prose naming a dead identifier is
+#   invisible to a source-text guard forever."
+#
+# WHAT IS DECIDABLE, AND WHAT IS NOT
+#   This guard checks only claims the repo can falsify MECHANICALLY. Two rules ship:
+#
+#   R1 `path`   A repo-ROOT-relative file path named in a comment that is not in the tree.
+#               Admission is deliberately narrow (see is_path_claim): the first segment must
+#               be a real top-level entry of THIS repo, the last must carry a known source
+#               extension, and the path must resolve nowhere — not as a tracked path, not as
+#               a tracked directory, and not as the TAIL of any tracked path (which is how
+#               module-relative prose such as `scripts/generate-catalog.mjs` inside
+#               openbank-admin-ui stays green). Glob/ellipsis forms are not claims and are
+#               skipped. Gitignored build outputs are skipped — they exist at build time.
+#
+#   R2 `repo`   A `JiRaska/<slug>` GitHub repository named in a comment that is archived or
+#               does not exist. Needs the network; DEGRADES TO A NOTICE, never to a pass and
+#               never to a red, when the API cannot be reached (see resolve_repo).
+#
+#   Two candidate rules were measured against origin/main and REJECTED. Both rejections are
+#   recorded here because "we did not build it" is the part a later reader cannot recover:
+#
+#   * k8s Service / namespace named in a comment but declared by no gitops manifest.
+#     REJECTED — UNSOUND GROUND TRUTH. The Service inventory is not derivable from the tree:
+#     Strimzi creates `openbank-cluster-kafka-bootstrap`, CNPG creates `<cluster>-rw`, and
+#     the Temporal chart creates `temporal-frontend`, none of which is a committed
+#     `kind: Service`. The strict `<svc>.<ns>.svc` form produced 5 findings on main and ALL
+#     FIVE were correct references the guard could not see. It would also not have caught
+#     the apicurio instance that motivated it, which is written `schema-registry:8081` — a
+#     bare name and port, not an FQDN.
+#
+#   * an identifier (class, function, config key) in a comment that appears nowhere.
+#     REJECTED — prose legitimately names deleted things in order to explain why they were
+#     deleted, and this repo's comments do that constantly ("the older, shorter form of this
+#     rule", "the `platform-admin` prose that survived the rename"). A guard here cannot
+#     distinguish a stale reference from a deliberate epitaph, and a gate that cries wolf
+#     gets ignored, which is worse than no gate.
+#
+# THE PRECEDENCE RULE FOR CODE-ABOUT-CODE — decided BEFORE the first run
+#   A hypothetical path in explanatory prose is not a claim, and no amount of text analysis
+#   can tell the two apart. So: AN EXPLICIT INLINE WAIVER WINS, AND NOTHING ELSE DOES.
+#   Write `stale-ref-ok: <reason>` anywhere in the same comment block and that block is
+#   skipped. There is no path allow-list and this file is NOT special-cased — it carries the
+#   marker like every other file, so the exemption is reviewable in the diff instead of
+#   hidden in the guard. That is the opposite of what burnt this repo three times
+#   (check-roles-allowed-realm.py, check-advisory-gate-registration.py, the platform-admin
+#   sweep), where a guard's own prose was the first thing it flagged.
+#
+#   KNOWN BLIND SPOT, stated rather than relied upon: a "comment" here means line/block
+#   comment SYNTAX. A Python docstring is a string literal, so this file's own module
+#   docstring would be out of scope — which is why the explanatory prose you are reading is
+#   written as `#` comments, subject to the rule. self_test() proves that: it feeds this
+#   very file's comment syntax a stale path and asserts the guard flags it.
+#
+# Usage:
+#     python3 .github/scripts/check-stale-comment-references.py              # advisory
+#     python3 .github/scripts/check-stale-comment-references.py --enforce    # exit 1
+#     python3 .github/scripts/check-stale-comment-references.py --self-test
+# ============================================================================
+"""Flag comments that name a file path or GitHub repo the tree can prove is gone."""
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# --------------------------------------------------------------------------- waiver
+
+# The one and only escape hatch. See "THE PRECEDENCE RULE" above.
+WAIVER = re.compile(r"stale-ref-ok\b")
+
+# --------------------------------------------------------------------------- comments
+
+C_STYLE = {".kt", ".kts", ".java", ".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs", ".scss"}
+HASH_STYLE = {".yaml", ".yml", ".sh", ".bash", ".py", ".toml", ".properties",
+              ".tf", ".tfvars", ".rego", ".cfg", ".conf", ".ini"}
+DASH_STYLE = {".sql"}
+HASH_NAMES = {"Dockerfile", "Makefile", ".gitignore", ".dockerignore"}
+
+
+def comment_style(path: str) -> str:
+    p = Path(path)
+    if p.suffix in C_STYLE:
+        return "c"
+    if p.suffix in HASH_STYLE:
+        return "hash"
+    if p.suffix in DASH_STYLE:
+        return "dash"
+    if p.name in HASH_NAMES or p.name.startswith("Dockerfile"):
+        return "hash"
+    return ""
+
+
+def _line_comments(text: str, marker: str) -> list[tuple[int, str]]:
+    """Consecutive comment lines are ONE block.
+
+    The waiver is documented as covering "the same comment block", and a reader writing a
+    ten-line header does not think of it as ten comments. Grouping also makes the waiver
+    usable: a `stale-ref-ok:` line placed under the sentence it explains would otherwise
+    waive nothing, which is a failure that reads exactly like the guard working.
+    Each block is reported at the line of the reference, so `file:line` still points at it.
+    """
+    pat = re.compile(r"^\s*" + re.escape(marker) + r"\s?(.*)$")
+    out: list[tuple[int, str]] = []
+    block: list[tuple[int, str]] = []
+
+    def flush() -> None:
+        # The waiver is evaluated over the WHOLE block; the lines are then reported
+        # individually so a finding still points at the line carrying the reference.
+        if block:
+            if not any(WAIVER.search(body) for _, body in block):
+                out.extend(block)
+            block.clear()
+
+    for i, line in enumerate(text.splitlines(), 1):
+        m = pat.match(line)
+        if m:
+            block.append((i, m.group(1)))
+        else:
+            flush()
+    flush()
+    return out
+
+
+def c_comments(text: str) -> list[tuple[int, str]]:
+    # Kotlin BLOCK COMMENTS NEST — a KDoc containing `/*` does not close at the first `*/`.
+    # Depth-counting mirrors that; a naive find("*/") would truncate the block and hide
+    # whatever the rest of it says (repo lore: reference-kotlin-block-comments-nest).
+    out: list[tuple[int, str]] = []
+    n = len(text)
+    i = 0
+    line_no = 1
+    depth = 0
+    buf: list[str] = []
+    start = 1
+    in_str: str | None = None
+    while i < n:
+        ch = text[i]
+        if ch == "\n":
+            line_no += 1
+            if depth:
+                buf.append("\n")
+            i += 1
+            continue
+        if depth:
+            if text.startswith("/*", i):
+                depth += 1
+                buf.append("/*")
+                i += 2
+                continue
+            if text.startswith("*/", i):
+                depth -= 1
+                i += 2
+                if depth == 0:
+                    out.append((start, "".join(buf)))
+                continue
+            buf.append(ch)
+            i += 1
+            continue
+        if in_str:
+            if ch == "\\":
+                i += 2
+                continue
+            if ch == in_str:
+                in_str = None
+            i += 1
+            continue
+        if ch in ('"', "'"):
+            in_str = ch
+            i += 1
+            continue
+        if text.startswith("//", i):
+            j = text.find("\n", i)
+            j = n if j < 0 else j
+            out.append((line_no, text[i + 2:j]))
+            i = j
+            continue
+        if text.startswith("/*", i):
+            depth = 1
+            start = line_no
+            buf = []
+            i += 2
+            continue
+        i += 1
+    return out
+
+
+def comments_of(path: str, text: str) -> list[tuple[int, str]]:
+    style = comment_style(path)
+    if style == "c":
+        return c_comments(text)
+    if style == "hash":
+        return _line_comments(text, "#")
+    if style == "dash":
+        return _line_comments(text, "--")
+    return []
+
+
+# --------------------------------------------------------------------------- R1: paths
+
+# Extensions that make a slash-separated token a FILE reference rather than prose that
+# happens to contain a slash ("openbank-libs-domain/openbank-libs-runtime", "and/or").
+SOURCE_EXTS = {
+    ".kt", ".kts", ".java", ".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs",
+    ".py", ".sh", ".bash", ".sql", ".rego", ".tf", ".tfvars",
+    ".yaml", ".yml", ".json", ".toml", ".xml", ".properties", ".md",
+    ".gradle", ".conf", ".txt", ".csv", ".proto", ".svg", ".png",
+}
+URL = re.compile(r"\b(?:https?|git|ssh|ftp)://\S+")
+PATHISH = re.compile(r"(?<![\w./-])((?:[A-Za-z0-9_.-]+/)+[A-Za-z0-9_.+-]+)")
+TRAILING = ".,;:)]}'\"`"
+
+
+def path_candidates(comment: str, top_level: set[str]) -> list[str]:
+    """Slash tokens in `comment` that are unambiguously a claim about a file in THIS repo."""
+    text = URL.sub(" ", comment)
+    out = []
+    for m in PATHISH.finditer(text):
+        cand = m.group(1).rstrip(TRAILING)
+        if "/" not in cand:
+            continue
+        # A glob, a placeholder or an elision is a PATTERN, not a claim about one file.
+        if any(c in cand for c in "*?{}<>$!|") or ".." in cand:
+            continue
+        segs = cand.split("/")
+        if any(not s or s.startswith("-") or s.endswith("-") for s in segs):
+            continue
+        # ROOT-ANCHORED ONLY. Without this the guard reads third-party paths
+        # (an action's `temurin/installer.ts`, oss-fuzz's `projects/openbank/build.sh`)
+        # as claims about this tree.
+        if segs[0] not in top_level:
+            continue
+        # `a.yaml/b.yaml` is prose alternation — "one or the other", never a path.
+        if "." in segs[0] and "." + segs[0].rsplit(".", 1)[-1] in SOURCE_EXTS:
+            continue
+        last = segs[-1]
+        ext = "." + last.rsplit(".", 1)[-1] if "." in last else ""
+        if ext not in SOURCE_EXTS:
+            continue
+        out.append(cand)
+    return out
+
+
+# --------------------------------------------------------------------------- R2: repos
+
+REPO_SLUG = re.compile(r"\bJiRaska/([A-Za-z0-9._-]+)\b")
+
+
+def resolve_repo(slug: str) -> tuple[str, str]:
+    """('ok'|'archived'|'missing'|'unknown', detail).
+
+    UNKNOWN is the fail-safe direction on purpose: no network must never read as a pass
+    (it prints a ::notice) and must never read as a red (a proxy-less runner would fail
+    every PR for a reason that has nothing to do with the PR).
+    """
+    if os.environ.get("STALE_REF_SKIP_NETWORK") == "1":
+        return "unknown", "network checks disabled"
+    try:
+        r = subprocess.run(
+            ["gh", "api", f"repos/JiRaska/{slug}", "--jq", "{archived: .archived}"],
+            capture_output=True, text=True, timeout=20,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+        return "unknown", f"gh unavailable ({type(exc).__name__})"
+    if r.returncode != 0:
+        err = (r.stderr or "").strip()
+        if "404" in err or "Not Found" in err:
+            return "missing", "GitHub returns 404"
+        return "unknown", err.splitlines()[0][:120] if err else "gh failed"
+    try:
+        archived = json.loads(r.stdout).get("archived")
+    except json.JSONDecodeError:
+        return "unknown", "unparseable gh output"
+    return ("archived", "repository is ARCHIVED") if archived else ("ok", "")
+
+
+# --------------------------------------------------------------------------- scanning
+
+# DERIVED artifacts are not scanned. Every `*-opa-bundle*.yaml` embeds rules.yaml verbatim,
+# so one stale comment in the source shows up 26 times — the guard would report a fleet of
+# defects where there is one, and the fix is never in the bundle anyway (it is regenerated).
+DERIVED = re.compile(r"opa-bundle[A-Za-z0-9._-]*\.ya?ml$")
+# Markdown is entirely prose; a path in an ADR is a HISTORICAL RECORD, not an instruction.
+# `docs/adr/*` deliberately cites repos and files that no longer exist. Different artifact,
+# different rule, out of scope here.
+SKIP_SUFFIX = (".md",)
+
+
+def tracked_files(root: Path) -> list[str]:
+    out = subprocess.run(["git", "-C", str(root), "ls-files", "-z"],
+                         capture_output=True, text=True, check=True).stdout
+    return [p for p in out.split("\0") if p]
+
+
+def gitignored(root: Path, paths: list[str]) -> set[str]:
+    """Paths git would ignore. A comment naming build/reports/bom.json is not stale —
+    the file exists after a build, which is exactly when it is read."""
+    if not paths:
+        return set()
+    r = subprocess.run(["git", "-C", str(root), "check-ignore", "--stdin"],
+                       input="\n".join(paths), capture_output=True, text=True)
+    return {ln.strip() for ln in r.stdout.splitlines() if ln.strip()}
+
+
+class Finding:
+    def __init__(self, rule: str, path: str, line: int, ref: str, detail: str):
+        self.rule, self.path, self.line, self.ref, self.detail = rule, path, line, ref, detail
+
+    def __str__(self) -> str:
+        return f"{self.path}:{self.line}: [{self.rule}] {self.ref} — {self.detail}"
+
+
+def scan_text(path: str, text: str, top_level: set[str], resolvable,
+              slug_state: dict[str, tuple[str, str]] | None = None) -> list[Finding]:
+    """Pure core, shared by the repo scan and the self-test."""
+    out: list[Finding] = []
+    for line, comment in comments_of(path, text):
+        if WAIVER.search(comment):
+            continue
+        for cand in path_candidates(comment, top_level):
+            if resolvable(cand):
+                continue
+            out.append(Finding("path", path, line, cand,
+                               "no such file in the tree (not tracked, not a directory, "
+                               "not the tail of any tracked path, not gitignored)"))
+        if slug_state is not None:
+            for m in REPO_SLUG.finditer(comment):
+                state, detail = slug_state.get(m.group(1), ("unknown", ""))
+                if state in ("archived", "missing"):
+                    out.append(Finding("repo", path, line, f"JiRaska/{m.group(1)}", detail))
+    return out
+
+
+def build_resolver(files: list[str]):
+    """Every suffix of every tracked path, indexed once.
+
+    MODULE-RELATIVE prose: `scripts/generate-catalog.mjs` written inside openbank-admin-ui
+    means openbank-admin-ui/scripts/generate-catalog.mjs. Resolving on the TAIL keeps that
+    green without the guard having to know module roots. Indexing beats scanning: the
+    linear form cost 48 s over ~60k paths.
+    """
+    universe: set[str] = set()
+    for f in files:
+        parts = f.split("/")
+        for i in range(len(parts)):          # every suffix, file and directory alike
+            for j in range(i + 1, len(parts) + 1):
+                if i == 0 or j == len(parts):
+                    universe.add("/".join(parts[i:j]))
+    return universe.__contains__
+
+
+def run(root: Path, want_network: bool) -> list[Finding]:
+    files = tracked_files(root)
+    top_level = {f.split("/")[0] for f in files}
+    resolvable = build_resolver(files)
+
+    # One pass over the tree: collect R1 findings and every repo slug that needs resolving.
+    raw: list[Finding] = []
+    slugs: set[str] = set()
+    hits: list[tuple[str, int, str]] = []          # (file, line, slug)
+    for f in files:
+        if f.endswith(SKIP_SUFFIX) or DERIVED.search(f) or not comment_style(f):
+            continue
+        try:
+            text = (root / f).read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        for line, comment in comments_of(f, text):
+            if WAIVER.search(comment):
+                continue
+            for m in REPO_SLUG.finditer(comment):
+                slugs.add(m.group(1))
+                hits.append((f, line, m.group(1)))
+        raw.extend(scan_text(f, text, top_level, resolvable))
+
+    # R1: drop build outputs git already knows about.
+    ignored = gitignored(root, sorted({x.ref for x in raw if x.rule == "path"}))
+    findings = [x for x in raw if not (x.rule == "path" and x.ref in ignored)]
+
+    # R2: resolve each distinct slug ONCE, then attribute.
+    state: dict[str, tuple[str, str]] = {}
+    for slug in sorted(slugs):
+        state[slug] = resolve_repo(slug) if want_network else ("unknown", "network skipped")
+    unknown = [s for s, (st, _) in state.items() if st == "unknown"]
+    if unknown:
+        print(f"::notice::stale-comment-references: repo rule UNRESOLVED for "
+              f"{', '.join('JiRaska/' + s for s in unknown)} — "
+              f"{state[unknown[0]][1]}. Not a pass and not a failure.")
+    for f, line, slug in hits:
+        st, detail = state.get(slug, ("unknown", ""))
+        if st in ("archived", "missing"):
+            findings.append(Finding("repo", f, line, f"JiRaska/{slug}", detail))
+    return findings
+
+
+# --------------------------------------------------------------------------- self-test
+
+# A synthetic tree. The resolver under test is build_resolver — the PRODUCTION one. An
+# earlier draft of this self-test hand-wrote its own resolver, and a deliberate break of
+# build_resolver then left all 22 cases green: the shipped resolution logic was covered by
+# nothing. Never let a self-test substitute its own copy of the code it is falsifying.
+_FILES = [
+    "docs/threat-models/openbank-ledger-service.md",
+    "openbank-ledger-service/src/main/resources/openapi.yaml",
+    "openbank-libs-domain/src/main/kotlin/Libs.kt",
+    "openbank-libs-runtime/src/main/kotlin/Runtime.kt",
+    "openbank-admin-ui/scripts/generate-catalog.mjs",
+    ".github/scripts/check-stale-comment-references.py",
+    "config/detekt/detekt.yml",
+    # A root-level `scripts/` MUST exist here, exactly as it does in the real tree. Without
+    # it `scripts/generate-catalog.mjs` is rejected by root-anchoring and never reaches the
+    # resolver — so the tail-resolution case was vacuous, and a break of build_resolver left
+    # the suite green. A must-not-flag case that is filtered out upstream tests nothing.
+    "scripts/add-license-headers.sh",
+]
+_TOP = {f.split("/")[0] for f in _FILES}
+_resolver_for_selftest = build_resolver(_FILES)
+
+
+# Each case is (filename, text). MUST_FLAG proves the rule fires; MUST_NOT_FLAG proves it
+# does not fire on the shapes that legitimately look like it. Both directions per rule —
+# a rule with only one direction tested is half-unfalsified.
+_MUST_FLAG = {
+    "hash comment, missing path": (
+        "a.yaml", "# see docs/threat-models/ledger-service.md for the model\nkey: 1\n"),
+    "kdoc, missing path": (
+        "A.kt", "/**\n * Regression guard, see docs/threat-models/ledger-service.md.\n */\nclass A\n"),
+    "kdoc NESTED block does not close early": (
+        "A.kt",
+        "/**\n * An inner /* nested */ comment.\n"
+        " * Then docs/threat-models/ledger-service.md.\n */\nclass A\n"),
+    "sql dash comment": (
+        "V1.sql", "-- rollback documented in docs/runbooks/ledger-tieout.md\nSELECT 1;\n"),
+    "dockerfile hash comment": (
+        "Dockerfile", "# baked by config/detekt/missing.yml\nFROM scratch\n"),
+    # The guard is subject to its own rule — this is THIS FILE's comment syntax carrying a
+    # stale path with no waiver. See "THE PRECEDENCE RULE" in the header.
+    "the guard's own comment syntax is not exempt": (
+        ".github/scripts/check-stale-comment-references.py",
+        "# an example such as docs/threat-models/ledger-service.md is still checked\n"),
+}
+_MUST_NOT_FLAG = {
+    "path that exists": (
+        "a.yaml", "# see docs/threat-models/openbank-ledger-service.md\n"),
+    "module-relative path resolvable by tail": (
+        "a.ts", "// built by scripts/generate-catalog.mjs\n"),
+    "glob pattern is not a claim": (
+        "a.yaml", "# docs/threat-models/*.md are generated\n"),
+    "elision is not a claim": (
+        "a.yaml", "# openbank-ledger-service/src/main/kotlin/.../Foo.kt\n"),
+    "placeholder is not a claim": (
+        "a.yaml", "# docs/threat-models/<service>.md\n"),
+    "third-party path is not root-anchored": (
+        "a.yml", "# documented by gradle/actions (guides/dependency-submission.md)\n"),
+    "prose alternation a.yaml/b.yaml": (
+        "a.yaml", "# regenerated from rules.yaml/governance.yaml\n"),
+    "URL is not a path": (
+        "a.yaml", "# https://example.com/docs/threat-models/ledger-service.md\n"),
+    "explicit waiver wins (same line)": (
+        "a.yaml", "# docs/threat-models/ledger-service.md  stale-ref-ok: hypothetical\n"),
+    "explicit waiver wins (elsewhere in the same block)": (
+        "a.yaml",
+        "# the first draft accepted docs/threat-models/ledger-service.md\n"
+        "# stale-ref-ok: that filename is an illustration, not a file\n"),
+    "code, not a comment": (
+        "a.kt", 'val p = "docs/threat-models/ledger-service.md"\n'),
+    "trailing-hyphen stub from an elided glob": (
+        "a.yaml", "# docs/runbooks/svc-*.md is generated\n"),
+    # Prose that slashes two names together. Only the extension filter rejects these —
+    # both segments are real top-level entries, so root-anchoring passes them through.
+    "extensionless prose slash between two module names": (
+        "a.yml", "# the openbank-libs-domain/openbank-libs-runtime split (ADR-0122)\n"),
+    "extensionless prose slash naming a concept": (
+        "a.kt", "// the config/CDI wiring is validated by quarkusBuild\n"),
+}
+_REPO_FLAG = {
+    "archived repo": ("a.yml", "# scope the token to JiRaska/open-bank\n",
+                      {"open-bank": ("archived", "repository is ARCHIVED")}),
+    "missing repo": ("a.yml", "# see JiRaska/does-not-exist\n",
+                     {"does-not-exist": ("missing", "GitHub returns 404")}),
+}
+_REPO_NO_FLAG = {
+    "live repo": ("a.yml", "# see JiRaska/open-bank-oss\n", {"open-bank-oss": ("ok", "")}),
+    "unresolved never fails": ("a.yml", "# see JiRaska/open-bank\n",
+                               {"open-bank": ("unknown", "no network")}),
+    "waived": ("a.yml", "# JiRaska/open-bank\n# stale-ref-ok: cited as history\n",
+               {"open-bank": ("archived", "x")}),
+}
+
+
+def self_test() -> int:
+    failures = 0
+    for label, (name, text) in _MUST_FLAG.items():
+        if not scan_text(name, text, _TOP, _resolver_for_selftest):
+            print(f"SELF-TEST FAIL: should have flagged — {label}")
+            failures += 1
+    for label, (name, text) in _MUST_NOT_FLAG.items():
+        got = scan_text(name, text, _TOP, _resolver_for_selftest)
+        if got:
+            print(f"SELF-TEST FAIL: false positive — {label}\n    {got[0]}")
+            failures += 1
+    for label, (name, text, st) in _REPO_FLAG.items():
+        if not [f for f in scan_text(name, text, _TOP, _resolver_for_selftest, st)
+                if f.rule == "repo"]:
+            print(f"SELF-TEST FAIL: repo rule should have flagged — {label}")
+            failures += 1
+    for label, (name, text, st) in _REPO_NO_FLAG.items():
+        got = [f for f in scan_text(name, text, _TOP, _resolver_for_selftest, st)
+               if f.rule == "repo"]
+        if got:
+            print(f"SELF-TEST FAIL: repo rule false positive — {label}\n    {got[0]}")
+            failures += 1
+    total = len(_MUST_FLAG) + len(_MUST_NOT_FLAG) + len(_REPO_FLAG) + len(_REPO_NO_FLAG)
+    if failures:
+        print(f"self-test: {failures} of {total} cases failed")
+        return 1
+    print(f"self-test: {total}/{total} cases pass "
+          f"({len(_MUST_FLAG) + len(_REPO_FLAG)} must-flag, "
+          f"{len(_MUST_NOT_FLAG) + len(_REPO_NO_FLAG)} must-not-flag)")
+    return 0
+
+
+# --------------------------------------------------------------------------- main
+
+def main() -> int:
+    if "--self-test" in sys.argv:
+        return self_test()
+    enforce = "--enforce" in sys.argv
+    root = Path(subprocess.run(["git", "rev-parse", "--show-toplevel"],
+                               capture_output=True, text=True, check=True).stdout.strip())
+    findings = run(root, want_network="--no-network" not in sys.argv)
+    if not findings:
+        print("stale comment references: OK (no comment names a missing file or dead repo)")
+        return 0
+    header = "comments naming something that does not exist:"
+    print(f"{'::error::' if enforce else '::warning::'}{header}")
+    for f in sorted(findings, key=lambda x: (x.rule, x.path, x.line)):
+        print(f"  - {f}")
+    print("\nFix the prose, or — when the reference is deliberately hypothetical — add\n"
+          "`stale-ref-ok: <reason>` to the same comment block. See\n"
+          ".github/scripts/check-stale-comment-references.py.")
+    return 1 if enforce else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/check-stale-comment-references.py
+++ b/.github/scripts/check-stale-comment-references.py
@@ -35,9 +35,16 @@
 #               openbank-admin-ui stays green). Glob/ellipsis forms are not claims and are
 #               skipped. Gitignored build outputs are skipped — they exist at build time.
 #
-#   R2 `repo`   A `JiRaska/<slug>` GitHub repository named in a comment that is archived or
-#               does not exist. Needs the network; DEGRADES TO A NOTICE, never to a pass and
-#               never to a red, when the API cannot be reached (see resolve_repo).
+#   R2 `repo`   A `JiRaska/<slug>` GitHub repository named in a comment that GitHub reports
+#               ARCHIVED. Needs the network; degrades to a ::notice — never to a pass and
+#               never to a red — when the API cannot be reached.
+#               It deliberately does NOT claim "the repo was deleted". A job's GITHUB_TOKEN
+#               is scoped to this repository, so a PRIVATE repo answers 404 exactly as a
+#               deleted one does, and GitHub offers no way to separate them. The first
+#               version did claim it, passed locally (owner credentials see everything) and
+#               went red in CI on `JiRaska/openbank-app`, which is private and alive. See
+#               resolve_repo — and validate any network probe with the credential its GATE
+#               will use, not the one on your laptop.
 #
 #   Two candidate rules were measured against origin/main and REJECTED. Both rejections are
 #   recorded here because "we did not build it" is the part a later reader cannot recover:
@@ -270,13 +277,34 @@ def path_candidates(comment: str, top_level: set[str]) -> list[str]:
 
 REPO_SLUG = re.compile(r"\bJiRaska/([A-Za-z0-9._-]+)\b")
 
+# The only repo state this rule CLAIMS. `invisible` (404) and `unknown` (no network) are
+# both reported as notices and never as findings — see resolve_repo for why 404 cannot
+# mean "deleted" under a repo-scoped CI token.
+FLAGGED = ("archived",)
+
 
 def resolve_repo(slug: str) -> tuple[str, str]:
-    """('ok'|'archived'|'missing'|'unknown', detail).
+    """('ok'|'archived'|'invisible'|'unknown', detail).
 
     UNKNOWN is the fail-safe direction on purpose: no network must never read as a pass
     (it prints a ::notice) and must never read as a red (a proxy-less runner would fail
     every PR for a reason that has nothing to do with the PR).
+
+    404 IS NOT "DOES NOT EXIST" — that is the whole reason this returns `invisible` and
+    not `missing`, and it was learned the expensive way. The first version flagged a 404
+    as a stale reference, which is correct against a token that can see everything and
+    WRONG against the one CI actually has: a job's GITHUB_TOKEN is scoped to this
+    repository, so a PRIVATE repo in the same account answers 404 exactly as a deleted one
+    does. `JiRaska/openbank-app` is private and alive, and the gate went red on it in CI
+    while passing locally, where `gh` is authenticated as the owner. GitHub offers no way
+    to tell the two apart, so the "repo was deleted" half of this rule is UNDECIDABLE from
+    CI and is deliberately not claimed. What survives is `archived`, which needs read
+    access to observe and is therefore never ambiguous — and which is the state the
+    motivating defect was in anyway.
+
+    The transferable half: a network probe must be validated with the CREDENTIAL its gate
+    will run under, not the one on the developer's laptop. Locally this rule reported OK
+    for the very reference CI failed on.
     """
     if os.environ.get("STALE_REF_SKIP_NETWORK") == "1":
         return "unknown", "network checks disabled"
@@ -290,7 +318,8 @@ def resolve_repo(slug: str) -> tuple[str, str]:
     if r.returncode != 0:
         err = (r.stderr or "").strip()
         if "404" in err or "Not Found" in err:
-            return "missing", "GitHub returns 404"
+            return "invisible", ("404 — deleted, or private and outside this token's "
+                                 "scope. GitHub does not distinguish the two; not claimed.")
         return "unknown", err.splitlines()[0][:120] if err else "gh failed"
     try:
         archived = json.loads(r.stdout).get("archived")
@@ -351,7 +380,7 @@ def scan_text(path: str, text: str, top_level: set[str], resolvable,
         if slug_state is not None:
             for m in REPO_SLUG.finditer(comment):
                 state, detail = slug_state.get(m.group(1), ("unknown", ""))
-                if state in ("archived", "missing"):
+                if state in FLAGGED:
                     out.append(Finding("repo", path, line, f"JiRaska/{m.group(1)}", detail))
     return out
 
@@ -406,14 +435,16 @@ def run(root: Path, want_network: bool) -> list[Finding]:
     state: dict[str, tuple[str, str]] = {}
     for slug in sorted(slugs):
         state[slug] = resolve_repo(slug) if want_network else ("unknown", "network skipped")
-    unknown = [s for s, (st, _) in state.items() if st == "unknown"]
+    # `invisible` is surfaced too, not silently dropped: a reader who sees only "OK" would
+    # reasonably assume every slug was checked, and one of them was not.
+    unknown = [s for s, (st, _) in state.items() if st in ("unknown", "invisible")]
     if unknown:
         print(f"::notice::stale-comment-references: repo rule UNRESOLVED for "
               f"{', '.join('JiRaska/' + s for s in unknown)} — "
               f"{state[unknown[0]][1]}. Not a pass and not a failure.")
     for f, line, slug in hits:
         st, detail = state.get(slug, ("unknown", ""))
-        if st in ("archived", "missing"):
+        if st in FLAGGED:
             findings.append(Finding("repo", f, line, f"JiRaska/{slug}", detail))
     return findings
 
@@ -501,13 +532,19 @@ _MUST_NOT_FLAG = {
 _REPO_FLAG = {
     "archived repo": ("a.yml", "# scope the token to JiRaska/open-bank\n",
                       {"open-bank": ("archived", "repository is ARCHIVED")}),
-    "missing repo": ("a.yml", "# see JiRaska/does-not-exist\n",
-                     {"does-not-exist": ("missing", "GitHub returns 404")}),
 }
 _REPO_NO_FLAG = {
     "live repo": ("a.yml", "# see JiRaska/open-bank-oss\n", {"open-bank-oss": ("ok", "")}),
     "unresolved never fails": ("a.yml", "# see JiRaska/open-bank\n",
                                {"open-bank": ("unknown", "no network")}),
+    # THE CI REGRESSION, pinned. `JiRaska/openbank-app` is private and alive; a job's
+    # repo-scoped GITHUB_TOKEN sees it as 404, identically to a deleted repo. Flagging
+    # `invisible` fails every PR forever on a correct reference — measured on run
+    # 30768813716, where this gate went red locally-green. Whoever is tempted to "also
+    # catch deleted repos" has to delete this case first.
+    "404 is not a claim — private repo looks deleted to a CI token": (
+        "a.yml", "# the app lives in JiRaska/openbank-app\n",
+        {"openbank-app": ("invisible", "404 — deleted, or private and out of scope")}),
     "waived": ("a.yml", "# JiRaska/open-bank\n# stale-ref-ok: cited as history\n",
                {"open-bank": ("archived", "x")}),
 }

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -43,7 +43,10 @@ on:
   # (issue #1419): without a per-PR submission the Gradle graph is main-only, and
   # dependency-review — which only ever compares submitted graphs — silently had
   # nothing to say about the fleet's primary language. This is the integration
-  # documented by gradle/actions (docs/dependency-submission.md). The path filter is
+  # documented by gradle/actions in its own docs/dependency-submission.md — a file in
+  # THAT repository, not this one.
+  # stale-ref-ok: the path above is gradle/actions', not a path in this tree.
+  # The path filter is
   # kept HERE and only here: a PR that changes no manifest cannot change resolution, so
   # its head needs no snapshot of its own — the gate has nothing to diff either way.
   pull_request:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -599,6 +599,19 @@ fire from *outside* it, so they stay here:
   `required_approving_review_count: 0` — it returns with `autoMergeRequest` null and the PR
   already
   MERGED, which reads like it did nothing.
+- **A gate that calls a network API must be falsified with the CREDENTIAL CI will use, not the
+  one on your laptop — and on GitHub a 404 does NOT mean "gone".** A job's `GITHUB_TOKEN` is
+  scoped to this repository, so a **private** repo in the same account answers `404` byte for
+  byte like a deleted one; `gh` on the owner's machine sees it fine. `check-stale-comment-
+  references.py` shipped a rule reading 404 as "this repo no longer exists", passed every local
+  run, and went red in CI on `JiRaska/openbank-app` — private, alive, correctly referenced. There
+  is no API field that separates the two, so that half of the rule was **dropped** rather than
+  tuned; only `archived` is claimed, since observing it requires read access and is therefore
+  unambiguous. Generalize: before asserting anything from an API response, ask which identity the
+  gate runs as and what that identity *cannot see* — a permission-shaped absence is
+  indistinguishable from a real one, and it always fails in the direction of a confident wrong
+  answer. The repo already knows "a gate that has only ever passed is unfalsified"; the sharper
+  form is that a gate falsified under the **wrong identity** is unfalsified too.
 - **Validate the PROBE, not the command inside it — in zsh a `for x in $VAR` loop runs ONCE.**
   zsh does not word-split an unquoted parameter (bash does), so a sweep written as
   `LIST="a b c"; for b in $LIST; do git show-ref --verify --quiet "refs/heads/$b" …` tests one

--- a/openbank-admin-ui/src/app/api/services/discovery/route.ts
+++ b/openbank-admin-ui/src/app/api/services/discovery/route.ts
@@ -6,8 +6,8 @@
 //
 // In-cluster: queries the K8s API for Deployments in the OpenBank domain
 // namespaces and returns readiness from .status.readyReplicas. The ServiceAccount
-// must have the openbank-discovery-reader ClusterRole bound via per-namespace
-// RoleBindings (see openbank-infra/gitops/components/admin-ui/rbac.yaml).
+// must have the admin-ui-discovery ClusterRole bound via per-namespace
+// RoleBindings (see openbank-infra/gitops/components/admin-ui/admin-ui.yaml).
 //
 // Off-cluster (local dev, no SA token): returns { source: "static", services: [] }
 // so callers degrade gracefully without crashing.

--- a/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: account-service
     app.kubernetes.io/part-of: accounts
   annotations:
-    openbank.tech/policy-checksum: "21038393636c7ec5"
+    openbank.tech/policy-checksum: "cc6526baf327fe4c"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1602,7 +1602,7 @@ data:
                                                 # SCA-completion-callback caller.
       - openbank-delegation-service            # ADR-0232: mints payment rights (customer-to-party grants) without moving
                                                 # money itself — money-path for the same reason consent/vop are. Threat
-                                                # model: docs/threat-models/delegation-service.md. four-eyes assessed:
+                                                # model: docs/threat-models/openbank-delegation-service.md. four-eyes assessed:
                                                 # delegation.offer/revoke/suspend are self-service or fraud-signal actions
                                                 # with SCA-bound ceremonies on both ends; the bank-side suspend lands via
                                                 # the fraud pipeline, not an operator console, so there is no

--- a/openbank-infra/gitops/components/accounts/account-service.yaml
+++ b/openbank-infra/gitops/components/accounts/account-service.yaml
@@ -37,7 +37,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-account-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "21038393636c7ec5"
+        openbank.tech/policy-checksum: "cc6526baf327fe4c"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/aml/aml-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/aml/aml-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: aml-service
     app.kubernetes.io/part-of: aml
   annotations:
-    openbank.tech/policy-checksum: "0ecb02924e3ece80"
+    openbank.tech/policy-checksum: "95affb5a2aadcc0a"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1575,7 +1575,7 @@ data:
                                                 # SCA-completion-callback caller.
       - openbank-delegation-service            # ADR-0232: mints payment rights (customer-to-party grants) without moving
                                                 # money itself — money-path for the same reason consent/vop are. Threat
-                                                # model: docs/threat-models/delegation-service.md. four-eyes assessed:
+                                                # model: docs/threat-models/openbank-delegation-service.md. four-eyes assessed:
                                                 # delegation.offer/revoke/suspend are self-service or fraud-signal actions
                                                 # with SCA-bound ceremonies on both ends; the bank-side suspend lands via
                                                 # the fraud pipeline, not an operator console, so there is no

--- a/openbank-infra/gitops/components/aml/aml-service.yaml
+++ b/openbank-infra/gitops/components/aml/aml-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-aml-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "0ecb02924e3ece80"
+        openbank.tech/policy-checksum: "95affb5a2aadcc0a"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: anacredit-service
     app.kubernetes.io/part-of: anacredit
   annotations:
-    openbank.tech/policy-checksum: "7a106f5a3592a893"
+    openbank.tech/policy-checksum: "5c47dc87e19ac52b"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1545,7 +1545,7 @@ data:
                                                 # SCA-completion-callback caller.
       - openbank-delegation-service            # ADR-0232: mints payment rights (customer-to-party grants) without moving
                                                 # money itself — money-path for the same reason consent/vop are. Threat
-                                                # model: docs/threat-models/delegation-service.md. four-eyes assessed:
+                                                # model: docs/threat-models/openbank-delegation-service.md. four-eyes assessed:
                                                 # delegation.offer/revoke/suspend are self-service or fraud-signal actions
                                                 # with SCA-bound ceremonies on both ends; the bank-side suspend lands via
                                                 # the fraud pipeline, not an operator console, so there is no

--- a/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
@@ -32,7 +32,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-anacredit-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "7a106f5a3592a893"
+        openbank.tech/policy-checksum: "5c47dc87e19ac52b"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/ap2/ap2-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/ap2/ap2-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: mcp-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "162fddbb364903ea"
+    openbank.tech/policy-checksum: "815a0bdcd5dd362c"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1513,7 +1513,7 @@ data:
                                                 # SCA-completion-callback caller.
       - openbank-delegation-service            # ADR-0232: mints payment rights (customer-to-party grants) without moving
                                                 # money itself — money-path for the same reason consent/vop are. Threat
-                                                # model: docs/threat-models/delegation-service.md. four-eyes assessed:
+                                                # model: docs/threat-models/openbank-delegation-service.md. four-eyes assessed:
                                                 # delegation.offer/revoke/suspend are self-service or fraud-signal actions
                                                 # with SCA-bound ceremonies on both ends; the bank-side suspend lands via
                                                 # the fraud pipeline, not an operator console, so there is no

--- a/openbank-infra/gitops/components/ap2/ap2-service.yaml
+++ b/openbank-infra/gitops/components/ap2/ap2-service.yaml
@@ -30,7 +30,7 @@ spec:
       annotations:
         # Roll the pod when the OPA policy bundle changes (subPath mounts don't hot-reload).
         # Kept in sync by gen-ap2-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "162fddbb364903ea"
+        openbank.tech/policy-checksum: "815a0bdcd5dd362c"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/audit/audit-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/audit/audit-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: audit-service
     app.kubernetes.io/part-of: audit
   annotations:
-    openbank.tech/policy-checksum: "7819014c8391d700"
+    openbank.tech/policy-checksum: "d2bde846ba0424e0"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1557,7 +1557,7 @@ data:
                                                 # SCA-completion-callback caller.
       - openbank-delegation-service            # ADR-0232: mints payment rights (customer-to-party grants) without moving
                                                 # money itself — money-path for the same reason consent/vop are. Threat
-                                                # model: docs/threat-models/delegation-service.md. four-eyes assessed:
+                                                # model: docs/threat-models/openbank-delegation-service.md. four-eyes assessed:
                                                 # delegation.offer/revoke/suspend are self-service or fraud-signal actions
                                                 # with SCA-bound ceremonies on both ends; the bank-side suspend lands via
                                                 # the fraud pipeline, not an operator console, so there is no

--- a/openbank-infra/gitops/components/audit/audit-service.yaml
+++ b/openbank-infra/gitops/components/audit/audit-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-audit-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "7819014c8391d700"
+        openbank.tech/policy-checksum: "d2bde846ba0424e0"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: balance-service
     app.kubernetes.io/part-of: balances
   annotations:
-    openbank.tech/policy-checksum: "7aafc695a565a7c0"
+    openbank.tech/policy-checksum: "c3d03934e43ebaef"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1646,7 +1646,7 @@ data:
                                                 # SCA-completion-callback caller.
       - openbank-delegation-service            # ADR-0232: mints payment rights (customer-to-party grants) without moving
                                                 # money itself — money-path for the same reason consent/vop are. Threat
-                                                # model: docs/threat-models/delegation-service.md. four-eyes assessed:
+                                                # model: docs/threat-models/openbank-delegation-service.md. four-eyes assessed:
                                                 # delegation.offer/revoke/suspend are self-service or fraud-signal actions
                                                 # with SCA-bound ceremonies on both ends; the bank-side suspend lands via
                                                 # the fraud pipeline, not an operator console, so there is no

--- a/openbank-infra/gitops/components/balances/balance-service.yaml
+++ b/openbank-infra/gitops/components/balances/balance-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-balance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "7aafc695a565a7c0"
+        openbank.tech/policy-checksum: "c3d03934e43ebaef"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: billing-service
     app.kubernetes.io/part-of: billing
   annotations:
-    openbank.tech/policy-checksum: "71b4a1b325239f71"
+    openbank.tech/policy-checksum: "defbb28d259c78d1"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1551,7 +1551,7 @@ data:
                                                 # SCA-completion-callback caller.
       - openbank-delegation-service            # ADR-0232: mints payment rights (customer-to-party grants) without moving
                                                 # money itself — money-path for the same reason consent/vop are. Threat
-                                                # model: docs/threat-models/delegation-service.md. four-eyes assessed:
+                                                # model: docs/threat-models/openbank-delegation-service.md. four-eyes assessed:
                                                 # delegation.offer/revoke/suspend are self-service or fraud-signal actions
                                                 # with SCA-bound ceremonies on both ends; the bank-side suspend lands via
                                                 # the fraud pipeline, not an operator console, so there is no

--- a/openbank-infra/gitops/components/billing/billing-service.yaml
+++ b/openbank-infra/gitops/components/billing/billing-service.yaml
@@ -27,7 +27,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-billing-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "71b4a1b325239f71"
+        openbank.tech/policy-checksum: "defbb28d259c78d1"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/campaign/campaign-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/campaign/campaign-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: campaign-service
     app.kubernetes.io/part-of: campaign
   annotations:
-    openbank.tech/policy-checksum: "2333279837337805"
+    openbank.tech/policy-checksum: "93c13316e9fb7f59"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1572,7 +1572,7 @@ data:
                                                 # SCA-completion-callback caller.
       - openbank-delegation-service            # ADR-0232: mints payment rights (customer-to-party grants) without moving
                                                 # money itself — money-path for the same reason consent/vop are. Threat
-                                                # model: docs/threat-models/delegation-service.md. four-eyes assessed:
+                                                # model: docs/threat-models/openbank-delegation-service.md. four-eyes assessed:
                                                 # delegation.offer/revoke/suspend are self-service or fraud-signal actions
                                                 # with SCA-bound ceremonies on both ends; the bank-side suspend lands via
                                                 # the fraud pipeline, not an operator console, so there is no

--- a/openbank-infra/gitops/components/campaign/campaign-service.yaml
+++ b/openbank-infra/gitops/components/campaign/campaign-service.yaml
@@ -25,7 +25,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-campaign-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "2333279837337805"
+        openbank.tech/policy-checksum: "93c13316e9fb7f59"
       labels:
         app.kubernetes.io/name: campaign-service
         app.kubernetes.io/part-of: campaign

--- a/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: consent-service
     app.kubernetes.io/part-of: consent
   annotations:
-    openbank.tech/policy-checksum: "e1e74429a5e7bb12"
+    openbank.tech/policy-checksum: "2afc9047453f98de"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1621,7 +1621,7 @@ data:
                                                 # SCA-completion-callback caller.
       - openbank-delegation-service            # ADR-0232: mints payment rights (customer-to-party grants) without moving
                                                 # money itself — money-path for the same reason consent/vop are. Threat
-                                                # model: docs/threat-models/delegation-service.md. four-eyes assessed:
+                                                # model: docs/threat-models/openbank-delegation-service.md. four-eyes assessed:
                                                 # delegation.offer/revoke/suspend are self-service or fraud-signal actions
                                                 # with SCA-bound ceremonies on both ends; the bank-side suspend lands via
                                                 # the fraud pipeline, not an operator console, so there is no

--- a/openbank-infra/gitops/components/consent/consent-service.yaml
+++ b/openbank-infra/gitops/components/consent/consent-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-consent-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "e1e74429a5e7bb12"
+        openbank.tech/policy-checksum: "2afc9047453f98de"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: copilot-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "ce5524bc481bda71"
+    openbank.tech/policy-checksum: "6387ab0928cbf0d3"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1637,7 +1637,7 @@ data:
                                                 # SCA-completion-callback caller.
       - openbank-delegation-service            # ADR-0232: mints payment rights (customer-to-party grants) without moving
                                                 # money itself — money-path for the same reason consent/vop are. Threat
-                                                # model: docs/threat-models/delegation-service.md. four-eyes assessed:
+                                                # model: docs/threat-models/openbank-delegation-service.md. four-eyes assessed:
                                                 # delegation.offer/revoke/suspend are self-service or fraud-signal actions
                                                 # with SCA-bound ceremonies on both ends; the bank-side suspend lands via
                                                 # the fraud pipeline, not an operator console, so there is no

--- a/openbank-infra/gitops/components/copilot/copilot-service.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-service.yaml
@@ -29,7 +29,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-copilot-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "ce5524bc481bda71"
+        openbank.tech/policy-checksum: "6387ab0928cbf0d3"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: customer-edge
     app.kubernetes.io/part-of: customer-edge
   annotations:
-    openbank.tech/policy-checksum: "34daf816face1be1"
+    openbank.tech/policy-checksum: "b79f1fc5ac50b00d"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -736,7 +736,7 @@ data:
                                                 # SCA-completion-callback caller.
       - openbank-delegation-service            # ADR-0232: mints payment rights (customer-to-party grants) without moving
                                                 # money itself — money-path for the same reason consent/vop are. Threat
-                                                # model: docs/threat-models/delegation-service.md. four-eyes assessed:
+                                                # model: docs/threat-models/openbank-delegation-service.md. four-eyes assessed:
                                                 # delegation.offer/revoke/suspend are self-service or fraud-signal actions
                                                 # with SCA-bound ceremonies on both ends; the bank-side suspend lands via
                                                 # the fraud pipeline, not an operator console, so there is no

--- a/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
@@ -65,7 +65,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-customer-edge-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "34daf816face1be1"
+        openbank.tech/policy-checksum: "b79f1fc5ac50b00d"
     spec:
       # Dedicated SA so EKS Pod Identity can hand the edge (and ONLY the edge) the
       # feedback-screenshots S3 role — ADR-0192, openbank-infra/aws/envs/sandbox-platform/

--- a/openbank-infra/gitops/components/delegation/delegation-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/delegation/delegation-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: delegation-service
     app.kubernetes.io/part-of: delegation
   annotations:
-    openbank.tech/policy-checksum: "1ec70542f75294d7"
+    openbank.tech/policy-checksum: "0916936f94622402"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1592,7 +1592,7 @@ data:
                                                 # SCA-completion-callback caller.
       - openbank-delegation-service            # ADR-0232: mints payment rights (customer-to-party grants) without moving
                                                 # money itself — money-path for the same reason consent/vop are. Threat
-                                                # model: docs/threat-models/delegation-service.md. four-eyes assessed:
+                                                # model: docs/threat-models/openbank-delegation-service.md. four-eyes assessed:
                                                 # delegation.offer/revoke/suspend are self-service or fraud-signal actions
                                                 # with SCA-bound ceremonies on both ends; the bank-side suspend lands via
                                                 # the fraud pipeline, not an operator console, so there is no

--- a/openbank-infra/gitops/components/delegation/delegation-service.yaml
+++ b/openbank-infra/gitops/components/delegation/delegation-service.yaml
@@ -25,7 +25,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-delegation-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "1ec70542f75294d7"
+        openbank.tech/policy-checksum: "0916936f94622402"
       labels:
         app.kubernetes.io/name: delegation-service
         app.kubernetes.io/part-of: delegation

--- a/openbank-infra/gitops/components/dispute-service/dispute-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/dispute-service/dispute-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: dispute-service
     app.kubernetes.io/part-of: dispute
   annotations:
-    openbank.tech/policy-checksum: "1d39896354dc7af0"
+    openbank.tech/policy-checksum: "d8dec317f0eed533"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1687,7 +1687,7 @@ data:
                                                 # SCA-completion-callback caller.
       - openbank-delegation-service            # ADR-0232: mints payment rights (customer-to-party grants) without moving
                                                 # money itself — money-path for the same reason consent/vop are. Threat
-                                                # model: docs/threat-models/delegation-service.md. four-eyes assessed:
+                                                # model: docs/threat-models/openbank-delegation-service.md. four-eyes assessed:
                                                 # delegation.offer/revoke/suspend are self-service or fraud-signal actions
                                                 # with SCA-bound ceremonies on both ends; the bank-side suspend lands via
                                                 # the fraud pipeline, not an operator console, so there is no

--- a/openbank-infra/gitops/components/dispute-service/dispute-service.yaml
+++ b/openbank-infra/gitops/components/dispute-service/dispute-service.yaml
@@ -15,7 +15,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-dispute-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "1d39896354dc7af0"
+        openbank.tech/policy-checksum: "d8dec317f0eed533"
       labels: {app.kubernetes.io/name: dispute-service, app.kubernetes.io/part-of: dispute}
     spec:
       securityContext:

--- a/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: document-service
     app.kubernetes.io/part-of: documents
   annotations:
-    openbank.tech/policy-checksum: "34daf816face1be1"
+    openbank.tech/policy-checksum: "b79f1fc5ac50b00d"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -736,7 +736,7 @@ data:
                                                 # SCA-completion-callback caller.
       - openbank-delegation-service            # ADR-0232: mints payment rights (customer-to-party grants) without moving
                                                 # money itself — money-path for the same reason consent/vop are. Threat
-                                                # model: docs/threat-models/delegation-service.md. four-eyes assessed:
+                                                # model: docs/threat-models/openbank-delegation-service.md. four-eyes assessed:
                                                 # delegation.offer/revoke/suspend are self-service or fraud-signal actions
                                                 # with SCA-bound ceremonies on both ends; the bank-side suspend lands via
                                                 # the fraud pipeline, not an operator console, so there is no

--- a/openbank-infra/gitops/components/document-service/document-service-service.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-service.yaml
@@ -43,7 +43,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-document-service-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "34daf816face1be1"
+        openbank.tech/policy-checksum: "b79f1fc5ac50b00d"
     spec:
       # ADR-0162 D4 (continued): a dedicated SA (not `default`) is what OpenBao's Kubernetes-auth
       # role `document-service-signing` is bound to — least-privilege, one identity per consumer.

--- a/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fraud-service
     app.kubernetes.io/part-of: fraud
   annotations:
-    openbank.tech/policy-checksum: "29423cced2110537"
+    openbank.tech/policy-checksum: "d96dec0c3464a8c1"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1562,7 +1562,7 @@ data:
                                                 # SCA-completion-callback caller.
       - openbank-delegation-service            # ADR-0232: mints payment rights (customer-to-party grants) without moving
                                                 # money itself — money-path for the same reason consent/vop are. Threat
-                                                # model: docs/threat-models/delegation-service.md. four-eyes assessed:
+                                                # model: docs/threat-models/openbank-delegation-service.md. four-eyes assessed:
                                                 # delegation.offer/revoke/suspend are self-service or fraud-signal actions
                                                 # with SCA-bound ceremonies on both ends; the bank-side suspend lands via
                                                 # the fraud pipeline, not an operator console, so there is no

--- a/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
@@ -23,7 +23,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fraud-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "29423cced2110537"
+        openbank.tech/policy-checksum: "d96dec0c3464a8c1"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fx-service
     app.kubernetes.io/part-of: fx
   annotations:
-    openbank.tech/policy-checksum: "6d442f957a65f415"
+    openbank.tech/policy-checksum: "4aaffbc7e3441be0"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1613,7 +1613,7 @@ data:
                                                 # SCA-completion-callback caller.
       - openbank-delegation-service            # ADR-0232: mints payment rights (customer-to-party grants) without moving
                                                 # money itself — money-path for the same reason consent/vop are. Threat
-                                                # model: docs/threat-models/delegation-service.md. four-eyes assessed:
+                                                # model: docs/threat-models/openbank-delegation-service.md. four-eyes assessed:
                                                 # delegation.offer/revoke/suspend are self-service or fraud-signal actions
                                                 # with SCA-bound ceremonies on both ends; the bank-side suspend lands via
                                                 # the fraud pipeline, not an operator console, so there is no

--- a/openbank-infra/gitops/components/fx-service/fx-service.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fx-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "6d442f957a65f415"
+        openbank.tech/policy-checksum: "4aaffbc7e3441be0"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: interest-service
     app.kubernetes.io/part-of: interest
   annotations:
-    openbank.tech/policy-checksum: "0631cf448af48985"
+    openbank.tech/policy-checksum: "5a025647351deca2"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1547,7 +1547,7 @@ data:
                                                 # SCA-completion-callback caller.
       - openbank-delegation-service            # ADR-0232: mints payment rights (customer-to-party grants) without moving
                                                 # money itself — money-path for the same reason consent/vop are. Threat
-                                                # model: docs/threat-models/delegation-service.md. four-eyes assessed:
+                                                # model: docs/threat-models/openbank-delegation-service.md. four-eyes assessed:
                                                 # delegation.offer/revoke/suspend are self-service or fraud-signal actions
                                                 # with SCA-bound ceremonies on both ends; the bank-side suspend lands via
                                                 # the fraud pipeline, not an operator console, so there is no

--- a/openbank-infra/gitops/components/interest-service/interest-service.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-service.yaml
@@ -16,7 +16,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-interest-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "0631cf448af48985"
+        openbank.tech/policy-checksum: "5a025647351deca2"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/kyc/kyc-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/kyc/kyc-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: kyc-service
     app.kubernetes.io/part-of: kyc
   annotations:
-    openbank.tech/policy-checksum: "f406aa58b19b0e41"
+    openbank.tech/policy-checksum: "52355ba6c7bc133e"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1575,7 +1575,7 @@ data:
                                                 # SCA-completion-callback caller.
       - openbank-delegation-service            # ADR-0232: mints payment rights (customer-to-party grants) without moving
                                                 # money itself — money-path for the same reason consent/vop are. Threat
-                                                # model: docs/threat-models/delegation-service.md. four-eyes assessed:
+                                                # model: docs/threat-models/openbank-delegation-service.md. four-eyes assessed:
                                                 # delegation.offer/revoke/suspend are self-service or fraud-signal actions
                                                 # with SCA-bound ceremonies on both ends; the bank-side suspend lands via
                                                 # the fraud pipeline, not an operator console, so there is no

--- a/openbank-infra/gitops/components/kyc/kyc-service.yaml
+++ b/openbank-infra/gitops/components/kyc/kyc-service.yaml
@@ -48,7 +48,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-kyc-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "f406aa58b19b0e41"
+        openbank.tech/policy-checksum: "52355ba6c7bc133e"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: ledger-service
     app.kubernetes.io/part-of: ledger
   annotations:
-    openbank.tech/policy-checksum: "fb59b0469a0266d7"
+    openbank.tech/policy-checksum: "91c8e8a732785a54"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1660,7 +1660,7 @@ data:
                                                 # SCA-completion-callback caller.
       - openbank-delegation-service            # ADR-0232: mints payment rights (customer-to-party grants) without moving
                                                 # money itself — money-path for the same reason consent/vop are. Threat
-                                                # model: docs/threat-models/delegation-service.md. four-eyes assessed:
+                                                # model: docs/threat-models/openbank-delegation-service.md. four-eyes assessed:
                                                 # delegation.offer/revoke/suspend are self-service or fraud-signal actions
                                                 # with SCA-bound ceremonies on both ends; the bank-side suspend lands via
                                                 # the fraud pipeline, not an operator console, so there is no

--- a/openbank-infra/gitops/components/ledger/ledger-service.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-service.yaml
@@ -38,7 +38,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-ledger-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "fb59b0469a0266d7"
+        openbank.tech/policy-checksum: "91c8e8a732785a54"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: lending-service
     app.kubernetes.io/part-of: lending
   annotations:
-    openbank.tech/policy-checksum: "32069ad5a5d94a5f"
+    openbank.tech/policy-checksum: "fe51ba58d6c9a2c3"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1655,7 +1655,7 @@ data:
                                                 # SCA-completion-callback caller.
       - openbank-delegation-service            # ADR-0232: mints payment rights (customer-to-party grants) without moving
                                                 # money itself — money-path for the same reason consent/vop are. Threat
-                                                # model: docs/threat-models/delegation-service.md. four-eyes assessed:
+                                                # model: docs/threat-models/openbank-delegation-service.md. four-eyes assessed:
                                                 # delegation.offer/revoke/suspend are self-service or fraud-signal actions
                                                 # with SCA-bound ceremonies on both ends; the bank-side suspend lands via
                                                 # the fraud pipeline, not an operator console, so there is no

--- a/openbank-infra/gitops/components/lending/lending-service.yaml
+++ b/openbank-infra/gitops/components/lending/lending-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-lending-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "32069ad5a5d94a5f"
+        openbank.tech/policy-checksum: "fe51ba58d6c9a2c3"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/mcp/mcp-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/mcp/mcp-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: mcp-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "162fddbb364903ea"
+    openbank.tech/policy-checksum: "815a0bdcd5dd362c"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1513,7 +1513,7 @@ data:
                                                 # SCA-completion-callback caller.
       - openbank-delegation-service            # ADR-0232: mints payment rights (customer-to-party grants) without moving
                                                 # money itself — money-path for the same reason consent/vop are. Threat
-                                                # model: docs/threat-models/delegation-service.md. four-eyes assessed:
+                                                # model: docs/threat-models/openbank-delegation-service.md. four-eyes assessed:
                                                 # delegation.offer/revoke/suspend are self-service or fraud-signal actions
                                                 # with SCA-bound ceremonies on both ends; the bank-side suspend lands via
                                                 # the fraud pipeline, not an operator console, so there is no

--- a/openbank-infra/gitops/components/mcp/mcp-service.yaml
+++ b/openbank-infra/gitops/components/mcp/mcp-service.yaml
@@ -29,7 +29,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-mcp-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "162fddbb364903ea"
+        openbank.tech/policy-checksum: "815a0bdcd5dd362c"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: notification-service
     app.kubernetes.io/part-of: notifications
   annotations:
-    openbank.tech/policy-checksum: "34daf816face1be1"
+    openbank.tech/policy-checksum: "b79f1fc5ac50b00d"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -736,7 +736,7 @@ data:
                                                 # SCA-completion-callback caller.
       - openbank-delegation-service            # ADR-0232: mints payment rights (customer-to-party grants) without moving
                                                 # money itself — money-path for the same reason consent/vop are. Threat
-                                                # model: docs/threat-models/delegation-service.md. four-eyes assessed:
+                                                # model: docs/threat-models/openbank-delegation-service.md. four-eyes assessed:
                                                 # delegation.offer/revoke/suspend are self-service or fraud-signal actions
                                                 # with SCA-bound ceremonies on both ends; the bank-side suspend lands via
                                                 # the fraud pipeline, not an operator console, so there is no

--- a/openbank-infra/gitops/components/notifications/notification-service.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service.yaml
@@ -39,7 +39,7 @@ spec:
       annotations:
         # Rolls the Deployment when the OPA policy bundle changes (subPath mounts don't
         # hot-reload). Kept in sync by gen-notification-opa-bundle.sh.
-        openbank.tech/policy-checksum: "34daf816face1be1"
+        openbank.tech/policy-checksum: "b79f1fc5ac50b00d"
       labels:
         app.kubernetes.io/name: notification-service
         app.kubernetes.io/part-of: notifications

--- a/openbank-infra/gitops/components/party/party-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/party/party-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: party-service
     app.kubernetes.io/part-of: party
   annotations:
-    openbank.tech/policy-checksum: "01a480769861911c"
+    openbank.tech/policy-checksum: "a49a05bbdc4616e0"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1584,7 +1584,7 @@ data:
                                                 # SCA-completion-callback caller.
       - openbank-delegation-service            # ADR-0232: mints payment rights (customer-to-party grants) without moving
                                                 # money itself — money-path for the same reason consent/vop are. Threat
-                                                # model: docs/threat-models/delegation-service.md. four-eyes assessed:
+                                                # model: docs/threat-models/openbank-delegation-service.md. four-eyes assessed:
                                                 # delegation.offer/revoke/suspend are self-service or fraud-signal actions
                                                 # with SCA-bound ceremonies on both ends; the bank-side suspend lands via
                                                 # the fraud pipeline, not an operator console, so there is no

--- a/openbank-infra/gitops/components/party/party-service.yaml
+++ b/openbank-infra/gitops/components/party/party-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-party-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "01a480769861911c"
+        openbank.tech/policy-checksum: "a49a05bbdc4616e0"
       labels:
         app.kubernetes.io/name: party-service
         app.kubernetes.io/part-of: party

--- a/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: card-issuance-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "887574e744dc58a9"
+    openbank.tech/policy-checksum: "c7d468c9dd763876"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1568,7 +1568,7 @@ data:
                                                 # SCA-completion-callback caller.
       - openbank-delegation-service            # ADR-0232: mints payment rights (customer-to-party grants) without moving
                                                 # money itself — money-path for the same reason consent/vop are. Threat
-                                                # model: docs/threat-models/delegation-service.md. four-eyes assessed:
+                                                # model: docs/threat-models/openbank-delegation-service.md. four-eyes assessed:
                                                 # delegation.offer/revoke/suspend are self-service or fraud-signal actions
                                                 # with SCA-bound ceremonies on both ends; the bank-side suspend lands via
                                                 # the fraud pipeline, not an operator console, so there is no

--- a/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: clearing-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "949e0465fe983e96"
+    openbank.tech/policy-checksum: "da05f103d4cc4643"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1605,7 +1605,7 @@ data:
                                                 # SCA-completion-callback caller.
       - openbank-delegation-service            # ADR-0232: mints payment rights (customer-to-party grants) without moving
                                                 # money itself — money-path for the same reason consent/vop are. Threat
-                                                # model: docs/threat-models/delegation-service.md. four-eyes assessed:
+                                                # model: docs/threat-models/openbank-delegation-service.md. four-eyes assessed:
                                                 # delegation.offer/revoke/suspend are self-service or fraud-signal actions
                                                 # with SCA-bound ceremonies on both ends; the bank-side suspend lands via
                                                 # the fraud pipeline, not an operator console, so there is no

--- a/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: domestic-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "4dc2f37c19685d60"
+    openbank.tech/policy-checksum: "18988998a43f1660"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1590,7 +1590,7 @@ data:
                                                 # SCA-completion-callback caller.
       - openbank-delegation-service            # ADR-0232: mints payment rights (customer-to-party grants) without moving
                                                 # money itself — money-path for the same reason consent/vop are. Threat
-                                                # model: docs/threat-models/delegation-service.md. four-eyes assessed:
+                                                # model: docs/threat-models/openbank-delegation-service.md. four-eyes assessed:
                                                 # delegation.offer/revoke/suspend are self-service or fraud-signal actions
                                                 # with SCA-bound ceremonies on both ends; the bank-side suspend lands via
                                                 # the fraud pipeline, not an operator console, so there is no

--- a/openbank-infra/gitops/components/payments/payments-services.yaml
+++ b/openbank-infra/gitops/components/payments/payments-services.yaml
@@ -42,7 +42,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-transaction-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "081bb120a3fd64a1" # transaction-opa-bundle
+        openbank.tech/policy-checksum: "4618ebae37c59cd2" # transaction-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -375,7 +375,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-payment-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "07057558a331dbca"
+        openbank.tech/policy-checksum: "9b261ece637b9880"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -729,7 +729,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-domestic-payment-opa-bundle.sh via the trailing marker
         # comment (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "4dc2f37c19685d60" # domestic-payment-opa-bundle
+        openbank.tech/policy-checksum: "18988998a43f1660" # domestic-payment-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1053,7 +1053,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-instant-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "b8ae697cb25dc660"
+        openbank.tech/policy-checksum: "28f4f3129e2d04fe"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1369,7 +1369,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-clearing-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "949e0465fe983e96" # clearing-opa-bundle
+        openbank.tech/policy-checksum: "da05f103d4cc4643" # clearing-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1658,7 +1658,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (ADR-0034). Value is stamped by
         # gen-standing-order-opa-bundle.sh — do not hand-edit.
-        openbank.tech/policy-checksum: "db59f936a99f34b3" # standing-order-opa-bundle
+        openbank.tech/policy-checksum: "a10cd14156908ed1" # standing-order-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1911,7 +1911,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-card-issuance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "887574e744dc58a9"
+        openbank.tech/policy-checksum: "c7d468c9dd763876"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2181,7 +2181,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-settlement-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "f2050a686d4539f2" # settlement-opa-bundle
+        openbank.tech/policy-checksum: "77b66b1febda0b78" # settlement-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2582,7 +2582,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-swift-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "54e3aa218d19d4d5"
+        openbank.tech/policy-checksum: "3108886d540f61e6"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2896,7 +2896,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-vop-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "3bc12307b10a014d"
+        openbank.tech/policy-checksum: "c2d59d373d55d880"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-instant
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "b8ae697cb25dc660"
+    openbank.tech/policy-checksum: "28f4f3129e2d04fe"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1563,7 +1563,7 @@ data:
                                                 # SCA-completion-callback caller.
       - openbank-delegation-service            # ADR-0232: mints payment rights (customer-to-party grants) without moving
                                                 # money itself — money-path for the same reason consent/vop are. Threat
-                                                # model: docs/threat-models/delegation-service.md. four-eyes assessed:
+                                                # model: docs/threat-models/openbank-delegation-service.md. four-eyes assessed:
                                                 # delegation.offer/revoke/suspend are self-service or fraud-signal actions
                                                 # with SCA-bound ceremonies on both ends; the bank-side suspend lands via
                                                 # the fraud pipeline, not an operator console, so there is no

--- a/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "07057558a331dbca"
+    openbank.tech/policy-checksum: "9b261ece637b9880"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1584,7 +1584,7 @@ data:
                                                 # SCA-completion-callback caller.
       - openbank-delegation-service            # ADR-0232: mints payment rights (customer-to-party grants) without moving
                                                 # money itself — money-path for the same reason consent/vop are. Threat
-                                                # model: docs/threat-models/delegation-service.md. four-eyes assessed:
+                                                # model: docs/threat-models/openbank-delegation-service.md. four-eyes assessed:
                                                 # delegation.offer/revoke/suspend are self-service or fraud-signal actions
                                                 # with SCA-bound ceremonies on both ends; the bank-side suspend lands via
                                                 # the fraud pipeline, not an operator console, so there is no

--- a/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: settlement-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "f2050a686d4539f2"
+    openbank.tech/policy-checksum: "77b66b1febda0b78"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1564,7 +1564,7 @@ data:
                                                 # SCA-completion-callback caller.
       - openbank-delegation-service            # ADR-0232: mints payment rights (customer-to-party grants) without moving
                                                 # money itself — money-path for the same reason consent/vop are. Threat
-                                                # model: docs/threat-models/delegation-service.md. four-eyes assessed:
+                                                # model: docs/threat-models/openbank-delegation-service.md. four-eyes assessed:
                                                 # delegation.offer/revoke/suspend are self-service or fraud-signal actions
                                                 # with SCA-bound ceremonies on both ends; the bank-side suspend lands via
                                                 # the fraud pipeline, not an operator console, so there is no

--- a/openbank-infra/gitops/components/payments/standing-order-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/standing-order-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: standing-order-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "db59f936a99f34b3"
+    openbank.tech/policy-checksum: "a10cd14156908ed1"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1549,7 +1549,7 @@ data:
                                                 # SCA-completion-callback caller.
       - openbank-delegation-service            # ADR-0232: mints payment rights (customer-to-party grants) without moving
                                                 # money itself — money-path for the same reason consent/vop are. Threat
-                                                # model: docs/threat-models/delegation-service.md. four-eyes assessed:
+                                                # model: docs/threat-models/openbank-delegation-service.md. four-eyes assessed:
                                                 # delegation.offer/revoke/suspend are self-service or fraud-signal actions
                                                 # with SCA-bound ceremonies on both ends; the bank-side suspend lands via
                                                 # the fraud pipeline, not an operator console, so there is no

--- a/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: swift-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "54e3aa218d19d4d5"
+    openbank.tech/policy-checksum: "3108886d540f61e6"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1567,7 +1567,7 @@ data:
                                                 # SCA-completion-callback caller.
       - openbank-delegation-service            # ADR-0232: mints payment rights (customer-to-party grants) without moving
                                                 # money itself — money-path for the same reason consent/vop are. Threat
-                                                # model: docs/threat-models/delegation-service.md. four-eyes assessed:
+                                                # model: docs/threat-models/openbank-delegation-service.md. four-eyes assessed:
                                                 # delegation.offer/revoke/suspend are self-service or fraud-signal actions
                                                 # with SCA-bound ceremonies on both ends; the bank-side suspend lands via
                                                 # the fraud pipeline, not an operator console, so there is no

--- a/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: transaction-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "081bb120a3fd64a1"
+    openbank.tech/policy-checksum: "4618ebae37c59cd2"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1620,7 +1620,7 @@ data:
                                                 # SCA-completion-callback caller.
       - openbank-delegation-service            # ADR-0232: mints payment rights (customer-to-party grants) without moving
                                                 # money itself — money-path for the same reason consent/vop are. Threat
-                                                # model: docs/threat-models/delegation-service.md. four-eyes assessed:
+                                                # model: docs/threat-models/openbank-delegation-service.md. four-eyes assessed:
                                                 # delegation.offer/revoke/suspend are self-service or fraud-signal actions
                                                 # with SCA-bound ceremonies on both ends; the bank-side suspend lands via
                                                 # the fraud pipeline, not an operator console, so there is no

--- a/openbank-infra/gitops/components/payments/vop-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/vop-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: vop-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "3bc12307b10a014d"
+    openbank.tech/policy-checksum: "c2d59d373d55d880"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1571,7 +1571,7 @@ data:
                                                 # SCA-completion-callback caller.
       - openbank-delegation-service            # ADR-0232: mints payment rights (customer-to-party grants) without moving
                                                 # money itself — money-path for the same reason consent/vop are. Threat
-                                                # model: docs/threat-models/delegation-service.md. four-eyes assessed:
+                                                # model: docs/threat-models/openbank-delegation-service.md. four-eyes assessed:
                                                 # delegation.offer/revoke/suspend are self-service or fraud-signal actions
                                                 # with SCA-bound ceremonies on both ends; the bank-side suspend lands via
                                                 # the fraud pipeline, not an operator console, so there is no

--- a/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: pid-service
     app.kubernetes.io/part-of: pid
   annotations:
-    openbank.tech/policy-checksum: "f105827297c12eb3"
+    openbank.tech/policy-checksum: "0241157d94471fcf"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1573,7 +1573,7 @@ data:
                                                 # SCA-completion-callback caller.
       - openbank-delegation-service            # ADR-0232: mints payment rights (customer-to-party grants) without moving
                                                 # money itself — money-path for the same reason consent/vop are. Threat
-                                                # model: docs/threat-models/delegation-service.md. four-eyes assessed:
+                                                # model: docs/threat-models/openbank-delegation-service.md. four-eyes assessed:
                                                 # delegation.offer/revoke/suspend are self-service or fraud-signal actions
                                                 # with SCA-bound ceremonies on both ends; the bank-side suspend lands via
                                                 # the fraud pipeline, not an operator console, so there is no

--- a/openbank-infra/gitops/components/pid/pid-service.yaml
+++ b/openbank-infra/gitops/components/pid/pid-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-pid-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "f105827297c12eb3"
+        openbank.tech/policy-checksum: "0241157d94471fcf"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/psd2-service/psd2-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/psd2-service/psd2-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: psd2-service
     app.kubernetes.io/part-of: psd2
   annotations:
-    openbank.tech/policy-checksum: "fb161a262350ca14"
+    openbank.tech/policy-checksum: "45ef6e729176acf0"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1646,7 +1646,7 @@ data:
                                                 # SCA-completion-callback caller.
       - openbank-delegation-service            # ADR-0232: mints payment rights (customer-to-party grants) without moving
                                                 # money itself — money-path for the same reason consent/vop are. Threat
-                                                # model: docs/threat-models/delegation-service.md. four-eyes assessed:
+                                                # model: docs/threat-models/openbank-delegation-service.md. four-eyes assessed:
                                                 # delegation.offer/revoke/suspend are self-service or fraud-signal actions
                                                 # with SCA-bound ceremonies on both ends; the bank-side suspend lands via
                                                 # the fraud pipeline, not an operator console, so there is no

--- a/openbank-infra/gitops/components/psd2-service/psd2-service.yaml
+++ b/openbank-infra/gitops/components/psd2-service/psd2-service.yaml
@@ -18,7 +18,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-psd2-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "fb161a262350ca14"
+        openbank.tech/policy-checksum: "45ef6e729176acf0"
       labels: {app.kubernetes.io/name: psd2-service, app.kubernetes.io/part-of: psd2}
     spec:
       securityContext:

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sanctions-service
     app.kubernetes.io/part-of: sanctions
   annotations:
-    openbank.tech/policy-checksum: "b98b1fb5cc87a0da"
+    openbank.tech/policy-checksum: "8c26b4c40b7ef025"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1551,7 +1551,7 @@ data:
                                                 # SCA-completion-callback caller.
       - openbank-delegation-service            # ADR-0232: mints payment rights (customer-to-party grants) without moving
                                                 # money itself — money-path for the same reason consent/vop are. Threat
-                                                # model: docs/threat-models/delegation-service.md. four-eyes assessed:
+                                                # model: docs/threat-models/openbank-delegation-service.md. four-eyes assessed:
                                                 # delegation.offer/revoke/suspend are self-service or fraud-signal actions
                                                 # with SCA-bound ceremonies on both ends; the bank-side suspend lands via
                                                 # the fraud pipeline, not an operator console, so there is no

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
@@ -49,7 +49,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sanctions-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "b98b1fb5cc87a0da"
+        openbank.tech/policy-checksum: "8c26b4c40b7ef025"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sca-service
     app.kubernetes.io/part-of: sca
   annotations:
-    openbank.tech/policy-checksum: "4bb602dc7ce9bed5"
+    openbank.tech/policy-checksum: "d4a982bacbb8bccf"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1587,7 +1587,7 @@ data:
                                                 # SCA-completion-callback caller.
       - openbank-delegation-service            # ADR-0232: mints payment rights (customer-to-party grants) without moving
                                                 # money itself — money-path for the same reason consent/vop are. Threat
-                                                # model: docs/threat-models/delegation-service.md. four-eyes assessed:
+                                                # model: docs/threat-models/openbank-delegation-service.md. four-eyes assessed:
                                                 # delegation.offer/revoke/suspend are self-service or fraud-signal actions
                                                 # with SCA-bound ceremonies on both ends; the bank-side suspend lands via
                                                 # the fraud pipeline, not an operator console, so there is no

--- a/openbank-infra/gitops/components/sca/sca-service.yaml
+++ b/openbank-infra/gitops/components/sca/sca-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sca-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "4bb602dc7ce9bed5"
+        openbank.tech/policy-checksum: "d4a982bacbb8bccf"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/statements/statement-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/statements/statement-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: statement-service
     app.kubernetes.io/part-of: statements
   annotations:
-    openbank.tech/policy-checksum: "f22b1eb754f88581"
+    openbank.tech/policy-checksum: "d892e3f7c9bbd17b"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1617,7 +1617,7 @@ data:
                                                 # SCA-completion-callback caller.
       - openbank-delegation-service            # ADR-0232: mints payment rights (customer-to-party grants) without moving
                                                 # money itself — money-path for the same reason consent/vop are. Threat
-                                                # model: docs/threat-models/delegation-service.md. four-eyes assessed:
+                                                # model: docs/threat-models/openbank-delegation-service.md. four-eyes assessed:
                                                 # delegation.offer/revoke/suspend are self-service or fraud-signal actions
                                                 # with SCA-bound ceremonies on both ends; the bank-side suspend lands via
                                                 # the fraud pipeline, not an operator console, so there is no

--- a/openbank-infra/gitops/components/statements/statement-service.yaml
+++ b/openbank-infra/gitops/components/statements/statement-service.yaml
@@ -26,7 +26,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-statement-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "f22b1eb754f88581"
+        openbank.tech/policy-checksum: "d892e3f7c9bbd17b"
       labels:
         app.kubernetes.io/name: statement-service
         app.kubernetes.io/part-of: statements

--- a/openbank-infra/gitops/components/tpp-registry/tpp-registry-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/tpp-registry/tpp-registry-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: tpp-registry-service
     app.kubernetes.io/part-of: tpp-registry
   annotations:
-    openbank.tech/policy-checksum: "5e66dadcb240f006"
+    openbank.tech/policy-checksum: "31c719249cc2bc3e"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1554,7 +1554,7 @@ data:
                                                 # SCA-completion-callback caller.
       - openbank-delegation-service            # ADR-0232: mints payment rights (customer-to-party grants) without moving
                                                 # money itself — money-path for the same reason consent/vop are. Threat
-                                                # model: docs/threat-models/delegation-service.md. four-eyes assessed:
+                                                # model: docs/threat-models/openbank-delegation-service.md. four-eyes assessed:
                                                 # delegation.offer/revoke/suspend are self-service or fraud-signal actions
                                                 # with SCA-bound ceremonies on both ends; the bank-side suspend lands via
                                                 # the fraud pipeline, not an operator console, so there is no

--- a/openbank-infra/gitops/components/tpp-registry/tpp-registry-service.yaml
+++ b/openbank-infra/gitops/components/tpp-registry/tpp-registry-service.yaml
@@ -23,7 +23,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-tpp-registry-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "5e66dadcb240f006"
+        openbank.tech/policy-checksum: "31c719249cc2bc3e"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/schedule/TieOutScheduler.kt
+++ b/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/schedule/TieOutScheduler.kt
@@ -121,9 +121,9 @@ class TieOutScheduler(
             // it silently ignores the injected `clock` and reads the JVM's real wall clock.
             // Harmless in production (the CDI clock is `Clock.systemUTC()`, so both give the same
             // instant and therefore the same Prague date), but it makes this method untestable
-            // with a fixed clock — exactly the class of clock-injection violation flagged
-            // fleet-wide in the closing audit (docs/audits/2026-07-16-closing-audit.md, systemic
-            // root cause 1).
+            // with a fixed clock — exactly the class of clock-injection violation the
+            // fleet-wide closing audit flagged as systemic root cause 1, and that
+            // .github/scripts/check-clock-injection.sh now gates.
             val through = LocalDate.now(clock.withZone(zone)).minusDays(1)
             val dates = catchUpDates(through)
             if (dates.isEmpty()) {

--- a/openbank-lending-service/src/test/kotlin/com/openbank/lending/infrastructure/rest/LendingSecurityTest.kt
+++ b/openbank-lending-service/src/test/kotlin/com/openbank/lending/infrastructure/rest/LendingSecurityTest.kt
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Test
 /**
  * Regression guard (C7/ADR-0030): no lending endpoint must be opened without role-gating.
  * Lending is a money-path service — unauthorised access would expose loan lifecycle actions.
- * Pure reflection — no Quarkus boot needed. Threat model: docs/threat-models/lending-service.md
+ * Pure reflection — no Quarkus boot needed. Threat model: docs/threat-models/openbank-lending-service.md
  */
 class LendingSecurityTest {
 

--- a/openbank-libs/governance/rules-opa-data.yaml
+++ b/openbank-libs/governance/rules-opa-data.yaml
@@ -50,7 +50,7 @@ money_path_services:
                                             # SCA-completion-callback caller.
   - openbank-delegation-service            # ADR-0232: mints payment rights (customer-to-party grants) without moving
                                             # money itself — money-path for the same reason consent/vop are. Threat
-                                            # model: docs/threat-models/delegation-service.md. four-eyes assessed:
+                                            # model: docs/threat-models/openbank-delegation-service.md. four-eyes assessed:
                                             # delegation.offer/revoke/suspend are self-service or fraud-signal actions
                                             # with SCA-bound ceremonies on both ends; the bank-side suspend lands via
                                             # the fraud pipeline, not an operator console, so there is no

--- a/openbank-libs/governance/rules.yaml
+++ b/openbank-libs/governance/rules.yaml
@@ -717,7 +717,7 @@ money_path_services:
                                             # SCA-completion-callback caller.
   - openbank-delegation-service            # ADR-0232: mints payment rights (customer-to-party grants) without moving
                                             # money itself — money-path for the same reason consent/vop are. Threat
-                                            # model: docs/threat-models/delegation-service.md. four-eyes assessed:
+                                            # model: docs/threat-models/openbank-delegation-service.md. four-eyes assessed:
                                             # delegation.offer/revoke/suspend are self-service or fraud-signal actions
                                             # with SCA-bound ceremonies on both ends; the bank-side suspend lands via
                                             # the fraud pipeline, not an operator console, so there is no

--- a/openbank-release-steward/src/main/kotlin/com/openbank/releasesteward/domain/model/ReleaseStewardModels.kt
+++ b/openbank-release-steward/src/main/kotlin/com/openbank/releasesteward/domain/model/ReleaseStewardModels.kt
@@ -54,7 +54,7 @@ data class ReleaseStewardFinding(
     val detectedAt: Instant,
     val title: String,
     // The module/service/file this finding is about, e.g. "openbank-transaction-service" or
-    // "openbank-ledger-service/openapi.yaml".
+    // "openbank-ledger-service/src/main/resources/openapi.yaml".
     val component: String,
     val prNumber: Int? = null,
     val prUrl: String? = null,


### PR DESCRIPTION
## Summary

Every source-text guard in this repo strips comments before matching, deliberately, so that
code-about-code does not trip it (#2450). Nothing therefore checks the prose — and the prose is
what a human reads and acts on. Measured instances in two days: a Kafka ACL header claiming the
broker ran `allow.everyone.if.no.acl.found=true` when it runs `false` (which is *why* nobody
granted the ACLs — 13 outbox rows went dead in production), an `application.yaml` documenting the
schema registry at the wrong host **and** port, and a workflow comment scoping tokens to an
archived repository.

New gate **`stale-comment-references`** (`enforced`, `supplychain` shard). It checks only what the
repo can falsify mechanically.

## Type of change

- [x] fix (bug fix)

## Linked issues

Refs #2450

## Rules implemented, and finding count for each

Measured on `origin/main` (`e7bc350ea`), across 4763 files carrying comments.

| Rule | What it flags | Findings on main |
|---|---|---|
| `path` | a repo-**root**-relative file path in a comment that resolves nowhere | **7** |
| `repo` | a `JiRaska/<slug>` GitHub repo that is **archived** | **0** |

All 7 are fixed in this PR, so the gate lands **enforced** against a zero-finding tree.

`path` admission is deliberately narrow, and each narrowing was forced by a measured
false-positive class rather than guessed:

| Admission rule | Findings before → after | The FP class it removes |
|---|---|---|
| naive slash-token | 209 | everything below |
| known source extension on the last segment | 209 → 95 | `openbank-libs-domain/openbank-libs-runtime`, `config/CDI` — prose that slashes two names |
| first segment is a real top-level entry | 95 → 42 | third-party paths: oss-fuzz `projects/openbank/build.sh`, an action's `temurin/installer.ts` |
| resolves as the **tail** of any tracked path | 42 → 7 | module-relative prose: `scripts/generate-catalog.mjs` inside `openbank-admin-ui` |

Globs, `...` elisions, `<placeholder>` forms and gitignored build outputs are excluded throughout —
a pattern is not a claim, and `build/reports/bom.json` exists exactly when it is read.

## The 7 findings, and what each turned out to be

| Where | Reference | Verdict |
|---|---|---|
| `openbank-libs/governance/rules.yaml:720` | `docs/threat-models/delegation-service.md` | stale — the file is `openbank-delegation-service.md` |
| `LendingSecurityTest.kt:16` | `docs/threat-models/lending-service.md` | stale — same naming slip, on a money-path service's threat model |
| `openbank-admin-ui/.../api/services/discovery/route.ts:10` | `openbank-infra/gitops/components/admin-ui/rbac.yaml` | stale — no such file; the RBAC lives in `admin-ui.yaml`, **and** the ClusterRole is named `admin-ui-discovery`, not `openbank-discovery-reader` |
| `TieOutScheduler.kt:125` | `docs/audits/2026-07-16-closing-audit.md` | stale — that audit was never committed |
| `ReleaseStewardModels.kt:57` | `openbank-ledger-service/openapi.yaml` | stale — the worked example named a path no service uses; specs live under `src/main/resources` |
| `check-gate-script-registration.py:73` | `.github/scripts/check-demo.py` | correct-as-written — a self-test fixture name. Waived. |
| `dependency-submission.yml:46` | `docs/dependency-submission.md` | correct-as-written — that is `gradle/actions`' own doc. Prose clarified **and** waived. |

## Rules rejected, and why

Recorded in the script header, not just here, because "we did not build it" is what a later reader
cannot recover.

**k8s Service / namespace in a comment that no gitops manifest declares — REJECTED, unsound ground
truth.** The Service inventory is not derivable from this tree. Strimzi creates
`openbank-cluster-kafka-bootstrap`, CNPG creates `<cluster>-rw`, the Temporal chart creates
`temporal-frontend` — none is a committed `kind: Service`. The strict `<svc>.<ns>.svc` formulation
produced **5 findings on main and all 5 were correct references** the guard simply could not see.
It would also not have caught the apicurio instance that motivated it: that comment reads
`service schema-registry:8081`, a bare name and port, not an FQDN. Both halves fail, so it is out.

**Identifier (class / function / config key) in a comment that appears nowhere — REJECTED, noisy by
construction.** Prose legitimately names deleted things *in order to explain why they were deleted*,
and this repo does that constantly ("the older, shorter form of this rule", "the `platform-admin`
prose that survived the rename"). The one formulation clean enough to ship — KDoc `[Identifier]`
links, substring-resolved — returns **0 findings**, but that zero is not evidence of health: it
accepts any name mentioned once anywhere in any `.kt` file, so it has almost no discriminating
power. The formulation with power (resolve against declarations) collides with every JDK, Quarkus
and Kotlin stdlib type the tree does not declare. A gate that cries wolf gets ignored, which is
worse than no gate.

## The first CI run found a real defect in the `repo` rule — worth reading

The rule originally flagged a **404** as "this repo no longer exists". Locally that was
green. In CI it went red on `JiRaska/openbank-app`, which is **private and alive**: a job's
`GITHUB_TOKEN` is scoped to this repository, so a private repo in the same account answers
404 *identically* to a deleted one, and GitHub exposes nothing that separates them. Every
local run said OK, because `gh` on the author's machine is the owner and can see it.

So the "repo was deleted" half is **undecidable from CI and is no longer claimed**. What
ships is `archived` only — a state that requires read access to observe, so it is never
ambiguous, and the state the motivating defect was actually in. A 404 now prints a
`::notice` next to the no-network case, so a slug that could not be checked is visible
rather than silently counted as fine.

Pinned as a must-**not**-flag self-test case naming the exact repo and the run that caught
it (`30768813716`), so anyone tempted to "also catch deleted repos" has to delete that case
first. Re-verified end to end under real credentials afterwards: a nonexistent slug →
notice, exit 0; `JiRaska/open-bank` → error, exit 1.

**The transferable lesson, and the reason this shipped wrong: validate a network probe with
the credential its GATE will run under, not the one on your laptop.** This repo already
knows "a gate that has only ever passed is unfalsified"; the sharper version is that a gate
falsified under the *wrong identity* is unfalsified too.

## Precedence for code-about-code — decided before the first run

**An explicit `stale-ref-ok: <reason>` in the same comment block wins, and nothing else does.**
No path allow-list, and this guard is **not** special-cased: it carries the marker like every other
file, so an exemption is visible in the diff instead of hidden in the checker. That is the inverse
of the three times this repo got this wrong (`check-roles-allowed-realm.py`,
`check-advisory-gate-registration.py`, the `platform-admin` sweep), where a guard's own prose was
the first thing it flagged. A self-test case feeds this guard's own comment syntax a stale path and
asserts it **is** flagged.

## Proving it can fail

`--self-test` has 25 cases, both directions for every rule. Beyond that, eight rules were broken in
place and the self-test re-run each time (source restored from a `cp` backup, verified byte-identical
by `shasum` — never `reset --hard`):

| Break | Self-test |
|---|---|
| comment nesting removed (naive `*/` close) | RED |
| waiver regex disabled | RED (2 cases) |
| glob/elision guard removed | RED |
| root-anchoring removed | RED |
| tail resolution removed | RED |
| extension filter removed | RED (2 cases) |
| `archived` no longer flagged | RED |

**Two of those were GREEN against the first draft**, and that is the load-bearing part of this
section. The self-test hand-wrote its own resolver, so breaking the *production* `build_resolver`
changed nothing it could see; and its `scripts/…` must-not-flag case was rejected upstream by
root-anchoring before ever reaching the resolver, so it tested nothing. Both are fixed — the
self-test now calls `build_resolver`, and its synthetic tree carries a root-level `scripts/`
exactly as the real one does.

End-to-end, both rules were also fired against a real tracked file (a temporary probe in `ci.yml`,
restored from backup): `--enforce` exits 1, plain run exits 0 with a `::warning`. The `repo`
resolver was validated against reality in all three directions — `JiRaska/open-bank` really is
`archived`, `open-bank-oss` is `ok`, a nonsense slug is `missing`.

## Self-assessment — where this can still be wrong

**Classes of stale prose that remain invisible.** These are the real limits, not hedging:

1. **The motivating defects themselves are mostly out of reach.** The Kafka ACL header asserted a
   *broker setting*; the apicurio comment asserted a *hostname and port*. Neither is a path or a
   repo slug, and neither rule here would have caught either one. What this gate catches is the
   file-reference subset of the class — real (5 stale references on main) but a subset.
2. **A comment that is wrong about something that exists.** The `discovery/route.ts` finding is the
   worked example: the guard caught the dead *path*, and was blind to the dead *ClusterRole name*
   sitting in the same sentence. I fixed both by hand; only one was mechanically detectable.
3. **Markdown is entirely out of scope**, so ADRs, runbooks and `CLAUDE.md` are unchecked. That is
   deliberate — an ADR citing a deleted file is a historical record, not an instruction — but it
   means the largest body of prose in the repo has no gate.
4. **String literals are not comments.** A Python docstring, a Kotlin `"""` block or a log message
   naming a dead path is invisible. This also means *this file's own module docstring* would be
   exempt, which is why its explanatory prose is written as `#` comments instead. Stated rather than
   relied on.
5. **Generated OPA bundles are skipped.** One stale comment in `rules.yaml` would otherwise report
   26 times, and the fix is never in the bundle. The source is scanned, so nothing is lost — but a
   hand-edit to a bundle would not be seen.
6. **Module-relative tail resolution is a real soundness give-up.** `scripts/foo.mjs` resolves if
   *any* tracked path ends in it, anywhere in the tree. A comment in service A naming a file that
   only exists under service B reads as fine. Tightening it to the containing module's root would
   catch that and would also flag the many correct cross-module references; I took the quieter side
   deliberately, and it is the first thing to revisit if this gate ever feels too weak.

7. **A deleted `JiRaska/<slug>` is not caught** — see the section above. Only `archived` is
   claimed, because 404 and "private, out of token scope" are the same response.

**Where it could produce a false green.** The `repo` rule degrades to a `::notice` both when the
GitHub API is unreachable and when a slug is invisible to the token — correct in both cases (a
proxy-less runner must not fail every PR, and a private repo is not a defect), but it means those
references are silently unchecked. It is a notice, not a pass, and the run log says so, but nobody
reads a notice. On `main` today that notice fires for `JiRaska/openbank-app` on every run, so the
`repo` rule effectively covers one slug. If that notice count grows, the rule is closer to dead
than the green suggests and should be treated that way.

## Note on overlap

#3508 (embed only the OPA-read subset of `rules.yaml` in the bundles) merged **while this branch was
being rebased**, which is worth recording because the intermediate state was genuinely wrong and
looked fine: `git checkout origin/main -- <file>` during conflict resolution pulled post-#3508
content onto a pre-#3508 rebase base, producing a 124-file diff full of content this PR never wrote.
Aborted and redone against the new `main`, re-applying the source edits surgically rather than by
copying files. The squash delta is 80 files: 11 source (the guard, its gate entry, 5 comment fixes,
2 waivers, `rules.yaml`, `CLAUDE.md`) and 69 regenerated bundles.

`main` then added six more gates while this was open, so `origin/main` was merged in and the
manifest checked for the silent-collision failure `gates.yaml` is prone to (a branch cut from an
older `main` replays its own copy on squash-merge and deregisters entries, while GitHub reports
CLEAN). Verified by id-set comparison, not by trusting the merge: **93 → 94, nothing dropped,
exactly one addition**. `check-gates-not-deregistered.py` agrees.

After #3508, a `rules.yaml` comment edit still restamps the fleet **when it lands in a key a policy
reads** — `money_path_services` is one, so its comments ride into `rules-opa-data.yaml`.
`gen-rules-opa-data.py` then all 40 bundle generators were re-run, in that order, after the final
edit; verified idempotent. `gates.yaml` is additive only: 87 → 88 entries, nothing deregistered.

The `ci.yml` change this PR originally carried (adding `GH_TOKEN` to the gates job so the `repo`
rule can reach the API) is **dropped** — #3502 added it to `main` first, for a different gate.

## Checklist

- [x] Gate registered in `.github/gates/gates.yaml` (`gate-script-registration` and
      `advisory-gate-registration` both green)
- [x] `--self-test` covers every rule in both directions, and is proven falsifiable
- [x] Zero findings on `main` after the fixes, so `mode: enforced`
- [x] OPA bundles regenerated after the final `rules.yaml` edit, idempotent
- [x] No hand-edited generated artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)
