### PR TITLE
chore(admin-ui): regenerate customer-app dossier for app 0.15.0

### DIFF
--- a/openbank-admin-ui/app-status.json
+++ b/openbank-admin-ui/app-status.json
@@ -12,7 +12,7 @@
   "asOf": "2026-07-29",
   "appRepo": "JiRaska/openbank-app",
   "derived": {
-    "version": "0.14.0",
+    "version": "0.15.0",
     "useFakeData": false,
     "edgeBaseUrl": "https://customer.open-bank.tech",
     "keycloakIssuer": "https://kc.open-bank.tech/realms/openbank-customers",


### PR DESCRIPTION
## What

Regenerates the committed customer-app dossier (`openbank-admin-ui/app-status.json`) so its `derived` block matches the current `JiRaska/openbank-app` release.

```
-    "version": "0.14.0",
+    "version": "0.15.0",
```

Single field; everything else in the derived block already matched.

## Why

`JiRaska/openbank-app` released `0.15.0`, and the ADR-0074 dossier content check runs with `--enforce`, so the `Customer-app dossier` job is red on **every** open PR regardless of what it touches:

```
derived-block drift:
  version: committed="0.14.0" → regenerated="0.15.0"
```

Failing job: https://github.com/JiRaska/open-bank-oss/actions/runs/31074794116/job/92530347409

It is time-based, not PR-specific: #3813 touches no dossier file and is red (job 2026-08-06T05:40Z), while #3787 shows the same check green from a job that ran 2026-08-05T15:20Z — before the app release.

## How

Derived data is never hand-edited (ADR-0029 #7), so this uses the same generator the "Regenerate & diff derived block" CI step invokes, against a clone of the app source:

```
node openbank-admin-ui/scripts/generate-app-status.mjs --app-repo <openbank-app>
```

The private app repo needs read access — CI gets it from `OPENBANK_APP_RO_TOKEN` (and prints the "Skip notice" step when that secret is absent). Locally the `gh` credential for the repo owner is enough to clone it.

## Verification

Enforce check reproduced red before, green after, on the same command CI runs:

```
node scripts/generate-app-status.mjs --app-repo <app> --against app-status.json --enforce --check
```

- before: `::error title=app-status derived drift::` … exit 1
- after: `✓ derived block matches the committed app-status.json`, exit 0

## Linked issues

Refs #3818

## Note

The normal path for this artefact is openbank-app CI regenerating it and opening the publish PR back into this repo. That did not happen for `0.15.0`, which is why the drift reached every open PR instead of landing as its own PR — captured in #3818 as a follow-up.
