### PR TITLE
fix(infra): read a service's CNPG backup structurally, not as a whole-file substring

### DIFF
--- a/openbank-infra/scripts/generate-service-runbooks.py
+++ b/openbank-infra/scripts/generate-service-runbooks.py
@@ -109,16 +109,15 @@ def owns_no_database(facts: dict) -> bool:
 
 def backup_configured(short: str) -> bool:
     """True iff a deployed manifest configures a backup for this service's datastore
-    (CNPG barmanObjectStore). Mirrors the readiness collector's C5 detection so the
-    runbook's DR text never claims a backup the cluster doesn't actually have."""
-    comp = GITOPS / "components"
-    if not comp.is_dir():
-        return False
-    for f in comp.rglob("*.yaml"):
-        t = read(f)
-        if "barmanObjectStore" in t and (short in t or f.parent.name.startswith(short)):
-            return True
-    return False
+    (a CNPG `kind: Cluster` declaring `spec.backup.barmanObjectStore`). Mirrors the readiness
+    collector's C5 detection so the runbook's DR text never claims a backup the cluster
+    doesn't actually have.
+
+    This used to be a whole-file substring test — `"barmanObjectStore" in text and short in text`
+    over every file under `components/` — which matched PROSE, not configuration. See
+    `gitops_facts.cnpg_backup_configured` for the collision it produced and why the answer is
+    now read structurally."""
+    return gitops_facts.cnpg_backup_configured(short, GITOPS)
 
 
 def dr_for(datastore: str, has_backup: bool, owns_no_db: bool = None) -> str:

--- a/openbank-infra/scripts/generate_service_runbooks_test.py
+++ b/openbank-infra/scripts/generate_service_runbooks_test.py
@@ -211,6 +211,87 @@ class RunbookGeneratorTest(unittest.TestCase):
         self.assertIn("barmanObjectStore", out)
         self.assertNotIn("RPO/RTO: undefined", out)
 
+    # -- backup detection is structural, not a substring match ---------------
+    def test_prose_naming_barman_is_not_a_configured_backup(self):
+        """The #3508 collision, in fixture form: a NON-Cluster document under the service's own
+        component directory that contains BOTH `barmanObjectStore` and the service short name.
+
+        That is exactly the shape the OPA bundle ConfigMap had — it embedded rules.yaml verbatim,
+        and rules.yaml names `barmanObjectStore` inside a rule DESCRIPTION. The old whole-file
+        substring test returned True for it, so mcp-service — which has no CNPG cluster anywhere —
+        shipped a runbook promising on-call `RPO target: <= 5 min (continuous archiving)`.
+        """
+        self.write_service(datastore="postgresql", database="openbank_widget")
+        (self.comp / "widget-opa-bundle.yaml").write_text(
+            "apiVersion: v1\n"
+            "kind: ConfigMap\n"
+            "metadata:\n  name: widget-opa-bundle\n  namespace: widgets\n"
+            "data:\n"
+            "  rules.yaml: |\n"
+            "    db_backup_associations:\n"
+            "      description: every CNPG Cluster must declare spec.backup.barmanObjectStore\n"
+            "      applies_to: widget-db and every other openbank cluster\n"
+        )
+        self.assertFalse(self.mod.backup_configured("widget"))
+        out = self.mod.render("widget")
+        self.assertIn("no backup configured", out)
+        self.assertNotIn("**RPO target:**", out)
+
+    def test_barman_in_a_cluster_comment_is_not_a_configured_backup(self):
+        """The same failure one layer in: a real CNPG Cluster whose only `barmanObjectStore` is a
+        comment explaining that it has none. A guard over source text needs an explicit rule for
+        code-about-code, and here the rule is: comments are stripped before the structure is read."""
+        self.write_service(datastore="postgresql", database="openbank_widget")
+        (self.comp / "widget-db.yaml").write_text(
+            "apiVersion: postgresql.cnpg.io/v1\n"
+            "kind: Cluster\n"
+            "metadata:\n  name: widget-db\n  namespace: widgets\n"
+            "spec:\n"
+            "  instances: 1\n"
+            "  # TODO: no spec.backup.barmanObjectStore yet — tracked by the backup sweep\n"
+        )
+        self.assertFalse(self.mod.backup_configured("widget"))
+
+    def test_barman_nested_somewhere_else_is_not_a_configured_backup(self):
+        """`barmanObjectStore` must be under `spec.backup`, not merely present in the document."""
+        self.write_service(datastore="postgresql", database="openbank_widget")
+        (self.comp / "widget-db.yaml").write_text(
+            "apiVersion: postgresql.cnpg.io/v1\n"
+            "kind: Cluster\n"
+            "metadata:\n"
+            "  name: widget-db\n"
+            "  annotations:\n"
+            "    barmanObjectStore: planned\n"
+            "spec:\n  instances: 1\n"
+        )
+        self.assertFalse(self.mod.backup_configured("widget"))
+
+    def test_a_real_barman_backup_is_detected(self):
+        self.write_service(datastore="postgresql", database="openbank_widget")
+        (self.comp / "widget-db.yaml").write_text(
+            "apiVersion: postgresql.cnpg.io/v1\n"
+            "kind: Cluster\n"
+            "metadata:\n  name: widget-db\n  namespace: widgets\n"
+            "spec:\n  backup:\n    barmanObjectStore:\n      destinationPath: s3://backups/widget\n"
+        )
+        self.assertTrue(self.mod.backup_configured("widget"))
+
+    def test_a_real_barman_backup_is_detected_in_a_multi_document_file(self):
+        """A Cluster sharing a file with other resources — the fleet's usual shape."""
+        self.write_service(datastore="postgresql", database="openbank_widget")
+        (self.comp / "widget-db.yaml").write_text(
+            "apiVersion: v1\n"
+            "kind: Secret\n"
+            "metadata:\n  name: widget-db-creds\n"
+            "stringData:\n  note: barmanObjectStore is configured on the cluster below\n"
+            "---\n"
+            "apiVersion: postgresql.cnpg.io/v1\n"
+            "kind: Cluster\n"
+            "metadata:\n  name: widget-db\n  namespace: widgets\n"
+            "spec:\n  backup:\n    barmanObjectStore:\n      destinationPath: s3://backups/widget\n"
+        )
+        self.assertTrue(self.mod.backup_configured("widget"))
+
     # -- the C6 contract the readiness collector reads ----------------------
     def test_every_rendered_runbook_carries_the_disaster_recovery_heading(self):
         """prod-readiness C6=2 is detected by this exact heading — stateless included."""

--- a/openbank-infra/scripts/gitops_facts.py
+++ b/openbank-infra/scripts/gitops_facts.py
@@ -40,6 +40,7 @@ __all__ = [
     "management_scraped_namespaces",
     "declared_datastore",
     "is_stateless",
+    "cnpg_backup_configured",
 ]
 
 # Most services live in `openbank-<short>-service`, but the three payment modules do not:
@@ -305,6 +306,110 @@ def management_scraped_namespaces(gitops: Path) -> dict[str, set[str]]:
             for t in targets:
                 out.setdefault(t, set()).add(name)
     return out
+
+
+def _strip_comment(line: str) -> str:
+    """Drop a `#` comment. Only a full-line `#` or one preceded by whitespace counts, so a value
+    like `destinationPath: s3://bucket/path#frag` survives."""
+    if line.lstrip().startswith("#"):
+        return ""
+    return re.split(r"\s#", line, maxsplit=1)[0]
+
+
+def _doc_entries(doc: str) -> list[tuple[int, str, str]]:
+    """(indent, key, value) for every mapping key in a single YAML document.
+
+    A deliberately small structural reader, not a YAML parser: this module is stdlib-only (it is
+    imported by scripts that must run on a bare runner), and the only questions asked of it are
+    "is this document `kind: X`" and "does it declare the key path a.b.c". Comments are stripped
+    first — the whole reason this exists is that a substring match cannot tell a configured key
+    from prose that names it.
+
+    A list-item key (`- name: x`) is recorded at the indent of the key itself, not the dash, so
+    it nests correctly under its parent.
+    """
+    out: list[tuple[int, str, str]] = []
+    for raw in doc.splitlines():
+        line = _strip_comment(raw)
+        if not line.strip():
+            continue
+        m = re.match(r"^(\s*)(-\s+)?([A-Za-z_][\w.\-]*)\s*:(\s.*|)$", line)
+        if not m:
+            continue
+        indent = len(m.group(1)) + (len(m.group(2)) if m.group(2) else 0)
+        out.append((indent, m.group(3), m.group(4).strip()))
+    return out
+
+
+def _has_key_path(entries: list[tuple[int, str, str]], path: tuple[str, ...]) -> bool:
+    """True iff `entries` declares the nested mapping path, rooted at the document's top level.
+
+    Each component must appear strictly inside the previous one's block (greater indent, before
+    the block dedents), so `spec.backup.barmanObjectStore` is not satisfied by a `barmanObjectStore`
+    that sits somewhere else in the document.
+    """
+    lo, hi, parent = 0, len(entries), -1
+    for depth, key in enumerate(path):
+        found = -1
+        end = hi
+        for i in range(lo, hi):
+            indent, k, _ = entries[i]
+            if indent <= parent:
+                end = i
+                break
+            if k == key and (depth > 0 or indent == 0):
+                found = i
+                break
+        if found < 0:
+            return False
+        parent = entries[found][0]
+        lo, hi = found + 1, end
+        for i in range(lo, hi):
+            if entries[i][0] <= parent:
+                hi = i
+                break
+    return True
+
+
+def _yaml_documents(text: str) -> list[str]:
+    """The documents of a possibly multi-document YAML file."""
+    return re.split(r"^---\s*$", text, flags=re.M)
+
+
+def cnpg_backup_configured(short: str, gitops: Path) -> bool:
+    """True iff a CNPG `kind: Cluster` document for this service declares `spec.backup.barmanObjectStore`.
+
+    Matching mirrors the prod-readiness collector's `gitops_files_for(short, "Cluster")`: when the
+    service has its own `components/<short>/` directory that directory IS the scope, and only
+    outside it does the service name have to appear in the document.
+
+    The previous implementation asked `"barmanObjectStore" in text and (short in text or ...)`
+    over every file under `components/`, which matched PROSE. `rules.yaml` carries the literal
+    `barmanObjectStore` inside a rule DESCRIPTION, and until #3508 every service's OPA bundle
+    ConfigMap embedded rules.yaml verbatim — so `components/<svc>/<svc>-opa-bundle.yaml` satisfied
+    both halves for many services, and their runbooks promised on-call an RPO the cluster could
+    not deliver (mcp-service, which has no CNPG cluster at all, promised "RPO target: <= 5 min").
+    #3508 removed the embed and the collision went away; the TEST did not, so any future file
+    under a component directory containing both strings would reproduce it. Hence: structure.
+    """
+    comp = gitops / "components" / short
+    scoped = comp.is_dir()
+    root = comp if scoped else gitops
+    if not root.is_dir():
+        return False
+    for f in sorted(root.rglob("*.yaml")):
+        text = read(f)
+        if "barmanObjectStore" not in text:
+            continue  # cheap prefilter — the key must be present literally to be present structurally
+        for doc in _yaml_documents(text):
+            if not scoped and short not in doc:
+                continue
+            entries = _doc_entries(doc)
+            if not any(i == 0 and k == "kind" and v == "Cluster" for i, k, v in entries):
+                continue
+            if _has_key_path(entries, ("spec", "backup", "barmanObjectStore")):
+                return True
+    return False
 
 
 def declared_datastore(short: str, repo: Path) -> str:


### PR DESCRIPTION
## Summary

`generate-service-runbooks.py:backup_configured` decided whether a service's database has a backup with a whole-file substring test, so it matched **prose**, not configuration. Detection is now structural: parse each YAML document under `openbank-infra/gitops/components/`, select the top-level `kind: Cluster` documents, and require the nested key path `spec.backup.barmanObjectStore` with comments stripped.

## Type of change

- [x] fix (bug fix)

## Linked issues

Refs #3508

## The defect

```python
def backup_configured(short: str) -> bool:
    for f in comp.rglob("*.yaml"):
        t = read(f)
        if "barmanObjectStore" in t and (short in t or f.parent.name.startswith(short)):
            return True
```

`openbank-libs/governance/rules.yaml` contains the literal `barmanObjectStore` inside a rule **description**, and until #3508 every service OPA bundle ConfigMap embedded `rules.yaml` verbatim — so `components/<svc>/<svc>-opa-bundle.yaml` satisfied both halves of the test for many services. `mcp-service` has no `barmanObjectStore` anywhere in its component directory, yet `docs/runbooks/svc-mcp.md` promised on-call `RPO target: <= 5 min (continuous archiving)`, `RTO <= 30 min`.

#3508 removed the embed and the gate correctly flipped mcp to "no backup configured" (that regenerated runbook shipped in #3508). The **collision** is gone; the **test** was still wrong — any future file under a component directory containing both strings reproduces it.

## Changes

- **New** `gitops_facts.cnpg_backup_configured(short, gitops)` — splits a manifest into YAML documents, keeps the ones whose top-level `kind` is `Cluster`, and asks for the key path `spec.backup.barmanObjectStore`. Service matching mirrors the prod-readiness collector's `gitops_files_for(short, "Cluster")`: `components/<short>/` is the scope when that directory exists, and only outside it does the short name have to appear in the document.
- **New** `_doc_entries` / `_has_key_path` / `_strip_comment` / `_yaml_documents` — a small indentation-aware key-path reader. Stdlib only, deliberately: `gitops_facts` is imported by scripts that must run on a bare runner (no pyyaml), and the module already documents that constraint.
- `generate-service-runbooks.py:backup_configured` is now a one-line delegate; both docstrings record what the substring test cost.
- Five new cases in `generate_service_runbooks_test.py` (details below).

## Runbook regeneration

`python3 openbank-infra/scripts/generate-service-runbooks.py --force` produces **no diff**. That is the expected result, not a missing step: #3508 had already removed the one live collision, and the corrected mcp runbook shipped there.

Old-vs-new detection was compared for all 56 modules that carry a `governance.yaml`. Exactly one service flips:

| service | old | new | why |
| --- | --- | --- | --- |
| `admin-ui` | `true` | `false` | False positive. `components/observability/goalert.yaml` declares a Cluster **with** `barmanObjectStore` and separately mentions `admin-ui`; the old whole-file test joined the two. admin-ui matches neither the generator's `openbank-*-service` glob nor the money-path list, so it has no generated runbook and no document changed. |

The other 55 agree, and every one of the 48 that reports `true` resolves to a real `kind: Cluster` with `spec.backup.barmanObjectStore` (`components/*/postgres.yaml` and friends).

## Falsifiability

The fix was reverted **in place** (whole-file substring restored, everything else untouched), the suite re-run, and the file restored from a `cp` backup — no `git reset --hard`.

Against the old implementation, 3 of the new cases fail:

```
FAIL: test_prose_naming_barman_is_not_a_configured_backup
FAIL: test_barman_in_a_cluster_comment_is_not_a_configured_backup
FAIL: test_barman_nested_somewhere_else_is_not_a_configured_backup
AssertionError: True is not false
```

- **`test_prose_naming_barman_is_not_a_configured_backup`** — the case this PR is about: a non-Cluster ConfigMap in the service's *own* component directory whose embedded `rules.yaml` text contains both `barmanObjectStore` and the short name. Asserts `backup_configured` is false **and** that the rendered runbook says `no backup configured` with no `**RPO target:**`.
- **`test_barman_in_a_cluster_comment_is_not_a_configured_backup`** — a real Cluster whose only `barmanObjectStore` is a comment explaining that it has none. A guard over source text needs an explicit rule for code-about-code; here the rule is that comments are stripped before the structure is read.
- **`test_barman_nested_somewhere_else_is_not_a_configured_backup`** — `barmanObjectStore` under `metadata.annotations` rather than `spec.backup`.

Two positives are added alongside so the new implementation cannot pass by answering "no" to everything: a single-document Cluster, and a multi-document file where the Cluster shares the file with a Secret (the fleet's usual shape). Full suite: 135 tests, green.

## Out of scope — a real gap this surfaces

**`mcp-service` genuinely has no CNPG backup.** `components/mcp/postgres.yaml` declares `mcp-db` (namespace `platform`, `instances: 1`) with no `spec.backup` block at all, while `openbank-mcp-service/governance.yaml` declares `primaryDatastore: PostgreSQL`, `databaseName: openbank_mcp`. Its runbook is now honest about it (`RPO/RTO: undefined`, prerequisite not met), but the gap itself is real.

Fleet-wide, 2 of 55 CNPG clusters declare no `barmanObjectStore`: `mcp-db` and `litellm-db` (`components/ai-platform/postgres.yaml`).

Enabling those backups belongs to the backup sweep, not here — a runbook-accuracy PR must not quietly change what the cluster does. Note for the reviewer: I could not find an **open** issue that owns "clusters with no `barmanObjectStore`". The nearest neighbours are #1444 (closed — Pod Identity associations for clusters that *do* declare a backup) and #3347 (run a real DR restore drill). If there is no such issue, one should be opened for these two clusters and `svc-mcp.md`'s "see the backup sweep" pointer aimed at it.

## Definition of Done

- [x] Unit tests added/updated (5 cases; 3 fail against the old implementation).
- [x] No new lint warnings.
- [ ] N/A — no Kotlin, no service code, no API, no DB migration, no event schema. `./gradlew` is not involved; the relevant gate is `governance-script` (`python3 -m unittest discover -s openbank-infra/scripts -p '*_test.py'`).

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@Suppress`.
- [x] No new third-party dependency — stdlib only, on purpose.

## Compliance impact

- [x] DORA — indirectly, and in the honest direction: a runbook promising an RPO the cluster cannot deliver is worse than one saying DR is not achievable yet. No control changes.

## Rollout / Rollback

- Deployment strategy: N/A — repo tooling only; nothing deploys.
- Rollback plan: revert the commit. The runbooks on `main` are unchanged either way.
- Data migration reversible: N/A

## Reviewer notes

- The structural reader is intentionally minimal, not a YAML parser. It answers exactly two questions ("is this document `kind: X`", "does it declare key path `a.b.c`") because `gitops_facts` must stay stdlib-only for bare runners.
- `prod-readiness-collector.py:score_c5_backup` is **not** changed here. It already narrows to `gitops_files_for(short, "Cluster")` before its `"barmanObjectStore" in read(f)` test, so it is far less exposed — but it is still a file-level substring test and could adopt `cnpg_backup_configured` in a follow-up. That would move readiness scores, so it does not belong in this PR.
