### PR TITLE
docs(ci): the minutes budget in services-ci.yml's header does not exist

### DIFF
--- a/.github/workflows/services-ci.yml
+++ b/.github/workflows/services-ci.yml
@@ -7,9 +7,30 @@
 #  build    -> calls the reusable _service-ci.yml once per changed module (matrix),
 #              so each service reports its own green/red status check.
 #
-# Minutes governance (GitHub Free, private repo = 2000 min/mo):
+# Why the matrix is path-scoped and runs are superseded:
 #  - path-scoped matrix: a typical PR builds only the handful of touched services
-#  - concurrency: cancel superseded runs on the same ref
+#  - concurrency: cancel superseded runs on the same ref (PR pushes only — a push to
+#    main gets a per-commit lane, see the concurrency block below)
+#
+# NOT a hosted-minutes budget. This header used to read "Minutes governance (GitHub Free,
+# private repo = 2000 min/mo)". That stopped being true when the repository went public:
+# GitHub-hosted minutes on a public repo are free and UNLIMITED — there is no monthly
+# allowance to govern and nothing here is billed by GitHub. The comment at the nightly
+# matrix further down this same file already said so, so the file contradicted itself and
+# the stale half was the one framing the whole design.
+#
+# The two constraints that are real are different resources, and conflating them is how the
+# wrong thing gets optimised:
+#
+#  - COST is AWS, not GitHub. The self-hosted ARC pool runs on EKS nodes we pay for, and it
+#    has a hard capacity ceiling as well (#2039: maxRunners is far below a full-fleet run,
+#    so an unscoped fan-out starves the queue for hours). That is the resource worth being
+#    careful with, and the only one attached to a bill.
+#  - WALL-CLOCK LATENCY is everyone's, on either pool. A full-fleet fan-out is minutes of
+#    waiting per PR whether or not anyone is charged for it.
+#
+# GitHub's own limit is a throughput cap, not a cost: the Free plan allows 20 concurrent
+# hosted jobs account-wide, shared with other repositories.
 name: Services CI
 
 on:


### PR DESCRIPTION
Comment-only. No behaviour changes.

## The contradiction

`services-ci.yml` opened with:

```
# Minutes governance (GitHub Free, private repo = 2000 min/mo):
```

and 300 lines further down, **in the same file**, said the nightly matrix runs on `ubuntu-latest` — *"hosted, free & unlimited on this public repo"*.

Both cannot be true. The repository is public (`gh api repos/JiRaska/open-bank-oss --jq .visibility` → `public`), so GitHub-hosted minutes are free and unlimited: there is no monthly allowance to govern, and nothing in this workflow is billed by GitHub.

## Why a stale comment is worth a PR here

The next person tuning this optimises for whichever constraint the header names — and the header named a budget that does not exist, while two genuinely different resources were being folded into one word:

- **Cost is AWS, not GitHub.** The self-hosted ARC pool runs on EKS nodes we pay for, and it has a hard capacity ceiling as well (#2039: `maxRunners` is far below a full-fleet run, so an unscoped fan-out starves the queue for hours). That is the resource attached to a bill.
- **Latency is everyone's**, on either pool, whether or not anyone is charged.

GitHub's own limit is a **throughput cap, not a cost**: the Free plan allows 20 concurrent hosted jobs account-wide, shared with other repositories — which the file already stated correctly further down.

The path-scoped matrix and supersede-on-PR-push are both still right. Only the stated reason was wrong, and it pointed at the wrong system.

## How it surfaced

While measuring a Docker Hub pull failure (#3562 / #3566). That analysis turned on whether hosted minutes are billed — the FinOps case for mirroring images to hosted runners came out ~$1.4k/month against **$0** saved, precisely *because* hosted minutes are free. Had anyone taken this header at face value, the arithmetic would have gone the other way.

## Not fixed here, deliberately

Other files mention private-repo billing (`docs/adr/0040`, `0082`, `platform-tofu.yml`, `substrate-tofu.yml`, `security.yml`). Those are either **general** statements that remain true ("GitHub bills hosted minutes on private repos") or **ADR records** of a decision taken when the repo's visibility was explicitly out of scope. An ADR is a record, not an instruction — rewriting it would falsify history. Only this header made a false claim about *this* repository *today*.

Also worth noting: comments are invisible to every gate in this repo **by design** — guards strip them so code-about-code does not trip them — so nothing was ever going to catch this. #3515's new `stale-comment-references` gate covers dead file paths and archived repo slugs; a factual claim like "2000 min/mo" is not mechanically decidable and stays a human problem.
