### PR TITLE
ci(services): name a Docker registry pull failure instead of blaming the tests

### DIFF
--- a/.github/scripts/check-testcontainers-registry-failure.py
+++ b/.github/scripts/check-testcontainers-registry-failure.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+"""
+Name a Docker-registry fetch failure as such, instead of leaving it disguised as a test bug.
+
+THE PROBLEM THIS SOLVES
+-----------------------
+`_service-ci.yml` runs every PR build on `ubuntu-latest` (only the main-push lane gets the
+self-hosted pool). The "Pre-warm Testcontainers image cache via ECR" step is gated on
+`runner.environment == 'self-hosted'`, so on the PR lane it is skipped entirely: there is no
+ECR pull-through cache and no in-cluster registry-cache, and Testcontainers pulls
+postgres/valkey/redpanda/apicurio straight from Docker Hub. When Docker Hub is slow or
+rate-limits the shared hosted-runner egress IP, the pull times out.
+
+What the reader then sees at the top of the log is:
+
+    LedgerPactProviderVerificationTest > ... FAILED
+    LedgerSchedulerVertxContextIT > the scheduled FX revaluation reaches its use case() FAILED
+
+Two named test failures. The actual cause sits ~900 lines further down, as a
+`ContainerFetchException` wrapped in four layers of Quarkus test-resource plumbing. Measured on
+run 30769096077 (job 91553216566, PR #3515): the registry error appears 32 times in that log and
+the reader has no reason to scroll to it, because the summary already offered a plausible and
+completely wrong explanation. The failure is MISDIAGNOSED BY CONSTRUCTION — it is not that the
+signal is missing, it is that a more legible and incorrect signal is printed above it.
+
+This script reads the JUnit XML that Gradle writes for the failing tests and, if the stack traces
+carry a registry-fetch signature, prints a `::error` naming Docker Hub and recommending a re-run.
+
+WHY THE JUnit XML AND NOT THE CONSOLE LOG
+-----------------------------------------
+Reading the XML needs no change to the "Build + test" step. The alternative — teeing the Gradle
+output to a file — puts a pipe in the repo's single most load-bearing command, where a missing
+`set -o pipefail` silently swallows the build's exit code (this repo has been bitten by
+`gradlew | tail` doing exactly that). A post-step that only reads artifacts already on disk
+cannot change the build verdict at all, which is the correct blast radius for a diagnostic.
+
+The trade-off is deliberate and bounded: if the pull failure aborts the task before any JUnit XML
+is written, this prints nothing and the job behaves exactly as it does today. It never makes the
+diagnosis worse, and there is no case where it turns a green build red.
+
+WHY THE SIGNATURES ARE WHAT THEY ARE
+------------------------------------
+`ContainerFetchException` is the discriminating one: Testcontainers raises it only when it cannot
+obtain an image, so it cannot be confused with a container that started and then misbehaved. The
+registry hostnames and `toomanyrequests` are corroborating. Deliberately NOT matched:
+`ConditionTimeoutException` alone (awaitility is used all over the test suite for reasons that
+have nothing to do with Docker) and `InternalServerErrorException` alone (a 500 from any
+docker-java call, including ones a real bug could provoke).
+
+Note the code-about-code hazard the repo documents: a checker that greps a text file matches
+prose ABOUT the string as readily as the string itself, and in this direction — a false POSITIVE
+that tells a reader to re-run a genuinely broken build — that is the expensive mistake. It is
+avoided structurally here rather than by comment-stripping: the scan reads the `<failure>` and
+`<error>` element TEXT out of parsed XML, never the raw file, so a test NAME or a source comment
+mentioning `ContainerFetchException` cannot trigger it. `--self-test` asserts that specific
+non-match.
+
+Exit code is ALWAYS 0. This is a diagnostic, not a gate: it runs under `if: failure()` when the
+job is already failing, and a non-zero exit here would only add a second red step saying nothing
+new.
+
+Usage:  check-testcontainers-registry-failure.py --service <name> [--self-test]
+"""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import sys
+import tempfile
+import xml.etree.ElementTree as ET
+
+# The discriminating signature. Testcontainers raises this ONLY on a failure to obtain an image.
+PRIMARY = "ContainerFetchException"
+
+# Corroborating signatures — any one of these alongside PRIMARY sharpens the message, and each is
+# also sufficient on its own because none of them can be produced by anything but a registry call.
+CORROBORATING = (
+    "registry-1.docker.io",
+    "toomanyrequests",
+    "You have reached your pull rate limit",
+    "Retrying pull for image",
+)
+
+
+def failure_texts(xml_path: pathlib.Path) -> list[str]:
+    """Return the text of every <failure>/<error> element, or [] if the file is unparseable.
+
+    Parsing rather than grepping is what keeps a test name or a source comment mentioning
+    `ContainerFetchException` from triggering a false positive.
+    """
+    try:
+        root = ET.parse(xml_path).getroot()
+    except (ET.ParseError, OSError):
+        return []
+    out = []
+    for el in root.iter():
+        if el.tag in ("failure", "error"):
+            out.append((el.get("message") or "") + "\n" + (el.text or ""))
+    return out
+
+
+def scan(results_dir: pathlib.Path) -> tuple[bool, set[str]]:
+    """(registry failure seen?, set of matched signatures) across every JUnit XML under the dir."""
+    matched: set[str] = set()
+    for xml_path in sorted(results_dir.rglob("*.xml")):
+        for text in failure_texts(xml_path):
+            if PRIMARY in text:
+                matched.add(PRIMARY)
+            for sig in CORROBORATING:
+                if sig in text:
+                    matched.add(sig)
+    return (bool(matched), matched)
+
+
+def self_test() -> int:
+    """Prove BOTH directions: the signature is detected, and prose about it is not."""
+    hit_xml = """<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="X"><testcase name="a" classname="X">
+<failure message="boom">org.testcontainers.containers.ContainerFetchException at GenericContainer.java:1308
+Status 500: {"message":"Get \\"https://registry-1.docker.io/v2/\\": context deadline exceeded"}</failure>
+</testcase></testsuite>
+"""
+    # The false-positive control: the signature appears as a TEST NAME and as free text outside
+    # any <failure>/<error> element — i.e. code about the code. It must NOT be reported.
+    miss_xml = """<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="X">
+<testcase name="reports a ContainerFetchException clearly" classname="X">
+<failure message="expected true">java.lang.AssertionError at Foo.kt:42</failure>
+</testcase>
+<system-out>registry-1.docker.io was mentioned here in passing</system-out>
+</testsuite>
+"""
+    ok = True
+    with tempfile.TemporaryDirectory() as tmp:
+        d = pathlib.Path(tmp)
+        (d / "hit").mkdir()
+        (d / "miss").mkdir()
+        (d / "hit" / "TEST-a.xml").write_text(hit_xml)
+        (d / "miss" / "TEST-b.xml").write_text(miss_xml)
+
+        seen, sigs = scan(d / "hit")
+        if not seen or PRIMARY not in sigs:
+            print(f"SELF-TEST FAIL: registry failure not detected (matched={sorted(sigs)})")
+            ok = False
+
+        seen, sigs = scan(d / "miss")
+        if seen:
+            print(f"SELF-TEST FAIL: false positive on prose-about-the-code (matched={sorted(sigs)})")
+            ok = False
+
+    print("SELF-TEST PASS" if ok else "SELF-TEST FAILED")
+    return 0 if ok else 1
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--service", help="module directory whose build/test-results is scanned")
+    ap.add_argument("--self-test", action="store_true")
+    args = ap.parse_args()
+
+    if args.self_test:
+        return self_test()
+    if not args.service:
+        print("--service is required (or use --self-test)", file=sys.stderr)
+        return 0
+
+    results = pathlib.Path(args.service) / "build" / "test-results"
+    if not results.is_dir():
+        return 0
+
+    seen, sigs = scan(results)
+    if not seen:
+        return 0
+
+    print(
+        "::error title=Build failed on a Docker registry pull, not on your code::"
+        f"Testcontainers could not fetch an image for {args.service}. "
+        "PR builds run on GitHub-hosted runners, which have no ECR pull-through cache, so images "
+        "come straight from Docker Hub and a slow or rate-limited pull surfaces as ordinary test "
+        "failures. The named tests above are almost certainly NOT the defect. "
+        f"Signatures: {', '.join(sorted(sigs))}. Re-run the job before investigating."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/_service-ci.yml
+++ b/.github/workflows/_service-ci.yml
@@ -485,6 +485,17 @@ jobs:
             -Dpact.provider.branch="${BRANCH}" \
             -Dpact.provider.tag="${BRANCH}"
 
+      # A Docker Hub pull failure surfaces as NAMED TEST FAILURES, ~900 lines above the actual
+      # cause, so the reader goes hunting for a test bug that is not there. The PR lane runs on
+      # `ubuntu-latest`, where the ECR pre-warm step above is skipped, so Testcontainers pulls
+      # straight from Docker Hub. Full reasoning in the script header. Diagnostic only: it reads
+      # JUnit XML already on disk, always exits 0, and can never change the build verdict.
+      - name: "Explain a Docker registry pull failure (diagnostic)"
+        if: failure()
+        run: |
+          python3 .github/scripts/check-testcontainers-registry-failure.py \
+            --service "${{ inputs.service }}"
+
       # rules.yaml: openapi_request_schema_conformance (advisory). Only the REQUEST-body half of
       # schema-vs-code — see the script header for why the response half is not attempted. The
       # existence guard is a bash `[ -f ]` rather than a YAML `if: hashFiles(...)` composition —


### PR DESCRIPTION
## Summary

A Testcontainers image pull that fails against Docker Hub is reported to the reader as **named test
failures**, with the real cause ~900 lines below. This adds a diagnostic step that names Docker Hub
in a `::error` when a build fails with a registry-fetch signature.

It **deliberately does not** extend the ECR pre-warm to hosted runners. The measurement below is why.

## The defect

On PR #3515, `build (openbank-ledger-service)` (job `91553216566`) showed:

```
LedgerPactProviderVerificationTest > ... FAILED
LedgerSchedulerVertxContextIT > the scheduled FX revaluation reaches its use case() FAILED
```

Neither test is broken. 900 lines down:

```
com.github.dockerjava.api.exception.InternalServerErrorException: Status 500:
  {"message":"Get \"https://registry-1.docker.io/v2/\": net/http: request canceled ...
Caused by: org.testcontainers.containers.ContainerFetchException
```

The registry error appears **32 times** in that log. The failure is misdiagnosed **by construction**:
the signal is not missing, a more legible and completely wrong one is printed above it.

Structural cause — `runs-on` puts every PR build on `ubuntu-latest`, while the "Pre-warm
Testcontainers image cache via ECR" step is gated on `runner.environment == 'self-hosted'`. On the PR
lane it is skipped entirely, so Testcontainers pulls straight from Docker Hub.

## Measurement

Sample: the last **1000 `services-ci.yml` runs**, 2026-07-31T23:40Z -> 2026-08-03T03:48Z (2.17 days).

A run's top-level `conclusion` reports the **latest attempt only**, so a re-run erases this failure
class entirely — the run behind the log above now reads `success`. The sample therefore enumerates
`/actions/runs/<id>/attempts/<n>/jobs` for every attempt, not the run conclusion.

| | count |
|---|---|
| `build (...)` job attempts | **6323** |
| succeeded | 5685 |
| **failed** | **125** |
| cancelled | 289 |
| still running at sample time | 224 |

Runner split — this is the exposed population:

| runner | build-job attempts | share |
|---|---|---|
| `openbank-build` (self-hosted, main lane; ECR pre-warm **runs**) | 4567 | 72% |
| `ubuntu-latest` (hosted PR lane; ECR pre-warm **skipped**) | **1756** | **28%** |

Grep-safety: none of the signatures used to classify (`ContainerFetchException`,
`registry-1.docker.io`, `toomanyrequests`, `Retrying pull for image`) appears anywhere in
`_service-ci.yml`, verified against `origin/main`. So a match in a job log cannot be the echoed
`run:` script listing — the documented trap for this repo.

## FinOps — why option (b) is rejected

Over-the-wire (compressed, linux/amd64) size of the four pre-warmed images, read from the registry
manifests rather than estimated:

| image | compressed |
|---|---|
| `postgres:16.3-alpine` | 92.4 MB |
| `valkey/valkey:7.2-alpine` | 15.8 MB |
| `redpandadata/redpanda:v24.1.2` | 162.3 MB |
| `apicurio/apicurio-registry-mem:2.6.2.Final` | 393.6 MB |
| **total** | **664.1 MB = 0.649 GB** |

**Denominator.** 1756 hosted build jobs / 2.17 days = **809/day = ~24 600/month**.

**Option (b1) — extend the ECR pre-warm to hosted runners via OIDC.** ECR data-transfer-out to the
internet (eu-north-1, first 10 TB) is $0.09/GB. Every hosted build would pull all four images:

> 24 600 builds/mo x 0.649 GB x $0.09/GB = **~$1 437/month**

against a saving measured in **$0**, because this repo is **public** and GitHub-hosted Actions
minutes are free. The re-run costs latency and attention, not money. Rejected.

**Option (b2) — pre-warm only the images the module needs.** Best case (a postgres-only module) is
92.4 MB: 24 600 x 0.0902 GB x $0.09 = **~$200/month**, still against $0 saved, and it needs a
per-module image manifest that nothing derives today — a new hand-maintained list of the very thing
it covers, which is the gate-scope failure mode this repo has already been bitten by. Rejected.

**Option (b3) — a bounded retry around the pull.** Already implemented, by Testcontainers itself: the
reference log shows `Retrying pull for image: postgres:16.3-alpine (104s remaining)` counting down a
120 s budget that then expired. A second retry layer on top of a retry that already failed buys
nothing. Rejected on evidence.

Worth noting the observed error is `Client.Timeout exceeded while awaiting headers` /
`context deadline exceeded`, **not** `toomanyrequests`. So a Docker Hub login — the usual $0 fix,
raising the anonymous per-IP pull limit — would not have helped this failure either.

**Recommendation: option (a) only, $0/month.** The argument does not depend on the exact
registry-failure count: even at the **upper bound** where every one of the 125 failures were registry
failures (2.0% of all build attempts), $1 437/month to avoid a **free** re-run is not a trade worth
making. The real cost here is a reader sent to debug a test that is not broken, and that is fixed by
printing the right sentence. (The exact classification of those 125 is still running and will be
added as a comment; it can only move the number down, i.e. strengthen this conclusion.)

## What this adds

A post-step under `if: failure()` that runs
`.github/scripts/check-testcontainers-registry-failure.py --service <svc>`, which reads the JUnit XML
Gradle already wrote and emits a `::error` naming Docker Hub when a failure carries a registry
signature.

Two deliberate design choices, both about failure modes this repo has paid for:

* **It reads JUnit XML, not a teed console log.** Teeing would put a pipe in the repo's most
  load-bearing command, where a missing `set -o pipefail` silently swallows the build's exit code. A
  step that only reads artifacts already on disk always exits 0 and cannot change the build verdict.
  Bounded trade-off: if the pull failure aborts before any XML is written it prints nothing and
  behaves exactly as today. It never makes the diagnosis worse.

* **It parses the XML and inspects `<failure>`/`<error>` element text, never greps the file.** A
  whole-file grep cannot distinguish the signature from a test name or a comment mentioning it. In
  this direction the collision is a **false positive telling a reader to re-run a genuinely broken
  build**, so the protection is structural rather than comment-stripping.

## Falsification

`--self-test` asserts both directions, and both were broken in place and observed red before being
restored from a `cp` backup:

| break | result |
|---|---|
| primary signature disabled | `SELF-TEST FAIL: registry failure not detected` (exit 1) |
| parsed lookup replaced by whole-file grep | `SELF-TEST FAIL: false positive on prose-about-the-code` (exit 1) |
| restored | `SELF-TEST PASS` (exit 0) |

Also verified locally: `check-workflow-run-step-size` passes (largest run script 18872 / limit 19000;
the new step is small), `check-gate-script-registration` counts the new script as invoked (87
scripts, 0 never run), and `actionlint` finding sets are identical between `origin/main` and this
branch — with the oracle validated against a known-bad file first, so its silence means something.

This PR is itself the GitHub-side validation of the workflow edit: `services-ci.yml` builds a canary
(`openbank-libs`) on a recipe-only change to `_service-ci.yml`, so the modified reusable workflow is
parsed and executed by this PR's own run.

## Linked issues

Closes #3562
Refs #3515
