### PR TITLE
docs(infra): measure NetworkPolicy coverage per pod, and name what a default-deny would sever

### DIFF
--- a/docs/runbooks/0010-networkpolicy-default-deny-measurement.md
+++ b/docs/runbooks/0010-networkpolicy-default-deny-measurement.md
@@ -132,3 +132,167 @@ property of the source tree at all. That set has to come from the flow logs.
 * and only then, one namespace at a time — starting with a namespace whose
   workloads are already fully policy-selected, where default-deny is provably a
   no-op for existing pods.
+
+## The measurement that decides the order: coverage is PER POD
+
+The last exit criterion above needs a number the repo cannot produce. Which pods
+are already policy-selected is a property of the cluster, not of gitops: CNPG
+Postgres instances are created by the CloudNativePG operator, so they carry no
+Deployment for `gen-network-policies.py` to derive from and appear in no
+component directory at all.
+
+`openbank-infra/scripts/netpol-coverage.py` reports it. It is read-only
+(`kubectl get pods/networkpolicies -o json`), costs nothing, and mutates nothing:
+
+```
+python3 openbank-infra/scripts/netpol-coverage.py
+python3 openbank-infra/scripts/netpol-coverage.py --direction Egress
+```
+
+Measured 2026-08-06 against the sandbox, 400 running pods:
+
+| | Ingress | Egress |
+|---|---|---|
+| pods selected by at least one policy | **109** | **5** |
+| pods selected by none | **291** | **395** |
+
+The 24-namespaces-without-a-policy figure understates this by an order of
+magnitude, and understates it in the reassuring direction. 27% of running pods
+are policy-selected for ingress; 1% for egress.
+
+### The 40-namespace blocker: every database is the uncovered workload
+
+In **40 namespaces the ONLY uncovered workload is `postgresql`**. That is one
+finding with two faces, and both matter:
+
+* **Today, without any default-deny**, every CNPG instance in the fleet accepts
+  a connection from any pod in the cluster on 5432. The allow-lists protect the
+  services and leave the data they guard reachable directly. This is the largest
+  measured exposure in the issue and it does not need a rollout to fix — it needs
+  a policy that does not exist.
+* **Under a namespace default-deny** those same pods are the ones newly cut off,
+  so applying default-deny to any of those 40 namespaces severs each service from
+  its own database. The service does not error usefully: it times out in Flyway at
+  boot and CrashLoops, and nothing in the stack trace says NetworkPolicy.
+
+And the failure is worse than an outage, because it is not cleanly reversible by
+the usual reflex. `components/temporal/temporal-network-policies.yaml` already
+records the mechanism, discovered the hard way in the one namespace that has a
+default-deny today: the CloudNativePG operator polls each instance manager on
+:8000, a default-deny drops that poll, the cluster never reports Healthy, and the
+**ArgoCD sync for that namespace hangs** on "waiting for healthy state" — so the
+follow-up commit that would relax the policy cannot apply itself.
+
+Any namespace default-deny therefore needs two carve-outs before it, per
+namespace, not one:
+
+* intra-namespace 5432 for the service → its own instances, and
+* `cnpg-system` → the CNPG pods on 8000 (instance-manager status) and 9187
+  (instance metrics),
+
+which is exactly the shape of `temporal-cnpg-operator`. Generalising that from a
+hand-written one-off into a derived policy for every CNPG cluster is the concrete
+stage-2 work item, and it is worth doing **on its own merits** — it closes the
+5432 exposure above whether or not default-deny ever lands.
+
+### Egress is not stage 3, and the live proof is already in the cluster
+
+The issue proposes default-deny-ingress and "zvážit egress". Ingress and egress
+are not two settings of one change: an egress policy denies everything it does
+not list **including same-namespace traffic**, so it takes the whole dependency
+graph of a workload to be correct, not just its callers.
+
+Four workloads have an egress policy today (`agent-service`, `copilot-service`,
+`litellm`, `rum-gateway`). One of them is broken by it right now:
+`copilot-service-egress-allow-list` has rules for DNS, LiteLLM, its Redis, IAM,
+customer-edge and OTLP — and no rule for 5432. The pod CrashLoops in Flyway with
+`SocketTimeoutException: Connect timed out` against a database in its own
+namespace. One missing rule, one dead service, no diagnostic anywhere naming the
+cause. (Fix in flight: #3885.) That is a single hand-written policy; a namespace
+default-deny-egress is the same class of defect multiplied by the fleet.
+
+What an egress allow-list has to carry, measured rather than assumed:
+
+* DNS to `kube-system` — without it nothing resolves and every symptom is wrong;
+* the EKS Pod Identity link-local credential endpoint. **87 pods across 50
+  namespaces** carry `eks.amazonaws.com/pod-identity=enabled`; a NetworkPolicy
+  cannot name it with a `namespaceSelector`, it needs an `ipBlock`, and without it
+  every AWS API call (S3 backups, Secrets Manager, ECR) fails at credential
+  fetch — a failure that looks like an IAM problem for as long as you let it;
+* same-namespace 5432 (see above), Kafka mTLS 9093 in `messaging`, OIDC in `iam`,
+  OTLP in `observability`, plus each service's cross-namespace REST callees;
+* egress to the internet for the feeds that have one, which today is expressed as
+  `ipBlock: 0.0.0.0/0` on 443 (`litellm-egress`) — i.e. the one dimension a
+  default-deny-egress would most like to constrain is the one nothing constrains.
+
+None of this is derivable from gitops env alone, which is the same hole stage 1
+enumerated for ingress, in a direction where the blast radius is larger. **Egress
+default-deny should be sequenced after ingress is complete fleet-wide, not
+alongside it.**
+
+### Which namespace goes first
+
+Seven namespaces report zero uncovered pods — the only places where a
+default-deny is provably a no-op for everything currently running:
+
+`admin-ui` (1 pod), `analytics` (2), `argo-rollouts` (3), `customer-edge` (2),
+`developer-portal` (2), `finrep` (1), `temporal` (6, already default-deny).
+
+Recommended order, and the reasoning rather than just the pick:
+
+1. **`finrep`** — one pod, no CNPG instance in the namespace, not money-path, its
+   callers are already derived, and a regulatory report that fails is noticed and
+   re-run rather than lost. Smallest blast radius that still proves the mechanism.
+2. **`analytics`** then **`developer-portal`** — same argument, two pods each.
+3. **`admin-ui`** only after the above: it is the operator's only window into the
+   platform, so a mistake there also removes the tool you would diagnose it with.
+4. **`customer-edge` last of the seven**, despite qualifying on the number: it is
+   the public edge, and it is the caller in two of the three `DROPPED` edges stage
+   1 found — a namespace with known-missing declarations is the wrong place to
+   start, not the right one.
+
+Everything else needs the CNPG carve-out first, by construction.
+
+### What proves it is safe before the next namespace
+
+Applying is a manual, owner-gated act (ADR-0060); nothing here applies anything.
+The check after the first namespace, before the second:
+
+1. `kubectl -n <ns> get pods` — every pod Ready, zero restarts added;
+2. the ArgoCD Application for that namespace still reports `Synced/Healthy` — this
+   is the CNPG deadlock probe, not a formality;
+3. Prometheus has an unbroken scrape for the namespace's targets (a dropped scrape
+   is the first symptom of an over-tight ingress policy, and it presents as
+   `TargetDown`, i.e. as a false alarm about the workload rather than about the
+   policy);
+4. the namespace's own golden path exercised end-to-end from a real caller, not a
+   port-forward — a port-forward enters via the API server and proves nothing
+   about pod-to-pod policy;
+5. `netpol-coverage.py --direction Ingress` still reports UNCOV=0 for it, i.e. no
+   pod was added meanwhile that the default-deny is now silently severing.
+
+Wait one full scheduling day before the next namespace. The flows this whole
+runbook cannot see are the infrequent ones.
+
+### What this measurement still does not see
+
+Stated plainly, because a network change that overstates its own evidence is how
+a platform goes dark:
+
+* **it is a snapshot of running pods.** A CronJob, a scheduler that fires monthly
+  (interest capitalization, year-close, FINREP/COREP render), a Job that only runs
+  during a release, and any break-glass path taken by hand are all invisible to
+  it — and every one of them is a flow a default-deny would sever with no warning
+  until the day it matters;
+* it answers "is this pod selected by a policy", never "is every flow this pod
+  needs in that policy". A covered pod can still be missing a rule — that is
+  precisely what `copilot-service` is;
+* KEDA scale-to-zero means "no pod running" and "no such workload" look identical
+  here, so a scaled-to-zero workload contributes nothing to either column;
+* it reads the cluster, so it says nothing about a namespace that exists in gitops
+  and has not synced.
+
+The flow logs stage 1 enables are what close the first two. Until a week of them
+has been harvested, the honest position on this issue is unchanged: **the
+allow-lists are not complete enough to enable default-deny anywhere except,
+possibly, the seven namespaces above — and the fleet-wide answer is still no.**

--- a/openbank-infra/scripts/netpol-coverage.py
+++ b/openbank-infra/scripts/netpol-coverage.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+"""Report NetworkPolicy coverage PER POD, live, read-only (issue #2691 stage 2).
+
+Why per pod and not per namespace
+---------------------------------
+"This namespace has NetworkPolicies" is the reassuring flattening. A policy
+selects specific pods by label, so a namespace can hold a dozen allow-lists and
+still leave a co-tenant workload — most importantly its CloudNativePG Postgres
+instances, which are operator-managed and carry no Deployment for
+`gen-network-policies.py` to derive from — selected by nothing at all.
+
+Under the VPC CNI in `standard` mode (ADR-0060) that distinction is the whole
+question a default-deny asks:
+
+  * a pod that IS selected by an Ingress policy is already deny-by-default for
+    ingress — a namespace default-deny changes nothing for it;
+  * a pod that is selected by NO policy is fully reachable, and a namespace
+    default-deny severs every flow into it that is not separately allow-listed.
+
+So the set this prints under `uncovered` is, exactly, the set a default-deny
+would newly cut off. That is the number stage 2 needs, and it is not derivable
+from the repo: CNPG pods exist only in the cluster.
+
+This tool MUTATES NOTHING. It runs `kubectl get pods/networkpolicies -A -o json`
+and reads them. Pass `--from <dir>` to read `pods.json` / `netpol.json` captured
+earlier instead of contacting a cluster.
+
+    python3 openbank-infra/scripts/netpol-coverage.py
+    python3 openbank-infra/scripts/netpol-coverage.py --direction Egress
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from collections import defaultdict
+
+# Namespaces whose pods are not app workloads and are out of scope for the
+# app-plane rollout (they get their own assessment, issue #2691 stage 4).
+INFRA_NS_HINT = {
+    "kube-system", "argocd", "keda", "kyverno", "falco", "vault", "cnpg-system",
+    "cert-manager", "external-secrets", "external-dns", "ingress-nginx", "vpa",
+    "arc-runners", "arc-systems", "registry-cache", "gradle-build-cache",
+    "reposilite", "finops-scaledown",
+}
+
+
+def selects(pod_selector, labels):
+    """True if a NetworkPolicy podSelector selects a pod with these labels.
+
+    Implements the subset of the selector grammar the fleet actually uses:
+    matchLabels (AND) plus In/NotIn/Exists/DoesNotExist matchExpressions. An
+    empty selector selects every pod in the namespace — that is the shape a
+    namespace-wide default-deny takes, so getting it right is the point.
+    """
+    sel = pod_selector or {}
+    for k, v in (sel.get("matchLabels") or {}).items():
+        if labels.get(k) != v:
+            return False
+    for expr in sel.get("matchExpressions") or []:
+        key, op = expr.get("key"), expr.get("operator")
+        vals = expr.get("values") or []
+        present = key in labels
+        if op == "In" and labels.get(key) not in vals:
+            return False
+        if op == "NotIn" and labels.get(key) in vals:
+            return False
+        if op == "Exists" and not present:
+            return False
+        if op == "DoesNotExist" and present:
+            return False
+    return True
+
+
+def coverage(pods, policies, direction="Ingress"):
+    """-> {ns: {"covered": [names], "uncovered": [names]}} for running pods."""
+    by_ns = defaultdict(list)
+    for p in policies:
+        by_ns[p["metadata"]["namespace"]].append(p)
+
+    out = defaultdict(lambda: {"covered": [], "uncovered": []})
+    for pod in pods:
+        if (pod.get("status") or {}).get("phase") in ("Succeeded", "Failed"):
+            continue  # completed Jobs are not a live attack surface
+        ns = pod["metadata"]["namespace"]
+        labels = pod["metadata"].get("labels") or {}
+        name = labels.get("app.kubernetes.io/name") or pod["metadata"]["name"]
+        hit = any(
+            direction in (pol["spec"].get("policyTypes") or [])
+            and selects(pol["spec"].get("podSelector"), labels)
+            for pol in by_ns[ns]
+        )
+        out[ns]["covered" if hit else "uncovered"].append(name)
+    return out
+
+
+def _kubectl(kind):
+    return json.loads(subprocess.run(
+        ["kubectl", "get", kind, "-A", "-o", "json"],
+        check=True, capture_output=True, text=True).stdout)["items"]
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--direction", default="Ingress", choices=["Ingress", "Egress"])
+    ap.add_argument("--from", dest="src", help="dir holding pods.json + netpol.json")
+    args = ap.parse_args()
+
+    if args.src:
+        pods = json.load(open(os.path.join(args.src, "pods.json")))["items"]
+        pols = json.load(open(os.path.join(args.src, "netpol.json")))["items"]
+    else:
+        pods, pols = _kubectl("pods"), _kubectl("networkpolicies")
+
+    cov = coverage(pods, pols, args.direction)
+    tot_c = tot_u = 0
+    print(f"{'NAMESPACE':30} {'COV':>4} {'UNCOV':>6}  workloads a default-deny-"
+          f"{args.direction.lower()} would newly cut off")
+    for ns in sorted(cov):
+        c, u = len(cov[ns]["covered"]), len(cov[ns]["uncovered"])
+        tot_c, tot_u = tot_c + c, tot_u + u
+        tag = " [infra]" if ns in INFRA_NS_HINT else ""
+        names = ",".join(sorted(set(cov[ns]["uncovered"])))
+        print(f"{ns:30} {c:4} {u:6}  {names}{tag}")
+    print(f"\ntotal: {tot_c} pods covered, {tot_u} uncovered "
+          f"({tot_c + tot_u} running)")
+    print("A namespace at UNCOV=0 is one where a default-deny is a no-op for "
+          "every pod that exists today — the only safe place to start.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/openbank-infra/scripts/netpol_coverage_test.py
+++ b/openbank-infra/scripts/netpol_coverage_test.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+"""Tests for netpol-coverage.py.
+
+The failure this guards against is one-directional and quiet: a selector bug
+that OVER-matches reports a pod as covered, i.e. reports that a default-deny is
+safe for it. So every case below asserts the uncovered side too, never only the
+covered one.
+"""
+
+import importlib.util
+import os
+import unittest
+
+_spec = importlib.util.spec_from_file_location(
+    "netpol_coverage",
+    os.path.join(os.path.dirname(os.path.abspath(__file__)), "netpol-coverage.py"),
+)
+nc = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(nc)
+
+
+def pod(ns, name, labels, phase="Running"):
+    return {"metadata": {"namespace": ns, "name": name, "labels": labels},
+            "status": {"phase": phase}}
+
+
+def policy(ns, name, selector, types=("Ingress",)):
+    return {"metadata": {"namespace": ns, "name": name},
+            "spec": {"podSelector": selector, "policyTypes": list(types)}}
+
+
+class SelectsTest(unittest.TestCase):
+    def test_empty_selector_selects_every_pod(self):
+        # This is the default-deny shape; if it did not match, the tool would
+        # report a protected namespace as unprotected.
+        self.assertTrue(nc.selects({}, {"a": "b"}))
+        self.assertTrue(nc.selects(None, {}))
+
+    def test_match_labels_are_anded_and_exact(self):
+        self.assertTrue(nc.selects({"matchLabels": {"a": "b"}}, {"a": "b", "c": "d"}))
+        self.assertFalse(nc.selects({"matchLabels": {"a": "b"}}, {"a": "z"}))
+        self.assertFalse(nc.selects({"matchLabels": {"a": "b"}}, {}))
+        self.assertFalse(
+            nc.selects({"matchLabels": {"a": "b", "c": "d"}}, {"a": "b"}))
+
+    def test_match_expressions(self):
+        In = {"matchExpressions": [{"key": "k", "operator": "In", "values": ["x"]}]}
+        self.assertTrue(nc.selects(In, {"k": "x"}))
+        self.assertFalse(nc.selects(In, {"k": "y"}))
+        self.assertFalse(nc.selects(In, {}))
+        Ex = {"matchExpressions": [{"key": "k", "operator": "Exists"}]}
+        self.assertTrue(nc.selects(Ex, {"k": ""}))
+        self.assertFalse(nc.selects(Ex, {"other": "1"}))
+
+
+class CoverageTest(unittest.TestCase):
+    def test_cnpg_pod_is_uncovered_when_policies_select_only_the_service(self):
+        """The fleet's actual shape: a namespace full of allow-lists whose
+        Postgres instances no policy selects. Reporting this namespace as
+        covered is the exact mistake that would sever every service from its
+        database."""
+        pods = [
+            pod("accounts", "account-service-1",
+                {"app.kubernetes.io/name": "account-service"}),
+            pod("accounts", "accounts-db-1",
+                {"app.kubernetes.io/name": "postgresql",
+                 "cnpg.io/cluster": "accounts-db"}),
+        ]
+        pols = [policy("accounts", "account-service-ingress-allow-list",
+                       {"matchLabels": {"app.kubernetes.io/name": "account-service"}})]
+        cov = nc.coverage(pods, pols)
+        self.assertEqual(cov["accounts"]["covered"], ["account-service"])
+        self.assertEqual(cov["accounts"]["uncovered"], ["postgresql"])
+
+    def test_policy_direction_is_honoured(self):
+        pods = [pod("platform", "copilot-1",
+                    {"app.kubernetes.io/name": "copilot-service"})]
+        pols = [policy("platform", "copilot-egress",
+                       {"matchLabels": {"app.kubernetes.io/name": "copilot-service"}},
+                       types=("Egress",))]
+        self.assertEqual(nc.coverage(pods, pols, "Egress")["platform"]["covered"],
+                         ["copilot-service"])
+        self.assertEqual(nc.coverage(pods, pols, "Ingress")["platform"]["uncovered"],
+                         ["copilot-service"])
+
+    def test_a_policy_does_not_leak_across_namespaces(self):
+        pods = [pod("aml", "aml-service-1", {"app.kubernetes.io/name": "x"})]
+        pols = [policy("accounts", "p", {})]
+        self.assertEqual(nc.coverage(pods, pols)["aml"]["uncovered"], ["x"])
+
+    def test_completed_pods_are_ignored(self):
+        pods = [pod("aml", "job-1", {"app.kubernetes.io/name": "j"}, phase="Succeeded")]
+        self.assertEqual(nc.coverage(pods, [])["aml"]["uncovered"], [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What this is

Stage 2 of the #2691 staged rollout. **No default-deny is enabled anywhere, no policy is added, nothing is applied.** Stage 1 (#3799) shipped the repo-side enumeration and the flow-log switch; its last exit criterion — "start with a namespace whose workloads are already fully policy-selected" — needs a number that cannot be derived from the repo, and this supplies it.

## Why the repo cannot answer it

Coverage is a property of **pods**, not namespaces. CNPG Postgres instances are created by the CloudNativePG operator: no Deployment for `gen-network-policies.py` to derive from, no component directory, no presence in gitops at all. "This namespace has NetworkPolicies" is the reassuring flattening — and it is wrong in the direction that gets a platform severed.

`openbank-infra/scripts/netpol-coverage.py` is read-only (`kubectl get pods/networkpolicies -o json`), costs nothing, and mutates nothing. Its unit tests assert the **uncovered** side of every case, because the selector bug that matters is the one that over-matches and reports a default-deny as safe.

## Measured, 2026-08-06, 400 running pods

| | Ingress | Egress |
|---|---|---|
| pods selected by at least one policy | **109** | **5** |
| pods selected by none | **291** | **395** |

The "24 namespaces without a policy" figure understates this by an order of magnitude, in the reassuring direction.

## What a default-deny would break today

**In 40 namespaces the only uncovered workload is `postgresql`.** One finding, two faces:

- **Today** every CNPG instance in the fleet accepts a connection from any pod in the cluster on 5432. The allow-lists protect the services and leave the data reachable directly. This is the largest measured exposure in the issue, and it needs a policy that does not exist — not a rollout.
- **Under a namespace default-deny** those same pods are the ones newly cut off, so each of those 40 namespaces would sever its service from its own database. The service does not error usefully: it times out in Flyway at boot and CrashLoops, and nothing in the stack trace says NetworkPolicy.

And it is not cleanly reversible by the usual reflex. `temporal-network-policies.yaml` already records the mechanism from the one namespace that has a default-deny: the CNPG operator polls each instance manager on :8000, default-deny drops the poll, the cluster never reports Healthy, and **the ArgoCD sync for that namespace hangs** on "waiting for healthy state" — so the commit that would relax the policy cannot apply itself. Any namespace default-deny needs two carve-outs first (intra-ns 5432; `cnpg-system` → 8000 + 9187).

**Egress is not a variant of the same change.** An egress policy denies same-namespace traffic too, so it needs the workload's whole dependency graph. Four workloads have one today and one is broken by it right now: `copilot-service-egress-allow-list` lists DNS, LiteLLM, Redis, IAM, customer-edge and OTLP — and no 5432. The pod CrashLoops in Flyway with `SocketTimeoutException: Connect timed out` against a database in its own namespace. One missing rule, one dead service, no diagnostic naming the cause (fix in flight: #3885). Beyond that, **87 pods across 50 namespaces** need the EKS Pod Identity credential endpoint, which no `namespaceSelector` can express — it takes an `ipBlock`, and without it every AWS call fails at credential fetch, looking like an IAM problem for as long as you let it.

## Staged proposal

1. **Not default-deny first — the CNPG allow-list first.** Generalise `temporal-cnpg-operator` into a derived policy for every CNPG cluster. It closes the 5432 exposure on its own merits and is the precondition for anything else.
2. **First namespace: `finrep`.** One pod, no CNPG instance, not money-path, callers already derived, and a failed regulatory report is noticed and re-run rather than lost. Then `analytics`, `developer-portal`. `admin-ui` only later (it is the window you would diagnose a mistake through). **`customer-edge` last of the seven** despite qualifying on the number — it is the public edge and the caller in two of the three `DROPPED` edges stage 1 found; a namespace with known-missing declarations is the wrong place to start.
3. Everything else waits on step 1 plus a week of harvested flow logs.

Verification recipe between namespaces is in the runbook: pods Ready with no added restarts, **ArgoCD `Synced/Healthy`** (the CNPG deadlock probe, not a formality), unbroken Prometheus scrape, the golden path from a real caller rather than a port-forward (a port-forward enters via the API server and proves nothing about pod-to-pod policy), and `netpol-coverage.py` still reporting UNCOV=0. One full scheduling day between namespaces.

## How complete this is — and what breaks if I am wrong

Not very, and the gaps are the dangerous kind. Stated here rather than in a footnote:

- **It is a snapshot of running pods.** A CronJob, a monthly scheduler (interest capitalization, year-close, FINREP/COREP render), a release-time Job, any break-glass path taken by hand — all invisible, and every one is a flow a default-deny severs with no warning until the day it matters.
- **It answers "is this pod selected by a policy", never "does that policy contain every flow this pod needs".** A covered pod can still be missing a rule; `copilot-service` is exactly that.
- KEDA scale-to-zero makes "no pod running" and "no such workload" identical here.
- It reads the cluster, so it says nothing about a namespace that exists in gitops and has not synced.

If I am wrong about a namespace, the failure mode is connection timeouts with no attributable error, across everything in it at once — which is why this PR proposes an ordering and a carve-out rather than a policy set. The honest position on the issue is unchanged: **the allow-lists are not complete enough to enable default-deny fleet-wide.** The seven zero-uncovered namespaces are the only defensible starting points, and even they should wait for the CNPG work.

## Verification done

- `netpol-coverage.py` cross-validated against an independently written ad-hoc probe: both report 109/400. Unit tests: 7 pass, including the CNPG shape and namespace isolation.
- Stage-1 numbers re-measured live: 110 policies, 74 namespaces, 0 default-deny — unchanged.
- `check-network-policy-code-edges.py` re-run: same 4 edges, no drift.
- `check-stale-comment-references.py`: OK.
- No cluster mutation of any kind; no `kubectl apply`, no `tofu apply`.

Refs #2691
