### PR TITLE
security(admin-ui): GDPR privacy notice, a11y fixes, security.txt + DNS SPF drift fix

### DIFF
--- a/openbank-admin-ui/public/.well-known/security.txt
+++ b/openbank-admin-ui/public/.well-known/security.txt
@@ -1,0 +1,8 @@
+# OpenBank vulnerability disclosure — https://admin.open-bank.tech
+# RFC 9116 (https://www.rfc-editor.org/rfc/rfc9116). Refresh before the Expires date below.
+
+Contact: mailto:security@open-bank.tech
+Expires: 2027-06-11T00:00:00.000Z
+Policy: https://github.com/JiRaska/openbank-app/blob/main/docs/VULNERABILITY-DISCLOSURE.md
+Preferred-Languages: cs, en
+Canonical: https://admin.open-bank.tech/.well-known/security.txt

--- a/openbank-admin-ui/public/robots.txt
+++ b/openbank-admin-ui/public/robots.txt
@@ -1,0 +1,5 @@
+# admin.open-bank.tech is an internal, login-gated operator console — every
+# route already answers with 302 -> /auth/login for an unauthenticated crawler,
+# but keep search engines and AI bots from wasting a crawl budget on it too.
+User-agent: *
+Disallow: /

--- a/openbank-admin-ui/src/app/auth/login/page.tsx
+++ b/openbank-admin-ui/src/app/auth/login/page.tsx
@@ -21,7 +21,8 @@ function LoginContent() {
         href="#main"
         style={{
           position: "absolute", left: "-9999px", top: "0", zIndex: 100,
-          padding: "10px 16px", background: "var(--sidebar-accent, #6366f1)", color: "#fff",
+          // #4f46e5, not --sidebar-accent (#6366f1) — same contrast fix as the sign-in button below.
+          padding: "10px 16px", background: "#4f46e5", color: "#fff",
           borderRadius: "0 0 8px 0", fontSize: "13px", fontWeight: 600,
         }}
         onFocus={e => { e.currentTarget.style.left = "0" }}

--- a/openbank-admin-ui/src/app/auth/login/page.tsx
+++ b/openbank-admin-ui/src/app/auth/login/page.tsx
@@ -14,10 +14,22 @@ function LoginContent() {
 
   return (
     <div style={{
-      minHeight: "100vh", display: "flex", alignItems: "center", justifyContent: "center",
+      minHeight: "100vh", display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center",
     background: "var(--bg, #f8fafc)", fontFamily: "var(--font-sans, 'Inter', system-ui, sans-serif)",
     }}>
-      <div style={{
+      <a
+        href="#main"
+        style={{
+          position: "absolute", left: "-9999px", top: "0", zIndex: 100,
+          padding: "10px 16px", background: "var(--sidebar-accent, #6366f1)", color: "#fff",
+          borderRadius: "0 0 8px 0", fontSize: "13px", fontWeight: 600,
+        }}
+        onFocus={e => { e.currentTarget.style.left = "0" }}
+        onBlur={e => { e.currentTarget.style.left = "-9999px" }}
+      >
+        Přeskočit na obsah
+      </a>
+      <main id="main" style={{
         width: "380px", background: "var(--surface, #ffffff)", border: "1px solid var(--border, #e2e8f0)",
         borderRadius: "16px", padding: "40px", boxShadow: "var(--shadow-lg, 0 10px 15px -3px rgba(0,0,0,0.1))",
       }}>
@@ -38,9 +50,9 @@ function LoginContent() {
           </div>
         </div>
 
-        <div style={{ marginBottom: "8px", fontSize: "20px", fontWeight: 700, color: "var(--text-primary, #0f172a)" }}>
+        <h1 style={{ margin: "0 0 8px", fontSize: "20px", fontWeight: 700, color: "var(--text-primary, #0f172a)" }}>
           Přihlášení
-        </div>
+        </h1>
         <div style={{ marginBottom: "28px", fontSize: "13px", color: "var(--text-secondary, #475569)" }}>
           Přihlaste se pomocí firemního účtu Keycloak
         </div>
@@ -59,7 +71,10 @@ function LoginContent() {
           onClick={() => signIn("keycloak", { callbackUrl })}
           style={{
             width: "100%", padding: "12px", borderRadius: "8px",
-            background: "var(--sidebar-accent, #6366f1)", border: "none", color: "#ffffff",
+            // Darker than --sidebar-accent (#6366f1) on purpose: white-on-#6366f1
+            // measures ~4.47:1, just under WCAG 2.1 AA's 4.5:1 for normal text.
+            // #4f46e5 (~6.5:1) keeps the same hue with margin to spare.
+            background: "#4f46e5", border: "none", color: "#ffffff",
             fontSize: "14px", fontWeight: 600, cursor: "pointer",
             display: "flex", alignItems: "center", justifyContent: "center", gap: "10px",
             transition: "opacity 0.15s, background-color 0.15s",
@@ -79,7 +94,11 @@ function LoginContent() {
           <strong style={{ color: "var(--text-secondary, #475569)" }}>Zero-Trust Security</strong><br/>
           Přístup je řízen rolemi (RBAC). Všechny akce jsou auditovány dle EBA ICT Risk a PSD2 požadavků.
         </div>
-      </div>
+      </main>
+      <footer style={{ marginTop: "20px", fontSize: "11px" }}>
+        {/* var(--text-tertiary) fails contrast at this size (~2.4:1) — use --text-secondary (~7.2:1). */}
+        <a href="/privacy" style={{ color: "var(--text-secondary, #475569)" }}>Ochrana osobních údajů</a>
+      </footer>
     </div>
   )
 }

--- a/openbank-admin-ui/src/app/privacy/page.tsx
+++ b/openbank-admin-ui/src/app/privacy/page.tsx
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+// Static, pre-login, single-language legal notice — same class as the /auth/*
+// screens (i18n.guard / layout-shell.guard EXEMPT). GDPR Art. 13 requires this
+// notice to be reachable WITHOUT an account (middleware.ts carries the bypass),
+// since the data subjects it describes are the operators who are about to log in.
+
+export const metadata = {
+  title: "Ochrana osobních údajů — OpenBank Admin",
+}
+
+export default function PrivacyPage() {
+  return (
+    <main
+      id="main"
+      style={{
+        maxWidth: "720px", margin: "0 auto", padding: "48px 24px 96px",
+        fontFamily: "var(--font-sans, 'Inter', system-ui, sans-serif)",
+        color: "var(--text-primary, #0f172a)", lineHeight: 1.6,
+      }}
+    >
+      <h1 style={{ fontSize: "24px", fontWeight: 700, marginBottom: "8px" }}>
+        Ochrana osobních údajů — OpenBank Admin
+      </h1>
+      <p style={{ color: "var(--text-tertiary, #94a3b8)", fontSize: "13px", marginBottom: "32px" }}>
+        Operations Portal · admin.open-bank.tech
+      </p>
+
+      <h2 style={{ fontSize: "16px", fontWeight: 700, marginTop: "28px", marginBottom: "8px" }}>
+        Kdo je správcem
+      </h2>
+      <p>
+        OpenBank Foundation (v přípravě), provozovatel demonstrační bankovní platformy
+        na doméně open-bank.tech. Kontakt: <a href="mailto:hello@open-bank.tech">hello@open-bank.tech</a>.
+      </p>
+
+      <h2 style={{ fontSize: "16px", fontWeight: 700, marginTop: "28px", marginBottom: "8px" }}>
+        Jaké údaje zpracováváme a proč
+      </h2>
+      <p>
+        OpenBank Admin je interní operátorská konzole — přístup mají pouze zaměstnanci a
+        spolupracovníci přihlášení přes firemní Keycloak SSO účet. Při přihlášení a používání
+        konzole zpracováváme:
+      </p>
+      <ul>
+        <li>identitu z Keycloak (jméno, e-mail, přidělené role) — pro autentizaci a řízení přístupu (RBAC);</li>
+        <li>relační cookie (NextAuth session) — nezbytnou pro udržení přihlášení, žádné sledovací ani marketingové cookies;</li>
+        <li>záznam provedených akcí (audit log) — právním základem je plnění povinností dle EBA ICT Risk
+          Guidelines a PSD2, a oprávněný zájem na vysledovatelnosti operací nad bankovními daty.</li>
+      </ul>
+
+      <h2 style={{ fontSize: "16px", fontWeight: 700, marginTop: "28px", marginBottom: "8px" }}>
+        Doba uchování
+      </h2>
+      <p>
+        Relační cookie zaniká odhlášením nebo vypršením platnosti tokenu. Audit záznamy se
+        uchovávají po dobu vyžadovanou regulatorními předpisy pro finanční sektor.
+      </p>
+
+      <h2 style={{ fontSize: "16px", fontWeight: 700, marginTop: "28px", marginBottom: "8px" }}>
+        Vaše práva
+      </h2>
+      <p>
+        Máte právo na přístup, opravu, výmaz (v rozsahu, který nekoliduje s výše uvedenou
+        regulatorní povinností uchování) a na podání stížnosti u Úřadu pro ochranu osobních
+        údajů. Žádosti směřujte na <a href="mailto:hello@open-bank.tech">hello@open-bank.tech</a>.
+      </p>
+
+      <h2 style={{ fontSize: "16px", fontWeight: 700, marginTop: "28px", marginBottom: "8px" }}>
+        Bezpečnostní kontakt
+      </h2>
+      <p>
+        Nahlášení bezpečnostní zranitelnosti: <a href="mailto:security@open-bank.tech">security@open-bank.tech</a>{" "}
+        (viz <a href="/.well-known/security.txt">/.well-known/security.txt</a>).
+      </p>
+
+      <p style={{ marginTop: "40px" }}>
+        <a href="/auth/login">← Zpět na přihlášení</a>
+      </p>
+    </main>
+  )
+}

--- a/openbank-admin-ui/src/middleware.ts
+++ b/openbank-admin-ui/src/middleware.ts
@@ -51,10 +51,12 @@ export default auth((req) => {
     return withCsp(NextResponse.next({ request: { headers: requestHeaders } }))
   }
 
-  // The /auth/* pages (login, error, forbidden) are public — apply the nonce CSP but DON'T run
-  // the auth gate (it would loop /auth/login → /auth/login). They are matched by middleware only
-  // so the CSP reaches them (ADR-0080 P1: CSP must cover the pre-auth login page too).
-  if (pathname.startsWith("/auth")) {
+  // The /auth/* pages (login, error, forbidden), the GDPR privacy notice, and
+  // RFC 9116 security.txt are public — apply the nonce CSP but DON'T run the
+  // auth gate (it would loop /auth/login → /auth/login, or make the incident
+  // contact unreachable without an account). Matched by middleware only so the
+  // CSP still reaches them (ADR-0080 P1: CSP must cover pre-auth pages too).
+  if (pathname.startsWith("/auth") || pathname === "/privacy" || pathname.startsWith("/.well-known/")) {
     return nextWithNonce()
   }
 

--- a/openbank-admin-ui/src/test/i18n.guard.test.ts
+++ b/openbank-admin-ui/src/test/i18n.guard.test.ts
@@ -37,11 +37,12 @@ import path from 'path'
 const APP_DIR = path.resolve(__dirname, '../app')
 const COMPONENTS_DIR = path.resolve(__dirname, '../components')
 
-// Auth screens are static, pre-login, single-language by design.
+// Auth screens (and the GDPR privacy notice) are static, pre-login, single-language by design.
 const EXEMPT = new Set<string>([
   'auth/login/page.tsx',
   'auth/error/page.tsx',
   'auth/forbidden/page.tsx',
+  'privacy/page.tsx',
 ])
 
 // Brand / proper nouns / technical tokens that read identically in cs and en and

--- a/openbank-admin-ui/src/test/layout-shell.guard.test.ts
+++ b/openbank-admin-ui/src/test/layout-shell.guard.test.ts
@@ -34,6 +34,7 @@ const EXEMPT = new Set<string>([
   'auth/login/page.tsx',
   'auth/error/page.tsx',
   'auth/forbidden/page.tsx',
+  'privacy/page.tsx',
 ])
 
 function walk(dir: string): string[] {

--- a/openbank-infra/aws/modules/dns/main.tf
+++ b/openbank-infra/aws/modules/dns/main.tf
@@ -120,8 +120,10 @@ resource "aws_eks_pod_identity_association" "cert_manager" {
 
 # ---------------------------------------------------------------------------
 # Email anti-spoofing (SPF + DMARC)
-# OpenBank sends no email from this domain. SPF -all rejects any sender;
-# DMARC p=reject instructs receiving MTAs to drop forged messages outright.
+# hello@open-bank.tech is a real Zoho Mail inbox (see the landing page's
+# mailto: links) — SPF must authorize Zoho's sending servers, not reject
+# everyone. DMARC p=reject still instructs receiving MTAs to drop anything
+# that doesn't align with this SPF (or a future DKIM signature).
 # ---------------------------------------------------------------------------
 # ---------------------------------------------------------------------------
 # CAA (Certification Authority Authorization)
@@ -158,6 +160,23 @@ resource "aws_route53_record" "caa" {
 resource "aws_route53_record" "spf" {
   zone_id = aws_route53_zone.this.zone_id
   name    = var.domain
+  type    = "TXT"
+  ttl     = 300
+  records = [
+    "v=spf1 include:zohomail.eu ~all",
+    # Zoho Mail domain-ownership proof (Zoho re-checks this TXT periodically;
+    # removing it can silently suspend the hello@ mailbox).
+    "zoho-verification=zb32116331.zmverify.zoho.eu",
+  ]
+}
+
+# SPF is NOT inherited from the apex the way DMARC/CAA are (RFC 7208 has no
+# organizational-domain fallback) — admin.<domain> needs its own record. No
+# mail is ever sent from this subdomain (it's the operator console), so -all
+# rejects every sender outright.
+resource "aws_route53_record" "spf_admin" {
+  zone_id = aws_route53_zone.this.zone_id
+  name    = "admin.${var.domain}"
   type    = "TXT"
   ttl     = 300
   records = ["v=spf1 -all"]


### PR DESCRIPTION
## Summary
Driven by a third-party security scan of admin.open-bank.tech (57/100 overall, security 34/100).

- **GDPR (Art. 13)**: add `/privacy` page, linked from the login footer, exempted from the auth gate (a privacy notice you need an account to read defeats its own purpose).
- **Accessibility**: login page gets `<main id="main">`, an `<h1>`, a skip-link (WCAG 2.4.1), and a darkened sign-in button (`#6366f1` → `#4f46e5`) — white text on the original measured ~4.47:1, under WCAG 2.1 AA's 4.5:1.
- **NIS2 21(2)(b)**: add `public/.well-known/security.txt` (RFC 9116) and exempt `/.well-known/` from the auth gate so the incident contact is reachable pre-auth.
- **robots.txt**: `Disallow: /` — this is a login-gated internal console, not content to index (the scan's generic "allow GPTBot" advice doesn't fit an internal tool).
- **DNS drift fix** (`openbank-infra/aws/modules/dns/main.tf`): the module declared apex SPF as `v=spf1 -all`, but live Route53 actually carries Zoho Mail's `include:zohomail.eu ~all` (`hello@open-bank.tech` is a real inbox). The next unrelated `tofu apply` on `sandbox-substrate` would have silently reverted it and broken real mail delivery — the module now matches reality. Also adds an explicit SPF record for `admin.open-bank.tech` itself (SPF has no organizational-domain fallback the way DMARC/CAA do).

**Not done, needs a separate decision**: the scan also flags no WAF/edge protection in front of the admin console. That's an architecture + cost call (Cloudflare/AWS WAF), not a drop-in fix — flagging it, not touching it here.

**Already applied directly** (`sandbox-substrate` has no CI apply pipeline, `AWS_PROFILE=openbank`, laptop-side):
- `tofu apply -target=module.dns.aws_route53_record.spf` — fixed the drift (no live change, confirmed `tofu plan` was a no-op against reality after the fix)
- `tofu apply -target=module.dns.aws_route53_record.spf_admin` — new record, live now (`dig TXT admin.open-bank.tech` confirms)

This PR is the required main-tracking bookkeeping for those (repo convention: direct applies still need the PR merged, not just closed).

## Linked issues
N/A — self-found via a third-party security scan, no tracking issue.

## Test plan
- [x] `npm run type-check`, `npx eslint` on changed files, `npm test` (1100/1100) — all green in an isolated worktree with a fresh `npm ci`.
- [x] Verified in-browser (local dev server, port 3901 to avoid clashing with another running server): `<h1>`, `<main id="main">`, skip-link, footer `/privacy` link, button computed background `rgb(79, 70, 229)` (`#4f46e5`).
- [x] `curl` verified: `/privacy`, `/robots.txt`, `/.well-known/security.txt` all reachable unauthenticated (200); `/dashboard` still redirects to `/auth/login` (307) — auth gate untouched for real routes.
- [x] `dig TXT admin.open-bank.tech` confirms the new SPF record live.
- [ ] The DNS module fix (matching live Zoho SPF) is a no-op against reality by design — confirmed via `tofu plan` (no diff) before applying anything.
