### PR TITLE
fix(aml): resolve the party an AML case is really about, instead of storing the account id

### DIFF
--- a/openbank-aml-service/build.gradle.kts
+++ b/openbank-aml-service/build.gradle.kts
@@ -33,6 +33,11 @@ dependencies {
     implementation(project(":openbank-libs-domain"))
     implementation(project(":openbank-libs-runtime"))
     implementation(libs.quarkus.scheduler)
+    // #3413: account -> party lookup for the resolution sweep (sweep-only; never on the
+    // case-creation path, so account-service being down can never lose an AML case).
+    implementation(libs.quarkus.rest.client.reactive)
+    implementation(libs.quarkus.rest.client.reactive.jackson)
+    implementation(libs.quarkus.oidc.client.reactive.filter)
     testImplementation(libs.quarkus.junit5)
     testImplementation(libs.assertj)
     testImplementation(libs.mockk)

--- a/openbank-aml-service/src/main/kotlin/com/openbank/aml/application/port/out/AmlCasePorts.kt
+++ b/openbank-aml-service/src/main/kotlin/com/openbank/aml/application/port/out/AmlCasePorts.kt
@@ -37,6 +37,18 @@ interface AmlCaseRepository {
     suspend fun update(amlCase: AmlCase, event: OutboxMessage): AmlCase
 
     /**
+     * Cases whose `party_id` is a copy of `account_id` — i.e. never resolved to a real party
+     * (#3413). Bounded by [limit]; the sweep re-runs.
+     */
+    suspend fun findUnresolvedParty(limit: Int): List<Pair<UUID, UUID>>
+
+    /** Point [caseId] at its real owning party. */
+    suspend fun resolveParty(caseId: UUID, partyId: UUID)
+
+    /** How many cases still carry an account id in `party_id`. Published as a gauge. */
+    suspend fun countUnresolvedParty(): Long
+
+    /**
      * Anonymizes PII in all AML cases for the given party (GDPR Art. 17 right of erasure).
      *
      * Sets [AmlCase.customerReference] to `"ERASED-<partyId>"` and nulls [AmlCase.matchedEntity]

--- a/openbank-aml-service/src/main/kotlin/com/openbank/aml/infrastructure/client/AccountServiceClient.kt
+++ b/openbank-aml-service/src/main/kotlin/com/openbank/aml/infrastructure/client/AccountServiceClient.kt
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.aml.infrastructure.client
+
+import io.quarkus.oidc.client.OidcClient
+import io.smallrye.mutiny.Uni
+import io.smallrye.mutiny.coroutines.awaitSuspending
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.enterprise.inject.Instance
+import jakarta.ws.rs.GET
+import jakarta.ws.rs.HeaderParam
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.PathParam
+import jakarta.ws.rs.Produces
+import jakarta.ws.rs.WebApplicationException
+import jakarta.ws.rs.core.MediaType
+import org.eclipse.microprofile.config.inject.ConfigProperty
+import org.eclipse.microprofile.rest.client.RestClientBuilder
+import org.jboss.logging.Logger
+import java.net.URI
+import java.util.UUID
+
+@Path("/api/v1/accounts")
+@Produces(MediaType.APPLICATION_JSON)
+interface AccountServiceRestClient {
+    @GET
+    @Path("/{accountId}")
+    fun getById(
+        @HeaderParam("Authorization") authorization: String,
+        @PathParam("accountId") accountId: String,
+    ): Uni<AccountDto>
+}
+
+data class AccountDto(val id: String, val partyId: String)
+
+/**
+ * Reads the owning party of an account, for the #3413 resolution sweep.
+ *
+ * Mirrors `openbank-domestic-payment`'s client of the same endpoint. It is used **only** by the
+ * sweep, never on the case-creation path: a case must never fail to be recorded because
+ * account-service is unreachable, so resolution is something that happens to a stored row
+ * afterwards, not a precondition for storing it.
+ */
+@ApplicationScoped
+class AccountServiceClient(
+    private val oidcClient: Instance<OidcClient>,
+    @ConfigProperty(
+        name = "quarkus.rest-client.account-service.url",
+        defaultValue = "http://account-service.accounts.svc:8100",
+    )
+    private val baseUrl: String,
+) {
+    private val log = Logger.getLogger(AccountServiceClient::class.java)
+
+    private val httpClient by lazy {
+        RestClientBuilder.newBuilder()
+            .baseUri(URI.create(baseUrl))
+            .build(AccountServiceRestClient::class.java)
+    }
+
+    /** The party owning [accountId], or `null` if it cannot be determined right now. */
+    @Suppress("TooGenericExceptionCaught")
+    suspend fun findPartyByAccountId(accountId: UUID): UUID? = try {
+        val token = oidcClient.get().tokens.awaitSuspending().accessToken
+        val dto = httpClient.getById("Bearer $token", accountId.toString()).awaitSuspending()
+        UUID.fromString(dto.partyId)
+    } catch (ex: WebApplicationException) {
+        if (ex.response.status != HTTP_NOT_FOUND) {
+            log.warnf(ex, "[party-resolution] lookup for account %s failed with HTTP %d", accountId, ex.response.status)
+        }
+        null
+    } catch (ex: Exception) {
+        log.warnf(ex, "[party-resolution] lookup for account %s failed", accountId)
+        null
+    }
+
+    private companion object {
+        const val HTTP_NOT_FOUND = 404
+    }
+}

--- a/openbank-aml-service/src/main/kotlin/com/openbank/aml/infrastructure/persistence/repository/AmlCaseRepositoryImpl.kt
+++ b/openbank-aml-service/src/main/kotlin/com/openbank/aml/infrastructure/persistence/repository/AmlCaseRepositoryImpl.kt
@@ -85,6 +85,23 @@ class AmlCaseRepositoryImpl(private val outboxRepository: AmlOutboxRepositoryImp
 
     // GDPR Art. 17: right of erasure — null out PII fields and replace customerReference with a
     // non-identifying sentinel so the case row itself (required for audit/SAR trails) survives.
+    // #3413: the rails satisfied a NOT NULL `party_id` with the debtor ACCOUNT id, so on every
+    // affected row the two columns are byte-for-byte equal — measured 6 of 6 payment cases. That
+    // equality is the detector; it cannot false-positive, because an account id and a party id are
+    // drawn from different tables and a genuine party is never its own account.
+    override suspend fun findUnresolvedParty(limit: Int): List<Pair<UUID, UUID>> = Panache.withSession {
+        find("partyId = accountId and accountId is not null").range(0, limit - 1).list()
+    }.awaitSuspending().map { it.caseId to it.accountId!! }
+
+    override suspend fun resolveParty(caseId: UUID, partyId: UUID) {
+        Panache.withTransaction {
+            update("partyId = ?1 where caseId = ?2", partyId, caseId)
+        }.awaitSuspending()
+    }
+
+    override suspend fun countUnresolvedParty(): Long =
+        Panache.withSession { count("partyId = accountId and accountId is not null") }.awaitSuspending()
+
     override suspend fun anonymizeByPartyId(partyId: UUID): Int = Panache.withTransaction {
         update(
             "customerReference = concat('ERASED-', cast(partyId as string))," +

--- a/openbank-aml-service/src/main/kotlin/com/openbank/aml/infrastructure/scheduler/PartyResolutionScheduler.kt
+++ b/openbank-aml-service/src/main/kotlin/com/openbank/aml/infrastructure/scheduler/PartyResolutionScheduler.kt
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+package com.openbank.aml.infrastructure.scheduler
+
+import com.openbank.aml.application.port.out.AmlCaseRepository
+import com.openbank.aml.infrastructure.client.AccountServiceClient
+import io.micrometer.core.instrument.Gauge
+import io.micrometer.core.instrument.MeterRegistry
+import io.quarkus.runtime.Startup
+import io.quarkus.scheduler.Scheduled
+import jakarta.annotation.PostConstruct
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.enterprise.inject.Instance
+import jakarta.inject.Inject
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.eclipse.microprofile.config.inject.ConfigProperty
+import org.jboss.logging.Logger
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * Points AML cases at the party that actually owns the account (#3413).
+ *
+ * ### The defect
+ *
+ * `aml_cases.party_id` is `NOT NULL`, and a payment carries only `debtorAccountId` — so the rails
+ * satisfied the constraint with the ACCOUNT id. It is a valid non-null UUID, nothing detected it,
+ * and it joins to no party. What that breaks is party-scoped: per-customer aggregation (a client
+ * with three accounts reads as three unrelated subjects — the pattern structuring detection exists
+ * to catch), the GDPR Art. 15 `?partyId=` subject-access query, and `anonymizeByPartyId`, the
+ * Art. 17 erasure path. Measured: on all 6 payment-path cases `party_id` equals `account_id`
+ * exactly, so nothing is lost by replacing it — the real party is one lookup away.
+ *
+ * ### Why a sweep, and not the two designs that were tried first
+ *
+ * **Not "make `partyId` nullable".** Measured with `oasdiff` against this service's own
+ * `openapi.yaml`: dropping it from the response's `required` is `response-property-became-optional`
+ * and keeping it required-but-`nullable: true` is `response-property-became-nullable` — **both**
+ * classify as breaking, so either costs a MAJOR bump and a `/api/v2/aml/cases` URL. And a null
+ * fixes none of the three things above; it only stops writing a wrong value.
+ *
+ * **Not a Kafka projection off `openbank.accounts.account.created`.** That topic is
+ * `cleanup.policy: delete` with 7-day retention and is not compacted, while most of the 77 accounts
+ * are older — so a fresh consumer could never learn their party, and the projection would look like
+ * it worked while resolving almost nothing.
+ *
+ * **Not resolution at ingest.** A case must never fail to be recorded because account-service is
+ * unreachable. Resolution is therefore something that happens to a stored row afterwards; the
+ * case-creation path is untouched by this class.
+ *
+ * ### Not silently wrong
+ *
+ * `openbank_aml_cases_party_unresolved` is published so the sweep cannot quietly resolve nothing —
+ * the failure this repo keeps meeting is a mechanism that reads as working while doing nothing.
+ *
+ * `suspend`, never `runBlocking` (#2148); the lookup runs on [Dispatchers.IO] because a blocking
+ * HTTP call on the scheduler's Vert.x context stalls the event loop and, under
+ * `ConcurrentExecution.SKIP`, one stalled tick wedges every later one.
+ */
+@Startup
+@ApplicationScoped
+class PartyResolutionScheduler {
+
+    @Inject
+    lateinit var caseRepository: AmlCaseRepository
+
+    @Inject
+    lateinit var accounts: AccountServiceClient
+
+    @Inject
+    lateinit var registryInstance: Instance<MeterRegistry>
+
+    @ConfigProperty(name = "openbank.aml.party-resolution.enabled", defaultValue = "true")
+    var enabled: Boolean = true
+
+    @ConfigProperty(name = "openbank.aml.party-resolution.batch-limit", defaultValue = "50")
+    var batchLimit: Int = DEFAULT_BATCH_LIMIT
+
+    private val log = Logger.getLogger(PartyResolutionScheduler::class.java)
+    private val unresolved = AtomicLong(0)
+
+    @PostConstruct
+    fun register() {
+        if (!registryInstance.isResolvable) return
+        Gauge.builder("openbank.aml.cases.party_unresolved", unresolved) { it.get().toDouble() }
+            .tag("service", "aml")
+            .strongReference(true)
+            .register(registryInstance.get())
+    }
+
+    @Scheduled(
+        every = "{openbank.aml.party-resolution.interval:30m}",
+        delayed = "{openbank.aml.party-resolution.initial-delay:2m}",
+        concurrentExecution = Scheduled.ConcurrentExecution.SKIP,
+    )
+    suspend fun sweep() {
+        if (!enabled) return
+        val batch = caseRepository.findUnresolvedParty(batchLimit)
+        if (batch.isNotEmpty()) {
+            log.infof("[party-resolution] resolving %d case(s) still holding an account id", batch.size)
+            for ((caseId, accountId) in batch) {
+                val partyId = withContext(Dispatchers.IO) { accounts.findPartyByAccountId(accountId) }
+                when {
+                    partyId == null ->
+                        log.warnf(
+                            "[party-resolution] account %s did not resolve; case %s left as is",
+                            accountId,
+                            caseId,
+                        )
+                    partyId == accountId ->
+                        // Would leave the row indistinguishable from unresolved and re-swept forever.
+                        log.errorf(
+                            "[party-resolution] account %s reports itself as its own party — refusing",
+                            accountId,
+                        )
+                    else -> {
+                        caseRepository.resolveParty(caseId, partyId)
+                        log.infof("[party-resolution] case %s → party %s", caseId, partyId)
+                    }
+                }
+            }
+        }
+        // Recomputed every tick, including a tick that resolved nothing, so the gauge reflects the
+        // backlog rather than the last batch size.
+        unresolved.set(caseRepository.countUnresolvedParty())
+    }
+
+    private companion object {
+        const val DEFAULT_BATCH_LIMIT = 50
+    }
+}

--- a/openbank-aml-service/src/main/resources/application.yaml
+++ b/openbank-aml-service/src/main/resources/application.yaml
@@ -46,6 +46,17 @@ quarkus:
       secret: ${OIDC_CLIENT_SECRET:CHANGE_ME_LOCAL_DEV_ONLY}
     tls:
       verification: none
+  oidc-client:
+    auth-server-url: ${QUARKUS_OIDC_AUTH_SERVER_URL:http://localhost:8080/realms/openbank}
+    client-id: openbank-services
+    credentials:
+      secret: ${OIDC_CLIENT_SECRET:CHANGE_ME_LOCAL_DEV_ONLY}
+    grant:
+      type: client
+  rest-client:
+    account-service:
+      url: ${ACCOUNT_SERVICE_URL:http://localhost:8100}
+      scope: jakarta.inject.Singleton
   redis:
     hosts: redis://localhost:6379
   smallrye-reactive-messaging:
@@ -144,6 +155,14 @@ mp:
   authz:
     enforce: "false"
 openbank:
+  aml:
+    # #3413: point cases at the party that owns the account, after the fact. Sweep-only —
+    # never on the case-creation path, so account-service being down cannot lose a case.
+    party-resolution:
+      enabled: ${AML_PARTY_RESOLUTION_ENABLED:true}
+      interval: 30m
+      initial-delay: 2m
+      batch-limit: 50
   outbox:
     dispatch-enabled: true
   rate-limit:

--- a/openbank-aml-service/src/test/kotlin/com/openbank/aml/it/PartyResolutionIT.kt
+++ b/openbank-aml-service/src/test/kotlin/com/openbank/aml/it/PartyResolutionIT.kt
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+package com.openbank.aml.it
+
+import com.openbank.aml.infrastructure.persistence.repository.AmlCaseRepositoryImpl
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.vertx.VertxContextSupport
+import io.smallrye.mutiny.coroutines.awaitSuspending
+import io.smallrye.mutiny.coroutines.uni
+import io.vertx.mutiny.pgclient.PgPool
+import io.vertx.mutiny.sqlclient.Tuple
+import jakarta.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.OffsetDateTime
+import java.util.UUID
+
+/**
+ * Real-Postgres cover for the #3413 detector and the update it drives.
+ *
+ * The whole sweep rests on one claim: a case that was never resolved has `party_id` byte-for-byte
+ * equal to `account_id`, because the rails satisfied a `NOT NULL` column with the debtor ACCOUNT id
+ * (measured: 6 of 6 payment cases in sandbox). If that predicate is wrong in either direction the
+ * sweep either misses every broken row or rewrites correct ones — on a compliance store, the second
+ * is much worse than the first, so both directions are asserted here.
+ *
+ * The lookup itself is not exercised: it is an HTTP call to account-service, and what needs pinning
+ * is which rows the sweep selects and what it writes, not that a rest-client works.
+ */
+@QuarkusTest
+@QuarkusTestResource(PostgresRedisTestResource::class)
+class PartyResolutionIT {
+
+    @Inject
+    lateinit var repository: AmlCaseRepositoryImpl
+
+    @Inject
+    lateinit var pool: PgPool
+
+    private fun <T> onEventLoop(block: suspend () -> T): T =
+        VertxContextSupport.subscribeAndAwait { uni(CoroutineScope(Dispatchers.Unconfined)) { block() } }
+
+    @BeforeEach
+    fun clear() {
+        onEventLoop { pool.query("DELETE FROM aml_cases").execute().awaitSuspending() }
+    }
+
+    private fun case(key: String, partyId: UUID, accountId: UUID?): UUID {
+        val caseId = UUID.randomUUID()
+        onEventLoop {
+            pool.preparedQuery(
+                """
+                INSERT INTO aml_cases
+                  (case_id, idempotency_key, party_id, account_id, customer_reference,
+                   screening_type, risk_level, status, alert_code, screened_at, created_at, updated_at)
+                VALUES ($1,$2,$3,$4,'ref','TRANSACTION_MONITORING','MEDIUM','OPEN','X',$5,$5,$5)
+                """.trimIndent(),
+            ).execute(Tuple.of(caseId, key, partyId, accountId).addOffsetDateTime(OffsetDateTime.now()))
+                .awaitSuspending()
+        }
+        return caseId
+    }
+
+    private fun partyOf(caseId: UUID): UUID = onEventLoop {
+        pool.preparedQuery("SELECT party_id FROM aml_cases WHERE case_id = $1")
+            .execute(Tuple.of(caseId)).awaitSuspending().iterator().next().getUUID("party_id")
+    }
+
+    @Test
+    fun `the detector selects exactly the cases that carry an account id as their party`() {
+        val account = UUID.randomUUID()
+        val brokenCase = case("broken", partyId = account, accountId = account)
+        // A correctly-resolved payment case: real party, real account, different values.
+        val healthy = case("healthy", partyId = UUID.randomUUID(), accountId = UUID.randomUUID())
+        // An onboarding case: real party, NO account. 51 of 57 rows in sandbox look like this and
+        // the sweep must never touch them — `account_id IS NULL` is why.
+        val onboarding = case("onboarding", partyId = UUID.randomUUID(), accountId = null)
+
+        val found = onEventLoop { repository.findUnresolvedParty(50) }
+
+        assertThat(found.map { it.first })
+            .describedAs("rewriting a correctly-resolved or onboarding case would corrupt compliance data")
+            .containsExactly(brokenCase)
+        assertThat(found.single().second).isEqualTo(account)
+        assertThat(onEventLoop { repository.countUnresolvedParty() }).isEqualTo(1)
+
+        // Untouched.
+        assertThat(partyOf(healthy)).isNotEqualTo(partyOf(brokenCase))
+        assertThat(partyOf(onboarding)).isNotNull()
+    }
+
+    @Test
+    fun `resolving a case points it at the real party and clears it from the backlog`() {
+        val account = UUID.randomUUID()
+        val realParty = UUID.randomUUID()
+        val caseId = case("to-resolve", partyId = account, accountId = account)
+
+        onEventLoop { repository.resolveParty(caseId, realParty) }
+
+        assertThat(partyOf(caseId)).isEqualTo(realParty)
+        assertThat(onEventLoop { repository.countUnresolvedParty() })
+            .describedAs("a resolved case must stop being re-swept")
+            .isZero()
+        assertThat(onEventLoop { repository.findUnresolvedParty(50) }).isEmpty()
+    }
+}


### PR DESCRIPTION
## What

aml_cases.party_id is NOT NULL and a payment carries only debtorAccountId, so three rails
satisfied the constraint with the debtor ACCOUNT id. It is a valid non-null UUID, nothing
detected it, and it joins to no party -- which breaks precisely the party-scoped things:
per-customer aggregation (a client with three accounts reads as three unrelated subjects),
the GDPR Art. 15 ?partyId= subject-access query, and anonymizeByPartyId, the Art. 17 erasure
path. #3404 fixed domestic-payment's happy path; sepa-instant and sepa-payment were untouched
and domestic's own lookup-failure fallback still writes the account id.

A sweep resolves it after the fact. Three other designs were tried first and each was
rejected by measurement, not taste:

  - Make partyId nullable. oasdiff against this service's own openapi.yaml: dropping it from
    the response's required list is response-property-became-optional, and keeping it required
    but nullable:true is response-property-became-nullable -- BOTH breaking, so either costs a
    MAJOR bump and a /api/v2/aml/cases URL. A null also fixes none of the three things above.
  - A Kafka projection off openbank.accounts.account.created. That topic is
    cleanup.policy=delete with 7-day retention and is not compacted, while most of the 77
    accounts are older -- a fresh consumer could never learn their party, and the projection
    would read as working while resolving almost nothing.
  - Resolution at ingest. A case must never fail to be recorded because account-service is
    unreachable, so the case-creation path is deliberately untouched by this change.

The detector is party_id = account_id, which holds byte-for-byte on every affected row
(measured 6 of 6 payment cases). PartyResolutionIT asserts BOTH directions against real
Postgres, because rewriting a correctly-resolved case -- or one of the 51 onboarding cases,
which carry a real party and no account -- is far worse than missing a broken one. Falsified:
widening the predicate to `accountId is not null` fails both tests.

openbank_aml_cases_party_unresolved is published so the sweep cannot quietly resolve nothing,
which is the failure mode this repo keeps meeting. The lookup runs on Dispatchers.IO: a
blocking HTTP call on the scheduler's Vert.x context stalls the event loop, and under
ConcurrentExecution.SKIP one stalled tick wedges every later one -- measured on #3266 earlier
today.

Existing rows are corrected by the sweep itself; no backfill migration is needed.

Closes #3413
Refs #3404, #3266, ADR-0032

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
