### PR TITLE
feat(campaign): stop journeys at the campaign's own send cap (ADR-0200 D1, #3585 slice 1)

### DIFF
--- a/openbank-admin-ui/src/app/campaigns/[id]/page.tsx
+++ b/openbank-admin-ui/src/app/campaigns/[id]/page.tsx
@@ -238,6 +238,7 @@ export default function CampaignDetailPage({ params }: { params: Promise<{ id: s
       case 'COMPLETED': return t('Dokončeno', 'Completed')
       case 'TERMINATED_CONSENT_REVOKED': return t('Ukončeno — odvolaný souhlas', 'Ended — consent withdrawn')
       case 'TERMINATED_SUPPRESSED': return t('Ukončeno — potlačeno', 'Ended — suppressed')
+      case 'STOPPED_MAX_SENDS': return t('Zastaveno — limit odeslání', 'Stopped — send cap reached')
       default: return s
     }
   }

--- a/openbank-admin-ui/src/components/campaigns/PeopleSummary.tsx
+++ b/openbank-admin-ui/src/components/campaigns/PeopleSummary.tsx
@@ -35,6 +35,7 @@ const STATE_TONE: Record<string, Tone> = {
   TERMINATED_CONSENT_REVOKED: 'warning',
   TERMINATED_SUPPRESSED: 'neutral',
   TERMINATED_CAMPAIGN_CLOSED: 'neutral',
+  STOPPED_MAX_SENDS: 'neutral',
 }
 
 export function PeopleSummary({
@@ -56,6 +57,7 @@ export function PeopleSummary({
       TERMINATED_CONSENT_REVOKED: t('Odvolali souhlas', 'Withdrew consent'),
       TERMINATED_SUPPRESSED: t('Zastaveni pravidlem', 'Stopped by a rule'),
       TERMINATED_CAMPAIGN_CLOSED: t('Kampaň byla uzavřena', 'Campaign was closed'),
+      STOPPED_MAX_SENDS: t('Dosažen limit odeslání', 'Send cap reached'),
     })[s] ?? s
 
   const rows = Array.isArray(enrolments) ? enrolments : []

--- a/openbank-admin-ui/src/test/people-summary.test.tsx
+++ b/openbank-admin-ui/src/test/people-summary.test.tsx
@@ -13,6 +13,7 @@ const ENROLMENTS = [
   { id: 'b', partyId: '026289e3-0b80-452a-be01-e69034838549', state: 'TERMINATED_SUPPRESSED', currentStep: 0 },
   { id: 'c', partyId: '5e3d6411-cb5b-4e94-83f8-de95495ef5dd', state: 'TERMINATED_CONSENT_REVOKED', currentStep: 1 },
   { id: 'd', partyId: '7a1b2c3d-0000-0000-0000-000000000000', state: 'ACTIVE', currentStep: 1 },
+  { id: 'e', partyId: '9c0ffee0-0000-0000-0000-000000000000', state: 'STOPPED_MAX_SENDS', currentStep: 1 },
 ]
 
 const show = (rows = ENROLMENTS) =>
@@ -34,12 +35,14 @@ describe('people summary', () => {
     expect(screen.getAllByText(/Stopped by a rule/).length).toBeGreaterThan(0)
     expect(screen.getAllByText(/Withdrew consent/).length).toBeGreaterThan(0)
     expect(screen.getAllByText(/Still in the journey/).length).toBeGreaterThan(0)
+    expect(screen.getAllByText(/Send cap reached/).length).toBeGreaterThan(0)
   })
 
   it('never shows a state enum as visible text', () => {
     const { container } = show()
 
     expect(container.textContent).not.toMatch(/TERMINATED_/)
+    expect(container.textContent).not.toMatch(/STOPPED_MAX_SENDS/)
     expect(container.textContent).not.toMatch(/\bACTIVE\b/)
   })
 

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/port/out/Ports.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/port/out/Ports.kt
@@ -41,6 +41,13 @@ interface SendLogRepository {
     suspend fun countRecentForParty(partyId: UUID, sinceEpochSeconds: Long): Int
 
     /**
+     * Lifetime SENT rows for one party in one campaign — the observable state the ADR-0200 D1
+     * stop condition (#3585) is evaluated against. Counts across journeys, so a re-enrolled
+     * party's cap covers every send the campaign ever made to them.
+     */
+    suspend fun countSendsForPartyInCampaign(campaignId: UUID, partyId: UUID): Int
+
+    /**
      * One page of send attempts for a campaign, newest first — the operator view of what happened.
      *
      * Paged at the repository, not in the caller: a campaign's send log has one row per party per

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/usecase/CampaignService.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/usecase/CampaignService.kt
@@ -15,6 +15,7 @@ import com.openbank.campaign.domain.model.CampaignStep
 import com.openbank.campaign.domain.model.Enrolment
 import com.openbank.campaign.domain.model.EnrolmentState
 import com.openbank.campaign.domain.model.SegmentRef
+import com.openbank.campaign.domain.model.StopCondition
 import com.openbank.libs.domain.identifiers.Ids
 import jakarta.enterprise.context.ApplicationScoped
 import org.jboss.logging.Logger
@@ -52,6 +53,7 @@ class CampaignService(
         segmentRef: SegmentRef,
         steps: List<CampaignStep>,
         createdBy: String,
+        stopCondition: StopCondition? = null,
     ): Campaign {
         val segment = segments.load(segmentRef.name, segmentRef.version)
             ?: throw NoSuchElementException("segment ${segmentRef.name}@${segmentRef.version} not found")
@@ -61,6 +63,7 @@ class CampaignService(
             goal = goal,
             segmentRef = SegmentRef(segment.name, segment.version),
             steps = steps.sortedBy { it.order },
+            stopCondition = stopCondition,
             state = CampaignState.DRAFT,
             createdBy = createdBy,
             approvedBy = null,

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/workflow/CampaignJourneyActivities.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/workflow/CampaignJourneyActivities.kt
@@ -5,18 +5,23 @@
 package com.openbank.campaign.application.workflow
 
 import com.openbank.campaign.domain.model.CampaignStep
+import com.openbank.campaign.domain.model.StopCondition
 import io.temporal.activity.ActivityInterface
 import java.util.UUID
 
 @ActivityInterface
 interface CampaignJourneyActivities {
-    fun loadSteps(campaignId: UUID): List<CampaignStep>
+    fun loadDefinition(campaignId: UUID): JourneyDefinition
+    fun sendsSoFar(campaignId: UUID, partyId: UUID): Int
     fun deliverStep(campaignId: UUID, partyId: UUID, stepOrder: Int): StepOutcome
     fun advanceStep(campaignId: UUID, partyId: UUID, stepOrder: Int)
     fun markCompleted(campaignId: UUID, partyId: UUID)
     fun markTerminated(campaignId: UUID, partyId: UUID, reason: TerminationReason)
 }
 
+/** Everything a journey needs from the campaign definition, in one activity call (#3585). */
+data class JourneyDefinition(val steps: List<CampaignStep>, val stopCondition: StopCondition?)
+
 enum class StepOutcome { SENT, SUPPRESSED }
 
-enum class TerminationReason { CONSENT_REVOKED, SUPPRESSED }
+enum class TerminationReason { CONSENT_REVOKED, SUPPRESSED, STOPPED_MAX_SENDS }

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/workflow/CampaignJourneyActivitiesImpl.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/workflow/CampaignJourneyActivitiesImpl.kt
@@ -8,7 +8,6 @@ import com.openbank.campaign.application.port.out.CampaignRepository
 import com.openbank.campaign.application.port.out.EnrolmentRepository
 import com.openbank.campaign.application.port.out.NotificationSendPort
 import com.openbank.campaign.application.port.out.SendLogRepository
-import com.openbank.campaign.domain.model.CampaignStep
 import com.openbank.campaign.domain.model.EnrolmentState
 import com.openbank.campaign.domain.model.SendOutcome
 import com.openbank.campaign.domain.model.SendRecord
@@ -46,8 +45,13 @@ open class CampaignJourneyActivitiesImpl(
     private val marketingScope: String,
 ) : CampaignJourneyActivities {
 
-    override fun loadSteps(campaignId: UUID): List<CampaignStep> = runBlockingOnWorker {
-        campaigns.findById(campaignId)?.steps ?: emptyList()
+    override fun loadDefinition(campaignId: UUID): JourneyDefinition = runBlockingOnWorker {
+        val campaign = campaigns.findById(campaignId)
+        JourneyDefinition(campaign?.steps ?: emptyList(), campaign?.stopCondition)
+    }
+
+    override fun sendsSoFar(campaignId: UUID, partyId: UUID): Int = runBlockingOnWorker {
+        sendLog.countSendsForPartyInCampaign(campaignId, partyId)
     }
 
     // The publish failure below is caught broadly on purpose: the point is that NO handoff failure
@@ -125,6 +129,7 @@ open class CampaignJourneyActivitiesImpl(
         val state = when (reason) {
             TerminationReason.CONSENT_REVOKED -> EnrolmentState.TERMINATED_CONSENT_REVOKED
             TerminationReason.SUPPRESSED -> EnrolmentState.TERMINATED_SUPPRESSED
+            TerminationReason.STOPPED_MAX_SENDS -> EnrolmentState.STOPPED_MAX_SENDS
         }
         enrolments.findByCampaignAndParty(campaignId, partyId)?.let {
             enrolments.save(it.copy(state = state, completedAt = Instant.now()))

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/workflow/CampaignJourneyWorkflowImpl.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/workflow/CampaignJourneyWorkflowImpl.kt
@@ -44,10 +44,19 @@ class CampaignJourneyWorkflowImpl : CampaignJourneyWorkflow {
     }
 
     override fun run(campaignId: UUID, partyId: UUID) {
-        val steps = activities.loadSteps(campaignId)
-        for (step in steps.sortedBy { it.order }) {
+        val definition = activities.loadDefinition(campaignId)
+        for (step in definition.steps.sortedBy { it.order }) {
             if (revoked) {
                 activities.markTerminated(campaignId, partyId, TerminationReason.CONSENT_REVOKED)
+                return
+            }
+            // ADR-0200 D1 stop condition (#3585): evaluated BEFORE each step — including the first,
+            // so a re-enrolled party already over the cap stops immediately — and only ever against
+            // observable state (the send log's SENT count), never a fabricated signal.
+            if (definition.stopCondition != null &&
+                definition.stopCondition.reachedBy(activities.sendsSoFar(campaignId, partyId))
+            ) {
+                activities.markTerminated(campaignId, partyId, TerminationReason.STOPPED_MAX_SENDS)
                 return
             }
             if (step.delaySeconds > 0) {

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/domain/model/Campaign.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/domain/model/Campaign.kt
@@ -19,6 +19,7 @@ data class Campaign(
     val goal: String,
     val segmentRef: SegmentRef,
     val steps: List<CampaignStep>,
+    val stopCondition: StopCondition? = null,
     val state: CampaignState,
     val createdBy: String,
     val approvedBy: String?,
@@ -100,6 +101,22 @@ data class CampaignStep(
 }
 
 enum class Channel { EMAIL }
+
+/**
+ * The campaign's own stop condition (ADR-0200 D1, issue #3585 slice 1), evaluated by the journey
+ * workflow BEFORE each step against observable state — never against a fabricated signal. Only
+ * conditions backed by data the service already holds are representable: the first (and so far
+ * only) one is the party's lifetime SENT count in this campaign, which the send log holds. A
+ * `null` stop condition means the journey always runs every step, exactly as before.
+ */
+data class StopCondition(val maxSendsPerParty: Int) {
+    init {
+        require(maxSendsPerParty >= 1) { "maxSendsPerParty must be >= 1 — a zero cap sends nothing" }
+    }
+
+    /** True when [sendsSoFar] already reached the cap, so the journey must stop before the next step. */
+    fun reachedBy(sendsSoFar: Int): Boolean = sendsSoFar >= maxSendsPerParty
+}
 
 /** A binding to a versioned segment artifact (ADR-0201 D1): never a query, always name@version. */
 data class SegmentRef(val name: String, val version: Int) {

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/domain/model/Enrolment.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/domain/model/Enrolment.kt
@@ -31,6 +31,14 @@ enum class EnrolmentState {
 
     /** Journey ended early because a step's suppression check failed (ADR-0200 D6). */
     TERMINATED_SUPPRESSED,
+
+    /**
+     * Journey stopped by the campaign's own stop condition (ADR-0200 D1, #3585): the party's
+     * lifetime send count in this campaign reached the definition's cap. Distinct from
+     * [TERMINATED_SUPPRESSED] — suppression is a per-step policy outcome, this is the definition
+     * choosing to end the journey, so the console can say why the funnel ended early.
+     */
+    STOPPED_MAX_SENDS,
 }
 
 /** A recorded send decision — the input to the frequency-cap evaluation (ADR-0219 D2). */

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/persistence/Persistence.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/persistence/Persistence.kt
@@ -23,6 +23,7 @@ import com.openbank.campaign.domain.model.SegmentCatalog
 import com.openbank.campaign.domain.model.SegmentRef
 import com.openbank.campaign.domain.model.SendOutcome
 import com.openbank.campaign.domain.model.SendRecord
+import com.openbank.campaign.domain.model.StopCondition
 import com.openbank.libs.domain.identifiers.Ids
 import io.quarkus.hibernate.reactive.panache.Panache
 import io.quarkus.hibernate.reactive.panache.PanacheEntityBase
@@ -61,6 +62,12 @@ class CampaignEntity : PanacheEntityBase() {
     // jsonb array column, which cannot be cast to String — every read threw ClassCastException.
     @Column(nullable = false, columnDefinition = "text")
     lateinit var stepsJson: String
+
+    // Nullable (V3): a campaign without a stop condition has no row content here — null, not an
+    // empty object, so "no condition" and "condition" can never be confused. Same text-not-jsonb
+    // reason as stepsJson.
+    @Column(columnDefinition = "text")
+    var stopConditionJson: String? = null
 
     @Column(nullable = false)
     lateinit var state: String
@@ -170,6 +177,7 @@ class PanacheCampaignRepository(private val mapper: ObjectMapper) :
         segmentName = this@toEntity.segmentRef.name
         segmentVersion = this@toEntity.segmentRef.version
         stepsJson = mapper.writeValueAsString(this@toEntity.steps)
+        stopConditionJson = this@toEntity.stopCondition?.let { mapper.writeValueAsString(it) }
         state = this@toEntity.state.name
         createdBy = this@toEntity.createdBy
         approvedBy = this@toEntity.approvedBy
@@ -183,6 +191,7 @@ class PanacheCampaignRepository(private val mapper: ObjectMapper) :
         goal = goal,
         segmentRef = SegmentRef(segmentName, segmentVersion),
         steps = mapper.readValue<List<CampaignStep>>(stepsJson),
+        stopCondition = stopConditionJson?.let { mapper.readValue<StopCondition>(it) },
         state = CampaignState.valueOf(state),
         createdBy = createdBy,
         approvedBy = approvedBy,
@@ -343,6 +352,15 @@ class PanacheSendLogRepository :
             partyId,
             SendOutcome.SENT.name,
             Instant.ofEpochSecond(sinceEpochSeconds),
+        )
+    }.awaitSuspending().toInt()
+
+    override suspend fun countSendsForPartyInCampaign(campaignId: UUID, partyId: UUID): Int = Panache.withSession {
+        count(
+            "campaignId = ?1 and partyId = ?2 and outcome = ?3",
+            campaignId,
+            partyId,
+            SendOutcome.SENT.name,
         )
     }.awaitSuspending().toInt()
 }

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/rest/CampaignResource.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/rest/CampaignResource.kt
@@ -8,6 +8,7 @@ import com.openbank.campaign.application.usecase.CampaignService
 import com.openbank.campaign.domain.model.CampaignStep
 import com.openbank.campaign.domain.model.Channel
 import com.openbank.campaign.domain.model.SegmentRef
+import com.openbank.campaign.domain.model.StopCondition
 import com.openbank.libs.authz.Authorize
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.ws.rs.GET
@@ -24,7 +25,11 @@ data class CreateCampaignRequest(
     val segmentName: String,
     val segmentVersion: Int,
     val steps: List<StepRequest>,
+    val stopCondition: StopConditionRequest? = null,
 )
+
+/** Optional on create (ADR-0200 D1, #3585): absent means the journey runs every step, as before. */
+data class StopConditionRequest(val maxSendsPerParty: Int)
 
 data class StepRequest(
     val order: Int,
@@ -91,6 +96,7 @@ class CampaignResource(private val service: CampaignService, private val jwt: Js
             SegmentRef(request.segmentName, request.segmentVersion),
             steps,
             createdBy,
+            request.stopCondition?.let { StopCondition(it.maxSendsPerParty) },
         )
         return Response.status(Response.Status.CREATED).entity(campaign).build()
     }

--- a/openbank-campaign-service/src/main/resources/db/migration/V3__campaign_stop_condition.sql
+++ b/openbank-campaign-service/src/main/resources/db/migration/V3__campaign_stop_condition.sql
@@ -1,0 +1,8 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+-- ADR-0200 D1 stop conditions (#3585 slice 1): the campaign definition gains an optional stop
+-- condition, evaluated by the journey workflow before each step against the send log's SENT count.
+-- Nullable: existing campaigns have no stop condition and read back exactly as before.
+-- Rollback: ALTER TABLE campaigns DROP COLUMN stop_condition_json;
+ALTER TABLE campaigns ADD COLUMN stop_condition_json text;

--- a/openbank-campaign-service/src/main/resources/openapi.yaml
+++ b/openbank-campaign-service/src/main/resources/openapi.yaml
@@ -4,7 +4,7 @@ openapi: 3.1.0
 info:
   title: Campaign Service API
   # major == openbank.api.version == URL /api/v1 (ADR-0048).
-  version: 1.7.0
+  version: 1.8.0
   description: >-
     Campaign management first slice (ADR-0200 / ADR-0209 D3): deterministic, versioned segments;
     per-enrolment Temporal journeys; consent-gated delivery through notification-service.
@@ -400,6 +400,8 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/CampaignStep'
+        stopCondition:
+          $ref: '#/components/schemas/StopCondition'
         state:
           type: string
           enum: [DRAFT, PENDING_APPROVAL, ACTIVE, PAUSED, CLOSED]
@@ -436,6 +438,17 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/CampaignStep'
+        stopCondition:
+          $ref: '#/components/schemas/StopCondition'
+    StopCondition:
+      type: object
+      required: [maxSendsPerParty]
+      description: >-
+        Optional journey stop condition (ADR-0200 D1). The workflow evaluates it before every
+        step against the party's lifetime SENT count in this campaign (send log); reaching the
+        cap ends the journey as STOPPED_MAX_SENDS. Absent means the journey runs every step.
+      properties:
+        maxSendsPerParty: { type: integer, minimum: 1 }
     ApprovalRequest:
       type: object
       deprecated: true

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/CampaignSendLogTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/CampaignSendLogTest.kt
@@ -47,6 +47,7 @@ class CampaignSendLogTest {
         object : SendLogRepository {
             override suspend fun record(send: SendRecord) = Unit
             override suspend fun countRecentForParty(partyId: UUID, sinceEpochSeconds: Long) = 0
+            override suspend fun countSendsForPartyInCampaign(campaignId: UUID, partyId: UUID) = 0
 
             // Filters and pages the way SQL does, so the test exercises the real contract rather
             // than a fake that always answers with everything.

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/usecase/CampaignSummaryQueryTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/usecase/CampaignSummaryQueryTest.kt
@@ -54,6 +54,7 @@ class CampaignSummaryQueryTest {
     private class Sends(private val cells: List<CampaignOutcomeCount>, var calls: Int = 0) : SendLogRepository {
         override suspend fun record(send: SendRecord) = Unit
         override suspend fun countRecentForParty(partyId: UUID, sinceEpochSeconds: Long) = 0
+        override suspend fun countSendsForPartyInCampaign(campaignId: UUID, partyId: UUID) = 0
         override suspend fun listByCampaign(campaignId: UUID, outcome: SendOutcome?, page: Int, size: Int) =
             emptyList<SendRecord>()
         override suspend fun countByCampaign(campaignId: UUID, outcome: SendOutcome?) = 0L

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/workflow/CampaignJourneyActivitiesTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/workflow/CampaignJourneyActivitiesTest.kt
@@ -89,6 +89,7 @@ class CampaignJourneyActivitiesTest {
             override suspend fun countByCampaign(campaignId: UUID, outcome: SendOutcome?) = 0L
             override suspend fun countByStepAndOutcome(campaignId: UUID) = emptyList<StepOutcomeCount>()
             override suspend fun countAllByCampaignAndOutcome() = emptyList<CampaignOutcomeCount>()
+            override suspend fun countSendsForPartyInCampaign(campaignId: UUID, partyId: UUID) = 0
         }
         val notificationSend = object : NotificationSendPort {
             override suspend fun requestSend(

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/domain/StopConditionTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/domain/StopConditionTest.kt
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+package com.openbank.campaign.domain
+
+import com.openbank.campaign.domain.model.StopCondition
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * The ADR-0200 D1 stop condition (#3585) is a domain rule, not workflow plumbing: the workflow
+ * only supplies the observable send count, the definition itself decides whether the cap is
+ * reached. Pinning the boundary here means a journey stops AT the cap, never one send past it.
+ */
+class StopConditionTest {
+
+    @Test
+    fun `cap must be at least one`() {
+        assertThrows(IllegalArgumentException::class.java) { StopCondition(0) }
+    }
+
+    @Test
+    fun `below the cap the journey continues`() {
+        assertFalse(StopCondition(2).reachedBy(0))
+        assertFalse(StopCondition(2).reachedBy(1))
+    }
+
+    @Test
+    fun `at the cap the journey stops before the next step`() {
+        assertTrue(StopCondition(2).reachedBy(2))
+    }
+
+    @Test
+    fun `past the cap stops too — a re-enrolled party is already over`() {
+        assertTrue(StopCondition(2).reachedBy(5))
+    }
+}

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/integration/CampaignRestContractIT.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/integration/CampaignRestContractIT.kt
@@ -259,4 +259,45 @@ class CampaignRestContractIT {
             body("message", org.hamcrest.Matchers.containsString("bodyHtml"))
         }
     }
+
+    @Test
+    fun `a stop condition survives the create-and-read round trip`() {
+        val id = Given {
+            contentType("application/json")
+            body(
+                """
+                {"name":"it-stop-condition","goal":"prove the HTTP contract","segmentName":"actives","segmentVersion":1,
+                 "steps":[{"order":1,"template":"MARKETING_PRODUCT_OFFER",
+                           "variables":{"offerTitle":"T","offerText":"X","ctaText":"Go"},"delaySeconds":0}],
+                 "stopCondition":{"maxSendsPerParty":2}}
+                """.trimIndent(),
+            )
+        } When {
+            post("/api/v1/campaigns")
+        } Then {
+            statusCode(201)
+            body("stopCondition.maxSendsPerParty", org.hamcrest.Matchers.equalTo(2))
+        } Extract {
+            path<String>("id")
+        }
+
+        When {
+            get("/api/v1/campaigns/$id")
+        } Then {
+            statusCode(200)
+            body("stopCondition.maxSendsPerParty", org.hamcrest.Matchers.equalTo(2))
+        }
+    }
+
+    @Test
+    fun `a draft without a stop condition reads back with none — absent never invents a cap`() {
+        val id = createDraft("it-no-stop-condition")
+
+        When {
+            get("/api/v1/campaigns/$id")
+        } Then {
+            statusCode(200)
+            body("stopCondition", org.hamcrest.Matchers.nullValue())
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Implements **slice 1 of #3585**: ADR-0200 D1 defines a campaign as *steps, delays, branch conditions, stop conditions* — the domain had only the first two. The definition gains an optional `stopCondition` (max sends per party), evaluated by the journey workflow **before every step** (including the first, so a re-enrolled party already over the cap stops immediately) against **observable state only** — the party's lifetime SENT count in this campaign from the send log. Reaching the cap ends the journey as the distinct `STOPPED_MAX_SENDS` state, so the console can say *why* a funnel ended early instead of showing a truncated one. Per the issue's own rule, conditions backed by nothing the service holds stay unrepresentable — no fabricated signals.

## Type of change

- [x] feat (new functionality)

## Linked issues

Refs #3585 (slice 1 of 4 — conversion signal, branch conditions and ADR-0220 surfaces follow in their own PRs per the issue's proposed sequence)

## Changes

**campaign-service (0.9.1 → 0.10.0):**
- Domain: `StopCondition` (≥ 1, `reachedBy` predicate as a domain rule), `Campaign.stopCondition`, `EnrolmentState.STOPPED_MAX_SENDS` (distinct from `TERMINATED_SUPPRESSED` — definition's choice vs per-step policy outcome).
- Workflow: new `loadDefinition` activity (steps + stop condition in one call — also keeps detekt `TooManyFunctions` under threshold); pre-step cap evaluation.
- Persistence: **V3 migration** `stop_condition_json text NULL` (rollback: `ALTER TABLE campaigns DROP COLUMN stop_condition_json;`), `countSendsForPartyInCampaign` port + Panache impl.
- REST: optional `stopCondition` on create + read; **openapi 1.7.0 → 1.8.0** (additive MINOR per ADR-0048, major invariant intact).

**admin-ui (0.91.3 → 0.92.0, version.txt + package.json in sync):**
- `STOPPED_MAX_SENDS` labelled in words (cs/en) on the campaign detail + people summary; raw enum stays only on `data-state`.

## Definition of Done

- [x] Hexagonal layering preserved (predicate in domain; ports extended, not bypassed).
- [x] Unit tests: `StopConditionTest` (4/4 — stops AT the cap, never one past).
- [x] Integration tests: `CampaignRestContractIT` 12/12 incl. new round-trip with/without stop condition.
- [x] Contract tests: n/a — no Pact consumer for this service; additive OpenAPI diff.
- [x] `./gradlew :openbank-campaign-service:ktlintCheck :detekt :test :koverVerify` — BUILD SUCCESSFUL.
- [x] OpenAPI spec updated (info.version 1.8.0).
- [x] Flyway migration added + rollback note (V3).
- [x] Avro — n/a. Docs — ADR-0200 D1 already names stop conditions; no ADR text change.

## Security checklist

- [x] No secrets/PII — the condition is a count threshold, no content.
- [x] No new `@Suppress`, no new dependency.
- [ ] Auth/crypto/payment code — no. PII path — no (counts only).

## Compliance impact

- [x] None — marketing-journey control flow; consent and suppression gates are untouched and still evaluated per step (ADR-0200 D2/D6).