### PR TITLE
chore(admin-ui): regenerate app-status.json for openbank-app 0.14.0

### DIFF
--- a/openbank-admin-ui/app-status.json
+++ b/openbank-admin-ui/app-status.json
@@ -12,7 +12,7 @@
   "asOf": "2026-07-29",
   "appRepo": "JiRaska/openbank-app",
   "derived": {
-    "version": "0.13.0",
+    "version": "0.14.0",
     "useFakeData": false,
     "edgeBaseUrl": "https://customer.open-bank.tech",
     "keycloakIssuer": "https://kc.open-bank.tech/realms/openbank-customers",


### PR DESCRIPTION
## Summary

The Customer-app dossier gate (`ci.yml` `app-status`, ADR-0074) is red on every open PR: the committed `derived` block pins `version: 0.13.0` while `JiRaska/openbank-app`'s default branch is at `0.14.0`. This regenerates `openbank-admin-ui/app-status.json` with the documented command; the diff is exactly the one drifted field the gate reports.

## Type of change

- [x] chore (build / tooling)

## Linked issues

N/A — derived-data refresh per ADR-0074 (the publish PR openbank-app CI normally opens did not materialise for 0.14.0)

## Changes

- `openbank-admin-ui/app-status.json`: `derived.version` 0.13.0 → 0.14.0 (generator output, not hand-edited — rule #7 compliant).

## Definition of Done

- [x] Derived artefact produced by its generator, verified with the gate's own enforce mode: `node scripts/generate-app-status.mjs --app-repo <checkout> --check --against app-status.json --enforce` → exit 0 (`✓ derived block matches`).
- [x] No hand-edit of derived data; no other field touched (diff is 1 insertion / 1 deletion).

## Security checklist

- [x] No secrets, tokens, passwords, or PII (content is the same derived facts the generator publishes by design: version, fake-data flag, edge URL, capability counts).
- [x] No new third-party dependency.

## Compliance impact

- [x] None

## Rollout / Rollback

- Deployment strategy: none — the file is consumed by the dossier gate and the admin-ui build at next CI run.
- Rollback plan: revert the squash commit (gate returns to red until the publish pipeline catches up).
- Data migration reversible: N/A

## Reviewer notes

The dossier workflow comment says openbank-app CI opens the publish PR on release — for 0.14.0 it did not. Worth a follow-up look at the app repo's publish pipeline so this manual refresh stays the exception, not the routine.