### PR TITLE
fix(lending): make origination state transitions atomic

### DIFF
--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/application/port/out/LendingRepositories.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/application/port/out/LendingRepositories.kt
@@ -14,7 +14,9 @@ import com.openbank.lending.domain.model.LoanStateSummary
 import com.openbank.libs.domain.identifiers.CollateralId
 import com.openbank.libs.domain.identifiers.LoanApplicationId
 import com.openbank.libs.domain.identifiers.LoanId
+import com.openbank.libs.lending.origination.OriginationState
 import io.smallrye.mutiny.Uni
+import java.time.OffsetDateTime
 import java.util.UUID
 
 interface LoanApplicationRepository {
@@ -31,7 +33,30 @@ interface LoanApplicationRepository {
      * pages to add up rows would be the same wrong answer, slower.
      */
     fun summariseByState(): Uni<List<ApplicationStateSummary>>
+
+    /**
+     * Blind write of the decision fields. Correct only where the caller is not deciding anything
+     * from the value it is overwriting — [compareAndSetStatus] is what an origination transition
+     * must use.
+     */
     fun update(application: LoanApplication): Uni<LoanApplication>
+
+    /**
+     * Move the application from [from] to [to] **only if** the stored row is still in [from], as a
+     * single statement. Returns the rows claimed: `1` when this caller won the transition, `0` when
+     * someone else already moved the row on.
+     *
+     * The caller must treat `0` as a refusal and must not perform any side effect of the transition
+     * — no evidence event, no workflow signal (issue #3850).
+     */
+    fun compareAndSetStatus(
+        id: LoanApplicationId,
+        from: OriginationState,
+        to: OriginationState,
+        decidedBy: String?,
+        decisionReason: String?,
+        decidedAt: OffsetDateTime?,
+    ): Uni<Int>
 }
 
 interface LoanRepository {

--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/application/usecase/LendingService.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/application/usecase/LendingService.kt
@@ -132,7 +132,7 @@ class LendingService(
             is OriginationTransitionResult.Rejected ->
                 Uni.createFrom().failure(IllegalStateException(result.reason))
             is OriginationTransitionResult.Applied ->
-                applications.update(outcome.recorded.copy(status = result.newState))
+                claimTransition(existing.status, outcome.recorded.copy(status = result.newState))
                     .signalWorkflow()
                     .call { _ -> events.emit(outcome.evidence) }
         }
@@ -146,6 +146,44 @@ class LendingService(
     private fun reflectionDaysFor(application: LoanApplication): Int? =
         complianceGuard.resolveOriginationPack(application.jurisdiction, application.productType)
             ?.pack?.reflectionPeriodDays
+
+    /**
+     * Claim an origination transition, or refuse.
+     *
+     * Every caller here has decided [updated] from a snapshot read in an earlier transaction, so it
+     * must not write blindly: the row may have moved on since. The conditional UPDATE re-tests the
+     * state the decision was taken against, and `0` rows claimed means someone else got there first
+     * — the same `IllegalStateException` the caller would have received a moment later, which the
+     * resource already maps (422 on advance, 409 on decide). Nothing downstream of a refusal runs:
+     * no evidence event, no workflow signal (issue #3850).
+     *
+     * On success the claimed application is returned from memory. `update` returned the re-read
+     * entity, which differs in one respect worth naming: `update` writes only status and the three
+     * decision fields, so the ASSESSMENT leg's engine outputs (`decisionOutcome`, price band, reason
+     * codes, input hash) were never persisted and the re-read blanked them out of the response. That
+     * persistence gap is pre-existing and is NOT fixed here — it needs its own change and its own
+     * test. What changes is only that the response now carries the values the engine computed
+     * instead of nulls.
+     */
+    private fun claimTransition(from: OriginationState, updated: LoanApplication): Uni<LoanApplication> =
+        applications.compareAndSetStatus(
+            updated.id,
+            from,
+            updated.status,
+            updated.decidedBy,
+            updated.decisionReason,
+            updated.decidedAt,
+        ).flatMap { claimed ->
+            if (claimed == 0) {
+                Uni.createFrom().failure(
+                    IllegalStateException(
+                        "Concurrent modification: application ${updated.id} is no longer in $from",
+                    ),
+                )
+            } else {
+                Uni.createFrom().item(updated)
+            }
+        }
 
     private fun Uni<LoanApplication>.signalWorkflow(): Uni<LoanApplication> =
         call { app -> workflowPort.stateEntered(app.id, app.status, reflectionDaysFor(app)) }
@@ -287,7 +325,7 @@ class LendingService(
                             is OriginationTransitionResult.Rejected ->
                                 Uni.createFrom().failure(IllegalStateException(result.reason))
                             is OriginationTransitionResult.Applied ->
-                                applications.update(existing.copy(status = result.newState))
+                                claimTransition(existing.status, existing.copy(status = result.newState))
                                     .signalWorkflow()
                                     .emitEvidence(
                                         existing.status.name,
@@ -319,7 +357,7 @@ class LendingService(
                     is OriginationTransitionResult.Rejected ->
                         Uni.createFrom().failure(IllegalStateException(result.reason))
                     is OriginationTransitionResult.Applied ->
-                        applications.update(existing.copy(status = result.newState))
+                        claimTransition(existing.status, existing.copy(status = result.newState))
                             .signalWorkflow()
                             .emitEvidence(
                                 existing.status.name,
@@ -364,7 +402,8 @@ class LendingService(
                     when (val result = machine.apply(transition(existing, existing.status, target, decidedBy))) {
                         is OriginationTransitionResult.Rejected ->
                             Uni.createFrom().failure(IllegalStateException(result.reason))
-                        is OriginationTransitionResult.Applied -> applications.update(
+                        is OriginationTransitionResult.Applied -> claimTransition(
+                            existing.status,
                             existing.copy(
                                 status = result.newState,
                                 decidedBy = decidedBy,
@@ -468,7 +507,14 @@ class LendingService(
                     is OriginationTransitionResult.Rejected ->
                         Uni.createFrom().failure(IllegalStateException(st.reason))
                     is OriginationTransitionResult.Applied ->
-                        applications.update(application.copy(status = st.newState))
+                        // Claimed, not blind-written: without the predicate two concurrent
+                        // disbursements of one READY_TO_DISBURSE application both post cash to the
+                        // ledger. The claim runs before the posting, so the loser pays nothing.
+                        // It does NOT make disbursement atomic — the loan row and its schedule are
+                        // written before the claim, so a refused racer still leaves an unreferenced
+                        // loan behind. That is pre-existing (today BOTH racers book one) and needs
+                        // its own change; see the pull request for #3850.
+                        claimTransition(application.status, application.copy(status = st.newState))
                             .call { savedApp ->
                                 events.emit(
                                     transitionEvidence(

--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/infrastructure/persistence/repository/LendingRepositories.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/infrastructure/persistence/repository/LendingRepositories.kt
@@ -110,6 +110,58 @@ class LoanApplicationRepositoryImpl @Inject constructor(
             s.persist(e).map { mapper.toDomain(e) }
         }
     }
+
+    /**
+     * The origination transitions do NOT go through [update].
+     *
+     * [update] is a blind write: it stores whatever the caller loaded, whenever the caller gets
+     * round to it. Every origination transition reads the row in one transaction ([findById],
+     * `@WithSession`), computes the next state from that snapshot in memory, and writes in another
+     * — so two `advance` calls arriving together both observe the same status, both compute the
+     * same forward edge, both pass the state machine, and both write. A lost update on the money
+     * path's approval gate: the status column ends up holding the right value, and the transition
+     * has been claimed twice, with two evidence records and two workflow signals for one step
+     * (issue #3850). On `decide()` the same window lets two checkers each cast what each believes
+     * is the deciding four-eyes vote, and the later write owns `decidedBy`/`decisionReason`.
+     *
+     * Making the expected state part of the UPDATE closes the window with no lock, no `@Version`
+     * column and no schema change: the database evaluates `status = :from` and the assignment in
+     * one statement, so exactly one of any number of concurrent callers claims the row and the rest
+     * get `0`. `OriginationConcurrentAdvanceIT` measures it; on the previous code it observed both
+     * advances accepted in 12 of 12 rounds.
+     *
+     * Same remedy, same reasoning as `JpaCompliancePackActivationRepository.compareAndSetDecision`.
+     */
+    @WithTransaction
+    override fun compareAndSetStatus(
+        id: LoanApplicationId,
+        from: OriginationState,
+        to: OriginationState,
+        decidedBy: String?,
+        decisionReason: String?,
+        decidedAt: OffsetDateTime?,
+    ): Uni<Int> = sf.withTransaction { s ->
+        s.createMutationQuery(ADVANCE_HQL)
+            .setParameter("to", to)
+            .setParameter("decidedBy", decidedBy)
+            .setParameter("reason", decisionReason)
+            .setParameter("decidedAt", decidedAt)
+            .setParameter("id", id.value)
+            .setParameter("from", from)
+            .executeUpdate()
+    }
+
+    private companion object {
+        /**
+         * The `and status = :from` clause is the whole point — without it this is [update] with
+         * extra steps. Named parameters because `decidedBy`, `decisionReason` and `decidedAt` are
+         * all nullable and a positional vararg cannot carry a null.
+         */
+        const val ADVANCE_HQL =
+            "update LoanApplicationEntity " +
+                "set status = :to, decidedBy = :decidedBy, decisionReason = :reason, decidedAt = :decidedAt " +
+                "where id = :id and status = :from"
+    }
 }
 
 @ApplicationScoped

--- a/openbank-lending-service/src/test/kotlin/com/openbank/lending/application/usecase/LendingServiceEdgeCasesTest.kt
+++ b/openbank-lending-service/src/test/kotlin/com/openbank/lending/application/usecase/LendingServiceEdgeCasesTest.kt
@@ -156,6 +156,18 @@ class LendingServiceEdgeCasesTest {
 
     // --- Intake validation ---------------------------------------------------------------------
 
+    /**
+     * The conditional UPDATE that claims an origination transition (issue #3850). [claimed] is the
+     * row count the database returns: `1` won the row, `0` lost the race to another caller.
+     */
+    private fun stubClaim(claimed: Int = 1) {
+        every { applications.compareAndSetStatus(any(), any(), any(), any(), any(), any()) } returns
+            Uni.createFrom().item(claimed)
+    }
+
+    private fun verifyClaims(times: Int) =
+        verify(exactly = times) { applications.compareAndSetStatus(any(), any(), any(), any(), any(), any()) }
+
     @Test
     fun `apply rejects a non-positive requested amount`() {
         assertThatThrownBy { service.apply(request(amount = "0.00"), "alice") }
@@ -215,7 +227,7 @@ class LendingServiceEdgeCasesTest {
         }.isInstanceOf(IllegalStateException::class.java)
             .hasMessageContaining("not awaiting a four-eyes decision")
 
-        verify(exactly = 0) { applications.update(any()) }
+        verifyClaims(0)
     }
 
     @Test
@@ -228,15 +240,14 @@ class LendingServiceEdgeCasesTest {
         }.isInstanceOf(IllegalArgumentException::class.java)
             .hasMessageContaining("Decider identity")
 
-        verify(exactly = 0) { applications.update(any()) }
+        verifyClaims(0)
     }
 
     @Test
     fun `decide records a rejection with the stated reason and decision time`() {
         val app = proposedApplication(proposer = "alice")
-        val updated: CapturingSlot<LoanApplication> = slot()
         every { applications.findById(app.id) } returns Uni.createFrom().item(app)
-        every { applications.update(capture(updated)) } answers { Uni.createFrom().item(updated.captured) }
+        stubClaim()
 
         val result = service.decide(
             app.id,

--- a/openbank-lending-service/src/test/kotlin/com/openbank/lending/application/usecase/LendingServiceTest.kt
+++ b/openbank-lending-service/src/test/kotlin/com/openbank/lending/application/usecase/LendingServiceTest.kt
@@ -106,24 +106,55 @@ class LendingServiceTest {
 
     private fun eur(v: String) = Money.of(v, "EUR")
 
+    /**
+     * The conditional UPDATE that claims an origination transition (issue #3850). [claimed] is the
+     * row count the database returns: `1` won the row, `0` lost the race to another caller.
+     */
+    private fun stubClaim(claimed: Int = 1) {
+        every { applications.compareAndSetStatus(any(), any(), any(), any(), any(), any()) } returns
+            Uni.createFrom().item(claimed)
+    }
+
+    private fun verifyClaims(times: Int) =
+        verify(exactly = times) { applications.compareAndSetStatus(any(), any(), any(), any(), any(), any()) }
+
     @Test
     fun `advance walks the canonical path skipping optional states by default`() {
         val app = proposedApplication().copy(status = OriginationState.SUBMITTED)
-        val slot: CapturingSlot<LoanApplication> = slot()
         every { applications.findById(app.id) } returns Uni.createFrom().item(app)
-        every { applications.update(capture(slot)) } answers { Uni.createFrom().item(slot.captured) }
+        stubClaim()
 
         val result = service.advance(app.id, "officer-1").await().indefinitely()
 
         assertThat(result.status).isEqualTo(OriginationState.KYC_PENDING)
-        verify(exactly = 1) { applications.update(any()) }
+        verifyClaims(1)
+    }
+
+    /**
+     * The half `OriginationConcurrentAdvanceIT` can only observe indirectly (issue #3850). The
+     * service computes the transition BEFORE it writes, so when the conditional UPDATE claims no
+     * row it is already holding a fully-advanced application — it must refuse, and it must not emit
+     * the evidence or signal the workflow for a step it did not take. `events.emit` is stubbed here,
+     * so a regression that emitted anyway would be caught by the verify rather than by an error.
+     */
+    @Test
+    fun `losing the advance race refuses and emits no transition evidence`() {
+        val app = proposedApplication().copy(status = OriginationState.SUBMITTED)
+        every { applications.findById(app.id) } returns Uni.createFrom().item(app)
+        stubClaim(claimed = 0)
+
+        assertThatThrownBy { service.advance(app.id, "officer-1").await().indefinitely() }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("no longer in SUBMITTED")
+
+        verify(exactly = 0) { events.emit(any<LendingOutboxMessage>()) }
     }
 
     @Test
     fun `advance from ASSESSMENT reaches DECISION_PENDING and cannot skip four-eyes`() {
         val app = proposedApplication().copy(status = OriginationState.ASSESSMENT)
         every { applications.findById(app.id) } returns Uni.createFrom().item(app)
-        every { applications.update(any()) } answers { Uni.createFrom().item(firstArg<LoanApplication>()) }
+        stubClaim()
 
         val first = service.advance(app.id, "officer-1").await().indefinitely()
         assertThat(first.status).isEqualTo(OriginationState.DECISION_PENDING)
@@ -147,7 +178,7 @@ class LendingServiceTest {
         val app = proposedApplication().copy(status = OriginationState.SUBMITTED, packVersion = 1)
         val evidenceSlot: CapturingSlot<LendingOutboxMessage> = slot()
         every { applications.findById(app.id) } returns Uni.createFrom().item(app)
-        every { applications.update(any()) } answers { Uni.createFrom().item(firstArg<LoanApplication>()) }
+        stubClaim()
         every { events.emit(capture(evidenceSlot)) } returns Uni.createFrom().item(Unit)
 
         service.advance(app.id, "officer-1").await().indefinitely()
@@ -166,7 +197,7 @@ class LendingServiceTest {
         val app = proposedApplication(proposer = "alice")
         val evidenceSlot: CapturingSlot<LendingOutboxMessage> = slot()
         every { applications.findById(app.id) } returns Uni.createFrom().item(app)
-        every { applications.update(any()) } answers { Uni.createFrom().item(firstArg<LoanApplication>()) }
+        stubClaim()
         every { events.emit(capture(evidenceSlot)) } returns Uni.createFrom().item(Unit)
 
         service.decide(app.id, DecisionRequest(approve = true, reason = "solid affordability"), "bob")
@@ -188,10 +219,9 @@ class LendingServiceTest {
             productType = "CONSUMER_CREDIT",
             packVersion = 1,
         )
-        val updateSlot: CapturingSlot<LoanApplication> = slot()
         val evidenceSlot = mutableListOf<LendingOutboxMessage>()
         every { applications.findById(app.id) } returns Uni.createFrom().item(app)
-        every { applications.update(capture(updateSlot)) } answers { Uni.createFrom().item(updateSlot.captured) }
+        stubClaim()
         every { events.emit(capture(evidenceSlot)) } returns Uni.createFrom().item(Unit)
 
         val result = service.advance(app.id, "officer-1").await().indefinitely()
@@ -212,7 +242,7 @@ class LendingServiceTest {
             residency = "CZ",
         )
         every { applications.findById(app.id) } returns Uni.createFrom().item(app)
-        every { applications.update(any()) } answers { Uni.createFrom().item(firstArg<LoanApplication>()) }
+        stubClaim()
 
         val result = service.advance(app.id, "officer-1").await().indefinitely()
 
@@ -225,7 +255,7 @@ class LendingServiceTest {
     fun `advance from ASSESSMENT with a missing input refers, never silently approves`() {
         val app = proposedApplication().copy(status = OriginationState.ASSESSMENT)
         every { applications.findById(app.id) } returns Uni.createFrom().item(app)
-        every { applications.update(any()) } answers { Uni.createFrom().item(firstArg<LoanApplication>()) }
+        stubClaim()
 
         val result = service.advance(app.id, "officer-1").await().indefinitely()
 
@@ -302,21 +332,20 @@ class LendingServiceTest {
         }.isInstanceOf(IllegalStateException::class.java)
             .hasMessageContaining("Four-eyes")
 
-        verify(exactly = 0) { applications.update(any()) }
+        verifyClaims(0)
     }
 
     @Test
     fun `decide approves when a different officer signs off`() {
         val app = proposedApplication(proposer = "alice")
-        val slot: CapturingSlot<LoanApplication> = slot()
         every { applications.findById(app.id) } returns Uni.createFrom().item(app)
-        every { applications.update(capture(slot)) } answers { Uni.createFrom().item(slot.captured) }
+        stubClaim()
 
         val result = service.decide(app.id, DecisionRequest(approve = true), "bob").await().indefinitely()
 
         assertThat(result.status).isEqualTo(OriginationState.OFFERED)
         assertThat(result.decidedBy).isEqualTo("bob")
-        verify(exactly = 1) { applications.update(any()) }
+        verifyClaims(1)
     }
 
     @Test
@@ -328,7 +357,7 @@ class LendingServiceTest {
         every { applications.findById(app.id) } returns Uni.createFrom().item(app)
         every { loans.save(any()) } answers { Uni.createFrom().item(firstArg<Loan>()) }
         every { installments.saveAll(capture(rowsSlot)) } answers { Uni.createFrom().item(rowsSlot.captured) }
-        every { applications.update(any()) } answers { Uni.createFrom().item(firstArg<LoanApplication>()) }
+        stubClaim()
         every { ledger.post(capture(postingSlot)) } returns Uni.createFrom().item(Unit)
         every { events.emit(any<LendingOutboxMessage>()) } returns Uni.createFrom().item(Unit)
 

--- a/openbank-lending-service/src/test/kotlin/com/openbank/lending/integration/OriginationConcurrentAdvanceIT.kt
+++ b/openbank-lending-service/src/test/kotlin/com/openbank/lending/integration/OriginationConcurrentAdvanceIT.kt
@@ -1,0 +1,221 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.lending.integration
+
+import com.openbank.lending.it.PostgresRedisTestResource
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.security.TestSecurity
+import io.restassured.RestAssured
+import io.smallrye.reactive.messaging.memory.InMemoryConnector
+import jakarta.inject.Inject
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.time.LocalDate
+import java.util.UUID
+import java.util.concurrent.Callable
+import java.util.concurrent.CyclicBarrier
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import javax.sql.DataSource
+
+/**
+ * One origination step must be applied AT MOST ONCE, however many operators press "advance" at the
+ * same moment (issue #3850).
+ *
+ * WHY NO EXISTING TEST SEES THIS
+ *
+ * Every other test of `advance` drives the flow sequentially, so the in-memory decision —
+ * `OriginationAdvance.nextState(existing.status, …)` computed from the row `findById` returned — is
+ * always taken against the committed result of the previous step and is always right. It is right
+ * for a reason that does not survive concurrency: `findById` carries `@WithSession` and `update`
+ * carries its own `@WithTransaction`, two separate transactions with no lock, no `@Version` column
+ * anywhere in this service, and no predicate on the expected state inside the UPDATE. Two `advance`
+ * calls arriving together therefore both read `SUBMITTED`, both compute `KYC_PENDING`, both pass the
+ * state machine, and both write — a lost update on the money path's approval gate.
+ *
+ * WHAT THE HARM IS
+ *
+ * The surviving `status` column looks correct, which is what makes this hard to see: both writers
+ * store the same value. What is duplicated is the *transition* — two `credit.application.transition`
+ * evidence records for one step, each naming its own actor, and two workflow signals. On a control
+ * whose whole purpose is that a named human moved the application from one state to the next, an
+ * audit trail asserting the step happened twice is not cosmetic. The same window on `decide()`
+ * (`LendingService.kt:346`) lets two checkers each believe they cast the deciding four-eyes vote,
+ * and whichever write lands last owns `decidedBy` / `decisionReason` / `decidedAt`.
+ *
+ * WHAT THIS TEST DOES, AND WHAT IT CANNOT PROMISE
+ *
+ * It races two real `POST /applications/{id}/advance` calls over real HTTP against the same
+ * application, [ROUNDS] times with a fresh application each round, synchronised on a
+ * [CyclicBarrier], and records two violation classes per round:
+ *
+ *  1. the raced `SUBMITTED -> KYC_PENDING` step recorded more than once;
+ *  2. any origination transition recorded twice for that application;
+ *  3. the raced step not recorded at all.
+ *
+ * It deliberately does NOT assert "exactly one request returned 200". Two 200s are legitimate when
+ * the second racer's read lands after the first commit: it then reads `KYC_PENDING` and takes the
+ * NEXT edge, which is correct serialised behaviour and not a lost update. That was measured — it
+ * happens — so a status-code assertion would have been a false red waiting to fire. The invariant
+ * that separates the defect from honest interleaving is that no single transition is claimed twice.
+ *
+ * It is a timing test and is honest about being probabilistic. It does NOT widen the window
+ * artificially — no sleep, no test hook in production code — so a round in which the two requests
+ * happen to serialise passes vacuously. That is why it runs [ROUNDS] rounds rather than one, and why
+ * the observed failure rate against unpatched code is recorded in the pull request. **It cannot
+ * produce a false RED** — one origination step recorded twice is a defect however the threads landed
+ * — **but it can produce a false GREEN**, on a machine slow or loaded enough that no round
+ * interleaves.
+ */
+@QuarkusTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@QuarkusTestResource(OriginationConcurrentAdvanceIT.InMemoryKafkaResource::class)
+@QuarkusTestResource(PostgresRedisTestResource::class)
+class OriginationConcurrentAdvanceIT {
+
+    class InMemoryKafkaResource : QuarkusTestResourceLifecycleManager {
+        override fun start(): Map<String, String> {
+            val props = InMemoryConnector.switchOutgoingChannelsToInMemory("lending-events-out").toMutableMap()
+            props["quarkus.kafka.devservices.enabled"] = "false"
+            props["openbank.outbox.dispatch-enabled"] = "false"
+            return props
+        }
+
+        override fun stop() = InMemoryConnector.clear()
+    }
+
+    @Inject
+    lateinit var dataSource: DataSource
+
+    private companion object {
+        /** Rounds of the race, each on its own freshly created application. */
+        const val ROUNDS = 12
+        const val BARRIER_TIMEOUT_SECONDS = 30L
+        const val PROPOSER = "advance-race-proposer"
+
+        /**
+         * The step raced. `SUBMITTED -> KYC_PENDING` is the first forward edge and needs no
+         * compliance pack, no credit-bureau call and no four-eyes identity, so nothing but the
+         * read-check-write window can decide the outcome. `ASSESSMENT` is deliberately avoided:
+         * it routes through the decision engine, whose latency would mask the window.
+         */
+        const val FROM_STATE = "SUBMITTED"
+        const val TO_STATE = "KYC_PENDING"
+    }
+
+    @Test
+    @TestSecurity(user = PROPOSER, roles = ["ROLE_LENDING_OFFICER", "ROLE_CREDIT_RISK"])
+    fun `two concurrent advances cannot both apply the same origination step`() {
+        val pool = Executors.newFixedThreadPool(2)
+        // One list, so a run reports every violation class it saw rather than only the first.
+        val violations = mutableListOf<String>()
+        try {
+            repeat(ROUNDS) { round ->
+                val id = submitApplication()
+                assertThat(statusOf(id)).isEqualTo(FROM_STATE)
+
+                val barrier = CyclicBarrier(2)
+                val first = pool.submit(advanceTask(barrier, id))
+                val second = pool.submit(advanceTask(barrier, id))
+                val statuses = listOf(first.get(), second.get())
+
+                val recorded = recordedTransitions(id)
+                val racedStep = recorded.count { it == "$FROM_STATE->$TO_STATE" }
+                if (racedStep > 1) {
+                    violations += "round $round: $racedStep records of $FROM_STATE -> $TO_STATE (statuses=$statuses)"
+                }
+                val duplicated = recorded.groupingBy { it }.eachCount().filterValues { it > 1 }
+                if (duplicated.isNotEmpty()) {
+                    violations += "round $round: transitions claimed more than once: $duplicated"
+                }
+                if (racedStep == 0) {
+                    violations += "round $round: the raced step was never recorded (statuses=$statuses)"
+                }
+            }
+        } finally {
+            pool.shutdownNow()
+        }
+
+        assertThat(violations)
+            .describedAs("origination steps applied more than once by concurrent advance calls")
+            .isEmpty()
+    }
+
+    private fun advanceTask(barrier: CyclicBarrier, id: String) = Callable {
+        barrier.await(BARRIER_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        RestAssured.given()
+            .contentType("application/json")
+            .post("/api/v1/lending/applications/$id/advance")
+            .statusCode
+    }
+
+    /**
+     * Created through the real maker endpoint rather than by a hand-written INSERT, so the row the
+     * race runs against is exactly the shape the service produces. The id is read back over JDBC
+     * because the response body wraps it in the `LoanApplicationId` value type.
+     */
+    private fun submitApplication(): String {
+        val body = """
+            {"partyId":"${UUID.randomUUID()}","requestedAmount":{"amount":"10000.00","currency":{"code":"EUR"}},
+            "nominalAnnualRate":0.05,"termPeriods":12,"firstDueDate":"${LocalDate.now().plusMonths(1)}"}
+        """.trimIndent()
+        RestAssured.given()
+            .contentType("application/json")
+            .body(body)
+            .post("/api/v1/lending/applications")
+            .then()
+            .statusCode(201)
+        return queryOne(
+            "SELECT id::text FROM loan_application WHERE proposed_by = ? ORDER BY created_at DESC LIMIT 1",
+            PROPOSER,
+        )
+    }
+
+    private fun statusOf(id: String): String =
+        queryOne("SELECT status::text FROM loan_application WHERE id = ?::uuid", id)
+
+    /**
+     * Every origination transition the application recorded, as `FROM->TO`, read out of the
+     * transactional outbox written by `LendingService.transitionEvidence`. A repeated entry means
+     * one step was claimed twice — the audit consequence of the lost update, and the thing a
+     * duplicated HTTP 200 only hints at.
+     */
+    private fun recordedTransitions(id: String): List<String> = dataSource.connection.use { conn ->
+        conn.prepareStatement(
+            """
+            SELECT payload FROM lending_outbox
+             WHERE aggregate_id = ?::uuid AND event_type = 'credit.application.transition'
+            """.trimIndent(),
+        ).use { st ->
+            st.setString(1, id)
+            st.executeQuery().use { rs -> rs.readTransitions() }
+        }
+    }
+
+    private fun java.sql.ResultSet.readTransitions(): List<String> {
+        val out = mutableListOf<String>()
+        while (next()) {
+            val payload = getString(1)
+            out += "${payload.field("fromState")}->${payload.field("toState")}"
+        }
+        return out
+    }
+
+    private fun String.field(name: String): String =
+        checkNotNull(Regex("\"$name\":\"([^\"]*)\"").find(this)) { "no $name in $this" }.groupValues[1]
+
+    private fun queryOne(sql: String, param: String): String = dataSource.connection.use { conn ->
+        conn.prepareStatement(sql).use { st ->
+            st.setString(1, param)
+            st.executeQuery().use { rs ->
+                check(rs.next()) { "no row for [$sql] with [$param]" }
+                rs.getString(1)
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Scope

Issue #3850 says `LendingService.advance` decides on a stale read and writes without a predicate,
and that `openbank-lending-service` has no optimistic locking anywhere. I re-verified every claim
rather than inheriting it, and built the reproduction the issue explicitly did not have.

This is the same defect class as **#3467 / #3837** (`CompliancePackActivationService.decide()`), and
it uses the same remedy. **No file overlap with #3837** — that PR touches
`CompliancePackActivationRepository/Service`, their two tests and
`docs/threat-models/openbank-lending-service.md`; this one touches `LendingService`, the loan-
application repository port and impl, their two unit tests and one new IT. Verified against #3837's
current file list. The threat model is deliberately untouched: both threat-model gates
(`threat-model-coverage`, `threat-model-updated-on-trust-boundary-change --enforce`) pass on this
branch without it, and editing it would have collided with #3837.

## What I verified from the issue, and what was wrong

| claim | verdict |
|---|---|
| `findById` is `@WithSession`, `update` carries its own `@WithTransaction` | **confirmed** |
| `update` blind-sets status via `s.find(...)` + field assignment | **confirmed** |
| `@Version` appears nowhere in `openbank-lending-service` | **confirmed** — `grep -c` is 0; the probe finds it in account-service, balance-service and document-service, so the empty result is an absence, not a broken grep |
| the four call sites are `LendingService.kt:269, :305, :335, :346` | **confirmed**, exactly — `advance`, `expireIfInState`, `advanceIfInState`, `decide` |
| the REST layer might serialise `advance` some other way | **checked, it does not** — no idempotency key, no distributed lock, no queue; `advanceApplication` is a bare `POST` straight into the use case |
| `TerminationService` may share the shape | **confirmed** — `withLoan` is `loans.findById` then `loans.update`, and `LoanRepositoryImpl.update` is the same blind field assignment. **Not fixed here**, see below |
| `OriginationDecisionService` may share the shape | **WRONG, and worth saying so.** It is a pure evaluator: it holds no repository, never reads and never writes. It cannot carry this defect |

Two things the issue did not mention that I found while measuring:

- **`disburse` is the worst instance of the family and is now fixed too.** `bookLoan` saves the loan
  and its schedule, blind-writes `DISBURSED`, and only then posts to the ledger — so two concurrent
  disbursements of one `READY_TO_DISBURSE` application both posted cash. The claim now runs before
  the posting, so the loser pays nothing. It does **not** make disbursement atomic: the loan row is
  still written before the claim, so a refused racer leaves an unreferenced loan behind. That is
  pre-existing (today *both* racers book one) and needs its own change.
- **`update` never persisted the decision-engine fields at all.** It writes only status, `decidedBy`,
  `decisionReason`, `decidedAt`, so `decisionOutcome`, price band, reason codes and the input hash
  computed on the ASSESSMENT leg were dropped, and the re-read blanked them out of the response.
  Also pre-existing, also not fixed here — but it is why `claimTransition` returns the claimed
  application from memory rather than re-reading. The visible consequence is that the ASSESSMENT
  advance response now carries the values the engine computed instead of nulls.

## Proven RED first — verbatim

`OriginationConcurrentAdvanceIT` was written and run against unpatched `origin/main` (`617011b4b`),
**and re-run in its final form against unpatched `main` after the assertions were revised**, so the
red below is the red of the test that ships. Two real `POST /applications/{id}/advance` calls race
over real HTTP on a `CyclicBarrier`, 12 rounds, a fresh application each round, no artificial window
widening.

```
java.lang.AssertionError: [origination steps applied more than once by concurrent advance calls]
Expecting empty but was: ["round 0: 2 records of SUBMITTED -> KYC_PENDING (statuses=[200, 200])",
    "round 0: transitions claimed more than once: {SUBMITTED->KYC_PENDING=2}",
    "round 1: 2 records of SUBMITTED -> KYC_PENDING (statuses=[200, 200])",
    "round 1: transitions claimed more than once: {SUBMITTED->KYC_PENDING=2}",
    ...
    "round 11: 2 records of SUBMITTED -> KYC_PENDING (statuses=[200, 200])",
    "round 11: transitions claimed more than once: {SUBMITTED->KYC_PENDING=2}"]
```

**12 of 12 rounds recorded the same origination step twice.** Every round, both racers.

### The assertion I removed, and why that matters

The first version of the test asserted "exactly one request returns 200". Against the **fixed** code
it went red once in 12 rounds — and inspecting it showed the round was correct: the second racer's
read landed *after* the first commit, so it read `KYC_PENDING` and took the next edge. Two 200s, two
different steps, no lost update. That assertion was a false red waiting to fire, so it is gone. What
the test asserts instead is the invariant that actually separates the defect from honest
interleaving: **no single transition is recorded twice**, read out of the transactional outbox that
`transitionEvidence` writes. On broken code that fires 12/12; on correct code it cannot fire for a
timing reason.

## The fix

`compareAndSetStatus` re-tests the expected state inside the UPDATE:

```
update LoanApplicationEntity
   set status = :to, decidedBy = :decidedBy, decisionReason = :reason, decidedAt = :decidedAt
 where id = :id and status = :from
```

The database evaluates the predicate and the assignment in one statement, so exactly one of any
number of concurrent callers claims the row. `claimTransition` in `LendingService` treats `0` as a
refusal, throwing the same `IllegalStateException` the caller would have got a moment later — which
the resource already maps: **422 on advance** (already declared in `openapi.yaml`), **409 on decide**
and on the other paths. Nothing downstream of a refusal runs: no evidence event, no workflow signal,
no ledger posting. Named parameters because all three decision fields are nullable and a positional
vararg cannot carry a null.

**Why not `@Version`:** it works and matches account-service, but it is a schema change on a live
table shared by many read paths, and optimistic locking surfaces as an `OptimisticLockException`
that then has to be mapped back to a sensible status. The predicate *is* the invariant, costs no
migration, and reuses the refusal path that already exists. Same call #3837 made.

**Why not `SELECT ... FOR UPDATE`:** it would hold a transaction open across the decision engine on
the ASSESSMENT leg, which is the expensive part of that call.

## No schema, no API, no version change

- **No Flyway migration** — the predicate uses the existing `status` column, so the `migrate-at-start`
  trap does not apply.
- **No `openapi.yaml` change** — 422 is already the declared refusal for advance, 409 for the rest.
  So no `info.version` bump and no race with a competing spec PR.
- `version.txt` untouched; release-please owns it. `fix` + `src/main` releases.

## Verification

| | result |
|---|---|
| `OriginationConcurrentAdvanceIT` on unpatched `main` | **FAILED** — 12/12 rounds double-recorded (above) |
| same test, with the fix | **PASSED**, three independent runs |
| `:openbank-lending-service:test` (211 tests) | PASSED |
| `ktlintCheck`, `detekt` | PASSED |
| `koverVerify` | PASSED |
| `:openbank-lending-service:quarkusBuild` | PASSED (CDI wiring — unit tests do not check it) |
| `check-threat-models.py`, `check-threat-model-diff.py --enforce` | PASSED |

Nine existing unit tests moved from stubbing `applications.update` to stubbing the claim. One new
unit test — `losing the advance race refuses and emits no transition evidence` — pins the half the IT
can only observe indirectly: the service computes the transition *before* it writes, so when the
UPDATE claims no row it is already holding a fully-advanced application and must not emit for a step
it did not take.

## What I did NOT verify, and what could still be wrong

1. **The IT is a timing test. It cannot produce a false RED — one origination step recorded twice is
   a defect however the threads landed — but it CAN produce a false GREEN.** It widens no window, so
   a round in which the two requests serialise passes vacuously. The measured rate against broken
   code was 12/12 per round on this machine; on a slower or busier runner it could be lower, and in
   principle a whole run could be green against broken code. That is the honest answer to "could
   your test pass against the old code": yes, with low probability, and the 12 rounds are what makes
   it unlikely rather than impossible.
2. **Only N=2 concurrent callers are measured.** The conditional UPDATE is correct for any N by
   construction; nothing here proves it for N>2.
3. **Only the `SUBMITTED -> KYC_PENDING` edge is raced.** `decide`, `expireIfInState` and `disburse`
   go through the identical `claimTransition` and are covered by unit tests, but no IT races them.
   `disburse` in particular deserves its own concurrency IT and does not have one.
4. **`TerminationService` is measured and NOT fixed.** `withLoan` + `loans.update` on `LoanEntity`
   carries the same read-check-write shape, including `proposeTermination`/`decideTermination`, which
   is another four-eyes control. Fixing it means a second conditional-update method on
   `LoanRepository` and its own reproduction; folding it into a money-path PR that already needs two
   approvals would have made this unreviewable. It needs its own issue and its own red test — I am
   claiming the shape, not a measured race.
5. **The disburse orphan-loan window is still open** (see Scope). The fix strictly reduces harm there
   — one ledger posting instead of two — but does not close it.
6. **Isolation level is the Testcontainers/deployed Postgres default (`READ COMMITTED`) only.** A
   single-statement conditional UPDATE is atomic there; no other level was exercised.
7. **Single JVM, not a multi-pod deployment.** That is the right scope — the defect is a database
   lost update and the fix is in the statement — but it is not a live multi-replica proof.
8. **The decision-engine persistence gap (see Scope) is named, not fixed**, and the response-shape
   change that falls out of `claimTransition` returning the in-memory application is a real, if
   small, behaviour change worth a reviewer's eye.

## Merge expectation

`openbank-lending-service` is money-path: 2 human approvals plus a threat model by rule. **This PR is
not expected to merge on my action, and that is the correct outcome.**

Closes #3850
Refs #3467, #3837

🤖 Generated with [Claude Code](https://claude.com/claude-code)
