### PR TITLE
fix(ci): run the admin-ui jobs on the Node version the app ships on

### DIFF
--- a/.github/workflows/admin-ui-deploy.yml
+++ b/.github/workflows/admin-ui-deploy.yml
@@ -118,7 +118,13 @@ jobs:
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '20'
+          # Matches the runtime image (openbank-admin-ui/Dockerfile: node:26-alpine). Pinned at 20
+          # it was three majors behind what ships, and #3569's jsdom bump made that fatal:
+          # jsdom 30 declares engines ^22.22.2 || ^24.15.0 || >=26 and pulls undici 8, whose
+          # cachestorage calls webidl.util.markAsUncloneable. On 20 every vitest worker died
+          # with "Failed to start forks worker", the run collected ZERO tests, and the job
+          # still reported a plain red — engine-strict is off, so npm ci installed it happily.
+          node-version: "26"
           cache: 'npm'
           cache-dependency-path: openbank-admin-ui/package-lock.json
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,13 @@ jobs:
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: "20"
+          # Matches the runtime image (openbank-admin-ui/Dockerfile: node:26-alpine). Pinned at 20
+          # it was three majors behind what ships, and #3569's jsdom bump made that fatal:
+          # jsdom 30 declares engines ^22.22.2 || ^24.15.0 || >=26 and pulls undici 8, whose
+          # cachestorage calls webidl.util.markAsUncloneable. On 20 every vitest worker died
+          # with "Failed to start forks worker", the run collected ZERO tests, and the job
+          # still reported a plain red — engine-strict is off, so npm ci installed it happily.
+          node-version: "26"
           cache: "npm"
           cache-dependency-path: openbank-admin-ui/package-lock.json
 
@@ -473,7 +479,13 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         if: env.APP_RO_TOKEN != ''
         with:
-          node-version: "20"
+          # Matches the runtime image (openbank-admin-ui/Dockerfile: node:26-alpine). Pinned at 20
+          # it was three majors behind what ships, and #3569's jsdom bump made that fatal:
+          # jsdom 30 declares engines ^22.22.2 || ^24.15.0 || >=26 and pulls undici 8, whose
+          # cachestorage calls webidl.util.markAsUncloneable. On 20 every vitest worker died
+          # with "Failed to start forks worker", the run collected ZERO tests, and the job
+          # still reported a plain red — engine-strict is off, so npm ci installed it happily.
+          node-version: "26"
           cache: "npm"
           cache-dependency-path: openbank-admin-ui/package-lock.json
 


### PR DESCRIPTION
## main is broken: every admin-ui test job collects zero tests

Since #3569 (`chore(deps-ui)(deps-dev): Bump jsdom`) merged, the `Admin UI` and `Admin UI build`
jobs fail on every PR with 79 identical errors and **no tests run at all**:

```
Error: [vitest-pool]: Failed to start forks worker for test files …/src/test/<any>.test.ts
Caused by: TypeError: webidl.util.markAsUncloneable is not a function
    ❯ new CacheStorage node_modules/undici/lib/web/cache/cachestorage.js:20:17

 Test Files  no tests
      Tests  no tests
     Errors  79 errors
```

## Cause

The declared engines and the CI runtime disagree:

| package | engines |
|---|---|
| `jsdom@30.0.1` | `^22.22.2 \|\| ^24.15.0 \|\| >=26.0.0` |
| `undici@8.9.0` (pulled by jsdom) | `>=22.19.0` |
| CI `setup-node` | **20** |

`markAsUncloneable` does not exist on Node 20, so undici's `CacheStorage` throws while the worker is
starting — before a single test file is imported. `engine-strict` is off, so `npm ci` installed it
without complaint and the mismatch surfaced only as a red job with an empty summary.

## Fix

Pin the admin-ui jobs to **26** — the version the app actually ships on
(`openbank-admin-ui/Dockerfile: FROM node:26-alpine`). CI was testing three majors behind the
runtime, which is the condition that let this land: a dependency legal for production was illegal for
CI, and nothing compared the two.

Three pins move (`ci.yml` admin-ui tests, `ci.yml` app-status which runs `npm ci` against the same
lockfile, `admin-ui-deploy.yml`). `security.yml`'s CodeQL pin stays at 20 — it does not install
admin-ui dependencies, so it is out of scope here rather than deliberately left behind.

## Verification

The failure is reproducible rather than intermittent — identical on two consecutive runs of #3584,
naming a different test file each time only because worker startup order varies. Locally these tests
pass on Node 26 (`node --version` → v26.5.0), which is the same runtime this pins CI to.

What this does **not** prove: that every admin-ui suite is clean on 26 in CI. That is what this PR's
own run establishes, and it is the thing to read before merging — a green here means the workers
started AND the suites passed; the current state on main cannot distinguish those two.
