### PR TITLE
fix(audit): let the chain walk cross the rows #3586 could not fix

### DIFF
--- a/openbank-audit-service/src/main/kotlin/com/openbank/audit/infrastructure/observability/AuditChainIntegrityGauge.kt
+++ b/openbank-audit-service/src/main/kotlin/com/openbank/audit/infrastructure/observability/AuditChainIntegrityGauge.kt
@@ -79,6 +79,7 @@ class AuditChainIntegrityGauge {
     private val intact = AtomicLong(0)
     private val checked = AtomicLong(0)
     private val unchained = AtomicLong(0)
+    private val unverifiableLegacy = AtomicLong(0)
     private val lastVerifiedEpochSeconds = AtomicLong(0)
 
     @PostConstruct
@@ -93,6 +94,17 @@ class AuditChainIntegrityGauge {
             .register(registry)
         Gauge.builder("openbank.audit.chain.entries.unchained") { unchained.get().toDouble() }
             .description("Audit entries predating the hash chain (no record_hash) — counted, not verifiable")
+            .strongReference(true)
+            .register(registry)
+        // Separate from `unchained` on purpose. These rows DO carry a hash; it simply cannot be
+        // recomputed, because the pre-#3586 canonical form hashed nanoseconds the database
+        // truncated (#3505). Reporting them as unchained would say "never had a hash", which is a
+        // different fact, and would let a genuine gap hide inside a known one. This series is
+        // expected to be CONSTANT: if it ever grows, something is writing the old form again.
+        Gauge.builder("openbank.audit.chain.entries.unverifiable.legacy") { unverifiableLegacy.get().toDouble() }
+            .description(
+                "Chained entries written with the pre-#3586 canonical form — permanently unverifiable, not broken",
+            )
             .strongReference(true)
             .register(registry)
         Gauge.builder("openbank.audit.chain.last.verified.timestamp.seconds") {
@@ -137,6 +149,7 @@ class AuditChainIntegrityGauge {
         intact.set(if (result.intact) 1 else 0)
         checked.set(result.checked)
         unchained.set(result.unchained)
+        unverifiableLegacy.set(result.unverifiableLegacy)
         lastVerifiedEpochSeconds.set(Instant.now().epochSecond)
 
         if (result.intact) {

--- a/openbank-audit-service/src/main/kotlin/com/openbank/audit/infrastructure/persistence/AuditRepository.kt
+++ b/openbank-audit-service/src/main/kotlin/com/openbank/audit/infrastructure/persistence/AuditRepository.kt
@@ -61,6 +61,22 @@ class AuditEntryEntity : PanacheEntity() {
     @Column(name = "record_hash")
     var recordHash: String? = null
 
+    /**
+     * Which canonical form [AuditRepository.chainHash] used for [recordHash].
+     *
+     * NULL means the pre-#3586 form, which hashed nanosecond `Instant.toString()` while
+     * `timestamptz` keeps microseconds — those rows are permanently unverifiable because the lost
+     * digits are not in the database (#3505). They are counted on their own rather than reported
+     * as broken: a failure to VERIFY is not evidence of tampering, and the pre-V5 `unchained`
+     * bucket already means something else ("never had a hash at all").
+     *
+     * It is a version number and not a boolean so the next canonical change — if there ever is
+     * one — is a new value rather than a second ad-hoc column, and so the boundary stays legible
+     * in the data instead of living in a comment.
+     */
+    @Column(name = "hash_version")
+    var hashVersion: Short? = null
+
     // ── Cross-channel correlation (ADR-0226): query indexes, NOT part of the chain hash — the
     // producer's raw event JSON (already hashed via `payload`) carries these fields verbatim, so
     // tamper-evidence covers them without recomputing every pre-V9 row.
@@ -116,6 +132,7 @@ class AuditRepository : PanacheRepository<AuditEntryEntity> {
                 it.sessionId = entry.sessionId
                 it.prevHash = prevHash
                 it.recordHash = chainHash(prevHash, stored)
+                it.hashVersion = HASH_VERSION_MICROS
             }
             Panache.withTransaction { persist(e) }.awaitSuspending()
         }
@@ -132,14 +149,22 @@ class AuditRepository : PanacheRepository<AuditEntryEntity> {
      *   The anchor row's own prevHash is used as the expected-previous for the walk, so
      *   the check is self-contained from that point onward.
      *   If the id is not found the walk starts from the beginning (fail-safe).
+     *
+     * Rows in the legacy segment ([isLegacyHashVersion]) are counted and skipped, and the walk then
+     * re-anchors `expectedPrev` on the first verifiable row's OWN prevHash. Without that re-anchor
+     * the boundary link would be compared against a hash from the other canonical form, and the
+     * first GOOD row would report as tampering — the same false positive this exists to remove,
+     * moved one row along.
      */
-    @Suppress("LoopWithTooManyJumpStatements", "NestedBlockDepth")
+    @Suppress("LoopWithTooManyJumpStatements", "NestedBlockDepth", "CyclomaticComplexMethod")
     suspend fun verifyChain(fromEntryId: UUID? = null): ChainVerification {
         var checked = 0L
         var unchained = 0L
+        var unverifiableLegacy = 0L
         var expectedPrev = GENESIS_HASH
         var page = 0
         var found = fromEntryId == null // skip scan if no anchor requested
+        var reAnchorAtNextVerifiable = false
 
         while (true) {
             val batch = Panache.withSession {
@@ -161,14 +186,25 @@ class AuditRepository : PanacheRepository<AuditEntryEntity> {
                     unchained++
                     continue
                 }
+                // A chained row whose hash_version is NULL was written with the pre-#3586
+                // canonical form, which hashed nanosecond precision the database then truncated
+                // (#3505). Its original digits are not in the database, so no rendering of the
+                // stored row can reproduce its hash — it is unverifiable, permanently, and that
+                // is NOT evidence of tampering. Counting it separately is the whole point: the
+                // pre-V5 `unchained` bucket means "never had a hash", which is a different fact,
+                // and merging the two would let a real gap hide inside a known one.
+                if (isLegacyHashVersion(e)) {
+                    unverifiableLegacy++
+                    reAnchorAtNextVerifiable = true
+                    continue
+                }
+                if (reAnchorAtNextVerifiable) {
+                    expectedPrev = e.prevHash ?: GENESIS_HASH
+                    reAnchorAtNextVerifiable = false
+                }
                 val recomputed = chainHash(e.prevHash ?: GENESIS_HASH, e.toDomain())
                 if (chainLinkBroken(e.prevHash, expectedPrev, e.recordHash!!, recomputed)) {
-                    return ChainVerification(
-                        intact = false,
-                        checked = checked,
-                        unchained = unchained,
-                        firstBrokenEntryId = e.entryId,
-                    )
+                    return ChainVerification(false, checked, unchained, unverifiableLegacy, e.entryId)
                 }
                 expectedPrev = e.recordHash!!
                 checked++
@@ -176,15 +212,66 @@ class AuditRepository : PanacheRepository<AuditEntryEntity> {
             page++
         }
         if (anchorMissed(found, fromEntryId)) {
-            return ChainVerification(intact = false, checked = 0, unchained = 0, anchorNotFound = true)
+            return ChainVerification(false, 0, 0, 0, anchorNotFound = true)
         }
-        return ChainVerification(
-            intact = true,
-            checked = checked,
-            unchained = unchained,
-            firstBrokenEntryId = null,
-        )
+        return ChainVerification(true, checked, unchained, unverifiableLegacy)
     }
+
+    /**
+     * Appends a row with the chain fields supplied verbatim, bypassing [save].
+     *
+     * Test seam, and it has to look like this for two reasons that are properties of the schema
+     * rather than choices:
+     *
+     * 1. `audit_entries` is append-only at the DATABASE level — `V2__compliance_fields.sql`
+     *    installs `RULE no_update_audit ... DO INSTEAD NOTHING`, which *silently discards* an
+     *    UPDATE rather than refusing it. A legacy row can therefore only be appended, never
+     *    demoted. (That same rule is why the legacy hashes could not have been backfilled even if
+     *    rewriting tamper-evidence had been acceptable.)
+     * 2. The id comes from `nextval('audit_entries_seq')` — the SAME allocator Hibernate uses — so
+     *    ids stay monotonic. Mixing allocators broke two earlier attempts: `MAX(id)+1` collides
+     *    with an id Hibernate has already reserved from its cached block (`V4` gives the sequence
+     *    `INCREMENT BY 50`), and letting Hibernate write a neighbouring row lands it at a LOWER id
+     *    than a raw `nextval`, scrambling chain order. A test needing consecutive rows must write
+     *    BOTH of them through this seam.
+     *
+     * Returns rows inserted so the caller can assert the seam did something — a seam that no-ops
+     * makes the test it supports pass for the wrong reason, which is how the first version of this
+     * test went green against unchanged code.
+     */
+    @Suppress("LongParameterList")
+    suspend fun appendRawRow(entry: AuditEntry, prevHash: String, recordHash: String, hashVersion: Short?): Int =
+        Panache.withTransaction {
+            Panache.getSession().flatMap { session ->
+                session.createNativeQuery<Any>(
+                    """
+                    INSERT INTO audit_entries
+                      (id, entry_id, event_type, aggregate_type, aggregate_id, actor_id, actor_type,
+                       payload, source_service, correlation_id, occurred_at, recorded_at,
+                       prev_hash, record_hash, hash_version)
+                    VALUES
+                      (nextval('audit_entries_seq'), :entryId, :eventType, :aggregateType,
+                       :aggregateId, :actorId, :actorType, :payload, :sourceService, :correlationId,
+                       :occurredAt, :recordedAt, :prevHash, :recordHash, :hashVersion)
+                    """.trimIndent(),
+                )
+                    .setParameter("entryId", entry.id)
+                    .setParameter("eventType", entry.eventType)
+                    .setParameter("aggregateType", entry.aggregateType)
+                    .setParameter("aggregateId", entry.aggregateId)
+                    .setParameter("actorId", entry.actorId)
+                    .setParameter("actorType", entry.actorType)
+                    .setParameter("payload", entry.payload)
+                    .setParameter("sourceService", entry.sourceService)
+                    .setParameter("correlationId", entry.correlationId)
+                    .setParameter("occurredAt", entry.occurredAt.truncatedTo(ChronoUnit.MICROS))
+                    .setParameter("recordedAt", entry.recordedAt.truncatedTo(ChronoUnit.MICROS))
+                    .setParameter("prevHash", prevHash)
+                    .setParameter("recordHash", recordHash)
+                    .setParameter("hashVersion", hashVersion)
+                    .executeUpdate()
+            }
+        }.awaitSuspending()
 
     suspend fun findByAggregateId(aggregateId: String, limit: Int = 100): List<AuditEntry> = Panache.withSession {
         find("aggregateId = ?1 ORDER BY occurredAt DESC", aggregateId).page(0, limit).list()
@@ -234,6 +321,13 @@ class AuditRepository : PanacheRepository<AuditEntryEntity> {
         private const val GENESIS_HASH = "0000000000000000000000000000000000000000000000000000000000000000"
         private const val CHAIN_PAGE_SIZE = 500
 
+        /**
+         * Canonical form 2: every timestamp truncated to microseconds before hashing, so the value
+         * hashed is the value `timestamptz` can give back. Form 1 is implicit (NULL) and is never
+         * written again — it exists only as the marker on rows that predate #3586.
+         */
+        internal const val HASH_VERSION_MICROS: Short = 2
+
         private val actChainJson = com.fasterxml.jackson.module.kotlin.jacksonObjectMapper()
         private val stringListType = object : com.fasterxml.jackson.core.type.TypeReference<List<String>>() {}
 
@@ -273,6 +367,15 @@ class AuditRepository : PanacheRepository<AuditEntryEntity> {
     }
 }
 
+/**
+ * A chained row written with the pre-#3586 canonical form: its hash covered nanoseconds the
+ * database truncated (#3505), so it can never be recomputed — unverifiable, not tampered with.
+ *
+ * File-scope rather than a method: it is a predicate about a ROW, and keeping it off the repository
+ * also keeps that class under detekt's function-count threshold.
+ */
+private fun isLegacyHashVersion(e: AuditEntryEntity) = e.recordHash != null && e.hashVersion == null
+
 /** Chain head snapshot used to capture a signed anchor (see [AuditRepository.chainHead]). */
 data class ChainHead(
     val entryId: UUID,
@@ -287,6 +390,14 @@ data class ChainVerification(
     val checked: Long,
     /** Rows written before the chain existed (V5) — counted, not verifiable. */
     val unchained: Long,
+    /**
+     * Rows that DO carry a `record_hash` but were written with the pre-#3586 canonical form, which
+     * hashed nanoseconds the database truncated (#3505). Permanently unverifiable — the lost digits
+     * are not in the database — and deliberately not folded into [unchained], which means the
+     * different fact "never had a hash at all". Keeping them apart is what stops a real gap hiding
+     * inside a known one.
+     */
+    val unverifiableLegacy: Long = 0,
     val firstBrokenEntryId: UUID? = null,
     /** True when the requested fromEntryId anchor was not found in the chain; intact is false. */
     val anchorNotFound: Boolean = false,

--- a/openbank-audit-service/src/main/resources/db/migration/V10__hash_version.sql
+++ b/openbank-audit-service/src/main/resources/db/migration/V10__hash_version.sql
@@ -1,0 +1,38 @@
+-- Records WHICH canonical form a row's `record_hash` was computed with, so a corrected
+-- canonicalisation does not silently invalidate the rows that predate it.
+--
+-- WHY THIS EXISTS. chainHash() hashed `Instant.toString()`, which renders NANOSECOND precision,
+-- while `timestamptz` stores MICROSECONDS. Every hash was therefore computed over a value the
+-- database immediately truncated, and on read-back the recomputation could never match. The chain
+-- had verified ZERO links since it shipped: `openbank_audit_chain_entries_checked` read 0 against
+-- 1066 chained rows, and `AuditChainBroken` was a permanent critical about a chain nobody had
+-- tampered with.
+--
+-- Proven rather than inferred (2026-08-03): taking the newest chained row and brute-forcing the
+-- 10^6 sub-microsecond combinations Postgres had discarded reproduced its stored record_hash
+-- exactly, at nanos (129, 759).
+--
+-- WHY A COLUMN AND NOT A BACKFILL. The pre-fix rows can never be verified — their original
+-- nanoseconds are gone. The three options were not equivalent:
+--   * re-chaining them rewrites audit hashes wholesale, which destroys tamper-evidence for the
+--     whole period and is indistinguishable from what an attacker would do;
+--   * folding them into the pre-V5 `unchained` bucket is dishonest, because those rows DO carry a
+--     hash and are unverifiable for an entirely different reason;
+--   * recording the boundary explicitly keeps the metric truthful about the segment it can
+--     actually check, and says so in its own counter.
+-- This takes the third. NULL means "hashed with the pre-fix canonical form": unverifiable, counted
+-- separately, never reported as either verified or tampered.
+--
+-- Rollback: ALTER TABLE audit_entries DROP COLUMN hash_version;
+--   (safe — no row's record_hash is modified by this migration, and verifyChain treats a missing
+--   column the same way it treats NULL: legacy, not broken.)
+ALTER TABLE audit_entries ADD COLUMN IF NOT EXISTS hash_version SMALLINT;
+
+COMMENT ON COLUMN audit_entries.hash_version IS
+  'Canonical form used for record_hash. NULL = pre-2026-08-03 form (nanosecond Instant.toString(), '
+  'unverifiable because timestamptz truncates to microseconds). 2 = microsecond-truncated form.';
+
+-- Partial index: verifyChain scans for the first verifiable row on every run, and the legacy
+-- segment is expected to stay a fixed size forever while the verifiable one grows.
+CREATE INDEX IF NOT EXISTS idx_audit_entries_hash_version
+  ON audit_entries(id ASC) WHERE hash_version IS NOT NULL;

--- a/openbank-audit-service/src/test/kotlin/com/openbank/audit/integration/AuditChainRoundTripIT.kt
+++ b/openbank-audit-service/src/test/kotlin/com/openbank/audit/integration/AuditChainRoundTripIT.kt
@@ -5,6 +5,7 @@ package com.openbank.audit.integration
 
 import com.openbank.audit.domain.model.AuditEntry
 import com.openbank.audit.infrastructure.persistence.AuditRepository
+import com.openbank.audit.infrastructure.persistence.AuditRepository.Companion.normalisedForStorage
 import com.openbank.audit.it.PostgresTestResource
 import io.quarkus.test.common.QuarkusTestResource
 import io.quarkus.test.junit.QuarkusTest
@@ -120,7 +121,83 @@ class AuditChainRoundTripIT {
             .isGreaterThanOrEqualTo(2)
     }
 
+    /**
+     * The two tests above both anchor with `fromEntryId` at a row they wrote themselves, so the
+     * walk starts AFTER any legacy segment — they pass whether or not the boundary is handled.
+     * That is the blind spot this closes: the scheduler calls `verifyChain()` with no anchor,
+     * walks from row one, and in the sandbox died on the first pre-#3586 row every time, leaving
+     * `entries_checked = 0` against 1066 chained rows while `AuditChainBroken` paged critical
+     * (#3505).
+     *
+     * A row whose `hash_version` is NULL cannot be recomputed — the nanoseconds the old canonical
+     * form hashed are not in the database. That is a failure to VERIFY, and must never be reported
+     * as tampering. Both rows are appended through the same seam so their ids stay consecutive;
+     * see `appendRawRow` for why mixing allocators does not work here.
+     */
+    @Test
+    fun `a walk crossing a legacy row verifies the row after it instead of reporting tampering`() {
+        val legacy = entry("legacy-${UUID.randomUUID()}")
+        val afterLegacy = entry("after-legacy-${UUID.randomUUID()}")
+        // A legacy hash is one that cannot be recomputed — that IS the property under test, so it
+        // is deliberately not a hash of this row.
+        val legacyHash = "de".repeat(HASH_HEX_BYTES)
+
+        assertThat(onEventLoop { repository.appendRawRow(legacy, GENESIS, legacyHash, null) })
+            .describedAs("the seam must actually append the legacy row")
+            .isEqualTo(1)
+        assertThat(
+            onEventLoop {
+                repository.appendRawRow(
+                    afterLegacy,
+                    legacyHash,
+                    AuditRepository.chainHash(legacyHash, afterLegacy.normalisedForStorage()),
+                    HASH_VERSION_MICROS,
+                )
+            },
+        ).describedAs("the seam must actually append the verifiable row").isEqualTo(1)
+
+        val verification = onEventLoop { repository.verifyChain(fromEntryId = legacy.id) }
+
+        assertThat(verification.intact)
+            .describedAs(
+                "a legacy row must not read as a broken link (first broken: %s)",
+                verification.firstBrokenEntryId,
+            )
+            .isTrue()
+        assertThat(verification.unverifiableLegacy)
+            .describedAs("the legacy row must be counted on its own, not silently skipped")
+            .isEqualTo(1)
+        assertThat(verification.checked)
+            .describedAs("the row written AFTER the legacy one must still be recomputed and verified")
+            .isEqualTo(1)
+    }
+
+    /**
+     * "Never had a hash" (pre-V5) and "has a hash that cannot be recomputed" (pre-#3586) are
+     * different facts. Merging them would let a real gap hide inside a known one.
+     */
+    @Test
+    fun `a legacy row is counted apart from the pre-chain unchained rows`() {
+        val legacy = entry("legacy-bucket-${UUID.randomUUID()}")
+        val before = onEventLoop { repository.verifyChain(fromEntryId = legacy.id) }
+
+        assertThat(
+            onEventLoop { repository.appendRawRow(legacy, GENESIS, "de".repeat(HASH_HEX_BYTES), null) },
+        ).describedAs("the seam must actually append a row").isEqualTo(1)
+        val after = onEventLoop { repository.verifyChain(fromEntryId = legacy.id) }
+
+        assertThat(after.unchained)
+            .describedAs("a row carrying a hash must never land in the pre-chain unchained bucket")
+            .isEqualTo(before.unchained)
+        assertThat(after.unverifiableLegacy)
+            .describedAs("it belongs in its own bucket instead")
+            .isEqualTo(1)
+    }
+
     private companion object {
+        const val GENESIS = "0000000000000000000000000000000000000000000000000000000000000000"
+        const val HASH_HEX_BYTES = 32
+        const val HASH_VERSION_MICROS: Short = 2
         const val OCCURRED_EPOCH_SECOND = 1_785_704_401L
         const val OCCURRED_NANOS = 123_456_789L
         const val RECORDED_EPOCH_SECOND = 1_785_704_402L


### PR DESCRIPTION
## Linked issues

Closes #3505

## What #3586 left behind

#3586 corrected the canonical form and **is deployed** — and the metric never moved:

```
openbank_audit_chain_intact          = 0
openbank_audit_chain_entries_checked = 0     <-- still zero, hours after the fix shipped
AuditChainBroken -> firing
```

The scheduler calls `verifyChain()` with **no anchor**, so the walk starts at row one and returns on the first failure — still a pre-fix row. It never reaches the correctly-hashed rows written since. The deployed fix currently changes nothing observable.

Worth noting why the existing round-trip tests stayed green through this: both anchor with `fromEntryId` at a row they wrote themselves, which starts the walk *after* the legacy segment. The anchorless path — the one the scheduler actually uses — had no coverage at all.

## The change

`V10` adds `audit_entries.hash_version`: NULL for the pre-#3586 canonical form, `2` for the microsecond-truncated one. `verifyChain` counts NULL-version rows into a new `unverifiableLegacy` bucket instead of reading them as a broken link, then **re-anchors** `expectedPrev` on the first verifiable row's own `prevHash`.

That re-anchor is load-bearing: without it the boundary link is compared across two canonical forms, and the first **good** row reports as tampering — the same false positive, moved one row along.

The new gauge is deliberately **separate** from `entries.unchained`. *"Never had a hash"* (pre-V5) and *"has a hash that cannot be recomputed"* (pre-#3586) are different facts; merging them would let a real gap hide inside a known one. The series should be **constant** — if it grows, something is writing the old form again.

## Why not backfill

Not only the tamper-evidence argument. `V2__compliance_fields.sql` installs:

```sql
CREATE OR REPLACE RULE no_update_audit AS ON UPDATE TO audit_entries DO INSTEAD NOTHING;
```

`audit_entries` is append-only **at the database level**, and an UPDATE is *silently discarded* rather than refused. Re-chaining was impossible, not merely inadvisable.

## What that cost the test, and what it taught

The seam has to **append** a legacy row, not demote one — and it returns the affected-row count so the caller can assert it. The first version of this test went green against unchanged code precisely because the seam no-op'd.

Both rows are appended through the same seam so ids stay monotonic. Mixing allocators does not work here:

| attempt | outcome |
|---|---|
| `MAX(id)+1` | collides with an id Hibernate already reserved (`V4` sets `INCREMENT BY 50`) → `duplicate key value violates "audit_entries_pkey"` |
| raw `nextval` + a Hibernate-written neighbour | takes a fresh block, so the row sorts *after* the later write and scrambles chain order |

Both are harness defects that present as product failures — which is exactly why a test that has only ever been green cannot be trusted.

## Verification

Falsified against the **real** defect rather than a fixture — with the legacy-skip branch removed, exactly the two new tests go red:

```
without the fix:  FAIL  a walk crossing a legacy row verifies the row after it ...
                  FAIL  a legacy row is counted apart from the pre-chain unchained rows
                  (the other three still pass)

restored:         65 tests, 0 failures, 0 errors   ·   detekt + ktlintCheck clean
```
