### PR TITLE
fix(fx): a derived inverse rate no longer reuses the source rate's id

### DIFF
--- a/docs/threat-models/openbank-fx-service.md
+++ b/docs/threat-models/openbank-fx-service.md
@@ -78,3 +78,12 @@ directly determines monetary outcomes — a manipulated rate is a financial-loss
     unaffected (keyed on `(source, pair, validFrom)`). Risk: a slightly stale CNB mid rate used in
     `spreadPct` display for at most 3 days. Rate table integrity and conversion accuracy are not affected
     (INTERNAL bid/ask are the settlement rates; CNB mid is display-only). Residual risk = **negligible**.
+- **2026-08-05** — Derived inverse-quote identity (#3374). `GET /api/v1/fx/rates/{base}/{quote}`
+  answered a pair derived by inverting the stored direction with the **source row's `id`**, so both
+  directions shared one identifier — a quote id could not be replayed to a direction (the §4
+  repudiation concern, and §5's "pin the rate id" assumption). The endpoint now answers `id: null` +
+  `derivedFrom: <source row id>` on a derived quote; a stored quote keeps its own id and no
+  `derivedFrom`. No new flow/surface/boundary — same endpoint, same data, honest identity.
+  `FxConversion.rateId` still references the real `fx_rates` row on both paths (FK unchanged), so
+  dispute defense via §5 is preserved. Risk class = **repudiation/auditability (reduced)**.
+  API contract: additive, `info.version` 1.5.0 → 1.6.0.

--- a/openbank-fx-service/src/main/kotlin/com/openbank/fx/application/port/in/FxPorts.kt
+++ b/openbank-fx-service/src/main/kotlin/com/openbank/fx/application/port/in/FxPorts.kt
@@ -4,13 +4,23 @@
 
 package com.openbank.fx.application.port.`in`
 
-import com.openbank.fx.domain.model.*
-import java.math.BigDecimal; import java.time.Instant; import java.util.UUID
+import com.openbank.fx.domain.model.FxConversion
+import com.openbank.fx.domain.model.FxRate
+import com.openbank.fx.domain.model.RateSource
+import com.openbank.fx.domain.model.RateType
+import java.time.Instant
+import java.util.UUID
 
 data class GetRateQuery(val baseCurrency: String, val quoteCurrency: String, val rateType: RateType = RateType.SPOT)
-data class ConvertCommand(val idempotencyKey: String, val partyId: UUID, val accountId: UUID?,
-    val fromCurrency: String, val toCurrency: String, val fromAmountMinorUnits: Long,
-    val partyName: String)
+data class ConvertCommand(
+    val idempotencyKey: String,
+    val partyId: UUID,
+    val accountId: UUID?,
+    val fromCurrency: String,
+    val toCurrency: String,
+    val fromAmountMinorUnits: Long,
+    val partyName: String,
+)
 
 data class GetRateHistoryQuery(
     val baseCurrency: String,
@@ -22,8 +32,16 @@ data class GetRateHistoryQuery(
     val offset: Int = 0,
 )
 
+/**
+ * The outcome of resolving a pair: the [rate] to quote, and — when the pair had to be answered by
+ * inverting the stored direction — [derivedFrom], the id of the stored row the quote was derived
+ * from. The REST layer nulls the response `id` on a derived quote (#3374); the domain [rate] keeps
+ * the source row's id either way, so `FxConversion.rateId` always names a real `fx_rates` row.
+ */
+data class ResolvedRate(val rate: FxRate, val derivedFrom: UUID?)
+
 interface FxUseCase {
-    suspend fun getRate(query: GetRateQuery): FxRate?
+    suspend fun getRate(query: GetRateQuery): ResolvedRate?
     suspend fun getAllRates(): List<FxRate>
     suspend fun getRateHistory(query: GetRateHistoryQuery): List<FxRate>
     suspend fun convert(cmd: ConvertCommand): FxConversion

--- a/openbank-fx-service/src/main/kotlin/com/openbank/fx/application/usecase/FxService.kt
+++ b/openbank-fx-service/src/main/kotlin/com/openbank/fx/application/usecase/FxService.kt
@@ -9,6 +9,7 @@ import com.openbank.fx.application.port.`in`.ConvertCommand
 import com.openbank.fx.application.port.`in`.FxUseCase
 import com.openbank.fx.application.port.`in`.GetRateHistoryQuery
 import com.openbank.fx.application.port.`in`.GetRateQuery
+import com.openbank.fx.application.port.`in`.ResolvedRate
 import com.openbank.fx.application.port.out.AmlCasePort
 import com.openbank.fx.application.port.out.AmlCaseRiskLevel
 import com.openbank.fx.application.port.out.FraudScoreCommand
@@ -79,11 +80,14 @@ class FxService(
      * customer edge turns the resulting null into `fx_rate_unavailable` + HTTP 502, so the app
      * reports a gateway error for what is really a missing derivation.
      *
-     * Inversion swaps bid and ask — see [FxRate.inverted].
+     * Inversion swaps bid and ask — see [FxRate.inverted]. A derived quote is reported with
+     * [ResolvedRate.derivedFrom] naming the stored row, so the REST layer can null the response
+     * `id` (#3374); the domain rate keeps the source id either way, so `FxConversion.rateId`
+     * always references a real `fx_rates` row.
      */
-    private suspend fun resolveRate(base: String, quote: String, type: RateType): FxRate? =
-        rateRepo.findLatest(base, quote, type)
-            ?: rateRepo.findLatest(quote, base, type)?.inverted()
+    private suspend fun resolveRate(base: String, quote: String, type: RateType): ResolvedRate? =
+        rateRepo.findLatest(base, quote, type)?.let { ResolvedRate(it, derivedFrom = null) }
+            ?: rateRepo.findLatest(quote, base, type)?.inverted()?.let { ResolvedRate(it, derivedFrom = it.id) }
 
     override suspend fun getAllRates() = rateRepo.findAll()
 
@@ -101,7 +105,7 @@ class FxService(
         convRepo.findByIdempotencyKey(cmd.idempotencyKey)?.let { return it }
         // Same resolution as the read path: a conversion must not be refused for a pair the bank
         // can price perfectly well from the other side.
-        val rate = resolveRate(cmd.fromCurrency, cmd.toCurrency, RateType.SPOT)
+        val rate = resolveRate(cmd.fromCurrency, cmd.toCurrency, RateType.SPOT)?.rate
             ?: error("No FX rate available for ${cmd.fromCurrency}/${cmd.toCurrency}")
         require(rate.isValid(Instant.now(clock))) { "FX rate expired for ${cmd.fromCurrency}/${cmd.toCurrency}" }
 

--- a/openbank-fx-service/src/main/kotlin/com/openbank/fx/infrastructure/rest/FxResource.kt
+++ b/openbank-fx-service/src/main/kotlin/com/openbank/fx/infrastructure/rest/FxResource.kt
@@ -9,7 +9,9 @@ import com.openbank.fx.application.port.`in`.ConvertCommand
 import com.openbank.fx.application.port.`in`.FxUseCase
 import com.openbank.fx.application.port.`in`.GetRateHistoryQuery
 import com.openbank.fx.application.port.`in`.GetRateQuery
+import com.openbank.fx.domain.model.FxRate
 import com.openbank.fx.domain.model.RateSource
+import com.openbank.fx.domain.model.RateType
 import com.openbank.libs.authz.Authorize
 import jakarta.annotation.security.RolesAllowed
 import jakarta.ws.rs.Consumes
@@ -24,6 +26,7 @@ import jakarta.ws.rs.core.MediaType
 import jakarta.ws.rs.core.Response
 import org.eclipse.microprofile.openapi.annotations.Operation
 import org.eclipse.microprofile.openapi.annotations.tags.Tag
+import java.math.BigDecimal
 import java.net.URI
 import java.time.Instant
 import java.util.UUID
@@ -36,6 +39,53 @@ data class ConvertRequest(
     val toCurrency: String,
     val fromAmountMinorUnits: Long,
 )
+
+/**
+ * Response for `GET /rates/{base}/{quote}`, mirroring the serialized [FxRate] shape.
+ *
+ * #3374: a quote derived by inverting the stored pair ([FxRate.inverted]) carried the source row's
+ * [FxRate.id], so both directions answered under one identifier — a client caching by `id` would
+ * serve one direction for the other, and an audit record referencing the quote id could not be
+ * replayed to a direction. A derived quote therefore answers with [id] null and the source row id
+ * in [derivedFrom]; a stored quote answers with its own [id] and [derivedFrom] null. The domain
+ * object keeps the source id internally — `FxConversion.rateId` must keep pointing at the row the
+ * price came from.
+ */
+data class FxRateResponse(
+    val id: UUID?,
+    val baseCurrency: String,
+    val quoteCurrency: String,
+    val bidRate: BigDecimal,
+    val askRate: BigDecimal,
+    val rateType: RateType,
+    val source: RateSource,
+    val validFrom: Instant,
+    val validTo: Instant,
+    val createdAt: Instant,
+    val pair: String,
+    val midRate: BigDecimal,
+    val spread: BigDecimal,
+    val derivedFrom: UUID?,
+) {
+    companion object {
+        fun of(rate: FxRate, derivedFrom: UUID?) = FxRateResponse(
+            id = if (derivedFrom != null) null else rate.id,
+            baseCurrency = rate.baseCurrency,
+            quoteCurrency = rate.quoteCurrency,
+            bidRate = rate.bidRate,
+            askRate = rate.askRate,
+            rateType = rate.rateType,
+            source = rate.source,
+            validFrom = rate.validFrom,
+            validTo = rate.validTo,
+            createdAt = rate.createdAt,
+            pair = rate.pair,
+            midRate = rate.midRate,
+            spread = rate.spread,
+            derivedFrom = derivedFrom,
+        )
+    }
+}
 
 @Path("/api/v1/fx")
 @Produces(MediaType.APPLICATION_JSON)
@@ -60,12 +110,16 @@ class FxResource(private val fxUseCase: FxUseCase, private val cnbIngestion: Cnb
         @PathParam("quote") quote: String,
         @QueryParam("source") source: String?,
     ): Response {
-        val rate = if (source?.uppercase() == RateSource.CNB.name) {
-            cnbIngestion.getCnbRate(base.uppercase(), quote.uppercase())
+        val requestedBase = base.uppercase()
+        val requestedQuote = quote.uppercase()
+        val body = if (source?.uppercase() == RateSource.CNB.name) {
+            // The ČNB path only ever looks up the exact stored direction — never derived.
+            cnbIngestion.getCnbRate(requestedBase, requestedQuote)?.let { FxRateResponse.of(it, derivedFrom = null) }
         } else {
-            fxUseCase.getRate(GetRateQuery(base.uppercase(), quote.uppercase()))
+            fxUseCase.getRate(GetRateQuery(requestedBase, requestedQuote))
+                ?.let { FxRateResponse.of(it.rate, it.derivedFrom) }
         }
-        return rate?.let { Response.ok(it).build() }
+        return body?.let { Response.ok(it).build() }
             ?: Response.status(404).entity(mapOf("error" to "Rate not found for $base/$quote")).build()
     }
 

--- a/openbank-fx-service/src/main/resources/openapi.yaml
+++ b/openbank-fx-service/src/main/resources/openapi.yaml
@@ -5,7 +5,7 @@ info:
   title: FX Service API
   # major == openbank.api.version == URL /api/v1 (ADR-0048). Minor bump (1.2 -> 1.3): additive
   # endpoint only (PATCH /approvals/{id}, ADR-0155 four-eyes) — no breaking change.
-  version: 1.5.0
+  version: 1.6.0
   description: >-
     Foreign exchange rates and currency conversion. On convert, the converting party's name is
     synchronously screened against the sanctions lists (ADR-0032): a clean party settles the
@@ -260,6 +260,20 @@ components:
     ExchangeRateResponse:
       type: object
       properties:
+        id:
+          type: string
+          format: uuid
+          nullable: true
+          description: >-
+            Identifier of the stored rate row. NULL when the quote was derived by inverting
+            the stored pair (#3374) — a derived quote has no row of its own.
+        derivedFrom:
+          type: string
+          format: uuid
+          nullable: true
+          description: >-
+            Identifier of the stored rate this quote was derived from, present exactly when the
+            pair was answered by inverting the stored direction (#3374). NULL for a stored quote.
         baseCurrency:
           type: string
         quoteCurrency:

--- a/openbank-fx-service/src/test/kotlin/com/openbank/fx/application/usecase/FxServiceTest.kt
+++ b/openbank-fx-service/src/test/kotlin/com/openbank/fx/application/usecase/FxServiceTest.kt
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.module.kotlin.kotlinModule
 import com.openbank.fx.application.port.`in`.ConvertCommand
 import com.openbank.fx.application.port.`in`.GetRateHistoryQuery
 import com.openbank.fx.application.port.`in`.GetRateQuery
+import com.openbank.fx.application.port.`in`.ResolvedRate
 import com.openbank.fx.application.port.out.AmlCasePort
 import com.openbank.fx.application.port.out.AmlCaseRiskLevel
 import com.openbank.fx.application.port.out.FraudScoreOutcome
@@ -124,25 +125,31 @@ class FxServiceTest {
 
     @Test
     fun `getRate answers from the reverse quote when only that direction is stored`() = runBlocking<Unit> {
+        val stored = fxRate()
         coEvery { rateRepo.findLatest("CZK", "EUR", RateType.SPOT) } returns null
-        coEvery { rateRepo.findLatest("EUR", "CZK", RateType.SPOT) } returns fxRate()
+        coEvery { rateRepo.findLatest("EUR", "CZK", RateType.SPOT) } returns stored
 
-        val rate = service.getRate(GetRateQuery("CZK", "EUR", RateType.SPOT))
+        val resolved = service.getRate(GetRateQuery("CZK", "EUR", RateType.SPOT))
 
-        assertThat(rate).isNotNull
-        assertThat(rate!!.baseCurrency).isEqualTo("CZK")
+        assertThat(resolved).isNotNull
+        val rate = resolved!!.rate
+        assertThat(rate.baseCurrency).isEqualTo("CZK")
         assertThat(rate.quoteCurrency).isEqualTo("EUR")
         // 1/25.10 (the ask side), not 1/24.90.
         assertThat(rate.bidRate).isEqualByComparingTo("0.03984064")
+        // #3374: the resolution names the stored row it was derived from.
+        assertThat(resolved.derivedFrom).isEqualTo(stored.id)
+        assertThat(rate.id).isEqualTo(stored.id)
     }
 
     @Test
     fun `a directly stored pair is never overridden by an inverse`() = runBlocking<Unit> {
         coEvery { rateRepo.findLatest("EUR", "CZK", RateType.SPOT) } returns fxRate()
 
-        val rate = service.getRate(GetRateQuery("EUR", "CZK", RateType.SPOT))
+        val resolved = service.getRate(GetRateQuery("EUR", "CZK", RateType.SPOT))
 
-        assertThat(rate!!.bidRate).isEqualByComparingTo("24.90")
+        assertThat(resolved!!.rate.bidRate).isEqualByComparingTo("24.90")
+        assertThat(resolved.derivedFrom).isNull()
         coVerify(exactly = 0) { rateRepo.findLatest("CZK", "EUR", RateType.SPOT) }
     }
 
@@ -324,7 +331,7 @@ class FxServiceTest {
 
         val result = service.getRate(query)
 
-        assertThat(result).isEqualTo(rate)
+        assertThat(result).isEqualTo(ResolvedRate(rate, derivedFrom = null))
         coVerify(exactly = 1) { rateRepo.findLatest(query.baseCurrency, query.quoteCurrency, query.rateType) }
     }
 

--- a/openbank-fx-service/src/test/kotlin/com/openbank/fx/infrastructure/rest/FxResourceTest.kt
+++ b/openbank-fx-service/src/test/kotlin/com/openbank/fx/infrastructure/rest/FxResourceTest.kt
@@ -9,6 +9,7 @@ import com.openbank.fx.application.port.`in`.ConvertCommand
 import com.openbank.fx.application.port.`in`.FxUseCase
 import com.openbank.fx.application.port.`in`.GetRateHistoryQuery
 import com.openbank.fx.application.port.`in`.GetRateQuery
+import com.openbank.fx.application.port.`in`.ResolvedRate
 import com.openbank.fx.domain.model.FxConversion
 import com.openbank.fx.domain.model.FxConversionStatus
 import com.openbank.fx.domain.model.FxRate
@@ -85,13 +86,35 @@ class FxResourceTest {
     @Test
     fun `getRate with no source returns the internal spot rate`(): Unit = runBlocking {
         val stored = rate()
-        coEvery { fxUseCase.getRate(GetRateQuery("EUR", "CZK")) } returns stored
+        coEvery { fxUseCase.getRate(GetRateQuery("EUR", "CZK")) } returns ResolvedRate(stored, derivedFrom = null)
 
         val resp = resource.getRate(base = "eur", quote = "czk", source = null)
 
         assertThat(resp.status).isEqualTo(200)
-        assertThat(resp.entity).isEqualTo(stored)
+        assertThat(resp.entity).isEqualTo(FxRateResponse.of(stored, derivedFrom = null))
         coVerify(exactly = 0) { cnbIngestion.getCnbRate(any(), any()) }
+    }
+
+    @Test
+    fun `getRate marks an inverted pair as derived - id null, source id in derivedFrom (#3374)`(): Unit = runBlocking {
+        val stored = rate() // EUR/CZK — the only direction the ČNB source ever stores
+        coEvery { fxUseCase.getRate(GetRateQuery("CZK", "EUR")) } returns
+            ResolvedRate(stored.inverted(), derivedFrom = stored.id)
+
+        val resp = resource.getRate(base = "czk", quote = "eur", source = null)
+
+        assertThat(resp.status).isEqualTo(200)
+        val body = resp.entity as FxRateResponse
+        assertThat(body.id).isNull()
+        assertThat(body.derivedFrom).isEqualTo(stored.id)
+        assertThat(body.pair).isEqualTo("CZK/EUR")
+        // The sides swap on inversion: bid = 1 / source ask, ask = 1 / source bid.
+        assertThat(
+            body.bidRate,
+        ).isEqualByComparingTo(BigDecimal.ONE.divide(stored.askRate, 8, java.math.RoundingMode.HALF_UP))
+        assertThat(
+            body.askRate,
+        ).isEqualByComparingTo(BigDecimal.ONE.divide(stored.bidRate, 8, java.math.RoundingMode.HALF_UP))
     }
 
     @Test
@@ -102,7 +125,7 @@ class FxResourceTest {
         val resp = resource.getRate(base = "eur", quote = "czk", source = "cnb")
 
         assertThat(resp.status).isEqualTo(200)
-        assertThat(resp.entity).isEqualTo(stored)
+        assertThat(resp.entity).isEqualTo(FxRateResponse.of(stored, derivedFrom = null))
         coVerify(exactly = 0) { fxUseCase.getRate(any()) }
     }
 


### PR DESCRIPTION
Closes #3374.

## The defect

`GET /api/v1/fx/rates/EUR/CZK` and `/CZK/EUR` answered with **the same `id`** — `FxRate.inverted()` carries the source row's id over, so both directions shared one identifier. The numbers were right (#3189); only the identity was wrong. A client caching quotes by `id` would serve one direction for the other, and a conversion audit record referencing the quote id cannot be replayed to a direction — the half that matters for money-path evidence.

## The fix — the issue's preferred option (2)

A derived quote answers with **`id: null`** and **`derivedFrom: <source row id>`**:

- `FxUseCase.getRate` now returns `ResolvedRate(rate, derivedFrom)`. The use case is the only place that knows whether the fallback inversion ran — the response pair matches the request either way, so the resource cannot infer it from the pair.
- `FxResource` maps to a new `FxRateResponse` DTO: stored quote → own `id`, `derivedFrom: null`; derived quote → `id: null`, `derivedFrom: <source id>`.
- **The domain is untouched.** `FxConversion.rateId = rate.id` still names a real `fx_rates` row (`fx_conversions.rate_id NOT NULL REFERENCES fx_rates`), because `inverted()` keeps the source id internally. The null lives only in the REST DTO, so CZK→foreign conversions are unaffected.

## Relationship to #3594 (same issue, option 1+2)

#3594 implements a deterministic derived id and is **blocked on the ASVS L3 gate**: any name-based UUID needs `MessageDigest`, and the banned-crypto-primitive check rejects the call site (`FxRate.kt:103-104`, SHA-256 included). Option (2) needs no hashing. #3594's FK objection to option (2) conflates the response DTO with the domain object — `rateId` is taken from the domain `FxRate`, which still carries the source row's id on an inversion. This PR also leaves #3594 free to land the `derivedFrom`-persistence idea later on top, if wanted.

## Verification

- `:openbank-fx-service:test` — full suite green (34 tests incl. the new derived-quote cases in `FxResourceTest` + `FxServiceTest`).
- `ktlintCheck`, `detekt`, `koverVerify`, `quarkusBuild` — green.
- `check-api-contract.py --base origin/main --enforce` — **additive change, `info.version` 1.5.0 → 1.6.0 OK**.
- `run-gates.py --group api` — ASVS L3 (banned crypto primitives) ok; route conformance + pact replay coverage pass.
- Existing consumer pact (`openbank-transaction-service → openbank-fx-service`, `GET /rates/EUR/CZK`) pins only `baseCurrency/quoteCurrency/bidRate/askRate` — unaffected; the stored direction keeps its shape, `derivedFrom` is additive.
