### PR TITLE
fix(lending): make the compliance-pack four-eyes decision atomic

### DIFF
--- a/docs/threat-models/openbank-lending-service.md
+++ b/docs/threat-models/openbank-lending-service.md
@@ -245,10 +245,16 @@ two authenticated principals to alter.
 | Repudiation — "who activated this rule set?" | Durable Postgres record per activation (`compliance_pack_activation`: maker, checker, reason, timestamps) + canonical SHA-256 `content_hash` pinned into the audit evidence (ADR-0214); unlike the Redis-backed ADR-0155 layer this trail is permanent |
 | DoS — boot bricked by a corrupt activation row | Deliberate fail-loud: boot refuses to start over a corrupt activation rather than originate unprotected; operator remediation is to fix the row (the in-memory registry cannot silently run with a partial rule set) |
 | Elevation of privilege — maker self-approves | Server-side identity from the JWT subject (never request body); segregation enforced twice: `Proposal.approve` and registry re-assertion |
+| Tampering — two decisions arriving together are BOTH applied, and a rejected pack is enforced anyway (#3467) | The decision is a conditional UPDATE (`... where id = :id and state = PROPOSED`), so exactly one of any number of concurrent deciders claims the row and the rest are refused. Previously `decide()` tested the state against a snapshot read in a separate transaction and then wrote unconditionally, so two decisions both passed; worse, the approve leg called `registry.activate` whether or not its write survived, leaving a REJECTED row beside a pod enforcing the pack that rejection refused — and `CompliancePackRegistry` has no de-activation path (ADR-0212 D3), so that pod enforced it until restart. `CompliancePackConcurrentDecideIT` measures the race over real HTTP; on the previous code it observed both decisions accepted in 10 of 12 rounds |
 
 **Residual risk:** pack enforcement ships behind the bootstrap flag (default `false`) until the
 CZ reference pack is seeded and activated — the guard cannot protect origination while off.
 Tracked as the named bootstrap follow-up (ADR-0212 D4).
+
+**Residual risk (concurrency):** the conditional UPDATE makes the *decision* atomic; it does not
+make the in-memory registry shared. A pack approved on one replica still reaches its siblings only
+by the convergence path, so the at-most-once guarantee here is about the durable decision, not about
+every pod agreeing at the same instant (#3467, and see the replica-convergence work tracked there).
 
 ## 9. Customer self-service origination intake (ADR-0211) — STRIDE supplement
 

--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/application/port/out/CompliancePackActivationRepository.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/application/port/out/CompliancePackActivationRepository.kt
@@ -20,6 +20,15 @@ interface CompliancePackActivationRepository {
     fun findById(id: UUID): Uni<CompliancePackActivationEntity?>
     fun findByState(state: ProposalState): Uni<List<CompliancePackActivationEntity>>
     fun findActivated(): Uni<List<CompliancePackActivationEntity>>
+
+    /**
+     * Apply a four-eyes decision to [entity] **only if** the stored row is still
+     * [ProposalState.PROPOSED], as a single statement. Returns the number of rows claimed: `1` when
+     * this caller won the decision, `0` when someone else already decided it.
+     *
+     * The caller must treat `0` as a refusal and must not perform any side effect of the decision.
+     */
+    fun compareAndSetDecision(entity: CompliancePackActivationEntity): Uni<Int>
 }
 
 @ApplicationScoped
@@ -42,6 +51,37 @@ class JpaCompliancePackActivationRepository :
     override fun save(entity: CompliancePackActivationEntity): Uni<CompliancePackActivationEntity> =
         Panache.getSession().flatMap { it.merge(entity) }
 
+    /**
+     * The decision leg does NOT go through [save].
+     *
+     * `save` is a blind upsert: it writes whatever the caller loaded, whenever the caller gets round
+     * to it. The checker leg reads the row in one transaction (`findById`, `@WithSession`), decides
+     * against that snapshot in memory, and writes in another — so two decisions arriving together
+     * both observe `PROPOSED`, both pass the service's `require(state == PROPOSED)` guard, and both
+     * write. A lost update on a segregation-of-duties control, and worse than a lost update: the
+     * approve leg activates the pack in the in-memory registry whether or not its write survived, so
+     * a REJECTED row can coexist with a pod enforcing the pack that rejection refused.
+     *
+     * Making the state test part of the UPDATE closes the window without a lock, a version column or
+     * a schema change — the database evaluates `state = PROPOSED` and the assignment in one
+     * statement, so exactly one of any number of concurrent deciders can claim the row and the rest
+     * get `0` back. `CompliancePackConcurrentDecideIT` measures it; on the previous code it observed
+     * both decisions accepted in 10 of 12 rounds.
+     */
+    @WithTransaction
+    override fun compareAndSetDecision(entity: CompliancePackActivationEntity): Uni<Int> =
+        Panache.getSession().flatMap { session ->
+            session.createMutationQuery(DECIDE_HQL)
+                .setParameter("state", entity.state)
+                .setParameter("decidedBy", entity.decidedBy)
+                .setParameter("decidedAt", entity.decidedAt)
+                .setParameter("reason", entity.decisionReason)
+                .setParameter("updatedAt", entity.updatedAt)
+                .setParameter("id", entity.id)
+                .setParameter("from", ProposalState.PROPOSED)
+                .executeUpdate()
+        }
+
     @WithSession
     override fun findById(id: UUID): Uni<CompliancePackActivationEntity?> = find("id", id).firstResult()
 
@@ -54,4 +94,17 @@ class JpaCompliancePackActivationRepository :
         "state in ?1 order by jurisdiction, productType, packVersion",
         listOf(ProposalState.APPROVED, ProposalState.EXECUTED),
     )
+
+    private companion object {
+        /**
+         * The `and state = :from` clause is the whole point — without it this is [save] with extra
+         * steps. Named parameters because [CompliancePackActivationEntity.decisionReason] is
+         * nullable and Panache's positional `update(String, vararg Any)` cannot carry a null.
+         */
+        const val DECIDE_HQL =
+            "update CompliancePackActivationEntity " +
+                "set state = :state, decidedBy = :decidedBy, decidedAt = :decidedAt, " +
+                "decisionReason = :reason, updatedAt = :updatedAt " +
+                "where id = :id and state = :from"
+    }
 }

--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/application/usecase/CompliancePackActivationService.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/application/usecase/CompliancePackActivationService.kt
@@ -97,9 +97,20 @@ class CompliancePackActivationService(
             // Measured, not theorised: with the persist-vs-merge defect still in place, the decide
             // call returned 500 and `GET /compliance-packs/active` nonetheless listed the pack
             // (CompliancePackActivationIT step 3 failing while step 4 passed).
-            activations.save(entity).map { saved ->
+            //
+            // The write is a CONDITIONAL update, not a blind save. The `require` above tested a
+            // snapshot read in a different transaction, so on its own it cannot stop two decisions
+            // arriving together from both passing and both writing — and the approve leg would then
+            // activate the pack whether or not its write won, leaving a REJECTED row next to a pod
+            // enforcing the pack it refused. `compareAndSetDecision` re-tests PROPOSED inside the
+            // UPDATE, so exactly one decision claims the row; everyone else is refused here, with
+            // the same 400 they would have received a second later.
+            activations.compareAndSetDecision(entity).map { claimed ->
+                require(claimed == 1) {
+                    "Activation proposal $proposalId was decided concurrently and is no longer decidable"
+                }
                 if (approve) registry.activate(decided)
-                saved.toView()
+                entity.toView()
             }
         }
 

--- a/openbank-lending-service/src/test/kotlin/com/openbank/lending/application/usecase/CompliancePackActivationServiceTest.kt
+++ b/openbank-lending-service/src/test/kotlin/com/openbank/lending/application/usecase/CompliancePackActivationServiceTest.kt
@@ -100,6 +100,32 @@ class CompliancePackActivationServiceTest {
         }.isInstanceOf(IllegalArgumentException::class.java)
     }
 
+    /**
+     * Losing the race must be inert, not merely unsuccessful. The service decides in memory before
+     * it writes, so by the time the write is refused it already holds a fully-approved proposal — and
+     * `registry.activate` on that value would enforce a pack whose decision never reached the
+     * database. `CompliancePackConcurrentDecideIT` shows the race happens; this pins what the loser
+     * is allowed to do when it does, which the IT can only observe indirectly.
+     */
+    @Test
+    fun `losing the decision race refuses AND leaves the registry untouched`() {
+        val losing = object : InMemoryActivationRepository() {
+            override fun compareAndSetDecision(entity: CompliancePackActivationEntity): Uni<Int> =
+                Uni.createFrom().item(0)
+        }
+        val racedService = CompliancePackActivationService(losing, registry, clock)
+        val pending = racedService.propose(czPackJson, "maker-1").await().indefinitely()
+
+        assertThatThrownBy {
+            racedService.decide(pending.id, approve = true, checker = "checker-2", reason = null)
+                .await().indefinitely()
+        }.isInstanceOf(IllegalArgumentException::class.java)
+
+        assertThat(registry.activePack("CZ", PackProductType.CONSUMER_CREDIT, LocalDate.parse("2026-08-15")))
+            .describedAs("a decision that did not claim the row must not activate the pack")
+            .isNull()
+    }
+
     @Test
     fun `pending list shows only undecided proposals`() {
         service.propose(czPackJson, "maker-1").await().indefinitely()
@@ -112,12 +138,29 @@ class CompliancePackActivationServiceTest {
         assertThat(pending.single().packVersion).isEqualTo(1)
     }
 
-    private class InMemoryActivationRepository : CompliancePackActivationRepository {
+    private open class InMemoryActivationRepository : CompliancePackActivationRepository {
         private val rows = mutableMapOf<UUID, CompliancePackActivationEntity>()
+
+        /**
+         * The COMMITTED state, tracked apart from the entity. [rows] aliases the caller's instance,
+         * so `rows[id].state` is whatever the caller last mutated in memory — a fake that tested
+         * that field would report a transition as committed before it had been written, which is
+         * precisely the confusion `compareAndSetDecision` exists to remove. Modelling the two
+         * separately is what lets this fake refuse a second decision the way the database does.
+         */
+        private val committed = mutableMapOf<UUID, ProposalState>()
 
         override fun save(entity: CompliancePackActivationEntity): Uni<CompliancePackActivationEntity> {
             rows[entity.id] = entity
+            committed[entity.id] = entity.state
             return Uni.createFrom().item(entity)
+        }
+
+        override fun compareAndSetDecision(entity: CompliancePackActivationEntity): Uni<Int> {
+            if (committed[entity.id] != ProposalState.PROPOSED) return Uni.createFrom().item(0)
+            rows[entity.id] = entity
+            committed[entity.id] = entity.state
+            return Uni.createFrom().item(1)
         }
 
         override fun findById(id: UUID): Uni<CompliancePackActivationEntity?> = Uni.createFrom().item(rows[id])

--- a/openbank-lending-service/src/test/kotlin/com/openbank/lending/integration/CompliancePackConcurrentDecideIT.kt
+++ b/openbank-lending-service/src/test/kotlin/com/openbank/lending/integration/CompliancePackConcurrentDecideIT.kt
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.lending.integration
+
+import com.openbank.lending.it.PostgresRedisTestResource
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.security.TestSecurity
+import io.restassured.RestAssured
+import io.restassured.module.kotlin.extensions.Extract
+import io.restassured.module.kotlin.extensions.Given
+import io.restassured.module.kotlin.extensions.Then
+import io.restassured.module.kotlin.extensions.When
+import jakarta.inject.Inject
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.util.concurrent.Callable
+import java.util.concurrent.CyclicBarrier
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import javax.sql.DataSource
+
+/**
+ * The four-eyes decision on a compliance pack must be applied AT MOST ONCE, and the pack must be
+ * enforceable only if the decision that won the row was an approval.
+ *
+ * WHY THIS IS NOT COVERED BY [CompliancePackActivationIT]
+ *
+ * That test drives the workflow sequentially, so the in-memory guard in
+ * `CompliancePackActivationService.decide()` — `require(entity.state == PROPOSED)` — always sees the
+ * committed result of the previous leg and is always right. It is right for a reason that does not
+ * survive concurrency: the guard reads the row through `findById` (`@WithSession`) and writes it
+ * through `save` (`@WithTransaction`), two separate transactions with no lock, no version column and
+ * no conditional predicate between them. Two decisions arriving together therefore both read
+ * `PROPOSED`, both pass the guard, and both write — a textbook lost update on a money-path
+ * segregation-of-duties control.
+ *
+ * The harm is not "the audit trail names the wrong checker", although it does. `decide()` calls
+ * `registry.activate(decided)` on the approve leg regardless of whether that leg's write survived, so
+ * a REJECTED row can coexist with a pod that is enforcing the pack the rejection refused. Nothing
+ * reconciles the two: `CompliancePackRegistry` has no de-activation path (ADR-0212 D3), so the pod
+ * enforces the rejected pack until it restarts.
+ *
+ * WHAT THIS TEST DOES, AND WHAT IT CANNOT PROMISE
+ *
+ * It races a real approve against a real reject on the same proposal, over real HTTP, [ROUNDS] times
+ * with a fresh proposal each round, and asserts two things per round:
+ *
+ *  1. exactly one of the two requests is accepted — the other must be refused, as it would be if the
+ *     two had arrived a second apart;
+ *  2. `GET /compliance-packs/active` lists the pack **iff** the surviving row is APPROVED/EXECUTED.
+ *
+ * Assertion 2 is the money-path one and does not depend on which decision wins.
+ *
+ * This is a timing test and is therefore honest about being probabilistic: it can only fail when the
+ * race actually interleaves. It does not artificially widen the window — no sleep, no test hook in
+ * production code — so a round in which the two requests happen to serialise passes vacuously. That
+ * is why it runs [ROUNDS] rounds rather than one: the observed failure rate on unpatched code is
+ * recorded in the pull request, and a single green round proves nothing. It cannot ever produce a
+ * false RED — an accepted second decision on a PROPOSED row is a defect however the threads landed.
+ */
+@QuarkusTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@QuarkusTestResource(PostgresRedisTestResource::class)
+class CompliancePackConcurrentDecideIT {
+
+    @Inject
+    lateinit var dataSource: DataSource
+
+    private val packTemplate: String by lazy {
+        checkNotNull(javaClass.getResourceAsStream("/compliance-packs/cz-consumer-credit-v1.json")) {
+            "the shipped CZ pack must be on the test classpath"
+        }.bufferedReader().readText()
+    }
+
+    private companion object {
+        /** Rounds of the race. Each uses its own pack version so the rounds cannot interfere. */
+        const val ROUNDS = 12
+
+        /** Pack versions 900..911 — clear of the real v1 and of [CompliancePackActivationIT]'s 999. */
+        const val FIRST_VERSION = 900
+        const val BARRIER_TIMEOUT_SECONDS = 30L
+    }
+
+    /**
+     * Both requests are issued as the same checker. That is not a weakening: the four-eyes rule the
+     * domain enforces is checker != maker, and both requests satisfy it, so both reach the
+     * read-check-write window this test is about. Using two distinct checkers would exercise the same
+     * window, and `@TestSecurity` binds one identity for the whole test method.
+     */
+    @Test
+    @TestSecurity(user = "pack-race-checker", roles = ["ROLE_COMPLIANCE"])
+    fun `a concurrent approve and reject cannot both be applied to one proposal`() {
+        val pool = Executors.newFixedThreadPool(2)
+        // One list, so a run reports EVERY violation it saw rather than only the first class of
+        // them. Two separate assertions would hide the enforced-despite-rejection cases behind the
+        // double-apply ones, and the second class is the one with money-path consequences.
+        val violations = mutableListOf<String>()
+        try {
+            repeat(ROUNDS) { round ->
+                val version = FIRST_VERSION + round
+                val proposalId = propose(version)
+                val barrier = CyclicBarrier(2)
+
+                val approve = pool.submit(decideTask(barrier, proposalId, approve = true))
+                val reject = pool.submit(decideTask(barrier, proposalId, approve = false))
+                val statuses = listOf(approve.get(), reject.get())
+
+                if (statuses.count { it == 200 } > 1) {
+                    violations += "v$version: both decisions accepted (statuses=$statuses)"
+                }
+
+                val state = stateOf(proposalId)
+                val isActive = activeVersions().contains(version)
+                // The invariant that matters even when the race does not interleave: what the
+                // origination guard enforces must agree with the row that records the decision.
+                if (state == "REJECTED" && isActive) {
+                    violations += "v$version: row is REJECTED yet the pack is enforced"
+                }
+                if (state in setOf("APPROVED", "EXECUTED") && !isActive) {
+                    violations += "v$version: row is $state yet the pack is not enforced"
+                }
+            }
+        } finally {
+            pool.shutdownNow()
+        }
+
+        assertThat(violations)
+            .describedAs("four-eyes decisions that were applied more than once, or a guard that disagrees with the row")
+            .isEmpty()
+    }
+
+    private fun decideTask(barrier: CyclicBarrier, proposalId: String, approve: Boolean) = Callable {
+        barrier.await(BARRIER_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        RestAssured.given()
+            .contentType("application/json")
+            .body("""{"approve":$approve,"reason":"race probe"}""")
+            .post("/api/v1/lending/compliance-packs/proposals/$proposalId/decide")
+            .statusCode
+    }
+
+    /**
+     * Proposed by a principal that is NOT the checker, so the four-eyes rule cannot be what refuses
+     * either racer. Written over plain JDBC because `@TestSecurity` binds one identity per method and
+     * the maker leg needs a different one; the columns are exactly what the maker endpoint writes.
+     */
+    private fun propose(version: Int): String {
+        val payload = packTemplate.replace(Regex("\"version\"\\s*:\\s*1"), "\"version\": $version")
+        val id = java.util.UUID.randomUUID().toString()
+        dataSource.connection.use { conn ->
+            conn.prepareStatement(
+                """
+                INSERT INTO compliance_pack_activation
+                    (id, state, jurisdiction, product_type, pack_version, effective_from, payload,
+                     content_hash, proposed_by, proposed_at, created_at, updated_at)
+                VALUES (?::uuid, 'PROPOSED', 'CZ', 'CONSUMER_CREDIT', ?, DATE '2026-08-01', ?,
+                        ?, 'pack-race-maker', now(), now(), now())
+                """.trimIndent(),
+            ).use { st ->
+                st.setString(1, id)
+                st.setInt(2, version)
+                st.setString(3, payload)
+                st.setString(4, "race-probe-$version")
+                st.executeUpdate()
+            }
+        }
+        return id
+    }
+
+    private fun stateOf(proposalId: String): String = dataSource.connection.use { conn ->
+        conn.prepareStatement("SELECT state FROM compliance_pack_activation WHERE id = ?::uuid").use { st ->
+            st.setString(1, proposalId)
+            st.executeQuery().use { rs ->
+                check(rs.next()) { "no compliance_pack_activation row for $proposalId" }
+                rs.getString("state")
+            }
+        }
+    }
+
+    private fun activeVersions(): List<Int> = Given {
+        contentType("application/json")
+    } When {
+        get("/api/v1/lending/compliance-packs/active")
+    } Then {
+        statusCode(200)
+    } Extract {
+        jsonPath().getList("packVersion", Int::class.java)
+    }
+}


### PR DESCRIPTION
## Scope — this is the *other half* of #3467

#3467 names two defects. The replica-divergence one is already addressed by the open **#3644**
(`CompliancePackRefresher`), which I did not duplicate. This PR takes the second, which #3467 and
#3644 both explicitly split out:

> `decide()` reads the row, checks `require(entity.state == PROPOSED)`, then writes in a separate
> reactive context. Two checkers approving concurrently can both pass that guard and both merge.

The two changes do not overlap: #3644 touches `CompliancePackConfig`, `CompliancePackRefresher`,
`CompliancePackRegistry` and `application.yaml`; this touches
`CompliancePackActivationRepository` and `CompliancePackActivationService`. Verified against
`origin/main` at `4ade3a08d`, no shared file.

## The defect

`CompliancePackActivationService.decide()` reads the proposal through `findById` (`@WithSession`),
decides against that snapshot **in memory**, and writes through `save` (`@WithTransaction`). Two
transactions, no lock, no version column, no conditional predicate. Two decisions arriving together
both observe `PROPOSED`, both pass `require(entity.state == PROPOSED)`, and both write.

The harm is not only that the audit trail names one checker while two acted. `decide()` calls
`registry.activate(decided)` on the approve leg **whether or not that leg's write survived**, so a
`REJECTED` row can coexist with a pod that is enforcing the pack the rejection refused — and
`CompliancePackRegistry` has no de-activation path (ADR-0212 D3), so the pod enforces the rejected
rule set until it restarts. On a money-path segregation-of-duties control that is not a stale cache.

## Proven RED first — and the red output

`CompliancePackConcurrentDecideIT` was written and run **before** any production change, against
`origin/main`. It races a real approve against a real reject on the same proposal over real HTTP,
12 rounds with a fresh proposal each round, synchronised on a `CyclicBarrier`.

```
java.lang.AssertionError: [a second decision was accepted on an already-decided proposal]
Expecting empty but was: ["v900 accepted=[200, 200]",
    "v901 accepted=[200, 200]",
    "v902 accepted=[200, 200]",
    "v903 accepted=[200, 200]",
    "v905 accepted=[200, 200]",
    "v906 accepted=[200, 200]",
    "v907 accepted=[200, 200]",
    "v909 accepted=[200, 200]",
    "v910 accepted=[200, 200]",
    "v911 accepted=[200, 200]"]
```

**10 of 12 rounds accepted both decisions.** Rounds 904 and 908 happened to serialise — that is the
test being honest rather than the defect being intermittent.

The assertions were then merged into one list so a run reports every violation class it saw rather
than only the first; the red output above is from the earlier two-assertion form, which is why it
shows only the double-apply class.

## The fix

`compareAndSetDecision` re-tests `PROPOSED` **inside** the UPDATE:

```
update CompliancePackActivationEntity
   set state = :state, decidedBy = :decidedBy, decidedAt = :decidedAt,
       decisionReason = :reason, updatedAt = :updatedAt
 where id = :id and state = :from
```

The database evaluates the predicate and the assignment in one statement, so exactly one of any
number of concurrent deciders claims the row. It returns the row count; `decide()` treats `0` as a
refusal — the same `400` the caller would have received a second later — and only the claimant
reaches `registry.activate`.

Named parameters rather than Panache's positional `update(String, vararg Any)` because
`decisionReason` is nullable and the vararg cannot carry a null.

**Why not a `@Version` column:** it would work, but it needs a Flyway migration on a live table, and
optimistic locking would surface as an `OptimisticLockException` that has to be mapped back to a
sensible status. The predicate is already exactly the invariant (`state == PROPOSED`), costs no
schema change, and the refusal path is the one that already exists.

**Why not a row lock:** `SELECT ... FOR UPDATE` would hold a transaction open across the pack
compile in `toProposal()`, which is the expensive part of this call.

## Verification

| | result |
|---|---|
| `CompliancePackConcurrentDecideIT` on unpatched `main` | **FAILED** — 10/12 rounds double-applied (output above) |
| same test, with the fix | **PASSED**, three independent runs |
| `CompliancePackActivationIT` (existing, 4 tests) | PASSED |
| `CompliancePackActivationServiceTest` (existing 7 + 1 new) | PASSED |
| `:openbank-lending-service:test` (full suite) | PASSED |
| `ktlintCheck`, `detekt` | PASSED |
| `:openbank-lending-service:quarkusBuild` | PASSED (CDI wiring — unit tests do not check it) |
| `threat-model-coverage` gate | PASSED |

The new unit test — `losing the decision race refuses AND leaves the registry untouched` — pins the
part the IT can only observe indirectly: the service decides in memory *before* it writes, so when
the write is refused it is already holding a fully-approved proposal, and it must not activate it.

The in-memory fake repository had to change to model this honestly. It aliased the caller's entity,
so `rows[id].state` was whatever the caller last mutated — a fake testing that field would report a
transition as committed before it was written, which is the exact confusion the conditional update
exists to remove. It now tracks committed state separately.

## No schema, no API change

- **No Flyway migration.** The predicate uses the existing `state` column, so the `migrate-at-start`
  trap does not apply here.
- **No `openapi.yaml` change.** `400` is already the declared response for
  `POST /compliance-packs/proposals/{id}/decide`; the concurrent-decision refusal reuses it via the
  existing `IllegalArgumentException` → 400 mapping in `CompliancePackResource`.
- `version.txt` untouched — release-please owns it. This is a `fix` touching `src/main`, so it
  releases.

## What I did NOT verify, and what could still be wrong

Stated plainly rather than buried.

1. **The IT is a timing test and cannot promise to go red.** It does not widen the window
   artificially — no sleep, no test hook in production code — so a round in which the two requests
   serialise passes vacuously. It cannot produce a false *red* (an accepted second decision on a
   PROPOSED row is a defect however the threads landed), but on a slower or busier runner the
   observed rate could differ from the 10/12 measured here, and in principle a run could be green
   against broken code. **This is the honest answer to "could your test pass against the OLD code":
   yes, with low probability per round, ~1/6 empirically per round and so very unlikely across 12.**
   I chose not to inflate the round count further because each round is a full propose+race+two
   queries and the suite already costs ~2 min.
2. **I did not test more than two concurrent deciders.** The conditional UPDATE is correct for N by
   construction, but only N=2 is measured.
3. **I did not verify behaviour under `READ COMMITTED` vs other isolation levels explicitly.** The
   test ran against the Testcontainers Postgres default (`READ COMMITTED`), which is also the
   deployed default; a single-statement conditional UPDATE is atomic there, but I did not exercise
   any other level.
4. **I did not run this against a real multi-replica deployment.** Both racers hit one JVM. That is
   the right scope — the defect is a database-level lost update, not a JVM one, and the fix is in
   the statement — but it is not a live multi-pod proof.
5. **`registry.activate` is still not transactional with the row.** If the process dies between the
   committed UPDATE and the in-memory activate, this pod is behind until convergence or restart.
   That is #3644's territory, not this PR's, and I have not closed it.
6. **I did not survey other four-eyes decide paths in this service for the same shape.**
   `LendingService.decide()` (collateral) and the origination `lending.approve` path look
   structurally similar and may carry the identical read-check-write defect. I did not measure them,
   so I am not claiming either way — worth its own issue rather than a claim here.
7. **I did not re-verify #3644 is still current** beyond confirming it is open, mergeable, and
   touches no file this PR touches.

## Merge expectation

`openbank-lending-service` is money-path: 2 human approvals by rule. This PR is **not expected to
merge** on my action, and that is the correct outcome.

Refs #3467, #3644, ADR-0212 D4

🤖 Generated with [Claude Code](https://claude.com/claude-code)
