### PR TITLE
fix(observability): delete 64 SLOMetricAbsent rules, keep liveness on up==0

### DIFF
--- a/.github/scripts/check-slo-registry.py
+++ b/.github/scripts/check-slo-registry.py
@@ -75,6 +75,14 @@ def main() -> int:
                     f"{name}: metadata.labels['openbank.io/money-path-service']={label_service!r} "
                     f"does not match the owning service {service!r}."
                 )
+            if spec.get("alerting", {}).get("absent") is not False:
+                violations.append(
+                    f"{name}: spec.alerting.absent must be explicitly false (issue #3333). Pyrra "
+                    f"defaults it to true, which emits a critical SLOMetricAbsent on "
+                    f"absent(<span-metric>) — a condition an IDLE service satisfies permanently, "
+                    f"since Tempo span-metrics only exist while traffic flows. Liveness is carried "
+                    f"by the up==0 rules in prometheus-rules-tier1.yaml instead."
+                )
 
     # An SLO object naming a service that isn't (or no longer is) money-path is orphaned data.
     money_path_shorts = {short_name(s) for s in money_path_services}
@@ -98,5 +106,29 @@ def main() -> int:
     return 0
 
 
+def self_test() -> int:
+    """Feed the absent-flag rule (issue #3333) an input it MUST reject and one it must accept.
+
+    The gate itself reads the real manifest, which is the only case it will ever see in CI; that
+    makes the failure path unexercised code. This harness exercises it directly on the predicate,
+    so a refactor that stops rejecting `absent: true` is caught at the point of change.
+    """
+    cases = [
+        ({"alerting": {"absent": False}}, False, "explicit false — the only accepted shape"),
+        ({}, True, "no alerting block at all — Pyrra defaults absent to true"),
+        ({"alerting": {}}, True, "alerting block without the key — same default"),
+        ({"alerting": {"absent": True}}, True, "explicitly re-enabled"),
+        ({"alerting": {"absent": "false"}}, True, "string, not bool — YAML would not disable it"),
+    ]
+    failures = 0
+    for spec, must_flag, why in cases:
+        flagged = spec.get("alerting", {}).get("absent") is not False
+        ok = flagged == must_flag
+        print(f"  {'ok  ' if ok else 'FAIL'} flagged={flagged!s:5} expected={must_flag!s:5}  {why}")
+        failures += not ok
+    print("SLO registry self-test:", "OK" if not failures else f"{failures} FAILED")
+    return 1 if failures else 0
+
+
 if __name__ == "__main__":
-    sys.exit(main())
+    sys.exit(self_test() if "--self-test" in sys.argv else main())

--- a/openbank-infra/gitops/components/delegation/external-secret-oidc.yaml
+++ b/openbank-infra/gitops/components/delegation/external-secret-oidc.yaml
@@ -18,6 +18,12 @@
 # KubeDeploymentReplicasMismatch/RolloutStuck, ArgoCDAppDegraded, PostgresWALArchiveFailing
 # and both Kyverno criticals.
 #
+# The SLOMetricAbsent x3 in that list no longer exist (issue #3333, pyrra-slo-money-path.yaml):
+# they were retired precisely BECAUSE they were in it. They fired here on a genuinely broken pod
+# and went on firing after the fix, unchanged, with `up == 1` — a signal present in both states
+# carries no information about either, and the nine other alerts above are what actually named
+# the fault. Read this list as evidence for the deletion, not against it.
+#
 # Deleting the "Prerequisite: seed the KV" line is part of the fix, not tidying: the seed
 # step existed only to satisfy the wrong key, so keeping it would preserve a manual rollout
 # action that has no purpose and that nobody performed anyway.

--- a/openbank-infra/gitops/components/observability/prometheus-rules-tier1.yaml
+++ b/openbank-infra/gitops/components/observability/prometheus-rules-tier1.yaml
@@ -36,6 +36,30 @@ spec:
           annotations:
             summary: "Payment service {{ $labels.container }} is down"
             description: "{{ $labels.container }} ({{ $labels.namespace }}) has been unreachable for >2m."
+        - alert: MoneyPathServiceDown
+          # The half of #3333's SLOMetricAbsent that was worth keeping, expressed on a signal that
+          # can actually carry it. The Pyrra absent rules were deleted because they watched Tempo
+          # span-metrics, which vanish when a service is merely idle; `up` comes from the fleet
+          # PodMonitor and is emitted whether or not anyone calls the service, so `up == 0` means
+          # "the pod is there and not answering", which is a fault in every environment.
+          #
+          # Scoped to the money-path namespaces that no other Down rule already covers —
+          # PaymentServiceDown owns payments+fx and LendingServiceDown owns lending, and a second
+          # rule over the same targets would just page twice for one outage. The remaining eleven
+          # are the money_path_services (rules.yaml) that live in a namespace of their own; ledger
+          # is among them, so the core money service had no liveness alert at all until now.
+          #
+          # `for: 10m` is measured, not guessed: over the retained window every `up == 0` on this
+          # job was a pod start or termination lasting at most 3 consecutive scrapes (~90s), so at
+          # 10m this rule contributes nothing to the idle alert set — which is the whole point of
+          # #3333. Pod-level churn is already covered by KubePodCrashLooping / KubePodNotReady.
+          expr: up{job="observability/openbank-services", namespace=~"ledger|accounts|balances|sdd|interest|sca|consent|fraud|billing|sanctions|delegation"} == 0
+          for: 10m
+          labels:
+            severity: critical
+          annotations:
+            summary: "Money-path service {{ $labels.container }} is down"
+            description: "{{ $labels.container }} ({{ $labels.namespace }}) has failed scraping for >10m — the pod exists but is not answering."
         - alert: HighErrorRate
           # The ratio alone is meaningless at trivial throughput: a service doing
           # 0.2 req/s with a couple of expected error spans (e.g. the security

--- a/openbank-infra/gitops/components/observability/pyrra-slo-money-path.yaml
+++ b/openbank-infra/gitops/components/observability/pyrra-slo-money-path.yaml
@@ -13,6 +13,22 @@
 #
 # Targets are REFERENCE defaults (rules.yaml: slo comment) — not calibrated against real
 # production traffic. Revisit once the load-benchmark / DR-drill scope of issue #669 lands.
+#
+# `alerting.absent: false` on EVERY object (issue #3333), and it is not a downgrade — the rule it
+# suppresses cannot express a fault at all. Pyrra defaults to emitting one critical `SLOMetricAbsent`
+# per indicator metric, `absent(<metric>) == 1`. Both indicators here are Tempo span-metrics, which
+# exist only while the service is RECEIVING TRAFFIC, so `absent` means "nobody called it recently",
+# never "it is gone" — and no `for:` duration helps, because on an idle service the condition is
+# permanent rather than transient. Measured 2026-08-06 in the sandbox: 64 such rules, all critical,
+# 12 of them firing — and `up{job="observability/openbank-services"}` was `1` for all five services
+# they named, i.e. every pod was alive and scraped while its SLO alert paged. Two of those services
+# emitted ZERO span samples in the whole retained window, so their rules could never have cleared.
+# Zero of the 64 have ever fired on a state that a down service produces and an idle one does not.
+# "Is the service gone" IS answerable without traffic, and by a different signal: `up == 0`, which
+# is what MoneyPathServiceDown / PaymentServiceDown / LendingServiceDown in
+# prometheus-rules-tier1.yaml assert. Deleting the absent rules therefore removes noise without
+# removing coverage. check-slo-registry.py enforces the flag so a new SLO cannot reintroduce it.
+# Burn-rate alerting is untouched: a real SLO breach still pages.
 ---
 apiVersion: pyrra.dev/v1alpha1
 kind: ServiceLevelObjective
@@ -28,6 +44,8 @@ metadata:
 spec:
   target: "99.9"
   window: 30d
+  alerting:
+    absent: false
   description: "openbank-ledger-service availability — non-error span ratio (issue #669, rules.yaml: slo.availability_target)."
   indicator:
     ratio:
@@ -50,6 +68,8 @@ metadata:
 spec:
   target: "99"
   window: 30d
+  alerting:
+    absent: false
   description: "openbank-ledger-service latency — share of requests faster than 1s (issue #669, rules.yaml: slo.latency_threshold_seconds)."
   indicator:
     latency:
@@ -72,6 +92,8 @@ metadata:
 spec:
   target: "99.9"
   window: 30d
+  alerting:
+    absent: false
   description: "openbank-transaction-service availability — non-error span ratio (issue #669, rules.yaml: slo.availability_target)."
   indicator:
     ratio:
@@ -94,6 +116,8 @@ metadata:
 spec:
   target: "99"
   window: 30d
+  alerting:
+    absent: false
   description: "openbank-transaction-service latency — share of requests faster than 1s (issue #669, rules.yaml: slo.latency_threshold_seconds)."
   indicator:
     latency:
@@ -116,6 +140,8 @@ metadata:
 spec:
   target: "99.9"
   window: 30d
+  alerting:
+    absent: false
   description: "openbank-account-service availability — non-error span ratio (issue #669, rules.yaml: slo.availability_target)."
   indicator:
     ratio:
@@ -138,6 +164,8 @@ metadata:
 spec:
   target: "99"
   window: 30d
+  alerting:
+    absent: false
   description: "openbank-account-service latency — share of requests faster than 1s (issue #669, rules.yaml: slo.latency_threshold_seconds)."
   indicator:
     latency:
@@ -160,6 +188,8 @@ metadata:
 spec:
   target: "99.9"
   window: 30d
+  alerting:
+    absent: false
   description: "openbank-balance-service availability — non-error span ratio (issue #669, rules.yaml: slo.availability_target)."
   indicator:
     ratio:
@@ -182,6 +212,8 @@ metadata:
 spec:
   target: "99"
   window: 30d
+  alerting:
+    absent: false
   description: "openbank-balance-service latency — share of requests faster than 1s (issue #669, rules.yaml: slo.latency_threshold_seconds)."
   indicator:
     latency:
@@ -204,6 +236,8 @@ metadata:
 spec:
   target: "99.9"
   window: 30d
+  alerting:
+    absent: false
   description: "openbank-sepa-payment availability — non-error span ratio (issue #669, rules.yaml: slo.availability_target)."
   indicator:
     ratio:
@@ -226,6 +260,8 @@ metadata:
 spec:
   target: "99"
   window: 30d
+  alerting:
+    absent: false
   description: "openbank-sepa-payment latency — share of requests faster than 1s (issue #669, rules.yaml: slo.latency_threshold_seconds)."
   indicator:
     latency:
@@ -248,6 +284,8 @@ metadata:
 spec:
   target: "99.9"
   window: 30d
+  alerting:
+    absent: false
   description: "openbank-sepa-instant availability — non-error span ratio (issue #669, rules.yaml: slo.availability_target)."
   indicator:
     ratio:
@@ -270,6 +308,8 @@ metadata:
 spec:
   target: "99"
   window: 30d
+  alerting:
+    absent: false
   description: "openbank-sepa-instant latency — share of requests faster than 1s (issue #669, rules.yaml: slo.latency_threshold_seconds)."
   indicator:
     latency:
@@ -292,6 +332,8 @@ metadata:
 spec:
   target: "99.9"
   window: 30d
+  alerting:
+    absent: false
   description: "openbank-domestic-payment availability — non-error span ratio (issue #669, rules.yaml: slo.availability_target)."
   indicator:
     ratio:
@@ -314,6 +356,8 @@ metadata:
 spec:
   target: "99"
   window: 30d
+  alerting:
+    absent: false
   description: "openbank-domestic-payment latency — share of requests faster than 1s (issue #669, rules.yaml: slo.latency_threshold_seconds)."
   indicator:
     latency:
@@ -336,6 +380,8 @@ metadata:
 spec:
   target: "99.9"
   window: 30d
+  alerting:
+    absent: false
   description: "openbank-clearing-service availability — non-error span ratio (issue #669, rules.yaml: slo.availability_target)."
   indicator:
     ratio:
@@ -358,6 +404,8 @@ metadata:
 spec:
   target: "99"
   window: 30d
+  alerting:
+    absent: false
   description: "openbank-clearing-service latency — share of requests faster than 1s (issue #669, rules.yaml: slo.latency_threshold_seconds)."
   indicator:
     latency:
@@ -380,6 +428,8 @@ metadata:
 spec:
   target: "99.9"
   window: 30d
+  alerting:
+    absent: false
   description: "openbank-swift-service availability — non-error span ratio (issue #669, rules.yaml: slo.availability_target)."
   indicator:
     ratio:
@@ -402,6 +452,8 @@ metadata:
 spec:
   target: "99"
   window: 30d
+  alerting:
+    absent: false
   description: "openbank-swift-service latency — share of requests faster than 1s (issue #669, rules.yaml: slo.latency_threshold_seconds)."
   indicator:
     latency:
@@ -424,6 +476,8 @@ metadata:
 spec:
   target: "99.9"
   window: 30d
+  alerting:
+    absent: false
   description: "openbank-fx-service availability — non-error span ratio (issue #669, rules.yaml: slo.availability_target)."
   indicator:
     ratio:
@@ -446,6 +500,8 @@ metadata:
 spec:
   target: "99"
   window: 30d
+  alerting:
+    absent: false
   description: "openbank-fx-service latency — share of requests faster than 1s (issue #669, rules.yaml: slo.latency_threshold_seconds)."
   indicator:
     latency:
@@ -468,6 +524,8 @@ metadata:
 spec:
   target: "99.9"
   window: 30d
+  alerting:
+    absent: false
   description: "openbank-lending-service availability — non-error span ratio (issue #669, rules.yaml: slo.availability_target)."
   indicator:
     ratio:
@@ -490,6 +548,8 @@ metadata:
 spec:
   target: "99"
   window: 30d
+  alerting:
+    absent: false
   description: "openbank-lending-service latency — share of requests faster than 1s (issue #669, rules.yaml: slo.latency_threshold_seconds)."
   indicator:
     latency:
@@ -512,6 +572,8 @@ metadata:
 spec:
   target: "99.9"
   window: 30d
+  alerting:
+    absent: false
   description: "openbank-sca-service availability — non-error span ratio (issue #669, rules.yaml: slo.availability_target)."
   indicator:
     ratio:
@@ -534,6 +596,8 @@ metadata:
 spec:
   target: "99"
   window: 30d
+  alerting:
+    absent: false
   description: "openbank-sca-service latency — share of requests faster than 1s (issue #669, rules.yaml: slo.latency_threshold_seconds)."
   indicator:
     latency:
@@ -556,6 +620,8 @@ metadata:
 spec:
   target: "99.9"
   window: 30d
+  alerting:
+    absent: false
   description: "openbank-consent-service availability — non-error span ratio (issue #669, rules.yaml: slo.availability_target)."
   indicator:
     ratio:
@@ -578,6 +644,8 @@ metadata:
 spec:
   target: "99"
   window: 30d
+  alerting:
+    absent: false
   description: "openbank-consent-service latency — share of requests faster than 1s (issue #669, rules.yaml: slo.latency_threshold_seconds)."
   indicator:
     latency:
@@ -600,6 +668,8 @@ metadata:
 spec:
   target: "99.9"
   window: 30d
+  alerting:
+    absent: false
   description: "openbank-fraud-service availability — non-error span ratio (issue #669, rules.yaml: slo.availability_target)."
   indicator:
     ratio:
@@ -622,6 +692,8 @@ metadata:
 spec:
   target: "99"
   window: 30d
+  alerting:
+    absent: false
   description: "openbank-fraud-service latency — share of requests faster than 1s (issue #669, rules.yaml: slo.latency_threshold_seconds)."
   indicator:
     latency:
@@ -644,6 +716,8 @@ metadata:
 spec:
   target: "99.9"
   window: 30d
+  alerting:
+    absent: false
   description: "openbank-billing-service availability — non-error span ratio (issue #669, rules.yaml: slo.availability_target)."
   indicator:
     ratio:
@@ -666,6 +740,8 @@ metadata:
 spec:
   target: "99"
   window: 30d
+  alerting:
+    absent: false
   description: "openbank-billing-service latency — share of requests faster than 1s (issue #669, rules.yaml: slo.latency_threshold_seconds)."
   indicator:
     latency:
@@ -688,6 +764,8 @@ metadata:
 spec:
   target: "99.9"
   window: 30d
+  alerting:
+    absent: false
   description: "openbank-settlement-service availability — non-error span ratio (issue #669, rules.yaml: slo.availability_target)."
   indicator:
     ratio:
@@ -710,6 +788,8 @@ metadata:
 spec:
   target: "99"
   window: 30d
+  alerting:
+    absent: false
   description: "openbank-settlement-service latency — share of requests faster than 1s (issue #669, rules.yaml: slo.latency_threshold_seconds)."
   indicator:
     latency:
@@ -732,6 +812,8 @@ metadata:
 spec:
   target: "99.9"
   window: 30d
+  alerting:
+    absent: false
   description: "openbank-sanctions-service availability — non-error span ratio (issue #669, rules.yaml: slo.availability_target)."
   indicator:
     ratio:
@@ -754,6 +836,8 @@ metadata:
 spec:
   target: "99"
   window: 30d
+  alerting:
+    absent: false
   description: "openbank-sanctions-service latency — share of requests faster than 1s (issue #669, rules.yaml: slo.latency_threshold_seconds)."
   indicator:
     latency:
@@ -776,6 +860,8 @@ metadata:
 spec:
   target: "99.9"
   window: 30d
+  alerting:
+    absent: false
   # NOTE (ADR-0171): VoP fails OPEN, so an error here does not fail a payment — the caller
   # renders no_data and the payment proceeds with a warning. This SLO therefore measures the
   # health of a *regulatory* control (IPR Art. 5c: the payer must be told), not payment
@@ -803,6 +889,8 @@ metadata:
 spec:
   target: "99"
   window: 30d
+  alerting:
+    absent: false
   # The fleet-uniform 1s threshold is tight for VoP: a verify is a two-hop lookup
   # (account-service -> party-service, ADR-0171 §4) on the payer's critical path, so this is
   # the SLO most likely to surface the latency cost the ADR accepts as a known negative.
@@ -828,6 +916,8 @@ metadata:
 spec:
   target: "99.9"
   window: 30d
+  alerting:
+    absent: false
   description: "openbank-sdd-service availability — non-error span ratio (issue #669, rules.yaml: slo.availability_target)."
   indicator:
     ratio:
@@ -850,6 +940,8 @@ metadata:
 spec:
   target: "99"
   window: 30d
+  alerting:
+    absent: false
   description: "openbank-sdd-service latency — share of requests faster than 1s (issue #669, rules.yaml: slo.latency_threshold_seconds)."
   indicator:
     latency:
@@ -872,6 +964,8 @@ metadata:
 spec:
   target: "99.9"
   window: 30d
+  alerting:
+    absent: false
   description: "openbank-interest-service availability — non-error span ratio (issue #669, rules.yaml: slo.availability_target)."
   indicator:
     ratio:
@@ -894,6 +988,8 @@ metadata:
 spec:
   target: "99"
   window: 30d
+  alerting:
+    absent: false
   description: "openbank-interest-service latency — share of requests faster than 1s (issue #669, rules.yaml: slo.latency_threshold_seconds)."
   indicator:
     latency:
@@ -916,6 +1012,8 @@ metadata:
 spec:
   target: "99.9"
   window: 30d
+  alerting:
+    absent: false
   description: "openbank-delegation-service availability — non-error span ratio (issue #669, rules.yaml: slo.availability_target)."
   indicator:
     ratio:
@@ -938,6 +1036,8 @@ metadata:
 spec:
   target: "99"
   window: 30d
+  alerting:
+    absent: false
   description: "openbank-delegation-service latency — share of requests faster than 1s (issue #669, rules.yaml: slo.latency_threshold_seconds)."
   indicator:
     latency:


### PR DESCRIPTION
Closes #3333. Part of #3343 / follows #3346.

## What changed

- `pyrra-slo-money-path.yaml`: `spec.alerting.absent: false` on all 42 ServiceLevelObjectives — this **deletes** the whole `SLOMetricAbsent` family. Burn-rate alerting is untouched.
- `prometheus-rules-tier1.yaml`: one new `MoneyPathServiceDown` on `up == 0`, covering the eleven money-path namespaces no existing Down rule covers.
- `check-slo-registry.py`: enforces the flag, so a new SLO cannot reintroduce the noise. Ships with `--self-test`.
- `delegation/external-secret-oidc.yaml`: corrects a comment that cites `SLOMetricAbsent x3` as evidence the alert works.

## Measurement (sandbox, 2026-08-06 — not the issue's numbers)

| | |
|---|---|
| `SLOMetricAbsent` rules | **64** (issue said 61; the family grew, #3346 did not touch it) |
| severity | 64/64 `critical` |
| `for:` | 42 × 11m, 21 × 3m, 1 × 6m |
| firing at measurement | **12**, across 5 services |
| `up{job="observability/openbank-services"}` for those 5 services | **1 — all of them** |
| rules that ever discriminated a fault from idleness | **0** |

Two of the five (`delegation`, `sepa-instant`) emitted **zero** span samples in the entire retained window, so their rules could never have cleared. `fraud`, `settlement` and `vop` emitted samples in ~8% of it.

Retention on this Prometheus is 12h, so "never fired on a fault" is a claim about the retained window plus the structure of the expression, not about all time. The structural half is what carries it: `absent(traces_spanmetrics_calls_total{...})` is true whenever nobody called the service, and the pod being alive does not enter into it.

## Per-class justification

**Delete (all 64).** The indicator is traffic-derived. `absent` = "no traffic", never "no service". Downgrading to `warning` was the cheap option and is the wrong one: a warning that is permanently true is still permanently true, and it still teaches people to skip the line. Lengthening `for:` cannot help either — the condition on an idle service does not expire.

**Gate on something that discriminates (the replacement).** `up` comes from the fleet PodMonitor and is emitted whether or not anyone calls the service. `PaymentServiceDown` and `LendingServiceDown` already own payments/fx/lending; `MoneyPathServiceDown` adds the other eleven — **`ledger` among them**, so the core money service had no liveness alert at all until this PR. Not noise-by-another-name, measured: every `up == 0` on this job in the retained window lasted at most 3 consecutive scrapes (~90s, a pod start or termination), so at `for: 10m` the new rule fires zero times at idle. Pod churn is already carried by `KubePodCrashLooping` / `KubePodNotReady`.

**Keep as-is: none.** No member of this family discriminates.

## Falsification

- The mechanism, against the **deployed** pyrra `v0.9.0` binary, not the CRD schema: the real manifest generates **63 `SLOMetricAbsent` and 168 `ErrorBudgetBurn`** before, **0 and 168** after. Known-positive first — without the flag the rule appears.
- The new gate assertion, against the real manifest with a `cp` backup: passes on the branch, fails when the first `absent` flag is flipped to `true`, fails when the block is deleted, passes again on restore. `--self-test` covers the shapes YAML makes easy to get wrong (missing block, missing key, string `"false"`).
- The new alert expression, against live Prometheus: selects 12 targets, currently 0 firing.

## The uncomfortable evidence, stated rather than buried

`delegation/external-secret-oidc.yaml` records that a missing OIDC key produced ~12 alerts including `SLOMetricAbsent x3` — the one case on file where this alert accompanied a real fault. It is still not a reason to keep it: it fired on the broken pod, and it is *still firing today* on the fixed pod with `up == 1`. A signal present in both states carries no information about either, and the nine other alerts in that list are what actually named the fault. The comment is updated to say so.
