### PR TITLE
feat(delegation): snapshot counterparty display names onto a grant

### DIFF
--- a/docs/threat-models/openbank-delegation-service.md
+++ b/docs/threat-models/openbank-delegation-service.md
@@ -11,7 +11,11 @@ is now stated in the row rather than implied away.
 ## Assets
 
 - `DelegationGrant` records — who may do what on whose resources (confidential; contract
-  evidence under the ADR-0118 retention schedule).
+  evidence under the ADR-0118 retention schedule). Since issue #3604 a grant also carries the two
+  counterparty **display names**, snapshotted at offer time from the eligibility lookup — so this
+  service now holds personal names at rest, not only party ids. Nothing else about the party is
+  stored: the pid client materialises `givenName`/`familyName` and drops the rest of
+  `coreAttributes` (birthdate, birth number, documents, nationality) at the parser.
 - Enforcement integrity of the whole platform: every product service's delegation
   projection trusts this service's event stream.
 - SCA ceremony integrity (grant + acceptance).
@@ -39,6 +43,7 @@ is now stated in the row rather than implied away.
 | T10 | Object-level grant used as execution channel | Aggregate invariant: EXECUTION capabilities rejected on object resource types; object grants are read-only disclosure. |
 | T11 | Unauthorized revoke / forged revoker | `revokedBy` is derived: a customer revoke acts as the party the edge authenticated and must be the grantor; the query parameter survives only on the role-gated bank path. Previously it was a required, trusted query parameter that both authorised the act and wrote the audit field, so any authenticated caller could revoke any grant and sign it as somebody else. `suspend`/`reinstate` are additionally narrowed to ROLE_OPERATOR/ROLE_ADMIN and reject a customer-scoped call. |
 | T12 | A grant outliving its `validTo` in the product projections | Hourly expiry sweep flips ACTIVE → EXPIRED and enqueues `DelegationExpired`, so projections close their rows. The sweep is a `suspend fun` (rules.yaml: scheduled_methods): as a plain `@Scheduled` method it ran with no Vert.x context, so every reactive Panache call threw HR000068 into a single ERROR line and the sweep had **never expired a grant**. A grant past `validTo` still reads as inactive to anything that computes it, so the exposure was the projections that need the event. |
+| T13 | Counterparty display name used as a party-name oracle, or leaked to a non-party (issue #3604) | The name is **snapshotted onto the grant at offer time**, never resolved at read time, so no lookup surface is created and customer-edge gains **no new authority** — its party OPA grants stay `party.consent.update` + `party:resolve` (the ADR-0072 blind-index dedup gate, not an id lookup). It rides the existing `DelegationResponse`, which T8 already scopes: a customer sees only grants they are grantor or grantee of, a list for another party is 403, and a grant the caller is not party to is 404. Both parties are by construction already identified to each other by the grant itself, so the name discloses nothing the relationship does not. The two alternatives were rejected for exactly this row: granting the edge `party.read` would let it read ANY party (the usage is scoped, the *grant* is what gets reviewed), and a dedicated display-name endpoint would create a new lookup surface for a value that does not need to be live. Residual: role-gated bank staff (`ROLE_OPERATOR`/`ROLE_ADMIN`) can read grants for any party and now see the names too — unchanged in scope from the ids they already saw, but a wider PII surface; and a snapshot goes stale on a legitimate rename, which is deliberate (an authorisation record states what was true at consent) but means the label is not an identity assertion. |
 
 ## Out of scope (tracked as follow-ups)
 

--- a/openbank-admin-ui/src/app/delegations/[id]/page.tsx
+++ b/openbank-admin-ui/src/app/delegations/[id]/page.tsx
@@ -25,6 +25,7 @@ import { EntityChip } from '@/components/entities/EntityChip'
 import {
   DelegationStatusBadge,
   capabilityLabels,
+  counterpartyLabel,
   formatCeiling,
   type Grant,
 } from '@/components/delegations/GrantView'
@@ -86,10 +87,10 @@ export default function DelegationDetailPage() {
               <dd><DelegationStatusBadge status={grant.status} /></dd>
 
               <dt style={{ color: 'var(--text-tertiary)' }}>{t('Udělil', 'Grantor')}</dt>
-              <dd><EntityChip type="party" id={grant.grantorPartyId} /></dd>
+              <dd><EntityChip type="party" id={grant.grantorPartyId} label={counterpartyLabel(grant.grantorName)} /></dd>
 
               <dt style={{ color: 'var(--text-tertiary)' }}>{t('Obdržel', 'Grantee')}</dt>
-              <dd><EntityChip type="party" id={grant.granteePartyId} /></dd>
+              <dd><EntityChip type="party" id={grant.granteePartyId} label={counterpartyLabel(grant.granteeName)} /></dd>
 
               <dt style={{ color: 'var(--text-tertiary)' }}>{t('Typ zdroje', 'Resource type')}</dt>
               <dd>{grant.resourceType}</dd>

--- a/openbank-admin-ui/src/app/delegations/page.tsx
+++ b/openbank-admin-ui/src/app/delegations/page.tsx
@@ -28,6 +28,7 @@ import { EntityChip } from '@/components/entities/EntityChip'
 import {
   DelegationStatusBadge,
   capabilityLabels,
+  counterpartyLabel,
   formatCeiling,
   type Grant,
 } from '@/components/delegations/GrantView'
@@ -276,7 +277,7 @@ function GrantTable({
               {grants.map(g => (
                 <tr key={g.id}>
                   <td><DelegationStatusBadge status={g.status} /></td>
-                  <td><EntityChip type="party" id={g.granteePartyId} /></td>
+                  <td><EntityChip type="party" id={g.granteePartyId} label={counterpartyLabel(g.granteeName)} /></td>
                   <td style={{ fontSize: '12px' }}>{g.resourceType}</td>
                   <td style={{ fontSize: '12px' }}>{capabilityLabels(g.capabilities)}</td>
                   <td style={{ fontSize: '12px' }}>{formatCeiling(g.perTransactionLimit)}</td>

--- a/openbank-admin-ui/src/components/delegations/GrantView.tsx
+++ b/openbank-admin-ui/src/components/delegations/GrantView.tsx
@@ -18,6 +18,13 @@ export type Grant = {
   id: string
   grantorPartyId: string
   granteePartyId: string
+  /**
+   * Counterparty display names snapshotted onto the grant at offer time (issue #3604). Null on
+   * grants offered before delegation-service carried the field, which is why every render goes
+   * through counterpartyLabel() rather than reading these directly.
+   */
+  grantorName?: string | null
+  granteeName?: string | null
   resourceType: string
   resourceId: string
   capabilities: string[]
@@ -55,6 +62,21 @@ export function DelegationStatusBadge({ status }: { status: string }) {
 export function capabilityLabels(capabilities: string[] | undefined): string {
   if (!capabilities?.length) return '—'
   return capabilities.join(', ')
+}
+
+/**
+ * The label for a counterparty chip (issue #3604).
+ *
+ * Returns `undefined`, never a blank or a placeholder, when the grant carries no snapshotted
+ * name — that is the signal EntityChip needs in order to fall back to its own resolution and
+ * then to a shortened id. An empty string would render as a chip with no text at all, which
+ * looks like a name that failed to load rather than one that was never captured.
+ *
+ * A whitespace-only name is treated as absent for the same reason.
+ */
+export function counterpartyLabel(name: string | null | undefined): string | undefined {
+  const trimmed = name?.trim()
+  return trimmed ? trimmed : undefined
 }
 
 /** A ceiling of `null` means UNCAPPED for that window — never render it as zero. */

--- a/openbank-admin-ui/src/test/delegation-counterparty-name.test.tsx
+++ b/openbank-admin-ui/src/test/delegation-counterparty-name.test.tsx
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+// Issue #3604 — a delegation counterparty must be identifiable by a human, not a truncated UUID.
+// The claim under test is exactly that: with a snapshotted name on the grant the chip renders the
+// NAME, and it renders it WITHOUT asking any service (which is the whole reason the name is
+// snapshotted at offer time — customer-edge has no permitted party-id lookup). Without a name the
+// chip must still degrade to its own resolution and then to a shortened id, never to a blank.
+//
+// The `fetch` assertions are load-bearing, not incidental: a fix that merely passed the id along
+// and resolved it client-side would satisfy a text assertion and none of the constraint.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import React from 'react'
+import { render, screen, cleanup, waitFor } from '@testing-library/react'
+import { EntityChip } from '@/components/entities/EntityChip'
+import { counterpartyLabel } from '@/components/delegations/GrantView'
+
+const PARTY_ID = '33333333-3333-4333-8333-333333333333'
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', vi.fn(async () => new Response('{}', { status: 200, headers: { 'content-type': 'application/json' } })))
+})
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+})
+
+describe('counterpartyLabel', () => {
+  it('passes a real name through', () => {
+    expect(counterpartyLabel('Alice Testerova')).toBe('Alice Testerova')
+  })
+
+  // Null/undefined/blank must all collapse to undefined, which is the ONLY value EntityChip
+  // treats as "resolve it yourself". '' would render an empty chip — a name that looks broken
+  // rather than one that was never captured.
+  it('treats an absent or blank name as no label at all', () => {
+    expect(counterpartyLabel(null)).toBeUndefined()
+    expect(counterpartyLabel(undefined)).toBeUndefined()
+    expect(counterpartyLabel('')).toBeUndefined()
+    expect(counterpartyLabel('   ')).toBeUndefined()
+  })
+})
+
+describe('delegation counterparty chip', () => {
+  it('shows the snapshotted name and asks no service for it', async () => {
+    render(<EntityChip type="party" id={PARTY_ID} label={counterpartyLabel('Alice Testerova')} />)
+
+    expect(await screen.findByText('Alice Testerova')).toBeTruthy()
+    // The regression this guards: the id must not be what the human reads.
+    expect(screen.queryByText('33333333…')).toBeNull()
+    expect(vi.mocked(global.fetch)).not.toHaveBeenCalled()
+  })
+
+  it('falls back to a shortened id, never a blank, when the grant carries no name', async () => {
+    // A grant offered before #3604: party-service answers, but with nothing usable as a label.
+    render(<EntityChip type="party" id={PARTY_ID} label={counterpartyLabel(null)} />)
+
+    await waitFor(() => expect(screen.getByText('33333333…')).toBeTruthy())
+  })
+})

--- a/openbank-delegation-service/src/main/kotlin/com/openbank/delegation/application/port/out/DelegationPorts.kt
+++ b/openbank-delegation-service/src/main/kotlin/com/openbank/delegation/application/port/out/DelegationPorts.kt
@@ -27,8 +27,21 @@ interface DelegationRepository {
     fun markExpired(id: UUID, expiredAt: OffsetDateTime, event: DomainEvent): Uni<Boolean>
 }
 
-/** ADR-0232 D5 — what the eligibility gate needs to know about a party, nothing more. */
-data class PartyEligibility(val partyId: UUID, val active: Boolean, val kycLevel: String)
+/**
+ * ADR-0232 D5 — what the eligibility gate needs to know about a party, nothing more.
+ *
+ * [displayName] is the ONE extra field, and it is not an eligibility input: it is the
+ * counterparty label snapshotted onto the grant at offer time (issue #3604). It is deliberately
+ * a single already-composed string rather than the party's core attributes — the grant record has
+ * no use for a birthdate, and the narrower the shape the less PII travels into this service.
+ * Null when pid-service returns no usable name; the caller must then fall back to the id.
+ */
+data class PartyEligibility(
+    val partyId: UUID,
+    val active: Boolean,
+    val kycLevel: String,
+    val displayName: String? = null,
+)
 
 interface PartyEligibilityClient {
     suspend fun eligibilityOf(partyId: UUID): PartyEligibility

--- a/openbank-delegation-service/src/main/kotlin/com/openbank/delegation/application/usecase/DelegationService.kt
+++ b/openbank-delegation-service/src/main/kotlin/com/openbank/delegation/application/usecase/DelegationService.kt
@@ -16,6 +16,7 @@ import com.openbank.delegation.application.port.`in`.RevokeDelegationUseCase
 import com.openbank.delegation.application.port.`in`.SuspendDelegationCommand
 import com.openbank.delegation.application.port.out.DelegationRepository
 import com.openbank.delegation.application.port.out.OwnershipVerdict
+import com.openbank.delegation.application.port.out.PartyEligibility
 import com.openbank.delegation.application.port.out.PartyEligibilityClient
 import com.openbank.delegation.application.port.out.ResourceOwnershipClient
 import com.openbank.delegation.application.port.out.ScaChallengeClient
@@ -442,6 +443,17 @@ class DelegationService(
         if (!grantee.active) {
             throw DelegationEligibilityException("grantee party ${command.granteePartyId} is not active")
         }
+        requireGranteeKyc(command, grantee)
+        return CounterpartyNames(grantorName = grantor.displayName, granteeName = grantee.displayName)
+    }
+
+    /**
+     * Split out of [verifyEligibility] only because that function now RETURNS the counterparty
+     * labels (issue #3604): detekt's `ThrowsCount` excludes trailing guard clauses, and a
+     * function with a real return value has none — so the same three unchanged throws crossed the
+     * threshold. The gate is behaviourally identical.
+     */
+    private fun requireGranteeKyc(command: OfferDelegationCommand, grantee: PartyEligibility) {
         val needsFullKyc = command.capabilities.any { it in DelegationGrant.EXECUTION_CAPABILITIES }
         val requiredKyc = if (needsFullKyc) "FULL" else "BASIC"
         if (KYC_RANK.getValue(grantee.kycLevel) < KYC_RANK.getValue(requiredKyc)) {
@@ -450,7 +462,6 @@ class DelegationService(
                     "is below required $requiredKyc for capabilities ${command.capabilities}",
             )
         }
-        return CounterpartyNames(grantorName = grantor.displayName, granteeName = grantee.displayName)
     }
 
     /** The two labels the eligibility lookup yields as a by-product (issue #3604). */

--- a/openbank-delegation-service/src/main/kotlin/com/openbank/delegation/application/usecase/DelegationService.kt
+++ b/openbank-delegation-service/src/main/kotlin/com/openbank/delegation/application/usecase/DelegationService.kt
@@ -83,7 +83,7 @@ class DelegationService(
         val now = OffsetDateTime.now(clock)
         requireCallerIs(command.callerPartyId, command.grantorPartyId)
         verifyResourceOwnership(command)
-        verifyEligibility(command)
+        val parties = verifyEligibility(command)
         // SCA last of the three gates: it SPENDS the challenge, so a request that was going to be
         // refused anyway must not cost the customer their ceremony.
         verifyAndConsumeSca(
@@ -96,6 +96,10 @@ class DelegationService(
         val grant = DelegationGrant(
             grantorPartyId = command.grantorPartyId,
             granteePartyId = command.granteePartyId,
+            // Snapshotted from the eligibility lookup that just ran — no extra call, and no new
+            // authority anywhere: this service is already permitted to read both parties (#3604).
+            grantorName = parties.grantorName,
+            granteeName = parties.granteeName,
             resourceType = command.resourceType,
             resourceId = command.resourceId,
             capabilities = command.capabilities,
@@ -429,7 +433,7 @@ class DelegationService(
      * offers, never wave them through. KYC requirements: FULL for execution
      * capabilities (they move money), BASIC for everything read-only/propose-only.
      */
-    private suspend fun verifyEligibility(command: OfferDelegationCommand) {
+    private suspend fun verifyEligibility(command: OfferDelegationCommand): CounterpartyNames {
         val grantor = partyEligibilityClient.eligibilityOf(command.grantorPartyId)
         if (!grantor.active) {
             throw DelegationEligibilityException("grantor party ${command.grantorPartyId} is not active")
@@ -446,7 +450,11 @@ class DelegationService(
                     "is below required $requiredKyc for capabilities ${command.capabilities}",
             )
         }
+        return CounterpartyNames(grantorName = grantor.displayName, granteeName = grantee.displayName)
     }
+
+    /** The two labels the eligibility lookup yields as a by-product (issue #3604). */
+    private data class CounterpartyNames(val grantorName: String?, val granteeName: String?)
 
     private companion object {
         const val SCA_PURPOSE_GRANT = "DELEGATION_GRANT"

--- a/openbank-delegation-service/src/main/kotlin/com/openbank/delegation/domain/model/DelegationGrant.kt
+++ b/openbank-delegation-service/src/main/kotlin/com/openbank/delegation/domain/model/DelegationGrant.kt
@@ -79,6 +79,15 @@ data class DelegationGrant(
     val id: UUID = Ids.newId(),
     val grantorPartyId: UUID,
     val granteePartyId: UUID,
+    /**
+     * Counterparty labels SNAPSHOTTED at offer time from the eligibility lookup this service
+     * already performs (issue #3604). Deliberately part of the authorisation record rather than a
+     * live lookup: a grant says who agreed to what at the moment they agreed, and a later rename
+     * must not silently rewrite that. Null for grants created before this field existed, and for
+     * a party pid-service returns no usable name for — consumers fall back to the party id.
+     */
+    val grantorName: String? = null,
+    val granteeName: String? = null,
     val resourceType: DelegationResourceType,
     val resourceId: UUID,
     val capabilities: Set<DelegationCapability>,

--- a/openbank-delegation-service/src/main/kotlin/com/openbank/delegation/infrastructure/client/PartyEligibilityClient.kt
+++ b/openbank-delegation-service/src/main/kotlin/com/openbank/delegation/infrastructure/client/PartyEligibilityClient.kt
@@ -20,10 +20,23 @@ import org.eclipse.microprofile.rest.client.inject.RestClient
 import java.util.UUID
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-data class PidPartyResponse(val id: UUID, val status: String, val kycAttributes: PidKycAttributes?)
+data class PidPartyResponse(
+    val id: UUID,
+    val status: String,
+    val kycAttributes: PidKycAttributes?,
+    val coreAttributes: PidCoreAttributes? = null,
+)
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class PidKycAttributes(val kycLevel: String?)
+
+/**
+ * Only the two name fields, out of a `PartyResponse.coreAttributes` that also carries birthdate,
+ * birth number, gender, birthplace, nationalities and identity documents. `@JsonIgnoreProperties`
+ * drops the rest at the parser, so none of it is ever materialised in this service (issue #3604).
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class PidCoreAttributes(val givenName: String? = null, val familyName: String? = null)
 
 @Path("/api/v1/parties")
 @RegisterRestClient(configKey = "pid-service")
@@ -46,6 +59,17 @@ class ResilientPartyEligibilityClient @Inject constructor(@RestClient private va
             partyId = party.id,
             active = party.status == "ACTIVE",
             kycLevel = party.kycAttributes?.kycLevel ?: "NONE",
+            displayName = displayNameOf(party.coreAttributes),
         )
     }
+
+    /**
+     * Null rather than an empty or half-formed string: the consumer of this field renders the
+     * party id when it is absent, and a blank label on a consent screen is worse than a UUID
+     * because it looks like a name that failed to load.
+     */
+    private fun displayNameOf(core: PidCoreAttributes?): String? = core
+        ?.let { listOfNotNull(it.givenName, it.familyName).joinToString(" ") { part -> part.trim() } }
+        ?.trim()
+        ?.takeIf { it.isNotEmpty() }
 }

--- a/openbank-delegation-service/src/main/kotlin/com/openbank/delegation/infrastructure/persistence/entity/DelegationGrantEntity.kt
+++ b/openbank-delegation-service/src/main/kotlin/com/openbank/delegation/infrastructure/persistence/entity/DelegationGrantEntity.kt
@@ -40,6 +40,13 @@ class DelegationGrantEntity : PanacheEntityBase() {
     @Column(name = "grantee_party_id", nullable = false)
     lateinit var granteePartyId: UUID
 
+    /** Nullable by design — see [DelegationGrant.grantorName] (issue #3604). */
+    @Column(name = "grantor_name", length = NAME_MAX_LENGTH)
+    var grantorName: String? = null
+
+    @Column(name = "grantee_name", length = NAME_MAX_LENGTH)
+    var granteeName: String? = null
+
     @Enumerated(EnumType.STRING)
     @Column(name = "resource_type", nullable = false)
     lateinit var resourceType: DelegationResourceType
@@ -130,6 +137,8 @@ class DelegationGrantEntity : PanacheEntityBase() {
         id = id,
         grantorPartyId = grantorPartyId,
         granteePartyId = granteePartyId,
+        grantorName = grantorName,
+        granteeName = granteeName,
         resourceType = resourceType,
         resourceId = resourceId,
         capabilities = capabilities.toSet(),
@@ -169,10 +178,15 @@ class DelegationGrantEntity : PanacheEntityBase() {
     }
 
     companion object {
+        /** Matches the `varchar(200)` in V3__delegation_counterparty_names.sql. */
+        const val NAME_MAX_LENGTH = 200
+
         fun fromDomain(g: DelegationGrant): DelegationGrantEntity = DelegationGrantEntity().apply {
             id = g.id
             grantorPartyId = g.grantorPartyId
             granteePartyId = g.granteePartyId
+            grantorName = g.grantorName?.take(NAME_MAX_LENGTH)
+            granteeName = g.granteeName?.take(NAME_MAX_LENGTH)
             resourceType = g.resourceType
             resourceId = g.resourceId
             capabilities = g.capabilities.toMutableSet()

--- a/openbank-delegation-service/src/main/kotlin/com/openbank/delegation/infrastructure/rest/dto/DelegationDtos.kt
+++ b/openbank-delegation-service/src/main/kotlin/com/openbank/delegation/infrastructure/rest/dto/DelegationDtos.kt
@@ -70,6 +70,18 @@ data class DelegationResponse(
     val id: UUID,
     val grantorPartyId: UUID,
     val granteePartyId: UUID,
+    /**
+     * Counterparty labels as snapshotted on the grant (issue #3604). Null on grants offered
+     * before the field existed; a client must fall back to the party id rather than render a
+     * blank, which on a consent screen reads as a name that failed to load.
+     *
+     * Disclosure boundary: every read path is party-scoped — `getDelegation` 404s a caller who is
+     * neither grantor nor grantee, and the list endpoints refuse a party id other than the
+     * authenticated one — so these names reach only the two parties to the grant and role-gated
+     * bank staff. They are NOT a party-name lookup: nothing here resolves an arbitrary id.
+     */
+    val grantorName: String?,
+    val granteeName: String?,
     val resourceType: DelegationResourceType,
     val resourceId: UUID,
     val capabilities: Set<DelegationCapability>,
@@ -93,6 +105,8 @@ data class DelegationResponse(
             id = g.id,
             grantorPartyId = g.grantorPartyId,
             granteePartyId = g.granteePartyId,
+            grantorName = g.grantorName,
+            granteeName = g.granteeName,
             resourceType = g.resourceType,
             resourceId = g.resourceId,
             capabilities = g.capabilities,

--- a/openbank-delegation-service/src/main/resources/db/migration/V3__delegation_counterparty_names.sql
+++ b/openbank-delegation-service/src/main/resources/db/migration/V3__delegation_counterparty_names.sql
@@ -1,0 +1,21 @@
+-- Issue #3604 — the accept screen showed the counterparty as a truncated UUID, so the person
+-- being asked to grant authority over their money could not tell who was asking. The display
+-- name is SNAPSHOTTED onto the grant at offer time from the pid-service eligibility lookup
+-- delegation-service already performs (ADR-0232 D5): no runtime lookup, no new authority for
+-- customer-edge, and the label the record carries is the one that was true at the moment of
+-- consent — a later rename must not silently rewrite who agreed to what.
+--
+-- Nullable, and left NULL for existing rows on purpose: there is no backfill. Manufacturing a
+-- name for a grant that was consented to without one would put a value into an authorisation
+-- record that was never part of it. Consumers fall back to the party id, exactly as today.
+--
+-- PII note: these are personal names at rest in one more service. That service already holds
+-- who may touch whose money, and the columns are read only by a party to the grant (the read
+-- paths are party-scoped in DelegationService) or by a role-gated bank operator.
+--
+-- Rollback:
+--   ALTER TABLE delegation_grants DROP COLUMN grantor_name;
+--   ALTER TABLE delegation_grants DROP COLUMN grantee_name;
+
+ALTER TABLE delegation_grants ADD COLUMN IF NOT EXISTS grantor_name varchar(200);
+ALTER TABLE delegation_grants ADD COLUMN IF NOT EXISTS grantee_name varchar(200);

--- a/openbank-delegation-service/src/main/resources/openapi.yaml
+++ b/openbank-delegation-service/src/main/resources/openapi.yaml
@@ -5,7 +5,7 @@ info:
     Customer-to-party delegated access (ADR-0232): granular, SCA-bound grants over
     products (accounts, savings goals, cards) and single objects (payment, statement,
     document). Lifecycle: OFFERED → ACTIVE → SUSPENDED/REVOKED/EXPIRED/RENOUNCED/DECLINED.
-  version: 1.1.0
+  version: 1.2.0
 servers:
   - url: http://localhost:8126
 tags:
@@ -302,6 +302,23 @@ components:
         id: { type: string, format: uuid }
         grantorPartyId: { type: string, format: uuid }
         granteePartyId: { type: string, format: uuid }
+        grantorName:
+          type: string
+          description: |
+            Counterparty display name snapshotted onto the grant at offer time (issue #3604),
+            from the pid-service eligibility lookup this service already performs. It is what was
+            true when the grant was made, not a live value — an authorisation record must not be
+            silently rewritten by a later rename.
+
+            Null on grants offered before this field existed, and when pid-service returns no
+            usable name. Clients fall back to the party id; they must not render a blank, which
+            on a consent screen reads as a name that failed to load.
+
+            Only ever returned to a party of the grant (the read paths are party-scoped) or to
+            role-gated bank staff. This is not a party-name lookup.
+        granteeName:
+          type: string
+          description: As grantorName, for the party receiving the grant.
         resourceType: { type: string }
         resourceId: { type: string, format: uuid }
         capabilities: { type: array, items: { type: string } }

--- a/openbank-delegation-service/src/test/kotlin/com/openbank/delegation/application/usecase/DelegationServiceTest.kt
+++ b/openbank-delegation-service/src/test/kotlin/com/openbank/delegation/application/usecase/DelegationServiceTest.kt
@@ -86,9 +86,57 @@ class DelegationServiceTest {
         )
     }
 
-    private fun eligibilityOk(grantorKyc: String = "FULL", granteeKyc: String = "FULL") {
-        coEvery { eligibilityClient.eligibilityOf(grantor) } returns PartyEligibility(grantor, true, grantorKyc)
-        coEvery { eligibilityClient.eligibilityOf(grantee) } returns PartyEligibility(grantee, true, granteeKyc)
+    private fun eligibilityOk(
+        grantorKyc: String = "FULL",
+        granteeKyc: String = "FULL",
+        grantorName: String? = null,
+        granteeName: String? = null,
+    ) {
+        coEvery { eligibilityClient.eligibilityOf(grantor) } returns
+            PartyEligibility(grantor, true, grantorKyc, grantorName)
+        coEvery { eligibilityClient.eligibilityOf(grantee) } returns
+            PartyEligibility(grantee, true, granteeKyc, granteeName)
+    }
+
+    /**
+     * Issue #3604 — the accept screen showed the counterparty as a truncated UUID, so the person
+     * asked to hand over authority over their money could not tell who was asking.
+     *
+     * Asserted on the SAVED AGGREGATE, not on the returned response: the point of the fix is that
+     * the label is persisted at the moment of consent, so it survives a later rename of the party
+     * and needs no runtime lookup (and therefore no new authority for customer-edge). A test that
+     * only read the response would still pass against an implementation that resolved the name
+     * on the way out.
+     */
+    @Test
+    fun `the offered grant snapshots both counterparty display names`(): Unit = runBlocking {
+        scaOk(grantor, "DELEGATION_GRANT")
+        eligibilityOk(grantorName = "Alice Testerova", granteeName = "Bob Zkousky")
+        val saved = slot<DelegationGrant>()
+        coEvery { repository.save(capture(saved), any()) } answers { firstArg() }
+
+        service.offer(offerCommand())
+
+        assertThat(saved.captured.grantorName).isEqualTo("Alice Testerova")
+        assertThat(saved.captured.granteeName).isEqualTo("Bob Zkousky")
+    }
+
+    /**
+     * A party pid-service returns no usable name for must leave the field NULL, never an empty
+     * string: consumers render the party id when the label is absent, and a blank chip on a
+     * consent screen looks like a name that failed to load rather than one never captured.
+     */
+    @Test
+    fun `a party with no name leaves the snapshot null rather than blank`(): Unit = runBlocking {
+        scaOk(grantor, "DELEGATION_GRANT")
+        eligibilityOk()
+        val saved = slot<DelegationGrant>()
+        coEvery { repository.save(capture(saved), any()) } answers { firstArg() }
+
+        service.offer(offerCommand())
+
+        assertThat(saved.captured.grantorName).isNull()
+        assertThat(saved.captured.granteeName).isNull()
     }
 
     private fun offerCommand(

--- a/openbank-delegation-service/src/test/kotlin/com/openbank/delegation/contract/DelegationPartyEligibilityPactConsumerTest.kt
+++ b/openbank-delegation-service/src/test/kotlin/com/openbank/delegation/contract/DelegationPartyEligibilityPactConsumerTest.kt
@@ -70,6 +70,14 @@ class DelegationPartyEligibilityPactConsumerTest {
                 o.stringValue("id", PARTY_ID)
                 o.stringValue("status", "ACTIVE")
                 o.`object`("kycAttributes") { kyc -> kyc.stringValue("kycLevel", "FULL") }
+                // issue #3604 — the counterparty display name snapshotted onto a grant comes from
+                // here. `stringType`, not `stringValue`: unlike status and kycLevel these are not
+                // a closed vocabulary the consumer ranks, so the contract is the PATH and the type,
+                // not the literal. The values match the provider's @State seed (synthetic).
+                o.`object`("coreAttributes") { core ->
+                    core.stringType("givenName", "Pact")
+                    core.stringType("familyName", "Verifier")
+                }
             }.build(),
         )
         .toPact()
@@ -89,5 +97,11 @@ class DelegationPartyEligibilityPactConsumerTest {
         // Asserted at the nested path the client actually reads — not `kycLevel` at the root,
         // which is exactly the shape change the elvis default would swallow.
         assertThat(body.getString("kycAttributes.kycLevel")).isEqualTo("FULL")
+        // Asserted at the nested paths ResilientPartyEligibilityClient reads to build the grant's
+        // counterparty label. If pid-service moved these, the client would snapshot null and the
+        // accept screen would silently go back to showing a UUID (issue #3604) — a fail-quiet
+        // regression the provider replay is what actually catches.
+        assertThat(body.getString("coreAttributes.givenName")).isEqualTo("Pact")
+        assertThat(body.getString("coreAttributes.familyName")).isEqualTo("Verifier")
     }
 }

--- a/openbank-delegation-service/src/test/kotlin/com/openbank/delegation/infrastructure/client/ResilientPartyEligibilityClientTest.kt
+++ b/openbank-delegation-service/src/test/kotlin/com/openbank/delegation/infrastructure/client/ResilientPartyEligibilityClientTest.kt
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.delegation.infrastructure.client
+
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+/**
+ * Issue #3604 — the counterparty display name that ends up on a delegation grant is composed
+ * here, from the eligibility lookup this service already performs. The composition is small and
+ * every one of its edge cases is a defect a customer would see on the accept screen, so each
+ * gets its own case.
+ *
+ * The one thing this file CANNOT prove is that pid-service still serves `coreAttributes` at that
+ * path with those names — a mocked rest-client answers whatever it is told. That is
+ * `DelegationPartyEligibilityPactConsumerTest` plus pid-service's `@PactFolder` replay.
+ */
+class ResilientPartyEligibilityClientTest {
+
+    private val rest: PidServiceRestClient = mockk()
+    private val client = ResilientPartyEligibilityClient(rest)
+    private val partyId: UUID = UUID.randomUUID()
+
+    private fun pidAnswers(core: PidCoreAttributes?) {
+        coEvery { rest.getParty(partyId) } returns PidPartyResponse(
+            id = partyId,
+            status = "ACTIVE",
+            kycAttributes = PidKycAttributes("FULL"),
+            coreAttributes = core,
+        )
+    }
+
+    @Test
+    fun `given and family name compose into one display name`(): Unit = runBlocking {
+        pidAnswers(PidCoreAttributes(givenName = "Alice", familyName = "Testerova"))
+
+        assertThat(client.eligibilityOf(partyId).displayName).isEqualTo("Alice Testerova")
+    }
+
+    @Test
+    fun `a single available name part is still a usable label`(): Unit = runBlocking {
+        pidAnswers(PidCoreAttributes(givenName = null, familyName = "Testerova"))
+
+        assertThat(client.eligibilityOf(partyId).displayName).isEqualTo("Testerova")
+    }
+
+    /**
+     * The whole point of returning null rather than "": the consumer renders the party id when
+     * the label is absent, and an empty chip on a consent screen reads as a name that failed to
+     * load. `""` would be truthy enough to pass through most fallbacks.
+     */
+    @Test
+    fun `blank name parts yield null, never an empty label`(): Unit = runBlocking {
+        pidAnswers(PidCoreAttributes(givenName = "   ", familyName = ""))
+
+        assertThat(client.eligibilityOf(partyId).displayName).isNull()
+    }
+
+    /** An older pid-service, or a response shape change, must not break eligibility itself. */
+    @Test
+    fun `an absent coreAttributes object still yields a usable eligibility verdict`(): Unit = runBlocking {
+        pidAnswers(null)
+
+        val eligibility = client.eligibilityOf(partyId)
+
+        assertThat(eligibility.displayName).isNull()
+        assertThat(eligibility.active).isTrue()
+        assertThat(eligibility.kycLevel).isEqualTo("FULL")
+    }
+}

--- a/openbank-delegation-service/src/test/kotlin/com/openbank/delegation/infrastructure/persistence/entity/DelegationGrantEntityTest.kt
+++ b/openbank-delegation-service/src/test/kotlin/com/openbank/delegation/infrastructure/persistence/entity/DelegationGrantEntityTest.kt
@@ -26,6 +26,10 @@ class DelegationGrantEntityTest {
             id = UUID.randomUUID(),
             grantorPartyId = UUID.randomUUID(),
             granteePartyId = UUID.randomUUID(),
+            // #3604 — the snapshotted counterparty labels are columns like any other, and this
+            // assertion is `isEqualTo(grant)`, so a mapping that dropped them would fail here.
+            grantorName = "Alice Testerova",
+            granteeName = "Bob Zkousky",
             resourceType = DelegationResourceType.PAYMENT,
             resourceId = UUID.randomUUID(),
             capabilities = setOf(DelegationCapability.OBJECT_READ),

--- a/openbank-delegation-service/src/test/kotlin/com/openbank/delegation/infrastructure/rest/dto/DelegationDtosTest.kt
+++ b/openbank-delegation-service/src/test/kotlin/com/openbank/delegation/infrastructure/rest/dto/DelegationDtosTest.kt
@@ -42,6 +42,29 @@ class DelegationDtosTest {
         assertThat(response.status).isEqualTo(DelegationStatus.ACTIVE)
     }
 
+    /**
+     * Issue #3604. The whole fix is worthless if the snapshotted label stops at the aggregate —
+     * the accept screen only ever sees `DelegationResponse`.
+     */
+    @Test
+    fun `DelegationResponse carries the snapshotted counterparty names to the client`() {
+        val named = grant().copy(grantorName = "Alice Testerova", granteeName = "Bob Zkousky")
+
+        val response = DelegationResponse.from(named)
+
+        assertThat(response.grantorName).isEqualTo("Alice Testerova")
+        assertThat(response.granteeName).isEqualTo("Bob Zkousky")
+    }
+
+    /** A pre-#3604 grant carries no label, and the response must say so rather than invent one. */
+    @Test
+    fun `a grant with no snapshotted name responds with nulls`() {
+        val response = DelegationResponse.from(grant())
+
+        assertThat(response.grantorName).isNull()
+        assertThat(response.granteeName).isNull()
+    }
+
     @Test
     fun `ExposureDto round-trips through the domain`() {
         val dto = ExposureDto(

--- a/openbank-pid-service/src/test/kotlin/com/openbank/pid/contract/PidPactFolderProviderVerificationTest.kt
+++ b/openbank-pid-service/src/test/kotlin/com/openbank/pid/contract/PidPactFolderProviderVerificationTest.kt
@@ -76,6 +76,21 @@ import java.util.concurrent.TimeUnit
  * because it serves whatever the pact says; only asking the real `PartyResource` for the real
  * `PartyResponse` can (#2269).
  *
+ * Since issue #3604 the same interaction also pins `coreAttributes.givenName` / `familyName`,
+ * and the identical argument applies with a customer-visible consequence: delegation-service
+ * snapshots those two fields into the counterparty label shown on the ACCEPT screen, tolerating
+ * their absence by design (null label -> the client falls back to the party id). So moving or
+ * renaming them would silently return that screen to showing an unidentifiable UUID — the exact
+ * defect #3604 fixed — with every consumer-side test still green. This replay is the only thing
+ * that goes red.
+ *
+ * Consequence for [stateActiveFullKycParty]: its `givenName`/`familyName` are no longer incidental
+ * fixture noise. They are the values the pact matches (by type, not literal), so the seed must
+ * keep populating both. Note that CI reaches this class only when pid-service is in the build
+ * set, which on a PR means a file under `openbank-pid-service/` changed — a diff confined to the
+ * `pacts` directory does NOT pull the provider in on the PR lane (only the push lane maps a pact
+ * file to both ends). A PR that edits a pact this class replays should touch this file too.
+ *
  * `@TestSecurity` matches `PartyResource.getById`'s `@RolesAllowed(Roles.OPERATOR, Roles.ADMIN)`.
  * Note what that means for the contract: this replay proves the ROUTE and the SHAPE, and asserts
  * nothing about who may call it. The M2M authorization of delegation-service against pid-service

--- a/pacts/openbank-delegation-service-openbank-pid-service.json
+++ b/pacts/openbank-delegation-service-openbank-pid-service.json
@@ -16,6 +16,10 @@
       },
       "response": {
         "body": {
+          "coreAttributes": {
+            "familyName": "Verifier",
+            "givenName": "Pact"
+          },
           "id": "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
           "kycAttributes": {
             "kycLevel": "FULL"
@@ -24,6 +28,26 @@
         },
         "headers": {
           "Content-Type": "application/json"
+        },
+        "matchingRules": {
+          "body": {
+            "$.coreAttributes.familyName": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.coreAttributes.givenName": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
         },
         "status": 200
       }


### PR DESCRIPTION
Closes #3604

## What the customer saw

Someone asked to accept a delegation — to hand another party authority over their money — was shown a truncated UUID as the counterparty. That is the one screen where the identity *is* the decision, so the consent could not be informed. Product defect and compliance defect at once (ADR-0150).

## Which layer was actually missing

Not the data, and not a modelling gap at the source. pid-service already returns `coreAttributes.givenName` / `familyName` on **the exact call delegation-service already makes at offer time** for the ADR-0232 D5 eligibility gate. Three things were missing downstream of it:

| Layer | State before |
|---|---|
| `PidPartyResponse` (delegation's pid client) | Did not declare the fields; `@JsonIgnoreProperties` dropped them at the parser |
| `DelegationGrant` / `delegation_grants` | Nowhere to put a name |
| `DelegationResponse` | Returned bare UUIDs |

So this is option **(1)** from the issue — snapshot the name on the grant at offer time — and it needs no new call and **no new authority anywhere**.

## Why snapshot rather than resolve

- **customer-edge gains nothing.** Its party OPA grants stay `party.consent.update` + `party:resolve` (the ADR-0072 blind-index dedup gate, which is not an id lookup). Option (2) would have given the edge `party.read` on *any* party — scoped in usage, unscoped in the grant, and the grant is what gets reviewed. Option (3) would have added a new lookup surface for a value that does not need to be live.
- **It is the more correct record.** An authorisation record should say who agreed to what *at the moment they agreed*. A later rename must not silently rewrite that.

## Disclosure — what the accepting party can now see

The names ride the existing `DelegationResponse`, whose read paths are already party-scoped (threat-model T8): a grant the caller is not party to is **404**, a list for another party is **403**. So they reach only the two parties to the grant and role-gated bank staff. Both parties are, by construction, already identified to each other by the grant itself, so the name discloses nothing the relationship does not.

Threat model gains **T13**, with the residuals stated rather than implied away:
- bank staff (`ROLE_OPERATOR`/`ROLE_ADMIN`) already read any grant and now see the names too — same scope, wider PII surface;
- a snapshot goes stale on a legitimate rename. Deliberate, but it means the label is **not an identity assertion**.

Only `givenName`/`familyName` are materialised; the rest of `coreAttributes` (birthdate, birth number, documents, nationality) is still dropped at the parser.

## Nullable everywhere, and never blank

No backfill: existing rows stay `NULL`. Manufacturing a name for a grant consented to without one would put a value into an authorisation record that was never part of it. Every consumer falls back to the party id — and specifically never to an empty string, because a blank chip on a consent screen reads as a name that *failed to load* rather than one never captured. That distinction is asserted in three places (`ResilientPartyEligibilityClientTest`, `DelegationServiceTest`, `counterpartyLabel`).

## Versioning

- **API contract:** `openapi.yaml` `info.version` **1.1.0 → 1.2.0**. Two optional response properties added; nothing existing changed or removed — a backward-compatible addition, hence minor. Read off live `origin/main` immediately before setting it.
- **Release version:** left to release-please (`feat` + a path outside `exclude-paths`).
- **DB:** `V3__delegation_counterparty_names.sql`, two nullable `varchar(200)` columns, rollback note in the file.

## Contract test

The pid consumer pact now pins `coreAttributes.givenName` / `familyName` as `stringType` — the path and the type are the contract, since unlike `status` / `kycLevel` these are not a closed vocabulary the consumer ranks. Values match pid's existing `@State` seed (synthetic).

The replay that actually backstops it is pid-service's `PidPactFolderProviderVerificationTest` — `@PactFolder`-sourced, ungated, and it already satisfies the new expectation from its existing `@State` seed (synthetic "Pact Verifier"), so the provider needs no behaviour change.

**Correction — a claim in the first version of this description was wrong.** It said `services-ci` builds both sides of a changed pact file, so the replay would run on this PR. That mapping exists **only in the push lane**. The PR lane fans out purely on `^<module>/`, so a diff confined to `pacts/` matches no module and the provider is *not* pulled in. Measured on this PR's own first run: `Detect changed services` decided *"per-module fan-out"* and the job matrix was `build (openbank-delegation-service)` alone — pid-service absent. Left unaddressed, the contract would have been replayed only *after* the merge, which is exactly the #2327 shape.

Addressed here by giving `PidPactFolderProviderVerificationTest` the documentation this change genuinely owes it — its `@State` seed's `givenName`/`familyName` are no longer incidental fixture noise but the values the pact matches — which also puts `openbank-pid-service` in the PR's build set, so the replay runs *before* the merge. Verify by reading the job list, not by trusting this paragraph.

That the PR lane cannot see the pact graph the push lane deliberately does is a real CI gap, wider than this PR (its push-lane counterpart states outright: *never under-build the Pact graph*). Not fixed here — editing shared change-detection logic inside a money-path PR is the wrong place for it, and it deserves its own issue.

## Deliberately out of scope

- `DelegationOffered` does **not** carry the names — an event-contract change the projections have no use for.
- **customer-edge is untouched.** It proxies the delegation JSON verbatim and its spec declares no response schema for these paths, so the field flows through with no edge change and no edge version bump.

## Self-assessment

**Verified:** the one local test failure (`DelegationExpirationSweepIT`) was environmental, not this change — a clean re-run of the module is green (70/70), and the failing run logged `Thread blocked for 27714 ms` under a parallel fleet build. Also verified: pid returns the fields on that route (`PartyResponse.coreAttributes`); the provider `@State` seeds them; the read paths are party-scoped (read the guard in `DelegationService.getDelegation` / `listByGrantor` / `listByGrantee`); the edge's party OPA action set; that a changed pact pulls the provider into the build.

**Assumed / not proven here:** nothing exercises the full offer→accept path against a real pid-service in this diff — the client is mocked in unit tests and the pact mock answers what it is told. The provider replay is what closes that, which is why it is the load-bearing half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

