### PR TITLE
docs(analytics-sink): correct stale msg-override comment to current state

### DIFF
--- a/openbank-analytics-sink/src/main/resources/application.yaml
+++ b/openbank-analytics-sink/src/main/resources/application.yaml
@@ -103,15 +103,19 @@ mp:
         # client default (latest) instead of earliest — a consumer would silently skip
         # backlogged messages on first boot.
         #
-        # This service has NO gitops manifest yet (never deployed — no version.txt, not a
-        # released component). Whoever wires up its first deployment manifest MUST set these
-        # via a properties-file ConfigMap loaded with QUARKUS_CONFIG_LOCATIONS
-        # (config_ordinal=500), matching the intended values previously in this YAML block:
+        # Both keys ARE set — from the deployed manifest, not from this file. The
+        # analytics-sink-msg-override ConfigMap in
+        # openbank-infra/gitops/components/analytics/analytics-sink.yaml carries them in its
+        # override.properties, mounted at /mnt/msg-config and loaded via the container's
+        # QUARKUS_CONFIG_LOCATIONS env var (a properties source, so no dot-quoting):
         #   mp.messaging.incoming.analytics-events-in.group.id=analytics-sink
         #   mp.messaging.incoming.analytics-events-in.auto.offset.reset=earliest
-        # Mirror the ConfigMap/mount/env-var structure already used by onboarding-service
+        # Same ConfigMap/mount/env-var structure as onboarding-service
         # (openbank-infra/gitops/components/onboarding/onboarding-service-msg-override.yaml)
-        # and other services in the #686 sweep. Do NOT set these via
+        # and the other services in the #686 sweep. Change either value THERE, not here.
+        # (Separately: this service still has no version.txt and is absent from
+        # release-please-config.json — it is deployed, but not a released component.)
+        # Do NOT set these via
         # MP_MESSAGING_INCOMING_ANALYTICS_EVENTS_IN_* env vars — SmallRye's env-var
         # reverse-mapping is ambiguous for hyphenated channel names like
         # analytics-events-in and can crash at boot (quarkusio/quarkus#30106,


### PR DESCRIPTION
## What

Comment-only fix in `openbank-analytics-sink/src/main/resources/application.yaml`, in the `mp.messaging.incoming.analytics-events-in` block.

## Why

The comment told a future contributor to do work that is already complete, and asserted the service is undeployed when it is deployed:

> This service has NO gitops manifest yet (never deployed — no version.txt, not a released component). Whoever wires up its first deployment manifest MUST set these via a properties-file ConfigMap loaded with QUARKUS_CONFIG_LOCATIONS ...

Verified against `origin/main`:

- `openbank-infra/gitops/components/analytics/analytics-sink.yaml` is a live Deployment (ECR image pin, Kafka mTLS keystore/truststore volumes, NetworkPolicy).
- The same file defines the `analytics-sink-msg-override` ConfigMap, whose `override.properties` sets exactly the two keys the comment asks for:
  - `mp.messaging.incoming.analytics-events-in.group.id=analytics-sink`
  - `mp.messaging.incoming.analytics-events-in.auto.offset.reset=earliest`
- It is mounted at `/mnt/msg-config` and loaded via `QUARKUS_CONFIG_LOCATIONS=/mnt/msg-config/override.properties`.

## What is kept

The #686 reasoning is unchanged and still load-bearing — the rewritten comment still says why these keys must NOT be dotted YAML keys (SmallRye Config's YAML source quotes any leaf key containing a dot, so `KafkaConnectorIncomingConfiguration`'s `getOptionalValue("group.id", ...)` never finds it, and both values silently fall back to defaults) and must NOT be `MP_MESSAGING_INCOMING_ANALYTICS_EVENTS_IN_*` env vars (ambiguous env-var reverse-mapping for hyphenated channel names; tried and reverted for fraud-service, #685 -> #698).

## The two claims are separate

"never deployed" was false; "not a released component" is still true and is retained as its own parenthetical — `openbank-analytics-sink` has no `version.txt` and does not appear in `release-please-config.json`.

## Notes

- The original comment specified `config_ordinal=500`; the actual ConfigMap does not set one. A `QUARKUS_CONFIG_LOCATIONS` properties file already outranks `application.yaml`, so the rewritten comment does not claim an ordinal that is not there.
- No shipped code or config values change. `docs()` type, so no release is cut.

Refs #686
