### PR TITLE
chore(infra): baseline AVD-AWS-0031 — ECR tag mutability is deliberate

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -50,6 +50,19 @@ AVD-AWS-0011
 # go-live condition (ADR-0027 C5). Sandbox cost-only scope.
 AVD-AWS-0095
 
+# ECR service-repository tags mutable (aws/envs/sandbox-platform/ecr-service-repositories.tf):
+# MUTABLE is load-bearing, not laziness — auto-deploy tags `sandbox-<sha>` and the
+# reconcile path (#2021, #3432) legitimately re-pushes a build for a sha it has
+# already pushed; under IMMUTABLE that re-push fails and the deploy self-heal
+# breaks. The one repository built off a version (openbank-admin-ui) is IMMUTABLE
+# in code and in the live account. Blast radius: the exemption is repo-wide, but
+# every openbank-* ECR repository flows through the single
+# `aws_ecr_repository.service` for_each resource, so the decision stays in one
+# reviewed place; a second ECR repository resource would need its own entry here.
+# Fleet-wide IMMUTABLE is a prod go-live condition (the sandbox re-dispatch loop
+# does not exist there).
+AVD-AWS-0031
+
 # ──────────────────────────────────────────────────────────────────────────────
 # Kubernetes — hardening follow-ups (tracked in issue #854 and related issues)
 # ──────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

The Trivy config gate (`security.yml`: fail on new HIGH/CRITICAL not in the `.trivyignore` baseline) went red on every PR after #3659 introduced `aws/envs/sandbox-platform/ecr-service-repositories.tf`: Trivy flags `aws_ecr_repository.service` with `AWS-0031 (HIGH): Repository tags are mutable` because it cannot see the `contains(local.ecr_immutable_repositories, each.key)` conditional. The MUTABLE default is documented in-file as load-bearing — auto-deploy tags `sandbox-<sha>` and the reconcile path (#2021, #3432) legitimately re-pushes a sha it has already built; under IMMUTABLE that re-push fails and deploy self-heal breaks. This PR registers the accepted risk in `.trivyignore` with rationale and blast-radius note, matching the file's existing accepted-deviation pattern.

## Type of change

- [x] chore (build / tooling)

## Linked issues

N/A — gate baseline for #3659's accepted risk

## Changes

- `.trivyignore`: add `AVD-AWS-0031` with justification — why MUTABLE is deliberate for the service repositories, why `openbank-admin-ui` stays IMMUTABLE, the blast radius of a repo-wide exemption (all openbank-* ECR repos flow through the single reviewed `for_each` resource), and fleet-wide IMMUTABLE noted as a prod go-live condition.

## Definition of Done

- [x] No new lint warnings (comment-only baseline entry).
- [x] Gate verified locally with the CI command verbatim: `trivy config --severity CRITICAL,HIGH --ignorefile .trivyignore --skip-version-check --format sarif --exit-code 1 openbank-infra` → exit 0, 0 findings (652 config files scanned, same as CI).

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] New suppression IS the change — justification stated here and in the baseline file: AVD-AWS-0031 is an accepted, documented design decision (deploy self-heal re-push), not an overlooked exposure; scan-on-push and registry-level scanning stay enabled.
- [x] No new third-party dependency.

## Compliance impact

- [x] None

## Rollout / Rollback

- Deployment strategy: none — `.trivyignore` is consumed by the Trivy workflow at scan time; takes effect on the next CI run.
- Rollback plan: revert the squash commit (gate returns to red until the code or baseline changes).
- Data migration reversible: N/A

## Reviewer notes

The alternative — flipping the fleet to IMMUTABLE — was rejected: it breaks the documented auto-deploy reconcile/self-heal path (#2021, #3432). If prod wants fleet-wide immutability, that belongs in the ADR-0027 go-live conditions, not as a quiet default flip here.