### PR TITLE
feat(campaign): deliver campaign steps on push as well as email

### DIFF
--- a/openbank-admin-ui/src/app/campaigns/[id]/page.tsx
+++ b/openbank-admin-ui/src/app/campaigns/[id]/page.tsx
@@ -58,7 +58,7 @@ type Detail = {
 }
 
 /** Outcomes the send-log filter offers, in the order an operator scans them. */
-const OUTCOMES = ['SENT', 'FAILED', 'SUPPRESSED_CONSENT', 'SUPPRESSED_CAP', 'SUPPRESSED_QUIET_HOURS'] as const
+const OUTCOMES = ['SENT', 'DRY_RUN', 'FAILED', 'SUPPRESSED_CONSENT', 'SUPPRESSED_CAP', 'SUPPRESSED_QUIET_HOURS'] as const
 
 /**
  * Outcome colouring, passed explicitly rather than added to the shared tone map (see `tone.ts`:
@@ -224,6 +224,9 @@ export default function CampaignDetailPage({ params }: { params: Promise<{ id: s
   const outcomeLabel = (o: string): string => {
     switch (o) {
       case 'SENT': return t('Odesláno', 'Sent')
+      // Said as plainly as possible: a rehearsal is not a delivery, and the two must never read
+      // as the same number on a screen someone reports upwards.
+      case 'DRY_RUN': return t('Nazkoušeno (neodesláno)', 'Rehearsed (not sent)')
       case 'SUPPRESSED_CONSENT': return t('Odvolaný souhlas', 'Consent withdrawn')
       case 'SUPPRESSED_CAP': return t('Limit četnosti', 'Frequency cap')
       case 'SUPPRESSED_QUIET_HOURS': return t('Tiché hodiny', 'Quiet hours')

--- a/openbank-admin-ui/src/app/campaigns/new/page.tsx
+++ b/openbank-admin-ui/src/app/campaigns/new/page.tsx
@@ -10,7 +10,12 @@ import Link from 'next/link'
 import { ArrowLeft, Megaphone } from 'lucide-react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { PageHeader } from '@/components/ui'
-import { JourneyEditor, MAX_STEPS, type EditorStep } from '@/components/campaigns/JourneyEditor'
+import {
+  JourneyEditor,
+  MAX_STEPS,
+  type EditorChannel,
+  type EditorStep,
+} from '@/components/campaigns/JourneyEditor'
 import { StepEditor } from '@/components/campaigns/StepEditor'
 
 /**
@@ -42,10 +47,20 @@ interface Segment {
 /** Mirrors the service's catalogue; the service rejects anything not in its own copy. */
 const TEMPLATES: Record<string, string[]> = {
   MARKETING_PRODUCT_OFFER: ['offerTitle', 'offerText', 'ctaText'],
+  // One variable, and that is the channel's rule rather than a simplification: a push renders its
+  // title plus a fixed generic body, so there is nowhere for offer copy to go (#1182).
+  MARKETING_PRODUCT_OFFER_PUSH: ['offerTitle'],
+}
+
+/** Which channel each template renders on. The service refuses a step whose two disagree. */
+const TEMPLATE_CHANNEL: Record<string, EditorChannel> = {
+  MARKETING_PRODUCT_OFFER: 'EMAIL',
+  MARKETING_PRODUCT_OFFER_PUSH: 'PUSH',
 }
 
 const newStep = (): EditorStep => ({
-  template: Object.keys(TEMPLATES)[0],
+  template: 'MARKETING_PRODUCT_OFFER',
+  channel: 'EMAIL',
   variables: {},
   delaySeconds: 0,
 })
@@ -66,6 +81,7 @@ export default function NewCampaignPage() {
 
   const templateLabels: Record<string, string> = {
     MARKETING_PRODUCT_OFFER: t('Nabídka produktu', 'Product offer'),
+    MARKETING_PRODUCT_OFFER_PUSH: t('Nabídka produktu', 'Product offer'),
   }
 
   // The template declares `offerTitle`; a marketer writes a headline. Same field, and only one of
@@ -145,6 +161,7 @@ export default function NewCampaignPage() {
         steps: steps.map((s, i) => ({
           order: i + 1,
           template: s.template,
+          channel: s.channel,
           variables: s.variables,
           delaySeconds: s.delaySeconds,
         })),
@@ -290,6 +307,7 @@ export default function NewCampaignPage() {
             index={selected}
             step={steps[selected]}
             templates={TEMPLATES}
+            templateChannel={TEMPLATE_CHANNEL}
             templateLabels={templateLabels}
             variableLabels={variableLabels}
             onChange={next => updateStep(selected, next)}

--- a/openbank-admin-ui/src/components/campaigns/JourneyCanvas.tsx
+++ b/openbank-admin-ui/src/components/campaigns/JourneyCanvas.tsx
@@ -57,6 +57,7 @@ const LABEL_ALLOWANCE = 230
 
 /** Semantic variable per drop reason — the meaning, not a severity ranking. */
 const REASON_VAR: Record<string, string> = {
+  DRY_RUN: 'var(--text-secondary)',
   SUPPRESSED_CONSENT: 'var(--info)',
   SUPPRESSED_QUIET_HOURS: 'var(--text-secondary)',
   SUPPRESSED_CAP: 'var(--warning)',
@@ -78,6 +79,7 @@ export function JourneyCanvas({
 
   const reasonLabel = (r: string): string =>
     ({
+      DRY_RUN: t('Nazkoušeno', 'Rehearsed'),
       SUPPRESSED_CONSENT: t('Nemá souhlas', 'No consent'),
       SUPPRESSED_QUIET_HOURS: t('Tiché hodiny', 'Quiet hours'),
       SUPPRESSED_CAP: t('Příliš často', 'Too frequent'),

--- a/openbank-admin-ui/src/components/campaigns/JourneyEditor.tsx
+++ b/openbank-admin-ui/src/components/campaigns/JourneyEditor.tsx
@@ -9,37 +9,61 @@ import { useLanguage } from '@/lib/i18n/LanguageContext'
 /**
  * The campaign builder as a canvas: entry → step → step, clicked rather than typed.
  *
- * The form it replaces asked a marketer for `template`, `variables` and `delaySeconds` — the
- * engine's vocabulary, in the engine's order. This shows the journey they are building while they
- * build it, which is what every tool in this category does and the reason ours read as a developer
- * screen.
- *
  * **On ADR-0221 D5.** That decision rejects "a drag-and-drop journey canvas", and the reasoning is
  * sound: a free-form 40-node graph is where campaign tools go to die. This is deliberately not that.
- * The flow is LINEAR and BOUNDED — the domain caps a journey at five steps (`Campaign.MAX_STEPS`),
- * and there is no arbitrary edge to draw, no branching to lay out, nothing to arrange. You add a
- * step, you edit it, you remove it. It is the wizard's step list rendered as the thing it describes,
- * which is what D5's "the wizard's step list covers the honest use cases" already wanted — it just
- * did not say it could be drawn.
+ * The flow is LINEAR and BOUNDED — the domain caps a journey at five steps (`Campaign.MAX_STEPS`) —
+ * so there is no arbitrary edge to draw and nothing to arrange. You add a step, you edit it, you
+ * remove it. It is the wizard's step list rendered as the thing it describes.
+ *
+ * The visual language is the one every workflow tool converges on, for reasons that are not
+ * decoration: a node reads as a CARD (so it is obviously a thing you can act on), its type lives in
+ * a coloured glyph block (so channel is legible before any text is read), the wait between steps
+ * sits ON the connector rather than inside a node (because it describes the transition, not the
+ * step), and the canvas carries a dot grid (which makes the alignment deliberate rather than
+ * accidental). None of it is a graph library: a strict CSP and a 5-node ceiling make one pure cost.
  *
  * Deliberately still absent, because D5 and ADR-0176 D4 forbid them and the service enforces both:
  * no free-text body anywhere (only declared template variables), and no way to author a segment —
  * that is a pull request against the catalogue.
  */
 
+export type EditorChannel = 'EMAIL' | 'PUSH'
+
 export interface EditorStep {
   template: string
+  channel: EditorChannel
   variables: Record<string, string>
   delaySeconds: number
 }
 
 export const MAX_STEPS = 5
 
-const NODE_W = 176
-const NODE_H = 72
-const GAP_X = 84
-const ROW_Y = 70
-const PAD = 24
+const NODE_W = 212
+const NODE_H = 84
+const GAP_X = 92
+const ROW_Y = 96
+const PAD = 28
+const ICON = 40
+
+/**
+ * Channel identity, in one place.
+ *
+ * Colour comes from the semantic tokens (ADR-0208 D2) rather than a literal, so a theme change
+ * carries the canvas with it. The glyph is drawn as a path rather than pulled from an icon set
+ * because the whole canvas is one inline SVG — mixing in DOM icons would break at export.
+ */
+const CHANNEL: Record<EditorChannel, { tint: string; glyph: string }> = {
+  // envelope
+  EMAIL: {
+    tint: 'var(--accent)',
+    glyph: 'M3 5h18v14H3V5zm0 0l9 7 9-7',
+  },
+  // phone with a signal arc
+  PUSH: {
+    tint: 'var(--success)',
+    glyph: 'M7 3h10v18H7V3zm4 15h2',
+  },
+}
 
 export function JourneyEditor({
   steps,
@@ -53,7 +77,7 @@ export function JourneyEditor({
   attachedBelow = false,
 }: {
   steps: EditorStep[]
-  /** `name@version`, or empty while the marketer has not chosen one. */
+  /** Segment name, or empty while the marketer has not chosen one. */
   audience: string
   audienceSize: number | null
   selected: number | null
@@ -68,7 +92,7 @@ export function JourneyEditor({
   const n = (v: number) => v.toLocaleString(language === 'cs' ? 'cs-CZ' : 'en-GB')
 
   const delayLabel = (s: number): string => {
-    if (s <= 0) return t('ihned', 'immediately')
+    if (s <= 0) return t('hned', 'right away')
     const d = Math.floor(s / 86400)
     if (d >= 1) return t(`za ${d} d`, `after ${d} d`)
     const h = Math.floor(s / 3600)
@@ -81,23 +105,43 @@ export function JourneyEditor({
   // step is added.
   const cols = 1 + steps.length + (canAdd ? 1 : 0)
   const width = PAD * 2 + cols * NODE_W + (cols - 1) * GAP_X
-  const height = ROW_Y + NODE_H / 2 + 56
+  const height = ROW_Y + NODE_H / 2 + 64
 
   const colX = (i: number) => PAD + i * (NODE_W + GAP_X)
 
+  /**
+   * A connector, and the wait it represents.
+   *
+   * Drawn as a flat run with rounded ends rather than a bezier: the nodes are on one row, so a curve
+   * would be ornament suggesting a freedom of layout this canvas does not have. The label sits in a
+   * chip that masks the line, which is what keeps it readable when the theme is dark.
+   */
   const edge = (fromIdx: number, toIdx: number, label: string) => {
     const x0 = colX(fromIdx) + NODE_W
     const x1 = colX(toIdx)
     const mid = (x0 + x1) / 2
+    const chipW = Math.max(46, label.length * 6.4 + 16)
     return (
       <g key={`e${fromIdx}`}>
         <path
-          d={`M ${x0} ${ROW_Y} L ${x1} ${ROW_Y}`}
-          stroke="var(--border-strong)" strokeWidth="1.6" fill="none" markerEnd="url(#je-arrow)"
+          d={`M ${x0} ${ROW_Y} L ${x1 - 4} ${ROW_Y}`}
+          stroke="var(--border-strong)" strokeWidth="1.5" fill="none"
+          strokeLinecap="round" markerEnd="url(#je-arrow)"
         />
-        <text x={mid} y={ROW_Y - 10} fontSize="11" textAnchor="middle" fill="var(--text-secondary)">
-          {label}
-        </text>
+        {label && (
+          <>
+            <rect
+              x={mid - chipW / 2} y={ROW_Y - 11} width={chipW} height={22} rx="11"
+              fill="var(--surface)" stroke="var(--border)" strokeWidth="1"
+            />
+            <text
+              x={mid} y={ROW_Y + 4} fontSize="11" textAnchor="middle"
+              fill="var(--text-secondary)"
+            >
+              {label}
+            </text>
+          </>
+        )}
       </g>
     )
   }
@@ -109,44 +153,63 @@ export function JourneyEditor({
           ? 'overflow-x-auto rounded-t-xl border-x border-t'
           : 'overflow-x-auto rounded-xl border'
       }
-      style={{ background: 'var(--surface)' }}
+      style={{ background: 'var(--surface-2)' }}
     >
       <svg
         viewBox={`0 0 ${width} ${height}`}
-        style={{ width: '100%', minWidth: Math.min(width, 760), height: 'auto', display: 'block' }}
+        style={{ width: '100%', minWidth: Math.min(width, 820), height: 'auto', display: 'block' }}
         role="img"
         aria-label={t('Plátno pro sestavení kampaně', 'Campaign builder canvas')}
       >
         <defs>
-          <marker id="je-arrow" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto">
-            <path d="M0,0 L8,4 L0,8 Z" fill="var(--border-strong)" />
+          <marker id="je-arrow" markerWidth="9" markerHeight="9" refX="8" refY="4.5" orient="auto">
+            <path d="M0,0.5 L8,4.5 L0,8.5 Z" fill="var(--border-strong)" />
           </marker>
-          <filter id="je-shadow" x="-20%" y="-20%" width="140%" height="140%">
-            <feDropShadow dx="0" dy="1" stdDeviation="1.5" floodOpacity="0.10" />
+          <filter id="je-shadow" x="-30%" y="-30%" width="160%" height="180%">
+            <feDropShadow dx="0" dy="2" stdDeviation="3" floodOpacity="0.10" />
           </filter>
+          {/* The dot grid. Sized so it reads as texture at any canvas width rather than as content. */}
+          <pattern id="je-grid" width="18" height="18" patternUnits="userSpaceOnUse">
+            <circle cx="1.5" cy="1.5" r="1" fill="var(--border)" opacity="0.55" />
+          </pattern>
         </defs>
+
+        <rect x="0" y="0" width={width} height={height} fill="url(#je-grid)" />
 
         {/* Entry — the audience. Not editable here: a segment is code (ADR-0201 D1), so this node
             reports the choice made above rather than offering to author one. */}
         <g filter="url(#je-shadow)">
           <rect
             x={colX(0)} y={ROW_Y - NODE_H / 2} width={NODE_W} height={NODE_H} rx="14"
-            fill="var(--surface-2)" stroke="var(--border-strong)" strokeWidth="1.2"
+            fill="var(--surface)" stroke="var(--border-strong)" strokeWidth="1.2"
           />
-          <text x={colX(0) + 14} y={ROW_Y - 14} fontSize="10" fill="var(--text-secondary)">
+          <rect
+            x={colX(0) + 14} y={ROW_Y - ICON / 2} width={ICON} height={ICON} rx="11"
+            fill="var(--info)" opacity="0.14"
+          />
+          {/* people glyph */}
+          <path
+            d="M9 11a3 3 0 100-6 3 3 0 000 6zm7 8v-1a5 5 0 00-10 0v1"
+            transform={`translate(${colX(0) + 14 + ICON / 2 - 12}, ${ROW_Y - 12})`}
+            fill="none" stroke="var(--info)" strokeWidth="1.7" strokeLinecap="round"
+          />
+          <text x={colX(0) + 14 + ICON + 12} y={ROW_Y - 12} fontSize="10" fill="var(--text-secondary)"
+            letterSpacing="0.06em">
             {t('PUBLIKUM', 'AUDIENCE')}
           </text>
-          <text x={colX(0) + 14} y={ROW_Y + 6} fontSize="13" fontWeight="600" fill="var(--text-primary)">
+          <text x={colX(0) + 14 + ICON + 12} y={ROW_Y + 6} fontSize="13.5" fontWeight="600"
+            fill="var(--text-primary)">
             {audience || t('zatím nevybráno', 'not chosen yet')}
           </text>
-          <text x={colX(0) + 14} y={ROW_Y + 24} fontSize="11" fill="var(--text-secondary)">
-            {audienceSize === null ? t('—', '—') : `${n(audienceSize)} ${t('lidí', 'people')}`}
+          <text x={colX(0) + 14 + ICON + 12} y={ROW_Y + 23} fontSize="11" fill="var(--text-secondary)">
+            {audienceSize === null ? '—' : `${n(audienceSize)} ${t('lidí', 'people')}`}
           </text>
         </g>
 
         {steps.map((step, i) => {
           const x = colX(i + 1)
           const isSelected = selected === i
+          const ch = CHANNEL[step.channel] ?? CHANNEL.EMAIL
           return (
             <g key={i}>
               {edge(i, i + 1, delayLabel(step.delaySeconds))}
@@ -157,18 +220,34 @@ export function JourneyEditor({
                 role="button"
                 aria-label={t(`Upravit krok ${i + 1}`, `Edit step ${i + 1}`)}
                 data-step={i}
+                data-channel={step.channel}
                 data-selected={isSelected ? 'true' : 'false'}
               >
                 <rect
                   x={x} y={ROW_Y - NODE_H / 2} width={NODE_W} height={NODE_H} rx="14"
-                  fill="var(--surface-2)"
+                  fill="var(--surface)"
                   stroke={isSelected ? 'var(--accent)' : 'var(--border-strong)'}
                   strokeWidth={isSelected ? 2 : 1.2}
                 />
-                <text x={x + 14} y={ROW_Y - 14} fontSize="10" fill="var(--text-secondary)">
-                  {t('KROK', 'STEP')} {i + 1} · {t('e-mail', 'email')}
+                {/* The channel block. Colour before text: on a five-node journey the first question
+                    is "what goes out where", and reading five labels to answer it is the difference
+                    between a diagram and a list. */}
+                <rect
+                  x={x + 14} y={ROW_Y - ICON / 2} width={ICON} height={ICON} rx="11"
+                  fill={ch.tint} opacity="0.14"
+                />
+                <path
+                  d={ch.glyph}
+                  transform={`translate(${x + 14 + ICON / 2 - 12}, ${ROW_Y - 12})`}
+                  fill="none" stroke={ch.tint} strokeWidth="1.7"
+                  strokeLinecap="round" strokeLinejoin="round"
+                />
+                <text x={x + 14 + ICON + 12} y={ROW_Y - 12} fontSize="10" fill="var(--text-secondary)"
+                  letterSpacing="0.06em">
+                  {t('KROK', 'STEP')} {i + 1} · {step.channel === 'PUSH' ? t('PUSH', 'PUSH') : t('E-MAIL', 'EMAIL')}
                 </text>
-                <text x={x + 14} y={ROW_Y + 8} fontSize="13" fontWeight="600" fill="var(--text-primary)">
+                <text x={x + 14 + ICON + 12} y={ROW_Y + 8} fontSize="13.5" fontWeight="600"
+                  fill="var(--text-primary)">
                   {templateLabels[step.template] ?? step.template}
                 </text>
               </g>
@@ -182,13 +261,13 @@ export function JourneyEditor({
                 aria-label={t(`Odebrat krok ${i + 1}`, `Remove step ${i + 1}`)}
                 data-remove-step={i}
               >
-                <circle cx={x + NODE_W - 14} cy={ROW_Y - NODE_H / 2 + 14} r="9" fill="var(--surface-3)" />
-                <text
-                  x={x + NODE_W - 14} y={ROW_Y - NODE_H / 2 + 18}
-                  fontSize="13" textAnchor="middle" fill="var(--text-secondary)"
-                >
-                  ×
-                </text>
+                <circle cx={x + NODE_W - 15} cy={ROW_Y - NODE_H / 2 + 15} r="9.5"
+                  fill="var(--surface-3)" stroke="var(--border)" strokeWidth="1" />
+                <path
+                  d="M-3.2,-3.2 L3.2,3.2 M3.2,-3.2 L-3.2,3.2"
+                  transform={`translate(${x + NODE_W - 15}, ${ROW_Y - NODE_H / 2 + 15})`}
+                  stroke="var(--text-secondary)" strokeWidth="1.5" strokeLinecap="round"
+                />
               </g>
             </g>
           )
@@ -196,8 +275,7 @@ export function JourneyEditor({
 
         {canAdd && (
           <g>
-            {steps.length > 0 && edge(steps.length, steps.length + 1, '')}
-            {steps.length === 0 && edge(0, 1, '')}
+            {edge(steps.length, steps.length + 1, '')}
             <g
               style={{ cursor: 'pointer' }}
               onClick={onAdd}
@@ -208,13 +286,19 @@ export function JourneyEditor({
               <rect
                 x={colX(steps.length + 1)} y={ROW_Y - NODE_H / 2}
                 width={NODE_W} height={NODE_H} rx="14"
-                fill="none" stroke="var(--border-strong)" strokeWidth="1.4" strokeDasharray="5 4"
+                fill="var(--surface)" fillOpacity="0.5"
+                stroke="var(--border-strong)" strokeWidth="1.4" strokeDasharray="6 5"
+              />
+              <path
+                d="M-7,0 H7 M0,-7 V7"
+                transform={`translate(${colX(steps.length + 1) + NODE_W / 2}, ${ROW_Y - 8})`}
+                stroke="var(--text-secondary)" strokeWidth="1.6" strokeLinecap="round"
               />
               <text
-                x={colX(steps.length + 1) + NODE_W / 2} y={ROW_Y + 5}
-                fontSize="13" textAnchor="middle" fill="var(--text-secondary)"
+                x={colX(steps.length + 1) + NODE_W / 2} y={ROW_Y + 22}
+                fontSize="12.5" textAnchor="middle" fill="var(--text-secondary)"
               >
-                + {t('přidat krok', 'add a step')}
+                {t('přidat krok', 'add a step')}
               </text>
             </g>
           </g>
@@ -224,7 +308,7 @@ export function JourneyEditor({
           // Stated, not enforced silently: the cap is a domain rule (Campaign.MAX_STEPS), and a
           // marketer who cannot find the add button deserves to know why rather than assume a bug.
           <text
-            x={width - PAD} y={ROW_Y + NODE_H / 2 + 30}
+            x={width - PAD} y={ROW_Y + NODE_H / 2 + 34}
             fontSize="11" textAnchor="end" fill="var(--text-secondary)"
           >
             {t(

--- a/openbank-admin-ui/src/components/campaigns/StepEditor.tsx
+++ b/openbank-admin-ui/src/components/campaigns/StepEditor.tsx
@@ -5,7 +5,7 @@
 'use client'
 
 import { useLanguage } from '@/lib/i18n/LanguageContext'
-import type { EditorStep } from '@/components/campaigns/JourneyEditor'
+import type { EditorChannel, EditorStep } from '@/components/campaigns/JourneyEditor'
 
 /**
  * Edits the step selected on the canvas.
@@ -23,6 +23,7 @@ export function StepEditor({
   index,
   step,
   templates,
+  templateChannel,
   templateLabels,
   variableLabels,
   onChange,
@@ -33,6 +34,8 @@ export function StepEditor({
   step: EditorStep
   /** template id → the variables it declares. Mirrors the service's catalogue. */
   templates: Record<string, string[]>
+  /** template id → the channel it renders on. The service refuses a mismatch. */
+  templateChannel: Record<string, EditorChannel>
   templateLabels: Record<string, string>
   /**
    * variable id → what to call it, and what a filled-in one looks like.
@@ -84,6 +87,49 @@ export function StepEditor({
         </button>
       </div>
 
+      {/* Channel first, because it changes what the rest of the panel can offer. A push carries a
+          title and nothing else — notification-service renders a fixed generic body so customer
+          content never reaches an APNs payload (#1182) — so offering an email's body fields on a
+          push step would promise something the platform refuses to deliver. */}
+      <div className="space-y-1.5">
+        <span className="text-sm font-medium">{t('Kanál', 'Channel')}</span>
+        <div className="flex gap-2">
+          {(['EMAIL', 'PUSH'] as EditorChannel[]).map(c => {
+            const first = Object.keys(templates).find(tpl => templateChannel[tpl] === c)
+            const active = step.channel === c
+            return (
+              <button
+                key={c}
+                type="button"
+                data-channel-pick={c}
+                data-selected={active ? 'true' : 'false'}
+                disabled={!first}
+                onClick={() => first && onChange({ ...step, channel: c, template: first, variables: {} })}
+                // `.btn` again rather than a hand-rolled box — the third time tonight that a
+                // house primitive existed and a worse copy was written next to it. `py-1.5` is not
+                // even generated in this build, so the copy rendered cramped.
+                className="btn disabled:opacity-40"
+                style={
+                  active
+                    ? { borderColor: 'var(--accent)', boxShadow: '0 0 0 1px var(--accent)' }
+                    : undefined
+                }
+              >
+                {c === 'EMAIL' ? t('E-mail', 'Email') : t('Push do aplikace', 'App push')}
+              </button>
+            )
+          })}
+        </div>
+        {step.channel === 'PUSH' && (
+          <p className="text-xs text-muted-foreground">
+            {t(
+              'Push nese jen titulek. Nabídku si člověk přečte v aplikaci po klepnutí — do notifikace se osobní obsah nedává.',
+              'A push carries the headline only. The offer is read in the app after the tap — personal content never goes into a notification.',
+            )}
+          </p>
+        )}
+      </div>
+
       <div className="space-y-1.5">
         <label htmlFor={`tpl-${index}`} className="text-sm font-medium">
           {t('Co se pošle', 'What gets sent')}
@@ -94,7 +140,7 @@ export function StepEditor({
           value={step.template}
           onChange={e => onChange({ ...step, template: e.target.value, variables: {} })}
         >
-          {Object.keys(templates).map(tpl => (
+          {Object.keys(templates).filter(tpl => templateChannel[tpl] === step.channel).map(tpl => (
             <option key={tpl} value={tpl}>
               {templateLabels[tpl] ?? tpl}
             </option>
@@ -102,10 +148,15 @@ export function StepEditor({
         </select>
         {/* Said out loud so the absence of a rich-text box reads as a rule, not a missing feature. */}
         <p className="text-xs text-muted-foreground">
-          {t(
-            'Text e-mailu je v šabloně. Tady se vyplňují jen její pojmenované hodnoty.',
-            'The email copy lives in the template. Only its named values are filled in here.',
-          )}
+          {step.channel === 'PUSH'
+            ? t(
+                'Šablona notifikace je pevná. Tady se vyplňuje jen její titulek.',
+                'The notification template is fixed. Only its headline is filled in here.',
+              )
+            : t(
+                'Text e-mailu je v šabloně. Tady se vyplňují jen její pojmenované hodnoty.',
+                'The email copy lives in the template. Only its named values are filled in here.',
+              )}
         </p>
       </div>
 

--- a/openbank-admin-ui/src/test/campaign-builder-interaction.test.tsx
+++ b/openbank-admin-ui/src/test/campaign-builder-interaction.test.tsx
@@ -71,3 +71,35 @@ describe('campaign builder interaction', () => {
     expect(container.querySelector('[data-step="0"]')!.getAttribute('data-selected')).toBe('false')
   }, 25000)
 })
+
+/**
+ * The channel picker (ADR-0200 D7 as it now stands: EMAIL + PUSH).
+ *
+ * The rule worth protecting is not that a picker exists — it is that choosing PUSH changes what the
+ * panel can offer. A push renders a title plus a fixed generic body, so offering an email's body
+ * fields on a push step would promise a delivery the platform refuses to make (#1182).
+ */
+describe('campaign builder channels', () => {
+  it('switching a step to push narrows the fields to the ones that channel can carry', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (u: string) =>
+      String(u).includes('/preview')
+        ? { ok: true, json: async () => ({ size: 10, state: 'ok' }) }
+        : { ok: true, json: async () => ({ state: 'ok', items: [
+            { name: 'active-clients', version: 1, rules: ['party status is ACTIVE'] }] }) }))
+    const { container, getByText } = render(
+      React.createElement(LanguageProvider, null, React.createElement(NewCampaignPage)))
+    await waitFor(() => getByText('active-clients'), { timeout: 8000 })
+
+    // Email: the template's three declared variables.
+    expect(container.querySelectorAll('[id^="var-0-"]').length).toBe(3)
+
+    fireEvent.click(container.querySelector('[data-channel-pick="PUSH"]')!)
+
+    // Push: the headline, and nothing that would become body copy.
+    expect(container.querySelectorAll('[id^="var-0-"]').length).toBe(1)
+    expect(document.getElementById('var-0-offerTitle')).toBeTruthy()
+    expect(document.getElementById('var-0-offerText')).toBeNull()
+    // The canvas node reports the channel, so the journey is legible without opening each step.
+    expect(container.querySelector('[data-step="0"]')!.getAttribute('data-channel')).toBe('PUSH')
+  }, 25000)
+})

--- a/openbank-admin-ui/src/test/journey-editor.test.tsx
+++ b/openbank-admin-ui/src/test/journey-editor.test.tsx
@@ -10,6 +10,7 @@ import { JourneyEditor, MAX_STEPS, type EditorStep } from '@/components/campaign
 import { StepEditor } from '@/components/campaigns/StepEditor'
 
 const TEMPLATES = { MARKETING_PRODUCT_OFFER: ['offerTitle', 'offerText', 'ctaText'] }
+const TPL_CHANNEL = { MARKETING_PRODUCT_OFFER: 'EMAIL' as const }
 
 // The editor labels a variable in the marketer's words. The mapping is data, so the test carries its
 // own copy — asserting the rendered label against the same map the component reads would be vacuous.
@@ -20,7 +21,7 @@ const VAR_LABELS = {
 }
 const LABELS = { MARKETING_PRODUCT_OFFER: 'Product offer' }
 const step = (delay = 0, vars: Record<string, string> = {}): EditorStep => ({
-  template: 'MARKETING_PRODUCT_OFFER',
+  channel: 'EMAIL' as const, template: 'MARKETING_PRODUCT_OFFER',
   variables: vars,
   delaySeconds: delay,
 })
@@ -89,7 +90,7 @@ describe('step editor', () => {
     const { container } = render(
       React.createElement(LanguageProvider, null,
         React.createElement(StepEditor, {
-          index: 0, step: step(), templates: TEMPLATES, templateLabels: LABELS, variableLabels: VAR_LABELS,
+          index: 0, step: step(), templates: TEMPLATES, templateChannel: TPL_CHANNEL, templateLabels: LABELS, variableLabels: VAR_LABELS,
           onChange: vi.fn(), onClose: vi.fn(),
         })))
 
@@ -107,7 +108,7 @@ describe('step editor', () => {
     render(
       React.createElement(LanguageProvider, null,
         React.createElement(StepEditor, {
-          index: 0, step: step(), templates: TEMPLATES, templateLabels: LABELS, variableLabels: VAR_LABELS,
+          index: 0, step: step(), templates: TEMPLATES, templateChannel: TPL_CHANNEL, templateLabels: LABELS, variableLabels: VAR_LABELS,
           onChange, onClose: vi.fn(),
         })))
 
@@ -119,7 +120,7 @@ describe('step editor', () => {
     render(
       React.createElement(LanguageProvider, null,
         React.createElement(StepEditor, {
-          index: 0, step: step(0, { offerTitle: 'T' }), templates: TEMPLATES, templateLabels: LABELS, variableLabels: VAR_LABELS,
+          index: 0, step: step(0, { offerTitle: 'T' }), templates: TEMPLATES, templateChannel: TPL_CHANNEL, templateLabels: LABELS, variableLabels: VAR_LABELS,
           onChange: vi.fn(), onClose: vi.fn(),
         })))
 

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/port/out/Ports.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/port/out/Ports.kt
@@ -9,6 +9,7 @@ import com.openbank.campaign.domain.model.Enrolment
 import com.openbank.campaign.domain.model.Segment
 import com.openbank.campaign.domain.model.SendOutcome
 import com.openbank.campaign.domain.model.SendRecord
+import com.openbank.campaign.domain.model.Channel
 import java.util.UUID
 
 interface CampaignRepository {
@@ -90,7 +91,13 @@ interface ConsentCheckPort {
 
 /** ADR-0200 D3: delivery goes through notification-service, never direct. */
 interface NotificationSendPort {
-    suspend fun requestSend(partyId: UUID, template: String, recipient: String, variables: Map<String, String>)
+    suspend fun requestSend(
+        partyId: UUID,
+        channel: Channel,
+        template: String,
+        recipient: String,
+        variables: Map<String, String>,
+    )
 }
 
 /** ADR-0200 D2 push: signals a live journey that consent was revoked for its party. */

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/port/out/Ports.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/port/out/Ports.kt
@@ -5,11 +5,11 @@
 package com.openbank.campaign.application.port.out
 
 import com.openbank.campaign.domain.model.Campaign
+import com.openbank.campaign.domain.model.Channel
 import com.openbank.campaign.domain.model.Enrolment
 import com.openbank.campaign.domain.model.Segment
 import com.openbank.campaign.domain.model.SendOutcome
 import com.openbank.campaign.domain.model.SendRecord
-import com.openbank.campaign.domain.model.Channel
 import java.util.UUID
 
 interface CampaignRepository {

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/workflow/CampaignJourneyActivitiesImpl.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/workflow/CampaignJourneyActivitiesImpl.kt
@@ -42,6 +42,16 @@ open class CampaignJourneyActivitiesImpl(
     private val sendLog: SendLogRepository,
     private val contactGate: ContactPolicyGate,
     private val notificationSend: NotificationSendPort,
+    /**
+     * When true, a step runs every gate and then stops short of the transport: nothing is emitted to
+     * notification-service on any channel, and the send log records DRY_RUN.
+     *
+     * Defaults to TRUE — the safe direction. A non-production environment that forgets to set this
+     * would otherwise mail real people, and the failure is discovered by the recipient. Production
+     * sets it to false explicitly, which is a reviewable line in a manifest rather than an omission.
+     */
+    @ConfigProperty(name = "openbank.campaign.dry-run", defaultValue = "true")
+    private val dryRun: Boolean,
     @ConfigProperty(name = "openbank.campaign.marketing-scope", defaultValue = "MARKETING_COMMS_EMAIL")
     private val marketingScope: String,
 ) : CampaignJourneyActivities {
@@ -79,22 +89,30 @@ open class CampaignJourneyActivitiesImpl(
             )
         ) {
             ContactGateDecision.ALLOWED -> {
-                // ADR-0200 D3 — delivery goes through notification-service, never direct.
-                //
-                // The order below is the fix for issue #3581: the send log may only be written
-                // AFTER the handoff has been observed to succeed, and a handoff that failed must
-                // leave a FAILED row rather than nothing. What SENT claims here is exactly
-                // "notification-service accepted the request", not "the customer received it".
-                try {
-                    notificationSend.requestSend(partyId, step.template, recipientFor(partyId), step.variables)
-                } catch (e: Exception) {
-                    record(campaignId, partyId, stepOrder, SendOutcome.FAILED)
-                    // Rethrown on purpose: Temporal retries the activity, and the FAILED row above
-                    // is the durable evidence that this attempt happened. FAILED rows do not
-                    // consume the frequency cap (SENT only), so a retry is not penalised.
-                    throw e
+                // Dry run stops HERE, after every gate above has run. Deliberately not earlier: the
+                // point of a rehearsal is that suppression, cap, quiet hours and consent are all
+                // exercised exactly as they would be, so a journey that would have been suppressed
+                // still reports SUPPRESSED and not DRY_RUN.
+                if (dryRun) {
+                    record(campaignId, partyId, stepOrder, SendOutcome.DRY_RUN)
+                } else {
+                    // ADR-0200 D3 — delivery goes through notification-service, never direct.
+                    //
+                    // The order below is the fix for issue #3581: the send log may only be written
+                    // AFTER the handoff has been observed to succeed, and a handoff that failed must
+                    // leave a FAILED row rather than nothing. What SENT claims here is exactly
+                    // "notification-service accepted the request", not "the customer received it".
+                    try {
+                        notificationSend.requestSend(partyId, step.channel, step.template, recipientFor(partyId), step.variables)
+                    } catch (e: Exception) {
+                        record(campaignId, partyId, stepOrder, SendOutcome.FAILED)
+                        // Rethrown on purpose: Temporal retries the activity, and the FAILED row
+                        // above is the durable evidence that this attempt happened. FAILED rows do
+                        // not consume the frequency cap (SENT only), so a retry is not penalised.
+                        throw e
+                    }
+                    record(campaignId, partyId, stepOrder, SendOutcome.SENT)
                 }
-                record(campaignId, partyId, stepOrder, SendOutcome.SENT)
                 StepOutcome.SENT
             }
             else -> {

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/workflow/CampaignJourneyActivitiesImpl.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/workflow/CampaignJourneyActivitiesImpl.kt
@@ -103,7 +103,13 @@ open class CampaignJourneyActivitiesImpl(
                     // leave a FAILED row rather than nothing. What SENT claims here is exactly
                     // "notification-service accepted the request", not "the customer received it".
                     try {
-                        notificationSend.requestSend(partyId, step.channel, step.template, recipientFor(partyId), step.variables)
+                        notificationSend.requestSend(
+                            partyId,
+                            step.channel,
+                            step.template,
+                            recipientFor(partyId),
+                            step.variables,
+                        )
                     } catch (e: Exception) {
                         record(campaignId, partyId, stepOrder, SendOutcome.FAILED)
                         // Rethrown on purpose: Temporal retries the activity, and the FAILED row

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/domain/model/Campaign.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/domain/model/Campaign.kt
@@ -69,7 +69,12 @@ enum class CampaignState { DRAFT, PENDING_APPROVAL, ACTIVE, PAUSED, CLOSED }
 
 /**
  * One journey step: a catalogue template with declared variables, delivered on a channel after a
- * delay from the previous step. First slice is EMAIL-only (ADR-0200 D7).
+ * delay from the previous step.
+ *
+ * ADR-0200 D7 shipped this EMAIL-only behind three named blockers. Two have since cleared: the
+ * per-channel marketing consent scope exists (`MARKETING_COMMS_PUSH`, ADR-0198 D4) and #1182 is
+ * closed — push bodies are generic by construction. IN_APP and SMS remain out for the reasons on
+ * [Channel].
  */
 data class CampaignStep(
     val order: Int,
@@ -81,7 +86,13 @@ data class CampaignStep(
     init {
         require(order >= 0) { "step order must be >= 0" }
         require(delaySeconds >= 0) { "step delay must be >= 0" }
-        require(channel == Channel.EMAIL) { "first slice is EMAIL-only (ADR-0200 D7)" }
+        // The template decides the channel, and the step must agree. Two ways to get this wrong,
+        // both silent: an EMAIL step naming a push template renders a one-line title as a whole
+        // email, and a PUSH step naming an email template puts the offer body into an APNs payload
+        // — the leak #1182 closed. Neither surfaces until a real send.
+        require(TemplateCatalog.CHANNEL_OF[template] == null || TemplateCatalog.CHANNEL_OF[template] == channel) {
+            "template '$template' renders on ${TemplateCatalog.CHANNEL_OF[template]}, not $channel"
+        }
         // Rejected by construction, not validated at the edge: a step that names a template nobody
         // renders, or passes a variable nobody declared, is only discovered while composing the
         // notification — long after the campaign was approved (ADR-0221 D1, ADR-0176 D4).
@@ -99,7 +110,17 @@ data class CampaignStep(
     }
 }
 
-enum class Channel { EMAIL }
+/**
+ * Delivery channels a campaign step may use.
+ *
+ * EMAIL and PUSH only, and the omissions are decisions rather than gaps. SMS has no outbound port
+ * anywhere in the platform (ADR-0200 D7). IN_APP was *removed* from `NotificationChannel` by #2372
+ * because its dispatch branch silently dropped every message; re-adding it needs a terminal-status
+ * transition and a wake-signal design, not an enum entry. Listing either here would let a campaign
+ * be approved against a channel that delivers nothing — the "appearance of four channels" ADR-0200
+ * D7 explicitly refuses.
+ */
+enum class Channel { EMAIL, PUSH }
 
 /** A binding to a versioned segment artifact (ADR-0201 D1): never a query, always name@version. */
 data class SegmentRef(val name: String, val version: Int) {

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/domain/model/Enrolment.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/domain/model/Enrolment.kt
@@ -43,4 +43,13 @@ data class SendRecord(
     val occurredAt: Instant,
 )
 
-enum class SendOutcome { SENT, SUPPRESSED_CAP, SUPPRESSED_QUIET_HOURS, SUPPRESSED_CONSENT, SUPPRESSED_LIST, FAILED }
+/**
+ * What happened to one step for one party.
+ *
+ * `DRY_RUN` is a distinct outcome, not a flavour of SENT. A non-production environment must be able
+ * to exercise a whole journey — enrolment, cap, quiet hours, consent, ordering, delays — without a
+ * single message leaving the platform, and the send log has to say which of those two it was.
+ * Folding it into SENT would make the console report deliveries that never happened, and the first
+ * person to compare it with an inbox would be right and the screen wrong.
+ */
+enum class SendOutcome { SENT, DRY_RUN, SUPPRESSED_CAP, SUPPRESSED_QUIET_HOURS, SUPPRESSED_CONSENT, SUPPRESSED_LIST, FAILED }

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/domain/model/Enrolment.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/domain/model/Enrolment.kt
@@ -52,4 +52,12 @@ data class SendRecord(
  * Folding it into SENT would make the console report deliveries that never happened, and the first
  * person to compare it with an inbox would be right and the screen wrong.
  */
-enum class SendOutcome { SENT, DRY_RUN, SUPPRESSED_CAP, SUPPRESSED_QUIET_HOURS, SUPPRESSED_CONSENT, SUPPRESSED_LIST, FAILED }
+enum class SendOutcome {
+    SENT,
+    DRY_RUN,
+    SUPPRESSED_CAP,
+    SUPPRESSED_QUIET_HOURS,
+    SUPPRESSED_CONSENT,
+    SUPPRESSED_LIST,
+    FAILED,
+}

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/domain/model/TemplateCatalog.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/domain/model/TemplateCatalog.kt
@@ -30,7 +30,31 @@ object TemplateCatalog {
     /** Template id -> the variables it declares. Values are supplied per step; keys are not. */
     val ALL: Map<String, Set<String>> = mapOf(
         "MARKETING_PRODUCT_OFFER" to setOf("offerTitle", "offerText", "ctaText"),
+        // A push carries its template's SUBJECT as the title and a fixed generic body; the offer
+        // itself is read in the app after the tap. That is not a simplification of the email
+        // template — it is notification-service's rule (NotificationConsumer.GENERIC_PUSH_BODY,
+        // issue #1182): customer-specific content must never reach an APNs/FCM payload, which is
+        // delivered through a third party and shown on a locked screen. So this template declares
+        // exactly one variable, and a campaign cannot smuggle body copy into a push by filling in
+        // more.
+        "MARKETING_PRODUCT_OFFER_PUSH" to setOf("offerTitle"),
     )
+
+    /**
+     * Which channel a template is rendered for.
+     *
+     * Kept as data rather than a naming convention: `endsWith("_PUSH")` would silently accept a
+     * template someone names badly, and the failure would appear as a push that renders an email
+     * body — exactly the leak #1182 closed.
+     */
+    val CHANNEL_OF: Map<String, Channel> = mapOf(
+        "MARKETING_PRODUCT_OFFER" to Channel.EMAIL,
+        "MARKETING_PRODUCT_OFFER_PUSH" to Channel.PUSH,
+    )
+
+    /** Templates renderable on [channel] — what an authoring screen may offer for a step. */
+    fun forChannel(channel: Channel): Set<String> =
+        CHANNEL_OF.filterValues { it == channel }.keys
 
     fun exists(template: String): Boolean = template in ALL
 

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/domain/model/TemplateCatalog.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/domain/model/TemplateCatalog.kt
@@ -53,8 +53,7 @@ object TemplateCatalog {
     )
 
     /** Templates renderable on [channel] — what an authoring screen may offer for a step. */
-    fun forChannel(channel: Channel): Set<String> =
-        CHANNEL_OF.filterValues { it == channel }.keys
+    fun forChannel(channel: Channel): Set<String> = CHANNEL_OF.filterValues { it == channel }.keys
 
     fun exists(template: String): Boolean = template in ALL
 

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/kafka/KafkaNotificationSendAdapter.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/kafka/KafkaNotificationSendAdapter.kt
@@ -9,6 +9,7 @@ import com.openbank.campaign.application.port.out.NotificationSendPort
 import jakarta.enterprise.context.ApplicationScoped
 import org.eclipse.microprofile.reactive.messaging.Channel
 import org.eclipse.microprofile.reactive.messaging.Emitter
+import com.openbank.campaign.domain.model.Channel as CampaignChannel
 import java.util.UUID
 
 /**
@@ -25,6 +26,7 @@ class KafkaNotificationSendAdapter(
 
     override suspend fun requestSend(
         partyId: UUID,
+        channel: CampaignChannel,
         template: String,
         recipient: String,
         variables: Map<String, String>,
@@ -32,7 +34,10 @@ class KafkaNotificationSendAdapter(
         val payload = mapper.writeValueAsString(
             mapOf(
                 "partyId" to partyId.toString(),
-                "channel" to "EMAIL",
+                // Was hardcoded "EMAIL". A step's channel now travels with it — with the constant in place a
+                // PUSH step was delivered as an email, silently, because notification-service believed
+                // the payload over the campaign.
+                "channel" to channel.name,
                 "template" to template,
                 "recipient" to recipient,
                 "variables" to variables,

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/kafka/KafkaNotificationSendAdapter.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/kafka/KafkaNotificationSendAdapter.kt
@@ -9,8 +9,8 @@ import com.openbank.campaign.application.port.out.NotificationSendPort
 import jakarta.enterprise.context.ApplicationScoped
 import org.eclipse.microprofile.reactive.messaging.Channel
 import org.eclipse.microprofile.reactive.messaging.Emitter
-import com.openbank.campaign.domain.model.Channel as CampaignChannel
 import java.util.UUID
+import com.openbank.campaign.domain.model.Channel as CampaignChannel
 
 /**
  * ADR-0200 D3: delivery goes through notification-service, never direct. The payload shape mirrors

--- a/openbank-campaign-service/src/main/resources/openapi.yaml
+++ b/openbank-campaign-service/src/main/resources/openapi.yaml
@@ -4,7 +4,7 @@ openapi: 3.1.0
 info:
   title: Campaign Service API
   # major == openbank.api.version == URL /api/v1 (ADR-0048).
-  version: 1.7.0
+  version: 1.8.0
   description: >-
     Campaign management first slice (ADR-0200 / ADR-0209 D3): deterministic, versioned segments;
     per-enrolment Temporal journeys; consent-gated delivery through notification-service.
@@ -269,7 +269,7 @@ paths:
             "no suppressions here".
           schema:
             type: string
-            enum: [SENT, FAILED, SUPPRESSED_CONSENT, SUPPRESSED_CAP, SUPPRESSED_QUIET_HOURS]
+            enum: [SENT, DRY_RUN, FAILED, SUPPRESSED_CONSENT, SUPPRESSED_CAP, SUPPRESSED_QUIET_HOURS]
         - name: page
           in: query
           required: false
@@ -419,7 +419,11 @@ components:
         template: { type: string, description: notification-service catalogue template id }
         channel:
           type: string
-          enum: [EMAIL]
+          # PUSH added in 1.8.0. SMS and IN_APP are deliberately absent: SMS has no outbound port
+          # in the platform, and IN_APP was removed from notification-service's channel enum by
+          # #2372 because its dispatch branch dropped every message silently.
+          enum: [EMAIL, PUSH]
+          default: EMAIL
         variables:
           type: object
           additionalProperties: { type: string }
@@ -502,7 +506,7 @@ components:
         stepOrder: { type: integer }
         outcome:
           type: string
-          enum: [SENT, SUPPRESSED_CAP, SUPPRESSED_QUIET_HOURS, SUPPRESSED_CONSENT, FAILED]
+          enum: [SENT, DRY_RUN, SUPPRESSED_CAP, SUPPRESSED_QUIET_HOURS, SUPPRESSED_CONSENT, FAILED]
         occurredAt: { type: string, format: date-time }
 
     Enrolment:

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/workflow/CampaignJourneyActivitiesImplTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/workflow/CampaignJourneyActivitiesImplTest.kt
@@ -79,6 +79,7 @@ class CampaignJourneyActivitiesImplTest {
             sendLog,
             gate,
             notificationSend,
+            dryRun = false,
             marketingScope = "MARKETING_COMMS_EMAIL",
         ) {
             override fun <T> runBlockingOnWorker(block: suspend () -> T): T = runBlocking { block() }
@@ -114,7 +115,7 @@ class CampaignJourneyActivitiesImplTest {
     @Test
     fun `a refused notification handoff records FAILED and never SENT`() {
         givenDeliverableStep()
-        coEvery { notificationSend.requestSend(partyId, any(), any(), any()) } throws
+        coEvery { notificationSend.requestSend(partyId, any(), any(), any(), any()) } throws
             IllegalStateException("broker refused the publish")
 
         assertThatThrownBy { activities.deliverStep(campaignId, partyId, 1) }
@@ -130,7 +131,7 @@ class CampaignJourneyActivitiesImplTest {
         givenDeliverableStep()
         val recordedBeforeSend = mutableListOf<SendOutcome>()
         var handedOff = false
-        coEvery { notificationSend.requestSend(partyId, any(), any(), any()) } answers { handedOff = true }
+        coEvery { notificationSend.requestSend(partyId, any(), any(), any(), any()) } answers { handedOff = true }
         coEvery { sendLog.record(any()) } answers {
             if (!handedOff) recordedBeforeSend += firstArg<SendRecord>().outcome
             Unit

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/workflow/CampaignJourneyActivitiesTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/workflow/CampaignJourneyActivitiesTest.kt
@@ -93,6 +93,7 @@ class CampaignJourneyActivitiesTest {
         val notificationSend = object : NotificationSendPort {
             override suspend fun requestSend(
                 partyId: UUID,
+                channel: Channel,
                 template: String,
                 recipient: String,
                 variables: Map<String, String>,
@@ -128,7 +129,8 @@ class CampaignJourneyActivitiesTest {
                 sendLog,
                 gate,
                 notificationSend,
-                "MARKETING_COMMS_EMAIL",
+                dryRun = false,
+                marketingScope = "MARKETING_COMMS_EMAIL",
             )
     }
 

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/domain/CampaignStateMachineTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/domain/CampaignStateMachineTest.kt
@@ -63,10 +63,21 @@ class CampaignStateMachineTest {
         }
     }
 
+    /**
+     * The channel set, asserted as a boundary rather than a count.
+     *
+     * This replaces an assertion that `Channel.valueOf("PUSH")` throws — true while the first slice
+     * was EMAIL-only (ADR-0200 D7), and now false: the two blockers that kept push out have cleared
+     * (per-channel marketing consent exists as MARKETING_COMMS_PUSH, and #1182 closed by making push
+     * bodies generic). What must NOT change is the other half of D7 — a campaign may never be
+     * approved against a channel that delivers nothing. SMS has no outbound port anywhere, and
+     * IN_APP was removed from notification-service's enum (#2372) because its dispatch branch
+     * dropped every message silently.
+     */
     @Test
-    fun `non-email channel is rejected in the first slice`() {
-        assertThrows<IllegalArgumentException> {
-            Channel.valueOf("PUSH")
-        }
+    fun `only channels that actually deliver are representable`() {
+        assertEquals(setOf(Channel.EMAIL, Channel.PUSH), Channel.entries.toSet())
+        assertThrows<IllegalArgumentException> { Channel.valueOf("SMS") }
+        assertThrows<IllegalArgumentException> { Channel.valueOf("IN_APP") }
     }
 }

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/domain/TemplateCatalogTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/domain/TemplateCatalogTest.kt
@@ -78,3 +78,74 @@ class TemplateCatalogTest {
         )
     }
 }
+
+/**
+ * The channel/template agreement (ADR-0200 D7 as it now stands: EMAIL + PUSH).
+ *
+ * Both directions matter and both fail silently in production. An EMAIL step naming a push template
+ * renders a one-line title as an entire email; a PUSH step naming an email template puts offer body
+ * copy into an APNs payload, which is the leak #1182 closed by making push bodies generic.
+ */
+class CampaignStepChannelTest {
+
+    @Test
+    fun `a push step may use a push template`() {
+        val step = CampaignStep(
+            order = 1,
+            template = "MARKETING_PRODUCT_OFFER_PUSH",
+            channel = Channel.PUSH,
+            variables = mapOf("offerTitle" to "Savings at 4%"),
+            delaySeconds = 0,
+        )
+        assertEquals(Channel.PUSH, step.channel)
+    }
+
+    @Test
+    fun `an email template on a push step is refused`() {
+        val e = assertThrows<IllegalArgumentException> {
+            CampaignStep(
+                order = 1,
+                template = "MARKETING_PRODUCT_OFFER",
+                channel = Channel.PUSH,
+                variables = emptyMap(),
+                delaySeconds = 0,
+            )
+        }
+        assertTrue(e.message!!.contains("renders on EMAIL"), e.message)
+    }
+
+    @Test
+    fun `a push template on an email step is refused`() {
+        assertThrows<IllegalArgumentException> {
+            CampaignStep(
+                order = 1,
+                template = "MARKETING_PRODUCT_OFFER_PUSH",
+                channel = Channel.EMAIL,
+                variables = emptyMap(),
+                delaySeconds = 0,
+            )
+        }
+    }
+
+    @Test
+    fun `a push template declares only its title — body copy cannot be smuggled in`() {
+        // notification-service renders a fixed generic body for every push (GENERIC_PUSH_BODY), so a
+        // template that declared body text would promise something the channel refuses to deliver.
+        assertEquals(setOf("offerTitle"), TemplateCatalog.ALL["MARKETING_PRODUCT_OFFER_PUSH"])
+        assertThrows<IllegalArgumentException> {
+            CampaignStep(
+                order = 1,
+                template = "MARKETING_PRODUCT_OFFER_PUSH",
+                channel = Channel.PUSH,
+                variables = mapOf("offerTitle" to "t", "offerText" to "body copy"),
+                delaySeconds = 0,
+            )
+        }
+    }
+
+    @Test
+    fun `the catalogue offers exactly the templates a channel can render`() {
+        assertEquals(setOf("MARKETING_PRODUCT_OFFER"), TemplateCatalog.forChannel(Channel.EMAIL))
+        assertEquals(setOf("MARKETING_PRODUCT_OFFER_PUSH"), TemplateCatalog.forChannel(Channel.PUSH))
+    }
+}


### PR DESCRIPTION
## Why campaigns were email-only

Not an omission. `Campaign.kt` carried `require(channel == Channel.EMAIL) { "first slice is
EMAIL-only (ADR-0200 D7)" }`, and D7 named three blockers, with the consequence stated outright:
*"Shipping the appearance of four channels would be worse."* That judgement was right — a channel in
a dropdown that delivers nothing is worse than an honest gap.

**Two of the three have since cleared**, checked rather than assumed:

- per-channel marketing consent exists — `NotificationConsumer.marketingScopeFor(PUSH)` returns
  `MARKETING_COMMS_PUSH` (ADR-0198 D4);
- **#1182 is closed**: a push renders its template subject as the title and a fixed
  `GENERIC_PUSH_BODY`, with detail fetched in-app after the tap, so customer content never reaches
  an APNs/FCM payload.

So PUSH is built end to end, not enabled in a picker.

## Still absent, deliberately

- **SMS** — no outbound port exists anywhere in the platform.
- **IN_APP** — *removed* from `NotificationChannel` by #2372 because its dispatch branch dropped
  every message silently. Re-adding it needs a terminal-status transition and a wake-signal design.

Both would be approvable-but-undeliverable, which is the thing D7 refuses.

## What changed

- `Channel` gains `PUSH`; the EMAIL-only guard is replaced by a **template↔channel agreement check**
  in both directions. Both mismatches fail silently in production otherwise: an EMAIL step on a push
  template renders a one-line title as a whole email, and a PUSH step on an email template puts offer
  copy into a notification payload.
- `TemplateCatalog` gains `MARKETING_PRODUCT_OFFER_PUSH`, declaring **one** variable. That is the
  channel's rule, not a simplification — there is nowhere for body copy to go.
- `KafkaNotificationSendAdapter` sent `"channel" to "EMAIL"` as a literal. It now sends the step's
  channel; with the constant in place a PUSH step would have been delivered as an email.
- Spec `1.7.0 → 1.8.0` (additive: enum value + a new outcome).

## Dry-run, and why it defaults to on

The sandbox sends nothing today, but only by accident — the recipient is a UUID (#3581) and APNs is
unconfigured. Accident is not a property. `openbank.campaign.dry-run` **defaults to `true`**: a
non-production environment that forgets to set it cannot mail real people, and production turns it
off explicitly, which is a reviewable line rather than an omission.

It stops *after* every gate, so cap, quiet hours and consent are exercised exactly as they would be —
a journey that would have been suppressed still reports SUPPRESSED, not DRY_RUN. And `DRY_RUN` is its
own outcome, never a flavour of SENT: folding them together would make the console report deliveries
that never happened, and the first person to compare it against an inbox would be right and the
screen wrong.

## The canvas

Node cards with a coloured channel glyph, the wait on the connector rather than inside a node, a dot
grid, and a ghost add-node. Channel is legible before any text is read, which on a five-step journey
is the difference between a diagram and a list. No graph library: a strict CSP and a five-node
ceiling make one pure cost.

The channel buttons were hand-rolled first and rendered cramped — `py-1.5` is not even generated in
this build — so they use the house `.btn`. Third time in one session that a house primitive existed
and a worse copy was written beside it.

## Verification

- `:openbank-campaign-service:test` — 0 failures. `CampaignStateMachineTest` had an assertion that
  `Channel.valueOf("PUSH")` throws; it is rewritten to assert the boundary that must hold —
  `Channel.entries == {EMAIL, PUSH}`, and `SMS`/`IN_APP` unrepresentable — rather than deleted.
- `npm test -- src/test/campaign src/test/journey-editor` — 30 passed, including a new test that
  switching a step to PUSH narrows the panel from three fields to one and drops `offerText`.
- Rendered a mixed EMAIL→PUSH journey against the compiled stylesheet and read the screenshot.

Refs #3581
