### PR TITLE
chore(admin-ui): regenerate app-status.json for openbank-app 0.15.0

### DIFF
--- a/openbank-admin-ui/app-status.json
+++ b/openbank-admin-ui/app-status.json
@@ -12,7 +12,7 @@
   "asOf": "2026-07-29",
   "appRepo": "JiRaska/openbank-app",
   "derived": {
-    "version": "0.14.0",
+    "version": "0.15.0",
     "useFakeData": false,
     "edgeBaseUrl": "https://customer.open-bank.tech",
     "keycloakIssuer": "https://kc.open-bank.tech/realms/openbank-customers",


### PR DESCRIPTION
## Summary

Second manual dossier refresh in two days (#3747 covered 0.14.0): openbank-app released **0.15.0** overnight (openbank-app#380), so the Customer-app dossier gate is red on every PR again — `version: committed="0.14.0" → regenerated="0.15.0"`. Regenerated with the documented command; the diff is exactly the one drifted field.

## Type of change

- [x] chore (build / tooling)

## Linked issues

Refs #2101

## Changes

- `openbank-admin-ui/app-status.json`: `derived.version` 0.14.0 → 0.15.0 (generator output, not hand-edited).

## Definition of Done

- [x] Verified with the gate's own enforce mode against a current openbank-app checkout: `--check --enforce` exits 0.

## Security checklist

- [x] No secrets, tokens, passwords, or PII (derived facts only: version, fake-data flag, edge URL, capability counts).
- [x] No new third-party dependency.

## Compliance impact

- [x] None

## Rollout / Rollback

- Deployment strategy: none — consumed by the dossier gate and the admin-ui build at next CI run.
- Rollback plan: revert the squash commit.
- Data migration reversible: N/A

## Reviewer notes

Root cause (now fully mapped, details in #2101): (1) `PLATFORM_RW_TOKEN` is not configured in openbank-app, and (2) even with it, the publish job would not run on releases — openbank-app's release-please merges with the default `GITHUB_TOKEN`, and pushes made by `GITHUB_TOKEN` never trigger workflows. All three release merges (#362, #374, #380) were by `app/github-actions`; no `app-status` push run exists after 2026-07-31. Two releases in two days = two manual refreshes; the ladder keeps growing until #2101 is fixed properly.