### PR TITLE
build(infra): move fleet runtime base from alpine/musl to ubi10-minimal glibc

### DIFF
--- a/.github/workflows/Dockerfile.deploy
+++ b/.github/workflows/Dockerfile.deploy
@@ -1,6 +1,17 @@
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+ARG BASE_IMAGE=eclipse-temurin:25-jre-ubi10-minimal@sha256:6031e5480f5d5818252a348980a192af0eab09e3380a55f75927e019f4d8136c
+FROM ${BASE_IMAGE}
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+
+# The deploy pipeline historically used an alpine base (musl). Issue #3354 moves the
+# fleet to a glibc runtime, so this Dockerfile must accept either base without a hard
+# rewrite. Alpine ships addgroup/adduser; RHEL-based bases (ubi-minimal) ship
+# groupadd/useradd via shadow-utils. Pick whichever is present and always drop to a
+# non-root user — the smoke gate (onnx-serving-smoke.yml) exercises the same path.
+RUN if command -v addgroup >/dev/null 2>&1 && command -v adduser >/dev/null 2>&1; then \
+        addgroup -S openbank && adduser -S openbank -G openbank; \
+    else \
+        groupadd -r openbank && useradd -r -g openbank openbank; \
+    fi
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -569,8 +569,8 @@ fire from *outside* it, so they stay here:
   `openbank-admin-ui/scripts/generate-cluster-topology.mjs` parses
   `openbank-ledger-service/Dockerfile` in `imageFacts()` and renders the base image into the
   /docs/cluster dossier (ADR-0081) — and when it cannot parse one it falls back to a HARDCODED
-  `eclipse-temurin:25-jre-alpine` literal, so removing the declaration would have resurrected the
-  fiction in the UI instead of retiring it (#3354, #3630). A second reader that is a *generator
+  `eclipse-temurin:25-jre-ubi10-minimal` literal, so removing the declaration would have resurrected
+  the fiction in the UI instead of retiring it (#3354, #3630). A second reader that is a *generator
   in another tree* is invisible from the file, from the deploy pipeline, and from the gate that
   owns the file's shape.
 - **An oversized `run:` script makes the WHOLE workflow unparseable — and GitHub says nothing.**

--- a/Dockerfile.scanner
+++ b/Dockerfile.scanner
@@ -1,6 +1,6 @@
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre-ubi10-minimal@sha256:6031e5480f5d5818252a348980a192af0eab09e3380a55f75927e019f4d8136c
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd -r openbank && useradd -r -g openbank openbank
 USER openbank
 COPY openbank-security-scanner/build/openbank-security-scanner-0.1.0-SNAPSHOT-runner.jar /app/quarkus-run.jar
 EXPOSE 8120

--- a/openbank-account-service/Dockerfile
+++ b/openbank-account-service/Dockerfile
@@ -15,9 +15,9 @@
 # Adding a build stage back here is enforced against by
 # .github/scripts/check-dockerfile-no-build-stage.py.
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre-ubi10-minimal@sha256:6031e5480f5d5818252a348980a192af0eab09e3380a55f75927e019f4d8136c
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd -r openbank && useradd -r -g openbank openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-admin-ui/cluster-topology.json
+++ b/openbank-admin-ui/cluster-topology.json
@@ -1,7 +1,7 @@
 {
   "schema": "openbank.cluster-topology/v1",
   "source": "derived (GitOps apps + manifests + a representative Dockerfile + Deployment securityContext) — ADR-0081",
-  "generatedAt": "2026-08-04T08:06:31.000Z",
+  "generatedAt": "2026-08-04T09:01:07.000Z",
   "counts": {
     "namespaces": 68,
     "networkPolicies": 108,
@@ -560,22 +560,22 @@
   ],
   "imageAnatomy": {
     "multiStage": false,
-    "buildBase": "eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0",
-    "runtimeBase": "eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0",
+    "buildBase": "eclipse-temurin:25-jre-ubi10-minimal@sha256:6031e5480f5d5818252a348980a192af0eab09e3380a55f75927e019f4d8136c",
+    "runtimeBase": "eclipse-temurin:25-jre-ubi10-minimal@sha256:6031e5480f5d5818252a348980a192af0eab09e3380a55f75927e019f4d8136c",
     "steps": [
       {
         "id": "build",
         "label": "Build stage (JDK)",
         "status": "live",
         "adr": [],
-        "detail": "Plný JDK (eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0) zkompiluje a sestaví aplikaci. Tento stage se NEDISTRIBUUJE — zůstává v něm jen nářadí."
+        "detail": "Plný JDK (eclipse-temurin:25-jre-ubi10-minimal@sha256:6031e5480f5d5818252a348980a192af0eab09e3380a55f75927e019f4d8136c) zkompiluje a sestaví aplikaci. Tento stage se NEDISTRIBUUJE — zůstává v něm jen nářadí."
       },
       {
         "id": "runtime",
         "label": "Runtime stage (JRE-only)",
         "status": "live",
         "adr": [],
-        "detail": "Distribuuje se jen štíhlý JRE (eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0) + aplikace. Menší image = menší útočná plocha, žádný kompilátor/shell nářadí navíc."
+        "detail": "Distribuuje se jen štíhlý JRE (eclipse-temurin:25-jre-ubi10-minimal@sha256:6031e5480f5d5818252a348980a192af0eab09e3380a55f75927e019f4d8136c) + aplikace. Menší image = menší útočná plocha, žádný kompilátor/shell nářadí navíc."
       },
       {
         "id": "nonroot",

--- a/openbank-admin-ui/src/test/origination-pipeline.test.tsx
+++ b/openbank-admin-ui/src/test/origination-pipeline.test.tsx
@@ -64,6 +64,10 @@ describe('wrap', () => {
 })
 
 describe('OriginationPipeline', () => {
+  beforeEach(() => {
+    vi.spyOn(Date, 'now').mockReturnValue(NOW)
+  })
+
   it('tints a waiting stage by how long the oldest item has waited', () => {
     render(React.createElement(Providers, null, React.createElement(OriginationPipeline, {
       items: [item('ASSESSMENT', 1), item('FOUR_EYES', 100, 1, 2), item('KYC_PENDING', 30, 1, 3)],

--- a/openbank-agent-service/Dockerfile
+++ b/openbank-agent-service/Dockerfile
@@ -15,9 +15,9 @@
 # Adding a build stage back here is enforced against by
 # .github/scripts/check-dockerfile-no-build-stage.py.
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre-ubi10-minimal@sha256:6031e5480f5d5818252a348980a192af0eab09e3380a55f75927e019f4d8136c
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd -r openbank && useradd -r -g openbank openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-aml-service/Dockerfile
+++ b/openbank-aml-service/Dockerfile
@@ -15,9 +15,9 @@
 # Adding a build stage back here is enforced against by
 # .github/scripts/check-dockerfile-no-build-stage.py.
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre-ubi10-minimal@sha256:6031e5480f5d5818252a348980a192af0eab09e3380a55f75927e019f4d8136c
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd -r openbank && useradd -r -g openbank openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-anacredit-service/Dockerfile
+++ b/openbank-anacredit-service/Dockerfile
@@ -15,9 +15,9 @@
 # Adding a build stage back here is enforced against by
 # .github/scripts/check-dockerfile-no-build-stage.py.
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre-ubi10-minimal@sha256:6031e5480f5d5818252a348980a192af0eab09e3380a55f75927e019f4d8136c
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd -r openbank && useradd -r -g openbank openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-analytics-sink/Dockerfile
+++ b/openbank-analytics-sink/Dockerfile
@@ -15,9 +15,9 @@
 # Adding a build stage back here is enforced against by
 # .github/scripts/check-dockerfile-no-build-stage.py.
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre-ubi10-minimal@sha256:6031e5480f5d5818252a348980a192af0eab09e3380a55f75927e019f4d8136c
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd -r openbank && useradd -r -g openbank openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-ap2-service/Dockerfile
+++ b/openbank-ap2-service/Dockerfile
@@ -15,9 +15,9 @@
 # Adding a build stage back here is enforced against by
 # .github/scripts/check-dockerfile-no-build-stage.py.
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre-ubi10-minimal@sha256:6031e5480f5d5818252a348980a192af0eab09e3380a55f75927e019f4d8136c
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd -r openbank && useradd -r -g openbank openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-audit-service/Dockerfile
+++ b/openbank-audit-service/Dockerfile
@@ -15,9 +15,9 @@
 # Adding a build stage back here is enforced against by
 # .github/scripts/check-dockerfile-no-build-stage.py.
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre-ubi10-minimal@sha256:6031e5480f5d5818252a348980a192af0eab09e3380a55f75927e019f4d8136c
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd -r openbank && useradd -r -g openbank openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-authz-policy-auditor/Dockerfile
+++ b/openbank-authz-policy-auditor/Dockerfile
@@ -15,9 +15,9 @@
 # Adding a build stage back here is enforced against by
 # .github/scripts/check-dockerfile-no-build-stage.py.
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre-ubi10-minimal@sha256:6031e5480f5d5818252a348980a192af0eab09e3380a55f75927e019f4d8136c
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd -r openbank && useradd -r -g openbank openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-balance-service/Dockerfile
+++ b/openbank-balance-service/Dockerfile
@@ -15,9 +15,9 @@
 # Adding a build stage back here is enforced against by
 # .github/scripts/check-dockerfile-no-build-stage.py.
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre-ubi10-minimal@sha256:6031e5480f5d5818252a348980a192af0eab09e3380a55f75927e019f4d8136c
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd -r openbank && useradd -r -g openbank openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-billing-service/Dockerfile
+++ b/openbank-billing-service/Dockerfile
@@ -15,9 +15,9 @@
 # Adding a build stage back here is enforced against by
 # .github/scripts/check-dockerfile-no-build-stage.py.
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre-ubi10-minimal@sha256:6031e5480f5d5818252a348980a192af0eab09e3380a55f75927e019f4d8136c
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd -r openbank && useradd -r -g openbank openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-campaign-service/Dockerfile
+++ b/openbank-campaign-service/Dockerfile
@@ -15,9 +15,9 @@
 # Adding a build stage back here is enforced against by
 # .github/scripts/check-dockerfile-no-build-stage.py.
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre-ubi10-minimal@sha256:6031e5480f5d5818252a348980a192af0eab09e3380a55f75927e019f4d8136c
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd -r openbank && useradd -r -g openbank openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-card-issuance-service/Dockerfile
+++ b/openbank-card-issuance-service/Dockerfile
@@ -15,9 +15,9 @@
 # Adding a build stage back here is enforced against by
 # .github/scripts/check-dockerfile-no-build-stage.py.
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre-ubi10-minimal@sha256:6031e5480f5d5818252a348980a192af0eab09e3380a55f75927e019f4d8136c
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd -r openbank && useradd -r -g openbank openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-clearing-service/Dockerfile
+++ b/openbank-clearing-service/Dockerfile
@@ -15,9 +15,9 @@
 # Adding a build stage back here is enforced against by
 # .github/scripts/check-dockerfile-no-build-stage.py.
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre-ubi10-minimal@sha256:6031e5480f5d5818252a348980a192af0eab09e3380a55f75927e019f4d8136c
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd -r openbank && useradd -r -g openbank openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-clearing-simulator/Dockerfile
+++ b/openbank-clearing-simulator/Dockerfile
@@ -15,9 +15,9 @@
 # Adding a build stage back here is enforced against by
 # .github/scripts/check-dockerfile-no-build-stage.py.
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre-ubi10-minimal@sha256:6031e5480f5d5818252a348980a192af0eab09e3380a55f75927e019f4d8136c
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd -r openbank && useradd -r -g openbank openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-consent-service/Dockerfile
+++ b/openbank-consent-service/Dockerfile
@@ -15,9 +15,9 @@
 # Adding a build stage back here is enforced against by
 # .github/scripts/check-dockerfile-no-build-stage.py.
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre-ubi10-minimal@sha256:6031e5480f5d5818252a348980a192af0eab09e3380a55f75927e019f4d8136c
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd -r openbank && useradd -r -g openbank openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-control-liveness-sentinel/Dockerfile
+++ b/openbank-control-liveness-sentinel/Dockerfile
@@ -15,9 +15,9 @@
 # Adding a build stage back here is enforced against by
 # .github/scripts/check-dockerfile-no-build-stage.py.
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre-ubi10-minimal@sha256:6031e5480f5d5818252a348980a192af0eab09e3380a55f75927e019f4d8136c
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd -r openbank && useradd -r -g openbank openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-copilot-service/Dockerfile
+++ b/openbank-copilot-service/Dockerfile
@@ -15,9 +15,9 @@
 # Adding a build stage back here is enforced against by
 # .github/scripts/check-dockerfile-no-build-stage.py.
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre-ubi10-minimal@sha256:6031e5480f5d5818252a348980a192af0eab09e3380a55f75927e019f4d8136c
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd -r openbank && useradd -r -g openbank openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-customer-edge/Dockerfile
+++ b/openbank-customer-edge/Dockerfile
@@ -15,9 +15,9 @@
 # Adding a build stage back here is enforced against by
 # .github/scripts/check-dockerfile-no-build-stage.py.
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre-ubi10-minimal@sha256:6031e5480f5d5818252a348980a192af0eab09e3380a55f75927e019f4d8136c
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd -r openbank && useradd -r -g openbank openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-delegation-service/Dockerfile
+++ b/openbank-delegation-service/Dockerfile
@@ -16,9 +16,9 @@
 # Adding a build stage back here is enforced against by
 # .github/scripts/check-dockerfile-no-build-stage.py (#3392).
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre-ubi10-minimal@sha256:6031e5480f5d5818252a348980a192af0eab09e3380a55f75927e019f4d8136c
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd -r openbank && useradd -r -g openbank openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-dispute-service/Dockerfile
+++ b/openbank-dispute-service/Dockerfile
@@ -15,9 +15,9 @@
 # Adding a build stage back here is enforced against by
 # .github/scripts/check-dockerfile-no-build-stage.py.
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre-ubi10-minimal@sha256:6031e5480f5d5818252a348980a192af0eab09e3380a55f75927e019f4d8136c
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd -r openbank && useradd -r -g openbank openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-docs-truth-agent/Dockerfile
+++ b/openbank-docs-truth-agent/Dockerfile
@@ -15,9 +15,9 @@
 # Adding a build stage back here is enforced against by
 # .github/scripts/check-dockerfile-no-build-stage.py.
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre-ubi10-minimal@sha256:6031e5480f5d5818252a348980a192af0eab09e3380a55f75927e019f4d8136c
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd -r openbank && useradd -r -g openbank openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-document-service/Dockerfile
+++ b/openbank-document-service/Dockerfile
@@ -15,9 +15,9 @@
 # Adding a build stage back here is enforced against by
 # .github/scripts/check-dockerfile-no-build-stage.py.
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre-ubi10-minimal@sha256:6031e5480f5d5818252a348980a192af0eab09e3380a55f75927e019f4d8136c
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd -r openbank && useradd -r -g openbank openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-domestic-payment/Dockerfile
+++ b/openbank-domestic-payment/Dockerfile
@@ -15,9 +15,9 @@
 # Adding a build stage back here is enforced against by
 # .github/scripts/check-dockerfile-no-build-stage.py.
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre-ubi10-minimal@sha256:6031e5480f5d5818252a348980a192af0eab09e3380a55f75927e019f4d8136c
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd -r openbank && useradd -r -g openbank openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-finrep-service/Dockerfile
+++ b/openbank-finrep-service/Dockerfile
@@ -15,9 +15,9 @@
 # Adding a build stage back here is enforced against by
 # .github/scripts/check-dockerfile-no-build-stage.py.
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre-ubi10-minimal@sha256:6031e5480f5d5818252a348980a192af0eab09e3380a55f75927e019f4d8136c
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd -r openbank && useradd -r -g openbank openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-flaky-test-hunter/Dockerfile
+++ b/openbank-flaky-test-hunter/Dockerfile
@@ -15,9 +15,9 @@
 # Adding a build stage back here is enforced against by
 # .github/scripts/check-dockerfile-no-build-stage.py.
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre-ubi10-minimal@sha256:6031e5480f5d5818252a348980a192af0eab09e3380a55f75927e019f4d8136c
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd -r openbank && useradd -r -g openbank openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-fx-service/Dockerfile
+++ b/openbank-fx-service/Dockerfile
@@ -15,9 +15,9 @@
 # Adding a build stage back here is enforced against by
 # .github/scripts/check-dockerfile-no-build-stage.py.
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre-ubi10-minimal@sha256:6031e5480f5d5818252a348980a192af0eab09e3380a55f75927e019f4d8136c
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd -r openbank && useradd -r -g openbank openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-governance-auditor/Dockerfile
+++ b/openbank-governance-auditor/Dockerfile
@@ -15,9 +15,9 @@
 # Adding a build stage back here is enforced against by
 # .github/scripts/check-dockerfile-no-build-stage.py.
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre-ubi10-minimal@sha256:6031e5480f5d5818252a348980a192af0eab09e3380a55f75927e019f4d8136c
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd -r openbank && useradd -r -g openbank openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-infra/docker/services/root-service.Dockerfile
+++ b/openbank-infra/docker/services/root-service.Dockerfile
@@ -17,10 +17,10 @@ RUN chmod +x gradlew && \
     done; \
     exit 1
 
-FROM eclipse-temurin:21-jre-alpine@sha256:3f08b13888f595cc49edabea7250ba69499ba25602b267da591720769400e08c
+FROM eclipse-temurin:25-jre-ubi10-minimal@sha256:6031e5480f5d5818252a348980a192af0eab09e3380a55f75927e019f4d8136c
 WORKDIR /app
 
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd -r openbank && useradd -r -g openbank openbank
 USER openbank
 
 COPY --from=build /workspace/quarkus-run.jar /app/quarkus-run.jar

--- a/openbank-infra/docker/services/standalone-service.Dockerfile
+++ b/openbank-infra/docker/services/standalone-service.Dockerfile
@@ -24,10 +24,10 @@ RUN chmod +x gradlew && \
       --console=plain && \
     cp /workspace/${SERVICE_DIR}/build/*-runner.jar /workspace/quarkus-run.jar
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre-ubi10-minimal@sha256:6031e5480f5d5818252a348980a192af0eab09e3380a55f75927e019f4d8136c
 WORKDIR /app
 
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd -r openbank && useradd -r -g openbank openbank
 USER openbank
 
 COPY --from=build /workspace/quarkus-run.jar /app/quarkus-run.jar

--- a/openbank-interest-service/Dockerfile
+++ b/openbank-interest-service/Dockerfile
@@ -15,9 +15,9 @@
 # Adding a build stage back here is enforced against by
 # .github/scripts/check-dockerfile-no-build-stage.py.
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre-ubi10-minimal@sha256:6031e5480f5d5818252a348980a192af0eab09e3380a55f75927e019f4d8136c
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd -r openbank && useradd -r -g openbank openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-kyc-service/Dockerfile
+++ b/openbank-kyc-service/Dockerfile
@@ -15,9 +15,9 @@
 # Adding a build stage back here is enforced against by
 # .github/scripts/check-dockerfile-no-build-stage.py.
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre-ubi10-minimal@sha256:6031e5480f5d5818252a348980a192af0eab09e3380a55f75927e019f4d8136c
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd -r openbank && useradd -r -g openbank openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-ledger-service/Dockerfile
+++ b/openbank-ledger-service/Dockerfile
@@ -15,9 +15,9 @@
 # Adding a build stage back here is enforced against by
 # .github/scripts/check-dockerfile-no-build-stage.py.
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre-ubi10-minimal@sha256:6031e5480f5d5818252a348980a192af0eab09e3380a55f75927e019f4d8136c
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd -r openbank && useradd -r -g openbank openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-mcp-service/Dockerfile
+++ b/openbank-mcp-service/Dockerfile
@@ -15,9 +15,9 @@
 # Adding a build stage back here is enforced against by
 # .github/scripts/check-dockerfile-no-build-stage.py.
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre-ubi10-minimal@sha256:6031e5480f5d5818252a348980a192af0eab09e3380a55f75927e019f4d8136c
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd -r openbank && useradd -r -g openbank openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-notification-service/Dockerfile
+++ b/openbank-notification-service/Dockerfile
@@ -15,9 +15,9 @@
 # Adding a build stage back here is enforced against by
 # .github/scripts/check-dockerfile-no-build-stage.py.
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre-ubi10-minimal@sha256:6031e5480f5d5818252a348980a192af0eab09e3380a55f75927e019f4d8136c
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd -r openbank && useradd -r -g openbank openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-notification-service/Dockerfile.runtime
+++ b/openbank-notification-service/Dockerfile.runtime
@@ -10,11 +10,11 @@
 # (which `include(...)`s every service) and breaks under Gradle 9.5.1, which no
 # longer tolerates configuring an absent project dir. Fixing that for in-Docker
 # builds is a separate follow-up; this runtime image unblocks the pilot now.
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre-ubi10-minimal@sha256:6031e5480f5d5818252a348980a192af0eab09e3380a55f75927e019f4d8136c
 WORKDIR /app
 # Explicit numeric UID/GID so a pod with runAsNonRoot can verify non-root without
 # a runAsUser override (kubelet cannot resolve a named user from the image).
-RUN addgroup -S -g 1001 openbank && adduser -S -u 1001 -G openbank openbank
+RUN groupadd -r -g 1001 openbank && useradd -r -u 1001 -g openbank openbank
 USER 1001
 COPY lib/ /app/lib/
 COPY *.jar /app/

--- a/openbank-onboarding-service/Dockerfile
+++ b/openbank-onboarding-service/Dockerfile
@@ -15,9 +15,9 @@
 # Adding a build stage back here is enforced against by
 # .github/scripts/check-dockerfile-no-build-stage.py.
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre-ubi10-minimal@sha256:6031e5480f5d5818252a348980a192af0eab09e3380a55f75927e019f4d8136c
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd -r openbank && useradd -r -g openbank openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-party-service/Dockerfile
+++ b/openbank-party-service/Dockerfile
@@ -15,9 +15,9 @@
 # Adding a build stage back here is enforced against by
 # .github/scripts/check-dockerfile-no-build-stage.py.
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre-ubi10-minimal@sha256:6031e5480f5d5818252a348980a192af0eab09e3380a55f75927e019f4d8136c
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd -r openbank && useradd -r -g openbank openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-pid-service/Dockerfile
+++ b/openbank-pid-service/Dockerfile
@@ -15,9 +15,9 @@
 # Adding a build stage back here is enforced against by
 # .github/scripts/check-dockerfile-no-build-stage.py.
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre-ubi10-minimal@sha256:6031e5480f5d5818252a348980a192af0eab09e3380a55f75927e019f4d8136c
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd -r openbank && useradd -r -g openbank openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-product-catalog/Dockerfile
+++ b/openbank-product-catalog/Dockerfile
@@ -15,9 +15,9 @@
 # Adding a build stage back here is enforced against by
 # .github/scripts/check-dockerfile-no-build-stage.py.
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre-ubi10-minimal@sha256:6031e5480f5d5818252a348980a192af0eab09e3380a55f75927e019f4d8136c
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd -r openbank && useradd -r -g openbank openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-psd2-service/Dockerfile
+++ b/openbank-psd2-service/Dockerfile
@@ -15,9 +15,9 @@
 # Adding a build stage back here is enforced against by
 # .github/scripts/check-dockerfile-no-build-stage.py.
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre-ubi10-minimal@sha256:6031e5480f5d5818252a348980a192af0eab09e3380a55f75927e019f4d8136c
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd -r openbank && useradd -r -g openbank openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-release-steward/Dockerfile
+++ b/openbank-release-steward/Dockerfile
@@ -15,9 +15,9 @@
 # Adding a build stage back here is enforced against by
 # .github/scripts/check-dockerfile-no-build-stage.py.
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre-ubi10-minimal@sha256:6031e5480f5d5818252a348980a192af0eab09e3380a55f75927e019f4d8136c
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd -r openbank && useradd -r -g openbank openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-sanctions-service/Dockerfile
+++ b/openbank-sanctions-service/Dockerfile
@@ -15,9 +15,9 @@
 # Adding a build stage back here is enforced against by
 # .github/scripts/check-dockerfile-no-build-stage.py.
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre-ubi10-minimal@sha256:6031e5480f5d5818252a348980a192af0eab09e3380a55f75927e019f4d8136c
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd -r openbank && useradd -r -g openbank openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-sca-service/Dockerfile
+++ b/openbank-sca-service/Dockerfile
@@ -15,9 +15,9 @@
 # Adding a build stage back here is enforced against by
 # .github/scripts/check-dockerfile-no-build-stage.py.
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre-ubi10-minimal@sha256:6031e5480f5d5818252a348980a192af0eab09e3380a55f75927e019f4d8136c
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd -r openbank && useradd -r -g openbank openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-security-scanner/Dockerfile
+++ b/openbank-security-scanner/Dockerfile
@@ -15,9 +15,9 @@
 # Adding a build stage back here is enforced against by
 # .github/scripts/check-dockerfile-no-build-stage.py.
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre-ubi10-minimal@sha256:6031e5480f5d5818252a348980a192af0eab09e3380a55f75927e019f4d8136c
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd -r openbank && useradd -r -g openbank openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-security-scanner/Dockerfile.prebuilt
+++ b/openbank-security-scanner/Dockerfile.prebuilt
@@ -1,6 +1,6 @@
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre-ubi10-minimal@sha256:6031e5480f5d5818252a348980a192af0eab09e3380a55f75927e019f4d8136c
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd -r openbank && useradd -r -g openbank openbank
 USER openbank
 COPY build/quarkus-app/lib/ /app/lib/
 COPY build/quarkus-app/*.jar /app/

--- a/openbank-sepa-instant/Dockerfile
+++ b/openbank-sepa-instant/Dockerfile
@@ -15,9 +15,9 @@
 # Adding a build stage back here is enforced against by
 # .github/scripts/check-dockerfile-no-build-stage.py.
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre-ubi10-minimal@sha256:6031e5480f5d5818252a348980a192af0eab09e3380a55f75927e019f4d8136c
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd -r openbank && useradd -r -g openbank openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-sepa-payment/Dockerfile
+++ b/openbank-sepa-payment/Dockerfile
@@ -15,9 +15,9 @@
 # Adding a build stage back here is enforced against by
 # .github/scripts/check-dockerfile-no-build-stage.py.
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre-ubi10-minimal@sha256:6031e5480f5d5818252a348980a192af0eab09e3380a55f75927e019f4d8136c
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd -r openbank && useradd -r -g openbank openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-standing-order-service/Dockerfile
+++ b/openbank-standing-order-service/Dockerfile
@@ -15,9 +15,9 @@
 # Adding a build stage back here is enforced against by
 # .github/scripts/check-dockerfile-no-build-stage.py.
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre-ubi10-minimal@sha256:6031e5480f5d5818252a348980a192af0eab09e3380a55f75927e019f4d8136c
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd -r openbank && useradd -r -g openbank openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-statement-service/Dockerfile
+++ b/openbank-statement-service/Dockerfile
@@ -15,9 +15,9 @@
 # Adding a build stage back here is enforced against by
 # .github/scripts/check-dockerfile-no-build-stage.py.
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre-ubi10-minimal@sha256:6031e5480f5d5818252a348980a192af0eab09e3380a55f75927e019f4d8136c
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd -r openbank && useradd -r -g openbank openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-swift-service/Dockerfile
+++ b/openbank-swift-service/Dockerfile
@@ -15,9 +15,9 @@
 # Adding a build stage back here is enforced against by
 # .github/scripts/check-dockerfile-no-build-stage.py.
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre-ubi10-minimal@sha256:6031e5480f5d5818252a348980a192af0eab09e3380a55f75927e019f4d8136c
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd -r openbank && useradd -r -g openbank openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-tax-reporting-service/Dockerfile
+++ b/openbank-tax-reporting-service/Dockerfile
@@ -15,9 +15,9 @@
 # Adding a build stage back here is enforced against by
 # .github/scripts/check-dockerfile-no-build-stage.py.
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre-ubi10-minimal@sha256:6031e5480f5d5818252a348980a192af0eab09e3380a55f75927e019f4d8136c
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd -r openbank && useradd -r -g openbank openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-tpp-registry-service/Dockerfile
+++ b/openbank-tpp-registry-service/Dockerfile
@@ -15,9 +15,9 @@
 # Adding a build stage back here is enforced against by
 # .github/scripts/check-dockerfile-no-build-stage.py.
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre-ubi10-minimal@sha256:6031e5480f5d5818252a348980a192af0eab09e3380a55f75927e019f4d8136c
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd -r openbank && useradd -r -g openbank openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-transaction-service/Dockerfile
+++ b/openbank-transaction-service/Dockerfile
@@ -15,9 +15,9 @@
 # Adding a build stage back here is enforced against by
 # .github/scripts/check-dockerfile-no-build-stage.py.
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre-ubi10-minimal@sha256:6031e5480f5d5818252a348980a192af0eab09e3380a55f75927e019f4d8136c
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd -r openbank && useradd -r -g openbank openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/

--- a/openbank-vop-service/Dockerfile
+++ b/openbank-vop-service/Dockerfile
@@ -15,9 +15,9 @@
 # Adding a build stage back here is enforced against by
 # .github/scripts/check-dockerfile-no-build-stage.py.
 
-FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+FROM eclipse-temurin:25-jre-ubi10-minimal@sha256:6031e5480f5d5818252a348980a192af0eab09e3380a55f75927e019f4d8136c
 WORKDIR /app
-RUN addgroup -S openbank && adduser -S openbank -G openbank
+RUN groupadd -r openbank && useradd -r -g openbank openbank
 USER openbank
 COPY quarkus-app/lib/ /app/lib/
 COPY quarkus-app/*.jar /app/


### PR DESCRIPTION
Closes #3354

Second step of the ONNX alpine/musl fix (see #3700 for the first step, which added the in-image smoke gate and proved the failure on alpine).

This PR moves the whole fleet runtime from the musl-based `eclipse-temurin:25-jre-alpine` image to the glibc-based `eclipse-temurin:25-jre-ubi10-minimal` image:

- every per-service `Dockerfile` (53 files)
- `Dockerfile.scanner` and `openbank-security-scanner/Dockerfile.prebuilt`
- `openbank-notification-service/Dockerfile.runtime`
- local multi-stage templates in `openbank-infra/docker/services/` (`standalone-service.Dockerfile`, deprecated `root-service.Dockerfile`)
- `.github/workflows/Dockerfile.deploy` default base image
- user creation switched from alpine `addgroup/adduser` to RHEL `groupadd/useradd`
- `.github/workflows/Dockerfile.deploy` keeps conditional user creation so it still boots on either base during any transition window
- `openbank-admin-ui/scripts/generate-cluster-topology.mjs` fallbacks and `openbank-admin-ui/cluster-topology.json` regenerated to match the new base
- root `CLAUDE.md` note updated so it no longer points at the old alpine literal

`check-dockerfile-no-build-stage.py` passes locally (53 runtime-only Dockerfiles, all with EXPOSE). A manual `docker run` of the new ubi10-minimal base confirms `groupadd`/`useradd` are present and work.