### PR TITLE
build(fleet): retire the alpine base from the 53 files that only declare it

### DIFF
--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -1024,6 +1024,21 @@ gates:
     run: |
       python3 .github/scripts/check-gates-not-deregistered.py --enforce
 
+  - id: dockerfile-runtime-only
+    name: "Dockerfiles are runtime-only, declare EXPOSE, share the deploy base (#3016/#3354, enforced)"
+    group: registry
+    mode: enforced
+    selftest: |
+      python3 .github/scripts/check-dockerfile-no-build-stage.py --self-test
+    selftest_expect: pass
+    run: |
+      # This lived as an inline step in ci.yml's `ui-build` job, which runs only when
+      # openbank-admin-ui/, */governance.yaml or the governance schema changed. So the gate
+      # that owns Dockerfile shape could not fire on a Dockerfile-only PR — the exact change
+      # it exists to catch — and reported nothing rather than reporting a skip. Found on
+      # #3629, whose 53 Dockerfile edits skipped it entirely. A shard runs unconditionally.
+      python3 .github/scripts/check-dockerfile-no-build-stage.py --enforce
+
   - id: gate-script-registration
     name: "every check-* script is actually run (#3240, enforced)"
     group: registry

--- a/.github/scripts/check-dockerfile-no-build-stage.py
+++ b/.github/scripts/check-dockerfile-no-build-stage.py
@@ -15,14 +15,30 @@ Nothing builds them. `auto-deploy.yml`, `ghcr-publish.yml` and
 `.github/workflows/Dockerfile.deploy`, and read exactly one thing from these files:
 the EXPOSE line.
 
-So two rules:
+So three rules:
 
   1. No build stage. A `FROM ... AS build` here is either dead text or a second,
      divergent definition of how images are made. Both are worse than nothing.
   2. EXPOSE is mandatory. It is the only live contract — losing it does not fail
      anything loudly, it silently sets the container port to 8080.
+  3. The FROM must be byte-identical to the one in `Dockerfile.deploy` (#3354).
 
-BOTH rules assume the file describes a Quarkus service deployed by that pipeline.
+Rule 3 exists because #3618 moved the fleet runtime base from
+`eclipse-temurin:25-jre-alpine` (musl) to `eclipse-temurin:25-jre` (glibc) — the
+ONNX Runtime `.so` openbank-fraud-service bundles is glibc-linked and had never
+loaded — and 53 files went on declaring the musl base. Nothing broke, which is the
+problem: a wrong FROM here is exactly the "reads as authoritative while being
+fiction" failure #3016 exists to prevent.
+
+Deleting the FROM instead would be worse, and that is not obvious. These files are
+NOT read only by the deploy pipeline: `openbank-admin-ui/scripts/generate-cluster-topology.mjs`
+parses `openbank-ledger-service/Dockerfile` for `imageFacts()` and renders the base
+image into the /docs/cluster dossier (ADR-0081). With no FROM to parse it falls back
+to a HARDCODED `eclipse-temurin:25-jre-alpine` literal — i.e. removing the second
+copy would resurrect the fiction in the UI rather than retire it. So: keep the FROM,
+and make it impossible for it to disagree.
+
+Rules 1 and 2 assume the file describes a Quarkus service deployed by that pipeline.
 Three `openbank-*/` directories are not that, and for them a build stage is the
 whole point (SELF_BUILT below). The first sweep flattened them into the generic
 Quarkus recipe, which broke the admin-ui image build for real: `admin-ui-deploy.yml`
@@ -38,6 +54,7 @@ prevent.
 Usage:
     check-dockerfile-no-build-stage.py            # warn
     check-dockerfile-no-build-stage.py --enforce  # fail
+    check-dockerfile-no-build-stage.py --self-test  # falsify rule 3 both ways
 """
 
 from __future__ import annotations
@@ -56,6 +73,22 @@ COPY_FROM_RE = re.compile(r'^\s*COPY\s+--from=', re.I | re.M)
 GRADLEW_RE = re.compile(r'^\s*RUN\s+.*gradlew', re.I | re.M)
 EXPOSE_RE = re.compile(r'^EXPOSE\s+(\d+)\s*$', re.M)
 QUARKUS_APP_RE = re.compile(r'^\s*COPY\s+.*\bquarkus-app/', re.I | re.M)
+# Matched against comment-STRIPPED text on purpose. Dockerfile.deploy's own header
+# quotes the retired `eclipse-temurin:25-jre-alpine` three times to explain why it is
+# retired, and every per-service header now names Dockerfile.deploy; a scan over raw
+# text would read that prose as a declaration. Same collision class as #2450.
+FROM_RE = re.compile(r'^FROM\s+(\S+)\s*$', re.M)
+
+DEPLOY_RECIPE = ".github/workflows/Dockerfile.deploy"
+
+# Files outside the openbank-*/Dockerfile glob that still declare the fleet runtime
+# base and so must track it. None is referenced by any workflow or script today —
+# they are declarations, same as the per-service ones, and drift the same way.
+EXTRA_FLEET_BASE = [
+    "Dockerfile.scanner",
+    "openbank-security-scanner/Dockerfile.prebuilt",
+    "openbank-notification-service/Dockerfile.runtime",
+]
 
 # Directories under openbank-*/ that are NOT Quarkus services built by the deploy
 # pipeline. Their Dockerfile is the real, self-contained recipe for the image, so
@@ -84,12 +117,117 @@ def strip_comments(text: str) -> str:
     return "\n".join(l for l in text.split("\n") if not l.lstrip().startswith("#"))
 
 
+def fleet_base_files(root: pathlib.Path) -> list[pathlib.Path]:
+    """Every file that declares the fleet runtime base, Dockerfile.deploy excluded."""
+    files = [p for p in sorted(root.glob("openbank-*/Dockerfile"))
+             if p.parts[-2] not in SELF_BUILT]
+    files += [root / name for name in EXTRA_FLEET_BASE if (root / name).is_file()]
+    return files
+
+
+def check_fleet_bases(root: pathlib.Path) -> list[str]:
+    """Rule 3: every declared runtime base equals Dockerfile.deploy's, exactly."""
+    deploy = root / DEPLOY_RECIPE
+    if not deploy.is_file():
+        return [f"{DEPLOY_RECIPE} is missing — it is the single source for the runtime "
+                f"base image and this check cannot run without it."]
+
+    froms = FROM_RE.findall(strip_comments(deploy.read_text(encoding="utf-8")))
+    if len(froms) != 1:
+        return [f"{DEPLOY_RECIPE} declares {len(froms)} FROM lines; expected exactly 1. "
+                f"The fleet runtime base must be stated once."]
+    expected = froms[0]
+
+    problems: list[str] = []
+    for path in fleet_base_files(root):
+        found = FROM_RE.findall(strip_comments(path.read_text(encoding="utf-8")))
+        if len(found) != 1:
+            problems.append(
+                f"{path.relative_to(root)}: declares {len(found)} FROM lines; expected "
+                f"exactly 1, matching {DEPLOY_RECIPE}.")
+            continue
+        if found[0] != expected:
+            problems.append(
+                f"{path.relative_to(root)}: FROM {found[0]} does not match "
+                f"{DEPLOY_RECIPE}, which declares FROM {expected}. Nothing builds this "
+                f"file, so a stale base breaks nothing and says the wrong thing forever "
+                f"(#3354) — and admin-ui's cluster dossier renders it. Copy the line.")
+    return problems
+
+
+def self_test() -> int:
+    """Falsify rule 3 in BOTH directions against a synthetic tree.
+
+    A check that has only ever passed is unfalsified. The negative case matters as
+    much as the positive one here: the rule reads comment-stripped text, and every
+    file it inspects contains prose naming both the old and the new base image, so a
+    scan over raw text would flag a correct tree.
+    """
+    import shutil
+    import tempfile
+
+    good = "FROM eclipse-temurin:25-jre@sha256:" + "a" * 64
+    bad = "FROM eclipse-temurin:25-jre-alpine@sha256:" + "b" * 64
+    # Prose naming the retired base, of the exact shape the real files carry.
+    prose = f"# This used to be {bad.removeprefix('FROM ')} and must never go back.\n"
+
+    failures = []
+    tmp = pathlib.Path(tempfile.mkdtemp())
+    try:
+        (tmp / ".github" / "workflows").mkdir(parents=True)
+        (tmp / DEPLOY_RECIPE).write_text(prose + good + "\nEXPOSE 8080\n")
+        (tmp / "openbank-a-service").mkdir()
+        (tmp / "openbank-b-service").mkdir()
+        agreeing = tmp / "openbank-a-service" / "Dockerfile"
+        drifted = tmp / "openbank-b-service" / "Dockerfile"
+
+        agreeing.write_text(prose + good + "\nEXPOSE 8100\n")
+        drifted.write_text(prose + good + "\nEXPOSE 8101\n")
+        if check_fleet_bases(tmp):
+            failures.append("a tree where every FROM agrees was flagged (false positive)")
+
+        drifted.write_text(prose + bad + "\nEXPOSE 8101\n")
+        found = check_fleet_bases(tmp)
+        if not any("openbank-b-service/Dockerfile" in p for p in found):
+            failures.append("a drifted FROM was NOT flagged (the rule cannot fire)")
+        if any("openbank-a-service/Dockerfile" in p for p in found):
+            failures.append("the agreeing file was flagged alongside the drifted one")
+
+        # An EXTRA_FLEET_BASE file must be in scope too, not just the glob.
+        drifted.write_text(prose + good + "\nEXPOSE 8101\n")
+        (tmp / EXTRA_FLEET_BASE[0]).write_text(prose + bad + "\nEXPOSE 8120\n")
+        if not any(EXTRA_FLEET_BASE[0] in p for p in check_fleet_bases(tmp)):
+            failures.append(f"{EXTRA_FLEET_BASE[0]} drift was NOT flagged (out of scope)")
+
+        # A SELF_BUILT directory has its own base on purpose and must be exempt.
+        (tmp / EXTRA_FLEET_BASE[0]).unlink()
+        exempt = tmp / next(iter(SELF_BUILT))
+        exempt.mkdir()
+        (exempt / "Dockerfile").write_text(prose + bad + "\nEXPOSE 3000\n")
+        if check_fleet_bases(tmp):
+            failures.append("a SELF_BUILT Dockerfile was held to the fleet base")
+    finally:
+        shutil.rmtree(tmp)
+
+    for f in failures:
+        print(f"self-test FAILED: {f}")
+    if failures:
+        return 1
+    print("check-dockerfile-no-build-stage --self-test: OK — rule 3 fires on drift, "
+          "stays quiet on agreement, covers the non-glob files, exempts SELF_BUILT")
+    return 0
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--enforce", action="store_true")
+    parser.add_argument("--self-test", action="store_true")
     args = parser.parse_args()
 
-    problems: list[str] = []
+    if args.self_test:
+        return self_test()
+
+    problems: list[str] = check_fleet_bases(pathlib.Path("."))
     ports: dict[str, list[str]] = {}
     seen_self_built: set[str] = set()
     checked = 0

--- a/.github/scripts/verify-image-native-libs.py
+++ b/.github/scripts/verify-image-native-libs.py
@@ -1,0 +1,337 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+# See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+"""Prove every native .so a service image ships can actually link in the runtime base (#3354).
+
+WHAT WENT WRONG WITHOUT THIS
+    openbank-fraud-service bundles com.microsoft.onnxruntime (ADR-0139 phase-1b). Its
+    libonnxruntime.so is linked against glibc + libstdc++; the runtime base was
+    eclipse-temurin:25-jre-alpine (musl). OrtEnvironment.getEnvironment() therefore threw
+    UnsatisfiedLinkError on the first request in EVERY deployed environment, from the day the
+    adapter shipped, and the model scored exactly nothing.
+
+    Nothing in this repo could see it, and that is the interesting part:
+
+      * the unit tests construct a real OrtEnvironment and assert a real score — but they run on
+        a glibc CI runner, so they are green against a musl image by construction;
+      * the Gradle build, detekt, ktlint and the image build itself never execute a line of
+        native code;
+      * the pod is Ready — the health probes never touch the model;
+      * and the adapter degrades to `null` on purpose, so the only trace is one ERROR line
+        (and, before #3376, a 500 on an unrelated read endpoint).
+
+    A green build proves nothing here. The only thing that can be wrong out loud is running the
+    real dynamic loader, from the real base image, over the real .so the image ships. That is
+    what this does.
+
+HOW
+    1. Read the runtime base from .github/workflows/Dockerfile.deploy — the single source every
+       image producer copies. NEVER give this script its own copy of the base: a second copy
+       moves with the first and keeps passing about an image nobody deploys.
+    2. Scan the service's fast-jar lib/ tree for jars carrying linux natives for the target
+       architecture, and extract those .so files.
+    3. `ldd` each one INSIDE that base image, on that platform.
+    4. Fail on any unresolved dependency.
+
+    Step 2 is what keeps this honest as the fleet changes: the scope is DERIVED from the jars a
+    service actually ships, not from a hand-kept list of "services with native code". A service
+    that gains a native dependency is covered the day it gains it, and one that drops it stops
+    paying for the check with nothing to update.
+
+    Intra-bundle sonames are not findings. onnxruntime ships libonnxruntime4j_jni.so, whose
+    NEEDED entry `libonnxruntime.so.1` is resolved at runtime because the JVM System.load()s its
+    sibling from the same extracted directory first. A missing dependency whose name matches an
+    extracted sibling is therefore ignored — matched against the extracted file set, which is
+    derived, not against a literal.
+
+USAGE
+    verify-image-native-libs.py <lib-dir> [--arch arm64|amd64] [--base IMAGE]
+    verify-image-native-libs.py --self-test
+
+    <lib-dir> is the fast-jar lib/ directory staged into the build context, e.g.
+    openbank-fraud-service/build/quarkus-app/lib. Exits 0 when there is nothing to check.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import zipfile
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+DOCKERFILE_DEPLOY = REPO_ROOT / ".github" / "workflows" / "Dockerfile.deploy"
+
+# Jar-internal directories holding Linux natives, per Docker platform arch. onnxruntime uses
+# `linux-aarch64`/`linux-x64`; other packagers use the uname spellings, so accept both.
+ARCH_DIR_PATTERNS = {
+    "arm64": re.compile(r"(^|/)linux[-_/](aarch64|arm64)/", re.I),
+    "amd64": re.compile(r"(^|/)linux[-_/](x64|x86[-_]64|amd64)/", re.I),
+}
+
+FROM_RE = re.compile(r"^\s*FROM\s+(\S+)", re.M)
+
+# `ldd` says it two ways and we must catch both, because the musl and glibc loaders disagree:
+#   glibc: "\tlibstdc++.so.6 => not found"
+#   musl:  "Error loading shared library libstdc++.so.6: No such file or directory (needed by ..)"
+GLIBC_MISSING_RE = re.compile(r"^\s*(\S+)\s+=>\s+not found\s*$", re.M)
+MUSL_MISSING_RE = re.compile(r"^Error loading shared library ([^:]+):", re.M)
+# musl also reports every unresolvable symbol; one line per symbol, thousands of them. Counted,
+# never printed in full.
+MUSL_RELOC_RE = re.compile(r"^Error relocating ", re.M)
+
+
+def read_base_image() -> str:
+    """The runtime base, read out of the committed Dockerfile — never a second copy."""
+    text = DOCKERFILE_DEPLOY.read_text(encoding="utf-8")
+    match = FROM_RE.search(text)
+    if not match:
+        sys.exit(f"::error::no FROM line in {DOCKERFILE_DEPLOY}")
+    return match.group(1)
+
+
+def find_native_entries(lib_dir: pathlib.Path, arch: str) -> list[tuple[pathlib.Path, str]]:
+    """(jar, entry) pairs for every Linux .so this image would ship for `arch`."""
+    pattern = ARCH_DIR_PATTERNS[arch]
+    found: list[tuple[pathlib.Path, str]] = []
+    for jar in sorted(lib_dir.rglob("*.jar")):
+        try:
+            with zipfile.ZipFile(jar) as zf:
+                for name in zf.namelist():
+                    if name.endswith(".so") and pattern.search(name):
+                        found.append((jar, name))
+        except zipfile.BadZipFile:
+            print(f"::warning::not a readable jar, skipped: {jar}")
+    return found
+
+
+def extract(entries: list[tuple[pathlib.Path, str]], dest: pathlib.Path) -> list[str]:
+    names: list[str] = []
+    for jar, entry in entries:
+        base = pathlib.PurePosixPath(entry).name
+        with zipfile.ZipFile(jar) as zf, open(dest / base, "wb") as out:
+            shutil.copyfileobj(zf.open(entry), out)
+        (dest / base).chmod(0o755)
+        names.append(base)
+    return names
+
+
+def parse_ldd(output: str, sibling_names: list[str]) -> list[str]:
+    """Unresolved dependencies in one `ldd` run, minus the ones a sibling in the bundle provides.
+
+    `sibling_names` is the extracted file set, so the exemption cannot drift away from what the
+    image actually ships. A NEEDED soname carries a version suffix the file on disk does not
+    (`libonnxruntime.so.1` vs `libonnxruntime.so`), hence the prefix match.
+    """
+    missing = set(GLIBC_MISSING_RE.findall(output)) | set(MUSL_MISSING_RE.findall(output))
+    unresolved = []
+    for dep in sorted(missing):
+        if any(dep == sib or dep.startswith(sib + ".") for sib in sibling_names):
+            continue
+        unresolved.append(dep)
+    return unresolved
+
+
+def platform_ref(base: str, arch: str) -> str:
+    """Rewrite an index reference to the PLATFORM-SPECIFIC manifest digest for `arch`.
+
+    An index digest cannot be materialised twice for two architectures in one daemon: the second
+    pull is refused with `cannot overwrite digest ...` (measured on Docker 29's containerd store).
+    ghcr-publish checks amd64 and arm64 back to back, so that is not hypothetical. The
+    per-platform manifest digests are distinct, so pulling those instead has no collision.
+
+    Falls back to `base` when the reference is not a multi-platform index, or when buildx is
+    unavailable — the plain reference is correct in both of those cases.
+    """
+    repo = base.split("@", 1)[0].split(":")[0] if "@" in base else base.rsplit(":", 1)[0]
+    proc = subprocess.run(
+        ["docker", "buildx", "imagetools", "inspect", "--raw", base],
+        capture_output=True, text=True, check=False,
+    )
+    if proc.returncode != 0:
+        return base
+    try:
+        index = json.loads(proc.stdout)
+    except json.JSONDecodeError:
+        return base
+    for manifest in index.get("manifests", []):
+        platform = manifest.get("platform", {})
+        if platform.get("os") == "linux" and platform.get("architecture") == arch:
+            return f"{repo}@{manifest['digest']}"
+    return base
+
+
+def resolve_local_image(base: str, arch: str) -> str:
+    """Pull the platform-specific manifest for `arch` and return its local image ID."""
+    ref = platform_ref(base, arch)
+    pull = subprocess.run(
+        ["docker", "pull", "--platform", f"linux/{arch}", ref],
+        capture_output=True, text=True, check=False,
+    )
+    if pull.returncode != 0:
+        sys.exit(f"::error::could not pull {ref} for linux/{arch}: {pull.stderr.strip()}")
+    inspect = subprocess.run(
+        ["docker", "image", "inspect", "--format", "{{.Id}}", ref],
+        capture_output=True, text=True, check=False,
+    )
+    if inspect.returncode != 0 or not inspect.stdout.strip():
+        sys.exit(f"::error::could not resolve a local image id for {ref}: {inspect.stderr.strip()}")
+    return inspect.stdout.strip()
+
+
+def ldd_in_base(base: str, arch: str, workdir: pathlib.Path, names: list[str]) -> dict[str, str]:
+    """Run ldd on each .so inside the real base image; returns {name: raw ldd output}."""
+    script = "; ".join(f'echo "@@ {n}"; ldd /n/{n} 2>&1 || true' for n in names)
+    image_id = resolve_local_image(base, arch)
+    proc = subprocess.run(
+        [
+            "docker", "run", "--rm", "--platform", f"linux/{arch}",
+            "-v", f"{workdir}:/n:ro", "--entrypoint", "sh", image_id, "-c", script,
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0 and not proc.stdout:
+        sys.exit(f"::error::could not run ldd in {base}: {proc.stderr.strip()}")
+    blocks: dict[str, str] = {}
+    current = None
+    for line in proc.stdout.splitlines():
+        if line.startswith("@@ "):
+            current = line[3:].strip()
+            blocks[current] = ""
+        elif current is not None:
+            blocks[current] += line + "\n"
+    return blocks
+
+
+def self_test() -> int:
+    """Falsify the verdict logic against REAL captured ldd output from both loaders.
+
+    The docker half cannot run everywhere; the parsing half is where a wrong answer would be
+    silent, so it is what gets a known-positive and a known-negative. Both fixtures are verbatim
+    excerpts of runs against the two candidate bases on linux/arm64.
+    """
+    musl_bad = (
+        "\t/lib/ld-musl-aarch64.so.1 (0xffffb93a0000)\n"
+        "\tlibdl.so.2 => /lib/ld-musl-aarch64.so.1 (0xffffb93a0000)\n"
+        "Error loading shared library libstdc++.so.6: No such file or directory"
+        " (needed by /n/libonnxruntime.so)\n"
+        "Error loading shared library libgcc_s.so.1: No such file or directory"
+        " (needed by /n/libonnxruntime.so)\n"
+        "Error loading shared library ld-linux-aarch64.so.1: No such file or directory"
+        " (needed by /n/libonnxruntime.so)\n"
+        "Error relocating /n/libonnxruntime.so: __cxa_begin_catch: symbol not found\n"
+    )
+    glibc_good = (
+        "\tlinux-vdso.so.1 (0x0000ffffbccdb000)\n"
+        "\tlibstdc++.so.6 => /usr/lib/aarch64-linux-gnu/libstdc++.so.6 (0x0000ffffbb870000)\n"
+        "\tlibgcc_s.so.1 => /usr/lib/aarch64-linux-gnu/libgcc_s.so.1 (0x0000ffffbb760000)\n"
+        "\tlibc.so.6 => /usr/lib/aarch64-linux-gnu/libc.so.6 (0x0000ffffbb590000)\n"
+        "\t/lib/ld-linux-aarch64.so.1 (0x0000ffffbcc90000)\n"
+    )
+    # The JNI shim on the WORKING base: its only "missing" entry is its own sibling, which the
+    # JVM loads first. This is the case the check must NOT flag, and the one a naive
+    # "any `not found` fails" rule would have failed on the correct image.
+    glibc_sibling = (
+        "\tlinux-vdso.so.1 (0x0000ffffa20cc000)\n"
+        "\tlibonnxruntime.so.1 => not found\n"
+        "\tlibc.so.6 => /usr/lib/aarch64-linux-gnu/libc.so.6 (0x0000ffffa1e70000)\n"
+    )
+    siblings = ["libonnxruntime.so", "libonnxruntime4j_jni.so"]
+    failures = []
+
+    got = parse_ldd(musl_bad, siblings)
+    want = ["ld-linux-aarch64.so.1", "libgcc_s.so.1", "libstdc++.so.6"]
+    if got != want:
+        failures.append(f"musl fixture: expected {want}, got {got}")
+
+    if parse_ldd(glibc_good, siblings):
+        failures.append(f"glibc fixture must be clean, got {parse_ldd(glibc_good, siblings)}")
+
+    if parse_ldd(glibc_sibling, siblings):
+        failures.append(
+            "an intra-bundle soname must not be a finding, got "
+            f"{parse_ldd(glibc_sibling, siblings)}"
+        )
+
+    # ...but it must still be a finding when no such sibling is shipped, or the exemption would
+    # swallow a genuinely absent library.
+    if parse_ldd(glibc_sibling, []) != ["libonnxruntime.so.1"]:
+        failures.append("a missing lib with no sibling must be reported")
+
+    # The base must come from the committed Dockerfile, and must be a glibc one today.
+    base = read_base_image()
+    if "alpine" in base or "musl" in base:
+        failures.append(f"Dockerfile.deploy base is musl again: {base} — see #3354")
+
+    for line in failures:
+        print(f"::error::self-test: {line}")
+    if failures:
+        return 1
+    print(f"self-test OK (base from Dockerfile.deploy: {base})")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("lib_dir", nargs="?", help="fast-jar lib/ directory staged into the image")
+    ap.add_argument("--arch", default="arm64", choices=sorted(ARCH_DIR_PATTERNS))
+    ap.add_argument("--base", default=None, help="override the base image (testing only)")
+    ap.add_argument("--self-test", action="store_true")
+    args = ap.parse_args()
+
+    if args.self_test:
+        return self_test()
+    if not args.lib_dir:
+        ap.error("lib_dir is required unless --self-test is given")
+
+    lib_dir = pathlib.Path(args.lib_dir)
+    if not lib_dir.is_dir():
+        sys.exit(f"::error::not a directory: {lib_dir}")
+
+    entries = find_native_entries(lib_dir, args.arch)
+    if not entries:
+        print(f"native-lib check: no linux/{args.arch} .so shipped under {lib_dir} — nothing to do")
+        return 0
+
+    base = args.base or read_base_image()
+    print(f"native-lib check: {len(entries)} .so for linux/{args.arch} against {base}")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        workdir = pathlib.Path(tmp)
+        names = extract(entries, workdir)
+        blocks = ldd_in_base(base, args.arch, workdir, names)
+
+        failed = False
+        for name in names:
+            output = blocks.get(name, "")
+            unresolved = parse_ldd(output, names)
+            relocs = len(MUSL_RELOC_RE.findall(output))
+            if unresolved:
+                failed = True
+                print(f"::error::{name}: unresolved in {base}: {', '.join(unresolved)}")
+                if relocs:
+                    print(f"::error::{name}: and {relocs} unresolvable relocation(s)")
+            else:
+                print(f"  ok  {name}")
+
+    if failed:
+        print(
+            "::error::the runtime base cannot load a native library this image ships. "
+            "This is exactly the #3354 failure: it is invisible to the build, to the health "
+            "probes and to every test that runs on a glibc runner. Fix the base in "
+            ".github/workflows/Dockerfile.deploy, do not skip this check."
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/Dockerfile.deploy
+++ b/.github/workflows/Dockerfile.deploy
@@ -1,6 +1,32 @@
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+# The ONE runtime recipe for every openbank-* Quarkus service image. Three producers copy this
+# file verbatim into their build context and append only EXPOSE / SBOM lines: auto-deploy.yml,
+# ghcr-publish.yml and openbank-infra/scripts/build-push-service.sh. Per-service
+# openbank-*/Dockerfile files are declarations only (#3016) — nothing builds them.
+#
+# WHY GLIBC AND NOT ALPINE (#3354). This was eclipse-temurin:25-jre-alpine, i.e. musl.
+# openbank-fraud-service bundles com.microsoft.onnxruntime (ADR-0139 phase-1b), whose
+# libonnxruntime.so is linked against glibc + libstdc++, so OrtEnvironment.getEnvironment() threw
+# UnsatisfiedLinkError in every deployed environment from the day the adapter shipped, and the
+# model scored exactly nothing. Measured on linux/arm64, onnxruntime 1.22.0:
+#
+#   eclipse-temurin:25-jre-alpine                 -> Error loading shared library libstdc++.so.6
+#   eclipse-temurin:25-jre-alpine + apk libstdc++ -> Error loading shared library ld-linux-aarch64.so.1
+#   eclipse-temurin:25-jre (glibc)                -> every NEEDED entry resolves
+#
+# The middle row is the point: installing libstdc++ does NOT work, it moves the failure to the
+# glibc dynamic loader. A glibc base is required, not preferred. Cost is +132MB per base layer
+# (224MB -> 356MB); at ~51 ECR repositories that is ~$0.67/month of storage, which is not a reason
+# to keep a runtime that cannot load a library the fleet ships.
+#
+# Do not revert to a musl base to reclaim the layer: .github/scripts/verify-image-native-libs.py
+# runs `ldd` on every bundled linux .so INSIDE this exact base before any image is pushed, and
+# fails the push. It reads the base image from THIS file — never give it a second copy.
+FROM eclipse-temurin:25-jre@sha256:681c543d6f36c50f45e9b5226930a46203dcfa351d3670e9d0bdf0dabae53539
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+# uid 100 / gid 101 reproduce exactly what busybox `adduser -S` yielded on the alpine base, so
+# nothing that assumed those numbers changes. Deployments pin runAsUser/runAsGroup anyway.
+RUN groupadd --system --gid 101 openbank \
+ && useradd --system --uid 100 --gid 101 --no-create-home --shell /usr/sbin/nologin openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/.github/workflows/auto-deploy.yml
+++ b/.github/workflows/auto-deploy.yml
@@ -500,6 +500,12 @@ jobs:
             bash "${GITHUB_WORKSPACE}/.github/scripts/ensure-ecr-repository.sh" "${svc}" \
               2>&1 | sed "s/^/[${svc}] /" || return 1
 
+            # ldd every bundled linux .so inside the real runtime base before pushing (#3354).
+            # No-op for a service shipping none. Reasoning is in the script header, not here
+            # — prose in a run: block costs the whole workflow (#3135).
+            python3 "${GITHUB_WORKSPACE}/.github/scripts/verify-image-native-libs.py" \
+              "${ctx}/quarkus-app/lib" --arch arm64 2>&1 | sed "s/^/[${svc}] /" || return 1
+
             echo "==> [${svc}] docker push → ${image}"
             docker buildx build \
               --platform linux/arm64 \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,21 +105,6 @@ jobs:
         working-directory: ${{ github.workspace }}
         run: bash .github/scripts/check-manifest-types-only.sh
 
-      # Per-service Dockerfiles are runtime recipes only; images come from
-      # .github/workflows/Dockerfile.deploy. Before #3016 every one of them carried a
-      # build stage that could not run, which read as authoritative while being fiction.
-      # This also guards the EXPOSE line — the only thing the deploy pipeline reads from
-      # those files, and whose loss silently defaults the container port to 8080 — and
-      # (#3354) that their FROM still equals Dockerfile.deploy's, so the runtime base is
-      # stated in exactly one place. The --self-test runs first because a check that has
-      # only ever passed is unfalsified: it drifts a synthetic tree and asserts the rule
-      # fires, and asserts it does NOT fire on prose naming the retired base image.
-      - name: Dockerfiles are runtime-only, declare EXPOSE, share the deploy base (#3016/#3354, enforced)
-        working-directory: ${{ github.workspace }}
-        run: |
-          python3 .github/scripts/check-dockerfile-no-build-stage.py --self-test
-          python3 .github/scripts/check-dockerfile-no-build-stage.py --enforce
-
       # ADR-0071: the governance manifest is code-derived from per-service
       # governance.yaml. Regenerate and fail on any module missing/with an invalid
       # governance.yaml. Phase 4: flipped from advisory (::warning::) to enforce

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,10 +109,16 @@ jobs:
       # .github/workflows/Dockerfile.deploy. Before #3016 every one of them carried a
       # build stage that could not run, which read as authoritative while being fiction.
       # This also guards the EXPOSE line — the only thing the deploy pipeline reads from
-      # those files, and whose loss silently defaults the container port to 8080.
-      - name: Dockerfiles are runtime-only and declare EXPOSE (#3016, enforced)
+      # those files, and whose loss silently defaults the container port to 8080 — and
+      # (#3354) that their FROM still equals Dockerfile.deploy's, so the runtime base is
+      # stated in exactly one place. The --self-test runs first because a check that has
+      # only ever passed is unfalsified: it drifts a synthetic tree and asserts the rule
+      # fires, and asserts it does NOT fire on prose naming the retired base image.
+      - name: Dockerfiles are runtime-only, declare EXPOSE, share the deploy base (#3016/#3354, enforced)
         working-directory: ${{ github.workspace }}
-        run: python3 .github/scripts/check-dockerfile-no-build-stage.py --enforce
+        run: |
+          python3 .github/scripts/check-dockerfile-no-build-stage.py --self-test
+          python3 .github/scripts/check-dockerfile-no-build-stage.py --enforce
 
       # ADR-0071: the governance manifest is code-derived from per-service
       # governance.yaml. Regenerate and fail on any module missing/with an invalid

--- a/.github/workflows/ghcr-publish.yml
+++ b/.github/workflows/ghcr-publish.yml
@@ -141,6 +141,11 @@ jobs:
             echo "COPY sbom/bom.json /app/sbom/bom.json" >> "${ctx}/Dockerfile"
             echo "ENV OPENBANK_SBOM_PATH=/app/sbom/bom.json" >> "${ctx}/Dockerfile"
           fi
+          # ldd every bundled linux .so inside the real runtime base before publishing (#3354).
+          # This image is multi-arch, so both loaders are checked. Reasoning lives in the script
+          # header — prose in a run: block costs the whole workflow (#3135).
+          python3 .github/scripts/verify-image-native-libs.py "${ctx}/quarkus-app/lib" --arch amd64
+          python3 .github/scripts/verify-image-native-libs.py "${ctx}/quarkus-app/lib" --arch arm64
           docker buildx build \
             --platform linux/amd64,linux/arm64 \
             --provenance=false \

--- a/Dockerfile.scanner
+++ b/Dockerfile.scanner
@@ -1,6 +1,10 @@
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+# The FROM below is the fleet runtime base and is checked against
+# .github/workflows/Dockerfile.deploy by
+# .github/scripts/check-dockerfile-no-build-stage.py (#3354).
+FROM eclipse-temurin:25-jre@sha256:681c543d6f36c50f45e9b5226930a46203dcfa351d3670e9d0bdf0dabae53539
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd --system --gid 101 openbank \
+ && useradd --system --uid 100 --gid 101 --no-create-home --shell /usr/sbin/nologin openbank
 USER openbank
 COPY openbank-security-scanner/build/openbank-security-scanner-0.1.0-SNAPSHOT-runner.jar /app/quarkus-run.jar
 EXPOSE 8120

--- a/openbank-account-service/Dockerfile
+++ b/openbank-account-service/Dockerfile
@@ -13,11 +13,13 @@
 # quarkus-app/, this builds the real image.
 #
 # Adding a build stage back here is enforced against by
-# .github/scripts/check-dockerfile-no-build-stage.py.
+# .github/scripts/check-dockerfile-no-build-stage.py, which also fails if the FROM above
+# drifts from Dockerfile.deploy — the runtime base is stated in exactly one place (#3354).
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre@sha256:681c543d6f36c50f45e9b5226930a46203dcfa351d3670e9d0bdf0dabae53539
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd --system --gid 101 openbank \
+ && useradd --system --uid 100 --gid 101 --no-create-home --shell /usr/sbin/nologin openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-agent-service/Dockerfile
+++ b/openbank-agent-service/Dockerfile
@@ -13,11 +13,13 @@
 # quarkus-app/, this builds the real image.
 #
 # Adding a build stage back here is enforced against by
-# .github/scripts/check-dockerfile-no-build-stage.py.
+# .github/scripts/check-dockerfile-no-build-stage.py, which also fails if the FROM above
+# drifts from Dockerfile.deploy — the runtime base is stated in exactly one place (#3354).
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre@sha256:681c543d6f36c50f45e9b5226930a46203dcfa351d3670e9d0bdf0dabae53539
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd --system --gid 101 openbank \
+ && useradd --system --uid 100 --gid 101 --no-create-home --shell /usr/sbin/nologin openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-aml-service/Dockerfile
+++ b/openbank-aml-service/Dockerfile
@@ -13,11 +13,13 @@
 # quarkus-app/, this builds the real image.
 #
 # Adding a build stage back here is enforced against by
-# .github/scripts/check-dockerfile-no-build-stage.py.
+# .github/scripts/check-dockerfile-no-build-stage.py, which also fails if the FROM above
+# drifts from Dockerfile.deploy — the runtime base is stated in exactly one place (#3354).
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre@sha256:681c543d6f36c50f45e9b5226930a46203dcfa351d3670e9d0bdf0dabae53539
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd --system --gid 101 openbank \
+ && useradd --system --uid 100 --gid 101 --no-create-home --shell /usr/sbin/nologin openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-aml-service/src/main/resources/docs/05-operations.cs.md
+++ b/openbank-aml-service/src/main/resources/docs/05-operations.cs.md
@@ -12,9 +12,9 @@
 # Lokální brána před PR
 ./gradlew detekt ktlintCheck koverVerify build
 
-# Kontejnerový image (vícefázový Dockerfile)
-#   build fáze: eclipse-temurin:20-jdk + gradlew quarkusBuild (fast-jar)
-#   runtime fáze: eclipse-temurin:25-jre-alpine, non-root uživatel, -XX:+UseZGC
+# Kontejnerový image (jednofázový; recept je .github/workflows/Dockerfile.deploy)
+#   build: hostem, ./gradlew build -Dquarkus.package.jar.type=fast-jar
+#   runtime: eclipse-temurin:25-jre (glibc, #3354), non-root uživatel, -XX:+UseZGC
 ```
 
 > Build používá host-side Gradle build, fast-jar packaging (`-Dquarkus.package.jar.type=fast-jar`) dle GitOps pravidel repa — nikdy in-Docker Gradle, nikdy uber-jar.

--- a/openbank-aml-service/src/main/resources/docs/05-operations.en.md
+++ b/openbank-aml-service/src/main/resources/docs/05-operations.en.md
@@ -12,9 +12,9 @@
 # Local gate before a PR
 ./gradlew detekt ktlintCheck koverVerify build
 
-# Container image (multi-stage Dockerfile)
-#   build stage: eclipse-temurin:20-jdk + gradlew quarkusBuild (fast-jar)
-#   runtime stage: eclipse-temurin:25-jre-alpine, non-root user, -XX:+UseZGC
+# Container image (single-stage; the recipe is .github/workflows/Dockerfile.deploy)
+#   build: host-side, ./gradlew build -Dquarkus.package.jar.type=fast-jar
+#   runtime: eclipse-temurin:25-jre (glibc, #3354), non-root user, -XX:+UseZGC
 ```
 
 > Build uses the host-side Gradle build, fast-jar packaging (`-Dquarkus.package.jar.type=fast-jar`), per the repo GitOps rules — never in-Docker Gradle, never uber-jar.

--- a/openbank-anacredit-service/Dockerfile
+++ b/openbank-anacredit-service/Dockerfile
@@ -13,11 +13,13 @@
 # quarkus-app/, this builds the real image.
 #
 # Adding a build stage back here is enforced against by
-# .github/scripts/check-dockerfile-no-build-stage.py.
+# .github/scripts/check-dockerfile-no-build-stage.py, which also fails if the FROM above
+# drifts from Dockerfile.deploy — the runtime base is stated in exactly one place (#3354).
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre@sha256:681c543d6f36c50f45e9b5226930a46203dcfa351d3670e9d0bdf0dabae53539
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd --system --gid 101 openbank \
+ && useradd --system --uid 100 --gid 101 --no-create-home --shell /usr/sbin/nologin openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-analytics-sink/Dockerfile
+++ b/openbank-analytics-sink/Dockerfile
@@ -13,11 +13,13 @@
 # quarkus-app/, this builds the real image.
 #
 # Adding a build stage back here is enforced against by
-# .github/scripts/check-dockerfile-no-build-stage.py.
+# .github/scripts/check-dockerfile-no-build-stage.py, which also fails if the FROM above
+# drifts from Dockerfile.deploy — the runtime base is stated in exactly one place (#3354).
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre@sha256:681c543d6f36c50f45e9b5226930a46203dcfa351d3670e9d0bdf0dabae53539
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd --system --gid 101 openbank \
+ && useradd --system --uid 100 --gid 101 --no-create-home --shell /usr/sbin/nologin openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-ap2-service/Dockerfile
+++ b/openbank-ap2-service/Dockerfile
@@ -13,11 +13,13 @@
 # quarkus-app/, this builds the real image.
 #
 # Adding a build stage back here is enforced against by
-# .github/scripts/check-dockerfile-no-build-stage.py.
+# .github/scripts/check-dockerfile-no-build-stage.py, which also fails if the FROM above
+# drifts from Dockerfile.deploy — the runtime base is stated in exactly one place (#3354).
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre@sha256:681c543d6f36c50f45e9b5226930a46203dcfa351d3670e9d0bdf0dabae53539
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd --system --gid 101 openbank \
+ && useradd --system --uid 100 --gid 101 --no-create-home --shell /usr/sbin/nologin openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-audit-service/Dockerfile
+++ b/openbank-audit-service/Dockerfile
@@ -13,11 +13,13 @@
 # quarkus-app/, this builds the real image.
 #
 # Adding a build stage back here is enforced against by
-# .github/scripts/check-dockerfile-no-build-stage.py.
+# .github/scripts/check-dockerfile-no-build-stage.py, which also fails if the FROM above
+# drifts from Dockerfile.deploy — the runtime base is stated in exactly one place (#3354).
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre@sha256:681c543d6f36c50f45e9b5226930a46203dcfa351d3670e9d0bdf0dabae53539
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd --system --gid 101 openbank \
+ && useradd --system --uid 100 --gid 101 --no-create-home --shell /usr/sbin/nologin openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-authz-policy-auditor/Dockerfile
+++ b/openbank-authz-policy-auditor/Dockerfile
@@ -13,11 +13,13 @@
 # quarkus-app/, this builds the real image.
 #
 # Adding a build stage back here is enforced against by
-# .github/scripts/check-dockerfile-no-build-stage.py.
+# .github/scripts/check-dockerfile-no-build-stage.py, which also fails if the FROM above
+# drifts from Dockerfile.deploy — the runtime base is stated in exactly one place (#3354).
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre@sha256:681c543d6f36c50f45e9b5226930a46203dcfa351d3670e9d0bdf0dabae53539
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd --system --gid 101 openbank \
+ && useradd --system --uid 100 --gid 101 --no-create-home --shell /usr/sbin/nologin openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-balance-service/Dockerfile
+++ b/openbank-balance-service/Dockerfile
@@ -13,11 +13,13 @@
 # quarkus-app/, this builds the real image.
 #
 # Adding a build stage back here is enforced against by
-# .github/scripts/check-dockerfile-no-build-stage.py.
+# .github/scripts/check-dockerfile-no-build-stage.py, which also fails if the FROM above
+# drifts from Dockerfile.deploy — the runtime base is stated in exactly one place (#3354).
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre@sha256:681c543d6f36c50f45e9b5226930a46203dcfa351d3670e9d0bdf0dabae53539
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd --system --gid 101 openbank \
+ && useradd --system --uid 100 --gid 101 --no-create-home --shell /usr/sbin/nologin openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-billing-service/Dockerfile
+++ b/openbank-billing-service/Dockerfile
@@ -13,11 +13,13 @@
 # quarkus-app/, this builds the real image.
 #
 # Adding a build stage back here is enforced against by
-# .github/scripts/check-dockerfile-no-build-stage.py.
+# .github/scripts/check-dockerfile-no-build-stage.py, which also fails if the FROM above
+# drifts from Dockerfile.deploy — the runtime base is stated in exactly one place (#3354).
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre@sha256:681c543d6f36c50f45e9b5226930a46203dcfa351d3670e9d0bdf0dabae53539
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd --system --gid 101 openbank \
+ && useradd --system --uid 100 --gid 101 --no-create-home --shell /usr/sbin/nologin openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-campaign-service/Dockerfile
+++ b/openbank-campaign-service/Dockerfile
@@ -13,11 +13,13 @@
 # quarkus-app/, this builds the real image.
 #
 # Adding a build stage back here is enforced against by
-# .github/scripts/check-dockerfile-no-build-stage.py.
+# .github/scripts/check-dockerfile-no-build-stage.py, which also fails if the FROM above
+# drifts from Dockerfile.deploy — the runtime base is stated in exactly one place (#3354).
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre@sha256:681c543d6f36c50f45e9b5226930a46203dcfa351d3670e9d0bdf0dabae53539
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd --system --gid 101 openbank \
+ && useradd --system --uid 100 --gid 101 --no-create-home --shell /usr/sbin/nologin openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-card-issuance-service/Dockerfile
+++ b/openbank-card-issuance-service/Dockerfile
@@ -13,11 +13,13 @@
 # quarkus-app/, this builds the real image.
 #
 # Adding a build stage back here is enforced against by
-# .github/scripts/check-dockerfile-no-build-stage.py.
+# .github/scripts/check-dockerfile-no-build-stage.py, which also fails if the FROM above
+# drifts from Dockerfile.deploy — the runtime base is stated in exactly one place (#3354).
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre@sha256:681c543d6f36c50f45e9b5226930a46203dcfa351d3670e9d0bdf0dabae53539
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd --system --gid 101 openbank \
+ && useradd --system --uid 100 --gid 101 --no-create-home --shell /usr/sbin/nologin openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-clearing-service/Dockerfile
+++ b/openbank-clearing-service/Dockerfile
@@ -13,11 +13,13 @@
 # quarkus-app/, this builds the real image.
 #
 # Adding a build stage back here is enforced against by
-# .github/scripts/check-dockerfile-no-build-stage.py.
+# .github/scripts/check-dockerfile-no-build-stage.py, which also fails if the FROM above
+# drifts from Dockerfile.deploy — the runtime base is stated in exactly one place (#3354).
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre@sha256:681c543d6f36c50f45e9b5226930a46203dcfa351d3670e9d0bdf0dabae53539
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd --system --gid 101 openbank \
+ && useradd --system --uid 100 --gid 101 --no-create-home --shell /usr/sbin/nologin openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-clearing-simulator/Dockerfile
+++ b/openbank-clearing-simulator/Dockerfile
@@ -13,11 +13,13 @@
 # quarkus-app/, this builds the real image.
 #
 # Adding a build stage back here is enforced against by
-# .github/scripts/check-dockerfile-no-build-stage.py.
+# .github/scripts/check-dockerfile-no-build-stage.py, which also fails if the FROM above
+# drifts from Dockerfile.deploy — the runtime base is stated in exactly one place (#3354).
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre@sha256:681c543d6f36c50f45e9b5226930a46203dcfa351d3670e9d0bdf0dabae53539
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd --system --gid 101 openbank \
+ && useradd --system --uid 100 --gid 101 --no-create-home --shell /usr/sbin/nologin openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-consent-service/Dockerfile
+++ b/openbank-consent-service/Dockerfile
@@ -13,11 +13,13 @@
 # quarkus-app/, this builds the real image.
 #
 # Adding a build stage back here is enforced against by
-# .github/scripts/check-dockerfile-no-build-stage.py.
+# .github/scripts/check-dockerfile-no-build-stage.py, which also fails if the FROM above
+# drifts from Dockerfile.deploy — the runtime base is stated in exactly one place (#3354).
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre@sha256:681c543d6f36c50f45e9b5226930a46203dcfa351d3670e9d0bdf0dabae53539
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd --system --gid 101 openbank \
+ && useradd --system --uid 100 --gid 101 --no-create-home --shell /usr/sbin/nologin openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-control-liveness-sentinel/Dockerfile
+++ b/openbank-control-liveness-sentinel/Dockerfile
@@ -13,11 +13,13 @@
 # quarkus-app/, this builds the real image.
 #
 # Adding a build stage back here is enforced against by
-# .github/scripts/check-dockerfile-no-build-stage.py.
+# .github/scripts/check-dockerfile-no-build-stage.py, which also fails if the FROM above
+# drifts from Dockerfile.deploy — the runtime base is stated in exactly one place (#3354).
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre@sha256:681c543d6f36c50f45e9b5226930a46203dcfa351d3670e9d0bdf0dabae53539
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd --system --gid 101 openbank \
+ && useradd --system --uid 100 --gid 101 --no-create-home --shell /usr/sbin/nologin openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-copilot-service/Dockerfile
+++ b/openbank-copilot-service/Dockerfile
@@ -13,11 +13,13 @@
 # quarkus-app/, this builds the real image.
 #
 # Adding a build stage back here is enforced against by
-# .github/scripts/check-dockerfile-no-build-stage.py.
+# .github/scripts/check-dockerfile-no-build-stage.py, which also fails if the FROM above
+# drifts from Dockerfile.deploy — the runtime base is stated in exactly one place (#3354).
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre@sha256:681c543d6f36c50f45e9b5226930a46203dcfa351d3670e9d0bdf0dabae53539
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd --system --gid 101 openbank \
+ && useradd --system --uid 100 --gid 101 --no-create-home --shell /usr/sbin/nologin openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-customer-edge/Dockerfile
+++ b/openbank-customer-edge/Dockerfile
@@ -13,11 +13,13 @@
 # quarkus-app/, this builds the real image.
 #
 # Adding a build stage back here is enforced against by
-# .github/scripts/check-dockerfile-no-build-stage.py.
+# .github/scripts/check-dockerfile-no-build-stage.py, which also fails if the FROM above
+# drifts from Dockerfile.deploy — the runtime base is stated in exactly one place (#3354).
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre@sha256:681c543d6f36c50f45e9b5226930a46203dcfa351d3670e9d0bdf0dabae53539
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd --system --gid 101 openbank \
+ && useradd --system --uid 100 --gid 101 --no-create-home --shell /usr/sbin/nologin openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-customer-edge/src/main/resources/docs/05-operations.cs.md
+++ b/openbank-customer-edge/src/main/resources/docs/05-operations.cs.md
@@ -13,7 +13,7 @@
 openbank-infra/scripts/build-push-service.sh customer-edge
 ```
 
-`Dockerfile` sestaví fast-jar ve stage `eclipse-temurin:25-jdk-alpine` a spustí ho na `eclipse-temurin:25-jre-alpine` s `-XX:+UseZGC`, exponuje port 8128.
+Image staví `.github/workflows/Dockerfile.deploy` z fast-jaru sestaveného na hostu — runtime base `eclipse-temurin:25-jre` (glibc, #3354), non-root uživatel `openbank`, `-XX:+UseZGC`, port 8128. `openbank-customer-edge/Dockerfile` nic nestaví (#3016); pipeline z něj čte jedinou věc, řádek `EXPOSE`.
 
 ## Endpointy
 

--- a/openbank-customer-edge/src/main/resources/docs/05-operations.en.md
+++ b/openbank-customer-edge/src/main/resources/docs/05-operations.en.md
@@ -13,7 +13,7 @@
 openbank-infra/scripts/build-push-service.sh customer-edge
 ```
 
-The `Dockerfile` builds the fast-jar in an `eclipse-temurin:25-jdk-alpine` stage and runs it on `eclipse-temurin:25-jre-alpine` with `-XX:+UseZGC`, exposing port 8128.
+The image is built by `.github/workflows/Dockerfile.deploy` from a host-side fast-jar — runtime base `eclipse-temurin:25-jre` (glibc, #3354), non-root `openbank` user, `-XX:+UseZGC`, port 8128. `openbank-customer-edge/Dockerfile` builds nothing (#3016); the pipeline reads exactly one thing from it, the `EXPOSE` line.
 
 ## Endpoints
 

--- a/openbank-delegation-service/Dockerfile
+++ b/openbank-delegation-service/Dockerfile
@@ -14,11 +14,13 @@
 # says is what actually happens.
 #
 # Adding a build stage back here is enforced against by
-# .github/scripts/check-dockerfile-no-build-stage.py (#3392).
+# .github/scripts/check-dockerfile-no-build-stage.py, which also fails if the FROM above
+# drifts from Dockerfile.deploy — the runtime base is stated in exactly one place (#3354).
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre@sha256:681c543d6f36c50f45e9b5226930a46203dcfa351d3670e9d0bdf0dabae53539
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd --system --gid 101 openbank \
+ && useradd --system --uid 100 --gid 101 --no-create-home --shell /usr/sbin/nologin openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-dispute-service/Dockerfile
+++ b/openbank-dispute-service/Dockerfile
@@ -13,11 +13,13 @@
 # quarkus-app/, this builds the real image.
 #
 # Adding a build stage back here is enforced against by
-# .github/scripts/check-dockerfile-no-build-stage.py.
+# .github/scripts/check-dockerfile-no-build-stage.py, which also fails if the FROM above
+# drifts from Dockerfile.deploy — the runtime base is stated in exactly one place (#3354).
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre@sha256:681c543d6f36c50f45e9b5226930a46203dcfa351d3670e9d0bdf0dabae53539
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd --system --gid 101 openbank \
+ && useradd --system --uid 100 --gid 101 --no-create-home --shell /usr/sbin/nologin openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-docs-truth-agent/Dockerfile
+++ b/openbank-docs-truth-agent/Dockerfile
@@ -13,11 +13,13 @@
 # quarkus-app/, this builds the real image.
 #
 # Adding a build stage back here is enforced against by
-# .github/scripts/check-dockerfile-no-build-stage.py.
+# .github/scripts/check-dockerfile-no-build-stage.py, which also fails if the FROM above
+# drifts from Dockerfile.deploy — the runtime base is stated in exactly one place (#3354).
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre@sha256:681c543d6f36c50f45e9b5226930a46203dcfa351d3670e9d0bdf0dabae53539
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd --system --gid 101 openbank \
+ && useradd --system --uid 100 --gid 101 --no-create-home --shell /usr/sbin/nologin openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-document-service/Dockerfile
+++ b/openbank-document-service/Dockerfile
@@ -13,11 +13,13 @@
 # quarkus-app/, this builds the real image.
 #
 # Adding a build stage back here is enforced against by
-# .github/scripts/check-dockerfile-no-build-stage.py.
+# .github/scripts/check-dockerfile-no-build-stage.py, which also fails if the FROM above
+# drifts from Dockerfile.deploy — the runtime base is stated in exactly one place (#3354).
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre@sha256:681c543d6f36c50f45e9b5226930a46203dcfa351d3670e9d0bdf0dabae53539
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd --system --gid 101 openbank \
+ && useradd --system --uid 100 --gid 101 --no-create-home --shell /usr/sbin/nologin openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-domestic-payment/Dockerfile
+++ b/openbank-domestic-payment/Dockerfile
@@ -13,11 +13,13 @@
 # quarkus-app/, this builds the real image.
 #
 # Adding a build stage back here is enforced against by
-# .github/scripts/check-dockerfile-no-build-stage.py.
+# .github/scripts/check-dockerfile-no-build-stage.py, which also fails if the FROM above
+# drifts from Dockerfile.deploy — the runtime base is stated in exactly one place (#3354).
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre@sha256:681c543d6f36c50f45e9b5226930a46203dcfa351d3670e9d0bdf0dabae53539
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd --system --gid 101 openbank \
+ && useradd --system --uid 100 --gid 101 --no-create-home --shell /usr/sbin/nologin openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-finrep-service/Dockerfile
+++ b/openbank-finrep-service/Dockerfile
@@ -13,11 +13,13 @@
 # quarkus-app/, this builds the real image.
 #
 # Adding a build stage back here is enforced against by
-# .github/scripts/check-dockerfile-no-build-stage.py.
+# .github/scripts/check-dockerfile-no-build-stage.py, which also fails if the FROM above
+# drifts from Dockerfile.deploy — the runtime base is stated in exactly one place (#3354).
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre@sha256:681c543d6f36c50f45e9b5226930a46203dcfa351d3670e9d0bdf0dabae53539
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd --system --gid 101 openbank \
+ && useradd --system --uid 100 --gid 101 --no-create-home --shell /usr/sbin/nologin openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-flaky-test-hunter/Dockerfile
+++ b/openbank-flaky-test-hunter/Dockerfile
@@ -13,11 +13,13 @@
 # quarkus-app/, this builds the real image.
 #
 # Adding a build stage back here is enforced against by
-# .github/scripts/check-dockerfile-no-build-stage.py.
+# .github/scripts/check-dockerfile-no-build-stage.py, which also fails if the FROM above
+# drifts from Dockerfile.deploy — the runtime base is stated in exactly one place (#3354).
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre@sha256:681c543d6f36c50f45e9b5226930a46203dcfa351d3670e9d0bdf0dabae53539
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd --system --gid 101 openbank \
+ && useradd --system --uid 100 --gid 101 --no-create-home --shell /usr/sbin/nologin openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-fraud-service/src/main/kotlin/com/openbank/fraud/infrastructure/ml/OnnxFraudModel.kt
+++ b/openbank-fraud-service/src/main/kotlin/com/openbank/fraud/infrastructure/ml/OnnxFraudModel.kt
@@ -101,7 +101,7 @@ class OnnxFraudModel(
          * `catch (ex: Exception)` in [loadSession] below never saw them and the class documented a
          * degradation it could not perform.
          *
-         * What that cost: the deploy image is `eclipse-temurin:25-jre-alpine` (musl, no libstdc++),
+         * What that cost: the deploy image was `eclipse-temurin:25-jre-alpine` (musl, no libstdc++),
          * onnxruntime's `libonnxruntime.so` is built against glibc, so `getEnvironment()` threw in
          * a FIELD INITIALIZER — construction of the bean failed, and CDI then failed every
          * injection point of it. `FraudResource.reviewQueue` is a read-only analyst query that

--- a/openbank-fraud-service/src/main/resources/application.yaml
+++ b/openbank-fraud-service/src/main/resources/application.yaml
@@ -141,14 +141,18 @@ mp:
           enabled: false
 openbank:
   # ML / shadow scoring (ADR-0139 phase-1b) — READ THIS BEFORE TRUSTING A "shadow score" NUMBER.
-  # The in-process ONNX adapter has NEVER loaded in a deployed environment: the fleet runtime
-  # image is eclipse-temurin:*-jre-alpine (musl) and onnxruntime's libonnxruntime.so is linked
-  # against glibc, so OrtEnvironment.getEnvironment() throws UnsatisfiedLinkError at startup and
-  # scoreShadow() returns null for every request. Verdicts are therefore rules-only, and always
-  # have been — measured on arm64: alpine fails on libstdc++.so.6, alpine + `apk add libstdc++`
-  # then fails on ld-linux-aarch64.so.1, and only a glibc base loads it (#3354). No verdict has
-  # ever differed because of this — the bundled model reproduces the previous pure-Kotlin
-  # logistic exactly — but any claim that the ONNX serving path "works" is unverified.
+  # The in-process ONNX adapter had NEVER loaded in a deployed environment up to #3618: the
+  # fleet runtime image was eclipse-temurin:*-jre-alpine (musl) and onnxruntime's
+  # libonnxruntime.so is linked against glibc, so OrtEnvironment.getEnvironment() threw
+  # UnsatisfiedLinkError at startup and scoreShadow() returned null for every request. Verdicts
+  # were therefore rules-only for the whole life of the adapter — measured on arm64: alpine
+  # fails on libstdc++.so.6, alpine + `apk add libstdc++` then fails on ld-linux-aarch64.so.1,
+  # and only a glibc base loads it (#3354). #3618 moved the base to eclipse-temurin:25-jre and
+  # gates it with .github/scripts/verify-image-native-libs.py, which resolves every NEEDED
+  # entry before a push. That proves the library CAN load; it is not yet a measurement of a
+  # deployed pod scoring, so treat a shadow score as unverified until one is observed. No
+  # verdict has ever differed because of this — the bundled model reproduces the previous
+  # pure-Kotlin logistic exactly.
   # openbank.ml.require-signature (ADR-0141 model-card pinning) only takes effect once it does.
   rate-limit:
     enabled: true

--- a/openbank-fraud-service/src/test/kotlin/com/openbank/fraud/infrastructure/ml/OnnxFraudModelTest.kt
+++ b/openbank-fraud-service/src/test/kotlin/com/openbank/fraud/infrastructure/ml/OnnxFraudModelTest.kt
@@ -13,6 +13,7 @@ import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.unmockkStatic
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.within
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 
@@ -34,6 +35,29 @@ class OnnxFraudModelTest {
         val second = model.scoreShadow(features)
         assertThat(first).isNotNull().isBetween(0.0, 1.0)
         assertThat(first).isEqualTo(second)
+    }
+
+    /**
+     * The model REALLY runs, and computes the documented logistic — not merely "something in
+     * [0,1]". The graph is `sigmoid(-4.0 + 0.30*h1 + 0.05*h24)` (gen_onnx_baseline_model.py), so
+     * h1=5, h24=12 has exactly one right answer. A stubbed adapter, a constant, or a degraded
+     * session returning null all fail this; the bounded/monotonic assertions above do not
+     * distinguish those.
+     *
+     * What this CANNOT catch, and why it needed a second mechanism (#3354): it runs on the CI
+     * runner's libc, not the runtime image's. The deploy image was musl while libonnxruntime.so is
+     * glibc-linked, so this test was green for the entire life of an adapter that had never once
+     * loaded in a deployed environment. `.github/scripts/verify-image-native-libs.py` is the half
+     * that runs the real loader against the real base image before any push.
+     */
+    @Test
+    fun `scores the documented logistic exactly, so a real inference must have happened`() {
+        val score = model.scoreShadow(
+            mapOf(VELOCITY_TXN_COUNT_H1.name to 5.0, VELOCITY_TXN_COUNT_H24.name to 12.0),
+        )
+        val logit = -4.0 + 0.30 * 5.0 + 0.05 * 12.0
+        val expected = 1.0 / (1.0 + kotlin.math.exp(-logit))
+        assertThat(score).isNotNull().isCloseTo(expected, within(1e-6))
     }
 
     @Test

--- a/openbank-fx-service/Dockerfile
+++ b/openbank-fx-service/Dockerfile
@@ -13,11 +13,13 @@
 # quarkus-app/, this builds the real image.
 #
 # Adding a build stage back here is enforced against by
-# .github/scripts/check-dockerfile-no-build-stage.py.
+# .github/scripts/check-dockerfile-no-build-stage.py, which also fails if the FROM above
+# drifts from Dockerfile.deploy — the runtime base is stated in exactly one place (#3354).
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre@sha256:681c543d6f36c50f45e9b5226930a46203dcfa351d3670e9d0bdf0dabae53539
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd --system --gid 101 openbank \
+ && useradd --system --uid 100 --gid 101 --no-create-home --shell /usr/sbin/nologin openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-governance-auditor/Dockerfile
+++ b/openbank-governance-auditor/Dockerfile
@@ -13,11 +13,13 @@
 # quarkus-app/, this builds the real image.
 #
 # Adding a build stage back here is enforced against by
-# .github/scripts/check-dockerfile-no-build-stage.py.
+# .github/scripts/check-dockerfile-no-build-stage.py, which also fails if the FROM above
+# drifts from Dockerfile.deploy — the runtime base is stated in exactly one place (#3354).
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre@sha256:681c543d6f36c50f45e9b5226930a46203dcfa351d3670e9d0bdf0dabae53539
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd --system --gid 101 openbank \
+ && useradd --system --uid 100 --gid 101 --no-create-home --shell /usr/sbin/nologin openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-infra/gitops/components/interest-service/interest-service-http-scaledobject.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-service-http-scaledobject.yaml
@@ -18,8 +18,8 @@
 # Modeled exactly on components/accounts/product-catalog-http-scaledobject.yaml (ADR-0083 pilot).
 #
 # Native-image status (T1 viability assumption per ADR-0057/rules.yaml finops_tiers.T1): NOT
-# native. interest-service's Dockerfile runs `quarkusBuild` (fast-jar) on a JVM (eclipse-temurin
-# jre-alpine) base — same as the product-catalog pilot itself, which is also fast-jar despite
+# native. interest-service ships `quarkusBuild` output (fast-jar) on a JVM (eclipse-temurin
+# 25-jre) base — same as the product-catalog pilot itself, which is also fast-jar despite
 # rules.yaml's `declared` comment claiming a passed native cold-start gate (no native Dockerfile
 # lane, no native CI step, and no `-Dquarkus.native.enabled` anywhere in this repo backs that
 # comment). Per the issue's explicit guidance, native is a T1 prerequisite/promotion gate, not a

--- a/openbank-infra/scripts/build-push-service.sh
+++ b/openbank-infra/scripts/build-push-service.sh
@@ -72,27 +72,23 @@ cp -r "${QA}" "${CTX}/quarkus-app"
 # Gradle produces quarkus-app files with 600 permissions (owner-only). The container
 # runs as a non-root 'openbank' user who can't read them → ClassNotFoundException.
 chmod -R a+r "${CTX}/quarkus-app"
-# Stage the SBOM (if produced) so the runtime stage can COPY it in.
-SBOM_COPY=""; SBOM_ENV=""
+# The runtime recipe is NOT written here. This script used to keep its own copy of it, and that
+# copy had drifted into a THIRD definition of how an OpenBank image is made — unpinned (no digest)
+# where the CI producers pinned one, and still on the musl base after #3354 moved the fleet to
+# glibc, so a laptop deploy of fraud-service would have re-shipped the exact defect CI had just
+# fixed. Copy the one file both CI producers copy, and append the same two variable parts they do.
+cp "${REPO_ROOT}/.github/workflows/Dockerfile.deploy" "${CTX}/Dockerfile"
 if [ -f "$BOM" ]; then
   mkdir -p "${CTX}/sbom"; cp "$BOM" "${CTX}/sbom/bom.json"; chmod a+r "${CTX}/sbom/bom.json"
-  SBOM_COPY=$'COPY sbom/bom.json /app/sbom/bom.json'
-  SBOM_ENV=$'ENV OPENBANK_SBOM_PATH=/app/sbom/bom.json'
+  echo "COPY sbom/bom.json /app/sbom/bom.json" >> "${CTX}/Dockerfile"
+  echo "ENV OPENBANK_SBOM_PATH=/app/sbom/bom.json" >> "${CTX}/Dockerfile"
 fi
-cat > "${CTX}/Dockerfile" <<EOF
-FROM eclipse-temurin:25-jre-alpine
-WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
-USER openbank
-COPY quarkus-app/lib/ /app/lib/
-COPY quarkus-app/*.jar /app/
-COPY quarkus-app/app/ /app/app/
-COPY quarkus-app/quarkus/ /app/quarkus/
-${SBOM_COPY}
-${SBOM_ENV}
-EXPOSE ${PORT}
-ENTRYPOINT ["java", "-XX:+UseZGC", "-Djava.util.logging.manager=org.jboss.logmanager.LogManager", "-jar", "/app/quarkus-run.jar"]
-EOF
+echo "EXPOSE ${PORT}" >> "${CTX}/Dockerfile"
+
+# ldd every bundled linux .so inside that base before pushing — a musl/glibc mismatch is invisible
+# to the build, to the health probes and to every test that runs on a glibc host (#3354).
+python3 "${REPO_ROOT}/.github/scripts/verify-image-native-libs.py" \
+  "${CTX}/quarkus-app/lib" --arch "${PLATFORM#linux/}"
 
 echo "==> ECR login + buildx push"
 aws ecr get-login-password --region "$AWS_REGION" | docker login --username AWS --password-stdin "$ECR_REGISTRY" >/dev/null

--- a/openbank-interest-service/Dockerfile
+++ b/openbank-interest-service/Dockerfile
@@ -13,11 +13,13 @@
 # quarkus-app/, this builds the real image.
 #
 # Adding a build stage back here is enforced against by
-# .github/scripts/check-dockerfile-no-build-stage.py.
+# .github/scripts/check-dockerfile-no-build-stage.py, which also fails if the FROM above
+# drifts from Dockerfile.deploy — the runtime base is stated in exactly one place (#3354).
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre@sha256:681c543d6f36c50f45e9b5226930a46203dcfa351d3670e9d0bdf0dabae53539
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd --system --gid 101 openbank \
+ && useradd --system --uid 100 --gid 101 --no-create-home --shell /usr/sbin/nologin openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-kyc-service/Dockerfile
+++ b/openbank-kyc-service/Dockerfile
@@ -13,11 +13,13 @@
 # quarkus-app/, this builds the real image.
 #
 # Adding a build stage back here is enforced against by
-# .github/scripts/check-dockerfile-no-build-stage.py.
+# .github/scripts/check-dockerfile-no-build-stage.py, which also fails if the FROM above
+# drifts from Dockerfile.deploy — the runtime base is stated in exactly one place (#3354).
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre@sha256:681c543d6f36c50f45e9b5226930a46203dcfa351d3670e9d0bdf0dabae53539
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd --system --gid 101 openbank \
+ && useradd --system --uid 100 --gid 101 --no-create-home --shell /usr/sbin/nologin openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-kyc-service/src/main/resources/docs/05-operations.cs.md
+++ b/openbank-kyc-service/src/main/resources/docs/05-operations.cs.md
@@ -13,7 +13,7 @@
 openbank-infra/scripts/build-push-service.sh kyc-service
 ```
 
-`Dockerfile` staví **fast-jar** (`-Dquarkus.package.jar.type=fast-jar`) a runtime stage kopíruje `quarkus-app/`. Runtime image: `eclipse-temurin:25-jre-alpine`, non-root uživatel `openbank`, ZGC. Nikdy nepoužívej uber-jar (prázdný `quarkus-app/` → crashloop).
+**fast-jar** (`-Dquarkus.package.jar.type=fast-jar`) se staví na hostu; image skládá `.github/workflows/Dockerfile.deploy`, které kopíruje `quarkus-app/`. Runtime image: `eclipse-temurin:25-jre` (glibc, #3354), non-root uživatel `openbank`, ZGC. Nikdy nepoužívej uber-jar (prázdný `quarkus-app/` → crashloop). `openbank-kyc-service/Dockerfile` nic nestaví (#3016) — pipeline z něj čte jen `EXPOSE`.
 
 ## Endpointy
 

--- a/openbank-kyc-service/src/main/resources/docs/05-operations.en.md
+++ b/openbank-kyc-service/src/main/resources/docs/05-operations.en.md
@@ -13,7 +13,7 @@
 openbank-infra/scripts/build-push-service.sh kyc-service
 ```
 
-The `Dockerfile` builds a **fast-jar** (`-Dquarkus.package.jar.type=fast-jar`) and the runtime stage copies `quarkus-app/`. Runtime image: `eclipse-temurin:25-jre-alpine`, non-root `openbank` user, ZGC. Never use uber-jar (empty `quarkus-app/` → crashloop).
+The **fast-jar** (`-Dquarkus.package.jar.type=fast-jar`) is built host-side; the image is assembled by `.github/workflows/Dockerfile.deploy`, which copies `quarkus-app/`. Runtime image: `eclipse-temurin:25-jre` (glibc, #3354), non-root `openbank` user, ZGC. Never use uber-jar (empty `quarkus-app/` → crashloop). `openbank-kyc-service/Dockerfile` builds nothing (#3016) — the pipeline reads only its `EXPOSE`.
 
 ## Endpoints
 

--- a/openbank-ledger-service/Dockerfile
+++ b/openbank-ledger-service/Dockerfile
@@ -13,11 +13,13 @@
 # quarkus-app/, this builds the real image.
 #
 # Adding a build stage back here is enforced against by
-# .github/scripts/check-dockerfile-no-build-stage.py.
+# .github/scripts/check-dockerfile-no-build-stage.py, which also fails if the FROM above
+# drifts from Dockerfile.deploy — the runtime base is stated in exactly one place (#3354).
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre@sha256:681c543d6f36c50f45e9b5226930a46203dcfa351d3670e9d0bdf0dabae53539
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd --system --gid 101 openbank \
+ && useradd --system --uid 100 --gid 101 --no-create-home --shell /usr/sbin/nologin openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-mcp-service/Dockerfile
+++ b/openbank-mcp-service/Dockerfile
@@ -13,11 +13,13 @@
 # quarkus-app/, this builds the real image.
 #
 # Adding a build stage back here is enforced against by
-# .github/scripts/check-dockerfile-no-build-stage.py.
+# .github/scripts/check-dockerfile-no-build-stage.py, which also fails if the FROM above
+# drifts from Dockerfile.deploy — the runtime base is stated in exactly one place (#3354).
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre@sha256:681c543d6f36c50f45e9b5226930a46203dcfa351d3670e9d0bdf0dabae53539
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd --system --gid 101 openbank \
+ && useradd --system --uid 100 --gid 101 --no-create-home --shell /usr/sbin/nologin openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-notification-service/Dockerfile
+++ b/openbank-notification-service/Dockerfile
@@ -13,11 +13,13 @@
 # quarkus-app/, this builds the real image.
 #
 # Adding a build stage back here is enforced against by
-# .github/scripts/check-dockerfile-no-build-stage.py.
+# .github/scripts/check-dockerfile-no-build-stage.py, which also fails if the FROM above
+# drifts from Dockerfile.deploy — the runtime base is stated in exactly one place (#3354).
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre@sha256:681c543d6f36c50f45e9b5226930a46203dcfa351d3670e9d0bdf0dabae53539
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd --system --gid 101 openbank \
+ && useradd --system --uid 100 --gid 101 --no-create-home --shell /usr/sbin/nologin openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-notification-service/Dockerfile.runtime
+++ b/openbank-notification-service/Dockerfile.runtime
@@ -10,11 +10,15 @@
 # (which `include(...)`s every service) and breaks under Gradle 9.5.1, which no
 # longer tolerates configuring an absent project dir. Fixing that for in-Docker
 # builds is a separate follow-up; this runtime image unblocks the pilot now.
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+# The FROM below is the fleet runtime base and is checked against
+# .github/workflows/Dockerfile.deploy by
+# .github/scripts/check-dockerfile-no-build-stage.py (#3354).
+FROM eclipse-temurin:25-jre@sha256:681c543d6f36c50f45e9b5226930a46203dcfa351d3670e9d0bdf0dabae53539
 WORKDIR /app
 # Explicit numeric UID/GID so a pod with runAsNonRoot can verify non-root without
 # a runAsUser override (kubelet cannot resolve a named user from the image).
-RUN addgroup -S -g 1001 openbank && adduser -S -u 1001 -G openbank openbank
+RUN groupadd --system --gid 1001 openbank \
+ && useradd --system --uid 1001 --gid 1001 --no-create-home --shell /usr/sbin/nologin openbank
 USER 1001
 COPY lib/ /app/lib/
 COPY *.jar /app/

--- a/openbank-onboarding-service/Dockerfile
+++ b/openbank-onboarding-service/Dockerfile
@@ -13,11 +13,13 @@
 # quarkus-app/, this builds the real image.
 #
 # Adding a build stage back here is enforced against by
-# .github/scripts/check-dockerfile-no-build-stage.py.
+# .github/scripts/check-dockerfile-no-build-stage.py, which also fails if the FROM above
+# drifts from Dockerfile.deploy — the runtime base is stated in exactly one place (#3354).
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre@sha256:681c543d6f36c50f45e9b5226930a46203dcfa351d3670e9d0bdf0dabae53539
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd --system --gid 101 openbank \
+ && useradd --system --uid 100 --gid 101 --no-create-home --shell /usr/sbin/nologin openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-onboarding-service/src/main/resources/docs/05-operations.cs.md
+++ b/openbank-onboarding-service/src/main/resources/docs/05-operations.cs.md
@@ -10,10 +10,10 @@
 ./gradlew :openbank-onboarding-service:quarkusDev
 
 # Docker image (multi-stage; fast-jar, JDK 25 Temurin, ZGC)
-docker build -f openbank-onboarding-service/Dockerfile -t openbank-onboarding-service .
+openbank-infra/scripts/build-push-service.sh onboarding-service
 ```
 
-Dockerfile staví fast-jar ve stage `eclipse-temurin:25-jdk-alpine` a běží jej na `eclipse-temurin:25-jre-alpine` jako non-root uživatel `openbank`, entrypoint `java -XX:+UseZGC … -jar /app/quarkus-run.jar`, exposing port 8130.
+Image staví `.github/workflows/Dockerfile.deploy` z fast-jaru sestaveného na hostu a běží na `eclipse-temurin:25-jre` (glibc, #3354) jako non-root uživatel `openbank`, entrypoint `java -XX:+UseZGC … -jar /app/quarkus-run.jar`, port 8130. `openbank-onboarding-service/Dockerfile` nic nestaví (#3016) — `docker build` proti němu selže, kontext neobsahuje `quarkus-app/`; pipeline z něj čte jen `EXPOSE`.
 
 ## Endpointy
 

--- a/openbank-onboarding-service/src/main/resources/docs/05-operations.en.md
+++ b/openbank-onboarding-service/src/main/resources/docs/05-operations.en.md
@@ -10,10 +10,10 @@
 ./gradlew :openbank-onboarding-service:quarkusDev
 
 # Docker image (multi-stage; fast-jar, JDK 25 Temurin, ZGC)
-docker build -f openbank-onboarding-service/Dockerfile -t openbank-onboarding-service .
+openbank-infra/scripts/build-push-service.sh onboarding-service
 ```
 
-The Dockerfile builds the fast-jar in a `eclipse-temurin:25-jdk-alpine` stage and runs it on `eclipse-temurin:25-jre-alpine` as a non-root `openbank` user, entrypoint `java -XX:+UseZGC … -jar /app/quarkus-run.jar`, exposing port 8130.
+The image is built by `.github/workflows/Dockerfile.deploy` from a host-side fast-jar and runs on `eclipse-temurin:25-jre` (glibc, #3354) as a non-root `openbank` user, entrypoint `java -XX:+UseZGC … -jar /app/quarkus-run.jar`, port 8130. `openbank-onboarding-service/Dockerfile` builds nothing (#3016) — `docker build` against it fails, the context has no `quarkus-app/`; the pipeline reads only its `EXPOSE`.
 
 ## Endpoints
 

--- a/openbank-party-service/Dockerfile
+++ b/openbank-party-service/Dockerfile
@@ -13,11 +13,13 @@
 # quarkus-app/, this builds the real image.
 #
 # Adding a build stage back here is enforced against by
-# .github/scripts/check-dockerfile-no-build-stage.py.
+# .github/scripts/check-dockerfile-no-build-stage.py, which also fails if the FROM above
+# drifts from Dockerfile.deploy — the runtime base is stated in exactly one place (#3354).
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre@sha256:681c543d6f36c50f45e9b5226930a46203dcfa351d3670e9d0bdf0dabae53539
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd --system --gid 101 openbank \
+ && useradd --system --uid 100 --gid 101 --no-create-home --shell /usr/sbin/nologin openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-pid-service/Dockerfile
+++ b/openbank-pid-service/Dockerfile
@@ -13,11 +13,13 @@
 # quarkus-app/, this builds the real image.
 #
 # Adding a build stage back here is enforced against by
-# .github/scripts/check-dockerfile-no-build-stage.py.
+# .github/scripts/check-dockerfile-no-build-stage.py, which also fails if the FROM above
+# drifts from Dockerfile.deploy — the runtime base is stated in exactly one place (#3354).
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre@sha256:681c543d6f36c50f45e9b5226930a46203dcfa351d3670e9d0bdf0dabae53539
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd --system --gid 101 openbank \
+ && useradd --system --uid 100 --gid 101 --no-create-home --shell /usr/sbin/nologin openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-pid-service/src/main/resources/docs/05-operations.cs.md
+++ b/openbank-pid-service/src/main/resources/docs/05-operations.cs.md
@@ -9,11 +9,11 @@
 # Dev režim (live reload)
 ./gradlew :openbank-pid-service:quarkusDev
 
-# Kontejner (vícestupňový Dockerfile, fast-jar, běží pod non-root uživatelem `openbank`)
-docker build -t openbank-pid-service -f openbank-pid-service/Dockerfile .
+# Kontejner (fast-jar, běží pod non-root uživatelem `openbank`)
+openbank-infra/scripts/build-push-service.sh pid-service
 ```
 
-Dockerfile staví na `eclipse-temurin:25-jdk-alpine`, běží na `25-jre-alpine`, kopíruje layout `quarkus-app/` a startuje s `-XX:+UseZGC`.
+Image skládá `.github/workflows/Dockerfile.deploy` z fast-jaru sestaveného na hostu: kopíruje layout `quarkus-app/` do runtime base `eclipse-temurin:25-jre` (glibc, #3354) a startuje s `-XX:+UseZGC`. `openbank-pid-service/Dockerfile` nic nestaví (#3016) — pipeline z něj čte jedinou věc, řádek `EXPOSE`.
 
 ## Endpointy / porty
 

--- a/openbank-pid-service/src/main/resources/docs/05-operations.en.md
+++ b/openbank-pid-service/src/main/resources/docs/05-operations.en.md
@@ -9,11 +9,11 @@
 # Run dev mode (live reload)
 ./gradlew :openbank-pid-service:quarkusDev
 
-# Container (multi-stage Dockerfile, fast-jar, runs as non-root user `openbank`)
-docker build -t openbank-pid-service -f openbank-pid-service/Dockerfile .
+# Container (fast-jar, runs as non-root user `openbank`)
+openbank-infra/scripts/build-push-service.sh pid-service
 ```
 
-The Dockerfile builds with `eclipse-temurin:25-jdk-alpine`, runs on `25-jre-alpine`, copies the `quarkus-app/` layout, and starts with `-XX:+UseZGC`.
+The image is assembled by `.github/workflows/Dockerfile.deploy` from a host-side fast-jar: it copies the `quarkus-app/` layout into the `eclipse-temurin:25-jre` runtime base (glibc, #3354) and starts with `-XX:+UseZGC`. `openbank-pid-service/Dockerfile` builds nothing (#3016) — the pipeline reads exactly one thing from it, the `EXPOSE` line.
 
 ## Endpoints / ports
 

--- a/openbank-product-catalog/Dockerfile
+++ b/openbank-product-catalog/Dockerfile
@@ -13,11 +13,13 @@
 # quarkus-app/, this builds the real image.
 #
 # Adding a build stage back here is enforced against by
-# .github/scripts/check-dockerfile-no-build-stage.py.
+# .github/scripts/check-dockerfile-no-build-stage.py, which also fails if the FROM above
+# drifts from Dockerfile.deploy — the runtime base is stated in exactly one place (#3354).
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre@sha256:681c543d6f36c50f45e9b5226930a46203dcfa351d3670e9d0bdf0dabae53539
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd --system --gid 101 openbank \
+ && useradd --system --uid 100 --gid 101 --no-create-home --shell /usr/sbin/nologin openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-product-catalog/src/main/resources/docs/05-operations.cs.md
+++ b/openbank-product-catalog/src/main/resources/docs/05-operations.cs.md
@@ -15,7 +15,7 @@
 
 ### Kontejnerový image
 
-`Dockerfile` builduje z **plného kořenového kontextu repa** (kořenový `settings.gradle.kts` `include`uje každý modul), spustí `:openbank-product-catalog:quarkusBuild` (fast-jar) a runtime stage zkopíruje `build/quarkus-app/` do image `temurin:25-jre-alpine`. Běží pod non-root uživatelem `openbank`, `EXPOSE`uje 8104 a startuje se ZGC.
+`:openbank-product-catalog:quarkusBuild` (fast-jar) běží na hostu z **plného kořenového kontextu repa** (kořenový `settings.gradle.kts` `include`uje každý modul) a `.github/workflows/Dockerfile.deploy` zkopíruje výsledný `quarkus-app/` do image `eclipse-temurin:25-jre` (glibc, #3354). Běží pod non-root uživatelem `openbank`, `EXPOSE`uje 8104 a startuje se ZGC. `openbank-product-catalog/Dockerfile` nic nestaví (#3016) — pipeline z něj čte jedinou věc, řádek `EXPOSE`.
 
 > Platformní pravidlo: **vždy fast-jar, nikdy uber-jar** — runtime stage kopíruje `quarkus-app/`. Builduj na hostiteli, ne in-Docker Gradle. Generický helper: `openbank-infra/scripts/build-push-service.sh openbank-product-catalog`.
 

--- a/openbank-product-catalog/src/main/resources/docs/05-operations.en.md
+++ b/openbank-product-catalog/src/main/resources/docs/05-operations.en.md
@@ -15,7 +15,7 @@
 
 ### Container image
 
-The `Dockerfile` builds from the **full repo root context** (the root `settings.gradle.kts` `include`s every module), runs `:openbank-product-catalog:quarkusBuild` (fast-jar), and the runtime stage copies `build/quarkus-app/` into a `temurin:25-jre-alpine` image. It runs as a non-root `openbank` user, `EXPOSE`s 8104, and starts with ZGC.
+`:openbank-product-catalog:quarkusBuild` (fast-jar) runs host-side from the **full repo root context** (the root `settings.gradle.kts` `include`s every module), and `.github/workflows/Dockerfile.deploy` copies the resulting `quarkus-app/` into an `eclipse-temurin:25-jre` image (glibc, #3354). It runs as a non-root `openbank` user, `EXPOSE`s 8104, and starts with ZGC. `openbank-product-catalog/Dockerfile` builds nothing (#3016) — the pipeline reads exactly one thing from it, the `EXPOSE` line.
 
 > Platform rule: **always fast-jar, never uber-jar** — the runtime stage copies `quarkus-app/`. Build host-side, not in-Docker Gradle. Generic build helper: `openbank-infra/scripts/build-push-service.sh openbank-product-catalog`.
 

--- a/openbank-psd2-service/Dockerfile
+++ b/openbank-psd2-service/Dockerfile
@@ -13,11 +13,13 @@
 # quarkus-app/, this builds the real image.
 #
 # Adding a build stage back here is enforced against by
-# .github/scripts/check-dockerfile-no-build-stage.py.
+# .github/scripts/check-dockerfile-no-build-stage.py, which also fails if the FROM above
+# drifts from Dockerfile.deploy — the runtime base is stated in exactly one place (#3354).
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre@sha256:681c543d6f36c50f45e9b5226930a46203dcfa351d3670e9d0bdf0dabae53539
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd --system --gid 101 openbank \
+ && useradd --system --uid 100 --gid 101 --no-create-home --shell /usr/sbin/nologin openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-release-steward/Dockerfile
+++ b/openbank-release-steward/Dockerfile
@@ -13,11 +13,13 @@
 # quarkus-app/, this builds the real image.
 #
 # Adding a build stage back here is enforced against by
-# .github/scripts/check-dockerfile-no-build-stage.py.
+# .github/scripts/check-dockerfile-no-build-stage.py, which also fails if the FROM above
+# drifts from Dockerfile.deploy — the runtime base is stated in exactly one place (#3354).
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre@sha256:681c543d6f36c50f45e9b5226930a46203dcfa351d3670e9d0bdf0dabae53539
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd --system --gid 101 openbank \
+ && useradd --system --uid 100 --gid 101 --no-create-home --shell /usr/sbin/nologin openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-sanctions-service/Dockerfile
+++ b/openbank-sanctions-service/Dockerfile
@@ -13,11 +13,13 @@
 # quarkus-app/, this builds the real image.
 #
 # Adding a build stage back here is enforced against by
-# .github/scripts/check-dockerfile-no-build-stage.py.
+# .github/scripts/check-dockerfile-no-build-stage.py, which also fails if the FROM above
+# drifts from Dockerfile.deploy — the runtime base is stated in exactly one place (#3354).
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre@sha256:681c543d6f36c50f45e9b5226930a46203dcfa351d3670e9d0bdf0dabae53539
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd --system --gid 101 openbank \
+ && useradd --system --uid 100 --gid 101 --no-create-home --shell /usr/sbin/nologin openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-sca-service/Dockerfile
+++ b/openbank-sca-service/Dockerfile
@@ -13,11 +13,13 @@
 # quarkus-app/, this builds the real image.
 #
 # Adding a build stage back here is enforced against by
-# .github/scripts/check-dockerfile-no-build-stage.py.
+# .github/scripts/check-dockerfile-no-build-stage.py, which also fails if the FROM above
+# drifts from Dockerfile.deploy — the runtime base is stated in exactly one place (#3354).
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre@sha256:681c543d6f36c50f45e9b5226930a46203dcfa351d3670e9d0bdf0dabae53539
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd --system --gid 101 openbank \
+ && useradd --system --uid 100 --gid 101 --no-create-home --shell /usr/sbin/nologin openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-sca-service/src/main/resources/docs/05-operations.cs.md
+++ b/openbank-sca-service/src/main/resources/docs/05-operations.cs.md
@@ -11,7 +11,7 @@ Práh pokrytí (kover): LINE ≥ 40 (money-path baseline; ratchet-only, cíl 70)
 
 ## Build image a deploy
 
-- **fast-jar, build na hostu** (CLAUDE.md GitOps pravidla). Dockerfile staví s `-Dquarkus.package.jar.type=fast-jar` a kopíruje `quarkus-app/` do runtime stage `eclipse-temurin:25-jre-alpine`; běží jako non-root uživatel `openbank` s `-XX:+UseZGC`. `EXPOSE 8110`.
+- **fast-jar, build na hostu** (CLAUDE.md GitOps pravidla). Image skládá `.github/workflows/Dockerfile.deploy`: kopíruje `quarkus-app/` do runtime base `eclipse-temurin:25-jre` (glibc, #3354) a běží jako non-root uživatel `openbank` s `-XX:+UseZGC`. `openbank-sca-service/Dockerfile` nic nestaví (#3016) — pipeline z něj čte jedinou věc, `EXPOSE 8110`.
 - Generický build: `openbank-infra/scripts/build-push-service.sh sca-service`.
 - **Flyway**: `migrate-at-start: true` s 10 connect-retries. Pokud kdy dojde k checksum mismatch na živé DB, dočasně nastav `QUARKUS_FLYWAY_REPAIR_AT_START=true`, pak odeber po ustálení (nikdy nepřepisuj aplikovanou migraci).
 

--- a/openbank-sca-service/src/main/resources/docs/05-operations.en.md
+++ b/openbank-sca-service/src/main/resources/docs/05-operations.en.md
@@ -11,7 +11,7 @@ Coverage floor (kover): LINE ≥ 40 (money-path baseline; ratchet-only, target 7
 
 ## Image build & deploy
 
-- **fast-jar, host-side build** (CLAUDE.md GitOps rules). The Dockerfile builds with `-Dquarkus.package.jar.type=fast-jar` and copies `quarkus-app/` into an `eclipse-temurin:25-jre-alpine` runtime stage; runs as non-root user `openbank` with `-XX:+UseZGC`. `EXPOSE 8110`.
+- **fast-jar, host-side build** (CLAUDE.md GitOps rules). The image is assembled by `.github/workflows/Dockerfile.deploy`: it copies `quarkus-app/` into the `eclipse-temurin:25-jre` runtime base (glibc, #3354) and runs as non-root user `openbank` with `-XX:+UseZGC`. `openbank-sca-service/Dockerfile` builds nothing (#3016) — the pipeline reads exactly one thing from it, `EXPOSE 8110`.
 - Generic build: `openbank-infra/scripts/build-push-service.sh sca-service`.
 - **Flyway**: `migrate-at-start: true` with 10 connect-retries. If a checksum mismatch ever occurs on a live DB, set `QUARKUS_FLYWAY_REPAIR_AT_START=true` temporarily, then remove once settled (never rewrite an applied migration).
 

--- a/openbank-security-scanner/Dockerfile
+++ b/openbank-security-scanner/Dockerfile
@@ -13,11 +13,13 @@
 # quarkus-app/, this builds the real image.
 #
 # Adding a build stage back here is enforced against by
-# .github/scripts/check-dockerfile-no-build-stage.py.
+# .github/scripts/check-dockerfile-no-build-stage.py, which also fails if the FROM above
+# drifts from Dockerfile.deploy — the runtime base is stated in exactly one place (#3354).
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre@sha256:681c543d6f36c50f45e9b5226930a46203dcfa351d3670e9d0bdf0dabae53539
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd --system --gid 101 openbank \
+ && useradd --system --uid 100 --gid 101 --no-create-home --shell /usr/sbin/nologin openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-security-scanner/Dockerfile.prebuilt
+++ b/openbank-security-scanner/Dockerfile.prebuilt
@@ -1,6 +1,10 @@
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+# The FROM below is the fleet runtime base and is checked against
+# .github/workflows/Dockerfile.deploy by
+# .github/scripts/check-dockerfile-no-build-stage.py (#3354).
+FROM eclipse-temurin:25-jre@sha256:681c543d6f36c50f45e9b5226930a46203dcfa351d3670e9d0bdf0dabae53539
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd --system --gid 101 openbank \
+ && useradd --system --uid 100 --gid 101 --no-create-home --shell /usr/sbin/nologin openbank
 USER openbank
 COPY build/quarkus-app/lib/ /app/lib/
 COPY build/quarkus-app/*.jar /app/

--- a/openbank-sepa-instant/Dockerfile
+++ b/openbank-sepa-instant/Dockerfile
@@ -13,11 +13,13 @@
 # quarkus-app/, this builds the real image.
 #
 # Adding a build stage back here is enforced against by
-# .github/scripts/check-dockerfile-no-build-stage.py.
+# .github/scripts/check-dockerfile-no-build-stage.py, which also fails if the FROM above
+# drifts from Dockerfile.deploy — the runtime base is stated in exactly one place (#3354).
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre@sha256:681c543d6f36c50f45e9b5226930a46203dcfa351d3670e9d0bdf0dabae53539
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd --system --gid 101 openbank \
+ && useradd --system --uid 100 --gid 101 --no-create-home --shell /usr/sbin/nologin openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-sepa-payment/Dockerfile
+++ b/openbank-sepa-payment/Dockerfile
@@ -13,11 +13,13 @@
 # quarkus-app/, this builds the real image.
 #
 # Adding a build stage back here is enforced against by
-# .github/scripts/check-dockerfile-no-build-stage.py.
+# .github/scripts/check-dockerfile-no-build-stage.py, which also fails if the FROM above
+# drifts from Dockerfile.deploy — the runtime base is stated in exactly one place (#3354).
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre@sha256:681c543d6f36c50f45e9b5226930a46203dcfa351d3670e9d0bdf0dabae53539
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd --system --gid 101 openbank \
+ && useradd --system --uid 100 --gid 101 --no-create-home --shell /usr/sbin/nologin openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-standing-order-service/Dockerfile
+++ b/openbank-standing-order-service/Dockerfile
@@ -13,11 +13,13 @@
 # quarkus-app/, this builds the real image.
 #
 # Adding a build stage back here is enforced against by
-# .github/scripts/check-dockerfile-no-build-stage.py.
+# .github/scripts/check-dockerfile-no-build-stage.py, which also fails if the FROM above
+# drifts from Dockerfile.deploy — the runtime base is stated in exactly one place (#3354).
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre@sha256:681c543d6f36c50f45e9b5226930a46203dcfa351d3670e9d0bdf0dabae53539
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd --system --gid 101 openbank \
+ && useradd --system --uid 100 --gid 101 --no-create-home --shell /usr/sbin/nologin openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-statement-service/Dockerfile
+++ b/openbank-statement-service/Dockerfile
@@ -13,11 +13,13 @@
 # quarkus-app/, this builds the real image.
 #
 # Adding a build stage back here is enforced against by
-# .github/scripts/check-dockerfile-no-build-stage.py.
+# .github/scripts/check-dockerfile-no-build-stage.py, which also fails if the FROM above
+# drifts from Dockerfile.deploy — the runtime base is stated in exactly one place (#3354).
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre@sha256:681c543d6f36c50f45e9b5226930a46203dcfa351d3670e9d0bdf0dabae53539
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd --system --gid 101 openbank \
+ && useradd --system --uid 100 --gid 101 --no-create-home --shell /usr/sbin/nologin openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-swift-service/Dockerfile
+++ b/openbank-swift-service/Dockerfile
@@ -13,11 +13,13 @@
 # quarkus-app/, this builds the real image.
 #
 # Adding a build stage back here is enforced against by
-# .github/scripts/check-dockerfile-no-build-stage.py.
+# .github/scripts/check-dockerfile-no-build-stage.py, which also fails if the FROM above
+# drifts from Dockerfile.deploy — the runtime base is stated in exactly one place (#3354).
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre@sha256:681c543d6f36c50f45e9b5226930a46203dcfa351d3670e9d0bdf0dabae53539
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd --system --gid 101 openbank \
+ && useradd --system --uid 100 --gid 101 --no-create-home --shell /usr/sbin/nologin openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-tax-reporting-service/Dockerfile
+++ b/openbank-tax-reporting-service/Dockerfile
@@ -13,11 +13,13 @@
 # quarkus-app/, this builds the real image.
 #
 # Adding a build stage back here is enforced against by
-# .github/scripts/check-dockerfile-no-build-stage.py.
+# .github/scripts/check-dockerfile-no-build-stage.py, which also fails if the FROM above
+# drifts from Dockerfile.deploy — the runtime base is stated in exactly one place (#3354).
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre@sha256:681c543d6f36c50f45e9b5226930a46203dcfa351d3670e9d0bdf0dabae53539
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd --system --gid 101 openbank \
+ && useradd --system --uid 100 --gid 101 --no-create-home --shell /usr/sbin/nologin openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-tpp-registry-service/Dockerfile
+++ b/openbank-tpp-registry-service/Dockerfile
@@ -13,11 +13,13 @@
 # quarkus-app/, this builds the real image.
 #
 # Adding a build stage back here is enforced against by
-# .github/scripts/check-dockerfile-no-build-stage.py.
+# .github/scripts/check-dockerfile-no-build-stage.py, which also fails if the FROM above
+# drifts from Dockerfile.deploy — the runtime base is stated in exactly one place (#3354).
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre@sha256:681c543d6f36c50f45e9b5226930a46203dcfa351d3670e9d0bdf0dabae53539
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd --system --gid 101 openbank \
+ && useradd --system --uid 100 --gid 101 --no-create-home --shell /usr/sbin/nologin openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-transaction-service/Dockerfile
+++ b/openbank-transaction-service/Dockerfile
@@ -13,11 +13,13 @@
 # quarkus-app/, this builds the real image.
 #
 # Adding a build stage back here is enforced against by
-# .github/scripts/check-dockerfile-no-build-stage.py.
+# .github/scripts/check-dockerfile-no-build-stage.py, which also fails if the FROM above
+# drifts from Dockerfile.deploy — the runtime base is stated in exactly one place (#3354).
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre@sha256:681c543d6f36c50f45e9b5226930a46203dcfa351d3670e9d0bdf0dabae53539
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd --system --gid 101 openbank \
+ && useradd --system --uid 100 --gid 101 --no-create-home --shell /usr/sbin/nologin openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-vop-service/Dockerfile
+++ b/openbank-vop-service/Dockerfile
@@ -13,11 +13,13 @@
 # quarkus-app/, this builds the real image.
 #
 # Adding a build stage back here is enforced against by
-# .github/scripts/check-dockerfile-no-build-stage.py.
+# .github/scripts/check-dockerfile-no-build-stage.py, which also fails if the FROM above
+# drifts from Dockerfile.deploy — the runtime base is stated in exactly one place (#3354).
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre@sha256:681c543d6f36c50f45e9b5226930a46203dcfa351d3670e9d0bdf0dabae53539
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd --system --gid 101 openbank \
+ && useradd --system --uid 100 --gid 101 --no-create-home --shell /usr/sbin/nologin openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/


### PR DESCRIPTION
## Summary

#3618 moves the fleet runtime base from `eclipse-temurin:25-jre-alpine` (musl) to
`eclipse-temurin:25-jre` (glibc). Nothing else builds images, so 53 Dockerfiles and 12 service
docs went on declaring the musl base and nothing broke — which is the problem. This retires
those declarations and adds the gate that stops the second copy drifting again.

**Stacked on #3618** — base branch is `fix/fraud-onnx-glibc-runtime-base`, not `main`. The new
rule compares each `FROM` against `Dockerfile.deploy`, which still says alpine on `main`, so this
cannot go green until the parent lands. Please do **not** merge #3618 with `--delete-branch`: that
closes this PR irreversibly (a closed PR whose base is gone can be neither reopened nor
retargeted). Either retarget this to `main` first, or merge #3618 without the flag.

## Type of change

- [x] chore (build / tooling) — commit type `build`, see *Why `build` and not `fix`* below

## Linked issues

Refs #3354
Refs #3016

## Changes

- **50 `openbank-*/Dockerfile`**, plus `Dockerfile.scanner`,
  `openbank-security-scanner/Dockerfile.prebuilt` and
  `openbank-notification-service/Dockerfile.runtime` — now carry `Dockerfile.deploy`'s `FROM`
  verbatim, and its `groupadd`/`useradd` form. busybox `addgroup`/`adduser` do not exist on the
  glibc base, so copying only the `FROM` would have left a recipe that cannot run.
  `Dockerfile.runtime` keeps its own uid/gid 1001.
- **12 `src/main/resources/docs/05-operations.{cs,en}.md`** — aml, customer-edge, kyc, onboarding,
  pid, product-catalog, sca. Every one also claimed a multi-stage in-Docker Gradle build that
  #3016 removed; pid's and onboarding's even gave a `docker build -f <svc>/Dockerfile .` command
  that cannot work, because the context has no `quarkus-app/`. Corrected together, not just the
  image name.
- **`openbank-fraud-service/src/main/resources/application.yaml` and `OnnxFraudModel.kt`** — both
  said in the present tense that the deploy image *is* alpine. #3618 makes that false the moment
  it lands. The application.yaml block now also states what #3618's `verify-image-native-libs.py`
  does and does not prove: the library can load; nobody has yet observed a deployed pod scoring.
- **`interest-service-http-scaledobject.yaml`** — one stale `jre-alpine` claim in a comment.
- **`check-dockerfile-no-build-stage.py` gains rule 3** + a `--self-test`, and the gate moves from
  an inline `ci.yml` step into `.github/gates/gates.yaml` — see below.

## The gate could not fire on this PR

Worth reading even if you skim the rest. The #3016 gate was an inline step in `ci.yml`'s
`ui-build` job, and that job is conditional:

```yaml
  ui-build:
    needs: changes-ui
    if: needs.changes-ui.outputs.changed == 'true'
```

`changes-ui` diffs `openbank-admin-ui/`, `*/governance.yaml` and the governance schema. **So the
gate that owns Dockerfile shape never ran on a PR that changes only Dockerfiles** — the exact
change it exists to catch. Not skipped-and-reported: the job is absent, and the aggregate check is
green about work it never did.

Measured on this branch's first commit: `Validate manifests` SUCCESS with 3 steps (it is an
aggregator over the `gates (...)` shards), `Admin UI build` SKIPPED, and the 53-Dockerfile diff
therefore checked by nothing. Both the pre-existing #3016 rules and the new rule 3 were vacuous
here.

Fixed in the second commit: declared in `.github/gates/gates.yaml`, group `registry`, `mode:
enforced`, `selftest_expect: pass`. Shards run unconditionally. `gate-script-registration` now
reports 80 in gates.yaml / 0 never run, and `gates-not-deregistered` 102 -> 103.

## Why keep the `FROM` at all, rather than delete it

The obvious long-term fix — stop these files carrying a `FROM`, since only `EXPOSE` is live — is
wrong here, and not obviously so. **They are not read only by the deploy pipeline.**
`openbank-admin-ui/scripts/generate-cluster-topology.mjs` parses
`openbank-ledger-service/Dockerfile` in `imageFacts()` and renders the base image into the
`/docs/cluster` dossier (ADR-0081). With no `FROM` to parse, `img.ok` is false and it falls back
to a **hardcoded `eclipse-temurin:25-jre-alpine` literal** — deleting the second copy would
resurrect the fiction in the UI instead of retiring it.

So: keep the declaration, and make it impossible for it to disagree.

## Falsifiability

Rule 3 reads **comment-stripped** text on purpose. `Dockerfile.deploy`'s header quotes the retired
image three times to explain why it is retired, and every per-service header now names
`Dockerfile.deploy`; a raw-text scan would read that prose as a declaration — the #2450 collision
class. `--self-test` asserts four things against a synthetic tree: the rule fires on a drifted
`FROM`, stays quiet when every `FROM` agrees (prose and all), covers the three files outside the
`openbank-*/Dockerfile` glob, and exempts `SELF_BUILT`.

Also falsified against the **real** tree, not only the synthetic one: reverting
`openbank-vop-service/Dockerfile` to the alpine digest gives `--enforce` exit 1 with the vop file
named; restoring it gives exit 0 (file restored and shasum-verified).

## Deliberately unchanged

`openbank-infra/docker/services/{standalone,root}-service.Dockerfile` still declare an alpine JRE.
Those are **live** — `openbank-infra/docker-compose.yml` builds 20 services from them — and are
self-contained multi-stage uber-jar recipes for local dev, not copies of the fleet base.
`openbank-fraud-service` is not among the compose services, so there is no ONNX exposure there.
Changing them would alter real local builds for no stated reason.

One follow-up filed rather than folded in, since it is a separate defect in a different tree —
**#3630**: the `generate-cluster-topology.mjs` fallback literals still describe a multi-stage
alpine build that has not existed since #3016, and the committed `cluster-topology.json` is stale
in the same way (`multiStage: true`, `buildBase: …25-jdk-alpine`). Rule 3 makes that fallback
unreachable in practice without making it correct.

## Why `build` and not `fix`

`<svc>/Dockerfile` and `<svc>/src/main/resources/**` are both release-triggering paths —
`exclude-paths` in `release-please-config.json` is `src/test` only — so a releasing type
(`feat`/`fix`/`perf`/`security`) on a PR touching ~50 service paths would cut ~50 patch releases
for a change that alters no shipped code.

Verified rather than assumed, both axes:

1. `release-please-config.json`'s `changelog-sections` marks `refactor` `docs` `test` `build` `ci`
   `chore` as `hidden: true`; only `feat` `fix` `perf` `security` are visible. (`rules.yaml`
   `commits` lists `refactor` as `semver_bump: patch`, which is why `build` was chosen over
   `refactor` — no ambiguity under either document.)
2. Empirically: `385d34653` `chore(fraud): …` (#3503) touched `openbank-fraud-service` outside
   `src/test`, and `openbank-fraud-service/CHANGELOG.md` has had no commit since. Same for
   `eef5ac945` `build: fix uber-jar COPY path in three service Dockerfiles` (#3015) — the closest
   precedent to this PR, same type, no release for any of the three services.

## Definition of Done

- [x] Hexagonal layering preserved (no production code changed; two comment corrections).
- [x] Unit tests added/updated — `--self-test` in `check-dockerfile-no-build-stage.py`.
- [ ] Integration tests — N/A, no service boundary involved.
- [ ] Contract tests — N/A, no public API changed.
- [x] No new lint warnings — `actionlint` clean on `ci.yml`; yamllint finding sets identical to
      `origin/main` under the CI config (probe validated against a known-positive duplicate key).
- [ ] OpenAPI / Flyway / Avro — N/A.
- [x] Docs updated.

## Security checklist

- [x] No secrets, tokens, passwords, or PII.
- [x] No new `@Suppress`.
- [x] No new third-party dependency.
- [ ] Auth / crypto / payment code — unchanged.
- [ ] PII path — unchanged.
- [ ] Cardholder data path — unchanged.

## Compliance impact

- [x] None

## Rollout / Rollback

- Deployment strategy: N/A — no image is built from any file in this diff. The one behavioural
  change is a CI gate.
- Rollback plan: revert the commit.
- Data migration reversible: N/A

## Reviewer notes

The gate is the part worth reviewing. The 53 file edits are mechanical and machine-applied; the
judgement calls are (a) keeping the `FROM` rather than deleting it, for the admin-ui reason above,
and (b) the scope of `EXTRA_FLEET_BASE` — three files nothing references today, which drift exactly
like the per-service ones and are now held to the same rule.
