### PR TITLE
fix(fx): give a derived inverse rate its own identity

### DIFF
--- a/openbank-fx-service/build.gradle.kts
+++ b/openbank-fx-service/build.gradle.kts
@@ -60,6 +60,10 @@ dependencies {
     // Consumer-driven contract for the aml-service case store (issue #2255, C3): fx is the consumer
     // of POST /api/v1/aml/cases, so this module also generates a pact.
     testImplementation(libs.pact.consumer)
+    // FxRateApiContractTest asserts the running endpoint against the committed openapi.yaml, which
+    // it PARSES rather than greps (#3374). No version: the Quarkus BOM manages it, same as
+    // openbank-ap2-service and openbank-pid-service, which carry the identical test shape.
+    testImplementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml")
 }
 
 kover {

--- a/openbank-fx-service/src/main/kotlin/com/openbank/fx/application/usecase/FxService.kt
+++ b/openbank-fx-service/src/main/kotlin/com/openbank/fx/application/usecase/FxService.kt
@@ -291,7 +291,10 @@ class FxService(
         toAmountMinorUnits = toAmountMinorUnits,
         appliedRate = rate.askRate,
         feeMinorUnits = feeMinorUnits,
-        rateId = rate.id,
+        // The STORED row, never the derived quote's own id (#3374). `fx_conversions.rate_id` is
+        // `NOT NULL REFERENCES fx_rates(id)`, so a derived id — which has no row — would fail the
+        // insert on a foreign-key violation for every CZK→foreign conversion.
+        rateId = rate.derivedFrom ?: rate.id,
         status = status,
         createdAt = createdAt,
         settledAt = settledAt,

--- a/openbank-fx-service/src/main/kotlin/com/openbank/fx/domain/model/FxRate.kt
+++ b/openbank-fx-service/src/main/kotlin/com/openbank/fx/domain/model/FxRate.kt
@@ -6,6 +6,8 @@ package com.openbank.fx.domain.model
 
 import java.math.BigDecimal
 import java.math.RoundingMode
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
 import java.time.Instant
 import java.util.UUID
 
@@ -23,6 +25,12 @@ data class FxRate(
     val validFrom: Instant,
     val validTo: Instant,
     val createdAt: Instant,
+    /**
+     * The id of the stored quote this one was derived from, or `null` when this IS the stored
+     * quote. Set only by [inverted]; nothing that reads a row out of `fx_rates` ever sets it,
+     * which is what makes "is this a derived quote?" answerable rather than inferred.
+     */
+    val derivedFrom: UUID? = null,
 ) {
     val pair: String get() = "$baseCurrency/$quoteCurrency"
     val midRate: BigDecimal get() = (bidRate + askRate).divide(BigDecimal.TWO)
@@ -44,10 +52,27 @@ data class FxRate(
      * CZK→foreign exchange — a systematic loss, in the customer's favour on one leg and the
      * bank's on the other, which is exactly the kind of error that does not announce itself.
      *
-     * [id] is carried over unchanged: this is a view of the SAME quote, not a new one, and
-     * FxConversion.rateId must keep pointing at the row the price came from.
+     * ## Identity (#3374)
+     *
+     * The first version of this method carried [id] over unchanged, so `EUR/CZK` and `CZK/EUR`
+     * answered under ONE identifier with different pairs and inverted numbers — an id that no
+     * longer identified what it named. A conversion audit record citing that id cannot be replayed
+     * to a direction.
+     *
+     * So the derived quote gets its own [id], [derivedId] over `(sourceId, "inverse")`: stable
+     * across calls (a client may cache by id) and distinct per direction. The link back to the row
+     * is not lost, it is made EXPLICIT in [derivedFrom] — which is the half the caller could not
+     * see before.
+     *
+     * **`FxConversion.rateId` must still reference the STORED row**, and not merely as bookkeeping:
+     * `fx_conversions.rate_id` is `NOT NULL REFERENCES fx_rates(id)`, and a derived id has no row,
+     * so writing it would fail every CZK→foreign conversion on a foreign-key violation. `FxService`
+     * therefore persists `rate.derivedFrom ?: rate.id`. Nulling the id instead — the shape #3374
+     * first proposed — would have hit the same constraint from the other side.
      */
     fun inverted(): FxRate = copy(
+        id = derivedId(id),
+        derivedFrom = id,
         baseCurrency = quoteCurrency,
         quoteCurrency = baseCurrency,
         bidRate = BigDecimal.ONE.divide(askRate, INVERSE_SCALE, RoundingMode.HALF_UP),
@@ -57,6 +82,42 @@ data class FxRate(
     private companion object {
         /** Matches the numeric(18,8) the rates are stored at, so a round trip does not drift. */
         const val INVERSE_SCALE = 8
+
+        /** Namespace separator; part of the hashed input, so changing it changes every derived id. */
+        const val INVERSE_NAMESPACE = "openbank.fx.rate.inverse"
+
+        private const val UUID_BYTES = 16
+        private const val VERSION_BYTE = 6
+        private const val VARIANT_BYTE = 8
+        private const val LOW_NIBBLE = 0x0f
+        private const val UUID_VERSION_8 = 0x80
+        private const val VARIANT_MASK = 0x3f
+        private const val VARIANT_RFC = 0x80
+        private const val BITS_PER_BYTE = 8
+        private const val BYTE_MASK = 0xffL
+
+        /**
+         * A name-based UUID for the inverse of [source], RFC 9562 version 8 (vendor-defined) over
+         * SHA-256 of `"<namespace>:<source>"`.
+         *
+         * Version 8 rather than the version 5 #3374 suggested because v5 is *defined* as SHA-1, and
+         * a SHA-1 call in a money-path service is a finding every scanner in this repo will raise —
+         * for a construction that is not a security control at all. v8 is exactly the escape hatch
+         * RFC 9562 provides for a name-based scheme with a different digest, and the property that
+         * matters here is identical: same input, same id, forever.
+         */
+        fun derivedId(source: UUID): UUID {
+            val digest = MessageDigest.getInstance("SHA-256")
+                .digest("$INVERSE_NAMESPACE:$source".toByteArray(StandardCharsets.UTF_8))
+                .copyOf(UUID_BYTES)
+            digest[VERSION_BYTE] = ((digest[VERSION_BYTE].toInt() and LOW_NIBBLE) or UUID_VERSION_8).toByte()
+            digest[VARIANT_BYTE] = ((digest[VARIANT_BYTE].toInt() and VARIANT_MASK) or VARIANT_RFC).toByte()
+            var hi = 0L
+            var lo = 0L
+            for (i in 0 until BITS_PER_BYTE) hi = (hi shl BITS_PER_BYTE) or (digest[i].toLong() and BYTE_MASK)
+            for (i in BITS_PER_BYTE until UUID_BYTES) lo = (lo shl BITS_PER_BYTE) or (digest[i].toLong() and BYTE_MASK)
+            return UUID(hi, lo)
+        }
     }
 }
 

--- a/openbank-fx-service/src/main/resources/openapi.yaml
+++ b/openbank-fx-service/src/main/resources/openapi.yaml
@@ -3,9 +3,12 @@
 openapi: 3.1.0
 info:
   title: FX Service API
-  # major == openbank.api.version == URL /api/v1 (ADR-0048). Minor bump (1.2 -> 1.3): additive
-  # endpoint only (PATCH /approvals/{id}, ADR-0155 four-eyes) — no breaking change.
-  version: 1.5.0
+  # major == openbank.api.version == URL /api/v1 (ADR-0048). Minor bump (1.5 -> 1.6): two response
+  # properties ADDED to ExchangeRateResponse (`id`, `derivedFrom`, #3374). Additive only — nothing
+  # is removed, no property changes type, and neither is required, so no client breaks. `id` was
+  # served for the whole life of the endpoint and never documented; documenting it now is therefore
+  # a spec correction, not a new field on the wire.
+  version: 1.6.0
   description: >-
     Foreign exchange rates and currency conversion. On convert, the converting party's name is
     synchronously screened against the sanctions lists (ADR-0032): a clean party settles the
@@ -259,7 +262,27 @@ components:
   schemas:
     ExchangeRateResponse:
       type: object
+      description: >-
+        A quote for one direction of a currency pair. It may be a stored row or DERIVED from the
+        opposite direction: the ČNB fixing, the only live source ingested, publishes FOREIGN→CZK
+        exclusively, so every stored pair is `X/CZK` and a CZK→foreign quote is computed by
+        inverting the stored one (bid and ask swap). `derivedFrom` is what tells the two apart.
       properties:
+        id:
+          type: string
+          format: uuid
+          description: >-
+            Identifies THIS quote — this pair, in this direction. On a derived quote it is computed
+            deterministically from `derivedFrom`, so it is stable across calls and safe to cache
+            by, but it is NOT the identifier of any row in the rate store. Use `derivedFrom` when
+            you need the stored row.
+        derivedFrom:
+          type: string
+          format: uuid
+          nullable: true
+          description: >-
+            The id of the stored quote this one was inverted from, or absent/null when this quote
+            IS the stored one. A conversion executed on a derived quote records this id, not `id`.
         baseCurrency:
           type: string
         quoteCurrency:

--- a/openbank-fx-service/src/test/kotlin/com/openbank/fx/application/usecase/FxServiceTest.kt
+++ b/openbank-fx-service/src/test/kotlin/com/openbank/fx/application/usecase/FxServiceTest.kt
@@ -162,6 +162,56 @@ class FxServiceTest {
         assertThat(conv.appliedRate).isEqualByComparingTo("0.04016064")
     }
 
+    // --- identity of a derived quote (#3374) -------------------------------------------------
+
+    @Test
+    fun `the two directions of one pair answer under different ids`() = runBlocking<Unit> {
+        // The reported defect: GET EUR/CZK and GET CZK/EUR returned the SAME id with inverted
+        // numbers, so the id could not be replayed to a direction.
+        val stored = fxRate()
+        coEvery { rateRepo.findLatest("EUR", "CZK", RateType.SPOT) } returns stored
+        coEvery { rateRepo.findLatest("CZK", "EUR", RateType.SPOT) } returns null
+
+        val direct = service.getRate(GetRateQuery("EUR", "CZK", RateType.SPOT))!!
+        val derived = service.getRate(GetRateQuery("CZK", "EUR", RateType.SPOT))!!
+
+        assertThat(derived.id).isNotEqualTo(direct.id)
+        assertThat(derived.derivedFrom).isEqualTo(stored.id)
+        assertThat(direct.derivedFrom).isNull()
+    }
+
+    @Test
+    fun `a conversion on a derived quote records the STORED row id`() = runBlocking<Unit> {
+        // The money-path property. `fx_conversions.rate_id` is NOT NULL REFERENCES fx_rates(id):
+        // a derived id has no row, so persisting it would fail the insert on a foreign-key
+        // violation for every CZK→foreign conversion — and the audit trail would cite an id
+        // nothing can resolve.
+        val stored = fxRate()
+        val command = convertCommand().copy(fromCurrency = "CZK", toCurrency = "EUR")
+        coEvery { rateRepo.findLatest("CZK", "EUR", RateType.SPOT) } returns null
+        coEvery { rateRepo.findLatest("EUR", "CZK", RateType.SPOT) } returns stored
+        coEvery { convRepo.saveWithOutbox(any(), any()) } answers { firstArg() }
+        clear()
+
+        val conv = service.convert(command)
+
+        assertThat(conv.rateId).isEqualTo(stored.id)
+        assertThat(conv.rateId).isNotEqualTo(stored.inverted().id)
+    }
+
+    @Test
+    fun `a conversion on a stored quote still records that row's id`() = runBlocking<Unit> {
+        // The `derivedFrom ?: id` fallback must not change the direct path.
+        val stored = fxRate()
+        coEvery { rateRepo.findLatest("EUR", "CZK", RateType.SPOT) } returns stored
+        coEvery { convRepo.saveWithOutbox(any(), any()) } answers { firstArg() }
+        clear()
+
+        val conv = service.convert(convertCommand().copy(fromCurrency = "EUR", toCurrency = "CZK"))
+
+        assertThat(conv.rateId).isEqualTo(stored.id)
+    }
+
     @Test
     fun `convert throws when rate is expired`() = runBlocking<Unit> {
         val command = convertCommand()

--- a/openbank-fx-service/src/test/kotlin/com/openbank/fx/contract/FxRateApiContractTest.kt
+++ b/openbank-fx-service/src/test/kotlin/com/openbank/fx/contract/FxRateApiContractTest.kt
@@ -1,0 +1,267 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.fx.contract
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper
+import com.openbank.fx.application.port.out.FxRateRepository
+import com.openbank.fx.domain.model.FxRate
+import com.openbank.fx.domain.model.RateSource
+import com.openbank.fx.domain.model.RateType
+import com.openbank.fx.integration.FxBootSmokeIT
+import com.openbank.fx.it.PostgresRedisTestResource
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.security.TestSecurity
+import io.quarkus.vertx.core.runtime.context.VertxContextSafetyToggle
+import io.restassured.RestAssured.given
+import io.vertx.core.Vertx
+import io.vertx.core.impl.ContextInternal
+import jakarta.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.launch
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.io.File
+import java.math.BigDecimal
+import java.time.Instant
+import java.util.UUID
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.Executor
+import java.util.concurrent.TimeUnit
+
+/**
+ * Spec-conformance contract test for the FX quote surface — the identity half of
+ * `ExchangeRateResponse` (issue #3374).
+ *
+ * ## Why this is not a Pact
+ *
+ * The one committed pact for this provider, `openbank-transaction-service-openbank-fx-service`,
+ * covers `GET /api/v1/fx/rates/EUR/CZK` — the STORED direction — and pins four fields, none of them
+ * `id`. The defect here lives in the DERIVED direction, which no in-repo consumer calls, so writing
+ * a pact for it would be writing a contract against a fictional consumer: it would prove only that
+ * a test agrees with itself. The counterparty for this property is the committed `openapi.yaml`,
+ * which is what the mobile app and any external integrator code against, so that document is what
+ * the assertions are derived from. (The existing pact is untouched and still replayed on every PR
+ * by [FxPactFolderProviderVerificationTest]; the two new response properties are additive, and pact
+ * ignores fields it does not name, so it cannot be affected either way.)
+ *
+ * ## The spec is PARSED, never grepped
+ *
+ * Every expectation below is navigated to by JSON-Pointer, so the test cannot pass by matching
+ * prose — the failure mode #2291 documents, where a `contains(...)` over YAML text scored services
+ * as covered on a comment. If `id` or `derivedFrom` is deleted from `ExchangeRateResponse`, the
+ * pointer resolves to null and this test fails before it ever issues a request.
+ *
+ * ## What it pins, and why each half is needed
+ *
+ *  - **Both directions carry an `id`, and the two ids DIFFER.** This is the reported defect: before
+ *    #3374 `EUR/CZK` and `CZK/EUR` answered under one identifier with inverted numbers, so the id
+ *    did not identify what it named and an audit record citing it could not be replayed to a
+ *    direction.
+ *  - **The derived quote's `derivedFrom` is the stored quote's `id`.** Provenance has to be
+ *    readable by the caller, not inferred from which way they happened to ask.
+ *  - **The stored quote declares no derivation.** A discriminator that is always set discriminates
+ *    nothing.
+ *  - **The derived `id` is stable across calls.** A per-request id would make the field useless as
+ *    a cache key or an audit reference — the same defect in a different shape.
+ *
+ * ## Driven for real
+ *
+ * `@QuarkusTest` + RestAssured rather than calling the use case directly, because the wire JSON is
+ * what the contract is about: the endpoint serialises the domain [FxRate], so Jackson property
+ * naming and null handling only exist after serialisation. [com.openbank.fx.domain.model.FxRateTest]
+ * and [com.openbank.fx.application.usecase.FxServiceTest] cover the derivation and the money-path
+ * `rateId` rule in-process; this covers the wire format.
+ *
+ * ## Known residual drift, deliberately NOT asserted here
+ *
+ * `ExchangeRateResponse` also declares `rate` and `validAt`, which the endpoint has never served,
+ * and omits nine properties it does serve (`bidRate`, `askRate`, `rateType`, `source`, `validFrom`,
+ * `validTo`, `createdAt`, `pair`, `midRate`). Exact set equality in both directions — the shape
+ * `Ap2ApiContractTest` uses — is the right end state, but reaching it means REMOVING two declared
+ * response properties, which `oasdiff` classifies as breaking and would force a major bump, i.e.
+ * `/api/v2` (ADR-0048 ties the spec major to the URL). That is a separate decision from fixing an
+ * id, so this test asserts the identity contract exactly and the type of every declared property it
+ * does find, and the wider realignment is left to its own change.
+ */
+@QuarkusTest
+@QuarkusTestResource(FxBootSmokeIT.InMemoryKafkaResource::class)
+@QuarkusTestResource(PostgresRedisTestResource::class)
+@TestSecurity(user = "00000000-0000-0000-0000-000000000099", roles = ["ROLE_OPERATOR"])
+class FxRateApiContractTest {
+
+    @Inject
+    lateinit var rateRepo: FxRateRepository
+
+    @Inject
+    lateinit var vertx: Vertx
+
+    private val spec: JsonNode = YAMLMapper().readTree(File(SPEC_PATH))
+
+    private val rateSchema: JsonNode
+        get() = spec.at(RATE_SCHEMA_POINTER).also {
+            assertThat(it.isMissingNode)
+                .describedAs("openapi.yaml must declare an ExchangeRateResponse schema")
+                .isFalse()
+        }
+
+    private lateinit var storedId: UUID
+
+    @BeforeEach
+    fun seedStoredQuote() {
+        // Only ONE direction is stored, mirroring how a fixing publishes it: the
+        // reverse answer must therefore be derived, which is the case under test.
+        runOnVertxContext {
+            val existing = rateRepo.findLatest(BASE, QUOTE, RateType.SPOT)
+            if (existing != null) {
+                storedId = existing.id
+                return@runOnVertxContext
+            }
+            val now = Instant.now()
+            val id = UUID.randomUUID()
+            rateRepo.save(
+                FxRate(
+                    id = id,
+                    baseCurrency = BASE,
+                    quoteCurrency = QUOTE,
+                    bidRate = BigDecimal("24.80"),
+                    askRate = BigDecimal("25.30"),
+                    rateType = RateType.SPOT,
+                    source = RateSource.CNB,
+                    validFrom = now.minusSeconds(HOUR_SECONDS),
+                    validTo = now.plusSeconds(DAY_SECONDS),
+                    createdAt = now,
+                ),
+            )
+            storedId = id
+        }
+    }
+
+    @Test
+    fun `the spec declares both identity properties on the quote schema`() {
+        // Read from the document rather than assumed, so deleting either property from
+        // openapi.yaml fails here instead of silently narrowing every assertion below.
+        listOf(ID_PROPERTY, DERIVED_FROM_PROPERTY).forEach { name ->
+            val property = rateSchema.at("/properties/$name")
+            assertThat(property.isMissingNode)
+                .describedAs("ExchangeRateResponse must declare '%s'", name)
+                .isFalse()
+            assertThat(property.path("type").asText()).isEqualTo("string")
+            assertThat(property.path("format").asText()).isEqualTo("uuid")
+        }
+    }
+
+    @Test
+    fun `the two directions of one pair answer under different ids`() {
+        val direct = quote(BASE, QUOTE)
+        val derived = quote(QUOTE, BASE)
+
+        assertThat(direct.path(ID_PROPERTY).asText()).isNotBlank()
+        assertThat(derived.path(ID_PROPERTY).asText()).isNotBlank()
+        assertThat(derived.path(ID_PROPERTY).asText())
+            .describedAs("a derived quote must not answer under the stored row's id (#3374)")
+            .isNotEqualTo(direct.path(ID_PROPERTY).asText())
+    }
+
+    @Test
+    fun `the derived quote names the stored row it came from`() {
+        val derived = quote(QUOTE, BASE)
+
+        assertThat(derived.path(DERIVED_FROM_PROPERTY).asText()).isEqualTo(storedId.toString())
+        assertThat(derived.path("baseCurrency").asText()).isEqualTo(QUOTE)
+        assertThat(derived.path("quoteCurrency").asText()).isEqualTo(BASE)
+    }
+
+    @Test
+    fun `the stored quote declares no derivation`() {
+        val direct = quote(BASE, QUOTE)
+
+        assertThat(direct.path(DERIVED_FROM_PROPERTY).isNull || direct.path(DERIVED_FROM_PROPERTY).isMissingNode)
+            .describedAs("a stored quote must not claim to be derived, or the field discriminates nothing")
+            .isTrue()
+        assertThat(direct.path(ID_PROPERTY).asText()).isEqualTo(storedId.toString())
+    }
+
+    @Test
+    fun `the derived id is stable across calls`() {
+        assertThat(quote(QUOTE, BASE).path(ID_PROPERTY).asText())
+            .isEqualTo(quote(QUOTE, BASE).path(ID_PROPERTY).asText())
+    }
+
+    @Test
+    fun `every declared property the endpoint serves carries the declared JSON type`() {
+        val derived = quote(QUOTE, BASE)
+
+        rateSchema.path("properties").fields().forEach { (name, declared) ->
+            val served = derived.path(name)
+            if (served.isMissingNode || served.isNull) return@forEach
+            when (declared.path("type").asText()) {
+                "string" -> assertThat(served.isTextual).describedAs("%s is a string", name).isTrue()
+                "number" -> assertThat(served.isNumber).describedAs("%s is a number", name).isTrue()
+                else -> Unit
+            }
+        }
+    }
+
+    private fun quote(base: String, quote: String): JsonNode {
+        val body = given().`when`().get("/api/v1/fx/rates/$base/$quote")
+            .then().statusCode(HTTP_OK)
+            .extract().body().asString()
+        return YAMLMapper().readTree(body)
+    }
+
+    /**
+     * Bridges a reactive-Panache block into a plain JUnit thread. [rateRepo] uses
+     * `Panache.withTransaction`/`withSession`, which needs a Vert.x context that a bare
+     * `@QuarkusTest` thread does not carry — same pattern and same reason as
+     * [FxPactFolderProviderVerificationTest.runOnVertxContext].
+     */
+    private fun runOnVertxContext(block: suspend () -> Unit) {
+        val future = CompletableFuture<Unit>()
+        val duplicated = (vertx.orCreateContext as ContextInternal).duplicate()
+        VertxContextSafetyToggle.setContextSafe(duplicated, true)
+        val dispatcher = Executor { command -> duplicated.runOnContext { command.run() } }.asCoroutineDispatcher()
+        CoroutineScope(dispatcher).launch {
+            try {
+                block()
+                future.complete(Unit)
+            } catch (t: Throwable) {
+                future.completeExceptionally(t)
+            }
+        }
+        future.get(AWAIT_SECONDS, TimeUnit.SECONDS)
+    }
+
+    private companion object {
+        const val SPEC_PATH = "src/main/resources/openapi.yaml"
+        const val RATE_SCHEMA_POINTER = "/components/schemas/ExchangeRateResponse"
+        const val ID_PROPERTY = "id"
+        const val DERIVED_FROM_PROPERTY = "derivedFrom"
+
+        // A SYNTHETIC pair, not EUR/CZK, and the reason matters beyond this test.
+        //
+        // `V1__create_fx.sql:39` seeds a stored `CZK/EUR` row. `FxService.getRate` tries the direct
+        // direction first, so in a fresh database `GET /rates/CZK/EUR` answers from that row and
+        // never derives anything — the very path under test does not run, and the assertion below
+        // sees a legitimate null `derivedFrom`. Using EUR/CZK here failed for exactly that reason.
+        //
+        // It also explains why #3374 was observable in sandbox and not locally: the seeded row's
+        // `validTo` is `NOW() + INTERVAL '1 day'` fixed at migration time, and `findLatest` filters
+        // `validTo > now`, so the seed ages out after a day. A long-lived environment therefore
+        // derives CZK/EUR; a freshly migrated one serves the stored row.
+        //
+        // Synthetic ISO 4217 codes in the user-assigned XA-XZ range, so no migration seed, no other
+        // test and no real fixing can supply the reverse direction and quietly make this vacuous.
+        const val BASE = "XQA"
+        const val QUOTE = "XQB"
+        const val HTTP_OK = 200
+        const val HOUR_SECONDS = 3600L
+        const val DAY_SECONDS = 86400L
+        const val AWAIT_SECONDS = 10L
+    }
+}

--- a/openbank-fx-service/src/test/kotlin/com/openbank/fx/domain/model/FxRateTest.kt
+++ b/openbank-fx-service/src/test/kotlin/com/openbank/fx/domain/model/FxRateTest.kt
@@ -78,12 +78,51 @@ class FxRateTest {
         assertThat(round.bidRate).isLessThan(round.askRate)
     }
 
+    // --- identity of a derived quote (#3374) -------------------------------------------------
+
     @Test
-    fun `the inverted quote keeps the id of the row it was derived from`() {
-        // FxConversion.rateId must still point at the stored quote the price came from.
+    fun `the inverted quote has its own id, not the source row's`() {
+        // The defect this replaces: EUR/CZK and CZK/EUR answered under ONE id with different
+        // pairs, so an id no longer identified what it named.
         val original = fxRate()
 
-        assertThat(original.inverted().id).isEqualTo(original.id)
+        assertThat(original.inverted().id).isNotEqualTo(original.id)
+    }
+
+    @Test
+    fun `the inverted quote names the row it came from`() {
+        val original = fxRate()
+
+        assertThat(original.inverted().derivedFrom).isEqualTo(original.id)
+    }
+
+    @Test
+    fun `a stored quote declares no derivation`() {
+        // The discriminator only works if it is absent on the other side.
+        assertThat(fxRate().derivedFrom).isNull()
+    }
+
+    @Test
+    fun `the derived id is deterministic across calls`() {
+        // A client may cache by id; a fresh id per request would make that cache useless and the
+        // id itself meaningless as a reference in an audit record.
+        val original = fxRate()
+
+        assertThat(original.inverted().id).isEqualTo(original.inverted().id)
+    }
+
+    @Test
+    fun `the derived id depends on the source row`() {
+        // Two different stored rows must not derive to one inverse id.
+        assertThat(fxRate().inverted().id).isNotEqualTo(fxRate().inverted().id)
+    }
+
+    @Test
+    fun `the derived id is a well-formed RFC 9562 version 8 UUID`() {
+        val derived = fxRate().inverted().id
+
+        assertThat(derived.version()).isEqualTo(EXPECTED_UUID_VERSION)
+        assertThat(derived.variant()).isEqualTo(EXPECTED_UUID_VARIANT)
     }
 
     @Test
@@ -112,4 +151,9 @@ class FxRateTest {
         validTo = validTo,
         createdAt = Instant.parse("2026-01-01T00:00:00Z"),
     )
+
+    private companion object {
+        const val EXPECTED_UUID_VERSION = 8
+        const val EXPECTED_UUID_VARIANT = 2
+    }
 }


### PR DESCRIPTION
Closes #3374.

## The defect

`GET /api/v1/fx/rates/EUR/CZK` and `.../CZK/EUR` returned **the same `id`** with different pairs and inverted numbers. The rates were right (#3189 fixed a permanent 502 there); only the identity was wrong — and an audit record citing that id cannot be replayed to a direction, which is the half that matters for money-path evidence.

## Why not the option the issue preferred

#3374 proposed nulling the `id` and adding `derivedFrom`. That would have failed hard:

```
fx_conversions.rate_id  NOT NULL REFERENCES fx_rates(id)
```

A derived quote has no row, so writing either a synthetic id or `null` breaks **every CZK→foreign conversion** on a foreign-key violation. `FxRate.inverted()`'s KDoc was protecting exactly this — `FxConversion.rateId` must keep pointing at the row the price came from.

So this combines the issue's options (1) and (2):

- the derived quote gets its **own deterministic id**, from `(sourceId, "inverse")` — stable across calls, so still usable as a cache key or audit reference, and distinct per direction;
- **`derivedFrom`** names the stored row explicitly, making "this is a derived quote" readable instead of inferred;
- `FxService` persists `rate.derivedFrom ?: rate.id`, so the price stays traceable to the row. A unit test pins that property directly (`conv.rateId == stored.id` **and** `!= stored.inverted().id`), on both the derived and the direct path.

## Spec

`1.5.0 → 1.6.0`. `ExchangeRateResponse` declared **neither** `id` nor `derivedFrom` before — the endpoint has always served an undocumented `id` — so documenting both is additive. Version re-read off live `origin/main` immediately before committing (still `1.5.0`, no race).

## The test finding, which is the interesting part

The new contract test uses a **synthetic currency pair**, not EUR/CZK, and the reason generalises.

`V1__create_fx.sql:39` seeds a stored **`CZK/EUR`** row. `getRate` tries the direct direction first, so in a freshly migrated database `GET /rates/CZK/EUR` answers from that row and **never derives anything** — the path under test does not run, and the assertion sees a legitimate null `derivedFrom`. Written against the real pair, the test failed for precisely that reason:

```
expected: "73932f33-8a7e-4dbd-ba2f-aa539dcb7f8a"
 but was: "null"
```

That also explains why **#3374 was observable in sandbox and not locally**: the seeded row's `validTo` is `NOW() + INTERVAL '1 day'`, fixed at migration time, and `findLatest` filters `validTo > now`. So the seed ages out after a day — a long-lived environment derives CZK/EUR, a fresh one serves the stored row. Nobody would have reproduced this on a clean database.

Synthetic ISO 4217 codes in the user-assigned `XA`-`XZ` range, so no migration seed, no other test and no real fixing can supply the reverse direction and quietly make the test vacuous.

## Contract-test shape

Not a pact, deliberately. The one committed pact for this provider covers the **stored** direction and pins four fields, none of them `id`; the defect lives in the **derived** direction, which no in-repo consumer calls. A pact for it would be a contract against a fictional consumer. The counterparty for this property is the committed `openapi.yaml`, so that document is what the assertions read — **parsed by JSON-Pointer, never grepped**, so it cannot pass by matching prose (#2291's failure mode). Delete `id` or `derivedFrom` from the schema and the test fails before it issues a request.

The existing pact is untouched and still replayed on every PR by `FxPactFolderProviderVerificationTest`.

## Verification

```
:openbank-fx-service:build          BUILD SUCCESSFUL
:openbank-fx-service:koverVerify    BUILD SUCCESSFUL
:openbank-fx-service:ktlintCheck    BUILD SUCCESSFUL
:openbank-fx-service:detekt         BUILD SUCCESSFUL
```

## Self-assessment

- **`money_path_services` includes `openbank-fx-service`**, so this wants 2 approvals by rule. Expect the merge to be blocked; that is the correct state.
- **Known residual spec drift, deliberately untouched:** `ExchangeRateResponse` also declares `rate` and `validAt`, which the endpoint has never served, and omits nine properties it does serve. Exact set equality is the right end state, but reaching it means *removing* two declared properties, which `oasdiff` classifies as breaking and would force `/api/v2` (ADR-0048 ties the spec major to the URL). That is a separate decision from fixing an id.
- **Not measured:** whether any external consumer already stores the old shared id. In-repo there is none, and the id was undocumented, but I cannot see outside the repo.
- The original authoring stalled mid-gate; I finished it, and the contract-test failure above was found by running the gate rather than by review.
