### PR TITLE
docs(delegation): state the CVE-2025-14969 verdict for delegation-service

### DIFF
--- a/openbank-libs/governance/vex/delegation-service.openvex.json
+++ b/openbank-libs/governance/vex/delegation-service.openvex.json
@@ -1,0 +1,15 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://open-bank.tech/vex/delegation-service",
+  "author": "OpenBank Security",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2025-14969"
+      },
+      "status": "affected",
+      "action_statement": "Resolved org.hibernate.reactive:hibernate-reactive-core is 3.4.1.Final (bundled by the Quarkus platform BOM io.quarkus.platform:quarkus-bom:3.37.2). The connection-leak DoS is fixed in 4.2.1.Final, a major-version jump that cannot be forced independently of the Quarkus platform (a bare force desyncs from the Quarkus-tested Vert.x/Hibernate-Reactive combination), so remediation is tracked as the Quarkus platform bump in issue #1446. Compensating controls in place: the reactive PostgreSQL pool is bounded with idle-connection eviction (shared openbank-libs default, PRs #1682/#1894), so a leaked-connection condition self-heals rather than permanently exhausting the pool, and every service is reachable only in-mesh (Istio STRICT mTLS) and via the authenticated BFF, not directly by an external client. Residual risk: medium-severity DoS only, no data exposure."
+    }
+  ]
+}


### PR DESCRIPTION
Closes #3648.

## What was actually missing

`delegation-service` was **the only released component with no `openbank-libs/governance/vex/*.openvex.json` file at all** — 41 others have one. So `CVE-2025-14969` sat `under_investigation` in its release VEX while every other component carried a triaged verdict for the same CVE.

## The verdict is not new, and not mine

All 41 state `affected` with an identical action statement: `hibernate-reactive-core` 3.4.1.Final is bundled by the Quarkus platform BOM, the connection-leak DoS is fixed in 4.2.1.Final, that is a major-version jump which cannot be forced independently of the platform (a bare force desyncs from the Quarkus-tested Vert.x/Hibernate-Reactive combination), so remediation is tracked as the Quarkus platform bump in **#1446** — with the bounded reactive pool + idle-connection eviction and in-mesh-only reachability as compensating controls, and residual risk stated as medium DoS, no data exposure.

Copied **verbatim**. A second, differently worded assessment of one CVE across 42 components is how two statements drift apart, and this repo has paid for that shape before (the NOTICE/README licence split, #2280).

## Verified rather than assumed

The fleet verdict only transfers if delegation-service actually carries the dependency. Its build declares `quarkus.hibernate.reactive.panache`, `quarkus.hibernate.reactive.panache.base` and `quarkus.reactive.pg.client` against the same `enforcedPlatform(libs.quarkus.bom)`, so `hibernate-reactive-core` arrives by the same route as everywhere else.

Worth recording the near-miss: my first check grepped the build file for `hibernate-reactive` and found **nothing**, because the version-catalog alias is dotted (`libs.quarkus.hibernate.reactive.panache`), not hyphenated. Had I trusted that silence, the correct answer would have looked like `not_affected` — the dangerous direction for a VEX statement.

## When this takes effect

Not immediately, and the issue says so: `vex-inventory.py` reads the **published release VEX**, not the committed file. Re-running it with this file in place still reports `delegation-service(under_investigation)`, which is the expected behaviour, not a failure of the change. The next release folds it into the evidence bundle and the triage issue auto-closes on the following weekly run.

## Commit type

`docs`, not `security`, deliberately. The file lives under `openbank-libs/governance/`, not under `openbank-delegation-service/`, so a releasing type would promise a release release-please cannot cut — the `release_scope_mismatch` shape. This records a verdict; it ships no code.

## Self-assessment

- **I did not independently assess the CVE.** I confirmed the dependency is present and applied the fleet's existing verdict. If that verdict is wrong, it is wrong in 42 places now instead of 41 — which is an argument for it being reviewed once, centrally, not for me having written a 42nd variant.
- **Only this CVE is stated.** `account-service` carries 15 statements; delegation-service now has 1. The others were never raised for delegation-service, so I have not pre-emptively copied them — if the scanner finds them, `vex-triage.yml` will open issues and each gets its own verdict.
- **Not verified:** that the release evidence bundle picks the file up correctly, since that only happens at delegation-service's next release. The mechanism is the one 41 other files already use.
