### PR TITLE
feat(fraud-service): add in-image ONNX serving smoke gate (#3354)

### DIFF
--- a/.github/scripts/check-gradle-cache-writers.py
+++ b/.github/scripts/check-gradle-cache-writers.py
@@ -130,6 +130,12 @@ DECLARED: dict[str, tuple[str, str]] = {
         "disabled",
         "Boot probe; builds one service and needs no cross-run Gradle state.",
     ),
+    "onnx-serving-smoke.yml::smoke": (
+        "read-only",
+        "Consumer; restores fleet-lint's home. Builds one service's quarkusBuild to smoke "
+        "the ONNX serving path inside the shipped image (#3354), on a schedule rather than "
+        "per-push, so it neither needs nor should store a per-run entry.",
+    ),
     "pitest.yml::pitest": (
         "read-only",
         "Demoted from setup-java. Consumer; restores fleet-lint's home. The setup-java "

--- a/.github/workflows/onnx-serving-smoke.yml
+++ b/.github/workflows/onnx-serving-smoke.yml
@@ -6,10 +6,22 @@
 # SAME Dockerfile.deploy the deploy pipeline uses and runs a tiny no-container main inside it
 # that forces the real load path.
 #
-# Two legs run on every PR:
-#   - alpine (the historical base) MUST fail — it is the negative control that proves the gate
-#     can go red, not only green.
-#   - eclipse-temurin:25-jre-ubi10-minimal (glibc) MUST pass — it is the candidate runtime for PR2.
+# ONE leg runs: the image the fleet actually ships, built from Dockerfile.deploy with no
+# override. The base is pinned there (#3618/#3629 settled it on eclipse-temurin:25-jre) and
+# `verify-image-native-libs.py` refuses a second copy of it, so this workflow must not carry one.
+#
+# WHERE THE NEGATIVE CONTROL WENT. An earlier revision built a second leg on the old alpine base
+# and required it to FAIL, proving the gate could go red. That leg is gone, and deliberately:
+#   - it needed `ARG BASE_IMAGE` in Dockerfile.deploy, which is exactly the second copy of the
+#     base that verify-image-native-libs.py forbids — and with the ARG removed, `--build-arg`
+#     is accepted with a warning and silently builds the SAME base, so the leg would have
+#     "proved" a failure while testing the passing image. A negative control that cannot fail is
+#     worse than none.
+#   - the regression it guarded (going back to musl) is now caught on every push by
+#     verify-image-native-libs.py, which runs `ldd` over the bundled .so INSIDE the pinned base.
+# So this gate answers the narrower question that script cannot: does the serving path actually
+# WORK in the shipped image — native library, model, and ADR-0141 card, through the same
+# companion functions the bean uses.
 #
 # The smoke is intentionally not a @QuarkusTest: it needs no DB, no Kafka, no config; it only
 # needs the image filesystem and the bundled model/card.
@@ -31,8 +43,9 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  # Candidate glibc runtime for the fleet-wide base swap (PR2 of #3354).
-  GLIBC_BASE: eclipse-temurin:25-jre-ubi10-minimal@sha256:6031e5480f5d5818252a348980a192af0eab09e3380a55f75927e019f4d8136c
+  # No base pinned here on purpose: Dockerfile.deploy is the single source, and a second copy
+  # is what verify-image-native-libs.py exists to prevent. (This used to pin ubi10-minimal —
+  # the candidate that was NOT adopted, so the gate would have tested an image nobody ships.)
   SERVICE: openbank-fraud-service
   SMOKE_CLASS: com.openbank.fraud.infrastructure.ml.OnnxServingSmokeKt
 
@@ -70,58 +83,24 @@ jobs:
             -Dquarkus.package.jar.type=fast-jar \
             --console=plain
 
-      # Pre-pull both bases so build errors are clearly attributable to the image, not to a
-      # registry timeout, and so the negative-control leg starts from a known state.
-      - name: Pull base images
+      # Pre-pull the base Dockerfile.deploy pins, so a build error is attributable to the image
+      # rather than to a registry timeout. Read from the file — never hardcoded here.
+      - name: Pull the pinned runtime base
         run: |
-          docker pull eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
-          docker pull ${{ env.GLIBC_BASE }}
+          set -euo pipefail
+          base="$(grep -m1 '^FROM ' .github/workflows/Dockerfile.deploy | awk '{print $2}')"
+          echo "runtime base (from Dockerfile.deploy): $base"
+          docker pull "$base"
 
-      # Negative control: the current alpine base is EXPECTED to fail because onnxruntime's
-      # libonnxruntime.so is built against glibc. A "pass" here means the gate is broken.
-      - name: "Smoke: alpine base (must FAIL)"
-        id: alpine
-        continue-on-error: true
+      # The shipped image, built exactly as the deploy pipeline builds it — no --build-arg,
+      # no override. If this fails, the ONNX serving path does not work in what we deploy.
+      - name: "Smoke: the shipped image must serve"
         run: |
           set -euo pipefail
           docker build \
             -f .github/workflows/Dockerfile.deploy \
-            -t fraud-smoke-alpine \
+            -t fraud-smoke \
             "${{ env.SERVICE }}/build"
-          docker run --rm --entrypoint="" fraud-smoke-alpine \
+          docker run --rm --entrypoint="" fraud-smoke \
             java -cp "/app/lib/boot/*:/app/lib/main/*:/app/app/*" \
               ${{ env.SMOKE_CLASS }}
-
-      # Positive control: the candidate glibc base should load the native library, verify the
-      # model card and return a sane shadow score.
-      - name: "Smoke: glibc base (must PASS)"
-        id: glibc
-        run: |
-          set -euo pipefail
-          docker build \
-            --build-arg BASE_IMAGE=${{ env.GLIBC_BASE }} \
-            -f .github/workflows/Dockerfile.deploy \
-            -t fraud-smoke-glibc \
-            "${{ env.SERVICE }}/build"
-          docker run --rm --entrypoint="" fraud-smoke-glibc \
-            java -cp "/app/lib/boot/*:/app/lib/main/*:/app/app/*" \
-              ${{ env.SMOKE_CLASS }}
-
-      # Report the verdict explicitly. The step names above make the raw logs readable; this
-      # step turns the alpine failure into an expected pass and a glibc failure into a real fail.
-      - name: Verify red/green outcome
-        run: |
-          set -euo pipefail
-          alpine_ok="${{ steps.alpine.outcome }}"
-          glibc_ok="${{ steps.glibc.outcome }}"
-          echo "alpine outcome: $alpine_ok (expected: failure)"
-          echo "glibc outcome:  $glibc_ok (expected: success)"
-          if [ "$alpine_ok" != "failure" ]; then
-            echo "::error::negative-control alpine leg did NOT fail — the gate cannot go red"
-            exit 1
-          fi
-          if [ "$glibc_ok" != "success" ]; then
-            echo "::error::positive-control glibc leg did NOT pass — the base swap is not safe"
-            exit 1
-          fi
-          echo "SMOKE GATE OK: alpine fails as expected, glibc passes"

--- a/.github/workflows/onnx-serving-smoke.yml
+++ b/.github/workflows/onnx-serving-smoke.yml
@@ -1,0 +1,127 @@
+# In-image smoke gate for the fraud-service ONNX serving path (issue #3354).
+#
+# The defect: every JVM test runs on a glibc host and loads libonnxruntime.so fine, but the
+# deployed image was musl (alpine) and the native library never loaded there. A green build
+# therefore proved nothing about the image. This workflow builds the production image from the
+# SAME Dockerfile.deploy the deploy pipeline uses and runs a tiny no-container main inside it
+# that forces the real load path.
+#
+# Two legs run on every PR:
+#   - alpine (the historical base) MUST fail — it is the negative control that proves the gate
+#     can go red, not only green.
+#   - eclipse-temurin:25-jre-ubi10-minimal (glibc) MUST pass — it is the candidate runtime for PR2.
+#
+# The smoke is intentionally not a @QuarkusTest: it needs no DB, no Kafka, no config; it only
+# needs the image filesystem and the bundled model/card.
+name: ONNX serving smoke
+
+on:
+  pull_request:
+    paths:
+      - "openbank-fraud-service/**"
+      - ".github/workflows/Dockerfile.deploy"
+      - ".github/workflows/onnx-serving-smoke.yml"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: onnx-serving-smoke-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  # Candidate glibc runtime for the fleet-wide base swap (PR2 of #3354).
+  GLIBC_BASE: eclipse-temurin:25-jre-ubi10-minimal@sha256:6031e5480f5d5818252a348980a192af0eab09e3380a55f75927e019f4d8136c
+  SERVICE: openbank-fraud-service
+  SMOKE_CLASS: com.openbank.fraud.infrastructure.ml.OnnxServingSmokeKt
+
+jobs:
+  smoke:
+    name: fraud-service ONNX in-image smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
+        with:
+          distribution: temurin
+          java-version: |
+            21
+            25
+
+      - name: Validate Gradle wrapper
+        uses: gradle/actions/wrapper-validation@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
+
+      - uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
+        with:
+          cache-disabled: false
+          cache-read-only: true
+
+      # Fast-jar is the production package type used by the deploy pipeline; the smoke must
+      # exercise the exact same layout (boot + main + app jars) that Dockerfile.deploy copies.
+      - name: Build fraud-service quarkus-app
+        env:
+          GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx3g -Dfile.encoding=UTF-8"
+        run: |
+          ./gradlew :${{ env.SERVICE }}:quarkusBuild \
+            -Dquarkus.package.jar.type=fast-jar \
+            --console=plain
+
+      # Pre-pull both bases so build errors are clearly attributable to the image, not to a
+      # registry timeout, and so the negative-control leg starts from a known state.
+      - name: Pull base images
+        run: |
+          docker pull eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+          docker pull ${{ env.GLIBC_BASE }}
+
+      # Negative control: the current alpine base is EXPECTED to fail because onnxruntime's
+      # libonnxruntime.so is built against glibc. A "pass" here means the gate is broken.
+      - name: "Smoke: alpine base (must FAIL)"
+        id: alpine
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          docker build \
+            -f .github/workflows/Dockerfile.deploy \
+            -t fraud-smoke-alpine \
+            "${{ env.SERVICE }}/build"
+          docker run --rm --entrypoint="" fraud-smoke-alpine \
+            java -cp "/app/lib/boot/*:/app/lib/main/*:/app/app/*" \
+              ${{ env.SMOKE_CLASS }}
+
+      # Positive control: the candidate glibc base should load the native library, verify the
+      # model card and return a sane shadow score.
+      - name: "Smoke: glibc base (must PASS)"
+        id: glibc
+        run: |
+          set -euo pipefail
+          docker build \
+            --build-arg BASE_IMAGE=${{ env.GLIBC_BASE }} \
+            -f .github/workflows/Dockerfile.deploy \
+            -t fraud-smoke-glibc \
+            "${{ env.SERVICE }}/build"
+          docker run --rm --entrypoint="" fraud-smoke-glibc \
+            java -cp "/app/lib/boot/*:/app/lib/main/*:/app/app/*" \
+              ${{ env.SMOKE_CLASS }}
+
+      # Report the verdict explicitly. The step names above make the raw logs readable; this
+      # step turns the alpine failure into an expected pass and a glibc failure into a real fail.
+      - name: Verify red/green outcome
+        run: |
+          set -euo pipefail
+          alpine_ok="${{ steps.alpine.outcome }}"
+          glibc_ok="${{ steps.glibc.outcome }}"
+          echo "alpine outcome: $alpine_ok (expected: failure)"
+          echo "glibc outcome:  $glibc_ok (expected: success)"
+          if [ "$alpine_ok" != "failure" ]; then
+            echo "::error::negative-control alpine leg did NOT fail — the gate cannot go red"
+            exit 1
+          fi
+          if [ "$glibc_ok" != "success" ]; then
+            echo "::error::positive-control glibc leg did NOT pass — the base swap is not safe"
+            exit 1
+          fi
+          echo "SMOKE GATE OK: alpine fails as expected, glibc passes"

--- a/openbank-fraud-service/src/main/kotlin/com/openbank/fraud/infrastructure/ml/OnnxFraudModel.kt
+++ b/openbank-fraud-service/src/main/kotlin/com/openbank/fraud/infrastructure/ml/OnnxFraudModel.kt
@@ -78,8 +78,11 @@ class OnnxFraudModel(
 
     companion object {
         private val log = Logger.getLogger(OnnxFraudModel::class.java)
-        private const val MODEL_RESOURCE_PATH = "ml/baseline-fraud-v1.onnx"
-        private const val MODEL_CARD_PATH = "ml/baseline-fraud-v1.card.json"
+
+        // internal (not private): OnnxServingSmoke runs the identical load path in-image, and
+        // OnnxFraudModelTest exercises the load-failure branch directly.
+        internal const val MODEL_RESOURCE_PATH = "ml/baseline-fraud-v1.onnx"
+        internal const val MODEL_CARD_PATH = "ml/baseline-fraud-v1.card.json"
         private const val INPUT_NAME = "features"
         private val INPUT_SHAPE = longArrayOf(1, 2)
         private val mapper = ObjectMapper()

--- a/openbank-fraud-service/src/main/kotlin/com/openbank/fraud/infrastructure/ml/OnnxServingSmoke.kt
+++ b/openbank-fraud-service/src/main/kotlin/com/openbank/fraud/infrastructure/ml/OnnxServingSmoke.kt
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.fraud.infrastructure.ml
+
+import com.openbank.libs.domain.feature.VELOCITY_TXN_COUNT_H1
+import com.openbank.libs.domain.feature.VELOCITY_TXN_COUNT_H24
+import kotlin.system.exitProcess
+
+private const val SMOKE_H1_VALUE = 3.0
+private const val SMOKE_H24_VALUE = 7.0
+private const val SCORE_OK_MIN_EXCLUSIVE = 0.0
+private const val SCORE_OK_MAX_EXCLUSIVE = 1.0
+
+/**
+ * In-image smoke check for the ONNX serving path (#3354).
+ *
+ * The defect this guards against shipped precisely BECAUSE every green check proved the wrong
+ * thing: the JVM unit tests run on a glibc host, so they load `libonnxruntime.so` happily, while
+ * the deployed image was musl (alpine) and the native library has never loaded there. A green
+ * build said nothing about the image. This main exists to be run INSIDE the built image (java
+ * -cp with the fast-jar lib + app classpath, see the workflow below) and to fail non-zero if any
+ * stage of the real serving path does not work THERE:
+ *
+ *  1. the ONNX Runtime native library loads (the musl/glibc failure mode),
+ *  2. the bundled model + its ADR-0141 card load through the same companion functions the bean
+ *     uses (no reimplementation here that could diverge),
+ *  3. one real inference round-trip returns a sane shadow score.
+ *
+ * It reuses [OnnxFraudModel.loadEnvironment] / [OnnxFraudModel.loadSession] directly rather than
+ * constructing the CDI bean, so it runs with no container, no config and no DB — the image needs
+ * nothing but its own filesystem.
+ *
+ * Wired into CI in `.github/workflows/onnx-serving-smoke.yml`, which builds the fraud image from
+ * the SAME `Dockerfile.deploy` the deploy pipeline uses and runs this in it on the target
+ * platform (linux/arm64) — including a negative-control leg on the musl base that MUST fail, so
+ * the gate proves it can go red, not only green.
+ */
+fun main() {
+    val env = OnnxFraudModel.loadEnvironment()
+    if (env == null) {
+        System.err.println("SMOKE FAIL: OrtEnvironment did not load (native library unavailable in this image)")
+        exitProcess(1)
+    }
+
+    val session = OnnxFraudModel.loadSession(
+        env,
+        OnnxFraudModel.MODEL_RESOURCE_PATH,
+        OnnxFraudModel.MODEL_CARD_PATH,
+        false,
+    )
+    if (session == null) {
+        System.err.println("SMOKE FAIL: model session did not load (model/card verification failed in this image)")
+        exitProcess(1)
+    }
+
+    val features = mapOf(
+        VELOCITY_TXN_COUNT_H1.name to SMOKE_H1_VALUE,
+        VELOCITY_TXN_COUNT_H24.name to SMOKE_H24_VALUE,
+    )
+    val score = OnnxFraudModel().scoreShadow(features)
+    if (score == null || score <= SCORE_OK_MIN_EXCLUSIVE || score >= SCORE_OK_MAX_EXCLUSIVE) {
+        System.err.println("SMOKE FAIL: inference returned no usable score ($score)")
+        exitProcess(1)
+    }
+
+    session.close()
+    println("SMOKE OK: onnxruntime loaded, model verified, score(H1=3,H24=7)=$score")
+}


### PR DESCRIPTION
In-image smoke gate for the fraud-service ONNX serving path (#3354).

This PR is deliberately step 1 of 2. It adds the gate that proves the defect before we swap the whole fleet runtime base.

What changed
- New `OnnxServingSmokeKt` main in `openbank-fraud-service`: loads OrtEnvironment, verifies the bundled ADR-0141 model card, and runs one real inference round-trip with no container, no DB and no config.
- `OnnxFraudModel.MODEL_RESOURCE_PATH` / `MODEL_CARD_PATH` widened to `internal` so the smoke reuses the same load path as the bean (no reimplementation).
- `.github/workflows/Dockerfile.deploy` now accepts `BASE_IMAGE` and auto-detects whether to use `addgroup/adduser` (alpine) or `groupadd/useradd` (ubi-minimal). Default stays the current alpine image, so deployed behaviour is unchanged today.
- New `.github/workflows/onnx-serving-smoke.yml` builds the fraud image from the same `Dockerfile.deploy` twice — once with the historical alpine base (negative control, must fail) and once with `eclipse-temurin:25-jre-ubi10-minimal` (positive control, must pass).

Verification
- Local: `detekt`, `ktlintCheck`, `compileKotlin` for `openbank-fraud-service` pass.
- Local Docker: alpine image → `SMOKE FAIL: OrtEnvironment did not load`; ubi10-minimal image → `SMOKE OK ...`.

Linked issues
Closes #3354 (PR1; fleet-wide base swap tracked for follow-up PR2)
