### PR TITLE
fix(money-path): a missing required query/header parameter answered 500, not 400

### DIFF
--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -1214,6 +1214,35 @@ gates:
     run: |
       bash .github/scripts/check-exception-mapper-collision.sh .
 
+  # A required @QueryParam/@HeaderParam/@MatrixParam declared with a NON-NULLABLE
+  # Kotlin reference type answers 500 when the caller omits it, never 400 — the
+  # caller cannot tell "I sent a bad request" from "the server is broken", and on
+  # a money path that decides whether they retry (issue #3104). Same root shape as
+  # the null-body 500s of #3032/#3050, one argument position over.
+  #
+  # The trap this gate exists to stop being re-learned: writing requireNotNull in
+  # the BODY of a non-suspend handler is dead code. Kotlin emits
+  # Intrinsics.checkNotNullParameter at bytecode offset 0, so the NPE has already
+  # thrown (verified with javap; a suspend function gets no intrinsic at all, and
+  # the null then flows into the body instead). The parameter must be declared
+  # NULLABLE for any guard to be reachable; libs-runtime maps the resulting
+  # IllegalArgumentException to 400 — never add a service-local mapper (#526).
+  #
+  # Ratchet, not a flat fail: remediation is per-handler (required / @DefaultValue
+  # / genuinely optional) and only the handler knows which. The 24 money-path
+  # sites are fixed; the 39 remaining are baselined in the script with their
+  # service, so a NEW occurrence fails and a baseline entry that becomes fixed is
+  # reported too. Self-test first — the must-NOT-flag half is what matters here,
+  # since an outbound REST-client interface carries the identical annotation and
+  # is not a defect (52 of the 115 raw matches on main). ENFORCED.
+  - id: nonnull-jaxrs-param-ratchet
+    name: "non-nullable required JAX-RS param ratchet (issue #3104, enforced)"
+    group: kotlin
+    mode: enforced
+    run: |
+      python3 .github/scripts/check-nonnull-jaxrs-params.py --self-test
+      python3 .github/scripts/check-nonnull-jaxrs-params.py --root .
+
   # openbank.outbox.dispatch-enabled guard (the CLAUDE.md "outbox footgun":
   # a service whose OutboxDispatcher actually gates on this flag silently
   # never dispatches if it's left at its false default — no error,

--- a/.github/scripts/check-nonnull-jaxrs-params.py
+++ b/.github/scripts/check-nonnull-jaxrs-params.py
@@ -171,6 +171,12 @@ def enclosing_type(src: str, offset: int):
     `kind` is the discriminator that matters: an `interface` is an outbound MicroProfile REST
     client, a `class` is an inbound resource. Files that hold both (a resource plus its client)
     resolve correctly because the LAST declaration before the offset wins.
+
+    Callers must exclude on `== "interface"`, NOT on `!= "class"`. A `companion object` declared
+    above a handler inside a resource class resolves to `object`, and excluding everything that is
+    not a `class` would then skip that handler silently — a false GREEN, which is the direction
+    that never announces itself. There are 0 such sites today; the point is that adding one must
+    not disarm the gate.
     """
     last = None
     for m in DECL_RE.finditer(src, 0, offset):
@@ -207,7 +213,7 @@ def scan_source(src: str, service: str, path: str):
             continue
 
         encl_kind, encl_name = enclosing_type(src, m.start())
-        if encl_kind != "class":
+        if encl_kind == "interface":
             continue  # outbound REST client — the caller supplies the argument
 
         yield {
@@ -265,6 +271,19 @@ class DemoResource {
 
     fun allowedPrimitive(@QueryParam("ok_primitive") g: Int): Response = TODO()
 
+    // A NAMED nested object above a handler must not disarm the check for handlers below it. With
+    // the exclusion written as `!= "class"` this site resolves to `object` and is silently skipped
+    // — a false GREEN, the direction that never announces itself. Excluding only `interface` keeps
+    // it flagged. (An unnamed `companion object` is NOT the hazard: DECL_RE requires a name after
+    // the keyword, so it never becomes the enclosing declaration. Measured — the first version of
+    // this fixture used `companion object` and passed against the broken exclusion too, i.e. it
+    // proved nothing.)
+    object Headers {
+        const val OPERATOR = "X-Operator-Id"
+    }
+
+    fun flaggedAfterNestedObject(@QueryParam("flag_after_object") i: String): Response = TODO()
+
     // A commented-out declaration must not count:
     // fun commentedOut(@QueryParam("comment_only") z: String): Response = TODO()
     fun stringLiteralIsNotADecl(): String = "@QueryParam(\\"literal_only\\") y: String"
@@ -277,7 +296,7 @@ interface DemoClient {
 }
 '''
 
-SELF_TEST_EXPECTED_FLAGGED = {"flag_plain", "flag_header", "flag_enum"}
+SELF_TEST_EXPECTED_FLAGGED = {"flag_plain", "flag_header", "flag_enum", "flag_after_object"}
 SELF_TEST_EXPECTED_ALLOWED = {
     "prose_only", "nested_prose", "ok_nullable", "ok_default_ann", "ok_kotlin_default",
     "ok_primitive", "comment_only", "literal_only", "ok_outbound",

--- a/.github/scripts/check-nonnull-jaxrs-params.py
+++ b/.github/scripts/check-nonnull-jaxrs-params.py
@@ -1,0 +1,366 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+#
+# A required @QueryParam / @HeaderParam / @MatrixParam declared with a NON-NULLABLE Kotlin
+# reference type answers 500 when the caller omits it, never 400 (issue #3104).
+#
+# THE MECHANISM, AND WHY THE OBVIOUS FIX IS DEAD CODE
+#   JAX-RS injects `null` for an absent parameter. Kotlin's null-safety is compile-time only, so the
+#   declared non-nullable type buys nothing at runtime — it only decides WHERE the failure lands:
+#
+#     fun f(@QueryParam("p") p: String)          -> Intrinsics.checkNotNullParameter at bytecode
+#                                                   offset 0. NPE before the first statement of the
+#                                                   body, every time. GenericExceptionMapper -> 500.
+#
+#     suspend fun f(@QueryParam("p") p: String)  -> NO intrinsic is emitted at all (verified against
+#                                                   the 2.3.21 compiler with javap, for suspending
+#                                                   and non-suspending bodies alike). `null` flows
+#                                                   into the body and fails at the first dereference,
+#                                                   usually still a 500 — but if nothing dereferences
+#                                                   it, the request silently proceeds with a null the
+#                                                   signature promised could not exist. That second
+#                                                   outcome is worse than the 500, and is invisible.
+#
+#   The consequence that traps people: writing `requireNotNull(p)` in the body of a NON-suspend
+#   handler compiles to nothing. The intrinsic has already thrown. The parameter MUST be declared
+#   nullable for any guard to be reachable:
+#
+#       @QueryParam("productId") productId: String?,       // then
+#       requireNotNull(productId) { "query parameter 'productId' is required" }
+#
+#   libs-runtime's CommonExceptionMappers maps IllegalArgumentException to 400 with the ApiError
+#   envelope and a traceId, so that is the whole fix. Do NOT add a service-local ExceptionMapper for
+#   a JDK type — two mappers for one type are selected at random per request (issue #526).
+#
+# WHY IT MATTERS ENOUGH TO GATE
+#   A client cannot tell "I sent a bad request" from "the server is broken", and on a money path that
+#   difference decides whether the caller retries. 5xx also drives alerting and burns SLO error
+#   budget, so the authenticated-fuzz lane reports these forever while they stay 5xx.
+#
+# WHAT IS AND IS NOT A FINDING
+#   flagged   an INBOUND JAX-RS resource (a `class`) whose param is a non-nullable reference type
+#             with no @DefaultValue and no Kotlin default value
+#   allowed   nullable type (`String?`)              -- the handler already owns the absent case
+#   allowed   @DefaultValue("...")                   -- JAX-RS never injects null
+#   allowed   a Kotlin default (`p: String = "x"`)   -- same
+#   allowed   a JVM primitive (`Int`, `Long`, ...)   -- JAX-RS supplies 0/false, not null. A
+#             different defect class, already mapped by DateTimeExceptionMapper (#3057).
+#   allowed   an OUTBOUND MicroProfile REST client (an `interface`) -- the annotation describes the
+#             request this service SENDS. The argument comes from our own Kotlin call site, which is
+#             compile-time checked, and an abstract method has no body to hold an intrinsic. 52 of
+#             the 115 raw matches on main are this, which is why a naive grep over-counts by ~2x.
+#
+# RATCHET, NOT A FLAT FAIL
+#   Remediation is genuinely per-handler — required (400 naming the parameter), defaultable
+#   (@DefaultValue), or actually optional (nullable) — and only the handler knows which. The
+#   money-path set is fixed; the remainder is BASELINED with its issue so a NEW occurrence fails
+#   while the known tail stays visible. A baseline entry that no longer occurs is reported too, so
+#   the list cannot rot in either direction.
+#
+# EXIT CODES
+#   0  no new occurrences, no stale baseline entries
+#   1  a new occurrence, or a baseline entry that is now fixed and should be removed
+#   2  the check could not run, or the self-test failed. Never conflated with 0.
+#
+# Run:  python3 .github/scripts/check-nonnull-jaxrs-params.py [--root .] [--self-test] [--list]
+
+import argparse
+import pathlib
+import re
+import sys
+
+PARAM_ANNOTATIONS = ("QueryParam", "HeaderParam", "MatrixParam")
+
+# JVM primitives: JAX-RS supplies the zero value, never null, so no NPE is possible here.
+KOTLIN_PRIMITIVES = {"Int", "Long", "Double", "Float", "Boolean", "Short", "Byte", "Char"}
+
+# The tail left after the money-path fix in #3104. Each entry is "<service>|<Class>|<param>".
+# The count per key is not recorded on purpose: several of these repeat the identical parameter
+# across sibling handlers (card-issuance's X-Operator-Id sevenfold), and pinning the count would
+# make an unrelated refactor fail the gate for no defect.
+BASELINE = {
+    # openbank-aml-service — POST /api/v1/aml/cases
+    "openbank-aml-service|AmlCaseResource|Idempotency-Key",
+    # openbank-card-issuance-service — operator attribution on every card lifecycle operation
+    "openbank-card-issuance-service|CardResource|Idempotency-Key",
+    "openbank-card-issuance-service|CardResource|X-Operator-Id",
+    "openbank-card-issuance-service|CardDelegationResource|partyId",
+    "openbank-card-issuance-service|CardDelegationResource|intent",
+    # openbank-customer-edge — the mobile/web BFF
+    "openbank-customer-edge|CustomerEdgeResource|currency",
+    "openbank-customer-edge|CustomerEdgeResource|accountId",
+    # openbank-dispute-service
+    "openbank-dispute-service|DisputeResource|actor",
+    # openbank-party-service
+    "openbank-party-service|PartyResource|Idempotency-Key",
+    # openbank-pid-service
+    "openbank-pid-service|PartyResource|index",
+    "openbank-pid-service|PartyResource|type",
+    "openbank-pid-service|PartyResource|value",
+    # openbank-psd2-service — Berlin Group headers on AIS/PIS
+    "openbank-psd2-service|AisResource|Consent-ID",
+    "openbank-psd2-service|PisResource|Consent-ID",
+    "openbank-psd2-service|PisResource|Idempotency-Key",
+    # openbank-statement-service
+    "openbank-statement-service|StatementResource|from",
+    "openbank-statement-service|StatementResource|to",
+    # openbank-tpp-registry-service
+    "openbank-tpp-registry-service|TppRegistryResource|tppId",
+    "openbank-tpp-registry-service|TppRegistryResource|role",
+}
+
+
+def strip_comments(src: str) -> str:
+    """Remove Kotlin comments while preserving line numbers and string literals.
+
+    Kotlin block comments NEST, so a KDoc containing `/*` does not end at the first `*/`. Getting
+    this wrong closes the comment early and leaks prose into the scan — which is how a guard ends up
+    flagging the very KDoc that explains the bug it exists to catch.
+    """
+    out = []
+    i, n, depth = 0, len(src), 0
+    while i < n:
+        if depth:
+            if src.startswith("/*", i):
+                depth += 1
+                i += 2
+            elif src.startswith("*/", i):
+                depth -= 1
+                i += 2
+            else:
+                if src[i] == "\n":
+                    out.append("\n")
+                i += 1
+            continue
+        if src.startswith("/*", i):
+            depth = 1
+            i += 2
+        elif src.startswith("//", i):
+            j = src.find("\n", i)
+            if j == -1:
+                break
+            out.append("\n")
+            i = j + 1
+        elif src.startswith('"""', i):
+            j = src.find('"""', i + 3)
+            j = n if j == -1 else j + 3
+            out.append(src[i:j])
+            i = j
+        elif src[i] == '"':
+            j = i + 1
+            while j < n and src[j] != '"':
+                j += 2 if src[j] == "\\" else 1
+            out.append(src[i:j + 1])
+            i = j + 1
+        else:
+            out.append(src[i])
+            i += 1
+    return "".join(out)
+
+
+ANNOTATION_RE = re.compile(
+    r"@(" + "|".join(PARAM_ANNOTATIONS) + r")\s*\(\s*\"([^\"]+)\"\s*\)",
+)
+DECL_RE = re.compile(r"^(?:[\w@\s]*?)\b(interface|class|object)\s+(\w+)", re.M)
+
+
+def enclosing_type(src: str, offset: int):
+    """(kind, name) of the class/interface/object lexically enclosing `offset`.
+
+    `kind` is the discriminator that matters: an `interface` is an outbound MicroProfile REST
+    client, a `class` is an inbound resource. Files that hold both (a resource plus its client)
+    resolve correctly because the LAST declaration before the offset wins.
+    """
+    last = None
+    for m in DECL_RE.finditer(src, 0, offset):
+        last = m
+    return (last.group(1), last.group(2)) if last else ("?", "?")
+
+
+def scan_source(src: str, service: str, path: str):
+    """Yield findings for one already-comment-stripped Kotlin source."""
+    for m in ANNOTATION_RE.finditer(src):
+        kind, param = m.group(1), m.group(2)
+        tail = src[m.end():]
+
+        # Consume any further annotations on the same parameter; @DefaultValue among them means
+        # JAX-RS never injects null.
+        j, has_default_ann = 0, False
+        while True:
+            nxt = re.match(r"\s*@(\w+)\s*(\([^()]*\))?", tail[j:])
+            if not nxt:
+                break
+            if nxt.group(1) == "DefaultValue":
+                has_default_ann = True
+            j += nxt.end()
+
+        decl = re.match(r"\s*(?:vararg\s+)?(?:va[lr]\s+)?(\w+)\s*:\s*([^,)=]+)", tail[j:])
+        if not decl:
+            continue
+        declared_type = decl.group(2).strip()
+        has_kotlin_default = tail[j + decl.end():].lstrip().startswith("=")
+
+        if declared_type.endswith("?") or declared_type in KOTLIN_PRIMITIVES:
+            continue
+        if has_default_ann or has_kotlin_default:
+            continue
+
+        encl_kind, encl_name = enclosing_type(src, m.start())
+        if encl_kind != "class":
+            continue  # outbound REST client — the caller supplies the argument
+
+        yield {
+            "key": f"{service}|{encl_name}|{param}",
+            "file": path,
+            "line": src.count("\n", 0, m.start()) + 1,
+            "annotation": kind,
+            "param": param,
+            "type": declared_type,
+            "kotlin_name": decl.group(1),
+        }
+
+
+def scan(root: str):
+    base = pathlib.Path(root)
+    findings = []
+    for p in sorted(base.rglob("*.kt")):
+        s = str(p)
+        if "/src/test/" in s or "/build/" in s or "/src/nativeTest/" in s:
+            continue
+        raw = p.read_text(encoding="utf-8", errors="replace")
+        if not any(a in raw for a in PARAM_ANNOTATIONS):
+            continue
+        rel = str(p.relative_to(base)) if p.is_relative_to(base) else s
+        service = rel.split("/")[0]
+        findings.extend(scan_source(strip_comments(raw), service, rel))
+    return findings
+
+
+# --- self-test ---------------------------------------------------------------------------------
+# Every branch of the classifier gets a case, and the must-NOT-flag half is the half that matters:
+# a guard that flags every param annotation is noise, and one that cannot tell an inbound resource
+# from an outbound client over-counts by roughly 2x on this repo.
+SELF_TEST_SOURCE = '''
+package com.openbank.demo
+
+/**
+ * Prose that names @QueryParam("prose_only") p: String deliberately — a guard that greps the file
+ * instead of the construct flags this KDoc. Block comments NEST: /* like this */ and the scan must
+ * still be inside a comment right here, where @HeaderParam("nested_prose") h: String appears.
+ */
+@Path("/api/v1/demo")
+class DemoResource {
+    fun flagged(@QueryParam("flag_plain") a: String): Response = TODO()
+
+    suspend fun flaggedSuspend(@HeaderParam("flag_header") b: String): Response = TODO()
+
+    fun flaggedEnum(@QueryParam("flag_enum") c: DemoKind): Response = TODO()
+
+    fun allowedNullable(@QueryParam("ok_nullable") d: String?): Response = TODO()
+
+    fun allowedDefaultAnn(@QueryParam("ok_default_ann") @DefaultValue("x") e: String): Response = TODO()
+
+    fun allowedKotlinDefault(@QueryParam("ok_kotlin_default") f: String = "x"): Response = TODO()
+
+    fun allowedPrimitive(@QueryParam("ok_primitive") g: Int): Response = TODO()
+
+    // A commented-out declaration must not count:
+    // fun commentedOut(@QueryParam("comment_only") z: String): Response = TODO()
+    fun stringLiteralIsNotADecl(): String = "@QueryParam(\\"literal_only\\") y: String"
+}
+
+@RegisterRestClient
+@Path("/api/v1/other")
+interface DemoClient {
+    fun outbound(@QueryParam("ok_outbound") h: String): Uni<String>
+}
+'''
+
+SELF_TEST_EXPECTED_FLAGGED = {"flag_plain", "flag_header", "flag_enum"}
+SELF_TEST_EXPECTED_ALLOWED = {
+    "prose_only", "nested_prose", "ok_nullable", "ok_default_ann", "ok_kotlin_default",
+    "ok_primitive", "comment_only", "literal_only", "ok_outbound",
+}
+
+
+def self_test() -> int:
+    flagged = {f["param"] for f in scan_source(strip_comments(SELF_TEST_SOURCE), "demo", "Demo.kt")}
+    failures = 0
+    for want in sorted(SELF_TEST_EXPECTED_FLAGGED):
+        ok = want in flagged
+        print(f"{'pass' if ok else 'FAIL'}  must flag   {want}")
+        failures += 0 if ok else 1
+    for want in sorted(SELF_TEST_EXPECTED_ALLOWED):
+        ok = want not in flagged
+        print(f"{'pass' if ok else 'FAIL'}  must allow  {want}")
+        failures += 0 if ok else 1
+
+    unexpected = flagged - SELF_TEST_EXPECTED_FLAGGED
+    if unexpected:
+        print(f"FAIL  flagged something the fixture did not declare: {sorted(unexpected)}")
+        failures += 1
+    else:
+        print("pass  no findings outside the declared fixture set")
+
+    total = len(SELF_TEST_EXPECTED_FLAGGED) + len(SELF_TEST_EXPECTED_ALLOWED) + 1
+    print(f"\nself-test: {total - failures} passed, {failures} failed")
+    return 0 if failures == 0 else 2
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Guard non-nullable required JAX-RS params (#3104)")
+    ap.add_argument("--root", default=".")
+    ap.add_argument("--self-test", action="store_true")
+    ap.add_argument("--list", action="store_true", help="print every finding, baselined or not")
+    args = ap.parse_args()
+
+    if args.self_test:
+        return self_test()
+
+    root = pathlib.Path(args.root)
+    if not root.is_dir():
+        print(f"::error::--root {args.root} is not a directory — the check could not run. NOT a pass.")
+        return 2
+
+    findings = scan(args.root)
+    if args.list:
+        for f in sorted(findings, key=lambda x: (x["file"], x["line"])):
+            mark = "baselined" if f["key"] in BASELINE else "NEW"
+            print(f"{mark:9} {f['file']}:{f['line']} @{f['annotation']}(\"{f['param']}\") "
+                  f"{f['kotlin_name']}: {f['type']}")
+        print(f"\n{len(findings)} finding(s), {len(BASELINE)} baseline key(s)")
+        return 0
+
+    seen = {f["key"] for f in findings}
+    new = [f for f in findings if f["key"] not in BASELINE]
+    stale = sorted(BASELINE - seen)
+
+    for f in sorted(new, key=lambda x: (x["file"], x["line"])):
+        print(
+            f"::error file={f['file']},line={f['line']}::"
+            f"@{f['annotation']}(\"{f['param']}\") is declared {f['kotlin_name']}: {f['type']} — "
+            f"non-nullable with no @DefaultValue, so an absent value answers 500, not 400. "
+            f"Declare it nullable and guard it "
+            f"(requireNotNull(...) {{ \"...\" }}); libs-runtime maps that to 400. "
+            f"A guard in the body of a NON-suspend handler is dead code — the Kotlin intrinsic "
+            f"throws first. See issue #3104.",
+        )
+    for k in stale:
+        print(
+            f"::error::STALE baseline entry {k} no longer occurs — it is fixed, or the resource is "
+            f"gone. Remove it from BASELINE in this script so the list keeps meaning something.",
+        )
+
+    if new or stale:
+        print(f"\n{len(new)} new occurrence(s), {len(stale)} stale baseline entr(ies).")
+        return 1
+    print(
+        f"non-nullable JAX-RS params: OK — {len(findings)} baselined occurrence(s), no new ones. "
+        f"The money-path set was fixed in #3104; the tail is per-handler work tracked there.",
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,24 @@ These are real, repeatable gotchas — worth knowing before they cost you a debu
   (RestAssured + `@TestSecurity`) and assert the row with a plain JDBC read. This is also the only
   way to prove transactional-outbox atomicity (status change + outbox row commit together) — a mocked
   repo can't. Pattern: `LendingOutboxWriteIT`, `ConsentRevocationOutboxIT`.
+- **A non-nullable `@QueryParam`/`@HeaderParam` is a 500, and `requireNotNull` in the body is DEAD
+  CODE — the parameter must be declared nullable.** JAX-RS injects `null` for an absent parameter;
+  Kotlin's null-safety is compile-time only, so the declared type only decides *where* the failure
+  lands, and every landing is a 500 (`GenericExceptionMapper`). Measured with `javap`: a plain `fun`
+  emits `Intrinsics.checkNotNullParameter` at **offset 0**, so a guard written in the body compiles
+  to nothing — the NPE already threw. A **`suspend fun` emits no intrinsic at all**, so the null
+  flows into the body and fails at the first dereference; where nothing dereferences it, the request
+  proceeds with a null the signature promised could not exist, which is worse than the 500 and
+  invisible. That is how three services shipped
+  `require(idempotencyKey.isNotBlank()) { "Idempotency-Key header is required" }` that answered
+  **500 for the absent header** — the exact case it was written for — and 400 only for a blank one.
+  Write `@QueryParam("x") x: String?` + `requireNotNull(x) { "query parameter 'x' is required" }`;
+  libs-runtime maps `IllegalArgumentException` to 400 (never add a service-local mapper, #526). The
+  primitive case differs and is out of scope: JAX-RS supplies `0`, not null. `@DefaultValue` is the
+  other correct answer where one exists. Enforced by `check-nonnull-jaxrs-params.py` (gate
+  `nonnull-jaxrs-param-ratchet`) — money-path fixed, the tail baselined (#3104, #3624). Counting
+  trap: an outbound REST-client **`interface`** carries the identical annotation and is NOT a defect
+  (the caller supplies the argument, compile-time checked), which is half of every naive grep.
 - **A Kotlin annotation binds to the NEXT declaration — a top-level function between `@Path` and its
   class silently steals it.** `McpEndpoint` had `@Path("/mcp")`, then a top-level
   `private fun String?.sanitizeForLog()`, then `class McpEndpoint`. The `@Path` bound to the

--- a/docs/threat-models/openbank-account-service.md
+++ b/docs/threat-models/openbank-account-service.md
@@ -86,6 +86,7 @@ not change any existing request's outcome until explicitly flipped.
 
 ## 6. Change log
 
+- **2026-08-03** — Missing required query/header parameter answered 500, not 400 (#3104). A required `@QueryParam`/`@HeaderParam` declared with a non-nullable Kotlin type was fed `null` by JAX-RS when the caller omitted it, and answered **500** rather than 400 (#3104). Kotlin's null-safety is compile-time only, so the declared type only decided where the failure landed: a non-suspend handler threw `Intrinsics.checkNotNullParameter` at the method boundary, and a **suspend** handler got no intrinsic at all, so the null flowed into the body. Six parameters: `Idempotency-Key` on openAccount, `currency` on resolvePocket, and the `partyId`/`role` and `partyId`/`intent` pairs on the two authorization-check endpoints. The authorization pairs are the security-relevant ones: they are the INPUTS to an access decision, so a null reaching the use case is a decision taken on an absent subject rather than a rejected request. No new caller, no new boundary; the endpoints and their `@RolesAllowed`/`@Authorize` gates are unchanged, and every guard runs AFTER authorization. Rollback: revert the commit (restores the 500).
 - **2026-07-09** — Account opening validates against product-catalog (ADR-0158, issue #668).
   New outbound trust boundary: `account-service → product-catalog` (`GET /api/v1/products/{id}`,
   unauthenticated, sync). `openAccount` now rejects a `productId` product-catalog confirms does

--- a/docs/threat-models/openbank-consent-service.md
+++ b/docs/threat-models/openbank-consent-service.md
@@ -52,6 +52,7 @@ escalating a consent is a direct path to unauthorized data access or payment ini
 
 ## 6. Change log
 
+- **2026-08-03** — Missing required query/header parameter answered 500, not 400 (#3104). A required `@QueryParam`/`@HeaderParam` declared with a non-nullable Kotlin type was fed `null` by JAX-RS when the caller omitted it, and answered **500** rather than 400 (#3104). Kotlin's null-safety is compile-time only, so the declared type only decided where the failure landed: a non-suspend handler threw `Intrinsics.checkNotNullParameter` at the method boundary, and a **suspend** handler got no intrinsic at all, so the null flowed into the body. Four parameters on the consent lifecycle: `partyId` on revoke, `scaSessionId` on activate, `reason` on reject, `scope` on hasActiveConsent. `scaSessionId` is the evidence that SCA completed, so a null reaching activate is a state transition with no SCA reference attached — the request must be rejected, not half-processed. hasActiveConsent already answered 400 by accident (`runCatching` swallowed the NPE); it now says which parameter is missing. No new caller or boundary. Rollback: revert.
 - **2026-07-17** — Completed ADR-0126 §D2: `/validate` response now carries `scopes`, `grantedAccounts`
   (covered IBANs; null = all of the party's accounts) and `frequencyPerDay` (PSD2 RTS Art. 10 AISP cap
   = 4) so a resource server can cache within that window. Additive optional fields (openapi

--- a/docs/threat-models/openbank-delegation-service.md
+++ b/docs/threat-models/openbank-delegation-service.md
@@ -54,3 +54,7 @@ is now stated in the row rather than implied away.
   status and KYC level only.
 - **The ADR-0232 D5 SME bridge is unimplemented**: nothing requires a LEGAL_ENTITY grantor's
   acting person to hold `delegation.manage` on that entity.
+
+## Change log
+
+- **2026-08-03** — Missing required query/header parameter answered 500, not 400 (#3104). A required `@QueryParam`/`@HeaderParam` declared with a non-nullable Kotlin type was fed `null` by JAX-RS when the caller omitted it, and answered **500** rather than 400 (#3104). Kotlin's null-safety is compile-time only, so the declared type only decided where the failure landed: a non-suspend handler threw `Intrinsics.checkNotNullParameter` at the method boundary, and a **suspend** handler got no intrinsic at all, so the null flowed into the body. Four parameters on the grantee-response endpoints: `granteePartyId` on accept/decline/renounce and `scaSessionId` on accept. Both are authorization-relevant — `granteePartyId` names WHO is responding to the grant and `scaSessionId` is the SCA evidence for accepting it — so a null reaching the use case is a delegation transition with no identified actor. The `X-Customer-Party-Id` header stays nullable by design (its absence is what distinguishes a bank-initiated call). No new caller or boundary. Rollback: revert.

--- a/docs/threat-models/openbank-domestic-payment.md
+++ b/docs/threat-models/openbank-domestic-payment.md
@@ -85,6 +85,7 @@ not change any existing request's outcome until explicitly flipped.
 
 ## 6. Change log
 
+- **2026-08-03** — Missing required query/header parameter answered 500, not 400 (#3104). A required `@QueryParam`/`@HeaderParam` declared with a non-nullable Kotlin type was fed `null` by JAX-RS when the caller omitted it, and answered **500** rather than 400 (#3104). Kotlin's null-safety is compile-time only, so the declared type only decided where the failure landed: a non-suspend handler threw `Intrinsics.checkNotNullParameter` at the method boundary, and a **suspend** handler got no intrinsic at all, so the null flowed into the body. `Idempotency-Key` on createPayment. The existing guard `require(idempotencyKey.isNotBlank())` could not run for an ABSENT header: this handler is `suspend`, so no intrinsic was emitted and `null.isNotBlank()` threw NPE — the replay control answered 500 in exactly the case it was written for, while a BLANK header correctly gave 400. Now `require(!idempotencyKey.isNullOrBlank())`. This is a control that was partially inoperative, not a new one. No new caller or boundary. Rollback: revert.
 - **2026-07-24** — Retire the legacy in-service orchestration; Temporal is the sole orchestrator
   (ADR-0120 Phase 6, issue #1917). `createPayment` no longer branches on `openbank.temporal.enabled`
   (removed) — it always dispatches `DomesticPaymentWorkflow` (screening → shadow fraud scoring → scheme

--- a/docs/threat-models/openbank-fx-service.md
+++ b/docs/threat-models/openbank-fx-service.md
@@ -51,6 +51,7 @@ directly determines monetary outcomes — a manipulated rate is a financial-loss
 
 ## 6. Change log
 
+- **2026-08-03** — Missing required query/header parameter answered 500, not 400 (#3104). A required `@QueryParam`/`@HeaderParam` declared with a non-nullable Kotlin type was fed `null` by JAX-RS when the caller omitted it, and answered **500** rather than 400 (#3104). Kotlin's null-safety is compile-time only, so the declared type only decided where the failure landed: a non-suspend handler threw `Intrinsics.checkNotNullParameter` at the method boundary, and a **suspend** handler got no intrinsic at all, so the null flowed into the body. `Idempotency-Key` on convert, the sibling of the null-body guard added by #3050 one argument position over. Same defect as domestic-payment: `require(key.isNotBlank())` in a `suspend` handler threw NPE on an absent header, so the replay control answered 500 for a missing key and 400 only for a blank one. Now `require(!key.isNullOrBlank())`. No new caller or boundary. Rollback: revert.
 - **2026-05-30** — Added `fx_outbox_seq` (Hibernate fix). Additive DDL only — no new flow/surface/
   boundary. Risk class = **availability**, mitigated by `HibernateSequenceGuardTest`.
   Rollback: `DROP SEQUENCE`.

--- a/docs/threat-models/openbank-interest-service.md
+++ b/docs/threat-models/openbank-interest-service.md
@@ -58,6 +58,7 @@ money-path service, not adjacent.
 
 ## 6. Change log
 
+- **2026-08-03** — Missing required query/header parameter answered 500, not 400 (#3104). A required `@QueryParam`/`@HeaderParam` declared with a non-nullable Kotlin type was fed `null` by JAX-RS when the caller omitted it, and answered **500** rather than 400 (#3104). Kotlin's null-safety is compile-time only, so the declared type only decided where the failure landed: a non-suspend handler threw `Intrinsics.checkNotNullParameter` at the method boundary, and a **suspend** handler got no intrinsic at all, so the null flowed into the body. `productId` on capitalize and effectiveRate — #3104's own reproduction case. Both handlers are non-suspend, so `POST /api/v1/interest/capitalize/{accountId}` without `?productId=` threw at the method boundary and rendered 500 before any authorization-independent work ran. No fund movement is reachable without the parameter in either the old or the new behaviour — the change is purely which status the rejected request carries, and 5xx here also burnt this service's SLO error budget. No new caller or boundary. Rollback: revert.
 - **2026-07-24** — Freeze the tax profile at claim time (issue #1355). `capitalize()`'s claim froze the
   accrual SET (gross) before the ledger post but re-called `taxProfilePort.resolve(accountId)` fresh on
   every attempt, including retries. The ledger idempotency key is amount-blind, so a retry after a

--- a/docs/threat-models/openbank-lending-service.md
+++ b/docs/threat-models/openbank-lending-service.md
@@ -293,6 +293,7 @@ against `lending.intake.caller-principal`, which refuses every call when unset.
 
 ## 10. Change log
 
+- **2026-08-03** — Missing required query/header parameter answered 500, not 400 (#3104). A required `@QueryParam`/`@HeaderParam` declared with a non-nullable Kotlin type was fed `null` by JAX-RS when the caller omitted it, and answered **500** rather than 400 (#3104). Kotlin's null-safety is compile-time only, so the declared type only decided where the failure landed: a non-suspend handler threw `Intrinsics.checkNotNullParameter` at the method boundary, and a **suspend** handler got no intrinsic at all, so the null flowed into the body. `partyId` on the two list endpoints (applications, loans). These are read-only queries scoped BY that party, so a null reaching the repository is a query with no subject; the handlers are non-suspend, so in practice it threw at the boundary and 500'd first. The `@Authorize(action = "lending.list")` gate is unchanged and still runs before the guard. No new caller or boundary. Rollback: revert.
 - **2026-07-31** — Termination and early-exit lifecycle (ADR-0215): termination
   sub-lifecycle states + guard, settlement quote (expired quote refused), statutory
   withdrawal with unwind journal + day interest, DPD/CRR-178 default gates, mandatory

--- a/docs/threat-models/openbank-sdd-service.md
+++ b/docs/threat-models/openbank-sdd-service.md
@@ -55,4 +55,5 @@ instruction, but the irreversible debit lives downstream.
 
 ## 6. Change log
 
+- **2026-08-03** — Missing required query/header parameter answered 500, not 400 (#3104). A required `@QueryParam`/`@HeaderParam` declared with a non-nullable Kotlin type was fed `null` by JAX-RS when the caller omitted it, and answered **500** rather than 400 (#3104). Kotlin's null-safety is compile-time only, so the declared type only decided where the failure landed: a non-suspend handler threw `Intrinsics.checkNotNullParameter` at the method boundary, and a **suspend** handler got no intrinsic at all, so the null flowed into the body. `accountId` on listMandates and `debitDate` on assessRefund. Both handlers are non-suspend and threw at the method boundary. `debitDate` is the input to the refund-window arithmetic (8-week / 13-month), so a request missing it must be rejected rather than defaulted — an UNPARSEABLE date is a different class and already 400 via `DateTimeExceptionMapper`. No new caller or boundary. Rollback: revert.
 - **2026-06-19** — Initial lightweight threat model (ADR-0030 D2).

--- a/docs/threat-models/openbank-sepa-payment.md
+++ b/docs/threat-models/openbank-sepa-payment.md
@@ -106,6 +106,7 @@ from clearing-simulator (cluster-internal, `ROLE_SERVICE`). New trust boundary:
 
 ## 6. Change log
 
+- **2026-08-03** — Missing required query/header parameter answered 500, not 400 (#3104). A required `@QueryParam`/`@HeaderParam` declared with a non-nullable Kotlin type was fed `null` by JAX-RS when the caller omitted it, and answered **500** rather than 400 (#3104). Kotlin's null-safety is compile-time only, so the declared type only decided where the failure landed: a non-suspend handler threw `Intrinsics.checkNotNullParameter` at the method boundary, and a **suspend** handler got no intrinsic at all, so the null flowed into the body. `Idempotency-Key` on createPayment. As in domestic-payment, the existing `require(idempotencyKey.isNotBlank())` could not run for an ABSENT header — this handler is `suspend`, so `null.isNotBlank()` threw NPE and the replay control answered 500 in exactly the case it existed for. A duplicate submission was never at risk (the store is only consulted with a real key), but the caller was told the server had broken when it had not. Now `require(!idempotencyKey.isNullOrBlank())`. No new caller or boundary. Rollback: revert.
 - **2026-07-24** — Retire the legacy in-service orchestration; Temporal is the sole orchestrator
   (ADR-0120 Phase 6, issue #1917). `createPayment` no longer branches on `openbank.temporal.enabled`
   (removed) — it always dispatches `SepaPaymentWorkflow` (screening → shadow fraud scoring → scheme

--- a/docs/threat-models/openbank-transaction-service.md
+++ b/docs/threat-models/openbank-transaction-service.md
@@ -167,6 +167,7 @@ and no existing request's outcome changes.
 
 ## 6. Change log
 
+- **2026-08-03** — Missing required query/header parameter answered 500, not 400 (#3104). A required `@QueryParam`/`@HeaderParam` declared with a non-nullable Kotlin type was fed `null` by JAX-RS when the caller omitted it, and answered **500** rather than 400 (#3104). Kotlin's null-safety is compile-time only, so the declared type only decided where the failure landed: a non-suspend handler threw `Intrinsics.checkNotNullParameter` at the method boundary, and a **suspend** handler got no intrinsic at all, so the null flowed into the body. `accountId` on listTransactions. Listing "transactions for an account" with no account is a malformed request; the null reached `ListTransactionsQuery` and answered 500. The sibling searchTransactions endpoint already declares `accountId` nullable by design (search is deliberately multi-criteria) and is untouched. No new caller or boundary; `@RolesAllowed` and `@Authorize(action = "transaction.list")` are unchanged and still run first. Rollback: revert.
 - **2026-07-12** — Wired the four-eyes (maker-checker) enforcement *mechanism* (ADR-0155) onto
   `transaction.reverse`, mirroring the account-service rollout (issue #413). New `ApprovalConfig`
   (`RedisApprovalStore` producer, wired onto this service's first-ever Redis client — reuses the

--- a/openbank-account-service/src/main/kotlin/com/openbank/account/infrastructure/rest/AccountResource.kt
+++ b/openbank-account-service/src/main/kotlin/com/openbank/account/infrastructure/rest/AccountResource.kt
@@ -124,8 +124,12 @@ class AccountResource(
     @Operation(summary = "Open a new account")
     suspend fun openAccount(
         request: OpenAccountRequest,
-        @HeaderParam("Idempotency-Key") idempotencyKey: String,
+        @HeaderParam("Idempotency-Key") idempotencyKey: String?,
     ): Response {
+        // Declared nullable on purpose (#3104): JAX-RS injects null for an absent header, and the
+        // non-nullable type only decided where the NPE landed — a 500 that tells the caller the
+        // server broke. libs-runtime maps IllegalArgumentException to 400.
+        requireNotNull(idempotencyKey) { "Idempotency-Key header is required" }
         idempotencyStore.get(idempotencyKey)?.let { cached ->
             return Response.status(cached.statusCode)
                 .entity(cached.responseBody)
@@ -375,10 +379,12 @@ class AccountResource(
     @Operation(summary = "Resolve which pocket settles a payment in a given currency")
     suspend fun resolvePocket(
         @PathParam("accountId") accountId: UUID,
-        @QueryParam("currency") currency: String,
+        @QueryParam("currency") currency: String?,
         @QueryParam("policy") @DefaultValue("CONVERT_TO_PRIMARY") policy: String,
         @HeaderParam(CUSTOMER_PARTY_HEADER) customerPartyId: UUID?,
     ): Response {
+        // #3104 — absent `currency` used to reach CurrencyCode.of(null) and answer 500.
+        requireNotNull(currency) { "query parameter 'currency' is required" }
         customerPartyId?.let {
             val account = accountUseCase.getAccount(GetAccountQuery(accountId))
             denyIfNotOwner(account.partyId, it)?.let { deny -> return deny }

--- a/openbank-account-service/src/main/kotlin/com/openbank/account/infrastructure/rest/AuthorizationResource.kt
+++ b/openbank-account-service/src/main/kotlin/com/openbank/account/infrastructure/rest/AuthorizationResource.kt
@@ -83,9 +83,12 @@ class AuthorizationResource(private val authorizationUseCase: AuthorizationUseCa
     @Authorize(action = "account.read", resource = "#accountId")
     suspend fun check(
         @PathParam("accountId") accountId: UUID,
-        @QueryParam("partyId") partyId: UUID,
-        @QueryParam("role") role: com.openbank.account.domain.model.AuthorizationRole,
+        @QueryParam("partyId") partyId: UUID?,
+        @QueryParam("role") role: com.openbank.account.domain.model.AuthorizationRole?,
     ): Response {
+        // #3104 — both are required; absent, they used to reach the use case as null and answer 500.
+        requireNotNull(partyId) { "query parameter 'partyId' is required" }
+        requireNotNull(role) { "query parameter 'role' is required" }
         val authorized = authorizationUseCase.isAuthorized(accountId, partyId, role)
         return Response.ok(mapOf("authorized" to authorized)).build()
     }

--- a/openbank-account-service/src/main/kotlin/com/openbank/account/infrastructure/rest/SavingsGoalDelegationResource.kt
+++ b/openbank-account-service/src/main/kotlin/com/openbank/account/infrastructure/rest/SavingsGoalDelegationResource.kt
@@ -37,9 +37,12 @@ class SavingsGoalDelegationResource(private val guard: SavingsGoalDelegationGuar
     @Operation(summary = "Whether a party may DEPOSIT / WITHDRAW / PROPOSE_WITHDRAW on the account's savings goal")
     suspend fun check(
         @PathParam("accountId") accountId: UUID,
-        @QueryParam("partyId") partyId: UUID,
-        @QueryParam("intent") intent: SavingsDelegationIntent,
+        @QueryParam("partyId") partyId: UUID?,
+        @QueryParam("intent") intent: SavingsDelegationIntent?,
     ): Response {
+        // #3104 — both are required; absent, they used to reach the guard as null and answer 500.
+        requireNotNull(partyId) { "query parameter 'partyId' is required" }
+        requireNotNull(intent) { "query parameter 'intent' is required" }
         val authorized = guard.isAuthorized(accountId, partyId, intent)
         return Response.ok(mapOf("authorized" to authorized)).build()
     }

--- a/openbank-consent-service/src/main/kotlin/com/openbank/consent/infrastructure/rest/ConsentResource.kt
+++ b/openbank-consent-service/src/main/kotlin/com/openbank/consent/infrastructure/rest/ConsentResource.kt
@@ -153,11 +153,14 @@ class ConsentResource(
     @Authorize(action = "consent.revoke", resource = "#granteeId")
     suspend fun revoke(
         @PathParam("id") id: UUID,
-        @QueryParam("partyId") partyId: UUID,
+        @QueryParam("partyId") partyId: UUID?,
         @QueryParam("granteeId") granteeId: String?,
         request: RevokeConsentRequest?,
     ): ConsentResponse {
         requireNotNull(request) { "request body is required" }
+        // #3104 — same defect one argument position over: absent, partyId reached
+        // RevokeConsentCommand as null and answered 500 instead of 400.
+        requireNotNull(partyId) { "query parameter 'partyId' is required" }
         val consent = revokeConsent.revokeConsent(RevokeConsentCommand(id, partyId, request.reason, granteeId))
         return ConsentResponse.from(consent)
     }
@@ -166,15 +169,24 @@ class ConsentResource(
     @POST
     @Path("/{id}/activate")
     @Authorize(action = "consent.activate", resource = "#id")
-    suspend fun activate(@PathParam("id") id: UUID, @QueryParam("scaSessionId") scaSessionId: UUID): ConsentResponse =
-        ConsentResponse.from(activateConsent.activateConsent(id, scaSessionId))
+    suspend fun activate(
+        @PathParam("id") id: UUID,
+        @QueryParam("scaSessionId") scaSessionId: UUID?,
+    ): ConsentResponse {
+        // #3104 — nullable + guard, because a guard in a non-nullable parameter's body is dead code.
+        requireNotNull(scaSessionId) { "query parameter 'scaSessionId' is required" }
+        return ConsentResponse.from(activateConsent.activateConsent(id, scaSessionId))
+    }
 
     @Operation(summary = "Reject a PENDING_SCA consent (e.g. customer cancelled SCA); transitions to REJECTED")
     @POST
     @Path("/{id}/reject")
     @Authorize(action = "consent.reject", resource = "#id")
-    suspend fun reject(@PathParam("id") id: UUID, @QueryParam("reason") reason: String): ConsentResponse =
-        ConsentResponse.from(activateConsent.rejectConsent(id, reason))
+    suspend fun reject(@PathParam("id") id: UUID, @QueryParam("reason") reason: String?): ConsentResponse {
+        // #3104 — a rejection with no reason is a bad request, not a broken server.
+        requireNotNull(reason) { "query parameter 'reason' is required" }
+        return ConsentResponse.from(activateConsent.rejectConsent(id, reason))
+    }
 
     @Operation(summary = "Validate whether a consent covers the requested scope and account (resource servers)")
     @POST
@@ -211,8 +223,13 @@ class ConsentResource(
     suspend fun hasActiveConsent(
         @PathParam("partyId") partyId: UUID,
         @PathParam("granteeId") granteeId: String,
-        @QueryParam("scope") scope: String,
+        @QueryParam("scope") scope: String?,
     ): ConsentCheckResponse {
+        // #3104 — this handler ALREADY answered 400 when the parameter was absent, because
+        // `runCatching` swallows the NPE from valueOf(null) and the requireNotNull below fires.
+        // Nullable + an explicit guard so the message names the missing parameter rather than
+        // reporting `unknown scope: null`, and so the declared type stops promising non-null.
+        requireNotNull(scope) { "query parameter 'scope' is required" }
         val required = runCatching { ConsentScope.valueOf(scope) }.getOrNull()
         requireNotNull(required) { "unknown scope: $scope" }
         val granted = validateConsent.hasActiveConsent(

--- a/openbank-consent-service/src/main/kotlin/com/openbank/consent/infrastructure/rest/ConsentResource.kt
+++ b/openbank-consent-service/src/main/kotlin/com/openbank/consent/infrastructure/rest/ConsentResource.kt
@@ -169,10 +169,7 @@ class ConsentResource(
     @POST
     @Path("/{id}/activate")
     @Authorize(action = "consent.activate", resource = "#id")
-    suspend fun activate(
-        @PathParam("id") id: UUID,
-        @QueryParam("scaSessionId") scaSessionId: UUID?,
-    ): ConsentResponse {
+    suspend fun activate(@PathParam("id") id: UUID, @QueryParam("scaSessionId") scaSessionId: UUID?): ConsentResponse {
         // #3104 — nullable + guard, because a guard in a non-nullable parameter's body is dead code.
         requireNotNull(scaSessionId) { "query parameter 'scaSessionId' is required" }
         return ConsentResponse.from(activateConsent.activateConsent(id, scaSessionId))

--- a/openbank-delegation-service/src/main/kotlin/com/openbank/delegation/infrastructure/rest/DelegationResource.kt
+++ b/openbank-delegation-service/src/main/kotlin/com/openbank/delegation/infrastructure/rest/DelegationResource.kt
@@ -163,11 +163,18 @@ class DelegationResource(
     @Authorize(action = "delegation.accept", resource = "#id")
     suspend fun accept(
         @PathParam("id") id: UUID,
-        @QueryParam("granteePartyId") granteePartyId: UUID,
-        @QueryParam("scaSessionId") scaSessionId: UUID,
+        @QueryParam("granteePartyId") granteePartyId: UUID?,
+        @QueryParam("scaSessionId") scaSessionId: UUID?,
         @HeaderParam(CUSTOMER_PARTY_HEADER) customerPartyId: UUID?,
-    ): DelegationResponse =
-        DelegationResponse.from(respondDelegation.accept(id, granteePartyId, scaSessionId, customerPartyId))
+    ): DelegationResponse {
+        // #3104 — both identify WHO is accepting and under which SCA session. Absent, they used to
+        // reach the use case as null and answer 500.
+        requireNotNull(granteePartyId) { "query parameter 'granteePartyId' is required" }
+        requireNotNull(scaSessionId) { "query parameter 'scaSessionId' is required" }
+        return DelegationResponse.from(
+            respondDelegation.accept(id, granteePartyId, scaSessionId, customerPartyId),
+        )
+    }
 
     @Operation(summary = "Decline an OFFERED grant (grantee)")
     @POST
@@ -175,9 +182,13 @@ class DelegationResource(
     @Authorize(action = "delegation.decline", resource = "#id")
     suspend fun decline(
         @PathParam("id") id: UUID,
-        @QueryParam("granteePartyId") granteePartyId: UUID,
+        @QueryParam("granteePartyId") granteePartyId: UUID?,
         @HeaderParam(CUSTOMER_PARTY_HEADER) customerPartyId: UUID?,
-    ): DelegationResponse = DelegationResponse.from(respondDelegation.decline(id, granteePartyId, customerPartyId))
+    ): DelegationResponse {
+        // #3104
+        requireNotNull(granteePartyId) { "query parameter 'granteePartyId' is required" }
+        return DelegationResponse.from(respondDelegation.decline(id, granteePartyId, customerPartyId))
+    }
 
     @Operation(summary = "Renounce an ACTIVE grant (grantee gives the access back)")
     @POST
@@ -185,9 +196,13 @@ class DelegationResource(
     @Authorize(action = "delegation.renounce", resource = "#id")
     suspend fun renounce(
         @PathParam("id") id: UUID,
-        @QueryParam("granteePartyId") granteePartyId: UUID,
+        @QueryParam("granteePartyId") granteePartyId: UUID?,
         @HeaderParam(CUSTOMER_PARTY_HEADER) customerPartyId: UUID?,
-    ): DelegationResponse = DelegationResponse.from(respondDelegation.renounce(id, granteePartyId, customerPartyId))
+    ): DelegationResponse {
+        // #3104
+        requireNotNull(granteePartyId) { "query parameter 'granteePartyId' is required" }
+        return DelegationResponse.from(respondDelegation.renounce(id, granteePartyId, customerPartyId))
+    }
 
     /**
      * `revokedBy` used to come from the query string and was both the authorisation ("you may

--- a/openbank-domestic-payment/src/main/kotlin/com/openbank/domestic/infrastructure/rest/DomesticPaymentResource.kt
+++ b/openbank-domestic-payment/src/main/kotlin/com/openbank/domestic/infrastructure/rest/DomesticPaymentResource.kt
@@ -61,9 +61,13 @@ class DomesticPaymentResource(
     @Operation(summary = "Create a domestic payment")
     suspend fun createPayment(
         request: CreateDomesticPaymentRequest,
-        @HeaderParam("Idempotency-Key") idempotencyKey: String,
+        @HeaderParam("Idempotency-Key") idempotencyKey: String?,
     ): Response {
-        require(idempotencyKey.isNotBlank()) { "Idempotency-Key header is required" }
+        // #3104 — the guard below could not run when the header was ABSENT: JAX-RS injected null,
+        // and `null.isNotBlank()` threw NPE, so the very case it exists for answered 500. `suspend`
+        // hid it further, since Kotlin emits no checkNotNullParameter intrinsic for a suspend
+        // function — the null reached the first dereference instead of failing at the boundary.
+        require(!idempotencyKey.isNullOrBlank()) { "Idempotency-Key header is required" }
 
         idempotencyStore.get(idempotencyKey)?.let { cached ->
             return Response.status(cached.statusCode)

--- a/openbank-fx-service/src/main/kotlin/com/openbank/fx/infrastructure/rest/FxResource.kt
+++ b/openbank-fx-service/src/main/kotlin/com/openbank/fx/infrastructure/rest/FxResource.kt
@@ -74,12 +74,15 @@ class FxResource(private val fxUseCase: FxUseCase, private val cnbIngestion: Cnb
     @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_PAYMENTS")
     @Authorize(action = "fx.convert", resource = "")
     @Operation(summary = "Execute FX conversion")
-    suspend fun convert(req: ConvertRequest?, @HeaderParam("Idempotency-Key") key: String): Response {
+    suspend fun convert(req: ConvertRequest?, @HeaderParam("Idempotency-Key") key: String?): Response {
         // A JSON `null` body deserialises to null despite the non-nullable Kotlin type, so the
         // first field access threw NPE and this answered 500 (#3038). libs-runtime maps
         // IllegalArgumentException to 400.
         requireNotNull(req) { "request body is required" }
-        require(key.isNotBlank()) { "Idempotency-Key required" }
+        // #3104 — the sibling of the line above, one argument position over. An ABSENT header
+        // injected null, so `key.isNotBlank()` threw NPE and this guard answered 500 rather than
+        // the 400 it was written to give.
+        require(!key.isNullOrBlank()) { "Idempotency-Key required" }
         val conv = fxUseCase.convert(
             ConvertCommand(
                 idempotencyKey = key,

--- a/openbank-interest-service/src/main/kotlin/com/openbank/interest/infrastructure/rest/InterestResource.kt
+++ b/openbank-interest-service/src/main/kotlin/com/openbank/interest/infrastructure/rest/InterestResource.kt
@@ -98,11 +98,19 @@ class InterestResource(
     @Authorize(action = "interest.create", resource = "#accountId")
     fun capitalize(
         @PathParam("accountId") accountId: UUID,
-        @QueryParam("productId") productId: String,
+        @QueryParam("productId") productId: String?,
         @QueryParam("toDate") toDate: String?,
-    ): Uni<Response> =
-        capitalizeUseCase.capitalize(accountId, productId, toDate?.let { LocalDate.parse(it) } ?: LocalDate.now(clock))
+    ): Uni<Response> {
+        // #3104's own reproduction case. This handler is NOT suspend, so Kotlin emits
+        // Intrinsics.checkNotNullParameter at bytecode offset 0: omitting `?productId=` threw NPE
+        // before the first statement ran, and GenericExceptionMapper rendered 500. A guard could
+        // only become reachable by declaring the parameter nullable — with the old signature it
+        // compiled to nothing.
+        requireNotNull(productId) { "query parameter 'productId' is required" }
+        return capitalizeUseCase
+            .capitalize(accountId, productId, toDate?.let { LocalDate.parse(it) } ?: LocalDate.now(clock))
             .map { Response.ok(it).build() }
+    }
 
     @GET
     @Path("/accruals/{accountId}")
@@ -163,9 +171,12 @@ class InterestResource(
     @Authorize(action = "interest.read", resource = "#accountId")
     fun effectiveRate(
         @PathParam("accountId") accountId: UUID,
-        @QueryParam("productId") productId: String,
+        @QueryParam("productId") productId: String?,
         @QueryParam("date") @DefaultValue("") date: String,
     ): Uni<Response> {
+        // #3104 — `date` is safe (it carries @DefaultValue, so JAX-RS never injects null);
+        // `productId` was not, and answered 500 when omitted.
+        requireNotNull(productId) { "query parameter 'productId' is required" }
         val on = if (date.isNotEmpty()) LocalDate.parse(date) else LocalDate.now(clock)
         return rateConfigUseCase.effectiveRate(accountId, productId, on)
             .map { it?.let { c -> Response.ok(c).build() } ?: Response.noContent().build() }

--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/infrastructure/rest/LendingResource.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/infrastructure/rest/LendingResource.kt
@@ -248,7 +248,11 @@ class LendingResource(
     @Path("/applications")
     @Operation(summary = "List a party's loan applications")
     @Authorize(action = "lending.list", resource = "")
-    fun listApplications(@QueryParam("partyId") partyId: UUID) = apply.listApplications(partyId)
+    // #3104 — non-suspend, so an absent `partyId` threw Intrinsics.checkNotNullParameter at the
+    // method boundary and answered 500. Nullable + requireNotNull is the only shape in which a
+    // guard runs at all; requireNotNull returns the value, so the expression body survives.
+    fun listApplications(@QueryParam("partyId") partyId: UUID?) =
+        apply.listApplications(requireNotNull(partyId) { "query parameter 'partyId' is required" })
 
     @GET
     @Path("/applications/recent")
@@ -345,7 +349,9 @@ class LendingResource(
         "ROLE_ADMIN",
     )
     @Authorize(action = "lending.list", resource = "")
-    fun listLoans(@QueryParam("partyId") partyId: UUID) = servicing.listLoans(partyId)
+    // #3104 — see listApplications above.
+    fun listLoans(@QueryParam("partyId") partyId: UUID?) =
+        servicing.listLoans(requireNotNull(partyId) { "query parameter 'partyId' is required" })
 
     @GET
     @Path("/loans/active")

--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/infrastructure/rest/LendingResource.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/infrastructure/rest/LendingResource.kt
@@ -244,13 +244,13 @@ class LendingResource(
     fun getApplication(@PathParam("id") id: UUID): Uni<Response> = apply.getApplication(LoanApplicationId(id))
         .map { it?.let { a -> Response.ok(a).build() } ?: Response.status(404).build() }
 
+    // #3104 — non-suspend, so an absent `partyId` threw Intrinsics.checkNotNullParameter at the
+    // method boundary and answered 500. Nullable + requireNotNull is the only shape in which a
+    // guard runs at all; requireNotNull returns the value, so the expression body survives.
     @GET
     @Path("/applications")
     @Operation(summary = "List a party's loan applications")
     @Authorize(action = "lending.list", resource = "")
-    // #3104 — non-suspend, so an absent `partyId` threw Intrinsics.checkNotNullParameter at the
-    // method boundary and answered 500. Nullable + requireNotNull is the only shape in which a
-    // guard runs at all; requireNotNull returns the value, so the expression body survives.
     fun listApplications(@QueryParam("partyId") partyId: UUID?) =
         apply.listApplications(requireNotNull(partyId) { "query parameter 'partyId' is required" })
 
@@ -337,6 +337,7 @@ class LendingResource(
     @Authorize(action = "lending.read", resource = "#id")
     fun getSchedule(@PathParam("id") id: UUID) = servicing.getSchedule(LoanId(id))
 
+    // #3104 — see listApplications above.
     @GET
     @Path("/loans")
     @Operation(summary = "List a party's loans")
@@ -349,7 +350,6 @@ class LendingResource(
         "ROLE_ADMIN",
     )
     @Authorize(action = "lending.list", resource = "")
-    // #3104 — see listApplications above.
     fun listLoans(@QueryParam("partyId") partyId: UUID?) =
         servicing.listLoans(requireNotNull(partyId) { "query parameter 'partyId' is required" })
 

--- a/openbank-sdd-service/src/main/kotlin/com/openbank/sdd/infrastructure/rest/SddResource.kt
+++ b/openbank-sdd-service/src/main/kotlin/com/openbank/sdd/infrastructure/rest/SddResource.kt
@@ -85,8 +85,10 @@ class SddResource(
     @RolesAllowed("ROLE_VIEWER", "ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_PAYMENTS", "ROLE_API")
     @Authorize(action = "sdd.list")
     @Operation(summary = "List an account's mandates")
-    fun listMandates(@QueryParam("accountId") accountId: UUID): Uni<Response> =
-        list.list(accountId).map { ms -> Response.ok(ms.map(MandateResponse::of)).build() }
+    // #3104 — non-suspend, so an absent `accountId` threw at the method boundary and answered 500.
+    fun listMandates(@QueryParam("accountId") accountId: UUID?): Uni<Response> =
+        list.list(requireNotNull(accountId) { "query parameter 'accountId' is required" })
+            .map { ms -> Response.ok(ms.map(MandateResponse::of)).build() }
 
     @GET
     @Path("/mandates/{id}")
@@ -166,9 +168,14 @@ class SddResource(
     @Operation(summary = "Assess a post-settlement refund claim (8-week unconditional / B2B none)")
     fun assessRefund(
         @PathParam("id") id: UUID,
-        @QueryParam("debitDate") debitDate: String,
+        @QueryParam("debitDate") debitDate: String?,
         @QueryParam("asOf") asOf: String?,
-    ): Uni<Response> =
-        refund.assessRefund(id, LocalDate.parse(debitDate), asOf?.let(LocalDate::parse) ?: LocalDate.now(clock))
+    ): Uni<Response> {
+        // #3104 — `asOf` was already optional; `debitDate` was not, and omitting it answered 500.
+        // An UNPARSEABLE debitDate is a different class and already 400 (DateTimeExceptionMapper).
+        requireNotNull(debitDate) { "query parameter 'debitDate' is required" }
+        return refund
+            .assessRefund(id, LocalDate.parse(debitDate), asOf?.let(LocalDate::parse) ?: LocalDate.now(clock))
             .map { Response.ok(RefundAssessmentResponse.of(it)).build() }
+    }
 }

--- a/openbank-sdd-service/src/main/kotlin/com/openbank/sdd/infrastructure/rest/SddResource.kt
+++ b/openbank-sdd-service/src/main/kotlin/com/openbank/sdd/infrastructure/rest/SddResource.kt
@@ -80,12 +80,12 @@ class SddResource(
         ),
     ).map { Response.status(Response.Status.CREATED).entity(MandateResponse.of(it)).build() }
 
+    // #3104 — non-suspend, so an absent `accountId` threw at the method boundary and answered 500.
     @GET
     @Path("/mandates")
     @RolesAllowed("ROLE_VIEWER", "ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_PAYMENTS", "ROLE_API")
     @Authorize(action = "sdd.list")
     @Operation(summary = "List an account's mandates")
-    // #3104 — non-suspend, so an absent `accountId` threw at the method boundary and answered 500.
     fun listMandates(@QueryParam("accountId") accountId: UUID?): Uni<Response> =
         list.list(requireNotNull(accountId) { "query parameter 'accountId' is required" })
             .map { ms -> Response.ok(ms.map(MandateResponse::of)).build() }

--- a/openbank-sepa-payment/src/main/kotlin/com/openbank/sepa/infrastructure/rest/SepaPaymentResource.kt
+++ b/openbank-sepa-payment/src/main/kotlin/com/openbank/sepa/infrastructure/rest/SepaPaymentResource.kt
@@ -48,9 +48,11 @@ class SepaPaymentResource(
     @Operation(summary = "Create a SEPA payment")
     suspend fun createPayment(
         request: CreateSepaPaymentRequest,
-        @HeaderParam("Idempotency-Key") idempotencyKey: String,
+        @HeaderParam("Idempotency-Key") idempotencyKey: String?,
     ): Response {
-        require(idempotencyKey.isNotBlank()) { "Idempotency-Key header is required" }
+        // #3104 — an ABSENT header injected null, so `null.isNotBlank()` threw NPE and this guard
+        // answered 500 in exactly the case it was written for. A blank header was always a 400.
+        require(!idempotencyKey.isNullOrBlank()) { "Idempotency-Key header is required" }
 
         idempotencyStore.get(idempotencyKey)?.let { cached ->
             return Response.status(cached.statusCode)

--- a/openbank-transaction-service/src/main/kotlin/com/openbank/transaction/infrastructure/rest/TransactionResource.kt
+++ b/openbank-transaction-service/src/main/kotlin/com/openbank/transaction/infrastructure/rest/TransactionResource.kt
@@ -61,10 +61,13 @@ class TransactionResource(
     @Authorize(action = "transaction.list", resource = "")
     @Operation(summary = "List transactions for an account")
     suspend fun listTransactions(
-        @QueryParam("accountId") accountId: UUID,
+        @QueryParam("accountId") accountId: UUID?,
         @QueryParam("limit") @DefaultValue("20") limit: Int,
         @QueryParam("cursor") cursor: String?,
     ): Response {
+        // #3104 — listing "transactions for an account" with no account is a bad request, not a
+        // server fault. Absent, this reached ListTransactionsQuery as null and answered 500.
+        requireNotNull(accountId) { "query parameter 'accountId' is required" }
         val page = transactionUseCase.listTransactions(ListTransactionsQuery(accountId, limit, cursor))
         return Response.ok(page.toResponse()).build()
     }


### PR DESCRIPTION
## What

A required `@QueryParam` / `@HeaderParam` declared with a non-nullable Kotlin reference type answers **500** when the caller omits it, never 400. A client cannot tell "I sent a bad request" from "the server is broken", and on a money path that difference decides whether they retry. Same root shape as the null-body 500s of #3032 / #3050, one argument position over.

This fixes the **24 money-path sites**, adds an **enforced ratchet gate**, and baselines the 39 remaining with #3624 tracking them.

## The measurement: 57 candidates → 63 sites → 24 fixed here

#3104 counted **57** candidate declarations. Rescanned with a comment-stripping parser the raw count is **115** — and the discriminator that neither number applies is **inbound vs outbound**:

| | count | verdict |
|---|---:|---|
| outbound MicroProfile REST **client interfaces** | 52 | **not a defect** |
| inbound JAX-RS **resource classes** | 63 | the real set |
| ├ money-path | 24 | fixed here |
| └ elsewhere | 39 | baselined, tracked in #3624 |

The 52 are not a defect for two independent reasons: the annotation there describes the request this service **sends**, so the argument comes from our own Kotlin call site and is compile-time checked; and an abstract interface method has no body to hold an intrinsic. A naive grep over-counts by roughly 2x because of them.

## Why the obvious fix is dead code — measured, not assumed

Both shapes compiled and read back with `javap` (Kotlin 2.3.21):

```
fun f(p: String)
  0: aload_1
  1: ldc           "p"
  3: invokestatic  kotlin/jvm/internal/Intrinsics.checkNotNullParameter   <-- offset 0
  6: goto 9                                                               <-- requireNotNull(p)
  9: aload_1                                                                  compiled to NOTHING

suspend fun f(p: String)
  0: aload_1
  1: areturn                        <-- no intrinsic emitted AT ALL
```

Two consequences, and the second is the one worth carrying forward:

1. Writing `requireNotNull(p)` in the body of a **non-suspend** handler is dead code — the intrinsic has already thrown. **The parameter must be declared nullable for any guard to be reachable.** That is what this PR does.
2. A **suspend** handler gets no intrinsic, so `null` flows into the body. Usually it still 500s at the first dereference — but where nothing dereferences it, the request proceeds with a null the signature promised could not exist. That outcome is worse than the 500 and invisible from every angle.

No new exception mapper anywhere: libs-runtime's `CommonExceptionMappers` already maps `IllegalArgumentException` to 400 with the `ApiError` envelope and a traceId. A service-local mapper for a JDK type races the libs one per request (#526).

## Two guards that could never run

sepa-payment, domestic-payment and fx-service already wrote:

```kotlin
require(idempotencyKey.isNotBlank()) { "Idempotency-Key header is required" }
```

Those handlers are `suspend`, so an **absent** header injected null and `null.isNotBlank()` threw NPE — the guard answered 500 in exactly the case it was written for, while a **blank** header correctly gave 400. Now `require(!idempotencyKey.isNullOrBlank())`.

## One site that was already correct

consent's `hasActiveConsent` already answered 400 for an absent `scope`, because `runCatching { ConsentScope.valueOf(scope) }` swallows the NPE and the `requireNotNull` under it fires. Changed anyway so the message names the missing parameter instead of reporting `unknown scope: null`, and so the declared type stops promising non-null — but it is **not** counted as a fixed 500.

## What changed

24 sites across account (6), consent (4), delegation (4), interest (2), lending (2), sdd (2), domestic-payment, fx, sepa-payment, transaction (1 each). Every one classified as **truly required** — none wanted `@DefaultValue`, none turned out to be genuinely optional.

No `openapi.yaml` changes: the specs are static and already declare these parameters. Only the status of an invalid request moves, 500 → 400.

## The gate

`.github/scripts/check-nonnull-jaxrs-params.py`, registered as `nonnull-jaxrs-param-ratchet` (group `kotlin`, **enforced**). `gates.yaml` id count 102 → 103, verified against live `origin/main` immediately before committing.

A **ratchet** rather than advisory: remediation is genuinely per-handler (required / `@DefaultValue` / actually optional) and only the handler knows which, so a flat check cannot be clean, and this repo's own lesson is that an advisory red gets merged past. The 39 remaining sites are baselined **with their service**, so a new occurrence fails **and** a baseline entry that becomes fixed is reported — the list cannot rot in either direction.

### Falsified in both directions before being trusted

Restoring from a `cp` backup, never `reset --hard` (there were 12 files of uncommitted work in the tree):

```
control (fixed tree)                              exit 0
revert one productId to non-nullable              exit 1, ::error naming file+line
restore                                           exit 0, byte-identical to backup

make a baselined site nullable                    exit 1, ::error STALE baseline entry
restore                                           exit 0, byte-identical to backup
```

The self-test is 14 cases and the **must-NOT-flag half is most of them**: the outbound interface, a nullable type, `@DefaultValue`, a Kotlin default, a primitive, a commented-out declaration, a string literal, and prose inside a **nested** block comment naming the annotation. Kotlin block comments nest, so a KDoc containing `/*` does not end at the first `*/`; the scan mirrors that and the fixture proves it. It asserts against the **construct** — the annotation plus the declared type — never a whole-file grep, so it cannot match the prose about the thing.

A 14th case was added after a latent **false green** was found in the gate itself: the inbound/outbound test excluded everything that was not a `class`, so a *named* nested `object` declared above a handler would have silently skipped every handler below it. 0 such sites exist today — the point is that adding one must not disarm the gate. It now excludes only `interface`.

Worth recording how that was caught, because the first attempt was vacuous: the fixture originally used a `companion object`, and reverting the exclusion to the broken form returned **14 passed, 0 failed** — green against the code it was written to reject, because `DECL_RE` needs a name after the keyword and an unnamed companion never becomes the enclosing declaration. The fixture was asserting a hazard that does not exist while the real one went uncovered. With `object Headers` the same injection reports `FAIL must flag flag_after_object`, exit 2. Reading the fixture would not have found this; only running the injection did.

## Threat models (ADR-0030 D2)

The `threat-model updated on trust-boundary change` gate flagged all ten services, correctly — it cannot know from a diff that a change to a money-path inbound REST surface is a status correction rather than a new surface, and that judgement is exactly what the entry records. Ten entries added, written per service because the security reading differs with the parameter:

- **idempotency key** — a *replay* control, and in three services it was partially inoperative (see above).
- **`partyId` / `role` / `intent` / `granteePartyId`** — *inputs to an access decision*. A null reaching the use case is a decision taken on an absent subject rather than a rejected request.
- **`scaSessionId`** — the *evidence* that SCA completed (consent activate, delegation accept).
- **`debitDate`** — the input to sdd's refund-window arithmetic; must be rejected, never defaulted.

Each states the same three things a reviewer needs — no new caller, no new trust boundary, and the guards run **after** the unchanged `@RolesAllowed` / `@Authorize` gates — plus its rollback. delegation-service had no change-log section; one was added rather than bolting the entry onto an unrelated heading.

## Verification

- `ktlintCheck` + `detekt` green locally on all 10 touched services.
- `:openbank-interest-service:build` green locally. A first run failed on `QuarkusBindException: Port already bound: 8081` — a concurrent build on this machine, the documented environmental failure, not this change; re-running it alone was green.
- The remaining 9 service builds are covered by the CI per-service matrix, which is the same gate.
- `run-gates.py --group security` green locally after the threat-model commit (it refuses to run without `PR_DIFF_BASE` rather than passing vacuously — worth knowing before trusting a local green on that one).

## Linked issues

Refs #3104 — the money-path half. Not closed: 39 non-money-path sites remain, tracked in #3624.
Refs #3038, #3050, #3032, #526

🤖 Generated with [Claude Code](https://claude.com/claude-code)
