### PR TITLE
fix(fraud): move the runtime image to glibc so the ONNX model can actually load

### DIFF
--- a/.github/scripts/verify-image-native-libs.py
+++ b/.github/scripts/verify-image-native-libs.py
@@ -1,0 +1,337 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+# See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+"""Prove every native .so a service image ships can actually link in the runtime base (#3354).
+
+WHAT WENT WRONG WITHOUT THIS
+    openbank-fraud-service bundles com.microsoft.onnxruntime (ADR-0139 phase-1b). Its
+    libonnxruntime.so is linked against glibc + libstdc++; the runtime base was
+    eclipse-temurin:25-jre-alpine (musl). OrtEnvironment.getEnvironment() therefore threw
+    UnsatisfiedLinkError on the first request in EVERY deployed environment, from the day the
+    adapter shipped, and the model scored exactly nothing.
+
+    Nothing in this repo could see it, and that is the interesting part:
+
+      * the unit tests construct a real OrtEnvironment and assert a real score — but they run on
+        a glibc CI runner, so they are green against a musl image by construction;
+      * the Gradle build, detekt, ktlint and the image build itself never execute a line of
+        native code;
+      * the pod is Ready — the health probes never touch the model;
+      * and the adapter degrades to `null` on purpose, so the only trace is one ERROR line
+        (and, before #3376, a 500 on an unrelated read endpoint).
+
+    A green build proves nothing here. The only thing that can be wrong out loud is running the
+    real dynamic loader, from the real base image, over the real .so the image ships. That is
+    what this does.
+
+HOW
+    1. Read the runtime base from .github/workflows/Dockerfile.deploy — the single source every
+       image producer copies. NEVER give this script its own copy of the base: a second copy
+       moves with the first and keeps passing about an image nobody deploys.
+    2. Scan the service's fast-jar lib/ tree for jars carrying linux natives for the target
+       architecture, and extract those .so files.
+    3. `ldd` each one INSIDE that base image, on that platform.
+    4. Fail on any unresolved dependency.
+
+    Step 2 is what keeps this honest as the fleet changes: the scope is DERIVED from the jars a
+    service actually ships, not from a hand-kept list of "services with native code". A service
+    that gains a native dependency is covered the day it gains it, and one that drops it stops
+    paying for the check with nothing to update.
+
+    Intra-bundle sonames are not findings. onnxruntime ships libonnxruntime4j_jni.so, whose
+    NEEDED entry `libonnxruntime.so.1` is resolved at runtime because the JVM System.load()s its
+    sibling from the same extracted directory first. A missing dependency whose name matches an
+    extracted sibling is therefore ignored — matched against the extracted file set, which is
+    derived, not against a literal.
+
+USAGE
+    verify-image-native-libs.py <lib-dir> [--arch arm64|amd64] [--base IMAGE]
+    verify-image-native-libs.py --self-test
+
+    <lib-dir> is the fast-jar lib/ directory staged into the build context, e.g.
+    openbank-fraud-service/build/quarkus-app/lib. Exits 0 when there is nothing to check.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import zipfile
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+DOCKERFILE_DEPLOY = REPO_ROOT / ".github" / "workflows" / "Dockerfile.deploy"
+
+# Jar-internal directories holding Linux natives, per Docker platform arch. onnxruntime uses
+# `linux-aarch64`/`linux-x64`; other packagers use the uname spellings, so accept both.
+ARCH_DIR_PATTERNS = {
+    "arm64": re.compile(r"(^|/)linux[-_/](aarch64|arm64)/", re.I),
+    "amd64": re.compile(r"(^|/)linux[-_/](x64|x86[-_]64|amd64)/", re.I),
+}
+
+FROM_RE = re.compile(r"^\s*FROM\s+(\S+)", re.M)
+
+# `ldd` says it two ways and we must catch both, because the musl and glibc loaders disagree:
+#   glibc: "\tlibstdc++.so.6 => not found"
+#   musl:  "Error loading shared library libstdc++.so.6: No such file or directory (needed by ..)"
+GLIBC_MISSING_RE = re.compile(r"^\s*(\S+)\s+=>\s+not found\s*$", re.M)
+MUSL_MISSING_RE = re.compile(r"^Error loading shared library ([^:]+):", re.M)
+# musl also reports every unresolvable symbol; one line per symbol, thousands of them. Counted,
+# never printed in full.
+MUSL_RELOC_RE = re.compile(r"^Error relocating ", re.M)
+
+
+def read_base_image() -> str:
+    """The runtime base, read out of the committed Dockerfile — never a second copy."""
+    text = DOCKERFILE_DEPLOY.read_text(encoding="utf-8")
+    match = FROM_RE.search(text)
+    if not match:
+        sys.exit(f"::error::no FROM line in {DOCKERFILE_DEPLOY}")
+    return match.group(1)
+
+
+def find_native_entries(lib_dir: pathlib.Path, arch: str) -> list[tuple[pathlib.Path, str]]:
+    """(jar, entry) pairs for every Linux .so this image would ship for `arch`."""
+    pattern = ARCH_DIR_PATTERNS[arch]
+    found: list[tuple[pathlib.Path, str]] = []
+    for jar in sorted(lib_dir.rglob("*.jar")):
+        try:
+            with zipfile.ZipFile(jar) as zf:
+                for name in zf.namelist():
+                    if name.endswith(".so") and pattern.search(name):
+                        found.append((jar, name))
+        except zipfile.BadZipFile:
+            print(f"::warning::not a readable jar, skipped: {jar}")
+    return found
+
+
+def extract(entries: list[tuple[pathlib.Path, str]], dest: pathlib.Path) -> list[str]:
+    names: list[str] = []
+    for jar, entry in entries:
+        base = pathlib.PurePosixPath(entry).name
+        with zipfile.ZipFile(jar) as zf, open(dest / base, "wb") as out:
+            shutil.copyfileobj(zf.open(entry), out)
+        (dest / base).chmod(0o755)
+        names.append(base)
+    return names
+
+
+def parse_ldd(output: str, sibling_names: list[str]) -> list[str]:
+    """Unresolved dependencies in one `ldd` run, minus the ones a sibling in the bundle provides.
+
+    `sibling_names` is the extracted file set, so the exemption cannot drift away from what the
+    image actually ships. A NEEDED soname carries a version suffix the file on disk does not
+    (`libonnxruntime.so.1` vs `libonnxruntime.so`), hence the prefix match.
+    """
+    missing = set(GLIBC_MISSING_RE.findall(output)) | set(MUSL_MISSING_RE.findall(output))
+    unresolved = []
+    for dep in sorted(missing):
+        if any(dep == sib or dep.startswith(sib + ".") for sib in sibling_names):
+            continue
+        unresolved.append(dep)
+    return unresolved
+
+
+def platform_ref(base: str, arch: str) -> str:
+    """Rewrite an index reference to the PLATFORM-SPECIFIC manifest digest for `arch`.
+
+    An index digest cannot be materialised twice for two architectures in one daemon: the second
+    pull is refused with `cannot overwrite digest ...` (measured on Docker 29's containerd store).
+    ghcr-publish checks amd64 and arm64 back to back, so that is not hypothetical. The
+    per-platform manifest digests are distinct, so pulling those instead has no collision.
+
+    Falls back to `base` when the reference is not a multi-platform index, or when buildx is
+    unavailable — the plain reference is correct in both of those cases.
+    """
+    repo = base.split("@", 1)[0].split(":")[0] if "@" in base else base.rsplit(":", 1)[0]
+    proc = subprocess.run(
+        ["docker", "buildx", "imagetools", "inspect", "--raw", base],
+        capture_output=True, text=True, check=False,
+    )
+    if proc.returncode != 0:
+        return base
+    try:
+        index = json.loads(proc.stdout)
+    except json.JSONDecodeError:
+        return base
+    for manifest in index.get("manifests", []):
+        platform = manifest.get("platform", {})
+        if platform.get("os") == "linux" and platform.get("architecture") == arch:
+            return f"{repo}@{manifest['digest']}"
+    return base
+
+
+def resolve_local_image(base: str, arch: str) -> str:
+    """Pull the platform-specific manifest for `arch` and return its local image ID."""
+    ref = platform_ref(base, arch)
+    pull = subprocess.run(
+        ["docker", "pull", "--platform", f"linux/{arch}", ref],
+        capture_output=True, text=True, check=False,
+    )
+    if pull.returncode != 0:
+        sys.exit(f"::error::could not pull {ref} for linux/{arch}: {pull.stderr.strip()}")
+    inspect = subprocess.run(
+        ["docker", "image", "inspect", "--format", "{{.Id}}", ref],
+        capture_output=True, text=True, check=False,
+    )
+    if inspect.returncode != 0 or not inspect.stdout.strip():
+        sys.exit(f"::error::could not resolve a local image id for {ref}: {inspect.stderr.strip()}")
+    return inspect.stdout.strip()
+
+
+def ldd_in_base(base: str, arch: str, workdir: pathlib.Path, names: list[str]) -> dict[str, str]:
+    """Run ldd on each .so inside the real base image; returns {name: raw ldd output}."""
+    script = "; ".join(f'echo "@@ {n}"; ldd /n/{n} 2>&1 || true' for n in names)
+    image_id = resolve_local_image(base, arch)
+    proc = subprocess.run(
+        [
+            "docker", "run", "--rm", "--platform", f"linux/{arch}",
+            "-v", f"{workdir}:/n:ro", "--entrypoint", "sh", image_id, "-c", script,
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0 and not proc.stdout:
+        sys.exit(f"::error::could not run ldd in {base}: {proc.stderr.strip()}")
+    blocks: dict[str, str] = {}
+    current = None
+    for line in proc.stdout.splitlines():
+        if line.startswith("@@ "):
+            current = line[3:].strip()
+            blocks[current] = ""
+        elif current is not None:
+            blocks[current] += line + "\n"
+    return blocks
+
+
+def self_test() -> int:
+    """Falsify the verdict logic against REAL captured ldd output from both loaders.
+
+    The docker half cannot run everywhere; the parsing half is where a wrong answer would be
+    silent, so it is what gets a known-positive and a known-negative. Both fixtures are verbatim
+    excerpts of runs against the two candidate bases on linux/arm64.
+    """
+    musl_bad = (
+        "\t/lib/ld-musl-aarch64.so.1 (0xffffb93a0000)\n"
+        "\tlibdl.so.2 => /lib/ld-musl-aarch64.so.1 (0xffffb93a0000)\n"
+        "Error loading shared library libstdc++.so.6: No such file or directory"
+        " (needed by /n/libonnxruntime.so)\n"
+        "Error loading shared library libgcc_s.so.1: No such file or directory"
+        " (needed by /n/libonnxruntime.so)\n"
+        "Error loading shared library ld-linux-aarch64.so.1: No such file or directory"
+        " (needed by /n/libonnxruntime.so)\n"
+        "Error relocating /n/libonnxruntime.so: __cxa_begin_catch: symbol not found\n"
+    )
+    glibc_good = (
+        "\tlinux-vdso.so.1 (0x0000ffffbccdb000)\n"
+        "\tlibstdc++.so.6 => /usr/lib/aarch64-linux-gnu/libstdc++.so.6 (0x0000ffffbb870000)\n"
+        "\tlibgcc_s.so.1 => /usr/lib/aarch64-linux-gnu/libgcc_s.so.1 (0x0000ffffbb760000)\n"
+        "\tlibc.so.6 => /usr/lib/aarch64-linux-gnu/libc.so.6 (0x0000ffffbb590000)\n"
+        "\t/lib/ld-linux-aarch64.so.1 (0x0000ffffbcc90000)\n"
+    )
+    # The JNI shim on the WORKING base: its only "missing" entry is its own sibling, which the
+    # JVM loads first. This is the case the check must NOT flag, and the one a naive
+    # "any `not found` fails" rule would have failed on the correct image.
+    glibc_sibling = (
+        "\tlinux-vdso.so.1 (0x0000ffffa20cc000)\n"
+        "\tlibonnxruntime.so.1 => not found\n"
+        "\tlibc.so.6 => /usr/lib/aarch64-linux-gnu/libc.so.6 (0x0000ffffa1e70000)\n"
+    )
+    siblings = ["libonnxruntime.so", "libonnxruntime4j_jni.so"]
+    failures = []
+
+    got = parse_ldd(musl_bad, siblings)
+    want = ["ld-linux-aarch64.so.1", "libgcc_s.so.1", "libstdc++.so.6"]
+    if got != want:
+        failures.append(f"musl fixture: expected {want}, got {got}")
+
+    if parse_ldd(glibc_good, siblings):
+        failures.append(f"glibc fixture must be clean, got {parse_ldd(glibc_good, siblings)}")
+
+    if parse_ldd(glibc_sibling, siblings):
+        failures.append(
+            "an intra-bundle soname must not be a finding, got "
+            f"{parse_ldd(glibc_sibling, siblings)}"
+        )
+
+    # ...but it must still be a finding when no such sibling is shipped, or the exemption would
+    # swallow a genuinely absent library.
+    if parse_ldd(glibc_sibling, []) != ["libonnxruntime.so.1"]:
+        failures.append("a missing lib with no sibling must be reported")
+
+    # The base must come from the committed Dockerfile, and must be a glibc one today.
+    base = read_base_image()
+    if "alpine" in base or "musl" in base:
+        failures.append(f"Dockerfile.deploy base is musl again: {base} — see #3354")
+
+    for line in failures:
+        print(f"::error::self-test: {line}")
+    if failures:
+        return 1
+    print(f"self-test OK (base from Dockerfile.deploy: {base})")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("lib_dir", nargs="?", help="fast-jar lib/ directory staged into the image")
+    ap.add_argument("--arch", default="arm64", choices=sorted(ARCH_DIR_PATTERNS))
+    ap.add_argument("--base", default=None, help="override the base image (testing only)")
+    ap.add_argument("--self-test", action="store_true")
+    args = ap.parse_args()
+
+    if args.self_test:
+        return self_test()
+    if not args.lib_dir:
+        ap.error("lib_dir is required unless --self-test is given")
+
+    lib_dir = pathlib.Path(args.lib_dir)
+    if not lib_dir.is_dir():
+        sys.exit(f"::error::not a directory: {lib_dir}")
+
+    entries = find_native_entries(lib_dir, args.arch)
+    if not entries:
+        print(f"native-lib check: no linux/{args.arch} .so shipped under {lib_dir} — nothing to do")
+        return 0
+
+    base = args.base or read_base_image()
+    print(f"native-lib check: {len(entries)} .so for linux/{args.arch} against {base}")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        workdir = pathlib.Path(tmp)
+        names = extract(entries, workdir)
+        blocks = ldd_in_base(base, args.arch, workdir, names)
+
+        failed = False
+        for name in names:
+            output = blocks.get(name, "")
+            unresolved = parse_ldd(output, names)
+            relocs = len(MUSL_RELOC_RE.findall(output))
+            if unresolved:
+                failed = True
+                print(f"::error::{name}: unresolved in {base}: {', '.join(unresolved)}")
+                if relocs:
+                    print(f"::error::{name}: and {relocs} unresolvable relocation(s)")
+            else:
+                print(f"  ok  {name}")
+
+    if failed:
+        print(
+            "::error::the runtime base cannot load a native library this image ships. "
+            "This is exactly the #3354 failure: it is invisible to the build, to the health "
+            "probes and to every test that runs on a glibc runner. Fix the base in "
+            ".github/workflows/Dockerfile.deploy, do not skip this check."
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/Dockerfile.deploy
+++ b/.github/workflows/Dockerfile.deploy
@@ -1,6 +1,32 @@
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+# The ONE runtime recipe for every openbank-* Quarkus service image. Three producers copy this
+# file verbatim into their build context and append only EXPOSE / SBOM lines: auto-deploy.yml,
+# ghcr-publish.yml and openbank-infra/scripts/build-push-service.sh. Per-service
+# openbank-*/Dockerfile files are declarations only (#3016) — nothing builds them.
+#
+# WHY GLIBC AND NOT ALPINE (#3354). This was eclipse-temurin:25-jre-alpine, i.e. musl.
+# openbank-fraud-service bundles com.microsoft.onnxruntime (ADR-0139 phase-1b), whose
+# libonnxruntime.so is linked against glibc + libstdc++, so OrtEnvironment.getEnvironment() threw
+# UnsatisfiedLinkError in every deployed environment from the day the adapter shipped, and the
+# model scored exactly nothing. Measured on linux/arm64, onnxruntime 1.22.0:
+#
+#   eclipse-temurin:25-jre-alpine                 -> Error loading shared library libstdc++.so.6
+#   eclipse-temurin:25-jre-alpine + apk libstdc++ -> Error loading shared library ld-linux-aarch64.so.1
+#   eclipse-temurin:25-jre (glibc)                -> every NEEDED entry resolves
+#
+# The middle row is the point: installing libstdc++ does NOT work, it moves the failure to the
+# glibc dynamic loader. A glibc base is required, not preferred. Cost is +132MB per base layer
+# (224MB -> 356MB); at ~51 ECR repositories that is ~$0.67/month of storage, which is not a reason
+# to keep a runtime that cannot load a library the fleet ships.
+#
+# Do not revert to a musl base to reclaim the layer: .github/scripts/verify-image-native-libs.py
+# runs `ldd` on every bundled linux .so INSIDE this exact base before any image is pushed, and
+# fails the push. It reads the base image from THIS file — never give it a second copy.
+FROM eclipse-temurin:25-jre@sha256:681c543d6f36c50f45e9b5226930a46203dcfa351d3670e9d0bdf0dabae53539
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+# uid 100 / gid 101 reproduce exactly what busybox `adduser -S` yielded on the alpine base, so
+# nothing that assumed those numbers changes. Deployments pin runAsUser/runAsGroup anyway.
+RUN groupadd --system --gid 101 openbank \
+ && useradd --system --uid 100 --gid 101 --no-create-home --shell /usr/sbin/nologin openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/.github/workflows/auto-deploy.yml
+++ b/.github/workflows/auto-deploy.yml
@@ -500,6 +500,12 @@ jobs:
             bash "${GITHUB_WORKSPACE}/.github/scripts/ensure-ecr-repository.sh" "${svc}" \
               2>&1 | sed "s/^/[${svc}] /" || return 1
 
+            # ldd every bundled linux .so inside the real runtime base before pushing (#3354).
+            # No-op for a service shipping none. Reasoning is in the script header, not here
+            # — prose in a run: block costs the whole workflow (#3135).
+            python3 "${GITHUB_WORKSPACE}/.github/scripts/verify-image-native-libs.py" \
+              "${ctx}/quarkus-app/lib" --arch arm64 2>&1 | sed "s/^/[${svc}] /" || return 1
+
             echo "==> [${svc}] docker push → ${image}"
             docker buildx build \
               --platform linux/arm64 \

--- a/.github/workflows/ghcr-publish.yml
+++ b/.github/workflows/ghcr-publish.yml
@@ -141,6 +141,11 @@ jobs:
             echo "COPY sbom/bom.json /app/sbom/bom.json" >> "${ctx}/Dockerfile"
             echo "ENV OPENBANK_SBOM_PATH=/app/sbom/bom.json" >> "${ctx}/Dockerfile"
           fi
+          # ldd every bundled linux .so inside the real runtime base before publishing (#3354).
+          # This image is multi-arch, so both loaders are checked. Reasoning lives in the script
+          # header — prose in a run: block costs the whole workflow (#3135).
+          python3 .github/scripts/verify-image-native-libs.py "${ctx}/quarkus-app/lib" --arch amd64
+          python3 .github/scripts/verify-image-native-libs.py "${ctx}/quarkus-app/lib" --arch arm64
           docker buildx build \
             --platform linux/amd64,linux/arm64 \
             --provenance=false \

--- a/openbank-fraud-service/src/test/kotlin/com/openbank/fraud/infrastructure/ml/OnnxFraudModelTest.kt
+++ b/openbank-fraud-service/src/test/kotlin/com/openbank/fraud/infrastructure/ml/OnnxFraudModelTest.kt
@@ -13,6 +13,7 @@ import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.unmockkStatic
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.within
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 
@@ -34,6 +35,29 @@ class OnnxFraudModelTest {
         val second = model.scoreShadow(features)
         assertThat(first).isNotNull().isBetween(0.0, 1.0)
         assertThat(first).isEqualTo(second)
+    }
+
+    /**
+     * The model REALLY runs, and computes the documented logistic — not merely "something in
+     * [0,1]". The graph is `sigmoid(-4.0 + 0.30*h1 + 0.05*h24)` (gen_onnx_baseline_model.py), so
+     * h1=5, h24=12 has exactly one right answer. A stubbed adapter, a constant, or a degraded
+     * session returning null all fail this; the bounded/monotonic assertions above do not
+     * distinguish those.
+     *
+     * What this CANNOT catch, and why it needed a second mechanism (#3354): it runs on the CI
+     * runner's libc, not the runtime image's. The deploy image was musl while libonnxruntime.so is
+     * glibc-linked, so this test was green for the entire life of an adapter that had never once
+     * loaded in a deployed environment. `.github/scripts/verify-image-native-libs.py` is the half
+     * that runs the real loader against the real base image before any push.
+     */
+    @Test
+    fun `scores the documented logistic exactly, so a real inference must have happened`() {
+        val score = model.scoreShadow(
+            mapOf(VELOCITY_TXN_COUNT_H1.name to 5.0, VELOCITY_TXN_COUNT_H24.name to 12.0),
+        )
+        val logit = -4.0 + 0.30 * 5.0 + 0.05 * 12.0
+        val expected = 1.0 / (1.0 + kotlin.math.exp(-logit))
+        assertThat(score).isNotNull().isCloseTo(expected, within(1e-6))
     }
 
     @Test

--- a/openbank-infra/scripts/build-push-service.sh
+++ b/openbank-infra/scripts/build-push-service.sh
@@ -72,27 +72,23 @@ cp -r "${QA}" "${CTX}/quarkus-app"
 # Gradle produces quarkus-app files with 600 permissions (owner-only). The container
 # runs as a non-root 'openbank' user who can't read them → ClassNotFoundException.
 chmod -R a+r "${CTX}/quarkus-app"
-# Stage the SBOM (if produced) so the runtime stage can COPY it in.
-SBOM_COPY=""; SBOM_ENV=""
+# The runtime recipe is NOT written here. This script used to keep its own copy of it, and that
+# copy had drifted into a THIRD definition of how an OpenBank image is made — unpinned (no digest)
+# where the CI producers pinned one, and still on the musl base after #3354 moved the fleet to
+# glibc, so a laptop deploy of fraud-service would have re-shipped the exact defect CI had just
+# fixed. Copy the one file both CI producers copy, and append the same two variable parts they do.
+cp "${REPO_ROOT}/.github/workflows/Dockerfile.deploy" "${CTX}/Dockerfile"
 if [ -f "$BOM" ]; then
   mkdir -p "${CTX}/sbom"; cp "$BOM" "${CTX}/sbom/bom.json"; chmod a+r "${CTX}/sbom/bom.json"
-  SBOM_COPY=$'COPY sbom/bom.json /app/sbom/bom.json'
-  SBOM_ENV=$'ENV OPENBANK_SBOM_PATH=/app/sbom/bom.json'
+  echo "COPY sbom/bom.json /app/sbom/bom.json" >> "${CTX}/Dockerfile"
+  echo "ENV OPENBANK_SBOM_PATH=/app/sbom/bom.json" >> "${CTX}/Dockerfile"
 fi
-cat > "${CTX}/Dockerfile" <<EOF
-FROM eclipse-temurin:25-jre-alpine
-WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
-USER openbank
-COPY quarkus-app/lib/ /app/lib/
-COPY quarkus-app/*.jar /app/
-COPY quarkus-app/app/ /app/app/
-COPY quarkus-app/quarkus/ /app/quarkus/
-${SBOM_COPY}
-${SBOM_ENV}
-EXPOSE ${PORT}
-ENTRYPOINT ["java", "-XX:+UseZGC", "-Djava.util.logging.manager=org.jboss.logmanager.LogManager", "-jar", "/app/quarkus-run.jar"]
-EOF
+echo "EXPOSE ${PORT}" >> "${CTX}/Dockerfile"
+
+# ldd every bundled linux .so inside that base before pushing — a musl/glibc mismatch is invisible
+# to the build, to the health probes and to every test that runs on a glibc host (#3354).
+python3 "${REPO_ROOT}/.github/scripts/verify-image-native-libs.py" \
+  "${CTX}/quarkus-app/lib" --arch "${PLATFORM#linux/}"
 
 echo "==> ECR login + buildx push"
 aws ecr get-login-password --region "$AWS_REGION" | docker login --username AWS --password-stdin "$ECR_REGISTRY" >/dev/null


### PR DESCRIPTION
## What

`openbank-fraud-service` bundles `com.microsoft.onnxruntime` (ADR-0139 phase-1b). Its
`libonnxruntime.so` is linked against **glibc + libstdc++**, and every service image is built from
`.github/workflows/Dockerfile.deploy` on `eclipse-temurin:25-jre-alpine` — **musl**. So
`OrtEnvironment.getEnvironment()` has never once succeeded in a deployed environment, and the model
has scored exactly nothing since the adapter shipped.

This moves the fleet runtime base to glibc, and adds a check that runs the real dynamic loader over
the real `.so` inside the real base image before any image is pushed.

## Root cause, as measured (not inferred)

Live sandbox pod `fraud-service-…` at 07:35 today, `fraud-service` container:

```
java.lang.UnsatisfiedLinkError: /tmp/onnxruntime-java.../libonnxruntime.so:
  Error loading shared library libstdc++.so.6: No such file or directory
  at ai.onnxruntime.OnnxRuntime.load(OnnxRuntime.java:387)
  at ai.onnxruntime.OrtEnvironment.<clinit>(OrtEnvironment.java:34)
```

`ldd` on the shipped `.so`, on `linux/arm64`, onnxruntime 1.22.0:

| base | verdict |
|---|---|
| `eclipse-temurin:25-jre-alpine` (today's) | `libstdc++.so.6`, `libgcc_s.so.1`, `ld-linux-aarch64.so.1` all unresolved, 3099 unresolvable relocations |
| `eclipse-temurin:25-jre` (glibc) | every NEEDED entry resolves |

The cheap fix does not work: adding `libstdc++` to the musl base only moves the failure to the glibc
dynamic loader. A glibc base is required, not preferred.

## What changed

* **`.github/workflows/Dockerfile.deploy`** → `eclipse-temurin:25-jre`, digest-pinned to the
  multi-arch index. Same vendor, same JRE, only the libc changes. `uid 100 / gid 101` are reproduced
  exactly so nothing that assumed the busybox `adduser -S` numbers moves. Cost: +132MB per base
  layer (224MB → 356MB), ~$0.67/month of ECR storage across ~51 repositories.
* **`.github/scripts/verify-image-native-libs.py`** (new) — extracts every linux `.so` the image
  would ship and runs `ldd` on each one **inside the base image it reads out of Dockerfile.deploy**.
  Wired into `auto-deploy.yml`, `ghcr-publish.yml` and `build-push-service.sh`, i.e. all three
  producers. Its scope is DERIVED from the jars a service actually ships, so there is no list of
  "services with native code" to keep in sync.
* **`openbank-infra/scripts/build-push-service.sh`** — this kept a **third** copy of the runtime
  recipe: unpinned (no digest) and still musl. A laptop deploy of fraud-service would have re-shipped
  the exact defect CI had just fixed. It now copies the same file the CI producers copy.
* **`OnnxFraudModelTest`** — the existing assertion was "score is in [0,1]", which a constant would
  satisfy. It now pins the documented logistic exactly, so only a real inference passes.

## Verification

Not "the build went green" — that is precisely what happened for the whole life of this defect.

1. An image built from the new recipe, run as the `openbank` user, loads the runtime and scores the
   documented input: `ENV OK: OrtEnvironment(name=ort-java,version=1.22.0)` / `SCORE: 0.13010845`,
   matching the value the new unit assertion pins.
2. The new check was falsified in both directions against the **real** `openbank-fraud-service`
   fast-jar: red on the old alpine digest, green on the new base, on both `amd64` and `arm64`.
3. Its `--self-test` was falsified too: pointed at a musl `Dockerfile.deploy` it fails; on this
   branch it passes.
4. The new test assertion was falsified by perturbing the intercept — it goes red.

Incidental finding: `liblz4-java.so` (Kafka's LZ4 codec) is also glibc-linked and could not have
loaded on the musl base either. It resolves cleanly on the new one.

## Merging this does NOT deploy it — read before closing #3354

`auto-deploy.yml`'s `Detect changed services` only selects a service when the push touched
`<svc>/src/main`, `<svc>/build.gradle.kts`, or a shared lib that service consumes. A change to
`.github/workflows/Dockerfile.deploy` matches none of those, so this merge rebuilds **zero**
services and every pod keeps running its musl image. The base change reaches a service only on its
next rebuild for some unrelated reason, or on an explicit dispatch:

```
gh workflow run auto-deploy.yml -R JiRaska/open-bank-oss -f services=openbank-fraud-service
```

(`-f services=` is space-separated if more are wanted.) Verify afterwards that the pod's log no
longer carries `UnsatisfiedLinkError`, and only then treat #3354 as closed. Related: the sandbox
pod is currently on fraud-service **0.10.0**, so it does not yet even carry the #3376 blast-radius
fix that shipped in 0.10.1 — `GET /api/v1/fraud/review-queue` was still answering 500 at 07:35
today.

## Not in this PR

49 per-service `openbank-*/Dockerfile` files and 8 `05-operations.*.md` docs still name the alpine
base. Those files are declaration-only (#3016) — nothing builds them — but they are now stale.
Sweeping them needs a deliberate commit-type call, because `<svc>/Dockerfile` and
`src/main/resources/**` are both release-triggering paths and a releasing type there would cut ~50
patch releases for a change that touches no service code. Tracked separately.

## Linked issues

Refs #3354

## Note for the reviewer

This touches `.github/workflows/`, so the merge hook requires a human. That is expected — leaving
the PR open for review rather than working around it.
