### PR TITLE
fix(admin-ui): build with webpack so GlitchTip gets source maps at all

### DIFF
--- a/openbank-admin-ui/CLAUDE.md
+++ b/openbank-admin-ui/CLAUDE.md
@@ -208,10 +208,28 @@ independent review gate.
 ```
 npm run type-check      # tsc --noEmit
 npm run test            # vitest run (includes the graceful-state guard)
-npx next build          # full production build
+npm run build           # full production build — `next build --webpack`, NOT bare `next build`
 npx eslint .            # lint
 ```
 
+- **`next build` under TURBOPACK emits no client source maps, so a crash reporter can never name a
+  line — build with `--webpack`.** Next 16 defaults to Turbopack, and `productionBrowserSourceMaps`
+  is read only by `next/dist/build/webpack*`, so setting it changes nothing: measured on 16.2.12,
+  `.next/static` held **0** `.map` files with the option on or off, against 1056 under
+  `.next/server`. GlitchTip therefore stored every admin-ui error with a minified title and an
+  **empty culprit** — the same information the person reporting it already had (#3235). Nothing goes
+  red about this: the config option is accepted, the upload plugin runs, and it uploads nothing.
+  Two follow-on traps, both measured rather than assumed:
+  - **Webpack rejects extra value exports from a `route.ts` that Turbopack tolerates** (`"X" is not a
+    valid Route export field`) — so the bundler switch surfaces latent route-file violations one
+    build at a time. Exported `type`/`interface` are fine (they are not in the value namespace); a
+    `const`/`function` is not.
+  - **Do NOT reach for `productionBrowserSourceMaps: true` once on webpack.** It forces
+    `devtool: 'source-map'`, appending `//# sourceMappingURL=` to every client chunk (198 of them
+    here) — which, with maps deleted after upload, is a 404 per chunk and a published index of where
+    the sources would be. Leave it unset: @sentry/nextjs then selects `hidden-source-map`, which
+    wrote the same maps for upload and left **0** pointers in the bundle while injecting debug IDs
+    into 354 chunks. Symbolication joins events to bundles on that debug ID, not on the release.
 - **A generator that VALIDATES something must read the schema, never re-type it — and the schema
   itself should have exactly one author.** `scripts/` holds the fleet's derived-data generators
   (`generate-governance.mjs`, `generate-catalog.mjs`, `generate-security-graph.mjs`, …) and several

--- a/openbank-admin-ui/Dockerfile
+++ b/openbank-admin-ui/Dockerfile
@@ -238,6 +238,21 @@ RUN --mount=type=secret,id=glitchtip_token \
     SENTRY_AUTH_TOKEN="$(cat /run/secrets/glitchtip_token 2>/dev/null || true)" \
     npm run build
 
+# Client source maps NEVER enter the runtime image. The upload happens inside `npm run build`
+# above, so by this line the maps have already served their only purpose.
+#
+# @sentry/nextjs deletes them itself (`sourcemaps.deleteSourcemapsAfterUpload`), and that is the
+# path that normally runs — but it is a plugin option, conditional on the plugin being reached at
+# all, and `.next/static` is COPY'd wholesale into the runtime stage two stages down. One skipped
+# hook and every original source of the operator console is downloadable from a public URL. This
+# line makes that outcome structurally impossible instead of configured-away: it costs nothing when
+# the delete already happened, and is the only thing standing between a plugin regression and a full
+# source disclosure. Do not remove it as redundant (#3235).
+RUN echo "maps before prune: $(find .next/static -name '*.map' | wc -l)" \
+ && find .next/static -name '*.map' -type f -delete \
+ && test "$(find .next/static -name '*.map' | wc -l)" -eq 0 \
+ && echo "maps in .next/static after prune: 0"
+
 # ──────────────────────────────────────────────────────────────────────
 # Stage 4: Runtime image — minimal surface, non-root.
 # ──────────────────────────────────────────────────────────────────────

--- a/openbank-admin-ui/next.config.mjs
+++ b/openbank-admin-ui/next.config.mjs
@@ -13,7 +13,13 @@ const securityHeaders = [
 ]
 
 const nextConfig = {
-  productionBrowserSourceMaps: true,
+  // NOTE: `productionBrowserSourceMaps` is deliberately NOT set — see the withSentryConfig block at
+  // the bottom of this file. It forces webpack's `devtool: 'source-map'`, which appends a
+  // `//# sourceMappingURL=` comment to all ~200 client chunks; @sentry/nextjs instead selects
+  // `hidden-source-map`, which writes the same maps for upload but leaves no pointer in the served
+  // bundle. Measured on this tree: with the option set, 198 client chunks advertised a .map that had
+  // already been deleted after upload — a 404 per chunk in devtools, and an index of exactly where
+  // the sources would be if a build ever skipped the delete.
   poweredByHeader: false,
   output: process.env.NEXT_STANDALONE === 'true' ? 'standalone' : undefined,
   // `pg` (node-postgres) uses dynamic requires (pg-native, connection-string).
@@ -48,16 +54,11 @@ const nextConfig = {
   },
 }
 
-// Upload wiring for GlitchTip (#3235) — a PREREQUISITE, not the fix.
-//
-// Measured on Next 16.2.12: this build runs Turbopack, which emits no CLIENT source maps
-// (`.next/static` has zero `.map` files, with or without a token) — `productionBrowserSourceMaps` is
-// a webpack-era option Turbopack ignores, and @sentry/nextjs says as much about its own hooks. So
-// there is currently nothing to upload and this block is a no-op until that is solved.
-//
-// It is here because the token plumbing and the release naming are the parts that CAN be got right
-// now, and because the alternative — wiring it later together with the Turbopack work — is how the
-// release string came to be pinned at a version nobody shipped.
+// Source-map upload to GlitchTip (#3235). This block only does anything under WEBPACK — hence
+// `next build --webpack` in package.json. Turbopack emits no client source maps at all (measured on
+// Next 16.2.12: `.next/static` had 0 `.map` files while `.next/server` had 1056), and
+// `productionBrowserSourceMaps` is read only by `next/dist/build/webpack*`, so under Turbopack there
+// is simply nothing for any plugin to upload.
 //
 // `telemetry: false` is not optional here — the plugin phones home to sentry.io by default, and this
 // estate reports to a self-hosted GlitchTip on an internal origin precisely so it does not.
@@ -70,10 +71,34 @@ export default withSentryConfig(nextConfig, {
   sentryUrl: 'https://glitchtip.open-bank.tech',
   authToken: process.env.SENTRY_AUTH_TOKEN,
   // Must equal what the SDK tags events with, or maps and events never join.
-  release: { name: `openbank-admin-ui@${process.env.BUILD_VERSION || 'dev'}` },
+  //
+  // The three `false`s are a SECURITY choice, not a preference, and each was measured by pointing
+  // `sentryUrl` at a request-logging stand-in and reading the traffic rather than the docs. On the
+  // defaults sentry-cli calls, per webpack compilation:
+  //   POST /api/0/projects/{org}/{proj}/releases/            ← create
+  //   PUT  /api/0/projects/{org}/{proj}/releases/{version}/  ← finalize
+  //   GET  /api/0/organizations/{org}/repos/                 ← setCommits auto-detect
+  // The GlitchTip ingress deliberately allow-lists ingest plus a couple of upload verbs and 404s
+  // the rest of the management API, so honouring those would mean exposing a release path that
+  // also answers DELETE on a host with no identity gate. Turning them off leaves the upload using
+  // ONLY chunk-upload + artifactbundle/assemble — the whole flow fits inside the allow-list, so
+  // nothing here depends on a 404 being tolerated.
+  //
+  // Nothing is lost: GlitchTip's own `assemble_artifacts` does `Release.objects.get_or_create()`
+  // from the bundle manifest, so the release still appears — and symbolication does not depend on
+  // it either way, it joins events to bundles on the injected debug ID
+  // (`javascript_event_processor.transform`).
+  release: {
+    name: `openbank-admin-ui@${process.env.BUILD_VERSION || 'dev'}`,
+    create: false,
+    finalize: false,
+    setCommits: false,
+  },
   sourcemaps: {
     // Uploaded, then deleted from the image: a .map served next to the bundle hands the whole
     // source to anyone who opens the console, which is the opposite of what this is for.
+    // The Dockerfile prunes `.next/static/**/*.map` again after the build, so a regression in this
+    // option cannot become a source disclosure.
     deleteSourcemapsAfterUpload: true,
   },
   silent: true,

--- a/openbank-admin-ui/package.json
+++ b/openbank-admin-ui/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "next dev -p 3000",
     "prebuild": "node scripts/collect-prod-readiness.mjs && node scripts/generate-origination-graph.mjs",
-    "build": "next build",
+    "build": "next build --webpack",
     "start": "next start -p 3000",
     "lint": "eslint .",
     "generate:app-status": "node scripts/generate-app-status.mjs",

--- a/openbank-admin-ui/src/app/api/delegations/projection-health/route.ts
+++ b/openbank-admin-ui/src/app/api/delegations/projection-health/route.ts
@@ -23,7 +23,10 @@ import { inCluster } from '@/lib/discovery'
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
 
-export const DELEGATION_TOPIC = 'openbank.delegation.events'
+// NOT exported: Next only permits its own route fields as exports from a route handler. Turbopack
+// tolerates an extra value export; webpack rejects the whole build with "is not a valid Route
+// export field" — and webpack is the only bundler that emits client source maps (#3235).
+const DELEGATION_TOPIC = 'openbank.delegation.events'
 const TIMEOUT_MS = 4000
 
 function kafkaUiBaseUrl(): string {

--- a/openbank-admin-ui/src/test/sourcemap-upload.guard.test.ts
+++ b/openbank-admin-ui/src/test/sourcemap-upload.guard.test.ts
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+// #3235: GlitchTip captured admin-ui errors and could not name a line — every event stored a
+// minified title and an empty culprit, which is the information the reporter already had.
+//
+// The fix has three parts, and each one is silent when it regresses:
+//
+//   1. the build runs WEBPACK. Turbopack emits no client source maps at all (measured on Next
+//      16.2.12: 0 `.map` files in `.next/static` against 1056 in `.next/server`), and
+//      `productionBrowserSourceMaps` is read only by `next/dist/build/webpack*`. Dropping
+//      `--webpack` therefore does not fail anything — it just quietly removes the input to the
+//      upload, and the console goes back to unattributable frames.
+//   2. `productionBrowserSourceMaps` stays OFF. It forces `devtool: 'source-map'`, which appends
+//      a `//# sourceMappingURL=` comment to every client chunk (198 of them, measured). Sentry's
+//      own default is `hidden-source-map`: same maps on disk for the upload, no pointer in the
+//      served bundle.
+//   3. the image never carries a client `.map`. The Sentry plugin deletes them after upload, but
+//      that is an option on a plugin that may not run; the Dockerfile prunes them again so a
+//      plugin regression cannot become a full source disclosure of the operator console.
+//
+// This guard asserts the CONSTRUCTS, not the presence of strings in the files — the comments in
+// next.config.mjs and the Dockerfile name every one of these settings while explaining them, so a
+// whole-file grep would pass on a tree where the setting itself had been deleted.
+
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'fs'
+import { join } from 'path'
+
+const UI_ROOT = process.cwd()
+
+/** Strip `#` comment lines from a Dockerfile so a rule is never satisfied by prose about it. */
+function stripDockerComments(src: string): string {
+  return src
+    .split('\n')
+    .filter((line) => !/^\s*#/.test(line))
+    .join('\n')
+}
+
+/** Strip `//` line comments from JS so a rule is never satisfied by prose about it. */
+function stripJsLineComments(src: string): string {
+  return src
+    .split('\n')
+    .filter((line) => !/^\s*\/\//.test(line))
+    .join('\n')
+}
+
+describe('client source maps reach GlitchTip and never the browser (#3235)', () => {
+  it('builds with webpack — the only bundler that emits client source maps', () => {
+    const pkg = JSON.parse(readFileSync(join(UI_ROOT, 'package.json'), 'utf8'))
+    expect(pkg.scripts.build).toContain('--webpack')
+  })
+
+  it('does not set productionBrowserSourceMaps, which would publish a sourceMappingURL', () => {
+    const config = stripJsLineComments(readFileSync(join(UI_ROOT, 'next.config.mjs'), 'utf8'))
+    expect(config).not.toMatch(/productionBrowserSourceMaps\s*:/)
+  })
+
+  it('deletes uploaded source maps rather than shipping them', () => {
+    const config = stripJsLineComments(readFileSync(join(UI_ROOT, 'next.config.mjs'), 'utf8'))
+    expect(config).toMatch(/deleteSourcemapsAfterUpload\s*:\s*true/)
+  })
+
+  it('does not ask GlitchTip to create a release — that path is not allow-listed at the edge', () => {
+    const config = stripJsLineComments(readFileSync(join(UI_ROOT, 'next.config.mjs'), 'utf8'))
+    expect(config).toMatch(/create\s*:\s*false/)
+  })
+
+  it('uploads to the self-hosted GlitchTip, never sentry.io, and sends no telemetry', () => {
+    const config = stripJsLineComments(readFileSync(join(UI_ROOT, 'next.config.mjs'), 'utf8'))
+    expect(config).toMatch(/sentryUrl:\s*'https:\/\/glitchtip\.open-bank\.tech'/)
+    expect(config).toMatch(/telemetry\s*:\s*false/)
+  })
+
+  it('prunes every client .map out of the image after the build', () => {
+    const dockerfile = stripDockerComments(readFileSync(join(UI_ROOT, 'Dockerfile'), 'utf8'))
+    // The prune must run in the build stage, i.e. before .next/static is copied to runtime.
+    const pruneIndex = dockerfile.indexOf(".next/static -name '*.map' -type f -delete")
+    const copyIndex = dockerfile.indexOf('COPY --from=build /app/.next/static')
+    expect(pruneIndex).toBeGreaterThan(-1)
+    expect(copyIndex).toBeGreaterThan(-1)
+    expect(pruneIndex).toBeLessThan(copyIndex)
+  })
+})

--- a/openbank-infra/gitops/apps/glitchtip.yaml
+++ b/openbank-infra/gitops/apps/glitchtip.yaml
@@ -140,6 +140,31 @@ spec:
                   # …/files/difs/assemble/ shares this prefix, so it matches too.
                   - path: /api/0/projects/[^/]+/[^/]+/files/(difs|dsyms)/?
                     pathType: ImplementationSpecific
+                  # JS source-map bundles for the admin-ui (#3235). Same shape as the dSYM
+                  # case above and for the same reason: without it, GlitchTip records that
+                  # the console broke and cannot say where — every event stored a minified
+                  # title and an EMPTY culprit, which is the information the user already
+                  # had when they complained.
+                  #
+                  # This ONE path is the whole widening, and it was derived by measurement,
+                  # not by reading docs: pointing the bundler plugin's `sentryUrl` at a
+                  # request-logging stand-in showed sentry-cli 2.58 issuing exactly
+                  #   GET  /api/0/organizations/<org>/chunk-upload/     (already allowed)
+                  #   POST /api/0/organizations/<org>/chunk-upload/     (already allowed)
+                  #   POST /api/0/organizations/<org>/artifactbundle/assemble/   ← 404 here
+                  # The three release calls it also made by default are NOT allowed and must
+                  # not be: `/api/0/projects/<org>/<proj>/releases/<version>/` answers DELETE.
+                  # `release.create: false` in next.config.mjs suppresses them, and nothing is
+                  # lost — GlitchTip's own `assemble_artifacts` does `Release.get_or_create()`
+                  # from the bundle manifest, and symbolication joins on the debug ID anyway
+                  # (`javascript_event_processor.transform`), never on the release.
+                  #
+                  # Anchored to `artifactbundle/assemble` on purpose: it takes a chunk-checksum
+                  # list and needs the same org token the chunk upload already needs, so it adds
+                  # an authenticated write of the same kind rather than new surface. Widening it
+                  # to `/api/0/organizations/[^/]+/` would re-open the management API.
+                  - path: /api/0/organizations/[^/]+/artifactbundle/assemble/?
+                    pathType: ImplementationSpecific
             tls:
               - secretName: glitchtip-tls
                 hosts:


### PR DESCRIPTION
## What

Makes admin-ui produce client source maps at all, and lets the upload reach GlitchTip through the
edge allow-list. Refs #3235.

## The premise, re-verified before changing anything

Against the live GlitchTip database — all 9 issues, oldest 06-26:

```
last_seen     | count | title                                      | culprit
08-02 04:22   |   3   | TypeError: s.map is not a function          | (EMPTY)
07-31 20:01   |  12   | C++ Exception: N12_GLOBAL__N_122ExceptionObj| (EMPTY)
07-11 13:03   |  27   | TypeError: fetch failed                     | (EMPTY)
06-26 08:49   |  16   | Error: Minified React error #31…            | (EMPTY)
```

And on the deployed console: `GET /_next/static/chunks/<chunk>.js.map` → **404**, with **0**
`sourceMappingURL` references in the served bundle. Events arrive; nothing can be attributed.

## Why the existing wiring could not work

#3243 already wired `withSentryConfig`, the auth token as a BuildKit secret, and a release string
derived from `BUILD_VERSION` — and said in its own config comment that it was a no-op. Re-measured
here on Next 16.2.12:

| build | `.map` in `.next/static` | `.map` in `.next/server` |
|---|---|---|
| Turbopack (today's default) | **0** | 1056 |
| webpack | 558 files offered to the uploader | — |

`productionBrowserSourceMaps` appears **only** under `next/dist/build/webpack*`, so under Turbopack
setting it changes nothing. Nothing goes red — the option is accepted, the plugin runs, it uploads
an empty set.

## What changed

- `package.json` — `build: next build --webpack`. `ci.yml`'s **Admin UI** job runs `npm run build`,
  so every PR now compiles the bundler that actually ships.
- `next.config.mjs` — `productionBrowserSourceMaps` stays **unset**, and `release.create` /
  `finalize` / `setCommits` are `false` (see below).
- `Dockerfile` — prunes `.next/static/**/*.map` after the build, before the runtime stage copies it.
- `src/app/api/delegations/projection-health/route.ts` — drops an `export` webpack rejects
  (`"DELEGATION_TOPIC" is not a valid Route export field`); Turbopack tolerates it. Last blocker.
- `openbank-infra/gitops/apps/glitchtip.yaml` — one new allow-listed path.
- `src/test/sourcemap-upload.guard.test.ts` — guard over all of the above.

## What it exposes — explicitly

**Nothing new is served.** Maps go to GlitchTip and not to the browser:

| | before | after |
|---|---|---|
| `.map` files reachable under `/_next/static` | 0 | 0 |
| `sourceMappingURL` in served chunks | 0 | **0** |
| chunks carrying an injected debug ID | 0 | 354 |

`productionBrowserSourceMaps: true` is deliberately **not** used, even though it is the documented
knob. It forces `devtool: 'source-map'`, which appended `//# sourceMappingURL=` to **198** client
chunks — a published index of exactly where the sources would be, plus a 404 per chunk once the maps
are deleted. Left unset, @sentry/nextjs selects `hidden-source-map`: same maps on disk for the
upload, no pointer in the bundle.

Two independent things then stop a map reaching the image: `sourcemaps.deleteSourcemapsAfterUpload`
(the plugin), and the Dockerfile prune (structural). The second exists because the first is an
option on a plugin that may not run, and `.next/static` is copied wholesale into the runtime stage.

## The ingress change, derived by measurement

`glitchtip.open-bank.tech` allow-lists ingest plus two upload verbs and 404s the rest of the
management API (ADR-0234 / #3174). Pointing the plugin's `sentryUrl` at a request-logging stand-in
showed sentry-cli 2.58 issuing, per webpack compilation:

```
POST /api/0/projects/openbank/openbank-admin-ui/releases/            ← create      (404 at edge)
GET  /api/0/organizations/openbank/repos/                            ← setCommits  (404 at edge)
PUT  /api/0/projects/openbank/openbank-admin-ui/releases/<version>/  ← finalize    (404 at edge)
GET  /api/0/organizations/openbank/chunk-upload/                     ← allowed
POST /api/0/organizations/openbank/chunk-upload/          × N        ← allowed
POST /api/0/organizations/openbank/artifactbundle/assemble/          ← 404 at edge
```

Only the last one is added to the allow-list. The three release calls are switched **off** in config
instead of being allow-listed: `/api/0/projects/{org}/{proj}/releases/{version}/` also answers
`DELETE`, and this host has no identity gate. Nothing is lost — GlitchTip's own `assemble_artifacts`
does `Release.objects.get_or_create()` from the bundle manifest, and symbolication joins events to
bundles on the **debug ID**, never on the release (`javascript_event_processor.transform`, read from
the running 6.1.4 image).

Result: the upload path fits entirely inside the allow-list, so nothing depends on a 404 being
tolerated.

## Verification

- Ingress emulator built from the committed path regexes, **validated in both directions first**
  (allow-listed path → 200, management path → 404) before being trusted.
- Full `npm run build` against it with a token set: upload completes, 0 unexpected 404s.
- `npm test` (with `pretest`).
- The new guard was falsified for real mid-work: it went red on a temporary `sentryUrl` pointing at
  localhost, which is exactly the regression it exists to catch.

## What is NOT proven

**No frame has been demonstrated resolving**, and it cannot be from here: the `GLITCHTIP_AUTH_TOKEN`
repo secret **does not exist** (`gh secret list` returns 8 secrets; it is not among them), so every
build to date skipped the upload by design. Creating it needs a GlitchTip login, which is a human
step. Until that exists and one deployed build has uploaded, this PR ships the prerequisites, not
the outcome — #3235 stays open.

## Cost

Compile time on this machine went 12.7s (Turbopack) → 27.5s (webpack) for the client compile. Runtime
is unaffected: same minified output, no maps served.
