### PR TITLE
feat(ci): a required @ConfigProperty must actually have a value

### DIFF
--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -1020,6 +1020,29 @@ gates:
     run: |
       python3 .github/scripts/check-extension-bean-config.py --enforce
 
+  # The root CLAUDE.md has documented this footgun for months with nothing enforcing it: a
+  # @ConfigProperty that is neither Optional<..> nor given a defaultValue throws SRCFG00040 at BOOT
+  # when no value is supplied — the service does not start. #2872's second defect was this shape
+  # (`Failed to load config value ... analytics.clickhouse-user`), on main, all checks green.
+  #
+  # Accepts a value from application.yaml (including a %profile root) OR from env on the gitops
+  # workload. Either source alone is a false positive waiting to happen; several services here
+  # configure purely from Deployment env.
+  #
+  # application.yaml is PARSED, not grepped — a comment naming a property must not count as
+  # supplying it, or a stale comment marks a service that cannot boot as configured.
+  #
+  # ENFORCED: 38 required declarations, 0 findings. Proven by deleting one real key and watching it
+  # name the exact file, property and missing env var.
+  - id: configproperty-supplied
+    name: "a required @ConfigProperty has a value (SRCFG00040, enforced)"
+    group: kotlin
+    mode: enforced
+    selftest: |
+      python3 .github/scripts/check-configproperty-supplied.py --self-test
+    run: |
+      python3 .github/scripts/check-configproperty-supplied.py --enforce
+
   - id: compliance-matrix
     name: "compliance-page evidence citations (#2370, enforced)"
     group: registry

--- a/.github/scripts/check-configproperty-supplied.py
+++ b/.github/scripts/check-configproperty-supplied.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""A required @ConfigProperty must have a value somewhere, or the service dies at boot.
+
+WHY THIS EXISTS
+---------------
+The root CLAUDE.md has documented this footgun for months with nothing enforcing it:
+
+    `@ConfigProperty` optional fields must be `Optional<String>`, not plain `String`, or a
+    missing value throws `SRCFG00040` at boot.
+
+campaign-service shipped the same shape as #2872's second defect — `Failed to load config value …
+analytics.clickhouse-user`, credentials never wired — and it was on `main`, merged, with every
+required check green. A missing value for a NON-optional property is not a warning: SmallRye
+refuses to start the application.
+
+WHAT IT CHECKS
+--------------
+For every `@ConfigProperty(name = "…")` in a service's `src/main` that is
+  - NOT declared `Optional<…>`, and
+  - has NO `defaultValue`,
+the property must be supplied by EITHER the service's own `application.yaml` (including a
+`%profile` root) OR an env var on its gitops workload (Quarkus' `FOO_BAR` mapping).
+
+Those three together are the whole contract: a property is required, so it needs a value; a
+property with a default or an `Optional` type does not.
+
+WHY BOTH SOURCES
+----------------
+Because either alone is a false positive waiting to happen. Several services here supply config
+purely from their Deployment env and say nothing about it in `application.yaml`. A guard that models
+only the source its author happened to think of reports the author's imagination back as a finding —
+learned expensively on a different gate the same night (#3444/#3453).
+
+WHAT IT DOES NOT CHECK
+----------------------
+That the value is CORRECT, or that a `defaultValue` is a sensible one. An empty-string default is
+still the silent-placeholder shape that #2872 defect 2 actually had — it boots and fails later — but
+flagging every `defaultValue = ""` is a judgement call with no mechanical answer, so it is out of
+scope rather than guessed at.
+
+Usage:  check-configproperty-supplied.py [--enforce] [--self-test]
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import pathlib
+import re
+import sys
+
+import yaml
+
+REPO = pathlib.Path(__file__).resolve().parents[2]
+COMPONENTS = REPO / "openbank-infra/gitops/components"
+WORKLOADS = {"Deployment", "Rollout", "StatefulSet", "DaemonSet"}
+SKIP_PREFIXES = ("openbank-libs",)
+
+# `@ConfigProperty(name = "x.y")` followed by the declaration whose type decides whether it is
+# required. Kotlin allows annotations and modifiers in between, hence the tolerant middle.
+CONFIG_RE = re.compile(
+    r'@ConfigProperty\s*\(\s*name\s*=\s*"([^"]+)"([^)]*)\)'
+    r'\s*(?:@\w+(?:\([^)]*\))?\s*)*'
+    r'(?:private\s+|internal\s+|public\s+)?(?:lateinit\s+)?va[lr]\s+\w+\s*:\s*([A-Za-z_][\w.]*)',
+    re.S,
+)
+
+
+def env_key(prop: str) -> str:
+    return prop.upper().replace(".", "_").replace("-", "_")
+
+
+def deployment_env(components: pathlib.Path) -> dict[str, set[str]]:
+    out: dict[str, set[str]] = collections.defaultdict(set)
+    if not components.is_dir():
+        return out
+    for path in components.rglob("*.yaml"):
+        try:
+            docs = list(yaml.safe_load_all(path.read_text(encoding="utf-8")))
+        except (yaml.YAMLError, OSError, UnicodeDecodeError):
+            continue
+        for doc in docs:
+            if not isinstance(doc, dict) or doc.get("kind") not in WORKLOADS:
+                continue
+            name = (doc.get("metadata") or {}).get("name", "")
+            podspec = (((doc.get("spec") or {}).get("template") or {}).get("spec") or {})
+            for container in podspec.get("containers") or []:
+                for entry in container.get("env") or []:
+                    if entry.get("name"):
+                        out[name].add(entry["name"])
+    return out
+
+
+def declared_keys(application_yaml: pathlib.Path) -> set[str]:
+    """Dotted property names present in the file, parsed rather than grepped.
+
+    Parsed on purpose: a comment naming a property must not count as supplying it. That collision
+    runs silently in the direction that matters — a stale comment would mark a service that cannot
+    boot as configured.
+    """
+    if not application_yaml.is_file():
+        return set()
+    try:
+        doc = yaml.safe_load(application_yaml.read_text(encoding="utf-8")) or {}
+    except (yaml.YAMLError, OSError, UnicodeDecodeError):
+        return set()
+
+    def walk(node, prefix=""):
+        if not isinstance(node, dict):
+            return
+        for key, value in node.items():
+            path = f"{prefix}{key}"
+            yield path
+            yield from walk(value, path + ".")
+
+    keys = set(walk(doc))
+    for key, value in doc.items():
+        if isinstance(key, str) and key.startswith("%"):
+            keys |= set(walk(value))
+    return keys
+
+
+def findings(repo: pathlib.Path = REPO) -> tuple[list[str], int]:
+    env = deployment_env(repo / "openbank-infra/gitops/components")
+    out: list[str] = []
+    required = 0
+
+    for main in sorted(repo.glob("openbank-*/src/main")):
+        service = main.parts[len(repo.parts)]
+        if service.startswith(SKIP_PREFIXES):
+            continue
+        keys = declared_keys(main / "resources/application.yaml")
+        short = service.removeprefix("openbank-")
+        supplied_env: set[str] = set()
+        for candidate in (service, short, f"{short}-service"):
+            supplied_env |= env.get(candidate, set())
+
+        for source in main.rglob("*.kt"):
+            try:
+                text = source.read_text(encoding="utf-8", errors="ignore")
+            except OSError:
+                continue
+            for match in CONFIG_RE.finditer(text):
+                prop, params, type_name = match.group(1), match.group(2), match.group(3)
+                if "defaultValue" in params or type_name == "Optional":
+                    continue
+                required += 1
+                if prop in keys or env_key(prop) in supplied_env:
+                    continue
+                rel = source.relative_to(repo)
+                out.append(
+                    f"{rel}: @ConfigProperty(\"{prop}\") is required — not Optional, no "
+                    f"defaultValue — and no value is supplied. It is absent from "
+                    f"{service}'s application.yaml and there is no {env_key(prop)} on its gitops "
+                    f"workload, so SmallRye throws SRCFG00040 and the service does not start. "
+                    f"Supply it, give it a defaultValue, or make the field Optional<…>.")
+
+    if required == 0:
+        out.append("no required @ConfigProperty was found anywhere — the scan is broken. "
+                   "Not reporting a clean run on that.")
+    return out, required
+
+
+def selftest() -> int:
+    import tempfile
+
+    def service(root: pathlib.Path, decl: str, app_yaml: str) -> None:
+        main = root / "openbank-demo/src/main"
+        (main / "kotlin").mkdir(parents=True, exist_ok=True)
+        (main / "kotlin/C.kt").write_text(decl, encoding="utf-8")
+        (main / "resources").mkdir(parents=True, exist_ok=True)
+        (main / "resources/application.yaml").write_text(app_yaml, encoding="utf-8")
+
+    required = '@ConfigProperty(name = "openbank.demo.url")\n    lateinit var url: String\n'
+    with_default = '@ConfigProperty(name = "openbank.demo.url", defaultValue = "x")\n    var url: String = "x"\n'
+    optional = '@ConfigProperty(name = "openbank.demo.url")\n    lateinit var url: Optional<String>\n'
+    supplied = "openbank:\n  demo:\n    url: http://x\n"
+    profile = "'%prod':\n  openbank:\n    demo:\n      url: http://x\n"
+    # A comment naming the property must NOT count — the silent direction.
+    comment = "# openbank.demo.url comes from the Deployment env\nquarkus:\n  http:\n    port: 8080\n"
+    empty = "quarkus:\n  http:\n    port: 8080\n"
+
+    cases = [
+        ("required and supplied", required, supplied, 1, 0),
+        ("required and supplied under a profile root", required, profile, 1, 0),
+        ("required and NOT supplied — the SRCFG00040 shape", required, empty, 1, 1),
+        ("only a COMMENT names it", required, comment, 1, 1),
+        ("has a defaultValue", with_default, empty, 0, 0),
+        ("is Optional", optional, empty, 0, 0),
+    ]
+    for label, decl, app_yaml, want_required, want in cases:
+        with tempfile.TemporaryDirectory() as d:
+            root = pathlib.Path(d)
+            service(root, decl, app_yaml)
+            got, req = findings(root)
+        if req != want_required:
+            print(f"selftest FAIL: {label} — expected {want_required} required property, saw {req}")
+            return 1
+        # The empty-scan guard adds a finding when nothing was required; discount it.
+        real = [f for f in got if "the scan is broken" not in f]
+        if len(real) != want:
+            print(f"selftest FAIL: {label} — expected {want} finding(s), got {len(real)}: {real}")
+            return 1
+
+    with tempfile.TemporaryDirectory() as d:
+        got, req = findings(pathlib.Path(d))
+        if req != 0 or not got:
+            print("selftest FAIL: an empty tree did not report that it found nothing.")
+            return 1
+
+    print(f"selftest OK: {len(cases)} fixture(s) — supplied, profile-scoped, unsupplied, "
+          f"comment-only, defaultValue, Optional, plus the empty-scan guard.")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--enforce", action="store_true")
+    ap.add_argument("--self-test", action="store_true", dest="self_test")
+    args = ap.parse_args()
+    if args.self_test:
+        return selftest()
+
+    found, required = findings()
+    for line in found:
+        print(("::error::" if args.enforce else "::warning::") + line)
+    print(f"check-configproperty-supplied: {required} required @ConfigProperty declaration(s) — "
+          f"{'clean.' if not found else f'{len(found)} finding(s) above.'}")
+    return 1 if found and args.enforce else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #2872 defect 2 — the last of that issue's five that is detectable from the repo alone. All four of its "mechanically detectable" defects now have enforced gates.

## The footgun, documented and unenforced

The root `CLAUDE.md` has carried this for months:

> `@ConfigProperty` optional fields must be `Optional<String>`, not plain `String`, or a missing value throws `SRCFG00040` at boot.

Nothing enforced it. #2872's second defect was exactly this shape — `Failed to load config value … analytics.clickhouse-user`, credentials never wired — on `main`, merged, every required check green. This is not a warning: SmallRye refuses to start the application.

## The rule

A `@ConfigProperty` that is **neither** `Optional<…>` **nor** given a `defaultValue` must have a value supplied by:

- the service's own `application.yaml`, including a `%profile` root, **or**
- an env var on its gitops workload (Quarkus' `FOO_BAR` mapping).

Enforced: **38 required declarations, 0 findings.**

## Two design points that decide whether this gate is honest

**Both config sources.** Either alone is a false positive waiting to happen — several services here configure purely from Deployment env and say nothing about it in `application.yaml`. A guard that models only the source its author happened to think of reports the author's imagination back as a finding. I learned that expensively earlier tonight on a different gate (#3444 → reverted by #3453), so it is designed in here rather than discovered later.

**`application.yaml` is parsed, not grepped.** A comment naming a property must not count as supplying it — otherwise a stale comment marks a service that cannot boot as configured. That is the code-about-code collision running in its silent direction, and it is pinned as a self-test case.

## Proven against the real tree

Deleting `mcp.server.name` from agent-service's `application.yaml`:

```
::error::openbank-agent-service/src/main/kotlin/.../McpEndpoint.kt:
@ConfigProperty("mcp.server.name") is required — not Optional, no defaultValue — and no value
is supplied. It is absent from openbank-agent-service's application.yaml and there is no
MCP_SERVER_NAME on its gitops workload, so SmallRye throws SRCFG00040 and the service does not
start.
```

Restored from a `cp` backup, confirmed green, working tree clean.

## Self-assessment — what this does not do

- **It does not judge a `defaultValue`.** An empty-string default is still the silent-placeholder shape that boots and fails later — arguably closer to what #2872 defect 2 actually was. Flagging every `defaultValue = ""` is a judgement call with no mechanical answer, so it is stated as out of scope rather than guessed at. Worth revisiting with a measurement.
- **Regex over Kotlin, not a parser.** An exotic declaration (a constructor-injected `@ConfigProperty`, a heavily annotated field) may not match, and that direction is a false *pass* — the bad direction. 38 declarations matched, which is consistent with a rough independent count, but I have not proven the regex sees every one.
- **The env check is name-based** (`<service>` / `<short>` / `<short>-service`). A workload named otherwise reads as unsupplied — the loud direction.
- **It does not check the value is usable.** A property set to `""` or to a dead URL passes. Hostname validity is `check-incluster-hostnames.py`'s territory (#3504); nothing checks ports anywhere yet.
- **`openbank-libs-*` is skipped** — a library has no deployable config of its own and its consumers supply it. That is an assumption, not a proof: a libs `@ConfigProperty` unsupplied by *every* consumer would be invisible here.

## Verification

```
check-configproperty-supplied.py --self-test   OK (6 fixtures + empty-scan guard)
check-configproperty-supplied.py --enforce     clean (38 declarations)
run-gates.py --only configproperty-supplied    PASS
check-gates-not-deregistered.py --enforce      clean (94 at merge-base, 95 here)
```

The manifest was re-taken from live `origin/main` immediately before committing, and the gate-id count verified 94 → 95 — following the rule from tonight's own incident: never carry a copy of `gates.yaml` across branches.
