### PR TITLE
fix(gitops): make the Keycloak realm templates actually importable

### DIFF
--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -1899,6 +1899,32 @@ gates:
     mode: enforced
     run: |
       python3 .github/scripts/check-roles-allowed-realm.py
+  # Keycloak realm templates must be IMPORTABLE (issue #3246). The three existing realm checks
+  # all compare NAME SETS — @RolesAllowed vs template, template vs live, template vs the import
+  # artifact — and every one of them is perfectly happy with a document Keycloak refuses to
+  # parse. Measured against quay.io/keycloak/keycloak:26.6.3 (the tag keycloak.yaml runs), the
+  # customers template had FOUR independent import-blocking defects and could never have
+  # rebuilt its realm: five `"comment"` keys (Jackson fails the whole import on an unrecognized
+  # field), a 490-char client description over the 255 column cap, a 37-char authenticator in a
+  # VARCHAR(36) column, and a composite referencing built-in roles an explicit-roles import does
+  # not create. Plus two confidential clients with no `secret`, so a rebuilt realm would issue
+  # random credentials neither service presents.
+  # Nothing could have caught any of it: `--import-realm` runs on COLD START ONLY and skips a
+  # realm that already exists, so the template is inert on every deploy, restart and DR restore,
+  # and ArgoCD is Synced/Healthy about a Secret it does not manage. The first observation of the
+  # defect would have been the rebuild it existed to survive.
+  # ENFORCED, because every rule is a fact about the file (a column width, a duplicate key, a
+  # missing field), never a judgement. A static gate cannot enumerate Keycloak's schema, so it
+  # narrows the window rather than closing it — components/keycloak/README.md keeps the real
+  # `docker run ... --import-realm` recipe, which is still required before changing a template.
+  - id: realm-template-importable
+    name: "Keycloak realm templates must be importable (issue #3246, enforced)"
+    group: security
+    mode: enforced
+    selftest: python3 .github/scripts/check-realm-template-importable.py --self-test
+    selftest_expect: pass
+    run: |
+      python3 .github/scripts/check-realm-template-importable.py
   - id: opa-bundle-apply-size
     name: OPA bundle must be installable (client-side apply annotation ceiling)
     group: gitops

--- a/.github/scripts/check-realm-template-importable.py
+++ b/.github/scripts/check-realm-template-importable.py
@@ -1,0 +1,425 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+#
+# Gate: can the committed Keycloak realm templates actually be IMPORTED? (issue #3246)
+#
+# WHY THIS EXISTS
+#   #3246 measured that the realm JSON Keycloak imports is a stale ancestor of the committed
+#   template (4 roles / 2 clients against 14 / 10). Reconciling the two is an owner-gated Vault
+#   write (runbook 0009). While preparing that write, the templates were run against the real
+#   Keycloak the cluster deploys — quay.io/keycloak/keycloak:26.6.3 — and the CUSTOMERS template
+#   did not import at all:
+#
+#     ERROR: Failed to run import
+#     ERROR: Unrecognized field "comment" (class ...ProtocolMapperRepresentation), not marked as
+#       ignorable ... ["clients"]->[0]->["protocolMappers"]->[1]->["comment"]
+#
+#   Keycloak deserializes a realm with Jackson and fails the WHOLE import on one unknown field.
+#   JSON has no comment syntax and Keycloak's schema has no comment field, so the five `"comment"`
+#   keys someone added for the next reader made the file unimportable. So the template was not
+#   merely a superset of the deployed artifact — it could never have rebuilt its realm, which is
+#   the property #3246 is actually about.
+#
+#   Nothing could have caught that. `--import-realm` runs on COLD START ONLY, and it skips a realm
+#   that already exists, so the template is inert on every deploy, every restart and every DR
+#   restore. ArgoCD is Synced/Healthy about a Secret it does not manage; the three existing realm
+#   checks (check-roles-allowed-realm, check-realm-role-parity, check-realm-import-parity) all
+#   compare NAME SETS and are perfectly happy with a document Keycloak refuses to parse. The first
+#   observation of the defect is the rebuild it was supposed to survive.
+#
+# WHAT THIS CHECKS, AND WHAT IT HONESTLY CANNOT
+#   A static gate CANNOT enumerate Keycloak's representation schema — that lives in Jackson
+#   annotations inside the server jar, it is version-specific, and it is not published in any form
+#   this repo can read offline. So this gate does not claim "the template imports". It claims:
+#   none of the defect classes below is present. They are the ones that (a) fail the entire import
+#   or silently produce a broken realm, and (b) are decidable from the file alone:
+#
+#     R1  a `comment`/`note`/`_comment`/`_doc`/`description_` key anywhere. Prose-in-JSON is the
+#         measured defect. Prose goes in components/keycloak/README.md, keyed by path.
+#     R2  a client `description` over 255 chars — Keycloak's column cap; a longer one fails the
+#         whole import. `openbank-edge-webauthn` was at 490.
+#     R3  a confidential client (`publicClient: false`) with no `secret`. Keycloak generates a
+#         random one on import, so a rebuilt realm issues credentials the service does not
+#         present — an auth outage that looks nothing like a missing JSON field.
+#     R4  a `secret` or `credentials[].value` that is NOT a `__PLACEHOLDER__` token. This repo is
+#         PUBLIC; a literal secret in a realm template is a disclosure, not a style problem.
+#     R5  a login-capable user missing `firstName`/`lastName`/`email` — Keycloak 26 answers
+#         "Account is not fully set up" at login with no hint why. `service-account-*` users are
+#         exempt: they never log in interactively, both real ones lack all three fields, and the
+#         template carrying them imports cleanly against 26.6.3. That carve-out exists because
+#         the first run of this gate produced it as a false positive on a correct file.
+#     R6  the file is not valid JSON at all.
+#     R7  a duplicate key in the same JSON object. Every JSON parser silently keeps the LAST
+#         occurrence, so the other one is discarded with no error anywhere — the same failure
+#         mode the repo already documents for duplicate YAML keys in application.yaml.
+#         `customers-realm-template.json` declared `authenticationFlows` twice, an empty array
+#         and the real four-flow list.
+#     R8  an `authenticationExecutions[].authenticator` over 36 characters. Keycloak's
+#         AUTHENTICATION_EXECUTION.AUTHENTICATOR column is VARCHAR(36) in the Liquibase
+#         changelog, so a longer value aborts the import mid-transaction with a raw SQL error
+#         ("Value too long for column ..."), not a validation message. The customers template
+#         carried `webauthn-register-passwordless-action` (37) — which also proves the live
+#         realm cannot contain it, since the same constraint applies to the deployed Postgres.
+#     R9  a composite realm role referencing a realm role the template does not declare. A full
+#         import with an explicit `roles.realm` list does NOT get Keycloak's automatic built-in
+#         realm roles, so the import aborts with "Unable to find composite realm role: <name>".
+#         `default-roles-openbank-customers` composed `offline_access` and `uma_authorization`,
+#         neither declared.
+#
+#   Measured on the pre-fix templates: 12 findings, covering R1 (×5), R2, R3 (×2), R7, R8 and R9.
+#   Each was independently confirmed against the real container — the customers realm needed all
+#   four import-blockers removed before `Realm 'openbank-customers' imported` appeared.
+#
+#   The residual risk — an unknown field this list does not name — is unbounded and is why
+#   README.md keeps the real `docker run ... --import-realm` recipe. Run it before changing a
+#   template. This gate narrows the window; it does not close it.
+#
+# FALSIFIABILITY
+#   `--self-test` builds an in-memory template for each rule, in BOTH directions: a clean document
+#   that must pass, and a document carrying exactly that defect which must be flagged. It also
+#   asserts the real committed templates are the ones being read, and every run prints how many
+#   files, clients and users it compared — a green with `templates=0` is a gate that never opened
+#   the file, and this makes that visible instead of silent.
+#
+# Run:
+#   python3 .github/scripts/check-realm-template-importable.py
+#   python3 .github/scripts/check-realm-template-importable.py --self-test
+
+import argparse
+import glob
+import json
+import sys
+
+REALM_GLOB = "openbank-infra/gitops/components/keycloak/*realm-template*.json"
+
+# R1. Keys a human adds for documentation. None exists in any Keycloak representation, so each
+# one fails the entire import with "Unrecognized field".
+PROSE_KEYS = {"comment", "_comment", "note", "_note", "doc", "_doc", "description_"}
+
+# R2. Keycloak's client.description column.
+DESCRIPTION_MAX = 255
+
+# R5. Keycloak 26 user-profile required attributes for a login-capable user.
+REQUIRED_USER_FIELDS = ("firstName", "lastName", "email")
+
+# R8. AUTHENTICATION_EXECUTION.AUTHENTICATOR is VARCHAR(36) in Keycloak's Liquibase changelog.
+AUTHENTICATOR_MAX = 36
+
+
+class DuplicateKey(ValueError):
+    """R7. Raised with every duplicated key path found while parsing."""
+
+
+def _no_duplicates(pairs):
+    """json object_pairs_hook that rejects a repeated key instead of keeping the last."""
+    seen, dupes = {}, []
+    for k, v in pairs:
+        if k in seen:
+            dupes.append(k)
+        seen[k] = v
+    if dupes:
+        raise DuplicateKey(", ".join(sorted(set(dupes))))
+    return seen
+
+
+def _is_placeholder(v):
+    return isinstance(v, str) and v.startswith("__") and v.endswith("__") and len(v) > 4
+
+
+def _walk_prose_keys(node, path=""):
+    """Yield (path, key) for every documentation-only key, at any depth."""
+    if isinstance(node, dict):
+        for k, v in node.items():
+            if k in PROSE_KEYS:
+                yield (path or "/", k)
+            yield from _walk_prose_keys(v, f"{path}/{k}")
+    elif isinstance(node, list):
+        for i, v in enumerate(node):
+            yield from _walk_prose_keys(v, f"{path}[{i}]")
+
+
+def check_realm(name, realm):
+    """Return (findings, counts) for one parsed realm document."""
+    findings = []
+    clients = realm.get("clients", []) or []
+    users = realm.get("users", []) or []
+
+    for path, key in _walk_prose_keys(realm):
+        findings.append(
+            f"[{name}] prose key `{key}` at {path} — Keycloak fails the WHOLE import on an "
+            f"unrecognized field (R1). Move the text to components/keycloak/README.md."
+        )
+
+    for c in clients:
+        cid = c.get("clientId", "<no clientId>")
+        desc = c.get("description") or ""
+        if len(desc) > DESCRIPTION_MAX:
+            findings.append(
+                f"[{name}] client `{cid}` description is {len(desc)} chars, over Keycloak's "
+                f"{DESCRIPTION_MAX} cap (R2) — a longer one fails the entire import."
+            )
+        if c.get("publicClient") is False:
+            if "secret" not in c:
+                findings.append(
+                    f"[{name}] confidential client `{cid}` declares no `secret` (R3) — Keycloak "
+                    f"generates a random one on import, so a rebuilt realm issues credentials the "
+                    f"service does not present. Add a `__PLACEHOLDER__` token."
+                )
+            elif not _is_placeholder(c.get("secret")):
+                findings.append(
+                    f"[{name}] client `{cid}` carries a literal `secret` (R4) — this repo is "
+                    f"PUBLIC. Use a `__PLACEHOLDER__` token."
+                )
+        for cred in c.get("credentials", []) or []:
+            if "value" in cred and not _is_placeholder(cred["value"]):
+                findings.append(
+                    f"[{name}] client `{cid}` has a literal credentials[].value (R4) — this repo "
+                    f"is PUBLIC. Use a `__PLACEHOLDER__` token."
+                )
+
+    for u in users:
+        uname = u.get("username", "<no username>")
+        # A service account never logs in interactively, so the user-profile requirement does not
+        # apply to it. Both `service-account-*` entries in realm-template.json lack all three
+        # fields and that template imports cleanly against 26.6.3 — measured, not assumed. Without
+        # this carve-out R5 would be a permanent false positive on a correct file.
+        is_service_account = uname.startswith("service-account-")
+        missing = [] if is_service_account else [f for f in REQUIRED_USER_FIELDS if not u.get(f)]
+        if missing:
+            findings.append(
+                f"[{name}] user `{uname}` is missing {missing} (R5) — Keycloak 26 answers "
+                f'"Account is not fully set up" at login with no hint why.'
+            )
+        for cred in u.get("credentials", []) or []:
+            if "value" in cred and not _is_placeholder(cred["value"]):
+                findings.append(
+                    f"[{name}] user `{uname}` has a literal credentials[].value (R4) — this repo "
+                    f"is PUBLIC. Use a `__PLACEHOLDER__` token."
+                )
+
+    # R9. A full import with an explicit roles.realm list does NOT get Keycloak's automatic
+    # built-in realm roles, so a composite referencing one aborts the import with
+    # "Unable to find composite realm role: <name>". Measured: `default-roles-openbank-customers`
+    # composed `offline_access` and `uma_authorization`, neither declared.
+    realm_roles = realm.get("roles", {}).get("realm", []) or []
+    declared = {r.get("name") for r in realm_roles}
+    for r in realm_roles:
+        for ref in (r.get("composites") or {}).get("realm", []) or []:
+            if ref not in declared:
+                findings.append(
+                    f"[{name}] composite role `{r.get('name')}` references realm role `{ref}`, "
+                    f"which the template does not declare (R9) — an explicit-roles import does "
+                    f"not get Keycloak's built-ins, so this aborts with "
+                    f"'Unable to find composite realm role: {ref}'."
+                )
+
+    for flow in realm.get("authenticationFlows", []) or []:
+        for ex in flow.get("authenticationExecutions", []) or []:
+            a = ex.get("authenticator")
+            if isinstance(a, str) and len(a) > AUTHENTICATOR_MAX:
+                findings.append(
+                    f"[{name}] flow `{flow.get('alias')}` execution authenticator `{a}` is "
+                    f"{len(a)} chars, over the VARCHAR({AUTHENTICATOR_MAX}) column (R8) — the "
+                    f"import aborts with a raw SQL 'Value too long for column' error."
+                )
+
+    return findings, (len(clients), len(users))
+
+
+def run(paths):
+    findings, n_clients, n_users = [], 0, 0
+    for p in paths:
+        try:
+            realm = json.loads(open(p, encoding="utf-8").read(), object_pairs_hook=_no_duplicates)
+        except DuplicateKey as e:
+            findings.append(
+                f"[{p}] duplicate JSON key(s) `{e}` (R7) — every parser silently keeps the LAST "
+                f"occurrence, so the other is discarded with no error anywhere."
+            )
+            continue
+        except json.JSONDecodeError as e:
+            findings.append(f"[{p}] is not valid JSON (R6): {e}")
+            continue
+        f, (c, u) = check_realm(realm.get("realm", p), realm)
+        findings += f
+        n_clients += c
+        n_users += u
+    return findings, n_clients, n_users
+
+
+# --------------------------------------------------------------------------------------------
+# Self-test: every rule, in BOTH directions.
+# --------------------------------------------------------------------------------------------
+
+def _clean():
+    return {
+        "realm": "t",
+        "clients": [
+            {"clientId": "pub", "publicClient": True, "description": "ok"},
+            {"clientId": "conf", "publicClient": False, "secret": "__X_SECRET__"},
+        ],
+        "users": [
+            {
+                "username": "a@b.c",
+                "firstName": "A",
+                "lastName": "B",
+                "email": "a@b.c",
+                "credentials": [{"type": "password", "value": "__PW__"}],
+            }
+        ],
+    }
+
+
+def self_test():
+    import copy
+
+    cases = []
+
+    ok, _ = check_realm("t", _clean())
+    cases.append(("clean template passes", ok == [], ok))
+
+    d = _clean()
+    d["clients"][0]["protocolMappers"] = [{"name": "m", "comment": "why"}]
+    f, _ = check_realm("t", d)
+    cases.append(("R1 nested prose key flagged", any("prose key" in x for x in f), f))
+
+    d = _clean()
+    d["clients"][0]["description"] = "x" * 256
+    f, _ = check_realm("t", d)
+    cases.append(("R2 over-long description flagged", any("over Keycloak" in x for x in f), f))
+    d["clients"][0]["description"] = "x" * 255
+    f, _ = check_realm("t", d)
+    cases.append(("R2 exactly 255 passes", f == [], f))
+
+    d = _clean()
+    del d["clients"][1]["secret"]
+    f, _ = check_realm("t", d)
+    cases.append(("R3 secret-less confidential client flagged", any("declares no" in x for x in f), f))
+
+    d = _clean()
+    d["clients"][1]["secret"] = "s3cr3t-literal"
+    f, _ = check_realm("t", d)
+    cases.append(("R4 literal client secret flagged", any("literal `secret`" in x for x in f), f))
+
+    d = _clean()
+    d["users"][0]["credentials"][0]["value"] = "hunter2"
+    f, _ = check_realm("t", d)
+    cases.append(("R4 literal user password flagged", any("credentials[].value" in x for x in f), f))
+
+    d = _clean()
+    del d["users"][0]["email"]
+    f, _ = check_realm("t", d)
+    cases.append(("R5 incomplete user flagged", any("not fully set up" in x for x in f), f))
+
+    # ...but a service account legitimately has none of the three. Both real ones in
+    # realm-template.json are shaped this way and that template imports cleanly.
+    d = _clean()
+    d["users"] = [{"username": "service-account-openbank-edge"}]
+    f, _ = check_realm("t", d)
+    cases.append(("R5 does NOT flag a service account", f == [], f))
+
+    # A public client with no secret must NOT be flagged — that is the correct shape.
+    d = _clean()
+    f, _ = check_realm("t", d)
+    cases.append(("public client with no secret not flagged", f == [], f))
+
+    # R7, exercised through run() because it is a parse-time rule, not a document rule.
+    import tempfile, os
+
+    with tempfile.TemporaryDirectory() as td:
+        dup = os.path.join(td, "dup.json")
+        open(dup, "w").write('{"realm":"t","authenticationFlows":[],"authenticationFlows":[1]}')
+        f, _, _ = run([dup])
+        cases.append(("R7 duplicate key flagged", any("duplicate JSON key" in x for x in f), f))
+
+        okf = os.path.join(td, "ok.json")
+        open(okf, "w").write(json.dumps(_clean()))
+        f, nc, nu = run([okf])
+        cases.append(("R7 non-duplicate file passes and IS read", f == [] and nc == 2 and nu == 1, (f, nc, nu)))
+
+        badj = os.path.join(td, "bad.json")
+        open(badj, "w").write("{not json")
+        f, _, _ = run([badj])
+        cases.append(("R6 invalid JSON flagged", any("not valid JSON" in x for x in f), f))
+
+    # R8. 37 chars is the measured real defect (`webauthn-register-passwordless-action`).
+    d = _clean()
+    d["authenticationFlows"] = [
+        {"alias": "f", "authenticationExecutions": [{"authenticator": "x" * 37}]}
+    ]
+    f, _ = check_realm("t", d)
+    cases.append(("R8 37-char authenticator flagged", any("VARCHAR(36)" in x for x in f), f))
+    d["authenticationFlows"][0]["authenticationExecutions"][0]["authenticator"] = "x" * 36
+    f, _ = check_realm("t", d)
+    cases.append(("R8 exactly 36 passes", f == [], f))
+
+    # R9, both directions.
+    d = _clean()
+    d["roles"] = {"realm": [{"name": "a", "composites": {"realm": ["missing"]}}]}
+    f, _ = check_realm("t", d)
+    cases.append(("R9 undeclared composite ref flagged", any("(R9)" in x for x in f), f))
+    d["roles"]["realm"].append({"name": "missing"})
+    f, _ = check_realm("t", d)
+    cases.append(("R9 declared composite ref passes", f == [], f))
+
+    # Scope: the glob must actually find the committed templates.
+    found = sorted(glob.glob(REALM_GLOB))
+    cases.append((f"glob finds the committed templates ({len(found)} found)", len(found) >= 2, found))
+
+    # And they must be the ones the gate is about.
+    names = {p.split("/")[-1] for p in found}
+    cases.append(
+        (
+            "both realm templates in scope",
+            {"realm-template.json", "customers-realm-template.json"} <= names,
+            sorted(names),
+        )
+    )
+
+    bad = 0
+    for label, passed, detail in cases:
+        print(f"  {'PASS' if passed else 'FAIL'}  {label}")
+        if not passed:
+            bad += 1
+            print(f"        got: {detail}")
+    print(f"self-test: {len(cases) - bad}/{len(cases)} passed")
+    _ = copy  # keep the import honest for future cases
+    return 1 if bad else 0
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--self-test", action="store_true")
+    args = ap.parse_args()
+
+    if args.self_test:
+        return self_test()
+
+    paths = sorted(glob.glob(REALM_GLOB))
+    if not paths:
+        print(f"::error::no realm template matched {REALM_GLOB} — the gate read nothing.")
+        return 1
+
+    findings, n_clients, n_users = run(paths)
+    print(
+        f"realm-template-importable: compared {len(paths)} template(s), "
+        f"{n_clients} client(s), {n_users} user(s) against 9 rules."
+    )
+    for p in paths:
+        print(f"  - {p}")
+    for f in findings:
+        print(f"::error::{f}")
+    if findings:
+        print(
+            f"::error::{len(findings)} finding(s). Keycloak imports a realm on COLD START ONLY, "
+            f"so a malformed template ships silently — see "
+            f"openbank-infra/gitops/components/keycloak/README.md."
+        )
+        return 1
+    print("OK — no known-fatal shape in any committed realm template.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/openbank-infra/gitops/components/keycloak/README.md
+++ b/openbank-infra/gitops/components/keycloak/README.md
@@ -1,0 +1,158 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# Keycloak realm templates
+
+Two realms, two committed templates:
+
+| template | realm | what reads it |
+|---|---|---|
+| `realm-template.json` | `openbank` | operator/staff realm (ADR-0065) |
+| `customers-realm-template.json` | `openbank-customers` | retail customer realm (ADR-0065) |
+
+## These files must stay IMPORTABLE, and that is not free
+
+Keycloak deserializes a realm JSON with Jackson and **fails the whole import on an
+unrecognized field** — it does not warn and skip. There is no comment syntax in JSON and
+none in Keycloak's schema, so any `"comment"`, `"note"` or `"_doc"` key added for the
+benefit of a human reader makes the file unimportable. Prose about these templates goes
+**here**, keyed by path, never inside the JSON.
+
+That is not hypothetical. Measured against `quay.io/keycloak/keycloak:26.6.3` (the version
+`keycloak.yaml` runs) on 2026-08-06, `customers-realm-template.json` carried five
+`"comment"` keys and the import died on the first one:
+
+```
+ERROR: Failed to run import
+ERROR: Unrecognized field "comment" (class org.keycloak.representations.idm.ProtocolMapperRepresentation),
+  not marked as ignorable ... ["clients"]->[0]->["protocolMappers"]->[1]->["comment"]
+```
+
+That was only the first of **four** independent import-blockers in that one file. Each was
+found by removing the previous one and running the container again:
+
+1. five `"comment"` keys — `Unrecognized field "comment"`;
+2. `openbank-edge-webauthn` `description` at 490 chars — over the 255 column cap;
+3. the flow execution authenticator `webauthn-register-passwordless-action` (37 chars) —
+   `Value too long for column "AUTHENTICATOR CHARACTER VARYING(36)"`. The same constraint
+   applies to the deployed Postgres, which proves the live realm cannot contain this value
+   either;
+4. `default-roles-openbank-customers` composing `offline_access` and `uma_authorization`
+   without declaring them — `Unable to find composite realm role: uma_authorization`. A
+   full import with an explicit `roles.realm` list does not get Keycloak's built-in roles.
+
+Plus two confidential clients with no `secret` at all (below). So the customers template
+could not have rebuilt its realm at all — which is what issue #3246 means by "the realm is
+not reproducible from git", one layer deeper than the stale-import-artifact measurement it
+started from. `realm-template.json` (the `openbank` realm) imported cleanly throughout.
+
+`check-realm-template-importable.py` (gate `realm-template-importable`) now enforces the
+static half of this. **A static gate cannot enumerate Keycloak's schema**, so it only
+catches the classes of defect listed in its header. Before changing a template, still run
+the real thing — import runs on **cold start only**, so a malformed template ships in
+total silence and is discovered by the rebuild it existed to survive:
+
+```sh
+# substitute the __PLACEHOLDER__ tokens into a scratch copy first (never commit it)
+docker run --rm -p 8080:8080 \
+  -v /tmp/realm.json:/opt/keycloak/data/import/realm.json \
+  quay.io/keycloak/keycloak:26.6.3 start-dev --import-realm
+```
+
+Look for `Realm '<name>' imported` **and** `Import finished successfully`, then mint a
+token and inspect the JWT. An import that "succeeds" having silently dropped a block
+prints nothing useful.
+
+### Version-specific shapes that fail the whole import
+
+- Authorization policies take a `config` map, not first-class fields.
+- A scope permission is `type: "scope"`, not `scope-permission`.
+- The `token-exchange` authorization scope must be declared **before** a permission
+  references it.
+- The requesting client needs `standard.token.exchange.enabled=true`.
+- A client `description` caps at **255 characters**; a longer one fails the entire import.
+- A user needs `firstName`/`lastName`/`email`, or Keycloak 26 answers "Account is not
+  fully set up" with no hint why.
+
+## Secrets
+
+Every client secret and user password is a `__PLACEHOLDER__` token. **This repo is
+public** — a literal must never land here. Real values live in Vault KV and reach the
+cluster through `components/external-secrets/es-*.yaml`; the substitution happens in a
+trusted shell at reconcile time, per
+[`docs/runbooks/0009-keycloak-realm-import-reconcile.md`](../../../../docs/runbooks/0009-keycloak-realm-import-reconcile.md).
+
+A **confidential** client (`publicClient: false`) with no `secret` field is not a
+harmless omission: Keycloak generates a random secret on import, so a rebuilt realm issues
+credentials the service does not present, and the failure appears as an authentication
+outage rather than as a missing field. Public clients correctly carry no secret —
+`openbank-app`, `openbank-grafana` and `apicurio-registry` are the three that legitimately
+have none.
+
+A placeholder here must use the same Vault value as the `es-*-oidc.yaml` entry the
+consuming service reads, or a cold-started realm and the running service disagree.
+
+## Relocated prose
+
+The five comments removed from `customers-realm-template.json`, by path.
+
+### `clients[openbank-app].protocolMappers[sub]`
+
+This realm import defines explicit (non-default) client scopes, so Keycloak does NOT
+attach the built-in `basic` and `roles` scopes that normally carry `sub` and
+`realm_access.roles`. Both are declared directly on the client so customer-edge can
+resolve identity (sub→partyId, ADR-0065/0069) and authorize (`@RolesAllowed ROLE_CUSTOMER`).
+
+### `clients[openbank-app].protocolMappers[openbank-edge-audience]`
+
+Adds `openbank-edge` to the JWT `aud` claim so that the copilot-service (OIDC
+client-id=`openbank-edge`, application-type=service) accepts customer bearer tokens.
+Quarkus service-type rejects JWTs whose `aud` is present but does not include client-id;
+tokens without an explicit audience mapper carry only Keycloak's built-in `account`
+audience, which causes Quarkus to fall back to introspection (denied — public client, no
+secret). `id.token.claim=false` keeps the ID token lean.
+
+### `clients[openbank-app].protocolMappers[openbank-rum-audience]`
+
+Adds `openbank-rum` to the JWT `aud` claim. The mobile-RUM ingest gateway (ADR-0088 §D4)
+is an OTel collector whose OIDC authenticator requires `audience=openbank-rum`, and
+`openbank-rum` is not a Keycloak client — it is a resource name — so it needs a CUSTOM
+audience, not a client one. Without this the app's session token carries only
+`openbank-edge` and every OTLP export is rejected 401: mobile RUM produced literally zero
+spans from the day it was switched on, and a crash's `trace_id` pointed at a trace that
+did not exist. `id.token.claim=false` keeps the ID token lean.
+
+### `clientScopes[profile]`
+
+This explicit-scope realm import does NOT get Keycloak's built-in client scopes. The app's
+authorize request includes `scope=openid profile` (OAuth2/OIDC standard), so `profile`
+must exist as an assigned scope or Keycloak rejects the request (`Invalid scopes: openid
+profile`). The app reads identity via the `sub` + realm-roles mappers on `openbank-app`,
+not profile claims, so this scope is intentionally claim-less — it only satisfies request
+validation.
+
+### `clientScopes[telemetry:rum]`
+
+RUM O4 consent enforcement (ADR-0088/O4). When the app requests this optional scope and
+the user consents, Keycloak fires the `openbank-rum` audience mapper, adding
+`openbank-rum` to the JWT `aud` claim. The RUM gateway OIDC extension accepts only
+`audience=openbank-rum`; tokens with only `aud=openbank-app` are rejected 401 —
+server-side enforcement without custom OTel processors.
+
+### `clients[openbank-edge-webauthn].description`
+
+Shortened to fit Keycloak's 255-char cap. In full: service-account client for
+customer-edge's own WebAuthn RP (ADR-0066 F2, variant B1, `WebAuthnKeycloakClient`).
+Creates the Keycloak user for a party enrolling a native passkey (`manage-users`), then
+mints that user a real session via RFC 8693 token-exchange scoped to the `openbank-app`
+audience (impersonation + a token-exchange fine-grained-authz permission on
+`openbank-app`). Kept separate from `customer-edge-admin`, whose blast radius is
+deliberately narrower (`party_id` attribute writes only).
+
+## What this does NOT fix
+
+The committed templates feed **nothing** today. Keycloak reads the Secrets
+`keycloak-realm-import` / `keycloak-customers-realm-import`, which External Secrets fills
+from Vault KV, and those are a strict stale ancestor of these files (measured in #3246:
+4 roles / 2 clients against 14 / 10). Making the templates importable is the precondition
+for the reconcile, not the reconcile itself — that is an owner-gated `vault kv put`,
+runbook 0009.

--- a/openbank-infra/gitops/components/keycloak/customers-realm-template.json
+++ b/openbank-infra/gitops/components/keycloak/customers-realm-template.json
@@ -77,7 +77,6 @@
           }
         },
         {
-          "comment": "This realm import defines explicit (non-default) client scopes, so Keycloak does NOT attach the built-in 'basic' and 'roles' scopes that normally carry `sub` and realm_access.roles. Both are declared directly on the client so customer-edge can resolve identity (sub→partyId, ADR-0065/0069) and authorize (@RolesAllowed ROLE_CUSTOMER).",
           "name": "sub",
           "protocol": "openid-connect",
           "protocolMapper": "oidc-sub-mapper",
@@ -102,7 +101,6 @@
           }
         },
         {
-          "comment": "Adds openbank-edge to the JWT aud claim so that the copilot-service (OIDC client-id=openbank-edge, application-type=service) accepts customer bearer tokens. Quarkus service-type rejects JWTs whose aud is present but does not include client-id; tokens without an explicit audience mapper carry only Keycloak's built-in 'account' audience, which causes Quarkus to fall back to introspection (denied — public client, no secret). id.token.claim=false keeps the ID token lean.",
           "name": "openbank-edge-audience",
           "protocol": "openid-connect",
           "protocolMapper": "oidc-audience-mapper",
@@ -114,7 +112,6 @@
           }
         },
         {
-          "comment": "Adds openbank-rum to the JWT aud claim. The mobile-RUM ingest gateway (ADR-0088 §D4, rum.open-bank.tech) is an OTel collector whose OIDC authenticator requires audience=openbank-rum, and openbank-rum is not a Keycloak client — it is a resource name — so it needs a CUSTOM audience, not a client one. Without this the app's session token carries only openbank-edge and every OTLP export is rejected 401: mobile RUM produced literally zero spans from the day it was switched on, and a crash's trace_id pointed at a trace that did not exist. id.token.claim=false keeps the ID token lean.",
           "name": "openbank-rum-audience",
           "protocol": "openid-connect",
           "protocolMapper": "oidc-audience-mapper",
@@ -133,6 +130,7 @@
       "description": "Service-account client for customer-edge: sets party_id user attribute after identity re-link (issue #1270 PR3 / ADR-0072 §5). Has manage-users on this realm only.",
       "enabled": true,
       "publicClient": false,
+      "secret": "__CUSTOMER_EDGE_ADMIN_CLIENT_SECRET__",
       "standardFlowEnabled": false,
       "implicitFlowEnabled": false,
       "directAccessGrantsEnabled": false,
@@ -145,9 +143,10 @@
     {
       "clientId": "openbank-edge-webauthn",
       "name": "Customer Edge WebAuthn RP",
-      "description": "Service-account client for customer-edge's own WebAuthn RP (ADR-0066 F2, variant B1, WebAuthnKeycloakClient). Creates the Keycloak user for a party enrolling a native passkey (manage-users), then mints that user a real session via RFC 8693 token-exchange scoped to the openbank-app audience (impersonation + a token-exchange fine-grained-authz permission on openbank-app). Kept separate from customer-edge-admin, whose blast radius is deliberately narrower (party_id attribute writes only).",
+      "description": "Service-account client for customer-edge's WebAuthn RP (ADR-0066 F2 variant B1). Creates the Keycloak user for a party enrolling a passkey, then token-exchanges it into an openbank-app session. Separate from customer-edge-admin; see README.md.",
       "enabled": true,
       "publicClient": false,
+      "secret": "__EDGE_WEBAUTHN_CLIENT_SECRET__",
       "standardFlowEnabled": false,
       "implicitFlowEnabled": false,
       "directAccessGrantsEnabled": false,
@@ -160,7 +159,6 @@
   ],
   "clientScopes": [
     {
-      "comment": "This explicit-scope realm import does NOT get Keycloak's built-in client scopes. The app's authorize request includes scope=openid profile (OAuth2/OIDC standard), so 'profile' must exist as an assigned scope or Keycloak rejects the request ('Invalid scopes: openid profile'). The app reads identity via the sub + realm-roles mappers on openbank-app, not profile claims, so this scope is intentionally claim-less — it only satisfies request validation.",
       "name": "profile",
       "description": "OIDC profile scope (request-validation only; claims come from mappers)",
       "protocol": "openid-connect",
@@ -220,7 +218,6 @@
       }
     },
     {
-      "comment": "RUM O4 consent enforcement (ADR-0088/O4). When the app requests this optional scope and the user consents, Keycloak fires the openbank-rum audience mapper, adding 'openbank-rum' to the JWT aud claim. The RUM gateway OIDC extension accepts only audience=openbank-rum; tokens with only aud=openbank-app are rejected 401 — server-side enforcement without custom OTel processors.",
       "name": "telemetry:rum",
       "description": "Allow the app to send anonymised performance telemetry to the RUM gateway",
       "protocol": "openid-connect",
@@ -251,6 +248,14 @@
         "description": "Authenticated retail customer — access to own resources only (deny-by-default via OPA, ADR-0065)"
       },
       {
+        "name": "offline_access",
+        "description": "${role_offline-access}"
+      },
+      {
+        "name": "uma_authorization",
+        "description": "${role_uma_authorization}"
+      },
+      {
         "name": "default-roles-openbank-customers",
         "description": "${role_default-roles}",
         "composite": true,
@@ -266,7 +271,6 @@
     "description": "${role_default-roles}"
   },
   "protocolMappers": [],
-  "authenticationFlows": [],
   "requiredActions": [
     {
       "alias": "VERIFY_EMAIL",
@@ -370,7 +374,7 @@
           "userSetupAllowed": false
         },
         {
-          "authenticator": "webauthn-register-passwordless-action",
+          "authenticator": "webauthn-register-passwordless",
           "authenticatorFlow": false,
           "requirement": "REQUIRED",
           "priority": 50,


### PR DESCRIPTION
## What this is

`Refs #3246`. The issue measures that the realm JSON Keycloak imports is a stale ancestor of the
committed template. Closing that gap is an owner-gated Vault write (runbook 0009). **While
preparing that write, the templates were run against the real Keycloak the cluster deploys and
the customers template did not import at all** — so the reconcile as written would have produced
nothing. This PR fixes that precondition and gates it.

## Re-measured against live `origin/main` before building anything

Both halves of the issue's table reproduce exactly. Templates read from `origin/main`, import
artifacts read from the projected Secrets in `iam` (read-only, nothing mutated):

| realm | artifact | roles | clients | users |
|---|---|---|---|---|
| `openbank` | repo template | 14 | 10 | 6 |
| `openbank` | import Secret | **4** | **2** | **1** |
| `openbank-customers` | repo template | 2 | 3 | 0 |
| `openbank-customers` | import Secret | **1** | **1** | 0 |

The customers artifact still carries the deprecated flat `defaultRoles` where the template has
`defaultRole`, as the issue's third comment records.

## The finding this PR acts on

`customers-realm-template.json` had **four independent import-blockers**, each found by removing
the previous one and running `quay.io/keycloak/keycloak:26.6.3` again (26.6.3 is the tag
`keycloak.yaml` runs — checked, not assumed):

1. five `"comment"` keys → `Unrecognized field "comment" (class ...ProtocolMapperRepresentation)`.
   Keycloak deserializes a realm with Jackson and fails the **whole** import on one unknown field.
2. `openbank-edge-webauthn` `description` at 490 chars → over the 255 column cap.
3. flow authenticator `webauthn-register-passwordless-action` (37 chars) →
   `Value too long for column "AUTHENTICATOR CHARACTER VARYING(36)"`. The same constraint applies
   to the deployed Postgres, which **proves the live realm cannot contain this value either**.
4. `default-roles-openbank-customers` composing `offline_access` / `uma_authorization` without
   declaring them → `Unable to find composite realm role: uma_authorization`. A full import with
   an explicit `roles.realm` list does not get Keycloak's built-in roles.

Plus a fifth defect the runbook already predicted: `customer-edge-admin` and
`openbank-edge-webauthn` are `publicClient: false` with **no `secret` field at all**, so a
rebuilt realm would generate random secrets neither service presents. Both now carry a
`__PLACEHOLDER__` token. And a sixth, incidental: `authenticationFlows` was declared **twice**,
an empty array and the real four-flow list — every JSON parser silently keeps the last.

`realm-template.json` (the `openbank` realm) imported cleanly throughout and is unchanged.

## Why nothing caught it

`--import-realm` runs on **cold start only** and skips a realm that already exists, so the
template is inert on every deploy, every restart and every DR restore. ArgoCD is Synced/Healthy
about a Secret it does not manage. And the three existing realm checks
(`check-roles-allowed-realm`, `check-realm-role-parity`, `check-realm-import-parity`) all compare
**name sets** — a document Keycloak refuses to parse passes all three. The first observation of
the defect would have been the rebuild it existed to survive.

## What was proven, and how

- Both templates import into 26.6.3: `Realm 'openbank' imported` and
  `Realm 'openbank-customers' imported`, each with `Import finished successfully`.
- Tokens mint and the JWTs are correct: `openbank-services` client_credentials →
  `realm_access.roles = ["ROLE_API"]`; `admin@openbank.local` password grant → 200; and
  **both** newly-secret-bearing confidential clients authenticate with the substituted
  placeholder (`azp=customer-edge-admin`, `azp=openbank-edge-webauthn`) — which is exactly the
  R3 defect proven fixed end to end.
- An `Import finished successfully` with **zero realms imported** was hit mid-verification (a
  stale single-file bind mount after `sed` changed the inode). Asserting on
  `Realm '<name>' imported`, not on the success line, is the only reason it was noticed — the
  runbook's warning about a silently-empty import is real.

## The gate

`realm-template-importable`, declared in `.github/gates/gates.yaml` (group `security`,
`mode: enforced`, `selftest_expect: pass`) — never as an inline workflow step. Nine decidable
defect classes: R1 prose keys, R2 description cap, R3 secret-less confidential client, R4 literal
secret (this repo is public), R5 incomplete login user, R6 invalid JSON, R7 duplicate key,
R8 authenticator column width, R9 undeclared composite reference.

Falsified in **both** directions:

- `--self-test`: **19/19**, every rule with a must-flag case *and* a must-not-flag case
  (255 passes / 256 fails; 36 passes / 37 fails; a public client with no secret is not flagged).
- Against the pre-fix templates from `origin/main`: **12 findings**, covering R1 (×5), R2, R3
  (×2), R7, R8, R9. Against this branch: clean.
- Every run prints `compared N template(s), N client(s), N user(s) against 9 rules` and lists the
  files, so a green cannot mean "it never opened the file". This is load-bearing: when the
  customers file failed to parse the client count visibly dropped 13 → 10.

R5 initially produced a **false positive** on a correct file — it flagged the two
`service-account-*` users, which legitimately have no `firstName`/`lastName`/`email` and are in
the template that imports cleanly. The carve-out and a regression case were added.

## Effect on merge — read this part

**Merging this changes nothing running, and does not by itself make the realm reproducible.**

- Keycloak reads the Vault-backed Secrets, not these files. No restart, no rollout, no session
  impact, no ArgoCD diff for Keycloak itself.
- The committed templates still feed nothing. This makes them *importable*, which is the
  precondition the reconcile needs; it is not the reconcile.
- **What the owner must do for it to take effect:** run
  `docs/runbooks/0009-keycloak-realm-import-reconcile.md` — the owner-gated `vault kv put` for
  both realms — and, per that runbook's close-out, empty `KNOWN_STALE` in
  `check-realm-import-parity.py` afterwards. Two new Vault KV values are now needed that the
  runbook did not have: `__CUSTOMER_EDGE_ADMIN_CLIENT_SECRET__` and
  `__EDGE_WEBAUTHN_CLIENT_SECRET__`, which **must** match the values
  `es-*-oidc.yaml` already serves to customer-edge (`openbank/customer-edge-admin`), or a
  cold-started realm issues credentials the service does not present.
- Verified this does not disturb the existing baseline: `check-realm-import-parity.py` run
  against the real projected Secrets with this branch's templates exits **0** with
  `newSince3246/*` empty everywhere — `offline_access`/`uma_authorization` are already in that
  script's `BUILTIN_ROLES` and subtracted from both sides.

## What I did NOT verify — and the blast radius if I am wrong

Getting auth wrong locks everyone out, so stating this plainly rather than burying it.

- **The `webauthn-register-passwordless` substitution is the weakest claim in this PR.** I did
  not read the live customers realm's registration flow — that needs an admin credential I am not
  handling. I know the committed value is impossible (37 chars into a `VARCHAR(36)` column, so no
  Keycloak has ever stored it), and I know the replacement imports and is already declared as a
  required action with `defaultAction: true` in the same file. I have **not** driven a passkey
  registration through the resulting flow. If it is wrong, the exposure is passkey *enrolment* in
  a rebuilt realm — not authentication in the running one, which this PR cannot reach.
- **The gate cannot claim "the template imports."** Keycloak's schema lives in Jackson annotations
  inside the server jar; a static check cannot enumerate it. An unknown field outside these nine
  classes still passes. That residual is why README.md keeps the real `docker run` recipe.
- **I did not verify against the cluster's own image**, `openbank-keycloak:26.6.3-optimized`, only
  upstream `quay.io/keycloak/keycloak:26.6.3`. Same version; a custom provider in the optimized
  build could in principle accept or reject something differently.
- **I did not test a full cold start against Postgres**, only the dev H2. The `VARCHAR(36)` and
  255 limits come from Keycloak's DB-independent Liquibase changelog, so they should hold, but the
  error text would differ.
- **Not tested: whether the two realms import together**, or the ExternalSecret's `merge` template
  path (it injects `loginTheme`/`displayNameHtml` into the Vault blob, not into these files).
- One pre-existing oddity left alone deliberately: every client in `realm-template.json` lists
  `openid` in `defaultClientScopes`, which is not a Keycloak client scope —
  `Referenced client scope 'openid' doesn't exist. Ignoring`. Harmless (`roles` is a real built-in
  and resolves; the M2M token carried `ROLE_API`), and changing scope wiring is an auth decision
  that does not belong in this PR.

**Blast radius if this PR is wrong: a future greenfield realm rebuild, not the running system.**
Nothing here is read by a live Keycloak, by a restart, or by a DB restore. It is strictly better
than `main`, where that same rebuild produces no customers realm at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
