### PR TITLE
feat(governance): agent swarm case-coordinator charter and case-budget schema (ADR-0244)

### DIFF
--- a/docs/agents/case-coordinator.md
+++ b/docs/agents/case-coordinator.md
@@ -1,0 +1,49 @@
+---
+id: case-coordinator
+plane: control
+adr: ADR-0244
+---
+
+# case-coordinator
+
+## Mission
+
+Owns a single running *case* — a long-running Temporal workflow opened for one disposition target
+(an alert, incident, or proposal lineage). The coordinator invites other chartered agents to
+contribute mid-flight via OPA-gated Temporal signals, enforces the per-case-class budget and
+deadline, judges when the swarm has converged, and emits **exactly one** human-in-the-loop proposal
+per case. It never writes to a business record directly; the only output is a proposal into the
+existing ADR-0031 approval queue.
+
+## Why this agent exists
+
+ADR-0202 covers agent-to-agent *hand-offs*: one agent finishes, another takes over. That pattern
+does not cover several agents working the *same* problem concurrently, correcting each other
+mid-flight, and converging on a better answer faster. The case-coordinator is the boundary that
+keeps that concurrency bounded and safe: one durable workflow owns the case, the budget is declared
+up front, pre-emption is deterministic, and the swarm cannot silently stall or explode in cost.
+Without a dedicated coordinator, the agent that detected a problem would also judge when it is
+solved — a conflict of interest that ADR-0244 D3 explicitly rejects.
+
+## Human oversight
+
+- `every: proposal` — every synthesized case outcome is a proposal into the HITL queue; a human
+disposes before any state changes.
+- `approver_must_differ_from: author` — segregation of duties is preserved even inside the swarm.
+- Case budgets, deadlines, and contested-rate thresholds are declared in `agents.yaml` under
+`case_classes`, so they are reviewable and versioned with the same governance rigor as tool tiers.
+
+## Known gaps (these are real, not aspirational)
+
+- **There is no `openbank-case-coordinator-agent` module yet.** This charter is the governance
+scaffold; the Quarkus service, Temporal workflow, signal handler, and OPA-gated capability check
+are follow-up work tracked by ADR-0244 delivery notes.
+- **No other charter currently grants `case.join` or `case.contribute`.** The coordinator is the only
+swarm participant defined today; other agents will gain swarm capabilities only after the signal
+contract and policy gate are implemented.
+- **The kill-switch-to-Temporal-cancellation wiring is not built.** The global and per-agent kill
+switches can halt agent runtimes today, but canceling an in-flight case workflow requires a new
+hook that does not yet exist.
+- **The LLM synthesis step is undefined.** Whether the coordinator uses an LLM for convergence
+judgement or a deterministic rule set is a downstream decision; this charter reserves the
+`case.synthesize` capability and leaves the implementation open.

--- a/openbank-libs/governance/agents.yaml
+++ b/openbank-libs/governance/agents.yaml
@@ -174,10 +174,58 @@ tool_tiers:
     - secrets.read.raw
 
 # ---------------------------------------------------------------------------------------
+# Case classes for agent swarm coordination (ADR-0244). A case is one long-running
+# Temporal workflow opened for a single disposition target. Default budgets and
+# convergence thresholds live here; per-class overrides are merged over default.
+# Every case names exactly one class. The case-coordinator charter owns convergence
+# judgement and budget enforcement; other charters may be granted case.join (and later
+# case.contribute) once the signal-handling wiring lands.
+# ---------------------------------------------------------------------------------------
+case_classes:
+  default:
+    budget:
+      tokens_per_case: 500000
+      max_contributions: 100
+      wall_clock_minutes: 60
+    concurrency:
+      max_open_cases: 10
+    convergence:
+      contested_rate_threshold: 0.30   # suspend case-open for this class above 30% contested
+  classes:
+    fraud-investigation:
+      budget:
+        tokens_per_case: 1000000
+        max_contributions: 200
+        wall_clock_minutes: 120
+      concurrency:
+        max_open_cases: 5
+      convergence:
+        contested_rate_threshold: 0.25
+    aml-alert:
+      budget:
+        tokens_per_case: 300000
+        max_contributions: 50
+        wall_clock_minutes: 30
+      concurrency:
+        max_open_cases: 20
+      convergence:
+        contested_rate_threshold: 0.40
+    incident-response:
+      budget:
+        tokens_per_case: 200000
+        max_contributions: 40
+        wall_clock_minutes: 20
+      concurrency:
+        max_open_cases: 15
+      convergence:
+        contested_rate_threshold: 0.35
+
+# ---------------------------------------------------------------------------------------
 # Agents. plane = control (oversight, proposal-only) | development (per-domain engineering)
 #                | customer (customer-facing assistant, ADR-0089 — its own SCA-gated regime).
 # Each charter answers: data_scope (what it reads), tools (what it calls), requires_human
-# (what must be approved), limits (budget/quota).
+# (what must be approved), limits (budget/quota). Swarm participants additionally declare
+# case_capabilities (ADR-0244).
 # ---------------------------------------------------------------------------------------
 agents:
 
@@ -779,3 +827,64 @@ agents:
     compliance:
       eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
       dora: "Art. 9 ICT risk detection; Art. 5 ICT risk management framework — fleet-wide static verification that a test suite's reported green state reflects tests that actually ran"
+
+  - id: case-coordinator
+    plane: control
+    charter: "ADR-0244"
+    description: >
+      Owns a running Temporal case workflow: invites chartered agents to contribute,
+      enforces the per-case-class budget and deadline, judges convergence, and emits
+      exactly one HITL proposal per case. Every swarm is bounded to one disposition
+      target; pre-emption is deterministic and replay-safe. The coordinator never
+      coordinates a case it opened; who detected is never who converged.
+    enabled: true
+    enforcement: block
+    data_scope:
+      read:
+        - case-workflow-history       # Temporal workflow history of cases it coordinates
+        - agent-proposals-readonly    # existing proposal queue metadata (no raw payload)
+        - read.governance             # agents.yaml case classes and charter capabilities
+      pii: masked
+    tools:
+      allow:
+        - tier: read
+          resources: [case-workflow, governance]
+        - tier: write_proposal
+          resources: [agent-proposal]   # emits one HITL proposal per case
+        - tier: execute
+          resources: [case-workflow-signal]  # sends deterministic pre-emption / convergence signals
+      deny:
+        - tier: write
+          resources: ["*"]             # never writes to a business record directly
+        - tier: execute
+          resources: [money.*, gh.pr.*, secrets.*]
+    case_capabilities:
+      # The coordinator is the only charter that may open, coordinate, and synthesize a case.
+      # Other agents may be granted case.join (and later case.contribute) in their own charters.
+      - case.open
+      - case.coordinate
+      - case.synthesize
+      - case.preempt
+    requires_human:
+      - every: proposal               # every synthesized proposal is a HITL proposal
+      - approver_must_differ_from: author
+      - record: reason
+    limits:
+      tokens_per_run: 50000
+      runs_per_day: 48                # one per active case hour is common; cap prevents runaway
+      kill_switch: true
+    audit:
+      capture:
+        - model_id
+        - prompt_hash
+        - tool_calls
+        - policy_decision
+        - case_id
+        - disposition_target
+        - case_class
+        - contributions_received
+        - synthesis_cited_contribution_ids
+        - human_approved_by
+    compliance:
+      eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, human disposes; not Annex III high-risk"
+      dora: "ICT change management (Art. 8–10); operational resilience via durable, bounded case coordination"

--- a/openbank-libs/governance/prompts/registry.yaml
+++ b/openbank-libs/governance/prompts/registry.yaml
@@ -149,3 +149,8 @@ charters:
     prompts: [system.v1]
     source: openbank-flaky-test-hunter LlmDiagnosisAdapter.SYSTEM_PROMPT
     placeholders: []
+
+  - id: case-coordinator
+    status: pending
+    blocked_by: ADR-0244
+    reason: New agent-plane charter; no module or LlmDiagnosisAdapter wiring yet.


### PR DESCRIPTION
Adds the governance scaffold for ADR-0244 agent swarm coordination — the first conceptual slice before building the `case-coordinator` module.

## Changes

- `openbank-libs/governance/agents.yaml`
  - New `case_classes` schema with default and per-class budgets (tokens, contributions, wall-clock), concurrency ceilings, and contested-rate thresholds.
  - New `case-coordinator` charter with `case.open`, `case.coordinate`, `case.synthesize`, `case.preempt` capabilities; HITL proposal-only output; explicit audit capture set.
- `openbank-libs/governance/prompts/registry.yaml`
  - Registers `case-coordinator` as `pending` (ADR-0148 backlog) until the module and LLM wiring exist.
- `docs/agents/case-coordinator.md`
  - Narrative charter: mission, why it exists, human oversight, and known gaps.

## Not in this PR

- The actual `openbank-case-coordinator-agent` module (AGPL registration in `rules.yaml` deferred until the module exists, to keep the license-boundary check self-consistent).
- Temporal workflow, signal handlers, OPA capability check, eval scenarios — all follow-up PRs.

## Type of change

- [x] feat

## Linked issues

Refs #3737
