### PR TITLE
feat(delegation): enforce OPA authorization (AUTHZ_ENFORCE=true)

### DIFF
--- a/openbank-infra/gitops/components/delegation/delegation-service.yaml
+++ b/openbank-infra/gitops/components/delegation/delegation-service.yaml
@@ -147,14 +147,13 @@ spec:
             # app dies with InactiveBeanException.
             - name: QUARKUS_REDIS_HOSTS
               value: redis://redis.delegation.svc:6379
-            # Kept ADVISORY (false) for the first rollout: the interceptor evaluates and
-            # records every decision but does NOT block while false, so the "would DENY"
-            # population can be confirmed empty in the live decision log before the
-            # enforce flip (a separate, deliberate follow-up per the rules.yaml guardrail).
-            # Flipping this before the sidecar is confirmed serving means failing closed on
-            # every call.
+            # OPA sidecar enforced (issue #3679). Advisory through the first rollout; coverage
+            # verified before the flip: delegation_rest_ext.rego grants all ten actions with the
+            # caller-narrowed rules (operator writes exclude service accounts, the edge principal
+            # is scoped to the customer action set, delegation.check is the only M2M action), and
+            # the sole declared caller is the admin-ui relaying a human operator's token.
             - name: AUTHZ_ENFORCE
-              value: "false"
+              value: "true"
           resources:
             requests:
               cpu: 100m


### PR DESCRIPTION
## Summary

Flips `AUTHZ_ENFORCE` to `true` for openbank-delegation-service (issue #3679) — OPA authorization moves from advisory (log-only) to enforced. Money-path service: threat model exists (docs/threat-models/openbank-delegation-service.md), 2 approvals required.

## Type of change

- [x] feat (behavior change: authorization now enforced)
- [ ] breaking change

## Linked issues

Refs #3679

## Pre-flip coverage verification (per the issue's phased plan)

 - All ten @Authorize actions are granted by `delegation_rest_ext.rego` with caller-narrowed rules: operator writes exclude `service-account-*`, the edge principal is scoped to the customer action set only, `delegation.check` is the sole M2M-reachable action.
- Sole declared ingress caller: admin-ui relaying a human operator's bearer token (network-policies).
- `./gradlew :openbank-delegation-service:test` green locally.
- gen-network-policies drift gate verified unaffected (generator output identical; the local gate failure was the uncommitted-change artifact).

## Reviewer checklist (money-path)

- [ ] Confirm the advisory-window decision log showed no unexpected would-DENYs (live check — not verifiable from the repo).
- [ ] Threat model: docs/threat-models/openbank-delegation-service.md

## Security checklist

- [x] No secrets / PII.
- [x] Auth code unchanged — this flips enforcement of the existing policy, it does not change policy logic.
- [x] Auth change → tag `security-review-required`.

## Compliance impact

- [ ] PCI DSS
- [x] DORA — ICT access control now enforced, not advisory
- [ ] GDPR
- [ ] PSD2 / SCA / RTS
- [ ] AML / 5AMLD
- [ ] CNB reporting
