### PR TITLE
fix(governance): classify standing-order and psd2 as money-path services

### DIFF
--- a/docs/threat-models/openbank-standing-order-service.md
+++ b/docs/threat-models/openbank-standing-order-service.md
@@ -1,0 +1,83 @@
+<!--
+SPDX-License-Identifier: Apache-2.0
+Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+-->
+# Threat model — openbank-standing-order-service
+
+- **Date:** 2026-08-03
+- **Status:** Lightweight STRIDE (ADR-0030 D2). **Money-path-adjacent** (recurring payment instruction, execution initiation) — listed in `rules.yaml: money_path_services` (issue #2188).
+- **Purpose:** Standing orders — recurring payment instruction lifecycle (create/amend/pause/resume/cancel) and the daily due-date sweep that initiates the actual transfers (ADR-0114).
+
+## 1. Scope & purpose
+
+The standing-order service stores a customer's recurring payment instruction and, once a day,
+sweeps for due orders (`StandingOrderExecutionScheduler`), writes a transactional-outbox row per
+due order, and dispatches `standing-order.due.v1` to Kafka. `StandingOrderDueConsumer` (#889)
+picks each due event up and, for a `SEPA_CREDIT` order, initiates the real credit transfer via
+`openbank-sepa-payment`'s `POST /api/v1/sepa-payments` — a gated money-path service that owns the
+irreversible debit (sanctions/AML gate, Temporal workflow, ledger booking). `DOMESTIC`/`INTERNAL`
+rails are not wired yet and are recorded as failures, never silently dropped.
+
+The service is **money-path-adjacent**: it authorises and schedules the instruction and triggers
+the transfer, but the fund movement itself lives downstream — the same class as
+openbank-sdd-service.
+
+## 2. Data flow (DFD)
+
+```
+[Customer Edge / Admin-UI] --HTTPS--> [openbank-standing-order-service]
+                                           |
+                     daily sweep (Quarkus scheduler)
+                                           |---> [outbox -> Kafka: standing-order.due.v1 / standing-order.failed.v1]
+                                           |
+                     SEPA execution   -----|---> [openbank-sepa-payment] (SCT, money-path)
+                     outcome           --- |---> [confirmExecution / recordFailure -> order state + outbox]
+```
+
+- **External entities:** customer-edge (authenticated customer), admin-UI (ROLE_OPERATOR),
+  sepa-payment (M2M callee).
+- **Trust boundaries:** edge → service (OIDC + OPA sidecar, currently AUTHZ_ENFORCE=false
+  advisory); service → Kafka (mTLS via Strimzi); service → sepa-payment (OIDC client credentials,
+  `openbank-services` client, ROLE_OPERATOR accepted by sepa-payment's createPayment).
+- **Assets:** standing-order instructions (debtor/creditor IBAN, BIC, amount, currency, schedule,
+  remittance info), execution history, idempotency keys.
+
+## 3. Authn/Authz
+
+- All REST endpoints: `@RolesAllowed` (ROLE_CUSTOMER for own orders, ROLE_OPERATOR/ROLE_ADMIN for
+  operator surface), verified by `StandingOrderSecurityTest` and `StandingOrderSecurityContractTest`.
+- OPA sidecar deployed (ADR-0034 Phase 5); `AUTHZ_ENFORCE=false` (advisory) — decisions are
+  evaluated and logged but not enforced yet; the flip is a deliberate follow-up with an
+  observation window (rules.yaml AUTHZ_ENFORCE guardrail, issue #3679 cohort).
+- Execution calls to sepa-payment are service-to-service (OIDC client credentials via
+  `OidcClientRequestReactiveFilter`), not ambient authority.
+- The scheduler/consumer path has no human in the loop by design; there is no operator
+  force-execute endpoint.
+
+## 4. STRIDE
+
+| Threat | Vector | Mitigation |
+|---|---|---|
+| **S**poofing | Forged `standing-order.due.v1` event initiates a transfer | Kafka mTLS (Strimzi) on the topic; consumer validates orderId shape and required debtor fields, records failure on malformed events; sepa-payment re-authenticates the M2M caller and applies its own sanctions/AML gate |
+| **T**ampering | Alter amount or creditor IBAN on the stored instruction or in flight | Order mutations go through the authenticated REST surface with `@RolesAllowed`; TLS in transit; amount is carried in minor units with currency-explicit conversion (`CurrencyCode.defaultFractionDigits`) — no float path |
+| **R**epudiation | Customer denies creating or amending the order | AuditEvent per order action; outbox-backed execution history (confirmExecution / recordFailure) ties every transfer attempt to the order and its deterministic `so-exec-{orderId}-{executionDate}` key |
+| **I**nfo disclosure | Leak creditor/debtor IBANs via logs, errors, or metrics | Consumer logs truncate payloads (`%.300s`) and never log full request bodies; error bodies carry codes only; metrics are low-cardinality (ADR-0077/0079) |
+| **D**oS | Duplicate execution from Kafka redelivery or scheduler re-run; poison-pill event wedges the group | Deterministic idempotency key `so-exec-{orderId}-{executionDate}` reused as sepa-payment's `Idempotency-Key` — a redelivery replays the cached 201 instead of double-paying; consumer swallows and acks any failure (parse, rail, DB) so one bad event cannot wedge the group |
+| **E**oP | Abuse an operator role to redirect a standing order to an attacker's IBAN | Order amendment is an authenticated write on the customer's own order (customer) or a logged operator action; the money-moving step re-runs sepa-payment's sanctions/AML screening on every execution, so a redirected creditor is screened at debit time, not only at order-creation time |
+
+## 5. Residual risks / assumptions
+
+- **Advisory authz:** `AUTHZ_ENFORCE=false` means the OPA sidecar logs but does not block; RBAC
+  (`@RolesAllowed`) is the only enforced fine-grained gate until the enforce flip (tracked in the
+  #3679 cohort).
+- **Unwired rails:** `DOMESTIC`/`INTERNAL` orders record an execution failure each due day until
+  the rail clients land — visible as repeated failure events, never silent; tracked as a #889
+  follow-up.
+- **Scheduler single-writer:** the daily sweep relies on the outbox claim protocol
+  (`StandingOrderOutboxClaimIT`) to avoid double-dispatch across replicas; idempotency at
+  sepa-payment is the backstop if that ever regresses.
+
+## 6. Change log
+
+- **2026-08-03** — Initial lightweight threat model (ADR-0030 D2), written for the
+  `money_path_services` classification (issue #2188).

--- a/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: account-service
     app.kubernetes.io/part-of: accounts
   annotations:
-    openbank.tech/policy-checksum: "87018ffa052c2227"
+    openbank.tech/policy-checksum: "e65546f15e22f41c"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1629,6 +1629,29 @@ data:
                                                 # sanctions.clear (deciding a screening hit) — the highest-risk action in this
                                                 # service, since a wrongly-cleared true positive is a real sanctions violation.
       - openbank-vop-service                   # ADR-0171: Verification of Payee (IPR Art. 5c) — sits on the pre-execution path of
+                                                # every euro credit transfer. Money-path for the same reason sca/consent/fraud are:
+                                                # it gates money movement without moving money itself.
+                                                # four-eyes assessed: the only REST surface is POST /vop/verify (vop.verify), a
+                                                # read-shaped check that mints nothing and decides nothing a human could collude on
+                                                # — there is nothing to maker-checker gate. The action that WOULD deserve a gate is
+                                                # a runtime change to `openbank.vop.max-edit-distance`: widening it silently turns
+                                                # genuine mismatches into reassuring amber warnings (threat model §3 Tampering).
+                                                # It is gitops-only config today, so it is covered by PR review rather than
+                                                # four_eyes.verbs; add a `vop.flip` verb here if it ever becomes operator-tunable.
+      - openbank-standing-order-service        # issue #2188: StandingOrderDueConsumer POSTs a real SCT to
+                                                # sepa-payment `/api/v1/sepa-payments` for every due order (#889, merged) —
+                                                # initiates money movement like sdd, not adjacent to it. Same class as sdd:
+                                                # it shapes the instruction, the irreversible debit lives downstream in a
+                                                # gated money-path service. Threat model:
+                                                # docs/threat-models/openbank-standing-order-service.md.
+                                                # four-eyes assessed: the only money-moving path is the scheduler-driven
+                                                # consumer (no human in the loop by design); the REST surface is
+                                                # customer/operator CRUD on orders (create/amend/pause/resume/cancel), whose
+                                                # effect is a FUTURE scheduled debit, not an immediate one — pausing or
+                                                # cancelling an order REDUCES money movement. There is no operator
+                                                # force-execute endpoint to maker-checker gate; add a verb here if one is
+                                                # ever added. Runs AUTHZ_ENFORCE=false (advisory) — joins the #3679 cohort.
+      - openbank-psd2-service                  # issue #2188 sibling sweep: PaymentInitiationService (PIS) calls
 
     money_path_action_prefixes:
       sepa-payment: [sepaPayment]

--- a/openbank-infra/gitops/components/accounts/account-service.yaml
+++ b/openbank-infra/gitops/components/accounts/account-service.yaml
@@ -37,7 +37,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-account-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "87018ffa052c2227"
+        openbank.tech/policy-checksum: "e65546f15e22f41c"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/aml/aml-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/aml/aml-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: aml-service
     app.kubernetes.io/part-of: aml
   annotations:
-    openbank.tech/policy-checksum: "f0853fffb25a66b6"
+    openbank.tech/policy-checksum: "2cd3972441cf6ac4"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1602,6 +1602,29 @@ data:
                                                 # sanctions.clear (deciding a screening hit) — the highest-risk action in this
                                                 # service, since a wrongly-cleared true positive is a real sanctions violation.
       - openbank-vop-service                   # ADR-0171: Verification of Payee (IPR Art. 5c) — sits on the pre-execution path of
+                                                # every euro credit transfer. Money-path for the same reason sca/consent/fraud are:
+                                                # it gates money movement without moving money itself.
+                                                # four-eyes assessed: the only REST surface is POST /vop/verify (vop.verify), a
+                                                # read-shaped check that mints nothing and decides nothing a human could collude on
+                                                # — there is nothing to maker-checker gate. The action that WOULD deserve a gate is
+                                                # a runtime change to `openbank.vop.max-edit-distance`: widening it silently turns
+                                                # genuine mismatches into reassuring amber warnings (threat model §3 Tampering).
+                                                # It is gitops-only config today, so it is covered by PR review rather than
+                                                # four_eyes.verbs; add a `vop.flip` verb here if it ever becomes operator-tunable.
+      - openbank-standing-order-service        # issue #2188: StandingOrderDueConsumer POSTs a real SCT to
+                                                # sepa-payment `/api/v1/sepa-payments` for every due order (#889, merged) —
+                                                # initiates money movement like sdd, not adjacent to it. Same class as sdd:
+                                                # it shapes the instruction, the irreversible debit lives downstream in a
+                                                # gated money-path service. Threat model:
+                                                # docs/threat-models/openbank-standing-order-service.md.
+                                                # four-eyes assessed: the only money-moving path is the scheduler-driven
+                                                # consumer (no human in the loop by design); the REST surface is
+                                                # customer/operator CRUD on orders (create/amend/pause/resume/cancel), whose
+                                                # effect is a FUTURE scheduled debit, not an immediate one — pausing or
+                                                # cancelling an order REDUCES money movement. There is no operator
+                                                # force-execute endpoint to maker-checker gate; add a verb here if one is
+                                                # ever added. Runs AUTHZ_ENFORCE=false (advisory) — joins the #3679 cohort.
+      - openbank-psd2-service                  # issue #2188 sibling sweep: PaymentInitiationService (PIS) calls
 
     money_path_action_prefixes:
       sepa-payment: [sepaPayment]

--- a/openbank-infra/gitops/components/aml/aml-service.yaml
+++ b/openbank-infra/gitops/components/aml/aml-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-aml-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "f0853fffb25a66b6"
+        openbank.tech/policy-checksum: "2cd3972441cf6ac4"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: anacredit-service
     app.kubernetes.io/part-of: anacredit
   annotations:
-    openbank.tech/policy-checksum: "743e052201b20b0a"
+    openbank.tech/policy-checksum: "43fc19b11d0e8f93"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1572,6 +1572,29 @@ data:
                                                 # sanctions.clear (deciding a screening hit) — the highest-risk action in this
                                                 # service, since a wrongly-cleared true positive is a real sanctions violation.
       - openbank-vop-service                   # ADR-0171: Verification of Payee (IPR Art. 5c) — sits on the pre-execution path of
+                                                # every euro credit transfer. Money-path for the same reason sca/consent/fraud are:
+                                                # it gates money movement without moving money itself.
+                                                # four-eyes assessed: the only REST surface is POST /vop/verify (vop.verify), a
+                                                # read-shaped check that mints nothing and decides nothing a human could collude on
+                                                # — there is nothing to maker-checker gate. The action that WOULD deserve a gate is
+                                                # a runtime change to `openbank.vop.max-edit-distance`: widening it silently turns
+                                                # genuine mismatches into reassuring amber warnings (threat model §3 Tampering).
+                                                # It is gitops-only config today, so it is covered by PR review rather than
+                                                # four_eyes.verbs; add a `vop.flip` verb here if it ever becomes operator-tunable.
+      - openbank-standing-order-service        # issue #2188: StandingOrderDueConsumer POSTs a real SCT to
+                                                # sepa-payment `/api/v1/sepa-payments` for every due order (#889, merged) —
+                                                # initiates money movement like sdd, not adjacent to it. Same class as sdd:
+                                                # it shapes the instruction, the irreversible debit lives downstream in a
+                                                # gated money-path service. Threat model:
+                                                # docs/threat-models/openbank-standing-order-service.md.
+                                                # four-eyes assessed: the only money-moving path is the scheduler-driven
+                                                # consumer (no human in the loop by design); the REST surface is
+                                                # customer/operator CRUD on orders (create/amend/pause/resume/cancel), whose
+                                                # effect is a FUTURE scheduled debit, not an immediate one — pausing or
+                                                # cancelling an order REDUCES money movement. There is no operator
+                                                # force-execute endpoint to maker-checker gate; add a verb here if one is
+                                                # ever added. Runs AUTHZ_ENFORCE=false (advisory) — joins the #3679 cohort.
+      - openbank-psd2-service                  # issue #2188 sibling sweep: PaymentInitiationService (PIS) calls
 
     money_path_action_prefixes:
       sepa-payment: [sepaPayment]

--- a/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
@@ -32,7 +32,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-anacredit-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "743e052201b20b0a"
+        openbank.tech/policy-checksum: "43fc19b11d0e8f93"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/ap2/ap2-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/ap2/ap2-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: mcp-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "8fa118af13486c2a"
+    openbank.tech/policy-checksum: "0b79e3d8d2adf22f"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1540,6 +1540,29 @@ data:
                                                 # sanctions.clear (deciding a screening hit) — the highest-risk action in this
                                                 # service, since a wrongly-cleared true positive is a real sanctions violation.
       - openbank-vop-service                   # ADR-0171: Verification of Payee (IPR Art. 5c) — sits on the pre-execution path of
+                                                # every euro credit transfer. Money-path for the same reason sca/consent/fraud are:
+                                                # it gates money movement without moving money itself.
+                                                # four-eyes assessed: the only REST surface is POST /vop/verify (vop.verify), a
+                                                # read-shaped check that mints nothing and decides nothing a human could collude on
+                                                # — there is nothing to maker-checker gate. The action that WOULD deserve a gate is
+                                                # a runtime change to `openbank.vop.max-edit-distance`: widening it silently turns
+                                                # genuine mismatches into reassuring amber warnings (threat model §3 Tampering).
+                                                # It is gitops-only config today, so it is covered by PR review rather than
+                                                # four_eyes.verbs; add a `vop.flip` verb here if it ever becomes operator-tunable.
+      - openbank-standing-order-service        # issue #2188: StandingOrderDueConsumer POSTs a real SCT to
+                                                # sepa-payment `/api/v1/sepa-payments` for every due order (#889, merged) —
+                                                # initiates money movement like sdd, not adjacent to it. Same class as sdd:
+                                                # it shapes the instruction, the irreversible debit lives downstream in a
+                                                # gated money-path service. Threat model:
+                                                # docs/threat-models/openbank-standing-order-service.md.
+                                                # four-eyes assessed: the only money-moving path is the scheduler-driven
+                                                # consumer (no human in the loop by design); the REST surface is
+                                                # customer/operator CRUD on orders (create/amend/pause/resume/cancel), whose
+                                                # effect is a FUTURE scheduled debit, not an immediate one — pausing or
+                                                # cancelling an order REDUCES money movement. There is no operator
+                                                # force-execute endpoint to maker-checker gate; add a verb here if one is
+                                                # ever added. Runs AUTHZ_ENFORCE=false (advisory) — joins the #3679 cohort.
+      - openbank-psd2-service                  # issue #2188 sibling sweep: PaymentInitiationService (PIS) calls
 
     money_path_action_prefixes:
       sepa-payment: [sepaPayment]

--- a/openbank-infra/gitops/components/ap2/ap2-service.yaml
+++ b/openbank-infra/gitops/components/ap2/ap2-service.yaml
@@ -30,7 +30,7 @@ spec:
       annotations:
         # Roll the pod when the OPA policy bundle changes (subPath mounts don't hot-reload).
         # Kept in sync by gen-ap2-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "8fa118af13486c2a"
+        openbank.tech/policy-checksum: "0b79e3d8d2adf22f"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/audit/audit-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/audit/audit-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: audit-service
     app.kubernetes.io/part-of: audit
   annotations:
-    openbank.tech/policy-checksum: "4c8793607257549c"
+    openbank.tech/policy-checksum: "c1615f52b1a4df07"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1584,6 +1584,29 @@ data:
                                                 # sanctions.clear (deciding a screening hit) — the highest-risk action in this
                                                 # service, since a wrongly-cleared true positive is a real sanctions violation.
       - openbank-vop-service                   # ADR-0171: Verification of Payee (IPR Art. 5c) — sits on the pre-execution path of
+                                                # every euro credit transfer. Money-path for the same reason sca/consent/fraud are:
+                                                # it gates money movement without moving money itself.
+                                                # four-eyes assessed: the only REST surface is POST /vop/verify (vop.verify), a
+                                                # read-shaped check that mints nothing and decides nothing a human could collude on
+                                                # — there is nothing to maker-checker gate. The action that WOULD deserve a gate is
+                                                # a runtime change to `openbank.vop.max-edit-distance`: widening it silently turns
+                                                # genuine mismatches into reassuring amber warnings (threat model §3 Tampering).
+                                                # It is gitops-only config today, so it is covered by PR review rather than
+                                                # four_eyes.verbs; add a `vop.flip` verb here if it ever becomes operator-tunable.
+      - openbank-standing-order-service        # issue #2188: StandingOrderDueConsumer POSTs a real SCT to
+                                                # sepa-payment `/api/v1/sepa-payments` for every due order (#889, merged) —
+                                                # initiates money movement like sdd, not adjacent to it. Same class as sdd:
+                                                # it shapes the instruction, the irreversible debit lives downstream in a
+                                                # gated money-path service. Threat model:
+                                                # docs/threat-models/openbank-standing-order-service.md.
+                                                # four-eyes assessed: the only money-moving path is the scheduler-driven
+                                                # consumer (no human in the loop by design); the REST surface is
+                                                # customer/operator CRUD on orders (create/amend/pause/resume/cancel), whose
+                                                # effect is a FUTURE scheduled debit, not an immediate one — pausing or
+                                                # cancelling an order REDUCES money movement. There is no operator
+                                                # force-execute endpoint to maker-checker gate; add a verb here if one is
+                                                # ever added. Runs AUTHZ_ENFORCE=false (advisory) — joins the #3679 cohort.
+      - openbank-psd2-service                  # issue #2188 sibling sweep: PaymentInitiationService (PIS) calls
 
     money_path_action_prefixes:
       sepa-payment: [sepaPayment]

--- a/openbank-infra/gitops/components/audit/audit-service.yaml
+++ b/openbank-infra/gitops/components/audit/audit-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-audit-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "4c8793607257549c"
+        openbank.tech/policy-checksum: "c1615f52b1a4df07"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: balance-service
     app.kubernetes.io/part-of: balances
   annotations:
-    openbank.tech/policy-checksum: "95c5b50695bdc6ec"
+    openbank.tech/policy-checksum: "fb5d9843a6695b09"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1673,6 +1673,29 @@ data:
                                                 # sanctions.clear (deciding a screening hit) — the highest-risk action in this
                                                 # service, since a wrongly-cleared true positive is a real sanctions violation.
       - openbank-vop-service                   # ADR-0171: Verification of Payee (IPR Art. 5c) — sits on the pre-execution path of
+                                                # every euro credit transfer. Money-path for the same reason sca/consent/fraud are:
+                                                # it gates money movement without moving money itself.
+                                                # four-eyes assessed: the only REST surface is POST /vop/verify (vop.verify), a
+                                                # read-shaped check that mints nothing and decides nothing a human could collude on
+                                                # — there is nothing to maker-checker gate. The action that WOULD deserve a gate is
+                                                # a runtime change to `openbank.vop.max-edit-distance`: widening it silently turns
+                                                # genuine mismatches into reassuring amber warnings (threat model §3 Tampering).
+                                                # It is gitops-only config today, so it is covered by PR review rather than
+                                                # four_eyes.verbs; add a `vop.flip` verb here if it ever becomes operator-tunable.
+      - openbank-standing-order-service        # issue #2188: StandingOrderDueConsumer POSTs a real SCT to
+                                                # sepa-payment `/api/v1/sepa-payments` for every due order (#889, merged) —
+                                                # initiates money movement like sdd, not adjacent to it. Same class as sdd:
+                                                # it shapes the instruction, the irreversible debit lives downstream in a
+                                                # gated money-path service. Threat model:
+                                                # docs/threat-models/openbank-standing-order-service.md.
+                                                # four-eyes assessed: the only money-moving path is the scheduler-driven
+                                                # consumer (no human in the loop by design); the REST surface is
+                                                # customer/operator CRUD on orders (create/amend/pause/resume/cancel), whose
+                                                # effect is a FUTURE scheduled debit, not an immediate one — pausing or
+                                                # cancelling an order REDUCES money movement. There is no operator
+                                                # force-execute endpoint to maker-checker gate; add a verb here if one is
+                                                # ever added. Runs AUTHZ_ENFORCE=false (advisory) — joins the #3679 cohort.
+      - openbank-psd2-service                  # issue #2188 sibling sweep: PaymentInitiationService (PIS) calls
 
     money_path_action_prefixes:
       sepa-payment: [sepaPayment]

--- a/openbank-infra/gitops/components/balances/balance-service.yaml
+++ b/openbank-infra/gitops/components/balances/balance-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-balance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "95c5b50695bdc6ec"
+        openbank.tech/policy-checksum: "fb5d9843a6695b09"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: billing-service
     app.kubernetes.io/part-of: billing
   annotations:
-    openbank.tech/policy-checksum: "0ed1121118c04aba"
+    openbank.tech/policy-checksum: "322125992d041989"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1578,6 +1578,29 @@ data:
                                                 # sanctions.clear (deciding a screening hit) — the highest-risk action in this
                                                 # service, since a wrongly-cleared true positive is a real sanctions violation.
       - openbank-vop-service                   # ADR-0171: Verification of Payee (IPR Art. 5c) — sits on the pre-execution path of
+                                                # every euro credit transfer. Money-path for the same reason sca/consent/fraud are:
+                                                # it gates money movement without moving money itself.
+                                                # four-eyes assessed: the only REST surface is POST /vop/verify (vop.verify), a
+                                                # read-shaped check that mints nothing and decides nothing a human could collude on
+                                                # — there is nothing to maker-checker gate. The action that WOULD deserve a gate is
+                                                # a runtime change to `openbank.vop.max-edit-distance`: widening it silently turns
+                                                # genuine mismatches into reassuring amber warnings (threat model §3 Tampering).
+                                                # It is gitops-only config today, so it is covered by PR review rather than
+                                                # four_eyes.verbs; add a `vop.flip` verb here if it ever becomes operator-tunable.
+      - openbank-standing-order-service        # issue #2188: StandingOrderDueConsumer POSTs a real SCT to
+                                                # sepa-payment `/api/v1/sepa-payments` for every due order (#889, merged) —
+                                                # initiates money movement like sdd, not adjacent to it. Same class as sdd:
+                                                # it shapes the instruction, the irreversible debit lives downstream in a
+                                                # gated money-path service. Threat model:
+                                                # docs/threat-models/openbank-standing-order-service.md.
+                                                # four-eyes assessed: the only money-moving path is the scheduler-driven
+                                                # consumer (no human in the loop by design); the REST surface is
+                                                # customer/operator CRUD on orders (create/amend/pause/resume/cancel), whose
+                                                # effect is a FUTURE scheduled debit, not an immediate one — pausing or
+                                                # cancelling an order REDUCES money movement. There is no operator
+                                                # force-execute endpoint to maker-checker gate; add a verb here if one is
+                                                # ever added. Runs AUTHZ_ENFORCE=false (advisory) — joins the #3679 cohort.
+      - openbank-psd2-service                  # issue #2188 sibling sweep: PaymentInitiationService (PIS) calls
 
     money_path_action_prefixes:
       sepa-payment: [sepaPayment]

--- a/openbank-infra/gitops/components/billing/billing-service.yaml
+++ b/openbank-infra/gitops/components/billing/billing-service.yaml
@@ -27,7 +27,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-billing-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "0ed1121118c04aba"
+        openbank.tech/policy-checksum: "322125992d041989"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/campaign/campaign-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/campaign/campaign-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: campaign-service
     app.kubernetes.io/part-of: campaign
   annotations:
-    openbank.tech/policy-checksum: "dca6e5cb1c79c7b1"
+    openbank.tech/policy-checksum: "609f01fbcb6d4680"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1599,6 +1599,29 @@ data:
                                                 # sanctions.clear (deciding a screening hit) — the highest-risk action in this
                                                 # service, since a wrongly-cleared true positive is a real sanctions violation.
       - openbank-vop-service                   # ADR-0171: Verification of Payee (IPR Art. 5c) — sits on the pre-execution path of
+                                                # every euro credit transfer. Money-path for the same reason sca/consent/fraud are:
+                                                # it gates money movement without moving money itself.
+                                                # four-eyes assessed: the only REST surface is POST /vop/verify (vop.verify), a
+                                                # read-shaped check that mints nothing and decides nothing a human could collude on
+                                                # — there is nothing to maker-checker gate. The action that WOULD deserve a gate is
+                                                # a runtime change to `openbank.vop.max-edit-distance`: widening it silently turns
+                                                # genuine mismatches into reassuring amber warnings (threat model §3 Tampering).
+                                                # It is gitops-only config today, so it is covered by PR review rather than
+                                                # four_eyes.verbs; add a `vop.flip` verb here if it ever becomes operator-tunable.
+      - openbank-standing-order-service        # issue #2188: StandingOrderDueConsumer POSTs a real SCT to
+                                                # sepa-payment `/api/v1/sepa-payments` for every due order (#889, merged) —
+                                                # initiates money movement like sdd, not adjacent to it. Same class as sdd:
+                                                # it shapes the instruction, the irreversible debit lives downstream in a
+                                                # gated money-path service. Threat model:
+                                                # docs/threat-models/openbank-standing-order-service.md.
+                                                # four-eyes assessed: the only money-moving path is the scheduler-driven
+                                                # consumer (no human in the loop by design); the REST surface is
+                                                # customer/operator CRUD on orders (create/amend/pause/resume/cancel), whose
+                                                # effect is a FUTURE scheduled debit, not an immediate one — pausing or
+                                                # cancelling an order REDUCES money movement. There is no operator
+                                                # force-execute endpoint to maker-checker gate; add a verb here if one is
+                                                # ever added. Runs AUTHZ_ENFORCE=false (advisory) — joins the #3679 cohort.
+      - openbank-psd2-service                  # issue #2188 sibling sweep: PaymentInitiationService (PIS) calls
 
     money_path_action_prefixes:
       sepa-payment: [sepaPayment]

--- a/openbank-infra/gitops/components/campaign/campaign-service.yaml
+++ b/openbank-infra/gitops/components/campaign/campaign-service.yaml
@@ -25,7 +25,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-campaign-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "dca6e5cb1c79c7b1"
+        openbank.tech/policy-checksum: "609f01fbcb6d4680"
       labels:
         app.kubernetes.io/name: campaign-service
         app.kubernetes.io/part-of: campaign

--- a/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: consent-service
     app.kubernetes.io/part-of: consent
   annotations:
-    openbank.tech/policy-checksum: "a6813f6436c88169"
+    openbank.tech/policy-checksum: "a59ca0d4439c9591"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1648,6 +1648,29 @@ data:
                                                 # sanctions.clear (deciding a screening hit) — the highest-risk action in this
                                                 # service, since a wrongly-cleared true positive is a real sanctions violation.
       - openbank-vop-service                   # ADR-0171: Verification of Payee (IPR Art. 5c) — sits on the pre-execution path of
+                                                # every euro credit transfer. Money-path for the same reason sca/consent/fraud are:
+                                                # it gates money movement without moving money itself.
+                                                # four-eyes assessed: the only REST surface is POST /vop/verify (vop.verify), a
+                                                # read-shaped check that mints nothing and decides nothing a human could collude on
+                                                # — there is nothing to maker-checker gate. The action that WOULD deserve a gate is
+                                                # a runtime change to `openbank.vop.max-edit-distance`: widening it silently turns
+                                                # genuine mismatches into reassuring amber warnings (threat model §3 Tampering).
+                                                # It is gitops-only config today, so it is covered by PR review rather than
+                                                # four_eyes.verbs; add a `vop.flip` verb here if it ever becomes operator-tunable.
+      - openbank-standing-order-service        # issue #2188: StandingOrderDueConsumer POSTs a real SCT to
+                                                # sepa-payment `/api/v1/sepa-payments` for every due order (#889, merged) —
+                                                # initiates money movement like sdd, not adjacent to it. Same class as sdd:
+                                                # it shapes the instruction, the irreversible debit lives downstream in a
+                                                # gated money-path service. Threat model:
+                                                # docs/threat-models/openbank-standing-order-service.md.
+                                                # four-eyes assessed: the only money-moving path is the scheduler-driven
+                                                # consumer (no human in the loop by design); the REST surface is
+                                                # customer/operator CRUD on orders (create/amend/pause/resume/cancel), whose
+                                                # effect is a FUTURE scheduled debit, not an immediate one — pausing or
+                                                # cancelling an order REDUCES money movement. There is no operator
+                                                # force-execute endpoint to maker-checker gate; add a verb here if one is
+                                                # ever added. Runs AUTHZ_ENFORCE=false (advisory) — joins the #3679 cohort.
+      - openbank-psd2-service                  # issue #2188 sibling sweep: PaymentInitiationService (PIS) calls
 
     money_path_action_prefixes:
       sepa-payment: [sepaPayment]

--- a/openbank-infra/gitops/components/consent/consent-service.yaml
+++ b/openbank-infra/gitops/components/consent/consent-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-consent-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "a6813f6436c88169"
+        openbank.tech/policy-checksum: "a59ca0d4439c9591"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: copilot-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "916dd2f78b56858b"
+    openbank.tech/policy-checksum: "0eb73cb130731327"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1664,6 +1664,29 @@ data:
                                                 # sanctions.clear (deciding a screening hit) — the highest-risk action in this
                                                 # service, since a wrongly-cleared true positive is a real sanctions violation.
       - openbank-vop-service                   # ADR-0171: Verification of Payee (IPR Art. 5c) — sits on the pre-execution path of
+                                                # every euro credit transfer. Money-path for the same reason sca/consent/fraud are:
+                                                # it gates money movement without moving money itself.
+                                                # four-eyes assessed: the only REST surface is POST /vop/verify (vop.verify), a
+                                                # read-shaped check that mints nothing and decides nothing a human could collude on
+                                                # — there is nothing to maker-checker gate. The action that WOULD deserve a gate is
+                                                # a runtime change to `openbank.vop.max-edit-distance`: widening it silently turns
+                                                # genuine mismatches into reassuring amber warnings (threat model §3 Tampering).
+                                                # It is gitops-only config today, so it is covered by PR review rather than
+                                                # four_eyes.verbs; add a `vop.flip` verb here if it ever becomes operator-tunable.
+      - openbank-standing-order-service        # issue #2188: StandingOrderDueConsumer POSTs a real SCT to
+                                                # sepa-payment `/api/v1/sepa-payments` for every due order (#889, merged) —
+                                                # initiates money movement like sdd, not adjacent to it. Same class as sdd:
+                                                # it shapes the instruction, the irreversible debit lives downstream in a
+                                                # gated money-path service. Threat model:
+                                                # docs/threat-models/openbank-standing-order-service.md.
+                                                # four-eyes assessed: the only money-moving path is the scheduler-driven
+                                                # consumer (no human in the loop by design); the REST surface is
+                                                # customer/operator CRUD on orders (create/amend/pause/resume/cancel), whose
+                                                # effect is a FUTURE scheduled debit, not an immediate one — pausing or
+                                                # cancelling an order REDUCES money movement. There is no operator
+                                                # force-execute endpoint to maker-checker gate; add a verb here if one is
+                                                # ever added. Runs AUTHZ_ENFORCE=false (advisory) — joins the #3679 cohort.
+      - openbank-psd2-service                  # issue #2188 sibling sweep: PaymentInitiationService (PIS) calls
 
     money_path_action_prefixes:
       sepa-payment: [sepaPayment]

--- a/openbank-infra/gitops/components/copilot/copilot-service.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-service.yaml
@@ -29,7 +29,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-copilot-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "916dd2f78b56858b"
+        openbank.tech/policy-checksum: "0eb73cb130731327"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: customer-edge
     app.kubernetes.io/part-of: customer-edge
   annotations:
-    openbank.tech/policy-checksum: "6c500a6f3b582bd1"
+    openbank.tech/policy-checksum: "99a64206f9e9605b"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -759,6 +759,29 @@ data:
                                                 # sanctions.clear (deciding a screening hit) — the highest-risk action in this
                                                 # service, since a wrongly-cleared true positive is a real sanctions violation.
       - openbank-vop-service                   # ADR-0171: Verification of Payee (IPR Art. 5c) — sits on the pre-execution path of
+                                                # every euro credit transfer. Money-path for the same reason sca/consent/fraud are:
+                                                # it gates money movement without moving money itself.
+                                                # four-eyes assessed: the only REST surface is POST /vop/verify (vop.verify), a
+                                                # read-shaped check that mints nothing and decides nothing a human could collude on
+                                                # — there is nothing to maker-checker gate. The action that WOULD deserve a gate is
+                                                # a runtime change to `openbank.vop.max-edit-distance`: widening it silently turns
+                                                # genuine mismatches into reassuring amber warnings (threat model §3 Tampering).
+                                                # It is gitops-only config today, so it is covered by PR review rather than
+                                                # four_eyes.verbs; add a `vop.flip` verb here if it ever becomes operator-tunable.
+      - openbank-standing-order-service        # issue #2188: StandingOrderDueConsumer POSTs a real SCT to
+                                                # sepa-payment `/api/v1/sepa-payments` for every due order (#889, merged) —
+                                                # initiates money movement like sdd, not adjacent to it. Same class as sdd:
+                                                # it shapes the instruction, the irreversible debit lives downstream in a
+                                                # gated money-path service. Threat model:
+                                                # docs/threat-models/openbank-standing-order-service.md.
+                                                # four-eyes assessed: the only money-moving path is the scheduler-driven
+                                                # consumer (no human in the loop by design); the REST surface is
+                                                # customer/operator CRUD on orders (create/amend/pause/resume/cancel), whose
+                                                # effect is a FUTURE scheduled debit, not an immediate one — pausing or
+                                                # cancelling an order REDUCES money movement. There is no operator
+                                                # force-execute endpoint to maker-checker gate; add a verb here if one is
+                                                # ever added. Runs AUTHZ_ENFORCE=false (advisory) — joins the #3679 cohort.
+      - openbank-psd2-service                  # issue #2188 sibling sweep: PaymentInitiationService (PIS) calls
 
     money_path_action_prefixes:
       sepa-payment: [sepaPayment]

--- a/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
@@ -65,7 +65,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-customer-edge-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "6c500a6f3b582bd1"
+        openbank.tech/policy-checksum: "99a64206f9e9605b"
     spec:
       # Dedicated SA so EKS Pod Identity can hand the edge (and ONLY the edge) the
       # feedback-screenshots S3 role — ADR-0192, openbank-infra/aws/envs/sandbox-platform/

--- a/openbank-infra/gitops/components/delegation/delegation-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/delegation/delegation-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: delegation-service
     app.kubernetes.io/part-of: delegation
   annotations:
-    openbank.tech/policy-checksum: "cc7404ce5b8ac81c"
+    openbank.tech/policy-checksum: "3b4f321fc40e98b3"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1619,6 +1619,29 @@ data:
                                                 # sanctions.clear (deciding a screening hit) — the highest-risk action in this
                                                 # service, since a wrongly-cleared true positive is a real sanctions violation.
       - openbank-vop-service                   # ADR-0171: Verification of Payee (IPR Art. 5c) — sits on the pre-execution path of
+                                                # every euro credit transfer. Money-path for the same reason sca/consent/fraud are:
+                                                # it gates money movement without moving money itself.
+                                                # four-eyes assessed: the only REST surface is POST /vop/verify (vop.verify), a
+                                                # read-shaped check that mints nothing and decides nothing a human could collude on
+                                                # — there is nothing to maker-checker gate. The action that WOULD deserve a gate is
+                                                # a runtime change to `openbank.vop.max-edit-distance`: widening it silently turns
+                                                # genuine mismatches into reassuring amber warnings (threat model §3 Tampering).
+                                                # It is gitops-only config today, so it is covered by PR review rather than
+                                                # four_eyes.verbs; add a `vop.flip` verb here if it ever becomes operator-tunable.
+      - openbank-standing-order-service        # issue #2188: StandingOrderDueConsumer POSTs a real SCT to
+                                                # sepa-payment `/api/v1/sepa-payments` for every due order (#889, merged) —
+                                                # initiates money movement like sdd, not adjacent to it. Same class as sdd:
+                                                # it shapes the instruction, the irreversible debit lives downstream in a
+                                                # gated money-path service. Threat model:
+                                                # docs/threat-models/openbank-standing-order-service.md.
+                                                # four-eyes assessed: the only money-moving path is the scheduler-driven
+                                                # consumer (no human in the loop by design); the REST surface is
+                                                # customer/operator CRUD on orders (create/amend/pause/resume/cancel), whose
+                                                # effect is a FUTURE scheduled debit, not an immediate one — pausing or
+                                                # cancelling an order REDUCES money movement. There is no operator
+                                                # force-execute endpoint to maker-checker gate; add a verb here if one is
+                                                # ever added. Runs AUTHZ_ENFORCE=false (advisory) — joins the #3679 cohort.
+      - openbank-psd2-service                  # issue #2188 sibling sweep: PaymentInitiationService (PIS) calls
 
     money_path_action_prefixes:
       sepa-payment: [sepaPayment]

--- a/openbank-infra/gitops/components/delegation/delegation-service.yaml
+++ b/openbank-infra/gitops/components/delegation/delegation-service.yaml
@@ -42,7 +42,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-delegation-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "cc7404ce5b8ac81c"
+        openbank.tech/policy-checksum: "3b4f321fc40e98b3"
       labels:
         app.kubernetes.io/name: delegation-service
         app.kubernetes.io/part-of: delegation

--- a/openbank-infra/gitops/components/dispute-service/dispute-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/dispute-service/dispute-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: dispute-service
     app.kubernetes.io/part-of: dispute
   annotations:
-    openbank.tech/policy-checksum: "488a3be284d0a60f"
+    openbank.tech/policy-checksum: "09c242d1834d06af"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1714,6 +1714,29 @@ data:
                                                 # sanctions.clear (deciding a screening hit) — the highest-risk action in this
                                                 # service, since a wrongly-cleared true positive is a real sanctions violation.
       - openbank-vop-service                   # ADR-0171: Verification of Payee (IPR Art. 5c) — sits on the pre-execution path of
+                                                # every euro credit transfer. Money-path for the same reason sca/consent/fraud are:
+                                                # it gates money movement without moving money itself.
+                                                # four-eyes assessed: the only REST surface is POST /vop/verify (vop.verify), a
+                                                # read-shaped check that mints nothing and decides nothing a human could collude on
+                                                # — there is nothing to maker-checker gate. The action that WOULD deserve a gate is
+                                                # a runtime change to `openbank.vop.max-edit-distance`: widening it silently turns
+                                                # genuine mismatches into reassuring amber warnings (threat model §3 Tampering).
+                                                # It is gitops-only config today, so it is covered by PR review rather than
+                                                # four_eyes.verbs; add a `vop.flip` verb here if it ever becomes operator-tunable.
+      - openbank-standing-order-service        # issue #2188: StandingOrderDueConsumer POSTs a real SCT to
+                                                # sepa-payment `/api/v1/sepa-payments` for every due order (#889, merged) —
+                                                # initiates money movement like sdd, not adjacent to it. Same class as sdd:
+                                                # it shapes the instruction, the irreversible debit lives downstream in a
+                                                # gated money-path service. Threat model:
+                                                # docs/threat-models/openbank-standing-order-service.md.
+                                                # four-eyes assessed: the only money-moving path is the scheduler-driven
+                                                # consumer (no human in the loop by design); the REST surface is
+                                                # customer/operator CRUD on orders (create/amend/pause/resume/cancel), whose
+                                                # effect is a FUTURE scheduled debit, not an immediate one — pausing or
+                                                # cancelling an order REDUCES money movement. There is no operator
+                                                # force-execute endpoint to maker-checker gate; add a verb here if one is
+                                                # ever added. Runs AUTHZ_ENFORCE=false (advisory) — joins the #3679 cohort.
+      - openbank-psd2-service                  # issue #2188 sibling sweep: PaymentInitiationService (PIS) calls
 
     money_path_action_prefixes:
       sepa-payment: [sepaPayment]

--- a/openbank-infra/gitops/components/dispute-service/dispute-service.yaml
+++ b/openbank-infra/gitops/components/dispute-service/dispute-service.yaml
@@ -15,7 +15,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-dispute-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "488a3be284d0a60f"
+        openbank.tech/policy-checksum: "09c242d1834d06af"
       labels: {app.kubernetes.io/name: dispute-service, app.kubernetes.io/part-of: dispute}
     spec:
       securityContext:

--- a/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: document-service
     app.kubernetes.io/part-of: documents
   annotations:
-    openbank.tech/policy-checksum: "6c500a6f3b582bd1"
+    openbank.tech/policy-checksum: "99a64206f9e9605b"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -759,6 +759,29 @@ data:
                                                 # sanctions.clear (deciding a screening hit) — the highest-risk action in this
                                                 # service, since a wrongly-cleared true positive is a real sanctions violation.
       - openbank-vop-service                   # ADR-0171: Verification of Payee (IPR Art. 5c) — sits on the pre-execution path of
+                                                # every euro credit transfer. Money-path for the same reason sca/consent/fraud are:
+                                                # it gates money movement without moving money itself.
+                                                # four-eyes assessed: the only REST surface is POST /vop/verify (vop.verify), a
+                                                # read-shaped check that mints nothing and decides nothing a human could collude on
+                                                # — there is nothing to maker-checker gate. The action that WOULD deserve a gate is
+                                                # a runtime change to `openbank.vop.max-edit-distance`: widening it silently turns
+                                                # genuine mismatches into reassuring amber warnings (threat model §3 Tampering).
+                                                # It is gitops-only config today, so it is covered by PR review rather than
+                                                # four_eyes.verbs; add a `vop.flip` verb here if it ever becomes operator-tunable.
+      - openbank-standing-order-service        # issue #2188: StandingOrderDueConsumer POSTs a real SCT to
+                                                # sepa-payment `/api/v1/sepa-payments` for every due order (#889, merged) —
+                                                # initiates money movement like sdd, not adjacent to it. Same class as sdd:
+                                                # it shapes the instruction, the irreversible debit lives downstream in a
+                                                # gated money-path service. Threat model:
+                                                # docs/threat-models/openbank-standing-order-service.md.
+                                                # four-eyes assessed: the only money-moving path is the scheduler-driven
+                                                # consumer (no human in the loop by design); the REST surface is
+                                                # customer/operator CRUD on orders (create/amend/pause/resume/cancel), whose
+                                                # effect is a FUTURE scheduled debit, not an immediate one — pausing or
+                                                # cancelling an order REDUCES money movement. There is no operator
+                                                # force-execute endpoint to maker-checker gate; add a verb here if one is
+                                                # ever added. Runs AUTHZ_ENFORCE=false (advisory) — joins the #3679 cohort.
+      - openbank-psd2-service                  # issue #2188 sibling sweep: PaymentInitiationService (PIS) calls
 
     money_path_action_prefixes:
       sepa-payment: [sepaPayment]

--- a/openbank-infra/gitops/components/document-service/document-service-service.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-service.yaml
@@ -43,7 +43,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-document-service-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "6c500a6f3b582bd1"
+        openbank.tech/policy-checksum: "99a64206f9e9605b"
     spec:
       # ADR-0162 D4 (continued): a dedicated SA (not `default`) is what OpenBao's Kubernetes-auth
       # role `document-service-signing` is bound to — least-privilege, one identity per consumer.

--- a/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fraud-service
     app.kubernetes.io/part-of: fraud
   annotations:
-    openbank.tech/policy-checksum: "a91c2ce3b8bc3ab2"
+    openbank.tech/policy-checksum: "b8502b83529f2a10"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1589,6 +1589,29 @@ data:
                                                 # sanctions.clear (deciding a screening hit) — the highest-risk action in this
                                                 # service, since a wrongly-cleared true positive is a real sanctions violation.
       - openbank-vop-service                   # ADR-0171: Verification of Payee (IPR Art. 5c) — sits on the pre-execution path of
+                                                # every euro credit transfer. Money-path for the same reason sca/consent/fraud are:
+                                                # it gates money movement without moving money itself.
+                                                # four-eyes assessed: the only REST surface is POST /vop/verify (vop.verify), a
+                                                # read-shaped check that mints nothing and decides nothing a human could collude on
+                                                # — there is nothing to maker-checker gate. The action that WOULD deserve a gate is
+                                                # a runtime change to `openbank.vop.max-edit-distance`: widening it silently turns
+                                                # genuine mismatches into reassuring amber warnings (threat model §3 Tampering).
+                                                # It is gitops-only config today, so it is covered by PR review rather than
+                                                # four_eyes.verbs; add a `vop.flip` verb here if it ever becomes operator-tunable.
+      - openbank-standing-order-service        # issue #2188: StandingOrderDueConsumer POSTs a real SCT to
+                                                # sepa-payment `/api/v1/sepa-payments` for every due order (#889, merged) —
+                                                # initiates money movement like sdd, not adjacent to it. Same class as sdd:
+                                                # it shapes the instruction, the irreversible debit lives downstream in a
+                                                # gated money-path service. Threat model:
+                                                # docs/threat-models/openbank-standing-order-service.md.
+                                                # four-eyes assessed: the only money-moving path is the scheduler-driven
+                                                # consumer (no human in the loop by design); the REST surface is
+                                                # customer/operator CRUD on orders (create/amend/pause/resume/cancel), whose
+                                                # effect is a FUTURE scheduled debit, not an immediate one — pausing or
+                                                # cancelling an order REDUCES money movement. There is no operator
+                                                # force-execute endpoint to maker-checker gate; add a verb here if one is
+                                                # ever added. Runs AUTHZ_ENFORCE=false (advisory) — joins the #3679 cohort.
+      - openbank-psd2-service                  # issue #2188 sibling sweep: PaymentInitiationService (PIS) calls
 
     money_path_action_prefixes:
       sepa-payment: [sepaPayment]

--- a/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
@@ -23,7 +23,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fraud-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "a91c2ce3b8bc3ab2"
+        openbank.tech/policy-checksum: "b8502b83529f2a10"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fx-service
     app.kubernetes.io/part-of: fx
   annotations:
-    openbank.tech/policy-checksum: "445a656924cffb31"
+    openbank.tech/policy-checksum: "e4a0e534e277dd89"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1640,6 +1640,29 @@ data:
                                                 # sanctions.clear (deciding a screening hit) — the highest-risk action in this
                                                 # service, since a wrongly-cleared true positive is a real sanctions violation.
       - openbank-vop-service                   # ADR-0171: Verification of Payee (IPR Art. 5c) — sits on the pre-execution path of
+                                                # every euro credit transfer. Money-path for the same reason sca/consent/fraud are:
+                                                # it gates money movement without moving money itself.
+                                                # four-eyes assessed: the only REST surface is POST /vop/verify (vop.verify), a
+                                                # read-shaped check that mints nothing and decides nothing a human could collude on
+                                                # — there is nothing to maker-checker gate. The action that WOULD deserve a gate is
+                                                # a runtime change to `openbank.vop.max-edit-distance`: widening it silently turns
+                                                # genuine mismatches into reassuring amber warnings (threat model §3 Tampering).
+                                                # It is gitops-only config today, so it is covered by PR review rather than
+                                                # four_eyes.verbs; add a `vop.flip` verb here if it ever becomes operator-tunable.
+      - openbank-standing-order-service        # issue #2188: StandingOrderDueConsumer POSTs a real SCT to
+                                                # sepa-payment `/api/v1/sepa-payments` for every due order (#889, merged) —
+                                                # initiates money movement like sdd, not adjacent to it. Same class as sdd:
+                                                # it shapes the instruction, the irreversible debit lives downstream in a
+                                                # gated money-path service. Threat model:
+                                                # docs/threat-models/openbank-standing-order-service.md.
+                                                # four-eyes assessed: the only money-moving path is the scheduler-driven
+                                                # consumer (no human in the loop by design); the REST surface is
+                                                # customer/operator CRUD on orders (create/amend/pause/resume/cancel), whose
+                                                # effect is a FUTURE scheduled debit, not an immediate one — pausing or
+                                                # cancelling an order REDUCES money movement. There is no operator
+                                                # force-execute endpoint to maker-checker gate; add a verb here if one is
+                                                # ever added. Runs AUTHZ_ENFORCE=false (advisory) — joins the #3679 cohort.
+      - openbank-psd2-service                  # issue #2188 sibling sweep: PaymentInitiationService (PIS) calls
 
     money_path_action_prefixes:
       sepa-payment: [sepaPayment]

--- a/openbank-infra/gitops/components/fx-service/fx-service.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fx-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "445a656924cffb31"
+        openbank.tech/policy-checksum: "e4a0e534e277dd89"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: interest-service
     app.kubernetes.io/part-of: interest
   annotations:
-    openbank.tech/policy-checksum: "095cbc2a932f316b"
+    openbank.tech/policy-checksum: "aef81e896164e05d"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1574,6 +1574,29 @@ data:
                                                 # sanctions.clear (deciding a screening hit) — the highest-risk action in this
                                                 # service, since a wrongly-cleared true positive is a real sanctions violation.
       - openbank-vop-service                   # ADR-0171: Verification of Payee (IPR Art. 5c) — sits on the pre-execution path of
+                                                # every euro credit transfer. Money-path for the same reason sca/consent/fraud are:
+                                                # it gates money movement without moving money itself.
+                                                # four-eyes assessed: the only REST surface is POST /vop/verify (vop.verify), a
+                                                # read-shaped check that mints nothing and decides nothing a human could collude on
+                                                # — there is nothing to maker-checker gate. The action that WOULD deserve a gate is
+                                                # a runtime change to `openbank.vop.max-edit-distance`: widening it silently turns
+                                                # genuine mismatches into reassuring amber warnings (threat model §3 Tampering).
+                                                # It is gitops-only config today, so it is covered by PR review rather than
+                                                # four_eyes.verbs; add a `vop.flip` verb here if it ever becomes operator-tunable.
+      - openbank-standing-order-service        # issue #2188: StandingOrderDueConsumer POSTs a real SCT to
+                                                # sepa-payment `/api/v1/sepa-payments` for every due order (#889, merged) —
+                                                # initiates money movement like sdd, not adjacent to it. Same class as sdd:
+                                                # it shapes the instruction, the irreversible debit lives downstream in a
+                                                # gated money-path service. Threat model:
+                                                # docs/threat-models/openbank-standing-order-service.md.
+                                                # four-eyes assessed: the only money-moving path is the scheduler-driven
+                                                # consumer (no human in the loop by design); the REST surface is
+                                                # customer/operator CRUD on orders (create/amend/pause/resume/cancel), whose
+                                                # effect is a FUTURE scheduled debit, not an immediate one — pausing or
+                                                # cancelling an order REDUCES money movement. There is no operator
+                                                # force-execute endpoint to maker-checker gate; add a verb here if one is
+                                                # ever added. Runs AUTHZ_ENFORCE=false (advisory) — joins the #3679 cohort.
+      - openbank-psd2-service                  # issue #2188 sibling sweep: PaymentInitiationService (PIS) calls
 
     money_path_action_prefixes:
       sepa-payment: [sepaPayment]

--- a/openbank-infra/gitops/components/interest-service/interest-service.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-service.yaml
@@ -16,7 +16,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-interest-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "095cbc2a932f316b"
+        openbank.tech/policy-checksum: "aef81e896164e05d"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/kyc/kyc-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/kyc/kyc-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: kyc-service
     app.kubernetes.io/part-of: kyc
   annotations:
-    openbank.tech/policy-checksum: "7bc7623cfee8c806"
+    openbank.tech/policy-checksum: "7394120ba7abd79e"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1602,6 +1602,29 @@ data:
                                                 # sanctions.clear (deciding a screening hit) — the highest-risk action in this
                                                 # service, since a wrongly-cleared true positive is a real sanctions violation.
       - openbank-vop-service                   # ADR-0171: Verification of Payee (IPR Art. 5c) — sits on the pre-execution path of
+                                                # every euro credit transfer. Money-path for the same reason sca/consent/fraud are:
+                                                # it gates money movement without moving money itself.
+                                                # four-eyes assessed: the only REST surface is POST /vop/verify (vop.verify), a
+                                                # read-shaped check that mints nothing and decides nothing a human could collude on
+                                                # — there is nothing to maker-checker gate. The action that WOULD deserve a gate is
+                                                # a runtime change to `openbank.vop.max-edit-distance`: widening it silently turns
+                                                # genuine mismatches into reassuring amber warnings (threat model §3 Tampering).
+                                                # It is gitops-only config today, so it is covered by PR review rather than
+                                                # four_eyes.verbs; add a `vop.flip` verb here if it ever becomes operator-tunable.
+      - openbank-standing-order-service        # issue #2188: StandingOrderDueConsumer POSTs a real SCT to
+                                                # sepa-payment `/api/v1/sepa-payments` for every due order (#889, merged) —
+                                                # initiates money movement like sdd, not adjacent to it. Same class as sdd:
+                                                # it shapes the instruction, the irreversible debit lives downstream in a
+                                                # gated money-path service. Threat model:
+                                                # docs/threat-models/openbank-standing-order-service.md.
+                                                # four-eyes assessed: the only money-moving path is the scheduler-driven
+                                                # consumer (no human in the loop by design); the REST surface is
+                                                # customer/operator CRUD on orders (create/amend/pause/resume/cancel), whose
+                                                # effect is a FUTURE scheduled debit, not an immediate one — pausing or
+                                                # cancelling an order REDUCES money movement. There is no operator
+                                                # force-execute endpoint to maker-checker gate; add a verb here if one is
+                                                # ever added. Runs AUTHZ_ENFORCE=false (advisory) — joins the #3679 cohort.
+      - openbank-psd2-service                  # issue #2188 sibling sweep: PaymentInitiationService (PIS) calls
 
     money_path_action_prefixes:
       sepa-payment: [sepaPayment]

--- a/openbank-infra/gitops/components/kyc/kyc-service.yaml
+++ b/openbank-infra/gitops/components/kyc/kyc-service.yaml
@@ -48,7 +48,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-kyc-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "7bc7623cfee8c806"
+        openbank.tech/policy-checksum: "7394120ba7abd79e"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: ledger-service
     app.kubernetes.io/part-of: ledger
   annotations:
-    openbank.tech/policy-checksum: "6af703996e489937"
+    openbank.tech/policy-checksum: "f94cc94ab173fa3f"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1687,6 +1687,29 @@ data:
                                                 # sanctions.clear (deciding a screening hit) — the highest-risk action in this
                                                 # service, since a wrongly-cleared true positive is a real sanctions violation.
       - openbank-vop-service                   # ADR-0171: Verification of Payee (IPR Art. 5c) — sits on the pre-execution path of
+                                                # every euro credit transfer. Money-path for the same reason sca/consent/fraud are:
+                                                # it gates money movement without moving money itself.
+                                                # four-eyes assessed: the only REST surface is POST /vop/verify (vop.verify), a
+                                                # read-shaped check that mints nothing and decides nothing a human could collude on
+                                                # — there is nothing to maker-checker gate. The action that WOULD deserve a gate is
+                                                # a runtime change to `openbank.vop.max-edit-distance`: widening it silently turns
+                                                # genuine mismatches into reassuring amber warnings (threat model §3 Tampering).
+                                                # It is gitops-only config today, so it is covered by PR review rather than
+                                                # four_eyes.verbs; add a `vop.flip` verb here if it ever becomes operator-tunable.
+      - openbank-standing-order-service        # issue #2188: StandingOrderDueConsumer POSTs a real SCT to
+                                                # sepa-payment `/api/v1/sepa-payments` for every due order (#889, merged) —
+                                                # initiates money movement like sdd, not adjacent to it. Same class as sdd:
+                                                # it shapes the instruction, the irreversible debit lives downstream in a
+                                                # gated money-path service. Threat model:
+                                                # docs/threat-models/openbank-standing-order-service.md.
+                                                # four-eyes assessed: the only money-moving path is the scheduler-driven
+                                                # consumer (no human in the loop by design); the REST surface is
+                                                # customer/operator CRUD on orders (create/amend/pause/resume/cancel), whose
+                                                # effect is a FUTURE scheduled debit, not an immediate one — pausing or
+                                                # cancelling an order REDUCES money movement. There is no operator
+                                                # force-execute endpoint to maker-checker gate; add a verb here if one is
+                                                # ever added. Runs AUTHZ_ENFORCE=false (advisory) — joins the #3679 cohort.
+      - openbank-psd2-service                  # issue #2188 sibling sweep: PaymentInitiationService (PIS) calls
 
     money_path_action_prefixes:
       sepa-payment: [sepaPayment]

--- a/openbank-infra/gitops/components/ledger/ledger-service.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-service.yaml
@@ -38,7 +38,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-ledger-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "6af703996e489937"
+        openbank.tech/policy-checksum: "f94cc94ab173fa3f"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: lending-service
     app.kubernetes.io/part-of: lending
   annotations:
-    openbank.tech/policy-checksum: "3a301190dbcdc205"
+    openbank.tech/policy-checksum: "5d79b9c52f3e71e2"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1682,6 +1682,29 @@ data:
                                                 # sanctions.clear (deciding a screening hit) — the highest-risk action in this
                                                 # service, since a wrongly-cleared true positive is a real sanctions violation.
       - openbank-vop-service                   # ADR-0171: Verification of Payee (IPR Art. 5c) — sits on the pre-execution path of
+                                                # every euro credit transfer. Money-path for the same reason sca/consent/fraud are:
+                                                # it gates money movement without moving money itself.
+                                                # four-eyes assessed: the only REST surface is POST /vop/verify (vop.verify), a
+                                                # read-shaped check that mints nothing and decides nothing a human could collude on
+                                                # — there is nothing to maker-checker gate. The action that WOULD deserve a gate is
+                                                # a runtime change to `openbank.vop.max-edit-distance`: widening it silently turns
+                                                # genuine mismatches into reassuring amber warnings (threat model §3 Tampering).
+                                                # It is gitops-only config today, so it is covered by PR review rather than
+                                                # four_eyes.verbs; add a `vop.flip` verb here if it ever becomes operator-tunable.
+      - openbank-standing-order-service        # issue #2188: StandingOrderDueConsumer POSTs a real SCT to
+                                                # sepa-payment `/api/v1/sepa-payments` for every due order (#889, merged) —
+                                                # initiates money movement like sdd, not adjacent to it. Same class as sdd:
+                                                # it shapes the instruction, the irreversible debit lives downstream in a
+                                                # gated money-path service. Threat model:
+                                                # docs/threat-models/openbank-standing-order-service.md.
+                                                # four-eyes assessed: the only money-moving path is the scheduler-driven
+                                                # consumer (no human in the loop by design); the REST surface is
+                                                # customer/operator CRUD on orders (create/amend/pause/resume/cancel), whose
+                                                # effect is a FUTURE scheduled debit, not an immediate one — pausing or
+                                                # cancelling an order REDUCES money movement. There is no operator
+                                                # force-execute endpoint to maker-checker gate; add a verb here if one is
+                                                # ever added. Runs AUTHZ_ENFORCE=false (advisory) — joins the #3679 cohort.
+      - openbank-psd2-service                  # issue #2188 sibling sweep: PaymentInitiationService (PIS) calls
 
     money_path_action_prefixes:
       sepa-payment: [sepaPayment]

--- a/openbank-infra/gitops/components/lending/lending-service.yaml
+++ b/openbank-infra/gitops/components/lending/lending-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-lending-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "3a301190dbcdc205"
+        openbank.tech/policy-checksum: "5d79b9c52f3e71e2"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/mcp/mcp-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/mcp/mcp-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: mcp-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "8fa118af13486c2a"
+    openbank.tech/policy-checksum: "0b79e3d8d2adf22f"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1540,6 +1540,29 @@ data:
                                                 # sanctions.clear (deciding a screening hit) — the highest-risk action in this
                                                 # service, since a wrongly-cleared true positive is a real sanctions violation.
       - openbank-vop-service                   # ADR-0171: Verification of Payee (IPR Art. 5c) — sits on the pre-execution path of
+                                                # every euro credit transfer. Money-path for the same reason sca/consent/fraud are:
+                                                # it gates money movement without moving money itself.
+                                                # four-eyes assessed: the only REST surface is POST /vop/verify (vop.verify), a
+                                                # read-shaped check that mints nothing and decides nothing a human could collude on
+                                                # — there is nothing to maker-checker gate. The action that WOULD deserve a gate is
+                                                # a runtime change to `openbank.vop.max-edit-distance`: widening it silently turns
+                                                # genuine mismatches into reassuring amber warnings (threat model §3 Tampering).
+                                                # It is gitops-only config today, so it is covered by PR review rather than
+                                                # four_eyes.verbs; add a `vop.flip` verb here if it ever becomes operator-tunable.
+      - openbank-standing-order-service        # issue #2188: StandingOrderDueConsumer POSTs a real SCT to
+                                                # sepa-payment `/api/v1/sepa-payments` for every due order (#889, merged) —
+                                                # initiates money movement like sdd, not adjacent to it. Same class as sdd:
+                                                # it shapes the instruction, the irreversible debit lives downstream in a
+                                                # gated money-path service. Threat model:
+                                                # docs/threat-models/openbank-standing-order-service.md.
+                                                # four-eyes assessed: the only money-moving path is the scheduler-driven
+                                                # consumer (no human in the loop by design); the REST surface is
+                                                # customer/operator CRUD on orders (create/amend/pause/resume/cancel), whose
+                                                # effect is a FUTURE scheduled debit, not an immediate one — pausing or
+                                                # cancelling an order REDUCES money movement. There is no operator
+                                                # force-execute endpoint to maker-checker gate; add a verb here if one is
+                                                # ever added. Runs AUTHZ_ENFORCE=false (advisory) — joins the #3679 cohort.
+      - openbank-psd2-service                  # issue #2188 sibling sweep: PaymentInitiationService (PIS) calls
 
     money_path_action_prefixes:
       sepa-payment: [sepaPayment]

--- a/openbank-infra/gitops/components/mcp/mcp-service.yaml
+++ b/openbank-infra/gitops/components/mcp/mcp-service.yaml
@@ -29,7 +29,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-mcp-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "8fa118af13486c2a"
+        openbank.tech/policy-checksum: "0b79e3d8d2adf22f"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: notification-service
     app.kubernetes.io/part-of: notifications
   annotations:
-    openbank.tech/policy-checksum: "6c500a6f3b582bd1"
+    openbank.tech/policy-checksum: "99a64206f9e9605b"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -759,6 +759,29 @@ data:
                                                 # sanctions.clear (deciding a screening hit) — the highest-risk action in this
                                                 # service, since a wrongly-cleared true positive is a real sanctions violation.
       - openbank-vop-service                   # ADR-0171: Verification of Payee (IPR Art. 5c) — sits on the pre-execution path of
+                                                # every euro credit transfer. Money-path for the same reason sca/consent/fraud are:
+                                                # it gates money movement without moving money itself.
+                                                # four-eyes assessed: the only REST surface is POST /vop/verify (vop.verify), a
+                                                # read-shaped check that mints nothing and decides nothing a human could collude on
+                                                # — there is nothing to maker-checker gate. The action that WOULD deserve a gate is
+                                                # a runtime change to `openbank.vop.max-edit-distance`: widening it silently turns
+                                                # genuine mismatches into reassuring amber warnings (threat model §3 Tampering).
+                                                # It is gitops-only config today, so it is covered by PR review rather than
+                                                # four_eyes.verbs; add a `vop.flip` verb here if it ever becomes operator-tunable.
+      - openbank-standing-order-service        # issue #2188: StandingOrderDueConsumer POSTs a real SCT to
+                                                # sepa-payment `/api/v1/sepa-payments` for every due order (#889, merged) —
+                                                # initiates money movement like sdd, not adjacent to it. Same class as sdd:
+                                                # it shapes the instruction, the irreversible debit lives downstream in a
+                                                # gated money-path service. Threat model:
+                                                # docs/threat-models/openbank-standing-order-service.md.
+                                                # four-eyes assessed: the only money-moving path is the scheduler-driven
+                                                # consumer (no human in the loop by design); the REST surface is
+                                                # customer/operator CRUD on orders (create/amend/pause/resume/cancel), whose
+                                                # effect is a FUTURE scheduled debit, not an immediate one — pausing or
+                                                # cancelling an order REDUCES money movement. There is no operator
+                                                # force-execute endpoint to maker-checker gate; add a verb here if one is
+                                                # ever added. Runs AUTHZ_ENFORCE=false (advisory) — joins the #3679 cohort.
+      - openbank-psd2-service                  # issue #2188 sibling sweep: PaymentInitiationService (PIS) calls
 
     money_path_action_prefixes:
       sepa-payment: [sepaPayment]

--- a/openbank-infra/gitops/components/notifications/notification-service.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service.yaml
@@ -39,7 +39,7 @@ spec:
       annotations:
         # Rolls the Deployment when the OPA policy bundle changes (subPath mounts don't
         # hot-reload). Kept in sync by gen-notification-opa-bundle.sh.
-        openbank.tech/policy-checksum: "6c500a6f3b582bd1"
+        openbank.tech/policy-checksum: "99a64206f9e9605b"
       labels:
         app.kubernetes.io/name: notification-service
         app.kubernetes.io/part-of: notifications

--- a/openbank-infra/gitops/components/observability/pyrra-slo-money-path.yaml
+++ b/openbank-infra/gitops/components/observability/pyrra-slo-money-path.yaml
@@ -946,3 +946,91 @@ spec:
       total:
         metric: traces_spanmetrics_calls_total{service="openbank-delegation-service"}
 ---
+apiVersion: pyrra.dev/v1alpha1
+kind: ServiceLevelObjective
+metadata:
+  name: openbank-standing-order-availability
+  namespace: observability
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+  labels:
+    app.kubernetes.io/part-of: observability
+    pyrra.dev/team: platform
+    openbank.io/money-path-service: openbank-standing-order-service
+spec:
+  target: "99.9"
+  window: 30d
+  description: "openbank-standing-order-service availability — non-error span ratio (issue #669, rules.yaml: slo.availability_target)."
+  indicator:
+    ratio:
+      errors:
+        metric: traces_spanmetrics_calls_total{service="openbank-standing-order-service",status_code="STATUS_CODE_ERROR"}
+      total:
+        metric: traces_spanmetrics_calls_total{service="openbank-standing-order-service"}
+---
+apiVersion: pyrra.dev/v1alpha1
+kind: ServiceLevelObjective
+metadata:
+  name: openbank-standing-order-latency
+  namespace: observability
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+  labels:
+    app.kubernetes.io/part-of: observability
+    pyrra.dev/team: platform
+    openbank.io/money-path-service: openbank-standing-order-service
+spec:
+  target: "99"
+  window: 30d
+  description: "openbank-standing-order-service latency — share of requests faster than 1s (issue #669, rules.yaml: slo.latency_threshold_seconds)."
+  indicator:
+    latency:
+      success:
+        metric: traces_spanmetrics_latency_bucket{service="openbank-standing-order-service",le="1"}
+      total:
+        metric: traces_spanmetrics_calls_total{service="openbank-standing-order-service"}
+---
+apiVersion: pyrra.dev/v1alpha1
+kind: ServiceLevelObjective
+metadata:
+  name: openbank-psd2-availability
+  namespace: observability
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+  labels:
+    app.kubernetes.io/part-of: observability
+    pyrra.dev/team: platform
+    openbank.io/money-path-service: openbank-psd2-service
+spec:
+  target: "99.9"
+  window: 30d
+  description: "openbank-psd2-service availability — non-error span ratio (issue #669, rules.yaml: slo.availability_target)."
+  indicator:
+    ratio:
+      errors:
+        metric: traces_spanmetrics_calls_total{service="openbank-psd2-service",status_code="STATUS_CODE_ERROR"}
+      total:
+        metric: traces_spanmetrics_calls_total{service="openbank-psd2-service"}
+---
+apiVersion: pyrra.dev/v1alpha1
+kind: ServiceLevelObjective
+metadata:
+  name: openbank-psd2-latency
+  namespace: observability
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+  labels:
+    app.kubernetes.io/part-of: observability
+    pyrra.dev/team: platform
+    openbank.io/money-path-service: openbank-psd2-service
+spec:
+  target: "99"
+  window: 30d
+  description: "openbank-psd2-service latency — share of requests faster than 1s (issue #669, rules.yaml: slo.latency_threshold_seconds)."
+  indicator:
+    latency:
+      success:
+        metric: traces_spanmetrics_latency_bucket{service="openbank-psd2-service",le="1"}
+      total:
+        metric: traces_spanmetrics_calls_total{service="openbank-psd2-service"}
+---

--- a/openbank-infra/gitops/components/party/party-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/party/party-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: party-service
     app.kubernetes.io/part-of: party
   annotations:
-    openbank.tech/policy-checksum: "d6822a2c3c58a209"
+    openbank.tech/policy-checksum: "bd46c36eb36098eb"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1611,6 +1611,29 @@ data:
                                                 # sanctions.clear (deciding a screening hit) — the highest-risk action in this
                                                 # service, since a wrongly-cleared true positive is a real sanctions violation.
       - openbank-vop-service                   # ADR-0171: Verification of Payee (IPR Art. 5c) — sits on the pre-execution path of
+                                                # every euro credit transfer. Money-path for the same reason sca/consent/fraud are:
+                                                # it gates money movement without moving money itself.
+                                                # four-eyes assessed: the only REST surface is POST /vop/verify (vop.verify), a
+                                                # read-shaped check that mints nothing and decides nothing a human could collude on
+                                                # — there is nothing to maker-checker gate. The action that WOULD deserve a gate is
+                                                # a runtime change to `openbank.vop.max-edit-distance`: widening it silently turns
+                                                # genuine mismatches into reassuring amber warnings (threat model §3 Tampering).
+                                                # It is gitops-only config today, so it is covered by PR review rather than
+                                                # four_eyes.verbs; add a `vop.flip` verb here if it ever becomes operator-tunable.
+      - openbank-standing-order-service        # issue #2188: StandingOrderDueConsumer POSTs a real SCT to
+                                                # sepa-payment `/api/v1/sepa-payments` for every due order (#889, merged) —
+                                                # initiates money movement like sdd, not adjacent to it. Same class as sdd:
+                                                # it shapes the instruction, the irreversible debit lives downstream in a
+                                                # gated money-path service. Threat model:
+                                                # docs/threat-models/openbank-standing-order-service.md.
+                                                # four-eyes assessed: the only money-moving path is the scheduler-driven
+                                                # consumer (no human in the loop by design); the REST surface is
+                                                # customer/operator CRUD on orders (create/amend/pause/resume/cancel), whose
+                                                # effect is a FUTURE scheduled debit, not an immediate one — pausing or
+                                                # cancelling an order REDUCES money movement. There is no operator
+                                                # force-execute endpoint to maker-checker gate; add a verb here if one is
+                                                # ever added. Runs AUTHZ_ENFORCE=false (advisory) — joins the #3679 cohort.
+      - openbank-psd2-service                  # issue #2188 sibling sweep: PaymentInitiationService (PIS) calls
 
     money_path_action_prefixes:
       sepa-payment: [sepaPayment]

--- a/openbank-infra/gitops/components/party/party-service.yaml
+++ b/openbank-infra/gitops/components/party/party-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-party-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "d6822a2c3c58a209"
+        openbank.tech/policy-checksum: "bd46c36eb36098eb"
       labels:
         app.kubernetes.io/name: party-service
         app.kubernetes.io/part-of: party

--- a/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: card-issuance-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "6740ceff5d58e70c"
+    openbank.tech/policy-checksum: "48fa347da95613aa"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1595,6 +1595,29 @@ data:
                                                 # sanctions.clear (deciding a screening hit) — the highest-risk action in this
                                                 # service, since a wrongly-cleared true positive is a real sanctions violation.
       - openbank-vop-service                   # ADR-0171: Verification of Payee (IPR Art. 5c) — sits on the pre-execution path of
+                                                # every euro credit transfer. Money-path for the same reason sca/consent/fraud are:
+                                                # it gates money movement without moving money itself.
+                                                # four-eyes assessed: the only REST surface is POST /vop/verify (vop.verify), a
+                                                # read-shaped check that mints nothing and decides nothing a human could collude on
+                                                # — there is nothing to maker-checker gate. The action that WOULD deserve a gate is
+                                                # a runtime change to `openbank.vop.max-edit-distance`: widening it silently turns
+                                                # genuine mismatches into reassuring amber warnings (threat model §3 Tampering).
+                                                # It is gitops-only config today, so it is covered by PR review rather than
+                                                # four_eyes.verbs; add a `vop.flip` verb here if it ever becomes operator-tunable.
+      - openbank-standing-order-service        # issue #2188: StandingOrderDueConsumer POSTs a real SCT to
+                                                # sepa-payment `/api/v1/sepa-payments` for every due order (#889, merged) —
+                                                # initiates money movement like sdd, not adjacent to it. Same class as sdd:
+                                                # it shapes the instruction, the irreversible debit lives downstream in a
+                                                # gated money-path service. Threat model:
+                                                # docs/threat-models/openbank-standing-order-service.md.
+                                                # four-eyes assessed: the only money-moving path is the scheduler-driven
+                                                # consumer (no human in the loop by design); the REST surface is
+                                                # customer/operator CRUD on orders (create/amend/pause/resume/cancel), whose
+                                                # effect is a FUTURE scheduled debit, not an immediate one — pausing or
+                                                # cancelling an order REDUCES money movement. There is no operator
+                                                # force-execute endpoint to maker-checker gate; add a verb here if one is
+                                                # ever added. Runs AUTHZ_ENFORCE=false (advisory) — joins the #3679 cohort.
+      - openbank-psd2-service                  # issue #2188 sibling sweep: PaymentInitiationService (PIS) calls
 
     money_path_action_prefixes:
       sepa-payment: [sepaPayment]

--- a/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: clearing-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "f0e58852856c4e93"
+    openbank.tech/policy-checksum: "f9a2540634aabf34"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1632,6 +1632,29 @@ data:
                                                 # sanctions.clear (deciding a screening hit) — the highest-risk action in this
                                                 # service, since a wrongly-cleared true positive is a real sanctions violation.
       - openbank-vop-service                   # ADR-0171: Verification of Payee (IPR Art. 5c) — sits on the pre-execution path of
+                                                # every euro credit transfer. Money-path for the same reason sca/consent/fraud are:
+                                                # it gates money movement without moving money itself.
+                                                # four-eyes assessed: the only REST surface is POST /vop/verify (vop.verify), a
+                                                # read-shaped check that mints nothing and decides nothing a human could collude on
+                                                # — there is nothing to maker-checker gate. The action that WOULD deserve a gate is
+                                                # a runtime change to `openbank.vop.max-edit-distance`: widening it silently turns
+                                                # genuine mismatches into reassuring amber warnings (threat model §3 Tampering).
+                                                # It is gitops-only config today, so it is covered by PR review rather than
+                                                # four_eyes.verbs; add a `vop.flip` verb here if it ever becomes operator-tunable.
+      - openbank-standing-order-service        # issue #2188: StandingOrderDueConsumer POSTs a real SCT to
+                                                # sepa-payment `/api/v1/sepa-payments` for every due order (#889, merged) —
+                                                # initiates money movement like sdd, not adjacent to it. Same class as sdd:
+                                                # it shapes the instruction, the irreversible debit lives downstream in a
+                                                # gated money-path service. Threat model:
+                                                # docs/threat-models/openbank-standing-order-service.md.
+                                                # four-eyes assessed: the only money-moving path is the scheduler-driven
+                                                # consumer (no human in the loop by design); the REST surface is
+                                                # customer/operator CRUD on orders (create/amend/pause/resume/cancel), whose
+                                                # effect is a FUTURE scheduled debit, not an immediate one — pausing or
+                                                # cancelling an order REDUCES money movement. There is no operator
+                                                # force-execute endpoint to maker-checker gate; add a verb here if one is
+                                                # ever added. Runs AUTHZ_ENFORCE=false (advisory) — joins the #3679 cohort.
+      - openbank-psd2-service                  # issue #2188 sibling sweep: PaymentInitiationService (PIS) calls
 
     money_path_action_prefixes:
       sepa-payment: [sepaPayment]

--- a/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: domestic-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "b1a329472478538a"
+    openbank.tech/policy-checksum: "5a14bac86219c8bf"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1617,6 +1617,29 @@ data:
                                                 # sanctions.clear (deciding a screening hit) — the highest-risk action in this
                                                 # service, since a wrongly-cleared true positive is a real sanctions violation.
       - openbank-vop-service                   # ADR-0171: Verification of Payee (IPR Art. 5c) — sits on the pre-execution path of
+                                                # every euro credit transfer. Money-path for the same reason sca/consent/fraud are:
+                                                # it gates money movement without moving money itself.
+                                                # four-eyes assessed: the only REST surface is POST /vop/verify (vop.verify), a
+                                                # read-shaped check that mints nothing and decides nothing a human could collude on
+                                                # — there is nothing to maker-checker gate. The action that WOULD deserve a gate is
+                                                # a runtime change to `openbank.vop.max-edit-distance`: widening it silently turns
+                                                # genuine mismatches into reassuring amber warnings (threat model §3 Tampering).
+                                                # It is gitops-only config today, so it is covered by PR review rather than
+                                                # four_eyes.verbs; add a `vop.flip` verb here if it ever becomes operator-tunable.
+      - openbank-standing-order-service        # issue #2188: StandingOrderDueConsumer POSTs a real SCT to
+                                                # sepa-payment `/api/v1/sepa-payments` for every due order (#889, merged) —
+                                                # initiates money movement like sdd, not adjacent to it. Same class as sdd:
+                                                # it shapes the instruction, the irreversible debit lives downstream in a
+                                                # gated money-path service. Threat model:
+                                                # docs/threat-models/openbank-standing-order-service.md.
+                                                # four-eyes assessed: the only money-moving path is the scheduler-driven
+                                                # consumer (no human in the loop by design); the REST surface is
+                                                # customer/operator CRUD on orders (create/amend/pause/resume/cancel), whose
+                                                # effect is a FUTURE scheduled debit, not an immediate one — pausing or
+                                                # cancelling an order REDUCES money movement. There is no operator
+                                                # force-execute endpoint to maker-checker gate; add a verb here if one is
+                                                # ever added. Runs AUTHZ_ENFORCE=false (advisory) — joins the #3679 cohort.
+      - openbank-psd2-service                  # issue #2188 sibling sweep: PaymentInitiationService (PIS) calls
 
     money_path_action_prefixes:
       sepa-payment: [sepaPayment]

--- a/openbank-infra/gitops/components/payments/payments-services.yaml
+++ b/openbank-infra/gitops/components/payments/payments-services.yaml
@@ -42,7 +42,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-transaction-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "c8c28bcd3ec74908" # transaction-opa-bundle
+        openbank.tech/policy-checksum: "625977bdca7976d4" # transaction-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -375,7 +375,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-payment-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "95808b195cdb58fd"
+        openbank.tech/policy-checksum: "cb3cad3069a09ac5"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -729,7 +729,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-domestic-payment-opa-bundle.sh via the trailing marker
         # comment (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "b1a329472478538a" # domestic-payment-opa-bundle
+        openbank.tech/policy-checksum: "5a14bac86219c8bf" # domestic-payment-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1053,7 +1053,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-instant-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "ff3101d1abe4abfd"
+        openbank.tech/policy-checksum: "0656c4a7e79f4a71"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1369,7 +1369,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-clearing-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "f0e58852856c4e93" # clearing-opa-bundle
+        openbank.tech/policy-checksum: "f9a2540634aabf34" # clearing-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1658,7 +1658,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (ADR-0034). Value is stamped by
         # gen-standing-order-opa-bundle.sh — do not hand-edit.
-        openbank.tech/policy-checksum: "057a2489c43caed2" # standing-order-opa-bundle
+        openbank.tech/policy-checksum: "e982df9ebfcb4638" # standing-order-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1911,7 +1911,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-card-issuance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "6740ceff5d58e70c"
+        openbank.tech/policy-checksum: "48fa347da95613aa"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2181,7 +2181,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-settlement-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "bfbcf6f49d72baa5" # settlement-opa-bundle
+        openbank.tech/policy-checksum: "dc5ca8618aff01f7" # settlement-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2582,7 +2582,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-swift-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "883b6a6b80ed2a7d"
+        openbank.tech/policy-checksum: "b0b561bea5884834"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2896,7 +2896,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-vop-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "da939ca353e0ee8a"
+        openbank.tech/policy-checksum: "966bb3550cbef0e9"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-instant
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "ff3101d1abe4abfd"
+    openbank.tech/policy-checksum: "0656c4a7e79f4a71"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1590,6 +1590,29 @@ data:
                                                 # sanctions.clear (deciding a screening hit) — the highest-risk action in this
                                                 # service, since a wrongly-cleared true positive is a real sanctions violation.
       - openbank-vop-service                   # ADR-0171: Verification of Payee (IPR Art. 5c) — sits on the pre-execution path of
+                                                # every euro credit transfer. Money-path for the same reason sca/consent/fraud are:
+                                                # it gates money movement without moving money itself.
+                                                # four-eyes assessed: the only REST surface is POST /vop/verify (vop.verify), a
+                                                # read-shaped check that mints nothing and decides nothing a human could collude on
+                                                # — there is nothing to maker-checker gate. The action that WOULD deserve a gate is
+                                                # a runtime change to `openbank.vop.max-edit-distance`: widening it silently turns
+                                                # genuine mismatches into reassuring amber warnings (threat model §3 Tampering).
+                                                # It is gitops-only config today, so it is covered by PR review rather than
+                                                # four_eyes.verbs; add a `vop.flip` verb here if it ever becomes operator-tunable.
+      - openbank-standing-order-service        # issue #2188: StandingOrderDueConsumer POSTs a real SCT to
+                                                # sepa-payment `/api/v1/sepa-payments` for every due order (#889, merged) —
+                                                # initiates money movement like sdd, not adjacent to it. Same class as sdd:
+                                                # it shapes the instruction, the irreversible debit lives downstream in a
+                                                # gated money-path service. Threat model:
+                                                # docs/threat-models/openbank-standing-order-service.md.
+                                                # four-eyes assessed: the only money-moving path is the scheduler-driven
+                                                # consumer (no human in the loop by design); the REST surface is
+                                                # customer/operator CRUD on orders (create/amend/pause/resume/cancel), whose
+                                                # effect is a FUTURE scheduled debit, not an immediate one — pausing or
+                                                # cancelling an order REDUCES money movement. There is no operator
+                                                # force-execute endpoint to maker-checker gate; add a verb here if one is
+                                                # ever added. Runs AUTHZ_ENFORCE=false (advisory) — joins the #3679 cohort.
+      - openbank-psd2-service                  # issue #2188 sibling sweep: PaymentInitiationService (PIS) calls
 
     money_path_action_prefixes:
       sepa-payment: [sepaPayment]

--- a/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "95808b195cdb58fd"
+    openbank.tech/policy-checksum: "cb3cad3069a09ac5"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1611,6 +1611,29 @@ data:
                                                 # sanctions.clear (deciding a screening hit) — the highest-risk action in this
                                                 # service, since a wrongly-cleared true positive is a real sanctions violation.
       - openbank-vop-service                   # ADR-0171: Verification of Payee (IPR Art. 5c) — sits on the pre-execution path of
+                                                # every euro credit transfer. Money-path for the same reason sca/consent/fraud are:
+                                                # it gates money movement without moving money itself.
+                                                # four-eyes assessed: the only REST surface is POST /vop/verify (vop.verify), a
+                                                # read-shaped check that mints nothing and decides nothing a human could collude on
+                                                # — there is nothing to maker-checker gate. The action that WOULD deserve a gate is
+                                                # a runtime change to `openbank.vop.max-edit-distance`: widening it silently turns
+                                                # genuine mismatches into reassuring amber warnings (threat model §3 Tampering).
+                                                # It is gitops-only config today, so it is covered by PR review rather than
+                                                # four_eyes.verbs; add a `vop.flip` verb here if it ever becomes operator-tunable.
+      - openbank-standing-order-service        # issue #2188: StandingOrderDueConsumer POSTs a real SCT to
+                                                # sepa-payment `/api/v1/sepa-payments` for every due order (#889, merged) —
+                                                # initiates money movement like sdd, not adjacent to it. Same class as sdd:
+                                                # it shapes the instruction, the irreversible debit lives downstream in a
+                                                # gated money-path service. Threat model:
+                                                # docs/threat-models/openbank-standing-order-service.md.
+                                                # four-eyes assessed: the only money-moving path is the scheduler-driven
+                                                # consumer (no human in the loop by design); the REST surface is
+                                                # customer/operator CRUD on orders (create/amend/pause/resume/cancel), whose
+                                                # effect is a FUTURE scheduled debit, not an immediate one — pausing or
+                                                # cancelling an order REDUCES money movement. There is no operator
+                                                # force-execute endpoint to maker-checker gate; add a verb here if one is
+                                                # ever added. Runs AUTHZ_ENFORCE=false (advisory) — joins the #3679 cohort.
+      - openbank-psd2-service                  # issue #2188 sibling sweep: PaymentInitiationService (PIS) calls
 
     money_path_action_prefixes:
       sepa-payment: [sepaPayment]

--- a/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: settlement-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "bfbcf6f49d72baa5"
+    openbank.tech/policy-checksum: "dc5ca8618aff01f7"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1591,6 +1591,29 @@ data:
                                                 # sanctions.clear (deciding a screening hit) — the highest-risk action in this
                                                 # service, since a wrongly-cleared true positive is a real sanctions violation.
       - openbank-vop-service                   # ADR-0171: Verification of Payee (IPR Art. 5c) — sits on the pre-execution path of
+                                                # every euro credit transfer. Money-path for the same reason sca/consent/fraud are:
+                                                # it gates money movement without moving money itself.
+                                                # four-eyes assessed: the only REST surface is POST /vop/verify (vop.verify), a
+                                                # read-shaped check that mints nothing and decides nothing a human could collude on
+                                                # — there is nothing to maker-checker gate. The action that WOULD deserve a gate is
+                                                # a runtime change to `openbank.vop.max-edit-distance`: widening it silently turns
+                                                # genuine mismatches into reassuring amber warnings (threat model §3 Tampering).
+                                                # It is gitops-only config today, so it is covered by PR review rather than
+                                                # four_eyes.verbs; add a `vop.flip` verb here if it ever becomes operator-tunable.
+      - openbank-standing-order-service        # issue #2188: StandingOrderDueConsumer POSTs a real SCT to
+                                                # sepa-payment `/api/v1/sepa-payments` for every due order (#889, merged) —
+                                                # initiates money movement like sdd, not adjacent to it. Same class as sdd:
+                                                # it shapes the instruction, the irreversible debit lives downstream in a
+                                                # gated money-path service. Threat model:
+                                                # docs/threat-models/openbank-standing-order-service.md.
+                                                # four-eyes assessed: the only money-moving path is the scheduler-driven
+                                                # consumer (no human in the loop by design); the REST surface is
+                                                # customer/operator CRUD on orders (create/amend/pause/resume/cancel), whose
+                                                # effect is a FUTURE scheduled debit, not an immediate one — pausing or
+                                                # cancelling an order REDUCES money movement. There is no operator
+                                                # force-execute endpoint to maker-checker gate; add a verb here if one is
+                                                # ever added. Runs AUTHZ_ENFORCE=false (advisory) — joins the #3679 cohort.
+      - openbank-psd2-service                  # issue #2188 sibling sweep: PaymentInitiationService (PIS) calls
 
     money_path_action_prefixes:
       sepa-payment: [sepaPayment]

--- a/openbank-infra/gitops/components/payments/standing-order-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/standing-order-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: standing-order-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "057a2489c43caed2"
+    openbank.tech/policy-checksum: "e982df9ebfcb4638"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1576,6 +1576,29 @@ data:
                                                 # sanctions.clear (deciding a screening hit) — the highest-risk action in this
                                                 # service, since a wrongly-cleared true positive is a real sanctions violation.
       - openbank-vop-service                   # ADR-0171: Verification of Payee (IPR Art. 5c) — sits on the pre-execution path of
+                                                # every euro credit transfer. Money-path for the same reason sca/consent/fraud are:
+                                                # it gates money movement without moving money itself.
+                                                # four-eyes assessed: the only REST surface is POST /vop/verify (vop.verify), a
+                                                # read-shaped check that mints nothing and decides nothing a human could collude on
+                                                # — there is nothing to maker-checker gate. The action that WOULD deserve a gate is
+                                                # a runtime change to `openbank.vop.max-edit-distance`: widening it silently turns
+                                                # genuine mismatches into reassuring amber warnings (threat model §3 Tampering).
+                                                # It is gitops-only config today, so it is covered by PR review rather than
+                                                # four_eyes.verbs; add a `vop.flip` verb here if it ever becomes operator-tunable.
+      - openbank-standing-order-service        # issue #2188: StandingOrderDueConsumer POSTs a real SCT to
+                                                # sepa-payment `/api/v1/sepa-payments` for every due order (#889, merged) —
+                                                # initiates money movement like sdd, not adjacent to it. Same class as sdd:
+                                                # it shapes the instruction, the irreversible debit lives downstream in a
+                                                # gated money-path service. Threat model:
+                                                # docs/threat-models/openbank-standing-order-service.md.
+                                                # four-eyes assessed: the only money-moving path is the scheduler-driven
+                                                # consumer (no human in the loop by design); the REST surface is
+                                                # customer/operator CRUD on orders (create/amend/pause/resume/cancel), whose
+                                                # effect is a FUTURE scheduled debit, not an immediate one — pausing or
+                                                # cancelling an order REDUCES money movement. There is no operator
+                                                # force-execute endpoint to maker-checker gate; add a verb here if one is
+                                                # ever added. Runs AUTHZ_ENFORCE=false (advisory) — joins the #3679 cohort.
+      - openbank-psd2-service                  # issue #2188 sibling sweep: PaymentInitiationService (PIS) calls
 
     money_path_action_prefixes:
       sepa-payment: [sepaPayment]

--- a/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: swift-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "883b6a6b80ed2a7d"
+    openbank.tech/policy-checksum: "b0b561bea5884834"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1594,6 +1594,29 @@ data:
                                                 # sanctions.clear (deciding a screening hit) — the highest-risk action in this
                                                 # service, since a wrongly-cleared true positive is a real sanctions violation.
       - openbank-vop-service                   # ADR-0171: Verification of Payee (IPR Art. 5c) — sits on the pre-execution path of
+                                                # every euro credit transfer. Money-path for the same reason sca/consent/fraud are:
+                                                # it gates money movement without moving money itself.
+                                                # four-eyes assessed: the only REST surface is POST /vop/verify (vop.verify), a
+                                                # read-shaped check that mints nothing and decides nothing a human could collude on
+                                                # — there is nothing to maker-checker gate. The action that WOULD deserve a gate is
+                                                # a runtime change to `openbank.vop.max-edit-distance`: widening it silently turns
+                                                # genuine mismatches into reassuring amber warnings (threat model §3 Tampering).
+                                                # It is gitops-only config today, so it is covered by PR review rather than
+                                                # four_eyes.verbs; add a `vop.flip` verb here if it ever becomes operator-tunable.
+      - openbank-standing-order-service        # issue #2188: StandingOrderDueConsumer POSTs a real SCT to
+                                                # sepa-payment `/api/v1/sepa-payments` for every due order (#889, merged) —
+                                                # initiates money movement like sdd, not adjacent to it. Same class as sdd:
+                                                # it shapes the instruction, the irreversible debit lives downstream in a
+                                                # gated money-path service. Threat model:
+                                                # docs/threat-models/openbank-standing-order-service.md.
+                                                # four-eyes assessed: the only money-moving path is the scheduler-driven
+                                                # consumer (no human in the loop by design); the REST surface is
+                                                # customer/operator CRUD on orders (create/amend/pause/resume/cancel), whose
+                                                # effect is a FUTURE scheduled debit, not an immediate one — pausing or
+                                                # cancelling an order REDUCES money movement. There is no operator
+                                                # force-execute endpoint to maker-checker gate; add a verb here if one is
+                                                # ever added. Runs AUTHZ_ENFORCE=false (advisory) — joins the #3679 cohort.
+      - openbank-psd2-service                  # issue #2188 sibling sweep: PaymentInitiationService (PIS) calls
 
     money_path_action_prefixes:
       sepa-payment: [sepaPayment]

--- a/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: transaction-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "c8c28bcd3ec74908"
+    openbank.tech/policy-checksum: "625977bdca7976d4"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1647,6 +1647,29 @@ data:
                                                 # sanctions.clear (deciding a screening hit) — the highest-risk action in this
                                                 # service, since a wrongly-cleared true positive is a real sanctions violation.
       - openbank-vop-service                   # ADR-0171: Verification of Payee (IPR Art. 5c) — sits on the pre-execution path of
+                                                # every euro credit transfer. Money-path for the same reason sca/consent/fraud are:
+                                                # it gates money movement without moving money itself.
+                                                # four-eyes assessed: the only REST surface is POST /vop/verify (vop.verify), a
+                                                # read-shaped check that mints nothing and decides nothing a human could collude on
+                                                # — there is nothing to maker-checker gate. The action that WOULD deserve a gate is
+                                                # a runtime change to `openbank.vop.max-edit-distance`: widening it silently turns
+                                                # genuine mismatches into reassuring amber warnings (threat model §3 Tampering).
+                                                # It is gitops-only config today, so it is covered by PR review rather than
+                                                # four_eyes.verbs; add a `vop.flip` verb here if it ever becomes operator-tunable.
+      - openbank-standing-order-service        # issue #2188: StandingOrderDueConsumer POSTs a real SCT to
+                                                # sepa-payment `/api/v1/sepa-payments` for every due order (#889, merged) —
+                                                # initiates money movement like sdd, not adjacent to it. Same class as sdd:
+                                                # it shapes the instruction, the irreversible debit lives downstream in a
+                                                # gated money-path service. Threat model:
+                                                # docs/threat-models/openbank-standing-order-service.md.
+                                                # four-eyes assessed: the only money-moving path is the scheduler-driven
+                                                # consumer (no human in the loop by design); the REST surface is
+                                                # customer/operator CRUD on orders (create/amend/pause/resume/cancel), whose
+                                                # effect is a FUTURE scheduled debit, not an immediate one — pausing or
+                                                # cancelling an order REDUCES money movement. There is no operator
+                                                # force-execute endpoint to maker-checker gate; add a verb here if one is
+                                                # ever added. Runs AUTHZ_ENFORCE=false (advisory) — joins the #3679 cohort.
+      - openbank-psd2-service                  # issue #2188 sibling sweep: PaymentInitiationService (PIS) calls
 
     money_path_action_prefixes:
       sepa-payment: [sepaPayment]

--- a/openbank-infra/gitops/components/payments/vop-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/vop-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: vop-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "da939ca353e0ee8a"
+    openbank.tech/policy-checksum: "966bb3550cbef0e9"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1598,6 +1598,29 @@ data:
                                                 # sanctions.clear (deciding a screening hit) — the highest-risk action in this
                                                 # service, since a wrongly-cleared true positive is a real sanctions violation.
       - openbank-vop-service                   # ADR-0171: Verification of Payee (IPR Art. 5c) — sits on the pre-execution path of
+                                                # every euro credit transfer. Money-path for the same reason sca/consent/fraud are:
+                                                # it gates money movement without moving money itself.
+                                                # four-eyes assessed: the only REST surface is POST /vop/verify (vop.verify), a
+                                                # read-shaped check that mints nothing and decides nothing a human could collude on
+                                                # — there is nothing to maker-checker gate. The action that WOULD deserve a gate is
+                                                # a runtime change to `openbank.vop.max-edit-distance`: widening it silently turns
+                                                # genuine mismatches into reassuring amber warnings (threat model §3 Tampering).
+                                                # It is gitops-only config today, so it is covered by PR review rather than
+                                                # four_eyes.verbs; add a `vop.flip` verb here if it ever becomes operator-tunable.
+      - openbank-standing-order-service        # issue #2188: StandingOrderDueConsumer POSTs a real SCT to
+                                                # sepa-payment `/api/v1/sepa-payments` for every due order (#889, merged) —
+                                                # initiates money movement like sdd, not adjacent to it. Same class as sdd:
+                                                # it shapes the instruction, the irreversible debit lives downstream in a
+                                                # gated money-path service. Threat model:
+                                                # docs/threat-models/openbank-standing-order-service.md.
+                                                # four-eyes assessed: the only money-moving path is the scheduler-driven
+                                                # consumer (no human in the loop by design); the REST surface is
+                                                # customer/operator CRUD on orders (create/amend/pause/resume/cancel), whose
+                                                # effect is a FUTURE scheduled debit, not an immediate one — pausing or
+                                                # cancelling an order REDUCES money movement. There is no operator
+                                                # force-execute endpoint to maker-checker gate; add a verb here if one is
+                                                # ever added. Runs AUTHZ_ENFORCE=false (advisory) — joins the #3679 cohort.
+      - openbank-psd2-service                  # issue #2188 sibling sweep: PaymentInitiationService (PIS) calls
 
     money_path_action_prefixes:
       sepa-payment: [sepaPayment]

--- a/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: pid-service
     app.kubernetes.io/part-of: pid
   annotations:
-    openbank.tech/policy-checksum: "443d05f6d1b65e02"
+    openbank.tech/policy-checksum: "8d877a3cee68303d"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1600,6 +1600,29 @@ data:
                                                 # sanctions.clear (deciding a screening hit) — the highest-risk action in this
                                                 # service, since a wrongly-cleared true positive is a real sanctions violation.
       - openbank-vop-service                   # ADR-0171: Verification of Payee (IPR Art. 5c) — sits on the pre-execution path of
+                                                # every euro credit transfer. Money-path for the same reason sca/consent/fraud are:
+                                                # it gates money movement without moving money itself.
+                                                # four-eyes assessed: the only REST surface is POST /vop/verify (vop.verify), a
+                                                # read-shaped check that mints nothing and decides nothing a human could collude on
+                                                # — there is nothing to maker-checker gate. The action that WOULD deserve a gate is
+                                                # a runtime change to `openbank.vop.max-edit-distance`: widening it silently turns
+                                                # genuine mismatches into reassuring amber warnings (threat model §3 Tampering).
+                                                # It is gitops-only config today, so it is covered by PR review rather than
+                                                # four_eyes.verbs; add a `vop.flip` verb here if it ever becomes operator-tunable.
+      - openbank-standing-order-service        # issue #2188: StandingOrderDueConsumer POSTs a real SCT to
+                                                # sepa-payment `/api/v1/sepa-payments` for every due order (#889, merged) —
+                                                # initiates money movement like sdd, not adjacent to it. Same class as sdd:
+                                                # it shapes the instruction, the irreversible debit lives downstream in a
+                                                # gated money-path service. Threat model:
+                                                # docs/threat-models/openbank-standing-order-service.md.
+                                                # four-eyes assessed: the only money-moving path is the scheduler-driven
+                                                # consumer (no human in the loop by design); the REST surface is
+                                                # customer/operator CRUD on orders (create/amend/pause/resume/cancel), whose
+                                                # effect is a FUTURE scheduled debit, not an immediate one — pausing or
+                                                # cancelling an order REDUCES money movement. There is no operator
+                                                # force-execute endpoint to maker-checker gate; add a verb here if one is
+                                                # ever added. Runs AUTHZ_ENFORCE=false (advisory) — joins the #3679 cohort.
+      - openbank-psd2-service                  # issue #2188 sibling sweep: PaymentInitiationService (PIS) calls
 
     money_path_action_prefixes:
       sepa-payment: [sepaPayment]

--- a/openbank-infra/gitops/components/pid/pid-service.yaml
+++ b/openbank-infra/gitops/components/pid/pid-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-pid-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "443d05f6d1b65e02"
+        openbank.tech/policy-checksum: "8d877a3cee68303d"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/psd2-service/psd2-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/psd2-service/psd2-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: psd2-service
     app.kubernetes.io/part-of: psd2
   annotations:
-    openbank.tech/policy-checksum: "a1935b29ef2b64d6"
+    openbank.tech/policy-checksum: "d3a8591d24d14a41"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1673,6 +1673,29 @@ data:
                                                 # sanctions.clear (deciding a screening hit) — the highest-risk action in this
                                                 # service, since a wrongly-cleared true positive is a real sanctions violation.
       - openbank-vop-service                   # ADR-0171: Verification of Payee (IPR Art. 5c) — sits on the pre-execution path of
+                                                # every euro credit transfer. Money-path for the same reason sca/consent/fraud are:
+                                                # it gates money movement without moving money itself.
+                                                # four-eyes assessed: the only REST surface is POST /vop/verify (vop.verify), a
+                                                # read-shaped check that mints nothing and decides nothing a human could collude on
+                                                # — there is nothing to maker-checker gate. The action that WOULD deserve a gate is
+                                                # a runtime change to `openbank.vop.max-edit-distance`: widening it silently turns
+                                                # genuine mismatches into reassuring amber warnings (threat model §3 Tampering).
+                                                # It is gitops-only config today, so it is covered by PR review rather than
+                                                # four_eyes.verbs; add a `vop.flip` verb here if it ever becomes operator-tunable.
+      - openbank-standing-order-service        # issue #2188: StandingOrderDueConsumer POSTs a real SCT to
+                                                # sepa-payment `/api/v1/sepa-payments` for every due order (#889, merged) —
+                                                # initiates money movement like sdd, not adjacent to it. Same class as sdd:
+                                                # it shapes the instruction, the irreversible debit lives downstream in a
+                                                # gated money-path service. Threat model:
+                                                # docs/threat-models/openbank-standing-order-service.md.
+                                                # four-eyes assessed: the only money-moving path is the scheduler-driven
+                                                # consumer (no human in the loop by design); the REST surface is
+                                                # customer/operator CRUD on orders (create/amend/pause/resume/cancel), whose
+                                                # effect is a FUTURE scheduled debit, not an immediate one — pausing or
+                                                # cancelling an order REDUCES money movement. There is no operator
+                                                # force-execute endpoint to maker-checker gate; add a verb here if one is
+                                                # ever added. Runs AUTHZ_ENFORCE=false (advisory) — joins the #3679 cohort.
+      - openbank-psd2-service                  # issue #2188 sibling sweep: PaymentInitiationService (PIS) calls
 
     money_path_action_prefixes:
       sepa-payment: [sepaPayment]

--- a/openbank-infra/gitops/components/psd2-service/psd2-service.yaml
+++ b/openbank-infra/gitops/components/psd2-service/psd2-service.yaml
@@ -18,7 +18,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-psd2-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "a1935b29ef2b64d6"
+        openbank.tech/policy-checksum: "d3a8591d24d14a41"
       labels: {app.kubernetes.io/name: psd2-service, app.kubernetes.io/part-of: psd2}
     spec:
       securityContext:

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sanctions-service
     app.kubernetes.io/part-of: sanctions
   annotations:
-    openbank.tech/policy-checksum: "33abcab12d5dc10c"
+    openbank.tech/policy-checksum: "37e83aab62c22ead"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1578,6 +1578,29 @@ data:
                                                 # sanctions.clear (deciding a screening hit) — the highest-risk action in this
                                                 # service, since a wrongly-cleared true positive is a real sanctions violation.
       - openbank-vop-service                   # ADR-0171: Verification of Payee (IPR Art. 5c) — sits on the pre-execution path of
+                                                # every euro credit transfer. Money-path for the same reason sca/consent/fraud are:
+                                                # it gates money movement without moving money itself.
+                                                # four-eyes assessed: the only REST surface is POST /vop/verify (vop.verify), a
+                                                # read-shaped check that mints nothing and decides nothing a human could collude on
+                                                # — there is nothing to maker-checker gate. The action that WOULD deserve a gate is
+                                                # a runtime change to `openbank.vop.max-edit-distance`: widening it silently turns
+                                                # genuine mismatches into reassuring amber warnings (threat model §3 Tampering).
+                                                # It is gitops-only config today, so it is covered by PR review rather than
+                                                # four_eyes.verbs; add a `vop.flip` verb here if it ever becomes operator-tunable.
+      - openbank-standing-order-service        # issue #2188: StandingOrderDueConsumer POSTs a real SCT to
+                                                # sepa-payment `/api/v1/sepa-payments` for every due order (#889, merged) —
+                                                # initiates money movement like sdd, not adjacent to it. Same class as sdd:
+                                                # it shapes the instruction, the irreversible debit lives downstream in a
+                                                # gated money-path service. Threat model:
+                                                # docs/threat-models/openbank-standing-order-service.md.
+                                                # four-eyes assessed: the only money-moving path is the scheduler-driven
+                                                # consumer (no human in the loop by design); the REST surface is
+                                                # customer/operator CRUD on orders (create/amend/pause/resume/cancel), whose
+                                                # effect is a FUTURE scheduled debit, not an immediate one — pausing or
+                                                # cancelling an order REDUCES money movement. There is no operator
+                                                # force-execute endpoint to maker-checker gate; add a verb here if one is
+                                                # ever added. Runs AUTHZ_ENFORCE=false (advisory) — joins the #3679 cohort.
+      - openbank-psd2-service                  # issue #2188 sibling sweep: PaymentInitiationService (PIS) calls
 
     money_path_action_prefixes:
       sepa-payment: [sepaPayment]

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
@@ -49,7 +49,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sanctions-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "33abcab12d5dc10c"
+        openbank.tech/policy-checksum: "37e83aab62c22ead"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sca-service
     app.kubernetes.io/part-of: sca
   annotations:
-    openbank.tech/policy-checksum: "057f66621add13ab"
+    openbank.tech/policy-checksum: "35277c5843a781ed"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1614,6 +1614,29 @@ data:
                                                 # sanctions.clear (deciding a screening hit) — the highest-risk action in this
                                                 # service, since a wrongly-cleared true positive is a real sanctions violation.
       - openbank-vop-service                   # ADR-0171: Verification of Payee (IPR Art. 5c) — sits on the pre-execution path of
+                                                # every euro credit transfer. Money-path for the same reason sca/consent/fraud are:
+                                                # it gates money movement without moving money itself.
+                                                # four-eyes assessed: the only REST surface is POST /vop/verify (vop.verify), a
+                                                # read-shaped check that mints nothing and decides nothing a human could collude on
+                                                # — there is nothing to maker-checker gate. The action that WOULD deserve a gate is
+                                                # a runtime change to `openbank.vop.max-edit-distance`: widening it silently turns
+                                                # genuine mismatches into reassuring amber warnings (threat model §3 Tampering).
+                                                # It is gitops-only config today, so it is covered by PR review rather than
+                                                # four_eyes.verbs; add a `vop.flip` verb here if it ever becomes operator-tunable.
+      - openbank-standing-order-service        # issue #2188: StandingOrderDueConsumer POSTs a real SCT to
+                                                # sepa-payment `/api/v1/sepa-payments` for every due order (#889, merged) —
+                                                # initiates money movement like sdd, not adjacent to it. Same class as sdd:
+                                                # it shapes the instruction, the irreversible debit lives downstream in a
+                                                # gated money-path service. Threat model:
+                                                # docs/threat-models/openbank-standing-order-service.md.
+                                                # four-eyes assessed: the only money-moving path is the scheduler-driven
+                                                # consumer (no human in the loop by design); the REST surface is
+                                                # customer/operator CRUD on orders (create/amend/pause/resume/cancel), whose
+                                                # effect is a FUTURE scheduled debit, not an immediate one — pausing or
+                                                # cancelling an order REDUCES money movement. There is no operator
+                                                # force-execute endpoint to maker-checker gate; add a verb here if one is
+                                                # ever added. Runs AUTHZ_ENFORCE=false (advisory) — joins the #3679 cohort.
+      - openbank-psd2-service                  # issue #2188 sibling sweep: PaymentInitiationService (PIS) calls
 
     money_path_action_prefixes:
       sepa-payment: [sepaPayment]

--- a/openbank-infra/gitops/components/sca/sca-service.yaml
+++ b/openbank-infra/gitops/components/sca/sca-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sca-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "057f66621add13ab"
+        openbank.tech/policy-checksum: "35277c5843a781ed"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/statements/statement-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/statements/statement-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: statement-service
     app.kubernetes.io/part-of: statements
   annotations:
-    openbank.tech/policy-checksum: "295fea349a6a7b8a"
+    openbank.tech/policy-checksum: "fcf07e290f1b0369"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1644,6 +1644,29 @@ data:
                                                 # sanctions.clear (deciding a screening hit) — the highest-risk action in this
                                                 # service, since a wrongly-cleared true positive is a real sanctions violation.
       - openbank-vop-service                   # ADR-0171: Verification of Payee (IPR Art. 5c) — sits on the pre-execution path of
+                                                # every euro credit transfer. Money-path for the same reason sca/consent/fraud are:
+                                                # it gates money movement without moving money itself.
+                                                # four-eyes assessed: the only REST surface is POST /vop/verify (vop.verify), a
+                                                # read-shaped check that mints nothing and decides nothing a human could collude on
+                                                # — there is nothing to maker-checker gate. The action that WOULD deserve a gate is
+                                                # a runtime change to `openbank.vop.max-edit-distance`: widening it silently turns
+                                                # genuine mismatches into reassuring amber warnings (threat model §3 Tampering).
+                                                # It is gitops-only config today, so it is covered by PR review rather than
+                                                # four_eyes.verbs; add a `vop.flip` verb here if it ever becomes operator-tunable.
+      - openbank-standing-order-service        # issue #2188: StandingOrderDueConsumer POSTs a real SCT to
+                                                # sepa-payment `/api/v1/sepa-payments` for every due order (#889, merged) —
+                                                # initiates money movement like sdd, not adjacent to it. Same class as sdd:
+                                                # it shapes the instruction, the irreversible debit lives downstream in a
+                                                # gated money-path service. Threat model:
+                                                # docs/threat-models/openbank-standing-order-service.md.
+                                                # four-eyes assessed: the only money-moving path is the scheduler-driven
+                                                # consumer (no human in the loop by design); the REST surface is
+                                                # customer/operator CRUD on orders (create/amend/pause/resume/cancel), whose
+                                                # effect is a FUTURE scheduled debit, not an immediate one — pausing or
+                                                # cancelling an order REDUCES money movement. There is no operator
+                                                # force-execute endpoint to maker-checker gate; add a verb here if one is
+                                                # ever added. Runs AUTHZ_ENFORCE=false (advisory) — joins the #3679 cohort.
+      - openbank-psd2-service                  # issue #2188 sibling sweep: PaymentInitiationService (PIS) calls
 
     money_path_action_prefixes:
       sepa-payment: [sepaPayment]

--- a/openbank-infra/gitops/components/statements/statement-service.yaml
+++ b/openbank-infra/gitops/components/statements/statement-service.yaml
@@ -26,7 +26,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-statement-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "295fea349a6a7b8a"
+        openbank.tech/policy-checksum: "fcf07e290f1b0369"
       labels:
         app.kubernetes.io/name: statement-service
         app.kubernetes.io/part-of: statements

--- a/openbank-infra/gitops/components/tpp-registry/tpp-registry-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/tpp-registry/tpp-registry-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: tpp-registry-service
     app.kubernetes.io/part-of: tpp-registry
   annotations:
-    openbank.tech/policy-checksum: "91fd5fc9a627d6e6"
+    openbank.tech/policy-checksum: "a000695b99c89b05"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1581,6 +1581,29 @@ data:
                                                 # sanctions.clear (deciding a screening hit) — the highest-risk action in this
                                                 # service, since a wrongly-cleared true positive is a real sanctions violation.
       - openbank-vop-service                   # ADR-0171: Verification of Payee (IPR Art. 5c) — sits on the pre-execution path of
+                                                # every euro credit transfer. Money-path for the same reason sca/consent/fraud are:
+                                                # it gates money movement without moving money itself.
+                                                # four-eyes assessed: the only REST surface is POST /vop/verify (vop.verify), a
+                                                # read-shaped check that mints nothing and decides nothing a human could collude on
+                                                # — there is nothing to maker-checker gate. The action that WOULD deserve a gate is
+                                                # a runtime change to `openbank.vop.max-edit-distance`: widening it silently turns
+                                                # genuine mismatches into reassuring amber warnings (threat model §3 Tampering).
+                                                # It is gitops-only config today, so it is covered by PR review rather than
+                                                # four_eyes.verbs; add a `vop.flip` verb here if it ever becomes operator-tunable.
+      - openbank-standing-order-service        # issue #2188: StandingOrderDueConsumer POSTs a real SCT to
+                                                # sepa-payment `/api/v1/sepa-payments` for every due order (#889, merged) —
+                                                # initiates money movement like sdd, not adjacent to it. Same class as sdd:
+                                                # it shapes the instruction, the irreversible debit lives downstream in a
+                                                # gated money-path service. Threat model:
+                                                # docs/threat-models/openbank-standing-order-service.md.
+                                                # four-eyes assessed: the only money-moving path is the scheduler-driven
+                                                # consumer (no human in the loop by design); the REST surface is
+                                                # customer/operator CRUD on orders (create/amend/pause/resume/cancel), whose
+                                                # effect is a FUTURE scheduled debit, not an immediate one — pausing or
+                                                # cancelling an order REDUCES money movement. There is no operator
+                                                # force-execute endpoint to maker-checker gate; add a verb here if one is
+                                                # ever added. Runs AUTHZ_ENFORCE=false (advisory) — joins the #3679 cohort.
+      - openbank-psd2-service                  # issue #2188 sibling sweep: PaymentInitiationService (PIS) calls
 
     money_path_action_prefixes:
       sepa-payment: [sepaPayment]

--- a/openbank-infra/gitops/components/tpp-registry/tpp-registry-service.yaml
+++ b/openbank-infra/gitops/components/tpp-registry/tpp-registry-service.yaml
@@ -23,7 +23,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-tpp-registry-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "91fd5fc9a627d6e6"
+        openbank.tech/policy-checksum: "a000695b99c89b05"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-libs/governance/rules-opa-data.yaml
+++ b/openbank-libs/governance/rules-opa-data.yaml
@@ -73,6 +73,29 @@ money_path_services:
                                             # sanctions.clear (deciding a screening hit) — the highest-risk action in this
                                             # service, since a wrongly-cleared true positive is a real sanctions violation.
   - openbank-vop-service                   # ADR-0171: Verification of Payee (IPR Art. 5c) — sits on the pre-execution path of
+                                            # every euro credit transfer. Money-path for the same reason sca/consent/fraud are:
+                                            # it gates money movement without moving money itself.
+                                            # four-eyes assessed: the only REST surface is POST /vop/verify (vop.verify), a
+                                            # read-shaped check that mints nothing and decides nothing a human could collude on
+                                            # — there is nothing to maker-checker gate. The action that WOULD deserve a gate is
+                                            # a runtime change to `openbank.vop.max-edit-distance`: widening it silently turns
+                                            # genuine mismatches into reassuring amber warnings (threat model §3 Tampering).
+                                            # It is gitops-only config today, so it is covered by PR review rather than
+                                            # four_eyes.verbs; add a `vop.flip` verb here if it ever becomes operator-tunable.
+  - openbank-standing-order-service        # issue #2188: StandingOrderDueConsumer POSTs a real SCT to
+                                            # sepa-payment `/api/v1/sepa-payments` for every due order (#889, merged) —
+                                            # initiates money movement like sdd, not adjacent to it. Same class as sdd:
+                                            # it shapes the instruction, the irreversible debit lives downstream in a
+                                            # gated money-path service. Threat model:
+                                            # docs/threat-models/openbank-standing-order-service.md.
+                                            # four-eyes assessed: the only money-moving path is the scheduler-driven
+                                            # consumer (no human in the loop by design); the REST surface is
+                                            # customer/operator CRUD on orders (create/amend/pause/resume/cancel), whose
+                                            # effect is a FUTURE scheduled debit, not an immediate one — pausing or
+                                            # cancelling an order REDUCES money movement. There is no operator
+                                            # force-execute endpoint to maker-checker gate; add a verb here if one is
+                                            # ever added. Runs AUTHZ_ENFORCE=false (advisory) — joins the #3679 cohort.
+  - openbank-psd2-service                  # issue #2188 sibling sweep: PaymentInitiationService (PIS) calls
 
 money_path_action_prefixes:
   sepa-payment: [sepaPayment]

--- a/openbank-libs/governance/rules.yaml
+++ b/openbank-libs/governance/rules.yaml
@@ -749,6 +749,31 @@ money_path_services:
                                             # genuine mismatches into reassuring amber warnings (threat model §3 Tampering).
                                             # It is gitops-only config today, so it is covered by PR review rather than
                                             # four_eyes.verbs; add a `vop.flip` verb here if it ever becomes operator-tunable.
+  - openbank-standing-order-service        # issue #2188: StandingOrderDueConsumer POSTs a real SCT to
+                                            # sepa-payment `/api/v1/sepa-payments` for every due order (#889, merged) —
+                                            # initiates money movement like sdd, not adjacent to it. Same class as sdd:
+                                            # it shapes the instruction, the irreversible debit lives downstream in a
+                                            # gated money-path service. Threat model:
+                                            # docs/threat-models/openbank-standing-order-service.md.
+                                            # four-eyes assessed: the only money-moving path is the scheduler-driven
+                                            # consumer (no human in the loop by design); the REST surface is
+                                            # customer/operator CRUD on orders (create/amend/pause/resume/cancel), whose
+                                            # effect is a FUTURE scheduled debit, not an immediate one — pausing or
+                                            # cancelling an order REDUCES money movement. There is no operator
+                                            # force-execute endpoint to maker-checker gate; add a verb here if one is
+                                            # ever added. Runs AUTHZ_ENFORCE=false (advisory) — joins the #3679 cohort.
+  - openbank-psd2-service                  # issue #2188 sibling sweep: PaymentInitiationService (PIS) calls
+                                            # transactionClient.initiatePayment for SCT/SCT_INST/domestic/SIPO — it
+                                            # initiates real payments like sdd/standing-order do, consent- and
+                                            # SCA-gated upstream (ADR-0090, ADR-0126). Already treated as money-path
+                                            # by the OPA-bundle converge work (#3422); this makes the list agree.
+                                            # Threat model: docs/threat-models/openbank-psd2-service.md.
+                                            # four-eyes assessed: initiation is TPP-driven under an eIDAS consent with
+                                            # SCA on the debtor — a maker/checker pair does not exist for a
+                                            # customer-consented machine flow; the bank-side actions that WOULD deserve
+                                            # a gate (TPP revocation, consent termination by an operator) are not
+                                            # wired as operator verbs today. Runs AUTHZ_ENFORCE=false (advisory) —
+                                            # joins the #3679 cohort.
 
 # ---------------------------------------------------------------------------------------
 # SLOs (issue #669 — operational evidence, scope item 3). Governed data: a single


### PR DESCRIPTION
## What

Adds `openbank-standing-order-service` and `openbank-psd2-service` to `rules.yaml: money_path_services`.

**standing-order** (the issue's finding): `StandingOrderDueConsumer` POSTs a real SCT to sepa-payment `/api/v1/sepa-payments` for every due order (#889) — it initiates money movement like sdd, not adjacent to it, but was absent from the list, so the threat-model / SLO / 2-approval requirements did not bind it (they did not bind PR #2180).

**psd2** (the issue's "worth checking at the same time" sibling sweep): `PaymentInitiationService` (PIS) calls `transactionClient.initiatePayment` for SCT / SCT_INST / domestic / SIPO — the same initiates-real-payments class as sdd. The OPA-bundle converge work (#3422) already treats psd2 as money-path; this makes the enforced list agree. The rest of the sweep (aml, card-issuance, dispute, mcp, ap2, tax-reporting, campaign, customer-edge, analytics-sink, kyc) found no other service that initiates fund movement — mcp/customer-edge only proxy authenticated callers.

## What lands together (a list edit alone would go red)

- `rules.yaml` — both entries with four-eyes assessments + the `AUTHZ_ENFORCE=false` (advisory) caveat. **Both join the #3679 cohort** — this change buys the threat model, the SLOs and the (currently unenforced, #2183) 2-approval rule, not runtime authz enforcement.
- `docs/threat-models/openbank-standing-order-service.md` — new lightweight STRIDE model (ADR-0030 D2). psd2 already ships one.
- `pyrra-slo-money-path.yaml` — governed availability + latency SLO pair per service (`check-slo-registry.py` is required).
- `rules-opa-data.yaml` regenerated + all 36 OPA bundles restamped — `money_path_services` is policy-read data (`data.rules.*`), so every service's bundle + policy-checksum annotation moves. Pods will roll on sync; that is the mechanism working as designed.

## Verified locally

- `check-slo-registry.py` — OK, 23 services / 46 objects
- `check-threat-models.py` — OK, all 23
- `check-podmonitor-namespace-coverage.py` — OK (payments + psd2 namespaces scraped)
- `check-accounting-clock.py --enforce` — OK for both new entries
- `check-finops-tiers.py` — no findings
- yamllint (CI config) — clean on the pyrra manifest and the whole components tree
- bundle regeneration idempotent (second run: no diff); ledger bundle embeds both new entries

The `public-readiness-audit.sh` gitleaks failure is a pre-existing full-history finding, identical without this change.

Closes #2188
Refs #2183, #3679, #3422