### PR TITLE
fix(ci): agent-review must not report a review that never happened

### DIFF
--- a/.github/scripts/check-agent-review-happened.sh
+++ b/.github/scripts/check-agent-review-happened.sh
@@ -1,0 +1,232 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+#
+# Terminal accountability guard for `agent-review`: a run that reviewed nothing must not
+# be readable as a review (issue #3488; the fallback half is #2161).
+#
+# WHY THIS EXISTS — measured, not assumed
+#   120 `Agent review` runs sampled over 2026-08-02T15:52 .. 2026-08-03T11:18 (classified
+#   from step conclusions, not from log text) contained ZERO model reviews:
+#
+#     75  deferred-to-human (sensitive scope — correct, no model was ever called)
+#     15  job skipped by the workflow `if:`
+#     27  primary reviewer failed -> dead Claude fallback -> job RED
+#      2  primary reviewer failed -> fallback SKIPPED  -> job GREEN, nothing reviewed
+#      1  checkout/git transport 503
+#      0  a review actually submitted by any model
+#
+#   The trigger is not intermittent and it is not a rate limit. Every single call to the
+#   primary reviewer returned:
+#
+#     410 GitHub Models is temporarily unavailable as part of a scheduled retirement brownout.
+#
+#   GitHub Models was fully retired on 2026-07-30 (GitHub Changelog, "GitHub Models is now
+#   retired"). The primary reviewer is therefore permanently dead, not flaky. The apparent
+#   ~40% pass rate in #3488 was runs that never called a model at all: the successes are
+#   deferred-to-human and skipped runs, and 100% of runs that attempted a review failed.
+#   Successes and failures interleaving minute by minute is that mix, not concurrency.
+#
+#   Two of the sampled runs are the reason this file exists rather than a tweak to
+#   check-claude-fallback-result.sh. That guard is gated on the Claude step having RUN
+#   (`steps.claude.outcome != 'skipped'`), so when the fallback is skipped — a Dependabot or
+#   fork PR, where `secrets.CLAUDE_CODE_OAUTH_TOKEN` is empty in the job context — the guard
+#   is skipped too and the job finishes GREEN having reviewed nothing. On the PR page a green
+#   `agent-review` reads exactly like a review that happened. That is the default reading once
+#   the fallback stops running for any reason, so it is the state worth closing.
+#
+# WHAT IT CHECKS
+#   Drives off STEP OUTCOMES, never log text (a job log embeds each step's own `run:` script,
+#   so grepping it matches strings that never executed). Passes only when a review demonstrably
+#   happened or was deliberately not attempted:
+#
+#     scope deferred to a human            -> PASS (a human was told, in a PR comment)
+#     primary verdict submitted            -> PASS (a real review was posted)
+#     fallback ran and check-claude-
+#       fallback-result.sh passed on its
+#       transcript                         -> PASS
+#     anything else                        -> FAIL, with the reason named
+#
+#   The transcript itself is NOT re-read here. check-claude-fallback-result.sh already does
+#   that, in its own step, unchanged; its step outcome arrives as FALLBACK_GUARD_OUTCOME.
+#   Two scripts each invoked directly by the workflow, rather than one calling the other —
+#   check-gate-script-registration.py deliberately does not count a caller that lives in
+#   .github/scripts, so delegating would have left the #2161 guard reading as an orphan.
+#
+#   Naming the reason is the point. Every failure in the sample was annotated as the #2161
+#   signature, so four separate causes — a retired primary, a dead OAuth token, the action
+#   refusing a bot actor, and a skipped fallback — all read as one known issue that nobody
+#   could act on. This guard reports which one it was.
+#
+#   When it fails it also posts the verdict as a PR comment (best-effort; the token is
+#   read-only on Dependabot and fork PRs). The job conclusion alone is a weak carrier: it is
+#   read as "the reviewer is broken again", and it is the only place the state appears today.
+#
+# Usage:  check-agent-review-happened.sh
+#         check-agent-review-happened.sh --self-test
+#
+# Environment (all optional; absent is treated as the pessimistic case):
+#   SCOPE_SKIP        "true" when the scope gate deferred to a human
+#   PRIMARY_OUTCOME   `steps.ghmodels.outcome`  (success|failure|skipped)
+#   SUBMIT_OUTCOME    `steps.submit.outcome`    (success|failure|skipped)
+#   CLAUDE_OUTCOME    `steps.claude.outcome`    (success|failure|skipped)
+#   FALLBACK_GUARD_OUTCOME
+#                     `steps.fallback_guard.outcome` — the #2161 transcript guard's verdict
+#   HAS_CLAUDE        "true" when the OAuth secret is visible in this job context
+#   PR, GH_TOKEN      used only for the best-effort PR comment
+
+set -uo pipefail
+
+# Set by evaluate(): a one-line, human-first statement of what happened.
+VERDICT=""
+
+evaluate() {
+  local scope_skip="${SCOPE_SKIP:-false}"
+  local primary="${PRIMARY_OUTCOME:-unknown}"
+  local submit="${SUBMIT_OUTCOME:-unknown}"
+  local claude="${CLAUDE_OUTCOME:-unknown}"
+  local has_claude="${HAS_CLAUDE:-false}"
+  local guard="${FALLBACK_GUARD_OUTCOME:-unknown}"
+
+  echo "step outcomes: scope_skip=$scope_skip primary=$primary submit=$submit claude=$claude guard=$guard has_claude=$has_claude"
+
+  if [ "$scope_skip" = "true" ]; then
+    VERDICT="No agent review — the change is in the sensitive class and was deliberately deferred to a human reviewer."
+    echo "$VERDICT"
+    return 0
+  fi
+
+  if [ "$submit" = "success" ]; then
+    VERDICT="Reviewed by the primary reviewer."
+    echo "$VERDICT"
+    return 0
+  fi
+
+  # Nothing was submitted by the primary. Name why, so the failure is actionable rather
+  # than another instance of "the known reviewer breakage".
+  local why
+  case "$primary" in
+    failure)
+      why="the primary reviewer (GitHub Models) failed. GitHub Models was RETIRED on 2026-07-30 and now answers every inference call with HTTP 410, so this is permanent, not transient — see the 'GitHub Models review' step for the exact error (#3488)." ;;
+    skipped)
+      why="the primary reviewer step did not run." ;;
+    success)
+      why="the primary reviewer answered but its verdict was not submitted (submit outcome=$submit)." ;;
+    *)
+      why="the primary reviewer's outcome could not be determined (outcome=$primary)." ;;
+  esac
+
+  case "$claude" in
+    skipped)
+      if [ "$has_claude" = "true" ]; then
+        VERDICT="NO REVIEW HAPPENED: $why The Claude fallback did not run."
+      else
+        VERDICT="NO REVIEW HAPPENED: $why The Claude fallback could not run either — CLAUDE_CODE_OAUTH_TOKEN is not visible in this job context, which is normal for a Dependabot or fork PR. Nothing reviewed this change; without this guard the job would be GREEN."
+      fi
+      echo "::error title=agent-review reviewed nothing::$VERDICT"
+      return 1
+      ;;
+    unknown)
+      VERDICT="NO REVIEW HAPPENED: $why The Claude fallback's outcome could not be determined, so there is no evidence any review took place."
+      echo "::error title=agent-review reviewed nothing::$VERDICT"
+      return 1
+      ;;
+  esac
+
+  # The fallback ran. Its own step outcome carries no information (the action exits 0 on a
+  # recorded failure), so the evidence is the transcript — read by the preceding
+  # `Verify the Claude fallback actually reviewed` step, whose outcome arrives here.
+  if [ "$guard" = "success" ]; then
+    VERDICT="Reviewed by the Claude fallback."
+    echo "$VERDICT"
+    return 0
+  fi
+
+  if [ "$guard" = "failure" ]; then
+    VERDICT="NO REVIEW HAPPENED: $why The Claude fallback ran but its transcript shows it did not review — see that step's annotations for which signature it was (a gateway rejection at turn 1 is #2161; a refusal to act for a bot actor is the action's own allowed_bots policy, not a credential problem)."
+  else
+    VERDICT="NO REVIEW HAPPENED: $why The Claude fallback ran, but the transcript guard did not report a verdict (outcome=$guard), so the run cannot be shown to have reviewed anything."
+  fi
+  echo "::error title=agent-review reviewed nothing::$VERDICT"
+  return 1
+}
+
+# Best-effort: make the state visible where humans read, not only in the job conclusion.
+post_pr_comment() {
+  local body="$1"
+  [ -n "${PR:-}" ] || return 0
+  [ -n "${GH_TOKEN:-}" ] || return 0
+  command -v gh >/dev/null 2>&1 || return 0
+  printf '%s\n' \
+    "⚠️ **Agent review did not review this PR.**" \
+    "" \
+    "$body" \
+    "" \
+    "_This job is advisory and not a required check — the PR is not rejected. It is red because no review happened, which must not be reported as a review (#3488)._" \
+    > /tmp/agent-review-no-review.md 2>/dev/null || return 0
+  gh pr comment "$PR" --body-file /tmp/agent-review-no-review.md >/dev/null 2>&1 \
+    || echo "::warning::could not post the no-review comment (the token is read-only on Dependabot and fork PRs)"
+}
+
+# ---------------------------------------------------------------------------------------
+
+self_test() {
+  local fails=0
+
+  check() { # <label> <expected-rc> <env assignments...>
+    local label="$1" want="$2"; shift 2
+    local got
+    ( unset SCOPE_SKIP PRIMARY_OUTCOME SUBMIT_OUTCOME CLAUDE_OUTCOME FALLBACK_GUARD_OUTCOME \
+            HAS_CLAUDE PR GH_TOKEN
+      # shellcheck disable=SC2163  # each "$@" element is a literal NAME=value assignment
+      export "$@"
+      evaluate >/dev/null 2>&1 )
+    got=$?
+    if [ "$got" -ne "$want" ]; then
+      echo "  FAIL: $label expected rc=$want got rc=$got"
+      fails=$((fails + 1))
+    else
+      echo "  ok:   $label (rc=$got)"
+    fi
+  }
+
+  echo "self-test — each branch is fed the input it must classify:"
+  # Passes. A guard that only ever reds is not a signal.
+  check "deferred to a human"              0 SCOPE_SKIP=true PRIMARY_OUTCOME=skipped SUBMIT_OUTCOME=skipped CLAUDE_OUTCOME=skipped
+  check "primary submitted a verdict"      0 SCOPE_SKIP=false PRIMARY_OUTCOME=success SUBMIT_OUTCOME=success CLAUDE_OUTCOME=skipped
+  check "fallback reviewed for real"       0 SCOPE_SKIP=false PRIMARY_OUTCOME=failure SUBMIT_OUTCOME=skipped CLAUDE_OUTCOME=success FALLBACK_GUARD_OUTCOME=success HAS_CLAUDE=true
+  # Fails. Each is a state observed in the 120-run sample.
+  check "410 primary + dead fallback"      1 SCOPE_SKIP=false PRIMARY_OUTCOME=failure SUBMIT_OUTCOME=skipped CLAUDE_OUTCOME=success FALLBACK_GUARD_OUTCOME=failure HAS_CLAUDE=true
+  check "410 primary + fallback SKIPPED"   1 SCOPE_SKIP=false PRIMARY_OUTCOME=failure SUBMIT_OUTCOME=skipped CLAUDE_OUTCOME=skipped HAS_CLAUDE=false
+  check "410 primary + guard not reached"  1 SCOPE_SKIP=false PRIMARY_OUTCOME=failure SUBMIT_OUTCOME=skipped CLAUDE_OUTCOME=failure FALLBACK_GUARD_OUTCOME=skipped HAS_CLAUDE=true
+  check "primary ok, submit failed"        1 SCOPE_SKIP=false PRIMARY_OUTCOME=success SUBMIT_OUTCOME=failure CLAUDE_OUTCOME=skipped HAS_CLAUDE=true
+  check "no environment at all"            1 IGNORED=1
+
+  if [ "$fails" -gt 0 ]; then
+    echo "self-test FAILED ($fails case(s))"
+    return 1
+  fi
+  echo "self-test OK — 8 cases."
+  return 0
+}
+
+# ---------------------------------------------------------------------------------------
+
+if [ "${1:-}" = "--self-test" ]; then
+  self_test
+  exit $?
+fi
+
+evaluate
+rc=$?
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+  printf '### Agent review outcome\n\n%s\n' "$VERDICT" >> "$GITHUB_STEP_SUMMARY"
+fi
+if [ "$rc" -ne 0 ]; then
+  post_pr_comment "$VERDICT"
+  echo
+  echo "This job is advisory and NOT a required check, so the PR is not rejected. It is red"
+  echo "because nothing reviewed this change — see #3488 for the retired primary reviewer and"
+  echo "#2161 for the fallback credential."
+fi
+exit "$rc"

--- a/.github/workflows/agent-review.yml
+++ b/.github/workflows/agent-review.yml
@@ -43,6 +43,17 @@
 #     exits 0 on its own recorded failure, so a guard step reads the transcript and
 #     fails the job instead (check-claude-fallback-result.sh). The token being dead is
 #     now visible; before, a dead standby and a healthy one were indistinguishable.
+#   * PRIMARY REVIEWER IS DEAD TOO (#3488). GitHub Models was fully RETIRED on
+#     2026-07-30; every `actions/ai-inference` call now answers
+#     `410 GitHub Models is temporarily unavailable as part of a scheduled retirement
+#     brownout`. So the primary is permanently down, not flaky, and with the #2161
+#     fallback also dead this workflow currently reviews NOTHING: across 120 runs
+#     sampled 2026-08-02..03, zero reviews were submitted by any model — the apparent
+#     pass rate was runs that never called a model (sensitive scope deferred to a
+#     human, or the job `if:` skipping). Restoring a reviewer means pointing the
+#     primary at a live inference endpoint, which is a credential decision for the
+#     owner. Until then the terminal guard below states, on the PR, that no review
+#     happened — see .github/scripts/check-agent-review-happened.sh.
 #
 # Prerequisites (one-time, outside this file):
 #   1. Settings → Actions → General → "Allow GitHub Actions to approve pull
@@ -351,6 +362,7 @@ jobs:
 
       # --- Submit the GitHub Models verdict ----------------------------------
       - name: Submit review (GitHub Models)
+        id: submit
         if: steps.scope.outputs.skip == 'false' && steps.ghmodels.outcome == 'success'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -454,11 +466,43 @@ jobs:
       # job. The standby reviewer was dead and every available signal said it was fine.
       #
       # `always()` so a crashed action still reaches the guard; the `skipped` test keeps
-      # it silent on the overwhelmingly common path where the primary reviewer worked.
-      # Failing here is safe: this job is non-blocking and not a required check, so a red
-      # means "no review happened", never "this PR is rejected".
+      # it silent on the overwhelmingly common path where the fallback did not run.
+      # Failing here is safe: this job is non-blocking and not a required check.
+      #
+      # It deliberately does NOT carry `continue-on-error` — that would make it an advisory
+      # gate, which check-advisory-gate-registration.py (#2392, enforced) correctly refuses
+      # unless rules.yaml gives it a target_enforce_date. It is not advisory; it is enforced
+      # and its outcome is ALSO read by the terminal guard below, which is what turns a bare
+      # red into a named cause and a PR comment.
       - name: Verify the Claude fallback actually reviewed
+        id: fallback_guard
         if: always() && steps.claude.outcome != 'skipped'
         env:
           EXECUTION_FILE: ${{ steps.claude.outputs.execution_file }}
         run: .github/scripts/check-claude-fallback-result.sh "$EXECUTION_FILE"
+
+      # --- A run that reviewed nothing must not be readable as a review ------------
+      # Terminal accountability guard (#3488). The step above is gated on the Claude step
+      # having RUN, so when the fallback is SKIPPED — a Dependabot or fork PR, where the
+      # OAuth secret is empty in the job context — that guard is skipped too and the job
+      # finishes GREEN having reviewed nothing. Measured twice in a 120-run sample, and it
+      # is the default reading once the fallback stops running for any reason.
+      #
+      # This step asks the whole question instead: did ANY review happen, and if not, which
+      # of the four causes was it. Rationale, the measured classification, and the HTTP 410
+      # that kills the primary reviewer are in the script header, not here (#3135: prose in
+      # a `run:` block can make the whole workflow unparseable).
+      #
+      # Failing is safe: this job is non-blocking and not a required check, so a red means
+      # "no review happened", never "this PR is rejected".
+      - name: Verify a review actually happened
+        if: always() && steps.scope.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+          SCOPE_SKIP: ${{ steps.scope.outputs.skip }}
+          PRIMARY_OUTCOME: ${{ steps.ghmodels.outcome }}
+          SUBMIT_OUTCOME: ${{ steps.submit.outcome }}
+          CLAUDE_OUTCOME: ${{ steps.claude.outcome }}
+          FALLBACK_GUARD_OUTCOME: ${{ steps.fallback_guard.outcome }}
+        run: .github/scripts/check-agent-review-happened.sh


### PR DESCRIPTION
## What

`agent-review` currently reviews **nothing**, and roughly a quarter of its runs report that as a red attributed to #2161 while the rest report it as a green.

The trigger is not #2161 and it is not intermittent: **GitHub Models was fully retired on 2026-07-30**. Every `actions/ai-inference` call now answers

```
410 GitHub Models is temporarily unavailable as part of a scheduled retirement brownout.
```

The primary reviewer is permanently dead. #2161 (the dead OAuth fallback) only decides what happens *next* — and the answer is either a red nobody can act on, or a green.

## Measurement

120 `Agent review` runs, 2026-08-02T15:52Z .. 2026-08-03T11:18Z, classified from **step conclusions** (`gh api .../actions/runs/<id>/jobs --jq '.steps[]'`), not log text:

| outcome | runs |
| --- | ---: |
| deferred-to-human (sensitive scope — no model ever called) | 75 |
| job skipped by the workflow `if:` | 15 |
| primary failed → dead Claude fallback → job **RED** | 27 |
| primary failed → fallback **skipped** → job **GREEN**, nothing reviewed | 2 |
| checkout/git transport 503 | 1 |
| **a review actually submitted, by any model** | **0** |

All 12 primary failures inspected in detail carried the 410, unanimously. So the "~40% failure" in #3488 is **100% of runs that attempted a review**; the successes are runs that never called a model. That also explains the minute-by-minute interleaving that looked like a concurrency limit — it is deferred-vs-attempted, not load.

One measurement note worth recording: the ai-inference step's own conclusion reads `success` even when it failed, because `continue-on-error: true` rewrites the reported conclusion. The discriminator is the downstream gated step — `Submit review (GitHub Models)` skipping means `steps.ghmodels.outcome == 'failure'`.

## Why a new step and not a tighter guard

The two GREEN rows. `check-claude-fallback-result.sh` is gated on the Claude step having **run** (`steps.claude.outcome != 'skipped'`). On a Dependabot or fork PR the OAuth secret is empty in the job context, the fallback is skipped, the guard is skipped with it, and the job finishes green having reviewed nothing. On the PR page that is indistinguishable from a review that happened — and it is the *default* reading the moment the fallback stops running for any reason.

## What this changes

- Adds `.github/scripts/check-agent-review-happened.sh`, a terminal accountability guard driven off step outcomes. It passes only when a review demonstrably happened, or was deliberately not attempted (sensitive scope deferred to a human, which already posts a comment).
- It **names which of the four causes** it was — retired primary, dead OAuth token, the action refusing a bot actor, or a skipped fallback — instead of letting all four read as "the known #2161 issue".
- On failure it **posts the verdict as a PR comment** (best-effort; the token is read-only on Dependabot and fork PRs). A job conclusion alone is a weak carrier and is the only place this state appears today.
- The #2161 transcript check keeps its own step and its own red, unchanged; it gains only an `id` so it can report its verdict to the terminal guard via `steps.fallback_guard.outcome`.
- Workflow header now records the retirement, so the next reader does not re-diagnose it.

Two gates in this repo shaped that design, both found by running them rather than by predicting them:

1. The first push had the terminal guard *calling* `check-claude-fallback-result.sh`. `check-gate-script-registration.py` (#3240, enforced) went red: it deliberately does not count a caller that lives in `.github/scripts`, so the #2161 guard would have read as an orphan nothing runs. Fixed by making both steps workflow-invoked, one passing its outcome to the other.
2. The second push gave that step `continue-on-error: true`, so a single step would own the verdict. `check-advisory-gate-registration.py` (#2392, enforced) went red, correctly: `continue-on-error` turns an enforced guard into an advisory gate, and an advisory gate with no `target_enforce_date` in `rules.yaml` is one that stays advisory forever. Reverted — the step keeps its own red, and the terminal guard is what turns that red into a named cause and a PR comment.

The job stays advisory and is not a required check, so a red still means "no review happened", never "this PR is rejected".

## What this deliberately does NOT do

Restoring an actual reviewer means pointing the primary at a live inference endpoint. That is a credential decision for the owner and is out of scope here. No secret is created, read or printed by this change.

## Falsification

`--self-test` runs 8 cases — 3 that MUST pass and 5 that MUST fail, each taken from a state observed in the sample above, including the exact green-with-no-review case that motivated the change. Verified green under macOS bash 3.2 and bash 5.2. `shellcheck` and `actionlint` clean; `run-gates.py --group registry` is PASS=14 WARN=1 FAIL=0 locally (the warning is a pre-existing advisory about `rest.rego`, untouched here). Largest `run:` step in the workflow is 7587 chars, well under the 19000 limit (#3135); the change shortens the `run:` block rather than growing it, with the reasoning in the script header.

Validated against **GitHub**, not only a YAML parser: the first push produced a run titled `Agent review` (so the file parsed and `name:` was read, not a run titled after the path), and the new step executed for real with substituted values — `step outcomes: scope_skip=true primary=skipped submit=skipped claude=skipped has_claude=true` — passing on the deferred path, which is the correct verdict for a `.github/*` PR.

## Risk

Low. The only behavioural change is that a run which reviewed nothing is now red and says so, where two of the sampled runs were previously green. The workflow is advisory and not a required status check.

## Linked issues

Refs #3488
Refs #2161
