### PR TITLE
feat(lending): register workflow liveness on the accrual and provisioning schedulers (ADR-0237)

### DIFF
--- a/.github/scripts/check-scheduler-liveness.py
+++ b/.github/scripts/check-scheduler-liveness.py
@@ -68,8 +68,6 @@ BASELINE = [
     "openbank-balance-service/src/main/kotlin/com/openbank/balance/infrastructure/schedule/ReconciliationFreshnessWatchdog.kt",
     "openbank-interest-service/src/main/kotlin/com/openbank/interest/infrastructure/scheduler/InterestAccrualScheduler.kt",
     "openbank-interest-service/src/main/kotlin/com/openbank/interest/infrastructure/scheduler/InterestCapitalizationScheduler.kt",
-    "openbank-lending-service/src/main/kotlin/com/openbank/lending/infrastructure/servicing/InterestAccrualScheduler.kt",
-    "openbank-lending-service/src/main/kotlin/com/openbank/lending/infrastructure/servicing/ProvisioningCycleScheduler.kt",
     # non-money-path
     "openbank-agent-service/src/main/kotlin/com/openbank/agent/application/OversightService.kt",
     "openbank-agent-service/src/main/kotlin/com/openbank/agent/infrastructure/observability/AgentMetricsAdapter.kt",

--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/infrastructure/servicing/InterestAccrualScheduler.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/infrastructure/servicing/InterestAccrualScheduler.kt
@@ -5,13 +5,18 @@
 package com.openbank.lending.infrastructure.servicing
 
 import com.openbank.lending.application.port.`in`.AccrueInterestUseCase
+import com.openbank.libs.observability.DomainMetrics
+import com.openbank.libs.observability.WorkflowLivenessRecorder
 import io.quarkus.hibernate.reactive.panache.Panache
+import io.quarkus.runtime.StartupEvent
 import io.quarkus.scheduler.Scheduled
 import io.smallrye.mutiny.Uni
 import jakarta.enterprise.context.ApplicationScoped
+import jakarta.enterprise.event.Observes
 import org.eclipse.microprofile.config.inject.ConfigProperty
 import org.jboss.logging.Logger
 import java.time.Clock
+import java.time.Duration
 import java.time.LocalDate
 
 /**
@@ -30,8 +35,19 @@ class InterestAccrualScheduler(
     @ConfigProperty(name = "lending.servicing.accrual.batch-size", defaultValue = "500")
     private val batchSize: Int,
     private val clock: Clock,
+    private val domainMetrics: DomainMetrics,
 ) {
     private val log = Logger.getLogger(InterestAccrualScheduler::class.java)
+
+    // Nullable, not `lateinit`: the gauge is a diagnostic, and a money-path job must never fail
+    // because its observability wiring was not initialised. `lateinit` turns a missed StartupEvent
+    // into an UninitializedPropertyAccessException thrown from the middle of the run.
+    private var liveness: WorkflowLivenessRecorder? = null
+
+    // ADR-0160 mechanism 3. Registered once at startup (CDI beans are singletons), not per-run.
+    fun onStart(@Observes @Suppress("UNUSED_PARAMETER") ev: StartupEvent) {
+        liveness = domainMetrics.registerWorkflowLiveness(WORKFLOW_NAME, Duration.ofDays(1))
+    }
 
     @Scheduled(
         every = "{lending.servicing.accrual.every}",
@@ -50,8 +66,16 @@ class InterestAccrualScheduler(
                 } else {
                     log.debugf("interest accrual pass: nothing due as of %s", outcome.asOf)
                 }
+                // ADR-0160 mechanism 3: record after the success path — zero work is a legitimate
+                // success (nothing due), never record in the failure path below.
+                liveness?.recordSuccess()
             }
             .onFailure().invoke { e -> log.error("interest accrual pass failed", e) }
             .replaceWithVoid()
+    }
+
+    private companion object {
+        /** ADR-0160 mechanism 3 workflow tag — stable, low-cardinality. */
+        const val WORKFLOW_NAME = "lending-interest-accrual"
     }
 }

--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/infrastructure/servicing/ProvisioningCycleScheduler.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/infrastructure/servicing/ProvisioningCycleScheduler.kt
@@ -5,13 +5,18 @@
 package com.openbank.lending.infrastructure.servicing
 
 import com.openbank.lending.application.port.`in`.RunProvisioningCycleUseCase
+import com.openbank.libs.observability.DomainMetrics
+import com.openbank.libs.observability.WorkflowLivenessRecorder
 import io.quarkus.hibernate.reactive.panache.Panache
+import io.quarkus.runtime.StartupEvent
 import io.quarkus.scheduler.Scheduled
 import io.smallrye.mutiny.Uni
 import jakarta.enterprise.context.ApplicationScoped
+import jakarta.enterprise.event.Observes
 import org.eclipse.microprofile.config.inject.ConfigProperty
 import org.jboss.logging.Logger
 import java.time.Clock
+import java.time.Duration
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 
@@ -36,9 +41,20 @@ class ProvisioningCycleScheduler(
     @ConfigProperty(name = "lending.provisioning.cycle.batch-size", defaultValue = "500")
     private val batchSize: Int,
     private val clock: Clock,
+    private val domainMetrics: DomainMetrics,
 ) {
     private val log = Logger.getLogger(ProvisioningCycleScheduler::class.java)
     private val periodFormat = DateTimeFormatter.ofPattern("yyyy-MM")
+
+    // Nullable, not `lateinit`: the gauge is a diagnostic, and a money-path job must never fail
+    // because its observability wiring was not initialised. `lateinit` turns a missed StartupEvent
+    // into an UninitializedPropertyAccessException thrown from the middle of the run.
+    private var liveness: WorkflowLivenessRecorder? = null
+
+    // ADR-0160 mechanism 3. Registered once at startup (CDI beans are singletons), not per-run.
+    fun onStart(@Observes @Suppress("UNUSED_PARAMETER") ev: StartupEvent) {
+        liveness = domainMetrics.registerWorkflowLiveness(WORKFLOW_NAME, Duration.ofHours(APPROX_MONTHLY_HOURS))
+    }
 
     @Scheduled(
         every = "{lending.provisioning.cycle.every}",
@@ -70,8 +86,19 @@ class ProvisioningCycleScheduler(
                         batchSize,
                     )
                 }
+                // ADR-0160 mechanism 3: record after the success path — a truncated pass that logs a
+                // warning is still a successful run of the control; never record in the failure path.
+                liveness?.recordSuccess()
             }
             .onFailure().invoke { e -> log.error("IFRS 9 provisioning cycle failed", e) }
             .replaceWithVoid()
+    }
+
+    private companion object {
+        /** ADR-0160 mechanism 3 workflow tag — stable, low-cardinality. */
+        const val WORKFLOW_NAME = "lending-provisioning-cycle"
+
+        /** Approximate monthly interval (720 h) matching `lending.provisioning.cycle.every` default. */
+        const val APPROX_MONTHLY_HOURS = 720L
     }
 }

--- a/openbank-lending-service/src/test/kotlin/com/openbank/lending/infrastructure/servicing/InterestAccrualSchedulerTest.kt
+++ b/openbank-lending-service/src/test/kotlin/com/openbank/lending/infrastructure/servicing/InterestAccrualSchedulerTest.kt
@@ -33,7 +33,8 @@ class InterestAccrualSchedulerTest {
 
     private val accrual = mockk<AccrueInterestUseCase>()
     private val clock = Clock.fixed(Instant.parse("2026-07-01T04:00:00Z"), ZoneOffset.UTC)
-    private val scheduler = InterestAccrualScheduler(accrual, batchSize = 250, clock = clock)
+    private val scheduler =
+        InterestAccrualScheduler(accrual, batchSize = 250, clock = clock, domainMetrics = mockk(relaxed = true))
 
     @BeforeEach
     fun stubPanacheSession() {

--- a/openbank-lending-service/src/test/kotlin/com/openbank/lending/infrastructure/servicing/LendingWorkflowLivenessTest.kt
+++ b/openbank-lending-service/src/test/kotlin/com/openbank/lending/infrastructure/servicing/LendingWorkflowLivenessTest.kt
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.lending.infrastructure.servicing
+
+import com.openbank.lending.application.port.`in`.AccrueInterestUseCase
+import com.openbank.lending.application.port.`in`.RunProvisioningCycleUseCase
+import com.openbank.lending.domain.model.AccrualOutcome
+import com.openbank.lending.domain.model.ProvisioningRunOutcome
+import com.openbank.libs.observability.DomainMetrics
+import com.openbank.libs.observability.WorkflowLivenessMetrics
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import io.quarkus.hibernate.reactive.panache.Panache
+import io.quarkus.runtime.StartupEvent
+import io.smallrye.mutiny.Uni
+import jakarta.enterprise.inject.Instance
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneOffset
+import java.util.function.Supplier
+
+/**
+ * ADR-0160 mechanism 3 liveness for the lending service's money-path schedulers (#3345).
+ *
+ * Mirrors [com.openbank.ledger.schedule.LedgerWorkflowLivenessTest]: drives the schedulers,
+ * not DomainMetrics directly, so both the registration AND the recordSuccess() call are pinned.
+ */
+class LendingWorkflowLivenessTest {
+
+    private fun metricsOver(registry: MeterRegistry): DomainMetrics {
+        val instance = mockk<Instance<MeterRegistry>>()
+        every { instance.isResolvable } returns true
+        every { instance.get() } returns registry
+        return DomainMetrics().apply { registryInstance = instance }
+    }
+
+    private fun ageOf(registry: MeterRegistry, workflow: String): Double? = registry
+        .find(WorkflowLivenessMetrics.LAST_SUCCESS_AGE_SECONDS)
+        .tag(WorkflowLivenessMetrics.WORKFLOW_TAG, workflow)
+        .gauge()
+        ?.value()
+
+    @BeforeEach
+    fun stubPanacheSession() {
+        mockkStatic(Panache::class)
+        every { Panache.withSession(any<Supplier<Uni<Void>>>()) } answers {
+            firstArg<Supplier<Uni<Void>>>().get()
+        }
+    }
+
+    @AfterEach
+    fun restorePanache() {
+        unmockkStatic(Panache::class)
+    }
+
+    @Test
+    fun `interest accrual registers a liveness gauge at startup and collapses its age on a successful run`() {
+        val registry = SimpleMeterRegistry()
+        val clock = Clock.fixed(Instant.parse("2026-07-01T04:00:00Z"), ZoneOffset.UTC)
+        val accrual = object : AccrueInterestUseCase {
+            override fun accrueDueInterest(asOf: LocalDate, limit: Int) =
+                Uni.createFrom().item(AccrualOutcome(asOf = asOf, installmentsAccrued = 2))
+        }
+        val scheduler =
+            InterestAccrualScheduler(accrual, batchSize = 500, clock = clock, domainMetrics = metricsOver(registry))
+
+        scheduler.onStart(StartupEvent())
+
+        val neverRan = ageOf(registry, "lending-interest-accrual")
+        assertThat(neverRan).describedAs("liveness gauge was not registered at startup").isNotNull()
+        assertThat(neverRan!!).isGreaterThan(FIFTY_YEARS_SECONDS)
+        assertThat(
+            registry.find(WorkflowLivenessMetrics.EXPECTED_INTERVAL_SECONDS)
+                .tag(WorkflowLivenessMetrics.WORKFLOW_TAG, "lending-interest-accrual")
+                .gauge()?.value(),
+        ).isEqualTo(Duration.ofDays(1).toSeconds().toDouble())
+
+        scheduler.runAccrualPass().await().indefinitely()
+
+        assertThat(ageOf(registry, "lending-interest-accrual")!!)
+            .describedAs("the job ran but recorded no success")
+            .isLessThan(TOLERANCE_SECONDS)
+    }
+
+    @Test
+    fun `interest accrual records success even when no installments were due (zero-work is a successful run)`() {
+        val registry = SimpleMeterRegistry()
+        val clock = Clock.fixed(Instant.parse("2026-07-01T04:00:00Z"), ZoneOffset.UTC)
+        val accrual = object : AccrueInterestUseCase {
+            override fun accrueDueInterest(asOf: LocalDate, limit: Int) =
+                Uni.createFrom().item(AccrualOutcome(asOf = asOf, installmentsAccrued = 0))
+        }
+        val scheduler =
+            InterestAccrualScheduler(accrual, batchSize = 500, clock = clock, domainMetrics = metricsOver(registry))
+        scheduler.onStart(StartupEvent())
+
+        scheduler.runAccrualPass().await().indefinitely()
+
+        assertThat(ageOf(registry, "lending-interest-accrual")!!)
+            .describedAs("zero-work run should still record success")
+            .isLessThan(TOLERANCE_SECONDS)
+    }
+
+    @Test
+    fun `a failed accrual pass records no success`() {
+        val registry = SimpleMeterRegistry()
+        val clock = Clock.fixed(Instant.parse("2026-07-01T04:00:00Z"), ZoneOffset.UTC)
+        val accrual = object : AccrueInterestUseCase {
+            override fun accrueDueInterest(asOf: LocalDate, limit: Int): Uni<AccrualOutcome> =
+                Uni.createFrom().failure(IllegalStateException("ledger down"))
+        }
+        val scheduler =
+            InterestAccrualScheduler(accrual, batchSize = 500, clock = clock, domainMetrics = metricsOver(registry))
+        scheduler.onStart(StartupEvent())
+
+        runCatching { scheduler.runAccrualPass().await().indefinitely() }
+
+        assertThat(ageOf(registry, "lending-interest-accrual")!!)
+            .describedAs("a failed run was recorded as a success")
+            .isGreaterThan(FIFTY_YEARS_SECONDS)
+    }
+
+    @Test
+    fun `provisioning cycle registers a liveness gauge at startup and collapses its age on a successful run`() {
+        val registry = SimpleMeterRegistry()
+        val clock = Clock.fixed(Instant.parse("2026-06-15T04:00:00Z"), ZoneOffset.UTC)
+        val cycleUseCase = object : RunProvisioningCycleUseCase {
+            override fun runProvisioningCycle(period: String, asOf: LocalDate, limit: Int) =
+                Uni.createFrom().item(ProvisioningRunOutcome(period = period, loansAssessed = 5, journalsPosted = 3))
+        }
+        val scheduler =
+            ProvisioningCycleScheduler(
+                cycleUseCase,
+                batchSize = 500,
+                clock = clock,
+                domainMetrics = metricsOver(registry),
+            )
+
+        scheduler.onStart(StartupEvent())
+
+        val neverRan = ageOf(registry, "lending-provisioning-cycle")
+        assertThat(neverRan).describedAs("liveness gauge was not registered at startup").isNotNull()
+        assertThat(neverRan!!).isGreaterThan(FIFTY_YEARS_SECONDS)
+        assertThat(
+            registry.find(WorkflowLivenessMetrics.EXPECTED_INTERVAL_SECONDS)
+                .tag(WorkflowLivenessMetrics.WORKFLOW_TAG, "lending-provisioning-cycle")
+                .gauge()?.value(),
+        ).isEqualTo(Duration.ofHours(720).toSeconds().toDouble())
+
+        scheduler.runProvisioningPass().await().indefinitely()
+
+        assertThat(ageOf(registry, "lending-provisioning-cycle")!!)
+            .describedAs("the job ran but recorded no success")
+            .isLessThan(TOLERANCE_SECONDS)
+    }
+
+    @Test
+    fun `a failed provisioning cycle records no success`() {
+        val registry = SimpleMeterRegistry()
+        val clock = Clock.fixed(Instant.parse("2026-06-15T04:00:00Z"), ZoneOffset.UTC)
+        val cycleUseCase = object : RunProvisioningCycleUseCase {
+            override fun runProvisioningCycle(
+                period: String,
+                asOf: LocalDate,
+                limit: Int,
+            ): Uni<ProvisioningRunOutcome> = Uni.createFrom().failure(IllegalStateException("db unavailable"))
+        }
+        val scheduler =
+            ProvisioningCycleScheduler(
+                cycleUseCase,
+                batchSize = 500,
+                clock = clock,
+                domainMetrics = metricsOver(registry),
+            )
+        scheduler.onStart(StartupEvent())
+
+        runCatching { scheduler.runProvisioningPass().await().indefinitely() }
+
+        assertThat(ageOf(registry, "lending-provisioning-cycle")!!)
+            .describedAs("a failed run was recorded as a success")
+            .isGreaterThan(FIFTY_YEARS_SECONDS)
+    }
+
+    private companion object {
+        const val TOLERANCE_SECONDS = 5.0
+        val FIFTY_YEARS_SECONDS = Duration.ofDays(50 * 365).toSeconds().toDouble()
+    }
+}

--- a/openbank-lending-service/src/test/kotlin/com/openbank/lending/infrastructure/servicing/ProvisioningCycleSchedulerTest.kt
+++ b/openbank-lending-service/src/test/kotlin/com/openbank/lending/infrastructure/servicing/ProvisioningCycleSchedulerTest.kt
@@ -32,7 +32,8 @@ class ProvisioningCycleSchedulerTest {
 
     private val cycle = mockk<RunProvisioningCycleUseCase>()
     private val clock = Clock.fixed(Instant.parse("2026-06-15T04:00:00Z"), ZoneOffset.UTC)
-    private val scheduler = ProvisioningCycleScheduler(cycle, batchSize = 500, clock = clock)
+    private val scheduler =
+        ProvisioningCycleScheduler(cycle, batchSize = 500, clock = clock, domainMetrics = mockk(relaxed = true))
 
     @BeforeEach
     fun stubPanacheSession() {


### PR DESCRIPTION
## Summary

Register ADR-0160 mechanism 3 workflow liveness on the two money-path schedulers in `openbank-lending-service`. Before this change, a scheduler that silently stopped running left no runtime signal — the liveness gap identified in ADR-0237 and tracked in #3345.

## Type of change

- [x] feat (new functionality)

## Linked issues

Refs #3345

## Changes

- `InterestAccrualScheduler`: inject `DomainMetrics`, register `lending-interest-accrual` liveness (expected interval 24 h) at `StartupEvent`, call `recordSuccess()` in the `.invoke {}` success path; zero-work runs record success.
- `ProvisioningCycleScheduler`: inject `DomainMetrics`, register `lending-provisioning-cycle` liveness (expected interval 720 h) at `StartupEvent`, call `recordSuccess()` in the `.invoke {}` success path.
- Remove both files from `BASELINE` in `.github/scripts/check-scheduler-liveness.py` — the advisory gate (#3636) fails if healed entries remain listed.
- Extend `InterestAccrualSchedulerTest` and `ProvisioningCycleSchedulerTest` with the new `domainMetrics` constructor param (relaxed mock; existing test behaviour unchanged).
- Add `LendingWorkflowLivenessTest`: 5 unit tests asserting gauge registration at startup, expected-interval gauge, age collapse on success, zero-work success, and age staying stale on a failed run.

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports).
- [x] Unit tests added/updated.
- [x] Integration tests added/updated (if service boundary involved).
- [x] Contract tests updated (if public API changed).
- [x] `./gradlew detekt ktlintCheck koverVerify build` passes.
- [x] No new lint warnings.
- [x] OpenAPI spec regenerated (if REST API changed).
- [x] Flyway migration added + rollback note (if DB changed).
- [x] Avro schema versioned backward-compatibly (if event changed).
- [x] Docs updated (README, ADR if architectural).

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings`, `as Any`, `@Suppress("...")` without justification.
- [x] No new third-party dependency.
- [x] Auth / crypto / payment code changed? No.

## Compliance impact

- [x] None

## Rollout / Rollback

- Deployment strategy: rolling
- Rollback plan: revert this commit; the liveness gauge is additive (no schema change, no config change required)
- Data migration reversible: N/A

## Reviewer notes

`liveness` is `nullable` (not `lateinit`) matching the pilot in `FxRevaluationScheduler` / `TieOutScheduler`. `recordSuccess()` is inside `.invoke {}` on the success arm; zero-work runs record success; `.onFailure()` never records.