### PR TITLE
ci(auto-deploy): trigger deploy on openbank-*/version.txt changes

### DIFF
--- a/.github/workflows/auto-deploy.yml
+++ b/.github/workflows/auto-deploy.yml
@@ -42,6 +42,11 @@ on:
       - "openbank-libs-domain/build.gradle.kts"
       - "openbank-libs-runtime/build.gradle.kts"
       - "build-logic/**"
+      # Release-please bumps version.txt, yet a release-only commit touches nothing
+      # under src/main/**. That left the new version with no image built, causing
+      # immediate deploy drift (issue #3597 et al.). Treat a version bump as a
+      # release marker that must deploy like a source change.
+      - "openbank-*/version.txt"
   # Self-heal reconcile (issue #2020). The per-push run is ONE-SHOT: a service that built
   # and pushed its image but was then blocked at the can-i-deploy contract gate by a
   # TRANSIENT verification lag (its build wave republished its consumer pact; the provider


### PR DESCRIPTION
ci(auto-deploy): trigger deploy on openbank-*/version.txt changes

Release-please bumps a service's `version.txt`, but a release-only commit does not match the `openbank-*/src/main/**` path filter, so the new version had no image built and immediately drifted from what is deployed.

This adds `openbank-*/version.txt` to the auto-deploy push trigger paths so a version bump is treated as a release marker and drives a deploy just like a source change.

This prevents future occurrences of the drift pattern seen in:
- #3597 (openbank-onboarding-service)
- #3363, #3364, #3365, #3366, #3367 (the broader deploy-drift series)

Existing drift on those services is not retroactively deployed by this PR; a one-time manual `workflow_dispatch` of `auto-deploy.yml` for the affected services can close the current gap after this merges.

Closes #3597
Refs #3363 #3364 #3365 #3366 #3367
