### PR TITLE
chore(governance): record agent-service as routed and egress as fully enforced

### DIFF
--- a/docs/compliance/eu-ai-act.md
+++ b/docs/compliance/eu-ai-act.md
@@ -89,25 +89,17 @@ not deployed.
 | Property | As-built value | AI Act / GDPR bearing |
 |---|---|---|
 | Gateway / egress choke point | `litellm` | A single in-cluster choke point exists — the place where residency, redaction and an egress NetworkPolicy CAN be enforced. Whether every caller is actually forced through it is the `Egress enforced` row, not this one. |
-| Egress enforced | `partial` | The gateway is enforced for its own egress, but at least one caller's pod can still reach a provider directly — the choke point is bypassable. |
-| Callers routed through the gateway | `copilot-service`, `control-liveness-sentinel`, `devops-agent`, `docs-truth-agent`, `finops-agent`, `flaky-test-hunter`, `governance-auditor`, `release-steward`, `authz-policy-auditor` | Prompt content from these systems has a single auditable egress path. |
-| Callers NOT routed | `agent-service` | Prompt content from these systems reaches a provider directly. |
+| Egress enforced | `full` | Every LLM caller is network-forced through the gateway; the provider is unreachable directly. |
+| Callers routed through the gateway | `copilot-service`, `agent-service`, `control-liveness-sentinel`, `devops-agent`, `docs-truth-agent`, `finops-agent`, `flaky-test-hunter`, `governance-auditor`, `release-steward`, `authz-policy-auditor` | Prompt content from these systems has a single auditable egress path. |
+| Callers NOT routed | none | Prompt content from these systems reaches a provider directly. |
 | Hosted (external) provider(s) | `deepinfra`, `groq` | Prompt content leaves the platform trust boundary — Art. 10 data governance applies. |
 | Sensitive-data routing | `none` | No routing separates sensitive from non-sensitive prompt data. |
 | Budgets enforced at | `charter` | Cost control only — not a data-governance control. |
 | Fallback | `none` | Single provider; on failure the agent degrades to a deterministic path. |
 
-> ⚠ **Partially closed gap (Art. 10 / GDPR).** A hosted external provider is in use
-> behind an in-cluster gateway, so the provider credential and the egress path are
-> centralised and auditable — but the gateway is not yet the *only* way out. Until
-> `egress_enforced` reads `full`, a caller pod can still reach the provider directly
-> and the choke point is a convention, not a control. Sensitive-data routing remains
-> absent either way. Residency, DPA and the synthetic-data licence position are
-> recorded in **ADR-0175**.
-
 ## Provenance
 
-- Source: `openbank-libs/governance/agents.yaml` (sha256 `7feff1674a83d5ea…`, 15 charters)
+- Source: `openbank-libs/governance/agents.yaml` (sha256 `cc7af1dd6eed558d…`, 15 charters)
 - Source: `openbank-libs/governance/ml-systems.yaml` (sha256 `9cd5cb5b20918520…`, 4 non-agent systems)
 - Related: ADR-0031 (agent governance), ADR-0084 (fraud scoring plane), ADR-0139/0140
   (ML decisioning platform), ADR-0141 (model registry), ADR-0142 (credit decisioning),

--- a/openbank-admin-ui/ai-governance-snapshot.json
+++ b/openbank-admin-ui/ai-governance-snapshot.json
@@ -142,7 +142,7 @@
   "facts": {
     "agentCharters": {
       "source": "openbank-libs/governance/agents.yaml",
-      "sha256": "7feff1674a83d5ea",
+      "sha256": "cc7af1dd6eed558d",
       "count": 15,
       "ids": [
         "compliance-officer",

--- a/openbank-infra/gitops/apps/agent.yaml
+++ b/openbank-infra/gitops/apps/agent.yaml
@@ -1,7 +1,7 @@
 # ArgoCD app for agent-service (admin-UI AI assistant backend, ADR-0031). Deploys
 # the platform-ns Deployment+Service from components/agent. Tracks the live sandbox
-# GitOps branch (same as the other component apps). The GROQ_API_KEY Secret is
-# delivered separately by ESO (es-agent-service in the external-secrets component).
+# GitOps branch (same as the other component apps). The LiteLLM virtual-key Secret
+# is delivered separately by ESO (es-agent-service in the external-secrets component).
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:

--- a/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: account-service
     app.kubernetes.io/part-of: accounts
   annotations:
-    openbank.tech/policy-checksum: "87018ffa052c2227"
+    openbank.tech/policy-checksum: "51089b7a8aecc12f"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -859,15 +859,18 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+    model_gateway_as_built:            # verified 2026-08-03 against gitops AND the running Deployments
       gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
                                        # #2019). Deployed and serving. It is the only workload holding a
                                        # provider key and the only one with an internet egress hole
                                        # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
-                                       # choke point — but see `egress_enforced` before treating it as a
-                                       # *complete* one.
+                                       # choke point — and with agent-service routed (#2209/#3300) and
+                                       # egress-locked (#2210) it is a *complete* one.
       routed:                          # read off the RUNNING Deployments' env, not off the manifests
         - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - agent-service                # AGENT_MODEL_ENDPOINT (#2209, direct GROQ path removed #3300) —
+                                       # verified live 2026-08-03: the running Deployment (image
+                                       # sandbox-b52f989b) resolves http://litellm.ai-platform.svc:4000/v1
         - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
         - devops-agent                 # DEVOPS_MODEL_ENDPOINT
         - docs-truth-agent             # LLM_GATEWAY_URL
@@ -876,15 +879,11 @@ data:
         - governance-auditor           # LLM_GATEWAY_URL
         - release-steward              # LLM_GATEWAY_URL
         - authz-policy-auditor         # LLM_GATEWAY_URL
-      not_routed:
-        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
-                                       # image resolves the baked-in api.groq.com URL until the rebuilt
-                                       # image rolls out. Promote it to `routed` only after re-reading
-                                       # the live Deployment — merged is not deployed.
-      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
-                                       # component still declares policyTypes: [Ingress] only, so the
-                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
-                                       # gated on the agent-service repoint actually being deployed.
+      egress_enforced: full            # ai-platform is egress-locked (litellm is the only internet
+                                       # hole); agent-service too: agent-service-egress-allow-list
+                                       # (#2210) is live in the platform namespace and the pod no longer
+                                       # carries a provider key (#3300), so the gateway cannot be
+                                       # bypassed. Verified live 2026-08-03.
       budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
       providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region

--- a/openbank-infra/gitops/components/accounts/account-service.yaml
+++ b/openbank-infra/gitops/components/accounts/account-service.yaml
@@ -37,7 +37,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-account-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "87018ffa052c2227"
+        openbank.tech/policy-checksum: "51089b7a8aecc12f"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/agent/agent-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/agent/agent-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: agent-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "e0aa410ca8309da1"
+    openbank.tech/policy-checksum: "1af1c79ed839da6b"
 data:
   agents.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -278,15 +278,18 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+    model_gateway_as_built:            # verified 2026-08-03 against gitops AND the running Deployments
       gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
                                        # #2019). Deployed and serving. It is the only workload holding a
                                        # provider key and the only one with an internet egress hole
                                        # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
-                                       # choke point — but see `egress_enforced` before treating it as a
-                                       # *complete* one.
+                                       # choke point — and with agent-service routed (#2209/#3300) and
+                                       # egress-locked (#2210) it is a *complete* one.
       routed:                          # read off the RUNNING Deployments' env, not off the manifests
         - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - agent-service                # AGENT_MODEL_ENDPOINT (#2209, direct GROQ path removed #3300) —
+                                       # verified live 2026-08-03: the running Deployment (image
+                                       # sandbox-b52f989b) resolves http://litellm.ai-platform.svc:4000/v1
         - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
         - devops-agent                 # DEVOPS_MODEL_ENDPOINT
         - docs-truth-agent             # LLM_GATEWAY_URL
@@ -295,15 +298,11 @@ data:
         - governance-auditor           # LLM_GATEWAY_URL
         - release-steward              # LLM_GATEWAY_URL
         - authz-policy-auditor         # LLM_GATEWAY_URL
-      not_routed:
-        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
-                                       # image resolves the baked-in api.groq.com URL until the rebuilt
-                                       # image rolls out. Promote it to `routed` only after re-reading
-                                       # the live Deployment — merged is not deployed.
-      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
-                                       # component still declares policyTypes: [Ingress] only, so the
-                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
-                                       # gated on the agent-service repoint actually being deployed.
+      egress_enforced: full            # ai-platform is egress-locked (litellm is the only internet
+                                       # hole); agent-service too: agent-service-egress-allow-list
+                                       # (#2210) is live in the platform namespace and the pod no longer
+                                       # carries a provider key (#3300), so the gateway cannot be
+                                       # bypassed. Verified live 2026-08-03.
       budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
       providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region

--- a/openbank-infra/gitops/components/agent/agent-service.yaml
+++ b/openbank-infra/gitops/components/agent/agent-service.yaml
@@ -33,7 +33,7 @@ spec:
       annotations:
         # Roll the pod when the OPA policy bundle changes (subPath mounts don't hot-reload).
         # Must match agent-opa-bundle's openbank.tech/policy-checksum (CI verifies, no drift).
-        openbank.tech/policy-checksum: "e0aa410ca8309da1"
+        openbank.tech/policy-checksum: "1af1c79ed839da6b"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/aml/aml-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/aml/aml-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: aml-service
     app.kubernetes.io/part-of: aml
   annotations:
-    openbank.tech/policy-checksum: "f0853fffb25a66b6"
+    openbank.tech/policy-checksum: "2cccf29bcd59fea5"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -832,15 +832,18 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+    model_gateway_as_built:            # verified 2026-08-03 against gitops AND the running Deployments
       gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
                                        # #2019). Deployed and serving. It is the only workload holding a
                                        # provider key and the only one with an internet egress hole
                                        # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
-                                       # choke point — but see `egress_enforced` before treating it as a
-                                       # *complete* one.
+                                       # choke point — and with agent-service routed (#2209/#3300) and
+                                       # egress-locked (#2210) it is a *complete* one.
       routed:                          # read off the RUNNING Deployments' env, not off the manifests
         - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - agent-service                # AGENT_MODEL_ENDPOINT (#2209, direct GROQ path removed #3300) —
+                                       # verified live 2026-08-03: the running Deployment (image
+                                       # sandbox-b52f989b) resolves http://litellm.ai-platform.svc:4000/v1
         - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
         - devops-agent                 # DEVOPS_MODEL_ENDPOINT
         - docs-truth-agent             # LLM_GATEWAY_URL
@@ -849,15 +852,11 @@ data:
         - governance-auditor           # LLM_GATEWAY_URL
         - release-steward              # LLM_GATEWAY_URL
         - authz-policy-auditor         # LLM_GATEWAY_URL
-      not_routed:
-        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
-                                       # image resolves the baked-in api.groq.com URL until the rebuilt
-                                       # image rolls out. Promote it to `routed` only after re-reading
-                                       # the live Deployment — merged is not deployed.
-      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
-                                       # component still declares policyTypes: [Ingress] only, so the
-                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
-                                       # gated on the agent-service repoint actually being deployed.
+      egress_enforced: full            # ai-platform is egress-locked (litellm is the only internet
+                                       # hole); agent-service too: agent-service-egress-allow-list
+                                       # (#2210) is live in the platform namespace and the pod no longer
+                                       # carries a provider key (#3300), so the gateway cannot be
+                                       # bypassed. Verified live 2026-08-03.
       budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
       providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region

--- a/openbank-infra/gitops/components/aml/aml-service.yaml
+++ b/openbank-infra/gitops/components/aml/aml-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-aml-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "f0853fffb25a66b6"
+        openbank.tech/policy-checksum: "2cccf29bcd59fea5"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: anacredit-service
     app.kubernetes.io/part-of: anacredit
   annotations:
-    openbank.tech/policy-checksum: "743e052201b20b0a"
+    openbank.tech/policy-checksum: "bdea669e62623bae"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -802,15 +802,18 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+    model_gateway_as_built:            # verified 2026-08-03 against gitops AND the running Deployments
       gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
                                        # #2019). Deployed and serving. It is the only workload holding a
                                        # provider key and the only one with an internet egress hole
                                        # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
-                                       # choke point — but see `egress_enforced` before treating it as a
-                                       # *complete* one.
+                                       # choke point — and with agent-service routed (#2209/#3300) and
+                                       # egress-locked (#2210) it is a *complete* one.
       routed:                          # read off the RUNNING Deployments' env, not off the manifests
         - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - agent-service                # AGENT_MODEL_ENDPOINT (#2209, direct GROQ path removed #3300) —
+                                       # verified live 2026-08-03: the running Deployment (image
+                                       # sandbox-b52f989b) resolves http://litellm.ai-platform.svc:4000/v1
         - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
         - devops-agent                 # DEVOPS_MODEL_ENDPOINT
         - docs-truth-agent             # LLM_GATEWAY_URL
@@ -819,15 +822,11 @@ data:
         - governance-auditor           # LLM_GATEWAY_URL
         - release-steward              # LLM_GATEWAY_URL
         - authz-policy-auditor         # LLM_GATEWAY_URL
-      not_routed:
-        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
-                                       # image resolves the baked-in api.groq.com URL until the rebuilt
-                                       # image rolls out. Promote it to `routed` only after re-reading
-                                       # the live Deployment — merged is not deployed.
-      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
-                                       # component still declares policyTypes: [Ingress] only, so the
-                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
-                                       # gated on the agent-service repoint actually being deployed.
+      egress_enforced: full            # ai-platform is egress-locked (litellm is the only internet
+                                       # hole); agent-service too: agent-service-egress-allow-list
+                                       # (#2210) is live in the platform namespace and the pod no longer
+                                       # carries a provider key (#3300), so the gateway cannot be
+                                       # bypassed. Verified live 2026-08-03.
       budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
       providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region

--- a/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
@@ -32,7 +32,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-anacredit-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "743e052201b20b0a"
+        openbank.tech/policy-checksum: "bdea669e62623bae"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/ap2/ap2-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/ap2/ap2-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: mcp-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "8fa118af13486c2a"
+    openbank.tech/policy-checksum: "6e5252c8a5fd0c18"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -770,15 +770,18 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+    model_gateway_as_built:            # verified 2026-08-03 against gitops AND the running Deployments
       gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
                                        # #2019). Deployed and serving. It is the only workload holding a
                                        # provider key and the only one with an internet egress hole
                                        # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
-                                       # choke point — but see `egress_enforced` before treating it as a
-                                       # *complete* one.
+                                       # choke point — and with agent-service routed (#2209/#3300) and
+                                       # egress-locked (#2210) it is a *complete* one.
       routed:                          # read off the RUNNING Deployments' env, not off the manifests
         - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - agent-service                # AGENT_MODEL_ENDPOINT (#2209, direct GROQ path removed #3300) —
+                                       # verified live 2026-08-03: the running Deployment (image
+                                       # sandbox-b52f989b) resolves http://litellm.ai-platform.svc:4000/v1
         - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
         - devops-agent                 # DEVOPS_MODEL_ENDPOINT
         - docs-truth-agent             # LLM_GATEWAY_URL
@@ -787,15 +790,11 @@ data:
         - governance-auditor           # LLM_GATEWAY_URL
         - release-steward              # LLM_GATEWAY_URL
         - authz-policy-auditor         # LLM_GATEWAY_URL
-      not_routed:
-        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
-                                       # image resolves the baked-in api.groq.com URL until the rebuilt
-                                       # image rolls out. Promote it to `routed` only after re-reading
-                                       # the live Deployment — merged is not deployed.
-      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
-                                       # component still declares policyTypes: [Ingress] only, so the
-                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
-                                       # gated on the agent-service repoint actually being deployed.
+      egress_enforced: full            # ai-platform is egress-locked (litellm is the only internet
+                                       # hole); agent-service too: agent-service-egress-allow-list
+                                       # (#2210) is live in the platform namespace and the pod no longer
+                                       # carries a provider key (#3300), so the gateway cannot be
+                                       # bypassed. Verified live 2026-08-03.
       budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
       providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region

--- a/openbank-infra/gitops/components/ap2/ap2-service.yaml
+++ b/openbank-infra/gitops/components/ap2/ap2-service.yaml
@@ -30,7 +30,7 @@ spec:
       annotations:
         # Roll the pod when the OPA policy bundle changes (subPath mounts don't hot-reload).
         # Kept in sync by gen-ap2-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "8fa118af13486c2a"
+        openbank.tech/policy-checksum: "6e5252c8a5fd0c18"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/audit/audit-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/audit/audit-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: audit-service
     app.kubernetes.io/part-of: audit
   annotations:
-    openbank.tech/policy-checksum: "4c8793607257549c"
+    openbank.tech/policy-checksum: "732c404a912b3794"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -814,15 +814,18 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+    model_gateway_as_built:            # verified 2026-08-03 against gitops AND the running Deployments
       gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
                                        # #2019). Deployed and serving. It is the only workload holding a
                                        # provider key and the only one with an internet egress hole
                                        # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
-                                       # choke point — but see `egress_enforced` before treating it as a
-                                       # *complete* one.
+                                       # choke point — and with agent-service routed (#2209/#3300) and
+                                       # egress-locked (#2210) it is a *complete* one.
       routed:                          # read off the RUNNING Deployments' env, not off the manifests
         - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - agent-service                # AGENT_MODEL_ENDPOINT (#2209, direct GROQ path removed #3300) —
+                                       # verified live 2026-08-03: the running Deployment (image
+                                       # sandbox-b52f989b) resolves http://litellm.ai-platform.svc:4000/v1
         - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
         - devops-agent                 # DEVOPS_MODEL_ENDPOINT
         - docs-truth-agent             # LLM_GATEWAY_URL
@@ -831,15 +834,11 @@ data:
         - governance-auditor           # LLM_GATEWAY_URL
         - release-steward              # LLM_GATEWAY_URL
         - authz-policy-auditor         # LLM_GATEWAY_URL
-      not_routed:
-        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
-                                       # image resolves the baked-in api.groq.com URL until the rebuilt
-                                       # image rolls out. Promote it to `routed` only after re-reading
-                                       # the live Deployment — merged is not deployed.
-      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
-                                       # component still declares policyTypes: [Ingress] only, so the
-                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
-                                       # gated on the agent-service repoint actually being deployed.
+      egress_enforced: full            # ai-platform is egress-locked (litellm is the only internet
+                                       # hole); agent-service too: agent-service-egress-allow-list
+                                       # (#2210) is live in the platform namespace and the pod no longer
+                                       # carries a provider key (#3300), so the gateway cannot be
+                                       # bypassed. Verified live 2026-08-03.
       budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
       providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region

--- a/openbank-infra/gitops/components/audit/audit-service.yaml
+++ b/openbank-infra/gitops/components/audit/audit-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-audit-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "4c8793607257549c"
+        openbank.tech/policy-checksum: "732c404a912b3794"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: balance-service
     app.kubernetes.io/part-of: balances
   annotations:
-    openbank.tech/policy-checksum: "95c5b50695bdc6ec"
+    openbank.tech/policy-checksum: "eb149a4623b1c995"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -903,15 +903,18 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+    model_gateway_as_built:            # verified 2026-08-03 against gitops AND the running Deployments
       gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
                                        # #2019). Deployed and serving. It is the only workload holding a
                                        # provider key and the only one with an internet egress hole
                                        # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
-                                       # choke point — but see `egress_enforced` before treating it as a
-                                       # *complete* one.
+                                       # choke point — and with agent-service routed (#2209/#3300) and
+                                       # egress-locked (#2210) it is a *complete* one.
       routed:                          # read off the RUNNING Deployments' env, not off the manifests
         - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - agent-service                # AGENT_MODEL_ENDPOINT (#2209, direct GROQ path removed #3300) —
+                                       # verified live 2026-08-03: the running Deployment (image
+                                       # sandbox-b52f989b) resolves http://litellm.ai-platform.svc:4000/v1
         - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
         - devops-agent                 # DEVOPS_MODEL_ENDPOINT
         - docs-truth-agent             # LLM_GATEWAY_URL
@@ -920,15 +923,11 @@ data:
         - governance-auditor           # LLM_GATEWAY_URL
         - release-steward              # LLM_GATEWAY_URL
         - authz-policy-auditor         # LLM_GATEWAY_URL
-      not_routed:
-        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
-                                       # image resolves the baked-in api.groq.com URL until the rebuilt
-                                       # image rolls out. Promote it to `routed` only after re-reading
-                                       # the live Deployment — merged is not deployed.
-      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
-                                       # component still declares policyTypes: [Ingress] only, so the
-                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
-                                       # gated on the agent-service repoint actually being deployed.
+      egress_enforced: full            # ai-platform is egress-locked (litellm is the only internet
+                                       # hole); agent-service too: agent-service-egress-allow-list
+                                       # (#2210) is live in the platform namespace and the pod no longer
+                                       # carries a provider key (#3300), so the gateway cannot be
+                                       # bypassed. Verified live 2026-08-03.
       budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
       providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region

--- a/openbank-infra/gitops/components/balances/balance-service.yaml
+++ b/openbank-infra/gitops/components/balances/balance-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-balance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "95c5b50695bdc6ec"
+        openbank.tech/policy-checksum: "eb149a4623b1c995"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: billing-service
     app.kubernetes.io/part-of: billing
   annotations:
-    openbank.tech/policy-checksum: "0ed1121118c04aba"
+    openbank.tech/policy-checksum: "4d5e30121c7164c5"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -808,15 +808,18 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+    model_gateway_as_built:            # verified 2026-08-03 against gitops AND the running Deployments
       gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
                                        # #2019). Deployed and serving. It is the only workload holding a
                                        # provider key and the only one with an internet egress hole
                                        # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
-                                       # choke point — but see `egress_enforced` before treating it as a
-                                       # *complete* one.
+                                       # choke point — and with agent-service routed (#2209/#3300) and
+                                       # egress-locked (#2210) it is a *complete* one.
       routed:                          # read off the RUNNING Deployments' env, not off the manifests
         - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - agent-service                # AGENT_MODEL_ENDPOINT (#2209, direct GROQ path removed #3300) —
+                                       # verified live 2026-08-03: the running Deployment (image
+                                       # sandbox-b52f989b) resolves http://litellm.ai-platform.svc:4000/v1
         - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
         - devops-agent                 # DEVOPS_MODEL_ENDPOINT
         - docs-truth-agent             # LLM_GATEWAY_URL
@@ -825,15 +828,11 @@ data:
         - governance-auditor           # LLM_GATEWAY_URL
         - release-steward              # LLM_GATEWAY_URL
         - authz-policy-auditor         # LLM_GATEWAY_URL
-      not_routed:
-        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
-                                       # image resolves the baked-in api.groq.com URL until the rebuilt
-                                       # image rolls out. Promote it to `routed` only after re-reading
-                                       # the live Deployment — merged is not deployed.
-      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
-                                       # component still declares policyTypes: [Ingress] only, so the
-                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
-                                       # gated on the agent-service repoint actually being deployed.
+      egress_enforced: full            # ai-platform is egress-locked (litellm is the only internet
+                                       # hole); agent-service too: agent-service-egress-allow-list
+                                       # (#2210) is live in the platform namespace and the pod no longer
+                                       # carries a provider key (#3300), so the gateway cannot be
+                                       # bypassed. Verified live 2026-08-03.
       budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
       providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region

--- a/openbank-infra/gitops/components/billing/billing-service.yaml
+++ b/openbank-infra/gitops/components/billing/billing-service.yaml
@@ -27,7 +27,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-billing-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "0ed1121118c04aba"
+        openbank.tech/policy-checksum: "4d5e30121c7164c5"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/campaign/campaign-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/campaign/campaign-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: campaign-service
     app.kubernetes.io/part-of: campaign
   annotations:
-    openbank.tech/policy-checksum: "dca6e5cb1c79c7b1"
+    openbank.tech/policy-checksum: "e486100deb6dc9c2"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -829,15 +829,18 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+    model_gateway_as_built:            # verified 2026-08-03 against gitops AND the running Deployments
       gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
                                        # #2019). Deployed and serving. It is the only workload holding a
                                        # provider key and the only one with an internet egress hole
                                        # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
-                                       # choke point — but see `egress_enforced` before treating it as a
-                                       # *complete* one.
+                                       # choke point — and with agent-service routed (#2209/#3300) and
+                                       # egress-locked (#2210) it is a *complete* one.
       routed:                          # read off the RUNNING Deployments' env, not off the manifests
         - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - agent-service                # AGENT_MODEL_ENDPOINT (#2209, direct GROQ path removed #3300) —
+                                       # verified live 2026-08-03: the running Deployment (image
+                                       # sandbox-b52f989b) resolves http://litellm.ai-platform.svc:4000/v1
         - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
         - devops-agent                 # DEVOPS_MODEL_ENDPOINT
         - docs-truth-agent             # LLM_GATEWAY_URL
@@ -846,15 +849,11 @@ data:
         - governance-auditor           # LLM_GATEWAY_URL
         - release-steward              # LLM_GATEWAY_URL
         - authz-policy-auditor         # LLM_GATEWAY_URL
-      not_routed:
-        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
-                                       # image resolves the baked-in api.groq.com URL until the rebuilt
-                                       # image rolls out. Promote it to `routed` only after re-reading
-                                       # the live Deployment — merged is not deployed.
-      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
-                                       # component still declares policyTypes: [Ingress] only, so the
-                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
-                                       # gated on the agent-service repoint actually being deployed.
+      egress_enforced: full            # ai-platform is egress-locked (litellm is the only internet
+                                       # hole); agent-service too: agent-service-egress-allow-list
+                                       # (#2210) is live in the platform namespace and the pod no longer
+                                       # carries a provider key (#3300), so the gateway cannot be
+                                       # bypassed. Verified live 2026-08-03.
       budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
       providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region

--- a/openbank-infra/gitops/components/campaign/campaign-service.yaml
+++ b/openbank-infra/gitops/components/campaign/campaign-service.yaml
@@ -25,7 +25,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-campaign-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "dca6e5cb1c79c7b1"
+        openbank.tech/policy-checksum: "e486100deb6dc9c2"
       labels:
         app.kubernetes.io/name: campaign-service
         app.kubernetes.io/part-of: campaign

--- a/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: consent-service
     app.kubernetes.io/part-of: consent
   annotations:
-    openbank.tech/policy-checksum: "a6813f6436c88169"
+    openbank.tech/policy-checksum: "62b39e7178916525"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -878,15 +878,18 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+    model_gateway_as_built:            # verified 2026-08-03 against gitops AND the running Deployments
       gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
                                        # #2019). Deployed and serving. It is the only workload holding a
                                        # provider key and the only one with an internet egress hole
                                        # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
-                                       # choke point — but see `egress_enforced` before treating it as a
-                                       # *complete* one.
+                                       # choke point — and with agent-service routed (#2209/#3300) and
+                                       # egress-locked (#2210) it is a *complete* one.
       routed:                          # read off the RUNNING Deployments' env, not off the manifests
         - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - agent-service                # AGENT_MODEL_ENDPOINT (#2209, direct GROQ path removed #3300) —
+                                       # verified live 2026-08-03: the running Deployment (image
+                                       # sandbox-b52f989b) resolves http://litellm.ai-platform.svc:4000/v1
         - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
         - devops-agent                 # DEVOPS_MODEL_ENDPOINT
         - docs-truth-agent             # LLM_GATEWAY_URL
@@ -895,15 +898,11 @@ data:
         - governance-auditor           # LLM_GATEWAY_URL
         - release-steward              # LLM_GATEWAY_URL
         - authz-policy-auditor         # LLM_GATEWAY_URL
-      not_routed:
-        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
-                                       # image resolves the baked-in api.groq.com URL until the rebuilt
-                                       # image rolls out. Promote it to `routed` only after re-reading
-                                       # the live Deployment — merged is not deployed.
-      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
-                                       # component still declares policyTypes: [Ingress] only, so the
-                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
-                                       # gated on the agent-service repoint actually being deployed.
+      egress_enforced: full            # ai-platform is egress-locked (litellm is the only internet
+                                       # hole); agent-service too: agent-service-egress-allow-list
+                                       # (#2210) is live in the platform namespace and the pod no longer
+                                       # carries a provider key (#3300), so the gateway cannot be
+                                       # bypassed. Verified live 2026-08-03.
       budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
       providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region

--- a/openbank-infra/gitops/components/consent/consent-service.yaml
+++ b/openbank-infra/gitops/components/consent/consent-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-consent-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "a6813f6436c88169"
+        openbank.tech/policy-checksum: "62b39e7178916525"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: copilot-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "916dd2f78b56858b"
+    openbank.tech/policy-checksum: "e4eb78bb83612fbf"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -894,15 +894,18 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+    model_gateway_as_built:            # verified 2026-08-03 against gitops AND the running Deployments
       gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
                                        # #2019). Deployed and serving. It is the only workload holding a
                                        # provider key and the only one with an internet egress hole
                                        # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
-                                       # choke point — but see `egress_enforced` before treating it as a
-                                       # *complete* one.
+                                       # choke point — and with agent-service routed (#2209/#3300) and
+                                       # egress-locked (#2210) it is a *complete* one.
       routed:                          # read off the RUNNING Deployments' env, not off the manifests
         - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - agent-service                # AGENT_MODEL_ENDPOINT (#2209, direct GROQ path removed #3300) —
+                                       # verified live 2026-08-03: the running Deployment (image
+                                       # sandbox-b52f989b) resolves http://litellm.ai-platform.svc:4000/v1
         - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
         - devops-agent                 # DEVOPS_MODEL_ENDPOINT
         - docs-truth-agent             # LLM_GATEWAY_URL
@@ -911,15 +914,11 @@ data:
         - governance-auditor           # LLM_GATEWAY_URL
         - release-steward              # LLM_GATEWAY_URL
         - authz-policy-auditor         # LLM_GATEWAY_URL
-      not_routed:
-        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
-                                       # image resolves the baked-in api.groq.com URL until the rebuilt
-                                       # image rolls out. Promote it to `routed` only after re-reading
-                                       # the live Deployment — merged is not deployed.
-      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
-                                       # component still declares policyTypes: [Ingress] only, so the
-                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
-                                       # gated on the agent-service repoint actually being deployed.
+      egress_enforced: full            # ai-platform is egress-locked (litellm is the only internet
+                                       # hole); agent-service too: agent-service-egress-allow-list
+                                       # (#2210) is live in the platform namespace and the pod no longer
+                                       # carries a provider key (#3300), so the gateway cannot be
+                                       # bypassed. Verified live 2026-08-03.
       budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
       providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region

--- a/openbank-infra/gitops/components/copilot/copilot-service.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-service.yaml
@@ -29,7 +29,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-copilot-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "916dd2f78b56858b"
+        openbank.tech/policy-checksum: "e4eb78bb83612fbf"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: customer-edge
     app.kubernetes.io/part-of: customer-edge
   annotations:
-    openbank.tech/policy-checksum: "6c500a6f3b582bd1"
+    openbank.tech/policy-checksum: "9d47f5dd25907fa1"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1134,15 +1134,18 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+    model_gateway_as_built:            # verified 2026-08-03 against gitops AND the running Deployments
       gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
                                        # #2019). Deployed and serving. It is the only workload holding a
                                        # provider key and the only one with an internet egress hole
                                        # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
-                                       # choke point — but see `egress_enforced` before treating it as a
-                                       # *complete* one.
+                                       # choke point — and with agent-service routed (#2209/#3300) and
+                                       # egress-locked (#2210) it is a *complete* one.
       routed:                          # read off the RUNNING Deployments' env, not off the manifests
         - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - agent-service                # AGENT_MODEL_ENDPOINT (#2209, direct GROQ path removed #3300) —
+                                       # verified live 2026-08-03: the running Deployment (image
+                                       # sandbox-b52f989b) resolves http://litellm.ai-platform.svc:4000/v1
         - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
         - devops-agent                 # DEVOPS_MODEL_ENDPOINT
         - docs-truth-agent             # LLM_GATEWAY_URL
@@ -1151,15 +1154,11 @@ data:
         - governance-auditor           # LLM_GATEWAY_URL
         - release-steward              # LLM_GATEWAY_URL
         - authz-policy-auditor         # LLM_GATEWAY_URL
-      not_routed:
-        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
-                                       # image resolves the baked-in api.groq.com URL until the rebuilt
-                                       # image rolls out. Promote it to `routed` only after re-reading
-                                       # the live Deployment — merged is not deployed.
-      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
-                                       # component still declares policyTypes: [Ingress] only, so the
-                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
-                                       # gated on the agent-service repoint actually being deployed.
+      egress_enforced: full            # ai-platform is egress-locked (litellm is the only internet
+                                       # hole); agent-service too: agent-service-egress-allow-list
+                                       # (#2210) is live in the platform namespace and the pod no longer
+                                       # carries a provider key (#3300), so the gateway cannot be
+                                       # bypassed. Verified live 2026-08-03.
       budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
       providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region

--- a/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
@@ -65,7 +65,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-customer-edge-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "6c500a6f3b582bd1"
+        openbank.tech/policy-checksum: "9d47f5dd25907fa1"
     spec:
       # Dedicated SA so EKS Pod Identity can hand the edge (and ONLY the edge) the
       # feedback-screenshots S3 role — ADR-0192, openbank-infra/aws/envs/sandbox-platform/

--- a/openbank-infra/gitops/components/delegation/delegation-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/delegation/delegation-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: delegation-service
     app.kubernetes.io/part-of: delegation
   annotations:
-    openbank.tech/policy-checksum: "cc7404ce5b8ac81c"
+    openbank.tech/policy-checksum: "691be5f2b5156777"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -849,15 +849,18 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+    model_gateway_as_built:            # verified 2026-08-03 against gitops AND the running Deployments
       gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
                                        # #2019). Deployed and serving. It is the only workload holding a
                                        # provider key and the only one with an internet egress hole
                                        # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
-                                       # choke point — but see `egress_enforced` before treating it as a
-                                       # *complete* one.
+                                       # choke point — and with agent-service routed (#2209/#3300) and
+                                       # egress-locked (#2210) it is a *complete* one.
       routed:                          # read off the RUNNING Deployments' env, not off the manifests
         - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - agent-service                # AGENT_MODEL_ENDPOINT (#2209, direct GROQ path removed #3300) —
+                                       # verified live 2026-08-03: the running Deployment (image
+                                       # sandbox-b52f989b) resolves http://litellm.ai-platform.svc:4000/v1
         - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
         - devops-agent                 # DEVOPS_MODEL_ENDPOINT
         - docs-truth-agent             # LLM_GATEWAY_URL
@@ -866,15 +869,11 @@ data:
         - governance-auditor           # LLM_GATEWAY_URL
         - release-steward              # LLM_GATEWAY_URL
         - authz-policy-auditor         # LLM_GATEWAY_URL
-      not_routed:
-        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
-                                       # image resolves the baked-in api.groq.com URL until the rebuilt
-                                       # image rolls out. Promote it to `routed` only after re-reading
-                                       # the live Deployment — merged is not deployed.
-      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
-                                       # component still declares policyTypes: [Ingress] only, so the
-                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
-                                       # gated on the agent-service repoint actually being deployed.
+      egress_enforced: full            # ai-platform is egress-locked (litellm is the only internet
+                                       # hole); agent-service too: agent-service-egress-allow-list
+                                       # (#2210) is live in the platform namespace and the pod no longer
+                                       # carries a provider key (#3300), so the gateway cannot be
+                                       # bypassed. Verified live 2026-08-03.
       budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
       providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region

--- a/openbank-infra/gitops/components/delegation/delegation-service.yaml
+++ b/openbank-infra/gitops/components/delegation/delegation-service.yaml
@@ -42,7 +42,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-delegation-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "cc7404ce5b8ac81c"
+        openbank.tech/policy-checksum: "691be5f2b5156777"
       labels:
         app.kubernetes.io/name: delegation-service
         app.kubernetes.io/part-of: delegation

--- a/openbank-infra/gitops/components/dispute-service/dispute-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/dispute-service/dispute-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: dispute-service
     app.kubernetes.io/part-of: dispute
   annotations:
-    openbank.tech/policy-checksum: "488a3be284d0a60f"
+    openbank.tech/policy-checksum: "048464e70295f2ae"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -944,15 +944,18 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+    model_gateway_as_built:            # verified 2026-08-03 against gitops AND the running Deployments
       gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
                                        # #2019). Deployed and serving. It is the only workload holding a
                                        # provider key and the only one with an internet egress hole
                                        # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
-                                       # choke point — but see `egress_enforced` before treating it as a
-                                       # *complete* one.
+                                       # choke point — and with agent-service routed (#2209/#3300) and
+                                       # egress-locked (#2210) it is a *complete* one.
       routed:                          # read off the RUNNING Deployments' env, not off the manifests
         - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - agent-service                # AGENT_MODEL_ENDPOINT (#2209, direct GROQ path removed #3300) —
+                                       # verified live 2026-08-03: the running Deployment (image
+                                       # sandbox-b52f989b) resolves http://litellm.ai-platform.svc:4000/v1
         - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
         - devops-agent                 # DEVOPS_MODEL_ENDPOINT
         - docs-truth-agent             # LLM_GATEWAY_URL
@@ -961,15 +964,11 @@ data:
         - governance-auditor           # LLM_GATEWAY_URL
         - release-steward              # LLM_GATEWAY_URL
         - authz-policy-auditor         # LLM_GATEWAY_URL
-      not_routed:
-        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
-                                       # image resolves the baked-in api.groq.com URL until the rebuilt
-                                       # image rolls out. Promote it to `routed` only after re-reading
-                                       # the live Deployment — merged is not deployed.
-      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
-                                       # component still declares policyTypes: [Ingress] only, so the
-                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
-                                       # gated on the agent-service repoint actually being deployed.
+      egress_enforced: full            # ai-platform is egress-locked (litellm is the only internet
+                                       # hole); agent-service too: agent-service-egress-allow-list
+                                       # (#2210) is live in the platform namespace and the pod no longer
+                                       # carries a provider key (#3300), so the gateway cannot be
+                                       # bypassed. Verified live 2026-08-03.
       budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
       providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region

--- a/openbank-infra/gitops/components/dispute-service/dispute-service.yaml
+++ b/openbank-infra/gitops/components/dispute-service/dispute-service.yaml
@@ -15,7 +15,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-dispute-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "488a3be284d0a60f"
+        openbank.tech/policy-checksum: "048464e70295f2ae"
       labels: {app.kubernetes.io/name: dispute-service, app.kubernetes.io/part-of: dispute}
     spec:
       securityContext:

--- a/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: document-service
     app.kubernetes.io/part-of: documents
   annotations:
-    openbank.tech/policy-checksum: "6c500a6f3b582bd1"
+    openbank.tech/policy-checksum: "9d47f5dd25907fa1"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1134,15 +1134,18 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+    model_gateway_as_built:            # verified 2026-08-03 against gitops AND the running Deployments
       gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
                                        # #2019). Deployed and serving. It is the only workload holding a
                                        # provider key and the only one with an internet egress hole
                                        # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
-                                       # choke point — but see `egress_enforced` before treating it as a
-                                       # *complete* one.
+                                       # choke point — and with agent-service routed (#2209/#3300) and
+                                       # egress-locked (#2210) it is a *complete* one.
       routed:                          # read off the RUNNING Deployments' env, not off the manifests
         - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - agent-service                # AGENT_MODEL_ENDPOINT (#2209, direct GROQ path removed #3300) —
+                                       # verified live 2026-08-03: the running Deployment (image
+                                       # sandbox-b52f989b) resolves http://litellm.ai-platform.svc:4000/v1
         - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
         - devops-agent                 # DEVOPS_MODEL_ENDPOINT
         - docs-truth-agent             # LLM_GATEWAY_URL
@@ -1151,15 +1154,11 @@ data:
         - governance-auditor           # LLM_GATEWAY_URL
         - release-steward              # LLM_GATEWAY_URL
         - authz-policy-auditor         # LLM_GATEWAY_URL
-      not_routed:
-        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
-                                       # image resolves the baked-in api.groq.com URL until the rebuilt
-                                       # image rolls out. Promote it to `routed` only after re-reading
-                                       # the live Deployment — merged is not deployed.
-      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
-                                       # component still declares policyTypes: [Ingress] only, so the
-                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
-                                       # gated on the agent-service repoint actually being deployed.
+      egress_enforced: full            # ai-platform is egress-locked (litellm is the only internet
+                                       # hole); agent-service too: agent-service-egress-allow-list
+                                       # (#2210) is live in the platform namespace and the pod no longer
+                                       # carries a provider key (#3300), so the gateway cannot be
+                                       # bypassed. Verified live 2026-08-03.
       budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
       providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region

--- a/openbank-infra/gitops/components/document-service/document-service-service.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-service.yaml
@@ -43,7 +43,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-document-service-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "6c500a6f3b582bd1"
+        openbank.tech/policy-checksum: "9d47f5dd25907fa1"
     spec:
       # ADR-0162 D4 (continued): a dedicated SA (not `default`) is what OpenBao's Kubernetes-auth
       # role `document-service-signing` is bound to — least-privilege, one identity per consumer.

--- a/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fraud-service
     app.kubernetes.io/part-of: fraud
   annotations:
-    openbank.tech/policy-checksum: "a91c2ce3b8bc3ab2"
+    openbank.tech/policy-checksum: "1e7d5d4b28429cdf"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -819,15 +819,18 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+    model_gateway_as_built:            # verified 2026-08-03 against gitops AND the running Deployments
       gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
                                        # #2019). Deployed and serving. It is the only workload holding a
                                        # provider key and the only one with an internet egress hole
                                        # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
-                                       # choke point — but see `egress_enforced` before treating it as a
-                                       # *complete* one.
+                                       # choke point — and with agent-service routed (#2209/#3300) and
+                                       # egress-locked (#2210) it is a *complete* one.
       routed:                          # read off the RUNNING Deployments' env, not off the manifests
         - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - agent-service                # AGENT_MODEL_ENDPOINT (#2209, direct GROQ path removed #3300) —
+                                       # verified live 2026-08-03: the running Deployment (image
+                                       # sandbox-b52f989b) resolves http://litellm.ai-platform.svc:4000/v1
         - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
         - devops-agent                 # DEVOPS_MODEL_ENDPOINT
         - docs-truth-agent             # LLM_GATEWAY_URL
@@ -836,15 +839,11 @@ data:
         - governance-auditor           # LLM_GATEWAY_URL
         - release-steward              # LLM_GATEWAY_URL
         - authz-policy-auditor         # LLM_GATEWAY_URL
-      not_routed:
-        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
-                                       # image resolves the baked-in api.groq.com URL until the rebuilt
-                                       # image rolls out. Promote it to `routed` only after re-reading
-                                       # the live Deployment — merged is not deployed.
-      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
-                                       # component still declares policyTypes: [Ingress] only, so the
-                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
-                                       # gated on the agent-service repoint actually being deployed.
+      egress_enforced: full            # ai-platform is egress-locked (litellm is the only internet
+                                       # hole); agent-service too: agent-service-egress-allow-list
+                                       # (#2210) is live in the platform namespace and the pod no longer
+                                       # carries a provider key (#3300), so the gateway cannot be
+                                       # bypassed. Verified live 2026-08-03.
       budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
       providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region

--- a/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
@@ -23,7 +23,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fraud-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "a91c2ce3b8bc3ab2"
+        openbank.tech/policy-checksum: "1e7d5d4b28429cdf"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fx-service
     app.kubernetes.io/part-of: fx
   annotations:
-    openbank.tech/policy-checksum: "445a656924cffb31"
+    openbank.tech/policy-checksum: "74774c8fed322618"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -870,15 +870,18 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+    model_gateway_as_built:            # verified 2026-08-03 against gitops AND the running Deployments
       gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
                                        # #2019). Deployed and serving. It is the only workload holding a
                                        # provider key and the only one with an internet egress hole
                                        # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
-                                       # choke point — but see `egress_enforced` before treating it as a
-                                       # *complete* one.
+                                       # choke point — and with agent-service routed (#2209/#3300) and
+                                       # egress-locked (#2210) it is a *complete* one.
       routed:                          # read off the RUNNING Deployments' env, not off the manifests
         - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - agent-service                # AGENT_MODEL_ENDPOINT (#2209, direct GROQ path removed #3300) —
+                                       # verified live 2026-08-03: the running Deployment (image
+                                       # sandbox-b52f989b) resolves http://litellm.ai-platform.svc:4000/v1
         - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
         - devops-agent                 # DEVOPS_MODEL_ENDPOINT
         - docs-truth-agent             # LLM_GATEWAY_URL
@@ -887,15 +890,11 @@ data:
         - governance-auditor           # LLM_GATEWAY_URL
         - release-steward              # LLM_GATEWAY_URL
         - authz-policy-auditor         # LLM_GATEWAY_URL
-      not_routed:
-        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
-                                       # image resolves the baked-in api.groq.com URL until the rebuilt
-                                       # image rolls out. Promote it to `routed` only after re-reading
-                                       # the live Deployment — merged is not deployed.
-      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
-                                       # component still declares policyTypes: [Ingress] only, so the
-                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
-                                       # gated on the agent-service repoint actually being deployed.
+      egress_enforced: full            # ai-platform is egress-locked (litellm is the only internet
+                                       # hole); agent-service too: agent-service-egress-allow-list
+                                       # (#2210) is live in the platform namespace and the pod no longer
+                                       # carries a provider key (#3300), so the gateway cannot be
+                                       # bypassed. Verified live 2026-08-03.
       budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
       providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region

--- a/openbank-infra/gitops/components/fx-service/fx-service.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fx-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "445a656924cffb31"
+        openbank.tech/policy-checksum: "74774c8fed322618"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: interest-service
     app.kubernetes.io/part-of: interest
   annotations:
-    openbank.tech/policy-checksum: "095cbc2a932f316b"
+    openbank.tech/policy-checksum: "3fc06f26018d9927"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -804,15 +804,18 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+    model_gateway_as_built:            # verified 2026-08-03 against gitops AND the running Deployments
       gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
                                        # #2019). Deployed and serving. It is the only workload holding a
                                        # provider key and the only one with an internet egress hole
                                        # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
-                                       # choke point — but see `egress_enforced` before treating it as a
-                                       # *complete* one.
+                                       # choke point — and with agent-service routed (#2209/#3300) and
+                                       # egress-locked (#2210) it is a *complete* one.
       routed:                          # read off the RUNNING Deployments' env, not off the manifests
         - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - agent-service                # AGENT_MODEL_ENDPOINT (#2209, direct GROQ path removed #3300) —
+                                       # verified live 2026-08-03: the running Deployment (image
+                                       # sandbox-b52f989b) resolves http://litellm.ai-platform.svc:4000/v1
         - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
         - devops-agent                 # DEVOPS_MODEL_ENDPOINT
         - docs-truth-agent             # LLM_GATEWAY_URL
@@ -821,15 +824,11 @@ data:
         - governance-auditor           # LLM_GATEWAY_URL
         - release-steward              # LLM_GATEWAY_URL
         - authz-policy-auditor         # LLM_GATEWAY_URL
-      not_routed:
-        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
-                                       # image resolves the baked-in api.groq.com URL until the rebuilt
-                                       # image rolls out. Promote it to `routed` only after re-reading
-                                       # the live Deployment — merged is not deployed.
-      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
-                                       # component still declares policyTypes: [Ingress] only, so the
-                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
-                                       # gated on the agent-service repoint actually being deployed.
+      egress_enforced: full            # ai-platform is egress-locked (litellm is the only internet
+                                       # hole); agent-service too: agent-service-egress-allow-list
+                                       # (#2210) is live in the platform namespace and the pod no longer
+                                       # carries a provider key (#3300), so the gateway cannot be
+                                       # bypassed. Verified live 2026-08-03.
       budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
       providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region

--- a/openbank-infra/gitops/components/interest-service/interest-service.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-service.yaml
@@ -16,7 +16,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-interest-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "095cbc2a932f316b"
+        openbank.tech/policy-checksum: "3fc06f26018d9927"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/kyc/kyc-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/kyc/kyc-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: kyc-service
     app.kubernetes.io/part-of: kyc
   annotations:
-    openbank.tech/policy-checksum: "7bc7623cfee8c806"
+    openbank.tech/policy-checksum: "359c5f0d1d4e0587"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -832,15 +832,18 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+    model_gateway_as_built:            # verified 2026-08-03 against gitops AND the running Deployments
       gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
                                        # #2019). Deployed and serving. It is the only workload holding a
                                        # provider key and the only one with an internet egress hole
                                        # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
-                                       # choke point — but see `egress_enforced` before treating it as a
-                                       # *complete* one.
+                                       # choke point — and with agent-service routed (#2209/#3300) and
+                                       # egress-locked (#2210) it is a *complete* one.
       routed:                          # read off the RUNNING Deployments' env, not off the manifests
         - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - agent-service                # AGENT_MODEL_ENDPOINT (#2209, direct GROQ path removed #3300) —
+                                       # verified live 2026-08-03: the running Deployment (image
+                                       # sandbox-b52f989b) resolves http://litellm.ai-platform.svc:4000/v1
         - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
         - devops-agent                 # DEVOPS_MODEL_ENDPOINT
         - docs-truth-agent             # LLM_GATEWAY_URL
@@ -849,15 +852,11 @@ data:
         - governance-auditor           # LLM_GATEWAY_URL
         - release-steward              # LLM_GATEWAY_URL
         - authz-policy-auditor         # LLM_GATEWAY_URL
-      not_routed:
-        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
-                                       # image resolves the baked-in api.groq.com URL until the rebuilt
-                                       # image rolls out. Promote it to `routed` only after re-reading
-                                       # the live Deployment — merged is not deployed.
-      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
-                                       # component still declares policyTypes: [Ingress] only, so the
-                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
-                                       # gated on the agent-service repoint actually being deployed.
+      egress_enforced: full            # ai-platform is egress-locked (litellm is the only internet
+                                       # hole); agent-service too: agent-service-egress-allow-list
+                                       # (#2210) is live in the platform namespace and the pod no longer
+                                       # carries a provider key (#3300), so the gateway cannot be
+                                       # bypassed. Verified live 2026-08-03.
       budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
       providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region

--- a/openbank-infra/gitops/components/kyc/kyc-service.yaml
+++ b/openbank-infra/gitops/components/kyc/kyc-service.yaml
@@ -48,7 +48,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-kyc-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "7bc7623cfee8c806"
+        openbank.tech/policy-checksum: "359c5f0d1d4e0587"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: ledger-service
     app.kubernetes.io/part-of: ledger
   annotations:
-    openbank.tech/policy-checksum: "6af703996e489937"
+    openbank.tech/policy-checksum: "b21ea31d477ed355"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -917,15 +917,18 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+    model_gateway_as_built:            # verified 2026-08-03 against gitops AND the running Deployments
       gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
                                        # #2019). Deployed and serving. It is the only workload holding a
                                        # provider key and the only one with an internet egress hole
                                        # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
-                                       # choke point — but see `egress_enforced` before treating it as a
-                                       # *complete* one.
+                                       # choke point — and with agent-service routed (#2209/#3300) and
+                                       # egress-locked (#2210) it is a *complete* one.
       routed:                          # read off the RUNNING Deployments' env, not off the manifests
         - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - agent-service                # AGENT_MODEL_ENDPOINT (#2209, direct GROQ path removed #3300) —
+                                       # verified live 2026-08-03: the running Deployment (image
+                                       # sandbox-b52f989b) resolves http://litellm.ai-platform.svc:4000/v1
         - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
         - devops-agent                 # DEVOPS_MODEL_ENDPOINT
         - docs-truth-agent             # LLM_GATEWAY_URL
@@ -934,15 +937,11 @@ data:
         - governance-auditor           # LLM_GATEWAY_URL
         - release-steward              # LLM_GATEWAY_URL
         - authz-policy-auditor         # LLM_GATEWAY_URL
-      not_routed:
-        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
-                                       # image resolves the baked-in api.groq.com URL until the rebuilt
-                                       # image rolls out. Promote it to `routed` only after re-reading
-                                       # the live Deployment — merged is not deployed.
-      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
-                                       # component still declares policyTypes: [Ingress] only, so the
-                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
-                                       # gated on the agent-service repoint actually being deployed.
+      egress_enforced: full            # ai-platform is egress-locked (litellm is the only internet
+                                       # hole); agent-service too: agent-service-egress-allow-list
+                                       # (#2210) is live in the platform namespace and the pod no longer
+                                       # carries a provider key (#3300), so the gateway cannot be
+                                       # bypassed. Verified live 2026-08-03.
       budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
       providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region

--- a/openbank-infra/gitops/components/ledger/ledger-service.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-service.yaml
@@ -38,7 +38,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-ledger-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "6af703996e489937"
+        openbank.tech/policy-checksum: "b21ea31d477ed355"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: lending-service
     app.kubernetes.io/part-of: lending
   annotations:
-    openbank.tech/policy-checksum: "3a301190dbcdc205"
+    openbank.tech/policy-checksum: "ec1d5ea1d093f683"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -912,15 +912,18 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+    model_gateway_as_built:            # verified 2026-08-03 against gitops AND the running Deployments
       gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
                                        # #2019). Deployed and serving. It is the only workload holding a
                                        # provider key and the only one with an internet egress hole
                                        # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
-                                       # choke point — but see `egress_enforced` before treating it as a
-                                       # *complete* one.
+                                       # choke point — and with agent-service routed (#2209/#3300) and
+                                       # egress-locked (#2210) it is a *complete* one.
       routed:                          # read off the RUNNING Deployments' env, not off the manifests
         - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - agent-service                # AGENT_MODEL_ENDPOINT (#2209, direct GROQ path removed #3300) —
+                                       # verified live 2026-08-03: the running Deployment (image
+                                       # sandbox-b52f989b) resolves http://litellm.ai-platform.svc:4000/v1
         - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
         - devops-agent                 # DEVOPS_MODEL_ENDPOINT
         - docs-truth-agent             # LLM_GATEWAY_URL
@@ -929,15 +932,11 @@ data:
         - governance-auditor           # LLM_GATEWAY_URL
         - release-steward              # LLM_GATEWAY_URL
         - authz-policy-auditor         # LLM_GATEWAY_URL
-      not_routed:
-        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
-                                       # image resolves the baked-in api.groq.com URL until the rebuilt
-                                       # image rolls out. Promote it to `routed` only after re-reading
-                                       # the live Deployment — merged is not deployed.
-      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
-                                       # component still declares policyTypes: [Ingress] only, so the
-                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
-                                       # gated on the agent-service repoint actually being deployed.
+      egress_enforced: full            # ai-platform is egress-locked (litellm is the only internet
+                                       # hole); agent-service too: agent-service-egress-allow-list
+                                       # (#2210) is live in the platform namespace and the pod no longer
+                                       # carries a provider key (#3300), so the gateway cannot be
+                                       # bypassed. Verified live 2026-08-03.
       budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
       providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region

--- a/openbank-infra/gitops/components/lending/lending-service.yaml
+++ b/openbank-infra/gitops/components/lending/lending-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-lending-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "3a301190dbcdc205"
+        openbank.tech/policy-checksum: "ec1d5ea1d093f683"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/mcp/mcp-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/mcp/mcp-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: mcp-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "8fa118af13486c2a"
+    openbank.tech/policy-checksum: "6e5252c8a5fd0c18"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -770,15 +770,18 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+    model_gateway_as_built:            # verified 2026-08-03 against gitops AND the running Deployments
       gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
                                        # #2019). Deployed and serving. It is the only workload holding a
                                        # provider key and the only one with an internet egress hole
                                        # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
-                                       # choke point — but see `egress_enforced` before treating it as a
-                                       # *complete* one.
+                                       # choke point — and with agent-service routed (#2209/#3300) and
+                                       # egress-locked (#2210) it is a *complete* one.
       routed:                          # read off the RUNNING Deployments' env, not off the manifests
         - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - agent-service                # AGENT_MODEL_ENDPOINT (#2209, direct GROQ path removed #3300) —
+                                       # verified live 2026-08-03: the running Deployment (image
+                                       # sandbox-b52f989b) resolves http://litellm.ai-platform.svc:4000/v1
         - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
         - devops-agent                 # DEVOPS_MODEL_ENDPOINT
         - docs-truth-agent             # LLM_GATEWAY_URL
@@ -787,15 +790,11 @@ data:
         - governance-auditor           # LLM_GATEWAY_URL
         - release-steward              # LLM_GATEWAY_URL
         - authz-policy-auditor         # LLM_GATEWAY_URL
-      not_routed:
-        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
-                                       # image resolves the baked-in api.groq.com URL until the rebuilt
-                                       # image rolls out. Promote it to `routed` only after re-reading
-                                       # the live Deployment — merged is not deployed.
-      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
-                                       # component still declares policyTypes: [Ingress] only, so the
-                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
-                                       # gated on the agent-service repoint actually being deployed.
+      egress_enforced: full            # ai-platform is egress-locked (litellm is the only internet
+                                       # hole); agent-service too: agent-service-egress-allow-list
+                                       # (#2210) is live in the platform namespace and the pod no longer
+                                       # carries a provider key (#3300), so the gateway cannot be
+                                       # bypassed. Verified live 2026-08-03.
       budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
       providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region

--- a/openbank-infra/gitops/components/mcp/mcp-service.yaml
+++ b/openbank-infra/gitops/components/mcp/mcp-service.yaml
@@ -29,7 +29,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-mcp-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "8fa118af13486c2a"
+        openbank.tech/policy-checksum: "6e5252c8a5fd0c18"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: notification-service
     app.kubernetes.io/part-of: notifications
   annotations:
-    openbank.tech/policy-checksum: "6c500a6f3b582bd1"
+    openbank.tech/policy-checksum: "9d47f5dd25907fa1"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1134,15 +1134,18 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+    model_gateway_as_built:            # verified 2026-08-03 against gitops AND the running Deployments
       gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
                                        # #2019). Deployed and serving. It is the only workload holding a
                                        # provider key and the only one with an internet egress hole
                                        # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
-                                       # choke point — but see `egress_enforced` before treating it as a
-                                       # *complete* one.
+                                       # choke point — and with agent-service routed (#2209/#3300) and
+                                       # egress-locked (#2210) it is a *complete* one.
       routed:                          # read off the RUNNING Deployments' env, not off the manifests
         - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - agent-service                # AGENT_MODEL_ENDPOINT (#2209, direct GROQ path removed #3300) —
+                                       # verified live 2026-08-03: the running Deployment (image
+                                       # sandbox-b52f989b) resolves http://litellm.ai-platform.svc:4000/v1
         - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
         - devops-agent                 # DEVOPS_MODEL_ENDPOINT
         - docs-truth-agent             # LLM_GATEWAY_URL
@@ -1151,15 +1154,11 @@ data:
         - governance-auditor           # LLM_GATEWAY_URL
         - release-steward              # LLM_GATEWAY_URL
         - authz-policy-auditor         # LLM_GATEWAY_URL
-      not_routed:
-        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
-                                       # image resolves the baked-in api.groq.com URL until the rebuilt
-                                       # image rolls out. Promote it to `routed` only after re-reading
-                                       # the live Deployment — merged is not deployed.
-      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
-                                       # component still declares policyTypes: [Ingress] only, so the
-                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
-                                       # gated on the agent-service repoint actually being deployed.
+      egress_enforced: full            # ai-platform is egress-locked (litellm is the only internet
+                                       # hole); agent-service too: agent-service-egress-allow-list
+                                       # (#2210) is live in the platform namespace and the pod no longer
+                                       # carries a provider key (#3300), so the gateway cannot be
+                                       # bypassed. Verified live 2026-08-03.
       budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
       providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region

--- a/openbank-infra/gitops/components/notifications/notification-service.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service.yaml
@@ -39,7 +39,7 @@ spec:
       annotations:
         # Rolls the Deployment when the OPA policy bundle changes (subPath mounts don't
         # hot-reload). Kept in sync by gen-notification-opa-bundle.sh.
-        openbank.tech/policy-checksum: "6c500a6f3b582bd1"
+        openbank.tech/policy-checksum: "9d47f5dd25907fa1"
       labels:
         app.kubernetes.io/name: notification-service
         app.kubernetes.io/part-of: notifications

--- a/openbank-infra/gitops/components/party/party-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/party/party-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: party-service
     app.kubernetes.io/part-of: party
   annotations:
-    openbank.tech/policy-checksum: "d6822a2c3c58a209"
+    openbank.tech/policy-checksum: "011f7bfb190e940e"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -841,15 +841,18 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+    model_gateway_as_built:            # verified 2026-08-03 against gitops AND the running Deployments
       gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
                                        # #2019). Deployed and serving. It is the only workload holding a
                                        # provider key and the only one with an internet egress hole
                                        # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
-                                       # choke point — but see `egress_enforced` before treating it as a
-                                       # *complete* one.
+                                       # choke point — and with agent-service routed (#2209/#3300) and
+                                       # egress-locked (#2210) it is a *complete* one.
       routed:                          # read off the RUNNING Deployments' env, not off the manifests
         - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - agent-service                # AGENT_MODEL_ENDPOINT (#2209, direct GROQ path removed #3300) —
+                                       # verified live 2026-08-03: the running Deployment (image
+                                       # sandbox-b52f989b) resolves http://litellm.ai-platform.svc:4000/v1
         - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
         - devops-agent                 # DEVOPS_MODEL_ENDPOINT
         - docs-truth-agent             # LLM_GATEWAY_URL
@@ -858,15 +861,11 @@ data:
         - governance-auditor           # LLM_GATEWAY_URL
         - release-steward              # LLM_GATEWAY_URL
         - authz-policy-auditor         # LLM_GATEWAY_URL
-      not_routed:
-        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
-                                       # image resolves the baked-in api.groq.com URL until the rebuilt
-                                       # image rolls out. Promote it to `routed` only after re-reading
-                                       # the live Deployment — merged is not deployed.
-      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
-                                       # component still declares policyTypes: [Ingress] only, so the
-                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
-                                       # gated on the agent-service repoint actually being deployed.
+      egress_enforced: full            # ai-platform is egress-locked (litellm is the only internet
+                                       # hole); agent-service too: agent-service-egress-allow-list
+                                       # (#2210) is live in the platform namespace and the pod no longer
+                                       # carries a provider key (#3300), so the gateway cannot be
+                                       # bypassed. Verified live 2026-08-03.
       budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
       providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region

--- a/openbank-infra/gitops/components/party/party-service.yaml
+++ b/openbank-infra/gitops/components/party/party-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-party-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "d6822a2c3c58a209"
+        openbank.tech/policy-checksum: "011f7bfb190e940e"
       labels:
         app.kubernetes.io/name: party-service
         app.kubernetes.io/part-of: party

--- a/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: card-issuance-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "6740ceff5d58e70c"
+    openbank.tech/policy-checksum: "8e290ced4a34dfd9"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -825,15 +825,18 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+    model_gateway_as_built:            # verified 2026-08-03 against gitops AND the running Deployments
       gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
                                        # #2019). Deployed and serving. It is the only workload holding a
                                        # provider key and the only one with an internet egress hole
                                        # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
-                                       # choke point — but see `egress_enforced` before treating it as a
-                                       # *complete* one.
+                                       # choke point — and with agent-service routed (#2209/#3300) and
+                                       # egress-locked (#2210) it is a *complete* one.
       routed:                          # read off the RUNNING Deployments' env, not off the manifests
         - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - agent-service                # AGENT_MODEL_ENDPOINT (#2209, direct GROQ path removed #3300) —
+                                       # verified live 2026-08-03: the running Deployment (image
+                                       # sandbox-b52f989b) resolves http://litellm.ai-platform.svc:4000/v1
         - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
         - devops-agent                 # DEVOPS_MODEL_ENDPOINT
         - docs-truth-agent             # LLM_GATEWAY_URL
@@ -842,15 +845,11 @@ data:
         - governance-auditor           # LLM_GATEWAY_URL
         - release-steward              # LLM_GATEWAY_URL
         - authz-policy-auditor         # LLM_GATEWAY_URL
-      not_routed:
-        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
-                                       # image resolves the baked-in api.groq.com URL until the rebuilt
-                                       # image rolls out. Promote it to `routed` only after re-reading
-                                       # the live Deployment — merged is not deployed.
-      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
-                                       # component still declares policyTypes: [Ingress] only, so the
-                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
-                                       # gated on the agent-service repoint actually being deployed.
+      egress_enforced: full            # ai-platform is egress-locked (litellm is the only internet
+                                       # hole); agent-service too: agent-service-egress-allow-list
+                                       # (#2210) is live in the platform namespace and the pod no longer
+                                       # carries a provider key (#3300), so the gateway cannot be
+                                       # bypassed. Verified live 2026-08-03.
       budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
       providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region

--- a/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: clearing-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "f0e58852856c4e93"
+    openbank.tech/policy-checksum: "a6d9c99b49a173ca"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -862,15 +862,18 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+    model_gateway_as_built:            # verified 2026-08-03 against gitops AND the running Deployments
       gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
                                        # #2019). Deployed and serving. It is the only workload holding a
                                        # provider key and the only one with an internet egress hole
                                        # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
-                                       # choke point — but see `egress_enforced` before treating it as a
-                                       # *complete* one.
+                                       # choke point — and with agent-service routed (#2209/#3300) and
+                                       # egress-locked (#2210) it is a *complete* one.
       routed:                          # read off the RUNNING Deployments' env, not off the manifests
         - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - agent-service                # AGENT_MODEL_ENDPOINT (#2209, direct GROQ path removed #3300) —
+                                       # verified live 2026-08-03: the running Deployment (image
+                                       # sandbox-b52f989b) resolves http://litellm.ai-platform.svc:4000/v1
         - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
         - devops-agent                 # DEVOPS_MODEL_ENDPOINT
         - docs-truth-agent             # LLM_GATEWAY_URL
@@ -879,15 +882,11 @@ data:
         - governance-auditor           # LLM_GATEWAY_URL
         - release-steward              # LLM_GATEWAY_URL
         - authz-policy-auditor         # LLM_GATEWAY_URL
-      not_routed:
-        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
-                                       # image resolves the baked-in api.groq.com URL until the rebuilt
-                                       # image rolls out. Promote it to `routed` only after re-reading
-                                       # the live Deployment — merged is not deployed.
-      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
-                                       # component still declares policyTypes: [Ingress] only, so the
-                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
-                                       # gated on the agent-service repoint actually being deployed.
+      egress_enforced: full            # ai-platform is egress-locked (litellm is the only internet
+                                       # hole); agent-service too: agent-service-egress-allow-list
+                                       # (#2210) is live in the platform namespace and the pod no longer
+                                       # carries a provider key (#3300), so the gateway cannot be
+                                       # bypassed. Verified live 2026-08-03.
       budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
       providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region

--- a/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: domestic-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "b1a329472478538a"
+    openbank.tech/policy-checksum: "193d1a5e57165f3d"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -847,15 +847,18 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+    model_gateway_as_built:            # verified 2026-08-03 against gitops AND the running Deployments
       gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
                                        # #2019). Deployed and serving. It is the only workload holding a
                                        # provider key and the only one with an internet egress hole
                                        # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
-                                       # choke point — but see `egress_enforced` before treating it as a
-                                       # *complete* one.
+                                       # choke point — and with agent-service routed (#2209/#3300) and
+                                       # egress-locked (#2210) it is a *complete* one.
       routed:                          # read off the RUNNING Deployments' env, not off the manifests
         - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - agent-service                # AGENT_MODEL_ENDPOINT (#2209, direct GROQ path removed #3300) —
+                                       # verified live 2026-08-03: the running Deployment (image
+                                       # sandbox-b52f989b) resolves http://litellm.ai-platform.svc:4000/v1
         - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
         - devops-agent                 # DEVOPS_MODEL_ENDPOINT
         - docs-truth-agent             # LLM_GATEWAY_URL
@@ -864,15 +867,11 @@ data:
         - governance-auditor           # LLM_GATEWAY_URL
         - release-steward              # LLM_GATEWAY_URL
         - authz-policy-auditor         # LLM_GATEWAY_URL
-      not_routed:
-        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
-                                       # image resolves the baked-in api.groq.com URL until the rebuilt
-                                       # image rolls out. Promote it to `routed` only after re-reading
-                                       # the live Deployment — merged is not deployed.
-      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
-                                       # component still declares policyTypes: [Ingress] only, so the
-                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
-                                       # gated on the agent-service repoint actually being deployed.
+      egress_enforced: full            # ai-platform is egress-locked (litellm is the only internet
+                                       # hole); agent-service too: agent-service-egress-allow-list
+                                       # (#2210) is live in the platform namespace and the pod no longer
+                                       # carries a provider key (#3300), so the gateway cannot be
+                                       # bypassed. Verified live 2026-08-03.
       budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
       providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region

--- a/openbank-infra/gitops/components/payments/payments-services.yaml
+++ b/openbank-infra/gitops/components/payments/payments-services.yaml
@@ -42,7 +42,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-transaction-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "c8c28bcd3ec74908" # transaction-opa-bundle
+        openbank.tech/policy-checksum: "7f276c2513f5bc6c" # transaction-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -375,7 +375,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-payment-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "95808b195cdb58fd"
+        openbank.tech/policy-checksum: "2081113dfe9205db"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -729,7 +729,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-domestic-payment-opa-bundle.sh via the trailing marker
         # comment (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "b1a329472478538a" # domestic-payment-opa-bundle
+        openbank.tech/policy-checksum: "193d1a5e57165f3d" # domestic-payment-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1053,7 +1053,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-instant-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "ff3101d1abe4abfd"
+        openbank.tech/policy-checksum: "dc8607fcb58f901b"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1369,7 +1369,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-clearing-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "f0e58852856c4e93" # clearing-opa-bundle
+        openbank.tech/policy-checksum: "a6d9c99b49a173ca" # clearing-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1658,7 +1658,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (ADR-0034). Value is stamped by
         # gen-standing-order-opa-bundle.sh — do not hand-edit.
-        openbank.tech/policy-checksum: "057a2489c43caed2" # standing-order-opa-bundle
+        openbank.tech/policy-checksum: "49612a47ae7553e9" # standing-order-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1911,7 +1911,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-card-issuance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "6740ceff5d58e70c"
+        openbank.tech/policy-checksum: "8e290ced4a34dfd9"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2181,7 +2181,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-settlement-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "bfbcf6f49d72baa5" # settlement-opa-bundle
+        openbank.tech/policy-checksum: "9ecda4e330d15410" # settlement-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2582,7 +2582,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-swift-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "883b6a6b80ed2a7d"
+        openbank.tech/policy-checksum: "6078a53fa6447a43"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2896,7 +2896,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-vop-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "da939ca353e0ee8a"
+        openbank.tech/policy-checksum: "7dbf7f001c049dd5"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-instant
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "ff3101d1abe4abfd"
+    openbank.tech/policy-checksum: "dc8607fcb58f901b"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -820,15 +820,18 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+    model_gateway_as_built:            # verified 2026-08-03 against gitops AND the running Deployments
       gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
                                        # #2019). Deployed and serving. It is the only workload holding a
                                        # provider key and the only one with an internet egress hole
                                        # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
-                                       # choke point — but see `egress_enforced` before treating it as a
-                                       # *complete* one.
+                                       # choke point — and with agent-service routed (#2209/#3300) and
+                                       # egress-locked (#2210) it is a *complete* one.
       routed:                          # read off the RUNNING Deployments' env, not off the manifests
         - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - agent-service                # AGENT_MODEL_ENDPOINT (#2209, direct GROQ path removed #3300) —
+                                       # verified live 2026-08-03: the running Deployment (image
+                                       # sandbox-b52f989b) resolves http://litellm.ai-platform.svc:4000/v1
         - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
         - devops-agent                 # DEVOPS_MODEL_ENDPOINT
         - docs-truth-agent             # LLM_GATEWAY_URL
@@ -837,15 +840,11 @@ data:
         - governance-auditor           # LLM_GATEWAY_URL
         - release-steward              # LLM_GATEWAY_URL
         - authz-policy-auditor         # LLM_GATEWAY_URL
-      not_routed:
-        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
-                                       # image resolves the baked-in api.groq.com URL until the rebuilt
-                                       # image rolls out. Promote it to `routed` only after re-reading
-                                       # the live Deployment — merged is not deployed.
-      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
-                                       # component still declares policyTypes: [Ingress] only, so the
-                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
-                                       # gated on the agent-service repoint actually being deployed.
+      egress_enforced: full            # ai-platform is egress-locked (litellm is the only internet
+                                       # hole); agent-service too: agent-service-egress-allow-list
+                                       # (#2210) is live in the platform namespace and the pod no longer
+                                       # carries a provider key (#3300), so the gateway cannot be
+                                       # bypassed. Verified live 2026-08-03.
       budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
       providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region

--- a/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "95808b195cdb58fd"
+    openbank.tech/policy-checksum: "2081113dfe9205db"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -841,15 +841,18 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+    model_gateway_as_built:            # verified 2026-08-03 against gitops AND the running Deployments
       gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
                                        # #2019). Deployed and serving. It is the only workload holding a
                                        # provider key and the only one with an internet egress hole
                                        # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
-                                       # choke point — but see `egress_enforced` before treating it as a
-                                       # *complete* one.
+                                       # choke point — and with agent-service routed (#2209/#3300) and
+                                       # egress-locked (#2210) it is a *complete* one.
       routed:                          # read off the RUNNING Deployments' env, not off the manifests
         - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - agent-service                # AGENT_MODEL_ENDPOINT (#2209, direct GROQ path removed #3300) —
+                                       # verified live 2026-08-03: the running Deployment (image
+                                       # sandbox-b52f989b) resolves http://litellm.ai-platform.svc:4000/v1
         - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
         - devops-agent                 # DEVOPS_MODEL_ENDPOINT
         - docs-truth-agent             # LLM_GATEWAY_URL
@@ -858,15 +861,11 @@ data:
         - governance-auditor           # LLM_GATEWAY_URL
         - release-steward              # LLM_GATEWAY_URL
         - authz-policy-auditor         # LLM_GATEWAY_URL
-      not_routed:
-        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
-                                       # image resolves the baked-in api.groq.com URL until the rebuilt
-                                       # image rolls out. Promote it to `routed` only after re-reading
-                                       # the live Deployment — merged is not deployed.
-      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
-                                       # component still declares policyTypes: [Ingress] only, so the
-                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
-                                       # gated on the agent-service repoint actually being deployed.
+      egress_enforced: full            # ai-platform is egress-locked (litellm is the only internet
+                                       # hole); agent-service too: agent-service-egress-allow-list
+                                       # (#2210) is live in the platform namespace and the pod no longer
+                                       # carries a provider key (#3300), so the gateway cannot be
+                                       # bypassed. Verified live 2026-08-03.
       budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
       providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region

--- a/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: settlement-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "bfbcf6f49d72baa5"
+    openbank.tech/policy-checksum: "9ecda4e330d15410"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -821,15 +821,18 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+    model_gateway_as_built:            # verified 2026-08-03 against gitops AND the running Deployments
       gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
                                        # #2019). Deployed and serving. It is the only workload holding a
                                        # provider key and the only one with an internet egress hole
                                        # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
-                                       # choke point — but see `egress_enforced` before treating it as a
-                                       # *complete* one.
+                                       # choke point — and with agent-service routed (#2209/#3300) and
+                                       # egress-locked (#2210) it is a *complete* one.
       routed:                          # read off the RUNNING Deployments' env, not off the manifests
         - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - agent-service                # AGENT_MODEL_ENDPOINT (#2209, direct GROQ path removed #3300) —
+                                       # verified live 2026-08-03: the running Deployment (image
+                                       # sandbox-b52f989b) resolves http://litellm.ai-platform.svc:4000/v1
         - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
         - devops-agent                 # DEVOPS_MODEL_ENDPOINT
         - docs-truth-agent             # LLM_GATEWAY_URL
@@ -838,15 +841,11 @@ data:
         - governance-auditor           # LLM_GATEWAY_URL
         - release-steward              # LLM_GATEWAY_URL
         - authz-policy-auditor         # LLM_GATEWAY_URL
-      not_routed:
-        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
-                                       # image resolves the baked-in api.groq.com URL until the rebuilt
-                                       # image rolls out. Promote it to `routed` only after re-reading
-                                       # the live Deployment — merged is not deployed.
-      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
-                                       # component still declares policyTypes: [Ingress] only, so the
-                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
-                                       # gated on the agent-service repoint actually being deployed.
+      egress_enforced: full            # ai-platform is egress-locked (litellm is the only internet
+                                       # hole); agent-service too: agent-service-egress-allow-list
+                                       # (#2210) is live in the platform namespace and the pod no longer
+                                       # carries a provider key (#3300), so the gateway cannot be
+                                       # bypassed. Verified live 2026-08-03.
       budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
       providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region

--- a/openbank-infra/gitops/components/payments/standing-order-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/standing-order-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: standing-order-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "057a2489c43caed2"
+    openbank.tech/policy-checksum: "49612a47ae7553e9"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -806,15 +806,18 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+    model_gateway_as_built:            # verified 2026-08-03 against gitops AND the running Deployments
       gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
                                        # #2019). Deployed and serving. It is the only workload holding a
                                        # provider key and the only one with an internet egress hole
                                        # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
-                                       # choke point — but see `egress_enforced` before treating it as a
-                                       # *complete* one.
+                                       # choke point — and with agent-service routed (#2209/#3300) and
+                                       # egress-locked (#2210) it is a *complete* one.
       routed:                          # read off the RUNNING Deployments' env, not off the manifests
         - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - agent-service                # AGENT_MODEL_ENDPOINT (#2209, direct GROQ path removed #3300) —
+                                       # verified live 2026-08-03: the running Deployment (image
+                                       # sandbox-b52f989b) resolves http://litellm.ai-platform.svc:4000/v1
         - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
         - devops-agent                 # DEVOPS_MODEL_ENDPOINT
         - docs-truth-agent             # LLM_GATEWAY_URL
@@ -823,15 +826,11 @@ data:
         - governance-auditor           # LLM_GATEWAY_URL
         - release-steward              # LLM_GATEWAY_URL
         - authz-policy-auditor         # LLM_GATEWAY_URL
-      not_routed:
-        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
-                                       # image resolves the baked-in api.groq.com URL until the rebuilt
-                                       # image rolls out. Promote it to `routed` only after re-reading
-                                       # the live Deployment — merged is not deployed.
-      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
-                                       # component still declares policyTypes: [Ingress] only, so the
-                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
-                                       # gated on the agent-service repoint actually being deployed.
+      egress_enforced: full            # ai-platform is egress-locked (litellm is the only internet
+                                       # hole); agent-service too: agent-service-egress-allow-list
+                                       # (#2210) is live in the platform namespace and the pod no longer
+                                       # carries a provider key (#3300), so the gateway cannot be
+                                       # bypassed. Verified live 2026-08-03.
       budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
       providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region

--- a/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: swift-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "883b6a6b80ed2a7d"
+    openbank.tech/policy-checksum: "6078a53fa6447a43"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -824,15 +824,18 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+    model_gateway_as_built:            # verified 2026-08-03 against gitops AND the running Deployments
       gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
                                        # #2019). Deployed and serving. It is the only workload holding a
                                        # provider key and the only one with an internet egress hole
                                        # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
-                                       # choke point — but see `egress_enforced` before treating it as a
-                                       # *complete* one.
+                                       # choke point — and with agent-service routed (#2209/#3300) and
+                                       # egress-locked (#2210) it is a *complete* one.
       routed:                          # read off the RUNNING Deployments' env, not off the manifests
         - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - agent-service                # AGENT_MODEL_ENDPOINT (#2209, direct GROQ path removed #3300) —
+                                       # verified live 2026-08-03: the running Deployment (image
+                                       # sandbox-b52f989b) resolves http://litellm.ai-platform.svc:4000/v1
         - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
         - devops-agent                 # DEVOPS_MODEL_ENDPOINT
         - docs-truth-agent             # LLM_GATEWAY_URL
@@ -841,15 +844,11 @@ data:
         - governance-auditor           # LLM_GATEWAY_URL
         - release-steward              # LLM_GATEWAY_URL
         - authz-policy-auditor         # LLM_GATEWAY_URL
-      not_routed:
-        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
-                                       # image resolves the baked-in api.groq.com URL until the rebuilt
-                                       # image rolls out. Promote it to `routed` only after re-reading
-                                       # the live Deployment — merged is not deployed.
-      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
-                                       # component still declares policyTypes: [Ingress] only, so the
-                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
-                                       # gated on the agent-service repoint actually being deployed.
+      egress_enforced: full            # ai-platform is egress-locked (litellm is the only internet
+                                       # hole); agent-service too: agent-service-egress-allow-list
+                                       # (#2210) is live in the platform namespace and the pod no longer
+                                       # carries a provider key (#3300), so the gateway cannot be
+                                       # bypassed. Verified live 2026-08-03.
       budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
       providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region

--- a/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: transaction-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "c8c28bcd3ec74908"
+    openbank.tech/policy-checksum: "7f276c2513f5bc6c"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -877,15 +877,18 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+    model_gateway_as_built:            # verified 2026-08-03 against gitops AND the running Deployments
       gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
                                        # #2019). Deployed and serving. It is the only workload holding a
                                        # provider key and the only one with an internet egress hole
                                        # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
-                                       # choke point — but see `egress_enforced` before treating it as a
-                                       # *complete* one.
+                                       # choke point — and with agent-service routed (#2209/#3300) and
+                                       # egress-locked (#2210) it is a *complete* one.
       routed:                          # read off the RUNNING Deployments' env, not off the manifests
         - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - agent-service                # AGENT_MODEL_ENDPOINT (#2209, direct GROQ path removed #3300) —
+                                       # verified live 2026-08-03: the running Deployment (image
+                                       # sandbox-b52f989b) resolves http://litellm.ai-platform.svc:4000/v1
         - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
         - devops-agent                 # DEVOPS_MODEL_ENDPOINT
         - docs-truth-agent             # LLM_GATEWAY_URL
@@ -894,15 +897,11 @@ data:
         - governance-auditor           # LLM_GATEWAY_URL
         - release-steward              # LLM_GATEWAY_URL
         - authz-policy-auditor         # LLM_GATEWAY_URL
-      not_routed:
-        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
-                                       # image resolves the baked-in api.groq.com URL until the rebuilt
-                                       # image rolls out. Promote it to `routed` only after re-reading
-                                       # the live Deployment — merged is not deployed.
-      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
-                                       # component still declares policyTypes: [Ingress] only, so the
-                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
-                                       # gated on the agent-service repoint actually being deployed.
+      egress_enforced: full            # ai-platform is egress-locked (litellm is the only internet
+                                       # hole); agent-service too: agent-service-egress-allow-list
+                                       # (#2210) is live in the platform namespace and the pod no longer
+                                       # carries a provider key (#3300), so the gateway cannot be
+                                       # bypassed. Verified live 2026-08-03.
       budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
       providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region

--- a/openbank-infra/gitops/components/payments/vop-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/vop-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: vop-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "da939ca353e0ee8a"
+    openbank.tech/policy-checksum: "7dbf7f001c049dd5"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -828,15 +828,18 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+    model_gateway_as_built:            # verified 2026-08-03 against gitops AND the running Deployments
       gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
                                        # #2019). Deployed and serving. It is the only workload holding a
                                        # provider key and the only one with an internet egress hole
                                        # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
-                                       # choke point — but see `egress_enforced` before treating it as a
-                                       # *complete* one.
+                                       # choke point — and with agent-service routed (#2209/#3300) and
+                                       # egress-locked (#2210) it is a *complete* one.
       routed:                          # read off the RUNNING Deployments' env, not off the manifests
         - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - agent-service                # AGENT_MODEL_ENDPOINT (#2209, direct GROQ path removed #3300) —
+                                       # verified live 2026-08-03: the running Deployment (image
+                                       # sandbox-b52f989b) resolves http://litellm.ai-platform.svc:4000/v1
         - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
         - devops-agent                 # DEVOPS_MODEL_ENDPOINT
         - docs-truth-agent             # LLM_GATEWAY_URL
@@ -845,15 +848,11 @@ data:
         - governance-auditor           # LLM_GATEWAY_URL
         - release-steward              # LLM_GATEWAY_URL
         - authz-policy-auditor         # LLM_GATEWAY_URL
-      not_routed:
-        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
-                                       # image resolves the baked-in api.groq.com URL until the rebuilt
-                                       # image rolls out. Promote it to `routed` only after re-reading
-                                       # the live Deployment — merged is not deployed.
-      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
-                                       # component still declares policyTypes: [Ingress] only, so the
-                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
-                                       # gated on the agent-service repoint actually being deployed.
+      egress_enforced: full            # ai-platform is egress-locked (litellm is the only internet
+                                       # hole); agent-service too: agent-service-egress-allow-list
+                                       # (#2210) is live in the platform namespace and the pod no longer
+                                       # carries a provider key (#3300), so the gateway cannot be
+                                       # bypassed. Verified live 2026-08-03.
       budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
       providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region

--- a/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: pid-service
     app.kubernetes.io/part-of: pid
   annotations:
-    openbank.tech/policy-checksum: "443d05f6d1b65e02"
+    openbank.tech/policy-checksum: "42cde31cff7d5b90"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -830,15 +830,18 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+    model_gateway_as_built:            # verified 2026-08-03 against gitops AND the running Deployments
       gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
                                        # #2019). Deployed and serving. It is the only workload holding a
                                        # provider key and the only one with an internet egress hole
                                        # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
-                                       # choke point — but see `egress_enforced` before treating it as a
-                                       # *complete* one.
+                                       # choke point — and with agent-service routed (#2209/#3300) and
+                                       # egress-locked (#2210) it is a *complete* one.
       routed:                          # read off the RUNNING Deployments' env, not off the manifests
         - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - agent-service                # AGENT_MODEL_ENDPOINT (#2209, direct GROQ path removed #3300) —
+                                       # verified live 2026-08-03: the running Deployment (image
+                                       # sandbox-b52f989b) resolves http://litellm.ai-platform.svc:4000/v1
         - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
         - devops-agent                 # DEVOPS_MODEL_ENDPOINT
         - docs-truth-agent             # LLM_GATEWAY_URL
@@ -847,15 +850,11 @@ data:
         - governance-auditor           # LLM_GATEWAY_URL
         - release-steward              # LLM_GATEWAY_URL
         - authz-policy-auditor         # LLM_GATEWAY_URL
-      not_routed:
-        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
-                                       # image resolves the baked-in api.groq.com URL until the rebuilt
-                                       # image rolls out. Promote it to `routed` only after re-reading
-                                       # the live Deployment — merged is not deployed.
-      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
-                                       # component still declares policyTypes: [Ingress] only, so the
-                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
-                                       # gated on the agent-service repoint actually being deployed.
+      egress_enforced: full            # ai-platform is egress-locked (litellm is the only internet
+                                       # hole); agent-service too: agent-service-egress-allow-list
+                                       # (#2210) is live in the platform namespace and the pod no longer
+                                       # carries a provider key (#3300), so the gateway cannot be
+                                       # bypassed. Verified live 2026-08-03.
       budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
       providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region

--- a/openbank-infra/gitops/components/pid/pid-service.yaml
+++ b/openbank-infra/gitops/components/pid/pid-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-pid-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "443d05f6d1b65e02"
+        openbank.tech/policy-checksum: "42cde31cff7d5b90"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/psd2-service/psd2-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/psd2-service/psd2-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: psd2-service
     app.kubernetes.io/part-of: psd2
   annotations:
-    openbank.tech/policy-checksum: "a1935b29ef2b64d6"
+    openbank.tech/policy-checksum: "9027d8252e51477e"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -903,15 +903,18 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+    model_gateway_as_built:            # verified 2026-08-03 against gitops AND the running Deployments
       gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
                                        # #2019). Deployed and serving. It is the only workload holding a
                                        # provider key and the only one with an internet egress hole
                                        # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
-                                       # choke point — but see `egress_enforced` before treating it as a
-                                       # *complete* one.
+                                       # choke point — and with agent-service routed (#2209/#3300) and
+                                       # egress-locked (#2210) it is a *complete* one.
       routed:                          # read off the RUNNING Deployments' env, not off the manifests
         - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - agent-service                # AGENT_MODEL_ENDPOINT (#2209, direct GROQ path removed #3300) —
+                                       # verified live 2026-08-03: the running Deployment (image
+                                       # sandbox-b52f989b) resolves http://litellm.ai-platform.svc:4000/v1
         - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
         - devops-agent                 # DEVOPS_MODEL_ENDPOINT
         - docs-truth-agent             # LLM_GATEWAY_URL
@@ -920,15 +923,11 @@ data:
         - governance-auditor           # LLM_GATEWAY_URL
         - release-steward              # LLM_GATEWAY_URL
         - authz-policy-auditor         # LLM_GATEWAY_URL
-      not_routed:
-        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
-                                       # image resolves the baked-in api.groq.com URL until the rebuilt
-                                       # image rolls out. Promote it to `routed` only after re-reading
-                                       # the live Deployment — merged is not deployed.
-      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
-                                       # component still declares policyTypes: [Ingress] only, so the
-                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
-                                       # gated on the agent-service repoint actually being deployed.
+      egress_enforced: full            # ai-platform is egress-locked (litellm is the only internet
+                                       # hole); agent-service too: agent-service-egress-allow-list
+                                       # (#2210) is live in the platform namespace and the pod no longer
+                                       # carries a provider key (#3300), so the gateway cannot be
+                                       # bypassed. Verified live 2026-08-03.
       budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
       providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region

--- a/openbank-infra/gitops/components/psd2-service/psd2-service.yaml
+++ b/openbank-infra/gitops/components/psd2-service/psd2-service.yaml
@@ -18,7 +18,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-psd2-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "a1935b29ef2b64d6"
+        openbank.tech/policy-checksum: "9027d8252e51477e"
       labels: {app.kubernetes.io/name: psd2-service, app.kubernetes.io/part-of: psd2}
     spec:
       securityContext:

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sanctions-service
     app.kubernetes.io/part-of: sanctions
   annotations:
-    openbank.tech/policy-checksum: "33abcab12d5dc10c"
+    openbank.tech/policy-checksum: "f7f32e63e9564c13"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -808,15 +808,18 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+    model_gateway_as_built:            # verified 2026-08-03 against gitops AND the running Deployments
       gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
                                        # #2019). Deployed and serving. It is the only workload holding a
                                        # provider key and the only one with an internet egress hole
                                        # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
-                                       # choke point — but see `egress_enforced` before treating it as a
-                                       # *complete* one.
+                                       # choke point — and with agent-service routed (#2209/#3300) and
+                                       # egress-locked (#2210) it is a *complete* one.
       routed:                          # read off the RUNNING Deployments' env, not off the manifests
         - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - agent-service                # AGENT_MODEL_ENDPOINT (#2209, direct GROQ path removed #3300) —
+                                       # verified live 2026-08-03: the running Deployment (image
+                                       # sandbox-b52f989b) resolves http://litellm.ai-platform.svc:4000/v1
         - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
         - devops-agent                 # DEVOPS_MODEL_ENDPOINT
         - docs-truth-agent             # LLM_GATEWAY_URL
@@ -825,15 +828,11 @@ data:
         - governance-auditor           # LLM_GATEWAY_URL
         - release-steward              # LLM_GATEWAY_URL
         - authz-policy-auditor         # LLM_GATEWAY_URL
-      not_routed:
-        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
-                                       # image resolves the baked-in api.groq.com URL until the rebuilt
-                                       # image rolls out. Promote it to `routed` only after re-reading
-                                       # the live Deployment — merged is not deployed.
-      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
-                                       # component still declares policyTypes: [Ingress] only, so the
-                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
-                                       # gated on the agent-service repoint actually being deployed.
+      egress_enforced: full            # ai-platform is egress-locked (litellm is the only internet
+                                       # hole); agent-service too: agent-service-egress-allow-list
+                                       # (#2210) is live in the platform namespace and the pod no longer
+                                       # carries a provider key (#3300), so the gateway cannot be
+                                       # bypassed. Verified live 2026-08-03.
       budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
       providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
@@ -49,7 +49,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sanctions-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "33abcab12d5dc10c"
+        openbank.tech/policy-checksum: "f7f32e63e9564c13"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sca-service
     app.kubernetes.io/part-of: sca
   annotations:
-    openbank.tech/policy-checksum: "057f66621add13ab"
+    openbank.tech/policy-checksum: "50b8022d41c8e6bb"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -844,15 +844,18 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+    model_gateway_as_built:            # verified 2026-08-03 against gitops AND the running Deployments
       gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
                                        # #2019). Deployed and serving. It is the only workload holding a
                                        # provider key and the only one with an internet egress hole
                                        # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
-                                       # choke point — but see `egress_enforced` before treating it as a
-                                       # *complete* one.
+                                       # choke point — and with agent-service routed (#2209/#3300) and
+                                       # egress-locked (#2210) it is a *complete* one.
       routed:                          # read off the RUNNING Deployments' env, not off the manifests
         - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - agent-service                # AGENT_MODEL_ENDPOINT (#2209, direct GROQ path removed #3300) —
+                                       # verified live 2026-08-03: the running Deployment (image
+                                       # sandbox-b52f989b) resolves http://litellm.ai-platform.svc:4000/v1
         - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
         - devops-agent                 # DEVOPS_MODEL_ENDPOINT
         - docs-truth-agent             # LLM_GATEWAY_URL
@@ -861,15 +864,11 @@ data:
         - governance-auditor           # LLM_GATEWAY_URL
         - release-steward              # LLM_GATEWAY_URL
         - authz-policy-auditor         # LLM_GATEWAY_URL
-      not_routed:
-        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
-                                       # image resolves the baked-in api.groq.com URL until the rebuilt
-                                       # image rolls out. Promote it to `routed` only after re-reading
-                                       # the live Deployment — merged is not deployed.
-      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
-                                       # component still declares policyTypes: [Ingress] only, so the
-                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
-                                       # gated on the agent-service repoint actually being deployed.
+      egress_enforced: full            # ai-platform is egress-locked (litellm is the only internet
+                                       # hole); agent-service too: agent-service-egress-allow-list
+                                       # (#2210) is live in the platform namespace and the pod no longer
+                                       # carries a provider key (#3300), so the gateway cannot be
+                                       # bypassed. Verified live 2026-08-03.
       budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
       providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region

--- a/openbank-infra/gitops/components/sca/sca-service.yaml
+++ b/openbank-infra/gitops/components/sca/sca-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sca-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "057f66621add13ab"
+        openbank.tech/policy-checksum: "50b8022d41c8e6bb"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/statements/statement-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/statements/statement-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: statement-service
     app.kubernetes.io/part-of: statements
   annotations:
-    openbank.tech/policy-checksum: "295fea349a6a7b8a"
+    openbank.tech/policy-checksum: "dfc4f2239aef2461"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -874,15 +874,18 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+    model_gateway_as_built:            # verified 2026-08-03 against gitops AND the running Deployments
       gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
                                        # #2019). Deployed and serving. It is the only workload holding a
                                        # provider key and the only one with an internet egress hole
                                        # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
-                                       # choke point — but see `egress_enforced` before treating it as a
-                                       # *complete* one.
+                                       # choke point — and with agent-service routed (#2209/#3300) and
+                                       # egress-locked (#2210) it is a *complete* one.
       routed:                          # read off the RUNNING Deployments' env, not off the manifests
         - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - agent-service                # AGENT_MODEL_ENDPOINT (#2209, direct GROQ path removed #3300) —
+                                       # verified live 2026-08-03: the running Deployment (image
+                                       # sandbox-b52f989b) resolves http://litellm.ai-platform.svc:4000/v1
         - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
         - devops-agent                 # DEVOPS_MODEL_ENDPOINT
         - docs-truth-agent             # LLM_GATEWAY_URL
@@ -891,15 +894,11 @@ data:
         - governance-auditor           # LLM_GATEWAY_URL
         - release-steward              # LLM_GATEWAY_URL
         - authz-policy-auditor         # LLM_GATEWAY_URL
-      not_routed:
-        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
-                                       # image resolves the baked-in api.groq.com URL until the rebuilt
-                                       # image rolls out. Promote it to `routed` only after re-reading
-                                       # the live Deployment — merged is not deployed.
-      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
-                                       # component still declares policyTypes: [Ingress] only, so the
-                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
-                                       # gated on the agent-service repoint actually being deployed.
+      egress_enforced: full            # ai-platform is egress-locked (litellm is the only internet
+                                       # hole); agent-service too: agent-service-egress-allow-list
+                                       # (#2210) is live in the platform namespace and the pod no longer
+                                       # carries a provider key (#3300), so the gateway cannot be
+                                       # bypassed. Verified live 2026-08-03.
       budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
       providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region

--- a/openbank-infra/gitops/components/statements/statement-service.yaml
+++ b/openbank-infra/gitops/components/statements/statement-service.yaml
@@ -26,7 +26,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-statement-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "295fea349a6a7b8a"
+        openbank.tech/policy-checksum: "dfc4f2239aef2461"
       labels:
         app.kubernetes.io/name: statement-service
         app.kubernetes.io/part-of: statements

--- a/openbank-infra/gitops/components/tpp-registry/tpp-registry-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/tpp-registry/tpp-registry-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: tpp-registry-service
     app.kubernetes.io/part-of: tpp-registry
   annotations:
-    openbank.tech/policy-checksum: "91fd5fc9a627d6e6"
+    openbank.tech/policy-checksum: "eacb814366d7c985"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -811,15 +811,18 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+    model_gateway_as_built:            # verified 2026-08-03 against gitops AND the running Deployments
       gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
                                        # #2019). Deployed and serving. It is the only workload holding a
                                        # provider key and the only one with an internet egress hole
                                        # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
-                                       # choke point — but see `egress_enforced` before treating it as a
-                                       # *complete* one.
+                                       # choke point — and with agent-service routed (#2209/#3300) and
+                                       # egress-locked (#2210) it is a *complete* one.
       routed:                          # read off the RUNNING Deployments' env, not off the manifests
         - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - agent-service                # AGENT_MODEL_ENDPOINT (#2209, direct GROQ path removed #3300) —
+                                       # verified live 2026-08-03: the running Deployment (image
+                                       # sandbox-b52f989b) resolves http://litellm.ai-platform.svc:4000/v1
         - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
         - devops-agent                 # DEVOPS_MODEL_ENDPOINT
         - docs-truth-agent             # LLM_GATEWAY_URL
@@ -828,15 +831,11 @@ data:
         - governance-auditor           # LLM_GATEWAY_URL
         - release-steward              # LLM_GATEWAY_URL
         - authz-policy-auditor         # LLM_GATEWAY_URL
-      not_routed:
-        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
-                                       # image resolves the baked-in api.groq.com URL until the rebuilt
-                                       # image rolls out. Promote it to `routed` only after re-reading
-                                       # the live Deployment — merged is not deployed.
-      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
-                                       # component still declares policyTypes: [Ingress] only, so the
-                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
-                                       # gated on the agent-service repoint actually being deployed.
+      egress_enforced: full            # ai-platform is egress-locked (litellm is the only internet
+                                       # hole); agent-service too: agent-service-egress-allow-list
+                                       # (#2210) is live in the platform namespace and the pod no longer
+                                       # carries a provider key (#3300), so the gateway cannot be
+                                       # bypassed. Verified live 2026-08-03.
       budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
       providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region

--- a/openbank-infra/gitops/components/tpp-registry/tpp-registry-service.yaml
+++ b/openbank-infra/gitops/components/tpp-registry/tpp-registry-service.yaml
@@ -23,7 +23,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-tpp-registry-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "91fd5fc9a627d6e6"
+        openbank.tech/policy-checksum: "eacb814366d7c985"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-libs/governance/agents.yaml
+++ b/openbank-libs/governance/agents.yaml
@@ -85,15 +85,18 @@ runtime:
 # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
 # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
 # ---------------------------------------------------------------------------------------
-model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+model_gateway_as_built:            # verified 2026-08-03 against gitops AND the running Deployments
   gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
                                    # #2019). Deployed and serving. It is the only workload holding a
                                    # provider key and the only one with an internet egress hole
                                    # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
-                                   # choke point — but see `egress_enforced` before treating it as a
-                                   # *complete* one.
+                                   # choke point — and with agent-service routed (#2209/#3300) and
+                                   # egress-locked (#2210) it is a *complete* one.
   routed:                          # read off the RUNNING Deployments' env, not off the manifests
     - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+    - agent-service                # AGENT_MODEL_ENDPOINT (#2209, direct GROQ path removed #3300) —
+                                   # verified live 2026-08-03: the running Deployment (image
+                                   # sandbox-b52f989b) resolves http://litellm.ai-platform.svc:4000/v1
     - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
     - devops-agent                 # DEVOPS_MODEL_ENDPOINT
     - docs-truth-agent             # LLM_GATEWAY_URL
@@ -102,15 +105,11 @@ model_gateway_as_built:            # verified 2026-07-25 against gitops AND the 
     - governance-auditor           # LLM_GATEWAY_URL
     - release-steward              # LLM_GATEWAY_URL
     - authz-policy-auditor         # LLM_GATEWAY_URL
-  not_routed:
-    - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
-                                   # image resolves the baked-in api.groq.com URL until the rebuilt
-                                   # image rolls out. Promote it to `routed` only after re-reading
-                                   # the live Deployment — merged is not deployed.
-  egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
-                                   # component still declares policyTypes: [Ingress] only, so the
-                                   # gateway is bypassable from that pod. #2210 adds the Egress half,
-                                   # gated on the agent-service repoint actually being deployed.
+  egress_enforced: full            # ai-platform is egress-locked (litellm is the only internet
+                                   # hole); agent-service too: agent-service-egress-allow-list
+                                   # (#2210) is live in the platform namespace and the pod no longer
+                                   # carries a provider key (#3300), so the gateway cannot be
+                                   # bypassed. Verified live 2026-08-03.
   budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
   providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
     deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region


### PR DESCRIPTION
## Summary

Closes the last open item of #1919: `model_gateway_as_built` still claimed agent-service was `not_routed` and `egress_enforced: partial`. Verified against the **live cluster 2026-08-03**: the running Deployment (image `sandbox-b52f989b`) resolves `AGENT_MODEL_ENDPOINT=http://litellm.ai-platform.svc:4000/v1` (direct GROQ path removed by #3300) and `networkpolicy/agent-service-egress-allow-list` (#2210) is present in the platform namespace — the LiteLLM choke point is complete, so the registry now says so (`routed`, `egress_enforced: full`) and the EU AI Act inventory drops its "partially closed gap" warning.

Supersedes #3603 (closed; the GROQ removal it carried landed separately in #3300).

## Type of change

- [x] chore (governance registry + generated artifacts)

## Linked issues

Closes #1919
Refs #3599 (ADR-0175 D3 — sensitive-data routing / EU inference tier, the remaining residency work)

## Changes

- `agents.yaml` — `model_gateway_as_built`: agent-service `not_routed → routed`, `egress_enforced: partial → full`, verification date → 2026-08-03 (evidence in comments).
- `docs/compliance/eu-ai-act.md` — regenerated via `gen-eu-ai-act.py` (drift-gated in `Validate manifests`).
- OPA bundle ConfigMaps + pod-roll checksum annotations restamped (`agents.yaml` is embedded policy data; standard fleet restamp).
- `apps/agent.yaml` — stale `GROQ_API_KEY` comment corrected (that secret entry no longer exists).

## Definition of Done

- [x] No application code changed (registry + generated artifacts only).
- [x] `opa test` + `build-bundle.sh` pass locally (15 charters, all drift assertions green).
- [x] Docs updated — eu-ai-act.md regenerated from the registry of record.

## Security checklist

- [x] No secrets, tokens, passwords, or PII — none added; the change records removal of a key path.
- [x] No new third-party dependency.
- [ ] Auth / crypto / payment code — not changed.

## Compliance impact

- [x] GDPR / EU AI Act — positive: the AI Act inventory (Art. 10 posture) now records the LLM egress choke point as fully enforced instead of partially; hosted-US residency derogation itself is unchanged and tracked as #3599.