### PR TITLE
fix(delegation): terminate-first rollout, so a one-replica deploy is not a deadlock

### DIFF
--- a/openbank-infra/gitops/components/delegation/delegation-service.yaml
+++ b/openbank-infra/gitops/components/delegation/delegation-service.yaml
@@ -17,6 +17,23 @@ metadata:
     app.kubernetes.io/part-of: delegation
 spec:
   replicas: 1
+  # Terminate-first, deliberately. With the default RollingUpdate (maxSurge 25% -> 1,
+  # maxUnavailable 25% -> 0) a ONE-replica Deployment must schedule the new pod BEFORE it may
+  # stop the old one, so the rollout needs room for two pods — and the old pod is holding exactly
+  # the resources the new one needs. On a cluster with no spare room that is a deadlock the
+  # rollout never escapes: observed 2026-08-03, the SCA-ceremony fix sat Pending for hours behind
+  # its own predecessor while `default` was at its Karpenter CPU limit (48/48) and no node had
+  # 448Mi free.
+  #
+  # The trade is a few seconds of unavailability per deploy. This service has one replica and no
+  # HA, so it is already unavailable for that moment whenever the pod is replaced; what changes is
+  # that the replacement can actually happen. A multi-replica money-path service should NOT copy
+  # this — there, surge is what buys zero-downtime and the capacity to do it is worth having.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: delegation-service


### PR DESCRIPTION
## The rollout could not finish, and never would have

#3537 (the SCA-ceremony fix, without which no customer can complete a delegation) built, got
pinned, and then sat `Pending` for hours. Not capacity in the ordinary sense — a deadlock.

A **one-replica** Deployment with the default `RollingUpdate` gets `maxSurge: 25%` → 1 and
`maxUnavailable: 25%` → **0**. Kubernetes must therefore schedule the new pod *before* it may stop
the old one, so the rollout needs room for **two** pods — and the old pod is holding exactly the
448Mi the new one needs.

Measured 2026-08-03:

```
FailedScheduling  0/32 nodes are available: 1 Too many pods, 20 Insufficient memory,
                  4 Insufficient cpu, 8 node(s) had untolerated taint(s)
nodepool default  cpu 48/48   nodes 23        <- at its Karpenter limit, cannot add a node
```

**Waiting does not fix it.** I assumed it would drain with the overnight CI queue; the queue
drained (cluster-pending 4 → 3) and the pod stayed `Pending`. That assumption was wrong and worth
recording, because "it's just load" is the comfortable reading of a `Pending` pod.

## Fix

`maxSurge: 0` / `maxUnavailable: 1` — the old pod goes first, freeing the slot the new one needs.

The trade is a few seconds of unavailability per deploy. **This service already has that**: one
replica, no HA, so it is unavailable for that moment whenever the pod is replaced. What changes is
that the replacement can happen at all.

## Scope, deliberately narrow

108 single-replica Deployments in this fleet carry the same default; only 2 are configured to
terminate first. On a full cluster none of them can roll. That is a fleet-wide finding and it is
filed separately rather than swept into this PR, because the answer is not "apply this everywhere":

- a **single-replica, no-HA** service loses nothing it had — fix it this way;
- a **multi-replica money-path** service must not copy it. There, surge is precisely what buys
  zero-downtime, and the right answer is having the capacity to surge, not giving up the property.

The distinction matters more than the one-line change.

Refs #3537
