### PR TITLE
fix(psd2): answer 400, not 500, for a missing required query/header parameter

### DIFF
--- a/.github/scripts/check-nonnull-jaxrs-params.py
+++ b/.github/scripts/check-nonnull-jaxrs-params.py
@@ -75,18 +75,14 @@ PARAM_ANNOTATIONS = ("QueryParam", "HeaderParam", "MatrixParam")
 # JVM primitives: JAX-RS supplies the zero value, never null, so no NPE is possible here.
 KOTLIN_PRIMITIVES = {"Int", "Long", "Double", "Float", "Boolean", "Short", "Byte", "Char"}
 
-# The tail left after the money-path fix in #3104. Each entry is "<service>|<Class>|<param>".
+# The tail left after the money-path fix in #3625, being worked through in #3624. psd2 and
+# card-issuance are done. Each entry is "<service>|<Class>|<param>".
 # The count per key is not recorded on purpose: several of these repeat the identical parameter
 # across sibling handlers (card-issuance's X-Operator-Id sevenfold), and pinning the count would
 # make an unrelated refactor fail the gate for no defect.
 BASELINE = {
     # openbank-aml-service — POST /api/v1/aml/cases
     "openbank-aml-service|AmlCaseResource|Idempotency-Key",
-    # openbank-card-issuance-service — operator attribution on every card lifecycle operation
-    "openbank-card-issuance-service|CardResource|Idempotency-Key",
-    "openbank-card-issuance-service|CardResource|X-Operator-Id",
-    "openbank-card-issuance-service|CardDelegationResource|partyId",
-    "openbank-card-issuance-service|CardDelegationResource|intent",
     # openbank-customer-edge — the mobile/web BFF
     "openbank-customer-edge|CustomerEdgeResource|currency",
     "openbank-customer-edge|CustomerEdgeResource|accountId",
@@ -98,10 +94,6 @@ BASELINE = {
     "openbank-pid-service|PartyResource|index",
     "openbank-pid-service|PartyResource|type",
     "openbank-pid-service|PartyResource|value",
-    # openbank-psd2-service — Berlin Group headers on AIS/PIS
-    "openbank-psd2-service|AisResource|Consent-ID",
-    "openbank-psd2-service|PisResource|Consent-ID",
-    "openbank-psd2-service|PisResource|Idempotency-Key",
     # openbank-statement-service
     "openbank-statement-service|StatementResource|from",
     "openbank-statement-service|StatementResource|to",

--- a/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/infrastructure/rest/CardDelegationResource.kt
+++ b/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/infrastructure/rest/CardDelegationResource.kt
@@ -37,9 +37,15 @@ class CardDelegationResource(private val guard: CardDelegationGuard) {
     @Operation(summary = "Whether a party may VIEW or MANAGE_LIMITS on a card (holder OR active delegation grant)")
     suspend fun check(
         @PathParam("id") id: UUID,
-        @QueryParam("partyId") partyId: UUID,
-        @QueryParam("intent") intent: CardDelegationIntent,
+        @QueryParam("partyId") partyId: UUID?,
+        @QueryParam("intent") intent: CardDelegationIntent?,
     ): Response {
+        // #3624 — both identify WHAT is being asked, so neither has a defensible default: an absent
+        // `intent` cannot be assumed to be VIEW, and an absent `partyId` has no caller to check.
+        // Declared non-nullable they answered 500; `suspend` emits no intrinsic, so the nulls
+        // reached CardDelegationGuard. libs-runtime maps IllegalArgumentException to 400.
+        requireNotNull(partyId) { "query parameter 'partyId' is required" }
+        requireNotNull(intent) { "query parameter 'intent' is required" }
         val authorized = guard.isAuthorized(id, partyId, intent)
         return Response.ok(mapOf("authorized" to authorized)).build()
     }

--- a/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/infrastructure/rest/CardResource.kt
+++ b/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/infrastructure/rest/CardResource.kt
@@ -44,8 +44,11 @@ class CardResource(private val cardUseCase: CardUseCase) {
     @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN")
     @Authorize(action = "card.create", resource = "")
     @Operation(summary = "Issue a new card")
-    suspend fun issueCard(req: IssueCardRequest, @HeaderParam("Idempotency-Key") key: String): Response {
-        require(key.isNotBlank()) { "Idempotency-Key header required" }
+    suspend fun issueCard(req: IssueCardRequest, @HeaderParam("Idempotency-Key") key: String?): Response {
+        // #3624 — this guard answered 500 in exactly the case it was written for. `suspend` emits no
+        // Intrinsics.checkNotNullParameter, so an ABSENT header arrived as null and
+        // `null.isNotBlank()` threw NPE; only a BLANK header ever reached the intended 400.
+        require(!key.isNullOrBlank()) { "Idempotency-Key header required" }
         val card = cardUseCase.issueCard(req.toCommand(key))
         return Response.created(URI.create("/api/v1/cards/${card.id}")).entity(card.toResponse()).build()
     }
@@ -116,8 +119,10 @@ class CardResource(private val cardUseCase: CardUseCase) {
     @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN")
     @Authorize(action = "card.activate", resource = "#id")
     @Operation(summary = "Activate a pending card")
-    suspend fun activate(@PathParam("id") id: UUID, @HeaderParam("X-Operator-Id") operatorId: String): Response =
-        Response.ok(cardUseCase.activateCard(CardStatusCommand(id, null, operatorId)).toResponse()).build()
+    suspend fun activate(@PathParam("id") id: UUID, @HeaderParam("X-Operator-Id") operatorId: String?): Response {
+        requireNotNull(operatorId) { OPERATOR_ID_REQUIRED }
+        return Response.ok(cardUseCase.activateCard(CardStatusCommand(id, null, operatorId)).toResponse()).build()
+    }
 
     @POST
     @Path("/{id}/block")
@@ -127,8 +132,11 @@ class CardResource(private val cardUseCase: CardUseCase) {
     suspend fun block(
         @PathParam("id") id: UUID,
         req: CardStatusRequest,
-        @HeaderParam("X-Operator-Id") operatorId: String,
-    ): Response = Response.ok(cardUseCase.blockCard(CardStatusCommand(id, req.reason, operatorId)).toResponse()).build()
+        @HeaderParam("X-Operator-Id") operatorId: String?,
+    ): Response {
+        requireNotNull(operatorId) { OPERATOR_ID_REQUIRED }
+        return Response.ok(cardUseCase.blockCard(CardStatusCommand(id, req.reason, operatorId)).toResponse()).build()
+    }
 
     @POST
     @Path("/{id}/cancel")
@@ -138,25 +146,31 @@ class CardResource(private val cardUseCase: CardUseCase) {
     suspend fun cancel(
         @PathParam("id") id: UUID,
         req: CardStatusRequest,
-        @HeaderParam("X-Operator-Id") operatorId: String,
-    ): Response =
-        Response.ok(cardUseCase.cancelCard(CardStatusCommand(id, req.reason, operatorId)).toResponse()).build()
+        @HeaderParam("X-Operator-Id") operatorId: String?,
+    ): Response {
+        requireNotNull(operatorId) { OPERATOR_ID_REQUIRED }
+        return Response.ok(cardUseCase.cancelCard(CardStatusCommand(id, req.reason, operatorId)).toResponse()).build()
+    }
 
     @POST
     @Path("/{id}/suspend")
     @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN")
     @Authorize(action = "card.suspend", resource = "#id")
     @Operation(summary = "Suspend a card temporarily")
-    suspend fun suspend(@PathParam("id") id: UUID, @HeaderParam("X-Operator-Id") operatorId: String): Response =
-        Response.ok(cardUseCase.suspendCard(CardStatusCommand(id, null, operatorId)).toResponse()).build()
+    suspend fun suspend(@PathParam("id") id: UUID, @HeaderParam("X-Operator-Id") operatorId: String?): Response {
+        requireNotNull(operatorId) { OPERATOR_ID_REQUIRED }
+        return Response.ok(cardUseCase.suspendCard(CardStatusCommand(id, null, operatorId)).toResponse()).build()
+    }
 
     @POST
     @Path("/{id}/resume")
     @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN")
     @Authorize(action = "card.resume", resource = "#id")
     @Operation(summary = "Resume a suspended card")
-    suspend fun resume(@PathParam("id") id: UUID, @HeaderParam("X-Operator-Id") operatorId: String): Response =
-        Response.ok(cardUseCase.resumeCard(CardStatusCommand(id, null, operatorId)).toResponse()).build()
+    suspend fun resume(@PathParam("id") id: UUID, @HeaderParam("X-Operator-Id") operatorId: String?): Response {
+        requireNotNull(operatorId) { OPERATOR_ID_REQUIRED }
+        return Response.ok(cardUseCase.resumeCard(CardStatusCommand(id, null, operatorId)).toResponse()).build()
+    }
 
     @PUT
     @Path("/{id}/limits")
@@ -167,12 +181,15 @@ class CardResource(private val cardUseCase: CardUseCase) {
     suspend fun updateLimits(
         @PathParam("id") id: UUID,
         req: UpdateLimitsRequest,
-        @HeaderParam("X-Operator-Id") operatorId: String,
-    ): Response = Response.ok(
-        cardUseCase.updateLimits(
-            UpdateLimitsCommand(id, req.dailyLimitMinorUnits, req.monthlyLimitMinorUnits, operatorId),
-        ).toResponse(),
-    ).build()
+        @HeaderParam("X-Operator-Id") operatorId: String?,
+    ): Response {
+        requireNotNull(operatorId) { OPERATOR_ID_REQUIRED }
+        return Response.ok(
+            cardUseCase.updateLimits(
+                UpdateLimitsCommand(id, req.dailyLimitMinorUnits, req.monthlyLimitMinorUnits, operatorId),
+            ).toResponse(),
+        ).build()
+    }
 
     @PUT
     @Path("/{id}/controls")
@@ -183,17 +200,32 @@ class CardResource(private val cardUseCase: CardUseCase) {
     suspend fun updateControls(
         @PathParam("id") id: UUID,
         req: UpdateControlsRequest,
-        @HeaderParam("X-Operator-Id") operatorId: String,
-    ): Response = Response.ok(
-        cardUseCase.updateControls(
-            UpdateControlsCommand(
-                id,
-                req.contactlessEnabled,
-                req.onlineEnabled,
-                req.atmEnabled,
-                req.abroadEnabled,
-                operatorId,
-            ),
-        ).toResponse(),
-    ).build()
+        @HeaderParam("X-Operator-Id") operatorId: String?,
+    ): Response {
+        requireNotNull(operatorId) { OPERATOR_ID_REQUIRED }
+        return Response.ok(
+            cardUseCase.updateControls(
+                UpdateControlsCommand(
+                    id,
+                    req.contactlessEnabled,
+                    req.onlineEnabled,
+                    req.atmEnabled,
+                    req.abroadEnabled,
+                    operatorId,
+                ),
+            ).toResponse(),
+        ).build()
+    }
+
+    private companion object {
+        // #3624 — X-Operator-Id is the AUDIT attribution on every card lifecycle write, so a null
+        // flowing through is worse than the 500 it actually produced. These are `suspend` handlers:
+        // no Intrinsics.checkNotNullParameter is emitted, and the null was carried into
+        // CardStatusCommand / UpdateLimitsCommand / UpdateControlsCommand. libs-runtime maps
+        // IllegalArgumentException to 400 with the ApiError envelope and a traceId.
+        //
+        // Deliberately NOT the `?: "unknown"` fallback secureDetails uses: that read is a lookup,
+        // these seven change a card's state and must not be attributed to a placeholder operator.
+        const val OPERATOR_ID_REQUIRED = "header 'X-Operator-Id' is required"
+    }
 }

--- a/openbank-psd2-service/src/main/kotlin/com/openbank/psd2/infrastructure/rest/AisResource.kt
+++ b/openbank-psd2-service/src/main/kotlin/com/openbank/psd2/infrastructure/rest/AisResource.kt
@@ -9,6 +9,7 @@ import com.openbank.psd2.application.port.`in`.AccountInformationUseCase
 import com.openbank.psd2.application.port.`in`.GetAccountsQuery
 import com.openbank.psd2.application.port.`in`.GetBalancesQuery
 import com.openbank.psd2.application.port.`in`.GetTransactionsQuery
+import com.openbank.psd2.application.usecase.Psd2RequestFormatException
 import com.openbank.psd2.domain.model.BookingStatus
 import jakarta.ws.rs.Consumes
 import jakarta.ws.rs.GET
@@ -31,9 +32,10 @@ class AisResource(private val ais: AccountInformationUseCase) {
     @Path("/accounts")
     @Authorize(action = "psd2.list", resource = "")
     suspend fun getAccounts(
-        @HeaderParam("Consent-ID") consentId: String,
+        @HeaderParam("Consent-ID") consentId: String?,
         @Context ctx: ContainerRequestContext,
     ): Response {
+        if (consentId.isNullOrBlank()) throw Psd2RequestFormatException(CONSENT_ID_REQUIRED)
         val tppId = ctx.getProperty("tppId") as? String ?: return missingTpp()
         val accounts = ais.getAccounts(GetAccountsQuery(consentId, tppId))
         return Response.ok(mapOf("accounts" to accounts)).build()
@@ -44,9 +46,10 @@ class AisResource(private val ais: AccountInformationUseCase) {
     @Authorize(action = "psd2.read", resource = "#accountId")
     suspend fun getBalances(
         @PathParam("accountId") accountId: String,
-        @HeaderParam("Consent-ID") consentId: String,
+        @HeaderParam("Consent-ID") consentId: String?,
         @Context ctx: ContainerRequestContext,
     ): Response {
+        if (consentId.isNullOrBlank()) throw Psd2RequestFormatException(CONSENT_ID_REQUIRED)
         val tppId = ctx.getProperty("tppId") as? String ?: return missingTpp()
         val balances = ais.getBalances(GetBalancesQuery(consentId, tppId, accountId))
         return Response.ok(mapOf("account" to mapOf("iban" to accountId), "balances" to balances)).build()
@@ -58,7 +61,7 @@ class AisResource(private val ais: AccountInformationUseCase) {
     @Suppress("LongParameterList")
     suspend fun getTransactions(
         @PathParam("accountId") accountId: String,
-        @HeaderParam("Consent-ID") consentId: String,
+        @HeaderParam("Consent-ID") consentId: String?,
         @QueryParam("dateFrom") dateFrom: String?,
         @QueryParam("dateTo") dateTo: String?,
         @QueryParam("bookingStatus") bookingStatus: String?,
@@ -66,6 +69,7 @@ class AisResource(private val ais: AccountInformationUseCase) {
         @QueryParam("afterCursor") afterCursor: String?,
         @Context ctx: ContainerRequestContext,
     ): Response {
+        if (consentId.isNullOrBlank()) throw Psd2RequestFormatException(CONSENT_ID_REQUIRED)
         val tppId = ctx.getProperty("tppId") as? String ?: return missingTpp()
         val page = ais.getTransactions(
             GetTransactionsQuery(
@@ -92,4 +96,16 @@ class AisResource(private val ais: AccountInformationUseCase) {
 
     private fun missingTpp() = Response.status(401)
         .entity(mapOf("tppMessages" to listOf(mapOf("category" to "ERROR", "code" to "CERTIFICATE_MISSING")))).build()
+
+    private companion object {
+        // #3624 — Consent-ID is mandated on every AIS call by the Berlin Group NextGenPSD2 spec.
+        // Declared non-nullable it could only ever be a 500: these handlers are `suspend`, so no
+        // Intrinsics.checkNotNullParameter is emitted and JAX-RS's null for an ABSENT header
+        // reached GetAccountsQuery / GetBalancesQuery / GetTransactionsQuery — telling the TPP the
+        // ASPSP had broken. Thrown as Psd2RequestFormatException, not require(), so the 400 carries
+        // this service's Berlin Group tppMessages envelope rather than libs-runtime's generic
+        // ApiError (the #526 shape lottery ExceptionMappers.kt documents); same shape as
+        // ObConsentResource's X-Request-ID guard.
+        const val CONSENT_ID_REQUIRED = "Consent-ID header is required"
+    }
 }

--- a/openbank-psd2-service/src/main/kotlin/com/openbank/psd2/infrastructure/rest/PisResource.kt
+++ b/openbank-psd2-service/src/main/kotlin/com/openbank/psd2/infrastructure/rest/PisResource.kt
@@ -40,8 +40,8 @@ class PisResource(
     @Authorize(action = "psd2.initiate", resource = "")
     suspend fun initiateSepa(
         payment: PaymentInitiation,
-        @HeaderParam("Consent-ID") consentId: String,
-        @HeaderParam("Idempotency-Key") idempotencyKey: String,
+        @HeaderParam("Consent-ID") consentId: String?,
+        @HeaderParam("Idempotency-Key") idempotencyKey: String?,
         @Context ctx: ContainerRequestContext,
     ): Response = initiatePayment(payment, consentId, idempotencyKey, PaymentProduct.SEPA_CREDIT_TRANSFERS, ctx)
 
@@ -50,8 +50,8 @@ class PisResource(
     @Authorize(action = "psd2.initiate", resource = "")
     suspend fun initiateInstantSepa(
         payment: PaymentInitiation,
-        @HeaderParam("Consent-ID") consentId: String,
-        @HeaderParam("Idempotency-Key") idempotencyKey: String,
+        @HeaderParam("Consent-ID") consentId: String?,
+        @HeaderParam("Idempotency-Key") idempotencyKey: String?,
         @Context ctx: ContainerRequestContext,
     ): Response = initiatePayment(payment, consentId, idempotencyKey, PaymentProduct.INSTANT_SEPA_CREDIT_TRANSFERS, ctx)
 
@@ -60,8 +60,8 @@ class PisResource(
     @Authorize(action = "psd2.initiate", resource = "")
     suspend fun initiateDomesticCz(
         payment: DomesticCzPayment,
-        @HeaderParam("Consent-ID") consentId: String,
-        @HeaderParam("Idempotency-Key") idempotencyKey: String,
+        @HeaderParam("Consent-ID") consentId: String?,
+        @HeaderParam("Idempotency-Key") idempotencyKey: String?,
         @Context ctx: ContainerRequestContext,
     ): Response = initiatePayment(payment, consentId, idempotencyKey, PaymentProduct.DOMESTIC_CZ, ctx)
 
@@ -70,8 +70,8 @@ class PisResource(
     @Authorize(action = "psd2.initiate", resource = "")
     suspend fun initiateSipo(
         payment: SipoPayment,
-        @HeaderParam("Consent-ID") consentId: String,
-        @HeaderParam("Idempotency-Key") idempotencyKey: String,
+        @HeaderParam("Consent-ID") consentId: String?,
+        @HeaderParam("Idempotency-Key") idempotencyKey: String?,
         @Context ctx: ContainerRequestContext,
     ): Response = initiatePayment(payment, consentId, idempotencyKey, PaymentProduct.SIPO, ctx)
 
@@ -90,15 +90,26 @@ class PisResource(
         return Response.ok(mapOf("transactionStatus" to status.name)).build()
     }
 
+    /**
+     * The four initiation handlers differ only in payment product, so both Berlin Group headers are
+     * validated once, here — the single place every one of them passes through.
+     *
+     * #3624: both used to be declared non-nullable, which bought nothing at runtime. These are
+     * `suspend` handlers, so Kotlin emits no `Intrinsics.checkNotNullParameter` and JAX-RS's null
+     * for an ABSENT header flowed straight in. `Consent-ID` then reached `InitiatePaymentCommand`
+     * as null, and `idempotencyKey.isBlank()` threw NPE — so the guard below answered 500 in
+     * exactly the case it was written for, while a BLANK header correctly gave 400.
+     */
     private suspend fun initiatePayment(
         payment: Any,
-        consentId: String,
-        idempotencyKey: String,
+        consentId: String?,
+        idempotencyKey: String?,
         product: PaymentProduct,
         ctx: ContainerRequestContext,
     ): Response {
         val tppId = ctx.getProperty("tppId") as? String ?: return tppMissing()
-        if (idempotencyKey.isBlank()) throw Psd2RequestFormatException("Idempotency-Key header is required")
+        if (consentId.isNullOrBlank()) throw Psd2RequestFormatException("Consent-ID header is required")
+        if (idempotencyKey.isNullOrBlank()) throw Psd2RequestFormatException("Idempotency-Key header is required")
 
         val cacheKey = paymentCreateKey(tppId, product, idempotencyKey)
         idempotencyStore.get(cacheKey)?.let { cached ->

--- a/openbank-psd2-service/src/test/kotlin/com/openbank/psd2/integration/Psd2MissingHeaderStatusIT.kt
+++ b/openbank-psd2-service/src/test/kotlin/com/openbank/psd2/integration/Psd2MissingHeaderStatusIT.kt
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.psd2.integration
+
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.junit.QuarkusTestProfile
+import io.quarkus.test.junit.TestProfile
+import io.restassured.module.kotlin.extensions.Given
+import io.restassured.module.kotlin.extensions.Then
+import io.restassured.module.kotlin.extensions.When
+import org.junit.jupiter.api.Test
+
+/**
+ * A missing Berlin Group `Consent-ID` must answer 400 (#3624, follow-up to #3104).
+ *
+ * This has to be driven over REAL HTTP. The defect lives in JAX-RS parameter injection, so a unit
+ * test that calls the handler supplies the very argument the framework does not — it passes against
+ * the broken code and can never see the bug.
+ *
+ * What the old signature actually did here is worth recording, because it is NOT the 500 the issue
+ * predicts. `getAccounts` is `suspend`, so Kotlin emits no `Intrinsics.checkNotNullParameter` and
+ * the null simply flowed into the body — where `ctx.getProperty("tppId")` short-circuits to
+ * `missingTpp()` first. Measured by reverting the fix and re-running this test: **401**, not 500.
+ * That is the third and worst outcome the gate's header describes: with a valid TPP certificate
+ * nothing short-circuits, and the null is carried into `GetAccountsQuery.consentId` — a field the
+ * signature promised could not be null. The 401 is also a lie in its own right: it blames the
+ * caller's certificate for a missing header.
+ *
+ * The second test is the control. With a `Consent-ID` present the request gets PAST the new guard
+ * and fails on the absent TPP certificate instead — it passes both before and after the fix on
+ * purpose, so that the first test's redness is attributable to the guard and nothing else.
+ */
+@QuarkusTest
+@TestProfile(Psd2MissingHeaderStatusIT.AuthzOffProfile::class)
+@QuarkusTestResource(Psd2BootSmokeIT.InMemoryKafkaResource::class)
+@QuarkusTestResource(com.openbank.psd2.it.PostgresRedisTestResource::class)
+class Psd2MissingHeaderStatusIT {
+
+    /**
+     * `authz.enforce` defaults to true and there is no OPA sidecar under test, so the PDP fails
+     * CLOSED and every `@Authorize` endpoint answers 503 before the handler is ever entered — which
+     * would make this IT green about nothing (measured: both assertions saw 503 until this profile
+     * was added). Turning enforcement off is what lets the request reach the parameter binding this
+     * test is about. Literal values only: a profile loads in a different classloader from the test
+     * class, so anything computed here is computed twice.
+     */
+    class AuthzOffProfile : QuarkusTestProfile {
+        override fun getConfigOverrides(): Map<String, String> = mapOf("authz.enforce" to "false")
+    }
+
+    @Test
+    fun `an absent Consent-ID on the AIS accounts read answers 400`() {
+        Given { this } When { get("/open-banking/v2/accounts") } Then { statusCode(400) }
+    }
+
+    @Test
+    fun `a present Consent-ID gets past the guard and fails on the absent TPP certificate`() {
+        Given {
+            header("Consent-ID", "11111111-2222-3333-4444-555555555555")
+        } When {
+            get("/open-banking/v2/accounts")
+        } Then {
+            statusCode(401)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

21 of the 39 non-money-path handlers in #3624 that answer 5xx (or worse, silently proceed) when a required query/header parameter is absent — the two services the issue names as priority. Each parameter is declared nullable and guarded, so the caller gets a 400 that names what is missing.

**Stacked.** Base is `fix/nonnull-queryparam-400` (#3625), which owns the gate script and the money-path half. This PR cannot and must not reach `main` ahead of it. Retarget to `main` once #3625 lands.

## Type of change

- [x] fix (bug fix)

## Linked issues

Refs #3624, Refs #3625, Refs #3104

## Changes

- **openbank-psd2-service (11 sites).** `Consent-ID` is mandated on every AIS/PIS call by the Berlin Group NextGenPSD2 spec; a TPP that omitted it was told the ASPSP was broken. Guards throw `Psd2RequestFormatException`, **not** `require()`, so the 400 carries this service's Berlin Group `tppMessages` envelope rather than libs-runtime's generic `ApiError` — the shape `ExceptionMappers.kt` already documents (#526), and the same form `ObConsentResource` uses for `X-Request-ID`.
- `PisResource`'s four initiation handlers funnel through one private helper, so both headers are validated once there. That helper already carried `if (idempotencyKey.isBlank()) throw ...` — **a guard that answered 500 in exactly the case it was written for**, because these handlers are `suspend`, no `Intrinsics.checkNotNullParameter` is emitted, and `null.isBlank()` threw NPE. Only a *blank* key ever reached the intended 400.
- **openbank-card-issuance-service (10 sites).** `X-Operator-Id` is the audit attribution on every card lifecycle write (activate/block/cancel/suspend/resume/limits/controls). Deliberately **not** given the `?: "unknown"` fallback `secureDetails` uses — that is a read; these seven change a card's state and must not be attributed to a placeholder operator. `issueCard`'s `Idempotency-Key` had the same never-reachable blank-guard. `CardDelegationResource`'s `partyId`/`intent` name what is being asked, so neither has a defensible default.
- Baseline entries for both services removed from `check-nonnull-jaxrs-params.py` in the same change. The gate errors on a stale entry, which is what keeps code and list in step.

### Classification

All 21 are **truly required**. Defaultable: 0. Genuinely optional: 0.

**Two** of the guards already written here could never run for the absent case, covering **five** of the 21 sites: psd2's lives in the private helper all four initiation handlers funnel through (4 sites), and card-issuance's is in `issueCard` (1 site).

### Testing, and what was actually measured

`Psd2MissingHeaderStatusIT` drives the AIS accounts read over **real HTTP** — the only layer at which this defect exists. A unit test calling the handler supplies the argument JAX-RS does not, so it passes against the broken signature.

Falsified by reverting the fix and re-running. Worth recording: the measured pre-fix status there was **401, not the 500 the issue predicts**. The handler is `suspend`, the null flowed into the body, and the TPP-certificate check short-circuited first. With a valid certificate nothing short-circuits and the null is carried into `GetAccountsQuery.consentId` — the silent-null outcome the gate's own header calls worse than a 500. The 401 was a lie in its own right: it blamed the caller's certificate for a missing header.

The second test is a control that passes both before and after, so the first test's redness is attributable to the guard alone. A `@TestProfile` turns `authz.enforce` off: without it there is no OPA sidecar under test, the PDP fails closed, and both assertions saw **503** — the IT would have been green about nothing.

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports).
- [x] Unit tests added/updated.
- [x] Integration tests added/updated (if service boundary involved).
- [x] Contract tests updated (if public API changed). — no pact change needed; both services' provider replays pass unchanged.
- [x] `./gradlew detekt ktlintCheck koverVerify build` passes. — per module, run sequentially (nine parallel Quarkus test JVMs collide on ports and produce `QuarkusBindException`).
- [x] No new lint warnings.
- [ ] OpenAPI spec regenerated (if REST API changed). — no route, parameter set or schema changed; only the status code for an already-invalid request.
- [x] Flyway migration added + rollback note (if DB changed). — n/a
- [x] Avro schema versioned backward-compatibly (if event changed). — n/a
- [x] Docs updated (README, ADR if architectural). — the mechanism is already documented in root `CLAUDE.md` and the gate script header.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings`, `as Any`, `@Suppress("...")` without justification.
- [x] No new third-party dependency, OR: dependency review attached.
- [x] Auth / crypto / payment code changed? — no. The change is strictly the status code for a request that was already invalid; no authorization decision moves.
- [x] PII path changed? — no.
- [x] Cardholder data path changed? — no. `secureDetails` is untouched.

## Compliance impact

- [x] PSD2 / SCA / RTS — a Berlin Group error response shape is now returned where a 5xx/401 was. Strictly closer to the spec: a missing mandated header is a client error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

