### PR TITLE
ci(governance): fail when a policy reads a data.rules key the subset cannot carry

### DIFF
--- a/.github/scripts/gen-rules-opa-data.py
+++ b/.github/scripts/gen-rules-opa-data.py
@@ -189,14 +189,63 @@ def build() -> tuple[str, list[str]]:
     return text, missing
 
 
-def report_missing(missing: list[str]) -> None:
+# A referenced key that cannot be selected is DECLARED debt, not a warning.
+#
+# `shared_m2m_write_prohibition` sat here as a ::warning:: on every run and nobody acted, because a
+# warning over a GENERATED artifact says "the committed document does not match reality" — there is
+# no judgement left to exercise, so advisory only makes the drift mergeable (the repo's own lesson,
+# #2156/#2216). Meanwhile `rest.rego:482` reads it, the register is undefined in-cluster, `r in
+# <undefined>` iterates nothing, and the `prohibited` rule that mitigates GHSA-58jq-9hq3-66jr has
+# never denied anything. Measured against the live bundles: 128 writes reachable by the shared M2M
+# client on services already running AUTHZ_ENFORCE=true (#3765/#3734).
+#
+# What made it invisible for so long: `rest_test.rego`'s regression test SUPPLIES the register it
+# tests against — `with data.rules.shared_m2m_write_prohibition.reasons as ["operator-ledger-write"]`
+# — so it is green about a rule that works given data production never has. Neither the policy source
+# nor its tests can reveal this; only evaluating against the deployed bundle can.
+#
+# So: today's one occurrence is declared with its reason and its issue, and anything NEW fails. A
+# declaration that becomes resolvable is reported too, so this cannot quietly become permanent.
+UNRESOLVABLE_DECLARED: dict[str, str] = {
+    "shared_m2m_write_prohibition": (
+        "nested under `change_requirements:` in rules.yaml, so it cannot be selected as a top-level "
+        "key. Promoting it is a POLICY DECISION, not an edit: 128 currently-reachable writes depend "
+        "on the very reasons the register names, so promotion denies live money-path callers. "
+        "Tracked in #3765/#3734 — remove this entry in the same change that promotes the key."
+    ),
+}
+
+
+def report_missing(missing: list[str]) -> int:
+    """Return 0 when every unresolvable key is declared, 1 otherwise."""
+    rc = 0
     for k in missing:
+        if k in UNRESOLVABLE_DECLARED:
+            print(
+                f"::notice::`data.rules.{k}` is referenced by a policy and is undefined in the "
+                f"cluster — declared debt: {UNRESOLVABLE_DECLARED[k]}",
+                file=sys.stderr,
+            )
+            continue
+        rc = 1
         print(
-            f"::warning::`data.rules.{k}` is referenced by a policy but is not a "
-            "top-level key of rules.yaml — it is undefined in the cluster today, and "
-            "stays undefined here. Promoting it would change policy decisions.",
+            f"::error::`data.rules.{k}` is referenced by a policy but is not a top-level key of "
+            "rules.yaml, so it is UNDEFINED in every deployed bundle. In rego `r in <undefined>` "
+            "iterates nothing, so the rule reading it cannot fire — and its unit tests can still be "
+            "green, because a test may supply the data with `with data.rules... as [...]`. Either "
+            "make it a top-level key (a policy decision — it changes live decisions) or declare it "
+            "in UNRESOLVABLE_DECLARED with the reason and the issue.",
             file=sys.stderr,
         )
+    stale = sorted(set(UNRESOLVABLE_DECLARED) - set(missing))
+    for k in stale:
+        rc = 1
+        print(
+            f"::error::`{k}` is declared unresolvable but IS now selectable — the debt is paid, so "
+            "drop its UNRESOLVABLE_DECLARED entry.",
+            file=sys.stderr,
+        )
+    return rc
 
 
 def self_test() -> int:
@@ -235,6 +284,20 @@ def self_test() -> int:
         print("FAIL: a real reference was stripped as a comment")
         ok = False
 
+    # The unresolvable-key ratchet, both directions. A rego rule reading a key the subset
+    # cannot carry resolves to `undefined`, which is indistinguishable from an empty list —
+    # both read as "nothing prohibited" — so silence here is the failure mode, not the pass.
+    if report_missing(["a_key_nobody_declared"]) == 0:
+        print("FAIL: an undeclared unresolvable key did not fail the check")
+        ok = False
+    if report_missing(sorted(UNRESOLVABLE_DECLARED)) != 0:
+        print("FAIL: a declared unresolvable key failed the check")
+        ok = False
+    # A declaration that is no longer missing is a paid debt still being claimed.
+    if report_missing([]) == 0 and UNRESOLVABLE_DECLARED:
+        print("FAIL: a stale UNRESOLVABLE_DECLARED entry was not reported")
+        ok = False
+
     print("self-test: PASS" if ok else "self-test: FAIL")
     return 0 if ok else 1
 
@@ -249,7 +312,7 @@ def main() -> int:
         return self_test()
 
     text, missing = build()
-    report_missing(missing)
+    missing_rc = report_missing(missing)
 
     if args.check:
         current = OUT.read_text(encoding="utf-8") if OUT.exists() else ""
@@ -262,11 +325,13 @@ def main() -> int:
             )
             return 1
         print(f"rules-opa-data.yaml is in sync ({len(text)} bytes)")
-        return 0
+        # In sync is not the same as sound: a policy can reference a key the subset cannot carry,
+        # in which case the file is correct AND the rule reading it is dead. Both must hold.
+        return missing_rc
 
     OUT.write_text(text, encoding="utf-8")
     print(f"wrote {OUT.relative_to(REPO)} ({len(text)} bytes)")
-    return 0
+    return missing_rc
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## The defect

`openbank-libs/governance/policies/rest.rego:482` reads

```rego
r in data.rules.shared_m2m_write_prohibition.reasons
```

`shared_m2m_write_prohibition` is nested under `change_requirements:` in `rules.yaml`, so
`gen-rules-opa-data.py` — which selects **top-level** keys — cannot carry it. Measured:

```
rest.rego                 1 reference
rules-opa-data.yaml       0 occurrences
rules.yaml:488            nested, not top-level
```

In rego an undefined reference and an empty list are indistinguishable at the call site: both
read as *nothing prohibited*. So the rule mitigating GHSA-58jq-9hq3-66jr has never fired in any
deployed bundle, and nothing went red about it.

Why the rego unit test did not catch it — it **supplies** the register itself:

```rego
not rest.allow with input as { ... }
    with data.rules.shared_m2m_write_prohibition.reasons as ["operator-ledger-write"]
```

That proves the rule's logic, never that the data reaches it in production.

## The change

The generator already detected this and printed `::warning`, which is addressed to nobody. It is
now a ratchet:

- an unresolvable `data.rules.<key>` **fails** `--check` unless it carries an
  `UNRESOLVABLE_DECLARED` entry stating why;
- a declaration that is **no longer** unresolvable also fails, so a paid debt cannot keep being
  claimed.

The one live case is seeded with its reason. Promoting the key is a policy decision, not an
edit — 128 currently-reachable writes depend on the very reasons the register names, so promotion
denies live money-path callers. Tracked in #3765 / #3734; the entry says to remove it in the same
change that promotes the key.

## No new gate

`--check` already runs in `opa-policy.yml`'s `verify` job (required context **OPA policy gate**),
whose `detect` scope covers `openbank-libs/governance/policies/` and `rules.yaml` — the only paths
that can introduce a new `data.rules.<key>`. Adding a `gates.yaml` entry would put a second copy of
the same check on every PR.

## Falsification

Both directions, against the real file, restored from a `cp` backup each time:

| input | rc | expected |
|---|---|---|
| unchanged tree | 0 | 0 |
| `rest.rego` + a reference to an undeclared unresolvable key | 1 | 1 |
| `UNRESOLVABLE_DECLARED` naming a key that IS selectable | 1 | 1 |

And the self-test is itself falsifiable — sabotaging `report_missing` to `return 0` turns 2 of its
3 new assertions red:

```
FAIL: an undeclared unresolvable key did not fail the check
FAIL: a stale UNRESOLVABLE_DECLARED entry was not reported
self-test: FAIL
```

Refs #3765
