### PR TITLE
test(admin-ui): fail the suite on React's unawaited-act warning

### DIFF
--- a/openbank-admin-ui/src/test/render-smoke.test.tsx
+++ b/openbank-admin-ui/src/test/render-smoke.test.tsx
@@ -38,7 +38,7 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import React from 'react'
-import { render, cleanup } from '@testing-library/react'
+import { render, cleanup, act } from '@testing-library/react'
 import { readFileSync } from 'fs'
 import path from 'path'
 
@@ -207,11 +207,18 @@ describe('admin-ui render-smoke — every page mounts', () => {
 
       try {
         if (isClientPage(rel)) {
-          render(React.createElement(Providers, null, React.createElement(Page!, props)))
+          // Awaited act: a client page reading use(params) suspends inside render()'s
+          // synchronous act scope and never resumes otherwise — the #3512 flake class the
+          // setup.ts gate now fails on. lending/applications/[id] is that page today.
+          await act(async () => {
+            render(React.createElement(Providers, null, React.createElement(Page!, props)))
+          })
         } else {
           // Async RSC: invoke it, await the tree, then really render it.
           const tree = await Page!(props)
-          render(React.createElement(Providers, null, tree as React.ReactNode))
+          await act(async () => {
+            render(React.createElement(Providers, null, tree as React.ReactNode))
+          })
         }
       } catch (err) {
         // A page that redirects/notFounds instead of returning a tree did its job.

--- a/openbank-admin-ui/src/test/setup.ts
+++ b/openbank-admin-ui/src/test/setup.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import '@testing-library/jest-dom'
+import { afterEach } from 'vitest'
 
 // ── Browser APIs this jsdom build does not implement ───────────────────────
 // These are NOT app-code mocks — they are the browser primitives jsdom leaves out,
@@ -59,3 +60,47 @@ if (typeof window !== 'undefined' && typeof window.matchMedia === 'undefined') {
 if (typeof window !== 'undefined' && typeof window.scrollTo === 'undefined') {
   Object.defineProperty(window, 'scrollTo', { writable: true, value: () => {} })
 }
+
+// ── Unawaited-act gate (#3550) ───────────────────────────────────────────────
+// React logs this on every run of the #3512 flake class — passing runs included:
+//   "A component suspended inside an `act` scope, but the `act` call was not awaited."
+// A bare render() of a use()-suspending tree hangs on its Suspense fallback forever and
+// then *usually passes anyway* if a sibling test already stamped the shared promise
+// fulfilled. Vitest intercepts console, so the warning reached nobody. Here the warning
+// fails the test that emitted it. Falsified by unawaited-act-gate.test.tsx, which
+// triggers the warning deliberately and asserts capture — a gate that has only ever
+// passed is unfalsified, so the proof test is part of the gate, not a nicety.
+
+const UNAWAITED_ACT_WARNING =
+  'A component suspended inside an `act` scope, but the `act` call was not awaited'
+
+let capturedUnawaitedAct: string | null = null
+
+const originalConsoleError = console.error.bind(console)
+console.error = (...args: unknown[]) => {
+  const msg = args.map(String).join(' ')
+  if (msg.includes(UNAWAITED_ACT_WARNING)) capturedUnawaitedAct = msg
+  originalConsoleError(...args)
+}
+
+// take() is the ONLY way a test may see the warning without being failed by the
+// afterEach below: the gate's own proof test consumes (and clears) it.
+;(globalThis as { __takeUnawaitedActWarning?: () => string | null }).__takeUnawaitedActWarning =
+  () => {
+    const w = capturedUnawaitedAct
+    capturedUnawaitedAct = null
+    return w
+  }
+
+afterEach(() => {
+  const w = capturedUnawaitedAct
+  capturedUnawaitedAct = null
+  if (w) {
+    throw new Error(
+      'React emitted the unawaited-act warning during this test. A bare render() of a ' +
+        'use()-suspending tree hangs on its Suspense fallback and then passes or fails by ' +
+        'sibling-test luck (#3512). Wrap the render: await act(async () => { render(...) }).\n' +
+        w,
+    )
+  }
+})

--- a/openbank-admin-ui/src/test/unawaited-act-gate.test.tsx
+++ b/openbank-admin-ui/src/test/unawaited-act-gate.test.tsx
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, it, expect } from 'vitest'
+import React, { Suspense, use } from 'react'
+import { render } from '@testing-library/react'
+
+// Falsification harness for the unawaited-act gate in src/test/setup.ts (#3550).
+//
+// The gate fails any test whose bare render() makes React log
+//   "A component suspended inside an `act` scope, but the `act` call was not awaited."
+// A gate that has only ever passed is unfalsified, so this file emits that warning
+// DELIBERATELY and asserts the gate captured it. take() clears the capture, which is
+// why this proof is the one test an unawaited render does NOT fail. If the gate ever
+// stops detecting the warning, take() returns null here and this file goes red —
+// the suite then distrusts the gate instead of silently trusting it.
+
+declare global {
+  var __takeUnawaitedActWarning: (() => string | null) | undefined
+}
+
+const params = Promise.resolve({ id: 'gate-proof' })
+
+function SuspendingLeaf() {
+  use(params)
+  return React.createElement('div', null, 'resumed')
+}
+
+describe('unawaited-act gate (#3550)', () => {
+  it('captures the warning a bare render() of a use()-suspending tree emits', async () => {
+    render(
+      React.createElement(
+        Suspense,
+        { fallback: null },
+        React.createElement(SuspendingLeaf),
+      ),
+    )
+    // The warning is queued against the act queue, not thrown synchronously — flush it.
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(globalThis.__takeUnawaitedActWarning?.()).toContain('not awaited')
+  })
+
+  it('reports nothing to take() when no test emitted the warning', () => {
+    expect(globalThis.__takeUnawaitedActWarning?.() ?? null).toBeNull()
+  })
+})


### PR DESCRIPTION
Refs #3550 (part 1 of 2 — the `compliance-packs-console` flake stays open: no reproduction, no evidence which of the two candidate causes it is).

## The problem

#3512 fixed three call sites where RTL's `render()` mounts a `use()`-suspending page and the tree never resumes — but nothing stops the class being reintroduced. React prints the diagnosis on every affected run (passing ones included) and vitest's console interception makes sure it reaches nobody. `use(params)` is the App Router idiom for async params and is spreading; the blast radius is bounded today only by accident (one page).

## The gate

`src/test/setup.ts` now captures React's

```
A component suspended inside an `act` scope, but the `act` call was not awaited.
```

and **fails the test that emitted it**, with the fix spelled out (`await act(async () => { render(...) })`).

## Falsification (both directions, per this repo's gate culture)

- **Known-positive**: `src/test/unawaited-act-gate.test.tsx` bare-renders a `use()`-suspending tree DELIBERATELY and asserts the gate captured the warning via `__takeUnawaitedActWarning()` — `take()` is the only way to see the warning without being failed. If the gate ever stops detecting, the proof file goes red.
- **Negative validation**: a throwaway test that bare-renders without `take()` fails locally with the gate's message (run, confirmed, deleted).

## The gate's first catch was real

`render-smoke.test.tsx` mounted `lending/applications/[id]` — the one page reading `use(params)` — with a bare `render()`. Both render paths there now use an awaited `act`. Suite: **81 files / 1097 tests green** (`npm test`, pretest included).

Also picks up the `Date.now` freeze for `origination-pipeline.test.tsx` (cherry-picked from #3709's branch so it can merge independently — the flake is failing on main today: hardcoded `NOW` of 2026-08-02 vs a real date of 2026-08-05 turns a 1-hour-old item >24h old and flips the expected tone).
