### PR TITLE
docs: a version bump against a stale base can collide with a shipped release

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -396,6 +396,17 @@ fire from *outside* it, so they stay here:
   `a9381b256` -> `13335a859`) and the reported line no longer existed. Reporting a defect that is
   already gone sends the reader hunting for nothing. Diff the file at the CURRENT head, not the
   head the run used.
+- **A version bump computed against a STALE base can collide with a release-please version that
+  already shipped — read the version on fresh `origin/main`, never on the local base.** A branch in
+  a shallow worktree saw the release manifest at admin-ui `0.91.3`, so the manual bump went to
+  `0.91.4` — a version #3721 had already released the day before (tag `admin-ui-v0.91.4` existed).
+  It survived only because the numbers happened to agree on merge; release-please then correctly
+  proposed `0.91.5` (#3753) for the unreleased fixes, and a slightly different timeline yields a
+  skipped number or a released version with no tag. The version-sync gate checks
+  `version.txt == package.json`, not "is this number still free". Before `/bump`: `git fetch` (a
+  shallow worktree's `origin/main` ref does not move on its own), then read `version.txt` and the
+  manifest AS OF `origin/main` — same rule as acting on CI findings: the current head, not the
+  base you branched from.
 - **Omitting `--delete-branch` does NOT protect someone else's worktree — the repo sets
   `delete_branch_on_merge: true`.** That setting deletes the remote ref regardless of the merge
   flag, so the precaution is theatre. The local branch and working tree survive (verified on


### PR DESCRIPTION
## Summary

Knowledge capture per CLAUDE.md's own rule (`knowledge_capture`): yesterday's session hit a new failure mode — a manual version bump computed in a shallow worktree whose `origin/main` ref was a day stale. The manifest read admin-ui `0.91.3`, so the bump went to `0.91.4` — which #3721 had already released (tag `admin-ui-v0.91.4` existed). Only release-please's post-merge run (#3753 → `0.91.5`) kept the release axis consistent. This adds the pitfall bullet next to the other stale-state entries, with the imperative fix: fetch and read `version.txt`/manifest as of `origin/main` before bumping.

## Type of change

- [x] docs

## Linked issues

N/A — knowledge capture of #3717/#3753 session evidence, per `rules.yaml: knowledge_capture`

## Changes

- `CLAUDE.md`: one bullet in *Engineering notes (common pitfalls)* — the stale-base bump failure mode, the evidence (#3721/#3753, tag `admin-ui-v0.91.4`), and why the version-sync gate cannot catch it (it checks `version.txt == package.json`, not whether the number is still free).

## Definition of Done

- [x] Docs only; no code, no version bump, no manifest change.
- [x] Style matches the surrounding pitfall bullets (bold failure mode, evidence with PR/tag refs, imperative fix).

## Security checklist

- [x] No secrets, tokens, passwords, or PII.

## Compliance impact

- [x] None

## Rollout / Rollback

- Deployment strategy: none — documentation.
- Rollback plan: revert the squash commit.
- Data migration reversible: N/A