### PR TITLE
fix(infra): let Karpenter garbage-collect instance profiles

### DIFF
--- a/openbank-infra/aws/modules/karpenter-iam/main.tf
+++ b/openbank-infra/aws/modules/karpenter-iam/main.tf
@@ -187,6 +187,28 @@ data "aws_iam_policy_document" "controller" {
       "iam:TagInstanceProfile",
       "iam:AddRoleToInstanceProfile",
       "iam:RemoveRoleFromInstanceProfile",
+      # ListInstanceProfiles is what the `instanceprofile.garbagecollection` controller calls,
+      # and it was the one verb missing — so that controller had thrown a 403 on every pass for
+      # the life of the cluster:
+      #
+      #   ERROR instanceprofile.garbagecollection  listing instance profiles ...
+      #   operation error IAM: ListInstanceProfiles ... StatusCode: 403
+      #
+      # measured 2026-08-03 firing every ~16 minutes. Two costs, and the second is the one that
+      # matters. (a) The GC cannot run, so an instance profile whose EC2NodeClass is deleted
+      # leaks permanently — invisible until the account nears the 1000-profile limit. Today the
+      # estate is clean (2 NodeClasses, 2 profiles), which is precisely why this is worth fixing
+      # now rather than during the incident. (b) A recurring ERROR that is always present and
+      # never actionable is how a log stops being read; this repo has paid for that lesson more
+      # than once.
+      #
+      # `Get`/`Create`/`Delete` here are already `Resource: "*"` — the AWS-published Karpenter
+      # policy scopes them by `aws:ResourceTag/kubernetes.io/cluster/<name>` instead, which is
+      # tighter and worth doing, but is a separate change. `ListInstanceProfiles` cannot be
+      # resource-scoped at all: it is a list operation over the account, so `"*"` is the only
+      # valid form and adding it grants no access to a profile the role could not already read
+      # by name via GetInstanceProfile.
+      "iam:ListInstanceProfiles",
     ]
     resources = ["*"]
   }


### PR DESCRIPTION
## Linked issues

Refs #3602

## What

The `instanceprofile.garbagecollection` controller calls `iam:ListInstanceProfiles` — the one verb this policy did not grant. It had therefore thrown a 403 on **every pass for the life of the cluster**:

```
ERROR instanceprofile.garbagecollection  listing instance profiles ...
      operation error IAM: ListInstanceProfiles ... StatusCode: 403
```

Measured 2026-08-03: firing every ~16 minutes.

## Why it is worth fixing now, while nothing is broken

Two costs, and the second is the one that matters.

1. **The GC cannot run**, so an instance profile whose `EC2NodeClass` is deleted leaks permanently — invisible until the account approaches the 1000-profile limit. The estate is clean today (**2 NodeClasses, 2 profiles**), which is precisely the argument for fixing it now rather than during the incident.
2. **A recurring ERROR that is always present and never actionable is how a log stops being read.** This repo has paid for that lesson more than once.

## Scope of the grant

`ListInstanceProfiles` **cannot** be resource-scoped — it is a list operation over the account, so `"*"` is the only valid form. It grants no access to a profile the role could not already read by name via the `GetInstanceProfile` it already holds.

Noted in the code but deliberately **not** changed here: `Get`/`Create`/`Delete` in this statement are already `Resource: "*"`, where the AWS-published Karpenter policy scopes them by `aws:ResourceTag/kubernetes.io/cluster/<name>`. That is tighter and worth doing as its own change.

## Verified live, not reasoned about

Applied with a `-target`ed plan (**exactly one in-place update**), restarted the controller, then read the same log line back:

```
before:  ERROR × every ~16 min, StatusCode: 403
after:   {'INFO': 3}, zero errors across three passes
```

## Warning for whoever applies `sandbox-substrate` next

An **unscoped** `tofu apply` there currently carries **nine other pre-existing drift changes**, including a `create`+`delete` of `module.network.aws_instance.fck_nat[0]` — forced by an AMI data source resolving to a newer image, i.e. it rebuilds the NAT and drops all egress from the private subnets.

That is why this change was applied with `-target`, and it is filed separately as #3602.
