### PR TITLE
fix(infra): read the shared OIDC client secret from one KV entry, and gate it

### DIFF
--- a/.github/scripts/check-oidc-client-secret-wiring.py
+++ b/.github/scripts/check-oidc-client-secret-wiring.py
@@ -19,16 +19,42 @@ could not authenticate. Nothing had logged it, because the path had never execut
 `fx_conversions` is empty, so it would have failed on the FIRST conversion anyone performed. Same
 shape as the ČNB feed 404 in #2204 — correct-looking until exercised.
 
-WHAT IT CHECKS — all three from committed artifacts, so it needs no cluster access:
+WHAT IT CHECKS — all four from committed artifacts, so it needs no cluster access:
 
   1. A service whose `src/main` contains `OidcClientRequestReactiveFilter` (or the blocking
      variant) MUST have an `OIDC_CLIENT_SECRET` env ref in its Deployment.
   2. That ref must be `optional: false`. An authorization-bearing credential that is allowed to be
      missing does not degrade gracefully; it sends unauthenticated requests.
   3. The Secret it names must be created by an `ExternalSecret` in gitops.
+  4. That ExternalSecret must read the ONE agreed KV entry (`rules.yaml:
+     oidc_client_secret_storage.shared_kv_entry`), not a per-service one. See below.
 
 And the converse, which is what makes it a shape rather than a checklist: a service with NO
 OIDC-filtered client should not carry the env ref at all.
+
+Check 4 — one credential, one KV entry (#3485)
+---------------------------------------------
+Checks 1-3 answer "is this secret delivered?" and cannot answer "delivered from WHERE?". The
+estate had split into two storage conventions for one credential — measured on main 2026-08-02,
+29 ExternalSecret entries read `account-service` and 10 read `<their-own>-service` — with nothing
+recording which was intended. The split is arbitrary rather than meaningful because the `openbank`
+realm defines exactly one confidential M2M client, `openbank-services`: a per-service KV entry
+holds a COPY of the one credential, seeded by copying the shared entry
+(`openbank-infra/scripts/seed-vault-gaps.sh` does that verbatim for audit-service).
+
+That makes the copies pure cost. Rotation is per-CLIENT, so one Keycloak rotation must fan out to
+every copy, with nothing enumerating them; and each copy needs a seed step that only a human
+performs. That step is the one that gets skipped — `openbank-delegation-service` shipped pointing
+at an entry nobody had written, ESO answered `Secret does not exist`, and the pod sat in
+`CreateContainerConfigError` for its entire life behind ~12 alerts that named everything except
+the cause (#3471).
+
+Scope: an entry is IN scope when its `secretKey` or its `remoteRef.property` is
+`OIDC_CLIENT_SECRET` — the name the shared client's secret is stored under everywhere. Workloads
+authenticating as a DIFFERENT realm client (admin-ui, customer-edge, the WebAuthn client) store
+theirs under `client-secret`/`kc-client-secret` and are correctly per-entry; they are out of
+scope, and that is the distinction the property name carries. If per-service realm clients are
+ever introduced this rule becomes wrong and must key off the client-id instead of the path.
 
 Usage:  check-oidc-client-secret-wiring.py [--enforce] [--selftest]
 Advisory by default (prints ::warning, exits 0) per the repo convention; --enforce fails the build.
@@ -44,6 +70,7 @@ import yaml
 
 REPO = pathlib.Path(__file__).resolve().parents[2]
 GITOPS = REPO / "openbank-infra" / "gitops"
+RULES = REPO / "openbank-libs" / "governance" / "rules.yaml"
 FILTER_MARKERS = ("OidcClientRequestReactiveFilter", "OidcClientRequestFilter")
 ENV_NAME = "OIDC_CLIENT_SECRET"
 
@@ -103,6 +130,47 @@ def provisioned_secrets() -> set[tuple[str, str]]:
     return out
 
 
+def storage_policy() -> tuple[str, dict[str, str]]:
+    """(shared KV entry, {externalsecret-name: reason}) from rules.yaml — never a second copy."""
+    block = (yaml.safe_load(RULES.read_text(encoding="utf-8")) or {}).get(
+        "oidc_client_secret_storage",
+    ) or {}
+    shared = block.get("shared_kv_entry")
+    if not shared:
+        raise SystemExit(
+            "rules.yaml: oidc_client_secret_storage.shared_kv_entry is missing — the checker has "
+            "no convention to enforce and would silently pass everything.",
+        )
+    return shared, dict(block.get("exemptions") or {})
+
+
+def shared_client_secret_entries() -> list[tuple[str, str, str, str, pathlib.Path]]:
+    """[(namespace, externalsecret, secretKey, remoteRef.key, manifest)] delivering the shared
+    openbank-services client secret. In scope iff the secretKey or the remote property is
+    OIDC_CLIENT_SECRET — a different realm client stores its secret under a different name."""
+    out: list[tuple[str, str, str, str, pathlib.Path]] = []
+    for path in GITOPS.rglob("*.yaml"):
+        try:
+            docs = list(yaml.safe_load_all(path.read_text(encoding="utf-8")))
+        except (yaml.YAMLError, UnicodeDecodeError):
+            continue
+        for doc in docs:
+            if not isinstance(doc, dict) or doc.get("kind") != "ExternalSecret":
+                continue
+            meta = doc.get("metadata") or {}
+            for entry in (doc.get("spec") or {}).get("data") or []:
+                if not isinstance(entry, dict):
+                    continue
+                remote = entry.get("remoteRef") or {}
+                if ENV_NAME not in (entry.get("secretKey"), remote.get("property")):
+                    continue
+                out.append((
+                    meta.get("namespace", ""), meta.get("name", "?"),
+                    str(entry.get("secretKey")), str(remote.get("key")), path,
+                ))
+    return out
+
+
 def oidc_env_refs() -> dict[str, tuple[str, str, bool, pathlib.Path]]:
     """{workload: (namespace, secret-name, optional, manifest)} for every OIDC_CLIENT_SECRET ref."""
     refs: dict[str, tuple[str, str, bool, pathlib.Path]] = {}
@@ -129,8 +197,69 @@ def oidc_env_refs() -> dict[str, tuple[str, str, bool, pathlib.Path]]:
     return refs
 
 
+def storage_findings(
+    entries: list[tuple[str, str, str, str, pathlib.Path]],
+    shared: str,
+    exemptions: dict[str, str],
+) -> list[str]:
+    """One finding per ExternalSecret reading a KV entry other than the agreed shared one, plus
+    one per stale exemption. Pure, so --selftest can drive it with synthetic input."""
+    findings: list[str] = []
+    used: set[str] = set()
+    for namespace, name, secret_key, remote_key, manifest in sorted(entries):
+        if remote_key == shared:
+            continue
+        if name in exemptions:
+            used.add(name)
+            print(f"::notice::{name} reads KV entry {remote_key!r} by exemption — "
+                  f"{exemptions[name]}")
+            continue
+        findings.append(
+            f"::error file={manifest.relative_to(REPO)}::ExternalSecret {namespace}/{name} "
+            f"delivers {secret_key} from KV entry {remote_key!r}, but the shared "
+            f"openbank-services client secret lives at {shared!r} "
+            f"(rules.yaml: oidc_client_secret_storage). There is one realm client, so a "
+            f"per-service entry is a COPY somebody has to seed by hand — and that is the step "
+            f"that gets skipped, leaving ESO with `Secret does not exist` and the pod in "
+            f"CreateContainerConfigError (#3471, #3485).",
+        )
+    for stale in sorted(set(exemptions) - used):
+        findings.append(
+            f"::error::stale oidc_client_secret_storage.exemptions entry {stale!r} — it no longer "
+            f"reads a non-shared KV entry (or no longer exists). Remove it from rules.yaml, so "
+            f"the exemption list can only shrink.",
+        )
+    return findings
+
+
 def selftest() -> int:
     """Prove the scans can distinguish the states they exist to tell apart."""
+    shared, exemptions = storage_policy()
+    entries = shared_client_secret_entries()
+    if not entries:
+        print("selftest FAIL: no ExternalSecret delivers the shared client secret — the storage "
+              "scan came back empty, which passes every manifest vacuously.")
+        return 1
+    # Falsifiability, both directions, on synthetic input the tree cannot supply.
+    fake = pathlib.Path(REPO / "openbank-infra" / "gitops" / "selftest.yaml")
+    must_flag = storage_findings([("ns", "es-x", ENV_NAME, "some-other-service", fake)],
+                                 shared, {})
+    must_pass = storage_findings([("ns", "es-x", ENV_NAME, shared, fake)], shared, {})
+    if len(must_flag) != 1:
+        print(f"selftest FAIL: a per-service KV entry produced {len(must_flag)} finding(s), "
+              f"expected 1 — the convention check cannot go red.")
+        return 1
+    if must_pass:
+        print("selftest FAIL: the agreed shared KV entry was flagged — the check would fail every "
+              "conforming manifest and get switched off.")
+        return 1
+    if len(storage_findings([], shared, {"es-ghost": "gone"})) != 1:
+        print("selftest FAIL: a stale exemption was not reported — the list could grow silently.")
+        return 1
+    print(f"selftest OK (storage): {len(entries)} shared-client-secret entry/entries, "
+          f"shared_kv_entry={shared!r}; a per-service key flags, the shared key does not, "
+          f"a stale exemption flags.")
+
     minting = services_minting_tokens()
     refs = oidc_env_refs()
     provisioned = provisioned_secrets()
@@ -159,7 +288,9 @@ def main() -> int:
     minting = services_minting_tokens()
     refs = oidc_env_refs()
     provisioned = provisioned_secrets()
-    findings: list[str] = []
+    shared, exemptions = storage_policy()
+    entries = shared_client_secret_entries()
+    findings: list[str] = storage_findings(entries, shared, exemptions)
     used_pending: set[str] = set()
 
     for workload, (namespace, secret, optional, manifest) in sorted(refs.items()):
@@ -204,7 +335,8 @@ def main() -> int:
         print(line if args.enforce else line.replace("::error", "::warning", 1))
     verdict = "clean." if not findings else f"{len(findings)} finding(s) above."
     print(f"check-oidc-client-secret-wiring: {len(refs)} {ENV_NAME} ref(s), {len(minting)} "
-          f"token-minting service(s), {len(provisioned)} provisioned secret(s) — {verdict}")
+          f"token-minting service(s), {len(provisioned)} provisioned secret(s), {len(entries)} "
+          f"shared-client-secret KV read(s) against {shared!r} — {verdict}")
     return 1 if findings and args.enforce else 0
 
 

--- a/openbank-infra/gitops/components/anacredit/oidc-externalsecret.yaml
+++ b/openbank-infra/gitops/components/anacredit/oidc-externalsecret.yaml
@@ -1,6 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # Projects the OIDC client secret for anacredit-service from OpenBao (Vault KV) into the
 # anacredit namespace so the Deployment can reference it via secretKeyRef.
+#
+# The KV entry is `account-service` — the shared one, not anacredit's own. anacredit-service
+# authenticates as `openbank-services`, the realm's single confidential M2M client, so a
+# per-service entry would hold a hand-copied duplicate of that one credential; #3485 and
+# rules.yaml: oidc_client_secret_storage explain why that costs a seed step and buys nothing.
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
@@ -24,5 +29,5 @@ spec:
   data:
     - secretKey: OIDC_CLIENT_SECRET
       remoteRef:
-        key: anacredit-service
+        key: account-service
         property: OIDC_CLIENT_SECRET

--- a/openbank-infra/gitops/components/campaign/external-secret-oidc.yaml
+++ b/openbank-infra/gitops/components/campaign/external-secret-oidc.yaml
@@ -1,8 +1,11 @@
 # campaign-service OIDC client secret from Vault → campaign-service-oidc Secret
 # (key OIDC_CLIENT_SECRET), shared openbank-services realm client. creationPolicy
 # Owner: ESO creates/owns and re-creates the Secret (mirrors every other service).
-# Prerequisite: the Vault KV must hold `campaign-service` with OIDC_CLIENT_SECRET set
-# to the openbank-services client secret (seed step in the rollout runbook).
+# Reads the SHARED KV entry `account-service`, which already holds the openbank-services client
+# secret every other service reads — so there is NO per-service seed step to skip. It used to name
+# `campaign-service`, whose prerequisite ("the KV must hold it") is the step that went missing for
+# delegation-service (#3471) and is still missing for mcp-service (#3485,
+# rules.yaml: oidc_client_secret_storage).
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
@@ -24,5 +27,5 @@ spec:
   data:
     - secretKey: OIDC_CLIENT_SECRET
       remoteRef:
-        key: campaign-service
+        key: account-service
         property: OIDC_CLIENT_SECRET

--- a/openbank-infra/gitops/components/external-secrets/README.md
+++ b/openbank-infra/gitops/components/external-secrets/README.md
@@ -74,19 +74,10 @@ Pull each current value from the live hand-made Secret and write it to Vault.
 The KV keys/properties below MUST match the `remoteRef` in each ExternalSecret.
 
 ```sh
-# account-service OIDC client secret
+# The shared openbank-services client secret. ONE entry, read by every service — see
+# "One credential, one entry" below. Historic path name; it is not account-service's own.
 vault kv put openbank/account-service \
   OIDC_CLIENT_SECRET="$(kubectl -n accounts get secret account-service-oidc \
-    -o jsonpath='{.data.OIDC_CLIENT_SECRET}' | base64 -d)"
-
-# balance-service OIDC client secret
-vault kv put openbank/balance-service \
-  OIDC_CLIENT_SECRET="$(kubectl -n balances get secret balance-service-oidc \
-    -o jsonpath='{.data.OIDC_CLIENT_SECRET}' | base64 -d)"
-
-# audit-service OIDC client secret (shared openbank-services realm client)
-vault kv put openbank/audit-service \
-  OIDC_CLIENT_SECRET="$(kubectl -n audit get secret audit-service-oidc \
     -o jsonpath='{.data.OIDC_CLIENT_SECRET}' | base64 -d)"
 
 # keycloak bootstrap admin
@@ -123,8 +114,45 @@ the original hand-made Secrets lacked, which let a prune delete them and left
 `Merge` unable to recreate them. Already-mounted env/volume secrets keep working
 across the cutover; a pod restart picks up future rotation.
 
+## One credential, one entry — the OIDC client secret convention
+
+The `openbank` realm defines exactly **one** confidential M2M client,
+`openbank-services` (`components/keycloak/realm-template.json`). Every service
+that mints a client-credentials token authenticates as it; there is no
+per-service realm client. So **every `OIDC_CLIENT_SECRET` ExternalSecret reads
+`remoteRef.key: account-service`** — the shared entry — and there is nothing to
+seed when a new service ships.
+
+That is the rule, not a habit. It is declared in `rules.yaml:
+oidc_client_secret_storage` and enforced by
+`.github/scripts/check-oidc-client-secret-wiring.py` (gate
+`oidc-client-secret-wiring`), which fails a manifest naming any other entry.
+
+Why not one entry per service: a per-service entry cannot hold a per-service
+credential — there is only one — so it holds a hand-copied duplicate. That buys
+no blast-radius isolation (rotating the client invalidates every copy at once),
+turns one rotation into N writes with nothing enumerating N, and adds a manual
+seed step per service. The seed step is the half that goes missing:
+`delegation-service` shipped pointing at an entry nobody had written and sat in
+`CreateContainerConfigError` for its whole life behind ~12 alerts naming
+everything but the cause (#3471); `mcp-service` had the same gap open, masked by
+`optional: true` (#3485). The estate was converged to the shared entry in #3485.
+
+A workload authenticating as a **different** realm client (admin-ui,
+customer-edge, the WebAuthn client) legitimately keeps its own entry. Those store
+the value under `client-secret`/`kc-client-secret`, and that property name is
+what puts them out of the rule's scope.
+
 ## Rotation (later)
 
 To rotate a secret: `vault kv put openbank/<entry> <key>=<new-value>`. ESO
 re-syncs within `refreshInterval` (1h) and updates the Secret; roll the
 consuming Deployment to pick up env-mounted values.
+
+Rotating the shared M2M client is therefore: set the new secret on
+`openbank-services` in Keycloak, `vault kv put openbank/account-service
+OIDC_CLIENT_SECRET=<new>` — **one** write — then roll every consuming Deployment.
+Env-mounted values do not hot-reload, so until the roll each pod keeps presenting
+the old secret and Keycloak rejects it: expect 401s on M2M calls between the KV
+write and the last roll. There is no way to make that window zero with a single
+client credential; sequence the roll money-path last.

--- a/openbank-infra/gitops/components/external-secrets/es-agent-service.yaml
+++ b/openbank-infra/gitops/components/external-secrets/es-agent-service.yaml
@@ -5,7 +5,10 @@
 # source and same shape as copilot's COPILOT_MODEL_API_KEY (es-copilot-service.yaml), each on its
 # own budgeted virtual key rather than the shared master key.
 #
-# OIDC_CLIENT_SECRET (openbank-services realm client) is unchanged.
+# OIDC_CLIENT_SECRET is the openbank-services realm client's secret, read from the SHARED KV entry
+# `account-service`. It used to read `agent-service`; there is exactly one such realm client, so
+# that entry was a hand-seeded copy of this same value — see #3485 and
+# rules.yaml: oidc_client_secret_storage for why the copy is cost without isolation.
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
@@ -39,5 +42,5 @@ spec:
         property: KEY_AGENT_SERVICE
     - secretKey: OIDC_CLIENT_SECRET
       remoteRef:
-        key: agent-service
+        key: account-service
         property: OIDC_CLIENT_SECRET

--- a/openbank-infra/gitops/components/external-secrets/es-audit-service-oidc.yaml
+++ b/openbank-infra/gitops/components/external-secrets/es-audit-service-oidc.yaml
@@ -1,5 +1,10 @@
 # audit-service OIDC client secret from Vault → audit-service-oidc Secret
 # (key OIDC_CLIENT_SECRET), shared openbank-services realm client.
+#
+# Read from the SHARED KV entry `account-service`. It used to read `audit-service`, an entry that
+# seed-vault-gaps.sh populated by copying this very value out of `account-service` — one credential
+# in two places, with a Keycloak rotation obliged to find both (#3485,
+# rules.yaml: oidc_client_secret_storage).
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
@@ -21,5 +26,5 @@ spec:
   data:
     - secretKey: OIDC_CLIENT_SECRET
       remoteRef:
-        key: audit-service
+        key: account-service
         property: OIDC_CLIENT_SECRET

--- a/openbank-infra/gitops/components/external-secrets/es-balance-service-oidc.yaml
+++ b/openbank-infra/gitops/components/external-secrets/es-balance-service-oidc.yaml
@@ -1,6 +1,9 @@
 # balance-service OIDC client secret from Vault → balance-service-oidc Secret
 # (key OIDC_CLIENT_SECRET), shared openbank-services realm client. creationPolicy
 # Owner: ESO creates/owns and re-creates the Secret (see es-account-service-oidc).
+#
+# Read from the SHARED KV entry `account-service`, not the `balance-service` entry this used to
+# name — one realm client, one entry (#3485, rules.yaml: oidc_client_secret_storage).
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
@@ -22,5 +25,5 @@ spec:
   data:
     - secretKey: OIDC_CLIENT_SECRET
       remoteRef:
-        key: balance-service
+        key: account-service
         property: OIDC_CLIENT_SECRET

--- a/openbank-infra/gitops/components/external-secrets/es-mcp-service.yaml
+++ b/openbank-infra/gitops/components/external-secrets/es-mcp-service.yaml
@@ -3,16 +3,14 @@
 # OIDC_CLIENT_SECRET (openbank-services realm client, ADR-0104 D3) — the SAME shared M2M client
 # transaction-service/lending-service/settlement-service/agent-service already use, so
 # RealAccountReadPort's downstream calls (account/balance/transaction/consent-service) authenticate
-# as the identical least-privilege service principal those services already grant reads to. Own KV
-# copy per the fleet convention (each service reads its own <svc>/OIDC_CLIENT_SECRET property, all
-# holding the same underlying client secret value — see agent-service's es-agent-service.yaml).
+# as the identical least-privilege service principal those services already grant reads to. Read
+# from the SHARED KV entry `account-service` (rules.yaml: oidc_client_secret_storage).
 #
-# NOT YET SEEDED: this ExternalSecret declares the KV coordinate; an operator must still write the
-# `openbank-services` client's secret value into OpenBao at key `mcp-service`, property
-# `OIDC_CLIENT_SECRET` (manual step, same as agent-service's own bootstrap — mirrors the "Add the
-# key + restart -> real data" comment in agent-service.yaml). Until then the Deployment's
-# `optional: true` secretKeyRef keeps the pod healthy; a downstream M2M call just 401s — no
-# regression, since RealAccountReadPort is still @Vetoed (not CDI-wired) regardless.
+# This used to name key `mcp-service` and carried a "NOT YET SEEDED" note: the coordinate was
+# declared, nobody ever wrote the value, and the Deployment's `optional: true` secretKeyRef kept
+# the pod green while every downstream M2M call would have gone out unauthenticated. That is the
+# #3471 failure mode caught before it bit — and the reason a per-service KV entry is not free:
+# it adds a manual seed step, and the seed step is the half that goes missing (#3485).
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
@@ -29,5 +27,5 @@ spec:
   data:
     - secretKey: OIDC_CLIENT_SECRET
       remoteRef:
-        key: mcp-service
+        key: account-service
         property: OIDC_CLIENT_SECRET

--- a/openbank-infra/gitops/components/external-secrets/es-sanctions-service-oidc.yaml
+++ b/openbank-infra/gitops/components/external-secrets/es-sanctions-service-oidc.yaml
@@ -1,5 +1,8 @@
 # sanctions-service OIDC client secret from OpenBao → sanctions-service-oidc
 # Secret (key OIDC_CLIENT_SECRET), shared openbank-services realm client.
+#
+# Read from the SHARED KV entry `account-service`, not the `sanctions-service` entry this used to
+# name — one realm client, one entry (#3485, rules.yaml: oidc_client_secret_storage).
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
@@ -21,5 +24,5 @@ spec:
   data:
     - secretKey: OIDC_CLIENT_SECRET
       remoteRef:
-        key: sanctions-service
+        key: account-service
         property: OIDC_CLIENT_SECRET

--- a/openbank-infra/gitops/components/sdd/oidc-externalsecret.yaml
+++ b/openbank-infra/gitops/components/sdd/oidc-externalsecret.yaml
@@ -1,6 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # Projects the OIDC client secret for sdd-service from OpenBao (Vault KV) into the
 # sdd namespace so the Deployment can reference it via secretKeyRef.
+#
+# The KV entry is `account-service` — the shared one, not sdd's own. sdd-service authenticates as
+# `openbank-services`, the realm's single confidential M2M client, so a per-service entry would be
+# a hand-seeded copy of that one credential (#3485, rules.yaml: oidc_client_secret_storage).
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
@@ -24,5 +28,5 @@ spec:
   data:
     - secretKey: OIDC_CLIENT_SECRET
       remoteRef:
-        key: sdd-service
+        key: account-service
         property: OIDC_CLIENT_SECRET

--- a/openbank-infra/gitops/components/statements/external-secret-oidc.yaml
+++ b/openbank-infra/gitops/components/statements/external-secret-oidc.yaml
@@ -1,8 +1,10 @@
 # statement-service OIDC client secret from Vault → statement-service-oidc Secret
 # (key OIDC_CLIENT_SECRET), shared openbank-services realm client. creationPolicy
 # Owner: ESO creates/owns and re-creates the Secret (mirrors es-balance-service-oidc).
-# Prerequisite: the Vault KV must hold `statement-service` with OIDC_CLIENT_SECRET set to
-# the openbank-services client secret (same value the other services pull from their key).
+# Reads the SHARED KV entry `account-service`, so there is no per-service seed step. It used to
+# name `statement-service` and its own comment gave the game away — "the same value the other
+# services pull from their key". One realm client, one entry (#3485,
+# rules.yaml: oidc_client_secret_storage).
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
@@ -24,5 +26,5 @@ spec:
   data:
     - secretKey: OIDC_CLIENT_SECRET
       remoteRef:
-        key: statement-service
+        key: account-service
         property: OIDC_CLIENT_SECRET

--- a/openbank-infra/gitops/components/tpp-registry/oidc-externalsecret.yaml
+++ b/openbank-infra/gitops/components/tpp-registry/oidc-externalsecret.yaml
@@ -1,6 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # Projects the OIDC client secret for tpp-registry-service from OpenBao (Vault KV) into the
 # tpp-registry namespace so the Deployment can reference it via secretKeyRef.
+#
+# The KV entry is `account-service` — the shared one, not tpp-registry's own. tpp-registry-service
+# authenticates as `openbank-services`, the realm's single confidential M2M client, so a
+# per-service entry would be a hand-seeded copy of that one credential (#3485,
+# rules.yaml: oidc_client_secret_storage).
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
@@ -24,5 +29,5 @@ spec:
   data:
     - secretKey: OIDC_CLIENT_SECRET
       remoteRef:
-        key: tpp-registry-service
+        key: account-service
         property: OIDC_CLIENT_SECRET

--- a/openbank-infra/scripts/seed-vault-gaps.sh
+++ b/openbank-infra/scripts/seed-vault-gaps.sh
@@ -2,7 +2,6 @@
 # Seed the Vault KV gaps that keep the `secrets` and `glitchtip` ArgoCD apps
 # Degraded (ExternalSecrets failing with "Secret does not exist"):
 #
-#   openbank/audit-service                   OIDC_CLIENT_SECRET
 #   openbank/keycloak-customers-realm-import openbank-customers-realm.json
 #   openbank/glitchtip                       SECRET_KEY + GRAFANA_API_TOKEN
 #   openbank/alertmanager                    SLACK_WEBHOOK   (needs $SLACK_WEBHOOK)
@@ -21,9 +20,10 @@
 #     ./openbank-infra/scripts/seed-vault-gaps.sh
 #
 # Notes:
-# - audit-service uses the SHARED `openbank-services` realm client, so its
-#   OIDC_CLIENT_SECRET equals the value ESO already syncs for the other
-#   services; we copy it from the live account-service-oidc Secret.
+# - There is no OIDC seeding here any more. Every service authenticates as the
+#   one `openbank-services` realm client and every ExternalSecret reads the one
+#   `openbank/account-service` entry (rules.yaml: oidc_client_secret_storage,
+#   #3485), so a new service needs no KV write at all.
 # - The customers realm JSON comes from the in-repo template (the same source
 #   seed-customers-realm.sh uses — but that script writes to the legacy
 #   `secret/` mount; the ClusterSecretStore reads `openbank/`, used here).
@@ -42,9 +42,11 @@ vault_kv_put() { # key prop=value... (values passed on stdin-safe argv)
     vault kv put "$@" >/dev/null
 }
 
-echo "[1/5] openbank/audit-service (shared openbank-services client secret)"
-OIDC_SECRET="$(kubectl -n accounts get secret account-service-oidc -o jsonpath='{.data.OIDC_CLIENT_SECRET}' | base64 -d)"
-vault_kv_put openbank/audit-service OIDC_CLIENT_SECRET="$OIDC_SECRET"
+echo "[1/5] openbank/audit-service — OBSOLETE, nothing written"
+echo "      audit-service's ExternalSecret now reads the shared openbank/account-service entry"
+echo "      directly (#3485). This step used to COPY that same value into a second KV entry,"
+echo "      which is exactly the duplication the convention removed — writing it again would"
+echo "      recreate an entry no ExternalSecret reads, for the next rotation to miss."
 
 echo "[2/5] openbank/keycloak-customers-realm-import (realm template JSON)"
 kubectl -n vault exec -i openbao-0 -- env VAULT_TOKEN="$VAULT_TOKEN" VAULT_ADDR=http://127.0.0.1:8200 \

--- a/openbank-libs/governance/rules.yaml
+++ b/openbank-libs/governance/rules.yaml
@@ -2075,6 +2075,51 @@ gitops_ref_integrity:
   # naming `Secret payments/vop-oidc`; restored, it passes.
   incident: 2026-07-16
 
+# WHERE the shared M2M client secret is stored. Companion to gitops_ref_integrity above:
+# that rule asks "does the Secret this workload reads get created by anything?"; this one asks
+# "does the KV coordinate that ExternalSecret reads name the entry we agreed on?".
+oidc_client_secret_storage:
+  script: .github/scripts/check-oidc-client-secret-wiring.py
+  wired_into: .github/gates/gates.yaml    # gate id oidc-client-secret-wiring, enforced
+  # THE FACT THE RULE RESTS ON: the `openbank` realm defines exactly ONE confidential M2M client,
+  # `openbank-services` (openbank-infra/gitops/components/keycloak/realm-template.json). Every
+  # service that mints a client-credentials token authenticates as it -- there is no per-service
+  # realm client anywhere. So a per-service KV entry does not hold a per-service credential; it
+  # holds a COPY of the one credential, seeded by copying the shared entry's value
+  # (openbank-infra/scripts/seed-vault-gaps.sh does exactly that for audit-service).
+  #
+  # WHY SHARED WINS, and it is not a majority argument:
+  #   * Blast radius is a property of the CREDENTIAL, not of the KV path. One client secret,
+  #     N copies -> rotating it in Keycloak invalidates all N at once. Splitting the storage
+  #     buys no isolation it does not already lack.
+  #   * Rotation gets WORSE with copies: one Keycloak rotation becomes N KV writes, with nothing
+  #     enumerating N. The ExternalSecrets README documents rotation as a single
+  #     `vault kv put openbank/<entry>` -- true only under this convention.
+  #   * The per-service form requires a seed step per service, and that step is the one that gets
+  #     skipped. It was skipped for delegation-service (#3471: ESO `Secret does not exist`, pod in
+  #     CreateContainerConfigError for its whole life, ~12 alerts naming everything but the cause)
+  #     and it is skipped RIGHT NOW for mcp-service, whose own ExternalSecret says "NOT YET SEEDED"
+  #     while `optional: true` keeps the pod green and its M2M calls unauthenticated.
+  # WHAT IT COSTS: the ability to rotate one service's credential independently. Nothing has that
+  # today and nothing can until per-service realm clients exist -- if they ever do, this rule is
+  # wrong and should key off the client-id, not the path.
+  rule: >-
+    Every ExternalSecret data entry that delivers the shared openbank-services client secret
+    (secretKey or remoteRef.property == OIDC_CLIENT_SECRET) must read remoteRef.key ==
+    shared_kv_entry. A workload needing a DIFFERENT realm client uses a different property name
+    and is out of scope.
+  shared_kv_entry: account-service
+  # The path is historical -- it is the shared entry, not account-service's own (the seeding
+  # runbook has said so since the Vault cutover). Renaming it to something honest, e.g.
+  # openbank-services-oidc, needs an operator `vault kv put` plus a same-PR flip of every
+  # remoteRef.key; it is a one-line change HERE once that write has happened.
+  basis: one_realm_client_implies_one_kv_entry
+  # Shrink-only, and empty on purpose. An entry is an admission that a service reads a different
+  # credential under the same property name; the checker also fails on a STALE entry, so an
+  # exemption cannot quietly become the permanent state.
+  exemptions: {}
+  incident: 2026-08-02
+
 deploy_coverage:
   script: .github/scripts/check-deploy-coverage.sh
   wired_into: .github/workflows/ci.yml   # governance job -> all-green (a REQUIRED check)


### PR DESCRIPTION
## What

One credential, one KV entry — declared in `rules.yaml`, enforced by the gate that already owns this area, and the estate converged onto it.

## The measurement

Re-derived from the **deployed** wiring on `main`, not from grep: workload `OIDC_CLIENT_SECRET` env ref → the Secret it names → the ExternalSecret that creates it → `remoteRef.key`.

```
29  remoteRef.key: account-service      the shared entry
10  remoteRef.key: <their-own>-service  anacredit, audit, balance, campaign, agent,
                                        mcp, sanctions, sdd, statement, tpp-registry
```

(39 rather than the issue's 28: counting ExternalSecret *entries* also catches pid-service, whose `secretKey` is `QUARKUS_OIDC_CREDENTIALS_SECRET` while the remote property is `OIDC_CLIENT_SECRET`. delegation-service is on the shared side since #3471. litellm/glitchtip do not read this property at all — glitchtip authenticates as its own realm client.)

## Why shared, and it is not a majority argument

The `openbank` realm defines exactly **one** confidential M2M client, `openbank-services` (`components/keycloak/realm-template.json`). There is no per-service realm client anywhere, and every one of the 10 per-service services carries `client-id: openbank-services` in its `application.yaml`. So a per-service KV entry never held a per-service credential — it held a hand-seeded **copy** of the one credential. `seed-vault-gaps.sh` made that literal: it populated `openbank/audit-service` by copying the value straight out of `account-service`.

That makes the copies cost without isolation:

- **Blast radius is a property of the credential, not the path.** Rotating `openbank-services` in Keycloak invalidates all N copies at once. Splitting the storage buys no isolation it does not already lack.
- **Rotation gets worse with copies.** One Keycloak rotation becomes N KV writes, with nothing enumerating N. The ExternalSecrets README documented rotation as a single `vault kv put openbank/<entry>` — true only under the shared convention.
- **Each copy needs a manual seed step, and that is the step that goes missing.** delegation-service shipped pointing at an entry nobody had written and sat in `CreateContainerConfigError` for its whole life behind ~12 alerts naming everything except the cause (#3471). `es-mcp-service.yaml` still carried a `NOT YET SEEDED` note — same defect, in its silent form, because `optional: true` kept the pod green while its M2M calls would have gone out unauthenticated.

**What it costs:** the ability to rotate one service's credential independently. Nothing has that today and nothing can until per-service realm clients exist. If they ever do, this rule is wrong and must key off the client-id rather than the path — `rules.yaml` says so in place.

**What it does not fix:** the shared entry's path is literally `account-service`, which reads as service-specific. It is the shared entry (the seeding runbook has said so since the Vault cutover), but the name still misleads. Renaming it to something honest needs an operator `vault kv put` plus a same-PR flip of every `remoteRef.key`; after that write it is a one-line change in `rules.yaml`. **Owner's call — not attempted here.**

## Transition risk

The repoint is a gitops-only change: no Vault write, no Keycloak action, nothing owner-gated.

- Both sides hold the same client's secret, so the delivered bytes are unchanged — except where a copy had drifted (already a stale credential) or was never seeded (mcp-service), where this is a fix.
- Env-mounted values are captured at container start, so nothing changes on a running pod until its next roll. There is no lockout window.
- The one way this could break is `openbank/account-service` not holding `OIDC_CLIENT_SECRET` — contradicted by the 29 workloads already reading it, several money-path. One command settles it if you want it settled: `vault kv get -field=OIDC_CLIENT_SECRET openbank/account-service` (do not echo the value).

Residual, stated plainly: after this, all 39 reads depend on one KV entry rather than 29. That is not a new single point of failure — it is the same one credential — but a bad write to that entry now reaches everything at once.

## The gate

Extends the existing `check-oidc-client-secret-wiring.py` with a fourth check. **No new gate id and no `gates.yaml` edit**: `oidc-client-secret-wiring` already owns this area, and a second copy of one rule is its own defect (#3009).

Scope is by property name — a workload authenticating as a *different* realm client (admin-ui, customer-edge, the WebAuthn client) stores its secret under `client-secret`/`kc-client-secret` and is correctly out of scope.

Falsified in both directions **against the real tree**, not only the synthetic self-test:

| probe | result |
|---|---|
| one manifest reverted to a per-service key, in place | exactly 1 `::error`, naming that file; exit 1 |
| restored from a `cp` backup | clean; exit 0 |
| `rules.yaml` exemption added for that entry | suppressed, prints a `::notice`; exit 0 |
| exemption left behind once the entry conforms again | reported as stale; exit 1 (shrink-only) |
| shared key fed to the checker synthetically | not flagged — the check cannot fail conforming manifests |

`--selftest` also refuses to pass on an empty scan, so a broken probe cannot report the estate clean.

`rules-opa-data.yaml` is unchanged — no `.rego` reads the new key, so no OPA bundle restamps.

## Linked issues

Refs #3485, #3471

The issue stays **open**: the KV-path rename is an owner action, and the acceptance criterion "migrated or explicitly exempted" is met for all 10 while the naming follow-up is not.

## Test plan

- `python3 .github/scripts/check-oidc-client-secret-wiring.py --selftest` → OK
- `python3 .github/scripts/check-oidc-client-secret-wiring.py --enforce` → clean, 39 reads against `account-service`
- `python3 .github/scripts/run-gates.py --group gitops` → the netpol drift gate passes on a committed tree; `loki-rule-load-test` fails locally on `BASE_REF: unbound variable` (CI-supplied), unrelated
- `bash -n openbank-infra/scripts/seed-vault-gaps.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
