### PR TITLE
fix(ci): restore three gates a stale branch silently deleted, and stop it recurring

### DIFF
--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -861,6 +861,96 @@ gates:
     run: |
       bash .github/scripts/ensure-ecr-repository.sh --self-test
 
+  # campaign-service's rollout died on `/bundle/rules-data.yaml: merge error` (#2872 defect 4).
+  # The sidecar runs `opa run --bundle /bundle` — DIRECTORY mode, where OPA derives a data
+  # document's path from its location in the tree. The bundle files were bit-identical to every
+  # healthy service's; only the MOUNTS differed. Mounted flat instead of at /bundle/<root>/data.yaml,
+  # two documents claim the same root, the bundle fails to load, and the container dies at boot.
+  #
+  # Nothing could see it: the ConfigMap is right, the args are right, the bundle drift gate compares
+  # CONTENT, and the service build knows nothing about mounts. The contradiction lives strictly
+  # between a Deployment's volumeMounts and the bundle's own manifest.json.
+  #
+  # The rule worth the effort is the quiet one: a data file under an UNDECLARED root is silently
+  # IGNORED by OPA rather than rejected, so the policy evaluates against absent data and no log
+  # explains the decision. Roots come from each bundle's own manifest.json — no per-service list.
+  #
+  # ENFORCED: 40 sidecars, 0 findings, 0 exceptions. Proven by flattening one real mount and
+  # watching it reproduce the campaign message.
+  # RESTORED. This entry was silently lost: #3486 added it and #3492 (branched from an older main,
+  # inserting at the SAME anchor in this file) squash-merged afterwards and took the file with its
+  # own version. GitHub reported both PRs MERGEABLE/CLEAN — a textbook semantic merge conflict, and
+  # the exact hazard this repo documents for parallel agents. The script survived on main
+  # registered nowhere, i.e. the meta-gate became the orphan it exists to detect. It is registered
+  # here again, and from now on its own rule makes that loss a build failure rather than silence.
+  #
+  # Every check-* script must be in this manifest, invoked from a tracked file, or a declared
+  # HELPER. #3240 found two that had never executed — one of them written to stop a regulatory
+  # drift, referenced from nowhere for its whole life.
+  - id: gitops-duplicate-resources
+    name: "No duplicate resource or env-list entry in a gitops manifest (issues #3450/#3460, enforced)"
+    group: gitops
+    mode: enforced
+    selftest: |
+      python3 .github/scripts/check-gitops-duplicate-resources.py --self-test
+    run: |
+      python3 .github/scripts/check-gitops-duplicate-resources.py --enforce
+
+  - id: scheduled-trigger-emitted
+    name: a declared SCHEDULED trigger must actually be emitted (an unreachable schedule fails silently)
+    group: kotlin
+    mode: enforced
+    run: |
+      # Falsified in three directions before wiring in: a new unemitted service fails, a
+      # baselined service that becomes covered ALSO fails (so the list cannot rot), and the
+      # tree as committed passes. 9 self-test cases, including comment-only mentions and
+      # Kotlin's NESTED block comments.
+      python3 .github/scripts/check-scheduled-trigger-emitted.py --self-test
+      python3 .github/scripts/check-scheduled-trigger-emitted.py --enforce
+
+  # On 2026-08-02 PR #3492 squash-merged and silently removed THREE enforced gates from this file
+  # — scheduled-trigger-emitted (#3484), gitops-duplicate-resources (#3474) and
+  # gate-script-registration (#3486), all added hours earlier. Nobody removed them: #3492 was
+  # branched from an older main and every new gate is appended near the same anchor, so its copy of
+  # this file replayed over the others'. GitHub reported MERGEABLE/CLEAN and all five required
+  # checks green. Three enforced gates stopped running and nothing said anything.
+  #
+  # gates.yaml is the highest-collision file in the tree precisely BECAUSE the manifest design
+  # worked: adding a gate is one entry in one file, so every agent edits the same region.
+  #
+  # gate-script-registration catches the SYMPTOM (an unrun check-* script) and did catch two of the
+  # three. It cannot see a lost entry whose script is invoked elsewhere, a gate whose run: is an
+  # inline command, or a silent enforced -> advisory downgrade. This compares the manifest with its
+  # own merge-base. Removal stays possible — it just has to be written down.
+  #
+  # Verified by replaying the real incident through it: 3 findings, one per lost gate.
+  - id: gates-not-deregistered
+    name: "no gate disappears from the manifest silently (enforced)"
+    group: registry
+    mode: enforced
+    selftest: |
+      python3 .github/scripts/check-gates-not-deregistered.py --self-test
+    run: |
+      python3 .github/scripts/check-gates-not-deregistered.py --enforce
+
+  - id: gate-script-registration
+    name: "every check-* script is actually run (#3240, enforced)"
+    group: registry
+    mode: enforced
+    selftest: |
+      python3 .github/scripts/check-gate-script-registration.py --self-test
+    run: |
+      python3 .github/scripts/check-gate-script-registration.py --enforce
+
+  - id: opa-sidecar-bundle-shape
+    name: "OPA sidecar data mounts match its .manifest roots (#2872, enforced)"
+    group: gitops
+    mode: enforced
+    selftest: |
+      python3 .github/scripts/check-opa-sidecar-bundle-shape.py --self-test
+    run: |
+      python3 .github/scripts/check-opa-sidecar-bundle-shape.py --enforce
+
   - id: compliance-matrix
     name: "compliance-page evidence citations (#2370, enforced)"
     group: registry

--- a/.github/scripts/check-gates-not-deregistered.py
+++ b/.github/scripts/check-gates-not-deregistered.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""A gate may not disappear from the manifest by accident. Removing one has to be said out loud.
+
+WHY THIS EXISTS — a measured incident, not a hypothetical
+---------------------------------------------------------
+On 2026-08-02, PR #3492 squash-merged and silently removed THREE enforced gates from
+`.github/gates/gates.yaml`:
+
+    scheduled-trigger-emitted     (added by #3484, hours earlier)
+    gitops-duplicate-resources    (added by #3474)
+    gate-script-registration      (added by #3486)
+
+Nobody removed them. #3492 was branched from an older `main` and every new gate is appended near the
+same anchor in this one file, so its version of `gates.yaml` simply replayed over the others'.
+GitHub reported the PR `MERGEABLE` / `CLEAN`; all five required checks were green. Three enforced
+gates stopped running and nothing said anything — the textbook semantic merge conflict this repo
+already documents for parallel agents, in its silent form.
+
+`gates.yaml` is the highest-collision file in the tree precisely BECAUSE the manifest design
+succeeded: adding a gate is now one entry in one file, so every agent adding a gate edits the same
+file in the same region.
+
+WHY THE OTHER GATE IS NOT ENOUGH
+--------------------------------
+`check-gate-script-registration.py` catches the *symptom* — a `check-*` script nothing runs — and it
+did catch two of the three above. It cannot catch a lost entry whose script is still invoked
+somewhere else, nor a gate whose `run:` is an inline command with no script at all, nor a gate
+silently downgraded from `enforced` to `advisory`. This one compares the manifest to its own past.
+
+WHAT IT CHECKS, against the merge-base with the default branch:
+  1. no gate id present there is missing here;
+  2. no gate has been downgraded from `enforced` to `advisory` —
+     the quieter half of the same failure.
+
+Either is allowed, but only DELIBERATELY: put a line in `gates.yaml` reading
+
+    # GATE-REMOVED: <id> — <reason>
+    # GATE-DOWNGRADED: <id> — <reason>
+
+so the intent lives next to the manifest and shows up in the diff a human reads. A removal that
+someone wrote down is a decision; a removal nobody wrote down is this incident.
+
+Usage:  check-gates-not-deregistered.py [--enforce] [--self-test] [--base <ref>]
+"""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import re
+import subprocess
+import sys
+
+import yaml
+
+REPO = pathlib.Path(__file__).resolve().parents[2]
+MANIFEST_REL = ".github/gates/gates.yaml"
+DEFAULT_BASE = "origin/main"
+
+REMOVED_RE = re.compile(r"^\s*#\s*GATE-REMOVED:\s*([A-Za-z0-9._-]+)\s*[—:-]", re.MULTILINE)
+DOWNGRADED_RE = re.compile(r"^\s*#\s*GATE-DOWNGRADED:\s*([A-Za-z0-9._-]+)\s*[—:-]", re.MULTILINE)
+
+
+def parse(text: str) -> dict[str, str]:
+    """gate id -> mode."""
+    doc = yaml.safe_load(text)
+    gates = doc["gates"] if isinstance(doc, dict) and "gates" in doc else doc
+    return {g["id"]: g.get("mode", "enforced") for g in gates if isinstance(g, dict) and "id" in g}
+
+
+def base_manifest(base: str) -> str | None:
+    """The manifest as of the merge-base, or None when the base ref is unavailable.
+
+    Uses the MERGE-BASE, not the base tip: on a branch cut before a gate was added, comparing
+    against the tip would demand entries this branch never had a chance to see, which is a false
+    positive on every stale branch. The merge-base asks the only honest question — did THIS branch
+    drop something it started with?
+    """
+    for ref in (base, base.split("/")[-1]):
+        try:
+            mb = subprocess.run(["git", "merge-base", "HEAD", ref], cwd=REPO,
+                                capture_output=True, text=True, check=True).stdout.strip()
+            return subprocess.run(["git", "show", f"{mb}:{MANIFEST_REL}"], cwd=REPO,
+                                  capture_output=True, text=True, check=True).stdout
+        except subprocess.CalledProcessError:
+            continue
+    return None
+
+
+def compare(before: str, after: str) -> list[str]:
+    old, new = parse(before), parse(after)
+    declared_removed = set(REMOVED_RE.findall(after))
+    declared_downgraded = set(DOWNGRADED_RE.findall(after))
+    out = []
+
+    for gid in sorted(set(old) - set(new) - declared_removed):
+        out.append(
+            f"gate '{gid}' ({old[gid]}) is in the manifest at the merge-base and gone here, with no "
+            f"'# GATE-REMOVED: {gid} — <reason>' line. Three enforced gates were lost exactly this "
+            f"way on 2026-08-02 by a stale branch replaying its own copy of this file, with the PR "
+            f"reporting MERGEABLE/CLEAN. If the removal is intended, say so in gates.yaml.")
+
+    for gid in sorted(set(old) & set(new)):
+        if old[gid] == "enforced" and new[gid] != "enforced" and gid not in declared_downgraded:
+            out.append(
+                f"gate '{gid}' was enforced at the merge-base and is now '{new[gid]}', with no "
+                f"'# GATE-DOWNGRADED: {gid} — <reason>' line. A gate that stops blocking is a "
+                f"policy decision; make it a visible one.")
+
+    # A declaration that is wrong in the other direction is also a finding — otherwise the markers
+    # rot into permanent noise, the failure mode of every hand-kept exception list in this repo.
+    for gid in sorted(declared_removed & set(new)):
+        out.append(f"'# GATE-REMOVED: {gid}' is declared but the gate is still in the manifest — "
+                   f"drop the stale declaration.")
+    for gid in sorted(declared_downgraded):
+        if gid in new and new[gid] == "enforced":
+            out.append(f"'# GATE-DOWNGRADED: {gid}' is declared but the gate is enforced — "
+                       f"drop the stale declaration.")
+    return out
+
+
+def selftest() -> int:
+    def man(entries: list[tuple[str, str]], extra: str = "") -> str:
+        body = "gates:\n" + "".join(
+            f"  - id: {i}\n    name: \"{i}\"\n    group: lint\n    mode: {m}\n    run: |\n      true\n"
+            for i, m in entries)
+        return body + extra
+
+    a = man([("one", "enforced"), ("two", "enforced"), ("three", "advisory")])
+    cases = [
+        ("nothing changed", a, 0),
+        ("a gate removed silently", man([("one", "enforced"), ("three", "advisory")]), 1),
+        ("a gate removed with a declaration",
+         man([("one", "enforced"), ("three", "advisory")], "\n# GATE-REMOVED: two — superseded\n"), 0),
+        ("enforced downgraded to advisory silently",
+         man([("one", "enforced"), ("two", "advisory"), ("three", "advisory")]), 1),
+        ("enforced downgraded with a declaration",
+         man([("one", "enforced"), ("two", "advisory"), ("three", "advisory")],
+             "\n# GATE-DOWNGRADED: two — blocked on #123\n"), 0),
+        ("a gate ADDED is fine", man([("one", "enforced"), ("two", "enforced"),
+                                      ("three", "advisory"), ("four", "enforced")]), 0),
+        ("advisory -> enforced is an upgrade, not a finding",
+         man([("one", "enforced"), ("two", "enforced"), ("three", "enforced")]), 0),
+        ("a stale GATE-REMOVED declaration is itself a finding",
+         man([("one", "enforced"), ("two", "enforced"), ("three", "advisory")],
+             "\n# GATE-REMOVED: two — superseded\n"), 1),
+        ("three removed at once — the real incident",
+         man([("one", "enforced")]), 2),
+    ]
+    for label, after, want in cases:
+        got = compare(a, after)
+        if len(got) != want:
+            print(f"selftest FAIL: {label} — expected {want}, got {len(got)}: {got}")
+            return 1
+
+    # The gate must not pass when it cannot read a base: silence would then mean "no base", which
+    # looks exactly like "nothing was removed".
+    if base_manifest("refs/heads/definitely-not-a-real-ref-xyz") is not None:
+        print("selftest FAIL: a bogus base ref resolved to something.")
+        return 1
+
+    print(f"selftest OK: {len(cases)} manifest transitions — silent removal and downgrade flagged, "
+          f"declared ones allowed, additions and upgrades ignored, stale declarations flagged.")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--enforce", action="store_true")
+    ap.add_argument("--self-test", action="store_true", dest="self_test")
+    ap.add_argument("--base", default=DEFAULT_BASE)
+    args = ap.parse_args()
+    if args.self_test:
+        return selftest()
+
+    after = (REPO / MANIFEST_REL).read_text(encoding="utf-8")
+    before = base_manifest(args.base)
+    if before is None:
+        # Not a finding: a shallow clone or a detached checkout has no base to compare with, and
+        # inventing one would fail every such run. Said out loud so the silence is not read as a
+        # pass, which is the distinction this whole file is about.
+        print(f"check-gates-not-deregistered: no merge-base with {args.base} available — "
+              f"NOT VERIFIED (this run proves nothing about removals).")
+        return 0
+
+    found = compare(before, after)
+    for line in found:
+        print(("::error::" if args.enforce else "::warning::") + line)
+    print(f"check-gates-not-deregistered: {len(parse(before))} gate(s) at the merge-base, "
+          f"{len(parse(after))} here — {'clean.' if not found else f'{len(found)} finding(s) above.'}")
+    return 1 if found and args.enforce else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/check-opa-sidecar-bundle-shape.py
+++ b/.github/scripts/check-opa-sidecar-bundle-shape.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""An OPA sidecar's data files must mount at the roots its own .manifest declares.
+
+WHY THIS EXISTS
+---------------
+campaign-service's rollout hit five independent boot failures, all on `main` with every required
+check green (#2872). The fourth was:
+
+    /bundle/rules-data.yaml: merge error
+
+The sidecar runs `opa run --server --bundle /bundle`, i.e. DIRECTORY mode, where OPA derives each
+data document's path in `data.*` from the file's location in the tree. The bundle files were
+bit-identical to every healthy service's — only the mount paths differed. Mounted FLAT as
+`/bundle/rules-data.yaml` instead of `/bundle/rules/data.yaml`, two documents claim the same root
+and OPA refuses to load the bundle at all. The container dies; the pod never becomes ready.
+
+Nothing could see it. The ConfigMap is correct, the args are correct, the bundle drift gate compares
+bundle CONTENT, and the service build knows nothing about mounts. The contradiction lives strictly
+between the Deployment's `volumeMounts` and the bundle's own `manifest.json` — two artifacts in this
+tree, with nothing comparing them, which is the shape four of those five defects shared.
+
+WHAT IT CHECKS, per container whose image is OPA:
+  1. `--bundle <dir>` is passed at all — without it OPA serves an empty policy and every
+     authorization decision silently falls through to the default.
+  2. `<dir>/.manifest` is mounted. Directory mode without a manifest loads with roots inferred,
+     which is how a bundle can appear healthy while answering about the wrong data.
+  3. Every `data.yaml`/`data.json` mounted under `<dir>` sits in a SUBDIRECTORY, never flat — the
+     exact #2865 shape.
+  4. That subdirectory is one of the `roots` declared in the bundle ConfigMap's `manifest.json`. A
+     data file under an undeclared root is silently ignored by OPA rather than rejected, so the
+     policy evaluates against absent data and denies (or permits) for a reason no log explains.
+
+Rule 4 is the one worth the effort: rule 3's failure is loud (the container crashes), rule 4's is
+silent. Both are cheap once the manifest is being read.
+
+DERIVED, NOT DECLARED: the roots come from each bundle's own `manifest.json`, so there is no
+per-service list to maintain and no exception file. 40 sidecars, 40 bundle ConfigMaps, zero
+findings and zero exceptions at registration.
+
+Usage:  check-opa-sidecar-bundle-shape.py [--enforce] [--self-test]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import sys
+
+import yaml
+
+REPO = pathlib.Path(__file__).resolve().parents[2]
+COMPONENTS = REPO / "openbank-infra/gitops/components"
+WORKLOADS = {"Deployment", "Rollout", "StatefulSet", "DaemonSet"}
+DATA_FILES = ("data.yaml", "data.json")
+
+
+def documents(root: pathlib.Path):
+    for path in sorted(root.rglob("*.yaml")):
+        try:
+            docs = list(yaml.safe_load_all(path.read_text(encoding="utf-8")))
+        except (yaml.YAMLError, OSError, UnicodeDecodeError):
+            continue
+        for doc in docs:
+            if isinstance(doc, dict):
+                yield path, doc
+
+
+def bundle_roots(root: pathlib.Path) -> dict[str, set[str]]:
+    """ConfigMap name -> the roots its manifest.json declares."""
+    out: dict[str, set[str]] = {}
+    for _, doc in documents(root):
+        if doc.get("kind") != "ConfigMap":
+            continue
+        data = doc.get("data") or {}
+        if "manifest.json" not in data:
+            continue
+        try:
+            roots = set(json.loads(data["manifest.json"]).get("roots") or [])
+        except (json.JSONDecodeError, TypeError):
+            roots = set()
+        out[(doc.get("metadata") or {}).get("name")] = roots
+    return out
+
+
+def bundle_dir(args: list[str]) -> str | None:
+    for i, arg in enumerate(args):
+        if arg == "--bundle" and i + 1 < len(args):
+            return args[i + 1]
+        if arg.startswith("--bundle="):
+            return arg.split("=", 1)[1]
+    return None
+
+
+def findings(root: pathlib.Path = COMPONENTS) -> tuple[list[str], int]:
+    roots_by_cm = bundle_roots(root)
+    out: list[str] = []
+    sidecars = 0
+
+    for path, doc in documents(root):
+        if doc.get("kind") not in WORKLOADS:
+            continue
+        podspec = (((doc.get("spec") or {}).get("template") or {}).get("spec") or {})
+        volumes = {v.get("name"): v for v in (podspec.get("volumes") or [])}
+        workload = (doc.get("metadata") or {}).get("name")
+        where = f"{workload} ({path.name})"
+
+        for container in podspec.get("containers") or []:
+            if "opa" not in str(container.get("image", "")).lower():
+                continue
+            sidecars += 1
+            args = [a for a in (container.get("args") or []) if isinstance(a, str)]
+            mounts = container.get("volumeMounts") or []
+
+            bdir = bundle_dir(args)
+            if not bdir:
+                out.append(f"{where}: the OPA sidecar passes no --bundle. It will serve an empty "
+                           f"policy and every decision falls through to the default, silently.")
+                continue
+
+            prefix = bdir.rstrip("/") + "/"
+            if not any((m.get("mountPath") or "") == prefix + ".manifest" for m in mounts):
+                out.append(f"{where}: no {prefix}.manifest mount. In directory mode OPA then "
+                           f"infers roots, so the bundle can load and answer about the wrong data.")
+
+            cm_names = {
+                (volumes.get(m.get("name"), {}).get("configMap") or {}).get("name")
+                for m in mounts
+                if "configMap" in (volumes.get(m.get("name")) or {})
+            }
+            declared: set[str] = set()
+            for name in cm_names:
+                declared |= roots_by_cm.get(name, set())
+
+            for mount in mounts:
+                mp = mount.get("mountPath") or ""
+                if not mp.startswith(prefix):
+                    continue
+                rel = mp[len(prefix):]
+                if not rel.endswith(DATA_FILES):
+                    continue
+                if "/" not in rel:
+                    out.append(
+                        f"{where}: {mp} is mounted FLAT. OPA derives a data document's path from "
+                        f"its directory, so two flat data files claim the same root and the bundle "
+                        f"fails to load with 'merge error' — the container dies at boot (#2865). "
+                        f"Mount it at {prefix}<root>/{rel.rsplit('-', 1)[-1]} instead.")
+                    continue
+                subdir = rel.rsplit("/", 1)[0]
+                if declared and subdir not in declared:
+                    out.append(
+                        f"{where}: {mp} sits under '{subdir}', which is not a root declared in the "
+                        f"bundle manifest {sorted(declared)}. OPA IGNORES data outside a declared "
+                        f"root rather than rejecting it, so the policy evaluates against absent "
+                        f"data and no log explains the decision.")
+
+    if sidecars == 0:
+        # Never report a clean run on an empty scan: zero sidecars and zero findings are the same
+        # output, and the fleet has 40.
+        out.append(f"no OPA sidecar found under {root} — the scan is broken or the image name "
+                   f"changed. Not reporting a clean run on that.")
+    return out, sidecars
+
+
+def selftest() -> int:
+    import tempfile
+
+    def workload(dirpath: pathlib.Path, mounts: list[tuple[str, str]], roots: list[str],
+                 args: list[str] | None = None, cm: bool = True) -> None:
+        dirpath.mkdir(parents=True, exist_ok=True)
+        vm = [{"name": "opa-bundle", "mountPath": mp, "subPath": sp} for mp, sp in mounts]
+        (dirpath / "w.yaml").write_text(yaml.safe_dump({
+            "apiVersion": "apps/v1", "kind": "Deployment", "metadata": {"name": "svc"},
+            "spec": {"template": {"spec": {
+                "volumes": [{"name": "opa-bundle", "configMap": {"name": "svc-opa-bundle"}}],
+                "containers": [{"name": "opa", "image": "openpolicyagent/opa:1.0.0",
+                                "args": args if args is not None else
+                                ["run", "--server", "--bundle", "/bundle"],
+                                "volumeMounts": vm}],
+            }}},
+        }), encoding="utf-8")
+        if cm:
+            (dirpath / "cm.yaml").write_text(yaml.safe_dump({
+                "apiVersion": "v1", "kind": "ConfigMap", "metadata": {"name": "svc-opa-bundle"},
+                "data": {"manifest.json": json.dumps({"roots": roots})},
+            }), encoding="utf-8")
+
+    healthy = [("/bundle/.manifest", "manifest.json"),
+               ("/bundle/rules/data.yaml", "rules-data.yaml"),
+               ("/bundle/agents/data.yaml", "agents-data.yaml")]
+
+    cases = [
+        ("the fleet-standard shape", healthy, ["rules", "agents"], None, True, 0),
+        # The exact #2865 failure: campaign mounted the data file flat.
+        ("a FLAT data mount (campaign's #2865 shape)",
+         [("/bundle/.manifest", "manifest.json"), ("/bundle/rules-data.yaml", "rules-data.yaml")],
+         ["rules"], None, True, 1),
+        ("a data file under an undeclared root",
+         [("/bundle/.manifest", "manifest.json"), ("/bundle/typo/data.yaml", "rules-data.yaml")],
+         ["rules"], None, True, 1),
+        ("no .manifest mounted",
+         [("/bundle/rules/data.yaml", "rules-data.yaml")], ["rules"], None, True, 1),
+        ("no --bundle argument at all", healthy, ["rules"],
+         ["run", "--server", "--addr=0.0.0.0:8181"], True, 1),
+        # No manifest ConfigMap: roots are unknown, so rule 4 must NOT fire on a guess — but rule 2
+        # still catches the missing manifest if it is missing. Here it is mounted, so: 0.
+        ("no bundle ConfigMap to read roots from", healthy, [], None, False, 0),
+    ]
+
+    for label, mounts, roots, args, cm, want in cases:
+        with tempfile.TemporaryDirectory() as d:
+            base = pathlib.Path(d)
+            workload(base / "c", mounts, roots, args, cm)
+            got, sidecars = findings(base)
+        if sidecars != 1:
+            print(f"selftest FAIL: {label} — expected to find 1 sidecar, found {sidecars}")
+            return 1
+        if len(got) != want:
+            print(f"selftest FAIL: {label} — expected {want} finding(s), got {len(got)}: {got}")
+            return 1
+
+    with tempfile.TemporaryDirectory() as d:
+        got, sidecars = findings(pathlib.Path(d))
+        if not got or sidecars != 0:
+            print("selftest FAIL: an empty tree did not report that it found nothing.")
+            return 1
+
+    print(f"selftest OK: {len(cases)} fixture(s) — flat mount, undeclared root, missing manifest, "
+          f"missing --bundle, unknown-roots restraint, and an empty tree.")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--enforce", action="store_true")
+    ap.add_argument("--self-test", action="store_true", dest="self_test")
+    args = ap.parse_args()
+    if args.self_test:
+        return selftest()
+
+    found, sidecars = findings()
+    for line in found:
+        print(("::error::" if args.enforce else "::warning::") + line)
+    print(f"check-opa-sidecar-bundle-shape: {sidecars} OPA sidecar(s) — "
+          f"{'clean.' if not found else f'{len(found)} finding(s) above.'}")
+    return 1 if found and args.enforce else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## An incident I caused, restored — plus the guard that stops it recurring

PR #3492 squash-merged tonight and silently removed **three enforced gates** from `.github/gates/gates.yaml`:

| gate | added by |
|---|---|
| `scheduled-trigger-emitted` | #3484, hours earlier |
| `gitops-duplicate-resources` | #3474 |
| `gate-script-registration` | #3486 |

**Nobody removed them.** #3492 was branched from an older `main`, and every new gate is appended near the same anchor in this one file, so its copy of `gates.yaml` replayed over the others'. GitHub reported the PR `MERGEABLE` / `CLEAN`, all five required checks green. Three enforced gates stopped running and nothing said anything.

That PR was mine, so this is a self-report, not a review finding.

`gates.yaml` is now the highest-collision file in the tree **precisely because the manifest design worked**: adding a gate is one entry in one file, so every parallel agent edits the same region. The success created the hazard.

All three are restored verbatim from the commits that added them, and verified to run and pass.

## 1. `gates-not-deregistered` — the structural fix

Compares the manifest with its own **merge-base**, not the base tip. That distinction matters: comparing against the tip would demand entries a branch cut earlier never had a chance to see, i.e. a false positive on every stale branch. The merge-base asks the only honest question — *did this branch drop something it started with?*

Flags two things:
- a gate id present at the merge-base and gone here;
- a gate downgraded from `enforced` to `advisory` — the quieter half of the same failure, and one no other check can see.

Removal stays possible. It just has to be **said out loud**:

```yaml
# GATE-REMOVED: <id> — <reason>
# GATE-DOWNGRADED: <id> — <reason>
```

so the intent sits in the diff a human reads. A declaration that is wrong in the *other* direction (declared removed, still present) is also a finding — otherwise the markers rot into the permanent exception list this repo keeps paying for.

**Verified by replaying the actual incident**, not by fixtures alone:

```
REPLAY of the real incident (#3492 over #3474/#3484/#3486): 3 finding(s)
  - gate 'gate-script-registration' (enforced) is in the manifest at the merge-base and gone here…
  - gate 'gitops-duplicate-resources' (enforced) …
  - gate 'scheduled-trigger-emitted' (enforced) …
```

### Why `gate-script-registration` was not enough

It catches the *symptom* — a `check-*` script nothing runs — and it did catch two of the three, which is how I found this at all. It cannot see:
- a lost entry whose script is still invoked from somewhere else,
- a gate whose `run:` is an inline command with no script,
- a silent `enforced` → `advisory` downgrade.

The two are complementary, and neither subsumes the other.

## 2. `opa-sidecar-bundle-shape` — #2872 defect 4

campaign-service died on `/bundle/rules-data.yaml: merge error`. The sidecar runs `opa run --bundle /bundle` — **directory mode**, where OPA derives a data document's path from its location in the tree. The bundle files were bit-identical to every healthy service's; only the **mounts** differed. Mounted flat instead of at `/bundle/<root>/data.yaml`, two documents claim the same root, the bundle fails to load, the container dies at boot.

Nothing could see it: the ConfigMap is right, the args are right, the bundle drift gate compares **content**, and the service build knows nothing about mounts. The contradiction lives strictly between a Deployment's `volumeMounts` and the bundle's own `manifest.json`.

Four rules, of which the last is the one worth the effort:

1. `--bundle` is passed at all (without it OPA serves an empty policy and every decision falls through, silently);
2. `<dir>/.manifest` is mounted;
3. no data file mounted **flat** — the exact #2865 shape, which crashes loudly;
4. every data file sits under a root declared in that bundle's `manifest.json` — **OPA ignores data outside a declared root rather than rejecting it**, so the policy evaluates against absent data and no log explains the decision.

Roots come from each bundle's own `manifest.json`, so there is no per-service list and no exception file. **40 sidecars, 0 findings, 0 exceptions.** Proven by flattening one real mount in `account-service.yaml` and watching it reproduce the campaign message, then restoring from a `cp` backup.

## Self-assessment

- **This PR is itself the hazard it describes.** It edits `gates.yaml` from a branch, so if another gate lands before it merges, the same replay could drop it. The new gate protects the *next* one, not this one — merge promptly, and if it conflicts, resolve by taking `origin/main`'s manifest and re-adding these entries rather than replaying this copy.
- **`gates-not-deregistered` cannot see a gate that was never merged** — a PR whose gate is dropped during conflict resolution before it ever reached `main` leaves no trace at any merge-base.
- **It does not check that a gate still does anything.** A gate whose `run:` was gutted to `true` keeps its id and its mode and passes this check. That is the reachability question `gate-script-registration` also declines to answer (#2327's shape).
- **`opa-sidecar-bundle-shape` reads only `openbank-infra/gitops/components`.** A sidecar defined elsewhere, or an image whose name does not contain `opa`, is invisible.
- **Rule 4 goes quiet when no bundle ConfigMap is found** rather than guessing at roots — deliberate, but it means a renamed ConfigMap downgrades rule 4 to nothing while rules 1-3 still run. Pinned as a self-test case so the restraint is intentional and visible.

## Verification

```
check-gates-not-deregistered.py --self-test    OK (9 transitions, both directions, stale declarations)
check-gates-not-deregistered.py --enforce      clean (86 at merge-base, 90 here)
check-opa-sidecar-bundle-shape.py --self-test  OK (6 fixtures incl. the campaign shape + empty tree)
check-opa-sidecar-bundle-shape.py --enforce    clean (40 sidecars)
run-gates.py --only gitops-duplicate-resources PASS   (restored)
run-gates.py --only scheduled-trigger-emitted  PASS   (restored)
run-gates.py --only gate-script-registration   PASS   (restored, 0 orphans)
run-gates.py --group lint                      PASS=5
```
