### PR TITLE
fix(customer-edge): answer 400, not 500, for a missing required query/header parameter

### DIFF
--- a/.github/scripts/check-nonnull-jaxrs-params.py
+++ b/.github/scripts/check-nonnull-jaxrs-params.py
@@ -56,7 +56,10 @@
 #   (@DefaultValue), or actually optional (nullable) — and only the handler knows which. The
 #   money-path set is fixed; the remainder is BASELINED with its issue so a NEW occurrence fails
 #   while the known tail stays visible. A baseline entry that no longer occurs is reported too, so
-#   the list cannot rot in either direction.
+#   the list cannot rot in either direction. As of #3624 the BASELINE is EMPTY — both halves are
+#   remediated — so today this is an outright "no occurrences" gate. Keep the ratchet machinery
+#   anyway: it is what lets the next genuinely-optional-but-unfixed site be recorded rather than
+#   silently suppressed.
 #
 # EXIT CODES
 #   0  no new occurrences, no stale baseline entries
@@ -75,32 +78,18 @@ PARAM_ANNOTATIONS = ("QueryParam", "HeaderParam", "MatrixParam")
 # JVM primitives: JAX-RS supplies the zero value, never null, so no NPE is possible here.
 KOTLIN_PRIMITIVES = {"Int", "Long", "Double", "Float", "Boolean", "Short", "Byte", "Char"}
 
-# The tail left after the money-path fix in #3625, being worked through in #3624. psd2 and
-# card-issuance are done. Each entry is "<service>|<Class>|<param>".
-# The count per key is not recorded on purpose: several of these repeat the identical parameter
-# across sibling handlers (card-issuance's X-Operator-Id sevenfold), and pinning the count would
-# make an unrelated refactor fail the gate for no defect.
-BASELINE = {
-    # openbank-aml-service — POST /api/v1/aml/cases
-    "openbank-aml-service|AmlCaseResource|Idempotency-Key",
-    # openbank-customer-edge — the mobile/web BFF
-    "openbank-customer-edge|CustomerEdgeResource|currency",
-    "openbank-customer-edge|CustomerEdgeResource|accountId",
-    # openbank-dispute-service
-    "openbank-dispute-service|DisputeResource|actor",
-    # openbank-party-service
-    "openbank-party-service|PartyResource|Idempotency-Key",
-    # openbank-pid-service
-    "openbank-pid-service|PartyResource|index",
-    "openbank-pid-service|PartyResource|type",
-    "openbank-pid-service|PartyResource|value",
-    # openbank-statement-service
-    "openbank-statement-service|StatementResource|from",
-    "openbank-statement-service|StatementResource|to",
-    # openbank-tpp-registry-service
-    "openbank-tpp-registry-service|TppRegistryResource|tppId",
-    "openbank-tpp-registry-service|TppRegistryResource|role",
-}
+# EMPTY, and that is the finished state — not an un-run check. The money-path 24 were fixed in
+# #3625 and the remaining 39 non-money-path sites in #3624, so every inbound occurrence in the tree
+# is now nullable-and-guarded and the gate is a plain "no new occurrences" ratchet.
+#
+# An entry added here needs a reason and an issue. The stale-entry rule below is what keeps the list
+# honest in the other direction: a key that no longer occurs is reported as an error, so a baseline
+# cannot quietly outlive the defect it was recording.
+#
+# Format is "<service>|<Class>|<param>". The count per key is deliberately NOT recorded: several of
+# the original 39 repeated the identical parameter across sibling handlers (card-issuance's
+# X-Operator-Id sevenfold), and pinning a count would make an unrelated refactor fail for no defect.
+BASELINE: set[str] = set()
 
 
 def strip_comments(src: str) -> str:
@@ -368,7 +357,8 @@ def main() -> int:
         return 1
     print(
         f"non-nullable JAX-RS params: OK — {len(findings)} baselined occurrence(s), no new ones. "
-        f"The money-path set was fixed in #3104; the tail is per-handler work tracked there.",
+        f"The money-path set was fixed in #3625 and the non-money-path tail in #3624; the baseline "
+        f"is empty, so any occurrence at all is now a new one.",
     )
     return 0
 

--- a/openbank-aml-service/src/main/kotlin/com/openbank/aml/infrastructure/rest/AmlCaseResource.kt
+++ b/openbank-aml-service/src/main/kotlin/com/openbank/aml/infrastructure/rest/AmlCaseResource.kt
@@ -47,9 +47,12 @@ class AmlCaseResource(
     @Operation(summary = "Submit an AML screening case")
     suspend fun createCase(
         request: CreateAmlCaseRequest,
-        @HeaderParam("Idempotency-Key") idempotencyKey: String,
+        @HeaderParam("Idempotency-Key") idempotencyKey: String?,
     ): Response {
-        require(idempotencyKey.isNotBlank()) { "Idempotency-Key header is required" }
+        // #3624 — this guard answered 500 in exactly the case it was written for. `suspend` emits
+        // no Intrinsics.checkNotNullParameter, so an ABSENT header arrived as null and
+        // `null.isNotBlank()` threw NPE; only a BLANK header ever reached the intended 400.
+        require(!idempotencyKey.isNullOrBlank()) { "Idempotency-Key header is required" }
 
         idempotencyStore.get(idempotencyKey)?.let { cached ->
             return Response.status(cached.statusCode)

--- a/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
+++ b/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
@@ -908,12 +908,18 @@ class CustomerEdgeResource(
     @Path("/accounts/{accountId}/pockets/resolve")
     @Authorize(action = "customer.pockets.read", resource = "#accountId")
     @Blocking
-    fun resolvePocket(@PathParam("accountId") accountId: UUID, @QueryParam("currency") currency: String): Response {
+    fun resolvePocket(@PathParam("accountId") accountId: UUID, @QueryParam("currency") currency: String?): Response {
+        // #3624 — a plain (non-suspend) handler emits Intrinsics.checkNotNullParameter at bytecode
+        // offset 0, so omitting ?currency= threw NPE before the first statement and answered 500.
+        // A guard is only reachable once the parameter is declared nullable. Answered with this
+        // resource's own badRequest() envelope, as listSddMandates already does for an absent
+        // accountId — the app parses that shape, and every other 400 here is an explicit Response.
+        val ccyRaw = currency ?: return badRequest("Missing currency")
         val customer = customer()
         if (!ownsAccount(accountId, customer.partyId)) {
             return forbidden("Account does not belong to caller")
         }
-        val ccy = currency.uppercase()
+        val ccy = ccyRaw.uppercase()
         if (!isValidCurrency(ccy)) return badRequest("Invalid currency code")
         return upstream.get(
             "$accountServiceUrl/api/v1/accounts/$accountId/pockets/resolve?currency=$ccy",
@@ -1397,17 +1403,19 @@ class CustomerEdgeResource(
     @Authorize(action = "customer.transactions.read")
     @Blocking
     fun listTransactions(
-        @QueryParam("accountId") accountId: UUID,
+        @QueryParam("accountId") accountId: UUID?,
         @QueryParam("limit") @DefaultValue("20") limit: Int,
         @QueryParam("cursor") cursor: String?,
     ): Response {
+        // #3624 — see listSddMandates: nullable + an explicit 400, not a 500 from the intrinsic.
+        val account = accountId ?: return badRequest("Missing accountId")
         val customer = customer()
-        if (!ownsAccount(accountId, customer.partyId)) {
+        if (!ownsAccount(account, customer.partyId)) {
             return forbidden("Account does not belong to caller")
         }
-        val query = buildTransactionsQuery(accountId, limit, cursor)
+        val query = buildTransactionsQuery(account, limit, cursor)
         val resp = upstream.get("$transactionServiceUrl/api/v1/transactions$query", customer.partyId.toString())
-        return enrichWithCounterpartyIban(resp, accountId, customer.partyId)
+        return enrichWithCounterpartyIban(resp, account, customer.partyId)
     }
 
     /**
@@ -1774,11 +1782,13 @@ class CustomerEdgeResource(
     @Path("/sepa-instant")
     @Authorize(action = "customer.payments.read")
     @Blocking
-    fun listSepaInstant(@QueryParam("accountId") accountId: UUID): Response {
+    fun listSepaInstant(@QueryParam("accountId") accountId: UUID?): Response {
+        // #3624 — see listSddMandates: nullable + an explicit 400, not a 500 from the intrinsic.
+        val account = accountId ?: return badRequest("Missing accountId")
         val customer = customer()
-        if (!ownsAccount(accountId, customer.partyId)) return forbidden("Account does not belong to caller")
+        if (!ownsAccount(account, customer.partyId)) return forbidden("Account does not belong to caller")
         return upstream.get(
-            "$sepaInstantServiceUrl/api/v1/sepa-instant/debtor/$accountId",
+            "$sepaInstantServiceUrl/api/v1/sepa-instant/debtor/$account",
             customer.partyId.toString(),
         )
     }
@@ -1796,11 +1806,13 @@ class CustomerEdgeResource(
     @Blocking
     fun recallSepaInstant(
         @PathParam("paymentId") paymentId: UUID,
-        @QueryParam("accountId") accountId: UUID,
+        @QueryParam("accountId") accountId: UUID?,
         body: String,
     ): Response {
+        // #3624 — see listSddMandates: nullable + an explicit 400, not a 500 from the intrinsic.
+        val account = accountId ?: return badRequest("Missing accountId")
         val customer = customer()
-        val accountJson = fetchAccount(accountId, customer.partyId)
+        val accountJson = fetchAccount(account, customer.partyId)
             ?: return forbidden("Account does not belong to caller")
         if (extractOwnerPartyId(accountJson) != customer.partyId.toString()) {
             return forbidden("Account does not belong to caller")
@@ -3287,10 +3299,12 @@ class CustomerEdgeResource(
     @Path("/disputes")
     @Authorize(action = "customer.disputes.read")
     @Blocking
-    fun listDisputes(@QueryParam("accountId") accountId: UUID): Response {
+    fun listDisputes(@QueryParam("accountId") accountId: UUID?): Response {
+        // #3624 — see listSddMandates: nullable + an explicit 400, not a 500 from the intrinsic.
+        val account = accountId ?: return badRequest("Missing accountId")
         val customer = customer()
-        if (!ownsAccount(accountId, customer.partyId)) return forbidden("Account does not belong to caller")
-        return upstream.get("$disputeServiceUrl/api/v1/disputes/account/$accountId", customer.partyId.toString())
+        if (!ownsAccount(account, customer.partyId)) return forbidden("Account does not belong to caller")
+        return upstream.get("$disputeServiceUrl/api/v1/disputes/account/$account", customer.partyId.toString())
     }
 
     /**

--- a/openbank-dispute-service/src/main/kotlin/com/openbank/dispute/infrastructure/rest/DisputeResource.kt
+++ b/openbank-dispute-service/src/main/kotlin/com/openbank/dispute/infrastructure/rest/DisputeResource.kt
@@ -80,15 +80,23 @@ class DisputeResource(
     @Path("/{id}/withdraw")
     @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_API")
     @Operation(summary = "Withdraw a dispute")
-    fun withdraw(@PathParam("id") id: UUID, @QueryParam("actor") actor: String): Uni<Response> =
-        updateUseCase.withdraw(id, actor).map { Response.ok(it).build() }
+    fun withdraw(@PathParam("id") id: UUID, @QueryParam("actor") actor: String?): Uni<Response> {
+        // #3624 — `actor` is the attribution recorded against the state change, so a default would
+        // put a placeholder into the dispute's history. A plain `fun` emits
+        // Intrinsics.checkNotNullParameter at offset 0, so an omitted ?actor= answered 500 and a
+        // guard in the body could not run; nullable makes it reachable and libs-runtime gives 400.
+        requireNotNull(actor) { ACTOR_REQUIRED }
+        return updateUseCase.withdraw(id, actor).map { Response.ok(it).build() }
+    }
 
     @POST
     @Path("/{id}/escalate")
     @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_API")
     @Operation(summary = "Escalate a dispute")
-    fun escalate(@PathParam("id") id: UUID, @QueryParam("actor") actor: String): Uni<Response> =
-        updateUseCase.escalate(id, actor).map { Response.ok(it).build() }
+    fun escalate(@PathParam("id") id: UUID, @QueryParam("actor") actor: String?): Uni<Response> {
+        requireNotNull(actor) { ACTOR_REQUIRED }
+        return updateUseCase.escalate(id, actor).map { Response.ok(it).build() }
+    }
 
     @POST
     @Path("/{id}/resolve")
@@ -132,5 +140,8 @@ class DisputeResource(
     companion object {
         /** RFC 4918 status code; not present in JAX-RS' [Response.Status] enum. */
         private const val UNPROCESSABLE_ENTITY = 422
+
+        /** #3624 — message for the absent-`actor` 400 shared by withdraw and escalate. */
+        private const val ACTOR_REQUIRED = "query parameter 'actor' is required"
     }
 }

--- a/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/rest/PartyResource.kt
+++ b/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/rest/PartyResource.kt
@@ -125,7 +125,14 @@ class PartyResource {
     @POST
     @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_KYC")
     @Operation(summary = "Create a new party (customer or company)")
-    suspend fun createParty(req: CreatePartyRequest, @HeaderParam("Idempotency-Key") idempotencyKey: String): Response {
+    suspend fun createParty(
+        req: CreatePartyRequest,
+        @HeaderParam("Idempotency-Key") idempotencyKey: String?,
+    ): Response {
+        // #3624 — the key is what makes a repeated create safe, so it cannot be defaulted or
+        // synthesised here: a server-generated one would make every retry a NEW party. `suspend`
+        // emits no intrinsic, so the null was carried into the command and only surfaced downstream.
+        require(!idempotencyKey.isNullOrBlank()) { "Idempotency-Key header is required" }
         val party = partyUseCase.createParty(req.toCommand(idempotencyKey))
         return Response.created(URI.create("/api/v1/parties/${party.id}")).entity(party.toResponse()).build()
     }

--- a/openbank-pid-service/src/main/kotlin/com/openbank/pid/infrastructure/rest/PartyResource.kt
+++ b/openbank-pid-service/src/main/kotlin/com/openbank/pid/infrastructure/rest/PartyResource.kt
@@ -214,8 +214,12 @@ class PartyResource(
             produces a 404 that is operationally indistinguishable from a genuine no-match.
         """,
     )
-    suspend fun resolveByIndex(@QueryParam("index") index: String): Response {
-        if (index.isBlank()) {
+    suspend fun resolveByIndex(@QueryParam("index") index: String?): Response {
+        // #3624 — the guard below already returns the right 400 for a BLANK index and could never
+        // return it for an ABSENT one: `suspend` emits no Intrinsics.checkNotNullParameter, so
+        // JAX-RS's null flowed in and `null.isBlank()` threw NPE -> 500. Widening the guard to
+        // isNullOrBlank() keeps the existing INVALID_PARAMETER response shape for both cases.
+        if (index.isNullOrBlank()) {
             return Response.status(Response.Status.BAD_REQUEST)
                 .entity(mapOf("code" to "INVALID_PARAMETER", "message" to "'index' query parameter is required"))
                 .build()
@@ -279,9 +283,15 @@ class PartyResource(
     @RolesAllowed(Roles.OPERATOR, Roles.ADMIN)
     @Operation(summary = "Get party by external ID (bankID sub, ROB AIFO, etc.)")
     suspend fun getByExternalId(
-        @QueryParam("type") type: ExternalIdType,
-        @QueryParam("value") value: String,
-    ): Response = Response.ok(getPartyUseCase.getByExternalId(type, value).toResponse()).build()
+        @QueryParam("type") type: ExternalIdType?,
+        @QueryParam("value") value: String?,
+    ): Response {
+        // #3624 — the pair IS the lookup key, so neither half has a default. `suspend` emits no
+        // intrinsic, so both nulls reached the use case; libs-runtime maps this to 400.
+        requireNotNull(type) { "query parameter 'type' is required" }
+        requireNotNull(value) { "query parameter 'value' is required" }
+        return Response.ok(getPartyUseCase.getByExternalId(type, value).toResponse()).build()
+    }
 
     @GET
     @RolesAllowed(Roles.OPERATOR, Roles.ADMIN)

--- a/openbank-statement-service/build.gradle.kts
+++ b/openbank-statement-service/build.gradle.kts
@@ -40,6 +40,11 @@ dependencies {
     testImplementation(libs.quarkus.junit5)
     testImplementation(libs.assertj)
     testImplementation(libs.mockk)
+    // StatementMissingParamStatusIT (#3624) drives the resource over REAL HTTP — the only layer at
+    // which a missing @QueryParam can be observed at all. A unit test calling the handler supplies
+    // the argument JAX-RS does not, so it passes against the broken signature.
+    testImplementation(libs.rest.assured.kotlin)
+    testImplementation(libs.quarkus.test.security)
     testImplementation(libs.smallrye.reactive.messaging.inmemory)
 
     // CI infra sweep (#578): isolated PostgreSQL per test JVM via Testcontainers.

--- a/openbank-statement-service/src/main/kotlin/com/openbank/statement/infrastructure/rest/StatementResource.kt
+++ b/openbank-statement-service/src/main/kotlin/com/openbank/statement/infrastructure/rest/StatementResource.kt
@@ -47,14 +47,24 @@ class StatementResource(
     @Operation(summary = "Close a month for every pocket of an account (assigns sequences, reconciles fail-closed)")
     fun close(
         @PathParam("accountId") accountId: UUID,
-        @QueryParam("from") from: String,
-        @QueryParam("to") to: String,
-    ): Uni<Response> = closePeriod.closeMonth(accountId, LocalDate.parse(from), LocalDate.parse(to))
-        .map { Response.ok(it).build() }
-        .onFailure(ReconciliationException::class.java)
-        .recoverWithItem { e ->
-            Response.status(Response.Status.CONFLICT).entity(mapOf("error" to e.message)).build()
-        }
+        @QueryParam("from") from: String?,
+        @QueryParam("to") to: String?,
+    ): Uni<Response> {
+        // #3624 — the period being closed has no defensible default: a close assigns legal
+        // sequences and is idempotent on (account, currency, period), so guessing the range would
+        // write the wrong statement rather than fail. This handler is a plain `fun`, so Kotlin
+        // emitted Intrinsics.checkNotNullParameter at bytecode offset 0 and an omitted ?from= threw
+        // NPE before the body ran — a guard written here would have been dead code. Nullable makes
+        // it reachable; libs-runtime maps IllegalArgumentException to 400.
+        requireNotNull(from) { FROM_REQUIRED }
+        requireNotNull(to) { TO_REQUIRED }
+        return closePeriod.closeMonth(accountId, LocalDate.parse(from), LocalDate.parse(to))
+            .map { Response.ok(it).build() }
+            .onFailure(ReconciliationException::class.java)
+            .recoverWithItem { e ->
+                Response.status(Response.Status.CONFLICT).entity(mapOf("error" to e.message)).build()
+            }
+    }
 
     @GET
     @Path("/{accountId}")
@@ -86,13 +96,24 @@ class StatementResource(
     fun export(
         @PathParam("accountId") accountId: UUID,
         @PathParam("currency") currency: String,
-        @QueryParam("from") from: String,
-        @QueryParam("to") to: String,
+        @QueryParam("from") from: String?,
+        @QueryParam("to") to: String?,
         @QueryParam("format") @DefaultValue("PDF") format: String,
-    ): Uni<Response> =
-        adHocExport.export(accountId, currency, LocalDate.parse(from), LocalDate.parse(to), parseFormat(format))
+    ): Uni<Response> {
+        // #3624 — `format` is safe (it carries @DefaultValue, so JAX-RS never injects null); the
+        // date range is the whole meaning of an ad-hoc export and was a 500 when omitted.
+        requireNotNull(from) { FROM_REQUIRED }
+        requireNotNull(to) { TO_REQUIRED }
+        return adHocExport
+            .export(accountId, currency, LocalDate.parse(from), LocalDate.parse(to), parseFormat(format))
             .map { rendered -> Response.ok(rendered.body).type(rendered.contentType).build() }
+    }
 
     private fun parseFormat(raw: String): StatementFormat =
         StatementFormat.entries.firstOrNull { it.name.equals(raw, ignoreCase = true) } ?: StatementFormat.PDF
+
+    private companion object {
+        const val FROM_REQUIRED = "query parameter 'from' is required"
+        const val TO_REQUIRED = "query parameter 'to' is required"
+    }
 }

--- a/openbank-statement-service/src/test/kotlin/com/openbank/statement/integration/StatementMissingParamStatusIT.kt
+++ b/openbank-statement-service/src/test/kotlin/com/openbank/statement/integration/StatementMissingParamStatusIT.kt
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+package com.openbank.statement.integration
+
+import com.openbank.statement.it.PostgresTestResource
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.junit.QuarkusTestProfile
+import io.quarkus.test.junit.TestProfile
+import io.quarkus.test.security.TestSecurity
+import io.restassured.module.kotlin.extensions.Given
+import io.restassured.module.kotlin.extensions.Then
+import io.restassured.module.kotlin.extensions.When
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * An omitted `from`/`to` on an ad-hoc export must answer 400, not 500 (#3624).
+ *
+ * This is the OTHER half of the mechanism from [Psd2MissingHeaderStatusIT]'s suspend handlers, and
+ * the unambiguous one: `export` is a plain `fun`, so Kotlin emits `Intrinsics.checkNotNullParameter`
+ * at bytecode offset 0. With the old non-nullable signature the NPE was thrown before the first
+ * statement of the body ran, `GenericExceptionMapper` rendered 500, and a `requireNotNull` written
+ * inside the body would have compiled to nothing. Verified by reverting the fix and re-running:
+ * this test reports 500.
+ *
+ * Only real HTTP can observe it — calling `export(...)` from a unit test supplies the argument JAX-RS
+ * does not, so such a test passes against the broken code.
+ *
+ * The second test is the control: with both dates present the request gets past the guard and fails
+ * further downstream, so the first test's redness is attributable to the guard alone.
+ */
+@QuarkusTest
+@TestProfile(StatementMissingParamStatusIT.AuthzOffProfile::class)
+@QuarkusTestResource(PostgresTestResource::class)
+class StatementMissingParamStatusIT {
+
+    /**
+     * `authz.enforce` defaults to true with no OPA sidecar under test, so `@Authorize` endpoints
+     * fail CLOSED with 503 before the handler is entered — the request would never reach the
+     * parameter binding this test is about. Literal values only: a profile loads in a different
+     * classloader from the test class, so anything computed here is computed twice.
+     */
+    class AuthzOffProfile : QuarkusTestProfile {
+        override fun getConfigOverrides(): Map<String, String> = mapOf("authz.enforce" to "false")
+    }
+
+    @TestSecurity(user = "tester", roles = ["ROLE_OPERATOR", "ROLE_ADMIN"])
+    @Test
+    fun `an ad-hoc export with no from or to answers 400`() {
+        Given { this } When {
+            get("/api/v1/statements/$ACCOUNT_ID/CZK/export")
+        } Then {
+            statusCode(400)
+        }
+    }
+
+    @TestSecurity(user = "tester", roles = ["ROLE_OPERATOR", "ROLE_ADMIN"])
+    @Test
+    fun `an ad-hoc export with both dates present gets past the guard`() {
+        val status = io.restassured.RestAssured
+            .given()
+            .get("/api/v1/statements/$ACCOUNT_ID/CZK/export?from=2026-01-01&to=2026-01-31")
+            .statusCode
+        assertThat(status)
+            .describedAs("with both dates supplied the request must get past the #3624 guard")
+            .isNotEqualTo(400)
+    }
+
+    private companion object {
+        const val ACCOUNT_ID = "11111111-2222-3333-4444-555555555555"
+    }
+}

--- a/openbank-tpp-registry-service/src/main/kotlin/com/openbank/tppregistry/infrastructure/rest/TppRegistryResource.kt
+++ b/openbank-tpp-registry-service/src/main/kotlin/com/openbank/tppregistry/infrastructure/rest/TppRegistryResource.kt
@@ -38,7 +38,13 @@ class TppRegistryResource(
     @GET
     @Path("/check")
     @RolesAllowed("ROLE_API", "ROLE_OPERATOR", "ROLE_ADMIN")
-    suspend fun checkAuthorization(@QueryParam("tppId") tppId: String, @QueryParam("role") role: String): Response {
+    suspend fun checkAuthorization(@QueryParam("tppId") tppId: String?, @QueryParam("role") role: String?): Response {
+        // #3624 — both name WHAT is being checked, so neither can default: this endpoint answers
+        // "is this TPP authorised for this role", and a guessed role would answer a question the
+        // caller did not ask. `suspend` emits no Intrinsics.checkNotNullParameter, so the nulls
+        // flowed in and `role.uppercase()` threw NPE -> 500. libs-runtime maps this to 400.
+        requireNotNull(tppId) { "query parameter 'tppId' is required" }
+        requireNotNull(role) { "query parameter 'role' is required" }
         val result = svc.checkAuthorization(
             CheckTppAuthorizationQuery(tppId, TppRole.valueOf(role.uppercase())),
         )


### PR DESCRIPTION
## Summary

The remaining 18 of the 39 sites in #3624, across seven services — and the last of them. `BASELINE` in `check-nonnull-jaxrs-params.py` is now **empty**, so the gate becomes an outright "no occurrences" ratchet rather than a tail-tracking one.

**Stacked.** Base is `fix/nonnull-params-psd2-cards` (#3658), which is itself based on `fix/nonnull-queryparam-400` (#3625). Merge order is #3625 → #3658 → this. Retarget as each lands.

## Type of change

- [x] fix (bug fix)

## Linked issues

Refs #3624, Refs #3625, Refs #3104

## Changes

Same mechanism throughout: JAX-RS injects `null` for an absent parameter, Kotlin's null-safety is compile-time only, and the parameter must be declared **nullable** before any guard in the body can run. A plain `fun` emits `Intrinsics.checkNotNullParameter` at bytecode offset 0 (guaranteed 500, and a guard written in the body compiles to nothing); a `suspend fun` emits no intrinsic, so the null flows in and fails at the first dereference — or silently does not.

**The error shape chosen per service is the one that service already uses for its 400s.** Introducing a second envelope into a resource that answers every other 400 with an explicit `Response` would be the #526 shape-lottery all over again.

- **customer-edge (5)** — `accountId` on four reads/writes plus `currency` on pocket resolve. Answered with this resource's own `badRequest()`, exactly as `listSddMandates` already does for an absent `accountId`; the app parses that shape. All are `@Blocking` plain `fun`s, i.e. the guaranteed-500 half.
- **statement (4)** — `from`/`to` on close and export. A period-close assigns legal sequences and is idempotent on `(account, currency, period)`, so a guessed range would write the **wrong** statement rather than fail; no default is defensible. `format` needed nothing — it already carries `@DefaultValue`.
- **pid (3)** — `resolveByIndex` already returned the right `INVALID_PARAMETER` 400 for a *blank* index and could never return it for an *absent* one. Widened to `isNullOrBlank()`, which keeps the existing response shape for both cases rather than swapping in a new one. `getByExternalId`'s `(type, value)` pair **is** the lookup key.
- **dispute (2)** — `actor` on withdraw/escalate is the attribution recorded against the state change; a default would write a placeholder into the dispute's history.
- **tpp-registry (2)** — `tppId`/`role` name what is being checked; a guessed role answers a question the caller did not ask.
- **aml (1), party (1)** — `Idempotency-Key`. aml's `require(idempotencyKey.isNotBlank())` is another guard that answered 500 in exactly the case it was written for. party's key is what makes a repeated create safe — synthesising one would make every retry a **new party**.

### Classification

All 18 **truly required**. Defaultable: 0. Genuinely optional: 0. Two of the 18 already had a guard that could never run for the absent case.

### Testing

`StatementMissingParamStatusIT` covers the **non-suspend** half over real HTTP — the only layer at which the defect exists. Falsified: with the fix reverted it reports **500**, and its control test (both dates supplied) passes either way, so the redness is attributable to the guard alone. A `@TestProfile` turns `authz.enforce` off; without it the PDP fails closed and every `@Authorize` endpoint answers 503 before the handler is entered.

This required `rest-assured-kotlin` and `quarkus-test-security` on statement-service's **test** classpath — the one dependency change in this PR, and the reason the fleet dependency-resolution job runs.

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports).
- [x] Unit tests added/updated.
- [x] Integration tests added/updated (if service boundary involved).
- [x] Contract tests updated (if public API changed). — no pact change needed; tpp-registry's and the others' provider replays pass unchanged.
- [x] `./gradlew detekt ktlintCheck koverVerify build` passes. — per module, run sequentially (parallel Quarkus test JVMs collide on ports and produce `QuarkusBindException`).
- [x] No new lint warnings.
- [ ] OpenAPI spec regenerated (if REST API changed). — no route, parameter set or schema changed; only the status code for an already-invalid request.
- [x] Flyway migration added + rollback note (if DB changed). — n/a
- [x] Avro schema versioned backward-compatibly (if event changed). — n/a
- [x] Docs updated (README, ADR if architectural). — gate script header updated to state the baseline is now empty and why the ratchet machinery stays.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings`, `as Any`, `@Suppress("...")` without justification.
- [ ] No new third-party dependency, OR: dependency review attached. — two **test-only** additions, both already in the version catalog and already used elsewhere in the fleet (`io.rest-assured:kotlin-extensions`, `io.quarkus:quarkus-test-security`). Nothing reaches a runtime classpath.
- [x] Auth / crypto / payment code changed? — no. customer-edge's IDOR ownership checks are untouched: the guard runs strictly *before* them and every `ownsAccount` call still receives the same value it did.
- [x] PII path changed? — no.
- [x] Cardholder data path changed? — no.

## Compliance impact

- [x] None — no regulatory surface changes; an already-invalid request now gets an accurate status code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
