### PR TITLE
chore(notifications): wire FCM push delivery (off until the Vault key is seeded)

### DIFF
--- a/openbank-infra/gitops/components/notifications/fcm-externalsecret.yaml
+++ b/openbank-infra/gitops/components/notifications/fcm-externalsecret.yaml
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+#
+# FCM service-account credential for notification-service PUSH delivery (FcmPushSender),
+# projected from Vault by the External Secrets Operator (ClusterSecretStore
+# `vault-kv`) into the in-namespace Secret `notification-service-fcm`.
+#
+# The service-account JSON (FCM_SERVICE_ACCOUNT_JSON) is the sensitive asset — anyone
+# holding it can send pushes to every Android install of the app (firebase.messaging
+# scope). It lives ONLY in Vault, never in Git or the Deployment manifest; only this
+# reference does. Same shape as apns-externalsecret.yaml.
+#
+# Until an operator writes the Vault key the ExternalSecret stays pending and the
+# Secret is absent — which is fine: the Deployment's secretKeyRefs are `optional:true`,
+# the pod starts, and FCM_ENABLED stays "false" until delivery is actually wanted, so a
+# not-yet-seeded Vault records Android pushes as skipped, never as failures. To enable
+# delivery: write the Vault key, flip FCM_ENABLED to "true" in notification-service.yaml,
+# and restart notification-service so the secret env is re-read.
+#
+#   bao kv patch openbank/notification-service \
+#     FCM_SERVICE_ACCOUNT_JSON=@openbank-android-fcm.json
+#
+# FCM_PROJECT_ID is optional (falls back to project_id inside the service-account JSON)
+# and is set inline in the Deployment env only if an override is ever needed.
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: notification-service-fcm
+  namespace: notifications
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: vault-kv
+  target:
+    name: notification-service-fcm
+    creationPolicy: Owner
+    deletionPolicy: Retain
+  template:
+      engineVersion: v2
+      mergePolicy: Merge
+      metadata:
+        annotations:
+          argocd.argoproj.io/compare-options: IgnoreExtraneous
+  data:
+    - secretKey: FCM_SERVICE_ACCOUNT_JSON
+      remoteRef:
+        key: notification-service
+        property: FCM_SERVICE_ACCOUNT_JSON

--- a/openbank-infra/gitops/components/notifications/fcm-externalsecret.yaml
+++ b/openbank-infra/gitops/components/notifications/fcm-externalsecret.yaml
@@ -37,11 +37,11 @@ spec:
     creationPolicy: Owner
     deletionPolicy: Retain
   template:
-      engineVersion: v2
-      mergePolicy: Merge
-      metadata:
-        annotations:
-          argocd.argoproj.io/compare-options: IgnoreExtraneous
+    engineVersion: v2
+    mergePolicy: Merge
+    metadata:
+      annotations:
+        argocd.argoproj.io/compare-options: IgnoreExtraneous
   data:
     - secretKey: FCM_SERVICE_ACCOUNT_JSON
       remoteRef:

--- a/openbank-infra/gitops/components/notifications/notification-service.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service.yaml
@@ -184,6 +184,19 @@ spec:
                   name: notification-service-apns
                   key: APNS_PRIVATE_KEY
                   optional: true
+            # PUSH delivery via FCM (FcmPushSender) — wired but deliberately OFF: enabling
+            # before the Vault key is seeded would record every Android push as a CONFIG
+            # failure instead of a skip. Activation is operational, not a code change:
+            # seed openbank/notification-service FCM_SERVICE_ACCOUNT_JSON (see
+            # fcm-externalsecret.yaml), flip FCM_ENABLED to "true", restart the service.
+            - name: FCM_ENABLED
+              value: "false"
+            - name: FCM_SERVICE_ACCOUNT_JSON
+              valueFrom:
+                secretKeyRef:
+                  name: notification-service-fcm
+                  key: FCM_SERVICE_ACCOUNT_JSON
+                  optional: true
             # Dotted-key YAML config bug workaround (issue #686): load the
             # notification-events-in / party-events-in group.id and auto.offset.reset
             # override (notification-service-msg-override ConfigMap, mounted below) as


### PR DESCRIPTION
## Summary

APNs is live for the TestFlight pilot, but Android push had **no wiring at all**: `FcmPushSender` ships in the service (OFF by default → skipped; enabled without credentials → per-send CONFIG failure, never a boot crash) and nothing projected a credential to it. This adds the full, safe wiring: ESO projection + optional env refs, deliberately **off** until the service-account JSON is seeded — so a not-yet-seeded Vault records Android pushes as *skipped*, never as failures.

## Type of change

- [x] chore (gitops)

## Linked issues

N/A — one-off gitops wiring; no tracker exists for FCM enablement. The activation itself (seed + flip) is an operational step documented in the ExternalSecret header.

## Changes

- `components/notifications/fcm-externalsecret.yaml` (new) — ExternalSecret `notification-service-fcm` projecting `FCM_SERVICE_ACCOUNT_JSON` from `openbank/notification-service` (same shape as `apns-externalsecret.yaml`, incl. the seed runbook).
- `components/notifications/notification-service.yaml` — `FCM_ENABLED: "false"` + optional `secretKeyRef` for the JSON.

**Activation (operational, post-merge):** `bao kv patch openbank/notification-service FCM_SERVICE_ACCOUNT_JSON=@<file>.json` → flip `FCM_ENABLED` to `"true"` → restart notification-service.

## Definition of Done

- [x] No application code changed (gitops only) — no version bump, no tests applicable.
- [x] Directory-scoped ArgoCD app picks up the new manifest automatically (no kustomization edit needed — verified).

## Security checklist

- [x] No secrets in git — only the Vault *reference*; the JSON itself is seeded out-of-band.
- [x] No new dependency. No auth/payment code.

## Compliance impact

- [x] None — delivery-channel wiring, disabled by default; notification categories/consent gates are untouched (MARKETING opt-out and SECURITY unmutable behavior unchanged).