### PR TITLE
fix(security-scanner): a publish the broker rejects must not be marked SENT

### DIFF
--- a/openbank-security-scanner/src/main/kotlin/com/openbank/security/infrastructure/outbox/SecurityOutboxDispatcher.kt
+++ b/openbank-security-scanner/src/main/kotlin/com/openbank/security/infrastructure/outbox/SecurityOutboxDispatcher.kt
@@ -3,6 +3,7 @@
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 package com.openbank.security.infrastructure.outbox
 
+import com.openbank.libs.domain.identifiers.Ids
 import com.openbank.security.infrastructure.persistence.repository.SecurityOutboxRepositoryImpl
 import io.quarkus.scheduler.Scheduled
 import io.smallrye.mutiny.Multi
@@ -11,7 +12,6 @@ import io.smallrye.reactive.messaging.kafka.Record
 import jakarta.enterprise.context.ApplicationScoped
 import org.eclipse.microprofile.reactive.messaging.Channel
 import org.eclipse.microprofile.reactive.messaging.Emitter
-import java.util.UUID
 
 @ApplicationScoped
 class SecurityOutboxDispatcher(
@@ -41,7 +41,7 @@ class SecurityOutboxDispatcher(
                 // those as SENT. Verify a publish on the BROKER, never on outbox status.
                 Uni.createFrom().completionStage {
                     emitter.send(
-                        Record.of(UUID.randomUUID().toString(), event.payload),
+                        Record.of(Ids.randomId().toString(), event.payload),
                     )
                 }
                     .chain { _ -> outboxRepository.markSentUni(event.eventId) }

--- a/openbank-security-scanner/src/main/kotlin/com/openbank/security/infrastructure/outbox/SecurityOutboxDispatcher.kt
+++ b/openbank-security-scanner/src/main/kotlin/com/openbank/security/infrastructure/outbox/SecurityOutboxDispatcher.kt
@@ -27,7 +27,23 @@ class SecurityOutboxDispatcher(
         outboxRepository.listProcessableUni(BATCH_SIZE)
             .onItem().transformToMulti { Multi.createFrom().iterable(it) }
             .onItem().transformToUniAndConcatenate { event ->
-                Uni.createFrom().item { emitter.send(Record.of(UUID.randomUUID().toString(), event.payload)) }
+                // `completionStage`, NOT `item`. `Emitter.send` returns a CompletionStage that
+                // completes when the broker ACKS; wrapping it with `item { }` made the Uni's VALUE
+                // that CompletionStage and completed the Uni the instant `send` RETURNED. So the
+                // chain below ran unconditionally and marked the row SENT for a publish that had
+                // not happened yet — and could still fail. A broker denial, an unreachable broker
+                // or a serialisation error all lost the event silently, with the outbox reporting
+                // success. `onFailure` could only ever see a synchronous throw from `send` itself,
+                // which is the one case that does not happen.
+                //
+                // Measured while fixing #3393: security-scanner is refused by the broker as
+                // ANONYMOUS on every publish, and its outbox would have recorded every one of
+                // those as SENT. Verify a publish on the BROKER, never on outbox status.
+                Uni.createFrom().completionStage {
+                    emitter.send(
+                        Record.of(UUID.randomUUID().toString(), event.payload),
+                    )
+                }
                     .chain { _ -> outboxRepository.markSentUni(event.eventId) }
                     .onFailure().recoverWithUni { ex ->
                         outboxRepository.markFailedUni(event.eventId, ex.message ?: ex.javaClass.simpleName)

--- a/openbank-security-scanner/src/test/kotlin/com/openbank/security/infrastructure/outbox/SecurityOutboxDispatcherTest.kt
+++ b/openbank-security-scanner/src/test/kotlin/com/openbank/security/infrastructure/outbox/SecurityOutboxDispatcherTest.kt
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+package com.openbank.security.infrastructure.outbox
+
+import com.openbank.security.application.port.out.SecurityOutboxEntry
+import com.openbank.security.application.port.out.SecurityOutboxStatus
+import com.openbank.security.infrastructure.persistence.repository.SecurityOutboxRepositoryImpl
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import io.smallrye.mutiny.Uni
+import io.smallrye.reactive.messaging.kafka.Record
+import org.eclipse.microprofile.reactive.messaging.Emitter
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.UUID
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionStage
+
+/**
+ * The outbox's whole promise is that a row marked SENT was actually published. This dispatcher broke
+ * that promise for every failure mode that matters.
+ *
+ * `Emitter.send` returns a [CompletionStage] that completes when the broker acknowledges. Wrapping it
+ * in `Uni.createFrom().item { … }` made the CompletionStage the Uni's *value* and completed the Uni
+ * the instant `send` RETURNED — so `.chain { markSent }` ran unconditionally, and `.onFailure()`
+ * could only ever observe a synchronous throw from `send` itself, which is the one case that does
+ * not happen. A broker denial, an unreachable broker or a serialisation error each lost the event
+ * while the outbox recorded success.
+ *
+ * That was not hypothetical here: security-scanner publishes as ANONYMOUS on a broker running
+ * `allow.everyone.if.no.acl.found=false`, so every publish is refused (#3393) — and every one would
+ * have been marked SENT.
+ *
+ * Both tests fail against the `item { }` shape and pass against `completionStage { }`, which is the
+ * only reason they are worth having.
+ */
+class SecurityOutboxDispatcherTest {
+
+    private fun entry(): SecurityOutboxEntry = SecurityOutboxEntry(
+        eventId = UUID.randomUUID(),
+        aggregateId = UUID.randomUUID(),
+        eventType = "security.scan.completed",
+        payload = """{"kind":"test"}""",
+        status = SecurityOutboxStatus.PENDING,
+        attemptCount = 0,
+        createdAt = Instant.EPOCH,
+        updatedAt = Instant.EPOCH,
+        sentAt = null,
+        lastError = null,
+    )
+
+    private fun dispatcherFor(
+        repo: SecurityOutboxRepositoryImpl,
+        sendResult: CompletionStage<Void>,
+    ): SecurityOutboxDispatcher {
+        val emitter = mockk<Emitter<Record<String, String>>>()
+        every { emitter.send(any<Record<String, String>>()) } returns sendResult
+        return SecurityOutboxDispatcher(repo, emitter)
+    }
+
+    @Test
+    fun `a publish the broker rejects is marked FAILED, never SENT`() {
+        val repo = mockk<SecurityOutboxRepositoryImpl>()
+        val row = entry()
+        every { repo.listProcessableUni(any()) } returns Uni.createFrom().item(listOf(row))
+        every { repo.markSentUni(any(), any()) } returns Uni.createFrom().voidItem()
+        every { repo.markFailedUni(any(), any(), any()) } returns Uni.createFrom().voidItem()
+
+        val refused = CompletableFuture<Void>().apply {
+            completeExceptionally(IllegalStateException("Not authorized to access topics"))
+        }
+
+        dispatcherFor(repo, refused).dispatchScheduledBatch().await().indefinitely()
+
+        // The assertion that would have caught #3393's silent loss.
+        verify(exactly = 0) { repo.markSentUni(row.eventId, any()) }
+        verify(exactly = 1) { repo.markFailedUni(row.eventId, any(), any()) }
+    }
+
+    @Test
+    fun `a publish the broker accepts is marked SENT`() {
+        val repo = mockk<SecurityOutboxRepositoryImpl>()
+        val row = entry()
+        every { repo.listProcessableUni(any()) } returns Uni.createFrom().item(listOf(row))
+        every { repo.markSentUni(any(), any()) } returns Uni.createFrom().voidItem()
+        every { repo.markFailedUni(any(), any(), any()) } returns Uni.createFrom().voidItem()
+
+        dispatcherFor(repo, CompletableFuture.completedFuture(null)).dispatchScheduledBatch()
+            .await().indefinitely()
+
+        verify(exactly = 1) { repo.markSentUni(row.eventId, any()) }
+        verify(exactly = 0) { repo.markFailedUni(row.eventId, any(), any()) }
+    }
+}


### PR DESCRIPTION
Found while reviewing #3393's investigation. Distinct defect, separate fix — #3642 touches only gitops, so these do not overlap.

## The outbox marked SENT for publishes that never happened

```kotlin
Uni.createFrom().item { emitter.send(Record.of(...)) }
    .chain { _ -> outboxRepository.markSentUni(event.eventId) }
    .onFailure().recoverWithUni { ... markFailedUni ... }
```

`Emitter.send` returns a `CompletionStage` that completes when the broker **acknowledges**. `item { }` made that CompletionStage the Uni's *value* and completed the Uni the instant `send` **returned**. So:

- `.chain { markSent }` ran **unconditionally**, before the publish had been acknowledged;
- `.onFailure()` could only ever observe a **synchronous throw from `send` itself** — the one case that does not happen.

A broker denial, an unreachable broker, or a serialisation error each lost the event silently while the outbox recorded success. That is precisely the guarantee a transactional outbox exists to provide.

**Not hypothetical.** security-scanner publishes as `ANONYMOUS` on a broker running `allow.everyone.if.no.acl.found=false`, so #3393 measured every publish being refused — and every one of those would have been recorded `SENT`.

The corollary is worth keeping beyond this fix: **verify a publish on the broker, never on outbox status.**

## The fix

`completionStage` instead of `item`, so the Uni completes when the *send* completes. `markSent` now runs only on success, and `onFailure` sees a real failure.

## Fleet check — this is the only one

Every other outbox dispatcher delegates to the shared `OutboxEventPublisher` port through a `suspend` function, which awaits correctly. **security-scanner is the only service that hand-rolled its own dispatcher**, and this is what that cost.

Moving it onto the shared publisher is the better end state and is deliberately **not** done here — that is a larger change than a correctness fix should carry, and it would collide with #3642's rollout of the same service.

## Red-then-green, in that order

The production change was reverted and the tests kept:

```
SecurityOutboxDispatcherTest > a publish the broker rejects is marked FAILED, never SENT() FAILED
2 tests completed, 1 failed
```

With the fix: 2/2, and the full module gate green (`build`, `detekt`, `ktlintCheck`, `koverVerify`).

The second test (accepted publish → SENT) passes in both states on purpose — it is the guard against "fix" it by never marking anything sent.

## Self-assessment

- **The failure was reproduced against a mock, not a live broker.** The mock returns a failed `CompletionStage`, which is what a denial produces; I did not observe a real refused publish marking a row SENT in the sandbox. #3393's measurement (zero-byte topic segments, broker `DefaultDeny` log) is the evidence that the denial is real; the SENT consequence follows from the code path.
- **Nothing here fixes the denial** — that is #3642, still open pending human review. Until it lands, security-scanner still cannot publish; it will now correctly record `FAILED` and retry rather than losing events.
- **`markFailed` increments `attemptCount`**, so once #3642 lands there may be a backlog of previously-SENT-but-never-published rows that this fix cannot recover — they are already marked `SENT`. Worth a look at the table when the identity lands, though #3393 measured the outbox as empty (nothing has ever called `persistInTransaction` from `src/main`), so the practical exposure today is likely zero.
