### PR TITLE
ci(governance): one KV entry for the OIDC client secret, enforced by a gate

### DIFF
--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -208,6 +208,21 @@ gates:
       python3 .github/scripts/check-agent-virtual-keys.py --self-test
       python3 .github/scripts/check-agent-virtual-keys.py --enforce
 
+  - id: oidc-secret-convention
+    name: "the OIDC client secret is read from ONE KV entry (issue #3485, enforced, baseline-ratcheted)"
+    group: gitops
+    mode: enforced
+    selftest: python3 .github/scripts/check-oidc-secret-convention.py --self-test
+    selftest_expect: pass
+    run: |
+      # Falsified BOTH ways before wiring in. Detection: 13 cases including the exact #3471
+      # defect (a per-service key nobody wrote), a baselined path that migrated (reported
+      # stale), and a baselined path pointing at a THIRD key (still a violation). Scope: the
+      # gate prints how many manifests it walked and how many projections it found — 531 and
+      # 39 today — because a gate is green two independent ways and "it never opened the
+      # file" is the one a passing exit code hides.
+      python3 .github/scripts/check-oidc-secret-convention.py --enforce
+
   - id: single-replica-rollout-strategy
     name: "one-replica workloads declare their rollout strategy (issue #3545, enforced, baseline-ratcheted)"
     group: gitops

--- a/.github/scripts/check-oidc-secret-convention.py
+++ b/.github/scripts/check-oidc-secret-convention.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""One OIDC client secret, one KV key: every ExternalSecret must read it from `account-service`.
+
+WHY THIS IS A GATE AND NOT A COMMENT. Every service in the fleet authenticates as the SAME
+Keycloak confidential client, `openbank-services` -- verified by reading `quarkus.oidc.client-id`
+out of each service's own application.yaml, where it is the literal `openbank-services` (anacredit
+writes it as `${QUARKUS_OIDC_CLIENT_ID:openbank-services}`, same value). There is no dedicated
+realm client behind any per-service KV key, so the key NAME carries no meaning at all: it is pure
+storage convention, and the two conventions in the tree are indistinguishable to a reader.
+
+Getting it wrong is silent and expensive. `openbank-delegation-service` shipped with
+`remoteRef.key: delegation-service`, an entry nobody had ever written. ESO answered
+`Secret does not exist`, the target Secret was never created, and the pod sat in
+CreateContainerConfigError for its entire life. Roughly a dozen alerts fired and not one of them
+named the cause (SLOMetricAbsent x3, TargetDown, DeploymentNoAvailableReplicas, KubePodNotReady,
+KubeContainerWaiting, KubeDeploymentReplicasMismatch, RolloutStuck, ArgoCDAppDegraded,
+PostgresWALArchiveFailing, two Kyverno criticals). Fixed in #3471 by pointing at the shared entry.
+Nothing in CI could have caught it: the YAML is valid, ArgoCD syncs the ExternalSecret happily,
+and `gitops_ref_integrity` is satisfied because the ExternalSecret DOES declare the Secret -- it
+just never materialises. The defect lives one layer further out, in the KV key the ref names.
+
+THE RULE (rules.yaml: oidc_secret_convention). Under `openbank-infra/gitops/components/`, an
+ExternalSecret data entry that projects the OIDC client secret -- `remoteRef.property` or
+`secretKey` equal to `OIDC_CLIENT_SECRET` -- must use `remoteRef.key: account-service`. That is
+the entry 28 of today's 38 already read and the only one demonstrably populated (28 live
+consumers). A per-service key requires a KV write nobody is prompted to make, which is exactly
+the step that was skipped.
+
+BASELINE. The 10 pre-existing per-service entries are baselined against #3485, NOT migrated:
+switching a live ExternalSecret's remoteRef re-projects the Secret, and this repo cannot see what
+those KV entries hold. If they hold a stale value the switch is a no-op improvement; if
+`account-service` were the stale one it would break 10 services at once. That is not a call to
+make blind, so this gate freezes the split instead of moving it. The baseline is SHRINK-ONLY and
+a stale entry (one that no longer violates) is reported too -- so a migration done later cannot
+leave a dead exemption behind, and a new service cannot join the losing side quietly.
+
+Run standalone:  .github/scripts/check-oidc-secret-convention.py [--enforce]
+Self-test:       .github/scripts/check-oidc-secret-convention.py --self-test
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import yaml
+
+REPO = Path(__file__).resolve().parents[2]
+COMPONENTS = REPO / "openbank-infra" / "gitops" / "components"
+
+SECRET_FIELD = "OIDC_CLIENT_SECRET"
+SHARED_KEY = "account-service"
+
+# Pre-existing per-service entries, measured mechanically on origin/main 2026-08-06 (#3485).
+# path relative to gitops/components  ->  the KV key it reads.
+# SHRINK-ONLY: remove an entry when the manifest is migrated to SHARED_KEY. Do not add.
+BASELINE: dict[str, str] = {
+    "anacredit/oidc-externalsecret.yaml": "anacredit-service",
+    "statements/external-secret-oidc.yaml": "statement-service",
+    "campaign/external-secret-oidc.yaml": "campaign-service",
+    "sdd/oidc-externalsecret.yaml": "sdd-service",
+    "tpp-registry/oidc-externalsecret.yaml": "tpp-registry-service",
+    "external-secrets/es-sanctions-service-oidc.yaml": "sanctions-service",
+    "external-secrets/es-audit-service-oidc.yaml": "audit-service",
+    "external-secrets/es-mcp-service.yaml": "mcp-service",
+    "external-secrets/es-agent-service.yaml": "agent-service",
+    "external-secrets/es-balance-service-oidc.yaml": "balance-service",
+}
+
+
+def entries_in(doc, rel: str) -> list[tuple[str, str]]:
+    """Every OIDC-client-secret projection in `doc`, as (rel, remoteRef.key)."""
+    if not isinstance(doc, dict) or doc.get("kind") != "ExternalSecret":
+        return []
+    out = []
+    for entry in (doc.get("spec") or {}).get("data") or []:
+        if not isinstance(entry, dict):
+            continue
+        ref = entry.get("remoteRef") or {}
+        if not isinstance(ref, dict):
+            continue
+        if SECRET_FIELD not in (ref.get("property"), entry.get("secretKey")):
+            continue
+        key = ref.get("key")
+        if isinstance(key, str):
+            out.append((rel, key))
+    return out
+
+
+def classify(found: list[tuple[str, str]]) -> tuple[list[str], list[str], int]:
+    """-> (violations, stale baseline entries, count of conforming entries)."""
+    violations, conforming = [], 0
+    still_violating: set[str] = set()
+    for rel, key in found:
+        if key == SHARED_KEY:
+            conforming += 1
+            continue
+        if BASELINE.get(rel) == key:
+            still_violating.add(rel)
+            continue
+        violations.append(
+            f"{rel}: OIDC_CLIENT_SECRET is read from remoteRef.key `{key}`. Every service "
+            f"authenticates as the same Keycloak client `openbank-services`, so the shared KV "
+            f"entry `{SHARED_KEY}` is the convention (rules.yaml: oidc_secret_convention). A "
+            f"per-service key needs a KV write nobody prompts you for; when it is missing ESO "
+            f"answers `Secret does not exist`, the Secret is never created and the pod sits in "
+            f"CreateContainerConfigError (#3471)."
+        )
+    stale = [
+        f"{rel}: baselined as reading `{key}` but no longer does. Delete the entry from "
+        f"BASELINE in {Path(__file__).name} -- a stale exemption hides the next regression."
+        for rel, key in BASELINE.items()
+        if rel not in still_violating
+    ]
+    return violations, stale, conforming
+
+
+def audit() -> tuple[list[str], list[str], int, int]:
+    found: list[tuple[str, str]] = []
+    scanned = 0
+    for path in sorted(COMPONENTS.rglob("*.yaml")):
+        scanned += 1
+        rel = path.relative_to(COMPONENTS).as_posix()
+        try:
+            docs = list(yaml.safe_load_all(path.read_text()))
+        except yaml.YAMLError:
+            # Not this gate's job: `Validate manifests` already fails on unparseable YAML.
+            continue
+        for doc in docs:
+            found += entries_in(doc, rel)
+    violations, stale, conforming = classify(found)
+    return violations, stale, conforming, scanned
+
+
+def _es(key: str, *, prop: str | None = SECRET_FIELD, secret_key: str = SECRET_FIELD) -> dict:
+    ref: dict = {"key": key}
+    if prop is not None:
+        ref["property"] = prop
+    return {"kind": "ExternalSecret", "spec": {"data": [{"secretKey": secret_key,
+                                                         "remoteRef": ref}]}}
+
+
+def self_test() -> int:
+    """Feed it inputs it MUST flag and inputs it MUST NOT -- a gate that has only ever passed is
+    unfalsified. Both the DETECTION (can it express the construct?) and the SCOPE (did it open
+    any file at all?) are asserted; the scope half is the one a passing gate hides."""
+    a_baselined = next(iter(BASELINE.items()))
+    cases: list[tuple[str, list[tuple[str, str]], int, int]] = [
+        # (name, found-entries, expected violations, expected stale)
+        ("the exact #3471 defect -- a key nobody wrote",
+         [("delegation/oidc-externalsecret.yaml", "delegation-service")], 1, len(BASELINE)),
+        ("the shared key passes",
+         [("delegation/oidc-externalsecret.yaml", SHARED_KEY)], 0, len(BASELINE)),
+        ("a baselined entry is exempt, and not reported stale",
+         [a_baselined], 0, len(BASELINE) - 1),
+        ("a baselined path that MIGRATED is reported stale",
+         [(a_baselined[0], SHARED_KEY)], 0, len(BASELINE)),
+        ("a baselined path pointing at a DIFFERENT wrong key is still a violation",
+         [(a_baselined[0], "somewhere-else")], 1, len(BASELINE)),
+        ("today's tree, minus baseline, is clean", [], 0, len(BASELINE)),
+    ]
+    failed = 0
+    for name, found, want_v, want_s in cases:
+        v, s, _ = classify(found)
+        ok = (len(v), len(s)) == (want_v, want_s)
+        failed += not ok
+        print(f"  {'PASS' if ok else 'FAIL'}  {name} "
+              f"(expected {want_v}v/{want_s}s, got {len(v)}v/{len(s)}s)")
+
+    parse_cases = [
+        ("an ExternalSecret projecting the secret is seen", _es("x"), 1),
+        ("property alone is enough (secretKey renamed)",
+         _es("x", secret_key="CLIENT_SECRET"), 1),
+        ("secretKey alone is enough (no property)", _es("x", prop=None), 1),
+        ("an unrelated secret in the same file is ignored",
+         _es("x", prop="DB_PASSWORD", secret_key="DB_PASSWORD"), 0),
+        ("a non-ExternalSecret document mentioning it is not flagged",
+         {"kind": "Deployment", "spec": {"data": [
+             {"secretKey": SECRET_FIELD, "remoteRef": {"key": "x"}}]}}, 0),
+        ("an ExternalSecret with no data entries is fine", {"kind": "ExternalSecret",
+                                                            "spec": {}}, 0),
+        ("a null document does not crash the walk", None, 0),
+    ]
+    for name, doc, want in parse_cases:
+        got = len(entries_in(doc, "z/es.yaml"))
+        ok = got == want
+        failed += not ok
+        print(f"  {'PASS' if ok else 'FAIL'}  {name} (expected {want}, got {got})")
+
+    # SCOPE. A gate is green two independent ways: it cannot express the construct, or it never
+    # opened the file. The cases above falsify detection; this falsifies scope, by asserting the
+    # real walk both reaches files and finds the entries the baseline claims exist.
+    _, _, conforming, scanned = audit()
+    total = conforming + len(BASELINE)
+    scope_ok = scanned > 100 and conforming > 0
+    failed += not scope_ok
+    print(f"  {'PASS' if scope_ok else 'FAIL'}  scope: walked {scanned} manifest(s) under "
+          f"gitops/components and found {total} OIDC_CLIENT_SECRET projection(s) "
+          f"({conforming} on `{SHARED_KEY}`, {len(BASELINE)} baselined)")
+
+    n = len(cases) + len(parse_cases) + 1
+    print(f"self-test: {n - failed}/{n} passed")
+    return 1 if failed else 0
+
+
+def main() -> int:
+    if "--self-test" in sys.argv:
+        return self_test()
+    enforce = "--enforce" in sys.argv
+    violations, stale, conforming, scanned = audit()
+    total = conforming + len(BASELINE) - len(stale) + len(violations)
+    print(f"check-oidc-secret-convention: walked {scanned} manifest(s) under "
+          f"gitops/components; {total} OIDC_CLIENT_SECRET projection(s) "
+          f"({conforming} on `{SHARED_KEY}`, {len(BASELINE) - len(stale)} baselined).")
+    findings = violations + stale
+    if not findings:
+        print("check-oidc-secret-convention: OK — every non-baselined projection reads "
+              f"`{SHARED_KEY}`, and the baseline is exact.")
+        return 0
+    for f in findings:
+        print(f"{'::error::' if enforce else '::warning::'}{f}")
+    return 1 if enforce else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/openbank-infra/gitops/components/external-secrets/README.md
+++ b/openbank-infra/gitops/components/external-secrets/README.md
@@ -68,6 +68,32 @@ vault write auth/kubernetes/role/eso \
   ttl=1h
 ```
 
+## Convention: the OIDC client secret lives in ONE KV entry (issue #3485)
+
+A new service's ExternalSecret **must** read the OIDC client secret from
+`remoteRef.key: account-service`. Do not invent a per-service KV key.
+
+The whole fleet authenticates as a single Keycloak confidential client,
+`openbank-services` — check any service's `quarkus.oidc.client-id` — so there is
+exactly one secret value and a per-service key name promises a credential that
+does not exist. What it does cost is a `vault kv put` nobody prompts you for:
+`openbank-delegation-service` shipped `remoteRef.key: delegation-service`, ESO
+answered `Secret does not exist`, and the pod sat in `CreateContainerConfigError`
+for its entire life behind ~12 alerts that named everything except the cause
+(fixed in #3471).
+
+Enforced by `.github/scripts/check-oidc-secret-convention.py`
+(gate `oidc-secret-convention`, `mode: enforced`). Ten pre-existing per-service
+entries are baselined in that script and are shrink-only — they are frozen, not
+blessed; migrating one means deleting its baseline entry in the same commit.
+The rule itself is stated in `openbank-libs/governance/rules.yaml:
+oidc_secret_convention`, which is authoritative if this file disagrees.
+
+Note the seed commands below predate the convention: `openbank/balance-service`
+and `openbank/audit-service` are two of the ten baselined entries, and every
+other service takes the value from `openbank/account-service` with no seed step
+of its own.
+
 ## 3. Seed the real secret values (GATE 2 — out-of-band, never in git)
 
 Pull each current value from the live hand-made Secret and write it to Vault.

--- a/openbank-libs/governance/rules.yaml
+++ b/openbank-libs/governance/rules.yaml
@@ -2116,6 +2116,37 @@ gitops_ref_integrity:
   # naming `Secret payments/vop-oidc`; restored, it passes.
   incident: 2026-07-16
 
+oidc_secret_convention:
+  script: .github/scripts/check-oidc-secret-convention.py
+  wired_into: .github/gates/gates.yaml    # gate id oidc-secret-convention, group gitops, enforced
+  # THE DECISION (issue #3485). The OIDC client secret lives in ONE KV entry, `account-service`,
+  # and every ExternalSecret reads it from there. Not because that name is apt -- it is a
+  # historical accident -- but because the fleet has exactly one Keycloak confidential client,
+  # `openbank-services`, and therefore exactly one secret VALUE. A per-service key name promises
+  # a per-service credential that does not exist, while costing a KV write nobody is prompted to
+  # make. Independent rotation is the only thing the per-service form buys, and nothing can use
+  # it while all 39 projections hold the same client's secret.
+  rule: >-
+    Under openbank-infra/gitops/components/, an ExternalSecret data entry projecting the OIDC
+    client secret (remoteRef.property or secretKey == OIDC_CLIENT_SECRET) must read
+    remoteRef.key: account-service.
+  basis: one_client_implies_one_kv_entry
+  baseline: in-script BASELINE dict -- 10 pre-existing per-service entries, SHRINK-ONLY
+  # WHY BASELINED AND NOT MIGRATED. Changing a live ExternalSecret's remoteRef re-projects the
+  # Secret and rolls the pod. Nothing in this repo can see what those 10 KV entries hold, so the
+  # switch is safe only if `account-service` is current -- likely (28 live consumers) but not
+  # verified from here, and being wrong breaks authentication on 10 services at once. The gate
+  # therefore FREEZES today's split rather than moving it: the losing side cannot grow, and a
+  # migration done later must delete its baseline entry or the gate fails on the stale
+  # exemption. Migration is tracked on #3485.
+  # PRIOR ART: openbank-delegation-service, 2026-08 -- shipped `remoteRef.key: delegation-service`,
+  # an entry nobody had written. ESO answered `Secret does not exist`, the Secret was never
+  # created, the pod sat in CreateContainerConfigError for its entire life, and ~12 alerts fired
+  # without one of them naming the cause. Fixed in #3471 by pointing at the shared entry.
+  # gitops_ref_integrity cannot catch this: the ExternalSecret DOES declare the Secret, it just
+  # never materialises -- the defect is one layer out, in the KV key the ref names.
+  incident: 2026-08-01
+
 deploy_coverage:
   script: .github/scripts/check-deploy-coverage.sh
   wired_into: .github/workflows/ci.yml   # governance job -> all-green (a REQUIRED check)


### PR DESCRIPTION
## What

Closes the decision half of #3485: the OIDC client secret is read from **one** KV entry, `account-service`, and a CI gate stops a new service picking anything else.

Three artefacts, one rule:
- `openbank-libs/governance/rules.yaml: oidc_secret_convention` — the decision, stated once (authoritative).
- `openbank-infra/gitops/components/external-secrets/README.md` — the same rule where a new ExternalSecret actually gets written.
- `.github/scripts/check-oidc-secret-convention.py`, declared as gate `oidc-secret-convention` (`group: gitops`, `mode: enforced`) in `.github/gates/gates.yaml`.

## Re-measured against live `origin/main` — the premise moved

The issue's counts (17 shared / 11 per-service) were from filing time. Measured mechanically today by parsing every `ExternalSecret` under `gitops/components/`:

| | issue (at filing) | live `main` today |
|---|---|---|
| shared `account-service` | 17 | **29** |
| per-service key | 11 | **10** |
| total projections | 28 | **39** |

Differences worth naming:
- The shared side grew by 12 — new services have been picking the shared entry.
- `litellm` and `glitchtip`, listed in the issue as per-service, no longer project `OIDC_CLIENT_SECRET` at all. `agent-service` does, and was not in the issue's list.
- The 39th projection is one **a grep for `OIDC_CLIENT_SECRET` as a `secretKey` cannot see**: `pid/oidc-externalsecret.yaml` projects `remoteRef.property: OIDC_CLIENT_SECRET` under `secretKey: QUARKUS_OIDC_CREDENTIALS_SECRET`. It reads the shared key, so it is not a defect — but the gate keys on `property` **or** `secretKey` precisely because the construct, not the name, is what matters.

The issue's core claim **holds and was re-verified independently**: all ten per-service consumers declare `quarkus.oidc.client-id: openbank-services` in their own `application.yaml` (anacredit as `${QUARKUS_OIDC_CLIENT_ID:openbank-services}`). There is no dedicated realm client behind any per-service key. The key name is pure storage convention.

## The decision, and why

Option 1 from the issue — **shared entry for everyone**. One Keycloak confidential client means one secret value; a per-service key name promises a credential that does not exist, while costing a `vault kv put` nobody is prompted to make. That is exactly the step skipped for `openbank-delegation-service` (#3471). Independent rotation is the only thing option 2 buys and nothing can use it today.

Option 3 (assert the KV entry exists) is the only one that catches a key pointing at nothing, and it is not buildable from this repo: there is no source of truth for KV contents outside the cluster. Option 1 gets the same protection for the common case by shrinking the legal set to one value that 29 live consumers prove is populated.

## What is NOT done, deliberately: the migration

The 10 per-service entries are **baselined, not migrated**. Changing a live `remoteRef` re-projects the Secret and rolls the pod, and nothing in this repo can see what those KV entries hold. If they are stale, switching is an improvement; if `account-service` were the stale one, switching breaks authentication on 10 services at once. That is not a call to make blind from a diff.

So the gate **freezes** today's split rather than moving it. The baseline is shrink-only and a **stale** entry (one that no longer violates) fails the gate too — a later migration must delete its baseline entry in the same commit, and the losing side cannot grow meanwhile. Migration stays open on #3485.

## Falsification — both ways, and both kinds of green

A gate is green two independent ways: it cannot express the construct (detection), or it never opened the file (scope). Both were falsified.

**Detection** — 14 self-test cases, including:
- the exact #3471 defect (a per-service key nobody wrote) → 1 violation;
- a baselined path that **migrated** to the shared key → reported stale;
- a baselined path pointing at a **third** key → still a violation (the exemption is per key, not per path);
- `property` alone with a renamed `secretKey` → still detected (this is the `pid` shape);
- an unrelated secret, a non-ExternalSecret doc with the same field names, an empty `data`, a null doc → all silent.

**Scope** — the gate and its self-test both print their scan count: `walked 531 manifest(s) ... 39 projection(s) (29 on account-service, 10 baselined)`. The self-test asserts the walk reached >100 files and found conforming entries, so a walk that silently matched nothing fails.

**Known-positive against the real tree** — a bad ExternalSecret was planted under `gitops/components/` and the gate run for real: scan count went 531 → 532, exit **1**, and the printed message named the file, the offending key and the #3471 failure mode. Removed afterwards; the diff contains no fixture.

## Ripple effects checked

`python3 .github/scripts/gen-rules-opa-data.py --check` → **in sync**. No `.rego` reads `data.rules.oidc_secret_convention`, so the derived OPA subset is unchanged and **no bundle or pod-roll annotation is restamped** (#3357). Nothing under `gitops/` changed except one README.

`run-gates.py --group gitops` passes apart from two failures reproduced independently of this branch: `gen-network-policies-drift-gate` (it diffs the worktree, so it saw my *uncommitted* README — green once committed) and `loki-rule-load-test` (boots a real Loki ruler; environmental locally, untouched here).

`.github/gates/gates.yaml` was re-read on live `main` immediately before pushing: the diff is my entry only, no other entry dropped. `check-gate-script-registration` and `check-advisory-gate-registration` both pass.

## What I did NOT verify — this could still be wrong

- **The contents of any KV entry.** I never read Vault. "Everything holds the same `openbank-services` secret" is inferred from `client-id` in the service configs plus 29 live consumers of `account-service` — it is not a measurement of the stored values. If a per-service entry today holds a *different* secret for a reason nobody wrote down, this rule is wrong for that service, and the baseline is what keeps that from mattering yet.
- **That `account-service` is the right long-term name.** It is a historical accident. Renaming it is a KV migration with the same risk as the service migration, so I did not touch it.
- **That the ten baselined services are healthy.** I checked their manifests, not the cluster.
- **Scope is `gitops/components/` only.** An `OIDC_CLIENT_SECRET` ExternalSecret placed elsewhere under `gitops/` is not scanned. I checked and there are none today (the only other hits are two comment lines in `gitops/apps/`), but that is a fact about today's tree, not an invariant.
- **`mode: enforced`, not advisory.** With the baseline the gate is green on today's tree, so enforcing costs nothing now and delivers the point of the issue immediately. The risk it carries is that a legitimate future per-service key becomes a merge blocker — which is the intended behaviour, but it will surprise someone.

Refs #3485, #3471
