### PR TITLE
fix(ci): derive can-i-deploy's self-clearing promise from the broker, not the verdict

### DIFF
--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -687,6 +687,23 @@ gates:
     run: |
       bash .github/scripts/probe-pact-version.sh --self-test
 
+  # The counterpart-verifiability probe (#3223). The classifier above says WHY a block
+  # happened; two of its classes end in a promise ("clears within one reconcile tick",
+  # "the reconcile re-drives it automatically") that was a hardcoded constant, not an
+  # observation — and on run 31080511057 all six blocked money-path services carried it
+  # while every counterpart version named was unverifiable by construction. This probe is
+  # what turns that promise into evidence, so its failure directions are what must be
+  # exercised: a contentless counterpart dominating a healthy one, and every probe failure
+  # degrading to `unknown` rather than to the reassuring answer.
+  - id: blocking-counterpart-probe-unit-test
+    name: "can-i-deploy counterpart verifiability probe (issue #3223, enforced)"
+    group: supplychain
+    mode: enforced
+    selftest: |
+      bash .github/scripts/probe-blocking-counterparts.sh --self-test
+    run: |
+      bash .github/scripts/probe-blocking-counterparts.sh --self-test
+
   # Workflow `run:` step size (#3082). GitHub rejects an oversized run script by making the
   # WHOLE workflow unparseable — zero jobs, no error message, every contributor's runs of that
   # file dead until someone reverts. It happened to auto-deploy.yml (#3135 -> #3139) and NOTHING

--- a/.github/scripts/classify-can-i-deploy-block.sh
+++ b/.github/scripts/classify-can-i-deploy-block.sh
@@ -44,6 +44,14 @@
 #     resolve-can-i-deploy-selector.sh. Only (no + workflow_dispatch) is treated specially;
 #     see the NOT_ASKED note below.
 #
+#   COUNTERPART_STATE / COUNTERPART_DETAIL — the caller's probe of the counterpart versions
+#     this verdict names, from probe-blocking-counterparts.sh (#3223):
+#       contentless → at least one of them carries NO pacts, so nothing can ever verify it
+#       has-pacts   → all of them have pacts; a missing verification really is the gap
+#       none        → the verdict names no counterpart version
+#       unknown     → the probe failed; neither durability nor transience is established
+#     Unset behaves as `none`, so a caller that does not probe keeps today's labelling.
+#
 #   PACT_VERSION_PRESENT — the caller's probe of
 #     GET <broker>/pacticipants/<svc>/versions/<sha>:
 #       no      → 404, this commit's build has published nothing yet
@@ -56,6 +64,8 @@
 #   UNVERIFIED    — a version exists but no verification result yet. Usually the
 #                   counterpart provider lagging by minutes; treated as transient, but
 #                   named separately so it is not mistaken for a passed verification.
+#   UNVERIFIABLE  — the block names a counterpart version that carries NO pacts, so no
+#                   verification can ever target it. Durable; waiting cannot help (#3223).
 #   NOT_ASKED     — the gate was never asked (#3454). resolve-can-i-deploy-selector.sh
 #                   REFUSEd to pick a selector, so no can-i-deploy verdict exists at all.
 #                   See the NOT_ASKED note below for why this is not PENDING_BUILD.
@@ -100,6 +110,27 @@
 # and test-classify-can-i-deploy-block.sh asserts the equivalence over the whole input
 # cross-product. A future edit to either file's condition reddens that test.
 #
+# WHY UNVERIFIABLE IS DERIVED FROM THE BROKER AND NOT HARDCODED PER VERDICT (issue #3223)
+# Two of the classes above end in a promise — PENDING_BUILD's "the 3-hourly reconcile
+# re-drives it automatically" and UNVERIFIED's "normally clears within one reconcile tick".
+# Both were written as constants attached to a verdict, and neither is a property this
+# script could observe: it makes no network call, so it cannot know whether waiting helps.
+#
+# For a large share of real blocks the promise is false. The version a verdict names as
+# "currently in <env>" is often a bookkeeping version with ZERO pacts, PUT into the broker
+# by record-deployment-on-merge.yml because the deployed sha published none (services-ci is
+# path-scoped). Nothing ever verifies a version with no pacts, so no number of reconcile
+# ticks changes the answer. Measured on run 31080511057 (2026-08-06): six money-path
+# services blocked, ALL labelled PENDING_BUILD, and every one of the seven distinct
+# counterpart versions the verdicts named carried 0 pacts — one of them created 13 days
+# earlier. Same false promise, third label; it has already been attached to PENDING_BUILD,
+# to UNVERIFIED, and (until #3454) to NOT_ASKED.
+#
+# So the durable/transient distinction now comes from evidence: probe-blocking-counterparts.sh
+# asks the broker about the exact versions the verdict named, and this script reports what
+# that probe found. When the probe cannot answer, the promise is qualified rather than
+# repeated — an unprovable reassurance is the failure mode, not a missing one.
+#
 # Always exits 0 — this is a labeller, not a gate.
 set -uo pipefail
 
@@ -113,9 +144,22 @@ PRESENT="${PACT_VERSION_PRESENT:-unknown}"
 # Same default as resolve-can-i-deploy-selector.sh: an absent EVENT_NAME behaves as a push,
 # so a caller that forgets to pass it keeps today's labelling instead of inventing NOT_ASKED.
 EVENT="${EVENT_NAME:-push}"
+CP_STATE="${COUNTERPART_STATE:-none}"
+CP_DETAIL="${COUNTERPART_DETAIL:-}"
 OUT="$(cat)"
 
 emit() { printf '%s\t%s\n' "$1" "$2"; }
+
+# A self-clearing claim may only be made when the counterpart probe SUPPORTS it. When the
+# probe could not answer, the claim is kept but marked unproven — silently dropping the
+# qualifier would leave the reader with the same unearned confidence.
+maybe_unproven() {
+  if [ "$CP_STATE" = "unknown" ]; then
+    printf '%s' "$1 — NOTE: the counterpart versions this verdict names could not be probed, so the self-clearing part of this message is unproven (#3223)"
+  else
+    printf '%s' "$1"
+  fi
+}
 
 # 0. NOT_ASKED is tested before EVERYTHING, including the regression check, and that is
 #    deliberate. On exactly these inputs resolve-can-i-deploy-selector.sh emits REFUSE, so
@@ -140,6 +184,18 @@ if grep -qiE 'pact (verification )?failed|verification.*(^| )failed|failed verif
   exit 0
 fi
 
+# 2. #3223. Tested before the PACT_VERSION_PRESENT case split, because it is the only
+#    branch here backed by a measurement and it contradicts what BOTH of the reachable
+#    branches would otherwise say. It is independent of whether THIS service published a
+#    version for THIS sha: the block is on the counterpart side, and a version with no
+#    pacts is unverifiable no matter what the consumer did. Run 31080511057 is the worked
+#    example — PACT_VERSION_PRESENT was `no` for all six blocked services, so every one
+#    reported PENDING_BUILD and promised a reconcile that could not deliver.
+if [ "$CP_STATE" = "contentless" ]; then
+  emit UNVERIFIABLE "blocked on counterpart version(s) that carry ZERO pacts — ${CP_DETAIL:-see the verdict}. No verification run targets a version with no pacts, so this will NOT clear on its own and waiting for a reconcile tick cannot help (#3223). The counterpart has to be deployed at a version that actually published pacts, or co-deployed with ${SVC}"
+  exit 0
+fi
+
 case "$PRESENT" in
   # #3432: the gate WAS asked, and by version number — the probe proved from git that the version
   # it named is byte-identical to the sha being deployed in every build input of this service. So
@@ -147,19 +203,19 @@ case "$PRESENT" in
   # PENDING_BUILD would be a lie (nothing is building; the answer arrived).
   equivalent:*)
     if grep -q 'There is no verified pact' <<< "$OUT"; then
-      emit UNVERIFIED "the counterpart has not verified this version yet — normally clears within one reconcile tick"
+      emit UNVERIFIED "$(maybe_unproven "the counterpart has not verified this version yet — normally clears within one reconcile tick")"
       exit 0
     fi
     emit UNKNOWN "blocked with a proven-equivalent version asked about by number and no recognised reason in the CLI output — read the job log for ${SVC}"
     exit 0
     ;;
   no)
-    emit PENDING_BUILD "no pact version published for this commit yet — its main-push build has not finished (one ARC runner, ~45 min/service); the 3-hourly reconcile re-drives it automatically"
+    emit PENDING_BUILD "$(maybe_unproven "no pact version published for this commit yet — its main-push build has not finished (one ARC runner, ~45 min/service); the 3-hourly reconcile re-drives it automatically")"
     exit 0
     ;;
   yes)
     if grep -q 'There is no verified pact' <<< "$OUT"; then
-      emit UNVERIFIED "a version exists for this commit but the counterpart has not verified it yet — normally clears within one reconcile tick"
+      emit UNVERIFIED "$(maybe_unproven "a version exists for this commit but the counterpart has not verified it yet — normally clears within one reconcile tick")"
       exit 0
     fi
     emit UNKNOWN "blocked with a version present and no recognised reason in the CLI output — read the job log for ${SVC}"

--- a/.github/scripts/derive-codeploy-set.py
+++ b/.github/scripts/derive-codeploy-set.py
@@ -104,7 +104,16 @@ PAIR_LINE = ("There is no verified pact", "The verification for the pact between
 # UNKNOWN is excluded for the same reason from the other direction: an unclassified block is
 # not positive evidence of anything, and the safe default is to say so rather than to name a
 # set. Records with no class at all keep today's behaviour, so older captures still parse.
-CODEPLOY_CLASSES = ("UNVERIFIED", "REGRESSION")
+#
+# UNVERIFIABLE (#3223) IS eligible, and for the reason stated above rather than despite it.
+# It is the one class backed by a measurement that the block is durable: the counterpart
+# version the verdict compared against carries zero pacts, so no verification will ever
+# target it and no reconcile tick can change the answer. It is also the class a co-deploy
+# actually remedies — deploying the counterpart alongside replaces that bookkeeping version
+# with one that has pacts. Before this class existed these same blocks arrived as UNVERIFIED
+# (already eligible) or as PENDING_BUILD (excluded, and mislabelled), so the allow-list
+# entry keeps the honest half of today's behaviour rather than widening it.
+CODEPLOY_CLASSES = ("UNVERIFIED", "REGRESSION", "UNVERIFIABLE")
 TRANSIENT_CLASSES = ("PENDING_BUILD",)
 
 # NOT_ASKED (#3454) is ineligible for a set by construction — CODEPLOY_CLASSES is an

--- a/.github/scripts/probe-blocking-counterparts.sh
+++ b/.github/scripts/probe-blocking-counterparts.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+# See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+#
+# ---------------------------------------------------------------------------------------
+# Are the counterpart versions this can-i-deploy verdict names CAPABLE of ever being
+# verified?  (issue #3223)
+#
+# WHY THIS EXISTS
+# can-i-deploy blocks with a per-pair line naming the version of a counterpart "currently
+# in <environment>":
+#
+#   There is no verified pact between the latest version of openbank-transaction-service
+#   with tag main (a26ad6a9...) and the version of openbank-balance-service currently in
+#   sandbox (e88849d6...)
+#
+# classify-can-i-deploy-block.sh then labels that block, and BOTH labels it can reach for
+# this shape carry a self-clearing promise: PENDING_BUILD says "the 3-hourly reconcile
+# re-drives it automatically", UNVERIFIED says "normally clears within one reconcile tick".
+# Neither is a property of the block — they are hardcoded per verdict, and the classifier
+# has no evidence for either, because it deliberately makes no network call.
+#
+# For a large share of today's blocks the promise is FALSE, and provably so. The version
+# named as "currently in sandbox" is frequently a bookkeeping version that carries ZERO
+# pacts: record-deployment-on-merge.yml PUTs a version into the broker when the deployed
+# sha has none (services-ci is path-scoped, so most shas publish nothing for most services)
+# and then records THAT as deployed. Nothing will ever verify a version with no pacts — no
+# verification run targets it, and no reconcile tick creates one. Measured 2026-08-06:
+# openbank-transaction-service's "currently in sandbox" version was created 2026-07-24 by
+# such a PUT (HTTP 201, run 30077670109) and still had 0 pacts and no tags 13 days and
+# dozens of reconcile ticks later.
+#
+# A verdict that tells an operator to wait, when waiting is structurally incapable of
+# helping, is worse than no message: it is the reason four deploy-drift issues sat open
+# while money-path services fell five patch releases behind.
+#
+# WHAT THIS DOES
+# Reads a can-i-deploy CLI output on stdin, extracts every (counterpart, version) pair the
+# verdict names as currently deployed, and asks the broker one question per pair: does that
+# version have any pacts?  It reports a STATE for the block as a whole, which
+# classify-can-i-deploy-block.sh turns into a class and a message. The classifier stays a
+# pure function; the network call lives here, where the self-test can stub it.
+#
+# Usage:
+#   probe-blocking-counterparts.sh < cli-output
+#
+# Env:
+#   PACT_BROKER_URL / PACT_BROKER_USERNAME / PACT_BROKER_PASSWORD  broker credentials
+#
+# Prints ONE tab-separated line: <state>\t<detail>
+#   contentless  at least one named counterpart version carries no pacts at all. Durable:
+#                no reconcile tick can clear it. <detail> lists them as <svc>@<sha8>.
+#   has-pacts    every named counterpart version has pacts, so the missing piece really is
+#                a verification result and waiting may genuinely help.
+#   none         the output names no counterpart version — nothing to say about it.
+#   unknown      a probe failed (broker unreachable, non-2xx, unparseable body). The caller
+#                must NOT read this as either "durable" or "transient".
+#
+# WHY EVERY FAILURE IS `unknown` AND NOT `has-pacts`
+# `has-pacts` is what preserves today's self-clearing promise. Degrading a failed probe to
+# it would restore the exact false reassurance this script exists to remove, on no evidence
+# — the safe direction here is to admit ignorance, because an unclassifiable block must not
+# borrow a transient class's comfort (the rule classify-can-i-deploy-block.sh's own header
+# already states for UNKNOWN).
+#
+# WHY THE SHA COMES FROM THE VERDICT AND NOT FROM THE BROKER
+# The question is about the version the GATE actually compared against, which the verdict
+# states verbatim. Re-deriving "what is currently deployed" from the broker would answer a
+# second, later question that can already disagree with the one that produced the block.
+#
+# Always exits 0: this reports a fact, it does not gate on one.
+set -uo pipefail
+
+# "and the version of <pacticipant> currently in <env> (<40-hex>)" — the shape the pact CLI
+# prints for a deployed-version comparison. Older/other phrasings that carry no sha simply
+# do not match, and the answer is then `none`, which changes nothing downstream.
+PAIR_RE='and the version of (openbank-[a-z0-9][a-z0-9-]*) currently in [a-zA-Z0-9_-]+ \(([0-9a-f]{40})\)'
+
+probe_one() { # <service> <sha> -> prints: contentless | has-pacts | unknown
+  local svc="$1" sha="$2" body auth
+  # Assembled into ONE variable before the flag: gitleaks' `curl-auth-user` rule matches the
+  # SHAPE `-u "$A:$B"` and cannot tell a variable reference from a literal, so the inline form
+  # fails the required check with no secret in it.
+  auth="${PACT_BROKER_USERNAME:-}:${PACT_BROKER_PASSWORD:-}"
+  body="$(curl -sf --max-time 20 -u "$auth" \
+    "${PACT_BROKER_URL:-}/pacticipants/${svc}/versions/${sha}" 2>/dev/null)" || { echo unknown; return; }
+  local n
+  # `pb:pact-versions` is an ARRAY of the pacts published at this version. Absent or empty
+  # both mean "no contract evidence at this version". `jq` failing on a non-JSON body is a
+  # probe failure, not an answer.
+  n="$(printf '%s' "$body" | jq -r '(._links["pb:pact-versions"] // []) | length' 2>/dev/null)" || { echo unknown; return; }
+  case "$n" in
+    ''|*[!0-9]*) echo unknown ;;
+    0)           echo contentless ;;
+    *)           echo has-pacts ;;
+  esac
+}
+
+run() {
+  local out pairs seen_any=0 saw_unknown=0 contentless=()
+  out="$(cat)"
+  # sed -E over grep -oE: we need two capture groups per match, and BSD grep has no -P.
+  pairs="$(printf '%s\n' "$out" \
+    | sed -nE "s/.*${PAIR_RE}.*/\1 \2/p" | sort -u)"
+  if [ -z "$pairs" ]; then
+    printf 'none\t%s\n' "the verdict names no counterpart version currently in the environment"
+    return
+  fi
+  while read -r cp sha; do
+    [ -n "${cp:-}" ] || continue
+    seen_any=1
+    case "$(probe_one "$cp" "$sha")" in
+      contentless) contentless+=("${cp}@${sha:0:8}") ;;
+      unknown)     saw_unknown=1 ;;
+    esac
+  done <<< "$pairs"
+  if [ "${#contentless[@]}" -gt 0 ]; then
+    printf 'contentless\t%s\n' "$(IFS=,; echo "${contentless[*]}")"
+    return
+  fi
+  if [ "$saw_unknown" -eq 1 ] || [ "$seen_any" -eq 0 ]; then
+    printf 'unknown\t%s\n' "could not probe every counterpart version named in the verdict"
+    return
+  fi
+  printf 'has-pacts\t%s\n' "every counterpart version named in the verdict has pacts published"
+}
+
+if [ "${1:-}" = "--self-test" ] || [ "${1:-}" = "--selftest" ]; then
+  # The broker has no public ingress (ADR-0056) and PACT_BROKER_URL is blank off main-push,
+  # so the real call can never run from a PR — curl is stubbed. What is NOT stubbed is the
+  # parsing and the aggregation, which is where every branch of the answer is decided.
+  self_tmp="$(mktemp -d)"; trap 'rm -rf "$self_tmp"' EXIT
+  cat > "$self_tmp/curl" <<'STUB'
+#!/usr/bin/env bash
+url="${@: -1}"
+case "$url" in
+  *openbank-empty-service/versions/*)  echo '{"_links":{"pb:pact-versions":[]}}' ;;
+  *openbank-full-service/versions/*)   echo '{"_links":{"pb:pact-versions":[{"name":"a"}]}}' ;;
+  *openbank-broken-service/versions/*) echo 'not json at all' ;;
+  *)                                   exit 7 ;;
+esac
+STUB
+  chmod +x "$self_tmp/curl"
+  me_abs="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
+  S40_A="$(printf 'a%.0s' $(seq 40))"
+  S40_B="$(printf 'b%.0s' $(seq 40))"
+  fails=0
+  line_for() { printf 'There is no verified pact between the latest version of openbank-demo-service with tag main (%s) and the version of %s currently in sandbox (%s)\n' "$S40_B" "$1" "$2"; }
+  case_is() { # <label> <want-state> <stdin>
+    local label="$1" want="$2" got
+    got="$(PATH="$self_tmp:$PATH" bash "$me_abs" <<< "$3" | cut -f1)"
+    if [ "$got" = "$want" ]; then echo "  ok   ${label} → ${got}"
+    else echo "  FAIL ${label}: want ${want}, got ${got}"; fails=$((fails + 1)); fi
+  }
+  echo "probe-blocking-counterparts.sh --self-test"
+  case_is "no counterpart line"            none        "Computer says no"
+  case_is "counterpart with 0 pacts"       contentless "$(line_for openbank-empty-service "$S40_A")"
+  case_is "counterpart with pacts"         has-pacts   "$(line_for openbank-full-service "$S40_A")"
+  case_is "unreachable broker"             unknown     "$(line_for openbank-missing-service "$S40_A")"
+  case_is "non-JSON body"                  unknown     "$(line_for openbank-broken-service "$S40_A")"
+  # contentless DOMINATES a mixed verdict: one unverifiable counterpart is enough to make
+  # waiting pointless, so it must not be diluted by a healthy sibling or a failed probe.
+  case_is "mixed contentless + healthy"    contentless "$(line_for openbank-full-service "$S40_A"; line_for openbank-empty-service "$S40_A")"
+  case_is "mixed contentless + unknown"    contentless "$(line_for openbank-missing-service "$S40_A"; line_for openbank-empty-service "$S40_A")"
+  case_is "healthy + unknown is unknown"   unknown     "$(line_for openbank-full-service "$S40_A"; line_for openbank-missing-service "$S40_A")"
+  # A short sha, or a phrasing without one, must not be read as a version to probe.
+  case_is "short sha is not a version"     none        "and the version of openbank-empty-service currently in sandbox (a5e5d32a)"
+  # The detail field must NAME the unverifiable versions — the whole point is that an
+  # operator can act on it without opening the broker.
+  detail="$(PATH="$self_tmp:$PATH" bash "$me_abs" <<< "$(line_for openbank-empty-service "$S40_A")" | cut -f2)"
+  if [ "$detail" = "openbank-empty-service@aaaaaaaa" ]; then echo "  ok   detail names the version"
+  else echo "  FAIL detail names the version: got '${detail}'"; fails=$((fails + 1)); fi
+  if [ "$fails" -eq 0 ]; then echo "probe-blocking-counterparts.sh self-test: PASS"; exit 0; fi
+  echo "probe-blocking-counterparts.sh self-test: ${fails} FAILURE(S)"; exit 1
+fi
+
+run

--- a/.github/scripts/test-classify-can-i-deploy-block.sh
+++ b/.github/scripts/test-classify-can-i-deploy-block.sh
@@ -27,7 +27,10 @@ fails=0
 check() {
   local name="$1" want="$2" present="$3" out="$4" event="${5:-}"
   local got
-  got="$(PACT_VERSION_PRESENT="$present" EVENT_NAME="$event" bash "$CLASSIFY" openbank-demo-service <<< "$out" | cut -f1)"
+  # COUNTERPART_STATE is pinned to `none` here so a leaked environment variable cannot
+  # decide a case; the #3223 cases below set it explicitly via check_cp.
+  got="$(PACT_VERSION_PRESENT="$present" EVENT_NAME="$event" COUNTERPART_STATE=none \
+    bash "$CLASSIFY" openbank-demo-service <<< "$out" | cut -f1)"
   if [ "$got" = "$want" ]; then
     echo "  ok   ${name} → ${got}"
   else
@@ -133,6 +136,60 @@ for p in yes no absent unknown "equivalent:${SHA_FIXTURE}"; do
     fi
   done
 done
+
+# 14-17 (#3223). The counterpart probe decides DURABILITY, and it must beat both classes
+#     that carry a self-clearing promise. The measured case is the one that matters: on run
+#     31080511057 every blocked service had PACT_VERSION_PRESENT=no, so all six reported
+#     PENDING_BUILD and promised a reconcile, while all seven counterpart versions the
+#     verdicts named carried zero pacts. Case 14 is that exact input.
+check_cp() { # <name> <want> <present> <cp-state> [event]
+  local name="$1" want="$2" present="$3" cp="$4" event="${5:-}" got
+  got="$(PACT_VERSION_PRESENT="$present" EVENT_NAME="$event" COUNTERPART_STATE="$cp" \
+    COUNTERPART_DETAIL="openbank-ledger-service@a5e5d32a" \
+    bash "$CLASSIFY" openbank-demo-service <<< "$NO_VERIFIED_PACT" | cut -f1)"
+  if [ "$got" = "$want" ]; then
+    echo "  ok   ${name} → ${got}"
+  else
+    echo "  FAIL ${name}: want ${want}, got ${got}"
+    fails=$((fails + 1))
+  fi
+}
+check_cp "contentless counterpart beats PENDING_BUILD" UNVERIFIABLE no contentless
+check_cp "contentless counterpart beats UNVERIFIED"    UNVERIFIABLE yes contentless
+check_cp "healthy counterparts keep PENDING_BUILD"     PENDING_BUILD no has-pacts
+check_cp "healthy counterparts keep UNVERIFIED"        UNVERIFIED yes has-pacts
+check_cp "unprobed counterparts keep the class"        PENDING_BUILD no unknown
+# A REGRESSION is an observed verification FAILURE and outranks everything: relabelling it
+# UNVERIFIABLE would hide a real broken contract behind a bookkeeping explanation.
+got_reg="$(PACT_VERSION_PRESENT=yes COUNTERPART_STATE=contentless bash "$CLASSIFY" \
+  openbank-demo-service <<< "$VERIFICATION_FAILED" | cut -f1)"
+if [ "$got_reg" = "REGRESSION" ]; then
+  echo "  ok   regression outranks contentless → REGRESSION"
+else
+  echo "  FAIL regression outranks contentless: got ${got_reg}"
+  fails=$((fails + 1))
+fi
+# The UNVERIFIABLE message must NAME the versions and must not promise a reconcile.
+msg_uv="$(PACT_VERSION_PRESENT=no COUNTERPART_STATE=contentless \
+  COUNTERPART_DETAIL="openbank-ledger-service@a5e5d32a" bash "$CLASSIFY" \
+  openbank-demo-service <<< "$NO_VERIFIED_PACT" | cut -f2-)"
+case "$msg_uv" in
+  *"openbank-ledger-service@a5e5d32a"*) echo "  ok   UNVERIFIABLE names the version" ;;
+  *) echo "  FAIL UNVERIFIABLE does not name the version: ${msg_uv}"; fails=$((fails + 1)) ;;
+esac
+if grep -qE 'clears within one reconcile|re-drives it automatically' <<< "$msg_uv"; then
+  echo "  FAIL UNVERIFIABLE repeats a self-clearing promise: ${msg_uv}"
+  fails=$((fails + 1))
+else
+  echo "  ok   UNVERIFIABLE makes no self-clearing promise"
+fi
+# An unprovable promise must be MARKED unprovable, not silently repeated.
+msg_unk="$(PACT_VERSION_PRESENT=no COUNTERPART_STATE=unknown bash "$CLASSIFY" \
+  openbank-demo-service <<< "$NO_VERIFIED_PACT" | cut -f2-)"
+case "$msg_unk" in
+  *unproven*) echo "  ok   unprobed counterparts qualify the promise" ;;
+  *) echo "  FAIL unprobed counterparts do not qualify the promise: ${msg_unk}"; fails=$((fails + 1)) ;;
+esac
 
 # 7. Missing argument is a usage error, not a silent classification.
 if PACT_VERSION_PRESENT=no bash "$CLASSIFY" </dev/null >/dev/null 2>&1; then

--- a/.github/scripts/test-derive-codeploy-set.sh
+++ b/.github/scripts/test-derive-codeploy-set.sh
@@ -154,6 +154,18 @@ There is no verified pact between version abc123 of openbank-fraud-service and t
 ===SERVICE openbank-transaction-service${TAB}PENDING_BUILD
 There is no verified pact between version def456 of openbank-transaction-service and the version of openbank-fraud-service currently deployed to sandbox"
 
+# 11b (#3223). UNVERIFIABLE is durable BY MEASUREMENT — the counterpart version carries no
+#     pacts — and a co-deploy is the remedy for exactly that, so it must be set-eligible.
+#     Before the class existed these blocks arrived as UNVERIFIED or PENDING_BUILD, so this
+#     asserts the allow-list did not lose the pair when the label changed.
+check "UNVERIFIABLE pair is a co-deploy set" \
+  "CODEPLOY${TAB}openbank-fraud-service openbank-transaction-service" \
+  "openbank-fraud-service openbank-transaction-service" \
+"===SERVICE openbank-fraud-service${TAB}UNVERIFIABLE
+There is no verified pact between version abc123 of openbank-fraud-service and the version of openbank-transaction-service currently deployed to sandbox
+===SERVICE openbank-transaction-service${TAB}UNVERIFIABLE
+There is no verified pact between version def456 of openbank-transaction-service and the version of openbank-fraud-service currently deployed to sandbox"
+
 # ── issue #3454: NOT_ASKED, the class where no verdict exists at all ─────────────────────
 # 12. A NOT_ASKED pair references each other exactly like a deadlocked one, and on a fleet
 #     dispatch this is EVERY blocked service (54 of 54 on run 30765380309). Recommending a

--- a/.github/workflows/auto-deploy.yml
+++ b/.github/workflows/auto-deploy.yml
@@ -960,12 +960,14 @@ jobs:
                 echo "::warning::can-i-deploy: ${svc} has counterpart(s) not yet recorded in sandbox — treating as deployable (ADR-0092)"
                 deployable_list+=("$svc")
               else
-                # Why is it blocked? A queue delay and a real regression give the SAME
-                # verdict (#2549) — classify-can-i-deploy-block.sh's header has the full
-                # reasoning and the unit test drives every branch. Reuse the probe taken
-                # above: a second call could disagree and explain a block decided on other
-                # evidence. Keep this comment SHORT (check-workflow-run-step-size.py).
-                cls_line="$(PACT_VERSION_PRESENT="$vpresent" \
+                # Why blocked? #2549 (lag vs regression) + #3223 (counterpart carries no pacts,
+                # so waiting cannot help). Reasoning in both script headers. Reuse $vpresent.
+                # A probe that cannot run must not abort the step nor restore the promise.
+                IFS=$'\t' read -r cp_st cp_dt \
+                  < <(bash .github/scripts/probe-blocking-counterparts.sh <<< "$cid_out") \
+                  || { cp_st=unknown; cp_dt=""; }
+                cls_line="$(PACT_VERSION_PRESENT="$vpresent" COUNTERPART_STATE="$cp_st" \
+                  COUNTERPART_DETAIL="$cp_dt" \
                   bash .github/scripts/classify-can-i-deploy-block.sh "$svc" <<< "$cid_out")"
                 cls="$(cut -f1 <<< "$cls_line")"
                 cls_why="$(cut -f2- <<< "$cls_line")"


### PR DESCRIPTION
## What this fixes

`can-i-deploy` block classes end in a **promise**: PENDING_BUILD's *"the 3-hourly reconcile
re-drives it automatically"* and UNVERIFIED's *"normally clears within one reconcile tick"*.
Both were constants attached to a verdict. `classify-can-i-deploy-block.sh` makes no network
call by design, so it could not know whether waiting helps — and for a large share of today's
blocks it does not, structurally.

This PR does **not** change the identifier scheme (that is the owner's call, see below). It
makes the durable/transient distinction come from **evidence**.

## Proven: which workflow writes the contentless versions

`record-deployment-on-merge.yml`'s idempotent `PUT` — the leading hypothesis in #3223, which
was explicitly not proven. It is now, by correlating a specific broker version with the run
that created it, to the second:

| observation | value |
|---|---|
| broker version `openbank-transaction-service` @ `a5e5d32a…` | `createdAt 2026-07-24T08:05:19Z`, `tags: []`, `pb:pact-versions: []` |
| its `deployed-versions` record (still `currentlyDeployed: true`) | `createdAt 2026-07-24T08:05:21Z` |
| run `30077670109`, job `record-deployment`, branch `chore/gitops-codeploy-swift-transaction-1348` | `08:05:18.9  version not in broker yet — creating it via REST (idempotent PUT)` <br> `08:05:19.5  PUT version → HTTP 201` <br> `08:05:21.4  Recorded deployment of openbank-transaction-service version a5e5d32a… to sandbox` |

`HTTP 201` is the decisive part: the version was **created** by that PUT, not found. No other
workflow on `main` calls `record-deployment` or PUTs a pacticipant version.

Two corrections to how this has been described:

- The recorded sha is the **image-tag sha**, not the gitops merge commit. `a5e5d32a` reached
  transaction-service because a reconcile tick rebuilt it at `main`'s tip and #2057 pinned
  `openbank-transaction-service:sandbox-a5e5d32a`. So the sha names a commit that touched the
  service zero times, exactly as #3223 says, but via the reconcile rebuild rather than via the
  branch name.
- On the runs measured tonight the verdict is **PENDING_BUILD**, not UNVERIFIED. On run
  `31080511057` all six blocked money-path services had `PACT_VERSION_PRESENT=no`, so every one
  reported *"its main-push build has not finished … the reconcile re-drives it automatically"*.
  The false promise is therefore not confined to the UNVERIFIED branch, and a fix scoped to that
  branch would have missed every service in that run.

## Measured, read-only, against the live broker

All **seven** distinct counterpart versions named by run `31080511057`'s verdicts carry zero pacts:

```
contentless  openbank-account-service@f409d797,openbank-balance-service@e88849d6,
             openbank-fraud-service@c1f2e5a5,openbank-fx-service@6138c3a7,
             openbank-pid-service@fe48f5b6,openbank-swift-service@fe48f5b6,
             openbank-transaction-service@a5e5d32a
```

That is the whole blocked set, all six of them money-path, every one promised a reconcile that
cannot deliver.

## The change

- **New `.github/scripts/probe-blocking-counterparts.sh`.** Parses the `(counterpart, version)`
  pairs the verdict itself names and asks the broker one question each: does that version have
  any pacts? Reports `contentless | has-pacts | none | unknown`. Every failure degrades to
  `unknown`, never to `has-pacts` — degrading to `has-pacts` would restore the false
  reassurance on no evidence.
- **`classify-can-i-deploy-block.sh`** gains `UNVERIFIABLE`: durable, names the offending
  versions, states that waiting cannot help. It is tested **before** the `PACT_VERSION_PRESENT`
  split (so it beats PENDING_BUILD too) and **after** REGRESSION (an observed verification
  failure still outranks it). When the probe returns `unknown`, the old message is kept but
  marked unproven rather than repeated as fact. The classifier stays a pure function — the
  network call lives in the probe, where a stubbed self-test can drive every branch.
- **`derive-codeploy-set.py`**: `UNVERIFIABLE` is co-deploy-eligible. It is the one class backed
  by a measurement that the block is durable, and a co-deploy is precisely its remedy. Before
  this class these blocks arrived as UNVERIFIED (already eligible) or PENDING_BUILD (excluded
  and mislabelled), so this keeps the honest half of today's behaviour rather than widening it.
- Both unit tests extended; the probe's self-test registered as an **enforced** gate.

**No deploy behaviour changes.** A blocked service stays blocked under every class; only the
label and the message move.

## Validation

- `probe-blocking-counterparts.sh --self-test` — 10 cases, including both directions of
  contentless-dominates and every probe failure mode. Falsified by construction: each case was
  run against the stub before the aggregation was written the way it is.
- Both directions checked against the **live broker** (read-only, port-forward): the contentless
  version answers `contentless`, and `openbank-transaction-service`'s current `main` version
  answers `has-pacts`. A probe that has only seen one answer proves nothing.
- The shell change was exercised as the **bytes extracted from `auto-deploy.yml`** (parsed out
  of the YAML with PyYAML, not retyped): real verdict + live broker → `UNVERIFIABLE`; probe
  script removed → the step survives under `-e` and falls back to today's label with the
  "unproven" qualifier.
- **Workflow validated against GitHub**, oracle validated first: a deliberately unparseable
  `auto-deploy.yml` pushed to a throwaway branch produced **1 run** (named after the file path,
  `failure`); this PR's version at the same head produced **0 runs**. Throwaway branch deleted.
- `run-gates.py --group supplychain`: 19/20 pass; the one failure is `release-scope-mismatch`,
  which refuses to run locally without `PR_DIFF_BASE`.
- `actionlint` finding set on `auto-deploy.yml` is **identical** to `origin/main`'s;
  `shellcheck` clean on the new script; largest `run:` step 18955 chars (limit 19000).
- After merging `main`: `.github/gates/gates.yaml` went 109 → 110 ids, diff is exactly the one
  added entry — checked because a clean merge can silently drop a neighbouring list entry.

## What I did NOT do, and what could still be wrong

- **I did not change what a pacticipant version is.** The owner's own comment on #3223 argues
  for content-addressed versions and states it is an ADR-level call, not unilateral. I did not
  write that ADR either: the proposal already exists in the owner's words on #3223, and a
  second copy authored by me would be me choosing its shape. This PR is complementary — after
  a content-id cutover the probe still answers correctly, and until then it stops the estate
  lying about it.
- **This does not unblock a single deploy.** Zero services deploy that did not before. It
  converts a false "wait" into an accurate "waiting cannot help, here is what has to move".
  If that reads as insufficient, that judgement is correct — the unblocking fix is the
  identifier decision.
- **Parsing risk.** The probe keys on the CLI's `"and the version of <svc> currently in <env>
  (<40-hex>)"` phrasing. A pact-CLI upgrade that rewords it silently yields `none` → today's
  behaviour, not a wrong answer, but also no fix. I did not pin or test against another CLI
  version.
- **`has-pacts` is not proof that waiting helps.** It only rules out this cause. #3306's other
  half — verifications publishing against a sha that is never the deployed one — still blocks
  permanently and will still be labelled UNVERIFIED/PENDING_BUILD here. I did not attempt it.
- **Cost.** Up to three broker calls per counterpart per blocked service, inside the existing
  `can-i-deploy` job. Small, but not measured under a fleet-sized block.
- **Not observed in CI.** The broker has no public ingress and `PACT_BROKER_URL` is blank off
  main-push, so the real probe path cannot run on this PR. Everything above is a self-test, a
  local run against the live broker, or an extraction of the real step — the first production
  evidence will be the first `main` push after merge.
- **The `unknown` fallback is silent about which it was.** A missing script and an unreachable
  broker both land on `unknown`; only the log line distinguishes them.

Refs #3223, #3306, #3596, #3432, #2549, #3454
