### PR TITLE
fix(ci): restore three gate registrations dropped by a stale-base merge

### DIFF
--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -1598,3 +1598,57 @@ gates:
       # OutOfSync/Progressing rather than failed. Five services, four money-path,
       # were drifted this way before the check existed.
       python3 .github/scripts/check-opa-bundle-apply-size.py
+
+  # The admin-ui compliance page renders 47 regulatory-conformance claims from a hardcoded
+  # literal. #2370 found it wrong in BOTH directions — GDPR rows marked `ok` citing columns
+  # that exist only in a Flyway migration, with nothing reading them — and #2667 corrected
+  # those rows BY HAND. The checker that stops them rotting again was written at the same
+  # time and then referenced from nowhere: no workflow, no manifest entry, and nothing in
+  # this repo iterates `.github/scripts/check-*` (this runner reads the manifest, not the
+  # directory). So it had never run once (#3240).
+  #
+  # ENFORCED, same reasoning as the two gates above: the claim is published to users, the
+  # evidence citation is mechanical, and advisory over a published claim means "the page
+  # says something the code does not support" is mergeable. Green on the current tree, and
+  # `--self-test` (added with this registration) proves the red is reachable.
+  # The meta-gate: every check-* script must be run by SOMETHING. #3240 found two that were not —
+  # check-compliance-matrix.py, written for #2370 with a docstring naming the exact regulatory
+  # drift it prevents and referenced from nowhere, and check-operator-write-naming.py, which
+  # rules.yaml names as its own ci_producer while nothing invoked it. Both had never executed.
+  #
+  # That is worse than an unfalsified gate: a check that has never run cannot go red, never
+  # appears in a run list, and its presence in the tree reads as coverage to anyone grepping for
+  # it. Registering those two was the fix; this is what stops the third.
+  #
+  # ENFORCED and clean at registration. It flags ITSELF until registered — the same
+  # self-reference check-advisory-gate-registration.py hit in #2450 — which is the cheapest
+  # possible demonstration that its red is reachable.
+  - id: gate-script-registration
+    name: "every check-* script is actually run (#3240, enforced)"
+    group: registry
+    mode: enforced
+    selftest: |
+      python3 .github/scripts/check-gate-script-registration.py --self-test
+    run: |
+      python3 .github/scripts/check-gate-script-registration.py --enforce
+
+  - id: gitops-duplicate-resources
+    name: "No duplicate resource or env-list entry in a gitops manifest (issues #3450/#3460, enforced)"
+    group: gitops
+    mode: enforced
+    selftest: |
+      python3 .github/scripts/check-gitops-duplicate-resources.py --self-test
+    run: |
+      python3 .github/scripts/check-gitops-duplicate-resources.py --enforce
+
+  - id: scheduled-trigger-emitted
+    name: a declared SCHEDULED trigger must actually be emitted (an unreachable schedule fails silently)
+    group: kotlin
+    mode: enforced
+    run: |
+      # Falsified in three directions before wiring in: a new unemitted service fails, a
+      # baselined service that becomes covered ALSO fails (so the list cannot rot), and the
+      # tree as committed passes. 9 self-test cases, including comment-only mentions and
+      # Kotlin's NESTED block comments.
+      python3 .github/scripts/check-scheduled-trigger-emitted.py --self-test
+      python3 .github/scripts/check-scheduled-trigger-emitted.py --enforce


### PR DESCRIPTION
## Linked issues

Refs #3474, #3484, #3486, #3492

## What happened

#3492 (`a7495f362`) removed three gate registrations while adding its own:

```
-  gate-script-registration      (#3486)
-  gitops-duplicate-resources    (#3474)
-  scheduled-trigger-emitted     (#3484)
+  ensure-ecr-repository
```

88 entries before, 86 after. All three scripts are still in the tree and still correct — they were simply no longer run by anything.

## Why nothing caught it

Git had no conflict to raise. The three entries and #3492's own sit in different regions of `gates.yaml`, so a branch carrying an older copy of the file merges cleanly and silently reverts whatever landed in between. #3492 was created at 21:07 with base `8712a3f58` — which *is* #3486's merge commit — so this is not a stale base in the usual sense; the file content simply predates it.

CI cannot see it either, and this is the part worth internalising: **a gate absent from the manifest is not a gate that fails, it is a gate that does not run.** The shard summary shrinks by three and reports PASS.

The sharpest detail is that `check-gate-script-registration.py` — whose entire purpose is "a check-\* script that nothing runs is now a build failure" (#3486, merged 40 minutes earlier) — **unregistered itself**. With it gone there was nothing left to notice the other two.

## The fix

All three entries restored verbatim, comment blocks included. `ensure-ecr-repository` kept.

Verified through the repo's own runner rather than by reading the file:

```
run-gates.py --only gate-script-registration      PASS
run-gates.py --only gitops-duplicate-resources    PASS
run-gates.py --only scheduled-trigger-emitted     PASS

check-gate-script-registration.py --enforce       exit 0
  79 check-* scripts — 70 in gates.yaml, 9 invoked elsewhere or declared, 0 never run
```

Before this change that last line read `3 never run`, naming exactly the three above.

90 entries, no duplicate ids.

## Worth considering separately

This class of loss is invisible by construction and will recur — `gates.yaml` is a single append-heavy file that nearly every infrastructure PR touches, and the manifest's own count is the only thing that moves. A gate asserting the entry count never decreases without an explicit declaration would catch it, in the same shape as the `KNOWN_UNCOVERED`/`HELPERS` lists elsewhere: removing a gate stays possible, but has to be stated. I have not written that here because it is a design question rather than a repair, and this PR should stay a repair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
