### PR TITLE
fix(audit): hash the timestamp the database actually stores

### DIFF
--- a/openbank-audit-service/CLAUDE.md
+++ b/openbank-audit-service/CLAUDE.md
@@ -1,0 +1,26 @@
+# openbank-audit-service — service notes
+
+## Engineering notes
+
+- **Never hash a value the database stores at lower precision than the JVM holds it.** The
+  tamper-evidence chain (ADR-0031 / ADR-0133) writes `record_hash` from the INCOMING
+  `AuditEntry` and re-derives it in `verifyChain()` from the object rebuilt out of the row, so
+  the two sides agree only if every hashed field survives the round-trip byte for byte.
+  `occurred_at`/`recorded_at` are `TIMESTAMPTZ` — microseconds — while `java.time.Instant`
+  carries nanoseconds, and on Linux (where the pods run, unlike macOS) `Instant.now()` really
+  does produce them. Hashing the unrounded value and storing the truncated one made every link
+  permanently unverifiable: the lost digits are not in the database, so no rendering of the
+  stored value can reproduce the hash. `openbank_audit_chain_entries_checked` sat at **0**
+  against 1066 chained rows, and `AuditChainBroken` was a permanent critical, from the day the
+  V5 chain shipped (#3505). `AuditRepository.normalisedForStorage()` now truncates to
+  microseconds on both the persist path and inside `chainHash`, so the two agree by
+  construction rather than by luck of the platform clock. If a future field is added to the
+  canonical list, ask what the column does to it before adding it.
+- **A hash-chain test that does not touch a real database proves nothing about the chain.**
+  Every unit test here hashes and verifies in-process, which is exactly the step where the two
+  sides disagreed — all of them were green for the whole life of the defect. `AuditChainRoundTripIT`
+  (Testcontainers, `PostgresTestResource`) is the one that can see it; it pins the instants to
+  literal NANOSECOND values so it proves the same thing on a developer's macOS as on a Linux
+  runner. Note `audit_entries` carries `no_update_audit`/`no_delete_audit` rules (V2), so a test
+  cannot clean up after itself — write with fresh `aggregate_id`s and anchor `verifyChain` with
+  `fromEntryId` instead of assuming an empty table.

--- a/openbank-audit-service/src/main/kotlin/com/openbank/audit/infrastructure/persistence/AuditRepository.kt
+++ b/openbank-audit-service/src/main/kotlin/com/openbank/audit/infrastructure/persistence/AuditRepository.kt
@@ -15,6 +15,7 @@ import jakarta.persistence.Entity
 import jakarta.persistence.Table
 import kotlinx.coroutines.sync.withLock
 import java.time.Instant
+import java.time.temporal.ChronoUnit
 import java.util.UUID
 
 @Entity
@@ -89,6 +90,14 @@ class AuditRepository : PanacheRepository<AuditEntryEntity> {
                 find("ORDER BY id DESC").page(0, 1).firstResult()
             }.awaitSuspending()
             val prevHash = prev?.recordHash ?: GENESIS_HASH
+            // Persist exactly the value that gets hashed (#3505). `occurred_at`/`recorded_at` are
+            // TIMESTAMPTZ, which keeps MICROseconds, while a java.time.Instant carries nanoseconds
+            // — on Linux, where the pods run, Instant.now() really does produce them. Hashing the
+            // unrounded value and storing the rounded one makes every link permanently
+            // unverifiable: verifyChain rebuilds the entry from the row, so the lost digits can
+            // never come back. Normalising here (and again inside chainHash) makes the two sides
+            // agree by construction rather than by luck of the platform clock.
+            val stored = entry.normalisedForStorage()
             val e = AuditEntryEntity().also {
                 it.entryId = entry.id
                 it.eventType = entry.eventType
@@ -99,14 +108,14 @@ class AuditRepository : PanacheRepository<AuditEntryEntity> {
                 it.payload = entry.payload
                 it.sourceService = entry.sourceService
                 it.correlationId = entry.correlationId
-                it.occurredAt = entry.occurredAt
-                it.recordedAt = entry.recordedAt
+                it.occurredAt = stored.occurredAt
+                it.recordedAt = stored.recordedAt
                 it.channel = entry.channel
                 it.actChain = entry.actChain.takeIf { chain -> chain.isNotEmpty() }
                     ?.let { chain -> actChainJson.writeValueAsString(chain) }
                 it.sessionId = entry.sessionId
                 it.prevHash = prevHash
-                it.recordHash = chainHash(prevHash, entry)
+                it.recordHash = chainHash(prevHash, stored)
             }
             Panache.withTransaction { persist(e) }.awaitSuspending()
         }
@@ -236,14 +245,27 @@ class AuditRepository : PanacheRepository<AuditEntryEntity> {
          */
         internal fun chainHash(prevHash: String, entry: AuditEntry): String {
             val payloadHash = sha256(entry.payload)
+            val e = entry.normalisedForStorage()
             val canonical = listOf(
-                prevHash, entry.id.toString(), entry.eventType, entry.aggregateType,
-                entry.aggregateId, entry.actorId ?: "", entry.actorType ?: "", payloadHash,
-                entry.sourceService, entry.correlationId ?: "",
-                entry.occurredAt.toString(), entry.recordedAt.toString(),
+                prevHash, e.id.toString(), e.eventType, e.aggregateType,
+                e.aggregateId, e.actorId ?: "", e.actorType ?: "", payloadHash,
+                e.sourceService, e.correlationId ?: "",
+                e.occurredAt.toString(), e.recordedAt.toString(),
             ).joinToString("|")
             return sha256(canonical)
         }
+
+        /**
+         * The entry as the database will hold it. `occurred_at`/`recorded_at` are TIMESTAMPTZ —
+         * microsecond precision — so any nanosecond digits are dropped on persist. Hashing the
+         * pre-truncation value is what made every link unverifiable (#3505); truncating here means
+         * the write side and the read side hash the same characters whatever precision the source
+         * clock had.
+         */
+        internal fun AuditEntry.normalisedForStorage(): AuditEntry = copy(
+            occurredAt = occurredAt.truncatedTo(ChronoUnit.MICROS),
+            recordedAt = recordedAt.truncatedTo(ChronoUnit.MICROS),
+        )
 
         private fun sha256(input: String): String = java.security.MessageDigest.getInstance("SHA-256")
             .digest(input.toByteArray(Charsets.UTF_8))

--- a/openbank-audit-service/src/test/kotlin/com/openbank/audit/integration/AuditChainRoundTripIT.kt
+++ b/openbank-audit-service/src/test/kotlin/com/openbank/audit/integration/AuditChainRoundTripIT.kt
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+package com.openbank.audit.integration
+
+import com.openbank.audit.domain.model.AuditEntry
+import com.openbank.audit.infrastructure.persistence.AuditRepository
+import com.openbank.audit.it.PostgresTestResource
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.vertx.VertxContextSupport
+import io.smallrye.mutiny.coroutines.uni
+import jakarta.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * Regression coverage for #3505: the hash chain is written from the INCOMING domain object and
+ * verified from the object reconstructed out of the database, so any field the round-trip does
+ * not preserve byte-for-byte makes `verifyChain()` fail on the first chained row forever
+ * (`openbank_audit_chain_entries_checked = 0` against 1066 chained rows in the sandbox).
+ *
+ * Every pre-existing test hashes and verifies in-process, which is exactly the step where the
+ * two sides disagree — only a real database round-trip can see it.
+ *
+ * The instants below carry deliberate NANOSECOND digits. `TIMESTAMPTZ` stores microseconds, so a
+ * nanosecond-precision `Instant` is silently rounded on persist while the hash was computed over
+ * the unrounded value. Using a literal (rather than `Instant.now()`) makes the test prove the same
+ * thing on macOS — whose `Clock.systemUTC()` already yields microseconds — as on Linux, where the
+ * production pods run and the JDK clock yields nanoseconds.
+ */
+@QuarkusTest
+@QuarkusTestResource(PostgresTestResource::class)
+class AuditChainRoundTripIT {
+
+    @Inject
+    lateinit var repository: AuditRepository
+
+    private fun <T> onEventLoop(block: suspend () -> T): T =
+        VertxContextSupport.subscribeAndAwait { uni(CoroutineScope(Dispatchers.Unconfined)) { block() } }
+
+    private fun entry(aggregateId: String) = AuditEntry(
+        id = UUID.randomUUID(),
+        eventType = "chain.roundtrip.test",
+        aggregateType = "ACCOUNT",
+        aggregateId = aggregateId,
+        actorId = "tester",
+        actorType = "HUMAN",
+        payload = """{"aggregateId":"$aggregateId"}""",
+        sourceService = "openbank-audit-service",
+        correlationId = "corr-$aggregateId",
+        // 123456789 ns and 987654321 ns — both lose their last three digits to TIMESTAMPTZ.
+        occurredAt = Instant.ofEpochSecond(OCCURRED_EPOCH_SECOND, OCCURRED_NANOS),
+        recordedAt = Instant.ofEpochSecond(RECORDED_EPOCH_SECOND, RECORDED_NANOS),
+    )
+
+    /**
+     * The mechanism behind the defect, pinned with LITERAL expectations rather than by re-applying
+     * the repository's own normalisation — a test that mirrors the implementation would stay green
+     * however the truncation changed. `TIMESTAMPTZ` truncates (it does not round: `…456789` becomes
+     * `…456`, never `…457`), and every other hashed field is returned verbatim.
+     */
+    @Test
+    fun `TIMESTAMPTZ returns microseconds, so only the timestamps change across the round-trip`() {
+        val aggregateId = "roundtrip-${UUID.randomUUID()}"
+        val written = entry(aggregateId)
+
+        onEventLoop { repository.save(written) }
+        val readBack = onEventLoop { repository.findByAggregateId(aggregateId) }.single()
+
+        assertThat(readBack.occurredAt)
+            .describedAs("occurred_at loses its nanosecond digits to TIMESTAMPTZ")
+            .isEqualTo(Instant.ofEpochSecond(OCCURRED_EPOCH_SECOND, 123_456_000L))
+        assertThat(readBack.recordedAt)
+            .describedAs("recorded_at loses its nanosecond digits to TIMESTAMPTZ")
+            .isEqualTo(Instant.ofEpochSecond(RECORDED_EPOCH_SECOND, 987_654_000L))
+        // Field-by-field for the rest, so a failure names the field the round-trip does not
+        // preserve rather than only saying "the hash differs".
+        assertThat(readBack)
+            .describedAs("no other field the chain hash covers may change across the round-trip")
+            .usingRecursiveComparison()
+            .ignoringFields("occurredAt", "recordedAt")
+            .isEqualTo(written)
+    }
+
+    @Test
+    fun `verifyChain confirms a link that this process just wrote`() {
+        val aggregateId = "verify-${UUID.randomUUID()}"
+        val written = entry(aggregateId)
+
+        onEventLoop { repository.save(written) }
+        val verification = onEventLoop { repository.verifyChain(fromEntryId = written.id) }
+
+        assertThat(verification.intact)
+            .describedAs("chain must verify from the row just written (broken: %s)", verification.firstBrokenEntryId)
+            .isTrue()
+        assertThat(verification.checked)
+            .describedAs("the freshly written row must actually be checked, not skipped")
+            .isGreaterThanOrEqualTo(1)
+    }
+
+    @Test
+    fun `verifyChain confirms consecutive links, not just an isolated row`() {
+        val first = entry("multi-a-${UUID.randomUUID()}")
+        val second = entry("multi-b-${UUID.randomUUID()}")
+
+        onEventLoop { repository.save(first) }
+        onEventLoop { repository.save(second) }
+        val verification = onEventLoop { repository.verifyChain(fromEntryId = first.id) }
+
+        assertThat(verification.intact)
+            .describedAs("both links must verify (first broken: %s)", verification.firstBrokenEntryId)
+            .isTrue()
+        assertThat(verification.checked)
+            .describedAs("both rows written here must be recomputed")
+            .isGreaterThanOrEqualTo(2)
+    }
+
+    private companion object {
+        const val OCCURRED_EPOCH_SECOND = 1_785_704_401L
+        const val OCCURRED_NANOS = 123_456_789L
+        const val RECORDED_EPOCH_SECOND = 1_785_704_402L
+        const val RECORDED_NANOS = 987_654_321L
+    }
+}


### PR DESCRIPTION
## What this fixes

`openbank_audit_chain_entries_checked = 0` against 1066 chained rows: the ADR-0031 / ADR-0133
tamper-evidence chain has never verified a single link, and `AuditChainBroken` is a permanent
critical. `verifyChain()` fails on `recordHash != recomputed` at the first chained row (id 951).
The chain's *shape* is fine — `prevHash` links correctly all the way down. Only the recomputation
disagrees.

## Root cause — the value that is hashed is not the value that is stored

`AuditRepository.save()` computes `chainHash(prevHash, entry)` from the **incoming** domain object.
`verifyChain()` computes `chainHash(e.prevHash, e.toDomain())` from the object **rebuilt out of the
persisted row**. Two of the twelve hashed fields do not survive that round-trip:

- `occurred_at` / `recorded_at` are `TIMESTAMPTZ` (`V1__create_audit.sql:12-13`) — PostgreSQL stores
  **microseconds**.
- `java.time.Instant` carries **nanoseconds**, and nothing in the service calls `truncatedTo(...)`.
- On Linux, where the pods run, `Instant.now(clock)` really does produce nanosecond digits. On macOS
  `Clock.systemUTC()` already returns microseconds, which is why this never reproduced locally —
  and why offline recomputation against the stored fields could not work either: the original digits
  are **not in the database**, so no rendering of the stored value can reproduce the hash.

### The canonical-string diff, measured against a real PostgreSQL

Writing `Instant.ofEpochSecond(1785704401, 123456789)` / `…402, 987654321)` and reading the row back
(`AuditChainRoundTripIT`, Testcontainers). The two canonical strings differ only in the last two
`|`-separated fields:

```
write  … |openbank-audit-service|corr-…|2026-08-02T21:00:01.123456789Z|2026-08-02T21:00:02.987654321Z
verify … |openbank-audit-service|corr-…|2026-08-02T21:00:01.123456Z   |2026-08-02T21:00:02.987654Z
                                                              ^^^ dropped        ^^^ dropped
```

AssertJ's field-by-field output on unpatched `main`, which is what names the fields rather than
guessing them:

```
field/property 'occurredAt' differ:
- actual value  : 2026-08-02T21:00:01.123456Z
- expected value: 2026-08-02T21:00:01.123456789Z

field/property 'recordedAt' differ:
- actual value  : 2026-08-02T21:00:02.987654Z
- expected value: 2026-08-02T21:00:02.987654321Z
```

Two details worth recording: `TIMESTAMPTZ` **truncates** rather than rounds (`…456789` becomes
`…456`, never `…457`), and every other hashed field — including the `TEXT` payload — comes back
verbatim, so the timestamps are the whole defect.

## The fix — forward correctness only

`AuditRepository.normalisedForStorage()` truncates both instants to microseconds, and it is applied
on **both** sides: on the persist path (so the column holds it) and inside `chainHash` (so the hash
covers it). The stored value and the hashed value are then the same value by construction, whatever
precision the source clock had — not by luck of the platform the pod happens to run on.

## What this does NOT fix, deliberately

**The 1066 existing rows stay unverifiable, and `AuditChainBroken` stays critical after this
merges.** They were hashed over digits that are not in the database; nothing can recover them. The
issue is explicit that re-chaining or relaxing the comparison would make the control *look* healthy
while proving less than it does now, and that is right — so neither is done here. What is needed is
an explicit re-baseline: a signed anchor recording "verification starts at row N, everything before
it is unverifiable, and here is why", with `verifyChain(fromEntryId = …)` (which already exists) as
the evaluated range. That is an evidence-retention judgement about a regulated log, not a code
change, so it is proposed on #3505 for the owner rather than decided here. **#3505 stays open.**

## Regression protection — proven red, then green

The reason no test caught this is that every existing test hashes and verifies **in-process**, which
is exactly the step where the two sides disagree; all 60 were green for the whole life of the defect.
`AuditChainRoundTripIT` drives a real PostgreSQL (`PostgresTestResource`) and pins the instants to
**literal nanosecond values**, so it proves the same thing on macOS as on a Linux runner instead of
depending on clock precision.

Run against **unpatched** `main` with the final test file (production change reverted, test kept):

```
FAIL verifyChain confirms consecutive links, not just an isolated row
FAIL verifyChain confirms a link that this process just wrote
PASS TIMESTAMPTZ returns microseconds, so only the timestamps change across the round-trip
```

With the fix: `3 tests completed, 0 failed`; full module `63 tests, 0 failed`.

The third test is a characterisation test with **literal** expected values, not a re-application of
the repository's own normalisation — a test that mirrored the implementation would stay green however
the truncation changed. It passes in both states on purpose: it describes PostgreSQL, not the fix.

## Gate

`:openbank-audit-service:build` (includes `test`, `ktlintCheck`, `koverVerify`), `detekt`,
`quarkusBuild` — all green locally.

No migration, no API change, no config change.

Refs #3505
