### PR TITLE
feat(observability): add the cross-AZ/egress detector D2 that the finops rules claimed to have

### DIFF
--- a/openbank-infra/gitops/components/observability/prometheus-rules-finops.yaml
+++ b/openbank-infra/gitops/components/observability/prometheus-rules-finops.yaml
@@ -1,6 +1,9 @@
 # FinOps cost anomaly detection rules (ADR-0112). Five detectors correspond to the
 # recurring AWS cost incidents documented in the ADR: NAT drain, cross-AZ traffic,
 # Karpenter node churn, EBS attachment failures, and CI runner pool pressure.
+# That sentence was aspirational until #3496: D1, D3, D4 and D5 were here and D2 —
+# the cross-AZ one — was not, so the file described a detector nobody had written.
+# Count the `detector:` labels below, not this paragraph, when auditing coverage.
 # All alerts route to GoAlert (which triggers the finops-agent Temporal workflow).
 # The openbank.finops.ai-costs group used to live here, holding one alert:
 # FinOpsAgentTokenBudgetExceeded, written against langfuse_agent_tokens_total,
@@ -70,6 +73,74 @@ spec:
           annotations:
             summary: "NAT egress 2× rolling avg — {{ $labels.namespace }}"
             description: "{{ $labels.namespace }} current egress rate is {{ $value | humanizePercentage }} of its 7-day average. Possible overnight batch runaway. Note: subquery requires 7d of retention — alert may be absent on fresh clusters."
+            runbook: "https://github.com/JiRaska/open-bank-oss/blob/main/docs/runbooks/0006-nat-egress-drain.md"
+
+    - name: openbank.finops.fleet-egress
+      interval: 5m
+      rules:
+        # D2: fleet-wide node egress. The header of this file has claimed a cross-AZ
+        # detector since the file was written; there was no D2 rule in it until #3496.
+        # That is the failure class this repo keeps meeting — a detector that exists in
+        # the prose and not in the ruleset reads as covered on every dashboard that
+        # counts detectors, and D1 sitting next to it (which watches per-namespace pod
+        # egress, i.e. a different thing) made the gap harder to see, not easier.
+        #
+        # What it would have caught: EUN1-DataTransfer-Regional-Bytes stepped 11x on
+        # 2026-07-27 and held for six days at ~$33/day (~$809/mo), which was ~70% of the
+        # entire AWS bill for that window. Nothing alerted. It was found by hand while
+        # pricing an unrelated node-shape change, and the cause (#3278: Loki's PVC hit
+        # 100%, so every Alloy push was rejected and retried indefinitely from all ~23
+        # nodes) was diagnosed and fixed for other reasons a week later.
+        #
+        # Why fleet-total rather than per-node or per-namespace:
+        #   - per-namespace (D1) cannot see it. Alloy's retry traffic is one DaemonSet
+        #     whose per-namespace share stayed under D1's 50 GB/day bar while the fleet
+        #     total went to ~3600 GB/day.
+        #   - per-node cannot get a threshold. The incident put ordinary nodes at
+        #     100-315 GB/day, but registry-cache's node legitimately serves ~108 GB/day
+        #     today, so any per-node bar either misses the low end or pages on images.
+        #   - the incident was a per-node MULTIPLIER (every long-lived node stepped
+        #     15-20x on the same day), which is exactly what a fleet sum expresses.
+        #
+        # Threshold calibration, measured on THIS series (not on CloudWatch — the two
+        # do not agree and the alert can only read this one):
+        #   quiet fleet today ........................ ~330 GB/day
+        #   busiest normal CI day observed (07-25) ... ~385 GB/day equivalent
+        #   incident plateau ......................... ~1700 GB/day equivalent
+        # 800 GB/day sits >2x above the busiest healthy day and >2x below the plateau.
+        #
+        # The two "equivalent" figures are DERIVED, and this is the number most likely
+        # to be wrong: node-exporter reads ~1.94x lower than EC2 NetworkOut here
+        # (measured over one 6 h window), because a node that is terminated mid-window
+        # stops contributing to `rate()` while CloudWatch keeps its bytes. Node churn is
+        # heavy on this cluster, so that factor moves. If this rule proves noisy or
+        # silent, re-derive the ratio before moving the bar.
+        #
+        # `device=~"ens[0-9]+"` restricts to the primary/secondary ENIs. Summing every
+        # device counts each byte ~7x, because the per-pod `eni*` veth legs and
+        # `pod-id-link*` carry the same traffic as the ENI it leaves through.
+        #
+        # This is a PROXY, and deliberately not what ADR-0112 D2 specifies. The ADR
+        # asks for "CloudWatch VPC FlowLogs cross-AZ bytes (via CW Metric Stream ->
+        # Prometheus)"; no metric stream has ever been deployed, which is why D2 was
+        # never written. Total node egress cannot separate the cross-AZ half from the
+        # same-AZ and internet halves — it fires on any egress runaway, cross-AZ or
+        # not. That is a deliberate trade: an approximate detector that exists beats
+        # an exact one that is waiting on infrastructure nobody has built. If the
+        # metric stream ever lands, replace this expression rather than adding to it.
+        - alert: FinOpsFleetEgressHigh
+          expr: |
+            sum(rate(node_network_transmit_bytes_total{device=~"ens[0-9]+"}[30m]))
+              * 86400 / 1e9 > 800
+          for: 1h
+          labels:
+            severity: warning
+            detector: D2
+            team: platform
+            route: finops-agent
+          annotations:
+            summary: "Fleet node egress {{ $value | printf \"%.0f\" }} GB/day — >2x normal"
+            description: "Summed node egress has held above 800 GB/day for an hour (healthy fleet is ~330, busiest observed CI day ~385). Roughly half of this cluster's egress crosses an AZ boundary and is billed in both directions, so a sustained step here lands on EUN1-DataTransfer-Regional-Bytes at ~$0.01/GB. Look for a retry storm before a workload: a rejected sink (Loki full, Kafka unavailable, a 5xx endpoint) makes every client resend, which is fleet-wide and uniform, whereas a real workload change is concentrated. Check per node with topk(10, sum by (instance) (rate(node_network_transmit_bytes_total{device=~\"ens[0-9]+\"}[30m]))) — uniform across nodes means an agent, one node means that node."
             runbook: "https://github.com/JiRaska/open-bank-oss/blob/main/docs/runbooks/0006-nat-egress-drain.md"
 
     - name: openbank.finops.karpenter-churn


### PR DESCRIPTION
Refs #3496
Refs #3352

## The finops rule file described a detector it did not have

`prometheus-rules-finops.yaml` opens with:

> Five detectors correspond to the recurring AWS cost incidents documented in the ADR: NAT drain, **cross-AZ traffic**, Karpenter node churn, EBS attachment failures, and CI runner pool pressure.

Counting the `detector:` labels underneath gives `D1, D1, D3, D3, D3, D4, D4, D5`. **D2 — the cross-AZ one — was never written.** The header is the only thing that said otherwise, and a dashboard that counts detectors reads that as five.

This is the shape the repo keeps meeting: the gap is invisible because something adjacent looks like it. D1 sits right there watching egress, so "egress is covered" is a reasonable thing to conclude from a skim. It watches a different thing.

## What it cost

Measured in #3496, and re-measured independently for this PR:

```
EUN1-DataTransfer-Regional-Bytes, GB/day billed
  07-24   327        07-28  3242
  07-25   397        07-29  3177
  07-26   502        07-30  3615
  07-27  1588  <-step 07-31  3661
                     08-01  3087
```

Six days at ~$33/day, ~$809/mo run rate. Over the 07-27..07-31 window that line was **$152.83 of a $217.31 total AWS bill — 70%**. Nothing alerted. It was found by hand while pricing an unrelated Karpenter node-shape change.

## Why D1 could not have caught it

The cause (confirmed below) was Alloy retrying rejected pushes against a full Loki, from every node. D1 is `sum by (namespace) (rate(container_network_transmit_bytes_total{...}))` with a 50 GB/day bar and `observability` **excluded from its own selector**. So the one namespace responsible was filtered out by construction, and even unfiltered the per-namespace share sat under the bar while the fleet total was at ~3600 GB/day.

A per-node rule does not work either: the incident put ordinary nodes at 100-315 GB/day, but the `registry-cache` node legitimately serves ~108 GB/day today, so any per-node bar either misses the low end or pages on image pulls. The incident was a per-node *multiplier* — every long-lived node stepped 15-20x on the same day — which is what a fleet sum expresses and neither of the other two does.

## Calibration

On the series the alert actually reads (`node_network_transmit_bytes_total{device=~"ens[0-9]+"}`), not on CloudWatch — the two do not agree and the alert can only see one of them:

| | GB/day |
|---|---|
| quiet fleet, measured now | ~330 |
| busiest normal CI day observed (07-25, 6123 workflow runs) | ~385 |
| **threshold** | **800** |
| incident plateau | ~1700 |

`for: 1h`, `severity: warning`, `route: finops-agent` — same routing as the other four detectors.

## Falsified both ways before committing

A threshold that has only ever been quiet is not evidence the query works.

```
expr at the committed bar (800)   -> empty          (correct: fleet is healthy)
same expr with the bar at 200     -> 323.9 GB/day   (query returns real data)
```

So the silence is the threshold, not a broken selector. The `device=~"ens[0-9]+"` filter matters and was measured: summing *every* device over-counts each byte ~7x, because the per-pod `eni*` veth legs and `pod-id-link*` carry the same bytes as the ENI they leave through.

## What this PR is honest about

**It is a proxy, not what ADR-0112 specifies.** The ADR asks D2 for "CloudWatch VPC FlowLogs cross-AZ bytes (via CW Metric Stream -> Prometheus)". No metric stream has ever been deployed — that is *why* D2 was never written. Total node egress cannot separate the cross-AZ half from the same-AZ and internet halves, so this fires on any sustained egress runaway, cross-AZ or not. That trade is written into the manifest, not just here, along with a note to replace the expression rather than add to it if the metric stream ever lands.

**The two "equivalent" figures in the table are derived and are the number most likely to be wrong.** node-exporter reads ~1.94x lower than EC2 `NetworkOut` here, measured over one 6-hour window; the cause is that a node terminated mid-window stops contributing to `rate()` while CloudWatch keeps its bytes. Node churn on this cluster is heavy, so that factor moves. The manifest says to re-derive the ratio before moving the bar rather than nudging the number.

## Cost

$0. One PrometheusRule group; no new workload, no new scrape target, no capacity change.

## Not in this PR

The root cause is already fixed — #3278 (Loki PVC 10Gi -> 30Gi, +$1.60/mo) landed 2026-08-02 13:24 UTC and fleet egress fell 78% within the hour. This PR does not re-fix it; it adds the signal that would have named it on day one instead of day six. The full measurement, the independent confirmation that #3496 and #3352 are **not** the same mechanism, and the cost-ordered options for what remains are posted on both issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
