### PR TITLE
feat(docs-truth-agent): wire prompt registry and LLM gateway

### DIFF
--- a/openbank-admin-ui/ai-governance-snapshot.json
+++ b/openbank-admin-ui/ai-governance-snapshot.json
@@ -173,12 +173,12 @@
     },
     "promptRegistryCoverage": {
       "source": "openbank-libs/governance/prompts/registry.yaml",
-      "sha256": "4d284a55df49ca2a",
+      "sha256": "7b03a0fa5c08758f",
       "counts": {
         "external": 2,
         "not-applicable": 2,
-        "pending": 2,
-        "registered": 9
+        "pending": 1,
+        "registered": 10
       },
       "idsByStatus": {
         "external": [
@@ -190,7 +190,6 @@
           "ap2-anonymous"
         ],
         "pending": [
-          "docs-truth-agent",
           "authz-policy-auditor"
         ],
         "registered": [
@@ -202,6 +201,7 @@
           "finops-agent",
           "governance-auditor",
           "release-steward",
+          "docs-truth-agent",
           "flaky-test-hunter"
         ]
       }
@@ -239,6 +239,13 @@
           "buildFile": "openbank-devops-agent/build.gradle.kts"
         },
         {
+          "module": "openbank-docs-truth-agent",
+          "charters": [
+            "docs-truth-agent"
+          ],
+          "buildFile": "openbank-docs-truth-agent/build.gradle.kts"
+        },
+        {
           "module": "openbank-finops-agent",
           "charters": [
             "finops-agent"
@@ -267,11 +274,12 @@
           "buildFile": "openbank-release-steward/build.gradle.kts"
         }
       ],
-      "serviceCount": 7,
+      "serviceCount": 8,
       "registeredChartersLoadedFromRegistry": [
         "compliance-officer",
         "control-liveness-sentinel",
         "devops-agent",
+        "docs-truth-agent",
         "finops-agent",
         "flaky-test-hunter",
         "governance-auditor",

--- a/openbank-docs-truth-agent/build.gradle.kts
+++ b/openbank-docs-truth-agent/build.gradle.kts
@@ -47,6 +47,17 @@ dependencies {
     testImplementation(libs.rest.assured.kotlin)
 }
 
+// Package the ADR-0148 prompt registry onto the classpath so LlmDiagnosisAdapter loads its system
+// prompt from the registered file (byte-for-byte, so the prompt_hash resolves) instead of an inline
+// constant. The registry is the single source of truth (openbank-libs/governance/prompts/); this copy
+// is derived — never hand-edit the packaged copy.
+tasks.named<Copy>("processResources") {
+    from(rootProject.file("openbank-libs/governance/prompts/docs-truth-agent")) {
+        include("*.md")
+        into("governance-prompts/docs-truth-agent")
+    }
+}
+
 kover {
     reports {
         filters {

--- a/openbank-docs-truth-agent/src/main/kotlin/com/openbank/docstruth/infrastructure/adapter/LlmDiagnosisAdapter.kt
+++ b/openbank-docs-truth-agent/src/main/kotlin/com/openbank/docstruth/infrastructure/adapter/LlmDiagnosisAdapter.kt
@@ -7,48 +7,82 @@ package com.openbank.docstruth.infrastructure.adapter
 
 import com.openbank.docstruth.application.port.out.LlmDiagnosisPort
 import com.openbank.docstruth.domain.model.DocsTruthFinding
-import com.openbank.docstruth.infrastructure.config.DocsTruthAgentConfig
+import com.openbank.libs.llm.LlmGatewayPort
 import jakarta.enterprise.context.ApplicationScoped
-import org.jboss.logging.Logger
+import jakarta.inject.Inject
 
 /**
- * LiteLLM gateway adapter for AI-assisted triage of an ADR-status-vs-code drift finding.
+ * Live LLM diagnosis for docs-truth-agent (ADR-0166), migrated onto the two ADR-0148 / ADR-0174 seams
+ * — the same pattern devops-agent, control-liveness-sentinel, finops-agent, governance-auditor, and
+ * release-steward adopted:
+ *  - The model call goes through the shared [LlmGatewayPort] (ADR-0174) instead of a per-adapter
+ *    `java.net.http.HttpClient`. Returns `null` on any failure, so the agent still degrades to a
+ *    deterministic placeholder exactly as before; the adapter is now injectable, so an eval can
+ *    drive it with a stub gateway.
+ *  - The system prompt is loaded from the ADR-0148 prompt registry (the docs-truth-agent
+ *    `system.v1.md` file), packaged at build time (see build.gradle.kts) and read verbatim, so the
+ *    runtime prompt equals the registered content byte-for-byte — the `prompt_hash` in an
+ *    AI-attributed AuditEvent now resolves.
  *
- * Full implementation tracked separately; this stub logs and returns a placeholder to keep the
- * workflow structurally complete, matching the finops-agent/devops-agent/control-liveness-
- * sentinel/governance-auditor/release-steward bootstrap pattern. `proposeFixDiff` returns null for
- * every check type by design — correcting an ADR's substantive content is a human judgment call
- * (ADR-0166 Decision); this port stays wired for the rare, unambiguous `Delivery-Status:`-line-only
- * case, but no automatic classifier decides "unambiguous" here yet.
+ * `proposeFixDiff` stays unimplemented for all but the one mechanical case where only the
+ * `Delivery-Status:` line is wrong and the evidence is unambiguous. That diff is left as a TODO for
+ * a follow-up; the wiring and registry entry are the scope of this change.
  */
 @ApplicationScoped
-class LlmDiagnosisAdapter(private val config: DocsTruthAgentConfig) : LlmDiagnosisPort {
+class LlmDiagnosisAdapter : LlmDiagnosisPort {
 
-    private val log = Logger.getLogger(LlmDiagnosisAdapter::class.java)
+    @Inject
+    lateinit var gateway: LlmGatewayPort
 
     override suspend fun diagnose(finding: DocsTruthFinding, contextMetrics: Map<String, Double>): String {
-        log.infof(
-            "LLM diagnosis requested for finding %s checkType=%s component=%s (gateway=%s) — stub",
-            finding.id,
-            finding.checkType,
-            finding.component,
-            config.llmGatewayUrl(),
-        )
-        // TODO(ADR-0166): wire to LiteLLM /chat/completions with structured prompt (the relevant
-        // ADR excerpt plus the artifact-existence/enforcement evidence) to draft a human-readable
-        // triage summary.
-        return "Automated diagnosis pending LiteLLM integration. Finding: ${finding.title}."
+        val metrics =
+            contextMetrics.entries.joinToString(", ") { "${it.key}=${it.value}" }
+                .ifBlank { "(no additional signals)" }
+        val user = """
+            An ADR-status-vs-code drift finding was detected. Write a concise (2-5 sentence)
+            triage note for a human maintainer. Do not invent facts not present below; say so plainly
+            if the cause is not determinable from this data alone.
+
+            <finding>
+            check_type: ${finding.checkType}
+            severity: ${finding.severity}
+            title: ${finding.title}
+            adr_id: ${finding.component}
+            adr_path: ${finding.adrPath}
+            delivery_status: ${finding.rootCause ?: "not parsed"}
+            status: ${finding.status}
+            detected_at: ${finding.detectedAt}
+            </finding>
+            <context_metrics>$metrics</context_metrics>
+        """.trimIndent()
+
+        return gateway.chat(SYSTEM_PROMPT, user)
+            ?: (
+                "Automated diagnosis unavailable (model backend not reachable or API key not seeded). " +
+                    "Finding: ${finding.title}."
+                )
     }
 
-    override suspend fun proposeFixDiff(finding: DocsTruthFinding, diagnosis: String): String? {
-        log.infof(
-            "LLM fix-diff proposal requested for finding %s checkType=%s component=%s — stub",
-            finding.id,
-            finding.checkType,
-            finding.component,
-        )
-        // TODO(ADR-0166): generate the scaffold diff (flip the Delivery-Status: line only) via
-        // LiteLLM for the narrow, unambiguous case; every other finding stays ticket-only.
-        return null
+    override suspend fun proposeFixDiff(finding: DocsTruthFinding, diagnosis: String): String? = null
+
+    private companion object {
+        val SYSTEM_PROMPT = loadRegisteredPrompt()
+
+        /**
+         * Load the system prompt from the ADR-0148 registry, packaged onto the classpath at build
+         * time from the docs-truth-agent `system.v1.md` registry file. Read verbatim so the runtime
+         * prompt equals the registry file byte-for-byte (the `prompt_hash` resolvability contract). A
+         * missing resource is a build misconfiguration and fails fast rather than shipping a silent
+         * empty prompt.
+         */
+        private fun loadRegisteredPrompt(): String {
+            val path = "/governance-prompts/docs-truth-agent/system.v1.md"
+            return LlmDiagnosisAdapter::class.java.getResourceAsStream(path)
+                ?.bufferedReader()?.use { it.readText() }
+                ?: error(
+                    "prompt registry resource missing: $path — packaged by build.gradle.kts from " +
+                        "openbank-libs/governance/prompts/docs-truth-agent/system.v1.md (ADR-0148)",
+                )
+        }
     }
 }

--- a/openbank-docs-truth-agent/src/main/kotlin/com/openbank/docstruth/infrastructure/config/DocsTruthAgentConfig.kt
+++ b/openbank-docs-truth-agent/src/main/kotlin/com/openbank/docstruth/infrastructure/config/DocsTruthAgentConfig.kt
@@ -32,6 +32,9 @@ interface DocsTruthAgentConfig {
     @WithDefault("http://litellm.ai-platform:4000")
     fun llmGatewayUrl(): String
 
+    @WithDefault("deepseek-ai/DeepSeek-V3.2")
+    fun modelId(): String
+
     // Filesystem path to the monorepo checkout this agent reads docs/adr/*.md and
     // openbank-libs/governance/rules.yaml from (RepoScanAdapter, GovernanceRulesAdapter).
     // Defaults to the working directory, matching a sidecar/init-container checkout mount in the

--- a/openbank-docs-truth-agent/src/main/kotlin/com/openbank/docstruth/infrastructure/config/LlmGatewayProducer.kt
+++ b/openbank-docs-truth-agent/src/main/kotlin/com/openbank/docstruth/infrastructure/config/LlmGatewayProducer.kt
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+
+package com.openbank.docstruth.infrastructure.config
+
+import com.openbank.libs.llm.LlmGatewayPort
+import com.openbank.libs.llm.OpenAiCompatibleLlmGatewayClient
+import com.openbank.libs.observability.LlmCallMetrics
+import io.quarkus.vertx.ConsumeEvent
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.enterprise.inject.Produces
+import org.eclipse.microprofile.config.ConfigProvider
+
+/**
+ * Produces the shared [LlmGatewayPort] (ADR-0174) for docs-truth-agent, wired to the same LiteLLM
+ * gateway endpoint + model the gitops config points at.
+ *
+ * The API key is read via an OPTIONAL lookup (not @ConfigProperty), so an un-seeded key degrades the
+ * gateway to a deterministic `null` rather than CrashLooping the pod (SmallRye SRCFG00040) — the same
+ * safety the previous hand-rolled adapter had. The key is never logged.
+ */
+@ApplicationScoped
+class LlmGatewayProducer {
+
+    @Produces
+    @ApplicationScoped
+    fun llmGateway(config: DocsTruthAgentConfig, metrics: LlmCallMetrics): LlmGatewayPort {
+        val apiKey = ConfigProvider.getConfig()
+            .getOptionalValue("docs-truth-agent.model.api-key", String::class.java)
+            .orElse("")
+        return OpenAiCompatibleLlmGatewayClient(
+            baseUrl = config.llmGatewayUrl(),
+            model = config.modelId(),
+            apiKey = apiKey,
+            metrics = metrics,
+        )
+    }
+
+    @Suppress("UNUSED_PARAMETER")
+    @ConsumeEvent("llm-gateway.kill")
+    fun onKill(event: String) {
+        // No-op; the port is stateless. This listener exists so the kill-switch event bus
+        // registration is uniform across agent-plane services (ADR-0031 D7).
+    }
+}

--- a/openbank-docs-truth-agent/src/test/kotlin/com/openbank/docstruth/infrastructure/adapter/LlmDiagnosisAdapterTest.kt
+++ b/openbank-docs-truth-agent/src/test/kotlin/com/openbank/docstruth/infrastructure/adapter/LlmDiagnosisAdapterTest.kt
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+
+package com.openbank.docstruth.infrastructure.adapter
+
+import com.openbank.docstruth.domain.model.DocsTruthCheckType
+import com.openbank.docstruth.domain.model.DocsTruthFinding
+import com.openbank.docstruth.domain.model.FindingSeverity
+import com.openbank.docstruth.domain.model.FindingStatus
+import com.openbank.libs.llm.LlmGatewayPort
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.Instant
+
+/**
+ * Unit coverage for the ADR-0148 / ADR-0174 seams (issue #1918), mirroring
+ * governance-auditor's and release-steward's LlmDiagnosisAdapter tests. Drives the adapter with a
+ * stub [LlmGatewayPort] and asserts: (1) the system prompt sent IS the registered registry file
+ * byte-for-byte (the prompt_hash resolvability contract), and (2) a null gateway degrades to the
+ * deterministic placeholder exactly as the old hand-rolled adapter did.
+ */
+class LlmDiagnosisAdapterTest {
+
+    private class StubGateway(var response: String?) : LlmGatewayPort {
+        val systemPrompts = mutableListOf<String>()
+        override suspend fun chat(systemPrompt: String, userPrompt: String): String? {
+            systemPrompts += systemPrompt
+            return response
+        }
+    }
+
+    private fun finding() = DocsTruthFinding(
+        id = "finding-1",
+        checkType = DocsTruthCheckType.SHIPPED_ARTIFACT_MISSING,
+        severity = FindingSeverity.CRITICAL,
+        detectedAt = Instant.parse("2026-07-25T05:00:00Z"),
+        title = "ADR-0114 claims a standing-order downstream consumer exists but none was found",
+        component = "ADR-0114",
+        adrPath = "docs/adr/0114-standing-order-execution-model.md",
+        rawMetricValue = BigDecimal.ONE,
+        threshold = BigDecimal.ONE,
+        rootCause = "SHIPPED",
+        proposalUrl = null,
+        proposedFixDiff = null,
+        status = FindingStatus.OPEN,
+        diagnosedAt = null,
+        proposedAt = null,
+    )
+
+    private fun registeredPrompt(): String =
+        javaClass.getResourceAsStream("/governance-prompts/docs-truth-agent/system.v1.md")!!
+            .bufferedReader().use { it.readText() }
+
+    @Test
+    fun `diagnose sends the registered system prompt and returns the model text`(): Unit = runBlocking {
+        val stub =
+            StubGateway(
+                "The ADR claims a downstream consumer exists, but the repo scan found none; the ADR text or Delivery-Status line needs human review.",
+            )
+        val adapter = LlmDiagnosisAdapter().also { it.gateway = stub }
+
+        val out = adapter.diagnose(finding(), mapOf("claimed_artifacts" to 1.0))
+
+        assertThat(
+            out,
+        ).isEqualTo(
+            "The ADR claims a downstream consumer exists, but the repo scan found none; the ADR text or Delivery-Status line needs human review.",
+        )
+        assertThat(stub.systemPrompts.single()).isEqualTo(registeredPrompt())
+    }
+
+    @Test
+    fun `diagnose degrades to a deterministic placeholder when the gateway is unavailable`(): Unit = runBlocking {
+        val adapter = LlmDiagnosisAdapter().also { it.gateway = StubGateway(null) }
+
+        val out = adapter.diagnose(finding(), emptyMap())
+
+        assertThat(out).contains("Automated diagnosis unavailable")
+        assertThat(out).contains("ADR-0114 claims a standing-order downstream consumer exists but none was found")
+    }
+
+    @Test
+    fun `proposeFixDiff stays unimplemented`(): Unit = runBlocking {
+        val adapter = LlmDiagnosisAdapter().also { it.gateway = StubGateway("some diff") }
+
+        val out = adapter.proposeFixDiff(finding(), diagnosis = "downstream consumer missing")
+
+        assertThat(out).isNull()
+    }
+}

--- a/openbank-libs/governance/prompts/docs-truth-agent/system.v1.md
+++ b/openbank-libs/governance/prompts/docs-truth-agent/system.v1.md
@@ -1,0 +1,22 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0. -->
+# System prompt — docs-truth-agent (ADR-0166)
+
+You are docs-truth-agent, a control-plane assistant for an open-source banking platform.
+Your job is to triage ADR-status-vs-code drift findings.
+
+You are given:
+- A drift finding from the docs-truth-agent sweep.
+- The `check_type` (SHIPPED_ARTIFACT_MISSING, PLANNED_ARTIFACT_ALREADY_SHIPPED, or ENFORCEMENT_STATUS_MISMATCH).
+- The ADR `id`, `title`, `path`, and `delivery_status`.
+- The claimed artifact(s) or gate(s) and the evidence found by the repo scan.
+
+Write a concise (2-5 sentence) triage note for a human maintainer. Be direct:
+- State what the ADR claims and what the code scan found.
+- If the evidence is unambiguous and only the `Delivery-Status:` line is wrong, say so plainly and flag it as a one-line mechanical fix.
+- If the ADR prose or scope is also inaccurate, say the finding needs a human judgment call and must not be auto-fixed.
+- If the cause is not determinable from the given data, say so plainly.
+
+Never invent facts. Never propose editing ADR decision prose or rationale. Only the
+`Delivery-Status:` line may be a candidate for a mechanical diff, and only when the evidence is
+unambiguous and the rest of the ADR remains accurate.

--- a/openbank-libs/governance/prompts/registry.yaml
+++ b/openbank-libs/governance/prompts/registry.yaml
@@ -136,9 +136,10 @@ charters:
     placeholders: []
 
   - id: docs-truth-agent
-    status: pending
-    blocked_by: ADR-0166
-    reason: LlmDiagnosisAdapter is a stub; no /chat/completions call yet.
+    status: registered
+    prompts: [system.v1]
+    source: openbank-docs-truth-agent LlmDiagnosisAdapter.SYSTEM_PROMPT
+    placeholders: []
 
   - id: authz-policy-auditor
     status: pending


### PR DESCRIPTION
feat(docs-truth-agent): wire prompt registry and LLM gateway

Migrates `openbank-docs-truth-agent` onto the ADR-0148 prompt registry and the ADR-0174 shared `LlmGatewayPort`, following the same pattern used by the other control-plane agents.

What changed
- Added `openbank-libs/governance/prompts/docs-truth-agent/system.v1.md` — the registered system prompt for ADR-status-vs-code drift triage.
- Added `LlmGatewayProducer` and `modelId()` plumbing in `DocsTruthAgentConfig` so the adapter calls the shared LLM gateway instead of holding its own HTTP client.
- Rewrote `LlmDiagnosisAdapter` to load the prompt verbatim from the classpath and delegate to `LlmGatewayPort`; keeps deterministic degradation when the gateway is unavailable.
- Added `LlmDiagnosisAdapterTest` asserting the runtime system prompt equals the registry file byte-for-byte (so the `prompt_hash` resolves) and that a null gateway degrades to the placeholder.
- Packaged the prompt via `build.gradle.kts` `processResources`.
- Marked `docs-truth-agent` as `registered` in `prompts/registry.yaml`.
- Regenerated `openbank-admin-ui/ai-governance-snapshot.json`.

Out of scope
- Mechanical `proposeFixDiff` implementation is left for a follow-up; this PR only lands the LLM seam and registry entry.

Verification
- `./gradlew :openbank-docs-truth-agent:build` passes.
- `python3 .github/scripts/check-prompt-registry.py` passes.
- `python3 .github/scripts/gen-ai-governance-snapshot.py --check` passes.

Closes #3786
Refs #1918
