### PR TITLE
feat(infra): declare the openbank-* ECR service repositories in OpenTofu

### DIFF
--- a/openbank-infra/aws/envs/sandbox-platform/ecr-service-repositories.tf
+++ b/openbank-infra/aws/envs/sandbox-platform/ecr-service-repositories.tf
@@ -1,0 +1,156 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Service image repositories (ECR private)
+# ─────────────────────────────────────────────────────────────────────────────
+# Until this file existed, `git grep aws_ecr_repository` over the whole monorepo
+# returned NOTHING: every openbank-* image repository in this account existed
+# because a human ran `aws ecr create-repository` once. None was reviewable, none
+# had its settings expressed anywhere, and nothing noticed one being deleted —
+# the visible symptom being a new service's first build dying at `Docker push`
+# with "The repository ... does not exist" (#3423, #3477).
+#
+# WHY THE SET IS DERIVED AND NOT TYPED
+# A hand-typed `for_each` list would be a second copy of the fleet roster, free to
+# drift from it — the exact shape this repo has been burned by repeatedly (the
+# pact drift scope, the deploy-coverage list, the Dockerfile exemption list). So
+# the set is READ OUT OF the artifacts that consume the registry:
+#
+#   1. every ECR image reference pinned in openbank-infra/gitops/** — i.e. every
+#      image ArgoCD actually pulls. That is the definition of "needs a repository":
+#      a workload that references it.
+#   2. the CI runner image, taken from `local.runner_image` in arc-runners.tf —
+#      the one openbank-* image with no gitops workload, and derived from the very
+#      string the runner pods pull rather than re-typed.
+#
+# Measured 2026-08-03 against the live registry: the gitops-derived set is 60
+# names and the live account holds exactly those 60 plus openbank-ci-runner. The
+# two agree with no exceptions in either direction, which is why (1)+(2) is used
+# as the source rather than release-please's package list — that list disagrees
+# BOTH ways. It omits the six deployed images that are not released components
+# (analytics-sink, developer-portal, document-renderer, keycloak, pyroscope-agent,
+# ci-runner) and includes openbank-tax-reporting-service, a released component
+# with no gitops workload, no auto-deploy entry and — correctly — no repository.
+# Deriving from it would have created a seventh unused repository and left six
+# real ones undeclared.
+#
+# A new service therefore gets its repository from the same PR that gives it a
+# gitops manifest, which is necessarily before its first image is pushed.
+#
+# NOT AN AUTO-CREATION AT PUSH TIME. .github/scripts/ensure-ecr-repository.sh
+# (#3492) stays as the fail-open runtime backstop for the window between a manual
+# `create-repository` and this file being applied; it is not the declaration.
+
+locals {
+  gitops_dir = "${path.module}/../../../gitops"
+
+  # Both extensions are in use under gitops/.
+  gitops_manifest_files = setunion(
+    fileset(local.gitops_dir, "**/*.yaml"),
+    fileset(local.gitops_dir, "**/*.yml"),
+  )
+
+  # An image reference, not a mention: the account-qualified ECR host, then the
+  # repository name, then a tag or a digest separator. Requiring the trailing
+  # [:@] is what keeps the Kyverno wildcard rules ("…amazonaws.com/openbank-*")
+  # out of the set — `*` is not a repository name, and a policy pattern is not a
+  # workload pin.
+  gitops_image_repositories = toset(flatten([
+    for f in local.gitops_manifest_files : [
+      for m in regexall(
+        "[0-9]{12}\\.dkr\\.ecr\\.[a-z0-9-]+\\.amazonaws\\.com/(openbank-[a-z0-9-]+)[:@]",
+        file("${local.gitops_dir}/${f}")
+      ) : m[0]
+    ]
+  ]))
+
+  # openbank-ci-runner has no gitops workload — ARC pulls it via the Helm values
+  # in arc-runners.tf. Split out of that same string so the two can never disagree.
+  ci_runner_repository = split("@", split("/", local.runner_image)[1])[0]
+
+  service_ecr_repositories = setunion(
+    local.gitops_image_repositories,
+    toset([local.ci_runner_repository]),
+  )
+
+  # Tag immutability, per repository, defaulting to MUTABLE.
+  #
+  # MUTABLE is load-bearing for the service repositories, not laziness: auto-deploy
+  # tags `sandbox-<sha>` and the reconcile path (#2021, #3432) legitimately
+  # re-dispatches a build for a sha it has already pushed. Under IMMUTABLE that
+  # re-push fails, so flipping the fleet would break the self-heal that exists to
+  # rescue stranded deploys.
+  #
+  # openbank-admin-ui is IMMUTABLE in the live account and stays that way — it is
+  # built by its own workflow (build-push-admin-ui.sh) off a version, not a sha,
+  # and tightening is never reverted here to make a plan quieter.
+  ecr_immutable_repositories = toset(["openbank-admin-ui"])
+}
+
+resource "aws_ecr_repository" "service" {
+  for_each = local.service_ecr_repositories
+
+  name                 = each.key
+  image_tag_mutability = contains(local.ecr_immutable_repositories, each.key) ? "IMMUTABLE" : "MUTABLE"
+
+  # AES256 (the ECR-managed key) rather than KMS: matches every repository that
+  # exists today, and a KMS switch is a destroy-and-recreate, not an in-place edit.
+  encryption_configuration {
+    encryption_type = "AES256"
+  }
+
+  # Scan-on-push is also owned registry-level for openbank-* by
+  # aws_ecr_registry_scanning_configuration in ecr-image-scanning.tf, so this is
+  # belt-and-braces rather than the only lever — but it is stated here on purpose.
+  # OMITTING the block is not neutral: the provider plans `scan_on_push = true ->
+  # null` on every repository that has it, i.e. leaving it out would have QUIETLY
+  # TURNED SCANNING OFF on 51 of the 61 as the price of a tidier file. The live
+  # per-repository values are inconsistent (10 read false, created before the
+  # registry rule); declaring `true` converges those ten upward in place and is a
+  # no-op on the rest.
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  # A repository is deleted only by a human who meant it. Removing a service's
+  # gitops manifest must not propose dropping the registry namespace its running
+  # pods still pull from — that would be a plan nobody reads carefully enough.
+  # Retiring a service is then deliberately two steps: drop the pin, then remove
+  # this guard in a PR that says so.
+  #
+  # Honest limit: prevent_destroy protects an instance that is IN STATE. Until the
+  # first apply adopts these 61, dropping a gitops pin removes a name from the
+  # derived set with nothing to object — there is no state entry to destroy. That
+  # window closes on the first apply, not on this merge.
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Adoption of the repositories that already exist
+# ─────────────────────────────────────────────────────────────────────────────
+# 61 repositories predate this file. Without this block the first plan proposes
+# to CREATE all 61, and the apply fails on RepositoryAlreadyExistsException.
+#
+# The import set is the INTERSECTION of the derived set with what the registry
+# actually holds, so this block is correct permanently rather than being a
+# one-shot migration file someone must remember to delete: an existing repository
+# is adopted, a brand-new service's repository is created, and a repository
+# already in state makes the import a no-op. A static import list would have
+# broken the plan for the next new service ("Cannot import non-existent remote
+# object") — the failure mode a migration artifact left in place always has.
+data "aws_ecr_repositories" "existing" {}
+
+import {
+  for_each = setintersection(
+    local.service_ecr_repositories,
+    toset(data.aws_ecr_repositories.existing.names),
+  )
+
+  to = aws_ecr_repository.service[each.value]
+  id = each.value
+}
+
+output "service_ecr_repository_names" {
+  description = "Every openbank-* image repository declared here (derived from the gitops image pins plus the ARC runner image)."
+  value       = sort(keys(aws_ecr_repository.service))
+}


### PR DESCRIPTION
Closes #3477. Refs #3423, #3444, #3453, #3492.

## What

`git grep aws_ecr_repository` returned **nothing**. All 61 `openbank-*` image repositories in the sandbox account exist because a human ran `aws ecr create-repository` once — undeclared, unreviewed, with no record of their settings and nothing that would notice one being deleted. This declares them.

The runtime half is already handled (#3492's fail-open `ensure-ecr-repository.sh`); this is the declarative half.

## The authoritative set — derived, not typed

#3423 named the trap up front: *"the list becomes a second place that can drift from `ALL_SERVICES`"*. So the set is read out of the artifacts that consume the registry:

1. every ECR image pinned under `openbank-infra/gitops/**` — the images ArgoCD actually pulls (60 names);
2. `openbank-ci-runner`, split out of the same `local.runner_image` string `arc-runners.tf` feeds the runner pods (1 name).

Measured against the live registry, that derived set is **61 names and the account holds exactly those 61** — no exception in either direction.

### Why not release-please's package list

The issue proposed deriving from `release-please-config.json`. Measured, that list disagrees with reality **both ways**:

| relation | names |
| --- | --- |
| ECR repo but not a released component | `analytics-sink`, `developer-portal`, `document-renderer`, `keycloak`, `pyroscope-agent`, `ci-runner` |
| released component but no ECR repo | `openbank-tax-reporting-service` |

`tax-reporting-service` has no gitops workload and no `ALL_SERVICES` entry, so having no repository is *correct*. Deriving from release-please would have created a seventh unused repository and left six real ones undeclared. The four sets otherwise nest cleanly: `ALL_SERVICES` (54) ⊂ released (56); gitops pins (60) = live ECR (61) − `ci-runner`.

## Adoption of the 61 that already exist

A config-driven `import` block, `for_each` over the **intersection** of the derived set with `data.aws_ecr_repositories.existing`. That makes it permanently correct rather than a one-shot migration file someone must remember to delete:

- existing repository → imported;
- brand-new service's repository → created;
- already in state → no-op.

A static import list would have broken the plan for the *next* new service (`Cannot import non-existent remote object`) — the failure mode a migration artifact left in place always has. Verified below.

## Plan verdict (`tofu plan -lock=false`, never `apply`)

```
Plan: 61 to import, 0 to add, 61 to change, 0 to destroy.
```

**No creation, no replacement, no destruction.** The 61 in-place changes are not a no-op and I am not claiming they are:

- **61 × `tags_all`** — the root's `default_tags` landing on repositories created outside OpenTofu. Three currently carry `ManagedBy = "manual"` / `"manual-first-deploy"`, which is exactly the state this PR ends.
- **9 × `scan_on_push: false -> true`** — `anacredit`, `analytics-sink`, `card-issuance`, `customer-edge`, `lending`, `pid`, `sdd`, `standing-order`, `tpp-registry`, all created before the registry-level scanning rule. In-place, monotone, security-positive.

### `scan_on_push` is stated on purpose

Omitting the block is **not** neutral. The first plan I ran left it out, on the argument that `aws_ecr_registry_scanning_configuration` already owns scan-on-push for `openbank-*` — and it planned `scan_on_push = true -> null` on 51 repositories. Leaving it out would have quietly disabled per-repository scanning as the price of a tidier file.

## Falsifiability

The derivation was fed a case it must flag. With one throwaway manifest added under `gitops/components/` pinning `…/openbank-zz-selftest:v1`:

```
length(local.service_ecr_repositories)                      61 -> 62
contains(…, "openbank-zz-selftest")                         true
tofu plan   Plan: 61 to import, 1 to add, 61 to change, 0 to destroy
```

Removed again → back to 61. This proves three things at once: a new gitops pin does reach the set; the import block does **not** error on a repository that does not exist yet; and the Kyverno wildcard patterns (`…amazonaws.com/openbank-*`, two files) are correctly excluded — the regex requires a real name followed by `:` or `@`, and a bogus wildcard name never appears.

## Known limits (stated, not hidden)

- **`prevent_destroy` protects an instance that is in state.** Until the first apply adopts these 61, dropping a gitops pin removes a name from the derived set with nothing to object to. That window closes on the first apply, not on this merge.
- **The plan is owner-gated.** `platform-tofu.yml` runs the read-only plan on this PR; the apply job is environment-gated. Nothing here applies anything.
- Not done in this PR: dropping `ecr:CreateRepository` from the CI role (issue point 3). That is only safe *after* the apply, and #3492's fail-open backstop depends on it until then — a follow-up, not a same-PR change.

## Verification

```
tofu fmt -check       clean
tofu validate         Success
tofu plan -lock=false -target=aws_ecr_repository.service   as above
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
