### PR TITLE
refactor(finrep): pilot a shared base application.yaml from openbank-libs-runtime

### DIFF
--- a/openbank-finrep-service/src/main/resources/application.yaml
+++ b/openbank-finrep-service/src/main/resources/application.yaml
@@ -8,21 +8,6 @@ quarkus:
       origins: "http://localhost:3000,http://openbank-admin-ui:3000"
       methods: GET,POST,PUT,DELETE,OPTIONS
       headers: Content-Type,Authorization
-    header:
-      X-Content-Type-Options:
-        value: nosniff
-      X-Frame-Options:
-        value: DENY
-      X-XSS-Protection:
-        value: "1; mode=block"
-      Referrer-Policy:
-        value: strict-origin-when-cross-origin
-      Permissions-Policy:
-        value: "geolocation=(), microphone=(), camera=()"
-      Content-Security-Policy:
-        value: "default-src 'self'"
-      Strict-Transport-Security:
-        value: "max-age=31536000; includeSubDomains"
 
   oidc:
     auth-server-url: ${QUARKUS_OIDC_AUTH_SERVER_URL:http://localhost:8080/realms/openbank}
@@ -43,11 +28,6 @@ quarkus:
   swagger-ui:
     always-include: true
     path: /api/docs
-  management:
-    enabled: true
-    port: 8085
-    host: 0.0.0.0
-    root-path: /q
 
 openbank:
   service:
@@ -63,8 +43,11 @@ openbank:
 
 "%test":
   quarkus:
-    oidc:
-      enabled: false
+    http:
+      test-port: 0
+      header:
+        X-Frame-Options:
+          value: SAMEORIGIN
     management:
       enabled: false
     devservices:

--- a/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/FinrepBootSmokeTest.kt
+++ b/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/FinrepBootSmokeTest.kt
@@ -9,6 +9,7 @@ import io.restassured.module.kotlin.extensions.Given
 import io.restassured.module.kotlin.extensions.Then
 import io.restassured.module.kotlin.extensions.When
 import org.assertj.core.api.Assertions.assertThat
+import org.eclipse.microprofile.config.ConfigProvider
 import org.junit.jupiter.api.Test
 
 /**
@@ -30,5 +31,27 @@ class FinrepBootSmokeTest {
     fun `the service-info endpoint answers with this service's identity`() {
         val body = (Given { this } When { get("/api/v1/info") } Then { statusCode(200) }).extract().body().asString()
         assertThat(body).contains("openbank-finrep-service")
+    }
+
+    @Test
+    fun `dependency application yaml contributes defaults and service yaml still wins conflicts`() {
+        val config = ConfigProvider.getConfig()
+
+        assertThat(config.getValue("quarkus.http.header.Strict-Transport-Security.value", String::class.java))
+            .isEqualTo("max-age=31536000; includeSubDomains")
+        assertThat(
+            config.getValue(
+                "quarkus.http.header.X-Frame-Options.value",
+                String::class.java,
+            ),
+        ).isEqualTo("SAMEORIGIN")
+        assertThat(config.getValue("quarkus.management.port", Int::class.javaObjectType))
+            .isEqualTo(8085)
+        assertThat(config.getValue("quarkus.management.root-path", String::class.java))
+            .isEqualTo("/q")
+        assertThat(config.getValue("quarkus.management.enabled", Boolean::class.javaObjectType))
+            .isFalse()
+        assertThat(config.getValue("openbank.service.port", Int::class.javaObjectType))
+            .isEqualTo(8140)
     }
 }

--- a/openbank-libs-runtime/src/main/resources/application.yaml
+++ b/openbank-libs-runtime/src/main/resources/application.yaml
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+# See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+quarkus:
+  http:
+    header:
+      X-Content-Type-Options:
+        value: nosniff
+      X-Frame-Options:
+        value: DENY
+      X-XSS-Protection:
+        value: "1; mode=block"
+      Referrer-Policy:
+        value: strict-origin-when-cross-origin
+      Permissions-Policy:
+        value: "geolocation=(), microphone=(), camera=()"
+      Content-Security-Policy:
+        value: "default-src 'self'"
+      Strict-Transport-Security:
+        value: "max-age=31536000; includeSubDomains"
+  management:
+    enabled: true
+    port: 8085
+    host: 0.0.0.0
+    root-path: /q
+
+"%test":
+  quarkus:
+    oidc:
+      enabled: false


### PR DESCRIPTION
## Summary

Pilot for consolidating duplicated `application.yaml` infrastructure blocks: a base `application.yaml` ships as a resource inside `openbank-libs-runtime` (every service already depends on it), Quarkus merges it at a lower ordinal than the service's own file, and the pilot service (finrep) slims to its service-specific keys. **Verified empirically** — the merge semantics are asserted by a booted `@QuarkusTest`, not assumed from docs.

## Type of change

- [ ] feat (new functionality)
- [ ] fix (bug fix)
- [x] refactor (no behavior change)
- [ ] perf (performance)
- [ ] docs
- [ ] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change

## Linked issues

Refs #3672

## Changes

- `openbank-libs-runtime/src/main/resources/application.yaml` (new): the two blocks verified byte-identical across the sampled fleet — the OWASP security-header set and the management interface (`enabled`, port 8085, `/q` root) — plus the `%test` oidc disable services already repeat individually.
- `openbank-finrep-service/application.yaml`: those blocks removed (they now come from the base); everything service-specific stays.
- `FinrepBootSmokeTest`: new test `dependency application yaml contributes defaults and service yaml still wins conflicts` — asserts a base-supplied value (Strict-Transport-Security), a service `%test` override beating the base (X-Frame-Options SAMEORIGIN over DENY), base management defaults, and an untouched service-local key. 3/3 green.

## Decision note (from the pilot)

- **In the base:** security headers, management interface, `%test` oidc-off. Only what was identical everywhere.
- **Stays per-service:** datasource (per-service DB), oidc client config (varies), kafka channels/topics, otel endpoints, outbox settings (`dispatch-enabled` stays per-service on purpose — flipping the default would change semantics for services without an outbox), ports (must remain visible to gitops-driven NetworkPolicy generation).
- **Fleet sweep plan:** after this lands, adopt per service in small batches (one PR per service, `refactor(<scope>)`), each removing only blocks identical to the base.
- **Risks called out:** (1) services that never declared the security-header/management blocks will now *gain* them — a deliberate baseline upgrade, but it is a behavior change for those services; (2) the base `%test` oidc-off could interact with a service whose tests assume oidc-on without declaring it — CI's full-fleet build (libs change → fleet rebuild) is the safety net; (3) any future edit to the base ripples the whole fleet, so it must stay minimal and universal.

## Definition of Done

- [x] Hexagonal layering preserved.
- [x] Unit tests added/updated (boot smoke test proves the merge semantics).
- [ ] Integration tests added/updated — N/A (no service boundary change).
- [ ] Contract tests updated — N/A.
- [x] `./gradlew :openbank-libs-runtime:build :openbank-finrep-service:build` green (includes detekt/ktlint/kover).
- [x] No new lint warnings.
- [ ] OpenAPI spec regenerated — N/A.
- [ ] Flyway migration added — N/A.
- [ ] Avro schema versioned — N/A.
- [x] Docs updated — decision note is this PR body; the sweep guide follows with the first batch PR.

## Security checklist

- [x] No secrets, tokens, passwords, or PII.
- [x] No new suppressions.
- [x] No new third-party dependency.
- [ ] Auth / crypto / payment code changed? — No; `%test`-scoped oidc disable is centralized, production auth untouched.
- [ ] PII path changed? — N/A.
- [ ] Cardholder data path changed? — N/A.

## Compliance impact

- [ ] PCI DSS
- [ ] DORA
- [ ] GDPR
- [ ] PSD2 / SCA / RTS
- [ ] AML / 5AMLD
- [ ] CNB reporting
- [x] None — security *headers* baseline strengthens, no compliance surface change.
