### PR TITLE
fix(ci): recompute the gitops bump against live main, so a deploy PR is not born conflicted

### DIFF
--- a/.github/workflows/admin-ui-deploy.yml
+++ b/.github/workflows/admin-ui-deploy.yml
@@ -424,6 +424,20 @@ jobs:
         id: rewrite
         run: |
           set -euo pipefail
+          # Recompute the bump against LIVE main, not against github.sha (#3194). The checkout
+          # above has no `ref:`, so on a push it holds the commit that triggered the build. The
+          # build takes minutes, admin-ui deploys are frequent, and if another one merges in that
+          # window create-pull-request branches from a main that no longer exists — both sides
+          # having rewritten the same `image:` line. The PR is then born CONFLICTED, which means
+          # no refs/pull/<n>/merge, which means NO workflow run at all: not skipped, absent. It
+          # reads as "waiting", never as broken, and the image is simply never deployed (four in
+          # one day, three closed undeployed).
+          #
+          # Safe because the rewrite is deterministic — set `image:` to the tag just built — so
+          # recomputing it against a newer main is always correct. It is what a human does when
+          # resolving this by hand.
+          git fetch origin main
+          git reset --hard origin/main
           TAG="${{ steps.build.outputs.tag }}"
           IMAGE="${ECR_REGISTRY}/${ECR_REPO}"
 

--- a/.github/workflows/auto-deploy.yml
+++ b/.github/workflows/auto-deploy.yml
@@ -1184,6 +1184,17 @@ jobs:
         id: rewrite
         run: |
           set -euo pipefail
+          # Recompute against LIVE main (#3194). Same exposure admin-ui-deploy.yml has: the
+          # checkout holds github.sha, the build takes minutes, and create-pull-request branches
+          # from that HEAD. If another deploy merges in the window, both sides have rewritten the
+          # same image: line and the PR is born CONFLICTED — which means no refs/pull/<n>/merge
+          # and therefore NO workflow run at all. Not skipped, absent. It renders as "waiting",
+          # never as broken, and the image is never deployed.
+          #
+          # Safe because the rewrite is deterministic — pin each image: to the tag just built —
+          # so recomputing against a newer main is always correct.
+          git fetch origin main
+          git reset --hard origin/main
           IMAGE_TAGS='${{ needs.build-push.outputs.image_tags }}'
           UPDATED=()
 


### PR DESCRIPTION
Closes #3194.

## What was happening

Four admin-ui deploy PRs in one day had **zero workflow runs** and were unmergeable the moment they opened. Three were closed having deployed nothing. The ones that merged the same day had **18 runs each**.

A PR that is **already conflicted when created** never gets `refs/pull/<n>/merge`, and `pull_request` workflows run against that ref — so no workflow is ever created. **Not skipped: absent.** Nothing reports, there is no run to re-run, and zero checks renders as *"waiting"*, never as broken. The image it carried is simply never deployed.

## Cause

The checkout has no `ref:`, so on a push it holds `github.sha` — the commit that triggered the build, not the tip of `main`. `create-pull-request` then branches from that HEAD. The build takes minutes and deploys are frequent, so if another one merges in that window both sides have rewritten the same `image:` line and the PR is born conflicted.

Self-reinforcing: the busier the deploy stream, the more often it fires, and each casualty leaves an image undeployed.

## Fix

`git fetch origin main && git reset --hard origin/main` immediately before the manifest rewrite.

Safe because the rewrite is **deterministic** — pin `image:` to the tag just built — so recomputing it against a newer `main` is always correct. It is exactly what a human does resolving this conflict by hand. `create-pull-request` has no rebase input of its own, so it has to happen before it runs.

## Also applied to `auto-deploy.yml`

The issue flagged it as worth checking. It has the **identical exposure**: same `chore/gitops-auto-deploy-${{ github.sha }}` branch shape, and `git fetch origin main` / `git reset --hard origin/main` appear **nowhere** in the file. Fixing only admin-ui would have left the larger deploy stream exposed.

## Verification

Validated against **GitHub**, not a YAML parser: a throwaway branch carrying both files produced **0 runs** — the correct answer for valid workflows on a non-main branch. The same oracle was validated in both directions earlier (a deliberately invalid file yields 1 run titled after the file path). Probe branch deleted.

`run-gates.py --group lint` PASS=6, including `yamllint` and `workflow-run-step-size` over both edited files.

## Self-assessment

- **Not reproduced end to end.** I did not create a racing deploy and observe a conflicted PR before/after. The mechanism is established by #3194's own measurement (4 PRs, 0 runs, versus 18 runs on the ones that merged), and the fix follows from it; but I am claiming the cause is removed, not that I watched it be removed.
- **The window is narrowed, not closed.** A merge landing between `git reset --hard origin/main` and `create-pull-request` would still conflict. That window is seconds rather than minutes, and closing it entirely needs a retry loop — worth adding if it recurs, not worth the complexity on a hypothesis.
- **Nothing here detects a recurrence.** #3194's closing point stands: only counting runs per head SHA distinguishes "waiting" from "born broken", and nothing does that today. A guard for it would be a separate change — and would want care, since it must not flag a PR that is legitimately still queueing.
- **Merge will be refused** — both files are under `.github/workflows`, which the repo's hook holds for human review. That is the correct final state.
