### PR TITLE
fix(libs): stamp AuditEvent and FlagExposure at construction, not Instant.EPOCH

### DIFF
--- a/openbank-libs-domain/src/main/kotlin/com/openbank/libs/audit/AuditEvent.kt
+++ b/openbank-libs-domain/src/main/kotlin/com/openbank/libs/audit/AuditEvent.kt
@@ -40,7 +40,13 @@ data class AuditEvent(
     val operation: String,
     val resourceType: String,
     val resourceId: String?,
-    val timestamp: Instant = Instant.EPOCH,
+    /**
+     * When the audited operation happened. Defaults to construction time, which is what every
+     * call site means — it previously defaulted to [Instant.EPOCH], and 23 of the 25 fleet
+     * construction sites take the default, so the whole trail claimed 1970-01-01T00:00:00Z.
+     * Pass an explicit value only when replaying or back-dating a historical operation.
+     */
+    val timestamp: Instant = Instant.now(),
     val ipAddress: String? = null,
     val userAgent: String? = null,
     val result: AuditResult = AuditResult.SUCCESS,

--- a/openbank-libs-domain/src/main/kotlin/com/openbank/libs/flags/FlagExposure.kt
+++ b/openbank-libs-domain/src/main/kotlin/com/openbank/libs/flags/FlagExposure.kt
@@ -28,7 +28,8 @@ data class FlagExposure(
     val variant: String,
     val targetingKey: String?,
     val reason: EvaluationReason,
-    val timestamp: Instant = Instant.EPOCH,
+    /** When the subject saw the variant. Defaults to construction time; [of] never passes one. */
+    val timestamp: Instant = Instant.now(),
     /** Ties the exposure back to the request log line (DORA reconstruction). */
     val traceId: String? = null,
 ) {
@@ -66,8 +67,9 @@ class LoggingExposurePublisher : ExposurePublisher {
 
     override suspend fun publish(exposure: FlagExposure) {
         log.infof(
-            "flag exposure exposureId=%s flag=%s variant=%s key=%s reason=%s traceId=%s",
+            "flag exposure exposureId=%s at=%s flag=%s variant=%s key=%s reason=%s traceId=%s",
             exposure.exposureId,
+            exposure.timestamp,
             exposure.flagKey,
             exposure.variant,
             exposure.targetingKey,

--- a/openbank-libs-domain/src/test/kotlin/com/openbank/libs/audit/AuditEventTest.kt
+++ b/openbank-libs-domain/src/test/kotlin/com/openbank/libs/audit/AuditEventTest.kt
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.libs.audit
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Duration
+import java.time.Instant
+
+/**
+ * The audit envelope is the evidentiary record (GDPR Art. 30, DORA Art. 17), so `timestamp`
+ * has to answer "when did this happen" for a caller that did not pass one — and 23 of the 25
+ * fleet construction sites do not pass one.
+ *
+ * These assert **recency**, deliberately, not non-nullity: `timestamp` defaulted to
+ * `Instant.EPOCH`, and every non-null / not-null-value assertion passes against 1970-01-01.
+ * That is exactly what let the default survive review.
+ */
+class AuditEventTest {
+
+    private fun event(timestamp: Instant? = null) = if (timestamp == null) {
+        AuditEvent(
+            actorId = "party-1",
+            actorType = "CUSTOMER",
+            operation = "account.party.created",
+            resourceType = "account",
+            resourceId = "acc-1",
+        )
+    } else {
+        AuditEvent(
+            actorId = "party-1",
+            actorType = "CUSTOMER",
+            operation = "account.party.created",
+            resourceType = "account",
+            resourceId = "acc-1",
+            timestamp = timestamp,
+        )
+    }
+
+    @Test
+    fun `an event built without an explicit timestamp is stamped at construction`() {
+        val before = Instant.now()
+
+        val stamped = event().timestamp
+
+        assertThat(stamped).isBetween(before.minusSeconds(1), Instant.now().plusSeconds(1))
+        assertThat(Duration.between(stamped, Instant.now()).abs())
+            .describedAs("audit timestamp must be recent, not the %s epoch default", Instant.EPOCH)
+            .isLessThan(Duration.ofMinutes(1))
+    }
+
+    @Test
+    fun `an explicit timestamp is preserved`() {
+        val explicit = Instant.parse("2026-01-02T03:04:05Z")
+
+        assertThat(event(explicit).timestamp).isEqualTo(explicit)
+    }
+}

--- a/openbank-libs-domain/src/test/kotlin/com/openbank/libs/flags/FlagExposureTest.kt
+++ b/openbank-libs-domain/src/test/kotlin/com/openbank/libs/flags/FlagExposureTest.kt
@@ -7,6 +7,7 @@ package com.openbank.libs.flags
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import java.time.Instant
 
 class FlagExposureTest {
 
@@ -22,6 +23,23 @@ class FlagExposureTest {
         assertThat(exposure.reason).isEqualTo(EvaluationReason.SPLIT)
         assertThat(exposure.traceId).isEqualTo("trace-1")
         assertThat(exposure.exposureId).isNotNull()
+    }
+
+    /**
+     * Asserts RECENCY, not non-nullity: `timestamp` defaulted to `Instant.EPOCH`, and `of` — the
+     * documented typical call site — never passed one, so every exposure was stamped 1970-01-01.
+     * A non-null assertion passes against that, which is what let it survive.
+     */
+    @Test
+    fun `of stamps the exposure at construction time`() {
+        val before = Instant.now()
+
+        val stamped = FlagExposure.of(
+            FlagEvaluation("checkout-flow", "treatment", variant = "b", reason = EvaluationReason.SPLIT),
+            targetingKey = "party-9",
+        ).timestamp
+
+        assertThat(stamped).isBetween(before.minusSeconds(1), Instant.now().plusSeconds(1))
     }
 
     @Test

--- a/openbank-libs-runtime/src/main/kotlin/com/openbank/libs/audit/AuditEventPublisher.kt
+++ b/openbank-libs-runtime/src/main/kotlin/com/openbank/libs/audit/AuditEventPublisher.kt
@@ -36,8 +36,12 @@ class LoggingAuditEventPublisher : AuditEventPublisher {
 
     override suspend fun publish(event: AuditEvent) {
         log.infof(
-            "audit event eventId=%s actor=%s actorType=%s op=%s resource=%s resourceId=%s result=%s traceId=%s",
+            // `timestamp` is logged explicitly: the log line's own time is when the fallback ran,
+            // not when the operation happened, and only the envelope's field survives a replay
+            // through a durable publisher (DORA Art. 17 reconstruction).
+            "audit event eventId=%s at=%s actor=%s actorType=%s op=%s resource=%s resourceId=%s result=%s traceId=%s",
             event.eventId,
+            event.timestamp,
             event.actorId,
             event.actorType,
             event.operation,


### PR DESCRIPTION
## What

`AuditEvent.timestamp` and `FlagExposure.timestamp` both defaulted to `Instant.EPOCH`. They now default to `Instant.now()` — construction time.

## Verification first (the interesting part)

Reported as the same defect class as #3874 (`ApiError.timestamp`) but on the audit trail, i.e. the evidentiary record. It is **not** as bad as that, and the reason is worth writing down.

Measured on `origin/main` @ `2985cfeab`:

- `openbank-libs-domain/.../audit/AuditEvent.kt:43` — `val timestamp: Instant = Instant.EPOCH`. Confirmed.
- 25 `AuditEvent(` construction sites under `src/main`; only `openbank-mcp-service`'s `McpCallAuditor` (x2) and `openbank-agent-service`'s `McpToolRegistry`/`McpEndpoint` pass `timestamp =`. Confirmed.
- **Nothing overrides it downstream.** The only implementation of `AuditEventPublisher` in the tree is `LoggingAuditEventPublisher`, which did not reference `timestamp` at all. There is no Panache entity, no mapper, no outbox envelope for `AuditEvent` — the type never reaches a DB or a wire.
- `openbank-audit-service`'s `AuditConsumer` reads `occurredAt` off the JSON, a field `AuditEvent` does not have, and falls back to `Instant.now(clock)`. So even once a Kafka publisher exists, the envelope's own time would be discarded at ingest.
- `FlagExposure` has **zero** production users outside `openbank-libs-domain`.

So no stored audit entry today says 1970. This is a latent trap, not a live corruption: the wrong default sits behind the exact extension point the `AuditEventPublisher` KDoc invites a contributor to add (`@Alternative @Priority` Kafka publisher), and would have shipped an epoch-stamped evidentiary record on the first one.

## Approach — why not the #3874 shape

#3874 made the parameter non-defaulted so the compiler enumerates the call sites. Weighed and rejected here: `AuditEvent` has 14 parameters and 25 call sites, and unlike an API error envelope the correct value is unambiguous at every one of them (construction time *is* when the operation happened). Enumerating them would produce 25 identical `timestamp = Instant.now()` lines. An explicit value is still honoured for replay/back-dating.

## Tests

Both assert **recency**, not non-nullity — a non-null assertion passes against `Instant.EPOCH`, which is precisely what let this survive review. `FlagExposureTest` already asserted every other field of `of()`, timestamp included by omission.

Red on the previous default:

```
AuditEventTest > an event built without an explicit timestamp is stamped at construction() FAILED
FlagExposureTest > of stamps the exposure at construction time() FAILED
6 tests completed, 2 failed
```

Green after. `:openbank-libs-domain:test :openbank-libs-runtime:test` and `ktlintCheck detekt` on both modules pass.

No call site changes, no equality-based assertions on `AuditEvent` anywhere in `src/test`, so no consumer is affected by the new default. Neither module carries a `version.txt`, so no bump.

## Follow-up, not fixed here

`AuditConsumer` keying on `occurredAt` while the canonical envelope names the field `timestamp` means the envelope's time is dropped at ingest. That is a real gap, but it only bites when a durable publisher exists, and picking the fix (rename the field vs. teach the consumer both names) is a contract decision worth its own PR.

Filed as #3883, with the evidence, the three candidate fixes, and acceptance criteria that require asserting `occurredAt` and `recordedAt` **differ** — equality is the bug, so an assertion tolerating it passes against it.

Refs #3874
Refs #3883

