### PR TITLE
feat(copilot): give conversation history a deletion path

### DIFF
--- a/openbank-copilot-service/CLAUDE.md
+++ b/openbank-copilot-service/CLAUDE.md
@@ -47,6 +47,29 @@ layer (advisory by default, `copilot.opa.enforce=false`; flip via `COPILOT_OPA_E
 once `copilot-opa-bundle.yaml` is deployed). OPA rego tool names synced to actual Kotlin `name` values.
 `ScheduledPaymentsTool` capability corrected to `account.scheduled-payments.read`.
 
+## Conversation history is personal data — and is now erasable (#3870)
+
+Durable chat transcripts live in Postgres (`conversation_history`, `PostgresConversationStore`).
+Free-text chat is where the least predictable personal data lands, so the retention path matters:
+
+- **`expires_at` is a read-side filter, not deletion.** `load` filters on `expires_at > now()`, so an
+  expired conversation stops being *served* while the row stays on disk and in every base backup.
+  `ConversationRetentionScheduler` is what actually removes it (daily 03:30 UTC,
+  `copilot.retention.conversation.enabled`).
+- **`PartyErasureConsumer`** consumes `PARTY_ERASED` and hard-deletes the party's rows (GDPR Art. 17,
+  ADR-0117), matching the shape the other seven consumers of that topic use.
+- **The erasure ops on `ConversationStore` are `suspend`, deliberately.** Both callers already run on
+  a Vert.x context, where the blocking `VertxContextSupport.subscribeAndAwait` bridge that `load` and
+  `append` use would throw. For the same reason the sweep is a `suspend @Scheduled` method — a plain
+  one runs on a bare `executor-thread` and dies with `HR000068` on the first reactive call.
+- **The header comment in `V1__conversation_history.sql` is now stale** — it says there is no sweep
+  and no `PARTY_ERASED` consumer "yet". It is deliberately NOT corrected: Flyway checksums the whole
+  file including comments, so editing an applied migration fails the service at boot. Believe this
+  file, not that one.
+- **Known gap:** the event carries `partyId`, but history is keyed on the OIDC `sub`. The customers
+  realm also defines a separate `party_id` claim, so where those differ the erasure matches nothing.
+  Tracked separately — do not read the consumer as complete coverage.
+
 ## Build
 
 ```

--- a/openbank-copilot-service/build.gradle.kts
+++ b/openbank-copilot-service/build.gradle.kts
@@ -40,6 +40,10 @@ dependencies {
     implementation(libs.quarkus.reactive.pg.client)
     implementation(libs.quarkus.flyway)
     implementation(libs.quarkus.jdbc.postgresql)
+    // PARTY_ERASED consumer — GDPR Art. 17 erasure of conversation history (#3870).
+    implementation(libs.quarkus.smallrye.kafka)
+    // Retention sweep that hard-deletes past-expires_at conversations (#3870).
+    implementation(libs.quarkus.scheduler)
 
     // Shared runtime plumbing: model gateway seam (ADR-0031), OPA authz (ADR-0034),
     // feature flags (ADR-0067), AI-attributed audit (ADR-0031 D5).

--- a/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/application/port/out/ConversationStore.kt
+++ b/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/application/port/out/ConversationStore.kt
@@ -5,6 +5,7 @@
 package com.openbank.copilot.application.port.out
 
 import com.openbank.copilot.domain.model.ChatMessage
+import java.time.Instant
 
 /**
  * Outbound port: short-lived conversation memory for the copilot (ADR-0089): without it every turn is stateless,
@@ -35,6 +36,30 @@ interface ConversationStore {
      * conversation, trimming to the most recent [MAX_MESSAGES] and (re)setting the TTL.
      */
     fun append(customerId: String, conversationId: String, newTurns: List<ChatMessage>)
+
+    /**
+     * Erase every conversation held for [customerId], returning how many were removed (GDPR Art. 17 /
+     * ADR-0117). Called by the `PARTY_ERASED` consumer.
+     *
+     * This is a **hard delete**, not the read-side `expires_at` filter [load] applies: an expired
+     * conversation stops being *served* but its free-text message bodies stay on disk (and in every
+     * base backup) until something removes the row. For an erasure request the difference between
+     * "not served" and "not held" is the whole question.
+     *
+     * `suspend`, deliberately: both callers (the Kafka consumer and the retention sweep) already run
+     * on a Vert.x context, where the blocking `VertxContextSupport.subscribeAndAwait` bridge the
+     * read/write path uses would throw. Keeping erasure suspending means it never needs that bridge.
+     */
+    suspend fun deleteForCustomer(customerId: String): Long
+
+    /** Erase one conversation. Scoped by [customerId], so it can never remove another customer's row. */
+    suspend fun deleteConversation(customerId: String, conversationId: String): Long
+
+    /**
+     * Hard-delete every conversation whose `expires_at` is at or before [now], returning the count.
+     * This is what turns the rolling TTL from a read filter into an actual retention guarantee.
+     */
+    suspend fun deleteExpired(now: Instant): Long
 
     companion object {
         /** Sliding TTL. A chat left idle past this loses its context — matches typical session UX. */

--- a/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/infrastructure/kafka/PartyErasureConsumer.kt
+++ b/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/infrastructure/kafka/PartyErasureConsumer.kt
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+package com.openbank.copilot.infrastructure.kafka
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.copilot.application.port.out.ConversationStore
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.inject.Inject
+import org.eclipse.microprofile.reactive.messaging.Incoming
+import org.jboss.logging.Logger
+import java.util.UUID
+
+/**
+ * Handles `PARTY_ERASED` from party-service (GDPR Art. 17 / ADR-0117, ADR-0238) by hard-deleting the
+ * erased party's copilot conversation history (#3870).
+ *
+ * Free-text chat transcripts are exactly where unpredictable personal data lands, and until this
+ * consumer existed copilot held them durably in Postgres with no deletion path at all — the 90-day
+ * `expires_at` is applied on *read*, so an expired conversation merely stopped being served while
+ * its message bodies stayed on disk and in every base backup.
+ *
+ * Shape is copied from the seven services that already consume this event (notification-service's
+ * `PartyErasureConsumer` is the closest sibling): `suspend @Incoming` so Quarkus dispatches on a
+ * Vert.x duplicated context and the reactive Panache delete below runs correctly; poison-pill safe,
+ * so any parse or delete failure is logged and the message acked rather than wedging the group.
+ *
+ * ## Identity caveat — read before trusting this as complete
+ *
+ * The event carries only `partyId`. Copilot keys conversation history on the OIDC `sub`
+ * (`CopilotChatResource.customerSubject()`), and the customers realm additionally defines a separate
+ * `party_id` claim backed by a user attribute, which customer-edge falls back to `sub` for only when
+ * that attribute is unset. Where the attribute IS set and differs from `sub`, the delete below
+ * matches nothing. That join is not fixed here — see the PR body and the follow-up issue.
+ */
+@ApplicationScoped
+class PartyErasureConsumer {
+
+    @Inject
+    lateinit var conversationStore: ConversationStore
+
+    @Inject
+    lateinit var objectMapper: ObjectMapper
+
+    private val log = Logger.getLogger(PartyErasureConsumer::class.java)
+
+    @Suppress("TooGenericExceptionCaught") // a consumer must never die on a single bad/foreign event
+    @Incoming("party-events-in")
+    suspend fun consume(payload: String) {
+        val node = try {
+            objectMapper.readTree(payload)
+        } catch (e: Exception) {
+            log.errorf(e, "[party-events-in] Failed to parse JSON payload: %.200s", payload)
+            return
+        }
+
+        if (node.path("eventType").asText() != "PARTY_ERASED") return
+
+        val partyId = runCatching { UUID.fromString(node.path("partyId").asText()) }.getOrNull()
+        if (partyId == null) {
+            log.warnf("[party-events-in] PARTY_ERASED without a valid partyId, skipping: %.200s", payload)
+            return
+        }
+
+        try {
+            val erased = conversationStore.deleteForCustomer(partyId.toString())
+            log.infof(
+                "[party-events-in] GDPR Art. 17: erased %d copilot conversation(s) for party %s",
+                erased,
+                partyId,
+            )
+        } catch (e: Exception) {
+            log.errorf(e, "[party-events-in] Failed to erase copilot conversations for party %s", partyId)
+        }
+    }
+}

--- a/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/infrastructure/persistence/InMemoryConversationStore.kt
+++ b/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/infrastructure/persistence/InMemoryConversationStore.kt
@@ -48,6 +48,22 @@ class InMemoryConversationStore(private val clock: Clock) : ConversationStore {
         log.debugf("InMemoryConversationStore: appended %d turn(s) key=%s", newTurns.size, k)
     }
 
+    override suspend fun deleteForCustomer(customerId: String): Long {
+        val prefix = "$customerId|"
+        val victims = store.keys.filter { it.startsWith(prefix) }
+        victims.forEach { store.remove(it) }
+        return victims.size.toLong()
+    }
+
+    override suspend fun deleteConversation(customerId: String, conversationId: String): Long =
+        if (store.remove(key(customerId, conversationId)) != null) 1L else 0L
+
+    override suspend fun deleteExpired(now: Instant): Long {
+        val victims = store.entries.filter { !now.isBefore(it.value.expiresAt) }.map { it.key }
+        victims.forEach { store.remove(it) }
+        return victims.size.toLong()
+    }
+
     private fun evictExpired() {
         val now = Instant.now(clock)
         store.entries.removeIf { now.isAfter(it.value.expiresAt) }

--- a/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/infrastructure/persistence/PostgresConversationStore.kt
+++ b/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/infrastructure/persistence/PostgresConversationStore.kt
@@ -139,6 +139,24 @@ class PostgresConversationStore(private val mapper: ObjectMapper) :
         }
     }
 
+    // ---- Erasure (GDPR Art. 17 / ADR-0117, #3870) --------------------------------------------
+    // These are `suspend` and deliberately do NOT go through the `vtx` bridge below: their callers
+    // (PartyErasureConsumer, ConversationRetentionScheduler) are suspend functions already dispatched
+    // on a Vert.x context, and `VertxContextSupport.subscribeAndAwait` throws when invoked from an
+    // event loop. A DELETE also removes the row outright — unlike `load`, which merely stops serving
+    // it once `expires_at` passes.
+
+    override suspend fun deleteForCustomer(customerId: String): Long =
+        Panache.withTransaction { delete("customerId = ?1", customerId) }.awaitSuspending()
+
+    override suspend fun deleteConversation(customerId: String, conversationId: String): Long =
+        Panache.withTransaction {
+            delete("customerId = ?1 and conversationId = ?2", customerId, conversationId)
+        }.awaitSuspending()
+
+    override suspend fun deleteExpired(now: Instant): Long =
+        Panache.withTransaction { delete("expiresAt <= ?1", now) }.awaitSuspending()
+
     data class StoredMessage(val role: ChatRole = ChatRole.USER, val content: String = "")
 
     private fun <T> vtx(block: suspend () -> T): T =

--- a/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/infrastructure/persistence/RedisConversationStore.kt
+++ b/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/infrastructure/persistence/RedisConversationStore.kt
@@ -16,6 +16,7 @@ import jakarta.enterprise.context.ApplicationScoped
 import jakarta.inject.Inject
 import kotlinx.coroutines.runBlocking
 import org.jboss.logging.Logger
+import java.time.Instant
 
 /**
  * Production conversation memory (Valkey/Redis). Stores one JSON array of [StoredMessage] per
@@ -31,6 +32,7 @@ class RedisConversationStore @Inject constructor(
 ) : ConversationStore {
     private val log = Logger.getLogger(RedisConversationStore::class.java)
     private val values by lazy { redis.value(String::class.java) }
+    private val keys by lazy { redis.key(String::class.java) }
 
     /** Wire form — deliberately minimal so a schema drift in [ChatMessage] can't corrupt history. */
     data class StoredMessage(val role: ChatRole = ChatRole.USER, val content: String = "")
@@ -67,6 +69,34 @@ class RedisConversationStore @Inject constructor(
             ConversationStore.TTL_SECONDS,
         )
     }
+
+    // ---- Erasure (GDPR Art. 17 / ADR-0117, #3870) --------------------------------------------
+
+    override suspend fun deleteForCustomer(customerId: String): Long {
+        val prefix = "copilot:conv:$customerId:"
+        // KEYS takes a glob, and customerId is caller-derived, so a metacharacter in it could widen
+        // the pattern across customers. The returned keys are therefore re-filtered on the LITERAL
+        // prefix before anything is deleted — the glob only narrows the scan, it never authorises.
+        val matched = keys.keys("$prefix*").awaitSuspending()
+            .filter { it.startsWith(prefix) }
+        if (matched.isEmpty()) return 0L
+        // Deleted one key at a time rather than with a spread vararg: an erasure set is tiny (a
+        // customer's open conversations), and the spread would copy the array on every call.
+        matched.forEach { keys.del(it).awaitSuspending() }
+        log.infof("RedisConversationStore: erased %d conversation(s) for a customer", matched.size)
+        return matched.size.toLong()
+    }
+
+    override suspend fun deleteConversation(customerId: String, conversationId: String): Long {
+        if (!ConversationStore.persistable(conversationId)) return 0L
+        return keys.del(key(customerId, conversationId)).awaitSuspending().toLong()
+    }
+
+    /**
+     * No-op by construction: Redis evicts on its own TTL, so there is never a past-expiry key left
+     * to sweep. Returning 0 is the honest answer, not a silent success.
+     */
+    override suspend fun deleteExpired(now: Instant): Long = 0L
 
     // customerId precedes conversationId, so a crafted conversationId can only ever land inside the
     // SAME customer's namespace — it can never escape to another customer's history.

--- a/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/infrastructure/retention/ConversationRetentionScheduler.kt
+++ b/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/infrastructure/retention/ConversationRetentionScheduler.kt
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+package com.openbank.copilot.infrastructure.retention
+
+import com.openbank.copilot.application.port.out.ConversationStore
+import io.quarkus.scheduler.Scheduled
+import io.quarkus.scheduler.Scheduled.ConcurrentExecution.SKIP
+import jakarta.enterprise.context.ApplicationScoped
+import org.eclipse.microprofile.config.inject.ConfigProperty
+import org.jboss.logging.Logger
+import java.time.Clock
+import java.time.Instant
+
+/**
+ * Turns copilot's 90-day conversation TTL from a read filter into an actual retention guarantee
+ * (#3870, ADR-0118 §5 / ADR-0238).
+ *
+ * `PostgresConversationStore.load` filters on `expires_at > now()`, so an expired conversation stops
+ * being *readable* — but nothing deleted the row, and the message text (free-text chat, i.e. the
+ * least predictable personal data this platform holds) stayed on disk and in every base backup
+ * indefinitely. This sweep hard-deletes those rows.
+ *
+ * ## `suspend fun` is load-bearing, not style
+ *
+ * A plain `@Scheduled` method is invoked by Quarkus on a bare `executor-thread` with **no Vert.x
+ * context**, so the reactive Panache delete would throw `HR000068` before any per-item `try/catch`
+ * and the tick would abort having done nothing, silently — the defect that left five schedulers in
+ * this repo never running (#2148, #2187). A `suspend` method is dispatched on a duplicated Vert.x
+ * context instead. `VertxContextSupport.subscribeAndAwait` is *not* the alternative: it throws when
+ * called from an event loop.
+ *
+ * Runs daily at 03:30 UTC by default; `concurrentExecution = SKIP` prevents overlap on a slow run.
+ * [enabled] defaults to **true**: unlike a brand-new retention policy, deleting past-`expires_at`
+ * rows only removes conversations the service already refuses to serve, so the sweep cannot destroy
+ * anything reachable through the API.
+ */
+@ApplicationScoped
+class ConversationRetentionScheduler(
+    private val conversationStore: ConversationStore,
+    private val clock: Clock,
+    @ConfigProperty(name = "copilot.retention.conversation.enabled", defaultValue = "true")
+    private val enabled: Boolean,
+) {
+
+    private val log = Logger.getLogger(ConversationRetentionScheduler::class.java)
+
+    @Suppress("TooGenericExceptionCaught") // one failed tick must not kill the schedule
+    @Scheduled(
+        cron = "{copilot.retention.conversation.cron:0 30 3 * * ?}",
+        concurrentExecution = SKIP,
+    )
+    suspend fun sweepExpiredConversations() {
+        if (!enabled) return
+        val now = Instant.now(clock)
+        try {
+            val deleted = conversationStore.deleteExpired(now)
+            if (deleted > 0) {
+                log.infof(
+                    "[retention] Hard-deleted %d copilot conversation(s) with expires_at <= %s",
+                    deleted,
+                    now,
+                )
+            }
+        } catch (e: Exception) {
+            log.errorf(e, "[retention] copilot conversation retention sweep failed at %s", now)
+        }
+    }
+}

--- a/openbank-copilot-service/src/main/resources/application.yaml
+++ b/openbank-copilot-service/src/main/resources/application.yaml
@@ -116,6 +116,23 @@ copilot:
   # once copilot-opa-bundle.yaml is deployed and the sidecar is live (issue #998 advisory→enforce).
   opa:
     enforce: ${COPILOT_OPA_ENFORCE:false}
+  # Hard-delete of past-expires_at conversation rows (#3870). Without this the 90-day TTL is a
+  # read-side filter only: expired conversations stop being served but stay on disk forever.
+  retention:
+    conversation:
+      enabled: ${COPILOT_RETENTION_ENABLED:true}
+
+# PARTY_ERASED consumer (GDPR Art. 17 / ADR-0117), mirroring the seven services already on this
+# topic. group.id / auto.offset.reset are deliberately NOT set here: SmallRye's YAML source quotes a
+# leaf key containing a literal dot, so `group.id:` would register as `..."group.id"` and never be
+# read (#686). They belong in the copilot-service msg-override ConfigMap in gitops.
+mp:
+  messaging:
+    incoming:
+      party-events-in:
+        connector: smallrye-kafka
+        topic: openbank.party.events
+        value.deserializer: org.apache.kafka.common.serialization.StringDeserializer
 
 # OPA sidecar (ADR-0034). Advisory mode by default.
 opa:
@@ -132,3 +149,17 @@ authz:
     datasource:
       devservices:
         enabled: true
+    # No broker under test: the PARTY_ERASED consumer is covered by a plain unit test, and a Kafka
+    # Dev Services container would only slow every @QuarkusTest in this module down. health-enabled
+    # false keeps the unreachable channel from failing readiness in the boot smoke test.
+    kafka:
+      devservices:
+        enabled: false
+  mp:
+    messaging:
+      incoming:
+        party-events-in:
+          health-enabled: false
+  kafka:
+    bootstrap:
+      servers: localhost:9092

--- a/openbank-copilot-service/src/test/kotlin/com/openbank/copilot/infrastructure/kafka/PartyErasureConsumerTest.kt
+++ b/openbank-copilot-service/src/test/kotlin/com/openbank/copilot/infrastructure/kafka/PartyErasureConsumerTest.kt
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+package com.openbank.copilot.infrastructure.kafka
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.copilot.application.port.out.ConversationStore
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+/**
+ * Routing/robustness cover for the PARTY_ERASED consumer (#3870). That the delete actually removes
+ * the ROW is proven against a real database in `ConversationErasureIT` — a mocked store here could
+ * not tell deletion from the read-side `expires_at` filter, which is the defect being fixed.
+ */
+class PartyErasureConsumerTest {
+
+    private val conversationStore = mockk<ConversationStore>()
+    private lateinit var consumer: PartyErasureConsumer
+
+    @BeforeEach
+    fun setUp() {
+        consumer = PartyErasureConsumer().also {
+            it.conversationStore = conversationStore
+            it.objectMapper = ObjectMapper()
+        }
+    }
+
+    @Test
+    fun `PARTY_ERASED erases the party's conversation history`(): Unit = runBlocking {
+        val partyId = UUID.randomUUID()
+        coEvery { conversationStore.deleteForCustomer(partyId.toString()) } returns 3L
+
+        consumer.consume("""{"eventType":"PARTY_ERASED","partyId":"$partyId"}""")
+
+        coVerify(exactly = 1) { conversationStore.deleteForCustomer(partyId.toString()) }
+    }
+
+    @Test
+    fun `other party events are ignored`(): Unit = runBlocking {
+        consumer.consume("""{"eventType":"PARTY_CREATED","partyId":"${UUID.randomUUID()}"}""")
+        consumer.consume("""{"eventType":"PARTY_UPDATED","partyId":"${UUID.randomUUID()}"}""")
+
+        coVerify(exactly = 0) { conversationStore.deleteForCustomer(any()) }
+    }
+
+    @Test
+    fun `a malformed payload is acked without throwing`(): Unit = runBlocking {
+        consumer.consume("not json")
+        consumer.consume("""{"eventType":"PARTY_ERASED"}""")
+        consumer.consume("""{"eventType":"PARTY_ERASED","partyId":"not-a-uuid"}""")
+
+        coVerify(exactly = 0) { conversationStore.deleteForCustomer(any()) }
+    }
+
+    @Test
+    fun `a store failure is swallowed so one bad message cannot wedge the consumer group`(): Unit = runBlocking {
+        val partyId = UUID.randomUUID()
+        coEvery { conversationStore.deleteForCustomer(partyId.toString()) } throws IllegalStateException("db down")
+
+        consumer.consume("""{"eventType":"PARTY_ERASED","partyId":"$partyId"}""")
+
+        coVerify(exactly = 1) { conversationStore.deleteForCustomer(partyId.toString()) }
+    }
+}

--- a/openbank-copilot-service/src/test/kotlin/com/openbank/copilot/it/ConversationErasureIT.kt
+++ b/openbank-copilot-service/src/test/kotlin/com/openbank/copilot/it/ConversationErasureIT.kt
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+package com.openbank.copilot.it
+
+import com.openbank.copilot.application.port.out.ConversationStore
+import com.openbank.copilot.domain.model.ChatMessage
+import com.openbank.copilot.domain.model.ChatRole
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.vertx.VertxContextSupport
+import io.smallrye.mutiny.coroutines.uni
+import jakarta.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import org.assertj.core.api.Assertions.assertThat
+import org.eclipse.microprofile.config.ConfigProvider
+import org.junit.jupiter.api.Test
+import java.sql.DriverManager
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * Proves copilot conversation history can actually be ERASED (#3870, GDPR Art. 17 / ADR-0117).
+ *
+ * ## Why every assertion is a direct JDBC query
+ *
+ * `ConversationStore.load` filters on `expires_at > now()`, so reading through it cannot distinguish
+ * "the row was deleted" from "the row is still there but no longer served" — and that distinction is
+ * the entire defect being fixed. A test that asserted `load(...).isEmpty()` would pass against the
+ * pre-fix code, where nothing ever deleted anything. So the fixtures are written through the store
+ * (the real production write path) and every verdict is read straight out of `conversation_history`.
+ *
+ * RED against the code before this change: `deleteForCustomer` / `deleteConversation` did not exist
+ * on the port at all, so these tests did not compile — and once stubbed to no-ops they fail on the
+ * row count, which is the assertion that matters.
+ *
+ * No real conversation content appears here; the fixtures are literal placeholder strings.
+ */
+@QuarkusTest
+@QuarkusTestResource(CopilotPostgresTestResource::class)
+class ConversationErasureIT {
+
+    @Inject
+    lateinit var store: ConversationStore
+
+    private val customer = "customer-${UUID.randomUUID()}"
+    private val other = "customer-${UUID.randomUUID()}"
+
+    private fun <T> onEventLoop(block: suspend () -> T): T =
+        VertxContextSupport.subscribeAndAwait { uni(CoroutineScope(Dispatchers.Unconfined)) { block() } }
+
+    /** Counts rows in the table itself — never through the store, which hides expired rows. */
+    private fun rowsFor(customerId: String): Int {
+        val config = ConfigProvider.getConfig()
+        DriverManager.getConnection(
+            config.getValue("quarkus.datasource.jdbc.url", String::class.java),
+            config.getValue("quarkus.datasource.username", String::class.java),
+            config.getValue("quarkus.datasource.password", String::class.java),
+        ).use { conn ->
+            conn.prepareStatement("SELECT count(*) FROM conversation_history WHERE customer_id = ?").use { ps ->
+                ps.setString(1, customerId)
+                ps.executeQuery().use { rs ->
+                    rs.next()
+                    return rs.getInt(1)
+                }
+            }
+        }
+    }
+
+    private fun seed(customerId: String, conversationId: String) {
+        store.append(customerId, conversationId, listOf(ChatMessage(ChatRole.USER, "placeholder-turn")))
+    }
+
+    @Test
+    fun `erasing a customer removes their rows from the table, not just from the read path`() {
+        seed(customer, "conv-a")
+        seed(customer, "conv-b")
+        assertThat(rowsFor(customer))
+            .describedAs("fixture must exist before erasure, or the test proves nothing")
+            .isEqualTo(2)
+
+        val erased = onEventLoop { store.deleteForCustomer(customer) }
+
+        assertThat(erased).isEqualTo(2L)
+        assertThat(rowsFor(customer))
+            .describedAs(
+                "PARTY_ERASED must leave NO conversation_history row for the party — before #3870 " +
+                    "the 90-day expires_at only stopped the row being served, it stayed on disk " +
+                    "and in every base backup indefinitely",
+            )
+            .isZero()
+    }
+
+    @Test
+    fun `erasing one customer leaves another customer's history untouched`() {
+        seed(customer, "conv-a")
+        seed(other, "conv-a")
+
+        onEventLoop { store.deleteForCustomer(customer) }
+
+        assertThat(rowsFor(customer)).isZero()
+        assertThat(rowsFor(other))
+            .describedAs("erasure is scoped by customer_id and must never widen across customers")
+            .isEqualTo(1)
+    }
+
+    @Test
+    fun `erasing a single conversation removes only that row`() {
+        seed(customer, "conv-a")
+        seed(customer, "conv-b")
+
+        val erased = onEventLoop { store.deleteConversation(customer, "conv-a") }
+
+        assertThat(erased).isEqualTo(1L)
+        assertThat(rowsFor(customer)).isEqualTo(1)
+    }
+
+    @Test
+    fun `deleteExpired removes a past-expiry row that load already refused to serve`() {
+        seed(customer, "conv-a")
+        // Backdate expires_at directly: append() always writes now + 90 days, so this is the only
+        // way to produce the state the sweep exists for. This is also the state that proves the
+        // read-side filter is not deletion — load() is empty here while the row is still present.
+        expireRow(customer)
+        assertThat(store.load(customer, "conv-a"))
+            .describedAs("an expired conversation is already unreadable — that is NOT erasure")
+            .isEmpty()
+        assertThat(rowsFor(customer))
+            .describedAs("…and the row is still very much on disk")
+            .isEqualTo(1)
+
+        val deleted = onEventLoop { store.deleteExpired(Instant.now()) }
+
+        assertThat(deleted).isGreaterThanOrEqualTo(1L)
+        assertThat(rowsFor(customer)).isZero()
+    }
+
+    private fun expireRow(customerId: String) {
+        val config = ConfigProvider.getConfig()
+        DriverManager.getConnection(
+            config.getValue("quarkus.datasource.jdbc.url", String::class.java),
+            config.getValue("quarkus.datasource.username", String::class.java),
+            config.getValue("quarkus.datasource.password", String::class.java),
+        ).use { conn ->
+            conn.prepareStatement(
+                "UPDATE conversation_history SET expires_at = now() - interval '1 day' WHERE customer_id = ?",
+            ).use { ps ->
+                ps.setString(1, customerId)
+                ps.executeUpdate()
+            }
+        }
+    }
+}

--- a/openbank-copilot-service/src/test/kotlin/com/openbank/copilot/it/ConversationRetentionSweepIT.kt
+++ b/openbank-copilot-service/src/test/kotlin/com/openbank/copilot/it/ConversationRetentionSweepIT.kt
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+package com.openbank.copilot.it
+
+import com.openbank.copilot.application.port.out.ConversationStore
+import com.openbank.copilot.domain.model.ChatMessage
+import com.openbank.copilot.domain.model.ChatRole
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.junit.QuarkusTestProfile
+import io.quarkus.test.junit.TestProfile
+import jakarta.inject.Inject
+import org.assertj.core.api.Assertions.assertThat
+import org.eclipse.microprofile.config.ConfigProvider
+import org.junit.jupiter.api.Test
+import java.sql.DriverManager
+
+/**
+ * Proves the retention sweep runs *as dispatched by the scheduler* and actually removes rows
+ * (#3870).
+ *
+ * ## Why this drives the real cron instead of calling the method
+ *
+ * The failure mode this guards against is in how the framework invokes the method, not in the body:
+ * a plain (non-`suspend`) `@Scheduled` method is run on a bare `executor-thread` with no Vert.x
+ * context, so the reactive Panache delete throws `HR000068` and the tick aborts silently having done
+ * nothing — the defect that left five schedulers in this repo never running (#2148, #2187). Calling
+ * `sweepExpiredConversations()` from a test supplies the very context the scheduler does not, so
+ * such a test passes against broken code and proves nothing.
+ *
+ * The profile below shrinks the cron to every two seconds against a real Postgres, and the test
+ * waits for a genuinely scheduler-dispatched run to have removed a past-expiry row.
+ *
+ * Ids are literals, not randomized in a companion object: a [QuarkusTestProfile] loads in a
+ * different classloader from the test class, so a companion initializes twice and a generated id
+ * would differ between the fixture and the assertion.
+ */
+@QuarkusTest
+@QuarkusTestResource(CopilotPostgresTestResource::class)
+@TestProfile(ConversationRetentionSweepIT.FastSweepProfile::class)
+class ConversationRetentionSweepIT {
+
+    class FastSweepProfile : QuarkusTestProfile {
+        override fun getConfigOverrides(): Map<String, String> = mapOf(
+            "quarkus.scheduler.enabled" to "true",
+            "copilot.retention.conversation.cron" to "*/2 * * * * ?",
+            "copilot.retention.conversation.enabled" to "true",
+        )
+    }
+
+    @Inject
+    lateinit var store: ConversationStore
+
+    @Test
+    fun `the scheduled sweep hard-deletes a past-expiry conversation`() {
+        store.append(CUSTOMER, CONVERSATION, listOf(ChatMessage(ChatRole.USER, "placeholder-turn")))
+        expireRow()
+        assertThat(rows())
+            .describedAs("fixture must be present and expired before the sweep, or nothing is proven")
+            .isEqualTo(1)
+
+        val swept = await { rows() == 0 }
+
+        assertThat(swept)
+            .describedAs(
+                "a scheduler-dispatched sweep must remove the row. Never removing one means the " +
+                    "tick threw HR000068 off the Vert.x context before the first query (#2148/#2187), " +
+                    "leaving the 90-day TTL a read filter rather than a retention guarantee",
+            )
+            .isTrue()
+    }
+
+    private fun await(ready: () -> Boolean): Boolean {
+        val deadline = System.nanoTime() + BUDGET_NANOS
+        while (System.nanoTime() < deadline) {
+            if (ready()) return true
+            Thread.sleep(POLL_INTERVAL_MILLIS)
+        }
+        return ready()
+    }
+
+    private fun <T> withConnection(block: (java.sql.Connection) -> T): T {
+        val config = ConfigProvider.getConfig()
+        return DriverManager.getConnection(
+            config.getValue("quarkus.datasource.jdbc.url", String::class.java),
+            config.getValue("quarkus.datasource.username", String::class.java),
+            config.getValue("quarkus.datasource.password", String::class.java),
+        ).use(block)
+    }
+
+    /** Read the table directly — `load` hides an expired row whether or not it was ever deleted. */
+    private fun rows(): Int = withConnection { conn ->
+        conn.prepareStatement("SELECT count(*) FROM conversation_history WHERE customer_id = ?").use { ps ->
+            ps.setString(1, CUSTOMER)
+            ps.executeQuery().use { rs ->
+                rs.next()
+                rs.getInt(1)
+            }
+        }
+    }
+
+    private fun expireRow() = withConnection { conn ->
+        conn.prepareStatement(
+            "UPDATE conversation_history SET expires_at = now() - interval '1 day' WHERE customer_id = ?",
+        ).use { ps ->
+            ps.setString(1, CUSTOMER)
+            ps.executeUpdate()
+        }
+    }
+
+    private companion object {
+        const val CUSTOMER = "sweep-it-customer"
+        const val CONVERSATION = "sweep-it-conversation"
+
+        /** Generous vs the 2 s cron so a slow CI runner cannot flake the wait. */
+        const val BUDGET_NANOS = 60_000_000_000L
+        const val POLL_INTERVAL_MILLIS = 250L
+    }
+}

--- a/openbank-copilot-service/src/test/kotlin/com/openbank/copilot/it/CopilotPostgresTestResource.kt
+++ b/openbank-copilot-service/src/test/kotlin/com/openbank/copilot/it/CopilotPostgresTestResource.kt
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+package com.openbank.copilot.it
+
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager
+import org.testcontainers.containers.PostgreSQLContainer
+
+/**
+ * Real Postgres for the erasure/retention ITs (#3870). Flyway runs against it, so the ITs exercise
+ * the actual `conversation_history` table rather than a Hibernate-generated approximation.
+ */
+class CopilotPostgresTestResource : QuarkusTestResourceLifecycleManager {
+    private lateinit var postgres: PostgreSQLContainer<*>
+
+    override fun start(): Map<String, String> {
+        postgres = PostgreSQLContainer("postgres:18-alpine")
+            .withDatabaseName("openbank_copilot")
+            .withUsername("openbank")
+            .withPassword("openbank")
+        postgres.start()
+        return mapOf(
+            "quarkus.datasource.reactive.url" to
+                "postgresql://${postgres.host}:${postgres.firstMappedPort}/${postgres.databaseName}",
+            "quarkus.datasource.jdbc.url" to postgres.jdbcUrl,
+            "quarkus.datasource.username" to postgres.username,
+            "quarkus.datasource.password" to postgres.password,
+            "quarkus.datasource.active" to "true",
+            "quarkus.flyway.enabled" to "true",
+            "quarkus.hibernate-orm.active" to "true",
+        )
+    }
+
+    override fun stop() {
+        if (::postgres.isInitialized) postgres.stop()
+    }
+}


### PR DESCRIPTION
## What this does

`openbank-copilot-service` held customer chat transcripts durably in Postgres with **no deletion
path**. `expires_at` is applied on *read*, so an expired conversation stopped being served while its
free-text message bodies stayed on disk — and in every base backup — indefinitely. Free-text chat is
where the least predictable personal data lands, so the difference between "not served" and "not
held" is the whole question.

Three things, in the order the issue asks for them:

1. **`ConversationStore` gains `deleteForCustomer` / `deleteConversation` / `deleteExpired`**, honoured
   by all three adapters (`Postgres`, `Redis`, `InMemory`).
2. **`PartyErasureConsumer`** consumes `PARTY_ERASED` and hard-deletes the party's rows. Shape copied
   from `notification-service`'s consumer — `suspend @Incoming`, poison-pill safe, no new convention.
3. **`ConversationRetentionScheduler`** sweeps past-`expires_at` rows daily at 03:30 UTC, turning the
   90-day TTL into a retention guarantee.

The erasure ops are `suspend` deliberately: both callers already run on a Vert.x context, where the
blocking `VertxContextSupport.subscribeAndAwait` bridge that `load`/`append` use would throw. The
sweep is a `suspend fun` for the same reason — a plain `@Scheduled` method runs on a bare
`executor-thread` and dies with `HR000068`.

## Issue measurements — all verified against live `origin/main`

| Claim in #3870 | Verdict |
|---|---|
| Port has only `load` + `append`, no delete | Confirmed |
| `expires_at` is a read-side filter, rows never deleted | Confirmed (`load` filters `expiresAt > ?3`; no `delete` anywhere) |
| `PARTY_ERASED` consumed by 7 services across 19 Kotlin files | Confirmed exactly — 20 matches, of which 1 is a YAML |
| The gap is recorded only in the migration comment | Confirmed |

Nothing in the issue was wrong.

## The red test, and what it is red about

**Erasure is asserted with a direct JDBC query, never through `load`.** Reading through the store
cannot distinguish "the row was deleted" from "the row is still there but no longer served" — which
is precisely the defect being fixed, so a `load(...).isEmpty()` assertion would pass against the
pre-fix code. Fixtures are written through the real production write path; every verdict is read out
of `conversation_history` directly.

Falsified by stubbing the three Postgres deletes to `= 0L` — all five new tests fail:

```
ConversationErasureIT > erasing a customer removes their rows from the table, not just from the read path() FAILED
    expected: 2L
     but was: 0L
ConversationErasureIT > erasing one customer leaves another customer's history untouched() FAILED
    expected: 0  but was: 1
ConversationErasureIT > erasing a single conversation removes only that row() FAILED
    expected: 1L but was: 0L
ConversationErasureIT > deleteExpired removes a past-expiry row that load already refused to serve() FAILED
    Expecting actual: 0L to be greater than or equal to: 1L
ConversationRetentionSweepIT > the scheduled sweep hard-deletes a past-expiry conversation() FAILED
5 tests completed, 5 failed
```

**Separately falsified against the scheduler defect itself**, which matters more than the assertion:
rewriting `sweepExpiredConversations` as a plain `fun … = runBlocking { }` makes
`ConversationRetentionSweepIT` go red with the real thing in the log —

```
[retention] copilot conversation retention sweep failed at 2026-08-06T09:43:40Z
java.lang.IllegalStateException: HR000068: This method should exclusively be invoked from a
Vert.x EventLoop thread; currently running on thread 'executor-thread-1 @coroutine#2'
```

so the IT genuinely detects the bug it exists to catch, rather than only detecting a missing DELETE.
It drives the real cron from a `@TestProfile` (`*/2 * * * * ?`) against a real Postgres; a test that
called the method directly would supply the very context the scheduler does not. Profile ids are
literals, not companion-generated, because a `QuarkusTestProfile` loads in a different classloader.

## Local gate

```
./gradlew --rerun-tasks :openbank-copilot-service:ktlintCheck :openbank-copilot-service:detekt :openbank-copilot-service:test
```

All three tasks appear as executed (not `UP-TO-DATE`). **125 tests, 0 failures**, of which the new
ones are `ConversationErasureIT` 4/4, `ConversationRetentionSweepIT` 1/1, `PartyErasureConsumerTest`
4/4 — counts read out of the JUnit XML, not off the console. `check-no-runblocking-in-scheduled.py`
passes: 77 `@Scheduled` methods checked, clean.

## What I did NOT verify, and what could still be wrong

- **The identity join is a real, unfixed gap — do not read this as complete erasure coverage.** The
  event carries only `partyId`. Copilot keys history on the OIDC `sub`
  (`CopilotChatResource.customerSubject()`), and `customers-realm-template.json` defines a *separate*
  `party_id` claim backed by a user attribute, which customer-edge falls back to `sub` for only when
  that attribute is unset (`WebAuthnKeycloakClient` line 227). Where the attribute is set and differs
  from `sub`, `deleteForCustomer(partyId)` matches nothing and the erasure silently deletes zero rows.
  I did not measure which is the case in the deployed realm. Fixing it properly means persisting the
  party id alongside `customer_id`, which is a schema + write-path change I kept out of this PR
  rather than expanding it — but it means the consumer's coverage is currently unproven in prod.
- **No Kafka identity is wired in gitops.** copilot-service has no `KafkaUser`/mTLS manifest and no
  `copilot-service-msg-override` ConfigMap, so `group.id` / `auto.offset.reset` are unset (left out of
  `application.yaml` on purpose — the #686 dotted-key trap) and the consumer will not actually
  receive anything until that lands. This PR is the code half only.
- **`deleteExpired` on the Redis adapter returns 0 by construction** (Redis evicts on its own TTL).
  That is honest rather than a silent success, but it is untested against a real Redis — the Redis
  adapter is not the default and I did not stand one up. The `InMemory` implementations are likewise
  covered only by compilation, not by a test.
- **The header comment in `V1__conversation_history.sql` is now stale** — it still says there is no
  sweep and no consumer "yet". Deliberately not corrected: Flyway checksums the whole file including
  comments, so editing an applied migration fails the service at boot. The correction went into
  `openbank-copilot-service/CLAUDE.md` instead.
- **No migration is added**, so the V-number collision risk does not apply here.
- I did not check whether ADR-0118 mandates a specific retention period for this data class; the 90
  days is inherited from #3711, unexamined.
- Erasure cascading to any derived store (embeddings, caches) remains unexamined, as the issue noted.
- The retention sweep defaults to **enabled**, unlike `SessionLogRetentionScheduler` which ships off.
  My reasoning is that it only removes rows the service already refuses to serve, so it cannot
  destroy anything reachable through the API — but that is a judgement call and reviewable.

Closes #3870
