### PR TITLE
fix(infra): give security-scanner a Kafka identity and move it onto mTLS :9093

### DIFF
--- a/docs/runbooks/0008-kafka-mtls-scheme-accepted-cutover.md
+++ b/docs/runbooks/0008-kafka-mtls-scheme-accepted-cutover.md
@@ -142,3 +142,72 @@ next image rebuild — currently blocked by the Pact `can-i-deploy` gate, **#266
 Do **not** try to force it via `MP_MESSAGING_INCOMING_*` env vars: SmallRye cannot
 take hyphenated mp.messaging channel config from env and the pod fails to start
 (tried and reverted, #2649 → #2659).
+
+## Stage 6 — remove the `plain:9092` listener (issue #3393)
+
+The last stage of this runbook, and the one that makes the rest of it enforceable
+rather than merely configured. **Everything above this heading was written while
+`allow.everyone.if.no.acl.found` was still `true` and the plaintext listener was
+in place; read it as history, not as instructions.** Specifically:
+
+- "Untouched: every other Kafka client (they keep using `plain:9092`)" and the
+  "Out of scope — cluster-wide gate flip" section were overtaken by **#2794**,
+  which flipped the gate to `false` for the whole cluster.
+- The verification commands that exec into the broker with
+  `--bootstrap-server localhost:9092` no longer have a listener to reach, and
+  the Stage-4 negative test ("an anonymous client on `plain:9092` is DENIED")
+  cannot be run at all any more — its outcome is now structural. A broker-local
+  check needs `:9093` plus a client `--command-config` carrying a KafkaUser
+  keystore.
+
+### What had to be true first
+
+The listener was kept because removing it was assumed to break clients. It did
+not grant anything — a client on it authenticates as `User:ANONYMOUS`, which
+holds no ACL and is denied on every resource once the gate is `false` — so
+"still on 9092" and "cannot use Kafka" were the same statement. Three workloads
+still named it on 2026-08-03, each resolved before the removal:
+
+| workload | state before | resolution |
+| --- | --- | --- |
+| `security-scanner-service` | no `KafkaUser` at all; both topic log segments 0 bytes since creation — it had never published | `KafkaUser security-scanner` + ACLs, moved to `:9093` |
+| `kafka-ui` | the only workload actually speaking on `:9092`; every request denied (`Principal = User:ANONYMOUS is Denied operation = DESCRIBE … based on rule DefaultDeny`, once per 30s poll), rendered as an empty cluster | `KafkaUser kafka-ui` + browse-scoped ACLs, moved to `:9093` |
+| `settlement-service` | `KAFKA_BOOTSTRAP_SERVERS` env with no `mp.messaging` config and no Kafka client in its source — dead value | env deleted |
+
+### Apply
+
+```
+argocd app sync kafka          # Strimzi rolls the broker to drop the listener
+kubectl -n messaging get kafka openbank-cluster -o yaml | yq '.status.listeners[].name'   # expect: tls  (only)
+```
+
+### Verify
+
+1. **Every client is still connected**, i.e. the roll changed nothing for them:
+   ```
+   kubectl get pods -A -l app.kubernetes.io/part-of=openbank --field-selector=status.phase=Running
+   kubectl logs -n <ns> deploy/<svc> --since=10m | grep -iE "SSL handshake|disconnected|TimeoutException"
+   ```
+2. **kafka-ui shows a populated cluster** — topic list, per-topic partitions and
+   consumer groups with lag. That is the observable this whole issue turned on:
+   before, the same screen showed an empty cluster and no error.
+3. **The denial log is gone.** The broker authorizer should no longer print
+   `User:ANONYMOUS is Denied` at all — previously once per 30s, forever:
+   ```
+   kubectl -n messaging logs openbank-cluster-dual-0 --since=10m | grep ANONYMOUS   # expect: nothing
+   ```
+4. **The derived NetworkPolicy names 9093, not 9092.** `gen-network-policies.py`
+   used to hardcode the port; it now derives it from the clients' bootstrap URLs,
+   so a stale port here is a real (if latent) hole rather than a cosmetic one:
+   ```
+   kubectl -n messaging get netpol kafka-broker-ingress-allow-list -o jsonpath='{.spec.ingress[*].ports[*].port}{"\n"}'
+   ```
+
+### Rollback
+
+Re-add the four listener lines to `components/kafka/kafka.yaml` and sync. Note
+what that does and does not buy: it restores *connectivity* on 9092, never
+*authorization* — an ANONYMOUS client is still denied on every resource by the
+gate. So it is only worth doing to quiet a connection-error loop while a real
+client-side problem is fixed, and it is not a path back to a working plaintext
+client. There is no such path; that is the point of the stage.

--- a/openbank-infra/gitops/components/audit/kafka-audit-mtls.yaml
+++ b/openbank-infra/gitops/components/audit/kafka-audit-mtls.yaml
@@ -3,8 +3,10 @@
 # Identity model (ADR-0137): mTLS gives each service exactly one client cert =
 # one KafkaUser = one principal for ALL of its Kafka traffic. The audit-service
 # is a pure consumer of domain events across 10 topics; it only needs Read+Describe
-# ACLs on those topics and Read on its consumer group. Topics not listed here
-# stay open under allow.everyone.if.no.acl.found=true (see kafka.yaml).
+# ACLs on those topics and Read on its consumer group. NOTE: "topics not listed here
+# stay open under allow.everyone.if.no.acl.found=true" stood here and has been false
+# since #2794 — a topic with no ACL is denied, not open, which is exactly how the six
+# subscriptions at the bottom of this list came to be receiving nothing (#3271).
 #
 # clearing.batch.event / security.ict.incident / security.scan.event added (ADR-0160
 # #996 triage): each was published with zero consumers since introduction — audit-service
@@ -12,12 +14,12 @@
 #
 # dispute.events / statement.event / sanctions.screening.event added (#996 round 2) —
 # each publisher has its own mTLS KafkaUser with a Write ACL on its topic, which makes
-# that topic ACL-guarded (no longer covered by allow.everyone.if.no.acl.found=true), so
-# audit-service needs an explicit Read+Describe grant to actually consume it. Verified
-# each has a real producer (a genuine outbox-row write) before adding — cards.events /
-# domestic.payment.events / sepa.payment.events have no dedicated mTLS KafkaUser and stay
-# open under allow-everyone, same as clearing/security-scanner above; no ACL change needed
-# for those three.
+# that topic ACL-guarded, so audit-service needs an explicit Read+Describe grant to
+# actually consume it. Verified each has a real producer (a genuine outbox-row write)
+# before adding. (The original note here went on to say cards.events /
+# domestic.payment.events / sepa.payment.events "stay open under allow-everyone, same as
+# clearing/security-scanner above; no ACL change needed for those three" — wrong on the
+# same stale premise, and all three were granted in #3271 once measured.)
 #
 # Strimzi User Operator mints a per-user Secret in `messaging` (user.crt/key/p12
 # + user.password + ca.crt). Those secrets are projected into the `audit` namespace

--- a/openbank-infra/gitops/components/kafka/kafka-ui-mtls.yaml
+++ b/openbank-infra/gitops/components/kafka/kafka-ui-mtls.yaml
@@ -1,0 +1,162 @@
+# Kafka mTLS identity for kafka-ui (ADR-0137; issue #3393)
+#
+# WHY THIS FILE EXISTS
+# kafka-ui pointed at the anonymous plaintext listener `…:9092`, so it authenticated as
+# `User:ANONYMOUS` — and the cluster runs `allow.everyone.if.no.acl.found: "false"`
+# (components/kafka/kafka.yaml), which denies that principal on every resource. Measured on the
+# live sandbox 2026-08-03: the broker authorizer logs
+# `Principal = User:ANONYMOUS is Denied operation = DESCRIBE from host = 10.80.86.183 … based on
+# rule DefaultDeny` once per 30s metadata poll (that host is the kafka-ui pod). Unlike
+# security-scanner — which had never *tried* to publish — kafka-ui is the one workload that was
+# genuinely talking to :9092 and being refused on every single request.
+#
+# The reason nobody noticed for months is the UI's own failure mode: a refused DESCRIBE comes back
+# as an empty topic/group list, and kafka-ui renders that as a cluster with no topics rather than
+# as an error. "Broken" and "quiet weekend" look identical on the screen.
+#
+# ACL SCOPE — why a browsing console needs far more than a producer
+# A service's KafkaUser names the handful of topics its `application.yaml` declares. A cluster
+# browser has no such list: its job is to enumerate whatever exists. So the grants are shaped by
+# what each screen calls, not by a topic inventory:
+#
+#   cluster  Describe        → broker list, cluster id, controller (AdminClient.describeCluster)
+#   cluster  DescribeConfigs → the Brokers ▸ Configs tab (AdminClient.describeConfigs on BROKER)
+#   topic *  Describe        → the topic list itself, partitions, leaders, offsets. This is the
+#                              operation that was being denied every 30s.
+#   topic *  DescribeConfigs → the Topics ▸ Settings tab (retention, cleanup.policy, …)
+#   topic openbank.* Read    → the Messages tab. Read is a FULL DATA GRANT, so it is the one thing
+#                              here that is scoped rather than wildcarded (see below).
+#   group *  Describe        → the Consumers screen and every lag figure. Lag needs both the group
+#                              offsets (group Describe) and the log-end offsets (topic Describe).
+#   group kafka-ui-* Read    → kafka-ui's own throwaway consumers when previewing messages. It
+#                              browses with `assign()`, which needs no group coordination, but it
+#                              still sets a `group.id`; granting Read on its own prefix covers the
+#                              path without betting on an implementation detail of v0.7.2.
+#
+# Read is granted on `openbank.` (prefix) and NOT on `*`. Two reasons, both deliberate:
+#   * Read on `*` would include `__consumer_offsets` and `__transaction_state`. Nobody browses
+#     those, and `__consumer_offsets` is the raw commit log of every consumer in the fleet.
+#   * The pod runs `AUTH_TYPE: DISABLED` (no app-layer auth; the NetworkPolicy admitting only the
+#     admin-ui namespace is the whole access control). Read on the business topics therefore means
+#     "anything that reaches this pod can read every domain event, including money-path payloads".
+#     That is a real widening of what this console can see versus today, where it can see nothing —
+#     it is the price of a working Messages tab, and it should be a conscious price. Cutting Read
+#     entirely still leaves a fully working topic/group/lag browser; that is the fallback if the
+#     exposure is judged too wide.
+#
+# NOT granted, on purpose: Write, Create, Delete, Alter, AlterConfigs and IdempotentWrite on any
+# resource, ClusterAction on the cluster, and Delete on any group (that is kafka-ui's "reset
+# offsets" / "delete group" action — a live mutation of another service's consumption). The
+# Deployment also gains `KAFKA_CLUSTERS_0_READONLY: "true"` so the UI hides those buttons instead
+# of offering them and failing with an authorization error, which is a worse way to learn the same
+# thing.
+---
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaUser
+metadata:
+  annotations:
+    # Certs (KafkaUser -> Strimzi secret -> ESO projection) must land before the Deployment rolls
+    # the pod onto mTLS; lower waves sync first and ArgoCD blocks on the ExternalSecrets below
+    # reaching SecretSynced.
+    argocd.argoproj.io/sync-wave: "-2"
+  name: kafka-ui
+  namespace: messaging
+  labels:
+    strimzi.io/cluster: openbank-cluster
+spec:
+  authentication:
+    type: tls
+  authorization:
+    type: simple
+    acls:
+      # Broker/cluster metadata: the Brokers screen, the cluster id, the controller.
+      - resource:
+          type: cluster
+        operations: [Describe, DescribeConfigs]
+        host: "*"
+      # Enumerate every topic — a browser cannot be given a topic list up front. This is the
+      # operation the broker was denying once per poll.
+      - resource:
+          type: topic
+          name: "*"
+          patternType: literal
+        operations: [Describe, DescribeConfigs]
+        host: "*"
+      # Message preview, business topics only. Deliberately not `*` — see the header.
+      - resource:
+          type: topic
+          name: openbank.
+          patternType: prefix
+        operations: [Read]
+        host: "*"
+      # The Consumers screen: group membership, committed offsets, lag.
+      - resource:
+          type: group
+          name: "*"
+          patternType: literal
+        operations: [Describe]
+        host: "*"
+      # kafka-ui's own ephemeral browsing consumers.
+      - resource:
+          type: group
+          name: kafka-ui-
+          patternType: prefix
+        operations: [Read, Describe]
+        host: "*"
+---
+# Projects the Strimzi-minted keystore secret (messaging/kafka-ui) into a secret the Deployment
+# mounts. kafka-ui is the FIRST mTLS client that already lives in `messaging`, so this projection
+# does not cross a namespace boundary the way every other one does, and mounting the Strimzi
+# secret directly would work. It goes through ESO anyway on purpose: `eso-kafka-cert-reader`'s
+# resourceNames list is the repo's inventory of who holds a Kafka client cert, and
+# `check-kafka-cert-reader-grant.py` (gate kafka-cert-reader-grant, enforced) derives that
+# inventory from the ExternalSecrets. A direct mount would make kafka-ui the one cert consumer
+# invisible to it — the same "the list is short, so the gate reads as passing" shape that check
+# exists to retire.
+#
+# The `kafka-ui` entry in that Role's resourceNames
+# (components/payments/kafka-scheme-accepted-acl.yaml) is what makes this readable; omitting it is
+# the #2749/#2872 failure — the ExternalSecret sits at SecretSyncedError, ArgoCD never advances
+# past sync-wave -1, and no pod is ever created.
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+  name: kafka-ui-kafka-keystore
+  namespace: messaging
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: kafka-messaging-certs
+  target:
+    name: kafka-ui-kafka-keystore
+    creationPolicy: Owner
+    deletionPolicy: Retain
+  dataFrom:
+    - extract:
+        key: kafka-ui
+---
+# Projects the cluster CA truststore (messaging/openbank-cluster-cluster-ca-cert) under the
+# `kafka-cluster-ca-truststore` name every other client's Deployment already uses. Shared pattern
+# with every other mTLS client.
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+  name: kafka-cluster-ca-truststore
+  namespace: messaging
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: kafka-messaging-certs
+  target:
+    name: kafka-cluster-ca-truststore
+    creationPolicy: Owner
+    deletionPolicy: Retain
+  dataFrom:
+    - extract:
+        key: openbank-cluster-cluster-ca-cert

--- a/openbank-infra/gitops/components/kafka/kafka-ui.yaml
+++ b/openbank-infra/gitops/components/kafka/kafka-ui.yaml
@@ -6,6 +6,14 @@
 # policy (kyverno or future NetworkPolicy) restricts access to the messaging
 # namespace + admin-ui pod; this matches the posture of Apicurio registry
 # (also internal-only, no app-layer auth).
+#
+# Kafka side: mTLS on :9093 as `User:kafka-ui` (ADR-0137, issue #3393). Identity and the ACL
+# reasoning are in kafka-ui-mtls.yaml. Until 2026-08-03 this pointed at the anonymous plaintext
+# listener :9092 and every request was refused — `Principal = User:ANONYMOUS is Denied operation =
+# DESCRIBE … based on rule DefaultDeny`, once per 30s poll — which the UI renders as a cluster with
+# no topics rather than as an error. Note that the ACLs deliberately stop short of anything
+# destructive, so the UI is also pinned READONLY below: an offered button that fails with an
+# authorization error is a worse way to learn that than a button that is not offered.
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -40,9 +48,40 @@ spec:
             - name: KAFKA_CLUSTERS_0_NAME
               value: openbank
             - name: KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS
-              value: openbank-cluster-kafka-bootstrap.messaging.svc:9092
+              value: openbank-cluster-kafka-bootstrap.messaging.svc:9093
             - name: KAFKA_CLUSTERS_0_SCHEMAREGISTRY
               value: http://apicurio-registry.messaging.svc:8080/apis/ccompat/v6
+            # Everything under KAFKA_CLUSTERS_0_PROPERTIES_* is passed verbatim to the underlying
+            # Kafka AdminClient/Consumer (Spring relaxed binding turns the underscores into the
+            # dots of a real client property: …_SECURITY_PROTOCOL -> `security.protocol`). That is
+            # the same mechanism kafka-ui's own SASL/MSK docs use, and it is why the keystore is
+            # configured here rather than through the cluster-level `ssl.*` block, whose shape has
+            # moved between 0.x releases.
+            - name: KAFKA_CLUSTERS_0_PROPERTIES_SECURITY_PROTOCOL
+              value: SSL
+            - name: KAFKA_CLUSTERS_0_PROPERTIES_SSL_KEYSTORE_LOCATION
+              value: /mnt/kafka-keystore/user.p12
+            - name: KAFKA_CLUSTERS_0_PROPERTIES_SSL_KEYSTORE_TYPE
+              value: PKCS12
+            - name: KAFKA_CLUSTERS_0_PROPERTIES_SSL_KEYSTORE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: kafka-ui-kafka-keystore
+                  key: user.password
+            - name: KAFKA_CLUSTERS_0_PROPERTIES_SSL_TRUSTSTORE_LOCATION
+              value: /mnt/kafka-truststore/ca.p12
+            - name: KAFKA_CLUSTERS_0_PROPERTIES_SSL_TRUSTSTORE_TYPE
+              value: PKCS12
+            - name: KAFKA_CLUSTERS_0_PROPERTIES_SSL_TRUSTSTORE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: kafka-cluster-ca-truststore
+                  key: ca.password
+            # Matches the ACL set (no Write/Create/Delete/Alter anywhere, no group Delete): the UI
+            # hides topic creation, message production and offset resets instead of offering them
+            # and failing at the broker.
+            - name: KAFKA_CLUSTERS_0_READONLY
+              value: "true"
             - name: DYNAMIC_CONFIG_ENABLED
               value: "false"
             - name: AUTH_TYPE
@@ -71,6 +110,24 @@ spec:
             capabilities:
               drop:
                 - ALL
+          volumeMounts:
+            # Deliberately NOT `optional: true`: if the ESO projection has not landed, the pod must
+            # stay at ContainerCreating rather than boot and fall back to a plaintext-shaped client
+            # that renders an empty cluster — which is precisely the failure this change exists to
+            # end (openbank-infra CLAUDE.md, the #1284 trade).
+            - name: kafka-keystore
+              mountPath: /mnt/kafka-keystore
+              readOnly: true
+            - name: kafka-truststore
+              mountPath: /mnt/kafka-truststore
+              readOnly: true
+      volumes:
+        - name: kafka-keystore
+          secret:
+            secretName: kafka-ui-kafka-keystore
+        - name: kafka-truststore
+          secret:
+            secretName: kafka-cluster-ca-truststore
 ---
 apiVersion: v1
 kind: Service

--- a/openbank-infra/gitops/components/kafka/kafka.yaml
+++ b/openbank-infra/gitops/components/kafka/kafka.yaml
@@ -3,7 +3,8 @@
 # (controller+broker) for FinOps; prod should split roles and raise replicas to
 # 3 with matching replication factors. Kafka version is intentionally omitted so
 # the operator pins its own supported default. Bootstrap Service for clients:
-# `openbank-cluster-kafka-bootstrap.messaging.svc:9092` (internal plaintext).
+# `openbank-cluster-kafka-bootstrap.messaging.svc:9093` (internal mTLS — the only
+# listener; the plaintext :9092 one was removed in #3393).
 apiVersion: kafka.strimzi.io/v1
 kind: KafkaNodePool
 metadata:
@@ -71,10 +72,11 @@ spec:
     # domestic-payment's own event topic had no Write grant and 13 outbox rows
     # went DEAD before anyone looked (#3271).
     #
-    # ACLs bind to the authenticated principal, not the listener, so the
-    # plaintext listener below grants nothing: an unauthenticated client is
-    # `User:ANONYMOUS`, which holds no ACL anywhere and is denied on every
-    # resource (`… is Denied … based on rule DefaultDeny` in the broker log).
+    # ACLs bind to the authenticated principal, not the listener. That is why the
+    # plaintext listener that used to sit below granted nothing while it existed —
+    # an unauthenticated client is `User:ANONYMOUS`, which holds no ACL anywhere and
+    # is denied on every resource (`… is Denied … based on rule DefaultDeny` in the
+    # broker log) — and why removing it (#3393) changed no principal's authority.
     authorization:
       type: simple
     # Broker-layer observability (Dynatrace-parity #0). Strimzi's bundled JMX
@@ -89,33 +91,34 @@ spec:
           name: kafka-metrics
           key: kafka-metrics-config.yml
     listeners:
-      # Anonymous plaintext listener — retained for backward compatibility.
+      # There is no `plain` (9092) listener any more — runbook 0008's last step, done
+      # here (#3393). What used to sit here was an anonymous plaintext listener kept
+      # "for backward compatibility" with a comment claiming all 33 clients had already
+      # migrated. That claim was false, and the listener granted nothing anyway: a
+      # client on it is `User:ANONYMOUS`, which holds no ACL and is denied on every
+      # resource by the deny-by-default config below. "Still on 9092" and "cannot use
+      # Kafka" were the same statement — which is exactly why it had to go: it was an
+      # entry point that could only ever produce silent failures.
       #
-      # It grants NOTHING: a client here is `User:ANONYMOUS`, which holds no ACL
-      # and is denied on every resource by the deny-by-default config below. So
-      # "still on 9092" and "cannot use Kafka" are the same statement, and it is
-      # not a hole — but it is an entry point that only ever produces silent
-      # failures, which is why it should go.
+      # Measured on the live sandbox 2026-08-03 (#3393), three workloads still declared
+      # :9092, and each is resolved before this removal rather than by it:
+      #   * security-scanner-service — no KafkaUser at all; both topic log segments were
+      #     0 bytes and dated their creation day, so it had never published anything.
+      #     Given an identity and moved to :9093 in the parent change.
+      #   * kafka-ui — the ONLY thing actually sending on :9092, refused on every
+      #     request (`Principal = User:ANONYMOUS is Denied operation = DESCRIBE … based
+      #     on rule DefaultDeny`, once per 30s poll) and rendering that as an empty
+      #     cluster. Now `User:kafka-ui` on :9093 (components/kafka/kafka-ui-mtls.yaml).
+      #   * settlement-service — carried KAFKA_BOOTSTRAP_SERVERS with no `mp.messaging`
+      #     config and no Kafka client in its source at all; the env var was dead and is
+      #     deleted (components/payments/payments-services.yaml).
       #
-      # "All 33 deployed Kafka clients migrated to mTLS:9093 (ADR-0137 fleet
-      # sweep complete)" stood here and was NOT true. Measured on the live
-      # sandbox 2026-08-03 (#3393), three workloads still declared :9092:
-      #   * security-scanner-service — no KafkaUser at all; both topic log
-      #     segments are 0 bytes and dated their creation day, so it has never
-      #     published anything. Given an identity in this change.
-      #   * kafka-ui — the ONLY thing actually sending on :9092 today, and every
-      #     request is refused (`Principal = User:ANONYMOUS is Denied operation =
-      #     DESCRIBE … based on rule DefaultDeny`, once per 30s poll). The UI
-      #     renders an empty cluster rather than an error. Needs its own
-      #     KafkaUser before the listener can go (#3393 follow-up).
-      #   * settlement-service — carries KAFKA_BOOTSTRAP_SERVERS but has no
-      #     `mp.messaging` config and opens no connection; the env var is dead.
-      # Removing the listener is still a follow-up step (runbook 0008), and it is
-      # blocked on kafka-ui, not on the services.
-      - name: plain
-        port: 9092
-        type: internal
-        tls: false
+      # Strimzi rolls the broker to drop the listener. Anything that appears on :9092
+      # after this fails to CONNECT instead of authenticating as ANONYMOUS and being
+      # denied per request — a louder failure than the one being removed, which is the
+      # point. Rollback is re-adding the four lines; it restores connectivity but not
+      # authorization, so it is only ever worth doing to quiet a connection-error loop.
+      #
       # mTLS listener (ADR-0137). Clients presenting a cluster-CA-signed client
       # cert authenticate as the matching KafkaUser principal; this is what the
       # payment.scheme-accepted producers/consumer use so their ACLs apply.
@@ -136,14 +139,12 @@ spec:
       transaction.state.log.min.isr: 1
       default.replication.factor: 1
       min.insync.replicas: 1
-      # Cluster-wide authorization posture: deny-by-default for ALL topics.
-      # User:ANONYMOUS (plaintext) is denied on every topic including those
-      # without explicit ACLs — which is why a client left on :9092 does not
-      # merely lose its ACLs, it loses Kafka entirely (see the listener comment
-      # above for the three that were still there on 2026-08-03). Non-deployed
-      # services (card-issuance, sdd, standing-order, tpp-registry) are RBAC
-      # pre-registered and will receive gitops mTLS manifests before their first
-      # deploy.
+      # Cluster-wide authorization posture: deny-by-default for ALL topics. A
+      # topic with no ACL is denied to every principal, so this stays load-bearing
+      # now that mTLS is the only way in: it is what makes an unlisted topic a
+      # denial rather than a default-open. Non-deployed services (card-issuance,
+      # sdd, standing-order, tpp-registry) are RBAC pre-registered and will
+      # receive gitops mTLS manifests before their first deploy.
       allow.everyone.if.no.acl.found: "false"
   # Consumer-lag visibility (Dynatrace-parity #0). The Kafka Exporter is a
   # separate pod (also on `tcp-prometheus`:9404) that turns consumer group

--- a/openbank-infra/gitops/components/kafka/kafka.yaml
+++ b/openbank-infra/gitops/components/kafka/kafka.yaml
@@ -59,15 +59,22 @@ spec:
     # ADR-0137 mTLS migration). KRaft inter-broker comms use the managed
     # controller listener and are unaffected by SimpleAuthorizer.
     #
-    # Enforcement model (ADR-0137): SimpleAuthorizer is *deny-by-default per
-    # resource that carries any ACL*, and *allow-everyone* only for resources
-    # with NO ACL (because allow.everyone.if.no.acl.found=true below). So a
-    # single topic can be locked down — `payment.scheme-accepted` (the money
-    # path) — by attaching ACLs to it, WITHOUT touching the other ~30 topics
-    # that have none. ACLs bind to the authenticated principal, not the
-    # listener, so the plaintext listener below does not weaken a locked topic:
-    # an unauthenticated client is `User:ANONYMOUS`, which is absent from the
-    # scheme-accepted ACLs and therefore denied.
+    # Enforcement model: SimpleAuthorizer is deny-by-default for EVERY resource,
+    # because `allow.everyone.if.no.acl.found: "false"` below (#2794). A topic
+    # with no ACL at all is therefore denied to everyone, not open — so every
+    # client needs a KafkaUser whose ACLs name every topic it touches.
+    #
+    # This comment previously described the opposite model ("allow-everyone only
+    # for resources with NO ACL, because allow.everyone.if.no.acl.found=true
+    # below"), which had been false since #2794 flipped the flag. That stale
+    # prose is what made a set of missing producer grants read as deliberate:
+    # domestic-payment's own event topic had no Write grant and 13 outbox rows
+    # went DEAD before anyone looked (#3271).
+    #
+    # ACLs bind to the authenticated principal, not the listener, so the
+    # plaintext listener below grants nothing: an unauthenticated client is
+    # `User:ANONYMOUS`, which holds no ACL anywhere and is denied on every
+    # resource (`… is Denied … based on rule DefaultDeny` in the broker log).
     authorization:
       type: simple
     # Broker-layer observability (Dynatrace-parity #0). Strimzi's bundled JMX
@@ -83,8 +90,28 @@ spec:
           key: kafka-metrics-config.yml
     listeners:
       # Anonymous plaintext listener — retained for backward compatibility.
-      # All 33 deployed Kafka clients migrated to mTLS:9093 (ADR-0137 fleet
-      # sweep complete). Removing the listener is a follow-up step (runbook 0008).
+      #
+      # It grants NOTHING: a client here is `User:ANONYMOUS`, which holds no ACL
+      # and is denied on every resource by the deny-by-default config below. So
+      # "still on 9092" and "cannot use Kafka" are the same statement, and it is
+      # not a hole — but it is an entry point that only ever produces silent
+      # failures, which is why it should go.
+      #
+      # "All 33 deployed Kafka clients migrated to mTLS:9093 (ADR-0137 fleet
+      # sweep complete)" stood here and was NOT true. Measured on the live
+      # sandbox 2026-08-03 (#3393), three workloads still declared :9092:
+      #   * security-scanner-service — no KafkaUser at all; both topic log
+      #     segments are 0 bytes and dated their creation day, so it has never
+      #     published anything. Given an identity in this change.
+      #   * kafka-ui — the ONLY thing actually sending on :9092 today, and every
+      #     request is refused (`Principal = User:ANONYMOUS is Denied operation =
+      #     DESCRIBE … based on rule DefaultDeny`, once per 30s poll). The UI
+      #     renders an empty cluster rather than an error. Needs its own
+      #     KafkaUser before the listener can go (#3393 follow-up).
+      #   * settlement-service — carries KAFKA_BOOTSTRAP_SERVERS but has no
+      #     `mp.messaging` config and opens no connection; the env var is dead.
+      # Removing the listener is still a follow-up step (runbook 0008), and it is
+      # blocked on kafka-ui, not on the services.
       - name: plain
         port: 9092
         type: internal
@@ -110,11 +137,13 @@ spec:
       default.replication.factor: 1
       min.insync.replicas: 1
       # Cluster-wide authorization posture: deny-by-default for ALL topics.
-      # All 33 deployed Kafka clients migrated to mTLS:9093 (ADR-0137 fleet
-      # sweep complete). User:ANONYMOUS (plaintext) is now denied on every topic
-      # including those without explicit ACLs. Non-deployed services
-      # (card-issuance, sdd, standing-order, tpp-registry) are RBAC pre-registered
-      # and will receive gitops mTLS manifests before their first deploy.
+      # User:ANONYMOUS (plaintext) is denied on every topic including those
+      # without explicit ACLs — which is why a client left on :9092 does not
+      # merely lose its ACLs, it loses Kafka entirely (see the listener comment
+      # above for the three that were still there on 2026-08-03). Non-deployed
+      # services (card-issuance, sdd, standing-order, tpp-registry) are RBAC
+      # pre-registered and will receive gitops mTLS manifests before their first
+      # deploy.
       allow.everyone.if.no.acl.found: "false"
   # Consumer-lag visibility (Dynatrace-parity #0). The Kafka Exporter is a
   # separate pod (also on `tcp-prometheus`:9404) that turns consumer group

--- a/openbank-infra/gitops/components/kafka/network-policies.yaml
+++ b/openbank-infra/gitops/components/kafka/network-policies.yaml
@@ -140,7 +140,7 @@ spec:
               kubernetes.io/metadata.name: tpp-registry
       ports:
         - protocol: TCP
-          port: 9092
+          port: 9093
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/openbank-infra/gitops/components/payments/kafka-scheme-accepted-acl.yaml
+++ b/openbank-infra/gitops/components/payments/kafka-scheme-accepted-acl.yaml
@@ -13,9 +13,9 @@
 # Identity model (ADR-0137): mTLS gives each *service* exactly one client cert =
 # one KafkaUser = one principal for ALL of its Kafka traffic, so KafkaUsers are
 # named after the service, not after a per-topic role. A KafkaUser's ACLs list
-# everything that service may do on the ACL'd resources; resources without ACLs
-# stay open under allow.everyone.if.no.acl.found=true (see kafka.yaml), so each
-# service needs an ACL for EVERY topic it touches. This comment used to say the
+# everything that service may do, and a resource with NO matching ACL is DENIED to
+# every principal (see kafka.yaml), so each service needs an ACL for EVERY topic it
+# touches. This comment used to say the
 # opposite — that resources without ACLs "stay open under
 # allow.everyone.if.no.acl.found=true", so a service's own domain-event topics
 # needed none. That was true until #2794 flipped the cluster to
@@ -432,6 +432,7 @@ rules:
       - analytics-sink                  # ADR-0022/0069: analytics bronze consumer (party/kyc/consent/sca/documents/onboarding-funnel), ns analytics (first ESO client there)
       - campaign-service                # ADR-0200: campaign journey delivery requests, ns campaign (first ESO client there); missing entry blocked the whole sandbox rollout at sync-wave -1 (#2749)
       - delegation-service              # ADR-0232: grant lifecycle producer, ns delegation (first ESO client there); same #2749 failure, observed again — the keystore ExternalSecret sat at SecretSyncedError and ArgoCD never advanced past sync-wave -1, so all 11 wave-0 resources stayed OutOfSync and no pod was ever created
+      - security-scanner                # issue #3393: last fleet workload without a KafkaUser — scan-event + ICT-incident producer, ns security-scanner (first ESO client there)
       - openbank-cluster-cluster-ca-cert
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/openbank-infra/gitops/components/payments/kafka-scheme-accepted-acl.yaml
+++ b/openbank-infra/gitops/components/payments/kafka-scheme-accepted-acl.yaml
@@ -433,6 +433,7 @@ rules:
       - campaign-service                # ADR-0200: campaign journey delivery requests, ns campaign (first ESO client there); missing entry blocked the whole sandbox rollout at sync-wave -1 (#2749)
       - delegation-service              # ADR-0232: grant lifecycle producer, ns delegation (first ESO client there); same #2749 failure, observed again — the keystore ExternalSecret sat at SecretSyncedError and ArgoCD never advanced past sync-wave -1, so all 11 wave-0 resources stayed OutOfSync and no pod was ever created
       - security-scanner                # issue #3393: last fleet workload without a KafkaUser — scan-event + ICT-incident producer, ns security-scanner (first ESO client there)
+      - kafka-ui                        # issue #3393: the cluster-browsing console, and the only workload that was actually SPEAKING on :9092 — every DESCRIBE denied as User:ANONYMOUS. Unusually, it runs IN `messaging`, so this projection does not cross a namespace; it goes through ESO anyway to stay in this inventory (see components/kafka/kafka-ui-mtls.yaml)
       - openbank-cluster-cluster-ca-cert
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/openbank-infra/gitops/components/payments/payments-services.yaml
+++ b/openbank-infra/gitops/components/payments/payments-services.yaml
@@ -2224,8 +2224,13 @@ spec:
             # enough; safe to leave briefly, repair is a no-op once checksums already match).
             - name: QUARKUS_FLYWAY_REPAIR_AT_START
               value: "true"
-            - name: KAFKA_BOOTSTRAP_SERVERS
-              value: openbank-cluster-kafka-bootstrap.messaging.svc:9092
+            # `KAFKA_BOOTSTRAP_SERVERS: …:9092` stood here and was dead (issue #3393):
+            # openbank-settlement-service has no `mp.messaging` config and no Kafka client
+            # anywhere under src/main, so it opened no connection and the value was never read.
+            # It mattered only because it made settlement-service read as a plaintext-listener
+            # client in every audit of who is still on :9092 — including
+            # `gen-network-policies.py`, which derives the broker allow-list from exactly this
+            # kind of env URL and so admitted `payments` on 9092 partly on its account.
             - name: QUARKUS_OIDC_AUTH_SERVER_URL
               value: http://keycloak.iam.svc:8080/realms/openbank
             - name: OIDC_CLIENT_SECRET

--- a/openbank-infra/gitops/components/security-scanner/kafka-security-scanner-mtls.yaml
+++ b/openbank-infra/gitops/components/security-scanner/kafka-security-scanner-mtls.yaml
@@ -1,0 +1,110 @@
+# Kafka mTLS identity for security-scanner (ADR-0137; issue #3393)
+#
+# WHY THIS FILE EXISTS
+# security-scanner was the last openbank service with NO KafkaUser. Both of its producers
+# pointed at the anonymous plaintext listener `…:9092`, so they authenticated as
+# `User:ANONYMOUS` — and the cluster runs `allow.everyone.if.no.acl.found: "false"`
+# (components/kafka/kafka.yaml), which denies that principal on every resource. Measured on the
+# live sandbox 2026-08-03: both topic log segments under
+# `/var/lib/kafka/data-0/kafka-log0/openbank.security.{scan.event,ict.incident}-0/` are
+# **0 bytes** and dated the day the topics were created, and the broker's authorizer logs
+# `Principal = User:ANONYMOUS is Denied … based on rule DefaultDeny` for every ANONYMOUS request
+# on :9092. Nothing has ever been published on either topic.
+#
+# The denial was never observed because the scanner has also never *tried*: nothing writes to
+# `security_outbox` (`SecurityOutboxRepositoryImpl.persistInTransaction` has no caller), so the
+# 5s dispatcher drains an empty table, and the one live produce path — `IctIncidentService`, on
+# `POST /api/v1/ict-incidents` — is only exercised by a human. That is the whole reason this is
+# being fixed BEFORE a producer starts working rather than after: the first real publish would
+# be denied, and the dispatcher swallows the failure (see below).
+#
+# IDENTITY MODEL (ADR-0137)
+# One client cert = one KafkaUser = one principal for all of a service's Kafka traffic. The
+# scanner has two `outgoing` channels and no `incoming` ones, so it needs Write+Describe on the
+# two topics its `application.yaml` names, and no consumer-group ACL.
+#
+# The name `security-scanner` is not cosmetic: `.github/scripts/check-kafka-acl-coverage.py`
+# matches a KafkaUser to a service by that name (module `openbank-security-scanner` minus the
+# prefix), and only a matching name makes the ACLs checkable at all — without it the service is
+# reported as an unverifiable `::notice::`, which is what it was until now.
+---
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaUser
+metadata:
+  annotations:
+    # Certs (KafkaUser -> Strimzi secret -> ESO projection) must land before the Deployment
+    # rolls the pod onto mTLS; lower waves sync first and ArgoCD blocks on the ExternalSecrets
+    # below reaching SecretSynced.
+    argocd.argoproj.io/sync-wave: "-2"
+  name: security-scanner
+  namespace: messaging
+  labels:
+    strimzi.io/cluster: openbank-cluster
+spec:
+  authentication:
+    type: tls
+  authorization:
+    type: simple
+    acls:
+      # mp.messaging.outgoing.security-events-out.topic — periodic scan verdicts.
+      - resource:
+          type: topic
+          name: openbank.security.scan.event
+          patternType: literal
+        operations: [Write, Describe]
+        host: "*"
+      # mp.messaging.outgoing.ict-incident-events-out.topic — DORA ICT incidents.
+      - resource:
+          type: topic
+          name: openbank.security.ict.incident
+          patternType: literal
+        operations: [Write, Describe]
+        host: "*"
+---
+# Projects the Strimzi-minted keystore secret (messaging/security-scanner) into the
+# security-scanner namespace so the pod volume can reference it directly. This is the FIRST ESO
+# client in this namespace, so the `security-scanner` entry added to the `eso-kafka-cert-reader`
+# Role's `resourceNames` (components/payments/kafka-scheme-accepted-acl.yaml) is what makes it
+# readable — omitting it is the #2749/#2872 failure: the ExternalSecret sits at
+# SecretSyncedError, ArgoCD never advances past sync-wave -1, and no pod is ever created.
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+  name: security-scanner-kafka-keystore
+  namespace: security-scanner
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: kafka-messaging-certs
+  target:
+    name: security-scanner-kafka-keystore
+    creationPolicy: Owner
+    deletionPolicy: Retain
+  dataFrom:
+    - extract:
+        key: security-scanner
+---
+# Projects the cluster CA truststore (messaging/openbank-cluster-cluster-ca-cert) into the
+# security-scanner namespace. Shared pattern with every other mTLS client.
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+  name: kafka-cluster-ca-truststore
+  namespace: security-scanner
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: kafka-messaging-certs
+  target:
+    name: kafka-cluster-ca-truststore
+    creationPolicy: Owner
+    deletionPolicy: Retain
+  dataFrom:
+    - extract:
+        key: openbank-cluster-cluster-ca-cert

--- a/openbank-infra/gitops/components/security-scanner/security-scanner-service.yaml
+++ b/openbank-infra/gitops/components/security-scanner/security-scanner-service.yaml
@@ -64,8 +64,36 @@ spec:
                 secretKeyRef:
                   name: security-scanner-db-app
                   key: password
+            # ADR-0137 / issue #3393: the mTLS listener :9093, NOT the anonymous
+            # plaintext :9092 this used to name. On :9092 the producers authenticated as
+            # `User:ANONYMOUS`, and the cluster runs allow.everyone.if.no.acl.found=false,
+            # so every publish would be denied on every topic. Nothing ever surfaced it
+            # because nothing has ever published: both topic log segments were 0 bytes on
+            # 2026-08-03, nothing writes to `security_outbox`, and the one live produce
+            # path (IctIncidentService, POST /api/v1/ict-incidents) is human-triggered.
+            # Identity + ACLs: kafka-security-scanner-mtls.yaml (KafkaUser `security-scanner`).
             - name: KAFKA_BOOTSTRAP_SERVERS
-              value: openbank-cluster-kafka-bootstrap.messaging.svc:9092
+              value: openbank-cluster-kafka-bootstrap.messaging.svc:9093
+            - name: KAFKA_SECURITY_PROTOCOL
+              value: SSL
+            - name: KAFKA_SSL_KEYSTORE_LOCATION
+              value: /mnt/kafka-keystore/user.p12
+            - name: KAFKA_SSL_KEYSTORE_TYPE
+              value: PKCS12
+            - name: KAFKA_SSL_KEYSTORE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: security-scanner-kafka-keystore
+                  key: user.password
+            - name: KAFKA_SSL_TRUSTSTORE_LOCATION
+              value: /mnt/kafka-truststore/ca.p12
+            - name: KAFKA_SSL_TRUSTSTORE_TYPE
+              value: PKCS12
+            - name: KAFKA_SSL_TRUSTSTORE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: kafka-cluster-ca-truststore
+                  key: ca.password
             # `QUARKUS_OIDC_ENABLED=false` used to sit here and did NOTHING: quarkus.oidc.enabled
             # is a BUILD-TIME property, so setting it through the environment cannot switch OIDC
             # off in an already-built image. It read as "auth is off for this service" while the
@@ -166,6 +194,16 @@ spec:
           volumeMounts:
             - name: tmp
               mountPath: /tmp
+            # Deliberately NOT `optional: true`: if the ESO projection has not landed, the
+            # pod must stay at ContainerCreating rather than boot and fall back to a
+            # plaintext-shaped client that silently publishes nothing (openbank-infra
+            # CLAUDE.md, the #1284 trade). A stalled pod is the loud failure we want here.
+            - name: kafka-keystore
+              mountPath: /mnt/kafka-keystore
+              readOnly: true
+            - name: kafka-truststore
+              mountPath: /mnt/kafka-truststore
+              readOnly: true
           resources:
             requests:
               cpu: 250m
@@ -176,6 +214,12 @@ spec:
       volumes:
         - name: tmp
           emptyDir: {}
+        - name: kafka-keystore
+          secret:
+            secretName: security-scanner-kafka-keystore
+        - name: kafka-truststore
+          secret:
+            secretName: kafka-cluster-ca-truststore
 ---
 apiVersion: v1
 kind: Service

--- a/openbank-infra/scripts/gen-network-policies.py
+++ b/openbank-infra/scripts/gen-network-policies.py
@@ -174,7 +174,16 @@ def main():
     edge_ports = defaultdict(set)  # (callee_ns, callee_svc) -> ports
     ingress_backends = defaultdict(set)  # (ns, svc-name) -> ports
     http_scaled_targets = set()  # (ns, app.kubernetes.io/name) fronted by an HTTPScaledObject
-    kafka_clients = set()
+    # ns -> the broker ports that namespace's clients actually name in their bootstrap URLs.
+    # The port is DERIVED rather than hardcoded (#3393): this rule used to emit a literal
+    # `port: 9092` for every client while 35 of 37 bootstrap URLs said 9093, so the allow-list
+    # named the right namespaces on the wrong port. It only ever looked like it worked because
+    # Strimzi's own `openbank-cluster-network-policy-kafka` opens both ports with no `from`
+    # selector and NetworkPolicies union — the same blanket policy this file's ConfigMap note
+    # already admits it is riding on. Hardcoding a port here is therefore a defect that cannot
+    # show up until the day that blanket policy is tightened, which is when the whole fleet's
+    # Kafka traffic would drop at once.
+    kafka_client_ports = defaultdict(set)
     # components/<dir> that declares the Strimzi `Kafka` CR — the broker pods are
     # operator-managed (no Deployment), so the derived broker policy has no workload
     # directory of its own to inherit.
@@ -215,7 +224,7 @@ def main():
                     edge_ports[(callee_ns, svc)].add(int(port))
             for _, kns, kport in KAFKA_RE.findall(blob):
                 if kns == MESSAGING_NS:
-                    kafka_clients.add(ns)
+                    kafka_client_ports[ns].add(int(kport))
 
         elif kind == "ConfigMap" and ns:
             # A Kafka client edge is NOT always visible in Deployment env (issue #2163).
@@ -240,9 +249,9 @@ def main():
             for v in (doc.get("data") or {}).values():
                 if not isinstance(v, str):
                     continue
-                for _, kns, _kport in KAFKA_RE.findall(v):
+                for _, kns, kport in KAFKA_RE.findall(v):
                     if kns == MESSAGING_NS:
-                        kafka_clients.add(ns)
+                        kafka_client_ports[ns].add(int(kport))
 
         elif kind == "Kafka" and ns == MESSAGING_NS:
             kafka_dir = os.path.dirname(path)
@@ -440,7 +449,16 @@ def main():
         })
 
     # ── Strimzi broker: derived client set on the client listener ───────────
-    if kafka_clients:
+    if kafka_client_ports:
+        # One rule per broker port, listing the namespaces that name THAT port. Grouping this
+        # way keeps the allow-list honest in both directions: a namespace on 9093 is not
+        # admitted to 9092, and a port no client names produces no rule at all — so the plain
+        # listener's removal (#3393) empties itself out of this file instead of leaving a rule
+        # nobody notices is stale.
+        ports_to_clients = defaultdict(set)
+        for client_ns, ports in kafka_client_ports.items():
+            for port in ports:
+                ports_to_clients[port].add(client_ns)
         by_dir[kafka_dir or ns_dir.get(MESSAGING_NS)].append({
             "apiVersion": "networking.k8s.io/v1",
             "kind": "NetworkPolicy",
@@ -459,10 +477,13 @@ def main():
                 "policyTypes": ["Ingress"],
                 "ingress": [
                     {"from": [{"podSelector": {}}]},  # operator/entity/kafka-ui
-                    {
-                        "from": [ns_peer(c) for c in sorted(kafka_clients)],
-                        "ports": [{"protocol": "TCP", "port": 9092}],
-                    },
+                    *[
+                        {
+                            "from": [ns_peer(c) for c in sorted(ports_to_clients[port])],
+                            "ports": [{"protocol": "TCP", "port": port}],
+                        }
+                        for port in sorted(ports_to_clients)
+                    ],
                 ],
             },
         })


### PR DESCRIPTION
## What this is

`security-scanner` gets a Kafka identity (`KafkaUser` + ACLs + ESO projection) and moves off the anonymous plaintext listener onto mTLS `:9093`, the shape every other client already uses.

Refs #3393.

## Real state, as MEASURED on the live sandbox (2026-08-03)

The issue's premise held on the important point and was wrong on two others. All of this was measured, not read off a manifest:

**The denial is real and total.** The broker logs, once per 30s:

```
Principal = User:ANONYMOUS is Denied operation = DESCRIBE from host = 10.80.86.183
  on resource = Cluster:LITERAL:kafka-cluster for request = DescribeLogDirs
  with resourceRefCount = 1 based on rule DefaultDeny
```

An ANONYMOUS metadata request on `:9092` returns **zero** topic-partitions — not "the two scanner topics are denied", *everything* is. `allow.everyone.if.no.acl.found: "false"` means a resource with no ACL is denied, not open.

**`security-scanner` has never published anything.** Ground truth, not inference — the on-disk log segments:

```
openbank.security.scan.event-0/00000000000000000000.log      0 bytes, Jun 4
openbank.security.ict.incident-0/00000000000000000000.log    0 bytes, Jun 4
```

**But not for the reason the issue gives.** #3350 has landed and is deployed (image `sandbox-9584ae90` is *after* `0a64027a1`); Flyway ran, `security_outbox` exists. The table is nonetheless **empty and always has been** — `SecurityOutboxRepositoryImpl.persistInTransaction` has **no caller anywhere in `src/main`**. So the dispatcher drains an empty table forever and never reaches the emitter. The one live produce path is `IctIncidentService` on `POST /api/v1/ict-incidents`, which is human-triggered. The scanner has not been silently denied — it has not tried.

**It is not the only workload on `:9092`.** Three are, and they differ:

| workload | on 9092 | actually sends? |
|---|---|---|
| `security-scanner-service` | yes | no — never has (this PR) |
| `kafka-ui` | yes | **yes, and every request is refused** — it is the `10.80.86.183` in the log above, and renders an empty cluster rather than an error |
| `payments/settlement-service` | yes | no — it has no `mp.messaging` config at all; the env var is dead |

**The issue's suggested verification does not work.** It proposes asserting a row leaves `security_outbox` with `sent_at` set. `SecurityOutboxDispatcher` wraps `emitter.send(...)` in `Uni.createFrom().item { … }`, which discards the returned `CompletionStage`, then chains `markSentUni` unconditionally. A denied publish would mark the row **SENT**. Verify on the broker side (topic offset / segment size), never on the outbox status.

## What changed

Two commits, deliberately separable — see the ordering section.

**Identity** (`b71dca0`) — changes no client behaviour:
- new `components/security-scanner/kafka-security-scanner-mtls.yaml`: `KafkaUser security-scanner` with `Write, Describe` on `openbank.security.scan.event` and `openbank.security.ict.incident` (the two topics `application.yaml` declares — two `outgoing` channels, no `incoming`, so no consumer-group ACL), plus the keystore + cluster-CA-truststore ExternalSecrets.
- `eso-kafka-cert-reader` Role `resourceNames` += `security-scanner`. This is the entry whose absence produced the #2749/#2872 failure twice: the ExternalSecret sits at `SecretSyncedError`, ArgoCD never advances past sync-wave -1, no pod is created.
- The user is named `security-scanner` (not `security-scanner-service`) because `check-kafka-acl-coverage.py` derives its match from the module name. That makes the ACLs *checkable*, which they were not: the service used to print as an unverifiable `::notice::`. The gate goes 88 → 90 pairs across 36 → 37 users, and the cert-reader gate 38 → 39, both clean, so **no baseline entry is needed in either**.

**Client** (`99b86d9`) — `KAFKA_BOOTSTRAP_SERVERS` → `:9093`, `KAFKA_SECURITY_PROTOCOL=SSL`, keystore/truststore env + mounts.

Neither secret ref is `optional: true`. Deliberate, per `openbank-infra/CLAUDE.md`: a missing projection must pin the pod at `ContainerCreating` (loud) rather than let it boot and silently publish nothing. This service is the argument for loud — it produced nothing for two months and no signal existed anywhere.

**Also corrected: the `allow.everyone.if.no.acl.found=true` claim, everywhere it still stood.** It has been false since #2794, and it is precisely what made a set of missing producer grants read as deliberate until 13 outbox rows went dead (#3271). Three copies survived that cleanup:
- `components/kafka/kafka.yaml` — the *authoritative* file, whose own `authorization:` block said "allow-everyone only for resources with NO ACL (because allow.everyone.if.no.acl.found=true below)" while the line 20 below it says `"false"`.
- `components/payments/kafka-scheme-accepted-acl.yaml` — the #3271 correction landed *underneath* the false sentence without deleting it, so the header stated the claim and then said "this comment used to say the opposite", quoting itself.
- `components/audit/kafka-audit-mtls.yaml` — twice, including a note asserting three topics "stay open under allow-everyone; no ACL change needed", which #3271 had already disproved by granting all three.

The `kafka.yaml` listener comment also claimed "All 33 deployed Kafka clients migrated to mTLS:9093 (ADR-0137 fleet sweep complete)". It now names the three that had not.

## Order an operator must apply this in

ArgoCD's sync-waves encode it (`KafkaUser` -2, `ExternalSecret`s -1, Deployment 0) — but the Role grant lives in a **different Application** (`payments`), so cross-app ordering is not guaranteed. Verify in order; do not skip to 4:

1. `kubectl -n messaging get role eso-kafka-cert-reader -o jsonpath='{.rules[0].resourceNames}'` contains `security-scanner`
2. `kubectl -n messaging get kafkauser security-scanner` is Ready **and** `kubectl -n messaging get secret security-scanner` exists — Strimzi's User Operator mints it on its own reconcile interval, not instantly
3. both ExternalSecrets in `ns/security-scanner` report `SecretSynced`
4. only then does the Deployment roll. **A pod at `ContainerCreating` means step 3 has not finished, not that this change is wrong** — wait, do not roll back

Verify the outcome on the **broker**, not the pod or the outbox: `POST /api/v1/ict-incidents`, then confirm `openbank.security.ict.incident-0/00000000000000000000.log` is no longer 0 bytes, and that no new `User:ANONYMOUS ... Denied` line names the scanner's pod IP.

Rollback = revert the second commit (`:9092`, no SSL). That restores the pre-change behaviour exactly, which is "connects and is denied everything".

## The plain listener stays — and here is what blocks removing it

Closing `:9092` **to security-scanner** is what this PR does. Removing the listener outright is not safe yet: `kafka-ui` still uses it, and it is the only thing actually sending there. It needs its own `KafkaUser` first (its consumer/describe surface is much wider than a producer's, so that is its own change with its own review). `settlement-service`'s env var is dead and can be deleted in passing by whoever does that. Tracked as the #3393 follow-up.

## Verification done here

- `check-kafka-acl-coverage.py --enforce` — clean, 90 pairs / 37 users, and **falsified in place**: renaming the ICT grant to a near-miss made it print the exact error naming `openbank.security.ict.incident` and exit 1; restored from a `cp` backup, back to exit 0. Its own `--selftest` passes.
- `check-kafka-cert-reader-grant.py --enforce` — clean, 39/39, both directions.
- `check-kafka-topics-exist.py` — 0 unresolved.
- `gen-network-policies.py` re-run: **no diff**. The derived broker allow-list keys on namespace, not port (it hardcodes 9092 for every client, including the 35 already on 9093 — a latent defect, not one this PR introduces or can fix).
- `run-gates.py --group gitops` — 19 PASS. The two non-passes are pre-existing and unrelated: `incluster-hostname-resolution` (advisory; 6 findings, none in any file here) and `loki-rule-load-test` (`BASE_REF: unbound variable`, a local-run artifact).

## What could still go wrong

- Strimzi could be slow to mint the secret and the pod sits at `ContainerCreating` for a few minutes. That is the designed failure and step 4 above says so, but an operator who reads it as breakage and reverts gets a service that is once again silently denied.
- The grant is correct for the topics `application.yaml` names **today**. A future producer that derives its topic in code is outside what `check-kafka-acl-coverage.py` can see, by that gate's own stated scope.
- This PR does not make the scanner publish. `security_outbox` still has no writer, so the scan-event topic stays empty until that is wired — the identity is now in place for when it is.
