### PR TITLE
fix(admin-ui): refresh the customer-app dossier version — it is blocking every PR

### DIFF
--- a/openbank-admin-ui/app-status.json
+++ b/openbank-admin-ui/app-status.json
@@ -12,7 +12,7 @@
   "asOf": "2026-07-29",
   "appRepo": "JiRaska/openbank-app",
   "derived": {
-    "version": "0.12.0",
+    "version": "0.13.0",
     "useFakeData": false,
     "edgeBaseUrl": "https://customer.open-bank.tech",
     "keycloakIssuer": "https://kc.open-bank.tech/realms/openbank-customers",

--- a/openbank-admin-ui/src/test/compliance-packs-console.test.tsx
+++ b/openbank-admin-ui/src/test/compliance-packs-console.test.tsx
@@ -90,10 +90,16 @@ describe('compliance pack activation console', () => {
     vi.stubGlobal('fetch', mockFetch({}))
     render(React.createElement(Providers, null, React.createElement(CompliancePacksPage)))
 
-    await waitFor(() => expect(screen.getByTestId('no-active')).toBeTruthy())
+    // Wait on the TEXT, not on the node. `no-active` is rendered on the very first pass —
+    // `active` starts empty — so waiting for the node to exist succeeds before any fetch has
+    // resolved, and the cell still reads "Not loaded.". Written the old way this assertion
+    // passed or failed on timing alone, and it started failing the first time the admin-ui
+    // suite actually ran on a PR that touched this directory.
     // With enforcement on and no pack, origination is refused fleet-wide. That is the whole
     // reason this screen exists before the flag flip, so it has to be said on the screen.
-    expect(screen.getByTestId('no-active').textContent).toMatch(/LENDING_ENFORCE_PACK/)
+    await waitFor(() =>
+      expect(screen.getByTestId('no-active').textContent).toMatch(/LENDING_ENFORCE_PACK/),
+    )
   })
 
   it('a refused pending read never renders as "nothing pending"', async () => {


### PR DESCRIPTION
## This is blocking every PR in the repository

```
the committed app-status.json no longer matches openbank-app source (1 field(s))
  version: committed="0.12.0" → regenerated="0.13.0"
```

`all-green` aggregates `Customer-app dossier`, so **every** pull request is BLOCKED — not only ones touching the admin UI.

Confirmed by comparison rather than assumption: the same check is red on #3548, whose entire diff is **one line of a gitops YAML**. That change cannot have caused it, so the failure is on `main`.

## The drift

A single field. `openbank-app` cut 0.13.0 and nothing here followed. The derived block is otherwise identical — `useFakeData`, edge base URL, issuer, client id, scopes, and all 18 capabilities (13 live / 4 partial / 1 planned) agree.

## On hand-editing a derived artifact

Normally the answer is to regenerate, and the generator is `openbank-admin-ui/scripts/generate-app-status.mjs`. It reads the **private** `openbank-app` repo through `OPENBANK_APP_RO_TOKEN`, a CI secret, so it cannot run here.

What makes editing safe regardless: **the check does not trust the file.** It regenerates the block and diffs it, so a wrong value stays red — the gate is the verification. And the value is not a guess; CI printed the regenerated one.

Refs ADR-0074
