### PR TITLE
chore(admin-ui): regenerate app-status.json for openbank-app 0.16.0

### DIFF
--- a/openbank-admin-ui/app-status.json
+++ b/openbank-admin-ui/app-status.json
@@ -12,7 +12,7 @@
   "asOf": "2026-07-29",
   "appRepo": "JiRaska/openbank-app",
   "derived": {
-    "version": "0.15.0",
+    "version": "0.16.0",
     "useFakeData": false,
     "edgeBaseUrl": "https://customer.open-bank.tech",
     "keycloakIssuer": "https://kc.open-bank.tech/realms/openbank-customers",


### PR DESCRIPTION
## Summary

Third manual dossier refresh this week (#3747 → 0.14.0, #3811 → 0.15.0): the fallback-verification dispatch of openbank-app's `release-please.yml` cut **0.16.0** (#383) ahead of the daily schedule. Merged by `GITHUB_TOKEN`, so the push did not trigger the `app-status` publish job — the expected behaviour until `RP_TOKEN` is set (openbank-app#382, layer-2 fix for #2101). Gate drift: `version: committed="0.15.0" → regenerated="0.16.0"`. Diff is exactly the one field.

## Type of change

- [x] chore (build / tooling)

## Linked issues

Refs #2101

## Changes

- `openbank-admin-ui/app-status.json`: `derived.version` 0.15.0 → 0.16.0 (generator output, not hand-edited).

## Definition of Done

- [x] Verified with the gate's own enforce mode against a current openbank-app checkout: `--check --enforce` exits 0.

## Security checklist

- [x] No secrets, tokens, passwords, or PII (derived facts only).
- [x] No new third-party dependency.

## Compliance impact

- [x] None

## Rollout / Rollback

- Deployment strategy: none — consumed by the dossier gate and the admin-ui build at next CI run.
- Rollback plan: revert the squash commit.
- Data migration reversible: N/A

## Reviewer notes

This should be the **last** manual refresh: once the PAT (#2101 comment) is set as `RP_TOKEN` + `PLATFORM_RW_TOKEN` in openbank-app, the next release merge both triggers `app-status` and gives the publish job its credentials. Current drift would still have needed this manual pass regardless — the publish job only fires on new pushes, nothing retroactive.