### PR TITLE
test(sdd,interest): extend the pitest money-path matrix to sdd and interest

### DIFF
--- a/.github/workflows/pitest.yml
+++ b/.github/workflows/pitest.yml
@@ -13,7 +13,7 @@ on:
       services:
         description: "Space-separated list of service modules to run pitest on (the matrix below is the source of truth)"
         required: false
-        default: "openbank-ledger-service openbank-balance-service openbank-account-service openbank-transaction-service openbank-fx-service openbank-sepa-payment openbank-sepa-instant openbank-domestic-payment openbank-fraud-service openbank-sanctions-service"
+        default: "openbank-ledger-service openbank-balance-service openbank-account-service openbank-transaction-service openbank-fx-service openbank-sepa-payment openbank-sepa-instant openbank-domestic-payment openbank-fraud-service openbank-sanctions-service openbank-sdd-service openbank-interest-service"
 
 # Restrictive top-level default (Scorecard Token-Permissions wants an explicit top-level
 # block); the pitest job below already declares contents: read too, belt-and-suspenders.
@@ -54,6 +54,13 @@ jobs:
           # the 1-2-file "thin domain" shape that excludes sca/consent/billing/clearing/swift/
           # lending/settlement. Local baseline: 67% mutation kill rate.
           - openbank-sanctions-service
+          # Issue #3675 sweep (2026-08-03): sdd (4 domain files — mandate lifecycle, collection
+          # authorisation and refund policy) and interest (6 domain files — withholding-tax and
+          # interest-accrual policy, ~470 LOC of money math) clear the same
+          # substantive-domain-math bar as sanctions. Remaining money-path services stay excluded
+          # by the thin-domain criterion (clearing/swift/lending/settlement/billing 1-2 files).
+          - openbank-sdd-service
+          - openbank-interest-service
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/openbank-interest-service/build.gradle.kts
+++ b/openbank-interest-service/build.gradle.kts
@@ -4,6 +4,9 @@
 
 plugins {
     id("openbank.quarkus-service")
+    // Inline version (not the shared catalog) so enabling mutation testing stays path-scoped to
+    // this service and does not trigger a fleet-wide rebuild. 1.19.0 supports Gradle 9.
+    id("info.solidsoft.pitest") version "1.19.0"
 }
 
 dependencies {
@@ -88,4 +91,20 @@ tasks.withType<Test> {
         "pact.provider.branch",
         "pact.provider.tag",
     ).forEach { key -> System.getProperty(key)?.let { systemProperty(key, it) } }
+}
+
+// Mutation testing on the money-path domain (ADR-0063 / ADR-0030 D3; money-path matrix
+// extension, issue #3675). Weekly + manual via pitest.yml, advisory — never a per-PR gate.
+// info.solidsoft.pitest 1.19.0 supports Gradle 9.
+pitest {
+    junit5PluginVersion = "1.2.3"
+    targetClasses = setOf("com.openbank.interest.domain.*")
+    targetTests = setOf("com.openbank.interest.domain.*", "com.openbank.interest.application.usecase.*")
+    // Advisory for now (ADR-0063): the pitest.yml job reports the score and warns below 70%; the
+    // Gradle task itself must not fail the run, so the threshold is 0. Raise to block later.
+    mutationThreshold = 0
+    outputFormats = setOf("XML", "HTML")
+    timestampedReports = false
+    threads = 4
+    excludedClasses = setOf("com.openbank.interest.domain.*Kt")
 }

--- a/openbank-sdd-service/build.gradle.kts
+++ b/openbank-sdd-service/build.gradle.kts
@@ -4,6 +4,9 @@
 
 plugins {
     id("openbank.quarkus-service")
+    // Inline version (not the shared catalog) so enabling mutation testing stays path-scoped to
+    // this service and does not trigger a fleet-wide rebuild. 1.19.0 supports Gradle 9.
+    id("info.solidsoft.pitest") version "1.19.0"
 }
 
 dependencies {
@@ -62,4 +65,20 @@ kover {
             }
         }
     }
+}
+
+// Mutation testing on the money-path domain (ADR-0063 / ADR-0030 D3; money-path matrix
+// extension, issue #3675). Weekly + manual via pitest.yml, advisory — never a per-PR gate.
+// info.solidsoft.pitest 1.19.0 supports Gradle 9.
+pitest {
+    junit5PluginVersion = "1.2.3"
+    targetClasses = setOf("com.openbank.sdd.domain.*")
+    targetTests = setOf("com.openbank.sdd.domain.*", "com.openbank.sdd.application.usecase.*")
+    // Advisory for now (ADR-0063): the pitest.yml job reports the score and warns below 70%; the
+    // Gradle task itself must not fail the run, so the threshold is 0. Raise to block later.
+    mutationThreshold = 0
+    outputFormats = setOf("XML", "HTML")
+    timestampedReports = false
+    threads = 4
+    excludedClasses = setOf("com.openbank.sdd.domain.*Kt")
 }


### PR DESCRIPTION
## Summary

Extends the weekly pitest money-path matrix (ADR-0063/ADR-0030 D3) to the two money-path services that clear the documented substantive-domain-math bar but weren't covered: **sdd** (4 domain files — mandate lifecycle, collection authorisation, refund policy) and **interest** (6 domain files — withholding-tax + interest-accrual policy, ~470 LOC of money math). Both falsified with a real local run before opening.

## Type of change

- [ ] feat (new functionality)
- [ ] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [ ] docs
- [ ] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change
- [x] test infrastructure (no shipped behavior change)

## Linked issues

Refs #3675

## Changes

- `openbank-sdd-service` + `openbank-interest-service` `build.gradle.kts`: pitest plugin (inline 1.19.0, path-scoped per the fleet convention) + `pitest {}` block mirroring the account-service pattern (domain target classes/tests, `mutationThreshold = 0` advisory, `*Kt` facade exclusion).
- `.github/workflows/pitest.yml`: matrix + `workflow_dispatch` default extended; comment documents why these two qualify and which services stay excluded (clearing/swift/lending/settlement/billing — thin domains).

## Local falsification (first real runs, not just green)

| Service | Mutations | Killed | Score | 70% advisory line |
|---|---|---|---|---|
| sdd | 61 | 46 | **75%** | above |
| interest | 60 | 36 | **60%** | below — weekly advisory warning will fire honestly |

Threshold stays 0 (advisory, ADR-0063) — interest's 60% is data for the team, not a gate failure.

## Definition of Done

- [x] Hexagonal layering preserved.
- [x] Unit tests added/updated — N/A, this adds mutation testing over existing tests.
- [ ] Integration tests — N/A.
- [ ] Contract tests — N/A.
- [x] `./gradlew :openbank-sdd-service:pitest :openbank-interest-service:pitest` + `ktlintCheck` green locally.
- [x] No new lint warnings.
- [ ] OpenAPI / Flyway / Avro — N/A.
- [ ] Docs updated — workflow comment carries the rationale.

## Security checklist

- [x] No secrets / PII.
- [x] No new suppressions.
- [x] No new third-party dependency (pitest plugin already used by 10 services).
- [ ] Auth / crypto / payment code changed? — No; build/test config only. Money-path label applies for review count.
- [ ] PII path changed? — N/A.
- [ ] Cardholder data path changed? — N/A.

## Compliance impact

- [ ] PCI DSS
- [x] DORA — strengthens verification evidence for money-path domain logic (advisory)
- [ ] GDPR
- [ ] PSD2 / SCA / RTS
- [ ] AML / 5AMLD
- [ ] CNB reporting
- [ ] None
