### PR TITLE
feat(ci): gate the App Router export class that dev can no longer show

### DIFF
--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -1114,6 +1114,27 @@ gates:
     run: |
       python3 .github/scripts/check-configproperty-supplied.py --enforce
 
+  # webpack rejects a non-route value export from an App Router route handler with
+  # `"X" is not a valid Route export field`. This has broken the admin-ui build twice —
+  # infra/status (#3262) and delegations/projection-health (#3611, where it was the last blocker to
+  # uploading source maps to GlitchTip at all).
+  #
+  # It is now MORE likely to recur: #3611 moved the production build to `next build --webpack`
+  # (Turbopack emits no client source maps), while `npm run dev` still uses Turbopack, which
+  # TOLERATES these exports. A developer cannot see this failure locally — the first signal is a red
+  # CI build on a change that looked fine everywhere they could look. That is the shape worth
+  # gating: not carelessness, but a defect the local feedback loop is structurally unable to show.
+  #
+  # ENFORCED: 87 route files, 0 findings. Proven by reintroducing the exact export #3611 removed.
+  - id: route-exports
+    name: "App Router route.ts exports only route fields (#3262/#3611, enforced)"
+    group: lint
+    mode: enforced
+    selftest: |
+      python3 .github/scripts/check-route-exports.py --self-test
+    run: |
+      python3 .github/scripts/check-route-exports.py --enforce
+
   - id: compliance-matrix
     name: "compliance-page evidence citations (#2370, enforced)"
     group: registry

--- a/.github/scripts/check-route-exports.py
+++ b/.github/scripts/check-route-exports.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""A Next.js App Router `route.ts` may export only route fields — anything else fails the build.
+
+WHY THIS EXISTS
+---------------
+webpack rejects a non-route value export from an App Router route handler:
+
+    "X" is not a valid Route export field
+
+This class has now broken the admin-ui build twice: `infra/status` (#3262) and
+`delegations/projection-health` (#3611), the latter being the last blocker to getting source maps
+uploaded to GlitchTip at all.
+
+It is now MORE likely to recur, not less. #3611 moved the production build to `next build --webpack`
+(Turbopack emits no client source maps, so `productionBrowserSourceMaps` was inert and the upload
+had been shipping an empty set with every step green). `npm run dev` still uses Turbopack, which
+TOLERATES these exports. So a developer cannot see this failure locally — the first signal is a red
+CI build, on a change that looked fine everywhere they could look.
+
+That is the shape worth gating: not a defect someone was careless about, but one the local feedback
+loop is structurally unable to show.
+
+WHAT IT CHECKS
+--------------
+For every `openbank-admin-ui/src/app/**/route.ts`, each `export` of a *value* (`const`, `let`, `var`,
+`function`, `class`) must be one of the fields Next.js recognises — the HTTP method handlers plus the
+route segment config. Type-only exports (`export type`, `export interface`) are erased at compile
+time and are always fine; `export default` is a separate Next error and out of scope here.
+
+The fix for a violation is never to add it to the allow-list below — that list is Next.js', not
+ours. Drop the `export` keyword (the value is almost always only used in that file), or move the
+constant to a module the route imports.
+
+Usage:  check-route-exports.py [--enforce] [--self-test]
+"""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import re
+import sys
+
+REPO = pathlib.Path(__file__).resolve().parents[2]
+APP_DIR = REPO / "openbank-admin-ui/src/app"
+
+# Next.js' own vocabulary. Do NOT extend this to make a build pass — see the module docstring.
+ALLOWED = {
+    # HTTP method handlers
+    "GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS",
+    # Route segment config
+    "dynamic", "dynamicParams", "revalidate", "fetchCache", "runtime", "preferredRegion",
+    "maxDuration", "generateStaticParams", "generateMetadata", "config",
+}
+
+# `export const X`, `export async function X`, `export class X` … but never `export type/interface`
+# (erased at compile time) and never `export default` (a different Next error).
+VALUE_EXPORT = re.compile(
+    r"^[ \t]*export\s+(?!type\b|interface\b|default\b)(?:async\s+)?"
+    r"(?:const|let|var|function|class)\s+([A-Za-z_$][\w$]*)",
+    re.MULTILINE,
+)
+
+
+def strip_comments(text: str) -> str:
+    """Remove block and line comments.
+
+    A comment quoting the error, or documenting why an export was removed, must not be read as an
+    export — the code-about-code collision this repo hits repeatedly. Strings are not parsed out:
+    a `//` inside a string literal would truncate the line, whose failure direction is a missed
+    export, so the self-test pins a URL-in-a-string case.
+    """
+    text = re.sub(r"/\*.*?\*/", "", text, flags=re.DOTALL)
+    return re.sub(r"(?<!:)//.*", "", text)
+
+
+def route_files(app_dir: pathlib.Path) -> list[pathlib.Path]:
+    return sorted(app_dir.rglob("route.ts")) + sorted(app_dir.rglob("route.tsx"))
+
+
+def findings(app_dir: pathlib.Path = APP_DIR) -> tuple[list[str], int]:
+    files = route_files(app_dir)
+    out: list[str] = []
+    for path in files:
+        try:
+            text = strip_comments(path.read_text(encoding="utf-8", errors="ignore"))
+        except OSError:
+            continue
+        for match in VALUE_EXPORT.finditer(text):
+            name = match.group(1)
+            if name in ALLOWED:
+                continue
+            rel = path.relative_to(REPO) if path.is_relative_to(REPO) else path
+            line = text[: match.start()].count("\n") + 1
+            out.append(
+                f"{rel}:{line}: exports '{name}', which is not a Route export field. webpack fails "
+                f"the build with \"{name}\" is not a valid Route export field — and `npm run dev` "
+                f"uses Turbopack, which tolerates it, so this is invisible locally (#3262, #3611). "
+                f"Drop the `export` keyword, or move the value into a module the route imports. Do "
+                f"not add it to the allow-list: that vocabulary is Next.js', not ours.")
+    return out, len(files)
+
+
+def selftest() -> int:
+    import tempfile
+
+    cases = [
+        ("a plain handler", "export async function GET() {}\n", 0),
+        ("route segment config", "export const dynamic = 'force-dynamic'\nexport async function GET() {}\n", 0),
+        # The exact #3611 shape.
+        ("a stray const export", "export const DELEGATION_TOPIC = 'x'\nexport async function GET() {}\n", 1),
+        ("a stray function export", "export function helper() {}\nexport async function POST() {}\n", 1),
+        ("a stray class export", "export class Thing {}\nexport async function GET() {}\n", 1),
+        # Type-only exports are erased at compile time — flagging them would be a false positive on
+        # a shape webpack accepts, and the fix suggested would be wrong.
+        ("an exported type", "export type Row = { a: string }\nexport async function GET() {}\n", 0),
+        ("an exported interface", "export interface Row { a: string }\nexport async function GET() {}\n", 0),
+        # Code-about-code, both directions.
+        ("a comment quoting the error",
+         "// export const FOO is not a valid Route export field\nexport async function GET() {}\n", 0),
+        ("a block comment naming an export",
+         "/* export const BAR = 1 */\nexport async function GET() {}\n", 0),
+        # A `//` inside a URL must not truncate the line and hide the export after it.
+        ("a URL in a string above a stray export",
+         "const u = 'https://x/y'\nexport const TOPIC = 'x'\nexport async function GET() {}\n", 1),
+        ("a non-exported const is fine", "const TOPIC = 'x'\nexport async function GET() {}\n", 0),
+    ]
+    for label, body, want in cases:
+        with tempfile.TemporaryDirectory() as d:
+            root = pathlib.Path(d) / "api/thing"
+            root.mkdir(parents=True)
+            (root / "route.ts").write_text(body, encoding="utf-8")
+            got, count = findings(pathlib.Path(d))
+        if count != 1:
+            print(f"selftest FAIL: {label} — expected to scan 1 route file, scanned {count}")
+            return 1
+        if len(got) != want:
+            print(f"selftest FAIL: {label} — expected {want} finding(s), got {len(got)}: {got}")
+            return 1
+
+    # An empty scan must not read as clean: zero routes and zero findings are the same output, and
+    # the real tree has 87. This is the shape in which the gate would be green about nothing.
+    with tempfile.TemporaryDirectory() as d:
+        got, count = findings(pathlib.Path(d))
+        if count != 0 or got:
+            print("selftest FAIL: the empty-tree case did not behave as expected.")
+            return 1
+    if len(route_files(APP_DIR)) < 20:
+        print(f"selftest FAIL: only {len(route_files(APP_DIR))} route file(s) found in the real "
+              f"tree — the scan is broken.")
+        return 1
+
+    print(f"selftest OK: {len(cases)} fixtures — stray const/function/class flagged, handlers and "
+          f"segment config allowed, type-only exports allowed, comments both ways, "
+          f"{len(route_files(APP_DIR))} real route files discovered.")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--enforce", action="store_true")
+    ap.add_argument("--self-test", action="store_true", dest="self_test")
+    args = ap.parse_args()
+    if args.self_test:
+        return selftest()
+
+    found, count = findings()
+    for line in found:
+        print(("::error::" if args.enforce else "::warning::") + line)
+    print(f"check-route-exports: {count} App Router route file(s) — "
+          f"{'clean.' if not found else f'{len(found)} finding(s) above.'}")
+    return 1 if found and args.enforce else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Refs #3262, #3611. Closes a class that has now broken the admin-ui build twice — and that, as of yesterday, a developer can no longer see locally.

## The class

webpack rejects a non-route value export from an App Router route handler:

```
"DELEGATION_TOPIC" is not a valid Route export field
```

| when | file | issue |
|---|---|---|
| earlier | `api/infra/status/route.ts` | #3262 |
| yesterday | `api/delegations/projection-health/route.ts` | #3611 — the **last blocker** to getting source maps uploaded to GlitchTip at all |

## Why gate it now rather than keep fixing instances

#3611 moved the production build to `next build --webpack`, because Turbopack emits **no client source maps** and `productionBrowserSourceMaps` is read only by `next/dist/build/webpack*` — so the upload had been shipping an empty set with every step green.

But `npm run dev` still runs Turbopack, and **Turbopack tolerates these exports**.

So the two bundlers now disagree, and the one a developer runs is the permissive one. The first signal is a red CI build on a change that looked fine everywhere they could look. That is the shape worth gating: not carelessness, but a defect the local feedback loop is *structurally unable* to show.

## The allow-list is Next.js', not ours

HTTP method handlers plus the route segment config. **The fix for a violation is never to extend it** — drop the `export` keyword (the value is almost always used only in that file), or move the constant into a module the route imports. The script says so in the finding text, where someone hitting it will actually read it.

Type-only exports (`export type`, `export interface`) are erased at compile time and are explicitly allowed. Flagging them would be a false positive on a shape webpack accepts, and the fix it suggested would be wrong.

**Enforced: 87 route files, 0 findings.**

## Falsified against the real defect

Reintroduced the exact export #3611 removed:

```
::error::openbank-admin-ui/src/app/api/delegations/projection-health/route.ts:29: exports
'DELEGATION_TOPIC', which is not a Route export field. … `npm run dev` uses Turbopack, which
tolerates it, so this is invisible locally (#3262, #3611).
```

Restored from a `cp` backup, clean again, working tree unchanged.

The self-test's 11 fixtures pin the code-about-code cases in **both** directions — a comment quoting the error must not be read as an export, and a stray export must still be found. One case exists because I nearly shipped the bug: stripping `//` comments can truncate a line containing a URL in a string, hiding an export below it, so `const u = 'https://x/y'` above a stray export is pinned.

## Self-assessment

- **Regex over TypeScript, not a parser.** An exotic form (`export { X }` re-export, `export * from`) is not matched. That direction is a false *pass* — the bad one. `export { X }` from a route is rare and I did not find any; worth revisiting if one appears.
- **It does not verify the build.** A file with only valid exports can still fail webpack for other reasons; this gate covers one named error, not "the build works".
- **The dev/prod bundler divergence itself is untouched.** This makes one consequence of it visible at PR time; it does not remove the divergence, and other Turbopack-vs-webpack differences will not be caught by it. That is worth its own look if a second class shows up.
- `run-gates.py --group lint` PASS=6; `gates-not-deregistered` clean (102 → 103, nothing dropped); `gate-script-registration` clean.
