### PR TITLE
feat(infra): compare the realm template to the artifact Keycloak would import

### DIFF
--- a/.github/scripts/check-realm-import-parity.py
+++ b/.github/scripts/check-realm-import-parity.py
@@ -1,0 +1,370 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+#
+# Detector: is the realm JSON Keycloak WOULD IMPORT on a cold start the same realm the
+# committed template describes? (issue #3246)
+#
+# WHY THIS EXISTS — THE THIRD COMPARISON
+#   Three artifacts describe each realm, and until this script only two of the three pairs
+#   were ever compared:
+#
+#     repo template  --(check-roles-allowed-realm.py, PR-time, enforced)-->  @RolesAllowed names
+#     repo template  --(check-realm-role-parity.py,   CronJob)------------>  the LIVE realm
+#     repo template  --(THIS SCRIPT)-------------------------------------->  the IMPORT artifact
+#
+#   The import artifact is the one that rebuilds the realm. keycloak.yaml's `realm-import`
+#   volume projects the Secrets `keycloak-realm-import` / `keycloak-customers-realm-import`,
+#   which ExternalSecrets fills from Vault KV. The committed template feeds NOTHING. So the
+#   file the enforced gate validates and the file Keycloak reads are two unrelated objects,
+#   and no observation of the live realm can tell them apart — `--import-realm` skips a realm
+#   that already exists, so the import artifact has had no effect since the realm first came up.
+#
+# MEASURED 2026-08-03 (issue #3246), sandbox, both realms:
+#
+#     realm                | artifact         | roles | clients | users
+#     ---------------------|------------------|-------|---------|------
+#     openbank             | repo template    |    14 |      10 |     6
+#     openbank             | import Secret    |     4 |       2 |     1
+#     openbank             | LIVE             |    14 |      10 |     4 (+2 service accounts,
+#                          |                  |       |         |       which /users never returns)
+#     openbank-customers   | repo template    |     2 |       3 |     0
+#     openbank-customers   | import Secret    |     1 |       1 |     0
+#     openbank-customers   | LIVE             |     2 |       3 |     0
+#
+#   The shape that decides everything downstream: the import artifact is a strict ANCESTOR of
+#   the template, not a divergent fork. Every name in it is also in the template, in both
+#   realms, in all three dimensions. Nothing live would be dropped by making the import
+#   artifact equal the template — which is why the convergence direction is Vault-to-repo and
+#   the repo template is authoritative. The reverse (scoping the enforced gate down to the
+#   import artifact) would make the gate honest about a 4-role blob and instantly fail ten
+#   roles' worth of `@RolesAllowed` sites that the running system serves correctly today.
+#
+# WHY THE BASELINE, AND WHY IT IS NOT A CHEAT
+#   #2540 makes the ordering point that this script has to respect: a detector shipped before
+#   the reconcile fires on its FIRST run, on a condition only a Vault write can clear. That is
+#   an alert which is the resting state from minute one — the failure mode this repo has
+#   already paid for. Only a Vault write clears it, and a Vault write is not something a PR can
+#   do.
+#
+#   So today's measured gap is declared in KNOWN_STALE, the same shape check-kafka-dotted-keys
+#   and check-pact-provider-replay use. That buys the property that matters: a NEW divergence —
+#   an eleventh role added to the template, a client removed from the import artifact — is red
+#   on the next run instead of disappearing into a gap that was already red. And the baseline
+#   is checked in BOTH directions, so the day the owner runs the reconcile the entry becomes
+#   stale and this script says so, which is what turns "someone should do the Vault write" into
+#   a signal rather than a note in an issue.
+#
+# WHAT IT DELIBERATELY DOES NOT DO
+#   It does not compare secret VALUES, and it must not: the template carries `__PLACEHOLDER__`
+#   tokens where the import artifact carries real client secrets and passwords. Only names are
+#   read — role names, clientIds, usernames — so this script's output is safe to publish into a
+#   ConfigMap. Anything that diffed the documents wholesale would leak credentials into the
+#   drift report.
+#
+# Run:
+#   python3 .github/scripts/check-realm-import-parity.py \
+#       --import openbank=/work/openbank-import.json \
+#       --import openbank-customers=/work/openbank-customers-import.json
+#   python3 .github/scripts/check-realm-import-parity.py --self-test
+#
+# A realm with no --import snapshot is reported as unchecked, never as clean.
+
+import argparse
+import json
+import pathlib
+import sys
+
+REALM_GLOB = "openbank-infra/gitops/components/keycloak/*realm-template*.json"
+
+# Server-managed names. Keycloak creates these itself, so their presence or absence in an
+# import artifact says nothing about drift. `default-roles-<realm>` is declared explicitly by
+# the customers template, so it has to be subtracted from BOTH sides or it is a permanent
+# finding in whichever direction it is missing.
+BUILTIN_CLIENTS = frozenset(
+    {"account", "account-console", "admin-cli", "broker", "realm-management",
+     "security-admin-console"},
+)
+BUILTIN_ROLES = frozenset({"offline_access", "uma_authorization", "uma_protection"})
+
+# ---------------------------------------------------------------------------
+# The measured 2026-08-03 gap (#3246). Every entry is a name the committed template declares
+# and the deployed import artifact does not carry, i.e. a name a cold-started cluster would
+# LOSE. Cleared by the Vault reconcile in docs/runbooks/0009-keycloak-realm-import-reconcile.md
+# — after which this dict must be emptied, and this script fails until it is.
+#
+# There is deliberately no baseline for the other direction (a name in the import artifact that
+# git does not declare): none exists today, and one appearing is exactly the review-nobody-did
+# case a cold start would materialise.
+# ---------------------------------------------------------------------------
+KNOWN_STALE = {
+    "openbank": {
+        "roles": {
+            "ROLE_AUDITOR", "ROLE_COMPLIANCE", "ROLE_CREDIT_RISK", "ROLE_DEMO", "ROLE_KYC",
+            "ROLE_KYC_OPENER", "ROLE_KYC_REVIEWER", "ROLE_LENDING_OFFICER", "ROLE_PAYMENTS",
+            "ROLE_SUPERVISOR", "mcp-caller",
+        },
+        "clients": {
+            "apicurio-registry", "argocd", "goalert", "openbank-edge", "openbank-glitchtip",
+            "openbank-grafana", "openbank-mcp-service", "openbao",
+        },
+        "users": {
+            "compliance2@openbank.local", "compliance@openbank.local", "demo@openbank.local",
+            "service-account-openbank-edge", "service-account-openbank-services",
+        },
+    },
+    "openbank-customers": {
+        "roles": set(),
+        "clients": {"customer-edge-admin", "openbank-edge-webauthn"},
+        "users": set(),
+    },
+}
+
+DIMENSIONS = ("roles", "clients", "users")
+
+
+def _names(doc: dict) -> dict:
+    """{dimension: {names}} for one realm document — template or import artifact alike.
+
+    Both sides are read by the SAME function on purpose. Two readers would drift, and the
+    whole defect class this script exists for is two artifacts nobody compared.
+    """
+    roles = doc.get("roles", {}) or {}
+    role_names = {r["name"] for r in (roles.get("realm") or [])}
+    for client_roles in (roles.get("client", {}) or {}).values():
+        role_names |= {r["name"] for r in client_roles or []}
+    return {
+        "roles": role_names - BUILTIN_ROLES - {f"default-roles-{doc.get('realm', '').lower()}"},
+        "clients": {c["clientId"] for c in (doc.get("clients") or [])} - BUILTIN_CLIENTS,
+        "users": {u["username"] for u in (doc.get("users") or [])},
+    }
+
+
+def template_names(root: pathlib.Path) -> dict:
+    """{realm: {dimension: {names}}} from every *realm-template*.json in the repo."""
+    out = {}
+    for p in sorted(root.glob(REALM_GLOB)):
+        doc = json.loads(p.read_text())
+        realm = doc.get("realm")
+        if not realm:
+            raise SystemExit(f"{p}: no `realm` key — cannot tell which realm it describes")
+        out[realm] = _names(doc)
+    return out
+
+
+def load_import(spec: str) -> tuple:
+    """Parse a `realm=path` snapshot of the projected import artifact."""
+    if "=" not in spec:
+        raise SystemExit(f"--import expects realm=path, got {spec!r}")
+    realm, _, path = spec.partition("=")
+    raw = sys.stdin.read() if path == "-" else pathlib.Path(path).read_text()
+    doc = json.loads(raw)
+    if not isinstance(doc, dict) or not doc.get("realm"):
+        raise SystemExit(f"{path}: not a realm document — treating as a failed capture")
+    if doc["realm"] != realm:
+        raise SystemExit(
+            f"{path}: describes realm {doc['realm']!r}, supplied as {realm!r} — refusing to "
+            f"compare a realm against another realm's template",
+        )
+    return realm, _names(doc)
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--root", default=".")
+    ap.add_argument(
+        "--import",
+        dest="imports",
+        action="append",
+        default=[],
+        metavar="REALM=PATH",
+        help="projected import artifact for a realm; PATH may be - for stdin. Repeatable.",
+    )
+    ap.add_argument("--self-test", action="store_true")
+    args = ap.parse_args(argv)
+    if args.self_test:
+        return _self_test()
+
+    root = pathlib.Path(args.root).resolve()
+    declared = template_names(root)
+    if not declared:
+        sys.stderr.write(f"::error::no realm template found under {REALM_GLOB} — cannot run blind\n")
+        return 1
+    imported = dict(load_import(s) for s in args.imports)
+
+    findings, report = [], {"realms": {}}
+    for realm in sorted(set(declared) | set(imported)):
+        want = declared.get(realm)
+        have = imported.get(realm)
+        if want is None:
+            findings.append(
+                f"realm `{realm}` has an import artifact but no template in git declares it — "
+                f"a cold start would create a realm nobody reviewed.",
+            )
+            report["realms"][realm] = {"status": "undeclared-realm"}
+            continue
+        if have is None:
+            findings.append(
+                f"realm `{realm}` has a template in git but no import artifact was supplied — "
+                f"UNCHECKED, not clean.",
+            )
+            report["realms"][realm] = {"status": "unchecked"}
+            continue
+
+        baseline = KNOWN_STALE.get(realm, {})
+        entry = {"status": "checked", "inSync": True}
+        for dim in DIMENSIONS:
+            missing = want[dim] - have[dim]
+            extra = have[dim] - want[dim]
+            known = set(baseline.get(dim, set()))
+            new_missing = sorted(missing - known)
+            healed = sorted(known - missing)
+            entry[f"declaredNotImported/{dim}"] = sorted(missing)
+            entry[f"importedNotDeclared/{dim}"] = sorted(extra)
+            entry[f"newSince3246/{dim}"] = new_missing
+            if missing or extra:
+                entry["inSync"] = False
+            for n in new_missing:
+                findings.append(
+                    f"realm `{realm}`: {dim[:-1]} `{n}` is declared in the committed template "
+                    f"and is NOT in the import artifact Keycloak would read. A cold-started "
+                    f"cluster would not have it. This is NEW since #3246 — it is not in "
+                    f"KNOWN_STALE. Reconcile the Vault copy "
+                    f"(docs/runbooks/0009-keycloak-realm-import-reconcile.md).",
+                )
+            for n in sorted(extra):
+                findings.append(
+                    f"realm `{realm}`: {dim[:-1]} `{n}` is in the import artifact and declared "
+                    f"NOWHERE in git. A cold start would create it and no review ever saw it. "
+                    f"Add it to the template, or remove it from the Vault copy.",
+                )
+            for n in healed:
+                findings.append(
+                    f"realm `{realm}`: {dim[:-1]} `{n}` is listed in KNOWN_STALE but the import "
+                    f"artifact now carries it — the #3246 reconcile has happened. Delete this "
+                    f"entry from KNOWN_STALE in check-realm-import-parity.py; a baseline that "
+                    f"outlives its gap is a gate that is green about nothing.",
+                )
+        report["realms"][realm] = entry
+
+    print(json.dumps(report, indent=2, sort_keys=True))
+    if findings:
+        for f in findings:
+            sys.stderr.write(f"::error title=Keycloak realm import parity::{f}\n")
+        sys.stderr.write(
+            f"::error::check-realm-import-parity: {len(findings)} finding(s). The committed "
+            f"template and the artifact Keycloak would import disagree beyond the #3246 "
+            f"baseline.\n",
+        )
+        return 1
+    checked = ", ".join(sorted(imported))
+    print(
+        f"realm import parity: no drift beyond the #3246 baseline for {checked}.",
+        file=sys.stderr,
+    )
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Self-test. Every case here was run against a DELIBERATELY broken input first — a checker
+# that has only ever seen the correct file is unfalsified.
+# ---------------------------------------------------------------------------
+
+def _doc(realm, roles=(), clients=(), users=()):
+    return {
+        "realm": realm,
+        "roles": {"realm": [{"name": r} for r in roles]},
+        "clients": [{"clientId": c} for c in clients],
+        "users": [{"username": u} for u in users],
+    }
+
+
+def _self_test() -> int:
+    import tempfile
+
+    failures = []
+
+    def check(label, cond):
+        if not cond:
+            failures.append(label)
+
+    with tempfile.TemporaryDirectory() as td:
+        root = pathlib.Path(td)
+        comp = root / "openbank-infra" / "gitops" / "components" / "keycloak"
+        comp.mkdir(parents=True)
+
+        def run(tmpl, imp, baseline):
+            (comp / "realm-template.json").write_text(json.dumps(tmpl))
+            p = root / "imp.json"
+            p.write_text(json.dumps(imp))
+            saved = dict(KNOWN_STALE)
+            KNOWN_STALE.clear()
+            KNOWN_STALE.update(baseline)
+            try:
+                return main(["--root", str(root), "--import", f"{tmpl['realm']}={p}"])
+            finally:
+                KNOWN_STALE.clear()
+                KNOWN_STALE.update(saved)
+
+        empty = {"openbank": {d: set() for d in DIMENSIONS}}
+
+        # 1. identical documents, empty baseline -> clean. The negative case: without it a
+        #    checker that always reports drift would pass every other case here.
+        check("identical sets must be clean",
+              run(_doc("openbank", ["R"], ["c"], ["u"]),
+                  _doc("openbank", ["R"], ["c"], ["u"]), empty) == 0)
+
+        # 2. a role in the template and not the import artifact, unbaselined -> red.
+        check("declared-not-imported role must be red",
+              run(_doc("openbank", ["R", "S"]), _doc("openbank", ["R"]), empty) == 1)
+
+        # 3. the same gap, baselined -> green. This is what keeps the first run off the alert.
+        check("baselined gap must be green",
+              run(_doc("openbank", ["R", "S"]), _doc("openbank", ["R"]),
+                  {"openbank": {"roles": {"S"}, "clients": set(), "users": set()}}) == 0)
+
+        # 4. a baseline entry whose gap has closed -> red. Without this the baseline would
+        #    silently become permanent once the reconcile lands.
+        check("stale baseline entry must be red",
+              run(_doc("openbank", ["R", "S"]), _doc("openbank", ["R", "S"]),
+                  {"openbank": {"roles": {"S"}, "clients": set(), "users": set()}}) == 1)
+
+        # 5. a name in the import artifact that git does not declare -> red, never baselined.
+        check("imported-not-declared must be red",
+              run(_doc("openbank", ["R"]), _doc("openbank", ["R", "GHOST"]), empty) == 1)
+
+        # 6. same for clients and users, since each dimension is compared separately and a
+        #    loop that dropped one would still pass cases 1-5.
+        check("client dimension must be compared",
+              run(_doc("openbank", ["R"], ["a"]), _doc("openbank", ["R"], []), empty) == 1)
+        check("user dimension must be compared",
+              run(_doc("openbank", ["R"], [], ["u"]), _doc("openbank", ["R"], [], []), empty) == 1)
+
+        # 7. built-ins on the live/import side must never register as drift.
+        check("builtin clients must be ignored",
+              run(_doc("openbank", ["R"], ["a"]),
+                  _doc("openbank", ["R"], ["a", "account", "admin-cli"]), empty) == 0)
+        check("builtin roles must be ignored",
+              run(_doc("openbank", ["R"]),
+                  _doc("openbank", ["R", "offline_access", "default-roles-openbank"]), empty) == 0)
+
+        # 8. a realm supplied under the wrong name must abort, not compare.
+        (comp / "realm-template.json").write_text(json.dumps(_doc("openbank", ["R"])))
+        p = root / "other.json"
+        p.write_text(json.dumps(_doc("openbank-customers", ["R"])))
+        try:
+            main(["--root", str(root), "--import", f"openbank={p}"])
+            failures.append("mismatched realm name must abort")
+        except SystemExit:
+            pass
+
+    for f in failures:
+        sys.stderr.write(f"::error::self-test FAILED: {f}\n")
+    if failures:
+        return 1
+    print("check-realm-import-parity self-test: all cases pass.", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/runbooks/0009-keycloak-realm-import-reconcile.md
+++ b/docs/runbooks/0009-keycloak-realm-import-reconcile.md
@@ -1,0 +1,188 @@
+# Runbook 0009 — Reconcile the Keycloak realm-import artifact to the committed template
+
+Status: Ready (procedure written and measured; the Vault write itself is owner-gated)
+Owner: Platform + Security
+Related: #3246 (this measurement), #2540 (roles: repo 14 / Vault 4 / live 14),
+#3244 (role assignments), ADR-0065 (the two-realm import), runbook 0005
+(Vault → OpenBao / External Secrets).
+
+## Why
+
+Keycloak reads its realm JSON from the Secrets `keycloak-realm-import` and
+`keycloak-customers-realm-import`, which External Secrets fills from Vault KV
+(`openbank-infra/gitops/components/external-secrets/es-keycloak-realm-import.yaml`).
+**The committed `realm-template.json` feeds nothing.** `--import-realm` also runs
+on cold start only, so the artifact has had no effect since each realm first came
+up — which is why the two could drift for months with ArgoCD `Synced/Healthy` and
+every gate green.
+
+Measured 2026-08-03 on the sandbox, all three layers, both realms:
+
+| realm | artifact | roles | clients | users |
+|---|---|---|---|---|
+| `openbank` | repo template | 14 | 10 | 6 |
+| `openbank` | import Secret | **4** | **2** | **1** |
+| `openbank` | live realm | 14 | 10 | 4 (+2 service accounts) |
+| `openbank-customers` | repo template | 2 | 3 | 0 |
+| `openbank-customers` | import Secret | **1** | **1** | 0 |
+| `openbank-customers` | live realm | 2 | 3 | 0 |
+
+The live `/users` endpoint never returns service accounts, which is why `openbank`
+reads 4 there against the template's 6; the two `service-account-*` entries the
+template declares exist live and hold their mappings.
+
+The shape that decides the direction: **the import artifact is a strict ancestor of
+the template, not a divergent fork.** Every name in it is also in the template, in
+both realms, in all three dimensions — `importedNotDeclared` is empty everywhere.
+So converging Vault to the repo drops nothing that exists today, while the reverse
+(scoping the enforced `rolesallowed-realm-parity` gate down to the import artifact)
+would make the gate honest about a 4-role blob and immediately fail ten roles' worth
+of `@RolesAllowed` sites the running system serves correctly.
+
+**Nothing is broken today. This is disaster-recovery preparation.** A green-field
+rebuild — new cluster, deleted realm, deliberate re-import into an empty DB — would
+produce a realm with 4 roles and 2 clients, so every `@RolesAllowed` naming one of
+the ten missing roles would match nothing and eight clients (ArgoCD, Grafana and
+OpenBao SSO, the customer edge's own M2M identity, `openbank-mcp-service`) would not
+exist. A DB restore is safe: `keycloak-db` has a barman S3 backup, and the realm
+survives in it.
+
+## Blast radius
+
+- Writes: two Vault KV properties. Nothing in the live realm changes.
+- Propagation: External Secrets refreshes hourly (`refreshInterval: 1h`), so both
+  Secrets update within the hour. Keycloak does **not** re-read them — no restart,
+  no rollout, no session impact. That is the point: the change is inert until a
+  cold start, which is precisely the event it exists for.
+- Not in scope: the live realm, `kcadm`, any role or client creation.
+
+## Pre-flight
+
+1. **Confirm the current gap is still what this runbook describes.** The detector
+   shipped with #3246 prints it, and running it is cheaper than re-deriving it:
+
+   ```sh
+   kubectl -n iam get secret keycloak-realm-import \
+     -o jsonpath='{.data.openbank-realm\.json}' | base64 -d > /tmp/ob-realm.json
+   kubectl -n iam get secret keycloak-customers-realm-import \
+     -o jsonpath='{.data.openbank-customers-realm\.json}' | base64 -d > /tmp/ob-customers.json
+   python3 .github/scripts/check-realm-import-parity.py \
+     --import openbank=/tmp/ob-realm.json \
+     --import openbank-customers=/tmp/ob-customers.json
+   ```
+
+   Exit 0 with a non-empty `declaredNotImported/*` = the measured baseline, proceed.
+   Exit 1 = something moved since; read the findings before writing anything.
+
+2. **Read the committed templates, and know they carry placeholders.** Every client
+   secret and user password in `realm-template.json` is a `__PLACEHOLDER__` token
+   (this is asserted by `check_realm_import_parity_test.py` and must stay true — the
+   repo is public). The write below substitutes real values in a local shell; the
+   substituted file must never be committed, echoed, or left on disk.
+
+3. **Collect the real values from the live realm, not from memory.** For each client
+   the template declares, the live secret is the authority:
+
+   ```sh
+   # per client, from a trusted shell with a bootstrap admin token
+   # GET /admin/realms/openbank/clients/<id>/client-secret
+   ```
+
+   A client whose secret is also held in a Vault KV entry that a service reads
+   (`es-*-oidc.yaml`) must use the SAME value, or the cold-started realm issues a
+   secret the service does not present.
+
+   **Two confidential clients in the customers template have no secret field at
+   all** — `customer-edge-admin` and `openbank-edge-webauthn` are
+   `publicClient: false` and carry neither a literal nor a `__PLACEHOLDER__`. On
+   import Keycloak generates a random secret for each, so a cold-started realm would
+   issue credentials neither service presents. (The two secret-less clients in the
+   `openbank` template, `openbank-grafana` and `apicurio-registry`, are
+   `publicClient: true` and correct as they stand.) Add placeholders for those two
+   in the same change as the reconcile, or the customers realm is reproducible in
+   name only. This is a template defect the reconcile surfaces; it is not caused by
+   it.
+
+4. **Verify the substituted file against a LOCAL Keycloak before writing it to
+   Vault.** Import runs on cold start only, so a malformed template ships silently
+   and is discovered by the rebuild it was meant to survive. The realm-JSON shapes
+   are version-specific traps (authorization policies want `config` maps; a scope
+   permission is `type: "scope"`; the `token-exchange` scope must be declared before
+   a permission references it; a client description over 255 chars fails the whole
+   import):
+
+   ```sh
+   docker run --rm -v /tmp/ob-realm-substituted.json:/opt/keycloak/data/import/realm.json \
+     quay.io/keycloak/keycloak:<the version keycloak.yaml runs> start-dev --import-realm
+   ```
+
+   Watch for `Realm 'openbank' imported` and no `ERROR`. Then mint a token for one
+   client and inspect the JWT's roles — an import that "succeeds" with a dropped
+   role block prints nothing useful.
+
+## Procedure (owner-gated — a Vault write, not a PR)
+
+Run from a trusted shell. Do not echo the values; do not leave the substituted file
+behind.
+
+```sh
+# 1. openbank realm
+vault kv put openbank/keycloak-realm-import \
+  openbank-realm.json=@/tmp/ob-realm-substituted.json
+
+# 2. openbank-customers realm. The KV key and property are declared in
+#    es-keycloak-customers-realm.yaml (`keycloak-customers-realm-import` /
+#    `openbank-customers-realm.json`); re-read them before writing, and note the
+#    ClusterSecretStore's mount path prefixes the key. The property name IS the
+#    mounted filename and Keycloak scans the directory for *.json.
+vault kv put openbank/keycloak-customers-realm-import \
+  openbank-customers-realm.json=@/tmp/ob-customers-substituted.json
+
+# 3. clean up
+shred -u /tmp/ob-realm-substituted.json /tmp/ob-customers-substituted.json
+```
+
+> The `vault kv put` recipe in
+> `openbank-infra/gitops/components/external-secrets/README.md` reads the LIVE
+> Secret back and writes it to Vault. That round-trip is what has kept the stale
+> ancestor alive: it can only ever re-store what is already there. Use this runbook
+> for the realm-import entries instead.
+
+## Verify
+
+```sh
+# ESO should re-sync within the hour; force it if you do not want to wait.
+kubectl -n iam annotate externalsecret keycloak-realm-import \
+  force-sync="$(date +%s)" --overwrite
+kubectl -n iam get externalsecret keycloak-realm-import \
+  -o jsonpath='{.status.conditions}'
+```
+
+Then re-run the pre-flight comparison. It must now go **red** with a "listed in
+KNOWN_STALE but the import artifact now carries it" finding for every reconciled
+name — that is the check telling you the baseline has outlived its gap, not a
+regression.
+
+## Close-out (a PR, and it is required)
+
+Empty `KNOWN_STALE` in `.github/scripts/check-realm-import-parity.py`. Until that
+lands, the `keycloak-realm-drift` CronJob fails nightly and `KubeJobFailed` fires.
+The failure is deliberate: a baseline that survives its own reconcile is a gate that
+is green about nothing, and the only way anyone learns the write happened is for the
+detector to say so.
+
+With `KNOWN_STALE` empty, the next role, client or user added to a template and not
+propagated to Vault is red on the following night's run — which is the property this
+whole exercise buys, and the thing neither of the two older comparisons can provide.
+
+## What this does NOT fix
+
+The two artifacts can still diverge tomorrow; this reconciles them once and detects
+the next divergence. Making them structurally unable to diverge is a larger change
+with its own decision to take — the shape is an ExternalSecret whose
+`spec.target.template.templateFrom` renders the committed template out of a
+ConfigMap ArgoCD manages, substituting only the `__PLACEHOLDER__` tokens from Vault
+KV. That makes the repo the structure of record and Vault the credential store,
+which is what each is actually good for. It also changes what a cold start produces,
+so it wants verification against a local Keycloak and a deliberate go-ahead, not a
+drive-by.

--- a/openbank-infra/CLAUDE.md
+++ b/openbank-infra/CLAUDE.md
@@ -19,6 +19,25 @@ out of it (they are path-scoped, not less important — several are live-inciden
   `check-roles-allowed-realm.py` was green the whole time: it compares the code to the TEMPLATE.
   Verify against the realm that actually runs (`kcadm.sh get roles -r openbank`) before believing any
   claim about which roles exist, and apply additions with `kcadm` — the file alone will not.
+- **"Template agrees with the live realm" is NOT "the realm is reproducible" — there is a THIRD
+  artifact, and it is the one a rebuild reads.** `keycloak.yaml`'s `realm-import` volume projects the
+  Secrets `keycloak-realm-import` / `keycloak-customers-realm-import`, which ExternalSecrets fills
+  from Vault KV; the committed template feeds nothing. So the two comparisons that existed
+  (`check-roles-allowed-realm.py` code→template, `check-realm-role-parity.py` template→live) can
+  BOTH be green about a realm that a green-field rebuild would not reproduce, and were: measured
+  2026-08-03 (#3246) the import artifact held 4 roles / 2 clients / 1 user against the template's
+  14 / 10 / 6, and 1 client against the customers template's 3 — while template and live agreed
+  exactly in both realms. It is a strict ANCESTOR, never a divergent fork, which is why the agreed
+  direction is Vault-converges-to-repo (nothing live is dropped) rather than scoping the enforced
+  gate down to the 4-role blob. `check-realm-import-parity.py` is the third comparison, run by the
+  `keycloak-realm-drift` CronJob off the SAME projected Secrets Keycloak mounts — never a second
+  copy, or it drifts from the one that deploys. It reads NAMES only: the template carries
+  `__PLACEHOLDER__` where the artifact carries real client secrets, and the report is a ConfigMap.
+  Today's gap is baselined in its `KNOWN_STALE` (#2540's ordering point: a detector shipped before
+  the reconcile is an alert that is the resting state from minute one, clearable only by a Vault
+  write). The reconcile procedure is `docs/runbooks/0009-keycloak-realm-import-reconcile.md`; the
+  `vault kv put` recipe in `components/external-secrets/README.md` reads the LIVE Secret back, so
+  re-running it as maintenance can only re-store the stale ancestor.
 - **ArgoCD does NOT diff hook resources — so anything a hook reads from its own manifest can never
   be changed in a way that triggers it.** A `argocd.argoproj.io/hook` object is excluded from the
   Application's desired-state comparison: `kubectl -n argocd get application <app> -o json` reports

--- a/openbank-infra/gitops/components/external-secrets/README.md
+++ b/openbank-infra/gitops/components/external-secrets/README.md
@@ -98,6 +98,14 @@ vault kv put openbank/keycloak-bootstrap \
 
 # keycloak realm import — whole JSON as a single property; KEY MUST be the
 # filename (openbank-realm.json) because the Deployment mounts it as a file.
+#
+# ONE-WAY CUTOVER ONLY. This reads the live Secret back into Vault, so it can
+# only ever re-store what is already there — and what is already there is a
+# stale ancestor of the committed template (#3246: 4 roles and 2 clients against
+# the template's 14 and 10). Re-running it as maintenance freezes that gap in
+# place. To CHANGE the realm-import content, follow
+# docs/runbooks/0009-keycloak-realm-import-reconcile.md, which writes the
+# committed template with its __PLACEHOLDER__ tokens substituted.
 vault kv put openbank/keycloak-realm-import \
   openbank-realm.json=@<(kubectl -n iam get secret keycloak-realm-import \
     -o jsonpath='{.data.openbank-realm\.json}' | base64 -d)

--- a/openbank-infra/gitops/components/keycloak-realm-drift/keycloak-realm-drift.yaml
+++ b/openbank-infra/gitops/components/keycloak-realm-drift/keycloak-realm-drift.yaml
@@ -15,8 +15,13 @@
 #   repo. The drift is one layer below what ArgoCD can see. And the template in git is not even
 #   the artifact Keycloak reads — keycloak.yaml's `realm-import` volume projects the out-of-band
 #   secrets `keycloak-realm-import` / `keycloak-customers-realm-import`, so the file the CI gate
-#   reads and the file Keycloak imports are two unrelated objects. Reading the LIVE realm is the
-#   only observation that covers both layers at once.
+#   reads and the file Keycloak imports are two unrelated objects. Reading the LIVE realm covers
+#   both layers at once, but it cannot SEPARATE them — the live realm agreeing with the template
+#   says nothing about what a rebuild would produce, because `--import-realm` has not fed the
+#   running realm since the day it first came up. Since #3246 this job also reads the import
+#   artifact directly (the same projected Secrets, mounted here too) and compares it to the
+#   template, which is the only observation that can see a realm that is correct today and
+#   unreproducible from git.
 #
 #   Measured 2026-07-26: ROLE_KYC, ROLE_KYC_OPENER, ROLE_KYC_REVIEWER and ROLE_SUPERVISOR were
 #   declared and absent; ROLE_DEMO was live and undeclared. 20 `@RolesAllowed` sites named the
@@ -38,12 +43,15 @@
 #   with the detail already readable.
 #
 # WHAT IT DELIBERATELY DOES NOT DO
-#   It does not reconcile. Issue #2540 leaves open whether the realm should be made to follow the
-#   template (a `kcadm` Job, or keycloak-config-cli); detection first, on purpose — a reconciler
-#   that writes to the identity provider is a much larger blast radius and wants its own decision.
-#   It also checks role EXISTENCE only, not role ASSIGNMENT. `service-account-openbank-services`
-#   held ROLE_OPERATOR live while the template declared no such user at all (#2442) — the same
-#   class one level deeper, and the natural next increment.
+#   It does not reconcile — neither the live realm nor the Vault copy. Detection first, on
+#   purpose: a job that writes to the identity provider, or to the KV holding every client
+#   secret, is a much larger blast radius and wants its own decision. #3246 settles the
+#   DIRECTION (the repo template is authoritative, the Vault copy converges to it) and
+#   docs/runbooks/0009-keycloak-realm-import-reconcile.md holds the procedure; the write itself
+#   is a human's.
+#   The import comparison reads NAMES only. It must never diff the documents: the template
+#   carries `__PLACEHOLDER__` tokens exactly where the import artifact carries real client
+#   secrets, and this job's report is published into a ConfigMap.
 #
 # NAMESPACE: `iam`, deliberately. Keycloak's ingress allow-list admits `podSelector: {}` — the
 # whole of `iam` — so a same-namespace caller needs no NetworkPolicy change, and the generated
@@ -297,11 +305,36 @@ spec:
                     > /work/final-users.json 2> /work/findings-users.txt \
                     || echo "findings" > /work/findings
                   cat /work/findings-users.txt
+
+                  # THIRD comparison (#3246): template vs the artifact Keycloak would IMPORT.
+                  # The two above both read the LIVE realm, which `--import-realm` stopped
+                  # feeding the day the realm first came up — so neither can see the import
+                  # artifact at all. Measured 2026-08-03 it is a strict ANCESTOR of the
+                  # template: openbank 4 roles / 2 clients / 1 user against 14 / 10 / 6.
+                  # The artifacts are read from the SAME projected Secrets keycloak.yaml
+                  # mounts, so this cannot compare a copy that has drifted from the one that
+                  # deploys. The checker reads NAMES ONLY — the files hold real client
+                  # secrets, and nothing derived from them may reach the report ConfigMap.
+                  python3 .github/scripts/check-realm-import-parity.py \
+                    --root /tmp/repo \
+                    --import "openbank=/realm-import/openbank-realm.json" \
+                    --import "openbank-customers=/realm-import/openbank-customers-realm.json" \
+                    > /work/final-import.json 2> /work/findings-import.txt \
+                    || echo "findings" > /work/findings
+                  cat /work/findings-import.txt
               volumeMounts:
                 - name: work
                   mountPath: /work
                 - name: tmp
                   mountPath: /tmp
+                # The same projected pair keycloak.yaml mounts at /opt/keycloak/data/import.
+                # No RBAC is added for it: the kubelet resolves a volume from the pod spec,
+                # so the ServiceAccount still cannot read any Secret through the API. The
+                # blast radius of this mount is bounded by the fact that this pod already
+                # holds the bootstrap admin credential.
+                - name: realm-import
+                  mountPath: /realm-import
+                  readOnly: true
 
           containers:
             # Phase 2 — publish the report, THEN fail. Order is load-bearing: the alert must fire
@@ -326,8 +359,12 @@ spec:
                   report = json.loads(raw) if raw else {"realms": {}, "captureFailed": True}
                   report["scannedAt"] = datetime.datetime.now(datetime.timezone.utc).strftime(
                       "%Y-%m-%dT%H:%M:%SZ")
-                  report["checkScope"] = "keycloak realm ROLE EXISTENCE + ROLE ASSIGNMENTS, template vs live"
-                  report["doesNotVerify"] = "client-role assignments; group membership"
+                  report["checkScope"] = (
+                      "keycloak realm ROLE EXISTENCE + ROLE ASSIGNMENTS, template vs live; "
+                      "plus ROLE/CLIENT/USER NAMES, template vs the import artifact (#3246)")
+                  report["doesNotVerify"] = (
+                      "client-role assignments; group membership; secret VALUES in the import "
+                      "artifact (names only, deliberately — the artifact holds real credentials)")
                   findings = pathlib.Path("/work/findings.txt")
                   report["findings"] = findings.read_text().splitlines() if findings.is_file() else []
                   users_raw = pathlib.Path("/work/final-users.json")
@@ -335,6 +372,11 @@ spec:
                   report["userRoleParity"] = json.loads(raw_u) if raw_u else {"captureFailed": True}
                   uf = pathlib.Path("/work/findings-users.txt")
                   report["userRoleFindings"] = uf.read_text().splitlines() if uf.is_file() else []
+                  imp = pathlib.Path("/work/final-import.json")
+                  raw_i = imp.read_text().strip() if imp.is_file() else ""
+                  report["importParity"] = json.loads(raw_i) if raw_i else {"captureFailed": True}
+                  imf = pathlib.Path("/work/findings-import.txt")
+                  report["importFindings"] = imf.read_text().splitlines() if imf.is_file() else []
                   print(json.dumps(report, indent=2, sort_keys=True))
                   PY
 
@@ -362,3 +404,14 @@ spec:
               emptyDir: {}
             - name: tmp
               emptyDir: {}
+            # Byte-for-byte the volume keycloak.yaml projects into the Keycloak pod. Declared
+            # the same way on purpose: a second copy of the realm JSON — fetched from Vault
+            # here, or re-templated — would be free to disagree with the one that deploys,
+            # which is the exact defect class #3246 is about.
+            - name: realm-import
+              projected:
+                sources:
+                  - secret:
+                      name: keycloak-realm-import
+                  - secret:
+                      name: keycloak-customers-realm-import

--- a/openbank-infra/scripts/check_realm_import_parity_test.py
+++ b/openbank-infra/scripts/check_realm_import_parity_test.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+"""Falsification suite for .github/scripts/check-realm-import-parity.py (issue #3246).
+
+Two jobs, and the second is the one a `--self-test` cannot do.
+
+The script's own `--self-test` proves the COMPARISON is falsifiable: it feeds synthetic
+documents that must be flagged and one pair that must not. That is run here so a change
+to the script cannot land without it.
+
+What synthetic fixtures cannot check is whether KNOWN_STALE still describes the REAL
+committed templates. A baseline entry naming a role no template declares can never clear
+— the gap it describes does not exist, so the reconcile can never close it and the entry
+is permanent dead weight that also silences the dimension it sits in. That check has to
+read the actual files in the repo, so it lives here.
+"""
+
+import json
+import pathlib
+import subprocess
+import sys
+import unittest
+
+REPO = pathlib.Path(__file__).resolve().parents[2]
+SCRIPT = REPO / ".github" / "scripts" / "check-realm-import-parity.py"
+
+
+def _load_module():
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("realm_import_parity", SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class SelfTest(unittest.TestCase):
+    def test_script_self_test_passes(self):
+        r = subprocess.run(
+            [sys.executable, str(SCRIPT), "--self-test"],
+            capture_output=True, text=True, cwd=REPO,
+        )
+        self.assertEqual(r.returncode, 0, f"--self-test failed:\n{r.stderr}")
+
+
+class BaselineDescribesRealTemplates(unittest.TestCase):
+    """Every KNOWN_STALE name must be declared by a committed template for that realm."""
+
+    def setUp(self):
+        self.mod = _load_module()
+        self.declared = self.mod.template_names(REPO)
+
+    def test_every_baselined_realm_has_a_template(self):
+        for realm in self.mod.KNOWN_STALE:
+            self.assertIn(
+                realm, self.declared,
+                f"KNOWN_STALE names realm {realm!r} but no *realm-template*.json declares it",
+            )
+
+    def test_every_baselined_name_is_declared(self):
+        for realm, dims in self.mod.KNOWN_STALE.items():
+            for dim, names in dims.items():
+                unknown = sorted(set(names) - self.declared[realm][dim])
+                self.assertEqual(
+                    unknown, [],
+                    f"KNOWN_STALE[{realm!r}][{dim!r}] names {unknown}, which the committed "
+                    f"template does not declare. Such an entry can never clear — the gap it "
+                    f"claims does not exist — and it silences a real gap of the same name.",
+                )
+
+    def test_dimensions_are_the_ones_the_checker_compares(self):
+        for realm, dims in self.mod.KNOWN_STALE.items():
+            self.assertEqual(
+                sorted(dims), sorted(self.mod.DIMENSIONS),
+                f"KNOWN_STALE[{realm!r}] must declare every dimension explicitly (an omitted "
+                f"one reads as 'no known gap' and is indistinguishable from a decision",
+            )
+
+
+class TemplatesCarryNoLiteralSecrets(unittest.TestCase):
+    """The committed templates must keep `__PLACEHOLDER__` tokens, never real values.
+
+    This repo is public and the import artifact this script compares against DOES hold real
+    client secrets. The reconcile procedure substitutes them at write time; nothing may ever
+    move in the other direction, and the cheapest place to notice is here.
+    """
+
+    def test_placeholders_only(self):
+        for p in sorted(REPO.glob(self.mod_glob())):
+            doc = json.loads(p.read_text())
+            for c in doc.get("clients") or []:
+                s = c.get("secret")
+                if s is not None:
+                    self.assertTrue(
+                        s.startswith("__") and s.endswith("__"),
+                        f"{p.name}: client {c['clientId']} carries a literal secret",
+                    )
+            for u in doc.get("users") or []:
+                for cred in u.get("credentials") or []:
+                    v = cred.get("value")
+                    if v is not None:
+                        self.assertTrue(
+                            v.startswith("__") and v.endswith("__"),
+                            f"{p.name}: user {u.get('username')} carries a literal credential",
+                        )
+
+    def mod_glob(self):
+        return _load_module().REALM_GLOB
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Adds the **third** of the three comparisons the Keycloak realm needs, and settles the direction of convergence #2540 left open.

Three artifacts describe each realm. Two pairs were compared; the pair that decides whether the realm is *reproducible* was not:

| comparison | who does it | existed? |
|---|---|---|
| `@RolesAllowed` names → repo template | `check-roles-allowed-realm.py` (PR-time, enforced) | yes |
| repo template → LIVE realm | `check-realm-role-parity.py` (`keycloak-realm-drift` CronJob) | yes |
| repo template → the IMPORT artifact | **this PR** | no |

`keycloak.yaml`'s `realm-import` volume projects the Secrets `keycloak-realm-import` / `keycloak-customers-realm-import`, which External Secrets fills from Vault KV. **The committed template feeds nothing**, and `--import-realm` runs on cold start only — so the import artifact has had no effect since each realm first came up, and no observation of the live realm can see it.

## Measured 2026-08-03, sandbox, all three layers, both realms

| realm | artifact | roles | clients | users |
|---|---|---|---|---|
| `openbank` | repo template | 14 | 10 | 6 |
| `openbank` | import Secret | **4** | **2** | **1** |
| `openbank` | live realm | 14 | 10 | 4 (+2 service accounts) |
| `openbank-customers` | repo template | 2 | 3 | 0 |
| `openbank-customers` | import Secret | **1** | **1** | 0 |
| `openbank-customers` | live realm | 2 | 3 | 0 |

Live `/users` never returns service accounts, which is why `openbank` reads 4 against the template's 6; both `service-account-*` entries exist live with their mappings.

Template and live agree **exactly** in both realms — so both existing comparisons are green about a realm a green-field rebuild would not reproduce. The customers realm had never been measured at this layer before; its import artifact holds one client against the template's three.

## Direction of convergence: Vault converges to the repo

The import artifact is a strict **ancestor** of the template, never a divergent fork — `importedNotDeclared` is empty in every dimension of both realms. So:

- Making the import artifact equal the template drops **nothing** that exists live. #2540's warning about load-bearing live-only roles (both KYC four-eyes roles among them) does not apply in this direction: the repo template already declares all 14.
- The alternative — scoping the enforced `rolesallowed-realm-parity` gate down to what actually deploys — would make the gate honest about a 4-role blob and instantly fail ten roles' worth of `@RolesAllowed` sites the running system serves correctly today. That is honesty bought by enshrining the stale artifact as authoritative.

Picked the first. The repo template is authoritative; the enforced gate becomes meaningful once the Vault copy follows it.

## What ships here (repo-side only — nothing writes to Vault or to the realm)

- **`.github/scripts/check-realm-import-parity.py`** — the third comparison, with `--self-test`. **Names only**: the template carries `__PLACEHOLDER__` exactly where the artifact carries real client secrets, and the drift report is published into a ConfigMap.
- **`keycloak-realm-drift` CronJob** runs it off the **same projected Secrets** Keycloak mounts, not a second copy fetched from Vault — a second copy is free to drift from the one that deploys, which is the defect class this whole issue is about. No RBAC added: the kubelet resolves a volume from the pod spec, so the ServiceAccount still cannot read any Secret through the API.
- **`KNOWN_STALE` baseline**, per #2540's ordering point: a detector shipped before the reconcile fires on its first run, on a condition only a Vault write can clear — an alert that is the resting state from minute one. Baselined, today's run is green; a **new** divergence is red immediately; and the baseline is checked in **both** directions, so the day the reconcile lands the stale entry says so rather than quietly becoming permanent. (Same shape as `check-kafka-dotted-keys.py` / `check-pact-provider-replay.py`.)
- **`check_realm_import_parity_test.py`** — runs the self-test, plus what synthetic fixtures cannot check: every baselined name is one the *real* committed templates declare (an entry naming a nonexistent role can never clear and silences its whole dimension), and the templates carry placeholders rather than literal credentials.
- **`docs/runbooks/0009-keycloak-realm-import-reconcile.md`** — the owner-gated `vault kv put`, its pre-flight (incl. verifying the substituted file against a local Keycloak, since import is cold-start-only), verification, and the close-out PR that empties the baseline.
- **external-secrets README** — its `vault kv put` recipe reads the LIVE Secret back into Vault, so re-running it as maintenance can only re-store the stale ancestor. Now says so and points at the runbook.
- **`openbank-infra/CLAUDE.md`** — one bullet: "template agrees with live" is not "the realm is reproducible".

## Extra finding the measurement surfaced

`customer-edge-admin` and `openbank-edge-webauthn` are `publicClient: false` in the customers template and carry **no `secret` field at all** — neither a literal nor a placeholder. A cold-started customers realm would generate random secrets neither service presents. Recorded in the runbook; it is a template defect the reconcile exposes, not one it causes. (The two secret-less clients in the `openbank` template are public clients and correct.)

## Falsification

- `--self-test`: 11 cases, including the negative (identical sets must be clean) and each dimension separately — a loop that dropped `clients` or `users` would still pass the role cases.
- The unit suite was falsified **in place**: adding `ROLE_NOT_IN_ANY_TEMPLATE` to `KNOWN_STALE` turns `test_every_baselined_name_is_declared` red with the exact message; restored from a `cp` backup, green again.
- Run against the **real** deployed artifacts + committed templates: exit 0, with the full gap in `declaredNotImported/*` and `importedNotDeclared/*` empty everywhere — which is the evidence for the strict-ancestor claim above.
- Local gate sweep: 104 gates, all green except `api-contract-gate` and `loki-rule-load-test` (both need a `sudo` install of `oasdiff`/`logcli` on this machine) and three advisories that name none of these files.

## What remains owner-gated

The `vault kv put` for both realms, and its close-out PR emptying `KNOWN_STALE`. Nothing in this PR can do either, and nothing in this PR changes the running system.

## Linked issues

Refs #3246
Refs #2540
