### PR TITLE
fix(admin-ui): stop single-use refresh tokens logging active operators out

### DIFF
--- a/openbank-admin-ui/src/lib/auth/authOptions.ts
+++ b/openbank-admin-ui/src/lib/auth/authOptions.ts
@@ -92,30 +92,95 @@ function extractRoles(jwt: string): string[] {
   return realmAccess?.roles?.filter(r => r.startsWith("ROLE_")) ?? []
 }
 
-async function refreshAccessToken(token: JWT): Promise<JWT> {
-  try {
-    const url = `${KEYCLOAK_INTERNAL_URL}/realms/${KEYCLOAK_REALM}/protocol/openid-connect/token`
-    const res = await fetch(url, {
-      method: "POST",
-      headers: { "Content-Type": "application/x-www-form-urlencoded" },
-      body: new URLSearchParams({
-        client_id: CLIENT_ID,
-        client_secret: CLIENT_SECRET,
-        grant_type: "refresh_token",
-        refresh_token: token.refreshToken as string,
-      }),
-    })
-    const refreshed = await res.json()
-    if (!res.ok) throw refreshed
+/**
+ * Refresh a minute BEFORE the access token actually expires. A token that is valid at the
+ * moment the JWT callback runs can still be expired by the time the upstream service
+ * validates it, and the realm's clock is not ours.
+ */
+const REFRESH_SKEW_MS = 60_000
+
+/**
+ * How long a completed rotation stays answerable by the refresh token it consumed.
+ * One access-token lifespan (300s) is the window in which stale copies of the cookie can
+ * still arrive; 120s covers the realistic tail without holding grants longer than needed.
+ */
+const ROTATION_CACHE_TTL_MS = 120_000
+
+type Rotation = Pick<JWT, "accessToken" | "accessTokenExpires" | "refreshToken" | "roles">
+
+/**
+ * Keyed by the refresh token that was SPENT, not by user.
+ *
+ * The realm sets `revokeRefreshToken: true` + `refreshTokenMaxReuse: 0`, so every refresh
+ * token is strictly single-use. Two things then break a session that is actively in use:
+ *
+ *  - **Stampede.** `auth()` is called independently by the middleware, ~30 route handlers and
+ *    `/api/gate` (nginx `auth_request`). Each decodes the SAME cookie, so once the access
+ *    token expires they all present the same refresh token at once. One wins; every other
+ *    gets `invalid_grant` and marks the session `RefreshAccessTokenError`, which the
+ *    middleware turns into a redirect to `/auth/login?error=SessionExpired`.
+ *  - **Rotation loss.** Only a response that reaches the browser can persist the rotated
+ *    token. `/api/gate` is an nginx auth subrequest (its `Set-Cookie` is discarded) and
+ *    `auth()` inside a Server Component cannot set cookies at all. Such a call spends the
+ *    refresh token and throws the replacement away, leaving the browser holding a revoked
+ *    one — the next refresh is then guaranteed to fail.
+ *
+ * Both are answered by remembering the result against the spent token: concurrent callers
+ * share one in-flight grant, and a later caller still carrying the old cookie is handed the
+ * already-rotated token instead of presenting a revoked one to Keycloak. The admin-ui runs a
+ * single replica, so an in-process map is sufficient; a multi-replica deployment would need a
+ * shared store instead.
+ */
+const rotationCache = new Map<string, { at: number; result: Promise<Rotation> }>()
+
+function pruneRotationCache(now: number): void {
+  for (const [key, entry] of rotationCache) {
+    if (now - entry.at > ROTATION_CACHE_TTL_MS) rotationCache.delete(key)
+  }
+}
+
+async function requestRotation(refreshToken: string): Promise<Rotation> {
+  const url = `${KEYCLOAK_INTERNAL_URL}/realms/${KEYCLOAK_REALM}/protocol/openid-connect/token`
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      client_id: CLIENT_ID,
+      client_secret: CLIENT_SECRET,
+      grant_type: "refresh_token",
+      refresh_token: refreshToken,
+    }),
+  })
+  const refreshed = await res.json()
+  if (!res.ok) throw refreshed
+  return {
     // Re-extract roles from new access token
-    const roles = extractRoles(refreshed.access_token)
-    return {
-      ...token,
-      accessToken: refreshed.access_token,
-      accessTokenExpires: Date.now() + refreshed.expires_in * 1000,
-      refreshToken: refreshed.refresh_token ?? token.refreshToken,
-      roles,
-    }
+    roles: extractRoles(refreshed.access_token),
+    accessToken: refreshed.access_token,
+    accessTokenExpires: Date.now() + refreshed.expires_in * 1000,
+    refreshToken: refreshed.refresh_token ?? refreshToken,
+  }
+}
+
+async function refreshAccessToken(token: JWT): Promise<JWT> {
+  const refreshToken = token.refreshToken as string | undefined
+  if (!refreshToken) return { ...token, error: "RefreshAccessTokenError" }
+
+  const now = Date.now()
+  pruneRotationCache(now)
+
+  let entry = rotationCache.get(refreshToken)
+  if (!entry) {
+    entry = { at: now, result: requestRotation(refreshToken) }
+    rotationCache.set(refreshToken, entry)
+    // A failed grant must not be remembered: the next request has to be free to try again
+    // (Keycloak may simply have been unreachable). Attach the handler here so the shared
+    // promise is never unhandled, and let the awaiting callers see the rejection too.
+    entry.result.catch(() => rotationCache.delete(refreshToken))
+  }
+
+  try {
+    return { ...token, ...(await entry.result), error: undefined }
   } catch {
     return { ...token, error: "RefreshAccessTokenError" }
   }
@@ -177,8 +242,8 @@ export const authOptions: NextAuthConfig = {
           })() : {}),
         }
       }
-      // Token still valid
-      if (Date.now() < (token.accessTokenExpires as number)) return token
+      // Token still valid, with a margin — see REFRESH_SKEW_MS.
+      if (Date.now() < (token.accessTokenExpires as number) - REFRESH_SKEW_MS) return token
       // Refresh
       return refreshAccessToken(token)
     },

--- a/openbank-admin-ui/src/test/authoptions-refresh.test.ts
+++ b/openbank-admin-ui/src/test/authoptions-refresh.test.ts
@@ -53,7 +53,7 @@ describe('authOptions — refresh failure surfaces as a session error', () => {
   it('does NOT refresh (or error) while the access token is still valid', async () => {
     const fetchSpy = vi.fn()
     vi.stubGlobal('fetch', fetchSpy)
-    const valid: JWT = { accessToken: 'ok', accessTokenExpires: Date.now() + 60_000 }
+    const valid: JWT = { accessToken: 'ok', accessTokenExpires: Date.now() + 300_000 }
     const out = await callJwt(valid)
     expect(out.error).toBeUndefined()
     expect(fetchSpy).not.toHaveBeenCalled()
@@ -72,6 +72,106 @@ describe('authOptions — refresh failure surfaces as a session error', () => {
     expect(out.error).toBeUndefined()
     expect(out.accessToken).toBe(rotated)
     expect(out.roles).toEqual(['ROLE_OPERATOR'])
+  })
+
+  it('refreshes ahead of expiry, not after it (skew)', async () => {
+    const fetchSpy = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ access_token: fakeJwt([]), expires_in: 300, refresh_token: 'skew-2' }),
+    })
+    vi.stubGlobal('fetch', fetchSpy)
+    // Not expired yet, but inside the skew window: an upstream call made with this token
+    // could still land after it expires, so it must be refreshed now.
+    const nearlyExpired: JWT = {
+      accessToken: 'stale', refreshToken: 'skew-1', accessTokenExpires: Date.now() + 30_000,
+    }
+    const out = await callJwt(nearlyExpired)
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+    expect(out.refreshToken).toBe('skew-2')
+  })
+
+  // The realm sets revokeRefreshToken + refreshTokenMaxReuse: 0, so a refresh token is
+  // single-use. Both tests below fail against a plain per-call refresh: the second grant
+  // gets invalid_grant and the session is marked expired while the operator is active.
+
+  it('collapses concurrent refreshes of the same token into ONE grant', async () => {
+    const rotated = fakeJwt(['ROLE_ADMIN'])
+    let grants = 0
+    vi.stubGlobal('fetch', vi.fn().mockImplementation(async () => {
+      grants += 1
+      // Only the FIRST presentation of a single-use refresh token can succeed.
+      if (grants > 1) return { ok: false, json: async () => ({ error: 'invalid_grant' }) }
+      return {
+        ok: true,
+        json: async () => ({ access_token: rotated, expires_in: 300, refresh_token: 'conc-2' }),
+      }
+    }))
+    const expired = (): JWT => ({
+      accessToken: 'stale', refreshToken: 'conc-1', accessTokenExpires: Date.now() - 1_000,
+    })
+    // The middleware, a route handler and /api/gate all decode the same cookie at once.
+    const outs = await Promise.all([callJwt(expired()), callJwt(expired()), callJwt(expired())])
+    expect(grants).toBe(1)
+    for (const out of outs) {
+      expect(out.error).toBeUndefined()
+      expect(out.refreshToken).toBe('conc-2')
+    }
+  })
+
+  it('answers a caller still holding the SPENT token with the rotated one', async () => {
+    const rotated = fakeJwt(['ROLE_ADMIN'])
+    let grants = 0
+    vi.stubGlobal('fetch', vi.fn().mockImplementation(async () => {
+      grants += 1
+      if (grants > 1) return { ok: false, json: async () => ({ error: 'invalid_grant' }) }
+      return {
+        ok: true,
+        json: async () => ({ access_token: rotated, expires_in: 300, refresh_token: 'lost-2' }),
+      }
+    }))
+    const expired = (): JWT => ({
+      accessToken: 'stale', refreshToken: 'lost-1', accessTokenExpires: Date.now() - 1_000,
+    })
+    // First caller is an nginx auth subrequest / Server Component: it spends the token but
+    // its Set-Cookie never reaches the browser, so the next request still carries 'lost-1'.
+    await callJwt(expired())
+    const second = await callJwt(expired())
+    expect(grants).toBe(1)
+    expect(second.error).toBeUndefined()
+    expect(second.accessToken).toBe(rotated)
+    expect(second.refreshToken).toBe('lost-2')
+  })
+
+  it('does not remember a FAILED grant — the next request retries', async () => {
+    let grants = 0
+    vi.stubGlobal('fetch', vi.fn().mockImplementation(async () => {
+      grants += 1
+      // Keycloak briefly unreachable, then healthy.
+      if (grants === 1) return { ok: false, json: async () => ({ error: 'temporarily_unavailable' }) }
+      return {
+        ok: true,
+        json: async () => ({ access_token: fakeJwt([]), expires_in: 300, refresh_token: 'retry-2' }),
+      }
+    }))
+    const expired = (): JWT => ({
+      accessToken: 'stale', refreshToken: 'retry-1', accessTokenExpires: Date.now() - 1_000,
+    })
+    expect((await callJwt(expired())).error).toBe('RefreshAccessTokenError')
+    const second = await callJwt(expired())
+    expect(grants).toBe(2)
+    expect(second.error).toBeUndefined()
+  })
+
+  it('clears a previous RefreshAccessTokenError once a refresh succeeds', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ access_token: fakeJwt([]), expires_in: 300, refresh_token: 'heal-2' }),
+    }))
+    const out = await callJwt({
+      accessToken: 'stale', refreshToken: 'heal-1',
+      accessTokenExpires: Date.now() - 1_000, error: 'RefreshAccessTokenError',
+    })
+    expect(out.error).toBeUndefined()
   })
 
   it('session callback propagates token.error to session.user.error', async () => {


### PR DESCRIPTION
## Problem

Operators are logged out of the admin portal a few minutes into an **active** session. Five minutes is exactly `accessTokenLifespan` in the realm.

Refresh *is* implemented (`refreshAccessToken` in `src/lib/auth/authOptions.ts`), but the realm sets `revokeRefreshToken: true` and `refreshTokenMaxReuse: 0` (`openbank-infra/gitops/components/keycloak/realm-template.json`), making every refresh token strictly single-use. `auth()` is called independently by `middleware.ts`, ~30 route handlers, and `/api/gate` — each decodes the same cookie and each ran its own grant.

- **Stampede.** A dashboard page fires several server-side `auth()` calls at once. Past expiry they all present the same refresh token. One wins; the rest get `invalid_grant`, set `error: "RefreshAccessTokenError"`, and the middleware redirects to `/auth/login?error=SessionExpired`.
- **Rotation loss.** Only a response reaching the browser can persist the rotated token. `/api/gate` is an nginx `auth_request` subrequest — nginx discards its `Set-Cookie`; `auth()` inside a Server Component cannot set cookies at all. Those calls spend the refresh token and discard the replacement, so the browser is left holding a revoked one and the *next* refresh is guaranteed to fail.

## Fix

Cache the rotation keyed by the refresh token it **spent**:

- concurrent callers share one in-flight grant (stampede);
- a caller still carrying the pre-rotation cookie gets the already-rotated token instead of presenting a revoked one (rotation loss);
- a **failed** grant is not cached, so a transient Keycloak outage stays retryable;
- refresh fires 60s **ahead** of expiry — a token valid when the JWT callback runs can still expire before the upstream service validates it;
- a successful refresh clears a stale `RefreshAccessTokenError`.

In-process map; admin-ui runs `replicas: 1`. Multi-replica would need a shared store — stated in the code.

## Verification

Five cases added to `src/test/authoptions-refresh.test.ts`, each modelling a single-use refresh token (second presentation returns `invalid_grant`). Reverting `authOptions.ts` to `main` with the new tests in place turns **four** of them red:

```
× refreshes ahead of expiry, not after it (skew)
× collapses concurrent refreshes of the same token into ONE grant
× answers a caller still holding the SPENT token with the rotated one
× clears a previous RefreshAccessTokenError once a refresh succeeds
```

With the fix: `npm test` → 79 files, 1089 tests passed. `tsc --noEmit` and `eslint` clean.

## Not changed

The realm's rotation settings stay as they are — this is an app-side bug, and a realm-template edit would not reach the running Keycloak anyway (import runs on cold start only).


## Linked issues

Closes #3619
