### PR TITLE
fix(copilot): give the PARTY_ERASED consumer a Kafka identity, a reachable broker and a reachable database

### DIFF
--- a/openbank-infra/gitops/components/copilot/copilot-service-msg-override.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-service-msg-override.yaml
@@ -1,0 +1,50 @@
+# Dotted-key YAML config bug workaround for copilot-service (issue #686, issue #3881).
+#
+# Quarkus's YAML config source unconditionally quotes any `mp.messaging.incoming.<channel>`
+# YAML leaf key containing a literal dot when registering it as a MicroProfile Config
+# property. A YAML key written as `group.id: foo` under `mp.messaging.incoming.<channel>:`
+# registers ONLY as `mp.messaging.incoming.<channel>."group.id"` — literal quotes in the
+# property name — never as the plain `...group.id` that
+# `KafkaConnectorIncomingConfiguration.getGroupId()` (and `auto.offset.reset`) actually read.
+# Nothing errors; the connector silently uses its own default.
+#
+# copilot's `application.yaml` therefore deliberately declares NEITHER key — it carries a
+# comment saying they belong here. That is not a stylistic preference. Were `group.id` left to
+# its default it would fall back to `quarkus.application.name` = `openbank-copilot-service`,
+# which the KafkaUser ACL (kafka-copilot-mtls.yaml) does NOT grant Read on, and every poll
+# would take a silent GroupAuthorizationException. The group below and the ACL there are one
+# fact written twice; they must agree.
+#
+# Why a properties FILE and not env vars: `party-events-in` is a HYPHENATED channel name, and
+# quarkusio/quarkus#30106 + smallrye/smallrye-reactive-messaging#2028 document a live,
+# unresolved upstream bug where an env-var override of a single leaf property on a hyphenated
+# channel crashes Quarkus at startup (`SRMSG00071`). notification-service and
+# transaction-service both use this properties-file mechanism for the same reason.
+#
+# auto.offset.reset=earliest — SAFE HERE, and deliberate. The warning in the root CLAUDE.md is
+# about forcing `earliest` onto a consumer group *already running* on the default, which
+# re-reads the topic from the beginning and mass-replays. `copilot-service-party` is a BRAND
+# NEW group with no committed offsets, so `earliest` versus `latest` is the difference between
+# starting at the topic's oldest retained record and starting at its head — there is no
+# existing position to rewind. Starting at the oldest record is what we want: `openbank.party.
+# events` has `retention.ms=604800000` (7 days), so a fresh consumer picks up any PARTY_ERASED
+# emitted in the last week that copilot could not act on because it had no Kafka identity at
+# all. Those erasures are real and were missed; replaying them deletes conversation rows that
+# GDPR Art. 17 says should already be gone. The bound is the retention window, not all history.
+#
+# config_ordinal=500 forces this source to outrank the baked application.yaml (~254).
+# Loaded via QUARKUS_CONFIG_LOCATIONS on the Deployment (copilot-service.yaml).
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: copilot-service-msg-override
+  namespace: platform
+  labels:
+    app.kubernetes.io/name: copilot-service
+    app.kubernetes.io/part-of: platform
+data:
+  override.properties: |
+    config_ordinal=500
+    mp.messaging.incoming.party-events-in.client.id=copilot-service-party-${quarkus.uuid}
+    mp.messaging.incoming.party-events-in.group.id=copilot-service-party
+    mp.messaging.incoming.party-events-in.auto.offset.reset=earliest

--- a/openbank-infra/gitops/components/copilot/copilot-service.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-service.yaml
@@ -1,5 +1,5 @@
-# copilot-service: the customer-facing AI assistant backend (ADR-0089). Stateless — no DB,
-# no Kafka. The governed reasoning loop runs server-side behind a provider-agnostic model
+# copilot-service: the customer-facing AI assistant backend (ADR-0089). The governed
+# reasoning loop runs server-side behind a provider-agnostic model
 # gateway. READ tools call the customer edge AS the customer (propagated bearer → ownership
 # enforced at the edge, ADR-0065). The HTTP @Authorize gate queries the OPA sidecar
 # (data.openbank.rest.allow) and the copilot tool-dispatch gate queries
@@ -86,10 +86,19 @@ spec:
                   optional: true
             # Postgres conversation history (#3710). The CNPG operator injects
             # copilot-db-app with PG_USER/PG_PASSWORD; REACTIVE_URL and JDBC_URL resolve them.
+            #
+            # The database name is `openbank_copilots`, PLURAL — that is what postgres.yaml's
+            # `bootstrap.initdb.database` creates and it is the only database on the cluster.
+            # These two URLs said `openbank_copilot` (singular) from the day #3710 added them,
+            # so no pod carrying the conversation store has ever reached its schema. Flyway's
+            # `migrate-at-start: true` retries the connection and then fails the boot, which is
+            # why the sandbox has been serving from a pre-#3710 ReplicaSet while the newer one
+            # CrashLoops: an erasure consumer cannot delete rows from a database its own pod
+            # cannot open (issue #3881).
             - name: REACTIVE_URL
-              value: postgresql://copilot-db-rw.platform.svc:5432/openbank_copilot
+              value: postgresql://copilot-db-rw.platform.svc:5432/openbank_copilots
             - name: JDBC_URL
-              value: jdbc:postgresql://copilot-db-rw.platform.svc:5432/openbank_copilot
+              value: jdbc:postgresql://copilot-db-rw.platform.svc:5432/openbank_copilots
             - name: POSTGRES_USER
               valueFrom:
                 secretKeyRef:
@@ -134,6 +143,39 @@ spec:
             # @Authorize HTTP interceptor to enforce decisions from data.openbank.rest.allow.
             - name: AUTHZ_ENFORCE
               value: "true"
+            # ── PARTY_ERASED consumer (GDPR Art. 17 / ADR-0117, #3875, issue #3881) ──
+            # Kafka consumer → Strimzi bootstrap (ADR-0137: mTLS on :9093). The plaintext
+            # :9092 listener is denied for every principal cluster-wide, so there is no
+            # non-mTLS path to fall back to. The keystore Secret is projected from
+            # `messaging` by kafka-copilot-mtls.yaml; the truststore Secret is the one
+            # agent-service already created in this namespace and is shared, not duplicated.
+            - name: KAFKA_BOOTSTRAP_SERVERS
+              value: openbank-cluster-kafka-bootstrap.messaging.svc:9093
+            - name: KAFKA_SECURITY_PROTOCOL
+              value: SSL
+            - name: KAFKA_SSL_KEYSTORE_LOCATION
+              value: /mnt/kafka-keystore/user.p12
+            - name: KAFKA_SSL_KEYSTORE_TYPE
+              value: PKCS12
+            - name: KAFKA_SSL_KEYSTORE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: copilot-service-kafka-keystore
+                  key: user.password
+            - name: KAFKA_SSL_TRUSTSTORE_LOCATION
+              value: /mnt/kafka-truststore/ca.p12
+            - name: KAFKA_SSL_TRUSTSTORE_TYPE
+              value: PKCS12
+            - name: KAFKA_SSL_TRUSTSTORE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: kafka-cluster-ca-truststore
+                  key: ca.password
+            # group.id / auto.offset.reset arrive as an external properties source, NOT as env
+            # vars and NOT from application.yaml — see copilot-service-msg-override.yaml for
+            # why both of those routes are broken for a hyphenated channel (#686).
+            - name: QUARKUS_CONFIG_LOCATIONS
+              value: /mnt/msg-config/override.properties
           startupProbe:
             httpGet:
               path: /q/health/started
@@ -162,6 +204,15 @@ spec:
           volumeMounts:
             - name: tmp
               mountPath: /tmp
+            - name: kafka-keystore
+              mountPath: /mnt/kafka-keystore
+              readOnly: true
+            - name: kafka-truststore
+              mountPath: /mnt/kafka-truststore
+              readOnly: true
+            - name: msg-override
+              mountPath: /mnt/msg-config
+              readOnly: true
           resources:
             requests:
               cpu: 100m
@@ -256,6 +307,25 @@ spec:
         - name: opa-bundle
           configMap:
             name: copilot-opa-bundle
+        # Projected by kafka-copilot-mtls.yaml's ExternalSecret from the Strimzi-minted
+        # `copilot-service` Secret in `messaging`.
+        - name: kafka-keystore
+          secret:
+            secretName: copilot-service-kafka-keystore
+            items:
+              - key: user.p12
+                path: user.p12
+        # Shared cluster-CA truststore — this Secret is created in `platform` by
+        # components/agent/kafka-agent-mtls.yaml and is deliberately not redeclared here.
+        - name: kafka-truststore
+          secret:
+            secretName: kafka-cluster-ca-truststore
+            items:
+              - key: ca.p12
+                path: ca.p12
+        - name: msg-override
+          configMap:
+            name: copilot-service-msg-override
 ---
 apiVersion: v1
 kind: Service

--- a/openbank-infra/gitops/components/copilot/kafka-copilot-mtls.yaml
+++ b/openbank-infra/gitops/components/copilot/kafka-copilot-mtls.yaml
@@ -1,0 +1,92 @@
+# Kafka mTLS identity + ACLs for openbank-copilot-service (ADR-0137, issue #3881).
+#
+# WHY THIS FILE EXISTS
+# --------------------
+# #3875 merged copilot's GDPR Art. 17 erasure path — `PartyErasureConsumer` consumes
+# `PARTY_ERASED` from `openbank.party.events` and hard-deletes that party's conversation
+# history. The consumer, its unit test and the retention sweep all landed and are on main.
+# In the cluster it could not receive a single event: copilot-service had **no KafkaUser,
+# no certificate, no KAFKA_* env and no Kafka manifest of any kind**. The broker runs
+# `authorization: simple` with `allow.everyone.if.no.acl.found=false`, so a workload with no
+# principal is denied outright and the consumer is never invoked. Nothing errors — which is
+# exactly why it survived a merge with every check green. The control existed and was not in
+# force.
+#
+# Identity model (ADR-0137): one KafkaUser = one mTLS client cert = one principal for all of
+# this service's Kafka traffic. The KafkaUser lives in `messaging` (where the Strimzi User
+# Operator watches); the Operator mints a per-user Secret of the same name there, and the
+# ExternalSecret below projects it into `platform`, where copilot-service runs.
+#
+# NOTE — the cluster-CA truststore ExternalSecret is deliberately NOT repeated here.
+# `kafka-cluster-ca-truststore` already exists in `platform`, created by agent-service
+# (components/agent/kafka-agent-mtls.yaml), whose header says in as many words that a second
+# Kafka client in this namespace should SHARE it rather than duplicate it. Two ExternalSecrets
+# with the same `target.name` in one namespace fight over the same Secret. copilot mounts that
+# existing Secret; it declares only its own keystore below.
+#
+# The `eso-kafka-cert-reader` Role in `messaging` grants ESO read access by a hand-kept
+# `resourceNames` list; `copilot-service` is added to it in the same commit as this file
+# (components/payments/kafka-scheme-accepted-acl.yaml). That pairing is enforced —
+# `check-kafka-cert-reader-grant.py` derives its required set from the ExternalSecrets that
+# read this store and fails BOTH ways, so neither half can land alone and there is no
+# exception list to opt into.
+---
+# ── KafkaUser: copilot-service ──────────────────────────────────────────────
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaUser
+metadata:
+  annotations:
+    # ADR-0137: certs must land before the platform Deployment rolls pods onto mTLS;
+    # lower waves sync first and ArgoCD blocks on ExternalSecrets reaching SecretSynced.
+    argocd.argoproj.io/sync-wave: "-2"
+  name: copilot-service
+  namespace: messaging
+  labels:
+    strimzi.io/cluster: openbank-cluster
+spec:
+  authentication:
+    type: tls
+  authorization:
+    type: simple
+    acls:
+      # Consumer-only. copilot produces nothing to Kafka: the erasure path is a pure
+      # consumer, and no Write grant belongs here until something actually writes.
+      - resource:
+          type: topic
+          name: openbank.party.events
+          patternType: literal
+        operations: [Read, Describe]
+        host: "*"
+      # Group name must match `group.id` in copilot-service-msg-override.yaml exactly. A
+      # mismatch is a silent GroupAuthorizationException on every poll, not a boot failure.
+      - resource:
+          type: group
+          name: copilot-service-party
+          patternType: literal
+        operations: [Read]
+        host: "*"
+---
+# ── ExternalSecret: copilot-service keystore ────────────────────────────────
+# Projects the Strimzi-minted `copilot-service` Secret from `messaging` into `platform`.
+# `dataFrom.extract` copies every key verbatim, preserving the binary PKCS#12 payload
+# byte-for-byte. deletionPolicy: Retain so a transient store/RBAC blip never deletes a live
+# keystore out from under a running pod.
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+  name: copilot-service-kafka-keystore
+  namespace: platform
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: kafka-messaging-certs
+  target:
+    name: copilot-service-kafka-keystore
+    creationPolicy: Owner
+    deletionPolicy: Retain
+  dataFrom:
+    - extract:
+        key: copilot-service

--- a/openbank-infra/gitops/components/copilot/networkpolicy-copilot-egress.yaml
+++ b/openbank-infra/gitops/components/copilot/networkpolicy-copilot-egress.yaml
@@ -49,6 +49,31 @@ spec:
       ports:
         - protocol: TCP
           port: 6379
+    # Same-namespace dependency: the single-owner CNPG conversation-history store
+    # (copilot-db-rw:5432, postgres.yaml). This rule was MISSING from the day this
+    # allow-list was written, and this policy is Egress default-deny, so every pod carrying
+    # the #3710 conversation store has been unable to open its own database: Flyway logs
+    # `Connection error: The connection attempt failed. (Caused by Connect timed out)` on a
+    # loop and the pod never goes Ready. Selecting by the CNPG-owned `cnpg.io/cluster` label
+    # rather than `podSelector: {}` keeps the rule to this one dependency instead of opening
+    # the whole namespace (issue #3881).
+    - to:
+        - podSelector:
+            matchLabels:
+              cnpg.io/cluster: copilot-db
+      ports:
+        - protocol: TCP
+          port: 5432
+    # PARTY_ERASED consumer → Strimzi broker on the mTLS listener (ADR-0137). Without this
+    # rule the KafkaUser and the mounted certificate are equally inert: the consumer would
+    # authenticate against a broker it cannot reach.
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: messaging
+      ports:
+        - protocol: TCP
+          port: 9093
     # Customer JWT verification (Keycloak JWKS / metadata).
     - to:
         - namespaceSelector:

--- a/openbank-infra/gitops/components/payments/kafka-scheme-accepted-acl.yaml
+++ b/openbank-infra/gitops/components/payments/kafka-scheme-accepted-acl.yaml
@@ -431,6 +431,7 @@ rules:
       - customer-edge                   # ADR-0086 audit trail + ADR-0072 resume, ns customer-edge (first ESO Kafka client there); missed by the #2665 sweep
       - analytics-sink                  # ADR-0022/0069: analytics bronze consumer (party/kyc/consent/sca/documents/onboarding-funnel), ns analytics (first ESO client there)
       - campaign-service                # ADR-0200: campaign journey delivery requests, ns campaign (first ESO client there); missing entry blocked the whole sandbox rollout at sync-wave -1 (#2749)
+      - copilot-service                 # issue #3881: PARTY_ERASED consumer (GDPR Art. 17, #3875), ns platform — second ESO Kafka client there after agent-service, sharing that namespace's kafka-cluster-ca-truststore rather than duplicating it
       - delegation-service              # ADR-0232: grant lifecycle producer, ns delegation (first ESO client there); same #2749 failure, observed again — the keystore ExternalSecret sat at SecretSyncedError and ArgoCD never advanced past sync-wave -1, so all 11 wave-0 resources stayed OutOfSync and no pod was ever created
       - openbank-cluster-cluster-ca-cert
 ---


### PR DESCRIPTION
## Summary

Wires copilot-service onto Kafka so the `PARTY_ERASED` consumer merged in #3875 can actually be
invoked — and fixes two further faults found while verifying it, either of which alone would have
kept the erasure path dead after the Kafka half landed.

**The plumbing is now real. The erasure is still not correct**, and the second half of #3881 is why.
That is measured below, not assumed.

Closes nothing on its own. Refs #3881, #3875, #3870, #3710.

## What was actually broken — three independent faults, none of which errors

I verified #3881's premise rather than inheriting it. It was right, and incomplete.

**1. No Kafka identity (as filed).** No KafkaUser, no certificate, no `KAFKA_*` env, no Kafka
manifest of any kind. The broker runs `authorization: simple` with
`allow.everyone.if.no.acl.found=false`, so a principal-less workload has no path to it and the
consumer is never invoked.

**2. No route to the broker even with an identity.** `networkpolicy-copilot-egress.yaml` is Egress
default-deny and had no rule for `messaging:9093`. A KafkaUser and a mounted keystore are equally
inert against a broker the pod cannot reach. (Broker *ingress* is fine — Strimzi's own
`openbank-cluster-network-policy-kafka` admits :9093 from anywhere; the generated
`kafka-broker-ingress-allow-list` only covers :9092, which is a separate matter and untouched here.)

**3. No route to its own database — so there was nothing to delete from.** The same allow-list has
no rule for `copilot-db:5432`, *and* the datasource URLs name `openbank_copilot` while
`postgres.yaml` creates `openbank_copilots`. `migrate-at-start: true` means Flyway fails the boot,
so **every pod carrying the #3710 conversation store has CrashLooped since the day it was added**;
the sandbox has been serving from a pre-#3710 ReplicaSet the whole time. Observed live: the newer
ReplicaSet's pod at 1/2 Ready with 20 restarts, logging
`Connection error: The connection attempt failed. (Caused by Connect timed out)` on a loop.

An erasure consumer cannot delete rows from a database its own pod has never opened.

## What this PR changes

- `kafka-copilot-mtls.yaml` — KafkaUser `copilot-service` (Read/Describe on `openbank.party.events`,
  Read on group `copilot-service-party`; consumer-only, no Write grant) + the keystore ExternalSecret.
  The cluster-CA truststore ExternalSecret is **deliberately not repeated**: `platform` already has
  one, created by agent-service, whose header says a second client here should share it. Two
  ExternalSecrets with the same `target.name` in one namespace fight over the same Secret.
- `kafka-scheme-accepted-acl.yaml` — `copilot-service` added to `eso-kafka-cert-reader`'s
  `resourceNames`, **in the same commit** as the ExternalSecret that requires it.
  `check-kafka-cert-reader-grant.py` derives its required set from those ExternalSecrets and fails
  both ways, so neither half can land alone. Gate goes 38/38 → 39/39 clean.
- `copilot-service-msg-override.yaml` — `group.id` / `auto.offset.reset` as an external properties
  source with `config_ordinal=500`. A YAML leaf key containing a dot never reaches the connector
  (#686), and env vars are not the workaround either: `party-events-in` is hyphenated, which trips
  the open upstream `SRMSG00071` bug. Same mechanism notification-service and transaction-service use.
- `copilot-service.yaml` — `KAFKA_*` env, keystore/truststore/msg-override mounts,
  `QUARKUS_CONFIG_LOCATIONS`, and the `openbank_copilots` database-name correction.
- `networkpolicy-copilot-egress.yaml` — egress to `messaging:9093` and to `copilot-db:5432`
  (selected by the CNPG-owned `cnpg.io/cluster` label, so the rule stays one dependency wide rather
  than opening the namespace as agent-service's `podSelector: {}` does).

`auto.offset.reset=earliest` — **safe here, and stated deliberately.** The hazard is forcing
`earliest` onto a group *already running* on the default, which rewinds it. `copilot-service-party`
is a brand-new group with no committed offsets, so there is no position to rewind: it starts at the
oldest retained record. `openbank.party.events` has `retention.ms=604800000`, so the bound is seven
days, and picking those up is the point — they are erasures copilot could not act on.

**No `.rego` and no `rules.yaml` key were touched, so no OPA bundle or pod-roll annotation is
restamped.** `gen-network-policies.py` was re-run and produced no diff. Enforced `gitops` gate group:
22 PASS / 2 pre-existing advisory warnings / 1 pre-existing unfalsified self-test, all unrelated to
these files.

## The partyId/sub question — MEASURED, and the answer is worse than filed

#3881 asked for a measurement of the deployed realm before any fix, and warned that a guess here is
worse than an obvious gap. I measured it read-only against the live sandbox, via the Keycloak and
party-service databases. No credential was handled in plaintext and nothing was mutated. Aggregates
only below — the underlying identifiers are personal data and stay out of this repo.

In realm `openbank-customers`, **35 users**:

| | count |
|---|---|
| `party_id` attribute set, and it equals the Keycloak user id (`sub`) | **0** |
| `party_id` attribute set, and it differs from `sub` | **9** |
| no `party_id` attribute at all | **26** |
| …of those 26, whose `sub` is a real party id in party-service | **0** |

So for **0 of 35 users** does the identity copilot stores (`CopilotChatResource.customerSubject()`
returns the JWT `sub`, confirmed) equal the identity the event carries. The ADR-0069 invariant
`sub == partyId` holds for **nobody** in the deployed realm. `deleteForCustomer(partyId)` will match
zero rows for every user, and log a clean success while doing it.

The join was validated against a known-positive before I believed the zero: injecting one real party
id into the same query returns exactly 1 match, so this is a true zero and not a broken cast.

Root cause is visible in the code and consistent with the data: `WebAuthnKeycloakClient.ensureUser`
creates the Keycloak user **without** setting `id`, so Keycloak generates a random UUID and
`party_id` is stored as a separate attribute. Only `seed-test-customer.sh` sets `id = partyId`, and
nothing in the live realm was created that way. `WebAuthnResource` already documents the divergence
in a comment.

**I did not fix this, on purpose.** The candidate fix — key conversation history on the `party_id`
claim with `sub` as fallback, the same resolution customer-edge already uses — changes which
conversation a customer resumes and orphans every existing row, and it is a decision about identity
in a money-path-adjacent service. That belongs in its own PR with a human on it, not smuggled into a
plumbing change. #3881 stays open for it. The measurement is posted there.

One thing I measured and cannot explain, reported as an observation and not a diagnosis: none of the
9 `party_id` attribute values corresponds to a row in party-service's `parties` table either (69
rows, spanning the whole period). So keying on `party_id` alone may not close the gap on its own.

## What still has to happen after merge

Merging this does not put erasure in force. In order:

1. ArgoCD syncs `copilot` and `payments`. The KafkaUser and ExternalSecrets are at sync-waves -2/-1,
   so ArgoCD blocks on them reaching `SecretSynced` before the Deployment rolls — if the
   `eso-kafka-cert-reader` grant were missing this would strand at wave -1 exactly as #2749 did.
2. The Strimzi User Operator mints the `copilot-service` Secret; ESO projects it into `platform`.
3. The Deployment rolls. **This is the first time a pod carrying #3710/#3875 will boot successfully**
   — the netpol and database-name fixes are what make that possible, so expect the conversation
   schema to be created by Flyway on that boot, not before.
4. Only then does the consumer join `copilot-service-party` and start receiving events.

No Vault value is required. Verify with: the KafkaUser Ready, the ExternalSecret `SecretSynced`, the
pod 2/2 with no Flyway retry loop, and the consumer group present on the broker with a committed
offset — the last of these is the only one that proves it is consuming.

## Critical self-evaluation — what I did NOT verify

- **I did not observe a single event flow end to end.** Nothing here is proven against a real
  `PARTY_ERASED`; this is a manifest change verified by gates, code reading and live read-only
  inspection of the cluster's current state. The first real proof is step 4 above.
- **No test asserts rows are gone by direct query.** #3881's item 3 is not addressed. `ConversationErasureIT`
  exists but I did not extend it, and reading through the store cannot distinguish deleted from
  filtered by `expires_at`. Given the key mismatch, such a test written today against the real key
  would fail — which is arguably the right time to write it, but it is not in this PR.
- **I did not verify the `user.password` / `ca.password` Secret keys exist under those exact names**
  for this KafkaUser; I copied the shape from notification-service and agent-service, which work. If
  Strimzi's key naming differed the pod would fail at boot loudly, not silently.
- **I did not check whether any `conversation_history` rows exist** — I could not, because the
  database has never been reachable. The table may not exist yet.
- **The 26 attribute-less users**: I proved their `sub` is not a party id. I did not establish what
  their `sub` *is*, or whether they are reachable customers at all.
- **The `openbank_copilot` → `openbank_copilots` rename assumes the CNPG bootstrap name is the
  intended one.** It is the only database on the cluster, so the alternative — renaming the database
  — would be the larger and more surprising change, but I did not confirm the original intent.

**What breaks if the key mismatch is real: it is real, and what breaks is the erasure itself.** After
this PR the consumer subscribes, receives the event, runs the delete, deletes nothing, and logs
`erased 0 copilot conversation(s)` at INFO. That is the exact failure mode #3881 called the more
dangerous half — a control that looks live in every dashboard and log while conversation transcripts
of an erased party stay on disk and in every base backup. **Do not read a green deploy of this PR as
GDPR Art. 17 coverage for copilot.** It is the prerequisite, not the control.
