### PR TITLE
fix(campaign,notification): resolve the EMAIL recipient from partyId, and stop the send log losing a failed handoff

### DIFF
--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/workflow/CampaignJourneyActivitiesImpl.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/workflow/CampaignJourneyActivitiesImpl.kt
@@ -35,7 +35,7 @@ import java.util.UUID
 @ApplicationScoped
 // activity wiring: repos + ports + policy config in one place, per the worker-registrar pattern
 @Suppress("LongParameterList")
-class CampaignJourneyActivitiesImpl(
+open class CampaignJourneyActivitiesImpl(
     private val campaigns: CampaignRepository,
     private val enrolments: EnrolmentRepository,
     private val sendLog: SendLogRepository,
@@ -55,6 +55,11 @@ class CampaignJourneyActivitiesImpl(
         campaigns.findById(campaignId)?.steps ?: emptyList()
     }
 
+    // The publish failure below is caught broadly on purpose: the point is that NO handoff failure
+    // may leave the send log without a row, and narrowing the catch would re-open the gap for
+    // whichever exception type the Kafka client happens to raise next (#3581). It is rethrown, so
+    // nothing is swallowed.
+    @Suppress("TooGenericExceptionCaught")
     override fun deliverStep(campaignId: UUID, partyId: UUID, stepOrder: Int): StepOutcome = runBlockingOnWorker {
         val campaign = campaigns.findById(campaignId) ?: return@runBlockingOnWorker StepOutcome.SUPPRESSED
         val step =
@@ -78,7 +83,26 @@ class CampaignJourneyActivitiesImpl(
         }
 
         // ADR-0200 D3 — delivery goes through notification-service, never direct.
-        notificationSend.requestSend(partyId, step.template, recipientFor(partyId), step.variables)
+        //
+        // The order below is the fix for issue #3581: the send log may only be written AFTER the
+        // handoff has been observed to succeed, and a handoff that failed must leave a FAILED row
+        // rather than nothing. Previously a refused publish let the exception escape the activity
+        // with no row written at all, so the funnel silently lost the party — a campaign that
+        // reached nobody and a console that had no way to say so.
+        //
+        // What SENT claims here is exactly "notification-service accepted the request onto
+        // `openbank.notification.requests`", not "the customer received it": the address is
+        // resolved and the mail is sent on the far side, and no delivery outcome is fed back yet.
+        // That feedback loop is the remaining half of #3581 and is tracked separately.
+        try {
+            notificationSend.requestSend(partyId, step.template, recipientFor(partyId), step.variables)
+        } catch (e: Exception) {
+            record(campaignId, partyId, stepOrder, SendOutcome.FAILED)
+            // Rethrown on purpose: Temporal retries the activity, and the FAILED row above is the
+            // durable evidence that this attempt happened. FAILED rows do not consume the
+            // frequency cap (`countRecentForParty` counts SENT only), so a retry is not penalised.
+            throw e
+        }
         record(campaignId, partyId, stepOrder, SendOutcome.SENT)
         StepOutcome.SENT
     }
@@ -122,8 +146,17 @@ class CampaignJourneyActivitiesImpl(
         }
     }
 
-    // The recipient address is resolved by notification-service from party data; the campaign
-    // never carries an e-mail address itself (ADR-0200 D3 — no PII duplication).
+    /**
+     * The `recipient` field of the notification request, deliberately the party id and NOT an
+     * address (ADR-0200 D3 — the campaign holds no PII).
+     *
+     * This comment used to claim notification-service resolved the address from party data, and
+     * nothing did: the UUID reached `Mail.withHtml(req.recipient, …)` verbatim as the SMTP
+     * envelope (#3581). notification-service now resolves a non-address recipient against
+     * party-service and fails closed when it cannot, which is what makes this line true —
+     * account-service and sca-service pass the party id here too, so the resolution belongs
+     * there, once, rather than in each caller.
+     */
     private fun recipientFor(partyId: UUID): String = partyId.toString()
 
     /**
@@ -133,8 +166,13 @@ class CampaignJourneyActivitiesImpl(
      * class and deliver nothing (same shape as the @Scheduled sweep in #2148/#2187). Bridge
      * through [VertxContextSupport] instead, exactly as `DomesticPaymentActivitiesImpl.vtx` does
      * — safe here precisely because an activity thread is never an event loop.
+     *
+     * `protected open` for the same reason `FxActivitiesImpl.vtx` is: a unit test cannot supply a
+     * Vert.x context, so it overrides this one bridge with `runBlocking` and drives the real
+     * activity logic. Without the seam `deliverStep` has no test at any layer — which is how the
+     * ordering defect in #3581 shipped.
      */
-    private fun <T> runBlockingOnWorker(block: suspend () -> T): T =
+    protected open fun <T> runBlockingOnWorker(block: suspend () -> T): T =
         VertxContextSupport.subscribeAndAwait { CoroutineScope(Dispatchers.Unconfined).async { block() }.asUni() }
 
     companion object {

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/workflow/CampaignJourneyActivitiesImplTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/workflow/CampaignJourneyActivitiesImplTest.kt
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.campaign.application.workflow
+
+import com.openbank.campaign.application.port.out.CampaignRepository
+import com.openbank.campaign.application.port.out.ConsentCheckPort
+import com.openbank.campaign.application.port.out.EnrolmentRepository
+import com.openbank.campaign.application.port.out.NotificationSendPort
+import com.openbank.campaign.application.port.out.SendLogRepository
+import com.openbank.campaign.domain.model.Campaign
+import com.openbank.campaign.domain.model.CampaignState
+import com.openbank.campaign.domain.model.CampaignStep
+import com.openbank.campaign.domain.model.Channel
+import com.openbank.campaign.domain.model.SegmentRef
+import com.openbank.campaign.domain.model.SendOutcome
+import com.openbank.campaign.domain.model.SendRecord
+import io.mockk.Runs
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * The send log must never disagree with what actually happened to the request (issue #3581).
+ *
+ * `deliverStep` recorded `SENT` on the line after the notification handoff, and a handoff the
+ * broker refused threw straight out of the activity with **no row written at all** — so the
+ * campaign console's funnel silently lost the party rather than showing a failure. These tests
+ * pin both halves: a refused handoff records FAILED and never SENT, and a successful one records
+ * SENT only after the handoff returned.
+ *
+ * The Vert.x bridge is overridden with `runBlocking`, the same seam `FxActivitiesImplTest` uses —
+ * a plain test thread carries no Vert.x context, and without the override the real activity logic
+ * is untestable at every layer, which is how this shipped.
+ */
+class CampaignJourneyActivitiesImplTest {
+
+    private val campaigns: CampaignRepository = mockk()
+    private val enrolments: EnrolmentRepository = mockk()
+    private val sendLog: SendLogRepository = mockk()
+    private val consentCheck: ConsentCheckPort = mockk()
+    private val notificationSend: NotificationSendPort = mockk()
+
+    private val campaignId = UUID.randomUUID()
+    private val partyId = UUID.randomUUID()
+
+    private val activities = object : CampaignJourneyActivitiesImpl(
+        campaigns,
+        enrolments,
+        sendLog,
+        consentCheck,
+        notificationSend,
+        maxSendsPerWeek = 2,
+        // Quiet hours are evaluated against the wall clock; a start == end window is never active,
+        // so the suppression branch cannot make these tests time-of-day dependent.
+        quietHoursStart = 0,
+        quietHoursEnd = 0,
+        marketingScope = "MARKETING_COMMS_EMAIL",
+    ) {
+        override fun <T> runBlockingOnWorker(block: suspend () -> T): T = runBlocking { block() }
+    }
+
+    private fun givenDeliverableStep() {
+        coEvery { campaigns.findById(campaignId) } returns Campaign(
+            id = campaignId,
+            name = "spring-offer",
+            goal = "activation",
+            segmentRef = SegmentRef("all", 1),
+            steps = listOf(
+                CampaignStep(
+                    order = 1,
+                    template = "MARKETING_PRODUCT_OFFER",
+                    channel = Channel.EMAIL,
+                    variables = emptyMap(),
+                    delaySeconds = 0,
+                ),
+            ),
+            state = CampaignState.ACTIVE,
+            createdBy = "operator",
+            approvedBy = "approver",
+            createdAt = Instant.now(),
+            updatedAt = Instant.now(),
+        )
+        coEvery { sendLog.countRecentForParty(partyId, any()) } returns 0
+        coEvery { consentCheck.hasActiveConsent(partyId, any()) } returns true
+        coEvery { sendLog.record(any()) } just Runs
+    }
+
+    @Test
+    fun `a refused notification handoff records FAILED and never SENT`() {
+        givenDeliverableStep()
+        coEvery { notificationSend.requestSend(partyId, any(), any(), any()) } throws
+            IllegalStateException("broker refused the publish")
+
+        assertThatThrownBy { activities.deliverStep(campaignId, partyId, 1) }
+            .isInstanceOf(IllegalStateException::class.java)
+
+        val recorded = slot<SendRecord>()
+        coVerify(exactly = 1) { sendLog.record(capture(recorded)) }
+        assertThat(recorded.captured.outcome).isEqualTo(SendOutcome.FAILED)
+    }
+
+    @Test
+    fun `a successful handoff records SENT only after the handoff returned`() {
+        givenDeliverableStep()
+        val recordedBeforeSend = mutableListOf<SendOutcome>()
+        var handedOff = false
+        coEvery { notificationSend.requestSend(partyId, any(), any(), any()) } answers { handedOff = true }
+        coEvery { sendLog.record(any()) } answers {
+            if (!handedOff) recordedBeforeSend += firstArg<SendRecord>().outcome
+            Unit
+        }
+
+        assertThat(activities.deliverStep(campaignId, partyId, 1)).isEqualTo(StepOutcome.SENT)
+
+        assertThat(recordedBeforeSend)
+            .withFailMessage("SENT was written before the notification handoff was observed: %s", recordedBeforeSend)
+            .isEmpty()
+        val recorded = slot<SendRecord>()
+        coVerify(exactly = 1) { sendLog.record(capture(recorded)) }
+        assertThat(recorded.captured.outcome).isEqualTo(SendOutcome.SENT)
+    }
+}

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/application/NotificationConsumer.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/application/NotificationConsumer.kt
@@ -13,6 +13,7 @@ import com.openbank.notification.application.port.out.OversightWebhookPublisher
 import com.openbank.notification.application.port.out.PushMessage
 import com.openbank.notification.application.port.out.PushSender
 import com.openbank.notification.domain.HtmlEscape
+import com.openbank.notification.domain.RecipientAddress
 import com.openbank.notification.domain.model.NotificationCategory
 import com.openbank.notification.domain.model.NotificationChannel
 import com.openbank.notification.domain.model.NotificationRequest
@@ -21,6 +22,7 @@ import com.openbank.notification.domain.model.NotificationTemplate
 import com.openbank.notification.domain.model.PushPlatform
 import com.openbank.notification.domain.model.TemplateSensitivity
 import com.openbank.notification.infrastructure.client.ConsentServiceClient
+import com.openbank.notification.infrastructure.client.PartyContactClient
 import com.openbank.notification.infrastructure.persistence.entity.NotificationEntity
 import com.openbank.notification.infrastructure.persistence.repository.DeviceTokenRepository
 import com.openbank.notification.infrastructure.persistence.repository.NotificationPreferenceRepository
@@ -90,6 +92,11 @@ class NotificationConsumer {
     @Inject
     @RestClient
     lateinit var consentServiceClient: ConsentServiceClient
+
+    /** Resolves the EMAIL envelope address from `partyId` (issue #3581) — see [resolveEmailRecipient]. */
+    @Inject
+    @RestClient
+    lateinit var partyContactClient: PartyContactClient
 
     private val log = Logger.getLogger(NotificationConsumer::class.java)
 
@@ -366,14 +373,69 @@ class NotificationConsumer {
         }
     }
 
+    /**
+     * Resolves the EMAIL envelope address, then delivers (issue #3581).
+     *
+     * Every producer on this topic puts the **party id** in `recipient` — campaign-service,
+     * account-service and sca-service all do — and nothing ever resolved it, so the UUID went to
+     * `Mail.withHtml(...)` verbatim and the mail could not be delivered. PUSH never had the bug
+     * because it resolves its destination from `partyId` in the device-token registry; EMAIL now
+     * does the same, here, rather than in each caller.
+     *
+     * Fail CLOSED: an unresolvable address records FAILED and sends nothing. The alternative —
+     * handing the mailer whatever arrived — is what produced a permanently green send funnel over
+     * mail that never left.
+     */
     private fun sendEmail(
         req: NotificationRequest,
         subject: String,
         body: String,
         entity: NotificationEntity,
-    ): Uni<Void> = mailer.send(Mail.withHtml(req.recipient, subject, body))
+    ): Uni<Void> = resolveEmailRecipient(req).chain { address ->
+        if (address.isEmpty()) {
+            // The party id is logged, never a candidate address — an unresolved recipient is
+            // exactly where a malformed value would be, and it is still customer data.
+            log.errorf(
+                "EMAIL not sent: no deliverable address for party=%s template=%s — recorded FAILED (#3581)",
+                req.partyId,
+                req.template,
+            )
+            markStatus(entity, "FAILED")
+        } else {
+            deliverEmail(req, address, subject, body, entity)
+        }
+    }
+
+    /**
+     * The supplied `recipient` when it already is an address, otherwise party-service's.
+     *
+     * Emits `""` for "not resolvable", never a null item: a `Uni` carrying null is the shape that
+     * bites callers of `Uni.createFrom().item(...)` in this codebase, and the caller's only
+     * question is deliverable-or-not. The lookup result is never cached — an address the customer
+     * changed is precisely what a cache would get wrong — and a party-service outage resolves to
+     * "not deliverable", so an outage suppresses rather than sends to a UUID.
+     */
+    private fun resolveEmailRecipient(req: NotificationRequest): Uni<String> =
+        if (RecipientAddress.isEmailAddress(req.recipient)) {
+            Uni.createFrom().item(req.recipient.trim())
+        } else {
+            partyContactClient.getParty(req.partyId)
+                .map { party -> party.email?.trim()?.takeIf { RecipientAddress.isEmailAddress(it) } ?: "" }
+                .onFailure().recoverWithItem { e ->
+                    log.warnf(e, "Party lookup failed for party=%s — EMAIL not deliverable (#3581)", req.partyId)
+                    ""
+                }
+        }
+
+    private fun deliverEmail(
+        req: NotificationRequest,
+        recipient: String,
+        subject: String,
+        body: String,
+        entity: NotificationEntity,
+    ): Uni<Void> = mailer.send(Mail.withHtml(recipient, subject, body))
         .onFailure().invoke { e ->
-            log.warnf(e, "Email send failed: to=%s template=%s", req.recipient, req.template)
+            log.warnf(e, "Email send failed: party=%s template=%s", req.partyId, req.template)
         }
         .onFailure().recoverWithUni { _ ->
             Panache.withTransaction {
@@ -392,7 +454,7 @@ class NotificationConsumer {
                     }
             }.replaceWithVoid()
         }
-        .onItem().invoke { _ -> log.infof("Email sent: to=%s template=%s", req.recipient, req.template) }
+        .onItem().invoke { _ -> log.infof("Email sent: party=%s template=%s", req.partyId, req.template) }
         // Only reachable if the mail genuinely went out (the FAILED path above already recovered
         // any send failure into a completed Uni). Never marks the row FAILED — that would be a
         // lie about a message that was actually delivered — logs loudly instead, and swallows so
@@ -401,9 +463,9 @@ class NotificationConsumer {
         .onFailure().invoke { e ->
             log.warnf(
                 e,
-                "Email sent but recording SENT status failed: to=%s template=%s — row left as-is, " +
+                "Email sent but recording SENT status failed: party=%s template=%s — row left as-is, " +
                     "NOT marked FAILED (the email was actually delivered)",
-                req.recipient,
+                req.partyId,
                 req.template,
             )
         }

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/domain/RecipientAddress.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/domain/RecipientAddress.kt
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.notification.domain
+
+/**
+ * Tells an e-mail address from something that is not one (issue #3581).
+ *
+ * Deliberately not a full RFC 5322 validator — the only judgement this makes is "may this string
+ * be handed to the mailer as an envelope address, or must it be resolved first?", and the thing it
+ * has to reject is a bare party UUID. A permissive shape check is right here: a stricter grammar
+ * would start rejecting real addresses, and the fallback for a rejected string is a party-service
+ * lookup, not a failure.
+ */
+object RecipientAddress {
+
+    /** A UUID has no `@`, so this alone separates a party id from an address. */
+    fun isEmailAddress(candidate: String?): Boolean {
+        val value = candidate?.trim().orEmpty()
+        if (value.isEmpty() || value.any { it.isWhitespace() }) return false
+        val at = value.indexOf('@')
+        if (at <= 0 || at != value.lastIndexOf('@')) return false
+        val domain = value.substring(at + 1)
+        return domain.length >= MIN_DOMAIN_LENGTH &&
+            domain.contains('.') &&
+            !domain.startsWith('.') &&
+            !domain.endsWith('.')
+    }
+
+    /** `a.bc` — the shortest thing that can be a host with a TLD. */
+    private const val MIN_DOMAIN_LENGTH = 4
+}

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/infrastructure/client/PartyContactClient.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/infrastructure/client/PartyContactClient.kt
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.notification.infrastructure.client
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import io.quarkus.oidc.client.reactive.filter.OidcClientRequestReactiveFilter
+import io.smallrye.mutiny.Uni
+import jakarta.ws.rs.GET
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.PathParam
+import jakarta.ws.rs.Produces
+import jakarta.ws.rs.core.MediaType
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient
+import java.util.UUID
+
+/**
+ * Resolves a party's e-mail address for EMAIL delivery (issue #3581).
+ *
+ * Every producer on `openbank.notification.requests` — campaign-service, account-service and
+ * sca-service alike — puts the **party id** in the request's `recipient` field, because none of
+ * them holds customer PII. Nothing resolved it, so the UUID reached `Mail.withHtml(...)` as the
+ * SMTP envelope and every such mail was undeliverable. PUSH never had this problem: it looks its
+ * destination up from `partyId` in the device-token registry. This client closes the asymmetry by
+ * giving EMAIL the same treatment, once, on the delivery side.
+ *
+ * `GET /api/v1/parties/{id}` is authorized to ROLE_VIEWER/OPERATOR/ADMIN/KYC/ROLE_API and the
+ * shared `openbank-services` client_credentials filter carries one of those — the same M2M pattern
+ * as [ConsentServiceClient]. The response is not cached: an address the customer has since changed
+ * is exactly the thing a cache would get wrong.
+ */
+@RegisterRestClient(configKey = "party-service")
+@RegisterProvider(OidcClientRequestReactiveFilter::class)
+@Path("/api/v1/parties")
+@Produces(MediaType.APPLICATION_JSON)
+interface PartyContactClient {
+    @GET
+    @Path("/{id}")
+    fun getParty(@PathParam("id") id: UUID): Uni<PartyContactResponse>
+}
+
+/**
+ * Only the address is read. `@JsonIgnoreProperties(ignoreUnknown = true)` is load-bearing: the
+ * party response carries the full customer record, and binding fields this service has no reason
+ * to hold would copy PII into a heap it never needs.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class PartyContactResponse(val email: String? = null)

--- a/openbank-notification-service/src/main/resources/application.yaml
+++ b/openbank-notification-service/src/main/resources/application.yaml
@@ -63,6 +63,13 @@ quarkus:
       url: ${CONSENT_SERVICE_URL:http://localhost:8106}
       connect-timeout: 2000
       read-timeout: 2000
+    # EMAIL envelope-address resolution (issue #3581). Timeouts match consent-service: a party
+    # lookup that hangs must not hold a Kafka record open, and a timeout resolves to "not
+    # deliverable", which records FAILED rather than mailing a party id.
+    party-service:
+      url: ${PARTY_SERVICE_URL:http://localhost:8111}
+      connect-timeout: 2000
+      read-timeout: 2000
   smallrye-reactive-messaging:
     kafka:
       bootstrap-servers: localhost:29092

--- a/openbank-notification-service/src/test/kotlin/com/openbank/notification/domain/RecipientAddressTest.kt
+++ b/openbank-notification-service/src/test/kotlin/com/openbank/notification/domain/RecipientAddressTest.kt
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.notification.domain
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+/**
+ * The one case this predicate exists for is the first one: a party UUID must not read as an
+ * address (issue #3581). Every producer on `openbank.notification.requests` puts a party id in
+ * `recipient`, and for the whole life of the service that string went to the mailer as the SMTP
+ * envelope — an assertion that the recipient parses as an address would have failed from the
+ * first commit, which is exactly why one lives here now.
+ *
+ * Addresses below are synthetic (`example.com`, an RFC 2606 reserved domain).
+ */
+class RecipientAddressTest {
+
+    @Test
+    fun `a party UUID is not an address`() {
+        assertThat(RecipientAddress.isEmailAddress(UUID.randomUUID().toString())).isFalse()
+    }
+
+    @Test
+    fun `ordinary addresses are accepted`() {
+        for (candidate in listOf("a.b@example.com", "party+campaign@sub.example.co.uk", " spaced@example.com ")) {
+            assertThat(RecipientAddress.isEmailAddress(candidate))
+                .withFailMessage("expected %s to be treated as an address", candidate)
+                .isTrue()
+        }
+    }
+
+    @Test
+    fun `non-addresses are rejected`() {
+        for (candidate in listOf(null, "", "   ", "no-at-sign", "@example.com", "two@@example.com", "a@b", "a@.com")) {
+            assertThat(RecipientAddress.isEmailAddress(candidate))
+                .withFailMessage("expected %s to be rejected", candidate)
+                .isFalse()
+        }
+    }
+}


### PR DESCRIPTION
Closes #3581 (recipient + send-log ordering). Two defects, one cause: campaign-service declared
success at the point it handed the request off, and the far side never resolved what it handed
over.

## 1. Every campaign e-mail was addressed to a party UUID

`recipientFor(partyId) = partyId.toString()`, and `NotificationConsumer` used that value as the
SMTP envelope with no lookup anywhere. Measured while confirming it: campaign is **not the only
caller** — `account-service` and `sca-service` also publish `"recipient" to partyId.toString()`.
So fixing it in campaign would have fixed one caller and left the shape that produced it, which
is what the issue argues.

Fixed on the delivery side: `PartyContactClient` resolves `GET /api/v1/parties/{id}` (shared
`openbank-services` client_credentials filter, same M2M pattern as `ConsentServiceClient`) and
EMAIL now gets the treatment PUSH always had. Fail closed — an unresolvable address records
FAILED and sends nothing. A `recipient` that already parses as an address is used as-is, so
producers passing a real address are unaffected. Not cached: an address the customer changed is
what a cache would get wrong.

## 2. The send log could not say a send had failed

Measured rather than assumed, because this looked like the `Uni.createFrom().item { send }` shape
fixed in #3646 and it is not: `emitter.send(payload).toCompletableFuture().join()` **does** await
the broker ack, and the channel does not disable `waitForWriteCompletion`. The real defect is the
other direction — a refused publish threw out of the activity and **no row was written at all**,
so the funnel silently lost the party. A campaign that reached nobody and a console with no way
to say so.

The handoff is now observed before the log is written; a refusal records FAILED and rethrows, so
Temporal still retries and the FAILED row is durable evidence. FAILED rows do not consume the
frequency cap (it counts SENT only), so a retry is not penalised.

### Red, then green

`runBlockingOnWorker` becomes `protected open` — the seam `FxActivitiesImpl.vtx` already uses.
Without it `deliverStep` had no test at any layer, which is how this shipped.

Against the **unpatched** delivery block:

```
CampaignJourneyActivitiesImplTest > a refused notification handoff records FAILED and never SENT() FAILED
  AssertionError: Verification failed: call 1 of 1: SendLogRepository(#3).record(...) was not called.
  Calls to same mock:
  1) SendLogRepository(#3).countRecentForParty(...)
```

That is the defect stated exactly: the attempt left no trace. Patched, both tests pass. The
second test (SENT is never written before the handoff returns) passes on the old code too — it is
a regression pin, not the probe.

## Consent gate — checked, and the old note is stale

A prior sweep recorded that marketing EMAIL has no consent gate. It does now, in two places:
`NotificationConsumer.gateMarketingOnConsent` runs ahead of the channel dispatch for every
MARKETING template (ADR-0198 D4), and campaign-service pulls live consent immediately before each
send (ADR-0200 D2). Nothing changed here.

## Still open

`SENT` in the campaign send log means "notification-service accepted the request onto
`openbank.notification.requests`", not "the customer received it" — no delivery outcome is fed
back to campaign. That is the design question the issue defers and it needs its own decision
(a delivery-result event carrying the campaign correlation the payload does not have today).
Tracked as a follow-up rather than guessed at here.

## Gate

`:openbank-campaign-service:build`, `:openbank-notification-service:build` (detekt, ktlint, tests)
and `koverVerify` for both: green locally.
