### PR TITLE
fix(delegation): the SCA pre-check made every customer ceremony impossible

### DIFF
--- a/openbank-delegation-service/src/main/kotlin/com/openbank/delegation/application/usecase/DelegationService.kt
+++ b/openbank-delegation-service/src/main/kotlin/com/openbank/delegation/application/usecase/DelegationService.kt
@@ -396,9 +396,21 @@ class DelegationService(
         if (challenge.partyId != expectedPartyId || challenge.purpose != expectedPurpose) {
             throw DelegationScaException("$errorPrefix challenge ${challenge.id} does not match party or purpose")
         }
-        if (challenge.status != "COMPLETED") {
-            throw DelegationScaException("$errorPrefix challenge ${challenge.id} is not completed")
-        }
+        // Deliberately NOT asserting status == "COMPLETED" here. A decoupled challenge
+        // (PUSH_NOTIFICATION / BIOMETRIC) sits at PENDING while holding a signature-verified
+        // device decision: `verify()` promotes it, and NOTHING a customer can reach calls verify —
+        // customer-edge exposes create / read / decision only. Payments work because the edge's own
+        // scaGate calls `consume`, which resolves a pending decoupled challenge itself before
+        // spending it ("resolve it now rather than refusing"). This pre-check ran BEFORE consume and
+        // rejected exactly the challenges consume would have legitimately resolved, so every
+        // customer-driven offer and accept failed with "challenge is not completed" — the whole
+        // ceremony was unreachable from the app.
+        //
+        // Approval is still enforced, and by the component that owns it: consume throws
+        // ScaChallengeNotApprovedException unless the challenge reaches COMPLETED, checks the party,
+        // refuses an already-spent challenge, and enforces dynamic linking. Asserting completion
+        // here as well only duplicated a weaker copy of that check at the one moment it could not
+        // yet be true.
     }
 
     @Suppress("TooGenericExceptionCaught") // includes sca-service's 409 for an already-spent challenge

--- a/openbank-delegation-service/src/test/kotlin/com/openbank/delegation/application/usecase/DelegationServiceTest.kt
+++ b/openbank-delegation-service/src/test/kotlin/com/openbank/delegation/application/usecase/DelegationServiceTest.kt
@@ -73,6 +73,19 @@ class DelegationServiceTest {
         )
     }
 
+    /**
+     * A decoupled challenge as the customer path actually presents it: PENDING, holding a
+     * signature-verified device decision that only `consume` will promote.
+     */
+    private fun scaPendingDecoupled(partyId: UUID, purpose: String) {
+        coEvery { scaClient.getChallenge(any()) } returns ScaChallengeSnapshot(
+            id = UUID.randomUUID(),
+            partyId = partyId,
+            purpose = purpose,
+            status = "PENDING",
+        )
+    }
+
     private fun eligibilityOk(grantorKyc: String = "FULL", granteeKyc: String = "FULL") {
         coEvery { eligibilityClient.eligibilityOf(grantor) } returns PartyEligibility(grantor, true, grantorKyc)
         coEvery { eligibilityClient.eligibilityOf(grantee) } returns PartyEligibility(grantee, true, granteeKyc)
@@ -148,6 +161,40 @@ class DelegationServiceTest {
         scaOk(grantor, "CONSENT_GRANT")
         // Ownership and eligibility are checked BEFORE the SCA gate (so a doomed request does not
         // spend the ceremony), hence both must be stubbed for the SCA assertion to be reached.
+        eligibilityOk()
+        assertThatThrownBy { runBlocking { service.offer(offerCommand()) } }
+            .isInstanceOf(DelegationScaException::class.java)
+        coVerify(exactly = 0) { repository.save(any<DelegationGrant>(), any()) }
+    }
+
+    @Test
+    fun `offer accepts a PENDING decoupled challenge and lets consume promote it`(): Unit = runBlocking {
+        // The state every customer-driven ceremony is actually in. NOTHING a customer can reach
+        // calls sca-service's verify(): customer-edge exposes create / read / decision only, and
+        // `decision` records the signed device decision without promoting the challenge. `consume`
+        // resolves it — payments rely on exactly that via the edge's scaGate. A pre-check on
+        // status == "COMPLETED" therefore rejected every offer and accept the app could make, and
+        // no test noticed because every fixture handed the service an already-COMPLETED challenge.
+        scaPendingDecoupled(grantor, "DELEGATION_GRANT")
+        eligibilityOk()
+        coEvery { repository.save(any<DelegationGrant>(), any()) } answers { firstArg() }
+
+        val grant = service.offer(offerCommand())
+
+        assertThat(grant.status).isEqualTo(DelegationStatus.OFFERED)
+
+        // Approval is still enforced — by consume, which owns it: it promotes the decision, refuses
+        // an unapproved or already-spent challenge, and binds dynamic linking.
+        coVerify(exactly = 1) { scaClient.consumeChallenge(any(), grantor) }
+        coVerify(exactly = 1) { repository.save(any<DelegationGrant>(), any()) }
+    }
+
+    @Test
+    fun `offer still rejects a PENDING challenge belonging to another party`(): Unit = runBlocking {
+        // Relaxing the status check must not relax the identity check: the party+purpose assertion
+        // is the half that cannot be delegated to consume, because consume is told which party to
+        // expect and would happily confirm the wrong one if we passed it through.
+        scaPendingDecoupled(UUID.randomUUID(), "DELEGATION_GRANT")
         eligibilityOk()
         assertThatThrownBy { runBlocking { service.offer(offerCommand()) } }
             .isInstanceOf(DelegationScaException::class.java)


### PR DESCRIPTION
## The delegation ceremony could not be completed from the app

`verifyAndConsumeSca` asserted `status == "COMPLETED"` **before** spending the challenge. That
rejected exactly the state every customer-driven offer and accept is in, so the whole ADR-0232
ceremony was unreachable from the mobile app — it failed with `challenge is not completed`.

The chain, verified against `origin/main`:

1. A decoupled challenge (`PUSH_NOTIFICATION` / `BIOMETRIC`) is created `PENDING`.
2. The app posts the signed device decision. `ScaService.recordDecision` writes it to the decision
   store and **returns the challenge unchanged** — still `PENDING`.
3. `verify()` → `verifyDecoupled()` is what promotes it (`challenge.complete(now)`).
4. **Nothing a customer can reach calls verify.** customer-edge exposes
   `POST /sca/challenges`, `GET /sca/challenges/{id}` and `POST /sca/challenges/{id}/decision`.
   No verify, no consume.
5. delegation-service then refused on the pre-check, before ever reaching consume.

## Why payments are unaffected

The edge's own `scaGate` calls `consume` server-to-server, and consume resolves a pending decoupled
challenge itself:

```kotlin
// A decoupled challenge may hold a signature-verified device decision that nobody has
// promoted yet (verify() is a separate call) — resolve it now rather than refusing.
if (challenge.status == ScaStatus.PENDING && (PUSH_NOTIFICATION || BIOMETRIC)) {
    challenge = verifyDecoupled(challenge, now)
}
```

delegation-service reaches `consume` too — `spendChallenge` is the very next call. The pre-check
just refused before it got there.

## Security is not reduced

Approval is still enforced by the component that owns it. `consume` promotes the decision, throws
`ScaChallengeNotApprovedException` unless the challenge reaches `COMPLETED`, checks the party,
refuses an already-spent challenge (compare-and-set on `consumedAt`, so two concurrent offers on one
challenge cannot both win), and enforces dynamic linking. The removed line was a weaker duplicate of
that check evaluated at the one moment it could not yet be true.

**The party+purpose assertion stays.** `consume` is *told* which party to expect, so it would
confirm whichever one it was handed — that half cannot be delegated to it. A test asserts a PENDING
challenge belonging to a different party is still refused.

## Why no test caught it

Every fixture handed the service an already-`COMPLETED` challenge — the state the customer path
never produces. The unit tests were green against a defect that made the feature unusable, which is
the failure mode this repo cares about most.

Both new tests were **falsified**: restoring the pre-check turns
`offer accepts a PENDING decoupled challenge` red; removing it again turns it green.

## Provenance

Found by the agent building the app's delegation UX (openbank-app#360), which could not make the
ceremony pass and traced it to the server rather than working around it client-side.

Refs #2971, #3164
