### PR TITLE
fix(infra): make declaring a Temporal namespace sufficient to register it

### DIFF
--- a/.github/scripts/check-temporal-namespace-registration.py
+++ b/.github/scripts/check-temporal-namespace-registration.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
-"""Guard: every Temporal namespace a service actually polls must be in the registration Job.
+"""Guard: the Temporal namespace list is COMPLETE, and lives somewhere ArgoCD can act on.
 
-WHY THIS EXISTS: `temporal-namespace-registration.yaml` carries a hand-written, space-separated
-`NAMESPACES` list. A service whose namespace is missing from it does not fail to start and does
-not go red — the Temporal worker connects to the frontend fine and only the *poll* is refused,
-so the failure lives entirely in a retry loop:
+WHY THIS EXISTS: the Temporal namespace set is a hand-written, space-separated list. A service
+whose namespace is missing from it does not fail to start and does not go red — the Temporal
+worker connects to the frontend fine and only the *poll* is refused, so the failure lives
+entirely in a retry loop:
 
     Failure in poller thread Workflow Poller taskQueue="openbank-lending-origination",
     namespace="openbank-lending": 2
@@ -33,10 +33,31 @@ required set from the two places a namespace can actually come from, and compare
 Precedence matters and is the campaign lesson in miniature: reading only (2) reports a namespace
 the service does not use, and reading only (1) misses every service that never sets the env.
 
+WHERE THE LIST IS ALLOWED TO LIVE (issue #3507) — the second half of this gate, and the reason a
+complete list was still not enough. The list used to be an inline env value on the registration
+Job, which is an ArgoCD **PostSync hook**. ArgoCD does not diff hooks: they are absent from the
+Application's desired-state comparison, which reports the Job's status as `None` while every
+other resource reads `Synced`. So editing only that file produced NO diff, no sync operation ran,
+and the hook never fired — making "add a namespace to the list", the sole edit anyone ever
+performs on it, the one edit that could not trigger it. Measured after #3475: the Application sat
+`Synced/Healthy` at the new revision with no Job in the namespace and `openbank-lending` still
+unregistered, until a manual sync was issued by hand.
+
+So the list must be declared on a resource ArgoCD COMPARES, and must be declared exactly once:
+  * on a hook  -> fail. The registration is unreachable by the edit that needs it.
+  * twice      -> fail. Two copies of a namespace list is the drift this gate exists to catch,
+                  reintroduced one level up.
+  * unconsumed -> fail. A ConfigMap nothing mounts or reads is a list that registers nothing —
+                  the same silent no-op wearing a different hat.
+
 WHAT IT DELIBERATELY DOES NOT DO: it does not fail on an EXTRA registered namespace. Registering
 a namespace nothing polls is harmless (an idle namespace costs nothing and retention reaps it),
 and several entries exist for workers that live outside this repo's `openbank-*` modules. Failing
 on extras would make the gate a maintenance tax with no defect behind it.
+
+It also cannot see the CLUSTER: whether a declared namespace actually exists in the running
+Temporal is not observable from a PR runner. That half is the `temporal-namespace-reconcile`
+CronJob, which registers whatever the sync path missed and then fails so KubeJobFailed carries it.
 """
 
 from __future__ import annotations
@@ -47,6 +68,8 @@ import re
 import sys
 import tempfile
 
+import yaml
+
 # `namespace: ${OPENBANK_TEMPORAL_NAMESPACE:openbank-lending}` under an `openbank.temporal` block.
 CONFIG_DEFAULT_RE = re.compile(
     r"namespace:\s*\$\{OPENBANK_TEMPORAL_NAMESPACE:(?P<ns>[A-Za-z0-9._-]+)\}"
@@ -55,24 +78,168 @@ CONFIG_DEFAULT_RE = re.compile(
 GITOPS_ENV_RE = re.compile(
     r"""name:\s*["']?OPENBANK_TEMPORAL_NAMESPACE["']?\s*\n\s*value:\s*["']?(?P<ns>[A-Za-z0-9._-]+)["']?"""
 )
-NAMESPACES_RE = re.compile(r"""name:\s*NAMESPACES\s*\n\s*value:\s*["'](?P<list>[^"']*)["']""")
 
-REGISTRATION = "openbank-infra/gitops/components/temporal/temporal-namespace-registration.yaml"
+TEMPORAL_DIR = "openbank-infra/gitops/components/temporal"
+NAMESPACE_SOURCE = f"{TEMPORAL_DIR}/temporal-namespace-config.yaml"
 GITOPS_COMPONENTS = "openbank-infra/gitops/components"
+
+HOOK_ANNOTATION_PREFIX = "argocd.argoproj.io/hook"
+WORKLOAD_KINDS = {"Deployment", "Rollout", "StatefulSet", "DaemonSet", "Job", "CronJob"}
 
 
 def strip_yaml_comments(text: str) -> str:
     """A `#` comment naming a namespace must not satisfy the check — the repo has been bitten by a
-    guard matching the prose about the thing instead of the thing."""
+    guard matching the prose about the thing instead of the thing. (The declaration scan below
+    parses YAML, where comments are dropped for free; this is for the regex-based scans.)"""
     return "\n".join(line if (h := line.find("#")) < 0 else line[:h] for line in text.splitlines())
 
 
+def _docs(path: pathlib.Path) -> list[dict]:
+    try:
+        loaded = yaml.safe_load_all(path.read_text(encoding="utf-8", errors="replace"))
+        return [d for d in loaded if isinstance(d, dict)]
+    except yaml.YAMLError:
+        # A templated or otherwise unparseable manifest cannot carry a declaration we can read;
+        # it is skipped, not treated as clean — the "no declaration at all" branch is fatal.
+        return []
+
+
+def _pod_specs(doc: dict) -> list[dict]:
+    spec = doc.get("spec") or {}
+    if doc.get("kind") == "CronJob":
+        template = ((spec.get("jobTemplate") or {}).get("spec") or {}).get("template") or {}
+    else:
+        template = spec.get("template") or {}
+    pod = template.get("spec")
+    return [pod] if isinstance(pod, dict) else []
+
+
+def _containers(pod: dict) -> list[dict]:
+    out = []
+    for key in ("initContainers", "containers"):
+        for container in pod.get(key) or []:
+            if isinstance(container, dict):
+                out.append(container)
+    return out
+
+
+def namespace_declarations(root: pathlib.Path) -> list[dict]:
+    """Every place under the temporal component that states a literal NAMESPACES value.
+
+    Returns one record per declaration: where it is, what it says, whether the resource carrying
+    it is an ArgoCD hook (and therefore never diffed), and — for a ConfigMap — its name, so the
+    caller can check something actually reads it.
+    """
+    found: list[dict] = []
+    directory = root / TEMPORAL_DIR
+    if not directory.is_dir():
+        return found
+    for path in sorted(directory.glob("*.yaml")):
+        rel = path.relative_to(root).as_posix()
+        for doc in _docs(path):
+            metadata = doc.get("metadata") or {}
+            annotations = metadata.get("annotations") or {}
+            record = {
+                "file": rel,
+                "kind": doc.get("kind"),
+                "name": metadata.get("name"),
+                "hook": any(str(k).startswith(HOOK_ANNOTATION_PREFIX) for k in annotations),
+            }
+            if doc.get("kind") == "ConfigMap":
+                value = (doc.get("data") or {}).get("NAMESPACES")
+                if isinstance(value, str):
+                    found.append({**record, "namespaces": set(value.split())})
+            for pod in _pod_specs(doc):
+                for container in _containers(pod):
+                    for env in container.get("env") or []:
+                        if not isinstance(env, dict) or env.get("name") != "NAMESPACES":
+                            continue
+                        if isinstance(env.get("value"), str):
+                            found.append({**record, "namespaces": set(env["value"].split())})
+    return found
+
+
+def configmap_consumers(root: pathlib.Path, name: str) -> list[str]:
+    """Workloads under the temporal component that read the named ConfigMap (env ref or volume)."""
+    consumers: list[str] = []
+    directory = root / TEMPORAL_DIR
+    if not directory.is_dir():
+        return consumers
+    for path in sorted(directory.glob("*.yaml")):
+        for doc in _docs(path):
+            if doc.get("kind") not in WORKLOAD_KINDS:
+                continue
+            for pod in _pod_specs(doc):
+                referenced = False
+                for volume in pod.get("volumes") or []:
+                    if isinstance(volume, dict) and (volume.get("configMap") or {}).get("name") == name:
+                        referenced = True
+                for container in _containers(pod):
+                    for env in container.get("env") or []:
+                        if not isinstance(env, dict):
+                            continue
+                        ref = (env.get("valueFrom") or {}).get("configMapKeyRef") or {}
+                        if ref.get("name") == name:
+                            referenced = True
+                    for source in container.get("envFrom") or []:
+                        if isinstance(source, dict) and (source.get("configMapRef") or {}).get("name") == name:
+                            referenced = True
+                if referenced:
+                    consumers.append(f"{doc.get('kind')}/{(doc.get('metadata') or {}).get('name')}")
+    return consumers
+
+
 def registered_namespaces(root: pathlib.Path) -> set[str] | None:
-    path = root / REGISTRATION
-    if not path.is_file():
+    """The declared namespace set, or None when the declaration is missing or unreachable.
+
+    Every None path prints its own ::error first — "the input is not what this check assumes" is a
+    different verdict from "the fleet is clean", and the repo has paid for conflating them.
+    """
+    declarations = namespace_declarations(root)
+    if not declarations:
+        print(
+            f"::error file={NAMESPACE_SOURCE}::no NAMESPACES declaration found anywhere under "
+            f"{TEMPORAL_DIR}/ — the check's own input is missing or reshaped, which is not the "
+            "same as the fleet being clean. Investigate before trusting this run."
+        )
         return None
-    match = NAMESPACES_RE.search(strip_yaml_comments(path.read_text(encoding="utf-8", errors="replace")))
-    return set(match.group("list").split()) if match else None
+
+    if len(declarations) > 1:
+        where = ", ".join(f"{d['file']} ({d['kind']}/{d['name']})" for d in declarations)
+        print(
+            f"::error file={NAMESPACE_SOURCE}::NAMESPACES is declared {len(declarations)} times "
+            f"({where}). Two copies of the Temporal namespace list is exactly the drift this gate "
+            "exists to catch, one level up: the copies are free to disagree and nothing else would "
+            "notice. Declare it once, in the ConfigMap, and have every consumer read it from there."
+        )
+        return None
+
+    declaration = declarations[0]
+    if declaration["hook"]:
+        print(
+            f"::error file={declaration['file']}::NAMESPACES is declared on an ArgoCD HOOK "
+            f"({declaration['kind']}/{declaration['name']}). ArgoCD does not diff hook resources — "
+            "they are excluded from the Application's desired-state comparison — so editing this "
+            "file produces no diff, no sync operation runs, and the registration never fires. That "
+            "makes 'add a namespace to the list', the only edit this resource ever receives, the "
+            "one edit that cannot trigger it (issue #3507). Move the list to a non-hook resource "
+            f"({NAMESPACE_SOURCE}) and reference it from the hook."
+        )
+        return None
+
+    if declaration["kind"] == "ConfigMap":
+        consumers = configmap_consumers(root, declaration["name"])
+        if not consumers:
+            print(
+                f"::error file={declaration['file']}::the ConfigMap "
+                f"`{declaration['name']}` declares NAMESPACES but no workload under "
+                f"{TEMPORAL_DIR}/ reads it (no configMapKeyRef, envFrom or volume). A list nothing "
+                "consumes registers nothing — a silent no-op that reads exactly like a working "
+                "mechanism, which is the failure class this gate was written for."
+            )
+            return None
+
+    return declaration["namespaces"]
 
 
 def gitops_env_overrides(root: pathlib.Path) -> dict[str, str]:
@@ -109,11 +276,6 @@ def required_namespaces(root: pathlib.Path) -> dict[str, str]:
 def check(root: pathlib.Path) -> int:
     registered = registered_namespaces(root)
     if registered is None:
-        print(
-            f"::error file={REGISTRATION}::could not read the NAMESPACES list from the Temporal "
-            "registration Job — the check's own input is missing or reshaped, which is not the "
-            "same as the fleet being clean. Investigate before trusting this run."
-        )
         return 1
 
     required = required_namespaces(root)
@@ -127,10 +289,10 @@ def check(root: pathlib.Path) -> int:
     missing = {svc: ns for svc, ns in sorted(required.items()) if ns not in registered}
     for service, namespace in missing.items():
         print(
-            f"::error file={REGISTRATION}::{service} polls Temporal namespace `{namespace}`, which "
-            "the registration Job does not create. The worker will retry forever against a "
-            "namespace that does not exist — the pod stays Ready, ArgoCD stays Healthy, no "
-            "workflow ever runs, and the only symptom is log volume. Add it to NAMESPACES."
+            f"::error file={NAMESPACE_SOURCE}::{service} polls Temporal namespace `{namespace}`, "
+            "which the registration ConfigMap does not declare. The worker will retry forever "
+            "against a namespace that does not exist — the pod stays Ready, ArgoCD stays Healthy, "
+            "no workflow ever runs, and the only symptom is log volume. Add it to NAMESPACES."
         )
 
     verdict = "clean." if not missing else f"{len(missing)} MISSING above."
@@ -142,17 +304,33 @@ def check(root: pathlib.Path) -> int:
 
 
 def self_test() -> int:
-    """Feed the checker the three shapes it must get right, including one it must NOT flag."""
+    """Feed the checker the shapes it must get right, including several it must NOT flag."""
     with tempfile.TemporaryDirectory() as tmp:
         root = pathlib.Path(tmp)
-        (root / GITOPS_COMPONENTS / "temporal").mkdir(parents=True)
+        (root / TEMPORAL_DIR).mkdir(parents=True)
         (root / GITOPS_COMPONENTS / "camp").mkdir(parents=True)
+        source = root / NAMESPACE_SOURCE
+        consumer = root / TEMPORAL_DIR / "temporal-namespace-registration.yaml"
 
-        def write_registration(namespaces: str) -> None:
-            (root / REGISTRATION).write_text(
-                "spec:\n  env:\n    - name: NAMESPACES\n"
-                f'      value: "{namespaces}"\n'
-                '    - name: RETENTION\n      value: "168h"\n'
+        def write_registration(namespaces: str, *, trailer: str = "") -> None:
+            """The shipped shape: a plain ConfigMap holding the list, read by a hook Job."""
+            source.write_text(
+                "apiVersion: v1\nkind: ConfigMap\nmetadata:\n"
+                "  name: temporal-namespace-registration\n  namespace: temporal\n"
+                f'data:\n  NAMESPACES: "{namespaces}"\n  RETENTION: "168h"\n{trailer}'
+            )
+
+        def write_consumer() -> None:
+            consumer.write_text(
+                "apiVersion: batch/v1\nkind: Job\nmetadata:\n"
+                "  name: temporal-namespace-registration\n  namespace: temporal\n"
+                "  annotations:\n    argocd.argoproj.io/hook: PostSync\n"
+                "spec:\n  template:\n    spec:\n      containers:\n"
+                "        - name: register\n          image: admin-tools\n          env:\n"
+                "            - name: NAMESPACES\n              valueFrom:\n"
+                "                configMapKeyRef:\n"
+                "                  name: temporal-namespace-registration\n"
+                "                  key: NAMESPACES\n"
             )
 
         def write_service(name: str, default_ns: str) -> None:
@@ -171,6 +349,7 @@ def self_test() -> int:
         (root / GITOPS_COMPONENTS / "camp" / "camp.yaml").write_text(
             "env:\n  - name: OPENBANK_TEMPORAL_NAMESPACE\n    value: openbank-camp\n"
         )
+        write_consumer()
 
         failures = []
 
@@ -193,12 +372,57 @@ def self_test() -> int:
             failures.append("flagged an EXTRA registered namespace, which is harmless by design")
 
         # A namespace named only in a comment must not satisfy the check.
-        write_registration("openbank-ok openbank-camp")
-        (root / REGISTRATION).write_text(
-            (root / REGISTRATION).read_text() + "\n# TODO: register openbank-lending here\n"
+        write_registration(
+            "openbank-ok openbank-camp", trailer="# TODO: register openbank-lending here\n"
         )
         if check(root) == 0:
             failures.append("was satisfied by a namespace appearing only in a COMMENT")
+
+        # ---- issue #3507: WHERE the list lives ------------------------------------------------
+        complete = "openbank-ok openbank-camp openbank-lending"
+        write_registration(complete)
+
+        # (a) A complete list carried on a hook resource is unreachable by the edit that needs it.
+        source_backup = source.read_text()
+        consumer_backup = consumer.read_text()
+        source.write_text(
+            "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: unrelated\n  namespace: temporal\n"
+            "data:\n  OTHER: x\n"
+        )
+        consumer.write_text(
+            "apiVersion: batch/v1\nkind: Job\nmetadata:\n"
+            "  name: temporal-namespace-registration\n  namespace: temporal\n"
+            "  annotations:\n    argocd.argoproj.io/hook: PostSync\n"
+            "spec:\n  template:\n    spec:\n      containers:\n"
+            "        - name: register\n          image: admin-tools\n          env:\n"
+            f'            - name: NAMESPACES\n              value: "{complete}"\n'
+        )
+        if check(root) == 0:
+            failures.append("accepted a COMPLETE list declared on an ArgoCD hook (issue #3507)")
+
+        # (b) The same list on a non-hook Job is fine — the rule is about the hook, not about Jobs.
+        consumer.write_text(consumer.read_text().replace("  annotations:\n    argocd.argoproj.io/hook: PostSync\n", ""))
+        if check(root) != 0:
+            failures.append("flagged a list on a NON-hook workload, which is legal")
+
+        # (c) Two declarations must fail even when both agree — copies drift later, not now.
+        source.write_text(source_backup)
+        if check(root) == 0:
+            failures.append("accepted TWO declarations of NAMESPACES")
+
+        # (d) A ConfigMap nothing reads registers nothing.
+        consumer.write_text(
+            "apiVersion: batch/v1\nkind: Job\nmetadata:\n  name: unrelated\n  namespace: temporal\n"
+            "spec:\n  template:\n    spec:\n      containers:\n"
+            "        - name: x\n          image: y\n"
+        )
+        if check(root) == 0:
+            failures.append("accepted a NAMESPACES ConfigMap that no workload consumes")
+
+        # (e) And the shipped shape — ConfigMap + hook Job reading it — must pass.
+        consumer.write_text(consumer_backup)
+        if check(root) != 0:
+            failures.append("flagged the shipped shape: a ConfigMap read by a hook Job")
 
         for message in failures:
             print(f"::error::self-test FAILED — the checker {message}.")

--- a/docs/adr/0101-temporal-durable-execution.md
+++ b/docs/adr/0101-temporal-durable-execution.md
@@ -86,12 +86,18 @@ workflows gets its own Temporal namespace (`openbank-payments`, `openbank-fx`,
 service's worker starts — a missing namespace does not crash the pod (readiness is a TCP probe
 on the HTTP port, not on Temporal), so the worker poller silently spins on
 `NOT_FOUND: Namespace <x> is not found` while the pod reports Healthy. Namespace registration is
-**declarative in GitOps**, not a manual break-glass step: an idempotent ArgoCD **PostSync hook
-Job** in `openbank-infra/gitops/components/temporal/temporal-namespace-registration.yaml`
-(temporal admin-tools image, `describe`-then-`create` per namespace) reconciles the namespace set
-on every sync. **Adding a Temporal service is a two-line change**: add its namespace to the
-`NAMESPACES` list in that Job *and* add the service namespace to the `temporal-platform-ingress`
-NetworkPolicy (`temporal-network-policies.yaml`) so its worker can reach the frontend gRPC port.
+**declarative in GitOps**, not a manual break-glass step: the namespace set and the
+`describe`-then-`create` script live in the `temporal-namespace-registration` **ConfigMap**
+(`openbank-infra/gitops/components/temporal/temporal-namespace-config.yaml`), and two workloads
+run it — an idempotent ArgoCD **PostSync hook Job** on every sync, and a daily
+`temporal-namespace-reconcile` **CronJob** that registers whatever the sync path missed and then
+fails so the gap is alerted rather than merely repaired. The list lives on the ConfigMap and not
+on the hook deliberately: ArgoCD does not diff hook resources, so a list carried there could
+never be changed in a way that triggered its own registration (issue #3507) —
+`check-temporal-namespace-registration.py` now fails any PR that moves it back.
+**Adding a Temporal service is a two-line change**: add its namespace to the `NAMESPACES` key in
+that ConfigMap *and* add the service namespace to the `temporal-platform-ingress` NetworkPolicy
+(`temporal-network-policies.yaml`) so its worker can reach the frontend gRPC port.
 
 **Worker placement**: each service (`sepa-payment-service` etc.) runs its own Temporal Worker
 in-process (Quarkus startup lifecycle bean). No separate worker service — keeps the service

--- a/docs/runbooks/0006-temporal-settlement-go-live.md
+++ b/docs/runbooks/0006-temporal-settlement-go-live.md
@@ -19,7 +19,7 @@ runbook flips settlement, in the safe order, with a stop/rollback at each gate.
 |------|-------|-----------|--------|
 | Temporal flag | `gitops/components/payments/payments-services.yaml` (settlement-service env) | `OPENBANK_TEMPORAL_ENABLED` **absent** ⇒ `openbank.temporal.enabled=false` | `true` |
 | Temporal server URL | same | `temporal-frontend.temporal.svc.cluster.local:7233` (set) | unchanged |
-| Temporal namespace | `openbank-settlement` (settlement's own `TemporalConfig` `@WithDefault`, like fx/statements — NOT `openbank-default`) | was **missing** from `temporal-namespace-registration.yaml` `NAMESPACES` → go-live NOT_FOUND | **added** ✅ |
+| Temporal namespace | `openbank-settlement` (settlement's own `TemporalConfig` `@WithDefault`, like fx/statements — NOT `openbank-default`) | was **missing** from the registration `NAMESPACES` list → go-live NOT_FOUND | **added** ✅ |
 | GL debit account | `SETTLEMENT_GL_DEBIT_ACCOUNT_ID` | `a0000000-…-0002` (2100 CZK deposit-control) | unchanged ✅ (correct for CZK) |
 | GL credit account | `SETTLEMENT_GL_CREDIT_ACCOUNT_ID` | `a0000000-…-0002` (same — payer/payee on subAccountId) | unchanged ✅ (correct for CZK) |
 | OPA enforcement | no `AUTHZ_ENFORCE` set ⇒ libs default (advisory) | `opa/settlement_activity.rego` deployed, advisory | `true` after validation |
@@ -54,7 +54,7 @@ per-currency control account.
    ```
    (SERVER_URL already present; NetworkPolicy `temporal-platform-ingress` already admits the
    payments namespace — PR #1600.) **The `openbank-settlement` namespace MUST be registered** in
-   `temporal-namespace-registration.yaml` `NAMESPACES` first — the first go-live (PR #1829) missed
+   `temporal-namespace-config.yaml` `NAMESPACES` first — the first go-live (PR #1829) missed
    this and the worker logged `NOT_FOUND: Namespace openbank-settlement is not found`; fixed by
    adding it to the registration. Verify the PostSync hook created it before relying on workflows.
 2. Roll ONE settlement replica first (canary) if running >1; otherwise watch the single pod's
@@ -101,6 +101,7 @@ flight (would fail GL currency validation until per-currency control accounts ar
 
 - ADR-0101 (Temporal durable execution) — settlement is P3 (#1471), real adapters + OPA (#1522).
 - New-Temporal-service checklist + namespace-registration mechanics: see the ADR-0101 notes and
-  `gitops/components/temporal/temporal-namespace-registration.yaml`.
+  `gitops/components/temporal/temporal-namespace-config.yaml` (the list and the script; the
+  PostSync hook and the daily reconcile CronJob both read it).
 - DST harness (ADR-0100, `openbank-simulation`) can model the settlement saga compensation under
   fault injection before/after this flip.

--- a/openbank-infra/CLAUDE.md
+++ b/openbank-infra/CLAUDE.md
@@ -19,6 +19,26 @@ out of it (they are path-scoped, not less important — several are live-inciden
   `check-roles-allowed-realm.py` was green the whole time: it compares the code to the TEMPLATE.
   Verify against the realm that actually runs (`kcadm.sh get roles -r openbank`) before believing any
   claim about which roles exist, and apply additions with `kcadm` — the file alone will not.
+- **ArgoCD does NOT diff hook resources — so anything a hook reads from its own manifest can never
+  be changed in a way that triggers it.** A `argocd.argoproj.io/hook` object is excluded from the
+  Application's desired-state comparison: `kubectl -n argocd get application <app> -o json` reports
+  every other resource `Synced` and the hook `status: None`, i.e. not compared at all. Editing only
+  the hook therefore produces no diff, no sync operation, and no hook run — the Application sits
+  `Synced/Healthy` at the new revision having done nothing. `temporal-namespace-registration` carried
+  its `NAMESPACES` list inline that way, and "add a namespace to the list" is the ONLY edit that file
+  ever receives, so the mechanism was inert for its sole use case; it had worked only when a namespace
+  addition happened to ride along with an unrelated change to a non-hook resource in the same
+  Application (settlement and campaign both reached production polling namespaces that did not exist,
+  and after #3475 `openbank-lending` needed a hand-issued sync). Its own comment asserted the
+  behaviour it did not have — the file was the only thing claiming the trigger existed. Fix, and the
+  general rule: **a hook's INPUT belongs on a resource ArgoCD compares** (a ConfigMap the hook reads
+  via `configMapKeyRef`/volume), so changing the input is what makes the app OutOfSync and the
+  resulting sync operation runs the hook. Enforced by
+  `check-temporal-namespace-registration.py` (#3507), which also rejects a second copy of the list
+  and a ConfigMap no workload consumes. Corollary for anything a hook provisions OUTSIDE Kubernetes
+  (a Temporal namespace, a realm, a bucket): ArgoCD cannot see it at all, so deletion out of band
+  produces no diff either — pair the hook with a reconciling CronJob that repairs the gap **and then
+  exits non-zero**, so KubeJobFailed carries it. A repair that exits 0 is one nobody ever learns about.
 - **A change under `openbank-libs-*/src/main/**` rebuilds the WHOLE fleet, and the deploy that
   follows fails on pacts that do not exist yet.** `Detect changed services` returned 58 modules for
   the #2475 role sweep; at `max-parallel: 4` and ~45 min a service that is ~11 h of queue. Auto-deploy

--- a/openbank-infra/gitops/components/temporal/kustomization.yaml
+++ b/openbank-infra/gitops/components/temporal/kustomization.yaml
@@ -9,5 +9,7 @@ resources:
   - temporal-namespace.yaml
   - temporal-helmrelease.yaml
   - temporal-network-policies.yaml
+  - temporal-namespace-config.yaml
   - temporal-namespace-registration.yaml
+  - temporal-namespace-reconcile.yaml
   - temporal-server-podmonitor.yaml

--- a/openbank-infra/gitops/components/temporal/temporal-namespace-config.yaml
+++ b/openbank-infra/gitops/components/temporal/temporal-namespace-config.yaml
@@ -1,0 +1,152 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+#
+# ---------------------------------------------------------------------------
+# The Temporal namespace SET, and the script that registers it (issue #3507).
+#
+# WHY THE LIST LIVES HERE AND NOT ON THE JOB
+#   It used to be an inline env value on `temporal-namespace-registration.yaml`, an
+#   ArgoCD PostSync **hook**. A hook is not part of the Application's desired-state
+#   tree — ArgoCD never diffs it, so editing ONLY the hook produces no diff, no sync
+#   operation, and the hook therefore never fires. That is not a subtlety of the
+#   diff output: `kubectl -n argocd get application temporal -o json` reports every
+#   other resource `Synced` and the hook Job `status: None`, i.e. not compared at all.
+#
+#   The single edit anyone ever makes to that Job is "add a namespace to the list" —
+#   precisely the edit that could not trigger it. Measured after #3475 merged: the
+#   Application sat `Synced/Healthy` at the new revision, no Job existed, and
+#   `openbank-lending` was still absent until someone ran a manual sync by hand. The
+#   mechanism was inert for its sole use case, and had only ever worked when a
+#   namespace addition happened to ride along with an unrelated change to a non-hook
+#   resource in the same Application.
+#
+#   A ConfigMap IS compared. So adding a namespace now changes a tracked resource,
+#   the Application goes OutOfSync, auto-sync runs a sync operation, and the sync
+#   operation runs its PostSync hook. The trigger is a structural property of where
+#   the list lives, not a convention anyone has to remember — which is the point:
+#   the previous mechanism relied on a comment asserting a behaviour it did not have.
+#
+# WHY THE SCRIPT LIVES HERE TOO
+#   Two workloads run it — the PostSync hook (registers on every sync) and the
+#   `temporal-namespace-reconcile` CronJob (registers whatever the sync path missed,
+#   and fails loudly when it had to). A second copy of a namespace list is the exact
+#   drift this file exists to prevent, so there is one copy of both the list and the
+#   logic, and both consumers mount it.
+#
+# WHEN A SERVICE ADOPTS TEMPORAL: add its namespace to NAMESPACES below AND to the
+# `temporal-platform-ingress` NetworkPolicy (temporal-network-policies.yaml) — both
+# are required; the NetworkPolicy gates frontend gRPC reachability and this list
+# gates namespace existence. `check-temporal-namespace-registration.py` fails the
+# PR if the list is short, and also fails if this declaration is ever moved back
+# onto a hook resource.
+# ---------------------------------------------------------------------------
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: temporal-namespace-registration
+  namespace: temporal
+  labels:
+    app.kubernetes.io/part-of: temporal
+    app.kubernetes.io/component: namespace-registration
+    openbank.io/derived: gitops-manual
+data:
+  # Space-separated list of Temporal NAMESPACES (not task queues) — the set of distinct
+  # `openbank.temporal.namespace` values across services that run workflows. Today:
+  # payments (sepa+domestic) → openbank-payments; fx → openbank-fx; statements →
+  # openbank-statements; settlement → openbank-settlement (its own TemporalConfig
+  # @WithDefault, like fx/statements — NOT openbank-default; an earlier comment here was
+  # wrong. The live worker polls namespace="openbank-settlement", confirmed by NOT_FOUND
+  # on go-live — runbook 0006). campaign → openbank-campaign (ADR-0200 journeys), added
+  # on its first rollout: its Deployment had no OPENBANK_TEMPORAL_NAMESPACE, so the worker
+  # defaulted to the bare `openbank` and hit exactly the NOT_FOUND this file exists to
+  # prevent. lending → openbank-lending, the THIRD time this list has been the thing that
+  # drifted. Measured in the sandbox 2026-08-02: the namespace was absent, so
+  # lending-service's workflow AND activity pollers both retried forever against a
+  # namespace Temporal has never held — ~2,000 ERROR lines/hour into Loki, and no
+  # origination workflow could start. Nothing went red: the pod is 2/2 and its readiness
+  # probe does not touch Temporal, so the only evidence was the log volume.
+  NAMESPACES: "openbank-default openbank-payments openbank-fx openbank-statements openbank-settlement openbank-finops openbank-devops openbank-liveness openbank-governance openbank-release openbank-docstruth openbank-authzaudit openbank-flakytest openbank-campaign openbank-lending"
+  RETENTION: "168h"
+  # Idempotent: each namespace is `describe`d first and only created if absent; a lost
+  # race on create is tolerated when the error says "already exists".
+  #
+  # REGISTRATION_MODE decides what a CREATE means, and that is the whole difference
+  # between the two callers:
+  #   sync-hook  — creating is the normal path (first install, or a namespace just added
+  #                to the list). Exit 0.
+  #   reconcile  — the sync path is supposed to have done this already. Both callers read
+  #                THIS ConfigMap, and ArgoCD syncs the ConfigMap and fires the hook in the
+  #                same operation, so the CronJob can never see a namespace the hook has
+  #                not already been asked to register. A create here therefore means the
+  #                sync path did not run or did not succeed — repair it, then exit 1 so a
+  #                failed Job raises KubeJobFailed with the detail already in the log.
+  register.sh: |
+    #!/bin/sh
+    set -eu
+
+    : "${TEMPORAL_ADDRESS:?}"
+    : "${NAMESPACES:?}"
+    : "${RETENTION:?}"
+    : "${REGISTRATION_MODE:?}"
+
+    echo "Temporal frontend: ${TEMPORAL_ADDRESS}"
+    echo "Mode:              ${REGISTRATION_MODE}"
+    echo "Namespaces:        ${NAMESPACES}"
+    echo "Retention:         ${RETENTION}"
+
+    # Wait for the frontend to answer (covers first-install and frontend restarts).
+    ready=0
+    i=1
+    while [ "$i" -le 60 ]; do
+      if temporal operator namespace list --address "${TEMPORAL_ADDRESS}" >/dev/null 2>&1; then
+        ready=1
+        break
+      fi
+      echo "waiting for temporal frontend... (${i}/60)"
+      i=$((i + 1))
+      sleep 5
+    done
+    if [ "$ready" -ne 1 ]; then
+      echo "ERROR: temporal frontend ${TEMPORAL_ADDRESS} not reachable" >&2
+      exit 1
+    fi
+
+    rc=0
+    created=""
+    for ns in ${NAMESPACES}; do
+      if temporal operator namespace describe --namespace "$ns" \
+           --address "${TEMPORAL_ADDRESS}" >/dev/null 2>&1; then
+        echo "[ok] ${ns} already exists"
+        continue
+      fi
+      echo "[create] ${ns} retention=${RETENTION}"
+      if temporal operator namespace create --namespace "$ns" \
+           --retention "${RETENTION}" \
+           --address "${TEMPORAL_ADDRESS}" 2>/tmp/create.err; then
+        echo "[created] ${ns}"
+        created="${created} ${ns}"
+      elif grep -qi "already exists" /tmp/create.err; then
+        # Lost the race with another replica / a concurrent sync — fine.
+        echo "[ok] ${ns} already exists (raced)"
+      else
+        echo "ERROR creating ${ns}:" >&2
+        cat /tmp/create.err >&2
+        rc=1
+      fi
+    done
+
+    if [ "$rc" -ne 0 ]; then
+      exit "$rc"
+    fi
+
+    if [ -n "${created}" ] && [ "${REGISTRATION_MODE}" = "reconcile" ]; then
+      echo "ERROR: reconcile had to create:${created}" >&2
+      echo "A declared namespace was missing from the running Temporal cluster. It has been" >&2
+      echo "created, so workers are unblocked — but the ArgoCD sync path that should have" >&2
+      echo "registered it did not. Check the temporal Application's last sync operation and" >&2
+      echo "the temporal-namespace-registration PostSync hook (issue #3507)." >&2
+      exit 1
+    fi
+
+    echo "Done: every declared namespace exists."

--- a/openbank-infra/gitops/components/temporal/temporal-namespace-reconcile.yaml
+++ b/openbank-infra/gitops/components/temporal/temporal-namespace-reconcile.yaml
@@ -1,0 +1,132 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+#
+# ---------------------------------------------------------------------------
+# Temporal namespace reconciler — the half that RUNS (issue #3507).
+#
+# WHAT THE SYNC PATH CANNOT COVER
+#   Moving the namespace list into a ConfigMap makes "declare a namespace" produce a
+#   real ArgoCD diff, so the PostSync hook fires on the merge that needs it. That fixes
+#   the trigger; it does not make a GAP observable. Two cases stay silent otherwise:
+#     * a namespace deleted out of band (the sync path only runs on a diff, and a
+#       deleted Temporal namespace produces none — Temporal namespaces are not
+#       Kubernetes objects, so ArgoCD cannot see them at all); and
+#     * a sync operation that ran and whose hook did not succeed for any reason.
+#   In both, the symptom is the one this whole component exists to avoid: workers
+#   poll a namespace that does not exist, the pods stay Ready, ArgoCD stays
+#   Synced/Healthy, and the only evidence is log volume.
+#
+# WHY IT REPAIRS **AND** FAILS
+#   It runs the same `register.sh` from the same ConfigMap the hook uses, in
+#   `reconcile` mode: missing namespaces are created (workers unblock without anyone
+#   being paged awake), and then the Job exits 1 *because it had to*. A repair that
+#   exits 0 is a repair nobody ever learns about — the failure is the signal that the
+#   sync path did not do its job, and kube-prometheus-stack's KubeJobFailed carries it
+#   with the detail already in the log. A clean run is a no-op and exits 0.
+#
+#   The obvious false positive — "the CronJob fires between a merge and its sync" —
+#   cannot happen: both this CronJob and the hook read the SAME ConfigMap, and ArgoCD
+#   applies that ConfigMap and runs the hook in one operation. This CronJob can never
+#   see a namespace the hook has not already been asked to register.
+#
+# NO KUBERNETES API ACCESS: it talks Temporal gRPC only, so the ServiceAccount token
+# is dropped exactly as on the hook Job. Intra-namespace ingress to the frontend is
+# already allowed by `temporal-intra-namespace` (podSelector: {}), so no NetworkPolicy
+# change is needed.
+# ---------------------------------------------------------------------------
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: temporal-namespace-reconcile
+  namespace: temporal
+  labels:
+    app.kubernetes.io/part-of: temporal
+    app.kubernetes.io/component: namespace-registration
+    openbank.io/derived: gitops-manual
+spec:
+  # 04:10 UTC daily — after keycloak-realm-drift's 03:40 and sbom-drift-scanner's
+  # 03:10, so the in-cluster drift detectors do not contend for one window.
+  schedule: "10 4 * * *"
+  timeZone: "UTC"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  # failedJobsHistoryLimit: 1 — KubeJobFailed fires per surviving failed Job OBJECT, so
+  # a higher limit turns one recurring failure into several permanent alerts (the
+  # 2026-08-02 alert drain: 11 of 37 firing alerts were KubeJobFailed tombstones).
+  failedJobsHistoryLimit: 1
+  startingDeadlineSeconds: 600
+  jobTemplate:
+    spec:
+      # The wait loop is 60 × 5s; allow one pass plus registration headroom.
+      activeDeadlineSeconds: 600
+      # No retry: a second attempt would find the namespaces this one just created and
+      # exit 0, erasing the very signal the first attempt raised.
+      backoffLimit: 0
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/part-of: temporal
+            app.kubernetes.io/component: namespace-registration
+        spec:
+          restartPolicy: Never
+          automountServiceAccountToken: false
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: reconcile-namespaces
+              image: docker.io/temporalio/admin-tools:1.29.7-tctl-1.18.4-cli-1.7.2
+              imagePullPolicy: IfNotPresent
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop:
+                    - ALL
+              env:
+                - name: HOME
+                  value: /tmp
+                - name: TEMPORAL_ADDRESS
+                  value: "temporal-frontend.temporal.svc.cluster.local:7233"
+                - name: REGISTRATION_MODE
+                  value: "reconcile"
+                - name: NAMESPACES
+                  valueFrom:
+                    configMapKeyRef:
+                      name: temporal-namespace-registration
+                      key: NAMESPACES
+                - name: RETENTION
+                  valueFrom:
+                    configMapKeyRef:
+                      name: temporal-namespace-registration
+                      key: RETENTION
+              command:
+                - /bin/sh
+                - /scripts/register.sh
+              resources:
+                requests:
+                  cpu: 50m
+                  memory: 64Mi
+                limits:
+                  cpu: 250m
+                  memory: 128Mi
+              volumeMounts:
+                - name: tmp
+                  mountPath: /tmp
+                - name: scripts
+                  mountPath: /scripts
+                  readOnly: true
+          volumes:
+            - name: tmp
+              emptyDir: {}
+            - name: scripts
+              configMap:
+                name: temporal-namespace-registration
+                defaultMode: 0555
+                items:
+                  - key: register.sh
+                    path: register.sh

--- a/openbank-infra/gitops/components/temporal/temporal-namespace-registration.yaml
+++ b/openbank-infra/gitops/components/temporal/temporal-namespace-registration.yaml
@@ -11,20 +11,23 @@
 # admintools pod (`temporal operator namespace create ...`); this Job makes it
 # declarative and idempotent so the namespace set lives in git.
 #
-# WHEN A SERVICE ADOPTS TEMPORAL: add its namespace to NAMESPACES below AND to the
-# `temporal-platform-ingress` NetworkPolicy (temporal-network-policies.yaml) — both
-# are required, the NetworkPolicy gates frontend gRPC reachability and this Job
-# gates namespace existence.
+# THE LIST AND THE SCRIPT ARE NOT HERE — they are in `temporal-namespace-config.yaml`,
+# deliberately, and that file explains why at length (issue #3507). Short form: this
+# Job is a HOOK, and ArgoCD does not diff hooks. Editing this file alone produces no
+# diff, so no sync operation runs and this hook never fires — which made the one edit
+# anyone ever performs ("add a namespace") the one edit that could not trigger it. The
+# namespace set now lives in a ConfigMap, a resource ArgoCD DOES compare, so changing
+# it makes the Application OutOfSync and the resulting sync operation runs this hook.
+# Do not move `NAMESPACES` back onto this Job; `check-temporal-namespace-registration.py`
+# fails the PR that tries.
 #
 # Hook choice — PostSync, NOT PreSync: a PreSync hook runs before the Application's
 # own resources are applied, so on first install the Temporal frontend would not yet
-# be running and namespace registration would fail. PostSync runs after sync; the
-# container additionally waits for the frontend to answer before registering, which
-# also covers frontend pod restarts. ArgoCD holds the Application in Progressing
-# until the Job completes, so a registration failure is visible (not silently green).
-#
-# Idempotency: each namespace is `describe`d first and only created if absent;
-# a lost race on create is tolerated when the error is "already exists".
+# be running and namespace registration would fail. PostSync runs after sync — after
+# the ConfigMap it reads has been applied — and the script additionally waits for the
+# frontend to answer before registering, which also covers frontend pod restarts.
+# ArgoCD holds the Application in Progressing until the Job completes, so a
+# registration failure is visible (not silently green).
 ---
 apiVersion: batch/v1
 kind: Job
@@ -36,15 +39,16 @@ metadata:
     app.kubernetes.io/component: namespace-registration
     openbank.io/derived: gitops-manual
   annotations:
-    # Runs after the Temporal server resources are synced. BeforeHookCreation keeps
-    # the last run visible for debugging and recreates the Job on every sync (so
-    # adding a namespace to the list below re-runs registration on the next sync).
+    # Runs after the Temporal server resources are synced. BeforeHookCreation keeps the
+    # last run visible for debugging and recreates the Job on every sync — so this Job
+    # re-runs whenever a sync operation happens, which (see above) is what changing the
+    # ConfigMap now causes. It is NOT what changing this file causes.
     argocd.argoproj.io/hook: PostSync
     argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
 spec:
   backoffLimit: 5
   # Hard ceiling so a permanently-unreachable frontend fails the hook instead of
-  # hanging the sync forever (wait loop below is 60 × 5s = 5m per attempt).
+  # hanging the sync forever (wait loop is 60 × 5s = 5m per attempt).
   activeDeadlineSeconds: 900
   ttlSecondsAfterFinished: 86400
   template:
@@ -82,77 +86,23 @@ spec:
               value: /tmp
             - name: TEMPORAL_ADDRESS
               value: "temporal-frontend.temporal.svc.cluster.local:7233"
-            # Space-separated list of Temporal NAMESPACES (not task queues) — the set
-            # of distinct `openbank.temporal.namespace` values across services that run
-            # workflows. Today: payments (sepa+domestic) → openbank-payments;
-            # fx → openbank-fx; statements → openbank-statements; settlement →
-            # openbank-settlement (its own TemporalConfig @WithDefault, like fx/statements —
-            # NOT openbank-default; an earlier comment here was wrong. The live worker polls
-            # namespace="openbank-settlement", confirmed by NOT_FOUND on go-live — runbook 0006).
-            # campaign → openbank-campaign (ADR-0200 journeys), added on its first rollout:
-            # its Deployment had no OPENBANK_TEMPORAL_NAMESPACE, so the worker defaulted to
-            # the bare `openbank` and hit exactly the NOT_FOUND this Job exists to prevent.
-            # lending → openbank-lending, the THIRD time this list has been the thing that
-            # drifted. Measured in the sandbox 2026-08-02: the namespace was absent, so
-            # lending-service's workflow AND activity pollers both retried forever against a
-            # namespace Temporal has never held — ~2,000 ERROR lines/hour into Loki, and no
-            # origination workflow could start. Nothing went red: the pod is 2/2 and its
-            # readiness probe does not touch Temporal, so the only evidence was the log volume.
-            # This list is now DERIVED-checked by check-temporal-namespace-registration.py, on
-            # the repo's rule that a hand-kept list of the thing a gate covers reads as
-            # *passing* when it is short rather than as *unchecked*.
+            # sync-hook: creating a namespace is the expected path here (first install,
+            # or one just added to the list), so a create is not an error.
+            - name: REGISTRATION_MODE
+              value: "sync-hook"
             - name: NAMESPACES
-              value: "openbank-default openbank-payments openbank-fx openbank-statements openbank-settlement openbank-finops openbank-devops openbank-liveness openbank-governance openbank-release openbank-docstruth openbank-authzaudit openbank-flakytest openbank-campaign openbank-lending"
+              valueFrom:
+                configMapKeyRef:
+                  name: temporal-namespace-registration
+                  key: NAMESPACES
             - name: RETENTION
-              value: "168h"
+              valueFrom:
+                configMapKeyRef:
+                  name: temporal-namespace-registration
+                  key: RETENTION
           command:
             - /bin/sh
-            - -c
-            - |
-              set -eu
-              echo "Temporal frontend: ${TEMPORAL_ADDRESS}"
-              echo "Namespaces:        ${NAMESPACES}"
-              echo "Retention:         ${RETENTION}"
-
-              # Wait for the frontend to answer (covers first-install + restarts).
-              ready=0
-              i=1
-              while [ "$i" -le 60 ]; do
-                if temporal operator namespace list --address "${TEMPORAL_ADDRESS}" >/dev/null 2>&1; then
-                  ready=1
-                  break
-                fi
-                echo "waiting for temporal frontend... (${i}/60)"
-                i=$((i + 1))
-                sleep 5
-              done
-              if [ "$ready" -ne 1 ]; then
-                echo "ERROR: temporal frontend ${TEMPORAL_ADDRESS} not reachable" >&2
-                exit 1
-              fi
-
-              rc=0
-              for ns in ${NAMESPACES}; do
-                if temporal operator namespace describe --namespace "$ns" \
-                     --address "${TEMPORAL_ADDRESS}" >/dev/null 2>&1; then
-                  echo "[ok] ${ns} already exists"
-                  continue
-                fi
-                echo "[create] ${ns} retention=${RETENTION}"
-                if temporal operator namespace create --namespace "$ns" \
-                     --retention "${RETENTION}" \
-                     --address "${TEMPORAL_ADDRESS}" 2>/tmp/create.err; then
-                  echo "[created] ${ns}"
-                elif grep -qi "already exists" /tmp/create.err; then
-                  # Lost the race with another replica / a concurrent sync — fine.
-                  echo "[ok] ${ns} already exists (raced)"
-                else
-                  echo "ERROR creating ${ns}:" >&2
-                  cat /tmp/create.err >&2
-                  rc=1
-                fi
-              done
-              exit "$rc"
+            - /scripts/register.sh
           resources:
             requests:
               cpu: 50m
@@ -163,6 +113,16 @@ spec:
           volumeMounts:
             - name: tmp
               mountPath: /tmp
+            - name: scripts
+              mountPath: /scripts
+              readOnly: true
       volumes:
         - name: tmp
           emptyDir: {}
+        - name: scripts
+          configMap:
+            name: temporal-namespace-registration
+            defaultMode: 0555
+            items:
+              - key: register.sh
+                path: register.sh


### PR DESCRIPTION
## Summary

The Temporal namespace list lived inline on an ArgoCD **PostSync hook**, and ArgoCD does not diff hooks — so the one edit that file ever receives ("add a namespace") was the one edit that could not trigger it. The list and its script move to a ConfigMap, a resource ArgoCD *does* compare, and a daily reconcile CronJob covers what no diff can see.

## Type of change

- [x] fix (bug fix)

## Linked issues

Closes #3507

## The verified mechanism

Not inferred from the docs — read off the live Application:

```
$ kubectl -n argocd get application temporal -o json | ...
Namespace       temporal                          Synced
Application     temporal-helm                     Synced
Job             temporal-namespace-registration   None      <-- not compared at all
ExternalSecret  temporal-db-credentials           Synced
... (every other resource Synced)

sync.status = Synced   revision = a6fbc62b3 (current main)   health = Healthy
last actual sync OPERATION: finishedAt 2026-08-02T21:17:54Z, revision HEAD
  -- i.e. the manual sync from the issue, not a reconcile
reconciledAt 2026-08-03T09:46:43Z   (reconciles happen; they produce no operation)
```

`status: None` on the hook is the whole defect in one field: a hook resource is excluded from the desired-state comparison, so editing it produces no diff, no sync operation runs, and the PostSync hook never fires. The Application reads `Synced/Healthy` at the correct revision the entire time.

All 15 declared namespaces **do** currently exist in the sandbox (verified via `temporal operator namespace list` on the admintools pod), including `openbank-lending` — created yesterday by the hand-issued sync in the issue, not by the merge. So the state is fine today and the *next* addition would have failed exactly the same way.

## Changes

- **`temporal-namespace-config.yaml` (new)** — a ConfigMap holding `NAMESPACES`, `RETENTION` and `register.sh`. This is the trigger fix, and it is structural rather than a convention anyone has to remember: a ConfigMap is compared, so adding a namespace makes the Application OutOfSync, auto-sync runs a sync operation, and the sync operation runs its PostSync hook. Preferred over a generated content-hash annotation on a non-hook resource (option 1 in the issue) because a hash is a second thing that can silently be forgotten or drift; the list simply living in a compared resource cannot.
- **`temporal-namespace-registration.yaml`** — the hook Job now reads both env keys via `configMapKeyRef` and runs the mounted `register.sh`. No behaviour change to registration itself. Its comment previously asserted "adding a namespace to the list below re-runs registration on the next sync", which was the false claim at the centre of this issue; it now states what the mechanism actually does and why the list is elsewhere.
- **`temporal-namespace-reconcile.yaml` (new)** — a daily CronJob running the same script from the same ConfigMap in `reconcile` mode. This is the detection half, and it covers what the sync path structurally cannot: **a Temporal namespace is not a Kubernetes object**, so one deleted out of band produces no ArgoCD diff and no sync, forever. It creates whatever is missing (workers unblock without a page) and *then* exits 1 because it had to — `KubeJobFailed` fires with the detail already in the log. A repair that exits 0 is a repair nobody ever learns about.
  - It cannot false-positive on the merge→sync window: both consumers read the *same* ConfigMap, and ArgoCD applies that ConfigMap and fires the hook in one operation, so this CronJob can never see a namespace the hook has not already been asked to register.
  - `backoffLimit: 0` deliberately — a retry would find what the first attempt just created and exit 0, erasing the signal. `failedJobsHistoryLimit: 1` per the 2026-08-02 alert-drain lesson.
- **`check-temporal-namespace-registration.py`** — keeps its completeness rule and gains the structural one. The list must be declared on a **non-hook** resource, **exactly once**, and something must **consume** it (an unread ConfigMap registers nothing — the same silent no-op wearing a different hat). Parsing moved from regex to YAML so the hook annotation can be associated with the document that actually carries the declaration.
- Prose that named the old location — ADR-0101, runbook 0006 — updated in the same PR. Stale prose naming a moved artifact is invisible to every gate forever.

## Falsification

Not "the self-test passes":

- **Against the real tree, in place.** `cp` backups taken, the two files restored to their exact pre-fix `origin/main` content, gate run: exits **1** with the hook message naming `Job/temporal-namespace-registration`. Restored from the backups: exits **0**. (`cp`, never `git reset --hard`.)
- **`--self-test`** now drives ten shapes, including four it must NOT flag: a complete list on a hook (red), the same list on a *non-hook* workload (green — the rule is about hooks, not about Jobs), two declarations that agree (red — copies drift later, not now), a ConfigMap nothing consumes (red), and the shipped ConfigMap+hook-Job shape (green).
- Local gitops shard: **18 PASS**. The two non-passes are pre-existing and unrelated — `incluster-hostname-resolution` (advisory, 6 findings in account/card-issuance/onboarding/settlement) and `loki-rule-load-test`, whose self-test needs `BASE_REF` which only CI sets.
- yamllint gate green; `gen-network-policies` drift green (it reads committed files — it "fails" locally against an uncommitted tree, which is an artifact of the local run, not drift).

## What this does NOT do

It does not make a missing namespace visible **at PR time** — a PR runner cannot reach the cluster. The CI gate covers "declared by a service, absent from the list"; the CronJob covers "in the list, absent from the running cluster". Neither covers a namespace that exists but is misconfigured (retention, archival) — nothing compares those, and this PR does not change that.

## Definition of Done

- [x] Docs updated (ADR-0101, runbook 0006, `openbank-infra/CLAUDE.md`).
- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new third-party dependency (the CronJob reuses the already-pinned `temporalio/admin-tools` image the hook Job uses).
- [x] PSS-restricted pod spec mirrored from the existing hook Job: non-root, `readOnlyRootFilesystem`, all capabilities dropped, `automountServiceAccountToken: false` (it speaks Temporal gRPC only — no Kubernetes API access, no ServiceAccount, no RBAC).

Not applicable: no Kotlin, no REST API, no DB migration, no event schema.

## Compliance impact

- [x] None
