### PR TITLE
feat(lending): turn on the fail-closed origination guard now the CZ pack is activated

### DIFF
--- a/openbank-infra/gitops/components/lending/lending-service.yaml
+++ b/openbank-infra/gitops/components/lending/lending-service.yaml
@@ -125,12 +125,21 @@ spec:
               value: "true"
             - name: OPENBANK_TEMPORAL_SERVER_URL
               value: temporal-frontend.temporal.svc.cluster.local:7233
-            # ADR-0212 D2/D4: fail-closed origination guard. STAYS false until the CZ
-            # reference pack is four-eyes-activated in this environment (compliance-
-            # packs/README.md runbook: seed -> activate -> verify /active -> flip).
-            # Flipping early refuses every origination with no pack present.
+            # ADR-0212 D2/D4: fail-closed origination guard. The runbook's precondition is
+            # met — the CZ consumer-credit pack v1 was four-eyes-activated in sandbox on
+            # 2026-08-02 (proposed by compliance@openbank.local, decided by
+            # compliance2@openbank.local, state EXECUTED) and /compliance-packs/active
+            # lists it.
+            #
+            # What this now refuses: any origination that does not name a (jurisdiction,
+            # productType) pair with an active pack. Customer intake is unaffected — it
+            # supplies CZ/CONSUMER_CREDIT from configuration rather than from the request,
+            # precisely so an applicant cannot pick which pack judges them, and CZ/
+            # CONSUMER_CREDIT is the pair that is active. Backoffice callers on
+            # POST /applications DO pass their own pair and will be refused for anything
+            # else, which is the point of the guard.
             - name: LENDING_ENFORCE_PACK
-              value: "false"
+              value: "true"
             # ADR-0211 customer intake (#3197). The applicant's own channel into
             # origination: customer-edge posts here with the party id it derived from the
             # customer JWT. Three values, each a refusal boundary rather than a preference:


### PR DESCRIPTION
## Precondition finally met

ADR-0212 D2's fail-closed origination guard has been off since it shipped, because its precondition could not be satisfied by anyone:

| blocker | PR |
|---|---|
| OPA never permitted pack activation | #3402 |
| persistence failed on both legs | #3448 |
| a single `ROLE_COMPLIANCE` account, so four-eyes could not complete | #3461 |

All three are fixed, and the CZ consumer-credit pack v1 is now **active in sandbox**:

```
EXECUTED | CZ | v1 | proposed by compliance@openbank.local
                   | decided  by compliance2@openbank.local
```

`GET /api/v1/lending/compliance-packs/active` lists it; the row is confirmed by a direct read of `compliance_pack_activation`, not only by the response that wrote it.

## What this refuses from now on

Any origination that does not name a `(jurisdiction, productType)` pair with an active pack.

**Customer intake is unaffected.** It supplies `CZ`/`CONSUMER_CREDIT` from configuration rather than from the request — deliberately, so an applicant cannot choose which compliance pack judges them — and that is the pair which is active.

**Backoffice callers on `POST /applications` do pass their own pair**, and anything other than `CZ`/`CONSUMER_CREDIT` will now be refused. That is the guard working, not a regression. Worth knowing before someone reads the first 400 as an outage.

## Why this is a separate PR from #3534

#3534 establishes that customer intake was never actually running — `@ConfigProperty` was ignored, so `LENDING_INTAKE_ENABLED=true` did nothing. Enforcing a compliance gate above a door nobody had opened would prove nothing and would tangle two independent failures in one deploy. This one lands after it.

Refs ADR-0212 D2/D4, #3402, #3448, #3461
