### PR TITLE
test(admin-ui): guard the GlitchTip source-map auth-token chain end to end

### DIFF
--- a/openbank-admin-ui/src/test/sourcemap-upload.guard.test.ts
+++ b/openbank-admin-ui/src/test/sourcemap-upload.guard.test.ts
@@ -29,6 +29,7 @@ import { readFileSync } from 'fs'
 import { join } from 'path'
 
 const UI_ROOT = process.cwd()
+const REPO_ROOT = join(UI_ROOT, '..')
 
 /** Strip `#` comment lines from a Dockerfile so a rule is never satisfied by prose about it. */
 function stripDockerComments(src: string): string {
@@ -71,6 +72,48 @@ describe('client source maps reach GlitchTip and never the browser (#3235)', () 
     const config = stripJsLineComments(readFileSync(join(UI_ROOT, 'next.config.mjs'), 'utf8'))
     expect(config).toMatch(/sentryUrl:\s*'https:\/\/glitchtip\.open-bank\.tech'/)
     expect(config).toMatch(/telemetry\s*:\s*false/)
+  })
+
+  it('hands the build an auth token, or nothing is ever uploaded', () => {
+    // The maps existing on disk is half the fix. `withSentryConfig` reads SENTRY_AUTH_TOKEN and,
+    // when it is empty, SKIPS the upload and completes the build normally — deliberately, so a
+    // local or PR build never fails for want of a credential. That same property is what makes
+    // this link silent: delete the mount below and every test here still passes, the image still
+    // builds, the deploy still goes green, and the console goes back to empty culprits.
+    const dockerfile = stripDockerComments(readFileSync(join(UI_ROOT, 'Dockerfile'), 'utf8'))
+    const buildRun = dockerfile.slice(
+      dockerfile.indexOf('--mount=type=secret,id=glitchtip_token'),
+      dockerfile.indexOf('npm run build') + 'npm run build'.length,
+    )
+    // A BuildKit secret, never an ARG: an ARG is recorded in `docker history` and would ship the
+    // credential inside an image anyone can pull.
+    expect(dockerfile).toContain('--mount=type=secret,id=glitchtip_token')
+    expect(dockerfile).not.toMatch(/^\s*ARG\s+(GLITCHTIP_AUTH_TOKEN|SENTRY_AUTH_TOKEN)/m)
+    // The mounted secret must actually reach the variable the plugin reads, in the same RUN.
+    expect(buildRun).toMatch(/SENTRY_AUTH_TOKEN=.*\/run\/secrets\/glitchtip_token/)
+  })
+
+  it('keeps the token chain whole from repo secret to the build', () => {
+    // Two hops live outside openbank-admin-ui/, so a PR touching only them does not run this
+    // suite (CI's admin-ui job is path-filtered). Asserting them here still catches the drift on
+    // the next admin-ui change, which is strictly better than the nothing that guards them today.
+    const script = readFileSync(
+      join(REPO_ROOT, 'openbank-infra/scripts/build-push-admin-ui.sh'),
+      'utf8',
+    )
+      .split('\n')
+      .filter((line) => !/^\s*#/.test(line))
+      .join('\n')
+    expect(script).toContain('id=glitchtip_token,env=GLITCHTIP_AUTH_TOKEN')
+
+    const workflow = readFileSync(
+      join(REPO_ROOT, '.github/workflows/admin-ui-deploy.yml'),
+      'utf8',
+    )
+      .split('\n')
+      .filter((line) => !/^\s*#/.test(line))
+      .join('\n')
+    expect(workflow).toMatch(/GLITCHTIP_AUTH_TOKEN:\s*\$\{\{\s*secrets\.GLITCHTIP_AUTH_TOKEN\s*\}\}/)
   })
 
   it('prunes every client .map out of the image after the build', () => {


### PR DESCRIPTION
## What

Guards the **credential half** of #3235. Adds two cases to
`openbank-admin-ui/src/test/sourcemap-upload.guard.test.ts`. No production code changes.

This is **not** the fix for #3235 — that landed in #3243 and #3611. This closes the one
remaining hole in what guards it.

## Why

The bundler half is fixed and guarded: webpack build, `productionBrowserSourceMaps` off,
`deleteSourcemapsAfterUpload`, Dockerfile prune. The credential half has no guard at all,
and it is the link that fails **silently**:

`withSentryConfig` reads `SENTRY_AUTH_TOKEN` and, when it is empty, **skips the upload and
completes the build normally** — deliberately, so a local or PR build never fails for want
of a credential. That property is exactly what makes a regression invisible. Remove the
BuildKit secret mount from the Dockerfile and:

- every existing test still passes,
- the image still builds,
- the deploy still goes green,
- and the console goes back to empty culprits — the original #3235 symptom, restored with
  nothing anywhere reporting it.

The chain is four hops and none of it was asserted: repo secret → `admin-ui-deploy.yml`
env → `build-push-admin-ui.sh --secret` → Dockerfile `--mount=type=secret` →
`SENTRY_AUTH_TOKEN` → plugin.

## What the two cases assert

1. The Dockerfile mounts `glitchtip_token` as a **BuildKit secret**, never an `ARG` (an ARG
   is recorded in `docker history` and would ship the credential inside a pullable image),
   and wires it into `SENTRY_AUTH_TOKEN` **in the same RUN**.
2. The chain from repo secret to build is whole: `admin-ui-deploy.yml` passes
   `secrets.GLITCHTIP_AUTH_TOKEN`, and `build-push-admin-ui.sh` forwards it as
   `--secret id=glitchtip_token,env=GLITCHTIP_AUTH_TOKEN`.

Both strip comments before asserting, matching the rest of this file: `next.config.mjs` and
the Dockerfile name every one of these settings *while explaining them*, so a whole-file
grep would pass on a tree where the setting itself had been deleted.

## Falsified, not merely observed green

Five mutations, each red on exactly one case, green again once restored:

| mutation | result |
|---|---|
| `--mount=type=secret,id=glitchtip_token` line removed | RED |
| token supplied as `ARG SENTRY_AUTH_TOKEN` instead | RED |
| mount kept, but `SENTRY_AUTH_TOKEN=""` instead of reading `/run/secrets/...` | RED |
| `env=GLITCHTIP_AUTH_TOKEN` dropped from the build script's `--secret` | RED |
| `secrets.GLITCHTIP_AUTH_TOKEN` dropped from `admin-ui-deploy.yml` | RED |
| all restored | 8 passed |

The first attempt at mutation 1 did not apply (a `perl` substitution silently matched
nothing) and the suite stayed green — which reads identically to a guard that works. It was
re-run with a substitution verified to have changed the file.

Full suite: `npm test` (not bare `npx vitest run`) — **81 files, 1102 tests, all passing**.
`eslint` clean on the changed file.

## Exposure

Unchanged by this PR, and worth restating: maps go to GlitchTip and are **never served**.
Two independent mechanisms — the plugin's `deleteSourcemapsAfterUpload`, and the Dockerfile
prune of `.next/static/**/*.map` before the runtime stage copies it. This PR adds a third
kind of protection to the *token*, not the maps: it makes an `ARG`-shaped credential leak
into `docker history` fail the suite.

## The workflow half, for the owner

`.github/workflows/admin-ui-deploy.yml` and `openbank-infra/scripts/build-push-admin-ui.sh`
live outside `openbank-admin-ui/`, and CI's admin-ui job is **path-filtered** — so a PR
touching only those two files does **not** run this suite. Asserting them here still catches
the drift on the next admin-ui change, which is strictly better than the nothing that guards
them today, but it is not equivalent to a gate.

The complete fix is a `.github/gates/gates.yaml` entry running the same three assertions
unconditionally in `Validate manifests`. That is a `.github/**` change needing human review,
so it is deliberately **not** in this PR.

## What this does NOT do — #3235 stays open

`GLITCHTIP_AUTH_TOKEN` **still does not exist**: `gh secret list` returns 8 secrets and it is
not among them. So every build to date has skipped the upload by design, **no frame has ever
been demonstrated resolving**, and this PR does not change that. Remaining work is unchanged
from the issue's second comment:

1. create a GlitchTip org auth token with `project:write` / `project:releases` and store it as
   the `GLITCHTIP_AUTH_TOKEN` repo secret (needs a GlitchTip login I should not perform);
2. deploy once with it set;
3. trigger a deliberate client-side throw and confirm the event names a file and a line.

## Self-assessment — what I did not verify

- **Not verified: that symbolication works.** No token exists, so no upload has happened.
  This PR guards the plumbing, and a whole guarded chain is still not a resolved frame.
- **Not verified end-to-end: the Docker build.** The assertions are static reads of the
  Dockerfile; I did not run `docker buildx build` with a real `--secret`, so I have not
  observed the mount delivering a token to the plugin. The mutation tests prove the *text* is
  required, not that the mechanism transports the value.
- **Not verified: that the upload succeeds against the live GlitchTip.** The edge allow-list
  fix (`artifactbundle/assemble`) is on main and was validated against an emulator in #3611,
  not against the running instance with a real token.
- **Not re-measured here: the map counts.** The 558-files / 354-chunks and 0-`sourceMappingURL`
  figures come from #3611; a local `next build --webpack` was started to reconfirm them but had
  not finished within this session, so I am citing the prior measurement rather than my own.
- **The cross-tree reads are a coupling.** If `build-push-admin-ui.sh` or `admin-ui-deploy.yml`
  is legitimately restructured, this admin-ui suite fails for a reason that is not an admin-ui
  fault. That is the intended trade, but it is a real cost.
- **#3174 checked, not assumed:** independent of this. That blocker is upstream
  (`GLITCHTIP_URL` drives both the UI URL and the DSN); the upload path blocker was our own
  Ingress and is already fixed on main. Neither gates the other.

Refs #3235
