### PR TITLE
docs(delegation): record that ADR-0232's amount-aware guards have no production caller

### DIFF
--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -1945,3 +1945,20 @@ gates:
       # not only a fixture — it exits 1 on origin/main's network module + substrate env and
       # 0 with the pin in place.
       python3 .github/scripts/check-nat-ami-pinned.py --enforce
+  - id: enforcement-reachability
+    name: "a declared enforcement function has a production caller (ADR-0232, issue #3615)"
+    group: kotlin
+    mode: enforced
+    selftest: python3 .github/scripts/check-enforcement-reachability.py --self-test
+    selftest_expect: pass
+    run: |
+      # AuthorizationService.isAuthorizedForAmount is the only amount-aware account guard in
+      # the fleet and the only enforcer of ADR-0232's perTransactionLimit — and every one of
+      # its call sites is a test. Nothing else in the repo can see that: the function compiles,
+      # is a CDI bean method, has a port declaring it and a green test class, and coverage
+      # INVERTS the signal (a well-tested unreachable guard scores higher than a lightly-tested
+      # reachable one). The registry in rules.yaml records what was measured; this gate fails in
+      # both directions, so an entry can neither rot into permanent furniture nor be silently
+      # closed. Falsified against the real tree before wiring in: injecting one production
+      # caller and, separately, flipping the declared status each produce exactly one finding.
+      python3 .github/scripts/check-enforcement-reachability.py --enforce

--- a/.github/scripts/check-enforcement-reachability.py
+++ b/.github/scripts/check-enforcement-reachability.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""A declared enforcement function must have a PRODUCTION caller (rules.yaml: enforcement_reachability).
+
+Why this exists
+---------------
+`AuthorizationService.isAuthorizedForAmount` is the only amount-aware account guard in the fleet
+and the only enforcer of ADR-0232's `perTransactionLimit` in account-service. Measured against
+`origin/main` on 2026-08-03, every one of its call sites is in `AuthorizationServiceDelegationTest`
+(issue #3615). The HTTP endpoint that looks like its front door,
+`GET /api/v1/accounts/{id}/authorizations/check`, calls the amount-free `isAuthorized` instead.
+
+Nothing in this repo could see that. The function compiles, it is a CDI bean method, its port
+declares it, its unit tests are green and thorough — and they are green about a function no
+request reaches. Coverage does not help either: a well-tested unreachable function has HIGHER
+coverage than a lightly-tested reachable one. The same shape produced #3613 one layer down, where
+`dailyLimit`/`monthlyLimit` were accepted by the API and counted by nothing.
+
+What this checks
+----------------
+For each entry in `rules.yaml: enforcement_reachability.declared`, count call sites of the symbol
+across every module's `src/main` Kotlin, excluding the files that DECLARE it (the implementation
+and its port interface), and excluding declaration lines themselves. Then compare the measured
+verdict against the declared `status`:
+
+  status: reachable    -> at least one production call site, else FAIL
+  status: unreachable  -> zero production call sites; a caller appearing FAILS too, asking for the
+                          registry (and the ADR delivery-status row that quotes it) to be updated
+
+The second direction is the point. A one-way check would let the entry rot into a permanent
+"known broken" nobody revisits, and would stay silent on the day the gap is actually closed — the
+`KNOWN_UNCOVERED`/baseline idiom this repo already uses in check-pact-provider-replay.py and
+check-single-replica-rollout-strategy.py, where a stale declaration is itself a finding.
+
+Deliberate limits
+-----------------
+Kotlin functions only. An unreachable HTTP endpoint or an unconsumed domain event is the same
+defect class, but detecting a route's callers means reasoning across the fleet's HTTP clients and
+the admin-ui, and detecting an unconsumed event is already
+check-event-consumer-liveness.py's job. A narrow gate that is falsifiable beats a broad one that
+guesses.
+
+Comment stripping matters here: this repo's KDoc discusses the very symbols being counted (see
+the `check-roles-allowed-realm.py` collision, ADR note in CLAUDE.md), and Kotlin block comments
+NEST, so a naive non-greedy strip closes early on a KDoc containing `/*`.
+
+Falsifiability
+--------------
+`--self-test` runs the counter over synthetic sources in both directions — a caller present, a
+caller only inside a comment, a caller only in a string, and a declaration line alone — and
+asserts the verdict each time, so a "clean" run has been shown capable of reporting dirty.
+
+Usage: check-enforcement-reachability.py [--root .] [--rules ...] [--self-test] [--enforce]
+"""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import re
+import sys
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover - the runner image always has it
+    print("::error::pyyaml unavailable — add it to the runner base image", file=sys.stderr)
+    raise SystemExit(1)
+
+REPO = pathlib.Path(__file__).resolve().parents[2]
+DEFAULT_RULES = "openbank-libs/governance/rules.yaml"
+
+
+def strip_comments(src: str) -> str:
+    """Remove Kotlin line comments, NESTING block comments, and string literals.
+
+    Strings go too because a path or a message naming the symbol is prose about the function, not
+    a call to it — same reason the comments go.
+    """
+    out: list[str] = []
+    i, n, depth = 0, len(src), 0
+    while i < n:
+        two = src[i : i + 2]
+        if depth:
+            if two == "/*":
+                depth += 1
+                i += 2
+                continue
+            if two == "*/":
+                depth -= 1
+                i += 2
+                continue
+            out.append("\n" if src[i] == "\n" else " ")
+            i += 1
+            continue
+        if two == "/*":
+            depth = 1
+            i += 2
+            continue
+        if two == "//":
+            while i < n and src[i] != "\n":
+                i += 1
+            continue
+        if src[i] in ('"', "'"):
+            quote = src[i]
+            triple = src[i : i + 3] == quote * 3
+            i += 3 if triple else 1
+            while i < n:
+                if not triple and src[i] == "\\":
+                    i += 2
+                    continue
+                if triple and src[i : i + 3] == quote * 3:
+                    i += 3
+                    break
+                if not triple and (src[i] == quote or src[i] == "\n"):
+                    i += 1
+                    break
+                out.append("\n" if src[i] == "\n" else " ")
+                i += 1
+            continue
+        out.append(src[i])
+        i += 1
+    return "".join(out)
+
+
+def call_sites(src: str, symbol: str) -> int:
+    """Count invocations of `symbol` in already-stripped Kotlin, ignoring its own declaration."""
+    call = re.compile(rf"(?<![A-Za-z0-9_]){re.escape(symbol)}\s*\(")
+    declaration = re.compile(rf"\bfun\s+{re.escape(symbol)}\s*\(")
+    return sum(1 for line in src.splitlines() if call.search(line) and not declaration.search(line))
+
+
+def production_sources(root: pathlib.Path) -> list[pathlib.Path]:
+    return sorted(
+        p
+        for p in root.glob("openbank-*/src/main/kotlin/**/*.kt")
+        if p.is_file()
+    )
+
+
+def measure(root: pathlib.Path, entry: dict) -> list[str]:
+    """Return the production files (repo-relative) that call this entry's symbol."""
+    symbol = entry["symbol"]
+    declaring = {(root / f).resolve() for f in entry.get("declared_in", [])}
+    hits: list[str] = []
+    for path in production_sources(root):
+        if path.resolve() in declaring:
+            continue
+        try:
+            src = strip_comments(path.read_text(encoding="utf-8"))
+        except UnicodeDecodeError:  # pragma: no cover
+            continue
+        if call_sites(src, symbol):
+            hits.append(str(path.relative_to(root)))
+    return hits
+
+
+def findings(root: pathlib.Path, rules_path: pathlib.Path) -> list[str]:
+    rules = yaml.safe_load(rules_path.read_text(encoding="utf-8")) or {}
+    declared = ((rules.get("enforcement_reachability") or {}).get("declared")) or []
+    out: list[str] = []
+    for entry in declared:
+        symbol = entry.get("symbol", "?")
+        status = entry.get("status")
+        issue = entry.get("issue")
+        for f in entry.get("declared_in", []):
+            if not (root / f).exists():
+                out.append(f"{symbol}: declared_in path does not exist: {f} — registry is stale")
+        callers = measure(root, entry)
+        if status == "reachable" and not callers:
+            out.append(
+                f"{symbol}: declared `reachable` but no production call site exists. "
+                f"Its tests are green about a function no request reaches "
+                f"({entry.get('why', 'see rules.yaml')})."
+            )
+        elif status == "unreachable" and callers:
+            out.append(
+                f"{symbol}: declared `unreachable` (issue #{issue}) but is now called from "
+                f"{', '.join(callers)}. If the enforcement path was wired, flip status to "
+                f"`reachable` and update the ADR delivery-status row that quotes this entry."
+            )
+        elif status not in ("reachable", "unreachable"):
+            out.append(f"{symbol}: status must be `reachable` or `unreachable`, got {status!r}")
+    return out
+
+
+SELF_TEST_CASES = [
+    ("val ok = service.isAuthorizedForAmount(a, b, c, d)", 1, "a real call"),
+    ("// service.isAuthorizedForAmount(a, b) is not wired yet", 0, "a call in a line comment"),
+    ("/* outer /* nested */ isAuthorizedForAmount(x) */\nval n = 1", 0, "a call inside NESTED block comments"),
+    ('val msg = "call isAuthorizedForAmount(x) here"', 0, "a call inside a string literal"),
+    ("override suspend fun isAuthorizedForAmount(\n    accountId: UUID,\n): Boolean = false", 0, "the declaration"),
+    ("val bad = notIsAuthorizedForAmount(x)", 0, "a longer identifier that merely contains the symbol"),
+    ("fun caller() {\n    return isAuthorizedForAmount(x)\n}", 1, "a call in a body below a different declaration"),
+]
+
+
+def self_test() -> int:
+    failures = 0
+    for src, expected, label in SELF_TEST_CASES:
+        got = call_sites(strip_comments(src), "isAuthorizedForAmount")
+        ok = got == expected
+        failures += 0 if ok else 1
+        print(f"  [{'ok' if ok else 'FAIL'}] {label}: expected {expected}, got {got}")
+    if failures:
+        print(f"::error::enforcement-reachability self-test: {failures} case(s) failed")
+        return 1
+    print(f"enforcement-reachability self-test: {len(SELF_TEST_CASES)} cases pass (both directions)")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", default=str(REPO))
+    parser.add_argument("--rules", default=DEFAULT_RULES)
+    parser.add_argument("--enforce", action="store_true")
+    parser.add_argument("--self-test", action="store_true")
+    args = parser.parse_args()
+
+    if args.self_test:
+        return self_test()
+
+    root = pathlib.Path(args.root).resolve()
+    problems = findings(root, root / args.rules)
+    for p in problems:
+        print(f"::{'error' if args.enforce else 'warning'}::enforcement-reachability: {p}")
+    if not problems:
+        print("enforcement-reachability: every declared enforcement function matches its declared status")
+    return 1 if (problems and args.enforce) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/adr/0232-delegated-access-customer-to-party-sharing-with-granular-capabilities.md
+++ b/docs/adr/0232-delegated-access-customer-to-party-sharing-with-granular-capabilities.md
@@ -198,6 +198,47 @@ transacting).
   external-disclosure port is shaped so VC issuance becomes a third
   delivery channel without reworking the aggregate.
 
+## Delivery status: is the enforcement path reachable, measured
+
+As of 2026-08-03, against `origin/main`, on **D3's enforcement half only** —
+whether a guard exists is a different question from whether anything asks it.
+Tracked as issue #3615.
+
+| Guard | Takes an amount | Production caller |
+| --- | --- | --- |
+| `AuthorizationService.isAuthorizedForAmount` (account) | yes | **None** — every call site is in `AuthorizationServiceDelegationTest` |
+| `GET /api/v1/accounts/{id}/authorizations/check` | no | None in-repo; calls the amount-free `isAuthorized` |
+| `GET /api/v1/accounts/{id}/savings-goal/delegation/check` | no | None in-repo |
+| `GET /api/v1/cards/{id}/delegation/check` | no | None in-repo |
+| `POST /api/v1/delegations/check` (delegation-service) | yes | The read-only admin-ui probe only |
+| `SavingsWithdrawalApproved` | — | **No consumer** in any service or in `openbank-contracts` |
+
+D3 calls the projection check "the last line before the money path". There is no
+money path behind it. No money-moving service — domestic-payment, sepa-payment,
+sepa-instant, swift, standing-order, settlement, clearing, transaction, ledger —
+reads a delegation grant or projection at all, and customer-edge payment
+initiation requires debtor-owner == the authenticated party, so a delegate is
+refused with 403 before any guard is consulted. `SavingsWithdrawalApproved` is
+documented in `SavingsProposalService` as "the executable instruction the
+payments path consumes"; nothing consumes it.
+
+The guards are correct code and are **kept**, unchanged. What is recorded here is
+that they are not invoked, because nothing in the repo could otherwise say so:
+each one compiles, is a CDI bean method or a registered route, has a port
+declaring it and a green test class — and coverage inverts the signal, since a
+well-tested unreachable guard scores higher than a lightly-tested reachable one.
+`isAuthorizedForAmount` is now declared in
+`rules.yaml: enforcement_reachability` and checked by the `enforcement-reachability`
+gate, which fails both when a `reachable` entry loses its last caller and when
+this `unreachable` entry gains one — so closing the gap requires updating this
+table rather than allowing it to go quietly stale.
+
+This is the same defect class as the `dailyLimit`/`monthlyLimit` refusal: there a
+declared number had no counter, here a declared check has no caller. The order of
+repair is the same and is stated in #3615 — a delegated payment path first, the
+guard consulted on it second, the cumulative counter last. A limit is only worth
+computing once there is a debit to refuse.
+
 ## Consequences
 
 **Positive**

--- a/openbank-libs/governance/rules.yaml
+++ b/openbank-libs/governance/rules.yaml
@@ -2274,6 +2274,33 @@ governance_manifest:
     - each_rule_has_a_test_that_fails_without_it
   incident: 2026-07-25
 
+# A function this repo describes as ENFORCING something must have a production caller. Nothing
+# else notices when it does not: it compiles, it is a bean method, its port declares it, and its
+# unit tests are green — about a function no request reaches. Coverage inverts the signal, since a
+# well-tested unreachable guard scores HIGHER than a lightly-tested reachable one.
+# Enforced by .github/scripts/check-enforcement-reachability.py (gate: enforcement-reachability).
+enforcement_reachability:
+  principle: >
+    Reachability is a property of the call graph, not of the code's docstring. An entry declares
+    what was MEASURED, and the gate fails in both directions — a `reachable` entry that loses its
+    last caller, and an `unreachable` entry that quietly gains one — so a known gap can neither rot
+    into permanent furniture nor be closed without the record being updated.
+  declared:
+    - symbol: isAuthorizedForAmount
+      module: openbank-account-service
+      status: unreachable
+      issue: 3615
+      declared_in:
+        - openbank-account-service/src/main/kotlin/com/openbank/account/application/usecase/AuthorizationService.kt
+        - openbank-account-service/src/main/kotlin/com/openbank/account/application/port/in/AccountPorts.kt
+      why: >
+        ADR-0232 D3's amount-aware guard and the only enforcer of perTransactionLimit in
+        account-service. Measured 2026-08-03: every call site is in AuthorizationServiceDelegationTest.
+        The endpoint that looks like its front door, GET /api/v1/accounts/{id}/authorizations/check,
+        calls the amount-free isAuthorized instead, and no money-moving service reads a delegation
+        grant at all — so there is no debit for a limit check to attach to yet. Flip to `reachable`
+        when the delegated payment path lands (#3615), not before.
+
 knowledge_capture:
   principle: >
     A corrected non-obvious mistake, a hard-won lesson, or a direction we keep must be


### PR DESCRIPTION
Follow-up to #3613, which refused `dailyLimit`/`monthlyLimit` because nothing enforces them. The same defect class applies one layer up, to the ceiling that PR kept accepting: the guard that enforces `perTransactionLimit` has no production caller.

## Measured against `origin/main`, 2026-08-03

| Guard | Takes an amount | Production caller |
| --- | --- | --- |
| `AuthorizationService.isAuthorizedForAmount` | yes | **None** — every call site is in `AuthorizationServiceDelegationTest` |
| `GET /api/v1/accounts/{id}/authorizations/check` | no | None in-repo; calls the amount-free `isAuthorized` |
| `GET /api/v1/accounts/{id}/savings-goal/delegation/check` | no | None in-repo |
| `GET /api/v1/cards/{id}/delegation/check` | no | None in-repo |
| `POST /api/v1/delegations/check` (delegation-service) | yes | The read-only admin-ui probe only |
| `SavingsWithdrawalApproved` | — | **No consumer** in any service or in `openbank-contracts` |

No money-moving service — domestic-payment, sepa-payment, sepa-instant, swift, standing-order, settlement, clearing, transaction, ledger — reads a delegation grant or projection at all, and customer-edge payment initiation requires debtor-owner == the authenticated party, so a delegate is refused with 403 before any guard is consulted. ADR-0232 D3 calls the projection check "the last line before the money path"; there is no money path behind it.

## What this PR does

Option (b) of the two available, deliberately. Wiring the delegated money path is a money-path change across customer-edge and domestic-payment that needs its own design, two approvals and a threat model — it is filed as #3615 with the order of repair. Deleting the guards was explicitly off the table: they are correct code, simply not invoked.

- **ADR-0232 gains a delivery-status section** stating per guard whether anything calls it, and why the ceiling half cannot be delivered before a debit exists to attach it to.
- **`rules.yaml: enforcement_reachability`** — a registry of functions this repo describes as *enforcing* something, each carrying its measured status and, when unreachable, the issue tracking the wiring.
- **`check-enforcement-reachability.py`**, gate `enforcement-reachability` (kotlin shard, enforced). It counts production call sites (comments, nested block comments and string literals stripped; the declaration line excluded) and fails in **both** directions: a `reachable` entry that loses its last caller, and an `unreachable` entry that silently gains one. The second direction is the point — a one-way check would let the entry rot into permanent furniture and would stay silent on the day the gap is actually closed.

Nothing else in the repo could have caught this. Each guard compiles, is a CDI bean method or a registered route, has a port declaring it and a green test class — and coverage inverts the signal, since a well-tested unreachable guard scores higher than a lightly-tested reachable one.

## Falsification

Against the real tree, not a fixture:

- injecting one production caller into `AuthorizationResource` → exactly one finding, exit 1;
- flipping the declared status to `reachable` with no caller → exactly one finding, exit 1;
- restored tree → clean, exit 0.

Plus 7 `--self-test` cases over the counter's near-misses: a call in a line comment, a call inside NESTED block comments, a call inside a string literal, the declaration line itself, and a longer identifier that merely contains the symbol.

`rules-opa-data.yaml` is unchanged — `enforcement_reachability` is not read by any `.rego`, so no OPA bundle is restamped.

Refs #3615
