### PR TITLE
fix(delegation): refuse non-SOLO approvalPolicy — ADR-0232 D8 co-signing is enforced nowhere

### DIFF
--- a/openbank-delegation-service/src/main/kotlin/com/openbank/delegation/application/usecase/DelegationService.kt
+++ b/openbank-delegation-service/src/main/kotlin/com/openbank/delegation/application/usecase/DelegationService.kt
@@ -28,6 +28,7 @@ import com.openbank.delegation.domain.event.DelegationRenounced
 import com.openbank.delegation.domain.event.DelegationRevoked
 import com.openbank.delegation.domain.event.DelegationSuspended
 import com.openbank.delegation.domain.event.EventMoney
+import com.openbank.delegation.domain.model.ApprovalPolicy
 import com.openbank.delegation.domain.model.DelegationCheckResult
 import com.openbank.delegation.domain.model.DelegationGrant
 import jakarta.enterprise.context.ApplicationScoped
@@ -66,6 +67,7 @@ class DelegationResourceOwnershipException(message: String) : RuntimeException(m
 class DelegationUnsupportedConstraintException(val code: String, message: String) : RuntimeException(message) {
     companion object {
         const val CODE_CUMULATIVE_LIMIT_UNSUPPORTED = "CUMULATIVE_LIMIT_UNSUPPORTED"
+        const val CODE_APPROVAL_POLICY_UNSUPPORTED = "APPROVAL_POLICY_UNSUPPORTED"
     }
 }
 
@@ -100,6 +102,7 @@ class DelegationService(
         val now = OffsetDateTime.now(clock)
         requireCallerIs(command.callerPartyId, command.grantorPartyId)
         rejectUnenforcedCeilings(command)
+        rejectUnenforcedApprovalPolicy(command)
         verifyResourceOwnership(command)
         verifyEligibility(command)
         // SCA last of the three gates: it SPENDS the challenge, so a request that was going to be
@@ -369,6 +372,35 @@ class DelegationService(
                 message = "${unenforced.joinToString(" and ")} cannot be accepted: this platform enforces only " +
                     "perTransactionLimit. No service counts cumulative spend against a grant, so a ceiling set " +
                     "here would never be applied to any payment. Omit the field (ADR-0232 D1/D6).",
+            )
+        }
+    }
+
+    /**
+     * ADR-0232 D8's co-signing promise, refused for the same reason as the cumulative ceilings:
+     * nothing counts approvals against a grant.
+     *
+     * `approvalPolicy` is accepted, checked for self-consistency (N_OF_M demands
+     * `requiredApprovals >= 2`), persisted, echoed and rendered — and never read by a decision.
+     * `DelegationGrant.covers` consults capability and `perTransactionLimit` only;
+     * `DelegationOffered` does not carry the policy; account-service's delegation projection has
+     * no column for it. So the one flow that could honour it — `SavingsProposalService.decide`,
+     * the D8 maker-checker — releases the withdrawal on a SINGLE owner decision no matter what
+     * the grantor chose. "Oba rodiče musí schválit výběr" is a number nobody counts.
+     *
+     * SOLO stays accepted: it is the default and it promises no second approver, so it is the one
+     * value that is honest today. Delivering the rest means replicating the policy onto the
+     * projection and counting decisions where the money moves — in that order, or the counter is
+     * a second unread field.
+     */
+    private fun rejectUnenforcedApprovalPolicy(command: OfferDelegationCommand) {
+        if (command.approvalPolicy != ApprovalPolicy.SOLO) {
+            throw DelegationUnsupportedConstraintException(
+                code = DelegationUnsupportedConstraintException.CODE_APPROVAL_POLICY_UNSUPPORTED,
+                message = "approvalPolicy ${command.approvalPolicy} cannot be accepted: no service counts " +
+                    "approvals against a grant, so a co-signing requirement set here would never be applied — " +
+                    "a single owner decision still releases the money. Only SOLO is enforced today. " +
+                    "Omit the field (ADR-0232 D8).",
             )
         }
     }

--- a/openbank-delegation-service/src/main/resources/openapi.yaml
+++ b/openbank-delegation-service/src/main/resources/openapi.yaml
@@ -5,7 +5,7 @@ info:
     Customer-to-party delegated access (ADR-0232): granular, SCA-bound grants over
     products (accounts, savings goals, cards) and single objects (payment, statement,
     document). Lifecycle: OFFERED → ACTIVE → SUSPENDED/REVOKED/EXPIRED/RENOUNCED/DECLINED.
-  version: 1.2.0
+  version: 1.3.0
 servers:
   - url: http://localhost:8126
 tags:
@@ -272,8 +272,21 @@ components:
             enum: [ACCOUNT_READ_BALANCES, ACCOUNT_READ_TRANSACTIONS, ACCOUNT_INITIATE_PAYMENT,
                    ACCOUNT_PROPOSE_PAYMENT, CARD_VIEW, CARD_MANAGE_LIMITS, SAVINGS_DEPOSIT,
                    SAVINGS_WITHDRAW, SAVINGS_PROPOSE_WITHDRAW, OBJECT_READ, DELEGATION_MANAGE]
-        approvalPolicy: { type: string, enum: [SOLO, ANY_ONE, ALL, N_OF_M] }
-        requiredApprovals: { type: integer }
+        approvalPolicy:
+          type: string
+          enum: [SOLO, ANY_ONE, ALL, N_OF_M]
+          default: SOLO
+          description: >-
+            Only SOLO is enforced. Any other value is rejected with 400 APPROVAL_POLICY_UNSUPPORTED:
+            no service counts approvals against a grant, so a co-signing requirement set here would
+            be stored and echoed while a single owner decision still releases the money. The enum
+            values remain listed because ADR-0232 D8 describes them as intended; they are not built.
+          x-unsupported-values: [ANY_ONE, ALL, N_OF_M]
+        requiredApprovals:
+          type: integer
+          deprecated: true
+          description: >-
+            Meaningful only with approvalPolicy=N_OF_M, which is rejected. Nothing counts approvals.
         perTransactionLimit:
           $ref: '#/components/schemas/MoneyDto'
           description: >-

--- a/openbank-delegation-service/src/test/kotlin/com/openbank/delegation/application/usecase/DelegationServiceTest.kt
+++ b/openbank-delegation-service/src/test/kotlin/com/openbank/delegation/application/usecase/DelegationServiceTest.kt
@@ -16,6 +16,7 @@ import com.openbank.delegation.application.port.out.ScaChallengeClient
 import com.openbank.delegation.application.port.out.ScaChallengeSnapshot
 import com.openbank.delegation.domain.event.DelegationOffered
 import com.openbank.delegation.domain.event.EventMoney
+import com.openbank.delegation.domain.model.ApprovalPolicy
 import com.openbank.delegation.domain.model.DelegationCapability
 import com.openbank.delegation.domain.model.DelegationCheckResult
 import com.openbank.delegation.domain.model.DelegationGrant
@@ -220,6 +221,83 @@ class DelegationServiceTest {
 
         assertThat(grant.perTransactionLimit).isEqualTo(limit)
         assertThat(grant.dailyLimit).isNull()
+        coVerify(exactly = 1) { repository.save(any<DelegationGrant>(), any()) }
+    }
+
+    /**
+     * ADR-0232 D8 promises `approvalPolicy` binds per-resource co-signing — "oba rodiče musí
+     * schválit výběr". It binds nothing. The field is accepted, validated for self-consistency
+     * (N_OF_M demands requiredApprovals >= 2), persisted, echoed and rendered in admin-ui, and
+     * read by no decision anywhere: `DelegationGrant.covers` consults capability and
+     * perTransactionLimit only, `DelegationOffered` does not carry it, and the account-service
+     * projection has no column for it — so account-service's `SavingsProposalService.decide`
+     * releases the money on a SINGLE owner decision whatever the policy said. Same shape as the
+     * cumulative ceilings: present at every layer except the enforcing one.
+     */
+    @Test
+    fun `offer refuses an N_OF_M approvalPolicy because no service counts approvals`(): Unit = runBlocking {
+        scaOk(grantor, "DELEGATION_GRANT")
+        eligibilityOk()
+
+        assertThatThrownBy {
+            runBlocking {
+                service.offer(
+                    offerCommand().copy(approvalPolicy = ApprovalPolicy.N_OF_M, requiredApprovals = 2),
+                )
+            }
+        }
+            .isInstanceOf(DelegationUnsupportedConstraintException::class.java)
+            .hasMessageContaining("approvalPolicy")
+            .hasMessageContaining("N_OF_M")
+
+        coVerify(exactly = 0) { repository.save(any<DelegationGrant>(), any()) }
+    }
+
+    @Test
+    fun `offer refuses every multi-party approvalPolicy, not just N_OF_M`(): Unit = runBlocking {
+        scaOk(grantor, "DELEGATION_GRANT")
+        eligibilityOk()
+
+        listOf(ApprovalPolicy.ANY_ONE, ApprovalPolicy.ALL).forEach { policy ->
+            assertThatThrownBy {
+                runBlocking { service.offer(offerCommand().copy(approvalPolicy = policy)) }
+            }
+                .describedAs("approvalPolicy %s must be refused", policy)
+                .isInstanceOf(DelegationUnsupportedConstraintException::class.java)
+                .hasMessageContaining(policy.name)
+        }
+
+        coVerify(exactly = 0) { repository.save(any<DelegationGrant>(), any()) }
+    }
+
+    /** The refusal must not spend the challenge — same reasoning as the ceiling gate. */
+    @Test
+    fun `offer refuses an unenforced approvalPolicy before spending the SCA challenge`(): Unit = runBlocking {
+        scaOk(grantor, "DELEGATION_GRANT")
+        eligibilityOk()
+
+        assertThatThrownBy {
+            runBlocking { service.offer(offerCommand().copy(approvalPolicy = ApprovalPolicy.ALL)) }
+        }
+            .isInstanceOf(DelegationUnsupportedConstraintException::class.java)
+
+        coVerify(exactly = 0) { scaClient.consumeChallenge(any(), any()) }
+    }
+
+    /**
+     * The control. SOLO is the default and is honest — it promises no extra approver and there is
+     * none. Without this the three tests above would pass against a service that had stopped
+     * accepting `approvalPolicy` altogether, which would break every ordinary grant.
+     */
+    @Test
+    fun `offer still accepts the default SOLO approvalPolicy`(): Unit = runBlocking {
+        scaOk(grantor, "DELEGATION_GRANT")
+        eligibilityOk()
+        coEvery { repository.save(any<DelegationGrant>(), any()) } answers { firstArg() }
+
+        val grant = service.offer(offerCommand().copy(approvalPolicy = ApprovalPolicy.SOLO))
+
+        assertThat(grant.approvalPolicy).isEqualTo(ApprovalPolicy.SOLO)
         coVerify(exactly = 1) { repository.save(any<DelegationGrant>(), any()) }
     }
 


### PR DESCRIPTION
## Stacked on #3613 — read that one first

Base is `fix/delegation-reject-unenforced-cumulative-ceilings`, not `main`. #3613 refuses
`dailyLimit`/`monthlyLimit`; this PR refuses the **third** unenforced constraint on the same
aggregate, found by doing the audit #3800 asks for in its last bullet. It reuses #3613's
`DelegationUnsupportedConstraintException` machinery rather than inventing a parallel rule, which
is why it is stacked instead of independent. **Retarget to `main` if #3613 lands first.**

## What I did NOT do

I did not re-implement #3800's headline fix. #3613 already implements it, is green, and carries
`Closes #3800`; a second copy of one rule is the drift failure this repo has been bitten by. I
verified #3613's premise independently instead (below) and then worked the residual nobody had
touched.

## The defect

`approvalPolicy` (`SOLO | ANY_ONE | ALL | N_OF_M`) and `requiredApprovals` are accepted on
`POST /api/v1/delegations`, validated for self-consistency, persisted, echoed back, and rendered
in admin-ui. **Nothing reads either to make a decision.**

Every non-test, non-build match in the repo, so the claim is checkable:

| Layer | Site |
| --- | --- |
| REST DTO (accept) | `DelegationDtos.kt:46-47`, `DelegationResource.kt:107-108` |
| Command | `DelegationUseCases.kt:37-38` |
| Aggregate (field) | `DelegationGrant.kt:85-86` |
| Aggregate (self-consistency only) | `DelegationGrant.kt:117-118` — `N_OF_M` demands `requiredApprovals >= 2` |
| Entity / DDL (persist) | `DelegationGrantEntity.kt:58,61,136-137,179-180`, `V1__init_delegation.sql:10-11,34` |
| DTO / spec (echo) | `DelegationDtos.kt:76-77,99-100`, `openapi.yaml` |
| admin-ui (display) | `delegations/[id]/page.tsx:101`, `GrantView.tsx:24-25` |

The only other hits in the repo are `openbank-governance-auditor`'s `requiredApprovals`, an
unrelated local variable about PR review counts.

The read side is empty in the two decisive places:

1. `DelegationGrant.covers` (`:129-133`) — the answer behind `POST /check` — consults capability
   and `perTransactionLimit` only.
2. `DelegationOffered` does not carry the policy, and account-service's projection
   (`DelegationProjectionEntity.kt`) has no column for it — I listed its columns; they stop at
   `per_tx_limit_amount`/`per_tx_limit_currency`. So no downstream service *could* enforce it.

**The consequence is on a money path.** `SavingsProposalService.decide`
(`openbank-account-service`, `:80-121`) is the ADR-0232 D8 maker-checker and the one flow that
could honour a co-signing rule. It requires `account.partyId == decidedByPartyId`, calls
`approvalStore.decide` once, and emits `SavingsWithdrawalApproved` — a **single** owner decision
releases the withdrawal whatever the grant said. D8's promise that both parents must approve a
shared-goal withdrawal is a number nobody counts, and the DB even constrains it to be >= 2, which
makes it look enforced.

## Why refuse rather than enforce

Same argument #3613 makes, and it holds harder here: the policy is not replicated to any
projection, so the enforcement point cannot even see it. Building a counter first would mean
choosing its home before the delegated money path exists, and it would read as implemented while
returning the same false assurance. Delivering D8 means replicating the policy onto the
projection and counting decisions where the money moves — in that order.

`SOLO` stays accepted: it is the default and promises no second approver, so it is the one value
that is honest today.

## Red first

Tests written and run **before** the production change:

```
DelegationServiceTest > offer refuses every multi-party approvalPolicy, not just N_OF_M() FAILED
    java.lang.AssertionError at DelegationServiceTest.kt:257
DelegationServiceTest > offer refuses an N_OF_M approvalPolicy because no service counts approvals() FAILED
    java.lang.AssertionError at DelegationServiceTest.kt:238
DelegationServiceTest > offer refuses an unenforced approvalPolicy before spending the SCA challenge() FAILED
    java.lang.AssertionError at DelegationServiceTest.kt:275

34 tests completed, 3 failed
```

After the change: 34 pass. The asymmetry is the point — the control
`offer still accepts the default SOLO approvalPolicy` is **green in both runs**, so the tests mean
"refuses multi-party policies", not "stopped accepting `approvalPolicy`".

## Spec

`info.version` 1.2.0 -> 1.3.0. Read off **live `main`** (1.1.0) as well as the parent branch
(1.2.0) immediately before writing this; 1.3.0 is the next free number in the stack. Needs
re-reading if this sits.

The enum values stay listed. Narrowing it to `[SOLO]` is what oasdiff reads as a breaking
restriction — the trap #3613's last commit was fixing — so the refusal is stated in `description`
and `x-unsupported-values` instead.

## Local gate

`:openbank-delegation-service:detekt :ktlintCheck :test` — BUILD SUCCESSFUL, and I checked all
three tasks actually appear in the output rather than trusting the exit code. `:quarkusBuild` also
green (no new bean, but cheap insurance).

## What I did NOT verify — please weigh these

- **No test proves the 400 is what a client actually receives.** These are use-case tests; they
  assert the exception, not the HTTP status. If
  `DelegationUnsupportedConstraintExceptionMapper` were not selected by JAX-RS this would surface
  as a 500. It is #3613's mapper, already carrying `CUMULATIVE_LIMIT_UNSUPPORTED`, so I have added
  no new wiring risk — but neither PR has an IT proving the mapper is registered. This is #3613's
  own self-declared weakest link and I have not closed it.
- **Existing rows are untouched.** Grants already stored with `ANY_ONE`/`ALL`/`N_OF_M` keep
  rehydrating and keep being echoed. Nobody has counted them or identified those grantors. Same
  residual #3800 records for the ceilings.
- **I did not update ADR-0232 D8.** #3613 adds a measured delivery-status section for D1 only;
  D8 still describes co-signing as a capability. Editing the same region would have conflicted
  with the parent. Follow-up, not done here.
- **I did not touch the other audit findings** (below). They are reported, not fixed.
- I did not run the full fleet build, the OPA/governance gates, or any contract replay locally —
  relying on CI for those.

## The rest of the audit #3800 asked for

D4/D5/D7/D8 swept for the same "present at every layer except the enforcing one" shape. Treat the
non-`approvalPolicy` rows as **findings needing their own issues**, not as claims this PR acts on:

| Element | Verdict |
| --- | --- |
| `approvalPolicy` / `requiredApprovals` (D8) | FALSE-PROMISE — **fixed here** |
| `exposure`: `redactionRules`, `maxViews`, `watermark`, `allowDownload` (D7) | FALSE-PROMISE — stored in `V1__init_delegation.sql`, echoed; no view counter, no redaction, no download gate anywhere in the repo |
| `OBJECT_READ` capability (D7) | FALSE-PROMISE — grantable; neither document-service nor statement-service references delegation or consumes the event stream |
| `ACCOUNT_PROPOSE_PAYMENT` capability (D8) | FALSE-PROMISE — grantable; no proposal endpoint, and account-service's own vocabulary omits it. Contrast `SAVINGS_PROPOSE_WITHDRAW`, which is genuinely wired |
| `DELEGATION_MANAGE` capability (D5) | FALSE-PROMISE — grantable; the D5 "statutory representative on a LEGAL_ENTITY grantor" rule has no code, and the eligibility DTO carries no `partyType`, so it cannot be expressed |
| Four-eyes on high-value payment grants (D4) | FALSE-PROMISE flag / ABSENT threshold — `authz.four-eyes.enforce` exists but only interpolates a startup log line; `delegation.offer` is in no `four_eyes.verbs`/`actions` list, and the service wires no `ApprovalStore` |
| Notification to both parties on every transition (D4) | ABSENT — notification-service does not consume `openbank.delegation.events` |
| Sanctions/PEP screening at grant time and on grantee status change (D5) | ABSENT — and structurally impossible today: the service has no `@Incoming` consumer at all, so a grantee later sanctioned keeps every ACTIVE grant until a human suspends |
| Dual consent, revocation, outbox events, KYC eligibility gate (D4/D5) | IMPLEMENTED |
| `SAVINGS_PROPOSE_WITHDRAW` maker-checker (D8) | IMPLEMENTED — except the N_OF_M half this PR refuses |

The ABSENT rows are honest gaps, not this defect class — nothing pretends they work. The
FALSE-PROMISE rows are the ones that mislead a customer.

Refs #3800
