### PR TITLE
ci(deps): stop the metadata-refresh job writing a 1181 MB Gradle cache

### DIFF
--- a/.github/scripts/check-gradle-cache-writers.py
+++ b/.github/scripts/check-gradle-cache-writers.py
@@ -144,10 +144,6 @@ DECLARED: dict[str, tuple[str, str]] = {
         "setup-java",
         "Same setup-java keying as pitest.",
     ),
-    "dependabot-verification-metadata.yml::refresh-metadata": (
-        "setup-java",
-        "Same setup-java keying as pitest.",
-    ),
     "perf-gate.yml::perf": (
         "read-only",
         "Consumer; restores fleet-lint's home. Weekly advisory k6 gate (ADR-0243) — "

--- a/.github/workflows/dependabot-verification-metadata.yml
+++ b/.github/workflows/dependabot-verification-metadata.yml
@@ -63,12 +63,20 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
           token: ${{ secrets.METADATA_REFRESH_PAT }}
 
+      # No `cache: gradle`. That input produced `setup-java-Linux-x64-gradle`, a single 1181 MB
+      # entry — 12% of the repo's 10 GB Actions-cache ceiling — for a job that runs only on a
+      # Dependabot PR that also has METADATA_REFRESH_PAT set, i.e. rarely (#3299). The cache was
+      # over the ceiling, so GitHub was evicting least-recently-used entries continuously and
+      # silently; every eviction is some other job re-resolving from scratch.
+      #
+      # It is also the wrong job to warm. This step REGENERATES verification metadata by resolving
+      # the dependency graph and hashing what it finds, so what is already on disk is exactly what
+      # it must not take for granted. The cost is a slower resolve on a job nobody waits on.
       - if: steps.tok.outputs.have == 'true'
         uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
         with:
           java-version: "25"
           distribution: temurin
-          cache: gradle
 
       - name: Regenerate verification metadata
         if: steps.tok.outputs.have == 'true'


### PR DESCRIPTION
Refs #3299. Frees **1181 MB — 12% of the 10 GB ceiling** — by removing one cache write.

## What

The Actions cache is at **10.11 GB against a 10 GB ceiling**, so GitHub is evicting least-recently-used entries continuously and silently. Nothing goes red; the cost lands as some *other* job re-resolving its dependencies from scratch, which makes PR feedback fast or slow depending on what else ran that day.

`setup-java`'s `cache: gradle` in `dependabot-verification-metadata.yml` produced `setup-java-Linux-x64-gradle`, a **single 1181 MB entry**, for a job that runs only on a Dependabot PR that *also* has `METADATA_REFRESH_PAT` set — i.e. rarely.

## Why this job in particular

It is the one place a warm Gradle cache is least appropriate. That step **regenerates** verification metadata by resolving the dependency graph and hashing what it finds, so what happens to be on disk already is exactly what it must not take for granted.

The cost of removing it is a slower resolve on a job nobody waits on. Against 12% of a ceiling every other job is being evicted from, that trade is not close.

## The gate caught my half-done change

`gradle-cache-writer-budget` (added for #3299) went red the moment I removed the cache and left the declaration behind:

```
::error::STALE  dependabot-verification-metadata.yml::refresh-metadata is declared but no
longer uses the Gradle cache. Remove the declaration.
```

That is the gate working exactly as designed — it fails in **both** directions, so a declaration list cannot quietly stop describing reality. Both halves are in this PR; it now reports `12 declared usages, 5/5 write-capable`, unchanged.

Worth saying plainly: I did not build that gate, and it found my mistake before CI did.

## What this does not do

- **It does not bring the pool under the ceiling on its own.** 10.11 GB − 1.18 GB ≈ 8.9 GB, which clears it *today*, but the two largest groups are still `gradle-dependencies-v1` (6 entries / 4523 MB) and `gradle-build-cache-v1` (25 entries / 3584 MB). Those are on the hot path for every build, so scoping their keys is a change with real downside and belongs in its own PR with its own measurement. #3299 stays open for it.
- **It does not measure the eviction rate**, before or after. I am claiming a 1181 MB reduction in the pool, which is directly observable, not an improvement in hit rate, which is not.
- The freed space is reclaimed as the entry ages out, not instantly.

## Verification

```
run-gates.py --only gradle-cache-writer-budget   PASS (12 declared, 5/5 write-capable)
run-gates.py --group lint                        PASS=5
```

Validated against GitHub rather than a YAML parser: a throwaway branch carrying both files produced **0 runs**, the correct answer for valid workflows on a non-main branch. Probe branch deleted.

**Merge will be refused** — this touches `.github/workflows`, which the repo's hook holds for human review. That is the correct final state; leaving it open.
