### PR TITLE
fix(ci): let a reconcile deploy by PROVING the two commits equivalent, not by borrowing a verdict

### DIFF
--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -583,6 +583,36 @@ gates:
     run: |
       bash .github/scripts/test-resolve-can-i-deploy-selector.sh
 
+  # The equivalence proof that lets a reconcile deploy at all (#3432). The selector above decides
+  # WHICH version to ask about; on a manual dispatch the honest answer used to be "none, refuse"
+  # for every service, because no pact version can exist for a sha services-ci never built. This
+  # decides whether the commit that DOES have one is byte-identical, from git alone — so it is the
+  # one thing standing between a justified verdict and a borrowed one, and it is a pure function
+  # with no network, which is exactly why its failure path can be exercised here.
+  - id: pact-version-tree-equivalence-unit-test
+    name: "pact version tree-equivalence unit test (issue #3432, enforced)"
+    group: supplychain
+    mode: enforced
+    selftest: |
+      bash .github/scripts/pact-version-tree-equivalent.sh --self-test
+    run: |
+      bash .github/scripts/pact-version-tree-equivalent.sh --self-test
+
+  # The broker half of #3432. It cannot be run against the real broker from a PR — no public
+  # ingress (ADR-0056), PACT_BROKER_URL blanked off main-push — so what this asserts is only the
+  # failure modes, against a stubbed curl: unreachable, non-2xx, unparseable, no version number,
+  # a version number that is not a sha, and a well-formed sha whose trees differ. Every one must
+  # degrade to `no`, which on a dispatch is #3318's REFUSE. A reconcile that cannot verify must
+  # not deploy.
+  - id: pact-version-probe-fail-closed-unit-test
+    name: "pact version probe fails closed (issue #3432, enforced)"
+    group: supplychain
+    mode: enforced
+    selftest: |
+      bash .github/scripts/probe-pact-version.sh --self-test
+    run: |
+      bash .github/scripts/probe-pact-version.sh --self-test
+
   # Workflow `run:` step size (#3082). GitHub rejects an oversized run script by making the
   # WHOLE workflow unparseable — zero jobs, no error message, every contributor's runs of that
   # file dead until someone reverts. It happened to auto-deploy.yml (#3135 -> #3139) and NOTHING

--- a/.github/scripts/classify-can-i-deploy-block.sh
+++ b/.github/scripts/classify-can-i-deploy-block.sh
@@ -37,7 +37,7 @@
 # its own, so test-classify-can-i-deploy-block.sh can drive every branch.
 #
 # Usage:
-#   PACT_VERSION_PRESENT=yes|no|absent|unknown [EVENT_NAME=<github.event_name>] \
+#   PACT_VERSION_PRESENT=yes|no|absent|unknown|equivalent:<sha> [EVENT_NAME=<github.event_name>] \
 #     classify-can-i-deploy-block.sh <service> < cli-output
 #
 #   EVENT_NAME — the triggering event, same vocabulary and same default (push) as
@@ -105,7 +105,7 @@ set -uo pipefail
 
 SVC="${1:-}"
 if [ -z "$SVC" ]; then
-  echo "usage: PACT_VERSION_PRESENT=yes|no|absent|unknown [EVENT_NAME=<event>] $0 <service> < cli-output" >&2
+  echo "usage: PACT_VERSION_PRESENT=yes|no|absent|unknown|equivalent:<sha> [EVENT_NAME=<event>] $0 <service> < cli-output" >&2
   exit 2
 fi
 
@@ -141,6 +141,18 @@ if grep -qiE 'pact (verification )?failed|verification.*(^| )failed|failed verif
 fi
 
 case "$PRESENT" in
+  # #3432: the gate WAS asked, and by version number — the probe proved from git that the version
+  # it named is byte-identical to the sha being deployed in every build input of this service. So
+  # this is the `yes` shape, not the `no` one: a real verdict about the real source exists, and
+  # PENDING_BUILD would be a lie (nothing is building; the answer arrived).
+  equivalent:*)
+    if grep -q 'There is no verified pact' <<< "$OUT"; then
+      emit UNVERIFIED "the counterpart has not verified this version yet — normally clears within one reconcile tick"
+      exit 0
+    fi
+    emit UNKNOWN "blocked with a proven-equivalent version asked about by number and no recognised reason in the CLI output — read the job log for ${SVC}"
+    exit 0
+    ;;
   no)
     emit PENDING_BUILD "no pact version published for this commit yet — its main-push build has not finished (one ARC runner, ~45 min/service); the 3-hourly reconcile re-drives it automatically"
     exit 0

--- a/.github/scripts/pact-version-tree-equivalent.sh
+++ b/.github/scripts/pact-version-tree-equivalent.sh
@@ -1,0 +1,387 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+# See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+#
+# ---------------------------------------------------------------------------------------
+# Are two commits BYTE-IDENTICAL in everything that builds one service's image? (issue #3432)
+#
+# THE DEADLOCK THIS OPENS, WITHOUT WEAKENING THE GATE
+# Pacts are published by each service's own services-ci PUSH lane. A `workflow_dispatch`
+# reconcile builds `sandbox-${GITHUB_SHA::8}` from the CURRENT main tip — a commit services-ci
+# never built for that service — so no pact version exists for it, and #3318 correctly REFUSES:
+# asking the broker about a different commit is not a gate. Measured on run 30761923908:
+# 54 of 54 services refused, `deployable=[]`. Reconcile is the ONLY mechanism for re-driving
+# services that missed their push deploy, and it is needed exactly when many are stranded —
+# which is exactly when it is guaranteed to deploy nothing.
+#
+# #3318's objection is to answering about a DIFFERENT commit. It does not apply when the two
+# commits are not different in any way that could reach this service's artifact. So instead of
+# borrowing a verdict on faith, PROVE the equivalence from git and only then ask the broker
+# about the sha that actually has a published version. Different in any relevant byte ⇒ today's
+# REFUSE, unchanged. This strengthens the argument rather than widening the exception.
+#
+# WHAT "RELEVANT" MEANS — MEASURED, NOT ASSUMED
+# auto-deploy's image is assembled (auto-deploy.yml, `Docker push (parallel)`) from exactly:
+#   * `<svc>/build/quarkus-app`      — the output of `:<svc>:quarkusBuild`
+#   * `<svc>/build/reports/bom.json` — the output of `:<svc>:cyclonedxBom`
+#   * `.github/workflows/Dockerfile.deploy` — copied in verbatim as the Dockerfile
+#   * an `EXPOSE` line grepped out of `<svc>/Dockerfile`
+# So the in-scope set is the Gradle build inputs of that module plus those two files.
+#
+# THE DEFAULT IS THE DESIGN: UNRECOGNISED ⇒ NOT EQUIVALENT
+# An include-list of "things that matter" fails silently in the dangerous direction — a shared
+# input nobody listed is ignored, the trees compare equal, and the verdict is borrowed for a
+# commit that really did change the artifact. So every changed path is classified into exactly
+# three buckets: IN SCOPE (compared), KNOWN-IRRELEVANT (justified below), or UNRECOGNISED —
+# and an UNRECOGNISED path is a refusal. A directory added to this repo tomorrow blocks the
+# equivalence until someone classifies it, instead of being waved through.
+#
+# WHY THESE PATHS ARE KNOWN-IRRELEVANT
+#   openbank-infra/  gitops manifests + terraform. Not a Gradle module (absent from
+#                    settings.gradle.kts) and not copied into any image, so it cannot change the
+#                    artifact. It is also the one tree that moves on EVERY deploy, so counting it
+#                    would make equivalence essentially unreachable — but the reason it is
+#                    excluded is that it is not a build input, not that excluding it is
+#                    convenient. Runtime CONFIG has never been within can-i-deploy's scope on any
+#                    path, push included; this does not narrow the gate.
+#   .github/         CI definitions. The two files that DO reach the image — Dockerfile.deploy
+#                    and auto-deploy.yml, which carries the Gradle flags — are in scope by name.
+#   docs/ pacts/ perf/ fuzz/ scripts/ LICENSES/ .security/ .devcontainer/ .clusterfuzzlite/
+#                    documentation, committed pact artefacts, load tests, fuzz harnesses,
+#                    operator scripts, licence texts — none is read by `:<svc>:quarkusBuild`.
+#                    (A `pacts/` change for THIS service always rides with a `<svc>/src/test`
+#                    change, which is in scope.)
+#   openbank-admin-ui/ openbank-api-gateway/ openbank-developer-portal/
+#   openbank-document-renderer/
+#                    not Gradle modules; separate build + deploy pipelines.
+#   another service's module directory
+#                    a sibling module this one does not declare a `project(":…")` dependency on
+#                    cannot enter its compile classpath. The dependency graph is derived from the
+#                    build files here, not listed, for the same reason libs-change-dependents.sh
+#                    derives it (#2983) — a hand-kept mapping rots.
+#   root *.md and repo metadata (LICENSE, NOTICE, REUSE.toml, CITATION.cff, CODEOWNERS,
+#                    codecov.yml, .gitignore, .gitattributes, .editorconfig, .gitleaks.toml,
+#                    .trivyignore, .pre-commit-config.yaml, release-please config + manifest)
+#                    prose and tooling config. Every OTHER root-level file is in scope: root is
+#                    where build.gradle.kts, settings.gradle.kts, gradle.properties and gradlew
+#                    live, so the safe default there is "counts".
+#
+# WHY OVER-BROAD ON THE SHARED MODULES
+# Every `openbank-libs*` module is compared for every service, whether or not this service
+# declares it. libs-change-dependents.sh's narrower derivation is right for deciding what to
+# REBUILD; here a miss is a false green, so the cheap direction is the safe one.
+#
+# WHY ANCESTRY IS REQUIRED
+# Tree equality alone is symmetric and would be satisfied by a revert or a rewritten history.
+# Requiring the pact commit to be an ANCESTOR of the commit being deployed keeps the claim to
+# what it is meant to be — "main moved, but not through anything this service is built from".
+#
+# WHY THE EXIT CODE IS THE ANSWER
+# Exit 0 means EQUIVALENT and nothing else does. A usage error, a missing object, an
+# unclassifiable path or an outright crash all exit non-zero, so a caller that keys on the exit
+# status fails closed to today's REFUSE without needing to parse anything.
+#
+# Usage:
+#   pact-version-tree-equivalent.sh <service> <pact_sha> <dispatch_sha>
+#   pact-version-tree-equivalent.sh --self-test
+#
+# Prints one TAB-separated line: EQUIVALENT|DIFFERENT<TAB><human reason>.
+set -uo pipefail
+
+verdict() { printf '%s\t%s\n' "$1" "$2"; }
+differs() { verdict DIFFERENT "$1"; exit 1; }
+
+# Root-level files that are prose or tooling metadata, never a build input. Everything else at
+# root counts — see the header: root is where the build config lives.
+ROOT_IGNORE_RE='^([^/]+\.md|LICENSE|NOTICE|REUSE\.toml|CITATION\.cff|CODEOWNERS|codecov\.yml|\.gitignore|\.gitattributes|\.editorconfig|\.gitleaks\.toml|\.trivyignore|\.pre-commit-config\.yaml|release-please-config\.json|\.release-please-manifest\.json)$'
+
+# Top-level directories that cannot reach a service image. Justified one by one in the header.
+IGNORED_DIR_RE='^(docs|pacts|perf|fuzz|scripts|LICENSES|openbank-contracts|openbank-infra|openbank-admin-ui|openbank-api-gateway|openbank-developer-portal|openbank-document-renderer|\.security|\.devcontainer|\.clusterfuzzlite|\.github)/'
+
+# The one `.github/` file that is literally COPY'd into the image, so it is re-admitted by name.
+# auto-deploy.yml itself is deliberately NOT here even though it carries the Gradle flags: the
+# image is built by the DISPATCH run under the dispatch sha's workflow either way, and the pact
+# verification never ran under auto-deploy.yml at all (that is _service-ci.yml's job). Demanding
+# it be unchanged would be asking for a guarantee the ordinary push path does not provide either —
+# and it is the single most-edited file in this pipeline, so it refused all 32 services on its own
+# when it was in scope (measured 2026-08-03).
+GITHUB_IN_SCOPE=(.github/workflows/Dockerfile.deploy)
+
+# Non-module directories that ARE build inputs for every module.
+GLOBAL_IN_SCOPE_DIRS=(gradle config build-logic)
+
+# Which subpaths of a DEPENDENCY module are compile inputs. Not a new opinion: this is the repo's
+# own definition, from libs-change-dependents.sh (`^<module>/(src/main|build.gradle.kts)` plus the
+# global `openbank-libs/gradle/` version catalog), and auto-deploy's own change detection excludes
+# `openbank-libs/governance/` in as many words — "data for CI checks + admin-ui, not a compile
+# input". Comparing the whole directory instead is not free caution: measured 2026-08-03, all 32
+# services with a main-tagged pact version were refused, and 12 of them ONLY because four files
+# under openbank-libs/governance/ had moved. The service's OWN directory is still compared whole.
+DEP_SUBPATHS=(src/main build.gradle.kts gradle)
+
+# ── git helpers ────────────────────────────────────────────────────────────────────────
+commit_exists() { git rev-parse -q --verify "$1^{commit}" >/dev/null 2>&1; }
+
+# Tree/blob object id of a path at a commit, or the literal ABSENT when the path is not there.
+# ABSENT vs ABSENT compares equal, which is correct: a path missing from both sides did not move.
+obj_at() { git rev-parse -q --verify "$1:$2" 2>/dev/null || echo ABSENT; }
+
+# Top-level directories that are Gradle modules at this commit.
+module_dirs_at() {
+  local sha="$1" d
+  git ls-tree -d --name-only "$sha" 2>/dev/null | while read -r d; do
+    git cat-file -e "$sha:$d/build.gradle.kts" 2>/dev/null && printf '%s\n' "$d"
+  done
+}
+
+# `project(":x")` declarations in one module's build file, as bare module names.
+project_deps_at() {
+  git show "$1:$2/build.gradle.kts" 2>/dev/null \
+    | command grep -oE 'project\("[:][A-Za-z0-9._-]+"\)' \
+    | sed -E 's/project\("://; s/"\)//' \
+    | sort -u
+}
+
+# Transitive closure of `project(":…")` from one module, plus every openbank-libs* module.
+# Over-broad on the libs by design (see header).
+in_scope_modules() {
+  # Two statements, not one: bash 3.2 (the macOS system bash) expands every word of a `local`
+  # before performing any of the assignments, so `local root="$2" queue="$root"` reads an unset
+  # `root` and dies under `set -u`.
+  local sha="$1" root="$2" seen="" cur dep m
+  local queue="$root"
+  while [ -n "$queue" ]; do
+    cur="${queue%%$'\n'*}"; queue="${queue#"$cur"}"; queue="${queue#$'\n'}"
+    case $'\n'"$seen"$'\n' in *$'\n'"$cur"$'\n'*) continue ;; esac
+    seen="${seen:+$seen$'\n'}$cur"
+    for dep in $(project_deps_at "$sha" "$cur"); do
+      git cat-file -e "$sha:$dep/build.gradle.kts" 2>/dev/null && queue="${queue:+$queue$'\n'}$dep"
+    done
+  done
+  for m in $(module_dirs_at "$sha"); do
+    case "$m" in openbank-libs*) case $'\n'"$seen"$'\n' in *$'\n'"$m"$'\n'*) ;; *) seen="$seen"$'\n'"$m" ;; esac ;; esac
+  done
+  printf '%s\n' "$seen" | command grep -v '^$' | sort -u
+}
+
+# ── the decision ───────────────────────────────────────────────────────────────────────
+equivalent() {
+  local svc="$1" pact_sha="$2" dispatch_sha="$3"
+
+  commit_exists "$pact_sha" \
+    || differs "pact version ${pact_sha} is not a commit in this checkout — nothing to compare against, so the verdict cannot be transferred"
+  commit_exists "$dispatch_sha" \
+    || differs "dispatch sha ${dispatch_sha} is not a commit in this checkout"
+
+  git cat-file -e "$dispatch_sha:$svc/build.gradle.kts" 2>/dev/null \
+    || differs "${svc} is not a Gradle module at ${dispatch_sha} — cannot derive what it is built from"
+
+  git merge-base --is-ancestor "$pact_sha" "$dispatch_sha" 2>/dev/null \
+    || differs "pact version ${pact_sha} is not an ancestor of ${dispatch_sha} — history diverged or was rewritten, so 'main moved forward without touching this service' is not what happened"
+
+  # 1. Build the list of in-scope PATHS: this service whole, each dependency module's compile
+  #    inputs, the global build directories, and the two `.github/` files that reach the image.
+  local scope="" m d a b
+  scope="$svc"
+  for m in $(in_scope_modules "$dispatch_sha" "$svc"); do
+    [ "$m" = "$svc" ] && continue
+    for d in "${DEP_SUBPATHS[@]}"; do scope="$scope"$'\n'"$m/$d"; done
+  done
+  for d in "${GLOBAL_IN_SCOPE_DIRS[@]}" "${GITHUB_IN_SCOPE[@]}"; do scope="$scope"$'\n'"$d"; done
+
+  # 2. Each of them must be the same git object at both commits. A tree object id is a recursive
+  #    hash of the whole subtree, so this is byte-equality of every file under it — including mode
+  #    changes and renames, which a name-only diff would not show.
+  for d in $(printf '%s\n' "$scope" | command grep -v '^$' | sort -u); do
+    a="$(obj_at "$pact_sha" "$d")"; b="$(obj_at "$dispatch_sha" "$d")"
+    [ "$a" = "$b" ] || differs "${d} differs between ${pact_sha:0:8} and ${dispatch_sha:0:8} (${a:0:8} vs ${b:0:8}) — it is a build input of ${svc}"
+  done
+
+  # 3. Classify every remaining changed path. Anything this script cannot place is a refusal.
+  local p top changed covered s
+  changed="$(git diff --name-only "$pact_sha" "$dispatch_sha" 2>/dev/null)" \
+    || differs "could not diff ${pact_sha} against ${dispatch_sha}"
+  while IFS= read -r p; do
+    [ -n "$p" ] || continue
+    case "$p" in */*) top="${p%%/*}" ;; *) top="" ;; esac
+    if [ -z "$top" ]; then
+      # A root-level file. Default is IN SCOPE, so a build-config file cannot slip past; step 1
+      # does not cover root files, so compare it here.
+      command grep -qE "$ROOT_IGNORE_RE" <<< "$p" && continue
+      a="$(obj_at "$pact_sha" "$p")"; b="$(obj_at "$dispatch_sha" "$p")"
+      [ "$a" = "$b" ] || differs "root file ${p} differs — root is where the build configuration lives, so it counts"
+      continue
+    fi
+    # Under an in-scope path: already compared byte-for-byte in step 2 (and equal, or we exited).
+    covered=0
+    while IFS= read -r s; do
+      [ -n "$s" ] || continue
+      case "$p" in "$s"|"$s"/*) covered=1; break ;; esac
+    done <<< "$scope"
+    [ "$covered" = 1 ] && continue
+    command grep -qE "$IGNORED_DIR_RE" <<< "$p" && continue
+    # Inside a Gradle module directory, but not one of its compile inputs: either a sibling module
+    # this service does not depend on, or a dependency's src/test, docs, governance data, version.txt
+    # or CHANGELOG.md — none of which is read by `:<svc>:quarkusBuild`.
+    if git cat-file -e "$dispatch_sha:$top/build.gradle.kts" 2>/dev/null \
+       || git cat-file -e "$pact_sha:$top/build.gradle.kts" 2>/dev/null; then
+      continue
+    fi
+    differs "changed path ${p} is in neither the build inputs of ${svc} nor the justified known-irrelevant set — refusing rather than guessing what a new top-level directory does"
+  done <<< "$changed"
+
+  verdict EQUIVALENT \
+    "${svc} and every build input of it are byte-identical at ${pact_sha:0:8} and ${dispatch_sha:0:8} (same git tree objects), and ${pact_sha:0:8} is an ancestor — the published verdict is about the same source, so it is not a verdict about a different commit"
+  exit 0
+}
+
+# ── self-test ──────────────────────────────────────────────────────────────────────────
+# Built on REAL git objects in a throwaway repo, because the whole script is git plumbing: a
+# mocked `git` would test the mock. Each case asserts the DIRECTION as well as the verdict — a
+# harness that only ever sees the equivalent case cannot notice the rule being deleted.
+selftest() {
+  local me tmp fail=0
+  me="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' RETURN
+
+  (
+    set -e
+    cd "$tmp"
+    git init -q .
+    git config user.email selftest@example.com
+    git config user.name selftest
+    git config commit.gpgsign false
+    mkdir -p svc-a/src/main openbank-libs-domain/src/main svc-b/src/main docs openbank-infra/gitops \
+             gradle config build-logic openbank-contracts .github/workflows
+    printf 'implementation(project(":openbank-libs-domain"))\n' > svc-a/build.gradle.kts
+    printf 'x\n' > svc-b/build.gradle.kts
+    printf 'x\n' > openbank-libs-domain/build.gradle.kts
+    printf 'x\n' > build.gradle.kts
+    printf 'x\n' > settings.gradle.kts
+    printf 'x\n' > gradle/verification-metadata.xml
+    printf 'x\n' > config/detekt.yml
+    printf 'x\n' > build-logic/build.gradle.kts
+    printf 'x\n' > openbank-contracts/api.yaml
+    printf 'x\n' > .github/workflows/Dockerfile.deploy
+    printf 'x\n' > .github/workflows/auto-deploy.yml
+    printf 'x\n' > svc-a/src/main/A.kt
+    printf 'x\n' > svc-b/src/main/B.kt
+    printf 'x\n' > openbank-libs-domain/src/main/D.kt
+    printf 'x\n' > docs/README.md
+    printf 'x\n' > README.md
+    printf 'x\n' > openbank-infra/gitops/app.yaml
+    git add -A && git commit -qm base
+  ) || { echo "selftest FAIL: could not build the fixture repo" >&2; return 1; }
+
+  local base; base="$(git -C "$tmp" rev-parse HEAD)"
+
+  # Helper: commit a change and return the new sha.
+  _commit() { ( cd "$tmp" && mkdir -p "$(dirname "$1")" && printf '%s\n' "$2" > "$1" && git add -A && git commit -qm "$1" ) >/dev/null && git -C "$tmp" rev-parse HEAD; }
+  _run() { ( cd "$tmp" && bash "$me" "$@" ); }
+
+  _expect() { # <label> <expected EQUIVALENT|DIFFERENT> <args...>
+    local label="$1" want="$2"; shift 2
+    local out rc got
+    out="$(_run "$@" 2>&1)"; rc=$?
+    got="$(printf '%s' "$out" | head -1 | cut -f1)"
+    if [ "$got" != "$want" ]; then
+      echo "selftest FAIL: ${label}: expected ${want}, got '${got}' (rc=${rc})" >&2; fail=1; return
+    fi
+    # Verdict and exit code must agree, or a caller keying on either one is reading a
+    # different answer from the one printed.
+    if [ "$want" = EQUIVALENT ] && [ "$rc" -ne 0 ]; then
+      echo "selftest FAIL: ${label}: printed EQUIVALENT but exited ${rc}" >&2; fail=1
+    fi
+    if [ "$want" = DIFFERENT ] && [ "$rc" -eq 0 ]; then
+      echo "selftest FAIL: ${label}: printed DIFFERENT but exited 0" >&2; fail=1
+    fi
+  }
+
+  # 1. Nothing changed at all.
+  _expect "identical commits" EQUIVALENT svc-a "$base" "$base"
+
+  # 2. Only another service, docs, gitops and a root .md moved — the reconcile case this exists
+  #    for. It MUST be equivalent or the fix delivers nothing.
+  local s; s="$(_commit svc-b/src/main/B.kt changed)"
+  s="$(_commit docs/README.md changed)"
+  s="$(_commit openbank-infra/gitops/app.yaml changed)"
+  s="$(_commit README.md changed)"
+  _expect "unrelated service + docs + gitops + root markdown" EQUIVALENT svc-a "$base" "$s"
+
+  # Every later case compares against its IMMEDIATE predecessor, so each one isolates exactly one
+  # changed path. Chaining them all back to `base` would make every case DIFFERENT for the reason
+  # the previous case introduced, and the assertions would pass while proving nothing.
+  local prev="$s"
+
+  # 3. This service's own source moved.
+  local s3; s3="$(_commit svc-a/src/main/A.kt changed)"
+  _expect "the service's own source changed" DIFFERENT svc-a "$prev" "$s3"
+  # ...and the equivalence for the OTHER service still holds over the same pair, which proves the
+  # comparison is per-service and not a blanket "did anything change".
+  _expect "svc-b is unaffected by svc-a's change" EQUIVALENT svc-b "$prev" "$s3"
+
+  # 4. A shared library moved. This is the case an under-broad scope gets wrong.
+  local s4; s4="$(_commit openbank-libs-domain/src/main/D.kt changed)"
+  _expect "shared libs module changed" DIFFERENT svc-a "$s3" "$s4"
+  # ...including for a service that does NOT declare it, because libs is deliberately over-broad.
+  _expect "shared libs change counts even without a declaration" DIFFERENT svc-b "$s3" "$s4"
+
+  # 4b. A shared module's NON-compile subtree. This is the narrowing that makes the whole feature
+  #     reachable — measured 2026-08-03, 12 of 32 services were refused for nothing but four files
+  #     under openbank-libs/governance/ — so it needs a case in both directions, not just the
+  #     src/main one above.
+  local s4b; s4b="$(_commit openbank-libs-domain/governance/data.yaml changed)"
+  _expect "shared module governance data changed" EQUIVALENT svc-a "$s4" "$s4b"
+  local s4c; s4c="$(_commit openbank-libs-domain/src/test/T.kt changed)"
+  _expect "shared module test source changed" EQUIVALENT svc-a "$s4b" "$s4c"
+  # ...but the service's OWN tree is compared whole, tests included: its consumer pact is generated
+  # from those tests, so a change there is a change to what was published.
+  local s4d; s4d="$(_commit svc-a/src/test/T.kt changed)"
+  _expect "the service's own test source changed" DIFFERENT svc-a "$s4c" "$s4d"
+
+  # 5. Root build configuration.
+  local s5; s5="$(_commit settings.gradle.kts changed)"
+  _expect "root settings.gradle.kts changed" DIFFERENT svc-a "$s4d" "$s5"
+
+  # 6. The Dockerfile that is copied into the image.
+  local s6; s6="$(_commit .github/workflows/Dockerfile.deploy changed)"
+  _expect "Dockerfile.deploy changed" DIFFERENT svc-a "$s5" "$s6"
+
+  # 7. A `.github/` path that is NOT a build input must not block.
+  local s7; s7="$(_commit .github/workflows/security.yml changed)"
+  _expect "an unrelated workflow changed" EQUIVALENT svc-a "$s6" "$s7"
+
+  # 8. A top-level directory this script has never heard of — the default that keeps an
+  #    include-list from failing silently.
+  local s8; s8="$(_commit brand-new-tree/thing.txt changed)"
+  _expect "unrecognised new top-level directory" DIFFERENT svc-a "$s7" "$s8"
+
+  # 9. A sha that does not exist.
+  _expect "pact sha absent from the checkout" DIFFERENT svc-a 0000000000000000000000000000000000000000 "$base"
+  _expect "dispatch sha absent from the checkout" DIFFERENT svc-a "$base" 0000000000000000000000000000000000000000
+
+  # 10. Ancestry. The pair MUST be one that case 2 already proved EQUIVALENT forwards, or the
+  #     assertion is vacuous: any pair that differs in scope would refuse for that reason and
+  #     stay red with the ancestry rule deleted. Reversed, only ancestry can reject it.
+  _expect "pact sha is not an ancestor" DIFFERENT svc-a "$s" "$base"
+
+  # 11. Usage errors fail closed.
+  _expect "missing arguments" DIFFERENT svc-a "$base"
+
+  [ "$fail" -eq 0 ] && echo "selftest OK: 17 cases on real git trees — identical, unrelated-elsewhere, own-source, own tests, shared-libs src/main (declared and not), a shared module's governance data and tests, root build config, baked-in Dockerfile, unrelated workflow, unknown directory, both missing shas, reversed ancestry, and a usage error; verdict and exit code asserted to agree in both directions."
+  return "$fail"
+}
+
+if [ "${1:-}" = "--self-test" ] || [ "${1:-}" = "--selftest" ]; then
+  selftest
+  exit $?
+fi
+
+if [ $# -ne 3 ]; then
+  verdict DIFFERENT "usage: $0 <service> <pact_sha> <dispatch_sha> — refusing rather than assuming equivalence"
+  exit 2
+fi
+
+equivalent "$1" "$2" "$3"

--- a/.github/scripts/probe-pact-version.sh
+++ b/.github/scripts/probe-pact-version.sh
@@ -45,12 +45,101 @@
 #                                 service is a separate invocation of this script.
 #   PACT_WAIT_PER_SERVICE_SECONDS per-service cap (default 60)
 #
-# Prints one word on stdout — yes | no | unknown — the same vocabulary
+# Prints one word on stdout — yes | no | absent | unknown | equivalent:<sha> — the same vocabulary
 # classify-can-i-deploy-block.sh and resolve-can-i-deploy-selector.sh consume. Progress goes to
 # stderr so it appears in the log without polluting the value.
 #
+# THE `equivalent:<sha>` ANSWER (issue #3432)
+# `no` on a `workflow_dispatch` is a dead end by construction: services-ci never built THIS sha for
+# THIS service, so no version for it can ever appear, and #3318 correctly refuses to answer about a
+# different commit. Measured on run 30761923908 — 54 of 54 services refused, `deployable=[]` — which
+# makes reconcile, the only mechanism for re-driving a service that missed its push deploy, unable
+# to deploy anything, exactly when it is most needed.
+#
+# So before reporting `no` on a non-push event, ask a narrower question: is the commit that DOES
+# have a published version byte-identical to this one in everything this service is built from? If
+# pact-version-tree-equivalent.sh proves it from git — same tree objects, and an ancestor — then the
+# published verdict is not about a different commit in any sense that can reach the artifact, and
+# the caller may ask the broker about that version by number. If it cannot prove it, the answer
+# stays `no` and #3318's refusal stands untouched.
+#
+# EVERY failure here degrades to `no`: an unreachable broker, a non-2xx, an answer that is not a
+# 40-hex sha, a missing script, a non-zero exit. A reconcile that cannot VERIFY must not deploy.
+#
 # Always exits 0: this reports a fact, it does not gate on one.
 set -uo pipefail
+
+if [ "${1:-}" = "--self-test" ] || [ "${1:-}" = "--selftest" ]; then
+  # Exercises the #3432 broker call against a STUBBED curl, because the real broker has no public
+  # ingress (ADR-0056) and PACT_BROKER_URL is blank off main-push — so this path can never be run
+  # from a PR. Everything asserted here is a FAILURE mode: the only thing that must be provable is
+  # that a probe which cannot verify degrades to `no`, which on a dispatch is #3318's REFUSE.
+  self_tmp="$(mktemp -d)"; trap 'rm -rf "$self_tmp"' EXIT
+  cat > "$self_tmp/curl" <<'STUB'
+#!/usr/bin/env bash
+# Two shapes are called: the status probes (-w '%{http_code}') and the latest-version body fetch.
+url="${@: -1}"
+for a in "$@"; do [ "$a" = "-w" ] && is_status=1; done
+if [ "${is_status:-0}" = 1 ]; then
+  case "$url" in
+    */versions/*) echo 404 ;;   # this sha has no version — the #3432 entry condition
+    *)            echo 200 ;;   # ...but the pacticipant exists, so the answer is `no`, not `absent`
+  esac
+  exit 0
+fi
+case "${STUB_MODE:-}" in
+  unreachable) exit 7 ;;                                  # could not connect
+  http500)     exit 22 ;;                                 # curl -f on a non-2xx
+  garbage)     echo 'not json at all' ;;
+  # Deliberately a rev git CAN resolve, and one that is trivially equivalent to itself. A shape
+  # check that is missing therefore turns this into `equivalent:HEAD` rather than into another
+  # failure — the case can only stay green while the 40-hex validation is really there.
+  notasha)     echo '{"number":"HEAD"}' ;;
+  empty)       echo '{}' ;;
+  ok)          echo "{\"number\":\"${STUB_SHA}\"}" ;;
+  *)           exit 7 ;;
+esac
+STUB
+  chmod +x "$self_tmp/curl"
+  me_abs="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
+  # A throwaway repo, so the git half is REAL — the equivalence must be decided by actual tree
+  # objects, not by whatever the surrounding checkout happens to look like when this runs.
+  repo="$self_tmp/repo"
+  mkdir -p "$repo/openbank-demo-service/src/main"
+  ( cd "$repo" && git init -q . \
+    && git config user.email s@e.x && git config user.name s && git config commit.gpgsign false \
+    && printf 'x\n' > openbank-demo-service/build.gradle.kts \
+    && printf 'x\n' > openbank-demo-service/src/main/A.kt \
+    && git add -A && git commit -qm base ) >/dev/null 2>&1
+  older_sha="$(git -C "$repo" rev-parse HEAD)"
+  ( cd "$repo" && printf 'changed\n' > openbank-demo-service/src/main/A.kt \
+    && git add -A && git commit -qm change ) >/dev/null 2>&1
+  head_sha="$(git -C "$repo" rev-parse HEAD)"
+  fails=0
+  probe_selftest_case() { # <label> <expected> <STUB_MODE> [STUB_SHA]
+    local label="$1" want="$2" mode="$3" sha="${4:-}" got
+    got="$(cd "$repo" && PATH="$self_tmp:$PATH" STUB_MODE="$mode" STUB_SHA="$sha" \
+      EVENT_NAME=workflow_dispatch \
+      PACT_BROKER_URL=http://stub PACT_BROKER_USERNAME=u PACT_BROKER_PASSWORD=p \
+      bash "$me_abs" openbank-demo-service "$head_sha" 2>/dev/null)"
+    if [ "$got" = "$want" ]; then echo "  ok   ${label} → ${got}"
+    else echo "  FAIL ${label}: want '${want}', got '${got}'"; fails=$((fails + 1)); fi
+  }
+  echo "probe-pact-version.sh (#3432 equivalence path, stubbed broker)"
+  probe_selftest_case "broker unreachable"                       no unreachable
+  probe_selftest_case "broker answers non-2xx"                   no http500
+  probe_selftest_case "answer is not JSON"                       no garbage
+  probe_selftest_case "answer has no version number"             no empty
+  probe_selftest_case "version number is not a sha"              no notasha
+  # A well-formed sha whose tree is NOT equivalent must still be `no` — the broker answering
+  # correctly is not the proof; git is.
+  probe_selftest_case "well-formed sha, trees differ"            no ok "$older_sha"
+  # ...and the one case that may pass: the same commit is trivially equivalent to itself.
+  probe_selftest_case "well-formed sha, trees identical" "equivalent:${head_sha}" ok "$head_sha"
+  if [ "$fails" -ne 0 ]; then echo "FAILED: ${fails} case(s)"; exit 1; fi
+  echo "PASS: every unverifiable broker answer degrades to 'no'; only a git-proven equivalence does not"
+  exit 0
+fi
 
 SVC="${1:-}"
 SHA="${2:-}"
@@ -100,6 +189,40 @@ probe() {
 
 budget_left() { [ -n "$BUDGET_FILE" ] && [ -f "$BUDGET_FILE" ] && cat "$BUDGET_FILE" || echo 0; }
 
+# The version number of this pacticipant's latest `main`-TAGGED version — which is precisely what
+# `can-i-deploy --latest main` resolves to, so proving equivalence against it justifies the exact
+# question the fallback would have asked blindly. Measured against the live broker on 2026-08-03:
+# GET /pacticipants/<svc>/latest-version/main answers 200 with `.number` = the full 40-hex git sha
+# (services-ci publishes with pacticipantVersionNumber=$GITHUB_SHA and tags=[main]).
+# Prints nothing at all unless the answer is a well-formed sha — every other outcome is silence,
+# and silence keeps the caller on `no`.
+latest_main_version() {
+  local auth body num
+  auth="${PACT_BROKER_USERNAME:-}:${PACT_BROKER_PASSWORD:-}"
+  body="$(curl -s -f --max-time 20 -u "$auth" \
+    "${PACT_BROKER_URL:-}/pacticipants/${SVC}/latest-version/main" 2>/dev/null)" || return 0
+  num="$(printf '%s' "$body" | jq -r '.number // empty' 2>/dev/null)" || return 0
+  command grep -qE '^[0-9a-f]{40}$' <<< "$num" || return 0
+  printf '%s' "$num"
+}
+
+# Can the published verdict be transferred to the sha being deployed? Only when git proves the two
+# commits identical in every build input of this service. Anything short of a clean exit 0 from the
+# checker — and that includes the script being absent — leaves `present` as it was.
+try_equivalence() {
+  local pact_sha out here
+  here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  [ -x "$here/pact-version-tree-equivalent.sh" ] || [ -f "$here/pact-version-tree-equivalent.sh" ] || return 0
+  pact_sha="$(latest_main_version)"
+  [ -n "$pact_sha" ] || { echo "    no main-tagged version to compare ${SVC} against" >&2; return 0; }
+  if out="$(bash "$here/pact-version-tree-equivalent.sh" "$SVC" "$pact_sha" "$SHA" 2>&1)"; then
+    echo "    ${SVC}: ${out}" >&2
+    printf 'equivalent:%s' "$pact_sha"
+  else
+    echo "    ${SVC}: ${out}" >&2
+  fi
+}
+
 present="$(probe)"
 
 if [ "$present" = "no" ] && [ "${EVENT_NAME:-}" = "push" ] && [ "$(budget_left)" -gt 0 ]; then
@@ -114,6 +237,15 @@ if [ "$present" = "no" ] && [ "${EVENT_NAME:-}" = "push" ] && [ "$(budget_left)"
   if [ "$waited" -gt 0 ]; then
     echo "    waited ${waited}s for ${SVC}'s pact version (budget left: $(budget_left)s) -> ${present}" >&2
   fi
+fi
+
+# On a non-push event the wait above never runs — the fleet was built at other commits, so no
+# amount of waiting can produce a version for THIS sha. That is where the equivalence question is
+# both necessary and answerable. On a push it is deliberately not asked: the wait is the correct
+# answer there, and services-ci will publish for this very sha.
+if [ "$present" = "no" ] && [ "${EVENT_NAME:-}" != "push" ]; then
+  eq="$(try_equivalence)"
+  [ -n "$eq" ] && present="$eq"
 fi
 
 echo "$present"

--- a/.github/scripts/resolve-can-i-deploy-selector.sh
+++ b/.github/scripts/resolve-can-i-deploy-selector.sh
@@ -56,12 +56,16 @@
 # behaviour is untouched.
 #
 # Usage:
-#   PACT_VERSION_PRESENT=yes|no|unknown [EVENT_NAME=<github.event_name>] \
+#   PACT_VERSION_PRESENT=yes|no|absent|unknown|equivalent:<sha> [EVENT_NAME=<github.event_name>] \
 #     resolve-can-i-deploy-selector.sh <service> <sha>
 #
 #   PACT_VERSION_PRESENT — the caller's probe of
 #     GET <broker>/pacticipants/<svc>/versions/<sha>, same vocabulary the classifier uses:
 #       yes     → 200, a version exists for THIS commit
+#       equivalent:<sha>
+#               → no version for THIS commit, but the probe PROVED from git that <sha> — the
+#                 commit that does have one — is byte-identical in every build input of this
+#                 service (#3432). Not a fallback: a narrower, justified question.
 #       no      → 404 on the version, but the pacticipant EXISTS: this commit has published nothing yet
 #       absent  → the broker does not know the pacticipant AT ALL (no contracts either way)
 #       unknown → the probe itself failed (broker unreachable / non-2xx-non-404)
@@ -77,7 +81,7 @@ set -uo pipefail
 SVC="${1:-}"
 SHA="${2:-}"
 if [ -z "$SVC" ] || [ -z "$SHA" ]; then
-  echo "usage: PACT_VERSION_PRESENT=yes|no|unknown $0 <service> <sha>" >&2
+  echo "usage: PACT_VERSION_PRESENT=yes|no|absent|unknown|equivalent:<sha> $0 <service> <sha>" >&2
   exit 2
 fi
 
@@ -88,7 +92,32 @@ EVENT="${EVENT_NAME:-push}"
 
 emit() { printf '%s\t%s\n' "$1" "$2"; }
 
+# A malformed `equivalent:` — no sha, or something that is not one — is not a proof of anything,
+# and must not become a bare `--version` with an empty argument, which the pact CLI would read as
+# the next flag. Demote it to plain `no`, which on a dispatch is #3318's REFUSE.
 case "$PRESENT" in
+  equivalent:*)
+    case "${PRESENT#equivalent:}" in
+      [0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]) ;;
+      *) PRESENT=no ;;
+    esac
+    ;;
+esac
+
+case "$PRESENT" in
+  equivalent:*)
+    # #3432. The probe could not find a version for THIS sha, but it proved — from git tree
+    # objects, via pact-version-tree-equivalent.sh — that the commit which DOES have one is
+    # byte-identical to this one in every input this service's image is built from, and is an
+    # ancestor of it. So this is not the #3318 case at all: there is no "different commit" here
+    # in any sense that can reach the artifact, and asking by version number is more precise than
+    # the `--latest main` that a push would have used. Without this the manual/reconcile path can
+    # deploy NOTHING, ever — 54 of 54 refused on run 30761923908 — which is the state the whole
+    # fleet lands in exactly when a reconcile is needed. The refusal below is untouched for every
+    # case where the equivalence could NOT be proved, including a broker the probe could not read.
+    emit "--version ${PRESENT#equivalent:}" \
+      "no pact version for ${SHA}, but ${PRESENT#equivalent:} is byte-identical to it in every build input of ${SVC} (git tree objects, ancestor) — asking about that version by number is a question about the same source, not about a different commit (#3432, #3318)"
+    ;;
   yes)
     # The precise question, and the one the broker's own warning asks for: can THIS commit
     # of this service go to sandbox? No race window, and a green here cannot be borrowed

--- a/.github/scripts/test-classify-can-i-deploy-block.sh
+++ b/.github/scripts/test-classify-can-i-deploy-block.sh
@@ -118,7 +118,7 @@ check "dispatch + no version + regression-looking stdin → still NOT_ASKED" NOT
 #     nothing structural forces that, they are two files. Assert the equivalence over the
 #     whole (probe × event) cross-product, so changing either condition alone goes red.
 SHA_FIXTURE="0e32873f8c52d37e1b6530e5bd5e94275e5cefae"
-for p in yes no absent unknown; do
+for p in yes no absent unknown "equivalent:${SHA_FIXTURE}"; do
   for e in push workflow_dispatch schedule; do
     sel="$(PACT_VERSION_PRESENT="$p" EVENT_NAME="$e" bash "$RESOLVE" openbank-demo-service "$SHA_FIXTURE" | cut -f1)"
     cls="$(PACT_VERSION_PRESENT="$p" EVENT_NAME="$e" bash "$CLASSIFY" openbank-demo-service </dev/null | cut -f1)"

--- a/.github/scripts/test-resolve-can-i-deploy-selector.sh
+++ b/.github/scripts/test-resolve-can-i-deploy-selector.sh
@@ -124,6 +124,35 @@ check "push + pacticipant absent → latest/main" "--latest main" absent push
 # And the #3318 case must still refuse — 'absent' must not have widened it.
 check "dispatch + version missing but pacticipant KNOWN → still REFUSE" "REFUSE" no workflow_dispatch
 
+# ── issue #3432: the equivalence answer ─────────────────────────────────────────────────
+# 10. THE POINT OF THIS ADDITION. A dispatch whose sha has no version, where the probe PROVED
+#     from git that the commit which does have one is byte-identical in every build input of
+#     this service, must ask about that version BY NUMBER — not `--latest main`, which would be
+#     the same verdict borrowed without an argument, and not REFUSE, which is what made the
+#     whole reconcile path unable to deploy anything (54 of 54 refused, run 30761923908).
+EQ_SHA="1111111111111111111111111111111111111111"
+check "dispatch + proven-equivalent version → ask about THAT version" \
+  "--version ${EQ_SHA}" "equivalent:${EQ_SHA}" workflow_dispatch
+check "schedule + proven-equivalent version → ask about THAT version, not latest/main" \
+  "--version ${EQ_SHA}" "equivalent:${EQ_SHA}" schedule
+
+# 11. THE GUARD THAT MATTERS MORE. The equivalence must never be reachable by accident: only
+#     the probe can produce this value, and it produces it only after a clean exit 0 from
+#     pact-version-tree-equivalent.sh. So a plain `no` on a dispatch — the same service, the
+#     same sha, the equivalence NOT proved — must still REFUSE. If someone ever widens the new
+#     branch into a fallback, this goes red.
+check "dispatch + no version and no proof → still REFUSE (#3318 intact)" "REFUSE" no workflow_dispatch
+
+# 12. The selector must not invent a version out of a malformed value. `equivalent` with no sha
+#     is not a proof; it must not become `--version ` with an empty argument.
+got_eq="$(PACT_VERSION_PRESENT="equivalent:" EVENT_NAME=workflow_dispatch bash "$RESOLVE" openbank-demo-service "$SHA" | cut -f1)"
+if [ "$got_eq" = "--version" ] || [ "$got_eq" = "--version " ]; then
+  echo "  FAIL malformed equivalent: produced a bare '--version' with no argument"
+  fails=$((fails + 1))
+else
+  echo "  ok   malformed 'equivalent:' does not produce a bare --version (got '${got_eq}')"
+fi
+
 if [ "$fails" -ne 0 ]; then
   echo "FAILED: ${fails} case(s)"
   exit 1


### PR DESCRIPTION
## What this changes

A `workflow_dispatch` reconcile could not deploy anything, by construction. Pacts are published by
each service's own **push** lane, so the current `main` tip a dispatch builds has no published pact
version for any service, and #3318 then correctly REFUSEs — asking the broker about a different
commit is not a gate. Measured on run 30761923908: **54 of 54 services refused, `deployable=[]`**.
Reconcile is the only mechanism for re-driving a service that missed its push deploy, and it is
guaranteed to deploy nothing exactly when the most services are stranded.

**#3318 is untouched, and nothing is widened into a warning.** Its objection is to answering about a
*different* commit. That objection does not apply when the two commits are not different in any way
that could reach the service's artifact — so instead of borrowing a verdict, the pipeline now
**proves** they are the same:

1. ask the broker which sha its latest `main`-tagged version belongs to;
2. compare the **git tree objects** of everything that service's image is built from at both shas,
   and require the pact commit to be an ancestor;
3. identical ⇒ ask the broker about that version **by number**, and log why that is legitimate;
4. anything else ⇒ today's REFUSE, unchanged.

## Is the broker able to answer question 1?

Yes — measured against the live broker on 2026-08-03, not assumed:
`GET /pacticipants/<svc>/latest-version/main` answers `200` with `.number` = the full 40-hex git
sha. `_service-ci.yml` publishes with `pacticipantVersionNumber=$GITHUB_SHA` and `tags: [main]`, so
that number is exactly what `can-i-deploy --latest main` resolves to. Proving equivalence against it
therefore justifies the precise question the blind fallback would have asked.

## What "equivalent" means, and why the scope is what it is

The scope is derived from what auto-deploy actually assembles into the image (`Docker push
(parallel)`): the output of `:<svc>:quarkusBuild` and `:<svc>:cyclonedxBom`, plus
`.github/workflows/Dockerfile.deploy` copied in verbatim. So the compared set is the service's own
directory **whole**, every module it declares via `project(":…")` transitively, **every**
`openbank-libs*` module whether declared or not (deliberately over-broad — a miss here is a false
green), the global build directories, root files, and `Dockerfile.deploy`.

The default is the design: every changed path is classified into **in-scope**, **known-irrelevant**
(each one justified in the script header) or **UNRECOGNISED** — and an unrecognised path refuses. An
include-list of "things that matter" fails silently in the direction of a false green, so a
directory added to this repo tomorrow blocks the equivalence until someone classifies it.

Two narrowings were made only after measuring, with the reason recorded in place:

| scope tried | services equivalent (of 32 with a main-tagged version) | why narrowed |
|---|---|---|
| whole module directories | 0 | 12 refused **only** for four files under `openbank-libs/governance/` — the tree auto-deploy's own change detection already excludes as "data for CI checks + admin-ui, not a compile input" |
| `auto-deploy.yml` in scope | 0 | it refused all 32 on its own, and the image is built by the dispatch run under the dispatch sha's workflow either way; the pact verification never ran under that file at all |

## Does it actually deliver?

Honestly measured, and the answer is "sometimes, and only when the dispatch is prompt". Against
`main` HEAD at the moment of writing, 0 of 32 services were equivalent — main had genuinely moved
through their build inputs. The useful number is the **width of the window** after a pact version is
published: `openbank-account-service` 5 commits / **192 min**, `openbank-ledger-service` 28 commits
/ **84 min**. So a reconcile dispatched when a strand is noticed — which is the case this exists for,
"services-ci published, auto-deploy failed, re-drive it" — lands inside the window; a dispatch hours
later does not, and correctly still refuses.

## Fail-closed

The broker call degrades to `no` — which on a dispatch is #3318's REFUSE — on an unreachable broker,
a non-2xx, an unparseable answer, an answer that is not a 40-hex sha, a missing checker, or a
non-zero exit from it. A reconcile that cannot verify must not deploy.

## Testing

The equivalence decision is a pure function of `(service, pact_sha, dispatch_sha)` and git, with a
`--self-test` on **real git trees** in a throwaway repo — 17 cases: identical commits; only another
service, docs, gitops and a root markdown moved; the service's own source; the service's own tests;
a shared library's `src/main` both for a service that declares it and one that does not; a shared
module's governance data and its tests (which must **not** block); root build config; the baked-in
Dockerfile; an unrelated workflow; an unknown top-level directory; both shas missing; reversed
ancestry; a usage error. Verdict and exit code are asserted to agree in both directions.

**Falsified, not merely passed.** Four rules were broken in place and the self-test went red each
time: dropping the `openbank-libs*` blanket, letting an unrecognised path pass, deleting the
ancestry requirement, and narrowing the comparison to the service directory. The ancestry case was
**rewritten** after the first attempt showed it was vacuous — the pair it used differed in scope
anyway, so it stayed red with the rule deleted.

The broker half has its own `--self-test` against a stubbed `curl` covering all five failure modes,
also falsified: dropping the 40-hex check and accepting the checker's output without reading its
exit code each turn it red. Both self-tests pass under bash 3.2 (macOS) and bash 5.2 (the runner).

Both are registered as **enforced** gates in `.github/gates/gates.yaml` (100 → 102 ids, unique,
verified against live `main` immediately before committing) and run green through
`run-gates.py --group supplychain`.

## No workflow change

`probe-pact-version.sh` already runs per service and already speaks a vocabulary
`resolve-can-i-deploy-selector.sh` and `classify-can-i-deploy-block.sh` consume, so the new
`equivalent:<sha>` answer travels the existing path. The NOT_ASKED ⇔ REFUSE cross-product test was
widened to include it.

## What this does NOT fix

Direction 3 of the issue — `Gitops PR` reporting **success** for a run that updated zero manifests —
is untouched here. That is a separate, independently valuable change and should not ride on this one.

## Linked issues

Refs #3432, #3318, #3082, #2549

🤖 Generated with [Claude Code](https://claude.com/claude-code)
