### PR TITLE
fix(gitops): make the six coincidental Kafka group.id values actually resolve

### DIFF
--- a/.github/scripts/check-kafka-dotted-keys.py
+++ b/.github/scripts/check-kafka-dotted-keys.py
@@ -17,11 +17,16 @@
 #   `*-msg-override.yaml` ConfigMap carrying `override.properties` with `config_ordinal=500`.
 #
 # WHAT THIS CHECKS, AND WHY THE TWO KEYS DIFFER
-#   `group.id`         — the fallback is `quarkus.application.name`. Six services get away with the
-#                        broken key purely because the value they wanted happens to equal their
-#                        application name. That is correct by coincidence: it breaks the day a
-#                        service is renamed, or a channel wants its own group (exactly what
-#                        transaction-service did). Accepted, but only when the values match.
+#   `group.id`         — the fallback is `quarkus.application.name`. Six services USED TO get away
+#                        with the broken key purely because the value they wanted happened to equal
+#                        their application name — correct by coincidence, not by design: it breaks
+#                        the day a service is renamed, or a channel wants its own group (exactly
+#                        what transaction-service did). All six now carry a `*-msg-override`
+#                        ConfigMap setting the same value (#2945), so an override is the ONLY thing
+#                        that makes a dotted `group.id` acceptable and the coincidence exemption is
+#                        gone. Removing it is what stops the next service re-introducing the
+#                        latent version of this bug: matching the app name would otherwise pass CI
+#                        while resolving through a fallback nobody chose.
 #   `auto.offset.reset`— there is no such coincidence available. The fallback is the connector's own
 #                        default, so a channel declaring a NON-default value and having no override
 #                        is running on the default while its config file says otherwise. This is the
@@ -37,8 +42,9 @@
 #
 # EXIT CODES
 #   0  no new occurrences, no stale baseline entries
-#   1  a new dotted key that neither matches its fallback nor has an override — or a baseline entry
-#      that is now covered and should be removed
+#   1  a dotted `group.id` with no override ConfigMap, a dotted `auto.offset.reset` asking for a
+#      non-default value with no override — or a baseline entry that is now covered and should be
+#      removed
 #   2  the check could not run (PyYAML missing, tree not found). Never conflated with 0.
 #
 # Run:  python3 .github/scripts/check-kafka-dotted-keys.py [--root .] [--self-test]
@@ -151,9 +157,10 @@ def scan(root):
                 if (service, channel, key) in overrides:
                     continue
 
-                # group.id survives when the fallback (quarkus.application.name) is the same string.
-                if key == "group.id" and name is not None and value == name:
-                    continue
+                # NOTE: `group.id == quarkus.application.name` used to be accepted here. It is not
+                # any more (#2945) — see the header. A value that merely happens to equal the
+                # fallback still does not RESOLVE, so accepting it means the config file and the
+                # running consumer agree by accident, which is not a property a gate can keep.
                 # auto.offset.reset survives only when it asks for the connector default anyway.
                 if key == "auto.offset.reset" and value == CONNECTOR_DEFAULT_OFFSET_RESET:
                     continue
@@ -164,75 +171,133 @@ def scan(root):
                     continue
 
                 fallback = name if key == "group.id" else CONNECTOR_DEFAULT_OFFSET_RESET
+                effect = (
+                    f"the effective value is the fallback ({fallback!r}) — which happens to equal "
+                    f"the declared one, so nothing is broken TODAY and everything breaks on the "
+                    f"first rename or channel-specific group (#2945)"
+                    if str(fallback) == value
+                    else f"the effective value is the fallback ({fallback!r}), not {value!r}"
+                )
                 findings.append(
                     f"{path}: channel '{channel}' sets `{key}: {value}` as a dotted YAML key with no "
                     f"*-msg-override ConfigMap.\n"
-                    f"       That key does not reach the connector (#686), so the effective value is "
-                    f"the fallback ({fallback!r}), not {value!r}.\n"
+                    f"       That key does not reach the connector (#686), so {effect}.\n"
                     f"       Fix: add `mp.messaging.incoming.{channel}.{key}={value}` to a "
                     f"`*-msg-override.yaml` ConfigMap (config_ordinal=500), as transaction-service does.",
                 )
     return findings, matched
 
 
-SELF_TEST_DOC = """
+SELF_TEST_SERVICES = {
+    # (service, application.yaml body, override.properties body or None)
+    "openbank-demo-covered-service": (
+        """
 quarkus:
   application:
-    name: openbank-demo-service
+    name: openbank-demo-covered-service
 mp:
   messaging:
     incoming:
-      matches-app-name:
-        group.id: openbank-demo-service
-      differs-from-app-name:
+      covered-in:
+        group.id: openbank-demo-covered-service
+""",
+        "config_ordinal=500\nmp.messaging.incoming.covered-in.group.id=openbank-demo-covered-service\n",
+    ),
+    # The regression this gate exists for since #2945: a group.id equal to the application name.
+    # It resolves to the right string today by ACCIDENT and must still be reported.
+    "openbank-demo-coincidence-service": (
+        """
+quarkus:
+  application:
+    name: openbank-demo-coincidence-service
+mp:
+  messaging:
+    incoming:
+      coincidence-in:
+        group.id: openbank-demo-coincidence-service
+""",
+        None,
+    ),
+    "openbank-demo-differs-service": (
+        """
+quarkus:
+  application:
+    name: openbank-demo-differs-service
+mp:
+  messaging:
+    incoming:
+      differs-in:
         group.id: some-other-group
-      asks-for-default:
+      asks-for-default-in:
         auto.offset.reset: latest
-      asks-for-non-default:
+      asks-for-non-default-in:
         auto.offset.reset: earliest
-"""
+""",
+        None,
+    ),
+}
+
+# channel -> must this channel appear in the findings?
+SELF_TEST_EXPECT = {
+    "covered-in": False,           # override ConfigMap sets it — the only acceptable shape
+    "coincidence-in": True,        # equal to quarkus.application.name, still does not resolve
+    "differs-in": True,            # differs from the fallback — the loud case
+    "asks-for-default-in": False,  # asks for the connector default anyway, so a no-op
+    "asks-for-non-default-in": True,
+}
 
 
 def self_test():
-    """Exercise the classifier against channels it MUST flag and channels it MUST NOT.
+    """Drive the REAL scan() over a synthetic tree, not a retyped copy of its classifier.
 
-    The must-NOT half is the one that matters: a guard that flags every dotted key would be noise,
-    and the whole point is that `group.id` matching the application name is genuinely harmless while
-    `auto.offset.reset: earliest` never is.
+    An earlier version of this self-test re-implemented the harmless/flagged decision inline. That
+    could not see load_overrides() at all, so the one rule that now decides every group.id verdict
+    — "is there an override ConfigMap" — was the one rule it never exercised. It also could not have
+    caught the change it was written alongside.
+
+    The must-NOT half is the half that matters: a guard that flags every dotted key is noise.
     """
-    doc = yaml.safe_load(SELF_TEST_DOC)
-    name = app_name(doc)
-    results = {}
-    for channel, cfg in incoming_channels(doc):
-        for key in WATCHED_KEYS:
-            if key not in cfg:
-                continue
-            value = str(cfg[key])
-            harmless = (key == "group.id" and value == name) or (
-                key == "auto.offset.reset" and value == CONNECTOR_DEFAULT_OFFSET_RESET
-            )
-            results[channel] = not harmless  # True == should be flagged
+    import tempfile
 
-    expected = {
-        "matches-app-name": False,
-        "differs-from-app-name": True,
-        "asks-for-default": False,
-        "asks-for-non-default": True,
-    }
     failures = 0
-    for channel, want in expected.items():
-        got = results.get(channel)
+    with tempfile.TemporaryDirectory() as tmp:
+        root = pathlib.Path(tmp)
+        for service, (app_yaml, override) in SELF_TEST_SERVICES.items():
+            res = root / service / "src" / "main" / "resources"
+            res.mkdir(parents=True)
+            (res / "application.yaml").write_text(app_yaml, encoding="utf-8")
+            if override is None:
+                continue
+            short = service[len("openbank-"):]
+            comp = root / "openbank-infra" / "gitops" / "components" / short
+            comp.mkdir(parents=True)
+            (comp / f"{short}-msg-override.yaml").write_text(
+                # The leading comment repeats the property name on purpose: a text guard that does
+                # not strip comments would read this prose as coverage (the silent direction of the
+                # "guard matches the text about the thing" failure).
+                f"# explains mp.messaging.incoming.covered-in.group.id=... and why it is here\n"
+                f"apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: {short}-msg-override\n"
+                f"data:\n  override.properties: |\n    " + override.replace("\n", "\n    "),
+                encoding="utf-8",
+            )
+
+        findings, _ = scan(str(root))
+
+    flagged = {ch for ch in SELF_TEST_EXPECT if any(f"channel '{ch}'" in f for f in findings)}
+    for channel, want in sorted(SELF_TEST_EXPECT.items()):
+        got = channel in flagged
         ok = got == want
         verdict = "flag" if want else "allow"
         print(f"{'pass' if ok else 'FAIL'}  {channel} -> {verdict}" + ("" if ok else f" (got flag={got})"))
         failures += 0 if ok else 1
 
-    # app_name must be read from the real path, or every group.id comparison silently "differs".
-    ok = name == "openbank-demo-service"
-    print(f"{'pass' if ok else 'FAIL'}  quarkus.application.name resolves" + ("" if ok else f" (got {name!r})"))
+    # A finding count larger than the expected set means scan() invented a channel we never declared.
+    ok = len(findings) == sum(SELF_TEST_EXPECT.values())
+    print(f"{'pass' if ok else 'FAIL'}  finding count == expected" + ("" if ok else f" (got {len(findings)})"))
     failures += 0 if ok else 1
 
-    print(f"\nself-test: {len(expected) + 1 - failures} passed, {failures} failed")
+    total = len(SELF_TEST_EXPECT) + 1
+    print(f"\nself-test: {total - failures} passed, {failures} failed")
     return 0 if failures == 0 else 2
 
 

--- a/openbank-infra/gitops/components/accounts/account-service-msg-override.yaml
+++ b/openbank-infra/gitops/components/accounts/account-service-msg-override.yaml
@@ -1,0 +1,52 @@
+# Makes account-service's Kafka consumer `group.id` reach the connector from a config source
+# SmallRye does not mangle (#686, #2945).
+#
+# THE MECHANISM
+#   application.yaml writes `group.id:` as a YAML leaf key under
+#   mp.messaging.incoming.<channel>. SmallRye's YAML config source quotes any leaf key containing
+#   a literal dot, so it registers only as ...<channel>."group.id" — quotes included — and
+#   KafkaConnectorIncomingConfiguration's plain getOptionalValue("group.id", …) never finds it.
+#   Nothing errors; the connector falls back to quarkus.application.name.
+#
+# WHY THIS FILE EXISTS WHEN NOTHING IS BROKEN
+#   account-service's declared group.id IS `openbank-account-service`, which is exactly what the
+#   fallback produces — so the broken key is a no-op today, by coincidence rather than by design.
+#   It stops being a no-op the moment the service is renamed, or a channel is given its own group
+#   (exactly what transaction-service did). This file makes the declared value the EFFECTIVE value,
+#   so that day is a config edit and not a silent consumer-group change on a money-path topic.
+#
+#   Deploying this changes no effective value: both channels keep the group
+#   `openbank-account-service`, which is the group the KafkaUser ACL
+#   (kafka-account-mtls.yaml) grants Read on, and the group that holds today's committed offsets.
+#
+# WHAT IS DELIBERATELY NOT HERE
+#   `auto.offset.reset: earliest` is declared for both channels in application.yaml and is subject
+#   to the same bug, so its effective value is the connector default (`latest`). It is NOT set here.
+#   Making it effective is an operational decision, not a config tidy-up: auto.offset.reset applies
+#   whenever a group has no valid committed offset, so on the next offset expiry
+#   (offsets.retention, 7d default — reachable for a KEDA-scaled service) the group would replay
+#   the whole retained log instead of resuming at the tail. See #2945 for the per-channel
+#   assessment and the owner decision that has to precede it.
+#
+#   Why a properties FILE and not env vars: quarkusio/quarkus#30106 and
+#   smallrye/smallrye-reactive-messaging#2028 document an unresolved upstream bug where an env-var
+#   override of a single leaf property on a HYPHENATED channel name crashes Quarkus at startup
+#   (SRMSG00071). Both channels here are hyphenated. Same reasoning as transaction-service's and
+#   kyc-service's equivalents, which this mirrors.
+#
+# config_ordinal=500 outranks the baked application.yaml (~254). Loaded via
+# QUARKUS_CONFIG_LOCATIONS on the Rollout; the location is optional, so an absent file warns
+# and boots.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: account-service-msg-override
+  namespace: accounts
+  labels:
+    app.kubernetes.io/name: account-service
+    app.kubernetes.io/part-of: accounts
+data:
+  override.properties: |
+    config_ordinal=500
+    mp.messaging.incoming.party-events-in.group.id=openbank-account-service
+    mp.messaging.incoming.delegation-events-in.group.id=openbank-account-service

--- a/openbank-infra/gitops/components/accounts/account-service.yaml
+++ b/openbank-infra/gitops/components/accounts/account-service.yaml
@@ -139,6 +139,13 @@ spec:
             # already attached to this Rollout) aborts on an error-rate/latency regression.
             - name: AUTHZ_ENFORCE
               value: "true"
+            # #686 / #2945: load the party-events-in / delegation-events-in group.id override
+            # (account-service-msg-override ConfigMap, mounted below) as an external Quarkus
+            # config source, so the dotted YAML keys' declared values actually reach the Kafka
+            # connector instead of silently falling back to quarkus.application.name.
+            # Optional location: if the file is absent Quarkus warns and continues.
+            - name: QUARKUS_CONFIG_LOCATIONS
+              value: /mnt/msg-config/override.properties
           startupProbe:
             tcpSocket:
               port: management
@@ -176,6 +183,9 @@ spec:
               readOnly: true
             - name: kafka-truststore
               mountPath: /mnt/kafka/truststore
+              readOnly: true
+            - name: msg-override
+              mountPath: /mnt/msg-config
               readOnly: true
           resources:
             requests:
@@ -273,6 +283,9 @@ spec:
         - name: kafka-truststore
           secret:
             secretName: kafka-cluster-ca-truststore
+        - name: msg-override
+          configMap:
+            name: account-service-msg-override
   strategy:
     canary:
       stableService: account-service

--- a/openbank-infra/gitops/components/aml/aml-service-msg-override.yaml
+++ b/openbank-infra/gitops/components/aml/aml-service-msg-override.yaml
@@ -1,0 +1,30 @@
+# Makes aml-service's Kafka consumer `group.id` reach the connector from a config source SmallRye
+# does not mangle (#686, #2945). Full mechanism + rationale:
+# openbank-infra/gitops/components/accounts/account-service-msg-override.yaml.
+#
+# Short form: a dotted YAML leaf key under mp.messaging.incoming.<channel> registers only as the
+# QUOTED property name, so the connector never reads it and silently falls back to
+# quarkus.application.name. aml-service's declared group.id happens to EQUAL that fallback, so the
+# broken key is a no-op by coincidence — until a rename or a channel-specific group makes it one.
+# Deploying this changes no effective value: the group stays `openbank-aml-service`, which is what
+# kafka-aml-mtls.yaml grants Read on and where today's committed offsets live.
+#
+# `auto.offset.reset: earliest` is declared in application.yaml and is subject to the same bug
+# (effective value: the connector default `latest`). It is deliberately NOT set here — making it
+# effective would replay the retained log on the next offset expiry. Owner decision, see #2945.
+#
+# Properties file rather than env vars: the hyphenated channel name hits the unresolved
+# quarkusio/quarkus#30106 / smallrye-reactive-messaging#2028 env-var split bug (SRMSG00071).
+# config_ordinal=500 outranks the baked application.yaml (~254); loaded via QUARKUS_CONFIG_LOCATIONS.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: aml-service-msg-override
+  namespace: aml
+  labels:
+    app.kubernetes.io/name: aml-service
+    app.kubernetes.io/part-of: aml
+data:
+  override.properties: |
+    config_ordinal=500
+    mp.messaging.incoming.party-events-in.group.id=openbank-aml-service

--- a/openbank-infra/gitops/components/aml/aml-service.yaml
+++ b/openbank-infra/gitops/components/aml/aml-service.yaml
@@ -108,6 +108,13 @@ spec:
             # empty, then a separate deliberate flip sets it true (rules.yaml AUTHZ_ENFORCE guardrail).
             - name: AUTHZ_ENFORCE
               value: "false"
+            # #686 / #2945: load the party-events-in group.id override (aml-service-msg-override
+            # ConfigMap, mounted below) as an external Quarkus config source, so the dotted YAML
+            # key's declared value actually reaches the Kafka connector instead of silently
+            # falling back to quarkus.application.name.
+            # Optional location: if the file is absent Quarkus warns and continues.
+            - name: QUARKUS_CONFIG_LOCATIONS
+              value: /mnt/msg-config/override.properties
           startupProbe:
             tcpSocket:
               port: management
@@ -139,6 +146,9 @@ spec:
               readOnly: true
             - name: kafka-truststore
               mountPath: /mnt/kafka/truststore
+              readOnly: true
+            - name: msg-override
+              mountPath: /mnt/msg-config
               readOnly: true
           resources:
             requests:
@@ -232,6 +242,9 @@ spec:
         - name: kafka-truststore
           secret:
             secretName: kafka-cluster-ca-truststore
+        - name: msg-override
+          configMap:
+            name: aml-service-msg-override
 ---
 apiVersion: v1
 kind: Service

--- a/openbank-infra/gitops/components/balances/balance-service-msg-override.yaml
+++ b/openbank-infra/gitops/components/balances/balance-service-msg-override.yaml
@@ -1,0 +1,35 @@
+# Makes balance-service's Kafka consumer `group.id` reach the connector from a config source
+# SmallRye does not mangle (#686, #2945). Full mechanism + rationale:
+# openbank-infra/gitops/components/accounts/account-service-msg-override.yaml.
+#
+# Short form: a dotted YAML leaf key under mp.messaging.incoming.<channel> registers only as the
+# QUOTED property name, so the connector never reads it and silently falls back to
+# quarkus.application.name. balance-service's declared group.id happens to EQUAL that fallback, so
+# the broken key is a no-op by coincidence — until a rename or a channel-specific group makes it
+# one. balance-service is money-path (rules.yaml: money_path_services) and consumes the ledger
+# journal, so a silent consumer-group change here is a balance-projection correctness event.
+# Deploying this changes no effective value: both channels keep the group
+# `openbank-balance-service`, which is what kafka-balance-mtls.yaml grants Read on and where
+# today's committed offsets live.
+#
+# `auto.offset.reset: earliest` is declared for both channels and is subject to the same bug
+# (effective value: the connector default `latest`). It is deliberately NOT set here — making it
+# effective would replay the retained ledger journal on the next offset expiry. Owner decision,
+# see #2945.
+#
+# Properties file rather than env vars: the hyphenated channel names hit the unresolved
+# quarkusio/quarkus#30106 / smallrye-reactive-messaging#2028 env-var split bug (SRMSG00071).
+# config_ordinal=500 outranks the baked application.yaml (~254); loaded via QUARKUS_CONFIG_LOCATIONS.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: balance-service-msg-override
+  namespace: balances
+  labels:
+    app.kubernetes.io/name: balance-service
+    app.kubernetes.io/part-of: balances
+data:
+  override.properties: |
+    config_ordinal=500
+    mp.messaging.incoming.ledger-events-in.group.id=openbank-balance-service
+    mp.messaging.incoming.balance-init-in.group.id=openbank-balance-service

--- a/openbank-infra/gitops/components/balances/balance-service.yaml
+++ b/openbank-infra/gitops/components/balances/balance-service.yaml
@@ -128,6 +128,13 @@ spec:
             # aborts the rollout if enforce regresses the error rate.
             - name: AUTHZ_ENFORCE
               value: "true"
+            # #686 / #2945: load the ledger-events-in / balance-init-in group.id override
+            # (balance-service-msg-override ConfigMap, mounted below) as an external Quarkus
+            # config source, so the dotted YAML keys' declared values actually reach the Kafka
+            # connector instead of silently falling back to quarkus.application.name.
+            # Optional location: if the file is absent Quarkus warns and continues.
+            - name: QUARKUS_CONFIG_LOCATIONS
+              value: /mnt/msg-config/override.properties
           startupProbe:
             tcpSocket:
               port: management
@@ -163,6 +170,9 @@ spec:
               readOnly: true
             - name: kafka-truststore
               mountPath: /mnt/kafka/truststore
+              readOnly: true
+            - name: msg-override
+              mountPath: /mnt/msg-config
               readOnly: true
           resources:
             requests:
@@ -259,6 +269,9 @@ spec:
         - name: kafka-truststore
           secret:
             secretName: kafka-cluster-ca-truststore
+        - name: msg-override
+          configMap:
+            name: balance-service-msg-override
   strategy:
     canary:
       stableService: balance-service

--- a/openbank-infra/gitops/components/document-service/document-service-msg-override.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-msg-override.yaml
@@ -1,0 +1,31 @@
+# Makes document-service's Kafka consumer `group.id` reach the connector from a config source
+# SmallRye does not mangle (#686, #2945). Full mechanism + rationale:
+# openbank-infra/gitops/components/accounts/account-service-msg-override.yaml.
+#
+# Short form: a dotted YAML leaf key under mp.messaging.incoming.<channel> registers only as the
+# QUOTED property name, so the connector never reads it and silently falls back to
+# quarkus.application.name. document-service's declared group.id happens to EQUAL that fallback,
+# so the broken key is a no-op by coincidence — until a rename or a channel-specific group makes
+# it one. Deploying this changes no effective value: the group stays `openbank-document-service`,
+# which is what kafka-document-service-mtls.yaml grants Read on and where today's committed
+# offsets live.
+#
+# `auto.offset.reset: earliest` is declared in application.yaml and is subject to the same bug
+# (effective value: the connector default `latest`). It is deliberately NOT set here — making it
+# effective would replay the retained log on the next offset expiry. Owner decision, see #2945.
+#
+# Properties file rather than env vars: the hyphenated channel name hits the unresolved
+# quarkusio/quarkus#30106 / smallrye-reactive-messaging#2028 env-var split bug (SRMSG00071).
+# config_ordinal=500 outranks the baked application.yaml (~254); loaded via QUARKUS_CONFIG_LOCATIONS.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: document-service-msg-override
+  namespace: documents
+  labels:
+    app.kubernetes.io/name: document-service
+    app.kubernetes.io/part-of: documents
+data:
+  override.properties: |
+    config_ordinal=500
+    mp.messaging.incoming.account-created-in.group.id=openbank-document-service

--- a/openbank-infra/gitops/components/document-service/document-service-service.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-service.yaml
@@ -204,6 +204,13 @@ spec:
             # the fine-grained PEP.
             - name: AUTHZ_ENFORCE
               value: "true"
+            # #686 / #2945: load the account-created-in group.id override
+            # (document-service-msg-override ConfigMap, mounted below) as an external Quarkus
+            # config source, so the dotted YAML key's declared value actually reaches the Kafka
+            # connector instead of silently falling back to quarkus.application.name.
+            # Optional location: if the file is absent Quarkus warns and continues.
+            - name: QUARKUS_CONFIG_LOCATIONS
+              value: /mnt/msg-config/override.properties
           startupProbe:
             httpGet:
               path: /q/health/started
@@ -240,6 +247,9 @@ spec:
               readOnly: true
             - name: signing-keystore
               mountPath: /mnt/signing-keystore
+              readOnly: true
+            - name: msg-override
+              mountPath: /mnt/msg-config
               readOnly: true
           resources:
             requests:
@@ -348,6 +358,9 @@ spec:
           secret:
             secretName: document-service-signing-keystore
             optional: true
+        - name: msg-override
+          configMap:
+            name: document-service-msg-override
             items:
               - key: keystore.p12
                 path: keystore.p12

--- a/openbank-infra/gitops/components/party/party-service-msg-override.yaml
+++ b/openbank-infra/gitops/components/party/party-service-msg-override.yaml
@@ -1,0 +1,36 @@
+# Makes party-service's Kafka consumer `group.id` reach the connector from a config source
+# SmallRye does not mangle (#686, #2945). Full mechanism + rationale:
+# openbank-infra/gitops/components/accounts/account-service-msg-override.yaml.
+#
+# Short form: a dotted YAML leaf key under mp.messaging.incoming.<channel> registers only as the
+# QUOTED property name, so the connector never reads it and silently falls back to
+# quarkus.application.name. party-service's declared group.id happens to EQUAL that fallback, so
+# the broken key is a no-op by coincidence — until a rename or a channel-specific group makes it
+# one. Three channels share the single group here, which is exactly the shape that would want
+# per-channel groups one day; that edit is the one this file makes safe.
+# Deploying this changes no effective value: all three channels keep the group
+# `openbank-party-service`, which is what kafka-party-mtls.yaml grants Read on and where today's
+# committed offsets live.
+#
+# `auto.offset.reset: earliest` is declared for all three channels and is subject to the same bug
+# (effective value: the connector default `latest`). It is deliberately NOT set here — making it
+# effective would replay the retained kyc/aml/consent logs on the next offset expiry. Owner
+# decision, see #2945.
+#
+# Properties file rather than env vars: the hyphenated channel names hit the unresolved
+# quarkusio/quarkus#30106 / smallrye-reactive-messaging#2028 env-var split bug (SRMSG00071).
+# config_ordinal=500 outranks the baked application.yaml (~254); loaded via QUARKUS_CONFIG_LOCATIONS.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: party-service-msg-override
+  namespace: party
+  labels:
+    app.kubernetes.io/name: party-service
+    app.kubernetes.io/part-of: party
+data:
+  override.properties: |
+    config_ordinal=500
+    mp.messaging.incoming.kyc-events-in.group.id=openbank-party-service
+    mp.messaging.incoming.aml-events-in.group.id=openbank-party-service
+    mp.messaging.incoming.consent-events-in.group.id=openbank-party-service

--- a/openbank-infra/gitops/components/party/party-service.yaml
+++ b/openbank-infra/gitops/components/party/party-service.yaml
@@ -163,6 +163,13 @@ spec:
             # default-deny NetworkPolicy. Resolves identically to the in-image default.
             - name: ACCOUNT_SERVICE_URL
               value: http://account-service.accounts.svc:8100
+            # #686 / #2945: load the kyc-events-in / aml-events-in / consent-events-in group.id
+            # override (party-service-msg-override ConfigMap, mounted below) as an external
+            # Quarkus config source, so the dotted YAML keys' declared values actually reach the
+            # Kafka connector instead of silently falling back to quarkus.application.name.
+            # Optional location: if the file is absent Quarkus warns and continues.
+            - name: QUARKUS_CONFIG_LOCATIONS
+              value: /mnt/msg-config/override.properties
           startupProbe:
             tcpSocket:
               port: management
@@ -194,6 +201,9 @@ spec:
               readOnly: true
             - name: kafka-truststore
               mountPath: /mnt/kafka/truststore
+              readOnly: true
+            - name: msg-override
+              mountPath: /mnt/msg-config
               readOnly: true
           resources:
             requests:
@@ -341,6 +351,9 @@ spec:
         - name: kafka-truststore
           secret:
             secretName: kafka-cluster-ca-truststore
+        - name: msg-override
+          configMap:
+            name: party-service-msg-override
   strategy:
     canary:
       stableService: party-service

--- a/openbank-infra/gitops/components/statements/statement-service-msg-override.yaml
+++ b/openbank-infra/gitops/components/statements/statement-service-msg-override.yaml
@@ -1,0 +1,30 @@
+# Makes statement-service's Kafka consumer `group.id` reach the connector from a config source
+# SmallRye does not mangle (#686, #2945). Full mechanism + rationale:
+# openbank-infra/gitops/components/accounts/account-service-msg-override.yaml.
+#
+# Short form: a dotted YAML leaf key under mp.messaging.incoming.<channel> registers only as the
+# QUOTED property name, so the connector never reads it and silently falls back to
+# quarkus.application.name. statement-service's declared group.id happens to EQUAL that fallback,
+# so the broken key is a no-op by coincidence — until a rename or a channel-specific group makes
+# it one. Deploying this changes no effective value: the group stays `openbank-statement-service`,
+# which is what kafka-statement-mtls.yaml grants Read on and where today's committed offsets live.
+#
+# `auto.offset.reset: earliest` is declared in application.yaml and is subject to the same bug
+# (effective value: the connector default `latest`). It is deliberately NOT set here — making it
+# effective would replay the retained log on the next offset expiry. Owner decision, see #2945.
+#
+# Properties file rather than env vars: the hyphenated channel name hits the unresolved
+# quarkusio/quarkus#30106 / smallrye-reactive-messaging#2028 env-var split bug (SRMSG00071).
+# config_ordinal=500 outranks the baked application.yaml (~254); loaded via QUARKUS_CONFIG_LOCATIONS.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: statement-service-msg-override
+  namespace: statements
+  labels:
+    app.kubernetes.io/name: statement-service
+    app.kubernetes.io/part-of: statements
+data:
+  override.properties: |
+    config_ordinal=500
+    mp.messaging.incoming.account-events-in.group.id=openbank-statement-service

--- a/openbank-infra/gitops/components/statements/statement-service.yaml
+++ b/openbank-infra/gitops/components/statements/statement-service.yaml
@@ -126,6 +126,13 @@ spec:
             # load-bearing.
             - name: AUTHZ_ENFORCE
               value: "false"
+            # #686 / #2945: load the account-events-in group.id override
+            # (statement-service-msg-override ConfigMap, mounted below) as an external Quarkus
+            # config source, so the dotted YAML key's declared value actually reaches the Kafka
+            # connector instead of silently falling back to quarkus.application.name.
+            # Optional location: if the file is absent Quarkus warns and continues.
+            - name: QUARKUS_CONFIG_LOCATIONS
+              value: /mnt/msg-config/override.properties
           startupProbe:
             tcpSocket:
               port: management
@@ -161,6 +168,9 @@ spec:
               readOnly: true
             - name: kafka-truststore
               mountPath: /mnt/kafka-truststore
+              readOnly: true
+            - name: msg-override
+              mountPath: /mnt/msg-config
               readOnly: true
           resources:
             requests:
@@ -255,6 +265,9 @@ spec:
         - name: kafka-truststore
           secret:
             secretName: kafka-cluster-ca-truststore
+        - name: msg-override
+          configMap:
+            name: statement-service-msg-override
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
## What this is

#2945 asked why six services' Kafka `group.id` values are correct **by coincidence** rather than
by design, and how thin that margin is. This makes them correct by design, for the `group.id` half
only, and leaves the `auto.offset.reset` half to the owner because changing it is a data event, not
a config edit.

## Measured, per channel

Effective values measured against the live sandbox cluster (kafka-exporter
`kafka_consumergroup_current_offset` / `kafka_topic_partition_*_offset`), not inferred. `group.id`
in every case equals `quarkus.application.name`, so the effective group today is the fallback and
happens to match the file.

| service | channel | topic | group (declared == effective) | committed offsets | money-path |
|---|---|---|---|---|---|
| account | party-events-in | openbank.party.events | openbank-account-service | yes (169/169) | yes |
| account | delegation-events-in | openbank.delegation.events | openbank-account-service | **none** | yes |
| aml | party-events-in | openbank.party.events | openbank-aml-service | yes (169/169) | no |
| balance | ledger-events-in | openbank.ledger.journal.posted | openbank-balance-service | yes (571/571) | yes |
| balance | balance-init-in | openbank.accounts.account.created | openbank-balance-service | yes (129/129) | yes |
| document | account-created-in | openbank.accounts.account.created | openbank-document-service | yes (129/129) | no |
| party | kyc-events-in | openbank.kyc.events | openbank-party-service | yes (115/115) | no |
| party | aml-events-in | openbank.aml.events | openbank-party-service | yes (109/109) | no |
| party | consent-events-in | openbank.consent.events | openbank-party-service | yes (10/10) | no |
| statement | account-events-in | openbank.accounts.account.created | openbank-statement-service | yes (129/129) | no |

Each service's KafkaUser ACL grants `Read` on exactly that literal group name, which is the second
independent confirmation that the fallback value is the one actually in use.

## What this changes

A `<svc>-msg-override.yaml` ConfigMap per service (`override.properties`, `config_ordinal=500`,
mounted via `QUARKUS_CONFIG_LOCATIONS`) setting `group.id` for all ten channels — the pattern
`transaction-service` and `kyc-service` already carry. **Every effective value is unchanged**: each
override sets the group the consumer is already committed on. The deploy restarts the six pods and
moves no offset.

The dotted YAML keys are deliberately **not** deleted. Local dev and tests read them fine; only the
deployed path breaks, so deleting them would make local behaviour match neither state.

`check-kafka-dotted-keys.py` drops the "a `group.id` equal to `quarkus.application.name` is
acceptable" exemption in the same change, so the coincidence cannot come back — an override
ConfigMap is now the only shape that passes. Falsified both ways: the new checker reports **10
findings against the pre-change tree and 0 against this one**. Its self-test was also rewritten to
drive the real `scan()` over a synthetic tree; the previous version re-implemented the classifier
inline and so could not exercise `load_overrides()` at all — the one rule that now decides every
`group.id` verdict.

## What this deliberately does NOT change: `auto.offset.reset`

All ten channels declare `auto.offset.reset: earliest` and it is subject to the identical bug, so
the effective value is the connector default (`latest`). Making it effective is an **operational**
decision and is left baselined in the checker.

The precise risk, which is narrower than "forcing earliest replays the topic": `auto.offset.reset`
only applies when a group has **no valid committed offset**. Nine of the ten channels have committed
offsets today, so flipping the setting would be inert *at the moment of deploy*. The exposure is
later — broker `offsets.retention` is the 7d default (no override in the Kafka CR), all seven topics
carry `retention.ms: 604800000`, and these services are KEDA-scaled, so a group idle past the
retention window loses its offsets and would then re-read the whole retained log instead of jumping
to the tail. Worst cases: `openbank.ledger.journal.posted` (411→571 retained, money-path balance
projection) and `openbank.party.events` (157→169, four consumers).

**One channel is genuinely safe and is worth calling out separately:** account's
`delegation-events-in` has **no committed offsets at all** and `openbank.delegation.events` is
**empty** (oldest == latest == 0). Setting `earliest` there is a no-op today by measurement rather
than by luck. It is still not in this PR: it would be a change with no benefit until the topic has
traffic, and it belongs in the same owner decision as the other nine.

## Linked issues

Refs #2945
Refs #686

## Deployment note

The six pods restart. account, balance and party are Argo Rollouts with `replicas: 1` and a canary
strategy, so each progresses through its `setWeight`/`pause` steps (account and balance additionally
run the `openbank-money-path-canary` analysis). Nothing here changes an offset or a group, so a
canary abort is a plain rollback with no data consequence.

## Checks run locally

- `check-kafka-dotted-keys.py` — self-test 6/6, clean against this tree, 10 findings against `main`
- `check-msg-channel-image-parity.py` — 25 channel overrides across 17 services, every one servable
  by the image actually deployed (this is what proves the ten new channel names are real)
- `check-gitops-secret-refs.py` — 522 declared / 385 references, every referenced ConfigMap declared
- `check-single-replica-rollout-strategy.py` — 0 new vs baseline
- `yamllint` over `openbank-infra .github` — clean

No Gradle module is touched, so no service build or `version.txt` is in scope.
