### PR TITLE
fix(infra): pin the fck-nat AMI so a plain tofu apply cannot rebuild egress

### DIFF
--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -1893,3 +1893,21 @@ gates:
       # disabled". Ratcheted against a baseline — new occurrences fail, today's are frozen
       # because removing a default makes config START applying and can flip live behaviour.
       python3 .github/scripts/check-configproperty-kotlin-defaults.py
+  - id: nat-ami-pinned
+    name: "NAT instance AMI is pinned (issue #3602, enforced)"
+    group: gitops
+    mode: enforced
+    selftest: python3 .github/scripts/check-nat-ami-pinned.py --self-test
+    selftest_expect: pass
+    run: |
+      # The fck-nat instance IS the private subnets' only egress path, and its `ami` came
+      # from a most_recent aws_ami data source. `ami` forces replacement, so every upstream
+      # AMI publication silently re-armed a destroy-and-recreate of the live NAT — with no
+      # commit and no author behind it. The state was fine; the ORDINARY command was the
+      # landmine, and it fired for whoever next applied the stack for an unrelated reason.
+      #
+      # BOTH halves are required and neither alone blocks (#2392): the script prints
+      # ::warning and exits 0 without --enforce. Falsified against the real pre-fix tree,
+      # not only a fixture — it exits 1 on origin/main's network module + substrate env and
+      # 0 with the pin in place.
+      python3 .github/scripts/check-nat-ami-pinned.py --enforce

--- a/.github/scripts/check-nat-ami-pinned.py
+++ b/.github/scripts/check-nat-ami-pinned.py
@@ -1,0 +1,334 @@
+#!/usr/bin/env python3
+"""Guard: the NAT instance's AMI is PINNED, so no plain `tofu apply` can rebuild egress.
+
+WHY THIS EXISTS (issue #3602)
+    `openbank-infra/aws/modules/network` runs the private subnets' egress through a single
+    fck-nat EC2 instance (ADR-0058). Its AMI came straight out of a `most_recent = true`
+    `aws_ami` data source:
+
+        data "aws_ami" "fck_nat" { most_recent = true  ... }
+        resource "aws_instance" "fck_nat" { ami = data.aws_ami.fck_nat[0].id }
+
+    `ami` is a replace-forcing attribute, and that data source re-resolves on EVERY plan. So
+    every time the upstream publisher shipped a patched AMI — no commit, no review, no author —
+    the plan silently re-armed with:
+
+        ~ ami = "ami-08c439a446e724124" -> "ami-0899dbf7e367fdbb4" # forces replacement
+
+    and dragged `aws_route_table.private` along with it, because the default route points at
+    the instance's primary ENI. The next person to apply this stack for ANY unrelated reason
+    (a one-line IAM fix is how it was found) destroyed and recreated the single NAT and dropped
+    all private-subnet egress. Nothing was wrong with the state; the ordinary command was the
+    landmine, and the person most likely to step on it is the one doing the obviously-correct
+    thing.
+
+    The class is general and not specific to NAT: an instance whose AMI is resolved rather than
+    declared has a replace scheduled by a third party on a timetable nobody in this repo sets.
+    On a singleton that IS the egress path, that is an outage waiting for an unrelated apply.
+
+WHAT IT CHECKS
+
+    R1 — no `aws_instance` under openbank-infra/aws/ may take its `ami` from a
+         `most_recent = true` aws_ami data source WITHOUT a pin variable in the same
+         expression. The shipped shape is the conditional
+
+             ami = var.nat_ami_id != "" ? var.nat_ami_id : data.aws_ami.fck_nat[0].id
+
+         where the data source is the BOOTSTRAP fallback for a greenfield environment that has
+         no instance yet, and every live environment pins. Deleting the pin half puts the
+         landmine straight back, and R1 is what notices.
+
+    R2 — every env module block that sets `egress_mode = "fck_nat"` must also pass a concrete
+         `nat_ami_id = "ami-..."`. R1 alone cannot see this: the module keeps a legal unpinned
+         fallback path, so an environment that simply never sets the variable is unpinned while
+         every file it references looks correct. R2 is the half that makes "unpinned" a
+         property of the environment rather than of the module.
+
+    Both rules read HCL with comments STRIPPED, because this file's own subject matter is the
+    forbidden shape: the prose above and the comments in `modules/network/main.tf` both contain
+    a literal `ami = data.aws_ami...` and a literal `most_recent = true`. A whole-file grep
+    cannot tell the thing from the prose about the thing, and would flag the very fix it exists
+    to protect.
+
+WHAT IT DELIBERATELY DOES NOT CHECK
+    That the pinned id is the newest available, or that it is the one currently running. Both
+    need an AWS call, and neither is a property of the repo — the point of a pin is that the
+    two are ALLOWED to diverge until a human decides otherwise. The upgrade path is a one-line
+    PR; see `var.nat_ami_id` for the lookup command.
+"""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import re
+import sys
+import tempfile
+
+AWS_DIR = pathlib.Path("openbank-infra/aws")
+ENVS_DIR = AWS_DIR / "envs"
+
+AMI_ID_RE = re.compile(r'^"ami-[0-9a-f]{8,17}"$')
+DATA_AWS_AMI_RE = re.compile(r"\bdata\.aws_ami\.([A-Za-z0-9_-]+)\b")
+VAR_REF_RE = re.compile(r"\bvar\.[A-Za-z0-9_-]+\b")
+
+
+def strip_comments(text: str) -> str:
+    """Remove HCL comments (# , // , /* */) without touching string literals.
+
+    Comment-stripping is not cosmetic here — see the module docstring. Newlines are preserved
+    so reported line numbers still match the file on disk.
+    """
+    out: list[str] = []
+    i, n = 0, len(text)
+    in_string = False
+    while i < n:
+        ch = text[i]
+        if in_string:
+            if ch == "\\" and i + 1 < n:
+                out.append(text[i : i + 2])
+                i += 2
+                continue
+            if ch == '"':
+                in_string = False
+            out.append(ch)
+            i += 1
+            continue
+        if ch == '"':
+            in_string = True
+            out.append(ch)
+            i += 1
+            continue
+        if ch == "#" or text.startswith("//", i):
+            while i < n and text[i] != "\n":
+                i += 1
+            continue
+        if text.startswith("/*", i):
+            end = text.find("*/", i + 2)
+            chunk = text[i:] if end == -1 else text[i : end + 2]
+            out.append("\n" * chunk.count("\n"))
+            i = n if end == -1 else end + 2
+            continue
+        out.append(ch)
+        i += 1
+    return "".join(out)
+
+
+def find_blocks(text: str, header_re: re.Pattern[str]) -> list[tuple[re.Match[str], str, int]]:
+    """Return (header match, block body, 1-based line of the header) for each matching block."""
+    blocks = []
+    for match in header_re.finditer(text):
+        start = text.find("{", match.end() - 1)
+        if start == -1:
+            continue
+        depth, i, n = 0, start, len(text)
+        in_string = False
+        while i < n:
+            ch = text[i]
+            if in_string:
+                if ch == "\\":
+                    i += 2
+                    continue
+                if ch == '"':
+                    in_string = False
+            elif ch == '"':
+                in_string = True
+            elif ch == "{":
+                depth += 1
+            elif ch == "}":
+                depth -= 1
+                if depth == 0:
+                    break
+            i += 1
+        blocks.append((match, text[start + 1 : i], text.count("\n", 0, match.start()) + 1))
+    return blocks
+
+
+def argument_value(body: str, name: str) -> str | None:
+    """The right-hand side of a top-level `name = ...` argument, or None if unset.
+
+    Single-line expressions only: every argument this gate reads is one, and a multi-line
+    expression that silently read as absent would be a false PASS. So an argument whose value
+    looks continued is returned verbatim rather than dropped — the caller then judges the text.
+    """
+    pattern = re.compile(rf"^[ \t]*{re.escape(name)}[ \t]*=[ \t]*(.+)$", re.MULTILINE)
+    match = pattern.search(body)
+    return match.group(1).strip() if match else None
+
+
+def scan(root: pathlib.Path) -> list[str]:
+    findings: list[str] = []
+    aws_root = root / AWS_DIR
+    if not aws_root.is_dir():
+        return findings
+
+    tf_files = sorted(p for p in aws_root.rglob("*.tf") if ".terraform" not in p.parts)
+
+    for path in tf_files:
+        rel = path.relative_to(root)
+        text = strip_comments(path.read_text(encoding="utf-8"))
+
+        # --- R1: an instance AMI that a third party can change ---------------------------
+        volatile: set[str] = set()
+        for match, body, _line in find_blocks(text, re.compile(r'data\s+"aws_ami"\s+"([A-Za-z0-9_-]+)"\s*')):
+            if argument_value(body, "most_recent") == "true":
+                volatile.add(match.group(1))
+
+        for match, body, line in find_blocks(text, re.compile(r'resource\s+"aws_instance"\s+"([A-Za-z0-9_-]+)"\s*')):
+            ami = argument_value(body, "ami")
+            if ami is None:
+                continue
+            referenced = set(DATA_AWS_AMI_RE.findall(ami)) & volatile
+            if referenced and not VAR_REF_RE.search(ami):
+                findings.append(
+                    f"{rel}:{line}: aws_instance.{match.group(1)} takes `ami` from the "
+                    f"most_recent data source(s) {sorted(referenced)} with no pin variable. "
+                    "That makes `ami` — a replace-forcing attribute — change whenever the "
+                    "upstream publisher ships an image, so an unrelated `tofu apply` rebuilds "
+                    "the instance (issue #3602). Use "
+                    "`ami = var.<pin> != \"\" ? var.<pin> : data.aws_ami.<x>[0].id`."
+                )
+
+        # --- R2: an environment that selects fck-nat must pin the AMI --------------------
+        if ENVS_DIR not in rel.parents:
+            continue
+        for match, body, line in find_blocks(text, re.compile(r'module\s+"([A-Za-z0-9_-]+)"\s*')):
+            if argument_value(body, "egress_mode") != '"fck_nat"':
+                continue
+            pin = argument_value(body, "nat_ami_id")
+            if pin is None or not AMI_ID_RE.match(pin):
+                shown = "unset" if pin is None else pin
+                findings.append(
+                    f"{rel}:{line}: module \"{match.group(1)}\" runs egress through a fck-nat "
+                    f"instance but nat_ami_id is {shown}. An environment with a live NAT must "
+                    "pin a concrete ami-... id, or the module falls back to the newest "
+                    "published AMI and a plain `tofu apply` destroys and recreates the single "
+                    "NAT, dropping all private-subnet egress (issue #3602)."
+                )
+    return findings
+
+
+def check(root: pathlib.Path, enforce: bool) -> int:
+    findings = scan(root)
+    level = "error" if enforce else "warning"
+    for finding in findings:
+        print(f"::{level}::{finding}")
+    verdict = f"{len(findings)} finding(s)" if findings else "clean"
+    print(f"check-nat-ami-pinned: {verdict}.")
+    return 1 if findings and enforce else 0
+
+
+def self_test() -> int:
+    """Feed the checker the shapes it must flag AND the shapes it must not."""
+    failures: list[str] = []
+    with tempfile.TemporaryDirectory() as tmp:
+        root = pathlib.Path(tmp)
+        module_dir = root / AWS_DIR / "modules" / "network"
+        env_dir = root / ENVS_DIR / "sandbox-substrate"
+        module_dir.mkdir(parents=True)
+        env_dir.mkdir(parents=True)
+        module_tf = module_dir / "main.tf"
+        env_tf = env_dir / "main.tf"
+
+        shipped_module = (
+            'data "aws_ami" "fck_nat" {\n'
+            "  count       = var.egress_mode == \"fck_nat\" ? 1 : 0\n"
+            "  most_recent = true\n"
+            "}\n\n"
+            'resource "aws_instance" "fck_nat" {\n'
+            "  count = var.egress_mode == \"fck_nat\" ? 1 : 0\n"
+            '  ami   = var.nat_ami_id != "" ? var.nat_ami_id : data.aws_ami.fck_nat[0].id\n'
+            "}\n"
+        )
+        shipped_env = (
+            'module "network" {\n'
+            '  source      = "../../modules/network"\n'
+            '  egress_mode = "fck_nat"\n'
+            '  nat_ami_id  = "ami-08c439a446e724124"\n'
+            "}\n"
+        )
+        module_tf.write_text(shipped_module)
+        env_tf.write_text(shipped_env)
+
+        def verdict() -> int:
+            return check(root, enforce=True)
+
+        # (a) The shipped shape must pass — a guard that flags its own fix is worse than none.
+        if verdict() != 0:
+            failures.append("flagged the shipped shape (pinned env + conditional module ami)")
+
+        # (b) R1: the pre-#3602 shape must be flagged.
+        module_tf.write_text(shipped_module.replace(
+            '  ami   = var.nat_ami_id != "" ? var.nat_ami_id : data.aws_ami.fck_nat[0].id',
+            "  ami   = data.aws_ami.fck_nat[0].id",
+        ))
+        if verdict() == 0:
+            failures.append("accepted `ami = data.aws_ami.fck_nat[0].id` off a most_recent source")
+
+        # (c) An aws_ami lookup that is NOT most_recent is a deterministic lookup, not a
+        #     landmine — R1 must not flag it, or the rule degenerates into "never use a data
+        #     source" and gets suppressed wholesale.
+        module_tf.write_text(
+            'data "aws_ami" "fixed" {\n  owners = ["self"]\n}\n\n'
+            'resource "aws_instance" "fck_nat" {\n  ami = data.aws_ami.fixed.id\n}\n'
+        )
+        if verdict() != 0:
+            failures.append("flagged an aws_ami data source that is not most_recent")
+
+        # (d) Code-about-code: the forbidden shape quoted inside comments must NOT be flagged.
+        #     This checker's own subject matter is the violation, so the comment-stripping is
+        #     load-bearing (the repo has paid for this collision several times).
+        module_tf.write_text(
+            "# The old, broken shape was:\n"
+            "#   data \"aws_ami\" \"fck_nat\" { most_recent = true }\n"
+            "#   ami = data.aws_ami.fck_nat[0].id\n"
+            "/* also: most_recent = true\n   ami = data.aws_ami.fck_nat[0].id */\n"
+            + shipped_module
+        )
+        if verdict() != 0:
+            failures.append("flagged the forbidden shape where it appears only inside comments")
+
+        module_tf.write_text(shipped_module)
+
+        # (e) R2: an env selecting fck_nat with no pin at all.
+        env_tf.write_text(shipped_env.replace('  nat_ami_id  = "ami-08c439a446e724124"\n', ""))
+        if verdict() == 0:
+            failures.append("accepted an fck_nat environment that sets no nat_ami_id")
+
+        # (f) R2: an empty pin is the bootstrap escape hatch, and a live env must not keep it.
+        env_tf.write_text(shipped_env.replace('"ami-08c439a446e724124"', '""'))
+        if verdict() == 0:
+            failures.append('accepted an fck_nat environment pinned to ""')
+
+        # (g) R2 must not fire on the managed-NAT mode, which has no instance to replace.
+        env_tf.write_text(
+            'module "network" {\n  source      = "../../modules/network"\n'
+            '  egress_mode = "managed_nat"\n}\n'
+        )
+        if verdict() != 0:
+            failures.append("flagged a managed_nat environment, which has no NAT instance at all")
+
+        # (h) Advisory mode must stay non-blocking even with a real finding present.
+        env_tf.write_text(shipped_env.replace('  nat_ami_id  = "ami-08c439a446e724124"\n', ""))
+        if check(root, enforce=False) != 0:
+            failures.append("exited non-zero without --enforce")
+
+    for message in failures:
+        print(f"::error::self-test FAILED — the checker {message}.")
+    print("check-nat-ami-pinned --self-test: " + ("clean." if not failures else "FAILED."))
+    return 1 if failures else 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Guard: the NAT instance's AMI is pinned.")
+    parser.add_argument("--root", default=".", help="repository root to scan")
+    parser.add_argument("--enforce", action="store_true", help="fail (exit 1) instead of warning")
+    parser.add_argument("--self-test", action="store_true", help="prove the checker's RED is reachable")
+    args = parser.parse_args()
+    if args.self_test:
+        return self_test()
+    return check(pathlib.Path(args.root), enforce=args.enforce)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/openbank-infra/CLAUDE.md
+++ b/openbank-infra/CLAUDE.md
@@ -204,6 +204,32 @@ out of it (they are path-scoped, not less important — several are live-inciden
   and changes nothing: a silent no-op indistinguishable from "already in sync". Always diff the
   regenerated `network-policies.yaml` files; never trust the generator's exit code.
 
+### OpenTofu / AWS substrate
+- **An `aws_instance` whose `ami` comes from a `most_recent = true` data source has a REPLACE
+  scheduled by a third party, on a timetable nobody here sets — and on the NAT that is an egress
+  outage waiting for an unrelated apply.** `modules/network`'s fck-nat instance (ADR-0058) took its
+  AMI straight from `data.aws_ami.fck_nat`, so every time the publisher shipped a patched image the
+  plan silently re-armed `~ ami = ... # forces replacement`, dragging `aws_route_table.private`
+  along with it because the default route points at the instance's primary ENI. Nothing was wrong
+  with the state; the ORDINARY command was the landmine, and it fired for whoever next planned this
+  stack for an unrelated reason — a one-line IAM fix is how it was found (#3602). Note that
+  `substrate-tofu.yml` DOES plan this root on every PR touching `envs/sandbox-substrate/**` or
+  `modules/**`, and applies it on manual dispatch; the preview was there and simply is not read on a
+  PR about something else, which is the more uncomfortable version of the story. Fix:
+  `var.nat_ami_id` pins the AMI and the data source is the bootstrap-only fallback, so a NAT upgrade
+  is a reviewable one-line diff applied in a window.
+  `check-nat-ami-pinned.py` (gate `nat-ami-pinned`) enforces both halves — the module must keep the
+  pin variable in the `ami` expression, and every `egress_mode = "fck_nat"` env must pass a concrete
+  `ami-...`. Generalize before reaching for `-target`: read the plan's `replace_paths`, and treat any
+  forcing attribute fed by a resolved-at-plan-time value as a landmine rather than a diff.
+- **A plan that is CLEAN of replaces can still carry a `create` for a resource that already exists
+  in AWS but is missing from state.** `aws_eip_association.fck_nat[0]` sat that way (a `-target`ed
+  apply is the likely cause), and its danger is entirely a function of what else the plan does: with
+  the instance being replaced it would have moved the EIP to a new instance; with the instance
+  unchanged the plan resolves `instance_id` to the SAME instance and the re-association is inert.
+  Read the resolved attribute values, not the action verb. The clean repair is `tofu import`, which
+  is a state write and therefore a deliberate operator step.
+
 ### OPA / Rego policies (ADR-0031/ADR-0034)
 - **Editing any shared policy source ripples the OPA bundle checksum of every service.** Each
   `openbank-infra/gitops/components/**/gen-*opa-bundle*.sh` embeds `rest.rego`, `agents.rego`,

--- a/openbank-infra/aws/envs/sandbox-substrate/main.tf
+++ b/openbank-infra/aws/envs/sandbox-substrate/main.tf
@@ -6,6 +6,13 @@ module "network" {
   az_count    = 3
   egress_mode = "fck_nat" # ADR-0058: replace managed NAT GW with fck-nat t4g.nano to remove per-GB processing fee
 
+  # The AMI the live NAT instance is ALREADY running. Pinned so that a newly
+  # published upstream fck-nat AMI cannot turn an unrelated `tofu apply` into a
+  # rebuild of the single NAT instance — which drops all private-subnet egress
+  # (issue #3602). Changing this line IS the NAT upgrade: it must be its own PR,
+  # applied in a window. See modules/network/variables.tf for the lookup command.
+  nat_ami_id = "ami-08c439a446e724124"
+
   tags = {
     Project     = "openbank"
     ManagedBy   = "opentofu"

--- a/openbank-infra/aws/modules/network/main.tf
+++ b/openbank-infra/aws/modules/network/main.tf
@@ -93,6 +93,12 @@ resource "aws_nat_gateway" "this" {
 }
 
 # --- fck-nat instance (count=0 when egress_mode=managed_nat) ----------------
+#
+# This data source is the BOOTSTRAP fallback only — it is consulted when
+# var.nat_ami_id is empty, i.e. on a brand-new environment that has no NAT
+# instance yet. Every environment that already runs one pins var.nat_ami_id, so
+# a newly published upstream AMI cannot silently force-replace a live NAT.
+# See var.nat_ami_id and issue #3602 for the full failure mode.
 data "aws_ami" "fck_nat" {
   count       = var.egress_mode == "fck_nat" ? 1 : 0
   most_recent = true
@@ -147,7 +153,10 @@ resource "aws_security_group" "fck_nat" {
 
 resource "aws_instance" "fck_nat" {
   count = var.egress_mode == "fck_nat" ? 1 : 0
-  ami   = data.aws_ami.fck_nat[0].id
+  # PINNED, deliberately (issue #3602). The data source below is the bootstrap
+  # fallback for an environment that has no NAT yet; a live environment pins,
+  # so `ami` only ever changes when a human changes it in a reviewed diff.
+  ami = var.nat_ami_id != "" ? var.nat_ami_id : data.aws_ami.fck_nat[0].id
   # t4g.nano/micro hit InsufficientInstanceCapacity in eu-north-1a; t4g.small
   # is reliably available and still comfortably sized for NAT-instance traffic.
   instance_type = "t4g.small"

--- a/openbank-infra/aws/modules/network/variables.tf
+++ b/openbank-infra/aws/modules/network/variables.tf
@@ -21,6 +21,38 @@ variable "tags" {
   default     = {}
 }
 
+variable "nat_ami_id" {
+  description = <<-EOT
+    PINNED AMI id for the fck-nat instance (egress_mode = "fck_nat").
+
+    Why a pin and not "whatever is newest": the fck-nat publisher ships a new AMI
+    every few weeks, and `data.aws_ami.fck_nat` (most_recent = true) re-resolves on
+    EVERY plan. Wired straight into aws_instance.fck_nat that made `ami` a
+    replace-forcing attribute which re-armed itself with no commit, no review and no
+    author — so the next `tofu apply` for ANY unrelated reason destroyed and
+    recreated the single NAT instance and dropped all private-subnet egress
+    (issue #3602). Pinning turns a NAT rebuild back into a deliberate decision that
+    shows up as a reviewable one-line diff.
+
+    Leave empty ONLY when bootstrapping a brand-new environment that has no NAT
+    instance yet — the module then falls back to the newest published AMI. Read the
+    id it chose out of the apply output and pin it in the same change; an env left
+    unpinned has the #3602 landmine re-armed.
+
+    Upgrading deliberately: find the newest AMI, put its id here, open a PR, and
+    apply in a window where a few minutes of lost egress is acceptable.
+      aws ec2 describe-images --owners 568608671756 --region <region> \
+        --filters 'Name=name,Values=fck-nat-al2023-hvm-*-arm64-*' \
+        --query 'reverse(sort_by(Images,&CreationDate))[:3].[ImageId,Name]' --output text
+  EOT
+  type        = string
+  default     = ""
+  validation {
+    condition     = var.nat_ami_id == "" || can(regex("^ami-[0-9a-f]{8,17}$", var.nat_ami_id))
+    error_message = "nat_ami_id must be empty (bootstrap only) or a concrete ami-... id."
+  }
+}
+
 variable "egress_mode" {
   description = "NAT egress strategy. 'managed_nat' = AWS-managed NAT Gateway (prod-safe default). 'fck_nat' = fck-nat t4g.nano instance (sandbox FinOps, removes per-GB processing fee, ADR-0058)."
   type        = string


### PR DESCRIPTION
Refs #3602

## The landmine, verified

`module.network.aws_instance.fck_nat[0]` is the private subnets' only egress path (ADR-0058), and
its `ami` came straight out of a `most_recent = true` `aws_ami` data source. `ami` is a
replace-forcing attribute and that data source re-resolves on **every** plan, so the trap re-arms
itself whenever the upstream publisher ships a patched image — no commit, no review, no author.

Read off the live sandbox state (read-only plan; nothing was applied):

```
['create','delete'] module.network.aws_instance.fck_nat[0]  replace_paths=[['ami']]
      ~ ami = "ami-08c439a446e724124" -> "ami-0899dbf7e367fdbb4" # forces replacement
['update']          module.network.aws_route_table.private
      - network_interface_id = "eni-05fcba0b9b672038c"
      + network_interface_id = (known after apply)
Plan: 2 to add, 7 to change, 1 to destroy.
```

The route-table update is the second half of the outage: the private default route points at the
instance's primary ENI, so replacing the instance moves the route too. `create_before_destroy` was
already set, which bounds the window but does not remove it.

**Correcting the issue's premise:** `sandbox-substrate` is *not* without a CI lane —
`substrate-tofu.yml` plans this root on every PR touching `envs/sandbox-substrate/**` or
`modules/**`, and applies it on `workflow_dispatch` with its own
`openbank-ci-tofu-apply-substrate` role. So the plan preview existed the whole time and was simply
not read on a PR about something else, which is the more uncomfortable version of the story: the
information was published and nobody was looking at it, and the manual dispatch is exactly the
human action the issue describes.

## The fix

`var.nat_ami_id` pins the AMI. The data source stays as the **bootstrap-only** fallback for an
environment that has no NAT instance yet; every live environment pins. A NAT upgrade becomes a
reviewable one-line diff applied in a chosen window, instead of a side effect of someone else's
change. `sandbox-substrate` is pinned to the AMI the instance is **already running**, so the fix
requires no apply to be correct.

Post-fix plan, same state, same command:

```
Plan: 1 to add, 6 to change, 0 to destroy.
```

Both `aws_instance.fck_nat[0]` and `aws_route_table.private` are gone from the plan.

Reproduced independently by CI on this PR — the `Substrate OpenTofu / tofu plan (preview)` job runs
its own read-only plan under the OIDC plan role and reports the same
`Plan: 1 to add, 6 to change, 0 to destroy` with no replace.

## The one thing left, and why it is now inert

`module.network.aws_eip_association.fck_nat[0]` still shows as a `create`. It is **pre-existing
state drift, not this change**: the association exists in AWS but is absent from `tofu state list`
(a `-target`ed apply is the likely cause). Its danger was entirely a function of the replace — with
a new instance it would have moved the EIP. With the instance unchanged the plan now resolves

```
+ instance_id = "i-0c7d75d5cc87b3c0a"
```

which is the same instance that already holds that allocation, so the re-association is a no-op
against AWS. The clean repair is `tofu import`, which is a state write and therefore an operator
step, not something a PR can do.

## The guard

`check-nat-ami-pinned.py` (gate `nat-ami-pinned`, enforced) blocks re-introduction in both places it
can happen:

* **R1** — no `aws_instance` under `openbank-infra/aws/` may take `ami` from a `most_recent = true`
  data source without a pin variable in the same expression.
* **R2** — every env module block setting `egress_mode = "fck_nat"` must pass a concrete
  `nat_ami_id = "ami-..."`. R1 alone cannot see this: the module keeps a legal unpinned fallback, so
  an environment that simply never sets the variable is unpinned while every file it references
  looks correct.

It strips HCL comments before matching, because this guard's own subject matter **is** the forbidden
shape — the module comments and the checker docstring both contain a literal
`ami = data.aws_ami...`, and a whole-file grep would flag the very fix it protects. The `--self-test`
covers that case explicitly, along with the `managed_nat` mode (must not flag) and a
non-`most_recent` data source (must not flag).

Falsified against the **real pre-fix tree**, not only fixtures: `--enforce` exits 1 on
`origin/main`'s `modules/network/main.tf` and `envs/sandbox-substrate/main.tf`, and 0 with the pin
in place.

## What is out of scope

The other six drifted resources in the plan — the AWS Config recorder status, the SPF record and the
four `aws_eks_addon` version bumps — are untouched here. They are updates, not replaces, and
draining them is a deliberate window with its own verification (the recorder in particular needs
**both** `recording` and `recordingMode.recordingFrequency` checked afterwards). Tracked on #3602.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
