### PR TITLE
fix(domestic-payment): give a payment held on an unavailable screen a way out

### DIFF
--- a/openbank-domestic-payment/src/main/kotlin/com/openbank/domestic/application/port/out/DomesticPaymentPorts.kt
+++ b/openbank-domestic-payment/src/main/kotlin/com/openbank/domestic/application/port/out/DomesticPaymentPorts.kt
@@ -37,6 +37,19 @@ interface DomesticPaymentRepository {
     /** Update a payment and enqueue a domain-event outbox message, atomically. */
     suspend fun update(payment: DomesticPayment, outboxMessage: OutboxMessage): DomesticPayment
 
+    /**
+     * Ids of payments still in `RECEIVED` that are worth screening again (#3266).
+     *
+     * A payment held because sanctions screening was unavailable has no other way out: the workflow
+     * completed, and nothing consumes the AML case's decision. Bounded three ways so a genuinely
+     * held payment is not re-screened forever — [maxAttempts], a [minAge] so a payment mid-flight is
+     * never touched, and [limit].
+     */
+    suspend fun findRedrivable(maxAttempts: Int, minAge: Instant, limit: Int): List<UUID>
+
+    /** Count one re-drive against [paymentId], before it is attempted. */
+    suspend fun recordRedriveAttempt(paymentId: UUID)
+
     /** How many payments currently sit in [status]. */
     suspend fun countByStatus(status: DomesticPaymentStatus): Long
 

--- a/openbank-domestic-payment/src/main/kotlin/com/openbank/domestic/infrastructure/persistence/entity/DomesticPaymentEntity.kt
+++ b/openbank-domestic-payment/src/main/kotlin/com/openbank/domestic/infrastructure/persistence/entity/DomesticPaymentEntity.kt
@@ -98,4 +98,11 @@ class DomesticPaymentEntity : PanacheEntity() {
 
     @Column(name = "updated_at", nullable = false)
     lateinit var updatedAt: Instant
+
+    /**
+     * How many times the #3266 sweep has re-screened this payment. Persistence-only — deliberately
+     * absent from the domain model, which describes the payment, not the recovery machinery.
+     */
+    @Column(name = "redrive_attempts", nullable = false)
+    var redriveAttempts: Int = 0
 }

--- a/openbank-domestic-payment/src/main/kotlin/com/openbank/domestic/infrastructure/persistence/repository/DomesticPaymentRepositoryImpl.kt
+++ b/openbank-domestic-payment/src/main/kotlin/com/openbank/domestic/infrastructure/persistence/repository/DomesticPaymentRepositoryImpl.kt
@@ -61,6 +61,22 @@ class DomesticPaymentRepositoryImpl(private val outboxRepository: DomesticPaymen
         query.range(offset, offset + limit - 1).list()
     }.awaitSuspending().map { it.toDomain() }
 
+    override suspend fun findRedrivable(maxAttempts: Int, minAge: Instant, limit: Int): List<UUID> =
+        Panache.withSession {
+            find(
+                "status = ?1 and redriveAttempts < ?2 and createdAt < ?3 order by createdAt asc",
+                DomesticPaymentStatus.RECEIVED.name,
+                maxAttempts,
+                minAge,
+            ).range(0, limit - 1).list()
+        }.awaitSuspending().map { it.paymentId }
+
+    override suspend fun recordRedriveAttempt(paymentId: UUID) {
+        Panache.withTransaction {
+            update("redriveAttempts = redriveAttempts + 1 where paymentId = ?1", paymentId)
+        }.awaitSuspending()
+    }
+
     override suspend fun update(payment: DomesticPayment, outboxMessage: OutboxMessage): DomesticPayment =
         Panache.withTransaction {
             find("paymentId", payment.id).firstResult()

--- a/openbank-domestic-payment/src/main/kotlin/com/openbank/domestic/infrastructure/scheduler/ScreeningRedriveScheduler.kt
+++ b/openbank-domestic-payment/src/main/kotlin/com/openbank/domestic/infrastructure/scheduler/ScreeningRedriveScheduler.kt
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+package com.openbank.domestic.infrastructure.scheduler
+
+import com.openbank.domestic.application.port.out.DomesticPaymentRepository
+import com.openbank.domestic.application.workflow.DomesticPaymentWorkflow
+import io.quarkus.scheduler.Scheduled
+import io.temporal.client.WorkflowClient
+import io.temporal.client.WorkflowOptions
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.inject.Inject
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.eclipse.microprofile.config.inject.ConfigProperty
+import org.jboss.logging.Logger
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+
+/**
+ * Re-screens payments left holding on an unavailable sanctions check (#3266).
+ *
+ * ### Why this exists
+ *
+ * `screenPayment` returns `REVIEW` when sanctions screening is unreachable, and the workflow then
+ * returns `RECEIVED` and **completes**. That hold is correct — on an outage a `HIT` is unknowable,
+ * and `applySddPolicy` only ever downgrades `REVIEW`, never `BLOCK`, so releasing would mean
+ * releasing un-screened. What was missing is the way out: nothing re-opens the hold. The AML case is
+ * opened `OPEN`, and this service has no messaging consumer, so deciding that case cannot release
+ * the payment. A dependency outage lasting minutes therefore became a permanent strand — one payment
+ * sat for hours, six others for weeks, while every alert stayed green.
+ *
+ * This sweep re-runs the **workflow**, so the payment is screened again and only advances if the
+ * screen now clears. It never releases anything on its own, and it is not a retry of the payment —
+ * `submitScheme` and `settlePayment` are reached only through the same gates as a first attempt.
+ *
+ * ### Why it is safe only now
+ *
+ * A re-drive reuses the idempotency keys `<paymentId>:debtor` / `:creditor`. Before #3264 a partially
+ * completed screen (debtor stored, creditor not) made the replay collide with
+ * `sanctions_checks_idempotency_key_key` and return 500, so the re-drive could not have worked. With
+ * that merged, the debtor replays its stored verdict and the creditor is screened fresh.
+ *
+ * ### Bounds
+ *
+ * Three, because an unbounded sweep would re-screen a genuinely held payment forever:
+ * [maxAttempts] on the row's own counter, [minAgeMinutes] so a payment still mid-flight is never
+ * touched, and [batchLimit] per tick. A payment that exhausts its attempts stays put and is now
+ * visible — `openbank_domestic_payments_non_terminal_oldest_age_seconds` (#3273) alerts on it.
+ *
+ * `suspend`, never `runBlocking` (#2148): Quarkus invokes a plain `@Scheduled` method on a bare
+ * executor thread with no Vert.x context, so the first reactive Panache query would throw HR000068
+ * before the per-item try/catch and the sweep would silently never run.
+ */
+@ApplicationScoped
+class ScreeningRedriveScheduler {
+
+    @Inject
+    lateinit var paymentRepository: DomesticPaymentRepository
+
+    @Inject
+    lateinit var workflowClient: WorkflowClient
+
+    @Inject
+    lateinit var clock: Clock
+
+    @ConfigProperty(name = "openbank.domestic.screening-redrive.enabled", defaultValue = "true")
+    var enabled: Boolean = true
+
+    @ConfigProperty(name = "openbank.domestic.screening-redrive.max-attempts", defaultValue = "5")
+    var maxAttempts: Int = DEFAULT_MAX_ATTEMPTS
+
+    @ConfigProperty(name = "openbank.domestic.screening-redrive.min-age-minutes", defaultValue = "10")
+    var minAgeMinutes: Long = DEFAULT_MIN_AGE_MINUTES
+
+    @ConfigProperty(name = "openbank.domestic.screening-redrive.batch-limit", defaultValue = "20")
+    var batchLimit: Int = DEFAULT_BATCH_LIMIT
+
+    @ConfigProperty(name = "openbank.temporal.task-queue", defaultValue = "openbank-domestic-payments")
+    lateinit var temporalTaskQueue: String
+
+    private val log = Logger.getLogger(ScreeningRedriveScheduler::class.java)
+
+    @Scheduled(
+        every = "{openbank.domestic.screening-redrive.interval:15m}",
+        delayed = "{openbank.domestic.screening-redrive.initial-delay:2m}",
+        concurrentExecution = Scheduled.ConcurrentExecution.SKIP,
+    )
+    suspend fun sweep() {
+        if (!enabled) {
+            log.debug("[screening-redrive] disabled — skipping")
+            return
+        }
+        val minAge = Instant.now(clock).minus(Duration.ofMinutes(minAgeMinutes))
+        val stuck = paymentRepository.findRedrivable(maxAttempts, minAge, batchLimit)
+        if (stuck.isEmpty()) return
+
+        log.infof("[screening-redrive] re-screening %d payment(s) held in RECEIVED", stuck.size)
+        for (paymentId in stuck) {
+            // Counted BEFORE the attempt: a re-drive that dies mid-flight must still consume its
+            // budget, or a payment that reliably kills the sweep is retried forever.
+            paymentRepository.recordRedriveAttempt(paymentId)
+            try {
+                // Temporal's start is a BLOCKING gRPC call. This method is `suspend`, so Quarkus
+                // dispatches it on a duplicated Vert.x context — blocking there stalls the event
+                // loop, and with ConcurrentExecution.SKIP one stalled tick wedges every later one.
+                // Measured: the sweep re-drove exactly one payment and then never ran again.
+                withContext(Dispatchers.IO) {
+                    val stub = workflowClient.newWorkflowStub(
+                        DomesticPaymentWorkflow::class.java,
+                        WorkflowOptions.newBuilder()
+                            .setTaskQueue(temporalTaskQueue)
+                            // Distinct id per attempt: the original workflow already completed, and
+                            // reusing its id would make the outcome depend on the server's id-reuse
+                            // policy rather than on this decision.
+                            .setWorkflowId("domestic-payment-$paymentId-redrive-${Instant.now(clock).toEpochMilli()}")
+                            .build(),
+                    )
+                    WorkflowClient.start(stub::process, paymentId)
+                }
+                log.infof("[screening-redrive] re-drove payment %s", paymentId)
+            } catch (@Suppress("TooGenericExceptionCaught") ex: Exception) {
+                // One payment must not abort the sweep for the rest — the #846 shape.
+                log.warnf(ex, "[screening-redrive] could not re-drive payment %s", paymentId)
+            }
+        }
+    }
+
+    private companion object {
+        const val DEFAULT_MAX_ATTEMPTS = 5
+        const val DEFAULT_MIN_AGE_MINUTES = 10L
+        const val DEFAULT_BATCH_LIMIT = 20
+    }
+}

--- a/openbank-domestic-payment/src/main/resources/application.yaml
+++ b/openbank-domestic-payment/src/main/resources/application.yaml
@@ -156,6 +156,15 @@ openbank:
     bic: ${OPENBANK_BIC:OPBKCZ22}
     bank-code: ${OPENBANK_BANK_CODE:2000}
   domestic:
+    # #3266: re-screen payments left holding on an unavailable sanctions check. Enabled by default
+    # because it only re-runs the designed flow — it re-screens, it never releases.
+    screening-redrive:
+      enabled: ${DOMESTIC_SCREENING_REDRIVE_ENABLED:true}
+      interval: 15m
+      initial-delay: 2m
+      max-attempts: 5
+      min-age-minutes: 10
+      batch-limit: 20
     scheme-submission:
       # ADR-0104 D4 Czech clearing pilot. OFF by default; when off, behaviour is exactly as before.
       enabled: ${DOMESTIC_SCHEME_SUBMISSION_ENABLED:false}

--- a/openbank-domestic-payment/src/main/resources/db/migration/V7__domestic_payments_redrive_attempts.sql
+++ b/openbank-domestic-payment/src/main/resources/db/migration/V7__domestic_payments_redrive_attempts.sql
@@ -1,0 +1,23 @@
+-- #3266: a payment held fail-closed on an unavailable sanctions screen had no way out.
+--
+-- The Temporal workflow returns RECEIVED and COMPLETES; the AML case is opened OPEN and nothing
+-- consumes its decision (domestic-payment has no messaging consumer at all), so a dependency
+-- outage lasting minutes became a permanent strand — one payment sat hours, others six weeks.
+-- Holding is correct: on an outage a HIT is unknowable, and applySddPolicy only ever downgrades
+-- REVIEW, never BLOCK. What was missing is something that re-opens the hold.
+--
+-- This counter bounds the re-drive sweep that now does. Without it the sweep would either
+-- re-screen a genuinely-held payment forever, or need an age window loose enough to be useless.
+-- Counting attempts makes the give-up point explicit and auditable on the row itself, which on a
+-- money-path table is worth a column.
+--
+-- ROLLBACK: ALTER TABLE domestic_payments DROP COLUMN redrive_attempts;
+-- Safe — nothing outside the sweep reads it, and dropping it only disables the re-drive bound.
+ALTER TABLE domestic_payments
+    ADD COLUMN redrive_attempts INTEGER NOT NULL DEFAULT 0;
+
+-- Partial: the sweep only ever looks at non-terminal rows under the cap, which is a tiny slice of
+-- a table that is mostly settled.
+CREATE INDEX idx_domestic_payments_redrivable
+    ON domestic_payments (created_at)
+    WHERE status = 'RECEIVED';

--- a/openbank-domestic-payment/src/test/kotlin/com/openbank/domestic/infrastructure/observability/DomesticPaymentStrandedGaugeTest.kt
+++ b/openbank-domestic-payment/src/test/kotlin/com/openbank/domestic/infrastructure/observability/DomesticPaymentStrandedGaugeTest.kt
@@ -44,6 +44,8 @@ class DomesticPaymentStrandedGaugeTest {
         override suspend fun list(status: DomesticPaymentStatus?, debtorAccountId: UUID?, limit: Int, offset: Int) =
             error("unused")
         override suspend fun update(payment: DomesticPayment, outboxMessage: OutboxMessage) = error("unused")
+        override suspend fun findRedrivable(maxAttempts: Int, minAge: Instant, limit: Int) = error("unused")
+        override suspend fun recordRedriveAttempt(paymentId: UUID) = error("unused")
     }
 
     private fun gaugeValue(registry: SimpleMeterRegistry, name: String, status: DomesticPaymentStatus): Double =

--- a/openbank-domestic-payment/src/test/kotlin/com/openbank/domestic/integration/ScreeningRedriveSweepIT.kt
+++ b/openbank-domestic-payment/src/test/kotlin/com/openbank/domestic/integration/ScreeningRedriveSweepIT.kt
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+package com.openbank.domestic.integration
+
+import com.openbank.domestic.it.PostgresRedisTestResource
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.junit.QuarkusTestProfile
+import io.quarkus.test.junit.TestProfile
+import io.quarkus.vertx.VertxContextSupport
+import io.smallrye.mutiny.coroutines.awaitSuspending
+import io.smallrye.mutiny.coroutines.uni
+import io.vertx.mutiny.pgclient.PgPool
+import io.vertx.mutiny.sqlclient.Tuple
+import jakarta.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Duration
+import java.time.Instant
+import java.util.UUID
+import java.util.concurrent.TimeUnit
+
+/**
+ * Drives the REAL #3266 sweep, on the real scheduler, against a real Postgres.
+ *
+ * Calling `ScreeningRedriveScheduler.sweep()` directly would prove nothing about the thing most
+ * likely to break it: a plain `@Scheduled` method runs on a bare executor thread with no Vert.x
+ * context, and the first reactive Panache query then throws HR000068 *before* any per-item
+ * try/catch — the sweep aborts having done nothing, silently. A direct call supplies the very
+ * context the scheduler does not, so it passes against broken code (#2148, five schedulers in this
+ * fleet had never run). Only letting Quarkus invoke it can see that.
+ *
+ * The profile therefore shrinks the interval instead of disabling it, and every override is a
+ * LITERAL: a `QuarkusTestProfile` loads in a different classloader from the test class, so a
+ * computed value here would hand the scheduler one number and the assertions another.
+ */
+@QuarkusTest
+@QuarkusTestResource(PostgresRedisTestResource::class)
+@TestProfile(ScreeningRedriveSweepIT.FastSweep::class)
+class ScreeningRedriveSweepIT {
+
+    class FastSweep : QuarkusTestProfile {
+        override fun getConfigOverrides(): Map<String, String> = mapOf(
+            "openbank.domestic.screening-redrive.enabled" to "true",
+            "openbank.domestic.screening-redrive.interval" to "2s",
+            "openbank.domestic.screening-redrive.initial-delay" to "1s",
+            "openbank.domestic.screening-redrive.max-attempts" to "2",
+            "openbank.domestic.screening-redrive.min-age-minutes" to "10",
+            "openbank.domestic.screening-redrive.batch-limit" to "20",
+            "quarkus.scheduler.enabled" to "true",
+        )
+    }
+
+    @Inject
+    lateinit var pool: PgPool
+
+    private fun <T> onEventLoop(block: suspend () -> T): T =
+        VertxContextSupport.subscribeAndAwait { uni(CoroutineScope(Dispatchers.Unconfined)) { block() } }
+
+    @BeforeEach
+    fun clear() {
+        onEventLoop {
+            pool.query("DELETE FROM domestic_payment_outbox").execute().awaitSuspending()
+            pool.query("DELETE FROM domestic_payments").execute().awaitSuspending()
+        }
+    }
+
+    /** Insert a RECEIVED payment directly, so the test controls age and attempt count exactly. */
+    private fun heldPayment(key: String, ageMinutes: Long, attempts: Int): UUID {
+        val id = UUID.randomUUID()
+        onEventLoop {
+            pool.preparedQuery(
+                """
+                INSERT INTO domestic_payments
+                  (payment_id, idempotency_key, status, debtor_account_id, debtor_account_number,
+                   debtor_bank_code, debtor_name, creditor_account_number, creditor_bank_code,
+                   creditor_name, amount, currency, priority, end_to_end_id, transfer_scope,
+                   created_at, updated_at, redrive_attempts)
+                VALUES ($1,$2,'RECEIVED',$3,'1000','0000','Payer','2000','0000','Payee',
+                        100.00,'CZK','STANDARD',$4,'INTERNAL_CLIENT',$5,$5,$6)
+                """.trimIndent(),
+            ).execute(
+                Tuple.of(id, key, UUID.randomUUID(), "E2E-$key")
+                    .addOffsetDateTime(
+                        Instant.now().minus(Duration.ofMinutes(ageMinutes)).atOffset(java.time.ZoneOffset.UTC),
+                    )
+                    .addInteger(attempts),
+            ).awaitSuspending()
+        }
+        return id
+    }
+
+    /** Poll until [check] holds, or fail with the last value — no awaitility dependency here,
+     *  because touching build.gradle.kts costs a fleet-wide dependency resolution. */
+    private fun awaitAttempts(id: UUID, timeout: Duration, check: (Int) -> Boolean): Int {
+        val deadline = System.nanoTime() + timeout.toNanos()
+        var last = attemptsOf(id)
+        while (System.nanoTime() < deadline) {
+            if (check(last)) return last
+            Thread.sleep(POLL_MS)
+            last = attemptsOf(id)
+        }
+        return last
+    }
+
+    private fun attemptsOf(id: UUID): Int = onEventLoop {
+        pool.preparedQuery("SELECT redrive_attempts FROM domestic_payments WHERE payment_id = $1")
+            .execute(Tuple.of(id)).awaitSuspending()
+            .iterator().next().getInteger("redrive_attempts")
+    }
+
+    /**
+     * The load-bearing test: the sweep actually runs under the scheduler (no HR000068), and it
+     * respects every bound. All three payments are asserted in one run, so an implementation that
+     * simply re-drives everything fails on the two that must be left alone.
+     */
+    @Test
+    fun `the real scheduler re-drives an eligible held payment and respects the bounds`() {
+        val eligible = heldPayment("held-eligible", ageMinutes = 60, attempts = 0)
+        val tooYoung = heldPayment("held-young", ageMinutes = 1, attempts = 0)
+        val exhausted = heldPayment("held-exhausted", ageMinutes = 60, attempts = 2)
+
+        assertThat(awaitAttempts(eligible, Duration.ofSeconds(30)) { it >= 1 })
+            .describedAs("the sweep must run on a Vert.x context and pick this up")
+            .isGreaterThanOrEqualTo(1)
+
+        assertThat(attemptsOf(tooYoung))
+            .describedAs("younger than min-age — a payment still mid-flight must never be touched")
+            .isZero()
+        assertThat(attemptsOf(exhausted))
+            .describedAs("at max-attempts — a genuinely held payment must not be re-screened forever")
+            .isEqualTo(2)
+    }
+
+    /** The counter must be bounded, not merely incremented — otherwise the sweep never gives up. */
+    @Test
+    fun `re-drives stop once the attempt budget is spent`() {
+        val id = heldPayment("held-budget", ageMinutes = 60, attempts = 0)
+
+        assertThat(awaitAttempts(id, Duration.ofSeconds(30)) { it >= 2 }).isEqualTo(2)
+        // Past the cap the row must stay put through several further ticks (interval is 2s).
+        Thread.sleep(TimeUnit.SECONDS.toMillis(8))
+        assertThat(attemptsOf(id))
+            .describedAs("max-attempts is 2 in this profile; the sweep must stop, not keep counting")
+            .isEqualTo(2)
+    }
+
+    private companion object {
+        const val POLL_MS = 1000L
+    }
+}


### PR DESCRIPTION
## What

Give a payment held on an unavailable sanctions screen a way out: a bounded, scheduled re-drive that
**re-screens** it. Adds `redrive_attempts` (Flyway `V7`), two repository methods, and
`ScreeningRedriveScheduler`.

## The issue's own framing was wrong, and implementing it literally would have been a regression

#3266 argues that an outage is treated as *more* suspicious than a real `POTENTIAL_HIT`, and calls
that backwards. It is not, and I filed it — the correction is on the issue:

- `applySddPolicy` downgrades **only** `REVIEW`, never `BLOCK`. When a screening result exists and is
  downgraded, you know the subject is not a `HIT`.
- On `ScreeningUnavailableException` you know **nothing**, and a `HIT` would have blocked.

So holding is the correct fail-closed behaviour. Routing the `catch` through `applySddPolicy` — the
obvious reading of the issue — would release `INTERNAL_CLIENT` payments un-screened whenever
sanctions-service is down. This PR deliberately does **not** do that.

## What was actually broken: the hold had no exit

The workflow returns `RECEIVED` and **completes**. The AML case is opened `OPEN`, and
`openbank-domestic-payment` has no messaging consumer at all (verified on `main`: the only class
under `infrastructure/kafka` is a publisher), so deciding that case cannot release the payment. A
dependency outage lasting minutes became a permanent strand — one payment for hours, six others for
weeks. A fail-closed hold is only defensible if something re-opens it.

The sweep re-runs the **workflow**, so the payment is screened again and advances only if the screen
now clears. It releases nothing on its own.

**It is only safe because #3264 merged.** A re-drive reuses `<paymentId>:debtor` / `:creditor`; before
that fix a partially completed screen made the replay collide with the unique index and return 500.

Bounded three ways so a genuinely held payment is not re-screened forever: `max-attempts` (on the
row, so the give-up point is auditable), `min-age-minutes` so a payment mid-flight is never touched,
and `batch-limit`. A payment that exhausts its budget stays put and is now visible — #3273's
`openbank_domestic_payments_non_terminal_oldest_age_seconds` alerts on it.

## The test found a real defect in this PR, twice

`ScreeningRedriveSweepIT` drives the **real** scheduler via a `@TestProfile` that shrinks the
interval, because a direct call to `sweep()` supplies the very Vert.x context the scheduler does not
and would pass against broken code (#2148). It earned that:

1. **First run: no ticks at all.** `delayed = "2m"` was hardcoded while the profile only shrank the
   interval, so the first tick was two minutes away and the test waited thirty seconds. The delay is
   now configurable and overridden in the profile.
2. **Then: exactly one re-drive, ever.** `WorkflowClient.start` is a blocking gRPC call, and a
   `suspend @Scheduled` method runs on a duplicated Vert.x context — blocking there stalls the event
   loop, and with `ConcurrentExecution.SKIP` one stalled tick wedges every later one. Symptoms fit
   exactly: the first payment reached `attempts=1` (recorded before the call), nothing after it
   moved, and running the second test alone hung past ten minutes. The start now runs on
   `Dispatchers.IO`.

Neither would have been visible from a direct method call. Both tests pass with the fix; before it,
the bounded-budget test read 0 against an expected 2.

## Notes

- `@Scheduled` is a `suspend fun` — mandatory here (#2148, `check-no-runblocking-in-scheduled.py`).
- Config overrides in the test profile are literals: a `QuarkusTestProfile` loads in a different
  classloader, so a computed value would hand the scheduler one number and the assertions another.
- No new dependency: the poll helper is hand-written rather than pulling in awaitility, because
  touching a `build.gradle.kts` costs a fleet-wide dependency resolution.
- The second question #3266 raises — why `INTERNAL_CLIENT` is screened inline at all, over a creditor
  name the payer typed — is untouched and still belongs in ADR-0032.

Closes #3266
Refs #3264, #3273
