### PR TITLE
fix(infra): terminate the realm-drift capture heredoc, so the detector can run at all

### DIFF
--- a/openbank-infra/gitops/components/keycloak-realm-drift/keycloak-realm-drift.yaml
+++ b/openbank-infra/gitops/components/keycloak-realm-drift/keycloak-realm-drift.yaml
@@ -253,25 +253,25 @@ spec:
                       "${KC_URL}/admin/realms/${REALM}/users?briefRepresentation=true&first=0&max=5000" \
                       > "/work/${REALM}-users.json"
                     REALM="${REALM}" TOKEN="${TOKEN}" KC_URL="${KC_URL}" python3 - <<'CAPTURE' > "/work/${REALM}-user-roles.json"
-                    import json, os, urllib.request
-                    realm, tok, url = os.environ["REALM"], os.environ["TOKEN"], os.environ["KC_URL"]
-                    def get(path):
-                        req = urllib.request.Request(f"{url}{path}", headers={"Authorization": f"Bearer {tok}"})
-                        return json.load(urllib.request.urlopen(req))
-                    out = {}
-                    for u in json.load(open(f"/work/{realm}-users.json")):
-                        out[u["username"]] = sorted(r["name"] for r in get(f"/admin/realms/{realm}/users/{u['id']}/role-mappings/realm"))
-                    builtin = {"account", "account-console", "admin-cli", "broker", "realm-management", "security-admin-console"}
-                    for c in json.load(open(f"/work/{realm}-clients.json")):
-                        if c.get("clientId") in builtin or not c.get("serviceAccountsEnabled"):
-                            continue
-                        try:
-                            sa = get(f"/admin/realms/{realm}/clients/{c['id']}/service-account-user")
-                        except Exception:
-                            continue
-                        out[sa["username"]] = sorted(r["name"] for r in get(f"/admin/realms/{realm}/users/{sa['id']}/role-mappings/realm"))
-                    json.dump(out, __import__("sys").stdout, indent=1, sort_keys=True)
-                    CAPTURE
+                  import json, os, urllib.request
+                  realm, tok, url = os.environ["REALM"], os.environ["TOKEN"], os.environ["KC_URL"]
+                  def get(path):
+                      req = urllib.request.Request(f"{url}{path}", headers={"Authorization": f"Bearer {tok}"})
+                      return json.load(urllib.request.urlopen(req))
+                  out = {}
+                  for u in json.load(open(f"/work/{realm}-users.json")):
+                      out[u["username"]] = sorted(r["name"] for r in get(f"/admin/realms/{realm}/users/{u['id']}/role-mappings/realm"))
+                  builtin = {"account", "account-console", "admin-cli", "broker", "realm-management", "security-admin-console"}
+                  for c in json.load(open(f"/work/{realm}-clients.json")):
+                      if c.get("clientId") in builtin or not c.get("serviceAccountsEnabled"):
+                          continue
+                      try:
+                          sa = get(f"/admin/realms/{realm}/clients/{c['id']}/service-account-user")
+                      except Exception:
+                          continue
+                      out[sa["username"]] = sorted(r["name"] for r in get(f"/admin/realms/{realm}/users/{sa['id']}/role-mappings/realm"))
+                  json.dump(out, __import__("sys").stdout, indent=1, sort_keys=True)
+                  CAPTURE
                     python3 -c "import json;print('  %d principal(s) with role mappings' % len(json.load(open('/work/${REALM}-user-roles.json'))))"
                   done
 


### PR DESCRIPTION

The keycloak-realm-drift CronJob has not run since #3244 added the role-ASSIGNMENT
capture. Every invocation dies before doing any work:

  /bin/sh: syntax error: unexpected end of file (expecting "done")

Two faults, both from the heredoc being written at the indentation of the `for REALM`
loop it sits inside:

  * `<<'CAPTURE'` (no dash) requires its terminator at column 0. The terminator was
    indented two spaces, so the shell never matched it, consumed the rest of the
    script as heredoc content, and hit EOF. `<<-` would NOT have fixed this: it
    strips leading TABS, and the indentation here is spaces.
  * A quoted heredoc preserves the body verbatim, so the two-space indent reached
    Python as a module-level indent — `IndentationError: unexpected indent`. That
    one was hidden behind the first: the script could never get far enough to run it.

Both are fixed by moving the body and the terminator to the script's column 0.
Verified on the script EXTRACTED from the committed manifest, not a retyped copy:
`sh -n` clean, and the Python body compiles.

WHAT IT COST
  The detector's red became its resting state. #3246 tracks the drift it reported on
  2026-08-01 (`declaredNotLive: ['mcp-caller']`); that finding is now known to be
  stale — the client role `mcp-caller` exists on `openbank-mcp-service` in the live
  realm, confirmed directly against the admin API (creating it returns 409). #3222 had
  already fixed the realm-vs-client comparison that made it a false positive. So for
  the last day the CronJob was red for a third, unrelated reason, about a realm that
  was in sync — and nothing said so, because a job that cannot start reports the same
  colour as a job that found something.

Refs #3246