### PR TITLE
feat(ci): an injected Quarkus extension bean must have the config that activates it

### DIFF
--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -993,6 +993,33 @@ gates:
     run: |
       python3 .github/scripts/check-kafka-cert-reader-grant.py --enforce
 
+  # campaign-service died with `InactiveBeanException: ReactiveRedisDataSource` (#2872 defect 3).
+  # Quarkus DEACTIVATES an extension's beans when the extension is on the classpath and
+  # unconfigured, so the service compiled, its tests passed — @ApplicationScoped is LAZY, so the
+  # producer is never invoked — and it died on the first request that resolved the bean.
+  #
+  # Checks BOTH config sources, application.yaml and the gitops Deployment env. Either alone is a
+  # false positive waiting to happen: fraud-service supplies QUARKUS_REDIS_HOSTS purely from its
+  # Deployment env and its application.yaml says nothing about Redis. An earlier draft that read
+  # only application.yaml flagged it — a service that is entirely correct.
+  #
+  # The bean->property table is DECLARED rather than derived, and that is deliberate: it encodes a
+  # Quarkus framework fact (which bean deactivates without which property), which lives in Quarkus
+  # and not in this tree. Everything about THIS repo is derived. A missing row narrows the gate,
+  # never breaks it.
+  #
+  # ENFORCED: 26 (service, property) pairs, 0 findings. Proven by removing BOTH sources for one
+  # real service and watching it reproduce the campaign failure — the first attempt removed only
+  # application.yaml and stayed green, correctly, because the env supplied it.
+  - id: extension-bean-config
+    name: "an injected Quarkus extension bean has the config that activates it (#2872, enforced)"
+    group: kotlin
+    mode: enforced
+    selftest: |
+      python3 .github/scripts/check-extension-bean-config.py --self-test
+    run: |
+      python3 .github/scripts/check-extension-bean-config.py --enforce
+
   - id: compliance-matrix
     name: "compliance-page evidence citations (#2370, enforced)"
     group: registry

--- a/.github/scripts/check-extension-bean-config.py
+++ b/.github/scripts/check-extension-bean-config.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""A Quarkus extension bean the code injects must have the config that activates it.
+
+WHY THIS EXISTS
+---------------
+campaign-service's rollout hit five boot failures, all on `main` with every required check green
+(#2872). The third was:
+
+    InactiveBeanException: ReactiveRedisDataSource
+
+Quarkus DEACTIVATES an extension's beans when the extension is on the classpath but unconfigured.
+The service produced a `RedisApprovalStore` over `ReactiveRedisDataSource`, declared no
+`quarkus.redis.hosts` anywhere, and shipped no Redis workload. It compiled, its tests passed, and it
+died on the first request that touched the bean.
+
+Unit tests cannot catch this: `@ApplicationScoped` is LAZY, so the producer is never invoked, and
+the failure surfaces only when a real request resolves the bean — which for a rarely-called path can
+be much later than the deploy.
+
+WHAT IT CHECKS
+--------------
+For each service, if any `src/main` Kotlin source references an extension bean in the table below,
+the corresponding property must be supplied by EITHER:
+
+  - the service's own `application.yaml`, or
+  - an env var on its Deployment/Rollout in `openbank-infra/gitops` (Quarkus' `FOO_BAR` mapping).
+
+Both sources, because either alone is a false positive waiting to happen: fraud-service supplies
+`QUARKUS_REDIS_HOSTS` purely from its Deployment env and its `application.yaml` says nothing about
+Redis. An earlier draft of this check that read only `application.yaml` flagged it — a service that
+is entirely correct. The general lesson, learned the expensive way tonight on a different gate: a
+guard that models only the part of the environment its author happened to think of reports the
+author's imagination back as a finding.
+
+WHY THE TABLE IS DECLARED AND NOT DERIVED
+-----------------------------------------
+This repo rightly distrusts hand-kept lists, so the exception is worth stating. BEAN_CONFIG maps a
+Quarkus framework fact — which extension bean deactivates without which property — and that fact
+lives in Quarkus, not in this tree. There is nothing here to derive it from. What IS derived is
+everything about this repo: which services reference the bean, and what config each one supplies.
+A missing table row makes this gate narrower, never wrong.
+
+Usage:  check-extension-bean-config.py [--enforce] [--self-test]
+"""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import re
+import sys
+
+import yaml
+
+REPO = pathlib.Path(__file__).resolve().parents[2]
+COMPONENTS = REPO / "openbank-infra/gitops/components"
+WORKLOADS = {"Deployment", "Rollout", "StatefulSet", "DaemonSet"}
+
+# Quarkus framework facts: bean type -> the property whose absence deactivates it.
+BEAN_CONFIG = {
+    "ReactiveRedisDataSource": "quarkus.redis.hosts",
+    "RedisDataSource": "quarkus.redis.hosts",
+}
+
+# A library has no deployable config of its own; its consumers supply it.
+SKIP_PREFIXES = ("openbank-libs",)
+
+
+def env_key(prop: str) -> str:
+    return prop.upper().replace(".", "_").replace("-", "_")
+
+
+def deployment_env() -> dict[str, set[str]]:
+    """workload name -> env var names declared on any of its containers."""
+    out: dict[str, set[str]] = {}
+    if not COMPONENTS.is_dir():
+        return out
+    for path in COMPONENTS.rglob("*.yaml"):
+        try:
+            docs = list(yaml.safe_load_all(path.read_text(encoding="utf-8")))
+        except (yaml.YAMLError, OSError, UnicodeDecodeError):
+            continue
+        for doc in docs:
+            if not isinstance(doc, dict) or doc.get("kind") not in WORKLOADS:
+                continue
+            name = (doc.get("metadata") or {}).get("name", "")
+            podspec = (((doc.get("spec") or {}).get("template") or {}).get("spec") or {})
+            names = out.setdefault(name, set())
+            for container in podspec.get("containers") or []:
+                for entry in container.get("env") or []:
+                    if entry.get("name"):
+                        names.add(entry["name"])
+    return out
+
+
+def supplies(prop: str, application_yaml: str) -> bool:
+    """Does this application.yaml set `prop`, in either flat or nested form?
+
+    Parsed, not grepped: a comment mentioning `quarkus.redis.hosts` — and fraud-service's manifest
+    has exactly such a comment — must not count as supplying it. That collision runs silently in
+    the direction that matters (a stale comment would mark a broken service as configured).
+    """
+    try:
+        doc = yaml.safe_load(application_yaml) or {}
+    except yaml.YAMLError:
+        return False
+
+    def walk(node, prefix=""):
+        if not isinstance(node, dict):
+            return
+        for key, value in node.items():
+            path = f"{prefix}{key}"
+            if path == prop or path.endswith("." + prop) or prop.endswith("." + path):
+                if not isinstance(value, dict):
+                    yield True
+            yield from walk(value, path + ".")
+
+    if any(walk(doc)):
+        return True
+    # Profile-scoped roots (%prod, %dev) nest the whole tree again.
+    for key, value in doc.items():
+        if isinstance(key, str) and key.startswith("%") and any(walk(value)):
+            return True
+    return False
+
+
+def findings(repo: pathlib.Path = REPO) -> tuple[list[str], int]:
+    env = deployment_env()
+    out: list[str] = []
+    checked = 0
+
+    for main in sorted(repo.glob("openbank-*/src/main")):
+        service = main.parts[len(repo.parts)]
+        if service.startswith(SKIP_PREFIXES):
+            continue
+
+        used: dict[str, str] = {}
+        for source in main.rglob("*.kt"):
+            try:
+                text = source.read_text(encoding="utf-8", errors="ignore")
+            except OSError:
+                continue
+            for bean, prop in BEAN_CONFIG.items():
+                if re.search(rf"\b{re.escape(bean)}\b", text):
+                    used.setdefault(prop, bean)
+        if not used:
+            continue
+
+        app = main / "resources/application.yaml"
+        app_text = app.read_text(encoding="utf-8", errors="ignore") if app.is_file() else ""
+
+        short = service.removeprefix("openbank-")
+        declared: set[str] = set()
+        for candidate in (service, short, f"{short}-service"):
+            declared |= env.get(candidate, set())
+
+        for prop, bean in sorted(used.items()):
+            checked += 1
+            if supplies(prop, app_text) or env_key(prop) in declared:
+                continue
+            out.append(
+                f"{service} injects {bean} but supplies no '{prop}' — not in its application.yaml "
+                f"and not as {env_key(prop)} on its gitops workload. Quarkus DEACTIVATES the "
+                f"extension's beans when it is on the classpath and unconfigured, so this compiles, "
+                f"passes tests (@ApplicationScoped is lazy, so the producer never runs) and dies "
+                f"with InactiveBeanException on the first request that resolves it (#2872/#2865).")
+
+    if checked == 0:
+        out.append(f"no service referencing any of {sorted(BEAN_CONFIG)} was found — the scan is "
+                   f"broken or the beans were renamed. Not reporting a clean run on that.")
+    return out, checked
+
+
+def selftest() -> int:
+    import tempfile
+
+    def service(root: pathlib.Path, name: str, bean: str | None, app_yaml: str) -> None:
+        main = root / name / "src/main"
+        (main / "kotlin").mkdir(parents=True, exist_ok=True)
+        body = f"import io.quarkus.redis.datasource.{bean}\nclass X(val r: {bean})\n" if bean else "class X\n"
+        (main / "kotlin/X.kt").write_text(body, encoding="utf-8")
+        (main / "resources").mkdir(parents=True, exist_ok=True)
+        (main / "resources/application.yaml").write_text(app_yaml, encoding="utf-8")
+
+    configured = "quarkus:\n  redis:\n    hosts: redis://localhost:6379\n"
+    # The shape that must NOT count: a comment naming the property. fraud-service's manifest has
+    # one, and treating it as configuration would mark a genuinely broken service as fine.
+    comment_only = "# quarkus.redis.hosts is supplied by the Deployment env\nquarkus:\n  http:\n    port: 8080\n"
+    profile = "'%prod':\n  quarkus:\n    redis:\n      hosts: redis://prod:6379\n"
+
+    cases = [
+        ("configured in application.yaml", "openbank-a", "ReactiveRedisDataSource", configured, 0),
+        ("configured under a profile root", "openbank-b", "ReactiveRedisDataSource", profile, 0),
+        ("only a COMMENT names the property", "openbank-c", "ReactiveRedisDataSource", comment_only, 1),
+        ("no config at all — campaign's #2865 shape", "openbank-d", "RedisDataSource", "quarkus:\n  http:\n    port: 8080\n", 1),
+    ]
+    for label, name, bean, app_yaml, want in cases:
+        with tempfile.TemporaryDirectory() as d:
+            root = pathlib.Path(d)
+            service(root, name, bean, app_yaml)
+            got, checked = findings(root)
+        if checked != 1:
+            print(f"selftest FAIL: {label} — expected to check 1 service, checked {checked}")
+            return 1
+        if len(got) != want:
+            print(f"selftest FAIL: {label} — expected {want} finding(s), got {len(got)}: {got}")
+            return 1
+
+    # A service that never mentions the bean must not be checked at all.
+    with tempfile.TemporaryDirectory() as d:
+        root = pathlib.Path(d)
+        service(root, "openbank-e", None, "quarkus:\n  http:\n    port: 8080\n")
+        got, checked = findings(root)
+        if checked != 0 or not got:
+            print(f"selftest FAIL: a service not using the bean was checked ({checked}), or an "
+                  f"empty scan reported clean.")
+            return 1
+
+    print(f"selftest OK: {len(cases)} fixture(s) — application.yaml, a profile root, a "
+          f"comment-only mention, no config at all, plus the empty-scan guard.")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--enforce", action="store_true")
+    ap.add_argument("--self-test", action="store_true", dest="self_test")
+    args = ap.parse_args()
+    if args.self_test:
+        return selftest()
+
+    found, checked = findings()
+    for line in found:
+        print(("::error::" if args.enforce else "::warning::") + line)
+    print(f"check-extension-bean-config: {checked} (service, extension-property) pair(s) — "
+          f"{'clean.' if not found else f'{len(found)} finding(s) above.'}")
+    return 1 if found and args.enforce else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #2872 defect 3 — the last of that issue's five that is mechanically detectable from the repo alone. With this, #2872's proposed checks 1, 2 and 3 all exist as enforced gates.

## What broke

campaign-service died with `InactiveBeanException: ReactiveRedisDataSource`. Quarkus **deactivates** an extension's beans when the extension is on the classpath and unconfigured. The service produced a store over `ReactiveRedisDataSource`, declared no `quarkus.redis.hosts` anywhere, and shipped no Redis workload.

Unit tests cannot catch this, structurally: `@ApplicationScoped` is **lazy**, so the producer is never invoked; the failure surfaces only when a real request resolves the bean — which for a rarely-called path can be long after the deploy went green.

## Both config sources, and why that is the whole point

The check accepts the property from the service's `application.yaml` **or** from env on its gitops Deployment.

Either alone is a false positive waiting to happen, and this is not hypothetical. **fraud-service supplies `QUARKUS_REDIS_HOSTS` purely from its Deployment env** and its `application.yaml` says nothing about Redis. The first draft of this check read only `application.yaml` and flagged fraud-service — a service that is entirely correct.

`application.yaml` is **parsed, not grepped**: fraud-service's manifest carries a comment naming `quarkus.redis.hosts`, and counting a comment as configuration would mark a genuinely broken service as fine. That is the code-about-code collision running in its silent direction.

## The declared table, stated openly

This repo distrusts hand-kept lists, so the exception is worth defending rather than hiding. `BEAN_CONFIG` maps a **Quarkus framework fact** — which extension bean deactivates without which property — and that fact lives in Quarkus, not in this tree; there is nothing here to derive it from.

Everything about *this repo* is derived: which services reference the bean, and what config each one supplies. **A missing table row makes the gate narrower, never wrong.**

Enforced: **26 (service, property) pairs, 0 findings.**

## The known-positive that did NOT fire, and why that matters

First attempt: remove `sca-service`'s `redis:` block from `application.yaml`. Gate stayed **green**.

That was not a bug — sca-service's Deployment supplies `QUARKUS_REDIS_HOSTS`, so clean was the right answer. Only removing **both** sources reproduces the failure:

```
::error::openbank-sca-service injects ReactiveRedisDataSource but supplies no
'quarkus.redis.hosts' — not in its application.yaml and not as QUARKUS_REDIS_HOSTS on its
gitops workload. … dies with InactiveBeanException on the first request that resolves it.
```

Restored from `cp` backups, confirmed green, working tree clean.

Recording it because the lesson generalises: **a known-positive that does not fire is a fact about the fixture, not about the gate.** Had I stopped at "it didn't go red, the gate must be broken", I would have loosened a correct rule.

## Self-assessment — what this does not cover

- **Only Redis today.** The table has two bean types. Other Quarkus extensions with the same deactivation behaviour (MongoDB, Elasticsearch, …) are unused here; adding one is a single line, but until then they are out of scope, not covered.
- **Reference, not use.** A Kotlin file that merely names the type in a KDoc counts as using it. That direction is a false *positive* — loud, cheap, and the safe way round.
- **The env check is name-based**, matching the workload by `<service>`, `<short>` or `<short>-service`. A component whose workload name follows none of those would look unconfigured; again the loud direction.
- **It does not verify the value.** A `QUARKUS_REDIS_HOSTS` pointing at a Redis that does not exist passes. That is `check-incluster-hostnames.py`'s territory (landed separately tonight in #3504), and neither gate checks ports.
- **#2872 defect 2 (unwired ClickHouse credentials) is still open.** It is a non-Optional `@ConfigProperty` with an empty default, a different shape from this one, and I have not measured how noisy a rule for it would be. Leaving #2872 open for it rather than claiming the issue closed.

## Verification

```
check-extension-bean-config.py --self-test    OK (4 fixtures + empty-scan guard)
check-extension-bean-config.py --enforce      clean (26 pairs)
run-gates.py --only extension-bean-config     PASS
check-gates-not-deregistered.py --enforce     clean (93 at merge-base, 94 here)
check-gate-script-registration.py --enforce   clean (0 orphans)
```
