### PR TITLE
fix(auto-deploy): fail gitops-pr closed when can-i-deploy blocks every service

### DIFF
--- a/.github/workflows/auto-deploy.yml
+++ b/.github/workflows/auto-deploy.yml
@@ -1236,6 +1236,10 @@ jobs:
           if [ "${#UPDATED[@]}" -eq 0 ]; then
             echo "No manifests changed — all images already up to date."
             echo "changed=false" >> "$GITHUB_OUTPUT"
+            if [ "${GATE_RAN}" = "true" ] && [ "${DEPLOYABLE_SERVICES}" = "[]" ]; then
+              echo "::error::contract gate ran but no service was deployable — failing gitops-pr closed so the run is not silently green (issue #3432)"
+              exit 1
+            fi
           else
             echo "changed=true" >> "$GITHUB_OUTPUT"
             printf '%s\n' "${UPDATED[@]}"


### PR DESCRIPTION
fix(auto-deploy): fail gitops-pr when can-i-deploy blocks every service

When `can-i-deploy` runs and emits an explicit empty `deployable` set, the `gitops-pr` rewrite step skips every manifest and still exits success. That makes a reconcile run that deployed nothing look successful next to the already-red contract gate.

This change fails the `gitops-pr` job closed only when:
- the contract gate ran (`GATE_RAN=true`), and
- it produced an explicit empty deployable set (`DEPLOYABLE_SERVICES=[]`), and
- no manifest was updated.

Legitimate "gate absent" or "already up to date" cases are left untouched.

Closes #3432 (direction 3)
