### PR TITLE
fix(gitops): every one-replica workload declares terminate-first, so a full cluster can still roll

### DIFF
--- a/.github/single-replica-rollout-strategy-baseline.txt
+++ b/.github/single-replica-rollout-strategy-baseline.txt
@@ -1,64 +1,13 @@
-openbank-infra/gitops/components/accounts/product-catalog.yaml: Deployment/product-catalog has replicas 1 and no declared rollout strategy
-openbank-infra/gitops/components/accounts/redis.yaml: Deployment/redis has replicas 1 and no declared rollout strategy
-openbank-infra/gitops/components/admin-ui/admin-ui.yaml: Deployment/admin-ui has replicas 1 and no declared rollout strategy
-openbank-infra/gitops/components/agent/agent-service.yaml: Deployment/agent-service has replicas 1 and no declared rollout strategy
-openbank-infra/gitops/components/ai-platform/litellm.yaml: Deployment/litellm has replicas 1 and no declared rollout strategy
-openbank-infra/gitops/components/aml/aml-service.yaml: Deployment/aml-service has replicas 1 and no declared rollout strategy
-openbank-infra/gitops/components/aml/redis.yaml: Deployment/redis has replicas 1 and no declared rollout strategy
-openbank-infra/gitops/components/anacredit/anacredit-service.yaml: Deployment/anacredit-service has replicas 1 and no declared rollout strategy
-openbank-infra/gitops/components/analytics/analytics-sink.yaml: Deployment/analytics-sink has replicas 1 and no declared rollout strategy
-openbank-infra/gitops/components/ap2/ap2-service.yaml: Deployment/ap2-service has replicas 1 and no declared rollout strategy
-openbank-infra/gitops/components/apicurio/registry.yaml: Deployment/apicurio-registry has replicas 1 and no declared rollout strategy
-openbank-infra/gitops/components/audit/audit-service.yaml: Deployment/audit-service has replicas 1 and no declared rollout strategy
-openbank-infra/gitops/components/authz-policy-auditor/authz-policy-auditor.yaml: Deployment/authz-policy-auditor has replicas 1 and no declared rollout strategy
-openbank-infra/gitops/components/balances/redis.yaml: Deployment/redis has replicas 1 and no declared rollout strategy
-openbank-infra/gitops/components/billing/billing-service.yaml: Deployment/billing-service has replicas 1 and no declared rollout strategy
-openbank-infra/gitops/components/billing/redis.yaml: Deployment/redis has replicas 1 and no declared rollout strategy
-openbank-infra/gitops/components/campaign/campaign-service.yaml: Deployment/campaign-service has replicas 1 and no declared rollout strategy
-openbank-infra/gitops/components/campaign/redis.yaml: Deployment/redis has replicas 1 and no declared rollout strategy
-openbank-infra/gitops/components/consent/redis.yaml: Deployment/redis has replicas 1 and no declared rollout strategy
-openbank-infra/gitops/components/control-liveness-sentinel/control-liveness-sentinel.yaml: Deployment/control-liveness-sentinel has replicas 1 and no declared rollout strategy
-openbank-infra/gitops/components/copilot/copilot-service.yaml: Deployment/copilot-service has replicas 1 and no declared rollout strategy
-openbank-infra/gitops/components/copilot/redis.yaml: Deployment/copilot-redis has replicas 1 and no declared rollout strategy
-openbank-infra/gitops/components/delegation/redis.yaml: Deployment/redis has replicas 1 and no declared rollout strategy
-openbank-infra/gitops/components/devops-agent/devops-agent.yaml: Deployment/devops-agent has replicas 1 and no declared rollout strategy
-openbank-infra/gitops/components/dispute-service/dispute-service.yaml: Deployment/dispute-service has replicas 1 and no declared rollout strategy
-openbank-infra/gitops/components/dispute-service/redis.yaml: Deployment/redis has replicas 1 and no declared rollout strategy
-openbank-infra/gitops/components/docs-truth-agent/docs-truth-agent.yaml: Deployment/docs-truth-agent has replicas 1 and no declared rollout strategy
-openbank-infra/gitops/components/document-renderer/document-renderer-service.yaml: Deployment/document-renderer has replicas 1 and no declared rollout strategy
-openbank-infra/gitops/components/document-service/document-service-service.yaml: Deployment/document-service has replicas 1 and no declared rollout strategy
-openbank-infra/gitops/components/document-service/redis.yaml: Deployment/redis has replicas 1 and no declared rollout strategy
-openbank-infra/gitops/components/finops-agent/finops-agent.yaml: Deployment/finops-agent has replicas 1 and no declared rollout strategy
-openbank-infra/gitops/components/finrep/finrep-service.yaml: Deployment/finrep-service has replicas 1 and no declared rollout strategy
-openbank-infra/gitops/components/flaky-test-hunter/flaky-test-hunter.yaml: Deployment/flaky-test-hunter has replicas 1 and no declared rollout strategy
-openbank-infra/gitops/components/fraud-service/redis.yaml: Deployment/redis has replicas 1 and no declared rollout strategy
-openbank-infra/gitops/components/fx-service/redis.yaml: Deployment/redis has replicas 1 and no declared rollout strategy
-openbank-infra/gitops/components/governance-auditor/governance-auditor.yaml: Deployment/governance-auditor has replicas 1 and no declared rollout strategy
-openbank-infra/gitops/components/interest-service/interest-service.yaml: Deployment/interest-service has replicas 1 and no declared rollout strategy
-openbank-infra/gitops/components/interest-service/redis.yaml: Deployment/redis has replicas 1 and no declared rollout strategy
-openbank-infra/gitops/components/kafka/kafka-ui.yaml: Deployment/kafka-ui has replicas 1 and no declared rollout strategy
-openbank-infra/gitops/components/ledger/redis.yaml: Deployment/redis has replicas 1 and no declared rollout strategy
-openbank-infra/gitops/components/lending/redis.yaml: Deployment/redis has replicas 1 and no declared rollout strategy
-openbank-infra/gitops/components/mcp/mcp-service.yaml: Deployment/mcp-service has replicas 1 and no declared rollout strategy
-openbank-infra/gitops/components/notifications/notification-service.yaml: Deployment/notification-service has replicas 1 and no declared rollout strategy
-openbank-infra/gitops/components/notifications/redis.yaml: Deployment/redis has replicas 1 and no declared rollout strategy
-openbank-infra/gitops/components/observability/holmes-rca.yaml: Deployment/holmes-rca has replicas 1 and no declared rollout strategy
-openbank-infra/gitops/components/observability/ntfy.yaml: Deployment/ntfy has replicas 1 and no declared rollout strategy
-openbank-infra/gitops/components/observability/pyrra.yaml: Deployment/pyrra-api has replicas 1 and no declared rollout strategy
-openbank-infra/gitops/components/observability/pyrra.yaml: Deployment/pyrra-kubernetes has replicas 1 and no declared rollout strategy
-openbank-infra/gitops/components/party/redis.yaml: Deployment/redis has replicas 1 and no declared rollout strategy
-openbank-infra/gitops/components/payments/payments-services.yaml: Deployment/card-issuance-service has replicas 1 and no declared rollout strategy
-openbank-infra/gitops/components/payments/payments-services.yaml: Deployment/clearing-simulator has replicas 1 and no declared rollout strategy
-openbank-infra/gitops/components/payments/payments-services.yaml: Deployment/standing-order-service has replicas 1 and no declared rollout strategy
-openbank-infra/gitops/components/payments/redis.yaml: Deployment/redis has replicas 1 and no declared rollout strategy
-openbank-infra/gitops/components/pid/pid-service.yaml: Deployment/pid-service has replicas 1 and no declared rollout strategy
-openbank-infra/gitops/components/psd2-service/psd2-service.yaml: Deployment/psd2-service has replicas 1 and no declared rollout strategy
-openbank-infra/gitops/components/psd2-service/redis.yaml: Deployment/redis has replicas 1 and no declared rollout strategy
-openbank-infra/gitops/components/release-steward/release-steward.yaml: Deployment/release-steward has replicas 1 and no declared rollout strategy
-openbank-infra/gitops/components/sanctions-service/redis.yaml: Deployment/redis has replicas 1 and no declared rollout strategy
-openbank-infra/gitops/components/sca/redis.yaml: Deployment/redis has replicas 1 and no declared rollout strategy
-openbank-infra/gitops/components/sdd/sdd-service.yaml: Deployment/sdd-service has replicas 1 and no declared rollout strategy
-openbank-infra/gitops/components/security-scanner/security-scanner-service.yaml: Deployment/security-scanner-service has replicas 1 and no declared rollout strategy
-openbank-infra/gitops/components/statements/statement-service.yaml: Deployment/statement-service has replicas 1 and no declared rollout strategy
-openbank-infra/gitops/components/tpp-registry/redis.yaml: Deployment/redis has replicas 1 and no declared rollout strategy
-openbank-infra/gitops/components/tpp-registry/tpp-registry-service.yaml: Deployment/tpp-registry-service has replicas 1 and no declared rollout strategy
+# Declared debt for check-single-replica-rollout-strategy.py (issue #3545).
+#
+# THIS FILE IS EMPTY ON PURPOSE, and empty is the state to keep it in.
+#
+# Every one-replica workload under openbank-infra/gitops now declares its rollout strategy:
+# 66 Deployments terminate-first (maxSurge 0 / maxUnavailable 1), 7 Recreate, 2 declare surge
+# deliberately (keycloak, pact-broker), 21 are canary Argo Rollouts, 1 is a StatefulSet.
+#
+# An entry added here is a one-replica workload that inherits the default maxSurge 1 /
+# maxUnavailable 0 — i.e. one that cannot roll when the cluster has no room for a second pod,
+# while reporting 1/1 READY throughout. It needs a reason, not just a line: say which of the
+# strategies it declined and why. The checker fails on a stale entry too, so a line that stops
+# matching must be deleted rather than left to outlive the debt it described.

--- a/openbank-infra/gitops/components/accounts/product-catalog.yaml
+++ b/openbank-infra/gitops/components/accounts/product-catalog.yaml
@@ -43,6 +43,16 @@ metadata:
     app.kubernetes.io/part-of: accounts
 spec:
   replicas: 1
+  # Terminate-first, deliberately (#3545): with one replica the default maxSurge 1 /
+  # maxUnavailable 0 needs room for two pods, and the old pod holds exactly those
+  # resources - on a full cluster the rollout never completes and reports 1/1 READY.
+  # This workload is single-replica BY CONSTRAINT: it holds per-pod in-memory state, so
+  # scaling it past 1 needs the #3467-class fix first, not a replica bump.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: product-catalog

--- a/openbank-infra/gitops/components/accounts/redis.yaml
+++ b/openbank-infra/gitops/components/accounts/redis.yaml
@@ -14,6 +14,15 @@ metadata:
     app.kubernetes.io/part-of: accounts
 spec:
   replicas: 1
+  # Terminate-first, deliberately (#3545). This is a single-writer cache on an emptyDir
+  # behind one ClusterIP Service: a SURGED second pod would answer half the traffic from an
+  # empty keyspace, so surge is not a property worth keeping here. It also makes the roll
+  # possible at all when the cluster has no room for two pods.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: redis

--- a/openbank-infra/gitops/components/admin-ui/admin-ui.yaml
+++ b/openbank-infra/gitops/components/admin-ui/admin-ui.yaml
@@ -15,6 +15,15 @@ metadata:
     app.kubernetes.io/part-of: app
 spec:
   replicas: 1
+  # Terminate-first, deliberately (#3545): with one replica the default maxSurge 1 /
+  # maxUnavailable 0 needs room for two pods, and the old pod holds exactly those
+  # resources - on a full cluster the rollout never completes while reporting 1/1 READY.
+  # No HA to lose: this workload is already unavailable for the moment its pod is replaced.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: admin-ui

--- a/openbank-infra/gitops/components/agent/agent-service.yaml
+++ b/openbank-infra/gitops/components/agent/agent-service.yaml
@@ -22,6 +22,16 @@ metadata:
     app.kubernetes.io/part-of: platform
 spec:
   replicas: 1
+  # Terminate-first, deliberately (#3545): with one replica the default maxSurge 1 /
+  # maxUnavailable 0 needs room for two pods, and the old pod holds exactly those
+  # resources - on a full cluster the rollout never completes and reports 1/1 READY.
+  # This workload is single-replica BY CONSTRAINT: it holds per-pod in-memory state, so
+  # scaling it past 1 needs the #3467-class fix first, not a replica bump.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: agent-service

--- a/openbank-infra/gitops/components/ai-platform/litellm.yaml
+++ b/openbank-infra/gitops/components/ai-platform/litellm.yaml
@@ -11,6 +11,15 @@ metadata:
     app.kubernetes.io/part-of: ai-platform
 spec:
   replicas: 1
+  # Terminate-first, deliberately (#3545): with one replica the default maxSurge 1 /
+  # maxUnavailable 0 needs room for two pods, and the old pod holds exactly those
+  # resources - on a full cluster the rollout never completes while reporting 1/1 READY.
+  # No HA to lose: this workload is already unavailable for the moment its pod is replaced.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: litellm

--- a/openbank-infra/gitops/components/aml/aml-service.yaml
+++ b/openbank-infra/gitops/components/aml/aml-service.yaml
@@ -11,6 +11,15 @@ metadata:
     app.kubernetes.io/part-of: aml
 spec:
   replicas: 1
+  # Terminate-first, deliberately (#3545): with one replica the default maxSurge 1 /
+  # maxUnavailable 0 needs room for two pods, and the old pod holds exactly those
+  # resources - on a full cluster the rollout never completes while reporting 1/1 READY.
+  # No HA to lose: this workload is already unavailable for the moment its pod is replaced.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: aml-service

--- a/openbank-infra/gitops/components/aml/redis.yaml
+++ b/openbank-infra/gitops/components/aml/redis.yaml
@@ -14,6 +14,15 @@ metadata:
     app.kubernetes.io/part-of: aml
 spec:
   replicas: 1
+  # Terminate-first, deliberately (#3545). This is a single-writer cache on an emptyDir
+  # behind one ClusterIP Service: a SURGED second pod would answer half the traffic from an
+  # empty keyspace, so surge is not a property worth keeping here. It also makes the roll
+  # possible at all when the cluster has no room for two pods.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: redis

--- a/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
@@ -21,6 +21,16 @@ metadata:
     app.kubernetes.io/part-of: anacredit
 spec:
   replicas: 1
+  # Terminate-first, deliberately (#3545): with one replica the default maxSurge 1 /
+  # maxUnavailable 0 needs room for two pods, and the old pod holds exactly those
+  # resources - on a full cluster the rollout never completes and reports 1/1 READY.
+  # This workload is single-replica BY CONSTRAINT: it holds per-pod in-memory state, so
+  # scaling it past 1 needs the #3467-class fix first, not a replica bump.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: anacredit-service

--- a/openbank-infra/gitops/components/analytics/analytics-sink.yaml
+++ b/openbank-infra/gitops/components/analytics/analytics-sink.yaml
@@ -41,6 +41,16 @@ metadata:
     app.kubernetes.io/part-of: openbank
 spec:
   replicas: 1
+  # Terminate-first, deliberately (#3545): with one replica the default maxSurge 1 /
+  # maxUnavailable 0 needs room for two pods, and the old pod holds exactly those
+  # resources - on a full cluster the rollout never completes and reports 1/1 READY.
+  # This workload is single-replica BY CONSTRAINT: it holds per-pod in-memory state, so
+  # scaling it past 1 needs the #3467-class fix first, not a replica bump.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: analytics-sink

--- a/openbank-infra/gitops/components/ap2/ap2-service.yaml
+++ b/openbank-infra/gitops/components/ap2/ap2-service.yaml
@@ -19,6 +19,15 @@ metadata:
     app.kubernetes.io/part-of: platform
 spec:
   replicas: 1
+  # Terminate-first, deliberately (#3545): with one replica the default maxSurge 1 /
+  # maxUnavailable 0 needs room for two pods, and the old pod holds exactly those
+  # resources - on a full cluster the rollout never completes while reporting 1/1 READY.
+  # No HA to lose: this workload is already unavailable for the moment its pod is replaced.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: ap2-service

--- a/openbank-infra/gitops/components/apicurio/registry.yaml
+++ b/openbank-infra/gitops/components/apicurio/registry.yaml
@@ -11,6 +11,15 @@ metadata:
     app.kubernetes.io/part-of: messaging
 spec:
   replicas: 1
+  # Terminate-first, deliberately (#3545): with one replica the default maxSurge 1 /
+  # maxUnavailable 0 needs room for two pods, and the old pod holds exactly those
+  # resources - on a full cluster the rollout never completes while reporting 1/1 READY.
+  # No HA to lose: this workload is already unavailable for the moment its pod is replaced.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: apicurio-registry

--- a/openbank-infra/gitops/components/audit/audit-service.yaml
+++ b/openbank-infra/gitops/components/audit/audit-service.yaml
@@ -11,6 +11,15 @@ metadata:
     app.kubernetes.io/part-of: audit
 spec:
   replicas: 1
+  # Terminate-first, deliberately (#3545): with one replica the default maxSurge 1 /
+  # maxUnavailable 0 needs room for two pods, and the old pod holds exactly those
+  # resources - on a full cluster the rollout never completes while reporting 1/1 READY.
+  # No HA to lose: this workload is already unavailable for the moment its pod is replaced.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: audit-service

--- a/openbank-infra/gitops/components/authz-policy-auditor/authz-policy-auditor.yaml
+++ b/openbank-infra/gitops/components/authz-policy-auditor/authz-policy-auditor.yaml
@@ -8,6 +8,15 @@ metadata:
     app.kubernetes.io/part-of: authz-policy-auditor
 spec:
   replicas: 1
+  # Terminate-first, deliberately (#3545): with one replica the default maxSurge 1 /
+  # maxUnavailable 0 needs room for two pods, and the old pod holds exactly those
+  # resources - on a full cluster the rollout never completes while reporting 1/1 READY.
+  # No HA to lose: this workload is already unavailable for the moment its pod is replaced.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: authz-policy-auditor

--- a/openbank-infra/gitops/components/balances/redis.yaml
+++ b/openbank-infra/gitops/components/balances/redis.yaml
@@ -15,6 +15,15 @@ metadata:
     app.kubernetes.io/part-of: balances
 spec:
   replicas: 1
+  # Terminate-first, deliberately (#3545). This is a single-writer cache on an emptyDir
+  # behind one ClusterIP Service: a SURGED second pod would answer half the traffic from an
+  # empty keyspace, so surge is not a property worth keeping here. It also makes the roll
+  # possible at all when the cluster has no room for two pods.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: redis

--- a/openbank-infra/gitops/components/billing/billing-service.yaml
+++ b/openbank-infra/gitops/components/billing/billing-service.yaml
@@ -16,6 +16,15 @@ metadata:
     app.kubernetes.io/part-of: billing
 spec:
   replicas: 1
+  # Terminate-first, deliberately (#3545): with one replica the default maxSurge 1 /
+  # maxUnavailable 0 needs room for two pods, and the old pod holds exactly those
+  # resources - on a full cluster the rollout never completes while reporting 1/1 READY.
+  # No HA to lose: this workload is already unavailable for the moment its pod is replaced.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: billing-service

--- a/openbank-infra/gitops/components/billing/redis.yaml
+++ b/openbank-infra/gitops/components/billing/redis.yaml
@@ -7,6 +7,15 @@ metadata:
   labels: {app.kubernetes.io/name: redis, app.kubernetes.io/part-of: billing}
 spec:
   replicas: 1
+  # Terminate-first, deliberately (#3545). This is a single-writer cache on an emptyDir
+  # behind one ClusterIP Service: a SURGED second pod would answer half the traffic from an
+  # empty keyspace, so surge is not a property worth keeping here. It also makes the roll
+  # possible at all when the cluster has no room for two pods.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   selector: {matchLabels: {app.kubernetes.io/name: redis}}
   template:
     metadata:

--- a/openbank-infra/gitops/components/campaign/campaign-service.yaml
+++ b/openbank-infra/gitops/components/campaign/campaign-service.yaml
@@ -17,6 +17,15 @@ metadata:
     app.kubernetes.io/part-of: campaign
 spec:
   replicas: 1
+  # Terminate-first, deliberately (#3545): with one replica the default maxSurge 1 /
+  # maxUnavailable 0 needs room for two pods, and the old pod holds exactly those
+  # resources - on a full cluster the rollout never completes while reporting 1/1 READY.
+  # No HA to lose: this workload is already unavailable for the moment its pod is replaced.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: campaign-service

--- a/openbank-infra/gitops/components/campaign/redis.yaml
+++ b/openbank-infra/gitops/components/campaign/redis.yaml
@@ -21,6 +21,15 @@ metadata:
     app.kubernetes.io/part-of: campaign
 spec:
   replicas: 1
+  # Terminate-first, deliberately (#3545). This is a single-writer cache on an emptyDir
+  # behind one ClusterIP Service: a SURGED second pod would answer half the traffic from an
+  # empty keyspace, so surge is not a property worth keeping here. It also makes the roll
+  # possible at all when the cluster has no room for two pods.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: redis

--- a/openbank-infra/gitops/components/consent/redis.yaml
+++ b/openbank-infra/gitops/components/consent/redis.yaml
@@ -14,6 +14,15 @@ metadata:
     app.kubernetes.io/part-of: consent
 spec:
   replicas: 1
+  # Terminate-first, deliberately (#3545). This is a single-writer cache on an emptyDir
+  # behind one ClusterIP Service: a SURGED second pod would answer half the traffic from an
+  # empty keyspace, so surge is not a property worth keeping here. It also makes the roll
+  # possible at all when the cluster has no room for two pods.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: redis

--- a/openbank-infra/gitops/components/control-liveness-sentinel/control-liveness-sentinel.yaml
+++ b/openbank-infra/gitops/components/control-liveness-sentinel/control-liveness-sentinel.yaml
@@ -8,6 +8,15 @@ metadata:
     app.kubernetes.io/part-of: control-liveness-sentinel
 spec:
   replicas: 1
+  # Terminate-first, deliberately (#3545): with one replica the default maxSurge 1 /
+  # maxUnavailable 0 needs room for two pods, and the old pod holds exactly those
+  # resources - on a full cluster the rollout never completes while reporting 1/1 READY.
+  # No HA to lose: this workload is already unavailable for the moment its pod is replaced.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: control-liveness-sentinel

--- a/openbank-infra/gitops/components/copilot/copilot-service.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-service.yaml
@@ -18,6 +18,16 @@ metadata:
     app.kubernetes.io/part-of: platform
 spec:
   replicas: 1
+  # Terminate-first, deliberately (#3545): with one replica the default maxSurge 1 /
+  # maxUnavailable 0 needs room for two pods, and the old pod holds exactly those
+  # resources - on a full cluster the rollout never completes and reports 1/1 READY.
+  # This workload is single-replica BY CONSTRAINT: it holds per-pod in-memory state, so
+  # scaling it past 1 needs the #3467-class fix first, not a replica bump.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: copilot-service

--- a/openbank-infra/gitops/components/copilot/redis.yaml
+++ b/openbank-infra/gitops/components/copilot/redis.yaml
@@ -17,6 +17,15 @@ metadata:
     app.kubernetes.io/part-of: copilot-service
 spec:
   replicas: 1
+  # Terminate-first, deliberately (#3545). This is a single-writer cache on an emptyDir
+  # behind one ClusterIP Service: a SURGED second pod would answer half the traffic from an
+  # empty keyspace, so surge is not a property worth keeping here. It also makes the roll
+  # possible at all when the cluster has no room for two pods.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: copilot-redis

--- a/openbank-infra/gitops/components/delegation/redis.yaml
+++ b/openbank-infra/gitops/components/delegation/redis.yaml
@@ -23,6 +23,15 @@ metadata:
     app.kubernetes.io/part-of: delegation
 spec:
   replicas: 1
+  # Terminate-first, deliberately (#3545). This is a single-writer cache on an emptyDir
+  # behind one ClusterIP Service: a SURGED second pod would answer half the traffic from an
+  # empty keyspace, so surge is not a property worth keeping here. It also makes the roll
+  # possible at all when the cluster has no room for two pods.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: redis

--- a/openbank-infra/gitops/components/devops-agent/devops-agent.yaml
+++ b/openbank-infra/gitops/components/devops-agent/devops-agent.yaml
@@ -8,6 +8,15 @@ metadata:
     app.kubernetes.io/part-of: devops-agent
 spec:
   replicas: 1
+  # Terminate-first, deliberately (#3545): with one replica the default maxSurge 1 /
+  # maxUnavailable 0 needs room for two pods, and the old pod holds exactly those
+  # resources - on a full cluster the rollout never completes while reporting 1/1 READY.
+  # No HA to lose: this workload is already unavailable for the moment its pod is replaced.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: devops-agent

--- a/openbank-infra/gitops/components/dispute-service/dispute-service.yaml
+++ b/openbank-infra/gitops/components/dispute-service/dispute-service.yaml
@@ -9,6 +9,15 @@ metadata:
   labels: {app.kubernetes.io/name: dispute-service, app.kubernetes.io/part-of: dispute}
 spec:
   replicas: 1
+  # Terminate-first, deliberately (#3545): with one replica the default maxSurge 1 /
+  # maxUnavailable 0 needs room for two pods, and the old pod holds exactly those
+  # resources - on a full cluster the rollout never completes while reporting 1/1 READY.
+  # No HA to lose: this workload is already unavailable for the moment its pod is replaced.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   selector: {matchLabels: {app.kubernetes.io/name: dispute-service}}
   template:
     metadata:

--- a/openbank-infra/gitops/components/dispute-service/redis.yaml
+++ b/openbank-infra/gitops/components/dispute-service/redis.yaml
@@ -7,6 +7,15 @@ metadata:
   labels: {app.kubernetes.io/name: redis, app.kubernetes.io/part-of: dispute}
 spec:
   replicas: 1
+  # Terminate-first, deliberately (#3545). This is a single-writer cache on an emptyDir
+  # behind one ClusterIP Service: a SURGED second pod would answer half the traffic from an
+  # empty keyspace, so surge is not a property worth keeping here. It also makes the roll
+  # possible at all when the cluster has no room for two pods.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   selector: {matchLabels: {app.kubernetes.io/name: redis}}
   template:
     metadata:

--- a/openbank-infra/gitops/components/docs-truth-agent/docs-truth-agent.yaml
+++ b/openbank-infra/gitops/components/docs-truth-agent/docs-truth-agent.yaml
@@ -8,6 +8,15 @@ metadata:
     app.kubernetes.io/part-of: docs-truth-agent
 spec:
   replicas: 1
+  # Terminate-first, deliberately (#3545): with one replica the default maxSurge 1 /
+  # maxUnavailable 0 needs room for two pods, and the old pod holds exactly those
+  # resources - on a full cluster the rollout never completes while reporting 1/1 READY.
+  # No HA to lose: this workload is already unavailable for the moment its pod is replaced.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: docs-truth-agent

--- a/openbank-infra/gitops/components/document-renderer/document-renderer-service.yaml
+++ b/openbank-infra/gitops/components/document-renderer/document-renderer-service.yaml
@@ -22,6 +22,15 @@ metadata:
     app.kubernetes.io/part-of: documents
 spec:
   replicas: 1
+  # Terminate-first, deliberately (#3545): with one replica the default maxSurge 1 /
+  # maxUnavailable 0 needs room for two pods, and the old pod holds exactly those
+  # resources - on a full cluster the rollout never completes while reporting 1/1 READY.
+  # No HA to lose: this workload is already unavailable for the moment its pod is replaced.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: document-renderer

--- a/openbank-infra/gitops/components/document-service/document-service-service.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-service.yaml
@@ -32,6 +32,15 @@ metadata:
     app.kubernetes.io/part-of: documents
 spec:
   replicas: 1
+  # Terminate-first, deliberately (#3545): with one replica the default maxSurge 1 /
+  # maxUnavailable 0 needs room for two pods, and the old pod holds exactly those
+  # resources - on a full cluster the rollout never completes while reporting 1/1 READY.
+  # No HA to lose: this workload is already unavailable for the moment its pod is replaced.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: document-service

--- a/openbank-infra/gitops/components/document-service/redis.yaml
+++ b/openbank-infra/gitops/components/document-service/redis.yaml
@@ -11,6 +11,15 @@ metadata:
   labels: {app.kubernetes.io/name: redis, app.kubernetes.io/part-of: documents}
 spec:
   replicas: 1
+  # Terminate-first, deliberately (#3545). This is a single-writer cache on an emptyDir
+  # behind one ClusterIP Service: a SURGED second pod would answer half the traffic from an
+  # empty keyspace, so surge is not a property worth keeping here. It also makes the roll
+  # possible at all when the cluster has no room for two pods.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   selector: {matchLabels: {app.kubernetes.io/name: redis}}
   template:
     metadata:

--- a/openbank-infra/gitops/components/finops-agent/finops-agent.yaml
+++ b/openbank-infra/gitops/components/finops-agent/finops-agent.yaml
@@ -8,6 +8,15 @@ metadata:
     app.kubernetes.io/part-of: finops-agent
 spec:
   replicas: 1
+  # Terminate-first, deliberately (#3545): with one replica the default maxSurge 1 /
+  # maxUnavailable 0 needs room for two pods, and the old pod holds exactly those
+  # resources - on a full cluster the rollout never completes while reporting 1/1 READY.
+  # No HA to lose: this workload is already unavailable for the moment its pod is replaced.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: finops-agent

--- a/openbank-infra/gitops/components/finrep/finrep-service.yaml
+++ b/openbank-infra/gitops/components/finrep/finrep-service.yaml
@@ -15,6 +15,15 @@ metadata:
     app.kubernetes.io/part-of: finrep
 spec:
   replicas: 1
+  # Terminate-first, deliberately (#3545): with one replica the default maxSurge 1 /
+  # maxUnavailable 0 needs room for two pods, and the old pod holds exactly those
+  # resources - on a full cluster the rollout never completes while reporting 1/1 READY.
+  # No HA to lose: this workload is already unavailable for the moment its pod is replaced.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: finrep-service

--- a/openbank-infra/gitops/components/flaky-test-hunter/flaky-test-hunter.yaml
+++ b/openbank-infra/gitops/components/flaky-test-hunter/flaky-test-hunter.yaml
@@ -8,6 +8,15 @@ metadata:
     app.kubernetes.io/part-of: flaky-test-hunter
 spec:
   replicas: 1
+  # Terminate-first, deliberately (#3545): with one replica the default maxSurge 1 /
+  # maxUnavailable 0 needs room for two pods, and the old pod holds exactly those
+  # resources - on a full cluster the rollout never completes while reporting 1/1 READY.
+  # No HA to lose: this workload is already unavailable for the moment its pod is replaced.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: flaky-test-hunter

--- a/openbank-infra/gitops/components/fraud-service/redis.yaml
+++ b/openbank-infra/gitops/components/fraud-service/redis.yaml
@@ -9,6 +9,15 @@ metadata:
   labels: {app.kubernetes.io/name: redis, app.kubernetes.io/part-of: fraud}
 spec:
   replicas: 1
+  # Terminate-first, deliberately (#3545). This is a single-writer cache on an emptyDir
+  # behind one ClusterIP Service: a SURGED second pod would answer half the traffic from an
+  # empty keyspace, so surge is not a property worth keeping here. It also makes the roll
+  # possible at all when the cluster has no room for two pods.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   selector: {matchLabels: {app.kubernetes.io/name: redis}}
   template:
     metadata:

--- a/openbank-infra/gitops/components/fx-service/redis.yaml
+++ b/openbank-infra/gitops/components/fx-service/redis.yaml
@@ -7,6 +7,15 @@ metadata:
   labels: {app.kubernetes.io/name: redis, app.kubernetes.io/part-of: fx}
 spec:
   replicas: 1
+  # Terminate-first, deliberately (#3545). This is a single-writer cache on an emptyDir
+  # behind one ClusterIP Service: a SURGED second pod would answer half the traffic from an
+  # empty keyspace, so surge is not a property worth keeping here. It also makes the roll
+  # possible at all when the cluster has no room for two pods.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   selector: {matchLabels: {app.kubernetes.io/name: redis}}
   template:
     metadata:

--- a/openbank-infra/gitops/components/governance-auditor/governance-auditor.yaml
+++ b/openbank-infra/gitops/components/governance-auditor/governance-auditor.yaml
@@ -8,6 +8,15 @@ metadata:
     app.kubernetes.io/part-of: governance-auditor
 spec:
   replicas: 1
+  # Terminate-first, deliberately (#3545): with one replica the default maxSurge 1 /
+  # maxUnavailable 0 needs room for two pods, and the old pod holds exactly those
+  # resources - on a full cluster the rollout never completes while reporting 1/1 READY.
+  # No HA to lose: this workload is already unavailable for the moment its pod is replaced.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: governance-auditor

--- a/openbank-infra/gitops/components/interest-service/interest-service.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-service.yaml
@@ -9,6 +9,15 @@ metadata:
   labels: {app.kubernetes.io/name: interest-service, app.kubernetes.io/part-of: interest}
 spec:
   replicas: 1
+  # Terminate-first, deliberately (#3545): with one replica the default maxSurge 1 /
+  # maxUnavailable 0 needs room for two pods, and the old pod holds exactly those
+  # resources - on a full cluster the rollout never completes while reporting 1/1 READY.
+  # No HA to lose: this workload is already unavailable for the moment its pod is replaced.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   selector: {matchLabels: {app.kubernetes.io/name: interest-service}}
   template:
     metadata:

--- a/openbank-infra/gitops/components/interest-service/redis.yaml
+++ b/openbank-infra/gitops/components/interest-service/redis.yaml
@@ -7,6 +7,15 @@ metadata:
   labels: {app.kubernetes.io/name: redis, app.kubernetes.io/part-of: interest}
 spec:
   replicas: 1
+  # Terminate-first, deliberately (#3545). This is a single-writer cache on an emptyDir
+  # behind one ClusterIP Service: a SURGED second pod would answer half the traffic from an
+  # empty keyspace, so surge is not a property worth keeping here. It also makes the roll
+  # possible at all when the cluster has no room for two pods.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   selector: {matchLabels: {app.kubernetes.io/name: redis}}
   template:
     metadata:

--- a/openbank-infra/gitops/components/kafka/kafka-ui.yaml
+++ b/openbank-infra/gitops/components/kafka/kafka-ui.yaml
@@ -17,6 +17,15 @@ metadata:
     app.kubernetes.io/part-of: messaging
 spec:
   replicas: 1
+  # Terminate-first, deliberately (#3545): with one replica the default maxSurge 1 /
+  # maxUnavailable 0 needs room for two pods, and the old pod holds exactly those
+  # resources - on a full cluster the rollout never completes while reporting 1/1 READY.
+  # No HA to lose: this workload is already unavailable for the moment its pod is replaced.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: kafka-ui

--- a/openbank-infra/gitops/components/ledger/redis.yaml
+++ b/openbank-infra/gitops/components/ledger/redis.yaml
@@ -14,6 +14,15 @@ metadata:
     app.kubernetes.io/part-of: ledger
 spec:
   replicas: 1
+  # Terminate-first, deliberately (#3545). This is a single-writer cache on an emptyDir
+  # behind one ClusterIP Service: a SURGED second pod would answer half the traffic from an
+  # empty keyspace, so surge is not a property worth keeping here. It also makes the roll
+  # possible at all when the cluster has no room for two pods.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: redis

--- a/openbank-infra/gitops/components/lending/redis.yaml
+++ b/openbank-infra/gitops/components/lending/redis.yaml
@@ -18,6 +18,15 @@ metadata:
     app.kubernetes.io/part-of: lending
 spec:
   replicas: 1
+  # Terminate-first, deliberately (#3545). This is a single-writer cache on an emptyDir
+  # behind one ClusterIP Service: a SURGED second pod would answer half the traffic from an
+  # empty keyspace, so surge is not a property worth keeping here. It also makes the roll
+  # possible at all when the cluster has no room for two pods.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: redis

--- a/openbank-infra/gitops/components/mcp/mcp-service.yaml
+++ b/openbank-infra/gitops/components/mcp/mcp-service.yaml
@@ -18,6 +18,16 @@ metadata:
     app.kubernetes.io/part-of: platform
 spec:
   replicas: 1
+  # Terminate-first, deliberately (#3545): with one replica the default maxSurge 1 /
+  # maxUnavailable 0 needs room for two pods, and the old pod holds exactly those
+  # resources - on a full cluster the rollout never completes and reports 1/1 READY.
+  # This workload is single-replica BY CONSTRAINT: it holds per-pod in-memory state, so
+  # scaling it past 1 needs the #3467-class fix first, not a replica bump.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: mcp-service

--- a/openbank-infra/gitops/components/notifications/notification-service.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service.yaml
@@ -31,6 +31,15 @@ spec:
   # is gone. Leaving the field absent would work only by Kubernetes' default-to-1, which
   # is an accident rather than a declaration.
   replicas: 1
+  # Terminate-first, deliberately (#3545): with one replica the default maxSurge 1 /
+  # maxUnavailable 0 needs room for two pods, and the old pod holds exactly those
+  # resources - on a full cluster the rollout never completes while reporting 1/1 READY.
+  # No HA to lose: this workload is already unavailable for the moment its pod is replaced.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: notification-service

--- a/openbank-infra/gitops/components/notifications/redis.yaml
+++ b/openbank-infra/gitops/components/notifications/redis.yaml
@@ -16,6 +16,15 @@ metadata:
     app.kubernetes.io/part-of: notifications
 spec:
   replicas: 1
+  # Terminate-first, deliberately (#3545). This is a single-writer cache on an emptyDir
+  # behind one ClusterIP Service: a SURGED second pod would answer half the traffic from an
+  # empty keyspace, so surge is not a property worth keeping here. It also makes the roll
+  # possible at all when the cluster has no room for two pods.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: redis

--- a/openbank-infra/gitops/components/observability/holmes-rca.yaml
+++ b/openbank-infra/gitops/components/observability/holmes-rca.yaml
@@ -151,6 +151,15 @@ metadata:
     app.kubernetes.io/part-of: observability
 spec:
   replicas: 1
+  # Terminate-first, deliberately (#3545): with one replica the default maxSurge 1 /
+  # maxUnavailable 0 needs room for two pods, and the old pod holds exactly those
+  # resources - on a full cluster the rollout never completes while reporting 1/1 READY.
+  # No HA to lose: this workload is already unavailable for the moment its pod is replaced.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: holmes-rca

--- a/openbank-infra/gitops/components/observability/ntfy.yaml
+++ b/openbank-infra/gitops/components/observability/ntfy.yaml
@@ -36,6 +36,15 @@ metadata:
     app.kubernetes.io/part-of: observability
 spec:
   replicas: 1
+  # Terminate-first, deliberately (#3545): with one replica the default maxSurge 1 /
+  # maxUnavailable 0 needs room for two pods, and the old pod holds exactly those
+  # resources - on a full cluster the rollout never completes while reporting 1/1 READY.
+  # No HA to lose: this workload is already unavailable for the moment its pod is replaced.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: ntfy

--- a/openbank-infra/gitops/components/observability/pyrra.yaml
+++ b/openbank-infra/gitops/components/observability/pyrra.yaml
@@ -117,6 +117,15 @@ metadata:
     app.kubernetes.io/component: kubernetes
 spec:
   replicas: 1
+  # Terminate-first, deliberately (#3545): with one replica the default maxSurge 1 /
+  # maxUnavailable 0 needs room for two pods, and the old pod holds exactly those
+  # resources - on a full cluster the rollout never completes while reporting 1/1 READY.
+  # No HA to lose: this workload is already unavailable for the moment its pod is replaced.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: pyrra
@@ -170,6 +179,15 @@ metadata:
     app.kubernetes.io/component: api
 spec:
   replicas: 1
+  # Terminate-first, deliberately (#3545): with one replica the default maxSurge 1 /
+  # maxUnavailable 0 needs room for two pods, and the old pod holds exactly those
+  # resources - on a full cluster the rollout never completes while reporting 1/1 READY.
+  # No HA to lose: this workload is already unavailable for the moment its pod is replaced.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: pyrra

--- a/openbank-infra/gitops/components/party/redis.yaml
+++ b/openbank-infra/gitops/components/party/redis.yaml
@@ -16,6 +16,15 @@ metadata:
     app.kubernetes.io/part-of: party
 spec:
   replicas: 1
+  # Terminate-first, deliberately (#3545). This is a single-writer cache on an emptyDir
+  # behind one ClusterIP Service: a SURGED second pod would answer half the traffic from an
+  # empty keyspace, so surge is not a property worth keeping here. It also makes the roll
+  # possible at all when the cluster has no room for two pods.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: redis

--- a/openbank-infra/gitops/components/payments/payments-services.yaml
+++ b/openbank-infra/gitops/components/payments/payments-services.yaml
@@ -1647,6 +1647,15 @@ metadata:
     app.kubernetes.io/part-of: payments
 spec:
   replicas: 1
+  # Terminate-first, deliberately (#3545): with one replica the default maxSurge 1 /
+  # maxUnavailable 0 needs room for two pods, and the old pod holds exactly those
+  # resources - on a full cluster the rollout never completes while reporting 1/1 READY.
+  # No HA to lose: this workload is already unavailable for the moment its pod is replaced.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: standing-order-service
@@ -1900,6 +1909,15 @@ metadata:
     app.kubernetes.io/part-of: payments
 spec:
   replicas: 1
+  # Terminate-first, deliberately (#3545): with one replica the default maxSurge 1 /
+  # maxUnavailable 0 needs room for two pods, and the old pod holds exactly those
+  # resources - on a full cluster the rollout never completes while reporting 1/1 READY.
+  # No HA to lose: this workload is already unavailable for the moment its pod is replaced.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: card-issuance-service
@@ -2459,6 +2477,15 @@ metadata:
     app.kubernetes.io/part-of: payments
 spec:
   replicas: 1
+  # Terminate-first, deliberately (#3545): with one replica the default maxSurge 1 /
+  # maxUnavailable 0 needs room for two pods, and the old pod holds exactly those
+  # resources - on a full cluster the rollout never completes while reporting 1/1 READY.
+  # No HA to lose: this workload is already unavailable for the moment its pod is replaced.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: clearing-simulator

--- a/openbank-infra/gitops/components/payments/redis.yaml
+++ b/openbank-infra/gitops/components/payments/redis.yaml
@@ -14,6 +14,15 @@ metadata:
     app.kubernetes.io/part-of: payments
 spec:
   replicas: 1
+  # Terminate-first, deliberately (#3545). This is a single-writer cache on an emptyDir
+  # behind one ClusterIP Service: a SURGED second pod would answer half the traffic from an
+  # empty keyspace, so surge is not a property worth keeping here. It also makes the roll
+  # possible at all when the cluster has no room for two pods.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: redis

--- a/openbank-infra/gitops/components/pid/pid-service.yaml
+++ b/openbank-infra/gitops/components/pid/pid-service.yaml
@@ -11,6 +11,16 @@ metadata:
     app.kubernetes.io/part-of: pid
 spec:
   replicas: 1
+  # Terminate-first, deliberately (#3545): with one replica the default maxSurge 1 /
+  # maxUnavailable 0 needs room for two pods, and the old pod holds exactly those
+  # resources - on a full cluster the rollout never completes and reports 1/1 READY.
+  # This workload is single-replica BY CONSTRAINT: it holds per-pod in-memory state, so
+  # scaling it past 1 needs the #3467-class fix first, not a replica bump.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: pid-service

--- a/openbank-infra/gitops/components/psd2-service/psd2-service.yaml
+++ b/openbank-infra/gitops/components/psd2-service/psd2-service.yaml
@@ -12,6 +12,15 @@ metadata:
   labels: {app.kubernetes.io/name: psd2-service, app.kubernetes.io/part-of: psd2}
 spec:
   replicas: 1
+  # Terminate-first, deliberately (#3545): with one replica the default maxSurge 1 /
+  # maxUnavailable 0 needs room for two pods, and the old pod holds exactly those
+  # resources - on a full cluster the rollout never completes while reporting 1/1 READY.
+  # No HA to lose: this workload is already unavailable for the moment its pod is replaced.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   selector: {matchLabels: {app.kubernetes.io/name: psd2-service}}
   template:
     metadata:

--- a/openbank-infra/gitops/components/psd2-service/redis.yaml
+++ b/openbank-infra/gitops/components/psd2-service/redis.yaml
@@ -7,6 +7,15 @@ metadata:
   labels: {app.kubernetes.io/name: redis, app.kubernetes.io/part-of: psd2}
 spec:
   replicas: 1
+  # Terminate-first, deliberately (#3545). This is a single-writer cache on an emptyDir
+  # behind one ClusterIP Service: a SURGED second pod would answer half the traffic from an
+  # empty keyspace, so surge is not a property worth keeping here. It also makes the roll
+  # possible at all when the cluster has no room for two pods.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   selector: {matchLabels: {app.kubernetes.io/name: redis}}
   template:
     metadata:

--- a/openbank-infra/gitops/components/release-steward/release-steward.yaml
+++ b/openbank-infra/gitops/components/release-steward/release-steward.yaml
@@ -8,6 +8,15 @@ metadata:
     app.kubernetes.io/part-of: release-steward
 spec:
   replicas: 1
+  # Terminate-first, deliberately (#3545): with one replica the default maxSurge 1 /
+  # maxUnavailable 0 needs room for two pods, and the old pod holds exactly those
+  # resources - on a full cluster the rollout never completes while reporting 1/1 READY.
+  # No HA to lose: this workload is already unavailable for the moment its pod is replaced.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: release-steward

--- a/openbank-infra/gitops/components/sanctions-service/redis.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/redis.yaml
@@ -10,6 +10,15 @@ metadata:
     app.kubernetes.io/part-of: sanctions
 spec:
   replicas: 1
+  # Terminate-first, deliberately (#3545). This is a single-writer cache on an emptyDir
+  # behind one ClusterIP Service: a SURGED second pod would answer half the traffic from an
+  # empty keyspace, so surge is not a property worth keeping here. It also makes the roll
+  # possible at all when the cluster has no room for two pods.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: redis

--- a/openbank-infra/gitops/components/sca/redis.yaml
+++ b/openbank-infra/gitops/components/sca/redis.yaml
@@ -14,6 +14,15 @@ metadata:
     app.kubernetes.io/part-of: sca
 spec:
   replicas: 1
+  # Terminate-first, deliberately (#3545). This is a single-writer cache on an emptyDir
+  # behind one ClusterIP Service: a SURGED second pod would answer half the traffic from an
+  # empty keyspace, so surge is not a property worth keeping here. It also makes the roll
+  # possible at all when the cluster has no room for two pods.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: redis

--- a/openbank-infra/gitops/components/sdd/sdd-service.yaml
+++ b/openbank-infra/gitops/components/sdd/sdd-service.yaml
@@ -11,6 +11,15 @@ metadata:
     app.kubernetes.io/part-of: sdd
 spec:
   replicas: 1
+  # Terminate-first, deliberately (#3545): with one replica the default maxSurge 1 /
+  # maxUnavailable 0 needs room for two pods, and the old pod holds exactly those
+  # resources - on a full cluster the rollout never completes while reporting 1/1 READY.
+  # No HA to lose: this workload is already unavailable for the moment its pod is replaced.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: sdd-service

--- a/openbank-infra/gitops/components/security-scanner/security-scanner-service.yaml
+++ b/openbank-infra/gitops/components/security-scanner/security-scanner-service.yaml
@@ -14,6 +14,16 @@ metadata:
     app.kubernetes.io/part-of: security-scanner
 spec:
   replicas: 1
+  # Terminate-first, deliberately (#3545): with one replica the default maxSurge 1 /
+  # maxUnavailable 0 needs room for two pods, and the old pod holds exactly those
+  # resources - on a full cluster the rollout never completes and reports 1/1 READY.
+  # This workload is single-replica BY CONSTRAINT: it holds per-pod in-memory state, so
+  # scaling it past 1 needs the #3467-class fix first, not a replica bump.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: security-scanner-service

--- a/openbank-infra/gitops/components/statements/statement-service.yaml
+++ b/openbank-infra/gitops/components/statements/statement-service.yaml
@@ -18,6 +18,15 @@ metadata:
     app.kubernetes.io/part-of: statements
 spec:
   replicas: 1
+  # Terminate-first, deliberately (#3545): with one replica the default maxSurge 1 /
+  # maxUnavailable 0 needs room for two pods, and the old pod holds exactly those
+  # resources - on a full cluster the rollout never completes while reporting 1/1 READY.
+  # No HA to lose: this workload is already unavailable for the moment its pod is replaced.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: statement-service

--- a/openbank-infra/gitops/components/tpp-registry/redis.yaml
+++ b/openbank-infra/gitops/components/tpp-registry/redis.yaml
@@ -11,6 +11,15 @@ metadata:
     app.kubernetes.io/part-of: tpp-registry
 spec:
   replicas: 1
+  # Terminate-first, deliberately (#3545). This is a single-writer cache on an emptyDir
+  # behind one ClusterIP Service: a SURGED second pod would answer half the traffic from an
+  # empty keyspace, so surge is not a property worth keeping here. It also makes the roll
+  # possible at all when the cluster has no room for two pods.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: redis

--- a/openbank-infra/gitops/components/tpp-registry/tpp-registry-service.yaml
+++ b/openbank-infra/gitops/components/tpp-registry/tpp-registry-service.yaml
@@ -12,6 +12,15 @@ metadata:
     app.kubernetes.io/part-of: tpp-registry
 spec:
   replicas: 1
+  # Terminate-first, deliberately (#3545): with one replica the default maxSurge 1 /
+  # maxUnavailable 0 needs room for two pods, and the old pod holds exactly those
+  # resources - on a full cluster the rollout never completes while reporting 1/1 READY.
+  # No HA to lose: this workload is already unavailable for the moment its pod is replaced.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: tpp-registry-service


### PR DESCRIPTION
## What

Every one-replica workload under `openbank-infra/gitops` now declares an explicit rollout
strategy. The 64 Deployments that still inherited the default get terminate-first
(`maxSurge: 0` / `maxUnavailable: 1`), and the `#3545` ratchet baseline goes from 64 lines to
zero.

A `replicas: 1` Deployment with the default `RollingUpdate` resolves to `maxSurge: 1` /
`maxUnavailable: 0`, so Kubernetes must schedule the new pod **before** it may stop the old one.
The roll needs room for two pods and the old pod holds exactly the resources the new one needs.
On a full cluster that is a deadlock, and it is silent: `kubectl get deploy` reports `1/1 READY`
throughout, because the pod that is healthy is the OLD one. #3544 fixed one instance of this by
hand after it held a security-relevant delegation fix out of production for hours.

## Re-measurement (against `origin/main`, 2026-08-06)

The issue's headline number is stale — the gate from #3579 landed in between, and #3544 and a
few others fixed workloads by hand.

| | count |
|---|---|
| workloads under `openbank-infra/gitops` | 98 |
| single-replica | **97** (the one exception is `developer-portal` at 2) |
| `Deployment` / `Rollout` / `StatefulSet` | 76 / 21 / 1 |
| single-replica Deployments inheriting the default strategy | **64** -> **0** |
| already declared before this PR | 7 `Recreate`, 2 deliberate surge (keycloak, pact-broker) |
| single-replica canary Argo `Rollout`s | **21**, 15 of them money-path — **not fixed here**, see below |

## By constraint vs by accident

This is the part that decides the fix, so it is stated per class rather than swept. Terminate-first
is the right answer for all 64 — a one-replica workload has no zero-downtime property to trade
away — but *why* differs, and the difference is what a later reader needs.

**22 Redis caches — by constraint, and surge is actively wrong for them.** Each is a
single-writer cache on an `emptyDir` (`--save "" --appendonly no`) behind one ClusterIP Service.
A surged second pod would answer half the traffic from an empty keyspace. Terminate-first is the
correct semantics here, not a trade.

**8 services that are single-replica by constraint because they hold per-pod in-memory state**:
`product-catalog`, `anacredit-service`, `analytics-sink`, `agent-service`, `copilot-service`,
`mcp-service`, `pid-service`, `security-scanner-service`. Each carries a
`ConcurrentHashMap`/`AtomicReference` its own pod owns — #3467 is exactly this shape for lending,
and #3644 surveys several of these. Their comment names the constraint and points at #3467, so a
later "lending/mcp is slow, scale it to 3" reads as the correctness change it would be rather than
a capacity tweak. **How I classified them is a shape detector, not a proof** — see self-assessment.

**34 remaining services and infra workloads — by accident.** No HA today; they are already
unavailable for the moment their single pod is replaced. What changes is that the replacement can
happen at all.

## FinOps

**Zero.** No replica count changes and no resource requests change: the fleet stays at 97
single-replica workloads plus `developer-portal` at 2, exactly as before. This PR only states what
the rollout should do with the pods that already exist.

## The trade this does make, stated plainly

With the default, a new pod that cannot start (bad image, Kyverno denial) leaves the old pod
serving. With terminate-first the old pod is gone first, so a bad image is an outage until it is
fixed rather than a stuck-but-serving rollout. That is a real cost and it is the reason this is a
per-class decision rather than a default. It is accepted here because the failure it replaces is
worse in the way that matters: the deadlock is silent, unbounded, and bites hardest when the
cluster is under pressure — which is exactly when you are shipping the fix.

## Not in this PR, deliberately: the 21 canary Rollouts

All 21 Argo `Rollout`s are `replicas: 1` with no `maxSurge`/`maxUnavailable` in their canary
block, so they take the same defaults and **cannot roll on a full cluster either**. The gate
counts a canary block as "declared", so they are structurally invisible to it — this is a blind
spot, not an oversight in the gate, and its own docstring says so.

Terminate-first would defeat the canary, so the only real answer for those is `replicas >= 2`,
which is a capacity decision with a price: doubling all 21 costs **+4.62 vCPU and +9.69 GiB of
requests**, against a `default` nodepool CPU cap of **48** live (72 declared in
`sandbox-platform/main.tf`; that drift is documented in place) — i.e. **+9.6% of the entire pool's
CPU ceiling**, into a pool that was measured at 48/48 when this issue was filed. That is not a
change to make as a sweep inside a strategy PR, so it is filed separately.

## Verification

- `check-single-replica-rollout-strategy.py --enforce`: `64 -> 0` findings, `0` stale baseline lines.
- Falsified in place: deleted the strategy block from `aml-service.yaml`, the gate went red naming
  that exact file; restored from a `cp` backup, green again. Both directions, on the real tree.
- Whole `gitops` gate shard re-run after committing: `PASS=20 WARN=1 UNFALSIFIED=1`. The two
  non-passes (`incluster-hostname-resolution` advisory, `loki-rule-load-test` needs a tool absent
  from this machine) reproduce identically on a clean `origin/main` checkout — pre-existing, not
  from this change.

### Linked issues

Refs #3545, #3544, #3467
