### PR TITLE
ci(governance): gate the self-hosted residency LABEL that ADR-0175 D3 will rely on

### DIFF
--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -208,6 +208,32 @@ gates:
       python3 .github/scripts/check-agent-virtual-keys.py --self-test
       python3 .github/scripts/check-agent-virtual-keys.py --enforce
 
+  - id: model-residency-claims
+    name: "a `sensitivity: self-hosted` model entry points in-cluster (ADR-0175 D3, issue #3599)"
+    group: gitops
+    mode: enforced
+    selftest: python3 .github/scripts/check-model-residency-claims.py --self-test
+    selftest_expect: pass
+    run: |
+      # Falsified BOTH ways before wiring in — the distinction this gate exists for is
+      # routed-to-EU vs routed-ANYWHERE, and a check that cannot tell those apart is
+      # worthless as a residency control.
+      #   Detection: 24 self-test cases, the first being the exact defect — a `self-hosted`
+      #   LABEL on `https://api.groq.com/openai/v1`. Also the underscore/mixed-case spellings
+      #   ModelGateway.parseSensitivity accepts, an env placeholder with an off-cluster
+      #   default, one with NO default, a userinfo smuggling attempt, and the near-misses it
+      #   must NOT flag (a `hosted` entry on the same US endpoint; a typo'd sensitivity,
+      #   which the Kotlin also reads as hosted).
+      #   Scope: both real service shapes were fed the violation and both went red with the
+      #   real path — agent-service's top-level `model-gateway` and copilot-service's nested
+      #   `copilot.model-gateway`. In that state the Kotlin fail-closed test stays GREEN
+      #   (a self-hosted model IS registered), which is precisely why the gate is needed.
+      # LIMIT, stated so nobody reads this as more than it is: CONFIG-LEVEL only. It proves
+      # the committed config cannot express an off-cluster self-hosted tier. It observes no
+      # request and cannot prove the host behind an in-cluster address is EU-resident — the
+      # egress NetworkPolicy is what constrains that, not this.
+      python3 .github/scripts/check-model-residency-claims.py --enforce
+
   - id: oidc-secret-convention
     name: "the OIDC client secret is read from ONE KV entry (issue #3485, enforced, baseline-ratcheted)"
     group: gitops

--- a/.github/scripts/check-model-residency-claims.py
+++ b/.github/scripts/check-model-residency-claims.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+"""A `sensitivity: self-hosted` model entry must point somewhere actually in-cluster.
+
+WHY THIS EXISTS (ADR-0175 D3, issue #3599).
+
+`ModelGateway.resolve()` is the data-residency control for LLM prompt content: when a caller
+passes `sensitive=true` it refuses the requested model and instead picks
+
+    registry.values.firstOrNull { it.sensitivity == Sensitivity.SELF_HOSTED }
+
+...failing closed with "sensitive request but no self-hosted model registered" if there is none.
+That fail-closed half is real and is covered by a falsifying unit test in both gateway copies.
+
+What NOTHING checks is the other half. `sensitivity` is a free-text field on a `model-gateway.
+models[]` entry, and `parseSensitivity` only compares the STRING: any entry may declare itself
+`self-hosted` while its `endpoint` points at a hosted US provider. The moment ADR-0175 D3's EU
+tier is registered -- the entire point of the issue -- a mislabelled or mis-typed endpoint sends
+class-1/2 prompt content to a US provider under a GDPR Chapter V control that every layer reports
+as working: the gateway logs `sensitive routing: X -> Y`, the fail-closed test still passes
+(a self-hosted model IS registered), and the EU AI Act inventory reads the residency claim off
+`agents.yaml` and renders it as a control.
+
+That is a green signal that cannot distinguish routed-to-EU from routed-anywhere. This gate is
+the layer at which that distinction is expressible in this repo, so it is the layer that asserts
+it.
+
+WHAT IT CANNOT DO -- read this before treating it as coverage. This is a CONFIG-LEVEL gate. It
+proves that the committed configuration cannot express an off-cluster self-hosted tier. It does
+NOT observe a single request, cannot see where a packet actually went, and cannot prove that the
+host behind an in-cluster address is EU-resident (an in-cluster Service could proxy anywhere --
+the egress NetworkPolicy, not this gate, is what constrains that). Runtime residency is not
+observable from this repository at all.
+
+THE RULES
+  R1  A self-hosted entry must declare an `endpoint`. Without one, the residency claim rests on
+      nothing at all.
+  R2  That endpoint must resolve to an in-cluster address (`*.svc`, `*.svc.cluster.local`,
+      `localhost`, `127.0.0.1`) -- as a literal, or as the DEFAULT of a `${VAR:default}`
+      placeholder. A public FQDN is rejected. An env placeholder with NO default is rejected
+      too: a residency claim whose target is supplied entirely at runtime cannot be verified
+      from the repo, which is the same as unverified.
+  R3  `agents.yaml: model_gateway_as_built.routing` and the registered tiers must agree, in
+      BOTH directions. `routing: none` while a self-hosted entry exists understates a live
+      control; anything other than `none` while no self-hosted entry exists is the machine-
+      claimed-but-absent control that issue #1280 already had to unwind once.
+
+Run standalone:  .github/scripts/check-model-residency-claims.py [--enforce]
+Self-test:       .github/scripts/check-model-residency-claims.py --self-test
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+REPO = Path(__file__).resolve().parents[2]
+AGENTS_YAML = REPO / "openbank-libs" / "governance" / "agents.yaml"
+
+# Mirrors ModelGateway.parseSensitivity: trim, lowercase, three accepted spellings. Kept in
+# lockstep deliberately -- a spelling this gate does not know but the Kotlin does would be a
+# self-hosted tier the gate never inspects.
+SELF_HOSTED_SPELLINGS = {"self-hosted", "self_hosted", "selfhosted"}
+
+# An address that cannot leave the cluster on its own. `.svc` covers the Kubernetes DNS forms;
+# localhost covers a sidecar. Anything else is a public name until proven otherwise.
+IN_CLUSTER = re.compile(
+    r"^(?:[a-z0-9-]+\.)*[a-z0-9-]+\.svc(?:\.cluster\.local)?$|^localhost$|^127\.0\.0\.1$"
+)
+
+ENV_PLACEHOLDER = re.compile(r"^\$\{([A-Za-z_][A-Za-z0-9_]*)(?::(.*))?\}$")
+
+
+def is_self_hosted(raw) -> bool:
+    return isinstance(raw, str) and raw.strip().lower() in SELF_HOSTED_SPELLINGS
+
+
+def host_of(url: str) -> str | None:
+    """Bare host of a URL, lowercased, port stripped. None when it does not look like one."""
+    m = re.match(r"^[a-z][a-z0-9+.-]*://([^/?#]+)", url.strip(), re.I)
+    if not m:
+        return None
+    authority = m.group(1)
+    authority = authority.rsplit("@", 1)[-1]          # strip any userinfo
+    return authority.rsplit(":", 1)[0].strip("[]").lower() if ":" in authority else authority.lower()
+
+
+def endpoint_findings(entry_id: str, endpoint, where: str) -> list[str]:
+    """R1 + R2 for one entry. Returns one message per distinct problem."""
+    if endpoint is None or (isinstance(endpoint, str) and not endpoint.strip()):
+        return [f"{where}: model '{entry_id}' declares sensitivity self-hosted but has NO endpoint "
+                f"— the residency claim rests on nothing (R1)."]
+    if not isinstance(endpoint, str):
+        return [f"{where}: model '{entry_id}' has a non-string endpoint ({endpoint!r}) (R1)."]
+
+    target = endpoint.strip()
+    placeholder = ENV_PLACEHOLDER.match(target)
+    if placeholder:
+        var, default = placeholder.group(1), placeholder.group(2)
+        if default is None or not default.strip():
+            return [f"{where}: model '{entry_id}' is self-hosted but its endpoint is ${{{var}}} "
+                    f"with no default — the residency target is supplied entirely at runtime and "
+                    f"cannot be verified from this repo (R2)."]
+        target = default.strip()
+
+    host = host_of(target)
+    if host is None:
+        return [f"{where}: model '{entry_id}' is self-hosted but its endpoint '{target}' is not a "
+                f"URL this gate can resolve to a host (R2)."]
+    if not IN_CLUSTER.match(host):
+        return [f"{where}: model '{entry_id}' declares sensitivity self-hosted but its endpoint "
+                f"resolves to '{host}', which is NOT in-cluster. Sensitive-context prompts routed "
+                f"to it leave the cluster — and every layer above still reports the residency "
+                f"control as working (R2)."]
+    return []
+
+
+def walk_model_gateways(node, where: str, path: str = "") -> list[tuple[str, list]]:
+    """Every `model-gateway.models` list at any depth (copilot nests its own under `copilot:`)."""
+    found = []
+    if isinstance(node, dict):
+        for key, value in node.items():
+            here = f"{path}.{key}" if path else str(key)
+            if key == "model-gateway" and isinstance(value, dict):
+                models = value.get("models")
+                if isinstance(models, list):
+                    found.append((f"{where} [{here}]", models))
+            found.extend(walk_model_gateways(value, where, here))
+    elif isinstance(node, list):
+        for i, value in enumerate(node):
+            found.extend(walk_model_gateways(value, where, f"{path}[{i}]"))
+    return found
+
+
+def audit_models(models: list, where: str) -> tuple[list[str], int]:
+    """R1+R2 over one models list. Returns (findings, self_hosted_count)."""
+    findings, count = [], 0
+    for entry in models or []:
+        if not isinstance(entry, dict) or not is_self_hosted(entry.get("sensitivity")):
+            continue
+        count += 1
+        findings.extend(endpoint_findings(str(entry.get("id", "<unnamed>")), entry.get("endpoint"), where))
+    return findings, count
+
+
+def audit_routing_record(routing, self_hosted_total: int) -> list[str]:
+    """R3, both directions."""
+    declared = str(routing).strip().lower() if routing is not None else "none"
+    if declared == "none" and self_hosted_total > 0:
+        return [f"agents.yaml: model_gateway_as_built.routing is 'none' but {self_hosted_total} "
+                f"self-hosted model entr(ies) are registered. The EU AI Act inventory is generated "
+                f"from this field, so it understates a control that exists (R3)."]
+    if declared != "none" and self_hosted_total == 0:
+        return [f"agents.yaml: model_gateway_as_built.routing declares '{declared}' but NO "
+                f"self-hosted model entry is registered anywhere. That is a machine-claimed "
+                f"residency control with nothing behind it — the exact shape issue #1280 had to "
+                f"unwind from 34 OPA bundles (R3)."]
+    return []
+
+
+def audit() -> list[str]:
+    findings, self_hosted_total = [], 0
+    sources = sorted(REPO.glob("openbank-*/src/main/resources/application.yaml"))
+    for src in sources:
+        try:
+            data = yaml.safe_load(src.read_text()) or {}
+        except yaml.YAMLError as exc:
+            findings.append(f"{src.relative_to(REPO)}: unparseable YAML ({exc.__class__.__name__}).")
+            continue
+        for where, models in walk_model_gateways(data, str(src.relative_to(REPO))):
+            f, n = audit_models(models, where)
+            findings.extend(f)
+            self_hosted_total += n
+
+    agents = yaml.safe_load(AGENTS_YAML.read_text()) or {}
+    routing = (agents.get("model_gateway_as_built") or {}).get("routing")
+    findings.extend(audit_routing_record(routing, self_hosted_total))
+    return findings
+
+
+def self_test() -> int:
+    """Every case the gate MUST reject, and the near-misses it must NOT. The first case is the
+    whole point of the gate: a self-hosted LABEL on a hosted US endpoint."""
+    model_cases = [
+        ("a self-hosted label on a hosted US endpoint is REJECTED",
+         [{"id": "eu-tier", "sensitivity": "self-hosted",
+           "endpoint": "https://api.groq.com/openai/v1"}], 1),
+        ("an in-cluster Service endpoint passes",
+         [{"id": "vllm", "sensitivity": "self-hosted", "endpoint": "http://vllm.copilot.svc:8000"}], 0),
+        ("svc.cluster.local passes",
+         [{"id": "v", "sensitivity": "self-hosted",
+           "endpoint": "http://vllm.ai-platform.svc.cluster.local:8000"}], 0),
+        ("a self-hosted entry with no endpoint at all is REJECTED",
+         [{"id": "v", "sensitivity": "self-hosted"}], 1),
+        ("an env placeholder whose DEFAULT is off-cluster is REJECTED",
+         [{"id": "v", "sensitivity": "self-hosted",
+           "endpoint": "${EU_MODEL_ENDPOINT:https://api.deepinfra.com/v1}"}], 1),
+        ("an env placeholder with an in-cluster default passes",
+         [{"id": "v", "sensitivity": "self-hosted",
+           "endpoint": "${EU_MODEL_ENDPOINT:http://vllm.ai-platform.svc:8000}"}], 0),
+        ("an env placeholder with NO default is REJECTED (unverifiable from the repo)",
+         [{"id": "v", "sensitivity": "self-hosted", "endpoint": "${EU_MODEL_ENDPOINT}"}], 1),
+        ("the underscore spelling ModelGateway also accepts is inspected, not skipped",
+         [{"id": "v", "sensitivity": "self_hosted", "endpoint": "https://api.groq.com/v1"}], 1),
+        ("mixed case and padding are normalised like parseSensitivity does",
+         [{"id": "v", "sensitivity": "  Self-Hosted  ", "endpoint": "https://api.groq.com/v1"}], 1),
+        ("a HOSTED entry on a US endpoint is not this gate's business",
+         [{"id": "v", "sensitivity": "hosted", "endpoint": "https://api.groq.com/v1"}], 0),
+        ("a typo'd sensitivity is HOSTED to the Kotlin too, so it is not inspected",
+         [{"id": "v", "sensitivity": "self hosted", "endpoint": "https://api.groq.com/v1"}], 0),
+        ("localhost (a sidecar) passes",
+         [{"id": "v", "sensitivity": "self-hosted", "endpoint": "http://localhost:8000/v1"}], 0),
+        ("a bare hostname that is not a URL is REJECTED rather than silently accepted",
+         [{"id": "v", "sensitivity": "self-hosted", "endpoint": "vllm.ai-platform.svc:8000"}], 1),
+        ("userinfo cannot smuggle an in-cluster name past the host check",
+         [{"id": "v", "sensitivity": "self-hosted",
+           "endpoint": "http://vllm.ai-platform.svc@api.groq.com/v1"}], 1),
+        ("a non-dict entry does not crash the walk", ["nonsense"], 0),
+        ("an empty list is clean", [], 0),
+    ]
+    routing_cases = [
+        ("routing 'none' with no tier is today's honest state", "none", 0, 0),
+        ("routing 'none' while a tier IS registered is record drift", "none", 1, 1),
+        ("a routing claim with no tier behind it is REJECTED", "class-based", 0, 1),
+        ("a routing claim backed by a tier passes", "class-based", 1, 0),
+        ("a missing routing key is read as 'none'", None, 0, 0),
+    ]
+    walk_cases = [
+        ("a nested model-gateway (copilot's shape) is found",
+         {"copilot": {"model-gateway": {"models": [{"id": "a"}]}}}, 1),
+        ("a top-level model-gateway (agent-service's shape) is found",
+         {"model-gateway": {"models": [{"id": "a"}]}}, 1),
+        ("a model-gateway with no models list yields nothing",
+         {"model-gateway": {"default-model": "x"}}, 0),
+    ]
+
+    failed = 0
+    for name, models, expected in model_cases:
+        got = len(audit_models(models, "test")[0])
+        ok = got == expected
+        failed += not ok
+        print(f"  {'PASS' if ok else 'FAIL'}  {name} (expected {expected}, got {got})")
+    for name, routing, count, expected in routing_cases:
+        got = len(audit_routing_record(routing, count))
+        ok = got == expected
+        failed += not ok
+        print(f"  {'PASS' if ok else 'FAIL'}  {name} (expected {expected}, got {got})")
+    for name, tree, expected in walk_cases:
+        got = len(walk_model_gateways(tree, "test"))
+        ok = got == expected
+        failed += not ok
+        print(f"  {'PASS' if ok else 'FAIL'}  {name} (expected {expected}, got {got})")
+
+    total = len(model_cases) + len(routing_cases) + len(walk_cases)
+    print(f"self-test: {total - failed}/{total} passed")
+    return 1 if failed else 0
+
+
+def main() -> int:
+    if "--self-test" in sys.argv:
+        return self_test()
+    enforce = "--enforce" in sys.argv
+    findings = audit()
+    if not findings:
+        print("check-model-residency-claims: OK — no self-hosted model entry points off-cluster, "
+              "and the agents.yaml routing record agrees with the registered tiers.")
+        print("Scope: CONFIG-LEVEL only. This gate cannot observe where a request actually went.")
+        return 0
+    for f in findings:
+        print(f"{'::error::' if enforce else '::warning::'}{f}")
+    print(f"\n{len(findings)} problem(s). A self-hosted LABEL is the whole of the ADR-0175 D3 "
+          f"residency control: ModelGateway.resolve() trusts it, the fail-closed test passes as "
+          f"soon as any entry carries it, and gen-eu-ai-act.py renders it as a control.")
+    return 1 if enforce else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What this does

Adds an **enforced** gate, `model-residency-claims`, that makes the `sensitivity: self-hosted`
label on a model-gateway entry mean something.

`ModelGateway.resolve()` is the ADR-0175 D3 residency control for LLM prompt content. On
`sensitive=true` it refuses the requested model and picks the first entry whose
`sensitivity == SELF_HOSTED`, failing closed when there is none. That half is real and both
gateway copies carry a falsifying test for it.

**Nothing checks the other half.** `sensitivity` is free text and `parseSensitivity` only compares
the string, so an entry can declare itself `self-hosted` while its `endpoint` points at a hosted
US provider. The moment #3599's EU tier is registered — the point of the issue — a mislabelled or
mis-typed endpoint sends class-1/2 prompt content off-cluster while every layer above reports the
control as working:

- the gateway logs `sensitive routing: X -> Y`,
- the fail-closed unit test still passes (a self-hosted model **is** registered),
- `gen-eu-ai-act.py` reads the routing record and renders it as a control.

That is a green signal that cannot distinguish *routed-to-EU* from *routed-anywhere*.

### The rules

| | |
|---|---|
| **R1** | a self-hosted entry must declare an `endpoint` |
| **R2** | it must resolve in-cluster (`*.svc`, `*.svc.cluster.local`, `localhost`) — as a literal or as the **default** of `${VAR:default}`. A public FQDN is rejected; so is an env placeholder with **no** default, whose target is supplied entirely at runtime and cannot be verified from the repo. |
| **R3** | `agents.yaml: model_gateway_as_built.routing` agrees with the registered tiers **in both directions** — `none` while a tier exists understates a live control; a routing claim with no tier behind it is the machine-claimed-but-absent shape #1280 had to unwind from 34 OPA bundles. |

## Falsification — both scope and detection

**Detection** — 24 self-test cases. The first is the exact defect: a `self-hosted` label on
`https://api.groq.com/openai/v1`. Also covered: the underscore/mixed-case spellings the Kotlin
accepts, an env default that is off-cluster, an env placeholder with no default, a userinfo
smuggling attempt (`http://vllm.ai-platform.svc@api.groq.com/v1`), and the near-misses it must
**not** flag — a `hosted` entry on the same US endpoint, and a typo'd `sensitivity` (which the
Kotlin also reads as hosted, so flagging it would be wrong).

**Scope** — a self-test proves logic, not reach. Both real service shapes were fed the violation
in the working tree and both went red with real paths:

```
::error::openbank-agent-service/.../application.yaml [model-gateway]: model 'eu-tier-FAKE'
  declares sensitivity self-hosted but its endpoint resolves to 'api.groq.com', which is NOT
  in-cluster. ... (R2)
::error::agents.yaml: model_gateway_as_built.routing is 'none' but 1 self-hosted model
  entr(ies) are registered. ... (R3)
```

```
::error::openbank-copilot-service/.../application.yaml [copilot.model-gateway]: model
  'eu-tier-FAKE' is self-hosted but its endpoint is ${COPILOT_EU_ENDPOINT} with no default —
  the residency target is supplied entirely at runtime ... (R2)
```

Both files were restored (`git status` clean). In that injected state the Kotlin fail-closed test
stays **green** — which is the whole argument for the gate.

Gate + self-test run clean through the runner (`run-gates.py --only model-residency-claims`), and
the `gitops` shard is unchanged apart from two pre-existing failures unrelated to this change
(`loki-rule-load-test`, `incluster-hostname-resolution`).

## What this does NOT do — please read before treating it as coverage

- **It is CONFIG-LEVEL and only that.** It proves the committed configuration cannot express an
  off-cluster self-hosted tier. It observes **no request**, and runtime residency is not
  observable from this repository at all.
- It **cannot** prove the host behind an in-cluster address is EU-resident — an in-cluster Service
  could proxy anywhere. The egress NetworkPolicy constrains that, not this gate.
- It **does not close #3599.** D3's actual blocker is an owner decision (self-hosted vLLM on a
  Karpenter GPU pool vs. an EU provider with DPA + regional pinning), and no code here can make it.
  This is the guard rail that has to exist *before* that tier is registered, not the tier.
- I did **not** touch `agents.yaml`. A one-line comment there would have restamped every OPA
  bundle (each `gen-*-opa-bundle.sh` embeds `agents.yaml` verbatim and hashes it into the
  `policy-checksum` pod-roll annotation) and rolled every policy-bearing pod. Not worth it for
  prose. `routing: none` is already the honest record.

**Pod roll: none.** No `.rego`, no `rules.yaml`, no `agents.yaml`, no gitops manifest, no service
code. `.github/` only.

## Validation I could not perform

`ai-platform/litellm-db` is currently in phase *"Not enough disk space"* (full 2Gi PVC, single
instance, no successful backups — owner's capacity call, #3555). **Nothing in this PR depends on
that** — the gate is a static reader of committed YAML and never contacts LiteLLM — but it does
mean the end-to-end path this gate guards could not have been exercised live tonight even had a
tier existed. I did not attempt any cluster change.

## Self-evaluation — what could still be wrong

- **The in-cluster regex is a heuristic.** `*.svc` / `svc.cluster.local` / `localhost` /
  `127.0.0.1`. A private IP (`10.x`) or an EU provider FQDN with a DPA would be rejected today.
  That errs toward false-positive, which for a residency control is the right direction, but it
  means registering a *contracted* EU provider needs a deliberate widening of R2 with a stated
  reason — by design, not an oversight.
- **`SELF_HOSTED_SPELLINGS` duplicates `parseSensitivity`.** A spelling added to the Kotlin and
  not here would be a self-hosted tier the gate never inspects. There is no gate on that gate;
  the Kotlin is 3 lines and stable, but it is a real seam.
- **Scope is `openbank-*/src/main/resources/application.yaml`.** A model registered only via a
  gitops env override, a profile file, or a `%prod.` block is out of scope. Only the two known
  gateways exist today, but a third registered elsewhere would be invisible.
- **`ModelGateway` still exists twice** (agent-service and copilot-service, ~92 diff-lines apart
  per the owner's #3599 comment). This gate covers both configs, so it is drift-tolerant on this
  axis — but the duplication itself is untouched and licence-blocked (both AGPL, libs is Apache).
- **Blast radius:** a new enforced gate on every PR. If R1–R3 are wrong it blocks merges; it
  cannot break a running service, deploy anything, or change a manifest. Cost is ~0.4s CPU in an
  existing shard.

Refs #3599, ADR-0175 D3, ADR-0031 D6, ADR-0174

🤖 Generated with [Claude Code](https://claude.com/claude-code)
