### PR TITLE
fix(infra): baseline AVD-AWS-0031 — ECR tag mutability is load-bearing for auto-deploy

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -86,3 +86,12 @@ AVD-KSV-0118
 # fails the admin-ui suite if another appears — the exclusion stays a thing
 # someone has to justify, not a default someone inherits.
 AVD-KSV-0108
+
+# ECR service-repository tags mutable (ecr-service-repositories.tf, #3659): MUTABLE
+# is load-bearing, not laziness — auto-deploy tags `sandbox-<sha>` and the reconcile
+# path (#2021, #3432) legitimately re-dispatches a build for a sha it has already
+# pushed; under IMMUTABLE that re-push fails and the deploy self-heal breaks. The
+# documented exception is openbank-admin-ui, which is IMMUTABLE (built off a version,
+# not a sha). Supply-chain integrity for deploys rides on the signed provenance /
+# attestation chain (ADR-0030, ADR-0121), not on tag immutability, in the sandbox.
+AVD-AWS-0031


### PR DESCRIPTION
## Summary

Since #3659 declared the ECR service repositories in OpenTofu, the Trivy gate fails on **every PR and on main** with `AWS-0031 (HIGH): Repository tags are mutable`. Mutable tags are a **deliberate, documented posture** in `ecr-service-repositories.tf`: auto-deploy tags `sandbox-<sha>` and the reconcile path (#2021, #3432) legitimately re-dispatches builds for an already-pushed sha — under IMMUTABLE that re-push fails and the deploy self-heal breaks. `openbank-admin-ui` stays IMMUTABLE (built off a version, not a sha). This adds the finding to `.trivyignore` with the reason written down, in the same shape as the other accepted-deviation entries.

## Type of change

- [x] fix (CI gate baseline)

## Linked issues

N/A — gate repair; the posture rationale lives in the .trivyignore entry itself (baseline convention).

## Changes

- `.trivyignore`: `AVD-AWS-0031` with the auto-deploy re-push rationale + the note that deploy integrity rides on signed provenance (ADR-0030/0121), not tag immutability, in the sandbox.

## Definition of Done

- [x] Baseline-only change; no infra resource modified. Trivy gate expected green again on main after merge.

## Compliance impact

- [x] None — documents an existing, reasoned posture; supply-chain integrity is carried by the attestation chain, unchanged.