### PR TITLE
fix(infra): give mcp-db and litellm-db a CNPG backup — the last 2 of 55 clusters with none

### DIFF
--- a/docs/runbooks/svc-mcp.md
+++ b/docs/runbooks/svc-mcp.md
@@ -53,9 +53,8 @@ triaging an incident that starts on `mcp`.
 
 ## Disaster recovery
 
-- **RPO/RTO: undefined** — no backup is configured yet (see the prerequisite below), so no recovery-point/time guarantee can be made today.
-- **⚠ Prerequisite NOT met:** this PostgreSQL cluster has **no backup configured** (`barmanObjectStore` absent — prod-readiness C5=1). **DR is not achievable today** and the RPO/RTO targets above do NOT yet apply. Enabling the CNPG backup is the blocking prerequisite (see the backup sweep). Once enabled, the procedure is:
-- **Mechanism (after enablement):** CNPG continuous WAL + base backups → PITR.
+- **RPO target:** ≤ 5 min (continuous archiving). **RTO target:** ≤ 30 min (restore + warm-up).
+- **Mechanism:** CloudNativePG continuous WAL archiving + base backups to S3 (`barmanObjectStore`). Point-in-time recovery (PITR).
 - **Restore:** create a `Cluster` with `bootstrap.recovery` pointing at the backup object store; CNPG replays WAL to the target time. See runbook 0003 (PG major upgrade) for the cluster-recreate mechanics.
 - **Verify:** `kubectl cnpg status <db>-rw -n <ns>` shows the recovered cluster Healthy and the `*-app` secret regenerated.
 

--- a/openbank-infra/aws/envs/sandbox-platform/db-backups.tf
+++ b/openbank-infra/aws/envs/sandbox-platform/db-backups.tf
@@ -231,6 +231,19 @@ locals {
     # backups" has no judgement left to exercise, so advisory just made it mergeable. The gate
     # is now enforced.
     delegation = { namespace = "delegation", sa = "delegation-db" }
+    # Added by #3555 with their barmanObjectStore + ScheduledBackup in the same change — the two
+    # clusters that still declared NO backup at all, out of 55. Both are `instances: 1`, so they
+    # had neither a replica nor a recovery point: a lost EBS volume was total data loss.
+    #
+    # They are the counterpart to the second wave above, and they stayed hidden for a different
+    # reason. mcp-db's runbook actively asserted the opposite — "RPO target: <= 5 min (continuous
+    # archiving)" — because the runbook generator decided "has a backup" with a whole-file
+    # substring test that matched the OPA bundle's embedded rules.yaml prose (#3508, #3551).
+    # litellm-db carried a comment declining backups "matching devops-agent's pattern", written
+    # after #1444/#1452 had already given devops-agent and the other seven control-plane agent
+    # DBs a barmanObjectStore each. Two different kinds of false statement, one effect.
+    mcp     = { namespace = "platform", sa = "mcp-db" }
+    litellm = { namespace = "ai-platform", sa = "litellm-db" }
   }
 }
 

--- a/openbank-infra/gitops/components/ai-platform/postgres.yaml
+++ b/openbank-infra/gitops/components/ai-platform/postgres.yaml
@@ -14,12 +14,21 @@
 # this repo has been bitten by before, and the reason a config-only `max_budget` was rejected as the
 # whole answer.
 #
-# NOTE: no S3 WAL/backup here, matching devops-agent's and the other control-plane agents' pattern —
-# that needs an EKS Pod Identity role (aws/.../db-backups.tf, #863). The stakes are deliberately
-# different from a banking DB: this holds spend counters and key metadata, not regulated records.
-# Losing it means budget windows restart and the virtual keys must be re-seeded, which is an
-# operational annoyance, not a retention breach. Backups become worth adding the day a key's spend
-# history is used as evidence rather than as a guardrail.
+# BACKUPS. This manifest used to say "no S3 WAL/backup here, matching devops-agent's and the other
+# control-plane agents' pattern". That premise expired before it was written: #1444/#1452 had
+# already given devops-agent, finops-agent, governance-auditor, docs-truth-agent,
+# authz-policy-auditor, flaky-test-hunter, control-liveness-sentinel and release-steward a
+# barmanObjectStore each — all 8 of them. So this cluster was not following a pattern, it was the
+# last exception to one, and nothing said so (#3555).
+#
+# The stakes argument was the weaker half anyway. Losing this database does not just restart budget
+# windows — the virtual keys ARE the mechanism that stops one agent burning the fleet's budget, and
+# re-seeding them is a manual, credential-handling step (#3276/#3284), not a self-healing one. Until
+# it is done every caller is back on the shared master key, which is the exact state the keys were
+# introduced to end. That is a control outage, not an annoyance.
+#
+# Credentials via EKS Pod Identity on the litellm-db ServiceAccount (aws/.../db-backups.tf, #863) —
+# barman reads the SDK chain, no secret. Sandbox S3 lifecycle expires after 35d.
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:
@@ -53,3 +62,24 @@ spec:
     initdb:
       database: litellm
       owner: litellm
+  backup:
+    retentionPolicy: "30d"
+    barmanObjectStore:
+      destinationPath: s3://openbank-sandbox-db-backups/litellm-db
+      s3Credentials:
+        inheritFromIAMRole: true
+      wal:
+        compression: gzip
+      data:
+        compression: gzip
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: litellm-db-daily
+  namespace: ai-platform
+spec:
+  schedule: "0 49 4 * * *"
+  backupOwnerReference: self
+  cluster:
+    name: litellm-db

--- a/openbank-infra/gitops/components/mcp/postgres.yaml
+++ b/openbank-infra/gitops/components/mcp/postgres.yaml
@@ -31,3 +31,37 @@ spec:
   postgresql:
     parameters:
       wal_keep_size: "64MB"
+      # Bound WAL so a checkpoint spike cannot fill the 2Gi volume (#1432) — mandatory once
+      # archiving is on, because an archive that falls behind keeps segments on the volume.
+      max_wal_size: "512MB"
+  # WAL archiving + daily base backups to S3 (ADR-0035, #863 pattern). Credentials via EKS Pod
+  # Identity on the mcp-db ServiceAccount (aws/.../db-backups.tf) — barman reads the SDK chain,
+  # no secret. Sandbox S3 lifecycle expires after 35d; prod needs compliance retention.
+  #
+  # This cluster had NO backup of any kind until #3555: `instances: 1`, no replica, no WAL
+  # archive, so a lost EBS volume or a failed node reclaim was total data loss. It went unseen
+  # because docs/runbooks/svc-mcp.md promised on-call "RPO target: <= 5 min (continuous
+  # archiving)" — the runbook generator decided "has a backup" with a whole-file substring test
+  # that matched the OPA bundle's embedded rules.yaml prose (#3508 removed the embed, #3551 made
+  # the detection structural, and only then did the gap become visible as a gap).
+  backup:
+    retentionPolicy: "30d"
+    barmanObjectStore:
+      destinationPath: s3://openbank-sandbox-db-backups/mcp-db
+      s3Credentials:
+        inheritFromIAMRole: true
+      wal:
+        compression: gzip
+      data:
+        compression: gzip
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: mcp-db-daily
+  namespace: platform
+spec:
+  schedule: "0 44 4 * * *"
+  backupOwnerReference: self
+  cluster:
+    name: mcp-db


### PR DESCRIPTION
## Summary

`mcp-db` and `litellm-db` were the last 2 of 55 CNPG clusters declaring no `spec.backup.barmanObjectStore` — no WAL archiving, no base backups, and `instances: 1` so no replica either. A lost EBS volume or a failed node reclaim was total, unrecoverable data loss for either database. Both now get the fleet pattern from `components/sca/postgres.yaml` (ADR-0035, #863).

## Type of change

- [x] fix (bug fix)

## Linked issues

Closes #3555 · Refs #3551, #3508, #1444

## Changes

- `components/mcp/postgres.yaml` — `backup.retentionPolicy: 30d` + `barmanObjectStore` (gzip'd WAL and data, `s3://openbank-sandbox-db-backups/mcp-db`, `inheritFromIAMRole: true`), a daily `ScheduledBackup` at `0 44 4 * * *`, and `max_wal_size: 512MB`. The WAL bound is mandatory once archiving is on: an archive that falls behind keeps segments on the 2Gi volume (#1432).
- `components/ai-platform/postgres.yaml` — the same, `s3://openbank-sandbox-db-backups/litellm-db`, `ScheduledBackup` at `0 49 4 * * *` (it already carried `max_wal_size`). The "no backups here" comment is replaced with why that reasoning expired.
- `aws/envs/sandbox-platform/db-backups.tf` — `mcp = { namespace = "platform", sa = "mcp-db" }` and `litellm = { namespace = "ai-platform", sa = "litellm-db" }`. Without these barman fails **every** archive with `Unable to locate credentials` and nothing goes red — the #1444 failure mode, which this list has now caused four times.
- `docs/runbooks/svc-mcp.md` — regenerated. The generator flips it from `RPO/RTO: undefined` to a stated RPO/RTO on its own now that the manifest is real; the `service-runbook-drift` gate requires the regenerated file to be committed.

## Why each stayed hidden — two different false statements, one effect

**mcp-db's runbook asserted the opposite.** It promised on-call `RPO target: <= 5 min (continuous archiving)`, `RTO <= 30 min`, because the runbook generator decided "has a backup" with a whole-file substring test that matched the OPA bundle's embedded `rules.yaml` **prose**. #3508 removed the embed, #3551 made the detection structural — and only then was the gap visible as a gap rather than as a documented guarantee.

**litellm-db declined backups on a premise that had already expired.** The manifest said "no S3 WAL/backup here, matching devops-agent's and the other control-plane agents' pattern". Measured on `main` today, all eight of those agent DBs carry a `barmanObjectStore` — #1444/#1452 gave them one:

```
devops-agent barman=1        finops-agent barman=1
governance-auditor barman=1  docs-truth-agent barman=1
authz-policy-auditor barman=1 flaky-test-hunter barman=1
control-liveness-sentinel barman=1  release-steward barman=1
```

So it was not following a pattern, it was the last exception to one, and the comment was the only thing asserting otherwise. Its stakes argument was the weaker half anyway: the virtual keys are the mechanism that stops one agent burning the fleet's budget, and re-seeding them is a manual credential-handling step (#3276/#3284), not self-healing. Until that is done every caller is back on the shared master key — the exact state the keys were introduced to end. That is a control outage, not "budget windows restart".

## Verification

`db-backup-association-gate` (enforced), against the branch:

```
CNPG clusters declaring a barmanObjectStore: 55
  ...targeting openbank-sandbox-db-backups: 54
pod-identity associations declared in .../db-backups.tf: 55
✓ every cluster targeting the managed bucket has an association
```

Both manifests parse as two documents each (`Cluster` + `ScheduledBackup`). `run-gates.py --group gitops`: 17 PASS, plus two failures that are **pre-existing and unrelated** to this diff — `incluster-hostname-resolution` (advisory, #1916; its findings mention neither `mcp-db`, `litellm-db` nor `ai-platform`) and `loki-rule-load-test` (self-test cannot run in this local environment; this PR touches no Loki rules).

Not verifiable from the repo, and deliberately not claimed: that archiving actually works. That needs the cluster — see below.

## Rollout / Rollback

- **Apply the Terraform through CI, not a laptop.** This is `envs/sandbox-platform`, which `platform-tofu.yml` (ADR-0060) applies via `workflow_dispatch` on `main` — the workflow exists precisely so a merged infra change is not left for a laptop `tofu apply`, and its apply job re-plans against locked state and applies that plan. An earlier revision of this section said the opposite ("manual `tofu apply`, no CI pipeline"); that was carried over from `sandbox-substrate`, a different env directory, and it was wrong.
- **Ordering.** The association must exist before the cluster starts archiving, or every WAL push fails with `Unable to locate credentials`. ArgoCD syncs the manifests on merge, so **dispatch `platform-tofu.yml` right after merging** — the window between the two is a window in which `PostgresWALArchiveFailing` is expected and self-clears once the association lands. This ordering is deliberate and known, not an oversight: the alternative (apply before merge) would put live infra ahead of `main`.
- The PR's own `tofu plan (preview)` job is the authority on what the apply does: `Plan: 2 to add, 0 to change, 0 to destroy` — the two `aws_eks_pod_identity_association` entries and nothing else. Infracost on this PR: `1 project has no cost estimate change`.
- **Verify by asking the cluster, not the manifest:** `kubectl cnpg status mcp-db -n platform` and `kubectl cnpg status litellm-db -n ai-platform` must show `Continuous Backup: OK`, and one base backup must complete. If the pod carries no `AWS_CONTAINER_CREDENTIALS_FULL_URI`, the association did not land (the campaign/delegation signature, not the #1759 admission race a restart fixes).
- Rollback: revert the commit; CNPG stops archiving. Objects already in S3 expire on the bucket's 35d lifecycle.
- Data migration reversible: N/A — no schema change.

## FinOps

Delta, with the denominator:

- **S3 storage:** two 2Gi databases, gzip'd, 30d retention behind the bucket's 35d lifecycle. Budget **≤10 GB per cluster** as a pessimistic ceiling → 2 × 10 GB × $0.023/GB-mo = **≈ $0.46/mo**, realistically nearer $0.05.
- **Requests:** WAL PUTs on two light databases at $0.005/1000 — cents.
- **Transfer:** **$0** — same-region S3 over the existing Gateway endpoint, so this never touches the fck-nat path and adds no NAT egress.
- **Compute:** **$0** — barman runs inside the CNPG pod that is already there. No new workload, no new node, no change to NodePool pressure.
- **IAM / Pod Identity:** **$0** — associations are free.

Total **under $1/month**, against a fleet whose largest single line item is ~$809/mo (cross-AZ transfer, #3496). This is not a new cost class: 53 of 55 clusters already carry exactly this configuration.

**$0 alternative considered and rejected.** For `mcp-db` it would mean declaring the agent-session store disposable — then the honest fix is a runbook saying "recovery is a redeploy, sessions are lost", not silence, and prod-readiness C5 stays 1 forever. For `litellm-db` it does not exist: the spend ledger and key metadata are not reconstructible. A cheaper variant (`retentionPolicy: 7d`) saves a fraction of an already-negligible number and would diverge from the fleet's `30d` — noted so the choice is deliberate, not adopted.

## Definition of Done

- [x] `db-backup-association-gate` green; manifests parse; runbook regenerated and committed.
- [ ] N/A — no Kotlin, no API, no Flyway migration, no event schema. `./gradlew` is not involved.
- [ ] **Post-merge:** dispatch `platform-tofu.yml` (apply job) and confirm `Continuous Backup: OK` on both clusters.

## Security checklist

- [x] No secrets, tokens, passwords, or PII — credentials come from EKS Pod Identity via the SDK chain; nothing is written to a manifest.
- [x] No new third-party dependency.
- [x] No new `@Suppress`.

## Compliance impact

- [x] DORA — this is the ICT continuity gap the issue describes. Two databases move from "no recovery point at all" to continuous archiving + daily base backups. Neither is a regulated-records store, so no retention obligation changes; the sandbox bucket's 35d lifecycle still applies and prod retention remains a separate decision (ADR-0035).

## Reviewer notes

- The comment rewrite in `ai-platform/postgres.yaml` is the load-bearing part of the diff for future readers: a stale "we deliberately don't do X here" comment is invisible to every gate and outlives the reason it was written. Worth reading it rather than the YAML.
- `goalert-db` still warns in the association gate — it backs up to a different, non-Terraform-managed bucket. Pre-existing, untouched here, and not part of the "no backup at all" set this PR closes.
