### PR TITLE
security(infra): drop SRI-less web3forms.com script from landing page

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -153,6 +153,12 @@ regexes = [
   # placeholder account digits) — a public API-contract example, not a secret;
   # the 10-digit string trips the rod-cislo numeric heuristic.
   '''0800000019''',
+  # Web3Forms' shared free hCaptcha sitekey (public by design — hCaptcha sitekeys are
+  # not secrets, only the widget's client-side identifier, same trust level as a
+  # Google Analytics measurement ID). Previously injected at runtime by the vendor's
+  # own script.js; now inlined in openbank-infra/web/landing/{index.html,main.js}
+  # since that script was dropped for being an SRI-less third-party include.
+  '''50b2fe65-b00b-4b9e-ad62-3ba471098be2''',
   # customer-edge test account base from the demo IBAN CZ6508000000192000145399
   # (bank 0800, prefix 19, base 2000145399). It is NOT a rodné číslo — month digits
   # "00" make it structurally invalid and it fails the mod-11 birth-number check; it

--- a/openbank-infra/aws/modules/static-site/main.tf
+++ b/openbank-infra/aws/modules/static-site/main.tf
@@ -140,7 +140,10 @@ resource "aws_cloudfront_response_headers_policy" "sec" {
         "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://*.hcaptcha.com",
         "font-src 'self' https://fonts.gstatic.com",
         "img-src 'self' data:",
-        "script-src 'self' https://web3forms.com https://js.hcaptcha.com https://*.hcaptcha.com",
+        # web3forms.com is deliberately absent: the landing page loads no script from it
+        # (unversioned, SRI-less third party). Only the form POST to api.web3forms.com remains,
+        # which is connect-src/form-action, not script-src.
+        "script-src 'self' https://js.hcaptcha.com https://*.hcaptcha.com",
         "connect-src 'self' https://api.web3forms.com https://*.hcaptcha.com",
         "frame-src https://hcaptcha.com https://*.hcaptcha.com",
         "object-src 'none'",

--- a/openbank-infra/web/landing/README-testflight.md
+++ b/openbank-infra/web/landing/README-testflight.md
@@ -32,9 +32,17 @@ generate a new key from that inbox at https://web3forms.com and swap it in.
 ## Spam protection
 
 - **Honeypot** (`botcheck`) — always on.
-- **hCaptcha** — DONE. Widget `<div class="h-captcha" data-captcha="true" data-theme="dark">` in
-  `#tf-form`, rendered by `https://web3forms.com/client/script.js` (loaded before `</body>`) using
-  Web3Forms' shared free sitekey `50b2fe65-b00b-4b9e-ad62-3ba471098be2`. `main.js` blocks submit
+- **hCaptcha** — DONE. Widget `<div class="h-captcha" data-sitekey="50b2fe65-…" data-theme="dark">`
+  in `#tf-form`, rendered by `loadHcaptcha()` in our own `main.js`, which injects
+  `https://js.hcaptcha.com/1/api.js?recaptchacompat=off` with Web3Forms' shared free sitekey
+  `50b2fe65-b00b-4b9e-ad62-3ba471098be2`.
+  - We used to load `https://web3forms.com/client/script.js` for this. It was an **unversioned
+    third-party script with no SRI** — a compromise of that origin would have run attacker code
+    inside this form (the polyfill.io class of supply-chain attack), and an `integrity` hash on an
+    unversioned URL just swaps that risk for a silently broken form on the vendor's next release.
+    Its only other features (uploadcare / filepond file uploads) are unused here, so it is gone and
+    `web3forms.com` is out of `script-src`. `api.web3forms.com` still receives the POST.
+  `main.js` blocks submit
   until the challenge is solved and resets the widget after success. The token rides along in the
   FormData as `h-captcha-response`.
   - ⚠️ On `localhost` the widget shows "Warning: localhost detected" — that's the shared sitekey's
@@ -54,7 +62,7 @@ Required policy (set it in the CloudFront response-headers policy):
 
 ```
 default-src 'self';
-script-src 'self' https://web3forms.com https://js.hcaptcha.com https://*.hcaptcha.com;
+script-src 'self' https://js.hcaptcha.com https://*.hcaptcha.com;
 style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://*.hcaptcha.com;
 font-src 'self' https://fonts.gstatic.com;
 img-src 'self' data:;

--- a/openbank-infra/web/landing/index.html
+++ b/openbank-infra/web/landing/index.html
@@ -272,7 +272,7 @@
             <input type="checkbox" name="consent" value="Consented (GDPR Art.6(1)(a))" required />
             <span>I consent to OpenBank storing my Apple ID email solely to send me an Apple TestFlight invite. The sandbox holds no real banking data; my email is never shared and can be deleted anytime via <a href="mailto:hello@open-bank.tech">hello@open-bank.tech</a>. (GDPR Art.6(1)(a).)</span>
           </label>
-          <div class="h-captcha" data-captcha="true" data-theme="dark"></div>
+          <div class="h-captcha" data-sitekey="50b2fe65-b00b-4b9e-ad62-3ba471098be2" data-theme="dark"></div>
           <button class="btn btn-primary tf-submit" type="submit">Request my invite →</button>
           <p class="tf-status" id="tf-status" role="status" aria-live="polite"></p>
         </form>
@@ -357,7 +357,5 @@
   </dialog>
 
   <script src="main.js"></script>
-  <!-- Web3Forms client script: renders the hCaptcha widget (data-captcha="true"). -->
-  <script src="https://web3forms.com/client/script.js" async defer></script>
 </body>
 </html>

--- a/openbank-infra/web/landing/main.js
+++ b/openbank-infra/web/landing/main.js
@@ -57,6 +57,30 @@ if (modal) {
   });
 }
 
+// hCaptcha widget loader.
+// Replaces the third-party https://web3forms.com/client/script.js, which was an
+// unversioned remote script with no SRI (see the SRI finding): a compromise there
+// would have run attacker code with full access to this form. Of everything that
+// script did (uploadcare/filepond uploaders we never use) only this remains — inject
+// hCaptcha's api.js with Web3Forms' public sitekey, exactly as it did.
+const HCAPTCHA_SITEKEY = '50b2fe65-b00b-4b9e-ad62-3ba471098be2';
+function loadHcaptcha() {
+  const widgets = document.querySelectorAll('.h-captcha');
+  if (!widgets.length || document.querySelector('script[src*="js.hcaptcha.com"]')) return;
+  widgets.forEach((w) => { if (!w.dataset.sitekey) w.dataset.sitekey = HCAPTCHA_SITEKEY; });
+  const s = document.createElement('script');
+  s.src = 'https://js.hcaptcha.com/1/api.js?recaptchacompat=off';
+  s.async = true;
+  s.defer = true;
+  document.body.appendChild(s);
+}
+loadHcaptcha();
+// bfcache restore: the widget is gone but our guard script tag may still be in the DOM.
+window.addEventListener('pageshow', (e) => {
+  if (!e.persisted) return;
+  if (window.hcaptcha) { try { window.hcaptcha.reset(); } catch (_) {} } else { loadHcaptcha(); }
+});
+
 // testflight signup form (Web3Forms, AJAX submit)
 const tfForm = document.getElementById('tf-form');
 if (tfForm) {


### PR DESCRIPTION
## Summary
- Drop the SRI-less `https://web3forms.com/client/script.js` include from the TestFlight landing form — an unversioned third-party script with no integrity pin, a compromise/malicious update of which would run arbitrary code with full access to the form (the polyfill.io class of supply-chain attack).
- Only used feature was rendering the hCaptcha widget; `main.js` now loads `js.hcaptcha.com/1/api.js` itself, same sitekey, same behavior (including the bfcache `pageshow` reset).
- `web3forms.com` removed from the CloudFront CSP `script-src`; `api.web3forms.com` stays (form POST, `connect-src`/`form-action`, unaffected).
- README-testflight.md updated to match.
- `.gitleaks.toml` allowlists the now-inlined public hCaptcha sitekey (previously injected by the vendor script at runtime, so it never appeared in our source before).

## Linked issues
N/A — self-found security hardening (unversioned/no-SRI third-party script), no tracking issue.

## Test plan
- [x] Served `openbank-infra/web/landing/index.html` locally and confirmed in-browser: `js.hcaptcha.com` script present, `web3forms.com/client` script absent, widget renders an iframe, `h-captcha-response` field present, no console errors.
- [x] `gitleaks detect --no-git` locally: no findings in the changed files.
- [ ] CSP change is Terraform (`openbank-infra/aws/modules/static-site/main.tf`) — takes effect on the next `tofu apply` of `sandbox-substrate`, not on this merge alone.