### PR TITLE
chore(agent): drop the GROQ_API_KEY rollout remnant, record full egress enforcement

### DIFF
--- a/openbank-infra/gitops/apps/agent.yaml
+++ b/openbank-infra/gitops/apps/agent.yaml
@@ -1,7 +1,7 @@
 # ArgoCD app for agent-service (admin-UI AI assistant backend, ADR-0031). Deploys
 # the platform-ns Deployment+Service from components/agent. Tracks the live sandbox
-# GitOps branch (same as the other component apps). The GROQ_API_KEY Secret is
-# delivered separately by ESO (es-agent-service in the external-secrets component).
+# GitOps branch (same as the other component apps). The LiteLLM virtual-key Secret
+# is delivered separately by ESO (es-agent-service in the external-secrets component).
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:

--- a/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: account-service
     app.kubernetes.io/part-of: accounts
   annotations:
-    openbank.tech/policy-checksum: "c04419a54a97b5a7"
+    openbank.tech/policy-checksum: "ec36201800659008"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -853,15 +853,19 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+    model_gateway_as_built:            # verified 2026-08-02 against gitops AND the running Deployments
       gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
                                        # #2019). Deployed and serving. It is the only workload holding a
                                        # provider key and the only one with an internet egress hole
                                        # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
-                                       # choke point — but see `egress_enforced` before treating it as a
-                                       # *complete* one.
+                                       # choke point — and since #2210 + the GROQ_API_KEY cleanup it is a
+                                       # *complete* one (see `egress_enforced`).
       routed:                          # read off the RUNNING Deployments' env, not off the manifests
         - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - agent-service                # AGENT_MODEL_ENDPOINT (#2209) — verified live 2026-08-02:
+                                       # http://litellm.ai-platform.svc:4000/v1 on the running
+                                       # Deployment (image sandbox-b52f989b); the direct GROQ_API_KEY
+                                       # path is removed from agent-service.yaml + es-agent-service.yaml
         - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
         - devops-agent                 # DEVOPS_MODEL_ENDPOINT
         - docs-truth-agent             # LLM_GATEWAY_URL
@@ -870,15 +874,10 @@ data:
         - governance-auditor           # LLM_GATEWAY_URL
         - release-steward              # LLM_GATEWAY_URL
         - authz-policy-auditor         # LLM_GATEWAY_URL
-      not_routed:
-        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
-                                       # image resolves the baked-in api.groq.com URL until the rebuilt
-                                       # image rolls out. Promote it to `routed` only after re-reading
-                                       # the live Deployment — merged is not deployed.
-      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
-                                       # component still declares policyTypes: [Ingress] only, so the
-                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
-                                       # gated on the agent-service repoint actually being deployed.
+      egress_enforced: full            # ai-platform is egress-locked (litellm is the only internet
+                                       # hole); agent-service is too: agent-service-egress-allow-list
+                                       # (#2210) is live in the platform namespace and the pod no longer
+                                       # carries a provider key, so the gateway cannot be bypassed.
       budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
       providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region

--- a/openbank-infra/gitops/components/accounts/account-service.yaml
+++ b/openbank-infra/gitops/components/accounts/account-service.yaml
@@ -37,7 +37,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-account-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "c04419a54a97b5a7"
+        openbank.tech/policy-checksum: "ec36201800659008"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/agent/agent-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/agent/agent-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: agent-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "1cf8773379881a4c"
+    openbank.tech/policy-checksum: "5e088079f0f89f61"
 data:
   agents.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -278,15 +278,19 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+    model_gateway_as_built:            # verified 2026-08-02 against gitops AND the running Deployments
       gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
                                        # #2019). Deployed and serving. It is the only workload holding a
                                        # provider key and the only one with an internet egress hole
                                        # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
-                                       # choke point — but see `egress_enforced` before treating it as a
-                                       # *complete* one.
+                                       # choke point — and since #2210 + the GROQ_API_KEY cleanup it is a
+                                       # *complete* one (see `egress_enforced`).
       routed:                          # read off the RUNNING Deployments' env, not off the manifests
         - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - agent-service                # AGENT_MODEL_ENDPOINT (#2209) — verified live 2026-08-02:
+                                       # http://litellm.ai-platform.svc:4000/v1 on the running
+                                       # Deployment (image sandbox-b52f989b); the direct GROQ_API_KEY
+                                       # path is removed from agent-service.yaml + es-agent-service.yaml
         - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
         - devops-agent                 # DEVOPS_MODEL_ENDPOINT
         - docs-truth-agent             # LLM_GATEWAY_URL
@@ -295,15 +299,10 @@ data:
         - governance-auditor           # LLM_GATEWAY_URL
         - release-steward              # LLM_GATEWAY_URL
         - authz-policy-auditor         # LLM_GATEWAY_URL
-      not_routed:
-        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
-                                       # image resolves the baked-in api.groq.com URL until the rebuilt
-                                       # image rolls out. Promote it to `routed` only after re-reading
-                                       # the live Deployment — merged is not deployed.
-      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
-                                       # component still declares policyTypes: [Ingress] only, so the
-                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
-                                       # gated on the agent-service repoint actually being deployed.
+      egress_enforced: full            # ai-platform is egress-locked (litellm is the only internet
+                                       # hole); agent-service is too: agent-service-egress-allow-list
+                                       # (#2210) is live in the platform namespace and the pod no longer
+                                       # carries a provider key, so the gateway cannot be bypassed.
       budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
       providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region

--- a/openbank-infra/gitops/components/agent/agent-service.yaml
+++ b/openbank-infra/gitops/components/agent/agent-service.yaml
@@ -33,7 +33,7 @@ spec:
       annotations:
         # Roll the pod when the OPA policy bundle changes (subPath mounts don't hot-reload).
         # Must match agent-opa-bundle's openbank.tech/policy-checksum (CI verifies, no drift).
-        openbank.tech/policy-checksum: "1cf8773379881a4c"
+        openbank.tech/policy-checksum: "5e088079f0f89f61"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -95,19 +95,8 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: agent-service-secrets
-                  key: AGENT_MODEL_API_KEY
-                  optional: true
-            # ROLLOUT WINDOW ONLY — remove with the es-agent-service.yaml entry once the repointed
-            # image is live. The image deployed at merge time predates the AGENT_MODEL_* seam and
-            # still resolves `agent.model.openai.api-key` from GROQ_API_KEY against api.groq.com;
-            # dropping it here in the same commit would break the assistant until the deploy lands.
-            # Its removal is the precondition for the agent-pod egress lock (ADR-0175 §4).
-            - name: GROQ_API_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: agent-service-secrets
-                  key: GROQ_API_KEY
-                  optional: true
+                   key: AGENT_MODEL_API_KEY
+                   optional: true
             # MCP tool backends — in-cluster ClusterIPs. get_account hits account-service
             # (accounts ns, live); balance via balance-service (balances ns, live).
             - name: QUARKUS_REST_CLIENT_ACCOUNT_SERVICE_URL

--- a/openbank-infra/gitops/components/agent/networkpolicy-agent-egress.yaml
+++ b/openbank-infra/gitops/components/agent/networkpolicy-agent-egress.yaml
@@ -12,7 +12,7 @@
 # Ingress for this pod stays generator-owned; this file is egress-only. NetworkPolicies are additive,
 # so adding `Egress` here does not weaken the generated ingress allow-list.
 #
-# PRECONDITION — do not merge before both hold:
+# PRECONDITION — both held before merge, verified live 2026-08-02:
 #   1. The agent-service image running in the sandbox honours AGENT_MODEL_ENDPOINT (i.e. the #1919
 #      routing change is deployed, not merely merged). An older image resolves the backend endpoint
 #      from the baked-in https://api.groq.com/openai/v1, which this policy denies.

--- a/openbank-infra/gitops/components/aml/aml-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/aml/aml-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: aml-service
     app.kubernetes.io/part-of: aml
   annotations:
-    openbank.tech/policy-checksum: "fa5acb2454f33e90"
+    openbank.tech/policy-checksum: "e4d6b60376215bc6"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -826,15 +826,19 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+    model_gateway_as_built:            # verified 2026-08-02 against gitops AND the running Deployments
       gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
                                        # #2019). Deployed and serving. It is the only workload holding a
                                        # provider key and the only one with an internet egress hole
                                        # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
-                                       # choke point — but see `egress_enforced` before treating it as a
-                                       # *complete* one.
+                                       # choke point — and since #2210 + the GROQ_API_KEY cleanup it is a
+                                       # *complete* one (see `egress_enforced`).
       routed:                          # read off the RUNNING Deployments' env, not off the manifests
         - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - agent-service                # AGENT_MODEL_ENDPOINT (#2209) — verified live 2026-08-02:
+                                       # http://litellm.ai-platform.svc:4000/v1 on the running
+                                       # Deployment (image sandbox-b52f989b); the direct GROQ_API_KEY
+                                       # path is removed from agent-service.yaml + es-agent-service.yaml
         - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
         - devops-agent                 # DEVOPS_MODEL_ENDPOINT
         - docs-truth-agent             # LLM_GATEWAY_URL
@@ -843,15 +847,10 @@ data:
         - governance-auditor           # LLM_GATEWAY_URL
         - release-steward              # LLM_GATEWAY_URL
         - authz-policy-auditor         # LLM_GATEWAY_URL
-      not_routed:
-        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
-                                       # image resolves the baked-in api.groq.com URL until the rebuilt
-                                       # image rolls out. Promote it to `routed` only after re-reading
-                                       # the live Deployment — merged is not deployed.
-      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
-                                       # component still declares policyTypes: [Ingress] only, so the
-                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
-                                       # gated on the agent-service repoint actually being deployed.
+      egress_enforced: full            # ai-platform is egress-locked (litellm is the only internet
+                                       # hole); agent-service is too: agent-service-egress-allow-list
+                                       # (#2210) is live in the platform namespace and the pod no longer
+                                       # carries a provider key, so the gateway cannot be bypassed.
       budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
       providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region

--- a/openbank-infra/gitops/components/aml/aml-service.yaml
+++ b/openbank-infra/gitops/components/aml/aml-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-aml-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "fa5acb2454f33e90"
+        openbank.tech/policy-checksum: "e4d6b60376215bc6"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: anacredit-service
     app.kubernetes.io/part-of: anacredit
   annotations:
-    openbank.tech/policy-checksum: "474aa347518209f2"
+    openbank.tech/policy-checksum: "457156d3022af5f1"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -796,15 +796,19 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+    model_gateway_as_built:            # verified 2026-08-02 against gitops AND the running Deployments
       gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
                                        # #2019). Deployed and serving. It is the only workload holding a
                                        # provider key and the only one with an internet egress hole
                                        # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
-                                       # choke point — but see `egress_enforced` before treating it as a
-                                       # *complete* one.
+                                       # choke point — and since #2210 + the GROQ_API_KEY cleanup it is a
+                                       # *complete* one (see `egress_enforced`).
       routed:                          # read off the RUNNING Deployments' env, not off the manifests
         - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - agent-service                # AGENT_MODEL_ENDPOINT (#2209) — verified live 2026-08-02:
+                                       # http://litellm.ai-platform.svc:4000/v1 on the running
+                                       # Deployment (image sandbox-b52f989b); the direct GROQ_API_KEY
+                                       # path is removed from agent-service.yaml + es-agent-service.yaml
         - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
         - devops-agent                 # DEVOPS_MODEL_ENDPOINT
         - docs-truth-agent             # LLM_GATEWAY_URL
@@ -813,15 +817,10 @@ data:
         - governance-auditor           # LLM_GATEWAY_URL
         - release-steward              # LLM_GATEWAY_URL
         - authz-policy-auditor         # LLM_GATEWAY_URL
-      not_routed:
-        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
-                                       # image resolves the baked-in api.groq.com URL until the rebuilt
-                                       # image rolls out. Promote it to `routed` only after re-reading
-                                       # the live Deployment — merged is not deployed.
-      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
-                                       # component still declares policyTypes: [Ingress] only, so the
-                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
-                                       # gated on the agent-service repoint actually being deployed.
+      egress_enforced: full            # ai-platform is egress-locked (litellm is the only internet
+                                       # hole); agent-service is too: agent-service-egress-allow-list
+                                       # (#2210) is live in the platform namespace and the pod no longer
+                                       # carries a provider key, so the gateway cannot be bypassed.
       budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
       providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region

--- a/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
@@ -32,7 +32,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-anacredit-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "474aa347518209f2"
+        openbank.tech/policy-checksum: "457156d3022af5f1"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/ap2/ap2-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/ap2/ap2-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: mcp-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "8dc9776bf0bad04b"
+    openbank.tech/policy-checksum: "687531d0b7c35b7b"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -764,15 +764,19 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+    model_gateway_as_built:            # verified 2026-08-02 against gitops AND the running Deployments
       gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
                                        # #2019). Deployed and serving. It is the only workload holding a
                                        # provider key and the only one with an internet egress hole
                                        # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
-                                       # choke point — but see `egress_enforced` before treating it as a
-                                       # *complete* one.
+                                       # choke point — and since #2210 + the GROQ_API_KEY cleanup it is a
+                                       # *complete* one (see `egress_enforced`).
       routed:                          # read off the RUNNING Deployments' env, not off the manifests
         - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - agent-service                # AGENT_MODEL_ENDPOINT (#2209) — verified live 2026-08-02:
+                                       # http://litellm.ai-platform.svc:4000/v1 on the running
+                                       # Deployment (image sandbox-b52f989b); the direct GROQ_API_KEY
+                                       # path is removed from agent-service.yaml + es-agent-service.yaml
         - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
         - devops-agent                 # DEVOPS_MODEL_ENDPOINT
         - docs-truth-agent             # LLM_GATEWAY_URL
@@ -781,15 +785,10 @@ data:
         - governance-auditor           # LLM_GATEWAY_URL
         - release-steward              # LLM_GATEWAY_URL
         - authz-policy-auditor         # LLM_GATEWAY_URL
-      not_routed:
-        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
-                                       # image resolves the baked-in api.groq.com URL until the rebuilt
-                                       # image rolls out. Promote it to `routed` only after re-reading
-                                       # the live Deployment — merged is not deployed.
-      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
-                                       # component still declares policyTypes: [Ingress] only, so the
-                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
-                                       # gated on the agent-service repoint actually being deployed.
+      egress_enforced: full            # ai-platform is egress-locked (litellm is the only internet
+                                       # hole); agent-service is too: agent-service-egress-allow-list
+                                       # (#2210) is live in the platform namespace and the pod no longer
+                                       # carries a provider key, so the gateway cannot be bypassed.
       budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
       providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region

--- a/openbank-infra/gitops/components/ap2/ap2-service.yaml
+++ b/openbank-infra/gitops/components/ap2/ap2-service.yaml
@@ -30,7 +30,7 @@ spec:
       annotations:
         # Roll the pod when the OPA policy bundle changes (subPath mounts don't hot-reload).
         # Kept in sync by gen-ap2-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "8dc9776bf0bad04b"
+        openbank.tech/policy-checksum: "687531d0b7c35b7b"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/audit/audit-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/audit/audit-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: audit-service
     app.kubernetes.io/part-of: audit
   annotations:
-    openbank.tech/policy-checksum: "53849077ece23fd3"
+    openbank.tech/policy-checksum: "c9b206bcd9bf2526"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -808,15 +808,19 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+    model_gateway_as_built:            # verified 2026-08-02 against gitops AND the running Deployments
       gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
                                        # #2019). Deployed and serving. It is the only workload holding a
                                        # provider key and the only one with an internet egress hole
                                        # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
-                                       # choke point — but see `egress_enforced` before treating it as a
-                                       # *complete* one.
+                                       # choke point — and since #2210 + the GROQ_API_KEY cleanup it is a
+                                       # *complete* one (see `egress_enforced`).
       routed:                          # read off the RUNNING Deployments' env, not off the manifests
         - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - agent-service                # AGENT_MODEL_ENDPOINT (#2209) — verified live 2026-08-02:
+                                       # http://litellm.ai-platform.svc:4000/v1 on the running
+                                       # Deployment (image sandbox-b52f989b); the direct GROQ_API_KEY
+                                       # path is removed from agent-service.yaml + es-agent-service.yaml
         - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
         - devops-agent                 # DEVOPS_MODEL_ENDPOINT
         - docs-truth-agent             # LLM_GATEWAY_URL
@@ -825,15 +829,10 @@ data:
         - governance-auditor           # LLM_GATEWAY_URL
         - release-steward              # LLM_GATEWAY_URL
         - authz-policy-auditor         # LLM_GATEWAY_URL
-      not_routed:
-        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
-                                       # image resolves the baked-in api.groq.com URL until the rebuilt
-                                       # image rolls out. Promote it to `routed` only after re-reading
-                                       # the live Deployment — merged is not deployed.
-      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
-                                       # component still declares policyTypes: [Ingress] only, so the
-                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
-                                       # gated on the agent-service repoint actually being deployed.
+      egress_enforced: full            # ai-platform is egress-locked (litellm is the only internet
+                                       # hole); agent-service is too: agent-service-egress-allow-list
+                                       # (#2210) is live in the platform namespace and the pod no longer
+                                       # carries a provider key, so the gateway cannot be bypassed.
       budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
       providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region

--- a/openbank-infra/gitops/components/audit/audit-service.yaml
+++ b/openbank-infra/gitops/components/audit/audit-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-audit-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "53849077ece23fd3"
+        openbank.tech/policy-checksum: "c9b206bcd9bf2526"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: balance-service
     app.kubernetes.io/part-of: balances
   annotations:
-    openbank.tech/policy-checksum: "bdab21a92483a5b5"
+    openbank.tech/policy-checksum: "c7330db4b020eaf3"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -897,15 +897,19 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+    model_gateway_as_built:            # verified 2026-08-02 against gitops AND the running Deployments
       gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
                                        # #2019). Deployed and serving. It is the only workload holding a
                                        # provider key and the only one with an internet egress hole
                                        # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
-                                       # choke point — but see `egress_enforced` before treating it as a
-                                       # *complete* one.
+                                       # choke point — and since #2210 + the GROQ_API_KEY cleanup it is a
+                                       # *complete* one (see `egress_enforced`).
       routed:                          # read off the RUNNING Deployments' env, not off the manifests
         - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - agent-service                # AGENT_MODEL_ENDPOINT (#2209) — verified live 2026-08-02:
+                                       # http://litellm.ai-platform.svc:4000/v1 on the running
+                                       # Deployment (image sandbox-b52f989b); the direct GROQ_API_KEY
+                                       # path is removed from agent-service.yaml + es-agent-service.yaml
         - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
         - devops-agent                 # DEVOPS_MODEL_ENDPOINT
         - docs-truth-agent             # LLM_GATEWAY_URL
@@ -914,15 +918,10 @@ data:
         - governance-auditor           # LLM_GATEWAY_URL
         - release-steward              # LLM_GATEWAY_URL
         - authz-policy-auditor         # LLM_GATEWAY_URL
-      not_routed:
-        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
-                                       # image resolves the baked-in api.groq.com URL until the rebuilt
-                                       # image rolls out. Promote it to `routed` only after re-reading
-                                       # the live Deployment — merged is not deployed.
-      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
-                                       # component still declares policyTypes: [Ingress] only, so the
-                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
-                                       # gated on the agent-service repoint actually being deployed.
+      egress_enforced: full            # ai-platform is egress-locked (litellm is the only internet
+                                       # hole); agent-service is too: agent-service-egress-allow-list
+                                       # (#2210) is live in the platform namespace and the pod no longer
+                                       # carries a provider key, so the gateway cannot be bypassed.
       budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
       providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region

--- a/openbank-infra/gitops/components/balances/balance-service.yaml
+++ b/openbank-infra/gitops/components/balances/balance-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-balance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "bdab21a92483a5b5"
+        openbank.tech/policy-checksum: "c7330db4b020eaf3"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: billing-service
     app.kubernetes.io/part-of: billing
   annotations:
-    openbank.tech/policy-checksum: "bd3fb79d132b4ae5"
+    openbank.tech/policy-checksum: "b8223d1dfbf4c67e"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -802,15 +802,19 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+    model_gateway_as_built:            # verified 2026-08-02 against gitops AND the running Deployments
       gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
                                        # #2019). Deployed and serving. It is the only workload holding a
                                        # provider key and the only one with an internet egress hole
                                        # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
-                                       # choke point — but see `egress_enforced` before treating it as a
-                                       # *complete* one.
+                                       # choke point — and since #2210 + the GROQ_API_KEY cleanup it is a
+                                       # *complete* one (see `egress_enforced`).
       routed:                          # read off the RUNNING Deployments' env, not off the manifests
         - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - agent-service                # AGENT_MODEL_ENDPOINT (#2209) — verified live 2026-08-02:
+                                       # http://litellm.ai-platform.svc:4000/v1 on the running
+                                       # Deployment (image sandbox-b52f989b); the direct GROQ_API_KEY
+                                       # path is removed from agent-service.yaml + es-agent-service.yaml
         - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
         - devops-agent                 # DEVOPS_MODEL_ENDPOINT
         - docs-truth-agent             # LLM_GATEWAY_URL
@@ -819,15 +823,10 @@ data:
         - governance-auditor           # LLM_GATEWAY_URL
         - release-steward              # LLM_GATEWAY_URL
         - authz-policy-auditor         # LLM_GATEWAY_URL
-      not_routed:
-        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
-                                       # image resolves the baked-in api.groq.com URL until the rebuilt
-                                       # image rolls out. Promote it to `routed` only after re-reading
-                                       # the live Deployment — merged is not deployed.
-      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
-                                       # component still declares policyTypes: [Ingress] only, so the
-                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
-                                       # gated on the agent-service repoint actually being deployed.
+      egress_enforced: full            # ai-platform is egress-locked (litellm is the only internet
+                                       # hole); agent-service is too: agent-service-egress-allow-list
+                                       # (#2210) is live in the platform namespace and the pod no longer
+                                       # carries a provider key, so the gateway cannot be bypassed.
       budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
       providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region

--- a/openbank-infra/gitops/components/billing/billing-service.yaml
+++ b/openbank-infra/gitops/components/billing/billing-service.yaml
@@ -27,7 +27,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-billing-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "bd3fb79d132b4ae5"
+        openbank.tech/policy-checksum: "b8223d1dfbf4c67e"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/campaign/campaign-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/campaign/campaign-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: campaign-service
     app.kubernetes.io/part-of: campaign
   annotations:
-    openbank.tech/policy-checksum: "bfc239a5ea069ad2"
+    openbank.tech/policy-checksum: "89fb3e19f4138d6c"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -823,15 +823,19 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+    model_gateway_as_built:            # verified 2026-08-02 against gitops AND the running Deployments
       gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
                                        # #2019). Deployed and serving. It is the only workload holding a
                                        # provider key and the only one with an internet egress hole
                                        # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
-                                       # choke point — but see `egress_enforced` before treating it as a
-                                       # *complete* one.
+                                       # choke point — and since #2210 + the GROQ_API_KEY cleanup it is a
+                                       # *complete* one (see `egress_enforced`).
       routed:                          # read off the RUNNING Deployments' env, not off the manifests
         - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - agent-service                # AGENT_MODEL_ENDPOINT (#2209) — verified live 2026-08-02:
+                                       # http://litellm.ai-platform.svc:4000/v1 on the running
+                                       # Deployment (image sandbox-b52f989b); the direct GROQ_API_KEY
+                                       # path is removed from agent-service.yaml + es-agent-service.yaml
         - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
         - devops-agent                 # DEVOPS_MODEL_ENDPOINT
         - docs-truth-agent             # LLM_GATEWAY_URL
@@ -840,15 +844,10 @@ data:
         - governance-auditor           # LLM_GATEWAY_URL
         - release-steward              # LLM_GATEWAY_URL
         - authz-policy-auditor         # LLM_GATEWAY_URL
-      not_routed:
-        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
-                                       # image resolves the baked-in api.groq.com URL until the rebuilt
-                                       # image rolls out. Promote it to `routed` only after re-reading
-                                       # the live Deployment — merged is not deployed.
-      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
-                                       # component still declares policyTypes: [Ingress] only, so the
-                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
-                                       # gated on the agent-service repoint actually being deployed.
+      egress_enforced: full            # ai-platform is egress-locked (litellm is the only internet
+                                       # hole); agent-service is too: agent-service-egress-allow-list
+                                       # (#2210) is live in the platform namespace and the pod no longer
+                                       # carries a provider key, so the gateway cannot be bypassed.
       budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
       providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region

--- a/openbank-infra/gitops/components/campaign/campaign-service.yaml
+++ b/openbank-infra/gitops/components/campaign/campaign-service.yaml
@@ -25,7 +25,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-campaign-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "bfc239a5ea069ad2"
+        openbank.tech/policy-checksum: "89fb3e19f4138d6c"
       labels:
         app.kubernetes.io/name: campaign-service
         app.kubernetes.io/part-of: campaign

--- a/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: consent-service
     app.kubernetes.io/part-of: consent
   annotations:
-    openbank.tech/policy-checksum: "fd74bae043202f56"
+    openbank.tech/policy-checksum: "1e2d8194decc65c4"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -872,15 +872,19 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+    model_gateway_as_built:            # verified 2026-08-02 against gitops AND the running Deployments
       gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
                                        # #2019). Deployed and serving. It is the only workload holding a
                                        # provider key and the only one with an internet egress hole
                                        # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
-                                       # choke point — but see `egress_enforced` before treating it as a
-                                       # *complete* one.
+                                       # choke point — and since #2210 + the GROQ_API_KEY cleanup it is a
+                                       # *complete* one (see `egress_enforced`).
       routed:                          # read off the RUNNING Deployments' env, not off the manifests
         - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - agent-service                # AGENT_MODEL_ENDPOINT (#2209) — verified live 2026-08-02:
+                                       # http://litellm.ai-platform.svc:4000/v1 on the running
+                                       # Deployment (image sandbox-b52f989b); the direct GROQ_API_KEY
+                                       # path is removed from agent-service.yaml + es-agent-service.yaml
         - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
         - devops-agent                 # DEVOPS_MODEL_ENDPOINT
         - docs-truth-agent             # LLM_GATEWAY_URL
@@ -889,15 +893,10 @@ data:
         - governance-auditor           # LLM_GATEWAY_URL
         - release-steward              # LLM_GATEWAY_URL
         - authz-policy-auditor         # LLM_GATEWAY_URL
-      not_routed:
-        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
-                                       # image resolves the baked-in api.groq.com URL until the rebuilt
-                                       # image rolls out. Promote it to `routed` only after re-reading
-                                       # the live Deployment — merged is not deployed.
-      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
-                                       # component still declares policyTypes: [Ingress] only, so the
-                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
-                                       # gated on the agent-service repoint actually being deployed.
+      egress_enforced: full            # ai-platform is egress-locked (litellm is the only internet
+                                       # hole); agent-service is too: agent-service-egress-allow-list
+                                       # (#2210) is live in the platform namespace and the pod no longer
+                                       # carries a provider key, so the gateway cannot be bypassed.
       budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
       providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region

--- a/openbank-infra/gitops/components/consent/consent-service.yaml
+++ b/openbank-infra/gitops/components/consent/consent-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-consent-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "fd74bae043202f56"
+        openbank.tech/policy-checksum: "1e2d8194decc65c4"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: copilot-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "8bcc4b88379730ca"
+    openbank.tech/policy-checksum: "a59af0e6d10c76c1"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -888,15 +888,19 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+    model_gateway_as_built:            # verified 2026-08-02 against gitops AND the running Deployments
       gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
                                        # #2019). Deployed and serving. It is the only workload holding a
                                        # provider key and the only one with an internet egress hole
                                        # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
-                                       # choke point — but see `egress_enforced` before treating it as a
-                                       # *complete* one.
+                                       # choke point — and since #2210 + the GROQ_API_KEY cleanup it is a
+                                       # *complete* one (see `egress_enforced`).
       routed:                          # read off the RUNNING Deployments' env, not off the manifests
         - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - agent-service                # AGENT_MODEL_ENDPOINT (#2209) — verified live 2026-08-02:
+                                       # http://litellm.ai-platform.svc:4000/v1 on the running
+                                       # Deployment (image sandbox-b52f989b); the direct GROQ_API_KEY
+                                       # path is removed from agent-service.yaml + es-agent-service.yaml
         - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
         - devops-agent                 # DEVOPS_MODEL_ENDPOINT
         - docs-truth-agent             # LLM_GATEWAY_URL
@@ -905,15 +909,10 @@ data:
         - governance-auditor           # LLM_GATEWAY_URL
         - release-steward              # LLM_GATEWAY_URL
         - authz-policy-auditor         # LLM_GATEWAY_URL
-      not_routed:
-        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
-                                       # image resolves the baked-in api.groq.com URL until the rebuilt
-                                       # image rolls out. Promote it to `routed` only after re-reading
-                                       # the live Deployment — merged is not deployed.
-      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
-                                       # component still declares policyTypes: [Ingress] only, so the
-                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
-                                       # gated on the agent-service repoint actually being deployed.
+      egress_enforced: full            # ai-platform is egress-locked (litellm is the only internet
+                                       # hole); agent-service is too: agent-service-egress-allow-list
+                                       # (#2210) is live in the platform namespace and the pod no longer
+                                       # carries a provider key, so the gateway cannot be bypassed.
       budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
       providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region

--- a/openbank-infra/gitops/components/copilot/copilot-service.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-service.yaml
@@ -29,7 +29,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-copilot-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "8bcc4b88379730ca"
+        openbank.tech/policy-checksum: "a59af0e6d10c76c1"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: customer-edge
     app.kubernetes.io/part-of: customer-edge
   annotations:
-    openbank.tech/policy-checksum: "ad2a8b43f6056e02"
+    openbank.tech/policy-checksum: "2da1c772093bbf3c"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -3078,15 +3078,19 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+    model_gateway_as_built:            # verified 2026-08-02 against gitops AND the running Deployments
       gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
                                        # #2019). Deployed and serving. It is the only workload holding a
                                        # provider key and the only one with an internet egress hole
                                        # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
-                                       # choke point — but see `egress_enforced` before treating it as a
-                                       # *complete* one.
+                                       # choke point — and since #2210 + the GROQ_API_KEY cleanup it is a
+                                       # *complete* one (see `egress_enforced`).
       routed:                          # read off the RUNNING Deployments' env, not off the manifests
         - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - agent-service                # AGENT_MODEL_ENDPOINT (#2209) — verified live 2026-08-02:
+                                       # http://litellm.ai-platform.svc:4000/v1 on the running
+                                       # Deployment (image sandbox-b52f989b); the direct GROQ_API_KEY
+                                       # path is removed from agent-service.yaml + es-agent-service.yaml
         - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
         - devops-agent                 # DEVOPS_MODEL_ENDPOINT
         - docs-truth-agent             # LLM_GATEWAY_URL
@@ -3095,15 +3099,10 @@ data:
         - governance-auditor           # LLM_GATEWAY_URL
         - release-steward              # LLM_GATEWAY_URL
         - authz-policy-auditor         # LLM_GATEWAY_URL
-      not_routed:
-        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
-                                       # image resolves the baked-in api.groq.com URL until the rebuilt
-                                       # image rolls out. Promote it to `routed` only after re-reading
-                                       # the live Deployment — merged is not deployed.
-      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
-                                       # component still declares policyTypes: [Ingress] only, so the
-                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
-                                       # gated on the agent-service repoint actually being deployed.
+      egress_enforced: full            # ai-platform is egress-locked (litellm is the only internet
+                                       # hole); agent-service is too: agent-service-egress-allow-list
+                                       # (#2210) is live in the platform namespace and the pod no longer
+                                       # carries a provider key, so the gateway cannot be bypassed.
       budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
       providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region

--- a/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
@@ -65,7 +65,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-customer-edge-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "ad2a8b43f6056e02"
+        openbank.tech/policy-checksum: "2da1c772093bbf3c"
     spec:
       # Dedicated SA so EKS Pod Identity can hand the edge (and ONLY the edge) the
       # feedback-screenshots S3 role — ADR-0192, openbank-infra/aws/envs/sandbox-platform/

--- a/openbank-infra/gitops/components/dispute-service/dispute-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/dispute-service/dispute-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: dispute-service
     app.kubernetes.io/part-of: dispute
   annotations:
-    openbank.tech/policy-checksum: "a4bdb61939eeaa73"
+    openbank.tech/policy-checksum: "2d887b1ff8761a28"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -938,15 +938,19 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+    model_gateway_as_built:            # verified 2026-08-02 against gitops AND the running Deployments
       gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
                                        # #2019). Deployed and serving. It is the only workload holding a
                                        # provider key and the only one with an internet egress hole
                                        # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
-                                       # choke point — but see `egress_enforced` before treating it as a
-                                       # *complete* one.
+                                       # choke point — and since #2210 + the GROQ_API_KEY cleanup it is a
+                                       # *complete* one (see `egress_enforced`).
       routed:                          # read off the RUNNING Deployments' env, not off the manifests
         - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - agent-service                # AGENT_MODEL_ENDPOINT (#2209) — verified live 2026-08-02:
+                                       # http://litellm.ai-platform.svc:4000/v1 on the running
+                                       # Deployment (image sandbox-b52f989b); the direct GROQ_API_KEY
+                                       # path is removed from agent-service.yaml + es-agent-service.yaml
         - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
         - devops-agent                 # DEVOPS_MODEL_ENDPOINT
         - docs-truth-agent             # LLM_GATEWAY_URL
@@ -955,15 +959,10 @@ data:
         - governance-auditor           # LLM_GATEWAY_URL
         - release-steward              # LLM_GATEWAY_URL
         - authz-policy-auditor         # LLM_GATEWAY_URL
-      not_routed:
-        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
-                                       # image resolves the baked-in api.groq.com URL until the rebuilt
-                                       # image rolls out. Promote it to `routed` only after re-reading
-                                       # the live Deployment — merged is not deployed.
-      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
-                                       # component still declares policyTypes: [Ingress] only, so the
-                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
-                                       # gated on the agent-service repoint actually being deployed.
+      egress_enforced: full            # ai-platform is egress-locked (litellm is the only internet
+                                       # hole); agent-service is too: agent-service-egress-allow-list
+                                       # (#2210) is live in the platform namespace and the pod no longer
+                                       # carries a provider key, so the gateway cannot be bypassed.
       budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
       providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region

--- a/openbank-infra/gitops/components/dispute-service/dispute-service.yaml
+++ b/openbank-infra/gitops/components/dispute-service/dispute-service.yaml
@@ -15,7 +15,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-dispute-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "a4bdb61939eeaa73"
+        openbank.tech/policy-checksum: "2d887b1ff8761a28"
       labels: {app.kubernetes.io/name: dispute-service, app.kubernetes.io/part-of: dispute}
     spec:
       securityContext:

--- a/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: document-service
     app.kubernetes.io/part-of: documents
   annotations:
-    openbank.tech/policy-checksum: "ad2a8b43f6056e02"
+    openbank.tech/policy-checksum: "2da1c772093bbf3c"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -3078,15 +3078,19 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+    model_gateway_as_built:            # verified 2026-08-02 against gitops AND the running Deployments
       gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
                                        # #2019). Deployed and serving. It is the only workload holding a
                                        # provider key and the only one with an internet egress hole
                                        # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
-                                       # choke point — but see `egress_enforced` before treating it as a
-                                       # *complete* one.
+                                       # choke point — and since #2210 + the GROQ_API_KEY cleanup it is a
+                                       # *complete* one (see `egress_enforced`).
       routed:                          # read off the RUNNING Deployments' env, not off the manifests
         - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - agent-service                # AGENT_MODEL_ENDPOINT (#2209) — verified live 2026-08-02:
+                                       # http://litellm.ai-platform.svc:4000/v1 on the running
+                                       # Deployment (image sandbox-b52f989b); the direct GROQ_API_KEY
+                                       # path is removed from agent-service.yaml + es-agent-service.yaml
         - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
         - devops-agent                 # DEVOPS_MODEL_ENDPOINT
         - docs-truth-agent             # LLM_GATEWAY_URL
@@ -3095,15 +3099,10 @@ data:
         - governance-auditor           # LLM_GATEWAY_URL
         - release-steward              # LLM_GATEWAY_URL
         - authz-policy-auditor         # LLM_GATEWAY_URL
-      not_routed:
-        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
-                                       # image resolves the baked-in api.groq.com URL until the rebuilt
-                                       # image rolls out. Promote it to `routed` only after re-reading
-                                       # the live Deployment — merged is not deployed.
-      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
-                                       # component still declares policyTypes: [Ingress] only, so the
-                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
-                                       # gated on the agent-service repoint actually being deployed.
+      egress_enforced: full            # ai-platform is egress-locked (litellm is the only internet
+                                       # hole); agent-service is too: agent-service-egress-allow-list
+                                       # (#2210) is live in the platform namespace and the pod no longer
+                                       # carries a provider key, so the gateway cannot be bypassed.
       budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
       providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region

--- a/openbank-infra/gitops/components/document-service/document-service-service.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-service.yaml
@@ -43,7 +43,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-document-service-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "ad2a8b43f6056e02"
+        openbank.tech/policy-checksum: "2da1c772093bbf3c"
     spec:
       # ADR-0162 D4 (continued): a dedicated SA (not `default`) is what OpenBao's Kubernetes-auth
       # role `document-service-signing` is bound to — least-privilege, one identity per consumer.

--- a/openbank-infra/gitops/components/external-secrets/es-agent-service.yaml
+++ b/openbank-infra/gitops/components/external-secrets/es-agent-service.yaml
@@ -1,14 +1,9 @@
 # agent-service secrets from OpenBao → agent-service-secrets Secret.
 #
 # AGENT_MODEL_API_KEY = the LiteLLM virtual key (ADR-0174/0175, #1919): agent-service authenticates
-# to the in-cluster gateway, NOT to the provider — the Groq key now lives only in ai-platform. Same
+# to the in-cluster gateway, NOT to the provider — the Groq key lives only in ai-platform. Same
 # source and same shape as copilot's COPILOT_MODEL_API_KEY (es-copilot-service.yaml), each on its
 # own budgeted virtual key rather than the shared master key.
-#
-# GROQ_API_KEY is retained ONLY for the rollout window: the currently-deployed image predates the
-# AGENT_MODEL_* config seam and still reads GROQ_API_KEY against api.groq.com directly. Drop it (and
-# the matching env in agent-service.yaml) once the repointed image is live — that removal is the
-# precondition for turning on the agent-pod egress lock.
 #
 # OIDC_CLIENT_SECRET (openbank-services realm client) is unchanged.
 apiVersion: external-secrets.io/v1beta1
@@ -42,10 +37,6 @@ spec:
       remoteRef:
         key: litellm
         property: KEY_AGENT_SERVICE
-    - secretKey: GROQ_API_KEY
-      remoteRef:
-        key: agent-service
-        property: GROQ_API_KEY
     - secretKey: OIDC_CLIENT_SECRET
       remoteRef:
         key: agent-service

--- a/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fraud-service
     app.kubernetes.io/part-of: fraud
   annotations:
-    openbank.tech/policy-checksum: "8a25f92b253d5c5e"
+    openbank.tech/policy-checksum: "24485d2e94942ac5"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -813,15 +813,19 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+    model_gateway_as_built:            # verified 2026-08-02 against gitops AND the running Deployments
       gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
                                        # #2019). Deployed and serving. It is the only workload holding a
                                        # provider key and the only one with an internet egress hole
                                        # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
-                                       # choke point — but see `egress_enforced` before treating it as a
-                                       # *complete* one.
+                                       # choke point — and since #2210 + the GROQ_API_KEY cleanup it is a
+                                       # *complete* one (see `egress_enforced`).
       routed:                          # read off the RUNNING Deployments' env, not off the manifests
         - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - agent-service                # AGENT_MODEL_ENDPOINT (#2209) — verified live 2026-08-02:
+                                       # http://litellm.ai-platform.svc:4000/v1 on the running
+                                       # Deployment (image sandbox-b52f989b); the direct GROQ_API_KEY
+                                       # path is removed from agent-service.yaml + es-agent-service.yaml
         - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
         - devops-agent                 # DEVOPS_MODEL_ENDPOINT
         - docs-truth-agent             # LLM_GATEWAY_URL
@@ -830,15 +834,10 @@ data:
         - governance-auditor           # LLM_GATEWAY_URL
         - release-steward              # LLM_GATEWAY_URL
         - authz-policy-auditor         # LLM_GATEWAY_URL
-      not_routed:
-        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
-                                       # image resolves the baked-in api.groq.com URL until the rebuilt
-                                       # image rolls out. Promote it to `routed` only after re-reading
-                                       # the live Deployment — merged is not deployed.
-      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
-                                       # component still declares policyTypes: [Ingress] only, so the
-                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
-                                       # gated on the agent-service repoint actually being deployed.
+      egress_enforced: full            # ai-platform is egress-locked (litellm is the only internet
+                                       # hole); agent-service is too: agent-service-egress-allow-list
+                                       # (#2210) is live in the platform namespace and the pod no longer
+                                       # carries a provider key, so the gateway cannot be bypassed.
       budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
       providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region

--- a/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
@@ -23,7 +23,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fraud-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "8a25f92b253d5c5e"
+        openbank.tech/policy-checksum: "24485d2e94942ac5"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fx-service
     app.kubernetes.io/part-of: fx
   annotations:
-    openbank.tech/policy-checksum: "da87a927e042b3cc"
+    openbank.tech/policy-checksum: "190015c3bfe49252"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -864,15 +864,19 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+    model_gateway_as_built:            # verified 2026-08-02 against gitops AND the running Deployments
       gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
                                        # #2019). Deployed and serving. It is the only workload holding a
                                        # provider key and the only one with an internet egress hole
                                        # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
-                                       # choke point — but see `egress_enforced` before treating it as a
-                                       # *complete* one.
+                                       # choke point — and since #2210 + the GROQ_API_KEY cleanup it is a
+                                       # *complete* one (see `egress_enforced`).
       routed:                          # read off the RUNNING Deployments' env, not off the manifests
         - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - agent-service                # AGENT_MODEL_ENDPOINT (#2209) — verified live 2026-08-02:
+                                       # http://litellm.ai-platform.svc:4000/v1 on the running
+                                       # Deployment (image sandbox-b52f989b); the direct GROQ_API_KEY
+                                       # path is removed from agent-service.yaml + es-agent-service.yaml
         - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
         - devops-agent                 # DEVOPS_MODEL_ENDPOINT
         - docs-truth-agent             # LLM_GATEWAY_URL
@@ -881,15 +885,10 @@ data:
         - governance-auditor           # LLM_GATEWAY_URL
         - release-steward              # LLM_GATEWAY_URL
         - authz-policy-auditor         # LLM_GATEWAY_URL
-      not_routed:
-        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
-                                       # image resolves the baked-in api.groq.com URL until the rebuilt
-                                       # image rolls out. Promote it to `routed` only after re-reading
-                                       # the live Deployment — merged is not deployed.
-      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
-                                       # component still declares policyTypes: [Ingress] only, so the
-                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
-                                       # gated on the agent-service repoint actually being deployed.
+      egress_enforced: full            # ai-platform is egress-locked (litellm is the only internet
+                                       # hole); agent-service is too: agent-service-egress-allow-list
+                                       # (#2210) is live in the platform namespace and the pod no longer
+                                       # carries a provider key, so the gateway cannot be bypassed.
       budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
       providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region

--- a/openbank-infra/gitops/components/fx-service/fx-service.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fx-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "da87a927e042b3cc"
+        openbank.tech/policy-checksum: "190015c3bfe49252"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: interest-service
     app.kubernetes.io/part-of: interest
   annotations:
-    openbank.tech/policy-checksum: "b3eb86d5c1301950"
+    openbank.tech/policy-checksum: "014616f1dd7df182"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -798,15 +798,19 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+    model_gateway_as_built:            # verified 2026-08-02 against gitops AND the running Deployments
       gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
                                        # #2019). Deployed and serving. It is the only workload holding a
                                        # provider key and the only one with an internet egress hole
                                        # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
-                                       # choke point — but see `egress_enforced` before treating it as a
-                                       # *complete* one.
+                                       # choke point — and since #2210 + the GROQ_API_KEY cleanup it is a
+                                       # *complete* one (see `egress_enforced`).
       routed:                          # read off the RUNNING Deployments' env, not off the manifests
         - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - agent-service                # AGENT_MODEL_ENDPOINT (#2209) — verified live 2026-08-02:
+                                       # http://litellm.ai-platform.svc:4000/v1 on the running
+                                       # Deployment (image sandbox-b52f989b); the direct GROQ_API_KEY
+                                       # path is removed from agent-service.yaml + es-agent-service.yaml
         - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
         - devops-agent                 # DEVOPS_MODEL_ENDPOINT
         - docs-truth-agent             # LLM_GATEWAY_URL
@@ -815,15 +819,10 @@ data:
         - governance-auditor           # LLM_GATEWAY_URL
         - release-steward              # LLM_GATEWAY_URL
         - authz-policy-auditor         # LLM_GATEWAY_URL
-      not_routed:
-        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
-                                       # image resolves the baked-in api.groq.com URL until the rebuilt
-                                       # image rolls out. Promote it to `routed` only after re-reading
-                                       # the live Deployment — merged is not deployed.
-      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
-                                       # component still declares policyTypes: [Ingress] only, so the
-                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
-                                       # gated on the agent-service repoint actually being deployed.
+      egress_enforced: full            # ai-platform is egress-locked (litellm is the only internet
+                                       # hole); agent-service is too: agent-service-egress-allow-list
+                                       # (#2210) is live in the platform namespace and the pod no longer
+                                       # carries a provider key, so the gateway cannot be bypassed.
       budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
       providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region

--- a/openbank-infra/gitops/components/interest-service/interest-service.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-service.yaml
@@ -16,7 +16,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-interest-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "b3eb86d5c1301950"
+        openbank.tech/policy-checksum: "014616f1dd7df182"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/kyc/kyc-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/kyc/kyc-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: kyc-service
     app.kubernetes.io/part-of: kyc
   annotations:
-    openbank.tech/policy-checksum: "b49285c61aac88b9"
+    openbank.tech/policy-checksum: "91a52b1595fc51b1"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -826,15 +826,19 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+    model_gateway_as_built:            # verified 2026-08-02 against gitops AND the running Deployments
       gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
                                        # #2019). Deployed and serving. It is the only workload holding a
                                        # provider key and the only one with an internet egress hole
                                        # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
-                                       # choke point — but see `egress_enforced` before treating it as a
-                                       # *complete* one.
+                                       # choke point — and since #2210 + the GROQ_API_KEY cleanup it is a
+                                       # *complete* one (see `egress_enforced`).
       routed:                          # read off the RUNNING Deployments' env, not off the manifests
         - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - agent-service                # AGENT_MODEL_ENDPOINT (#2209) — verified live 2026-08-02:
+                                       # http://litellm.ai-platform.svc:4000/v1 on the running
+                                       # Deployment (image sandbox-b52f989b); the direct GROQ_API_KEY
+                                       # path is removed from agent-service.yaml + es-agent-service.yaml
         - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
         - devops-agent                 # DEVOPS_MODEL_ENDPOINT
         - docs-truth-agent             # LLM_GATEWAY_URL
@@ -843,15 +847,10 @@ data:
         - governance-auditor           # LLM_GATEWAY_URL
         - release-steward              # LLM_GATEWAY_URL
         - authz-policy-auditor         # LLM_GATEWAY_URL
-      not_routed:
-        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
-                                       # image resolves the baked-in api.groq.com URL until the rebuilt
-                                       # image rolls out. Promote it to `routed` only after re-reading
-                                       # the live Deployment — merged is not deployed.
-      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
-                                       # component still declares policyTypes: [Ingress] only, so the
-                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
-                                       # gated on the agent-service repoint actually being deployed.
+      egress_enforced: full            # ai-platform is egress-locked (litellm is the only internet
+                                       # hole); agent-service is too: agent-service-egress-allow-list
+                                       # (#2210) is live in the platform namespace and the pod no longer
+                                       # carries a provider key, so the gateway cannot be bypassed.
       budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
       providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region

--- a/openbank-infra/gitops/components/kyc/kyc-service.yaml
+++ b/openbank-infra/gitops/components/kyc/kyc-service.yaml
@@ -48,7 +48,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-kyc-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "b49285c61aac88b9"
+        openbank.tech/policy-checksum: "91a52b1595fc51b1"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: ledger-service
     app.kubernetes.io/part-of: ledger
   annotations:
-    openbank.tech/policy-checksum: "8ee41d406d2afac6"
+    openbank.tech/policy-checksum: "da4e38c71299c068"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -911,15 +911,19 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+    model_gateway_as_built:            # verified 2026-08-02 against gitops AND the running Deployments
       gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
                                        # #2019). Deployed and serving. It is the only workload holding a
                                        # provider key and the only one with an internet egress hole
                                        # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
-                                       # choke point — but see `egress_enforced` before treating it as a
-                                       # *complete* one.
+                                       # choke point — and since #2210 + the GROQ_API_KEY cleanup it is a
+                                       # *complete* one (see `egress_enforced`).
       routed:                          # read off the RUNNING Deployments' env, not off the manifests
         - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - agent-service                # AGENT_MODEL_ENDPOINT (#2209) — verified live 2026-08-02:
+                                       # http://litellm.ai-platform.svc:4000/v1 on the running
+                                       # Deployment (image sandbox-b52f989b); the direct GROQ_API_KEY
+                                       # path is removed from agent-service.yaml + es-agent-service.yaml
         - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
         - devops-agent                 # DEVOPS_MODEL_ENDPOINT
         - docs-truth-agent             # LLM_GATEWAY_URL
@@ -928,15 +932,10 @@ data:
         - governance-auditor           # LLM_GATEWAY_URL
         - release-steward              # LLM_GATEWAY_URL
         - authz-policy-auditor         # LLM_GATEWAY_URL
-      not_routed:
-        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
-                                       # image resolves the baked-in api.groq.com URL until the rebuilt
-                                       # image rolls out. Promote it to `routed` only after re-reading
-                                       # the live Deployment — merged is not deployed.
-      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
-                                       # component still declares policyTypes: [Ingress] only, so the
-                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
-                                       # gated on the agent-service repoint actually being deployed.
+      egress_enforced: full            # ai-platform is egress-locked (litellm is the only internet
+                                       # hole); agent-service is too: agent-service-egress-allow-list
+                                       # (#2210) is live in the platform namespace and the pod no longer
+                                       # carries a provider key, so the gateway cannot be bypassed.
       budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
       providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region

--- a/openbank-infra/gitops/components/ledger/ledger-service.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-service.yaml
@@ -38,7 +38,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-ledger-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "8ee41d406d2afac6"
+        openbank.tech/policy-checksum: "da4e38c71299c068"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: lending-service
     app.kubernetes.io/part-of: lending
   annotations:
-    openbank.tech/policy-checksum: "e6e468f8de3e49b3"
+    openbank.tech/policy-checksum: "2bda0825879fe9df"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -889,15 +889,19 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+    model_gateway_as_built:            # verified 2026-08-02 against gitops AND the running Deployments
       gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
                                        # #2019). Deployed and serving. It is the only workload holding a
                                        # provider key and the only one with an internet egress hole
                                        # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
-                                       # choke point — but see `egress_enforced` before treating it as a
-                                       # *complete* one.
+                                       # choke point — and since #2210 + the GROQ_API_KEY cleanup it is a
+                                       # *complete* one (see `egress_enforced`).
       routed:                          # read off the RUNNING Deployments' env, not off the manifests
         - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - agent-service                # AGENT_MODEL_ENDPOINT (#2209) — verified live 2026-08-02:
+                                       # http://litellm.ai-platform.svc:4000/v1 on the running
+                                       # Deployment (image sandbox-b52f989b); the direct GROQ_API_KEY
+                                       # path is removed from agent-service.yaml + es-agent-service.yaml
         - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
         - devops-agent                 # DEVOPS_MODEL_ENDPOINT
         - docs-truth-agent             # LLM_GATEWAY_URL
@@ -906,15 +910,10 @@ data:
         - governance-auditor           # LLM_GATEWAY_URL
         - release-steward              # LLM_GATEWAY_URL
         - authz-policy-auditor         # LLM_GATEWAY_URL
-      not_routed:
-        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
-                                       # image resolves the baked-in api.groq.com URL until the rebuilt
-                                       # image rolls out. Promote it to `routed` only after re-reading
-                                       # the live Deployment — merged is not deployed.
-      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
-                                       # component still declares policyTypes: [Ingress] only, so the
-                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
-                                       # gated on the agent-service repoint actually being deployed.
+      egress_enforced: full            # ai-platform is egress-locked (litellm is the only internet
+                                       # hole); agent-service is too: agent-service-egress-allow-list
+                                       # (#2210) is live in the platform namespace and the pod no longer
+                                       # carries a provider key, so the gateway cannot be bypassed.
       budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
       providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region

--- a/openbank-infra/gitops/components/lending/lending-service.yaml
+++ b/openbank-infra/gitops/components/lending/lending-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-lending-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "e6e468f8de3e49b3"
+        openbank.tech/policy-checksum: "2bda0825879fe9df"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/mcp/mcp-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/mcp/mcp-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: mcp-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "8dc9776bf0bad04b"
+    openbank.tech/policy-checksum: "687531d0b7c35b7b"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -764,15 +764,19 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+    model_gateway_as_built:            # verified 2026-08-02 against gitops AND the running Deployments
       gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
                                        # #2019). Deployed and serving. It is the only workload holding a
                                        # provider key and the only one with an internet egress hole
                                        # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
-                                       # choke point — but see `egress_enforced` before treating it as a
-                                       # *complete* one.
+                                       # choke point — and since #2210 + the GROQ_API_KEY cleanup it is a
+                                       # *complete* one (see `egress_enforced`).
       routed:                          # read off the RUNNING Deployments' env, not off the manifests
         - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - agent-service                # AGENT_MODEL_ENDPOINT (#2209) — verified live 2026-08-02:
+                                       # http://litellm.ai-platform.svc:4000/v1 on the running
+                                       # Deployment (image sandbox-b52f989b); the direct GROQ_API_KEY
+                                       # path is removed from agent-service.yaml + es-agent-service.yaml
         - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
         - devops-agent                 # DEVOPS_MODEL_ENDPOINT
         - docs-truth-agent             # LLM_GATEWAY_URL
@@ -781,15 +785,10 @@ data:
         - governance-auditor           # LLM_GATEWAY_URL
         - release-steward              # LLM_GATEWAY_URL
         - authz-policy-auditor         # LLM_GATEWAY_URL
-      not_routed:
-        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
-                                       # image resolves the baked-in api.groq.com URL until the rebuilt
-                                       # image rolls out. Promote it to `routed` only after re-reading
-                                       # the live Deployment — merged is not deployed.
-      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
-                                       # component still declares policyTypes: [Ingress] only, so the
-                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
-                                       # gated on the agent-service repoint actually being deployed.
+      egress_enforced: full            # ai-platform is egress-locked (litellm is the only internet
+                                       # hole); agent-service is too: agent-service-egress-allow-list
+                                       # (#2210) is live in the platform namespace and the pod no longer
+                                       # carries a provider key, so the gateway cannot be bypassed.
       budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
       providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region

--- a/openbank-infra/gitops/components/mcp/mcp-service.yaml
+++ b/openbank-infra/gitops/components/mcp/mcp-service.yaml
@@ -29,7 +29,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-mcp-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "8dc9776bf0bad04b"
+        openbank.tech/policy-checksum: "687531d0b7c35b7b"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: notification-service
     app.kubernetes.io/part-of: notifications
   annotations:
-    openbank.tech/policy-checksum: "ad2a8b43f6056e02"
+    openbank.tech/policy-checksum: "2da1c772093bbf3c"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -3078,15 +3078,19 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+    model_gateway_as_built:            # verified 2026-08-02 against gitops AND the running Deployments
       gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
                                        # #2019). Deployed and serving. It is the only workload holding a
                                        # provider key and the only one with an internet egress hole
                                        # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
-                                       # choke point — but see `egress_enforced` before treating it as a
-                                       # *complete* one.
+                                       # choke point — and since #2210 + the GROQ_API_KEY cleanup it is a
+                                       # *complete* one (see `egress_enforced`).
       routed:                          # read off the RUNNING Deployments' env, not off the manifests
         - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - agent-service                # AGENT_MODEL_ENDPOINT (#2209) — verified live 2026-08-02:
+                                       # http://litellm.ai-platform.svc:4000/v1 on the running
+                                       # Deployment (image sandbox-b52f989b); the direct GROQ_API_KEY
+                                       # path is removed from agent-service.yaml + es-agent-service.yaml
         - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
         - devops-agent                 # DEVOPS_MODEL_ENDPOINT
         - docs-truth-agent             # LLM_GATEWAY_URL
@@ -3095,15 +3099,10 @@ data:
         - governance-auditor           # LLM_GATEWAY_URL
         - release-steward              # LLM_GATEWAY_URL
         - authz-policy-auditor         # LLM_GATEWAY_URL
-      not_routed:
-        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
-                                       # image resolves the baked-in api.groq.com URL until the rebuilt
-                                       # image rolls out. Promote it to `routed` only after re-reading
-                                       # the live Deployment — merged is not deployed.
-      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
-                                       # component still declares policyTypes: [Ingress] only, so the
-                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
-                                       # gated on the agent-service repoint actually being deployed.
+      egress_enforced: full            # ai-platform is egress-locked (litellm is the only internet
+                                       # hole); agent-service is too: agent-service-egress-allow-list
+                                       # (#2210) is live in the platform namespace and the pod no longer
+                                       # carries a provider key, so the gateway cannot be bypassed.
       budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
       providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region

--- a/openbank-infra/gitops/components/notifications/notification-service.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service.yaml
@@ -39,7 +39,7 @@ spec:
       annotations:
         # Rolls the Deployment when the OPA policy bundle changes (subPath mounts don't
         # hot-reload). Kept in sync by gen-notification-opa-bundle.sh.
-        openbank.tech/policy-checksum: "ad2a8b43f6056e02"
+        openbank.tech/policy-checksum: "2da1c772093bbf3c"
       labels:
         app.kubernetes.io/name: notification-service
         app.kubernetes.io/part-of: notifications

--- a/openbank-infra/gitops/components/party/party-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/party/party-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: party-service
     app.kubernetes.io/part-of: party
   annotations:
-    openbank.tech/policy-checksum: "7e06faf3d5f149d9"
+    openbank.tech/policy-checksum: "7b0eeae080d6530a"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -835,15 +835,19 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+    model_gateway_as_built:            # verified 2026-08-02 against gitops AND the running Deployments
       gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
                                        # #2019). Deployed and serving. It is the only workload holding a
                                        # provider key and the only one with an internet egress hole
                                        # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
-                                       # choke point — but see `egress_enforced` before treating it as a
-                                       # *complete* one.
+                                       # choke point — and since #2210 + the GROQ_API_KEY cleanup it is a
+                                       # *complete* one (see `egress_enforced`).
       routed:                          # read off the RUNNING Deployments' env, not off the manifests
         - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - agent-service                # AGENT_MODEL_ENDPOINT (#2209) — verified live 2026-08-02:
+                                       # http://litellm.ai-platform.svc:4000/v1 on the running
+                                       # Deployment (image sandbox-b52f989b); the direct GROQ_API_KEY
+                                       # path is removed from agent-service.yaml + es-agent-service.yaml
         - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
         - devops-agent                 # DEVOPS_MODEL_ENDPOINT
         - docs-truth-agent             # LLM_GATEWAY_URL
@@ -852,15 +856,10 @@ data:
         - governance-auditor           # LLM_GATEWAY_URL
         - release-steward              # LLM_GATEWAY_URL
         - authz-policy-auditor         # LLM_GATEWAY_URL
-      not_routed:
-        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
-                                       # image resolves the baked-in api.groq.com URL until the rebuilt
-                                       # image rolls out. Promote it to `routed` only after re-reading
-                                       # the live Deployment — merged is not deployed.
-      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
-                                       # component still declares policyTypes: [Ingress] only, so the
-                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
-                                       # gated on the agent-service repoint actually being deployed.
+      egress_enforced: full            # ai-platform is egress-locked (litellm is the only internet
+                                       # hole); agent-service is too: agent-service-egress-allow-list
+                                       # (#2210) is live in the platform namespace and the pod no longer
+                                       # carries a provider key, so the gateway cannot be bypassed.
       budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
       providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region

--- a/openbank-infra/gitops/components/party/party-service.yaml
+++ b/openbank-infra/gitops/components/party/party-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-party-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "7e06faf3d5f149d9"
+        openbank.tech/policy-checksum: "7b0eeae080d6530a"
       labels:
         app.kubernetes.io/name: party-service
         app.kubernetes.io/part-of: party

--- a/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: card-issuance-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "fbdf2cf037aec3f6"
+    openbank.tech/policy-checksum: "cb8429503180757d"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -819,15 +819,19 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+    model_gateway_as_built:            # verified 2026-08-02 against gitops AND the running Deployments
       gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
                                        # #2019). Deployed and serving. It is the only workload holding a
                                        # provider key and the only one with an internet egress hole
                                        # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
-                                       # choke point — but see `egress_enforced` before treating it as a
-                                       # *complete* one.
+                                       # choke point — and since #2210 + the GROQ_API_KEY cleanup it is a
+                                       # *complete* one (see `egress_enforced`).
       routed:                          # read off the RUNNING Deployments' env, not off the manifests
         - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - agent-service                # AGENT_MODEL_ENDPOINT (#2209) — verified live 2026-08-02:
+                                       # http://litellm.ai-platform.svc:4000/v1 on the running
+                                       # Deployment (image sandbox-b52f989b); the direct GROQ_API_KEY
+                                       # path is removed from agent-service.yaml + es-agent-service.yaml
         - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
         - devops-agent                 # DEVOPS_MODEL_ENDPOINT
         - docs-truth-agent             # LLM_GATEWAY_URL
@@ -836,15 +840,10 @@ data:
         - governance-auditor           # LLM_GATEWAY_URL
         - release-steward              # LLM_GATEWAY_URL
         - authz-policy-auditor         # LLM_GATEWAY_URL
-      not_routed:
-        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
-                                       # image resolves the baked-in api.groq.com URL until the rebuilt
-                                       # image rolls out. Promote it to `routed` only after re-reading
-                                       # the live Deployment — merged is not deployed.
-      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
-                                       # component still declares policyTypes: [Ingress] only, so the
-                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
-                                       # gated on the agent-service repoint actually being deployed.
+      egress_enforced: full            # ai-platform is egress-locked (litellm is the only internet
+                                       # hole); agent-service is too: agent-service-egress-allow-list
+                                       # (#2210) is live in the platform namespace and the pod no longer
+                                       # carries a provider key, so the gateway cannot be bypassed.
       budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
       providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region

--- a/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: clearing-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "57d982547721e26f"
+    openbank.tech/policy-checksum: "89579c9278ab85da"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -856,15 +856,19 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+    model_gateway_as_built:            # verified 2026-08-02 against gitops AND the running Deployments
       gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
                                        # #2019). Deployed and serving. It is the only workload holding a
                                        # provider key and the only one with an internet egress hole
                                        # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
-                                       # choke point — but see `egress_enforced` before treating it as a
-                                       # *complete* one.
+                                       # choke point — and since #2210 + the GROQ_API_KEY cleanup it is a
+                                       # *complete* one (see `egress_enforced`).
       routed:                          # read off the RUNNING Deployments' env, not off the manifests
         - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - agent-service                # AGENT_MODEL_ENDPOINT (#2209) — verified live 2026-08-02:
+                                       # http://litellm.ai-platform.svc:4000/v1 on the running
+                                       # Deployment (image sandbox-b52f989b); the direct GROQ_API_KEY
+                                       # path is removed from agent-service.yaml + es-agent-service.yaml
         - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
         - devops-agent                 # DEVOPS_MODEL_ENDPOINT
         - docs-truth-agent             # LLM_GATEWAY_URL
@@ -873,15 +877,10 @@ data:
         - governance-auditor           # LLM_GATEWAY_URL
         - release-steward              # LLM_GATEWAY_URL
         - authz-policy-auditor         # LLM_GATEWAY_URL
-      not_routed:
-        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
-                                       # image resolves the baked-in api.groq.com URL until the rebuilt
-                                       # image rolls out. Promote it to `routed` only after re-reading
-                                       # the live Deployment — merged is not deployed.
-      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
-                                       # component still declares policyTypes: [Ingress] only, so the
-                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
-                                       # gated on the agent-service repoint actually being deployed.
+      egress_enforced: full            # ai-platform is egress-locked (litellm is the only internet
+                                       # hole); agent-service is too: agent-service-egress-allow-list
+                                       # (#2210) is live in the platform namespace and the pod no longer
+                                       # carries a provider key, so the gateway cannot be bypassed.
       budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
       providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region

--- a/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: domestic-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "e643a274b1dab4cc"
+    openbank.tech/policy-checksum: "8009d74e41d27db1"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -841,15 +841,19 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+    model_gateway_as_built:            # verified 2026-08-02 against gitops AND the running Deployments
       gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
                                        # #2019). Deployed and serving. It is the only workload holding a
                                        # provider key and the only one with an internet egress hole
                                        # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
-                                       # choke point — but see `egress_enforced` before treating it as a
-                                       # *complete* one.
+                                       # choke point — and since #2210 + the GROQ_API_KEY cleanup it is a
+                                       # *complete* one (see `egress_enforced`).
       routed:                          # read off the RUNNING Deployments' env, not off the manifests
         - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - agent-service                # AGENT_MODEL_ENDPOINT (#2209) — verified live 2026-08-02:
+                                       # http://litellm.ai-platform.svc:4000/v1 on the running
+                                       # Deployment (image sandbox-b52f989b); the direct GROQ_API_KEY
+                                       # path is removed from agent-service.yaml + es-agent-service.yaml
         - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
         - devops-agent                 # DEVOPS_MODEL_ENDPOINT
         - docs-truth-agent             # LLM_GATEWAY_URL
@@ -858,15 +862,10 @@ data:
         - governance-auditor           # LLM_GATEWAY_URL
         - release-steward              # LLM_GATEWAY_URL
         - authz-policy-auditor         # LLM_GATEWAY_URL
-      not_routed:
-        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
-                                       # image resolves the baked-in api.groq.com URL until the rebuilt
-                                       # image rolls out. Promote it to `routed` only after re-reading
-                                       # the live Deployment — merged is not deployed.
-      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
-                                       # component still declares policyTypes: [Ingress] only, so the
-                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
-                                       # gated on the agent-service repoint actually being deployed.
+      egress_enforced: full            # ai-platform is egress-locked (litellm is the only internet
+                                       # hole); agent-service is too: agent-service-egress-allow-list
+                                       # (#2210) is live in the platform namespace and the pod no longer
+                                       # carries a provider key, so the gateway cannot be bypassed.
       budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
       providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region

--- a/openbank-infra/gitops/components/payments/payments-services.yaml
+++ b/openbank-infra/gitops/components/payments/payments-services.yaml
@@ -42,7 +42,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-transaction-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "ec42300c96897580" # transaction-opa-bundle
+        openbank.tech/policy-checksum: "952a421170e03ddd" # transaction-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -375,7 +375,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-payment-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "8f1939c00a9d3712"
+        openbank.tech/policy-checksum: "2be09c82c4a51258"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -729,7 +729,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-domestic-payment-opa-bundle.sh via the trailing marker
         # comment (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "e643a274b1dab4cc" # domestic-payment-opa-bundle
+        openbank.tech/policy-checksum: "8009d74e41d27db1" # domestic-payment-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1053,7 +1053,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-instant-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "19efe11cc45ad512"
+        openbank.tech/policy-checksum: "9879fb43bfd8dbe9"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1369,7 +1369,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-clearing-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "57d982547721e26f" # clearing-opa-bundle
+        openbank.tech/policy-checksum: "89579c9278ab85da" # clearing-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1658,7 +1658,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (ADR-0034). Value is stamped by
         # gen-standing-order-opa-bundle.sh — do not hand-edit.
-        openbank.tech/policy-checksum: "5513c410ad03eaac" # standing-order-opa-bundle
+        openbank.tech/policy-checksum: "89aa513595d26f7e" # standing-order-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1911,7 +1911,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-card-issuance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "fbdf2cf037aec3f6"
+        openbank.tech/policy-checksum: "cb8429503180757d"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2181,7 +2181,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-settlement-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "caba3cf1be0b6629" # settlement-opa-bundle
+        openbank.tech/policy-checksum: "562b0c222d2f662c" # settlement-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2582,7 +2582,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-swift-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "0251c3eccfd15386"
+        openbank.tech/policy-checksum: "ea236aae388ac0e4"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2896,7 +2896,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-vop-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "06e06c027b09cbba"
+        openbank.tech/policy-checksum: "c41b2fbc2f8ea8cf"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-instant
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "19efe11cc45ad512"
+    openbank.tech/policy-checksum: "9879fb43bfd8dbe9"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -814,15 +814,19 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+    model_gateway_as_built:            # verified 2026-08-02 against gitops AND the running Deployments
       gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
                                        # #2019). Deployed and serving. It is the only workload holding a
                                        # provider key and the only one with an internet egress hole
                                        # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
-                                       # choke point — but see `egress_enforced` before treating it as a
-                                       # *complete* one.
+                                       # choke point — and since #2210 + the GROQ_API_KEY cleanup it is a
+                                       # *complete* one (see `egress_enforced`).
       routed:                          # read off the RUNNING Deployments' env, not off the manifests
         - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - agent-service                # AGENT_MODEL_ENDPOINT (#2209) — verified live 2026-08-02:
+                                       # http://litellm.ai-platform.svc:4000/v1 on the running
+                                       # Deployment (image sandbox-b52f989b); the direct GROQ_API_KEY
+                                       # path is removed from agent-service.yaml + es-agent-service.yaml
         - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
         - devops-agent                 # DEVOPS_MODEL_ENDPOINT
         - docs-truth-agent             # LLM_GATEWAY_URL
@@ -831,15 +835,10 @@ data:
         - governance-auditor           # LLM_GATEWAY_URL
         - release-steward              # LLM_GATEWAY_URL
         - authz-policy-auditor         # LLM_GATEWAY_URL
-      not_routed:
-        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
-                                       # image resolves the baked-in api.groq.com URL until the rebuilt
-                                       # image rolls out. Promote it to `routed` only after re-reading
-                                       # the live Deployment — merged is not deployed.
-      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
-                                       # component still declares policyTypes: [Ingress] only, so the
-                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
-                                       # gated on the agent-service repoint actually being deployed.
+      egress_enforced: full            # ai-platform is egress-locked (litellm is the only internet
+                                       # hole); agent-service is too: agent-service-egress-allow-list
+                                       # (#2210) is live in the platform namespace and the pod no longer
+                                       # carries a provider key, so the gateway cannot be bypassed.
       budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
       providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region

--- a/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "8f1939c00a9d3712"
+    openbank.tech/policy-checksum: "2be09c82c4a51258"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -835,15 +835,19 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+    model_gateway_as_built:            # verified 2026-08-02 against gitops AND the running Deployments
       gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
                                        # #2019). Deployed and serving. It is the only workload holding a
                                        # provider key and the only one with an internet egress hole
                                        # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
-                                       # choke point — but see `egress_enforced` before treating it as a
-                                       # *complete* one.
+                                       # choke point — and since #2210 + the GROQ_API_KEY cleanup it is a
+                                       # *complete* one (see `egress_enforced`).
       routed:                          # read off the RUNNING Deployments' env, not off the manifests
         - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - agent-service                # AGENT_MODEL_ENDPOINT (#2209) — verified live 2026-08-02:
+                                       # http://litellm.ai-platform.svc:4000/v1 on the running
+                                       # Deployment (image sandbox-b52f989b); the direct GROQ_API_KEY
+                                       # path is removed from agent-service.yaml + es-agent-service.yaml
         - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
         - devops-agent                 # DEVOPS_MODEL_ENDPOINT
         - docs-truth-agent             # LLM_GATEWAY_URL
@@ -852,15 +856,10 @@ data:
         - governance-auditor           # LLM_GATEWAY_URL
         - release-steward              # LLM_GATEWAY_URL
         - authz-policy-auditor         # LLM_GATEWAY_URL
-      not_routed:
-        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
-                                       # image resolves the baked-in api.groq.com URL until the rebuilt
-                                       # image rolls out. Promote it to `routed` only after re-reading
-                                       # the live Deployment — merged is not deployed.
-      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
-                                       # component still declares policyTypes: [Ingress] only, so the
-                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
-                                       # gated on the agent-service repoint actually being deployed.
+      egress_enforced: full            # ai-platform is egress-locked (litellm is the only internet
+                                       # hole); agent-service is too: agent-service-egress-allow-list
+                                       # (#2210) is live in the platform namespace and the pod no longer
+                                       # carries a provider key, so the gateway cannot be bypassed.
       budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
       providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region

--- a/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: settlement-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "caba3cf1be0b6629"
+    openbank.tech/policy-checksum: "562b0c222d2f662c"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -815,15 +815,19 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+    model_gateway_as_built:            # verified 2026-08-02 against gitops AND the running Deployments
       gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
                                        # #2019). Deployed and serving. It is the only workload holding a
                                        # provider key and the only one with an internet egress hole
                                        # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
-                                       # choke point — but see `egress_enforced` before treating it as a
-                                       # *complete* one.
+                                       # choke point — and since #2210 + the GROQ_API_KEY cleanup it is a
+                                       # *complete* one (see `egress_enforced`).
       routed:                          # read off the RUNNING Deployments' env, not off the manifests
         - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - agent-service                # AGENT_MODEL_ENDPOINT (#2209) — verified live 2026-08-02:
+                                       # http://litellm.ai-platform.svc:4000/v1 on the running
+                                       # Deployment (image sandbox-b52f989b); the direct GROQ_API_KEY
+                                       # path is removed from agent-service.yaml + es-agent-service.yaml
         - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
         - devops-agent                 # DEVOPS_MODEL_ENDPOINT
         - docs-truth-agent             # LLM_GATEWAY_URL
@@ -832,15 +836,10 @@ data:
         - governance-auditor           # LLM_GATEWAY_URL
         - release-steward              # LLM_GATEWAY_URL
         - authz-policy-auditor         # LLM_GATEWAY_URL
-      not_routed:
-        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
-                                       # image resolves the baked-in api.groq.com URL until the rebuilt
-                                       # image rolls out. Promote it to `routed` only after re-reading
-                                       # the live Deployment — merged is not deployed.
-      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
-                                       # component still declares policyTypes: [Ingress] only, so the
-                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
-                                       # gated on the agent-service repoint actually being deployed.
+      egress_enforced: full            # ai-platform is egress-locked (litellm is the only internet
+                                       # hole); agent-service is too: agent-service-egress-allow-list
+                                       # (#2210) is live in the platform namespace and the pod no longer
+                                       # carries a provider key, so the gateway cannot be bypassed.
       budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
       providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region

--- a/openbank-infra/gitops/components/payments/standing-order-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/standing-order-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: standing-order-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "5513c410ad03eaac"
+    openbank.tech/policy-checksum: "89aa513595d26f7e"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -800,15 +800,19 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+    model_gateway_as_built:            # verified 2026-08-02 against gitops AND the running Deployments
       gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
                                        # #2019). Deployed and serving. It is the only workload holding a
                                        # provider key and the only one with an internet egress hole
                                        # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
-                                       # choke point — but see `egress_enforced` before treating it as a
-                                       # *complete* one.
+                                       # choke point — and since #2210 + the GROQ_API_KEY cleanup it is a
+                                       # *complete* one (see `egress_enforced`).
       routed:                          # read off the RUNNING Deployments' env, not off the manifests
         - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - agent-service                # AGENT_MODEL_ENDPOINT (#2209) — verified live 2026-08-02:
+                                       # http://litellm.ai-platform.svc:4000/v1 on the running
+                                       # Deployment (image sandbox-b52f989b); the direct GROQ_API_KEY
+                                       # path is removed from agent-service.yaml + es-agent-service.yaml
         - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
         - devops-agent                 # DEVOPS_MODEL_ENDPOINT
         - docs-truth-agent             # LLM_GATEWAY_URL
@@ -817,15 +821,10 @@ data:
         - governance-auditor           # LLM_GATEWAY_URL
         - release-steward              # LLM_GATEWAY_URL
         - authz-policy-auditor         # LLM_GATEWAY_URL
-      not_routed:
-        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
-                                       # image resolves the baked-in api.groq.com URL until the rebuilt
-                                       # image rolls out. Promote it to `routed` only after re-reading
-                                       # the live Deployment — merged is not deployed.
-      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
-                                       # component still declares policyTypes: [Ingress] only, so the
-                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
-                                       # gated on the agent-service repoint actually being deployed.
+      egress_enforced: full            # ai-platform is egress-locked (litellm is the only internet
+                                       # hole); agent-service is too: agent-service-egress-allow-list
+                                       # (#2210) is live in the platform namespace and the pod no longer
+                                       # carries a provider key, so the gateway cannot be bypassed.
       budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
       providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region

--- a/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: swift-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "0251c3eccfd15386"
+    openbank.tech/policy-checksum: "ea236aae388ac0e4"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -818,15 +818,19 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+    model_gateway_as_built:            # verified 2026-08-02 against gitops AND the running Deployments
       gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
                                        # #2019). Deployed and serving. It is the only workload holding a
                                        # provider key and the only one with an internet egress hole
                                        # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
-                                       # choke point — but see `egress_enforced` before treating it as a
-                                       # *complete* one.
+                                       # choke point — and since #2210 + the GROQ_API_KEY cleanup it is a
+                                       # *complete* one (see `egress_enforced`).
       routed:                          # read off the RUNNING Deployments' env, not off the manifests
         - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - agent-service                # AGENT_MODEL_ENDPOINT (#2209) — verified live 2026-08-02:
+                                       # http://litellm.ai-platform.svc:4000/v1 on the running
+                                       # Deployment (image sandbox-b52f989b); the direct GROQ_API_KEY
+                                       # path is removed from agent-service.yaml + es-agent-service.yaml
         - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
         - devops-agent                 # DEVOPS_MODEL_ENDPOINT
         - docs-truth-agent             # LLM_GATEWAY_URL
@@ -835,15 +839,10 @@ data:
         - governance-auditor           # LLM_GATEWAY_URL
         - release-steward              # LLM_GATEWAY_URL
         - authz-policy-auditor         # LLM_GATEWAY_URL
-      not_routed:
-        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
-                                       # image resolves the baked-in api.groq.com URL until the rebuilt
-                                       # image rolls out. Promote it to `routed` only after re-reading
-                                       # the live Deployment — merged is not deployed.
-      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
-                                       # component still declares policyTypes: [Ingress] only, so the
-                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
-                                       # gated on the agent-service repoint actually being deployed.
+      egress_enforced: full            # ai-platform is egress-locked (litellm is the only internet
+                                       # hole); agent-service is too: agent-service-egress-allow-list
+                                       # (#2210) is live in the platform namespace and the pod no longer
+                                       # carries a provider key, so the gateway cannot be bypassed.
       budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
       providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region

--- a/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: transaction-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "ec42300c96897580"
+    openbank.tech/policy-checksum: "952a421170e03ddd"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -871,15 +871,19 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+    model_gateway_as_built:            # verified 2026-08-02 against gitops AND the running Deployments
       gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
                                        # #2019). Deployed and serving. It is the only workload holding a
                                        # provider key and the only one with an internet egress hole
                                        # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
-                                       # choke point — but see `egress_enforced` before treating it as a
-                                       # *complete* one.
+                                       # choke point — and since #2210 + the GROQ_API_KEY cleanup it is a
+                                       # *complete* one (see `egress_enforced`).
       routed:                          # read off the RUNNING Deployments' env, not off the manifests
         - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - agent-service                # AGENT_MODEL_ENDPOINT (#2209) — verified live 2026-08-02:
+                                       # http://litellm.ai-platform.svc:4000/v1 on the running
+                                       # Deployment (image sandbox-b52f989b); the direct GROQ_API_KEY
+                                       # path is removed from agent-service.yaml + es-agent-service.yaml
         - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
         - devops-agent                 # DEVOPS_MODEL_ENDPOINT
         - docs-truth-agent             # LLM_GATEWAY_URL
@@ -888,15 +892,10 @@ data:
         - governance-auditor           # LLM_GATEWAY_URL
         - release-steward              # LLM_GATEWAY_URL
         - authz-policy-auditor         # LLM_GATEWAY_URL
-      not_routed:
-        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
-                                       # image resolves the baked-in api.groq.com URL until the rebuilt
-                                       # image rolls out. Promote it to `routed` only after re-reading
-                                       # the live Deployment — merged is not deployed.
-      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
-                                       # component still declares policyTypes: [Ingress] only, so the
-                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
-                                       # gated on the agent-service repoint actually being deployed.
+      egress_enforced: full            # ai-platform is egress-locked (litellm is the only internet
+                                       # hole); agent-service is too: agent-service-egress-allow-list
+                                       # (#2210) is live in the platform namespace and the pod no longer
+                                       # carries a provider key, so the gateway cannot be bypassed.
       budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
       providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region

--- a/openbank-infra/gitops/components/payments/vop-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/vop-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: vop-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "06e06c027b09cbba"
+    openbank.tech/policy-checksum: "c41b2fbc2f8ea8cf"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -822,15 +822,19 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+    model_gateway_as_built:            # verified 2026-08-02 against gitops AND the running Deployments
       gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
                                        # #2019). Deployed and serving. It is the only workload holding a
                                        # provider key and the only one with an internet egress hole
                                        # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
-                                       # choke point — but see `egress_enforced` before treating it as a
-                                       # *complete* one.
+                                       # choke point — and since #2210 + the GROQ_API_KEY cleanup it is a
+                                       # *complete* one (see `egress_enforced`).
       routed:                          # read off the RUNNING Deployments' env, not off the manifests
         - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - agent-service                # AGENT_MODEL_ENDPOINT (#2209) — verified live 2026-08-02:
+                                       # http://litellm.ai-platform.svc:4000/v1 on the running
+                                       # Deployment (image sandbox-b52f989b); the direct GROQ_API_KEY
+                                       # path is removed from agent-service.yaml + es-agent-service.yaml
         - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
         - devops-agent                 # DEVOPS_MODEL_ENDPOINT
         - docs-truth-agent             # LLM_GATEWAY_URL
@@ -839,15 +843,10 @@ data:
         - governance-auditor           # LLM_GATEWAY_URL
         - release-steward              # LLM_GATEWAY_URL
         - authz-policy-auditor         # LLM_GATEWAY_URL
-      not_routed:
-        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
-                                       # image resolves the baked-in api.groq.com URL until the rebuilt
-                                       # image rolls out. Promote it to `routed` only after re-reading
-                                       # the live Deployment — merged is not deployed.
-      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
-                                       # component still declares policyTypes: [Ingress] only, so the
-                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
-                                       # gated on the agent-service repoint actually being deployed.
+      egress_enforced: full            # ai-platform is egress-locked (litellm is the only internet
+                                       # hole); agent-service is too: agent-service-egress-allow-list
+                                       # (#2210) is live in the platform namespace and the pod no longer
+                                       # carries a provider key, so the gateway cannot be bypassed.
       budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
       providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region

--- a/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: pid-service
     app.kubernetes.io/part-of: pid
   annotations:
-    openbank.tech/policy-checksum: "8abf18240c318861"
+    openbank.tech/policy-checksum: "4a21dc736bdac161"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -824,15 +824,19 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+    model_gateway_as_built:            # verified 2026-08-02 against gitops AND the running Deployments
       gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
                                        # #2019). Deployed and serving. It is the only workload holding a
                                        # provider key and the only one with an internet egress hole
                                        # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
-                                       # choke point — but see `egress_enforced` before treating it as a
-                                       # *complete* one.
+                                       # choke point — and since #2210 + the GROQ_API_KEY cleanup it is a
+                                       # *complete* one (see `egress_enforced`).
       routed:                          # read off the RUNNING Deployments' env, not off the manifests
         - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - agent-service                # AGENT_MODEL_ENDPOINT (#2209) — verified live 2026-08-02:
+                                       # http://litellm.ai-platform.svc:4000/v1 on the running
+                                       # Deployment (image sandbox-b52f989b); the direct GROQ_API_KEY
+                                       # path is removed from agent-service.yaml + es-agent-service.yaml
         - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
         - devops-agent                 # DEVOPS_MODEL_ENDPOINT
         - docs-truth-agent             # LLM_GATEWAY_URL
@@ -841,15 +845,10 @@ data:
         - governance-auditor           # LLM_GATEWAY_URL
         - release-steward              # LLM_GATEWAY_URL
         - authz-policy-auditor         # LLM_GATEWAY_URL
-      not_routed:
-        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
-                                       # image resolves the baked-in api.groq.com URL until the rebuilt
-                                       # image rolls out. Promote it to `routed` only after re-reading
-                                       # the live Deployment — merged is not deployed.
-      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
-                                       # component still declares policyTypes: [Ingress] only, so the
-                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
-                                       # gated on the agent-service repoint actually being deployed.
+      egress_enforced: full            # ai-platform is egress-locked (litellm is the only internet
+                                       # hole); agent-service is too: agent-service-egress-allow-list
+                                       # (#2210) is live in the platform namespace and the pod no longer
+                                       # carries a provider key, so the gateway cannot be bypassed.
       budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
       providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region

--- a/openbank-infra/gitops/components/pid/pid-service.yaml
+++ b/openbank-infra/gitops/components/pid/pid-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-pid-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "8abf18240c318861"
+        openbank.tech/policy-checksum: "4a21dc736bdac161"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/psd2-service/psd2-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/psd2-service/psd2-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: psd2-service
     app.kubernetes.io/part-of: psd2
   annotations:
-    openbank.tech/policy-checksum: "4ef4e723b5c3c09e"
+    openbank.tech/policy-checksum: "49d23a5e8f98b521"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -897,15 +897,19 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+    model_gateway_as_built:            # verified 2026-08-02 against gitops AND the running Deployments
       gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
                                        # #2019). Deployed and serving. It is the only workload holding a
                                        # provider key and the only one with an internet egress hole
                                        # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
-                                       # choke point — but see `egress_enforced` before treating it as a
-                                       # *complete* one.
+                                       # choke point — and since #2210 + the GROQ_API_KEY cleanup it is a
+                                       # *complete* one (see `egress_enforced`).
       routed:                          # read off the RUNNING Deployments' env, not off the manifests
         - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - agent-service                # AGENT_MODEL_ENDPOINT (#2209) — verified live 2026-08-02:
+                                       # http://litellm.ai-platform.svc:4000/v1 on the running
+                                       # Deployment (image sandbox-b52f989b); the direct GROQ_API_KEY
+                                       # path is removed from agent-service.yaml + es-agent-service.yaml
         - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
         - devops-agent                 # DEVOPS_MODEL_ENDPOINT
         - docs-truth-agent             # LLM_GATEWAY_URL
@@ -914,15 +918,10 @@ data:
         - governance-auditor           # LLM_GATEWAY_URL
         - release-steward              # LLM_GATEWAY_URL
         - authz-policy-auditor         # LLM_GATEWAY_URL
-      not_routed:
-        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
-                                       # image resolves the baked-in api.groq.com URL until the rebuilt
-                                       # image rolls out. Promote it to `routed` only after re-reading
-                                       # the live Deployment — merged is not deployed.
-      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
-                                       # component still declares policyTypes: [Ingress] only, so the
-                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
-                                       # gated on the agent-service repoint actually being deployed.
+      egress_enforced: full            # ai-platform is egress-locked (litellm is the only internet
+                                       # hole); agent-service is too: agent-service-egress-allow-list
+                                       # (#2210) is live in the platform namespace and the pod no longer
+                                       # carries a provider key, so the gateway cannot be bypassed.
       budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
       providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region

--- a/openbank-infra/gitops/components/psd2-service/psd2-service.yaml
+++ b/openbank-infra/gitops/components/psd2-service/psd2-service.yaml
@@ -18,7 +18,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-psd2-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "4ef4e723b5c3c09e"
+        openbank.tech/policy-checksum: "49d23a5e8f98b521"
       labels: {app.kubernetes.io/name: psd2-service, app.kubernetes.io/part-of: psd2}
     spec:
       securityContext:

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sanctions-service
     app.kubernetes.io/part-of: sanctions
   annotations:
-    openbank.tech/policy-checksum: "540b83d58644c54a"
+    openbank.tech/policy-checksum: "b8d6fb00bae8b0c0"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -802,15 +802,19 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+    model_gateway_as_built:            # verified 2026-08-02 against gitops AND the running Deployments
       gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
                                        # #2019). Deployed and serving. It is the only workload holding a
                                        # provider key and the only one with an internet egress hole
                                        # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
-                                       # choke point — but see `egress_enforced` before treating it as a
-                                       # *complete* one.
+                                       # choke point — and since #2210 + the GROQ_API_KEY cleanup it is a
+                                       # *complete* one (see `egress_enforced`).
       routed:                          # read off the RUNNING Deployments' env, not off the manifests
         - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - agent-service                # AGENT_MODEL_ENDPOINT (#2209) — verified live 2026-08-02:
+                                       # http://litellm.ai-platform.svc:4000/v1 on the running
+                                       # Deployment (image sandbox-b52f989b); the direct GROQ_API_KEY
+                                       # path is removed from agent-service.yaml + es-agent-service.yaml
         - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
         - devops-agent                 # DEVOPS_MODEL_ENDPOINT
         - docs-truth-agent             # LLM_GATEWAY_URL
@@ -819,15 +823,10 @@ data:
         - governance-auditor           # LLM_GATEWAY_URL
         - release-steward              # LLM_GATEWAY_URL
         - authz-policy-auditor         # LLM_GATEWAY_URL
-      not_routed:
-        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
-                                       # image resolves the baked-in api.groq.com URL until the rebuilt
-                                       # image rolls out. Promote it to `routed` only after re-reading
-                                       # the live Deployment — merged is not deployed.
-      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
-                                       # component still declares policyTypes: [Ingress] only, so the
-                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
-                                       # gated on the agent-service repoint actually being deployed.
+      egress_enforced: full            # ai-platform is egress-locked (litellm is the only internet
+                                       # hole); agent-service is too: agent-service-egress-allow-list
+                                       # (#2210) is live in the platform namespace and the pod no longer
+                                       # carries a provider key, so the gateway cannot be bypassed.
       budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
       providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
@@ -49,7 +49,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sanctions-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "540b83d58644c54a"
+        openbank.tech/policy-checksum: "b8d6fb00bae8b0c0"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sca-service
     app.kubernetes.io/part-of: sca
   annotations:
-    openbank.tech/policy-checksum: "2280a616083a0c24"
+    openbank.tech/policy-checksum: "2f10166e55ca8874"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -838,15 +838,19 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+    model_gateway_as_built:            # verified 2026-08-02 against gitops AND the running Deployments
       gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
                                        # #2019). Deployed and serving. It is the only workload holding a
                                        # provider key and the only one with an internet egress hole
                                        # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
-                                       # choke point — but see `egress_enforced` before treating it as a
-                                       # *complete* one.
+                                       # choke point — and since #2210 + the GROQ_API_KEY cleanup it is a
+                                       # *complete* one (see `egress_enforced`).
       routed:                          # read off the RUNNING Deployments' env, not off the manifests
         - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - agent-service                # AGENT_MODEL_ENDPOINT (#2209) — verified live 2026-08-02:
+                                       # http://litellm.ai-platform.svc:4000/v1 on the running
+                                       # Deployment (image sandbox-b52f989b); the direct GROQ_API_KEY
+                                       # path is removed from agent-service.yaml + es-agent-service.yaml
         - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
         - devops-agent                 # DEVOPS_MODEL_ENDPOINT
         - docs-truth-agent             # LLM_GATEWAY_URL
@@ -855,15 +859,10 @@ data:
         - governance-auditor           # LLM_GATEWAY_URL
         - release-steward              # LLM_GATEWAY_URL
         - authz-policy-auditor         # LLM_GATEWAY_URL
-      not_routed:
-        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
-                                       # image resolves the baked-in api.groq.com URL until the rebuilt
-                                       # image rolls out. Promote it to `routed` only after re-reading
-                                       # the live Deployment — merged is not deployed.
-      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
-                                       # component still declares policyTypes: [Ingress] only, so the
-                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
-                                       # gated on the agent-service repoint actually being deployed.
+      egress_enforced: full            # ai-platform is egress-locked (litellm is the only internet
+                                       # hole); agent-service is too: agent-service-egress-allow-list
+                                       # (#2210) is live in the platform namespace and the pod no longer
+                                       # carries a provider key, so the gateway cannot be bypassed.
       budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
       providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region

--- a/openbank-infra/gitops/components/sca/sca-service.yaml
+++ b/openbank-infra/gitops/components/sca/sca-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sca-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "2280a616083a0c24"
+        openbank.tech/policy-checksum: "2f10166e55ca8874"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/statements/statement-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/statements/statement-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: statement-service
     app.kubernetes.io/part-of: statements
   annotations:
-    openbank.tech/policy-checksum: "82b7f76a958a8c88"
+    openbank.tech/policy-checksum: "60dfc09304d8c2c7"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -868,15 +868,19 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+    model_gateway_as_built:            # verified 2026-08-02 against gitops AND the running Deployments
       gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
                                        # #2019). Deployed and serving. It is the only workload holding a
                                        # provider key and the only one with an internet egress hole
                                        # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
-                                       # choke point — but see `egress_enforced` before treating it as a
-                                       # *complete* one.
+                                       # choke point — and since #2210 + the GROQ_API_KEY cleanup it is a
+                                       # *complete* one (see `egress_enforced`).
       routed:                          # read off the RUNNING Deployments' env, not off the manifests
         - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - agent-service                # AGENT_MODEL_ENDPOINT (#2209) — verified live 2026-08-02:
+                                       # http://litellm.ai-platform.svc:4000/v1 on the running
+                                       # Deployment (image sandbox-b52f989b); the direct GROQ_API_KEY
+                                       # path is removed from agent-service.yaml + es-agent-service.yaml
         - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
         - devops-agent                 # DEVOPS_MODEL_ENDPOINT
         - docs-truth-agent             # LLM_GATEWAY_URL
@@ -885,15 +889,10 @@ data:
         - governance-auditor           # LLM_GATEWAY_URL
         - release-steward              # LLM_GATEWAY_URL
         - authz-policy-auditor         # LLM_GATEWAY_URL
-      not_routed:
-        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
-                                       # image resolves the baked-in api.groq.com URL until the rebuilt
-                                       # image rolls out. Promote it to `routed` only after re-reading
-                                       # the live Deployment — merged is not deployed.
-      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
-                                       # component still declares policyTypes: [Ingress] only, so the
-                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
-                                       # gated on the agent-service repoint actually being deployed.
+      egress_enforced: full            # ai-platform is egress-locked (litellm is the only internet
+                                       # hole); agent-service is too: agent-service-egress-allow-list
+                                       # (#2210) is live in the platform namespace and the pod no longer
+                                       # carries a provider key, so the gateway cannot be bypassed.
       budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
       providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region

--- a/openbank-infra/gitops/components/statements/statement-service.yaml
+++ b/openbank-infra/gitops/components/statements/statement-service.yaml
@@ -26,7 +26,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-statement-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "82b7f76a958a8c88"
+        openbank.tech/policy-checksum: "60dfc09304d8c2c7"
       labels:
         app.kubernetes.io/name: statement-service
         app.kubernetes.io/part-of: statements

--- a/openbank-infra/gitops/components/tpp-registry/tpp-registry-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/tpp-registry/tpp-registry-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: tpp-registry-service
     app.kubernetes.io/part-of: tpp-registry
   annotations:
-    openbank.tech/policy-checksum: "48c3c17233e4549a"
+    openbank.tech/policy-checksum: "58a68f33046779e0"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -805,15 +805,19 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+    model_gateway_as_built:            # verified 2026-08-02 against gitops AND the running Deployments
       gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
                                        # #2019). Deployed and serving. It is the only workload holding a
                                        # provider key and the only one with an internet egress hole
                                        # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
-                                       # choke point — but see `egress_enforced` before treating it as a
-                                       # *complete* one.
+                                       # choke point — and since #2210 + the GROQ_API_KEY cleanup it is a
+                                       # *complete* one (see `egress_enforced`).
       routed:                          # read off the RUNNING Deployments' env, not off the manifests
         - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - agent-service                # AGENT_MODEL_ENDPOINT (#2209) — verified live 2026-08-02:
+                                       # http://litellm.ai-platform.svc:4000/v1 on the running
+                                       # Deployment (image sandbox-b52f989b); the direct GROQ_API_KEY
+                                       # path is removed from agent-service.yaml + es-agent-service.yaml
         - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
         - devops-agent                 # DEVOPS_MODEL_ENDPOINT
         - docs-truth-agent             # LLM_GATEWAY_URL
@@ -822,15 +826,10 @@ data:
         - governance-auditor           # LLM_GATEWAY_URL
         - release-steward              # LLM_GATEWAY_URL
         - authz-policy-auditor         # LLM_GATEWAY_URL
-      not_routed:
-        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
-                                       # image resolves the baked-in api.groq.com URL until the rebuilt
-                                       # image rolls out. Promote it to `routed` only after re-reading
-                                       # the live Deployment — merged is not deployed.
-      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
-                                       # component still declares policyTypes: [Ingress] only, so the
-                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
-                                       # gated on the agent-service repoint actually being deployed.
+      egress_enforced: full            # ai-platform is egress-locked (litellm is the only internet
+                                       # hole); agent-service is too: agent-service-egress-allow-list
+                                       # (#2210) is live in the platform namespace and the pod no longer
+                                       # carries a provider key, so the gateway cannot be bypassed.
       budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
       providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region

--- a/openbank-infra/gitops/components/tpp-registry/tpp-registry-service.yaml
+++ b/openbank-infra/gitops/components/tpp-registry/tpp-registry-service.yaml
@@ -23,7 +23,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-tpp-registry-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "48c3c17233e4549a"
+        openbank.tech/policy-checksum: "58a68f33046779e0"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-libs/governance/agents.yaml
+++ b/openbank-libs/governance/agents.yaml
@@ -85,15 +85,19 @@ runtime:
 # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
 # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
 # ---------------------------------------------------------------------------------------
-model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+model_gateway_as_built:            # verified 2026-08-02 against gitops AND the running Deployments
   gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
                                    # #2019). Deployed and serving. It is the only workload holding a
                                    # provider key and the only one with an internet egress hole
                                    # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
-                                   # choke point — but see `egress_enforced` before treating it as a
-                                   # *complete* one.
+                                   # choke point — and since #2210 + the GROQ_API_KEY cleanup it is a
+                                   # *complete* one (see `egress_enforced`).
   routed:                          # read off the RUNNING Deployments' env, not off the manifests
     - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+    - agent-service                # AGENT_MODEL_ENDPOINT (#2209) — verified live 2026-08-02:
+                                   # http://litellm.ai-platform.svc:4000/v1 on the running
+                                   # Deployment (image sandbox-b52f989b); the direct GROQ_API_KEY
+                                   # path is removed from agent-service.yaml + es-agent-service.yaml
     - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
     - devops-agent                 # DEVOPS_MODEL_ENDPOINT
     - docs-truth-agent             # LLM_GATEWAY_URL
@@ -102,15 +106,10 @@ model_gateway_as_built:            # verified 2026-07-25 against gitops AND the 
     - governance-auditor           # LLM_GATEWAY_URL
     - release-steward              # LLM_GATEWAY_URL
     - authz-policy-auditor         # LLM_GATEWAY_URL
-  not_routed:
-    - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
-                                   # image resolves the baked-in api.groq.com URL until the rebuilt
-                                   # image rolls out. Promote it to `routed` only after re-reading
-                                   # the live Deployment — merged is not deployed.
-  egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
-                                   # component still declares policyTypes: [Ingress] only, so the
-                                   # gateway is bypassable from that pod. #2210 adds the Egress half,
-                                   # gated on the agent-service repoint actually being deployed.
+  egress_enforced: full            # ai-platform is egress-locked (litellm is the only internet
+                                   # hole); agent-service is too: agent-service-egress-allow-list
+                                   # (#2210) is live in the platform namespace and the pod no longer
+                                   # carries a provider key, so the gateway cannot be bypassed.
   budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
   providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
     deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region


### PR DESCRIPTION
## Summary

Completes the LiteLLM gateway egress enforcement (#1919): the repointed agent-service image is live and verified against the running Deployment (`AGENT_MODEL_ENDPOINT=http://litellm.ai-platform.svc:4000/v1`, image `sandbox-b52f989b`), and the #2210 egress NetworkPolicy is in place — so the direct-to-provider `GROQ_API_KEY` path is dead config, removed here together with the `model_gateway_as_built` truth update (`egress_enforced: partial → full`).

## Type of change

- [x] chore (build / tooling — gitops + governance registry)

## Linked issues

Closes #1919
Refs #3599 (ADR-0175 D3 — sensitive-data routing / EU inference tier, the remaining open residency work)

## Changes

- `components/agent/agent-service.yaml` — `GROQ_API_KEY` env removed (marked "ROLLOUT WINDOW ONLY"; the window is over — verified live, see below).
- `components/external-secrets/es-agent-service.yaml` — matching `GROQ_API_KEY` secretKey entry removed; provider key now exists only in the ai-platform gateway pod.
- `openbank-libs/governance/agents.yaml` — `model_gateway_as_built`: agent-service promoted `not_routed → routed`, `egress_enforced: partial → full`, verification date → 2026-08-02. **Live evidence:** `kubectl get deploy agent-service -n platform` shows `AGENT_MODEL_ENDPOINT=http://litellm.ai-platform.svc:4000/v1` on image `sandbox-b52f989b` and `networkpolicy/agent-service-egress-allow-list` present in the platform namespace.
- `docs/compliance/eu-ai-act.md` — regenerated via `gen-eu-ai-act.py` (drift-gated in the required `Validate manifests` job); the "Partially closed gap" warning is gone, egress now reads `full`.
- 39 OPA bundle ConfigMaps + pod-roll checksum annotations restamped (`agents.yaml` is embedded policy data — the standard fleet restamp, same as #2212).
- `apps/agent.yaml`, `networkpolicy-agent-egress.yaml` — stale comments updated to the verified state.

## Definition of Done

- [x] Hexagonal layering preserved — no application code changed.
- [x] Unit tests — n/a (gitops + governance data).
- [x] `./gradlew detekt ktlintCheck koverVerify build` — n/a (no Kotlin change).
- [x] OpenAPI / Flyway / Avro — n/a.
- [x] Docs updated — `eu-ai-act.md` regenerated; agents.yaml is the registry of record.
- [x] `opa test` + `build-bundle.sh` pass locally (15 charters, all drift assertions green).

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs — **this PR only REMOVES a provider-key projection** (the value itself never lived in git; the OpenBao KV entry `agent-service/GROQ_API_KEY` can be retired out-of-band after merge).
- [x] No new third-party dependency.
- [x] Auth / crypto / payment code changed? — no (secret *reference* removal + network-policy comment).
- [ ] PII / cardholder path — no.

## Compliance impact

- [x] GDPR / EU AI Act — positive: the AI Act inventory now records the choke point as fully egress-enforced instead of partially; the gateway is the single auditable prompt-egress path (Art. 10 data-governance posture improved; residency derogation for hosted US providers is unchanged and tracked as #3599).

## Rollout note

ArgoCD will roll the agent-service pod on the env removal. Safety was verified *before* this PR: the running image already resolves its LLM backend from `AGENT_MODEL_*` (not `GROQ_API_KEY`), so the roll is a no-op behaviourally. Rollback: revert this PR.