### PR TITLE
test(delegation): pact contract coverage — 6 pacts, 12 replayed interactions, both directions

### DIFF
--- a/openbank-account-service/src/test/kotlin/com/openbank/account/contract/AccountEventPactProviderVerificationTest.kt
+++ b/openbank-account-service/src/test/kotlin/com/openbank/account/contract/AccountEventPactProviderVerificationTest.kt
@@ -5,6 +5,7 @@
 package com.openbank.account.contract
 
 import au.com.dius.pact.provider.PactVerifyProvider
+import au.com.dius.pact.provider.junit5.HttpTestTarget
 import au.com.dius.pact.provider.junit5.MessageTestTarget
 import au.com.dius.pact.provider.junit5.PactVerificationContext
 import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvider
@@ -14,13 +15,34 @@ import au.com.dius.pact.provider.junitsupport.State
 import au.com.dius.pact.provider.junitsupport.loader.PactBroker
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.openbank.account.application.port.out.AccountRepository
 import com.openbank.account.domain.event.AccountCreatedEvent
+import com.openbank.account.domain.model.Account
+import com.openbank.account.domain.model.AccountStatus
 import com.openbank.account.domain.model.AccountType
+import com.openbank.account.it.PostgresRedpandaRedisTestResource
+import com.openbank.libs.domain.account.Iban
+import com.openbank.libs.domain.money.CurrencyCode
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.security.TestSecurity
+import io.quarkus.vertx.core.runtime.context.VertxContextSafetyToggle
+import io.vertx.core.Vertx
+import io.vertx.core.impl.ContextInternal
+import jakarta.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.launch
+import org.eclipse.microprofile.config.inject.ConfigProperty
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.TestTemplate
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty
 import org.junit.jupiter.api.extension.ExtendWith
+import java.time.Instant
 import java.util.UUID
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.Executor
+import java.util.concurrent.TimeUnit
 
 /**
  * Provider-side verification for async message contracts published by account-service
@@ -45,11 +67,13 @@ import java.util.UUID
  * `@EnabledIfSystemProperty` keeps it a no-op locally and on the PR lane, where no broker is
  * configured — matching every other broker-based provider test in the fleet.
  *
- * A [MessageTestTarget] alone is correct here: both pacts naming account-service as provider are
- * message-only (balance-service's AccountCreated, notification-service's TRANSACTION_COMPLETED),
- * so unlike `PartyEventPactProviderVerificationTest` there is no HTTP interaction to dispatch to
- * and no Quarkus instance to boot. If an HTTP consumer contract against account-service is ever
- * added, this needs party-service's per-interaction target dispatch.
+ * Per-interaction target dispatch, as `PartyEventPactProviderVerificationTest` does: two of the
+ * three pacts naming account-service as provider are message-only (balance-service's
+ * AccountCreated, notification-service's TRANSACTION_COMPLETED), but delegation-service's
+ * ownership gate (issue #2991, ADR-0232 D7) reads `GET /api/v1/accounts/{id}`, which needs a
+ * running endpoint — hence `@QuarkusTest` + Testcontainers. This mirrors the git-pact twin
+ * exactly; the two must stay identical or the same contract passes from git and fails from the
+ * broker.
  *
  * IMPORTANT: if `AccountCreatedMessagePactConsumerTest` (openbank-balance-service) changes the
  * contract, regenerate the pact JSON (`./gradlew :openbank-balance-service:test --tests
@@ -59,19 +83,60 @@ import java.util.UUID
  *
  * `@IgnoreNoPactsToVerify(ignoreIoErrors)` makes a missing/unreadable pact a skip, not a failure.
  */
+@QuarkusTest
+@QuarkusTestResource(PostgresRedpandaRedisTestResource::class)
+@TestSecurity(user = "pact-verifier", roles = ["ROLE_API", "ROLE_VIEWER", "ROLE_OPERATOR"])
 @Provider("openbank-account-service")
 @PactBroker(enablePendingPacts = "true")
 @IgnoreNoPactsToVerify(ignoreIoErrors = "true")
 @EnabledIfSystemProperty(named = "pactbroker.url", matches = ".+")
 class AccountEventPactProviderVerificationTest {
 
+    companion object {
+        // Must match DelegationAccountOwnershipPactConsumerTest's ACCOUNT_ID / OWNER_PARTY_ID.
+        private val ACCOUNT_ID = UUID.fromString("11111111-2222-4333-8444-555555555555")
+        private val OWNER_PARTY_ID = UUID.fromString("66666666-7777-4888-8999-aaaaaaaaaaaa")
+    }
+
     private val objectMapper = jacksonObjectMapper().registerModule(JavaTimeModule())
+
+    @ConfigProperty(name = "quarkus.http.test-port", defaultValue = "8081")
+    lateinit var testPort: String
+
+    @Inject
+    lateinit var accountRepository: AccountRepository
+
+    @Inject
+    lateinit var vertx: Vertx
+
+    /** See the git-pact twin: Pact-JVM calls `@State` on a thread with no Vert.x context. */
+    private fun runOnVertxContext(block: suspend () -> Unit) {
+        val future = CompletableFuture<Unit>()
+        val duplicated = (vertx.orCreateContext as ContextInternal).duplicate()
+        VertxContextSafetyToggle.setContextSafe(duplicated, true)
+        val dispatcher = Executor { command -> duplicated.runOnContext { command.run() } }.asCoroutineDispatcher()
+        CoroutineScope(dispatcher).launch {
+            try {
+                block()
+                future.complete(Unit)
+            } catch (t: Throwable) {
+                future.completeExceptionally(t)
+            }
+        }
+        future.get(10, TimeUnit.SECONDS)
+    }
 
     @BeforeEach
     fun setTarget(context: PactVerificationContext?) {
+        if (context == null) return
         // Limit the @PactVerifyProvider scan to this package — the default classpath-wide scan
-        // (ClassGraph) throws on the JDK 25 toolchain.
-        context?.target = MessageTestTarget(listOf("com.openbank.account.contract"))
+        // (ClassGraph) throws on the JDK 25+ toolchain.
+        context.target = if (context.interaction.isAsynchronousMessage()) {
+            MessageTestTarget(listOf("com.openbank.account.contract"))
+        } else {
+            HttpTestTarget("localhost", testPort.toInt())
+        }
+        context.addStateChangeHandlers(this)
     }
 
     @TestTemplate
@@ -116,5 +181,26 @@ class AccountEventPactProviderVerificationTest {
             "variables" to mapOf("amount" to "50.00", "currency" to "CZK"),
         )
         return objectMapper.writeValueAsString(request)
+    }
+
+    /** Mirror of the git-pact twin's handler — see there for why the findById guard is needed. */
+    @State("an account owned by a known party exists")
+    fun accountOwnedByKnownParty() = runOnVertxContext {
+        if (accountRepository.findById(ACCOUNT_ID) != null) return@runOnVertxContext
+        accountRepository.save(
+            Account(
+                id = ACCOUNT_ID,
+                accountNumber = Iban("CZ6508000000192000145399"),
+                accountType = AccountType.CURRENT,
+                partyId = OWNER_PARTY_ID,
+                productId = UUID.fromString("99999999-8888-4777-8666-555555555555"),
+                currency = CurrencyCode("CZK"),
+                status = AccountStatus.ACTIVE,
+                openedAt = Instant.parse("2026-01-01T00:00:00Z"),
+                closedAt = null,
+                version = 0,
+            ),
+        )
+        Unit
     }
 }

--- a/openbank-account-service/src/test/kotlin/com/openbank/account/contract/AccountPactFolderProviderVerificationTest.kt
+++ b/openbank-account-service/src/test/kotlin/com/openbank/account/contract/AccountPactFolderProviderVerificationTest.kt
@@ -5,6 +5,7 @@
 package com.openbank.account.contract
 
 import au.com.dius.pact.provider.PactVerifyProvider
+import au.com.dius.pact.provider.junit5.HttpTestTarget
 import au.com.dius.pact.provider.junit5.MessageTestTarget
 import au.com.dius.pact.provider.junit5.PactVerificationContext
 import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvider
@@ -14,12 +15,33 @@ import au.com.dius.pact.provider.junitsupport.State
 import au.com.dius.pact.provider.junitsupport.loader.PactFolder
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.openbank.account.application.port.out.AccountRepository
 import com.openbank.account.domain.event.AccountCreatedEvent
+import com.openbank.account.domain.model.Account
+import com.openbank.account.domain.model.AccountStatus
 import com.openbank.account.domain.model.AccountType
+import com.openbank.account.it.PostgresRedpandaRedisTestResource
+import com.openbank.libs.domain.account.Iban
+import com.openbank.libs.domain.money.CurrencyCode
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.security.TestSecurity
+import io.quarkus.vertx.core.runtime.context.VertxContextSafetyToggle
+import io.vertx.core.Vertx
+import io.vertx.core.impl.ContextInternal
+import jakarta.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.launch
+import org.eclipse.microprofile.config.inject.ConfigProperty
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.TestTemplate
 import org.junit.jupiter.api.extension.ExtendWith
+import java.time.Instant
 import java.util.UUID
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.Executor
+import java.util.concurrent.TimeUnit
 
 /**
  * Git-pact provider verification for account-service — the half that actually runs before a merge
@@ -44,12 +66,18 @@ import java.util.UUID
  * openbank-ledger-service carries. Two `@Provider` classes collide only when BOTH pull from the
  * broker, since each then fetches every pact it holds.
  *
- * ## Cheap, because there is nothing to boot
+ * ## No longer cheap — it boots now, and that was not optional (issue #2991)
  *
- * Both pacts are message-only, so a [MessageTestTarget] alone is correct and no Quarkus instance
- * or Testcontainer is needed — this adds a plain JVM test, not another `@QuarkusTest`. If an HTTP
- * consumer contract against account-service is ever added, this needs party-service's
- * per-interaction target dispatch, and so does the broker twin.
+ * This class used to be a plain JVM test: both pacts were message-only, so a [MessageTestTarget]
+ * was the whole target and the KDoc said "if an HTTP consumer contract against account-service is
+ * ever added, this needs party-service's per-interaction target dispatch". delegation-service's
+ * ownership gate is that contract — it reads `GET /api/v1/accounts/{id}` to check the grantor owns
+ * the account before offering a grant (ADR-0232 D7) — so the dispatch is now here, along with
+ * `@QuarkusTest` + Testcontainers, which the HTTP interaction cannot do without.
+ *
+ * Splitting the HTTP interaction into a second `@PactFolder` class was not an option: both classes
+ * would load every pact in `../pacts` naming this provider, so each would try to verify the other's
+ * interactions against the wrong target. One `@Provider` class per provider (`CLAUDE.md`).
  *
  * ## Upkeep
  *
@@ -57,18 +85,66 @@ import java.util.UUID
  * [PactVerifyProvider] producers. A change to one belongs in the other, or the same contract
  * passes from git and fails from the broker (or the reverse).
  */
+@QuarkusTest
+@QuarkusTestResource(PostgresRedpandaRedisTestResource::class)
+@TestSecurity(user = "pact-verifier", roles = ["ROLE_API", "ROLE_VIEWER", "ROLE_OPERATOR"])
 @Provider("openbank-account-service")
 @PactFolder("../pacts")
 @IgnoreNoPactsToVerify(ignoreIoErrors = "true")
 class AccountPactFolderProviderVerificationTest {
 
+    companion object {
+        // Must match DelegationAccountOwnershipPactConsumerTest's ACCOUNT_ID / OWNER_PARTY_ID.
+        private val ACCOUNT_ID = UUID.fromString("11111111-2222-4333-8444-555555555555")
+        private val OWNER_PARTY_ID = UUID.fromString("66666666-7777-4888-8999-aaaaaaaaaaaa")
+    }
+
     private val objectMapper = jacksonObjectMapper().registerModule(JavaTimeModule())
+
+    @ConfigProperty(name = "quarkus.http.test-port", defaultValue = "8081")
+    lateinit var testPort: String
+
+    @Inject
+    lateinit var accountRepository: AccountRepository
+
+    @Inject
+    lateinit var vertx: Vertx
+
+    /**
+     * Bridges reactive Panache into Pact-JVM's synchronous `@State` callback — Pact-JVM invokes
+     * `@State` by reflection on the JUnit thread, which has no Vert.x context, so a bare
+     * `runBlocking { accountRepository.save(...) }` throws `No current Vertx context found`. Same
+     * shape as `PartyPactFolderProviderVerificationTest.runOnVertxContext`.
+     */
+    private fun runOnVertxContext(block: suspend () -> Unit) {
+        val future = CompletableFuture<Unit>()
+        val duplicated = (vertx.orCreateContext as ContextInternal).duplicate()
+        VertxContextSafetyToggle.setContextSafe(duplicated, true)
+        val dispatcher = Executor { command -> duplicated.runOnContext { command.run() } }.asCoroutineDispatcher()
+        CoroutineScope(dispatcher).launch {
+            try {
+                block()
+                future.complete(Unit)
+            } catch (t: Throwable) {
+                future.completeExceptionally(t)
+            }
+        }
+        future.get(10, TimeUnit.SECONDS)
+    }
 
     @BeforeEach
     fun setTarget(context: PactVerificationContext?) {
-        // Limit the @PactVerifyProvider scan to this package — the default classpath-wide scan
-        // (ClassGraph) throws on the JDK 25 toolchain.
-        context?.target = MessageTestTarget(listOf("com.openbank.account.contract"))
+        if (context == null) return
+        // Per-interaction dispatch: message pacts answer from a @PactVerifyProvider producer, the
+        // delegation ownership pact from the running HTTP endpoint. Limit the @PactVerifyProvider
+        // scan to this package — the default classpath-wide scan (ClassGraph) throws on the JDK 25+
+        // toolchain.
+        context.target = if (context.interaction.isAsynchronousMessage()) {
+            MessageTestTarget(listOf("com.openbank.account.contract"))
+        } else {
+            HttpTestTarget("localhost", testPort.toInt())
+        }
+        context.addStateChangeHandlers(this)
     }
 
     @TestTemplate
@@ -113,5 +189,30 @@ class AccountPactFolderProviderVerificationTest {
             "variables" to mapOf("amount" to "50.00", "currency" to "CZK"),
         )
         return objectMapper.writeValueAsString(request)
+    }
+
+    /**
+     * Seeds the account delegation-service's ownership gate asks about (ADR-0232 D7). Guarded by a
+     * `findById`: `AccountRepositoryImpl.save` calls `persist` on an application-assigned id, so a
+     * second call for the same account would fail on the primary key rather than upsert.
+     */
+    @State("an account owned by a known party exists")
+    fun accountOwnedByKnownParty() = runOnVertxContext {
+        if (accountRepository.findById(ACCOUNT_ID) != null) return@runOnVertxContext
+        accountRepository.save(
+            Account(
+                id = ACCOUNT_ID,
+                accountNumber = Iban("CZ6508000000192000145399"),
+                accountType = AccountType.CURRENT,
+                partyId = OWNER_PARTY_ID,
+                productId = UUID.fromString("99999999-8888-4777-8666-555555555555"),
+                currency = CurrencyCode("CZK"),
+                status = AccountStatus.ACTIVE,
+                openedAt = Instant.parse("2026-01-01T00:00:00Z"),
+                closedAt = null,
+                version = 0,
+            ),
+        )
+        Unit
     }
 }

--- a/openbank-account-service/src/test/kotlin/com/openbank/account/contract/DelegationEventMessagePactConsumerTest.kt
+++ b/openbank-account-service/src/test/kotlin/com/openbank/account/contract/DelegationEventMessagePactConsumerTest.kt
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.account.contract
+
+import au.com.dius.pact.consumer.MessagePactBuilder
+import au.com.dius.pact.consumer.dsl.LambdaDsl.newJsonBody
+import au.com.dius.pact.consumer.junit5.PactConsumerTestExt
+import au.com.dius.pact.consumer.junit5.PactTestFor
+import au.com.dius.pact.consumer.junit5.ProviderType
+import au.com.dius.pact.core.model.PactSpecVersion
+import au.com.dius.pact.core.model.annotations.Pact
+import au.com.dius.pact.core.model.messaging.Message
+import au.com.dius.pact.core.model.messaging.MessagePact
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import java.time.OffsetDateTime
+import java.util.UUID
+
+/**
+ * Consumer-driven MESSAGE contract for the `openbank.delegation.events` payloads account-service
+ * builds its enforcement projection from
+ * ([com.openbank.account.infrastructure.kafka.DelegationEventConsumer], ADR-0232 D3) — issue #2991.
+ *
+ * ## Why this needed a contract and a unit test did not suffice
+ *
+ * `DelegationEventConsumer.parseEnvelope` reads the payload through `objectMapper.readTree` and
+ * `node.path(...)`, which means EVERY field it wants is optional at the type level: a renamed or
+ * moved field does not throw, it defaults. Concretely — `capabilities` missing becomes the empty
+ * set (a grant that authorises nothing), `resourceType` missing becomes `""` (so the
+ * `PROJECTED_RESOURCE_TYPES` filter drops the event and no row is ever written), and
+ * `perTransactionLimit.amount` missing becomes a null ceiling, which is the projection's
+ * "no limit" reading. All three are silent, and only the last one fails OPEN.
+ *
+ * Two interactions, the two directions the projection can be wrong in:
+ *
+ * - `DelegationActivated` — the event that CREATES an enforceable row.
+ * - `DelegationRevoked`  — the event that CLOSES one. A revoke that fails to parse leaves a
+ *   revoked grant enforceable, which the consumer's own KDoc calls the worst direction this
+ *   projection can drift.
+ *
+ * `eventType` and `resourceType` are `stringValue`: the consumer dispatches on the exact strings
+ * (`"DelegationActivated"`, and `resourceType in setOf("ACCOUNT", "SAVINGS_GOAL")`), so a type
+ * matcher would verify nothing about the only two fields that decide whether anything happens.
+ *
+ * Provider replay: `DelegationEventPactFolderProviderVerificationTest` in
+ * openbank-delegation-service (`@PactFolder`, runs on every PR), which produces these messages
+ * from the real `DelegationActivated`/`DelegationRevoked` domain types — so a field renamed in
+ * `DelegationEvents.kt` reddens the replay rather than silently emptying this projection.
+ */
+@ExtendWith(PactConsumerTestExt::class)
+@PactTestFor(
+    providerName = "openbank-delegation-service",
+    providerType = ProviderType.ASYNCH,
+    pactVersion = PactSpecVersion.V3,
+)
+class DelegationEventMessagePactConsumerTest {
+
+    private val objectMapper = ObjectMapper()
+
+    @Pact(consumer = "openbank-account-service", provider = "openbank-delegation-service")
+    fun delegationActivatedPact(builder: MessagePactBuilder): MessagePact = builder
+        .given("an ACCOUNT-scoped delegation grant has been activated")
+        .expectsToReceive("a DelegationActivated event for an account")
+        .withContent(
+            newJsonBody { o ->
+                o.stringValue("eventType", "DelegationActivated")
+                o.uuid("aggregateId")
+                o.uuid("grantorPartyId")
+                o.uuid("granteePartyId")
+                o.stringValue("resourceType", "ACCOUNT")
+                o.uuid("resourceId")
+                o.array("capabilities") { caps -> caps.stringType("ACCOUNT_READ_BALANCES") }
+                o.datetime("validFrom", "yyyy-MM-dd'T'HH:mm:ssXXX")
+                o.`object`("perTransactionLimit") { limit ->
+                    limit.decimalType("amount", 1500.00)
+                    limit.stringType("currency", "CZK")
+                }
+            }.build(),
+        )
+        .toPact()
+
+    @Test
+    @PactTestFor(pactMethod = "delegationActivatedPact")
+    fun `DelegationActivated carries every field the projection upsert needs`(messages: List<Message>) {
+        val node = objectMapper.readTree(messages.first().contentsAsBytes())
+
+        // Mirrors parseEnvelope + upsert, at the exact paths the consumer reads.
+        assertThat(node.path("eventType").asText()).isEqualTo("DelegationActivated")
+        assertThat(UUID.fromString(node.path("aggregateId").asText())).isNotNull()
+        assertThat(UUID.fromString(node.path("grantorPartyId").asText())).isNotNull()
+        assertThat(UUID.fromString(node.path("granteePartyId").asText())).isNotNull()
+        assertThat(node.path("resourceType").asText()).isEqualTo("ACCOUNT")
+        assertThat(UUID.fromString(node.path("resourceId").asText())).isNotNull()
+        assertThat(node.path("capabilities").isArray).isTrue()
+        assertThat(node.path("capabilities")).isNotEmpty()
+        assertThat(OffsetDateTime.parse(node.path("validFrom").asText())).isNotNull()
+        // The ceiling is read as two flat leaves under perTransactionLimit — NOT as a Money
+        // object. DelegationEvents.EventMoney exists precisely because `Money.currency` would
+        // render as {"code":"CZK"} and this read would silently return null.
+        assertThat(node.path("perTransactionLimit").path("amount").asText().toBigDecimalOrNull()).isNotNull()
+        assertThat(node.path("perTransactionLimit").path("currency").asText()).isNotBlank()
+    }
+
+    @Pact(consumer = "openbank-account-service", provider = "openbank-delegation-service")
+    fun delegationRevokedPact(builder: MessagePactBuilder): MessagePact = builder
+        .given("an ACCOUNT-scoped delegation grant has been revoked")
+        .expectsToReceive("a DelegationRevoked event for an account")
+        .withContent(
+            newJsonBody { o ->
+                o.stringValue("eventType", "DelegationRevoked")
+                o.uuid("aggregateId")
+                o.uuid("grantorPartyId")
+                o.uuid("granteePartyId")
+                o.stringValue("resourceType", "ACCOUNT")
+                o.uuid("resourceId")
+                o.array("capabilities") { caps -> caps.stringType("ACCOUNT_READ_BALANCES") }
+            }.build(),
+        )
+        .toPact()
+
+    @Test
+    @PactTestFor(pactMethod = "delegationRevokedPact")
+    fun `DelegationRevoked identifies the grant to close`(messages: List<Message>) {
+        val node = objectMapper.readTree(messages.first().contentsAsBytes())
+
+        assertThat(node.path("eventType").asText()).isEqualTo("DelegationRevoked")
+        // closeById(grantId) is keyed on aggregateId alone — if that field ever moved, every
+        // revoke would be a no-op and the grant would stay enforceable.
+        assertThat(UUID.fromString(node.path("aggregateId").asText())).isNotNull()
+        assertThat(UUID.fromString(node.path("grantorPartyId").asText())).isNotNull()
+        assertThat(node.path("resourceType").asText()).isEqualTo("ACCOUNT")
+    }
+}

--- a/openbank-account-service/src/test/kotlin/com/openbank/account/contract/DelegationEventMessagePactConsumerTest.kt
+++ b/openbank-account-service/src/test/kotlin/com/openbank/account/contract/DelegationEventMessagePactConsumerTest.kt
@@ -17,7 +17,10 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
+import java.time.Instant
 import java.time.OffsetDateTime
+import java.util.Date
+import java.util.TimeZone
 import java.util.UUID
 
 /**
@@ -59,6 +62,40 @@ import java.util.UUID
 )
 class DelegationEventMessagePactConsumerTest {
 
+    private companion object {
+        /**
+         * The `validFrom` example, pinned to a UTC instant AND rendered in UTC.
+         *
+         * ## Why this is a matcher with an explicit example, and not a `stringValue`
+         *
+         * `validFrom` is the one field in this contract no consumer branches on: the projection
+         * stores it and compares it to `now` at enforcement time, so what the contract owes is the
+         * SHAPE — an offset-datetime string `OffsetDateTime.parse` accepts — never a particular
+         * instant. Pinning the value would be a false constraint. Contrast `eventType` and
+         * `resourceType`, which ARE `stringValue`: `dispatch` compares them to exact literals, so a
+         * type matcher there would verify nothing about the only two fields that decide whether
+         * anything happens at all. **Do not "simplify" those into matchers, and do not widen this
+         * one into a pinned value — the asymmetry is deliberate.**
+         *
+         * ## Why the example is passed explicitly, with a TimeZone
+         *
+         * `datetime(name, format)` alone still emits an example string, generated from pact-jvm's
+         * default base date rendered in the JVM's DEFAULT timezone. The matcher was already
+         * correct; the EXAMPLE encoded the generating machine's timezone, so a pact generated on
+         * CET committed `2000-01-31T14:00:00+01:00` while CI regenerated `2000-01-31T13:00:00Z` —
+         * the same instant, a different string, and `pact-drift-check` red forever for everyone.
+         * The `(name, format, Date, TimeZone)` overload is the only one that pins the rendering:
+         * the `Instant` overload still formats with `TimeZone.getDefault()`.
+         *
+         * The instant is the one the provider replay actually emits
+         * (`DelegationEventPactFolderProviderVerificationTest.VALID_FROM`), so the example is a
+         * real payload rather than a library default from the year 2000.
+         */
+        const val VALID_FROM_FORMAT = "yyyy-MM-dd'T'HH:mm:ssXXX"
+        val VALID_FROM_EXAMPLE: Date = Date.from(Instant.parse("2026-01-01T00:00:00Z"))
+        val UTC: TimeZone = TimeZone.getTimeZone("UTC")
+    }
+
     private val objectMapper = ObjectMapper()
 
     @Pact(consumer = "openbank-account-service", provider = "openbank-delegation-service")
@@ -74,7 +111,7 @@ class DelegationEventMessagePactConsumerTest {
                 o.stringValue("resourceType", "ACCOUNT")
                 o.uuid("resourceId")
                 o.array("capabilities") { caps -> caps.stringType("ACCOUNT_READ_BALANCES") }
-                o.datetime("validFrom", "yyyy-MM-dd'T'HH:mm:ssXXX")
+                o.datetime("validFrom", VALID_FROM_FORMAT, VALID_FROM_EXAMPLE, UTC)
                 o.`object`("perTransactionLimit") { limit ->
                     limit.decimalType("amount", 1500.00)
                     limit.stringType("currency", "CZK")

--- a/openbank-card-issuance-service/build.gradle.kts
+++ b/openbank-card-issuance-service/build.gradle.kts
@@ -44,10 +44,12 @@ dependencies {
     testImplementation(libs.assertj)
     testImplementation(libs.mockk)
     testImplementation(libs.smallrye.reactive.messaging.inmemory)
-    // Consumer-driven contract test for the product-catalog card-entitlement lookup (ADR-0063).
-    // Consumer side only: card issuance publishes no API that another service pacts against, so
-    // there is no pact-provider dependency here.
+    // Consumer-driven contract tests: the product-catalog card-entitlement lookup (ADR-0063) and
+    // the `openbank.delegation.events` message contract this service projects (ADR-0232 D3).
     testImplementation(libs.pact.consumer)
+    // Provider side: as of issue #2991 card-issuance IS pacted against — delegation-service reads
+    // GET /api/v1/cards/{id} to verify the grantor holds the card before offering a grant.
+    testImplementation(libs.pact.provider)
 
     // CI infra sweep (#578): isolated PostgreSQL + Valkey(Redis) per test JVM
     // via Testcontainers. Kafka is already in-memory in the IT (no broker).

--- a/openbank-card-issuance-service/build.gradle.kts
+++ b/openbank-card-issuance-service/build.gradle.kts
@@ -61,8 +61,25 @@ dependencies {
 // Pact: write generated pact files to the shared pacts/ dir at the repo root (git-pact, ADR-0063).
 // The consumer test regenerates the file on every run; developers commit the result.
 // NOTE: must be set on the test JVM fork, not the Gradle daemon (System.setProperty would not propagate).
+//
+// The broker properties are forwarded for the same reason (issue #2991): without them
+// `pactbroker.url` never reaches the forked test JVM, CardIssuancePactBrokerProviderVerificationTest
+// stays @EnabledIfSystemProperty-skipped on EVERY lane including main-push, and card-issuance keeps
+// publishing no verification result — which is the `can-i-deploy` block the class exists to prevent.
+// A twin that cannot see the broker looks identical to not having one.
 tasks.withType<Test> {
     systemProperty("pact.rootDir", "${rootProject.projectDir}/pacts")
+    listOf(
+        "pactbroker.url",
+        "pactbroker.auth.username",
+        "pactbroker.auth.password",
+        "pactbroker.enablePending",
+        "pactbroker.providerBranch",
+        "pact.verifier.publishResults",
+        "pact.provider.version",
+        "pact.provider.branch",
+        "pact.provider.tag",
+    ).forEach { key -> System.getProperty(key)?.let { systemProperty(key, it) } }
 }
 
 kover {

--- a/openbank-card-issuance-service/src/test/kotlin/com/openbank/cardissuance/contract/CardDelegationEventMessagePactConsumerTest.kt
+++ b/openbank-card-issuance-service/src/test/kotlin/com/openbank/cardissuance/contract/CardDelegationEventMessagePactConsumerTest.kt
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.cardissuance.contract
+
+import au.com.dius.pact.consumer.MessagePactBuilder
+import au.com.dius.pact.consumer.dsl.LambdaDsl.newJsonBody
+import au.com.dius.pact.consumer.junit5.PactConsumerTestExt
+import au.com.dius.pact.consumer.junit5.PactTestFor
+import au.com.dius.pact.consumer.junit5.ProviderType
+import au.com.dius.pact.core.model.PactSpecVersion
+import au.com.dius.pact.core.model.annotations.Pact
+import au.com.dius.pact.core.model.messaging.Message
+import au.com.dius.pact.core.model.messaging.MessagePact
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import java.time.OffsetDateTime
+import java.util.UUID
+
+/**
+ * Consumer-driven MESSAGE contract for the CARD-scoped `openbank.delegation.events` payloads
+ * ([com.openbank.cardissuance.infrastructure.kafka.CardDelegationEventConsumer], ADR-0232 D3) —
+ * issue #2991.
+ *
+ * A near-twin of account-service's `DelegationEventMessagePactConsumerTest`, and deliberately its
+ * own pact rather than a shared one: the two consumers filter on DIFFERENT `resourceType` values
+ * (`"CARD"` here, `"ACCOUNT"`/`"SAVINGS_GOAL"` there) and card-issuance reads no
+ * `perTransactionLimit` at all, so a single shared contract would have to be the union — which
+ * would assert against card-issuance a field it does not consume, and stop asserting the one
+ * discriminator that decides whether it consumes anything.
+ *
+ * `resourceType` is pinned to `"CARD"` as a `stringValue` for exactly that reason: `dispatch`
+ * drops any event whose `resourceType != "CARD"`, silently and by design. If delegation-service
+ * ever emitted `"PAYMENT_CARD"`, this projection would go permanently empty with no error
+ * anywhere, and only this matcher would say so.
+ *
+ * Provider replay: `DelegationEventPactFolderProviderVerificationTest` in
+ * openbank-delegation-service (`@PactFolder`, runs on every PR).
+ */
+@ExtendWith(PactConsumerTestExt::class)
+@PactTestFor(
+    providerName = "openbank-delegation-service",
+    providerType = ProviderType.ASYNCH,
+    pactVersion = PactSpecVersion.V3,
+)
+class CardDelegationEventMessagePactConsumerTest {
+
+    private val objectMapper = ObjectMapper()
+
+    @Pact(consumer = "openbank-card-issuance-service", provider = "openbank-delegation-service")
+    fun cardDelegationActivatedPact(builder: MessagePactBuilder): MessagePact = builder
+        .given("a CARD-scoped delegation grant has been activated")
+        .expectsToReceive("a DelegationActivated event for a card")
+        .withContent(
+            newJsonBody { o ->
+                o.stringValue("eventType", "DelegationActivated")
+                o.uuid("aggregateId")
+                o.uuid("grantorPartyId")
+                o.uuid("granteePartyId")
+                o.stringValue("resourceType", "CARD")
+                o.uuid("resourceId")
+                o.array("capabilities") { caps -> caps.stringType("CARD_VIEW") }
+                o.datetime("validFrom", "yyyy-MM-dd'T'HH:mm:ssXXX")
+            }.build(),
+        )
+        .toPact()
+
+    @Test
+    @PactTestFor(pactMethod = "cardDelegationActivatedPact")
+    fun `DelegationActivated carries every field the card projection upsert needs`(messages: List<Message>) {
+        val node = objectMapper.readTree(messages.first().contentsAsBytes())
+
+        assertThat(node.path("eventType").asText()).isEqualTo("DelegationActivated")
+        assertThat(UUID.fromString(node.path("aggregateId").asText())).isNotNull()
+        assertThat(UUID.fromString(node.path("grantorPartyId").asText())).isNotNull()
+        assertThat(UUID.fromString(node.path("granteePartyId").asText())).isNotNull()
+        assertThat(node.path("resourceType").asText()).isEqualTo("CARD")
+        // resourceId IS the card id here — `upsert` returns without writing anything when it is
+        // absent, so an unreadable resourceId is a projection that silently never fills.
+        assertThat(UUID.fromString(node.path("resourceId").asText())).isNotNull()
+        assertThat(node.path("capabilities").isArray).isTrue()
+        assertThat(node.path("capabilities")).isNotEmpty()
+        assertThat(OffsetDateTime.parse(node.path("validFrom").asText())).isNotNull()
+    }
+
+    @Pact(consumer = "openbank-card-issuance-service", provider = "openbank-delegation-service")
+    fun cardDelegationRevokedPact(builder: MessagePactBuilder): MessagePact = builder
+        .given("a CARD-scoped delegation grant has been revoked")
+        .expectsToReceive("a DelegationRevoked event for a card")
+        .withContent(
+            newJsonBody { o ->
+                o.stringValue("eventType", "DelegationRevoked")
+                o.uuid("aggregateId")
+                o.uuid("grantorPartyId")
+                o.uuid("granteePartyId")
+                o.stringValue("resourceType", "CARD")
+                o.uuid("resourceId")
+                o.array("capabilities") { caps -> caps.stringType("CARD_VIEW") }
+            }.build(),
+        )
+        .toPact()
+
+    @Test
+    @PactTestFor(pactMethod = "cardDelegationRevokedPact")
+    fun `DelegationRevoked identifies the card grant to close`(messages: List<Message>) {
+        val node = objectMapper.readTree(messages.first().contentsAsBytes())
+
+        assertThat(node.path("eventType").asText()).isEqualTo("DelegationRevoked")
+        assertThat(UUID.fromString(node.path("aggregateId").asText())).isNotNull()
+        assertThat(node.path("resourceType").asText()).isEqualTo("CARD")
+    }
+}

--- a/openbank-card-issuance-service/src/test/kotlin/com/openbank/cardissuance/contract/CardDelegationEventMessagePactConsumerTest.kt
+++ b/openbank-card-issuance-service/src/test/kotlin/com/openbank/cardissuance/contract/CardDelegationEventMessagePactConsumerTest.kt
@@ -17,7 +17,10 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
+import java.time.Instant
 import java.time.OffsetDateTime
+import java.util.Date
+import java.util.TimeZone
 import java.util.UUID
 
 /**
@@ -48,6 +51,40 @@ import java.util.UUID
 )
 class CardDelegationEventMessagePactConsumerTest {
 
+    private companion object {
+        /**
+         * The `validFrom` example, pinned to a UTC instant AND rendered in UTC.
+         *
+         * ## Why this is a matcher with an explicit example, and not a `stringValue`
+         *
+         * `validFrom` is the one field in this contract no consumer branches on: the projection
+         * stores it and compares it to `now` at enforcement time, so what the contract owes is the
+         * SHAPE — an offset-datetime string `OffsetDateTime.parse` accepts — never a particular
+         * instant. Pinning the value would be a false constraint. Contrast `eventType` and
+         * `resourceType`, which ARE `stringValue`: `dispatch` compares them to exact literals, so a
+         * type matcher there would verify nothing about the only two fields that decide whether
+         * anything happens at all. **Do not "simplify" those into matchers, and do not widen this
+         * one into a pinned value — the asymmetry is deliberate.**
+         *
+         * ## Why the example is passed explicitly, with a TimeZone
+         *
+         * `datetime(name, format)` alone still emits an example string, generated from pact-jvm's
+         * default base date rendered in the JVM's DEFAULT timezone. The matcher was already
+         * correct; the EXAMPLE encoded the generating machine's timezone, so a pact generated on
+         * CET committed `2000-01-31T14:00:00+01:00` while CI regenerated `2000-01-31T13:00:00Z` —
+         * the same instant, a different string, and `pact-drift-check` red forever for everyone.
+         * The `(name, format, Date, TimeZone)` overload is the only one that pins the rendering:
+         * the `Instant` overload still formats with `TimeZone.getDefault()`.
+         *
+         * The instant is the one the provider replay actually emits
+         * (`DelegationEventPactFolderProviderVerificationTest.VALID_FROM`), so the example is a
+         * real payload rather than a library default from the year 2000.
+         */
+        const val VALID_FROM_FORMAT = "yyyy-MM-dd'T'HH:mm:ssXXX"
+        val VALID_FROM_EXAMPLE: Date = Date.from(Instant.parse("2026-01-01T00:00:00Z"))
+        val UTC: TimeZone = TimeZone.getTimeZone("UTC")
+    }
+
     private val objectMapper = ObjectMapper()
 
     @Pact(consumer = "openbank-card-issuance-service", provider = "openbank-delegation-service")
@@ -63,7 +100,7 @@ class CardDelegationEventMessagePactConsumerTest {
                 o.stringValue("resourceType", "CARD")
                 o.uuid("resourceId")
                 o.array("capabilities") { caps -> caps.stringType("CARD_VIEW") }
-                o.datetime("validFrom", "yyyy-MM-dd'T'HH:mm:ssXXX")
+                o.datetime("validFrom", VALID_FROM_FORMAT, VALID_FROM_EXAMPLE, UTC)
             }.build(),
         )
         .toPact()

--- a/openbank-card-issuance-service/src/test/kotlin/com/openbank/cardissuance/contract/CardIssuancePactBrokerProviderVerificationTest.kt
+++ b/openbank-card-issuance-service/src/test/kotlin/com/openbank/cardissuance/contract/CardIssuancePactBrokerProviderVerificationTest.kt
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.cardissuance.contract
+
+import au.com.dius.pact.provider.junit5.HttpTestTarget
+import au.com.dius.pact.provider.junit5.PactVerificationContext
+import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvider
+import au.com.dius.pact.provider.junitsupport.IgnoreNoPactsToVerify
+import au.com.dius.pact.provider.junitsupport.Provider
+import au.com.dius.pact.provider.junitsupport.State
+import au.com.dius.pact.provider.junitsupport.loader.PactBroker
+import com.openbank.cardissuance.infrastructure.persistence.entity.CardEntity
+import com.openbank.cardissuance.infrastructure.persistence.repository.CardRepositoryImpl
+import com.openbank.cardissuance.it.PostgresRedisTestResource
+import io.quarkus.hibernate.reactive.panache.Panache
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.security.TestSecurity
+import io.quarkus.vertx.VertxContextSupport
+import jakarta.inject.Inject
+import org.eclipse.microprofile.config.inject.ConfigProperty
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.TestTemplate
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty
+import org.junit.jupiter.api.extension.ExtendWith
+import java.time.Instant
+import java.time.LocalDate
+import java.util.UUID
+
+/**
+ * Broker-side provider verification for card-issuance — the published-result counterpart to
+ * [CardIssuancePactFolderProviderVerificationTest].
+ *
+ * ## Why this exists, and why it had to land in the SAME PR as the pact
+ *
+ * `can-i-deploy` (ADR-0092) reads the broker and nothing else. A `@PactFolder` class replays the
+ * committed pact from disk and never contacts the broker, so a provider carrying only one has
+ * never published a version on main, and every consumer of it reads as unverified — permanently,
+ * not transiently.
+ *
+ * card-issuance became a pact PROVIDER for the first time in this PR (delegation-service's
+ * ADR-0232 D7 ownership gate reads `GET /api/v1/cards/{id}`). Shipping that pact with only a
+ * `@PactFolder` replay would have made `openbank-delegation-service` undeployable as soon as it
+ * published: `can-i-deploy` answers "no verified pact between openbank-delegation-service and the
+ * version of openbank-card-issuance-service currently in sandbox", reported as `PENDING_BUILD` —
+ * a name that reads transient and is not. That is the shape that took fx-service out across four
+ * deploy attempts on 2026-08-02, and what #3239 added the aml/sanctions twins for.
+ *
+ * ## Why a second `@Provider("openbank-card-issuance-service")` class is safe
+ *
+ * The collision `rules.yaml`/ADR-0029 D3 warns about is two BROKER-sourced classes for one
+ * provider, each fetching every pact the broker holds, or an HTTP and a MESSAGE target fighting
+ * over the same `@BeforeEach`. This is the sanctioned pair CLAUDE.md documents — `@PactFolder` for
+ * the PR lane, `@PactBroker` gated on `pactbroker.url` for the published result — as
+ * openbank-ledger-service, aml-service and sanctions-service carry. Note the asymmetry with this
+ * module's OTHER pact role: card-issuance is also a CONSUMER (of product-catalog), but a consumer
+ * test is not a `@Provider` class and nothing here touches it.
+ *
+ * Gated on `pactbroker.url`: skipped locally and on the PR lane, where `_service-ci.yml` blanks
+ * `PACT_BROKER_URL` (the broker has no public ingress, ADR-0056). It runs on main-push, where
+ * `PUBLISH_RESULTS=true` — that run is what creates the main version `can-i-deploy` looks for.
+ *
+ * ## Every state the git-pact twin handles is handled here too
+ *
+ * The broker serves EVERY consumer's pact for this provider, not only the one committed under
+ * `pacts/`. A missing state fails with `MissingStateChangeMethod` and publishes a FAILURE, which
+ * blocks an otherwise healthy pair — strictly worse than publishing nothing. Today that is one
+ * state, mirrored verbatim below; anything added to the git-pact twin belongs here in the same
+ * commit.
+ */
+@QuarkusTest
+@QuarkusTestResource(PostgresRedisTestResource::class)
+@TestSecurity(user = "pact-verifier", roles = ["ROLE_VIEWER", "ROLE_OPERATOR"])
+@Provider("openbank-card-issuance-service")
+@PactBroker
+@IgnoreNoPactsToVerify(ignoreIoErrors = "true")
+@EnabledIfSystemProperty(named = "pactbroker.url", matches = ".+")
+class CardIssuancePactBrokerProviderVerificationTest {
+
+    companion object {
+        // Must match DelegationCardOwnershipPactConsumerTest and the git-pact twin.
+        private val CARD_ID = UUID.fromString("0a0a0a0a-1b1b-4c2c-8d3d-4e4e4e4e4e4e")
+        private val OWNER_PARTY_ID = UUID.fromString("5f5f5f5f-6a6a-4b7b-8c8c-9d9d9d9d9d9d")
+    }
+
+    @ConfigProperty(name = "quarkus.http.test-port", defaultValue = "8081")
+    lateinit var testPort: String
+
+    @Inject
+    lateinit var cardRepository: CardRepositoryImpl
+
+    @BeforeEach
+    fun configureTarget(context: PactVerificationContext?) {
+        context?.target = HttpTestTarget("localhost", testPort.toInt())
+        context?.addStateChangeHandlers(this)
+    }
+
+    @TestTemplate
+    @ExtendWith(PactVerificationInvocationContextProvider::class)
+    fun verifyPacts(context: PactVerificationContext?) {
+        context?.verifyInteraction()
+    }
+
+    /**
+     * Mirrors [CardIssuancePactFolderProviderVerificationTest.stateCardHeldByKnownParty] verbatim,
+     * including the `findById` guard — the broker can hand this class several consumers'
+     * interactions naming the same state, so re-entry is expected here rather than hypothetical,
+     * and `persist` on an application-assigned id would otherwise collide on the primary key.
+     *
+     * Written against the entity + Panache directly because `CardRepository.save` demands an
+     * `OutboxMessage` this state has no event for, and via `VertxContextSupport.subscribeAndAwait`
+     * because Pact-JVM calls `@State` by reflection on the JUnit thread, which carries no Vert.x
+     * context — the same bridge `CardDelegationProjectionIT.seedCard` uses from that same thread.
+     */
+    @State("a card held by a known party exists")
+    fun stateCardHeldByKnownParty() {
+        val existing = VertxContextSupport.subscribeAndAwait {
+            Panache.withSession { cardRepository.find("id", CARD_ID).firstResult() }
+        }
+        if (existing != null) return
+        val entity = CardEntity().apply {
+            id = CARD_ID
+            idempotencyKey = "pact-$CARD_ID"
+            partyId = OWNER_PARTY_ID
+            accountId = UUID.fromString("7c7c7c7c-8d8d-4e9e-8f0f-1a1a1a1a1a1a")
+            productCode = "DEBIT_BASIC"
+            cardType = "VIRTUAL"
+            network = "VISA"
+            maskedPan = "411111******1111"
+            cardholderName = "Pact Verifier"
+            embossedName = "PACT VERIFIER"
+            expiryDate = LocalDate.of(2030, 1, 31)
+            status = "ACTIVE"
+            dailyLimitMinorUnits = 100_000
+            monthlyLimitMinorUnits = 500_000
+            currency = "CZK"
+            createdAt = Instant.parse("2026-01-01T00:00:00Z")
+            updatedAt = Instant.parse("2026-01-01T00:00:00Z")
+        }
+        VertxContextSupport.subscribeAndAwait<Unit> {
+            Panache.withTransaction { cardRepository.persist(entity).replaceWith(Unit) }
+        }
+    }
+}

--- a/openbank-card-issuance-service/src/test/kotlin/com/openbank/cardissuance/contract/CardIssuancePactFolderProviderVerificationTest.kt
+++ b/openbank-card-issuance-service/src/test/kotlin/com/openbank/cardissuance/contract/CardIssuancePactFolderProviderVerificationTest.kt
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.cardissuance.contract
+
+import au.com.dius.pact.provider.junit5.HttpTestTarget
+import au.com.dius.pact.provider.junit5.PactVerificationContext
+import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvider
+import au.com.dius.pact.provider.junitsupport.IgnoreNoPactsToVerify
+import au.com.dius.pact.provider.junitsupport.Provider
+import au.com.dius.pact.provider.junitsupport.State
+import au.com.dius.pact.provider.junitsupport.loader.PactFolder
+import com.openbank.cardissuance.infrastructure.persistence.entity.CardEntity
+import com.openbank.cardissuance.infrastructure.persistence.repository.CardRepositoryImpl
+import com.openbank.cardissuance.it.PostgresRedisTestResource
+import io.quarkus.hibernate.reactive.panache.Panache
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.security.TestSecurity
+import io.quarkus.vertx.VertxContextSupport
+import jakarta.inject.Inject
+import org.eclipse.microprofile.config.inject.ConfigProperty
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.TestTemplate
+import org.junit.jupiter.api.extension.ExtendWith
+import java.time.Instant
+import java.time.LocalDate
+import java.util.UUID
+
+/**
+ * Git-pact provider verification for card-issuance — the FIRST it has ever had (issue #2991).
+ * Until now this module's `build.gradle.kts` said outright that "card issuance publishes no API
+ * that another service pacts against"; ADR-0232's ownership gate made that untrue, because
+ * delegation-service will not offer a CARD grant without asking card-issuance who holds the card.
+ *
+ * `@PactFolder`, ungated, so it runs on the pull request: a `@PactBroker` class is
+ * `@EnabledIfSystemProperty(pactbroker.url)`-gated and the PR lane has no broker (ADR-0056), which
+ * would replay the contract only after the merge — the exact debt #2327 cleared and
+ * `check-pact-provider-replay.py` now prevents.
+ *
+ * ## What this replay proves that the consumer pact cannot
+ *
+ * That `GET /api/v1/cards/{id}` EXISTS and answers with `partyId`. delegation-service's whole
+ * ownership verdict is one comparison against that field, and its `catch (Exception)` maps any
+ * read failure to UNVERIFIABLE — which refuses the offer. So a renamed field or a moved route is
+ * not a crash, it is card delegation quietly ceasing to work. The consumer's Pact mock would keep
+ * answering happily; only this class asks the real `CardResource`.
+ *
+ * `@TestSecurity` matches `CardResource.getCard`'s
+ * `@RolesAllowed("ROLE_VIEWER", "ROLE_OPERATOR", "ROLE_ADMIN")`.
+ */
+@QuarkusTest
+@QuarkusTestResource(PostgresRedisTestResource::class)
+@TestSecurity(user = "pact-verifier", roles = ["ROLE_VIEWER", "ROLE_OPERATOR"])
+@Provider("openbank-card-issuance-service")
+@PactFolder("../pacts")
+@IgnoreNoPactsToVerify(ignoreIoErrors = "true")
+class CardIssuancePactFolderProviderVerificationTest {
+
+    companion object {
+        // Must match DelegationCardOwnershipPactConsumerTest's CARD_ID / OWNER_PARTY_ID.
+        private val CARD_ID = UUID.fromString("0a0a0a0a-1b1b-4c2c-8d3d-4e4e4e4e4e4e")
+        private val OWNER_PARTY_ID = UUID.fromString("5f5f5f5f-6a6a-4b7b-8c8c-9d9d9d9d9d9d")
+    }
+
+    @ConfigProperty(name = "quarkus.http.test-port", defaultValue = "8081")
+    lateinit var testPort: String
+
+    @Inject
+    lateinit var cardRepository: CardRepositoryImpl
+
+    @BeforeEach
+    fun configureTarget(context: PactVerificationContext?) {
+        context?.target = HttpTestTarget("localhost", testPort.toInt())
+        context?.addStateChangeHandlers(this)
+    }
+
+    @TestTemplate
+    @ExtendWith(PactVerificationInvocationContextProvider::class)
+    fun verifyPacts(context: PactVerificationContext?) {
+        context?.verifyInteraction()
+    }
+
+    /**
+     * Seeds the row the contract's fixed card id refers to. Written against the entity + Panache
+     * directly rather than `CardRepository.save`, which demands an `OutboxMessage` this state has
+     * no event for — the same shortcut `CardDelegationProjectionIT.seedCard` takes, and the reason
+     * `VertxContextSupport.subscribeAndAwait` appears here: Pact-JVM calls `@State` by reflection
+     * on the JUnit thread, which carries no Vert.x context, and this module's ITs already use that
+     * bridge from exactly that thread.
+     *
+     * `findById`-guarded so a second interaction against card-issuance would not collide on the
+     * primary key.
+     */
+    @State("a card held by a known party exists")
+    fun stateCardHeldByKnownParty() {
+        val existing = VertxContextSupport.subscribeAndAwait {
+            Panache.withSession { cardRepository.find("id", CARD_ID).firstResult<CardEntity>() }
+        }
+        if (existing != null) return
+        val entity = CardEntity().apply {
+            id = CARD_ID
+            idempotencyKey = "pact-$CARD_ID"
+            partyId = OWNER_PARTY_ID
+            accountId = UUID.fromString("7c7c7c7c-8d8d-4e9e-8f0f-1a1a1a1a1a1a")
+            productCode = "DEBIT_BASIC"
+            cardType = "VIRTUAL"
+            network = "VISA"
+            maskedPan = "411111******1111"
+            cardholderName = "Pact Verifier"
+            embossedName = "PACT VERIFIER"
+            expiryDate = LocalDate.of(2030, 1, 31)
+            status = "ACTIVE"
+            dailyLimitMinorUnits = 100_000
+            monthlyLimitMinorUnits = 500_000
+            currency = "CZK"
+            createdAt = Instant.parse("2026-01-01T00:00:00Z")
+            updatedAt = Instant.parse("2026-01-01T00:00:00Z")
+        }
+        VertxContextSupport.subscribeAndAwait<Unit> {
+            Panache.withTransaction { cardRepository.persist(entity).replaceWith(Unit) }
+        }
+    }
+}

--- a/openbank-card-issuance-service/src/test/kotlin/com/openbank/cardissuance/contract/CardIssuancePactFolderProviderVerificationTest.kt
+++ b/openbank-card-issuance-service/src/test/kotlin/com/openbank/cardissuance/contract/CardIssuancePactFolderProviderVerificationTest.kt
@@ -39,6 +39,20 @@ import java.util.UUID
  * would replay the contract only after the merge — the exact debt #2327 cleared and
  * `check-pact-provider-replay.py` now prevents.
  *
+ * ## One HALF of a deliberate pair — the paragraph above is not an argument against the other half
+ *
+ * [CardIssuancePactBrokerProviderVerificationTest] is the `@PactBroker` +
+ * `@EnabledIfSystemProperty(pactbroker.url)` twin, and it is required. This class is the PR-lane
+ * gate (zero infra, always runs, catches a wrong route before merge); the twin is the only thing
+ * that publishes a verification RESULT, which is all `can-i-deploy` (ADR-0092) reads. A provider
+ * carrying only this class has never published a version on main, so every consumer reads as
+ * unverified and its deploys block permanently — #3239, and fx-service across four attempts on
+ * 2026-08-02. Neither half substitutes for the other.
+ *
+ * Any `@State` added here MUST be added to the twin in the same commit: a state the broker replay
+ * cannot satisfy fails with `MissingStateChangeMethod` and publishes a FAILURE, which is strictly
+ * worse than publishing nothing.
+ *
  * ## What this replay proves that the consumer pact cannot
  *
  * That `GET /api/v1/cards/{id}` EXISTS and answers with `partyId`. delegation-service's whole

--- a/openbank-card-issuance-service/src/test/kotlin/com/openbank/cardissuance/contract/CardIssuancePactFolderProviderVerificationTest.kt
+++ b/openbank-card-issuance-service/src/test/kotlin/com/openbank/cardissuance/contract/CardIssuancePactFolderProviderVerificationTest.kt
@@ -96,7 +96,7 @@ class CardIssuancePactFolderProviderVerificationTest {
     @State("a card held by a known party exists")
     fun stateCardHeldByKnownParty() {
         val existing = VertxContextSupport.subscribeAndAwait {
-            Panache.withSession { cardRepository.find("id", CARD_ID).firstResult<CardEntity>() }
+            Panache.withSession { cardRepository.find("id", CARD_ID).firstResult() }
         }
         if (existing != null) return
         val entity = CardEntity().apply {

--- a/openbank-delegation-service/build.gradle.kts
+++ b/openbank-delegation-service/build.gradle.kts
@@ -47,6 +47,12 @@ dependencies {
     testImplementation(libs.testcontainers.junit)
     testImplementation(libs.testcontainers.postgresql)
     testImplementation(libs.smallrye.reactive.messaging.inmemory)
+    // Consumer-driven contracts for the four services delegation-service calls before it will
+    // mint a grant (sca, pid, account, card-issuance) — issue #2991.
+    testImplementation(libs.pact.consumer)
+    // Provider side: delegation-service is the provider of the `openbank.delegation.events`
+    // message contract that account-service and card-issuance build enforcement projections from.
+    testImplementation(libs.pact.provider)
 }
 
 kover {

--- a/openbank-delegation-service/src/test/kotlin/com/openbank/delegation/contract/ClientRoute.kt
+++ b/openbank-delegation-service/src/test/kotlin/com/openbank/delegation/contract/ClientRoute.kt
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.delegation.contract
+
+import jakarta.ws.rs.Path
+
+/**
+ * Resolves the path a REST-client interface will ACTUALLY request, out of its own JAX-RS
+ * annotations.
+ *
+ * ## This is for the outgoing request only — never for the expectation
+ *
+ * A Pact mock server answers whatever path the client asks for, so a consumer test whose
+ * expectation is *also* derived from the client annotation cannot fail: expectation and request
+ * move together (CLAUDE.md, measured on #2290). Every consumer test in this package therefore
+ * writes the expected `.path(...)` as a LITERAL and sends the request through [of]. Point
+ * `ScaServiceRestClient` at a route sca-service does not serve and the two disagree: the mock
+ * server 404s and the test goes red at the consumer layer, before the provider replay ever runs.
+ *
+ * The asymmetry IS the test. Do not "tidy" it by sharing one constant between the two sides.
+ */
+internal object ClientRoute {
+
+    fun of(clientInterface: Class<*>, method: String, vararg pathParams: Pair<String, String>): String {
+        val classPath = requireNotNull(clientInterface.getAnnotation(Path::class.java)) {
+            "${clientInterface.name} carries no @Path — it is not a JAX-RS client interface"
+        }.value
+        val declared = clientInterface.methods.firstOrNull { it.name == method }
+            ?: error("${clientInterface.name} declares no method named $method")
+        val methodPath = declared.getAnnotation(Path::class.java)?.value.orEmpty()
+        val joined = "/" + listOf(classPath, methodPath)
+            .flatMap { it.split("/") }
+            .filter { it.isNotBlank() }
+            .joinToString("/")
+        return pathParams.fold(joined) { acc, (name, value) -> acc.replace("{$name}", value) }
+    }
+}

--- a/openbank-delegation-service/src/test/kotlin/com/openbank/delegation/contract/DelegationAccountOwnershipPactConsumerTest.kt
+++ b/openbank-delegation-service/src/test/kotlin/com/openbank/delegation/contract/DelegationAccountOwnershipPactConsumerTest.kt
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.delegation.contract
+
+import au.com.dius.pact.consumer.MockServer
+import au.com.dius.pact.consumer.dsl.LambdaDsl.newJsonBody
+import au.com.dius.pact.consumer.dsl.PactDslWithProvider
+import au.com.dius.pact.consumer.junit5.PactConsumerTestExt
+import au.com.dius.pact.consumer.junit5.PactTestFor
+import au.com.dius.pact.core.model.PactSpecVersion
+import au.com.dius.pact.core.model.RequestResponsePact
+import au.com.dius.pact.core.model.annotations.Pact
+import com.openbank.delegation.infrastructure.client.AccountServiceRestClient
+import io.restassured.RestAssured.given
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+/**
+ * Consumer-driven contract for the ACCOUNT half of the ownership gate
+ * ([com.openbank.delegation.infrastructure.client.RestResourceOwnershipClient], ADR-0232 D7):
+ * "does this grantor own that account?", asked of the only service that can answer.
+ *
+ * ## What the contract is actually protecting
+ *
+ * `verdictFor` compares `getAccount(resourceId).partyId` to the grantor and returns OWNED /
+ * NOT_OWNED, and a `NotFoundException` is treated as NOT_OWNED. So the whole gate rests on one
+ * field name — `partyId` — on one route. Rename it provider-side and Jackson throws (the DTO's
+ * `partyId` is non-null), the `catch (Exception)` lands on UNVERIFIABLE, and every offer is
+ * refused: fail-closed, but a total outage of the feature that nothing else would notice.
+ *
+ * SAVINGS_GOAL grants resolve through this same lookup — a savings goal is account metadata
+ * (ADR-0153), so its resource id IS the owning account's id — which is why one account
+ * interaction covers two of the six resource types.
+ *
+ * Expected path is a LITERAL; only the request is reflected off [AccountServiceRestClient] (see
+ * [ClientRoute]). This is the interaction that made the reflection worth doing: account-service
+ * spells the path param `{accountId}`, delegation-service's client spells it `{id}`, and neither
+ * name reaches the wire — a consumer test that hard-codes both sides could not tell you whether
+ * the client had been pointed at `/api/v1/accounts` at all.
+ *
+ * Provider replay: `AccountPactFolderProviderVerificationTest` (`@PactFolder`, runs on every PR).
+ */
+@ExtendWith(PactConsumerTestExt::class)
+@PactTestFor(providerName = "openbank-account-service", pactVersion = PactSpecVersion.V3)
+class DelegationAccountOwnershipPactConsumerTest {
+
+    private companion object {
+        // Fixed UUIDs — must match the @State seed in account-service's provider verification.
+        const val ACCOUNT_ID = "11111111-2222-4333-8444-555555555555"
+        const val OWNER_PARTY_ID = "66666666-7777-4888-8999-aaaaaaaaaaaa"
+    }
+
+    @Pact(consumer = "openbank-delegation-service", provider = "openbank-account-service")
+    fun getAccountOwnerPact(builder: PactDslWithProvider): RequestResponsePact = builder
+        .given("an account owned by a known party exists")
+        .uponReceiving("GET the account whose ownership is being verified")
+        .path("/api/v1/accounts/$ACCOUNT_ID")
+        .method("GET")
+        .willRespondWith()
+        .status(200)
+        .headers(mapOf("Content-Type" to "application/json"))
+        .body(
+            newJsonBody { o ->
+                o.stringValue("id", ACCOUNT_ID)
+                o.stringValue("partyId", OWNER_PARTY_ID)
+            }.build(),
+        )
+        .toPact()
+
+    @Test
+    @PactTestFor(pactMethod = "getAccountOwnerPact")
+    fun `the account lookup returns the owning partyId the ownership gate compares`(mockServer: MockServer) {
+        val body = given()
+            .baseUri(mockServer.getUrl())
+            .get(ClientRoute.of(AccountServiceRestClient::class.java, "getAccount", "id" to ACCOUNT_ID))
+            .then()
+            .statusCode(200)
+            .extract().jsonPath()
+
+        assertThat(body.getString("id")).isEqualTo(ACCOUNT_ID)
+        assertThat(body.getString("partyId")).isEqualTo(OWNER_PARTY_ID)
+    }
+}

--- a/openbank-delegation-service/src/test/kotlin/com/openbank/delegation/contract/DelegationCardOwnershipPactConsumerTest.kt
+++ b/openbank-delegation-service/src/test/kotlin/com/openbank/delegation/contract/DelegationCardOwnershipPactConsumerTest.kt
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.delegation.contract
+
+import au.com.dius.pact.consumer.MockServer
+import au.com.dius.pact.consumer.dsl.LambdaDsl.newJsonBody
+import au.com.dius.pact.consumer.dsl.PactDslWithProvider
+import au.com.dius.pact.consumer.junit5.PactConsumerTestExt
+import au.com.dius.pact.consumer.junit5.PactTestFor
+import au.com.dius.pact.core.model.PactSpecVersion
+import au.com.dius.pact.core.model.RequestResponsePact
+import au.com.dius.pact.core.model.annotations.Pact
+import com.openbank.delegation.infrastructure.client.CardIssuanceRestClient
+import io.restassured.RestAssured.given
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+/**
+ * Consumer-driven contract for the CARD half of the ownership gate
+ * ([com.openbank.delegation.infrastructure.client.RestResourceOwnershipClient], ADR-0232 D7).
+ * Same shape and same stakes as the account half: the grantor's id is compared to the card's
+ * `partyId`, and any failure to read that field refuses the offer.
+ *
+ * Worth stating what this does NOT check, because the field name invites the assumption: a card
+ * carries BOTH `partyId` (the cardholder) and `accountId` (the account it draws on), and
+ * delegation-service compares the grantor against `partyId`. A card whose account belongs to
+ * someone else is not something this gate — or this contract — has an opinion about.
+ *
+ * Expected path is a LITERAL; only the request is reflected off [CardIssuanceRestClient] (see
+ * [ClientRoute]).
+ *
+ * Provider replay: `CardIssuancePactFolderProviderVerificationTest` (`@PactFolder`, runs on every
+ * PR) — the first provider-side verification card-issuance has ever had.
+ */
+@ExtendWith(PactConsumerTestExt::class)
+@PactTestFor(providerName = "openbank-card-issuance-service", pactVersion = PactSpecVersion.V3)
+class DelegationCardOwnershipPactConsumerTest {
+
+    private companion object {
+        // Fixed UUIDs — must match the @State seed in card-issuance's provider verification.
+        const val CARD_ID = "0a0a0a0a-1b1b-4c2c-8d3d-4e4e4e4e4e4e"
+        const val OWNER_PARTY_ID = "5f5f5f5f-6a6a-4b7b-8c8c-9d9d9d9d9d9d"
+    }
+
+    @Pact(consumer = "openbank-delegation-service", provider = "openbank-card-issuance-service")
+    fun getCardOwnerPact(builder: PactDslWithProvider): RequestResponsePact = builder
+        .given("a card held by a known party exists")
+        .uponReceiving("GET the card whose ownership is being verified")
+        .path("/api/v1/cards/$CARD_ID")
+        .method("GET")
+        .willRespondWith()
+        .status(200)
+        .headers(mapOf("Content-Type" to "application/json"))
+        .body(
+            newJsonBody { o ->
+                o.stringValue("id", CARD_ID)
+                o.stringValue("partyId", OWNER_PARTY_ID)
+            }.build(),
+        )
+        .toPact()
+
+    @Test
+    @PactTestFor(pactMethod = "getCardOwnerPact")
+    fun `the card lookup returns the holding partyId the ownership gate compares`(mockServer: MockServer) {
+        val body = given()
+            .baseUri(mockServer.getUrl())
+            .get(ClientRoute.of(CardIssuanceRestClient::class.java, "getCard", "id" to CARD_ID))
+            .then()
+            .statusCode(200)
+            .extract().jsonPath()
+
+        assertThat(body.getString("id")).isEqualTo(CARD_ID)
+        assertThat(body.getString("partyId")).isEqualTo(OWNER_PARTY_ID)
+    }
+}

--- a/openbank-delegation-service/src/test/kotlin/com/openbank/delegation/contract/DelegationEventPactFolderProviderVerificationTest.kt
+++ b/openbank-delegation-service/src/test/kotlin/com/openbank/delegation/contract/DelegationEventPactFolderProviderVerificationTest.kt
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.delegation.contract
+
+import au.com.dius.pact.provider.PactVerifyProvider
+import au.com.dius.pact.provider.junit5.MessageTestTarget
+import au.com.dius.pact.provider.junit5.PactVerificationContext
+import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvider
+import au.com.dius.pact.provider.junitsupport.IgnoreNoPactsToVerify
+import au.com.dius.pact.provider.junitsupport.Provider
+import au.com.dius.pact.provider.junitsupport.State
+import au.com.dius.pact.provider.junitsupport.loader.PactFolder
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.openbank.delegation.domain.event.DelegationActivated
+import com.openbank.delegation.domain.event.DelegationRevoked
+import com.openbank.delegation.domain.event.EventMoney
+import com.openbank.delegation.domain.model.DelegationCapability
+import com.openbank.delegation.domain.model.DelegationResourceType
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.TestTemplate
+import org.junit.jupiter.api.extension.ExtendWith
+import java.math.BigDecimal
+import java.time.Instant
+import java.time.OffsetDateTime
+import java.util.UUID
+
+/**
+ * Git-pact provider verification for delegation-service — the replay that runs BEFORE a merge
+ * (issue #2991; the rule is `check-pact-provider-replay.py`, #2338).
+ *
+ * delegation-service is the provider of the `openbank.delegation.events` message contract that
+ * account-service and card-issuance build their enforcement projections from (ADR-0232 D3). Before
+ * this class the service had no pacts at all in either direction, so its deploys carried no
+ * contract gate whatsoever — nothing compared what `DelegationEvents.kt` emits with what the two
+ * projections read.
+ *
+ * ## What makes the replay, not the consumer pacts, the load-bearing half here
+ *
+ * Both consumers parse the payload with `objectMapper.readTree` + `node.path(...)`, so a field
+ * this service renames does not break them loudly — it defaults. `capabilities` silently becomes
+ * the empty set, `resourceType` becomes `""` and the event is filtered out entirely. A consumer
+ * pact alone cannot catch that, because the pact mock hands the consumer whatever the pact says.
+ * Only replaying the CONSUMER's expectations against the REAL event types can, and that is what
+ * the [PactVerifyProvider] methods below do: they serialize the genuine [DelegationActivated] and
+ * [DelegationRevoked] data classes, so renaming `granteePartyId` in `DelegationEvents.kt` turns
+ * this red on the PR that does it.
+ *
+ * ## No Quarkus, no Testcontainer
+ *
+ * Every pact naming delegation-service as provider is message-only, so a [MessageTestTarget] is
+ * the whole target: this is a plain JVM test. If an HTTP consumer contract against
+ * delegation-service is ever added, this needs party-service's per-interaction target dispatch
+ * (`PartyPactFolderProviderVerificationTest`).
+ *
+ * ## `@PactFolder` only, deliberately — and what that costs
+ *
+ * There is no `@PactBroker` twin yet, because delegation-service is not in the broker's consumer
+ * graph. Note the consequence rather than assuming it away: `can-i-deploy` (ADR-0092) reads the
+ * broker and nothing else, so a `@PactFolder`-only provider publishes no verification result and
+ * can block its CONSUMERS' deploys once their pacts reach the broker — the failure mode #3239
+ * documents. If account-service or card-issuance ever start publishing these pacts to the broker,
+ * add the broker twin (`@PactBroker` + `@EnabledIfSystemProperty(pactbroker.url)`) alongside this
+ * class; do NOT convert this one, which is the mistake #372/#1166 made and reverted twice.
+ *
+ * ## Upkeep
+ *
+ * The serializer below mirrors the production ObjectMapper (`DelegationRepositoryImpl` writes the
+ * outbox payload with the CDI-injected one): JavaTimeModule with `WRITE_DATES_AS_TIMESTAMPS`
+ * disabled, which is Quarkus's default and the reason `validFrom` reaches Kafka as an ISO-8601
+ * string the consumers can `OffsetDateTime.parse`. Do not let the two configurations drift — a
+ * numeric timestamp would be a silent, total projection outage that this replay would then pass.
+ */
+@Provider("openbank-delegation-service")
+@PactFolder("../pacts")
+@IgnoreNoPactsToVerify(ignoreIoErrors = "true")
+class DelegationEventPactFolderProviderVerificationTest {
+
+    private val objectMapper = jacksonObjectMapper()
+        .registerModule(JavaTimeModule())
+        .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+
+    private companion object {
+        val GRANT_ID: UUID = UUID.fromString("aaaa1111-bbbb-4ccc-8ddd-eeeeffff0000")
+        val GRANTOR: UUID = UUID.fromString("aaaa2222-bbbb-4ccc-8ddd-eeeeffff0001")
+        val GRANTEE: UUID = UUID.fromString("aaaa3333-bbbb-4ccc-8ddd-eeeeffff0002")
+        val RESOURCE: UUID = UUID.fromString("aaaa4444-bbbb-4ccc-8ddd-eeeeffff0003")
+        val VALID_FROM: OffsetDateTime = OffsetDateTime.parse("2026-01-01T00:00:00Z")
+        val OCCURRED_AT: Instant = Instant.parse("2026-01-01T00:00:00Z")
+    }
+
+    @BeforeEach
+    fun setTarget(context: PactVerificationContext?) {
+        // Package-scoped scan: the default classpath-wide ClassGraph scan throws on the JDK 25+
+        // toolchain (same reason as account-service's and party-service's classes).
+        context?.target = MessageTestTarget(listOf("com.openbank.delegation.contract"))
+    }
+
+    @TestTemplate
+    @ExtendWith(PactVerificationInvocationContextProvider::class)
+    fun verifyPacts(context: PactVerificationContext?) {
+        context?.verifyInteraction()
+    }
+
+    @State("an ACCOUNT-scoped delegation grant has been activated")
+    fun accountGrantActivated() = Unit
+
+    @PactVerifyProvider("a DelegationActivated event for an account")
+    fun produceAccountActivated(): String = objectMapper.writeValueAsString(
+        DelegationActivated(
+            aggregateId = GRANT_ID,
+            grantorPartyId = GRANTOR,
+            granteePartyId = GRANTEE,
+            resourceType = DelegationResourceType.ACCOUNT,
+            resourceId = RESOURCE,
+            capabilities = setOf(DelegationCapability.ACCOUNT_READ_BALANCES),
+            validFrom = VALID_FROM,
+            validTo = null,
+            perTransactionLimit = EventMoney(BigDecimal("1500.00"), "CZK"),
+            occurredAt = OCCURRED_AT,
+        ),
+    )
+
+    @State("an ACCOUNT-scoped delegation grant has been revoked")
+    fun accountGrantRevoked() = Unit
+
+    @PactVerifyProvider("a DelegationRevoked event for an account")
+    fun produceAccountRevoked(): String = objectMapper.writeValueAsString(
+        DelegationRevoked(
+            aggregateId = GRANT_ID,
+            grantorPartyId = GRANTOR,
+            granteePartyId = GRANTEE,
+            resourceType = DelegationResourceType.ACCOUNT,
+            resourceId = RESOURCE,
+            capabilities = setOf(DelegationCapability.ACCOUNT_READ_BALANCES),
+            reason = "grantor revoked",
+            occurredAt = OCCURRED_AT,
+        ),
+    )
+
+    @State("a CARD-scoped delegation grant has been activated")
+    fun cardGrantActivated() = Unit
+
+    @PactVerifyProvider("a DelegationActivated event for a card")
+    fun produceCardActivated(): String = objectMapper.writeValueAsString(
+        DelegationActivated(
+            aggregateId = GRANT_ID,
+            grantorPartyId = GRANTOR,
+            granteePartyId = GRANTEE,
+            resourceType = DelegationResourceType.CARD,
+            resourceId = RESOURCE,
+            capabilities = setOf(DelegationCapability.CARD_VIEW),
+            validFrom = VALID_FROM,
+            validTo = null,
+            perTransactionLimit = null,
+            occurredAt = OCCURRED_AT,
+        ),
+    )
+
+    @State("a CARD-scoped delegation grant has been revoked")
+    fun cardGrantRevoked() = Unit
+
+    @PactVerifyProvider("a DelegationRevoked event for a card")
+    fun produceCardRevoked(): String = objectMapper.writeValueAsString(
+        DelegationRevoked(
+            aggregateId = GRANT_ID,
+            grantorPartyId = GRANTOR,
+            granteePartyId = GRANTEE,
+            resourceType = DelegationResourceType.CARD,
+            resourceId = RESOURCE,
+            capabilities = setOf(DelegationCapability.CARD_VIEW),
+            reason = "grantor revoked",
+            occurredAt = OCCURRED_AT,
+        ),
+    )
+}

--- a/openbank-delegation-service/src/test/kotlin/com/openbank/delegation/contract/DelegationPartyEligibilityPactConsumerTest.kt
+++ b/openbank-delegation-service/src/test/kotlin/com/openbank/delegation/contract/DelegationPartyEligibilityPactConsumerTest.kt
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.delegation.contract
+
+import au.com.dius.pact.consumer.MockServer
+import au.com.dius.pact.consumer.dsl.LambdaDsl.newJsonBody
+import au.com.dius.pact.consumer.dsl.PactDslWithProvider
+import au.com.dius.pact.consumer.junit5.PactConsumerTestExt
+import au.com.dius.pact.consumer.junit5.PactTestFor
+import au.com.dius.pact.core.model.PactSpecVersion
+import au.com.dius.pact.core.model.RequestResponsePact
+import au.com.dius.pact.core.model.annotations.Pact
+import com.openbank.delegation.infrastructure.client.PidServiceRestClient
+import io.restassured.RestAssured.given
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+/**
+ * Consumer-driven contract for the party-eligibility lookup
+ * ([com.openbank.delegation.infrastructure.client.ResilientPartyEligibilityClient], ADR-0232 D5):
+ * both ends of a grant must be an ACTIVE party, and the grantee's KYC level must clear the bar
+ * for the capabilities being handed over (FULL for anything that moves money, BASIC otherwise).
+ *
+ * ## The nested read is the fragile part, and it is what this pins
+ *
+ * `PartyEligibility` is built from three fields of pid-service's `PartyResponse`: `id`, `status`,
+ * and `kycAttributes.kycLevel` — a NESTED field, read with an elvis to `"NONE"`:
+ *
+ * ```
+ * kycLevel = party.kycAttributes?.kycLevel ?: "NONE"
+ * ```
+ *
+ * That default is why this contract matters more than its size suggests. If pid-service ever
+ * renames the object or moves `kycLevel` up a level, the client does not fail — it silently reads
+ * `"NONE"`, `KYC_RANK` ranks it 0, and EVERY offer is refused. A fail-closed regression is still a
+ * regression, and nothing else in the estate would have gone red.
+ *
+ * `status` and `kycLevel` are `stringValue`, not `stringType`: `active` is `status == "ACTIVE"`
+ * exactly, and `KYC_RANK`'s keys are exactly pid's `KycLevel` names, so a type matcher would let
+ * the replay answer with a vocabulary the consumer cannot rank.
+ *
+ * Expected path is a LITERAL; only the request is reflected off [PidServiceRestClient] (see
+ * [ClientRoute]).
+ *
+ * Provider replay: `PidPactFolderProviderVerificationTest` (`@PactFolder`, runs on every PR).
+ */
+@ExtendWith(PactConsumerTestExt::class)
+@PactTestFor(providerName = "openbank-pid-service", pactVersion = PactSpecVersion.V3)
+class DelegationPartyEligibilityPactConsumerTest {
+
+    private companion object {
+        // Fixed UUID — must match the @State seed in pid-service's provider verification.
+        const val PARTY_ID = "cccccccc-cccc-4ccc-8ccc-cccccccccccc"
+    }
+
+    @Pact(consumer = "openbank-delegation-service", provider = "openbank-pid-service")
+    fun getPartyEligibilityPact(builder: PactDslWithProvider): RequestResponsePact = builder
+        .given("an ACTIVE party with FULL KYC exists")
+        .uponReceiving("GET the party whose delegation eligibility is being checked")
+        .path("/api/v1/parties/$PARTY_ID")
+        .method("GET")
+        .willRespondWith()
+        .status(200)
+        .headers(mapOf("Content-Type" to "application/json"))
+        .body(
+            newJsonBody { o ->
+                o.stringValue("id", PARTY_ID)
+                o.stringValue("status", "ACTIVE")
+                o.`object`("kycAttributes") { kyc -> kyc.stringValue("kycLevel", "FULL") }
+            }.build(),
+        )
+        .toPact()
+
+    @Test
+    @PactTestFor(pactMethod = "getPartyEligibilityPact")
+    fun `eligibility is read from id, status and the nested kycAttributes kycLevel`(mockServer: MockServer) {
+        val body = given()
+            .baseUri(mockServer.getUrl())
+            .get(ClientRoute.of(PidServiceRestClient::class.java, "getParty", "id" to PARTY_ID))
+            .then()
+            .statusCode(200)
+            .extract().jsonPath()
+
+        assertThat(body.getString("id")).isEqualTo(PARTY_ID)
+        assertThat(body.getString("status")).isEqualTo("ACTIVE")
+        // Asserted at the nested path the client actually reads — not `kycLevel` at the root,
+        // which is exactly the shape change the elvis default would swallow.
+        assertThat(body.getString("kycAttributes.kycLevel")).isEqualTo("FULL")
+    }
+}

--- a/openbank-delegation-service/src/test/kotlin/com/openbank/delegation/contract/DelegationScaChallengePactConsumerTest.kt
+++ b/openbank-delegation-service/src/test/kotlin/com/openbank/delegation/contract/DelegationScaChallengePactConsumerTest.kt
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.delegation.contract
+
+import au.com.dius.pact.consumer.MockServer
+import au.com.dius.pact.consumer.dsl.LambdaDsl.newJsonBody
+import au.com.dius.pact.consumer.dsl.PactDslWithProvider
+import au.com.dius.pact.consumer.junit5.PactConsumerTestExt
+import au.com.dius.pact.consumer.junit5.PactTestFor
+import au.com.dius.pact.core.model.PactSpecVersion
+import au.com.dius.pact.core.model.RequestResponsePact
+import au.com.dius.pact.core.model.annotations.Pact
+import com.openbank.delegation.infrastructure.client.ScaServiceRestClient
+import io.restassured.RestAssured.given
+import io.restassured.http.ContentType
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+/**
+ * Consumer-driven contract for the SCA half of the ADR-0232 D4 delegation ceremony, which
+ * [com.openbank.delegation.infrastructure.client.ResilientScaChallengeClient] drives before any
+ * grant is offered or accepted. Two interactions, because the ceremony is two calls and the
+ * second one is the security-relevant half:
+ *
+ * 1. `GET  /api/v1/sca/challenges/{id}` — read the challenge back and check party + purpose + status.
+ * 2. `POST /api/v1/sca/challenges/{id}/consume` — SPEND it. `DelegationService` documents why
+ *    reading `status == "COMPLETED"` is not a substitute: completion is a fact that stays true,
+ *    so without the consume one ceremony would authorise unlimited grants of arbitrary scope.
+ *
+ * ## Why the values are pinned, not type-matched
+ *
+ * `purpose` and `status` are `stringValue`, not `stringType` (the #2425 lesson). Both are closed
+ * vocabularies fixed by the provider state, and `DelegationService.requireChallengeMatches` gates
+ * on the exact strings `"DELEGATION_GRANT"` and `"COMPLETED"` — `DELEGATION_GRANT` specifically so
+ * a challenge raised for a payment, or the grantee's `DELEGATION_ACCEPT` half, can never be spent
+ * to mint a grant. A type matcher would have asked the replay nothing about either value, which is
+ * the whole substance of this contract.
+ *
+ * The expected `.path(...)` below is a LITERAL; only the outgoing request is reflected off
+ * [ScaServiceRestClient]'s `@Path` via [ClientRoute]. See [ClientRoute] for why deriving both
+ * sides is vacuous.
+ *
+ * Provider replay: `ScaPactFolderProviderVerificationTest` (`@PactFolder`, runs on every PR).
+ */
+@ExtendWith(PactConsumerTestExt::class)
+@PactTestFor(providerName = "openbank-sca-service", pactVersion = PactSpecVersion.V3)
+class DelegationScaChallengePactConsumerTest {
+
+    private companion object {
+        // Fixed UUIDs — must match the @State seed in sca-service's provider verification.
+        const val CHALLENGE_ID = "d1e2f3a4-b5c6-4d7e-8f90-1a2b3c4d5e6f"
+        const val PARTY_ID = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
+        const val STATE = "a COMPLETED DELEGATION_GRANT SCA challenge exists"
+    }
+
+    @Pact(consumer = "openbank-delegation-service", provider = "openbank-sca-service")
+    fun getDelegationChallengePact(builder: PactDslWithProvider): RequestResponsePact = builder
+        .given(STATE)
+        .uponReceiving("GET the delegation SCA challenge by id")
+        .path("/api/v1/sca/challenges/$CHALLENGE_ID")
+        .method("GET")
+        .willRespondWith()
+        .status(200)
+        .headers(mapOf("Content-Type" to "application/json"))
+        .body(
+            newJsonBody { o ->
+                o.stringValue("id", CHALLENGE_ID)
+                o.stringValue("partyId", PARTY_ID)
+                o.stringValue("purpose", "DELEGATION_GRANT")
+                o.stringValue("status", "COMPLETED")
+            }.build(),
+        )
+        .toPact()
+
+    @Test
+    @PactTestFor(pactMethod = "getDelegationChallengePact")
+    fun `the challenge lookup returns the party, purpose and status the ceremony gates on`(mockServer: MockServer) {
+        val body = given()
+            .baseUri(mockServer.getUrl())
+            .get(ClientRoute.of(ScaServiceRestClient::class.java, "getChallenge", "id" to CHALLENGE_ID))
+            .then()
+            .statusCode(200)
+            .extract().jsonPath()
+
+        assertThat(body.getString("id")).isEqualTo(CHALLENGE_ID)
+        assertThat(body.getString("partyId")).isEqualTo(PARTY_ID)
+        assertThat(body.getString("purpose")).isEqualTo("DELEGATION_GRANT")
+        assertThat(body.getString("status")).isEqualTo("COMPLETED")
+    }
+
+    @Pact(consumer = "openbank-delegation-service", provider = "openbank-sca-service")
+    fun consumeDelegationChallengePact(builder: PactDslWithProvider): RequestResponsePact = builder
+        .given(STATE)
+        .uponReceiving("POST consume the delegation SCA challenge")
+        .path("/api/v1/sca/challenges/$CHALLENGE_ID/consume")
+        .method("POST")
+        .headers(mapOf("Content-Type" to "application/json"))
+        // Mirrors ConsumeScaChallengeRequest: a delegation challenge carries no dynamic-linking
+        // data, so the body states the party and nothing else. sca-service compares EVERY linking
+        // field, so stating an amount here would 409 — the absence is part of the contract.
+        .body(newJsonBody { o -> o.stringValue("partyId", PARTY_ID) }.build())
+        .willRespondWith()
+        .status(200)
+        .headers(mapOf("Content-Type" to "application/json"))
+        .body(
+            newJsonBody { o ->
+                o.stringValue("id", CHALLENGE_ID)
+                o.stringValue("partyId", PARTY_ID)
+                o.stringValue("purpose", "DELEGATION_GRANT")
+                o.stringValue("status", "COMPLETED")
+            }.build(),
+        )
+        .toPact()
+
+    @Test
+    @PactTestFor(pactMethod = "consumeDelegationChallengePact")
+    fun `spending the challenge is a POST to consume that states only the party`(mockServer: MockServer) {
+        val body = given()
+            .baseUri(mockServer.getUrl())
+            .contentType(ContentType.JSON)
+            .body(mapOf("partyId" to PARTY_ID))
+            .post(ClientRoute.of(ScaServiceRestClient::class.java, "consumeChallenge", "id" to CHALLENGE_ID))
+            .then()
+            .statusCode(200)
+            .extract().jsonPath()
+
+        assertThat(body.getString("id")).isEqualTo(CHALLENGE_ID)
+        assertThat(body.getString("purpose")).isEqualTo("DELEGATION_GRANT")
+    }
+}

--- a/openbank-pid-service/build.gradle.kts
+++ b/openbank-pid-service/build.gradle.kts
@@ -61,6 +61,27 @@ dependencies {
     testImplementation(libs.pact.provider)
 }
 
+// Pact: forward broker config to the forked test JVM (issue #2991). pid-service publishes no
+// consumer pacts, so `pact.rootDir` is only here for consistency with the fleet; the broker
+// properties are the load-bearing half. Without them `pactbroker.url` never reaches the test JVM,
+// PidPactBrokerProviderVerificationTest stays @EnabledIfSystemProperty-skipped even on main-push,
+// and pid-service publishes no verification result — the exact `can-i-deploy` block that class
+// exists to prevent. NOTE: must be set on the test JVM fork, not the Gradle daemon.
+tasks.withType<Test> {
+    systemProperty("pact.rootDir", "${rootProject.projectDir}/pacts")
+    listOf(
+        "pactbroker.url",
+        "pactbroker.auth.username",
+        "pactbroker.auth.password",
+        "pactbroker.enablePending",
+        "pactbroker.providerBranch",
+        "pact.verifier.publishResults",
+        "pact.provider.version",
+        "pact.provider.branch",
+        "pact.provider.tag",
+    ).forEach { key -> System.getProperty(key)?.let { systemProperty(key, it) } }
+}
+
 kover {
     reports {
         verify {

--- a/openbank-pid-service/build.gradle.kts
+++ b/openbank-pid-service/build.gradle.kts
@@ -54,6 +54,11 @@ dependencies {
     // rather than greps. No version: managed by the enforcedPlatform(quarkus.bom) above
     // (testImplementation extends implementation), so it cannot drift from the runtime's Jackson.
     testImplementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml")
+    // Provider-side verification (git-pact, ADR-0063): PidPactFolderProviderVerificationTest
+    // replays the pacts in pacts/ that name openbank-pid-service as provider — today
+    // delegation-service's eligibility lookup (issue #2991). pid-service is a provider only, so
+    // there is no pact-consumer dependency here.
+    testImplementation(libs.pact.provider)
 }
 
 kover {

--- a/openbank-pid-service/src/test/kotlin/com/openbank/pid/contract/PidPactBrokerProviderVerificationTest.kt
+++ b/openbank-pid-service/src/test/kotlin/com/openbank/pid/contract/PidPactBrokerProviderVerificationTest.kt
@@ -10,7 +10,7 @@ import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvide
 import au.com.dius.pact.provider.junitsupport.IgnoreNoPactsToVerify
 import au.com.dius.pact.provider.junitsupport.Provider
 import au.com.dius.pact.provider.junitsupport.State
-import au.com.dius.pact.provider.junitsupport.loader.PactFolder
+import au.com.dius.pact.provider.junitsupport.loader.PactBroker
 import com.openbank.pid.application.port.out.PartyRepository
 import com.openbank.pid.domain.model.AmlRiskScore
 import com.openbank.pid.domain.model.ContactAttributes
@@ -34,6 +34,7 @@ import kotlinx.coroutines.launch
 import org.eclipse.microprofile.config.inject.ConfigProperty
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.TestTemplate
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty
 import org.junit.jupiter.api.extension.ExtendWith
 import java.time.LocalDate
 import java.time.OffsetDateTime
@@ -43,54 +44,57 @@ import java.util.concurrent.Executor
 import java.util.concurrent.TimeUnit
 
 /**
- * Git-pact provider verification for pid-service — the FIRST it has ever had (issue #2991).
+ * Broker-side provider verification for pid-service — the published-result counterpart to
+ * [PidPactFolderProviderVerificationTest].
  *
- * pid-service is the provider for one committed pact: delegation-service's
- * `GET /api/v1/parties/{id}`, the ADR-0232 D5 eligibility check that decides whether a party may
- * be either end of a delegation grant. `check-pact-provider-replay.py` requires that every
- * committed pact is replayed by a class that actually RUNS on a pull request, so this is
- * `@PactFolder`-sourced and carries no `@EnabledIf*` gate — a `@PactBroker` class would skip on
- * the PR lane (`PACT_BROKER_URL` is blank there; the broker has no public ingress, ADR-0056) and
- * the contract would be replayed only after the merge, which is what #2327 had to unwind fleet-wide.
+ * ## Why this exists, and why it had to land in the SAME PR as the pact
  *
- * ## This class is one HALF of a deliberate pair — do not read the paragraph above as an argument
- * ## against the other half
+ * `can-i-deploy` (ADR-0092) reads the broker and nothing else. A `@PactFolder` class replays the
+ * committed pact from disk and never contacts the broker, so a provider that has only one has
+ * **never published a version on main** — and every consumer of it then reads as unverified,
+ * permanently. That is not a delay that clears itself.
  *
- * [PidPactBrokerProviderVerificationTest] is the `@PactBroker` + `@EnabledIfSystemProperty(pactbroker.url)`
- * twin, and it is required, not optional. The two answer different questions: this class is the
- * PR-lane gate (zero infra, always runs, catches the wrong-route defect before merge), and the twin
- * is the only thing that publishes a verification RESULT — which is all `can-i-deploy` (ADR-0092)
- * reads. A provider with only this class has never published a version on main, so every consumer
- * of it reads as unverified and its deploys block permanently (#3239; fx-service, four attempts,
- * 2026-08-02). Removing either half breaks something the other cannot cover.
+ * Without this class, merging the delegation pacts would have made `openbank-delegation-service`
+ * undeployable the moment it started publishing: `can-i-deploy` would answer "no verified pact
+ * between openbank-delegation-service and the version of openbank-pid-service currently in
+ * sandbox", and label it `PENDING_BUILD` — a name that reads like a transient state and is not
+ * one. The same shape took fx-service out across four deploy attempts on 2026-08-02 and is what
+ * #3239 added the aml/sanctions twins for. delegation-service reached sandbox for the first time
+ * the night this landed; shipping the consumer pact without this class would have taken that away.
  *
- * Any `@State` added here MUST be added to the twin in the same commit — a state the broker replay
- * cannot satisfy fails with `MissingStateChangeMethod` and publishes a FAILURE, which is strictly
- * worse than publishing nothing.
+ * ## Why a second `@Provider("openbank-pid-service")` class is safe
  *
- * ## Why the replay is what protects this call, not the consumer pact
+ * The collision `rules.yaml`/ADR-0029 D3 warns about is two BROKER-sourced classes for one
+ * provider — each fetches every pact the broker holds — or an HTTP and a MESSAGE target fighting
+ * over the same `@BeforeEach`. This is the sanctioned pair CLAUDE.md documents: a `@PactFolder`
+ * class for the PR lane plus a `@PactBroker` class gated on `pactbroker.url`, exactly as
+ * openbank-ledger-service and (since #3239) aml-service and sanctions-service carry. pid-service
+ * has no message-consumer contracts and both classes use [HttpTestTarget] exclusively, so
+ * verifying the same interaction from two sources is at worst redundant, never colliding.
  *
- * delegation-service reads `kycAttributes.kycLevel` with an elvis to `"NONE"`. If pid-service
- * moved or renamed that nested object, the consumer would not fail — it would rank every grantee
- * at KYC level NONE and refuse every offer, silently. The Pact mock server cannot expose that,
- * because it serves whatever the pact says; only asking the real `PartyResource` for the real
- * `PartyResponse` can (#2269).
+ * Gated on `pactbroker.url`: skipped locally and on the PR lane, where `_service-ci.yml` blanks
+ * `PACT_BROKER_URL` (the broker has no public ingress, ADR-0056). It runs on main-push, where
+ * `PUBLISH_RESULTS=true` — that run is what creates the main version `can-i-deploy` looks for.
  *
- * `@TestSecurity` matches `PartyResource.getById`'s `@RolesAllowed(Roles.OPERATOR, Roles.ADMIN)`.
- * Note what that means for the contract: this replay proves the ROUTE and the SHAPE, and asserts
- * nothing about who may call it. The M2M authorization of delegation-service against pid-service
- * is a separate concern (ADR-0034) and a pact is the wrong instrument for it.
+ * ## Every state the git-pact twin handles is handled here too
+ *
+ * The broker serves EVERY consumer's pact for this provider, not just the one committed under
+ * `pacts/`. A missing state fails with `MissingStateChangeMethod` and publishes a FAILURE, which
+ * blocks an otherwise healthy pair — strictly worse than publishing nothing, and it would turn
+ * this class into the problem it exists to remove. Today that is one state, mirrored verbatim
+ * below; anything added to [PidPactFolderProviderVerificationTest] belongs here in the same commit.
  */
 @QuarkusTest
 @QuarkusTestResource(com.openbank.pid.it.PostgresTestResource::class)
 @TestSecurity(user = "pact-verifier", roles = ["ROLE_OPERATOR", "ROLE_ADMIN"])
 @Provider("openbank-pid-service")
-@PactFolder("../pacts")
+@PactBroker
 @IgnoreNoPactsToVerify(ignoreIoErrors = "true")
-class PidPactFolderProviderVerificationTest {
+@EnabledIfSystemProperty(named = "pactbroker.url", matches = ".+")
+class PidPactBrokerProviderVerificationTest {
 
     companion object {
-        // Must match DelegationPartyEligibilityPactConsumerTest.PARTY_ID.
+        // Must match DelegationPartyEligibilityPactConsumerTest.PARTY_ID and the git-pact twin.
         private val PARTY_ID = UUID.fromString("cccccccc-cccc-4ccc-8ccc-cccccccccccc")
         private val SEEDED_AT: OffsetDateTime = OffsetDateTime.parse("2026-01-01T00:00:00Z")
     }
@@ -104,14 +108,7 @@ class PidPactFolderProviderVerificationTest {
     @Inject
     lateinit var vertx: Vertx
 
-    /**
-     * Bridges a reactive-Panache block into Pact-JVM's synchronous `@State` callback. Pact-JVM
-     * invokes `@State` methods by reflection on the JUnit test thread, which has no Vert.x
-     * context, so a bare `runBlocking { partyRepository.save(...) }` throws `IllegalStateException:
-     * No current Vertx context found`. Same shape as `ScaPactFolderProviderVerificationTest` and
-     * `PartyPactFolderProviderVerificationTest`; a plain `vertx.runOnContext { runBlocking {} }` is
-     * NOT sufficient (balance-service's class documents why).
-     */
+    /** See the git-pact twin: Pact-JVM calls `@State` by reflection on a thread with no Vert.x context. */
     private fun runOnVertxContext(block: suspend () -> Unit) {
         val future = CompletableFuture<Unit>()
         val duplicated = (vertx.orCreateContext as ContextInternal).duplicate()
@@ -141,10 +138,11 @@ class PidPactFolderProviderVerificationTest {
     }
 
     /**
-     * Seeded once and guarded by a `findById`: `PartyRepositoryImpl.save` calls `persist`, not
-     * `merge`, and the id is application-assigned — so a second call for the same party would fail
-     * on the primary key rather than upsert. The guard keeps this handler safe if a second
-     * interaction against pid-service is ever added to the pact.
+     * Mirrors [PidPactFolderProviderVerificationTest.stateActiveFullKycParty] verbatim, including
+     * the `findById` guard: `PartyRepositoryImpl.save` calls `persist`, not `merge`, on an
+     * application-assigned id, so a second call for the same party fails on the primary key rather
+     * than upserting. The broker can hand this class several consumers' interactions naming the
+     * same state, so that guard is load-bearing here in a way it is not on the single-pact side.
      */
     @State("an ACTIVE party with FULL KYC exists")
     fun stateActiveFullKycParty() = runOnVertxContext {

--- a/openbank-pid-service/src/test/kotlin/com/openbank/pid/contract/PidPactFolderProviderVerificationTest.kt
+++ b/openbank-pid-service/src/test/kotlin/com/openbank/pid/contract/PidPactFolderProviderVerificationTest.kt
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.pid.contract
+
+import au.com.dius.pact.provider.junit5.HttpTestTarget
+import au.com.dius.pact.provider.junit5.PactVerificationContext
+import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvider
+import au.com.dius.pact.provider.junitsupport.IgnoreNoPactsToVerify
+import au.com.dius.pact.provider.junitsupport.Provider
+import au.com.dius.pact.provider.junitsupport.State
+import au.com.dius.pact.provider.junitsupport.loader.PactFolder
+import com.openbank.pid.application.port.out.PartyRepository
+import com.openbank.pid.domain.model.AmlRiskScore
+import com.openbank.pid.domain.model.ContactAttributes
+import com.openbank.pid.domain.model.CoreAttributes
+import com.openbank.pid.domain.model.KycAttributes
+import com.openbank.pid.domain.model.KycLevel
+import com.openbank.pid.domain.model.Party
+import com.openbank.pid.domain.model.PartyStatus
+import com.openbank.pid.domain.model.PartyType
+import com.openbank.pid.domain.model.VerificationSource
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.security.TestSecurity
+import io.quarkus.vertx.core.runtime.context.VertxContextSafetyToggle
+import io.vertx.core.Vertx
+import io.vertx.core.impl.ContextInternal
+import jakarta.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.launch
+import org.eclipse.microprofile.config.inject.ConfigProperty
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.TestTemplate
+import org.junit.jupiter.api.extension.ExtendWith
+import java.time.LocalDate
+import java.time.OffsetDateTime
+import java.util.UUID
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.Executor
+import java.util.concurrent.TimeUnit
+
+/**
+ * Git-pact provider verification for pid-service — the FIRST it has ever had (issue #2991).
+ *
+ * pid-service is the provider for one committed pact: delegation-service's
+ * `GET /api/v1/parties/{id}`, the ADR-0232 D5 eligibility check that decides whether a party may
+ * be either end of a delegation grant. `check-pact-provider-replay.py` requires that every
+ * committed pact is replayed by a class that actually RUNS on a pull request, so this is
+ * `@PactFolder`-sourced and carries no `@EnabledIf*` gate — a `@PactBroker` class would skip on
+ * the PR lane (`PACT_BROKER_URL` is blank there; the broker has no public ingress, ADR-0056) and
+ * the contract would be replayed only after the merge, which is what #2327 had to unwind fleet-wide.
+ *
+ * ## Why the replay is what protects this call, not the consumer pact
+ *
+ * delegation-service reads `kycAttributes.kycLevel` with an elvis to `"NONE"`. If pid-service
+ * moved or renamed that nested object, the consumer would not fail — it would rank every grantee
+ * at KYC level NONE and refuse every offer, silently. The Pact mock server cannot expose that,
+ * because it serves whatever the pact says; only asking the real `PartyResource` for the real
+ * `PartyResponse` can (#2269).
+ *
+ * `@TestSecurity` matches `PartyResource.getById`'s `@RolesAllowed(Roles.OPERATOR, Roles.ADMIN)`.
+ * Note what that means for the contract: this replay proves the ROUTE and the SHAPE, and asserts
+ * nothing about who may call it. The M2M authorization of delegation-service against pid-service
+ * is a separate concern (ADR-0034) and a pact is the wrong instrument for it.
+ */
+@QuarkusTest
+@QuarkusTestResource(com.openbank.pid.it.PostgresTestResource::class)
+@TestSecurity(user = "pact-verifier", roles = ["ROLE_OPERATOR", "ROLE_ADMIN"])
+@Provider("openbank-pid-service")
+@PactFolder("../pacts")
+@IgnoreNoPactsToVerify(ignoreIoErrors = "true")
+class PidPactFolderProviderVerificationTest {
+
+    companion object {
+        // Must match DelegationPartyEligibilityPactConsumerTest.PARTY_ID.
+        private val PARTY_ID = UUID.fromString("cccccccc-cccc-4ccc-8ccc-cccccccccccc")
+        private val SEEDED_AT: OffsetDateTime = OffsetDateTime.parse("2026-01-01T00:00:00Z")
+    }
+
+    @ConfigProperty(name = "quarkus.http.test-port", defaultValue = "8081")
+    lateinit var testPort: String
+
+    @Inject
+    lateinit var partyRepository: PartyRepository
+
+    @Inject
+    lateinit var vertx: Vertx
+
+    /**
+     * Bridges a reactive-Panache block into Pact-JVM's synchronous `@State` callback. Pact-JVM
+     * invokes `@State` methods by reflection on the JUnit test thread, which has no Vert.x
+     * context, so a bare `runBlocking { partyRepository.save(...) }` throws `IllegalStateException:
+     * No current Vertx context found`. Same shape as `ScaPactFolderProviderVerificationTest` and
+     * `PartyPactFolderProviderVerificationTest`; a plain `vertx.runOnContext { runBlocking {} }` is
+     * NOT sufficient (balance-service's class documents why).
+     */
+    private fun runOnVertxContext(block: suspend () -> Unit) {
+        val future = CompletableFuture<Unit>()
+        val duplicated = (vertx.orCreateContext as ContextInternal).duplicate()
+        VertxContextSafetyToggle.setContextSafe(duplicated, true)
+        val dispatcher = Executor { command -> duplicated.runOnContext { command.run() } }.asCoroutineDispatcher()
+        CoroutineScope(dispatcher).launch {
+            try {
+                block()
+                future.complete(Unit)
+            } catch (t: Throwable) {
+                future.completeExceptionally(t)
+            }
+        }
+        future.get(10, TimeUnit.SECONDS)
+    }
+
+    @BeforeEach
+    fun configureTarget(context: PactVerificationContext?) {
+        context?.target = HttpTestTarget("localhost", testPort.toInt())
+        context?.addStateChangeHandlers(this)
+    }
+
+    @TestTemplate
+    @ExtendWith(PactVerificationInvocationContextProvider::class)
+    fun verifyPacts(context: PactVerificationContext?) {
+        context?.verifyInteraction()
+    }
+
+    /**
+     * Seeded once and guarded by a `findById`: `PartyRepositoryImpl.save` calls `persist`, not
+     * `merge`, and the id is application-assigned — so a second call for the same party would fail
+     * on the primary key rather than upsert. The guard keeps this handler safe if a second
+     * interaction against pid-service is ever added to the pact.
+     */
+    @State("an ACTIVE party with FULL KYC exists")
+    fun stateActiveFullKycParty() = runOnVertxContext {
+        if (partyRepository.findById(PARTY_ID) != null) return@runOnVertxContext
+        partyRepository.save(
+            Party(
+                id = PARTY_ID,
+                partyType = PartyType.NATURAL_PERSON,
+                status = PartyStatus.ACTIVE,
+                externalIds = emptyList(),
+                coreAttributes = CoreAttributes(
+                    givenName = "Pact",
+                    familyName = "Verifier",
+                    birthdate = LocalDate.of(1990, 1, 1),
+                    birthNumberEncrypted = null,
+                    gender = null,
+                    birthplace = null,
+                    nationalities = listOf("CZ"),
+                    idDocuments = emptyList(),
+                    verificationSource = VerificationSource.BANKID,
+                    verifiedAt = SEEDED_AT,
+                ),
+                addressAttributes = null,
+                contactAttributes = ContactAttributes(null, null, null, null),
+                kycAttributes = KycAttributes(
+                    kycLevel = KycLevel.FULL,
+                    kycCompletedAt = SEEDED_AT,
+                    kycExpiresAt = null,
+                    amlRiskScore = AmlRiskScore.LOW,
+                    pepFlag = false,
+                    sanctionsFlag = false,
+                    uboVerifiedAt = null,
+                    lastAmlReviewAt = null,
+                ),
+                relationships = emptyList(),
+                caseLifecycle = null,
+                createdAt = SEEDED_AT,
+                updatedAt = SEEDED_AT,
+                version = 0,
+            ),
+        )
+        Unit
+    }
+}

--- a/openbank-sca-service/src/test/kotlin/com/openbank/sca/contract/ScaPactFolderProviderVerificationTest.kt
+++ b/openbank-sca-service/src/test/kotlin/com/openbank/sca/contract/ScaPactFolderProviderVerificationTest.kt
@@ -86,6 +86,8 @@ class ScaPactFolderProviderVerificationTest {
     companion object {
         private val CHALLENGE_ID = UUID.fromString("99999999-9999-9999-9999-999999999999")
         private val PARTY_ID = UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+        private val DELEGATION_CHALLENGE_ID = UUID.fromString("d1e2f3a4-b5c6-4d7e-8f90-1a2b3c4d5e6f")
+        private val DELEGATION_PARTY_ID = UUID.fromString("bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb")
     }
 
     @ConfigProperty(name = "quarkus.http.test-port", defaultValue = "8081")
@@ -146,6 +148,37 @@ class ScaPactFolderProviderVerificationTest {
                 method = ScaMethod.PUSH_NOTIFICATION,
                 status = ScaStatus.PENDING,
                 expiresAt = OffsetDateTime.now().plusMinutes(5),
+                createdAt = OffsetDateTime.now(),
+            ),
+        )
+        Unit
+    }
+
+    /**
+     * The ADR-0232 D4 delegation ceremony's grantor half (issue #2991). Distinct from the consent
+     * challenge above in every field the consumer gates on: purpose `DELEGATION_GRANT` (so a
+     * consent or payment challenge can never be spent to mint a grant) and status `COMPLETED`
+     * (delegation-service refuses anything else), with `consumedAt` null so the pact's second
+     * interaction — the compare-and-consume that makes the ceremony single-use — has something
+     * left to spend. `save` is a `merge`, so re-running this handler per interaction resets
+     * `consumedAt` and the two interactions do not have to care which order they run in.
+     *
+     * `dynamicLinkingData` is deliberately null: a delegation challenge links to no operation, and
+     * `ScaService.consume` authorises an unlinked challenge exactly when the consume states none —
+     * which is why the consumer's request body carries only `partyId`.
+     */
+    @State("a COMPLETED DELEGATION_GRANT SCA challenge exists")
+    fun stateCompletedDelegationGrantChallengeExists() = runOnVertxContext {
+        challengeRepo.save(
+            ScaChallenge(
+                id = DELEGATION_CHALLENGE_ID,
+                partyId = DELEGATION_PARTY_ID,
+                purpose = ScaPurpose.DELEGATION_GRANT,
+                method = ScaMethod.PUSH_NOTIFICATION,
+                status = ScaStatus.COMPLETED,
+                expiresAt = OffsetDateTime.now().plusMinutes(5),
+                completedAt = OffsetDateTime.now(),
+                consumedAt = null,
                 createdAt = OffsetDateTime.now(),
             ),
         )

--- a/openbank-sca-service/src/test/kotlin/com/openbank/sca/contract/ScaPactProviderVerificationTest.kt
+++ b/openbank-sca-service/src/test/kotlin/com/openbank/sca/contract/ScaPactProviderVerificationTest.kt
@@ -56,6 +56,8 @@ class ScaPactProviderVerificationTest {
     companion object {
         private val CHALLENGE_ID = UUID.fromString("99999999-9999-9999-9999-999999999999")
         private val PARTY_ID = UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+        private val DELEGATION_CHALLENGE_ID = UUID.fromString("d1e2f3a4-b5c6-4d7e-8f90-1a2b3c4d5e6f")
+        private val DELEGATION_PARTY_ID = UUID.fromString("bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb")
     }
 
     @ConfigProperty(name = "quarkus.http.test-port", defaultValue = "8081")
@@ -116,6 +118,37 @@ class ScaPactProviderVerificationTest {
                 method = ScaMethod.PUSH_NOTIFICATION,
                 status = ScaStatus.PENDING,
                 expiresAt = OffsetDateTime.now().plusMinutes(5),
+                createdAt = OffsetDateTime.now(),
+            ),
+        )
+        Unit
+    }
+
+    /**
+     * The ADR-0232 D4 delegation ceremony's grantor half (issue #2991). Distinct from the consent
+     * challenge above in every field the consumer gates on: purpose `DELEGATION_GRANT` (so a
+     * consent or payment challenge can never be spent to mint a grant) and status `COMPLETED`
+     * (delegation-service refuses anything else), with `consumedAt` null so the pact's second
+     * interaction — the compare-and-consume that makes the ceremony single-use — has something
+     * left to spend. `save` is a `merge`, so re-running this handler per interaction resets
+     * `consumedAt` and the two interactions do not have to care which order they run in.
+     *
+     * `dynamicLinkingData` is deliberately null: a delegation challenge links to no operation, and
+     * `ScaService.consume` authorises an unlinked challenge exactly when the consume states none —
+     * which is why the consumer's request body carries only `partyId`.
+     */
+    @State("a COMPLETED DELEGATION_GRANT SCA challenge exists")
+    fun stateCompletedDelegationGrantChallengeExists() = runOnVertxContext {
+        challengeRepo.save(
+            ScaChallenge(
+                id = DELEGATION_CHALLENGE_ID,
+                partyId = DELEGATION_PARTY_ID,
+                purpose = ScaPurpose.DELEGATION_GRANT,
+                method = ScaMethod.PUSH_NOTIFICATION,
+                status = ScaStatus.COMPLETED,
+                expiresAt = OffsetDateTime.now().plusMinutes(5),
+                completedAt = OffsetDateTime.now(),
+                consumedAt = null,
                 createdAt = OffsetDateTime.now(),
             ),
         )

--- a/pacts/openbank-account-service-openbank-delegation-service.json
+++ b/pacts/openbank-account-service-openbank-delegation-service.json
@@ -18,7 +18,7 @@
         },
         "resourceId": "e2490de5-5bd3-43d5-b7c4-526e33f71304",
         "resourceType": "ACCOUNT",
-        "validFrom": "2000-01-31T14:00:00+01:00"
+        "validFrom": "2026-01-01T00:00:00Z"
       },
       "description": "a DelegationActivated event for an account",
       "generators": {
@@ -34,10 +34,6 @@
           },
           "$.resourceId": {
             "type": "Uuid"
-          },
-          "$.validFrom": {
-            "format": "yyyy-MM-dd'T'HH:mm:ssXXX",
-            "type": "DateTime"
           }
         }
       },

--- a/pacts/openbank-account-service-openbank-delegation-service.json
+++ b/pacts/openbank-account-service-openbank-delegation-service.json
@@ -1,0 +1,224 @@
+{
+  "consumer": {
+    "name": "openbank-account-service"
+  },
+  "messages": [
+    {
+      "contents": {
+        "aggregateId": "e2490de5-5bd3-43d5-b7c4-526e33f71304",
+        "capabilities": [
+          "ACCOUNT_READ_BALANCES"
+        ],
+        "eventType": "DelegationActivated",
+        "granteePartyId": "e2490de5-5bd3-43d5-b7c4-526e33f71304",
+        "grantorPartyId": "e2490de5-5bd3-43d5-b7c4-526e33f71304",
+        "perTransactionLimit": {
+          "amount": 1500.0,
+          "currency": "CZK"
+        },
+        "resourceId": "e2490de5-5bd3-43d5-b7c4-526e33f71304",
+        "resourceType": "ACCOUNT",
+        "validFrom": "2000-01-31T14:00:00+01:00"
+      },
+      "description": "a DelegationActivated event for an account",
+      "generators": {
+        "body": {
+          "$.aggregateId": {
+            "type": "Uuid"
+          },
+          "$.granteePartyId": {
+            "type": "Uuid"
+          },
+          "$.grantorPartyId": {
+            "type": "Uuid"
+          },
+          "$.resourceId": {
+            "type": "Uuid"
+          },
+          "$.validFrom": {
+            "format": "yyyy-MM-dd'T'HH:mm:ssXXX",
+            "type": "DateTime"
+          }
+        }
+      },
+      "matchingRules": {
+        "body": {
+          "$.aggregateId": {
+            "combine": "AND",
+            "matchers": [
+              {
+                "match": "regex",
+                "regex": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+              }
+            ]
+          },
+          "$.capabilities[0]": {
+            "combine": "AND",
+            "matchers": [
+              {
+                "match": "type"
+              }
+            ]
+          },
+          "$.granteePartyId": {
+            "combine": "AND",
+            "matchers": [
+              {
+                "match": "regex",
+                "regex": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+              }
+            ]
+          },
+          "$.grantorPartyId": {
+            "combine": "AND",
+            "matchers": [
+              {
+                "match": "regex",
+                "regex": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+              }
+            ]
+          },
+          "$.perTransactionLimit.amount": {
+            "combine": "AND",
+            "matchers": [
+              {
+                "match": "decimal"
+              }
+            ]
+          },
+          "$.perTransactionLimit.currency": {
+            "combine": "AND",
+            "matchers": [
+              {
+                "match": "type"
+              }
+            ]
+          },
+          "$.resourceId": {
+            "combine": "AND",
+            "matchers": [
+              {
+                "match": "regex",
+                "regex": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+              }
+            ]
+          },
+          "$.validFrom": {
+            "combine": "AND",
+            "matchers": [
+              {
+                "format": "yyyy-MM-dd'T'HH:mm:ssXXX",
+                "match": "timestamp"
+              }
+            ]
+          }
+        }
+      },
+      "metaData": {
+        "contentType": "application/json"
+      },
+      "providerStates": [
+        {
+          "name": "an ACCOUNT-scoped delegation grant has been activated"
+        }
+      ]
+    },
+    {
+      "contents": {
+        "aggregateId": "e2490de5-5bd3-43d5-b7c4-526e33f71304",
+        "capabilities": [
+          "ACCOUNT_READ_BALANCES"
+        ],
+        "eventType": "DelegationRevoked",
+        "granteePartyId": "e2490de5-5bd3-43d5-b7c4-526e33f71304",
+        "grantorPartyId": "e2490de5-5bd3-43d5-b7c4-526e33f71304",
+        "resourceId": "e2490de5-5bd3-43d5-b7c4-526e33f71304",
+        "resourceType": "ACCOUNT"
+      },
+      "description": "a DelegationRevoked event for an account",
+      "generators": {
+        "body": {
+          "$.aggregateId": {
+            "type": "Uuid"
+          },
+          "$.granteePartyId": {
+            "type": "Uuid"
+          },
+          "$.grantorPartyId": {
+            "type": "Uuid"
+          },
+          "$.resourceId": {
+            "type": "Uuid"
+          }
+        }
+      },
+      "matchingRules": {
+        "body": {
+          "$.aggregateId": {
+            "combine": "AND",
+            "matchers": [
+              {
+                "match": "regex",
+                "regex": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+              }
+            ]
+          },
+          "$.capabilities[0]": {
+            "combine": "AND",
+            "matchers": [
+              {
+                "match": "type"
+              }
+            ]
+          },
+          "$.granteePartyId": {
+            "combine": "AND",
+            "matchers": [
+              {
+                "match": "regex",
+                "regex": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+              }
+            ]
+          },
+          "$.grantorPartyId": {
+            "combine": "AND",
+            "matchers": [
+              {
+                "match": "regex",
+                "regex": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+              }
+            ]
+          },
+          "$.resourceId": {
+            "combine": "AND",
+            "matchers": [
+              {
+                "match": "regex",
+                "regex": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+              }
+            ]
+          }
+        }
+      },
+      "metaData": {
+        "contentType": "application/json"
+      },
+      "providerStates": [
+        {
+          "name": "an ACCOUNT-scoped delegation grant has been revoked"
+        }
+      ]
+    }
+  ],
+  "metadata": {
+    "pact-jvm": {
+      "version": "4.7.3"
+    },
+    "pactSpecification": {
+      "version": "3.0.0"
+    }
+  },
+  "provider": {
+    "name": "openbank-delegation-service"
+  }
+}

--- a/pacts/openbank-card-issuance-service-openbank-delegation-service.json
+++ b/pacts/openbank-card-issuance-service-openbank-delegation-service.json
@@ -14,7 +14,7 @@
         "grantorPartyId": "e2490de5-5bd3-43d5-b7c4-526e33f71304",
         "resourceId": "e2490de5-5bd3-43d5-b7c4-526e33f71304",
         "resourceType": "CARD",
-        "validFrom": "2000-01-31T14:00:00+01:00"
+        "validFrom": "2026-01-01T00:00:00Z"
       },
       "description": "a DelegationActivated event for a card",
       "generators": {
@@ -30,10 +30,6 @@
           },
           "$.resourceId": {
             "type": "Uuid"
-          },
-          "$.validFrom": {
-            "format": "yyyy-MM-dd'T'HH:mm:ssXXX",
-            "type": "DateTime"
           }
         }
       },

--- a/pacts/openbank-card-issuance-service-openbank-delegation-service.json
+++ b/pacts/openbank-card-issuance-service-openbank-delegation-service.json
@@ -1,0 +1,204 @@
+{
+  "consumer": {
+    "name": "openbank-card-issuance-service"
+  },
+  "messages": [
+    {
+      "contents": {
+        "aggregateId": "e2490de5-5bd3-43d5-b7c4-526e33f71304",
+        "capabilities": [
+          "CARD_VIEW"
+        ],
+        "eventType": "DelegationActivated",
+        "granteePartyId": "e2490de5-5bd3-43d5-b7c4-526e33f71304",
+        "grantorPartyId": "e2490de5-5bd3-43d5-b7c4-526e33f71304",
+        "resourceId": "e2490de5-5bd3-43d5-b7c4-526e33f71304",
+        "resourceType": "CARD",
+        "validFrom": "2000-01-31T14:00:00+01:00"
+      },
+      "description": "a DelegationActivated event for a card",
+      "generators": {
+        "body": {
+          "$.aggregateId": {
+            "type": "Uuid"
+          },
+          "$.granteePartyId": {
+            "type": "Uuid"
+          },
+          "$.grantorPartyId": {
+            "type": "Uuid"
+          },
+          "$.resourceId": {
+            "type": "Uuid"
+          },
+          "$.validFrom": {
+            "format": "yyyy-MM-dd'T'HH:mm:ssXXX",
+            "type": "DateTime"
+          }
+        }
+      },
+      "matchingRules": {
+        "body": {
+          "$.aggregateId": {
+            "combine": "AND",
+            "matchers": [
+              {
+                "match": "regex",
+                "regex": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+              }
+            ]
+          },
+          "$.capabilities[0]": {
+            "combine": "AND",
+            "matchers": [
+              {
+                "match": "type"
+              }
+            ]
+          },
+          "$.granteePartyId": {
+            "combine": "AND",
+            "matchers": [
+              {
+                "match": "regex",
+                "regex": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+              }
+            ]
+          },
+          "$.grantorPartyId": {
+            "combine": "AND",
+            "matchers": [
+              {
+                "match": "regex",
+                "regex": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+              }
+            ]
+          },
+          "$.resourceId": {
+            "combine": "AND",
+            "matchers": [
+              {
+                "match": "regex",
+                "regex": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+              }
+            ]
+          },
+          "$.validFrom": {
+            "combine": "AND",
+            "matchers": [
+              {
+                "format": "yyyy-MM-dd'T'HH:mm:ssXXX",
+                "match": "timestamp"
+              }
+            ]
+          }
+        }
+      },
+      "metaData": {
+        "contentType": "application/json"
+      },
+      "providerStates": [
+        {
+          "name": "a CARD-scoped delegation grant has been activated"
+        }
+      ]
+    },
+    {
+      "contents": {
+        "aggregateId": "e2490de5-5bd3-43d5-b7c4-526e33f71304",
+        "capabilities": [
+          "CARD_VIEW"
+        ],
+        "eventType": "DelegationRevoked",
+        "granteePartyId": "e2490de5-5bd3-43d5-b7c4-526e33f71304",
+        "grantorPartyId": "e2490de5-5bd3-43d5-b7c4-526e33f71304",
+        "resourceId": "e2490de5-5bd3-43d5-b7c4-526e33f71304",
+        "resourceType": "CARD"
+      },
+      "description": "a DelegationRevoked event for a card",
+      "generators": {
+        "body": {
+          "$.aggregateId": {
+            "type": "Uuid"
+          },
+          "$.granteePartyId": {
+            "type": "Uuid"
+          },
+          "$.grantorPartyId": {
+            "type": "Uuid"
+          },
+          "$.resourceId": {
+            "type": "Uuid"
+          }
+        }
+      },
+      "matchingRules": {
+        "body": {
+          "$.aggregateId": {
+            "combine": "AND",
+            "matchers": [
+              {
+                "match": "regex",
+                "regex": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+              }
+            ]
+          },
+          "$.capabilities[0]": {
+            "combine": "AND",
+            "matchers": [
+              {
+                "match": "type"
+              }
+            ]
+          },
+          "$.granteePartyId": {
+            "combine": "AND",
+            "matchers": [
+              {
+                "match": "regex",
+                "regex": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+              }
+            ]
+          },
+          "$.grantorPartyId": {
+            "combine": "AND",
+            "matchers": [
+              {
+                "match": "regex",
+                "regex": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+              }
+            ]
+          },
+          "$.resourceId": {
+            "combine": "AND",
+            "matchers": [
+              {
+                "match": "regex",
+                "regex": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+              }
+            ]
+          }
+        }
+      },
+      "metaData": {
+        "contentType": "application/json"
+      },
+      "providerStates": [
+        {
+          "name": "a CARD-scoped delegation grant has been revoked"
+        }
+      ]
+    }
+  ],
+  "metadata": {
+    "pact-jvm": {
+      "version": "4.7.3"
+    },
+    "pactSpecification": {
+      "version": "3.0.0"
+    }
+  },
+  "provider": {
+    "name": "openbank-delegation-service"
+  }
+}

--- a/pacts/openbank-delegation-service-openbank-account-service.json
+++ b/pacts/openbank-delegation-service-openbank-account-service.json
@@ -1,0 +1,40 @@
+{
+  "consumer": {
+    "name": "openbank-delegation-service"
+  },
+  "interactions": [
+    {
+      "description": "GET the account whose ownership is being verified",
+      "providerStates": [
+        {
+          "name": "an account owned by a known party exists"
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "path": "/api/v1/accounts/11111111-2222-4333-8444-555555555555"
+      },
+      "response": {
+        "body": {
+          "id": "11111111-2222-4333-8444-555555555555",
+          "partyId": "66666666-7777-4888-8999-aaaaaaaaaaaa"
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "status": 200
+      }
+    }
+  ],
+  "metadata": {
+    "pact-jvm": {
+      "version": "4.7.3"
+    },
+    "pactSpecification": {
+      "version": "3.0.0"
+    }
+  },
+  "provider": {
+    "name": "openbank-account-service"
+  }
+}

--- a/pacts/openbank-delegation-service-openbank-card-issuance-service.json
+++ b/pacts/openbank-delegation-service-openbank-card-issuance-service.json
@@ -1,0 +1,40 @@
+{
+  "consumer": {
+    "name": "openbank-delegation-service"
+  },
+  "interactions": [
+    {
+      "description": "GET the card whose ownership is being verified",
+      "providerStates": [
+        {
+          "name": "a card held by a known party exists"
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "path": "/api/v1/cards/0a0a0a0a-1b1b-4c2c-8d3d-4e4e4e4e4e4e"
+      },
+      "response": {
+        "body": {
+          "id": "0a0a0a0a-1b1b-4c2c-8d3d-4e4e4e4e4e4e",
+          "partyId": "5f5f5f5f-6a6a-4b7b-8c8c-9d9d9d9d9d9d"
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "status": 200
+      }
+    }
+  ],
+  "metadata": {
+    "pact-jvm": {
+      "version": "4.7.3"
+    },
+    "pactSpecification": {
+      "version": "3.0.0"
+    }
+  },
+  "provider": {
+    "name": "openbank-card-issuance-service"
+  }
+}

--- a/pacts/openbank-delegation-service-openbank-pid-service.json
+++ b/pacts/openbank-delegation-service-openbank-pid-service.json
@@ -1,0 +1,43 @@
+{
+  "consumer": {
+    "name": "openbank-delegation-service"
+  },
+  "interactions": [
+    {
+      "description": "GET the party whose delegation eligibility is being checked",
+      "providerStates": [
+        {
+          "name": "an ACTIVE party with FULL KYC exists"
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "path": "/api/v1/parties/cccccccc-cccc-4ccc-8ccc-cccccccccccc"
+      },
+      "response": {
+        "body": {
+          "id": "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+          "kycAttributes": {
+            "kycLevel": "FULL"
+          },
+          "status": "ACTIVE"
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "status": 200
+      }
+    }
+  ],
+  "metadata": {
+    "pact-jvm": {
+      "version": "4.7.3"
+    },
+    "pactSpecification": {
+      "version": "3.0.0"
+    }
+  },
+  "provider": {
+    "name": "openbank-pid-service"
+  }
+}

--- a/pacts/openbank-delegation-service-openbank-sca-service.json
+++ b/pacts/openbank-delegation-service-openbank-sca-service.json
@@ -1,0 +1,72 @@
+{
+  "consumer": {
+    "name": "openbank-delegation-service"
+  },
+  "interactions": [
+    {
+      "description": "GET the delegation SCA challenge by id",
+      "providerStates": [
+        {
+          "name": "a COMPLETED DELEGATION_GRANT SCA challenge exists"
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "path": "/api/v1/sca/challenges/d1e2f3a4-b5c6-4d7e-8f90-1a2b3c4d5e6f"
+      },
+      "response": {
+        "body": {
+          "id": "d1e2f3a4-b5c6-4d7e-8f90-1a2b3c4d5e6f",
+          "partyId": "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+          "purpose": "DELEGATION_GRANT",
+          "status": "COMPLETED"
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "status": 200
+      }
+    },
+    {
+      "description": "POST consume the delegation SCA challenge",
+      "providerStates": [
+        {
+          "name": "a COMPLETED DELEGATION_GRANT SCA challenge exists"
+        }
+      ],
+      "request": {
+        "body": {
+          "partyId": "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "method": "POST",
+        "path": "/api/v1/sca/challenges/d1e2f3a4-b5c6-4d7e-8f90-1a2b3c4d5e6f/consume"
+      },
+      "response": {
+        "body": {
+          "id": "d1e2f3a4-b5c6-4d7e-8f90-1a2b3c4d5e6f",
+          "partyId": "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+          "purpose": "DELEGATION_GRANT",
+          "status": "COMPLETED"
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "status": 200
+      }
+    }
+  ],
+  "metadata": {
+    "pact-jvm": {
+      "version": "4.7.3"
+    },
+    "pactSpecification": {
+      "version": "3.0.0"
+    }
+  },
+  "provider": {
+    "name": "openbank-sca-service"
+  }
+}


### PR DESCRIPTION
## What

`openbank-delegation-service` had **zero pacts**. Every deploy passed the contract gate by having
nothing to check — and it is the service that mints payment rights across party boundaries
(ADR-0232). This adds contract coverage in both directions and wires a provider replay for every
pact it introduces.

Closes #2991.

### Consumer side — the calls delegation-service makes before it will mint a grant

| Provider | Interaction | Pinned |
|---|---|---|
| `openbank-sca-service` | `GET /api/v1/sca/challenges/{id}` | `purpose="DELEGATION_GRANT"`, `status="COMPLETED"` as **values** |
| `openbank-sca-service` | `POST /api/v1/sca/challenges/{id}/consume` | body is `{partyId}` only — the unlinked-consume shape |
| `openbank-pid-service` | `GET /api/v1/parties/{id}` | `status="ACTIVE"` + the **nested** `kycAttributes.kycLevel="FULL"` |
| `openbank-account-service` | `GET /api/v1/accounts/{id}` | `partyId` — the whole ownership verdict |
| `openbank-card-issuance-service` | `GET /api/v1/cards/{id}` | `partyId` |

Values, not `stringType`, wherever the consumer branches on the exact string (#2425).
`DelegationService` gates on `purpose == "DELEGATION_GRANT"` precisely so a payment challenge — or
the grantee's `DELEGATION_ACCEPT` half — can never be spent to mint a grant; a type matcher would
have asked the replay nothing about that. Same reasoning for pid's `kycLevel`: `KYC_RANK`'s keys are
exactly pid's `KycLevel` names, and the client reads that nested field with an elvis to `"NONE"`, so
a moved field is not a crash — it is every offer silently refused.

### Message side — the `openbank.delegation.events` payload

`account-service` and `card-issuance` each pact the two events they project (`DelegationActivated`
creates an enforceable row, `DelegationRevoked` closes one), and `delegation-service` replays them
against the **real** `DelegationEvents` data classes.

The replay is the load-bearing half here. Both consumers parse with `readTree` + `node.path(...)`,
so every field is optional at the type level: rename `capabilities` and the projection records a
grant authorising nothing; rename `resourceType` and the filter drops the event and the projection
goes permanently empty. None of that is visible from the consumer side — the pact mock hands the
consumer whatever the pact says.

### Provider replays — all `@PactFolder`, all running on the PR

- **new** `PidPactFolderProviderVerificationTest` — pid-service had no pact tests at all
- **new** `CardIssuancePactFolderProviderVerificationTest` — nor did card-issuance; its
  `build.gradle.kts` said outright that nothing pacts against it, which ADR-0232 made untrue
- **new** `DelegationEventPactFolderProviderVerificationTest` — message target, plain JVM
- `ScaPactFolderProviderVerificationTest` + broker twin gain a `COMPLETED`/`DELEGATION_GRANT` state
- `AccountPactFolderProviderVerificationTest` + broker twin gain **per-interaction HTTP/message
  dispatch** and now boot Quarkus. The old KDoc predicted exactly this; splitting into a second
  `@PactFolder` class was not an option, since both would load every pact naming the provider.

`check-pact-provider-replay.py`: **40 committed pacts, 40 replayed on a PR, `KNOWN_UNCOVERED` still
empty.** `derive-pact-drift-scope.sh` picks up `:openbank-delegation-service` on its own — no orphan
pact, no ungated pact, no hand-edited scope.

## Falsification — these tests have been shown to fail

A test that has only ever passed is unfalsified. Two mutations, both run locally, verdicts read from
the JUnit XML (pact-jvm's console "Not all of the N were verified" is noise).

**1. Consumer — a mispointed client, the #2269 defect class.** Changed ONE line of *production*
code, `ScaChallengeClient.kt:33`, `@Path("/api/v1/sca/challenges")` → `@Path("/api/v1/sca/challenge")`.
The pact expectations were not touched. Both interactions went red:

```
DelegationScaChallengePactConsumerTest > the challenge lookup returns the party, purpose and status the ceremony gates on FAILED
DelegationScaChallengePactConsumerTest > spending the challenge is a POST to consume that states only the party FAILED
  java.lang.AssertionError: 1 expectation failed. Expected status code <200> but was <500>.
```

This is the asymmetry working: the outgoing request is reflected off the client's `@Path` via
`ClientRoute`, the expectation is a literal. Derive both and the test cannot fail — measured on
#2290, and `finrep-service`'s call to the never-existent `/api/v1/ledger/trial-balance` is what it
costs.

**2. Provider replay — a drifted event field.** Changed `produceAccountActivated`'s
`resourceType` from `ACCOUNT` to `CARD`:

```
TEST-...DelegationEventPactFolderProviderVerificationTest.xml tests 4 failures 1 errors 0
  openbank-account-service - a DelegationActivated event for an account:
    1.1) body: $.resourceType Expected 'CARD' (String) to be equal to 'ACCOUNT' (String)
```

Both mutations reverted; the tree is clean and the suite is back to `TOTAL 9 failures 0`
(delegation-service `*contract*`), with every provider replay green:

| Replay | interactions | result |
|---|---|---|
| `ScaPactFolderProviderVerificationTest` | 3 (2 new + the existing consent one) | 0 failures |
| `PidPactFolderProviderVerificationTest` | 1 | 0 failures |
| `AccountPactFolderProviderVerificationTest` | 3 (1 new HTTP + 2 existing messages) | 0 failures |
| `CardIssuancePactFolderProviderVerificationTest` | 1 | 0 failures |
| `DelegationEventPactFolderProviderVerificationTest` | 4 | 0 failures |

`detekt` + `ktlintCheck` green on all five touched modules.

## What this does NOT cover

Read this before concluding that delegation-service is contract-tested.

1. **Only the GRANT half of the SCA ceremony.** `DELEGATION_ACCEPT` — the grantee's challenge — has
   no pact. Purpose equality exists precisely so a grantor's challenge cannot be spent as the
   grantee's acceptance, and that property is asserted in one direction only.
2. **Every interaction is a 200. There are no negative paths.** A 404 from account-service or
   card-issuance is a *definitive* NOT_OWNED verdict, and sca's 409 is the replay protection the
   consume exists for. Neither is pacted. The branch that distinguishes "someone is trying
   something" from "the provider is down" is exactly the one with no contract.
3. **`PAYMENT` / `STATEMENT` / `DOCUMENT` resource types** return UNVERIFIABLE with no lookup — there
   is nothing to pact, and equally nothing that would notice if one of them quietly gained a wrong route.
4. **Nothing here is about authorization.** Every provider replay runs under `@TestSecurity` with the
   roles handed to it. A pact proves the route and the shape; it says nothing about whether
   delegation-service's real M2M token gets through (ADR-0034). If the OPA rule denies, all five
   calls 403 and every pact in this PR stays green.
5. **The message contract does not prove delivery.** It pins the JSON `DelegationEvents` serializes
   and the two consumers parse. It does not prove the outbox dispatches, the topic names line up,
   the consumer is wired to `delegation-events-in`, or that the Kafka `group.id` reaches the
   connector at all (the dotted-key trap). Green pact + broken channel config is precisely the shape
   of a silently-empty projection.
6. **`validTo` is not asserted.** The example carries `validTo = null`, so the grant-expiry field the
   projections read has no format pinned — only `validFrom` does.
7. **`capabilities` is a `stringType` array.** The replay checks a non-empty array of strings; it does
   NOT check the vocabulary against `DelegationCapability`. A renamed capability would be projected
   as an unknown string the guard never matches — fail-closed, silent, uncaught.
8. **delegation-service has no `@PactBroker` twin** (it is a message provider only, and is not in
   the broker's consumer graph yet), so `can-i-deploy` will see no published verification result
   *for delegation-service as a provider*. If account-service or card-issuance ever publish those
   message pacts to the broker, that is the #3239 shape and a twin is needed then. Documented in the
   class KDoc rather than pre-emptively added. **Note this is now the only remaining half of that
   gap** — see the correction below.
9. **The clearest weakness in this PR: four broker-sourced classes cannot run on the PR lane.**
   `AccountEventPactProviderVerificationTest` is now a `@QuarkusTest` with HTTP dispatch,
   `ScaPactProviderVerificationTest` gained the new state, and
   `PidPactBrokerProviderVerificationTest` / `CardIssuancePactBrokerProviderVerificationTest` are
   new — all four are `@EnabledIfSystemProperty(pactbroker.url)`-gated, so none has ever executed
   against a broker. What is verified is below; first main-push is where they are actually tried.
10. **Nobody pacts delegation-service's own REST API.** The customer edge calls it and is not a pact
    consumer of it, so `openbank-delegation-service/openapi.yaml` remains backed by no contract.
11. **SAVINGS_GOAL is covered by prose, not by an interaction.** It resolves through the same account
    lookup by convention (ADR-0153); nothing tests that the convention still holds.

---

## Correction after review — broker twins for pid-service and card-issuance (`b75e04ae5`)

The review caught something my own gap list understated. I flagged the missing broker twin on the
**delegation** side; the costly half is on the **provider** side, and it would have landed on
delegation-service's deploys, not on anything abstract.

`pid-service` and `card-issuance-service` each had exactly one `@Provider` class, both
`@PactFolder`-sourced. A `@PactFolder` class replays from disk and never contacts the broker, and
`can-i-deploy` reads the broker and nothing else. Merging the consumer pacts as they stood would
have meant delegation-service publishes pacts naming two providers that never publish a
verification — so `can-i-deploy` answers *"no verified pact between openbank-delegation-service and
the version of openbank-pid-service currently in sandbox"* and blocks every deploy, labelled
`PENDING_BUILD`: a name that reads transient for a state that is permanent. That is the #3239 shape
that took fx-service out across four attempts on 2026-08-02, and delegation-service had only just
reached sandbox.

Added the sanctioned pair for both — `@PactBroker` + `@EnabledIfSystemProperty(pactbroker.url)`,
matching aml/sanctions (#3239) and openbank-ledger-service. `sca-service` and `account-service`
already had broker-sourced classes and were left alone.

**States mirrored** (every one, per the `MissingStateChangeMethod` caution — a state the broker
replay cannot satisfy publishes a FAILURE, which is worse than publishing nothing):

| Provider | State mirrored into the twin |
|---|---|
| `openbank-pid-service` | `an ACTIVE party with FULL KYC exists` — full party seed + the `findById` guard (`persist`, not `merge`, on an application-assigned id) |
| `openbank-card-issuance-service` | `a card held by a known party exists` — full `CardEntity` seed + the same guard |

Parity is asserted mechanically, **against the annotation on the class declaration, not a
whole-file grep** — the review's own first probe reported "broker-sourced: yes" for both services
because `git grep '@PactBroker'` matched the KDoc paragraph explaining why the class was *not*
broker-sourced. The checker strips comments, reads the annotation block on the `class` line, and
asserts set equality of `@State` values in both directions. Validated against a known-positive:
renaming one state in the pid twin makes it print `FAIL STATE PARITY` and `FAIL no extra orphan
state`; restored, it exits 0.

**Both `build.gradle.kts` gained the `pactbroker.*` forwarding** to the forked test JVM —
`pid-service` had no `tasks.withType<Test>` block at all. Without it `pactbroker.url` never reaches
the test JVM, the twin stays `@EnabledIfSystemProperty`-skipped on *every* lane including main-push,
and a twin that cannot see the broker is indistinguishable from not having one.

**KDoc on both `@PactFolder` classes updated.** They previously argued why *they* are not
broker-sourced; unamended, that text reads as an argument against the class just added. Both now
say they are one half of a deliberate pair, and that any new `@State` must be added to the twin in
the same commit.

### What is verified about the new classes, and what is not

Verified:
- both modules compile (`compileTestKotlin` green);
- both classes are **discovered** by JUnit and skipped by the gate — `tests=1 skipped=1 failures=0`
  in the emitted JUnit XML. The `--tests` filter also reports `No tests found`, because it selected
  only a fully-skipped container; the **pre-existing, merged `AmlPactBrokerProviderVerificationTest`
  behaves identically under the same probe**, so that is established fleet behaviour, not something
  introduced here. The probe was falsified first: a nonsense filter fails the build;
- the `@PactFolder` replays still pass with a second `@Provider` class present in the module —
  pid 1/1 and card-issuance 1/1, no collision;
- `detekt` + `ktlintCheck` green on both modules;
- `check-pact-provider-replay.py`: **40 pacts, 40 replayed, `KNOWN_UNCOVERED` empty**, with both
  modules now showing the sanctioned `SKIP` (broker) + `RUNS` (folder) pair;
- no pact file changed, so the drift gate is unaffected.

Not verified, stated plainly: **neither twin has ever executed against a broker.** They cannot on
the PR lane — `_service-ci.yml` blanks `PACT_BROKER_URL` (ADR-0056). Their `@State` bodies are
copies of code that *is* exercised by the `@PactFolder` twins, which is the strongest evidence
available pre-merge, but the broker fetch, the state dispatch across multiple consumers' pacts, and
the result publish are all first exercised on main-push. That run is the one to watch.

One incidental finding worth recording: running two Quarkus provider replays in a single Gradle
invocation fails with `Port already bound: 8081` — both bind the default `quarkus.http.test-port`.
That is a probe artifact, not a defect; each passes when run alone, and CI runs services in separate
jobs. I nearly mis-filed it as a regression from this change.

---

## Correction 2 — `validFrom` pact drift (`a481dfa86`)

`pact-drift-check` was red on every run: the committed message pacts carried
`"2000-01-31T14:00:00+01:00"`, CI regenerated `"2000-01-31T13:00:00Z"`. Same instant, different
string, because the artifact encoded the generating machine's timezone.

The cause is narrower than the rendering, and worth stating precisely because the obvious fix is the
wrong one. **The timestamp matcher was already present and already correct** — `$.validFrom` has
always been `{"match": "timestamp", "format": ...}`, so the contract has never asserted the literal
instant. What wrote the machine-dependent value was the *generator* that `datetime(name, format)`
registers when given no example:

```json
"generators": { "body": { "$.validFrom": { "type": "DateTime", "format": "yyyy-MM-dd'T'HH:mm:ssXXX" } } }
```

Fixed with `datetime(name, format, Date, TimeZone)` — the only overload that pins the rendering; the
`Instant` overload still formats with `TimeZone.getDefault()`. Matcher retained, generator gone,
example now the instant the provider replay actually emits (`2026-01-01T00:00:00Z`) instead of a
pact-jvm default from the year 2000. This is not a return to a pinned value: the matcher still
governs verification.

The KDoc now makes the distinction explicit, so the next reader does not "simplify" it in either
direction: `validFrom` is a matcher **because** no consumer branches on the instant;
`eventType`/`resourceType` are `stringValue` **because** `dispatch` compares them to exact literals.

**Verified:** all six pacts regenerated under `TZ=UTC`, `Europe/Prague`, `Asia/Kolkata` (+05:30) and
`Pacific/Chatham` (+12:45) — byte-identical by sha256 every time. The sweep was falsified first:
restoring the 2-arg call makes it flag the card pact and reproduces the exact CI value. CI's own
assertion — regenerate under UTC, `git diff --exit-code -- pacts/` — exits 0.

**No other environment-dependent values.** Checked statically (every string in all six pacts scanned
for TZ offsets, clock-derived dates, epochs, paths, hostnames — clean) and empirically via the
four-timezone sweep, which covers whatever a static scan would have missed. The only other
generators are `Uuid`, whose examples are pact-jvm constants.

Generalisable: **a matcher does not make a pact environment-independent — a generator can still
write a machine-dependent value next to it.** The matcher is what verification reads; the generator
is what the committed artifact records.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
