### PR TITLE
fix(sanctions): make the scheduled-refresh de-duplication zone-consistent, and retire two accounting-clock exemptions

### DIFF
--- a/.github/scripts/check-accounting-clock.py
+++ b/.github/scripts/check-accounting-clock.py
@@ -82,21 +82,14 @@ BANNED = [
 # exemption and its fix move together and this debt cannot quietly become permanent. Tracked in
 # issue #2963; see it for why each is not a one-line change.
 ALLOWLIST: dict[str, str] = {
-    "openbank-transaction-service/src/main/kotlin/com/openbank/transaction/domain/settlement/"
-    "SettlementDateResolver.kt": (
-        "#2963 — settlement/booking-date rolling, entangled with #1302 item 3 (reconciliation false "
-        "drift). Changing the zone handling alone risks moving the drift rather than fixing it."
-    ),
     "openbank-fx-service/src/main/kotlin/com/openbank/fx/application/usecase/"
     "CnbRateIngestionService.kt": (
-        "#2963 — ČNB fixing day may legitimately be a publication calendar rather than the "
-        "accounting day. The code does not currently say which it means; that has to be decided "
-        "before it can be mechanically converted."
-    ),
-    "openbank-sanctions-service/src/main/kotlin/com/openbank/sanctions/application/usecase/"
-    "SanctionsListService.kt": (
-        "#2963 — ZoneId.systemDefault() in list-refresh bookkeeping, not an accounting date. Worst "
-        "in principle (host-dependent), least consequential in practice; wants the injected clock."
+        "#2963 — DECIDED (not deferred): this is the ČNB PUBLICATION calendar, not the accounting "
+        "day. A fixing is declared by the ČNB for a named business day and published at 14:30 "
+        "Prague; the day boundaries that bound validFrom/validTo are the publisher's, not the "
+        "bank's books. Same value as AccountingClock.BANK_ZONE today only because the ČNB is a "
+        "Prague institution and this entity keeps its books in Prague — binding it to the "
+        "accounting zone would encode a coincidence as a dependency. The file states this in place."
     ),
 }
 

--- a/openbank-fx-service/src/main/kotlin/com/openbank/fx/application/usecase/CnbRateIngestionService.kt
+++ b/openbank-fx-service/src/main/kotlin/com/openbank/fx/application/usecase/CnbRateIngestionService.kt
@@ -38,6 +38,25 @@ class CnbRateIngestionService(
     private val clock: Clock,
 ) : CnbRateIngestionUseCase {
 
+    /**
+     * The ČNB **publication** calendar, deliberately NOT the accounting day
+     * ([com.openbank.libs.domain.calendar.AccountingClock.BANK_ZONE]) — issue #2963 asked which of
+     * the two this means, and the answer is the publication one.
+     *
+     * The ČNB declares a fixing for a named business day and publishes it at 14:30 Prague time;
+     * that day's boundaries are properties of the *publisher*, so `validFrom`/`validTo` here mark
+     * the window a published fixing is the current one, not a window in the bank's books. The
+     * distinction is invisible today because the ČNB is a Prague institution and this bank keeps
+     * its books in Prague, so the two constants hold the same value — but they are answers to
+     * different questions and would have to move independently if either ever changed (a
+     * non-Czech entity consuming the ČNB fixing; a ČNB calendar change). Binding this to
+     * `AccountingClock` would make the coincidence look like a dependency.
+     *
+     * This is why the `check-accounting-clock.py` ALLOWLIST entry for this file is KEPT rather
+     * than removed: the gate's rule ("the accounting zone is declared once") is correct and this
+     * value is not the accounting zone. The entry's reason now records a decision instead of an
+     * open question.
+     */
     private val zone: ZoneId = ZoneId.of("Europe/Prague")
 
     private val enabled: Set<String>

--- a/openbank-sanctions-service/src/main/kotlin/com/openbank/sanctions/application/usecase/SanctionsListService.kt
+++ b/openbank-sanctions-service/src/main/kotlin/com/openbank/sanctions/application/usecase/SanctionsListService.kt
@@ -14,7 +14,6 @@ import jakarta.enterprise.context.ApplicationScoped
 import jakarta.inject.Inject
 import jakarta.ws.rs.NotFoundException
 import java.time.Clock
-import java.time.ZoneId
 import java.time.ZonedDateTime
 import java.util.UUID
 
@@ -144,7 +143,16 @@ class SanctionsListService(
         if (now.hour != cronHour || now.minute != cronMinute) return false
 
         val lastRun = lastUpdatedAt ?: return true
-        val lastRunAt = ZonedDateTime.ofInstant(lastRun, ZONE_ID)
+        // Read the last run in the SAME zone as [now] — which is the injected clock's zone, UTC in
+        // production. This comparison is a same-minute equality on (year, dayOfYear, hour, minute):
+        // it is only meaningful if both sides are in one zone, and it used to read `now` from the
+        // clock and `lastRunAt` from ZoneId.systemDefault(). Those agree only when the JVM default
+        // happens to be UTC, so on any other host the de-duplication compared two different
+        // clocks and was wrong in BOTH directions: a just-completed run read as not-yet-run (the
+        // list re-imports on the next tick inside the due minute), and an unrelated run offset by
+        // exactly the zone offset read as already-run (the due refresh is skipped). Not a zone
+        // choice: taking the zone from `now` makes both sides one zone by construction.
+        val lastRunAt = ZonedDateTime.ofInstant(lastRun, now.zone)
         return !(
             lastRunAt.year == now.year &&
                 lastRunAt.dayOfYear == now.dayOfYear &&
@@ -155,6 +163,5 @@ class SanctionsListService(
 
     companion object {
         private val ALLOWED_DAYS = setOf("MON", "TUE", "WED", "THU", "FRI", "SAT", "SUN")
-        private val ZONE_ID: ZoneId = ZoneId.systemDefault()
     }
 }

--- a/openbank-sanctions-service/src/test/kotlin/com/openbank/sanctions/application/usecase/SanctionsListServiceTest.kt
+++ b/openbank-sanctions-service/src/test/kotlin/com/openbank/sanctions/application/usecase/SanctionsListServiceTest.kt
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Test
 import java.time.Clock
 import java.time.Instant
 import java.time.ZoneOffset
+import java.util.TimeZone
 import java.util.UUID
 
 /**
@@ -297,6 +298,88 @@ class SanctionsListServiceTest {
 
         coVerify { repo.markUpdated("EU_CONSOLIDATED", 5) }
         coVerify(exactly = 0) { repo.markUpdated("OFAC_SDN", any()) }
+    }
+
+    // ──── scheduledRefresh — the same-minute de-duplication is zone-consistent (#2963) ─────────
+    //
+    // These two are the falsifying pair for the ZoneId.systemDefault() removal. They FORCE the JVM
+    // default zone to Europe/Prague, because the defect was invisible on a UTC host — and the
+    // production container is UTC, which is why nothing ever caught it. `now` comes from the
+    // injected clock (UTC here); `lastRunAt` used to come from the host default. On a +01:00 host
+    // the comparison was wrong in both directions, so the two tests below assert both. Each fails
+    // against the pre-#2963 code and passes after it; neither can pass by accident, since the
+    // assertion is on whether the importer ran at all.
+    //
+    // The default zone is restored in a finally block — leaving it set would silently retune every
+    // later test in this JVM.
+
+    private fun <T> withDefaultZone(zone: String, body: () -> T): T {
+        val previous = TimeZone.getDefault()
+        TimeZone.setDefault(TimeZone.getTimeZone(zone))
+        return try {
+            body()
+        } finally {
+            TimeZone.setDefault(previous)
+        }
+    }
+
+    @Test
+    fun `scheduledRefresh skips a list already refreshed this minute even off-UTC`() {
+        withDefaultZone("Europe/Prague") {
+            runBlocking {
+                // clock is fixed at 2024-01-15T12:00:00Z; this list is due at 12:00 and ALREADY ran
+                // at exactly that instant, so the same-minute guard must suppress it. Read in the
+                // host default the last run reads 13:00 local, which does not equal 12:00 UTC, and
+                // the guard used to conclude the list had never run.
+                val due = sampleList(
+                    listType = "OFAC_SDN",
+                    sourceUrl = "https://example.com/sdn.xml",
+                    cronHour = 12,
+                    cronMinute = 0,
+                ).copy(lastUpdatedAt = Instant.parse("2024-01-15T12:00:00Z"))
+                coEvery { repo.listSanctionsLists() } returns listOf(due)
+                // The refresh path is fully stubbed so that a wrongly-due list would SUCCEED. Left
+                // unstubbed, mockk throws inside refresh(), scheduledRefresh() swallows it, and
+                // `importList` is never reached — so the assertion below would hold for the wrong
+                // reason and pass against the very code it exists to reject.
+                coEvery { repo.findByListType("OFAC_SDN") } returns due
+                coEvery {
+                    importer.importList(SanctionsListType.OFAC_SDN, "https://example.com/sdn.xml")
+                } returns 7
+                coEvery { repo.markUpdated("OFAC_SDN", 7) } returns due.copy(lastEntryCount = 7)
+
+                service.scheduledRefresh()
+
+                coVerify(exactly = 0) { importer.importList(any(), any()) }
+            }
+        }
+    }
+
+    @Test
+    fun `scheduledRefresh still refreshes when the previous run was an hour earlier off-UTC`() {
+        withDefaultZone("Europe/Prague") {
+            runBlocking {
+                // Previous run at 11:00Z is a DIFFERENT minute from now (12:00Z), so the list is
+                // due. Read in the host default 11:00Z is 12:00 local — which the old comparison
+                // matched against 12:00 UTC and used to skip a refresh that was genuinely owed.
+                val due = sampleList(
+                    listType = "OFAC_SDN",
+                    sourceUrl = "https://example.com/sdn.xml",
+                    cronHour = 12,
+                    cronMinute = 0,
+                ).copy(lastUpdatedAt = Instant.parse("2024-01-15T11:00:00Z"))
+                coEvery { repo.listSanctionsLists() } returns listOf(due)
+                coEvery { repo.findByListType("OFAC_SDN") } returns due
+                coEvery {
+                    importer.importList(SanctionsListType.OFAC_SDN, "https://example.com/sdn.xml")
+                } returns 7
+                coEvery { repo.markUpdated("OFAC_SDN", 7) } returns due.copy(lastEntryCount = 7)
+
+                service.scheduledRefresh()
+
+                coVerify { importer.importList(SanctionsListType.OFAC_SDN, "https://example.com/sdn.xml") }
+            }
+        }
     }
 
     private fun sampleList(

--- a/openbank-transaction-service/src/main/kotlin/com/openbank/transaction/domain/settlement/SettlementDateResolver.kt
+++ b/openbank-transaction-service/src/main/kotlin/com/openbank/transaction/domain/settlement/SettlementDateResolver.kt
@@ -4,6 +4,7 @@
 
 package com.openbank.transaction.domain.settlement
 
+import com.openbank.libs.domain.calendar.AccountingClock
 import com.openbank.libs.domain.calendar.BusinessCalendar
 import com.openbank.libs.domain.calendar.BusinessDayConvention
 import java.time.Instant
@@ -30,7 +31,24 @@ data class SettlementDates(val bookingDate: LocalDate, val valueDate: LocalDate)
  */
 object SettlementDateResolver {
 
-    val BANK_ZONE: ZoneId = ZoneId.of("Europe/Prague")
+    /**
+     * The accounting zone the booking date is read in — owned by [AccountingClock.BANK_ZONE]
+     * (ADR-0207 D1), not restated here. The booking date IS an accounting date: it is the day
+     * a payment lands in the books, so it must be the same day the ledger and the year-close
+     * think it is. Restating the zone locally is what let two components inside one service
+     * disagree about the date for two hours a day, half the year.
+     *
+     * This is a same-value substitution: the constant is `Europe/Prague` on both sides, so no
+     * booking or value date moves. What changes is that there is now one owner of the answer.
+     */
+    val BANK_ZONE: ZoneId = AccountingClock.BANK_ZONE
+
+    /**
+     * Daily submission cut-off, in [BANK_ZONE]. Deliberately NOT [AccountingClock.cutoff]: that
+     * is the instant the *accounting day* rolls over (midnight), whereas this is the operational
+     * deadline after which a payment received on a business day books to the next one. The two
+     * are different business rules that happen to be expressed in the same units.
+     */
     val DEFAULT_CUTOFF: LocalTime = LocalTime.of(16, 0)
     const val FX_SPOT_LAG_DAYS: Int = 2
 

--- a/openbank-transaction-service/src/test/kotlin/com/openbank/transaction/domain/settlement/SettlementDateResolverTest.kt
+++ b/openbank-transaction-service/src/test/kotlin/com/openbank/transaction/domain/settlement/SettlementDateResolverTest.kt
@@ -4,12 +4,15 @@
 
 package com.openbank.transaction.domain.settlement
 
+import com.openbank.libs.domain.calendar.AccountingClock
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
+import java.time.ZoneOffset
 
 class SettlementDateResolverTest {
 
@@ -119,6 +122,59 @@ class SettlementDateResolverTest {
                 requestedValueDate = LocalDate.of(2026, 6, 13),
             )
             assertThat(dates.valueDate).isEqualTo(LocalDate.of(2026, 6, 15))
+        }
+    }
+
+    @Nested
+    inner class BankZoneOwnership {
+
+        /**
+         * The booking date is an accounting date, so this resolver's zone must be the one
+         * [AccountingClock] owns (ADR-0207 D1) — not a second copy that can drift from it.
+         *
+         * Honest about what this proves: #2963's change to the resolver is value-identical
+         * (`ZoneId.of("Europe/Prague")` -> `AccountingClock.BANK_ZONE`), so no test can tell the
+         * old code from the new one by its output, and none below claims to. What this assertion
+         * catches is the FUTURE divergence the change exists to prevent: if either constant is
+         * edited alone, this goes red.
+         */
+        @Test
+        fun `the resolver's bank zone is the one AccountingClock owns`() {
+            assertThat(SettlementDateResolver.BANK_ZONE).isEqualTo(AccountingClock.BANK_ZONE)
+        }
+
+        /**
+         * And that the choice is load-bearing rather than decorative: a literal instant late on a
+         * summer evening UTC is already the NEXT calendar day in Prague, so the two zones book to
+         * different days from the same instant. The cut-off is widened to end-of-day here so the
+         * only thing under test is the zone — with the production 16:00 cut-off both zones happen
+         * to roll to the same next business day and the disagreement would be masked.
+         *
+         * Note the instant is written as a literal. Deriving it from `BANK_ZONE` (as the helper at
+         * the top of this file does) would move the input and the expectation together and assert
+         * nothing about which zone is right.
+         */
+        @Test
+        fun `a late-evening UTC instant books a day later in the bank zone than in UTC`() {
+            val instant = Instant.parse("2026-06-03T22:30:00Z") // Wed 22:30 UTC == Thu 00:30 Prague
+
+            val inBankZone = SettlementDateResolver.resolve(
+                now = instant,
+                paymentCurrency = "CZK",
+                settlementCurrency = "CZK",
+                cutoff = LocalTime.MAX,
+            )
+            val inUtc = SettlementDateResolver.resolve(
+                now = instant,
+                paymentCurrency = "CZK",
+                settlementCurrency = "CZK",
+                zone = ZoneOffset.UTC,
+                cutoff = LocalTime.MAX,
+            )
+
+            assertThat(inBankZone.bookingDate).isEqualTo(LocalDate.of(2026, 6, 4))
+            assertThat(inUtc.bookingDate).isEqualTo(LocalDate.of(2026, 6, 3))
+            assertThat(inBankZone.bookingDate).isNotEqualTo(inUtc.bookingDate)
         }
     }
 }


### PR DESCRIPTION
Closes #2963. Refs #2962, #1302.

The `check-accounting-clock.py` gate (ADR-0207 D1) was green *because* three money-path sites were
allowlisted — a control that exists and is not in force. This decides each one on its merits rather
than sweeping them, and moves each exemption together with its verdict.

## Per site

| Site | Zone | Verdict |
|---|---|---|
| `openbank-sanctions-service` `SanctionsListService` | `now.zone` (whatever clock is injected; UTC in prod) | **Defect fixed**, entry removed |
| `openbank-transaction-service` `SettlementDateResolver` | `AccountingClock.BANK_ZONE` (Europe/Prague) | **Ownership fixed**, entry removed |
| `openbank-fx-service` `CnbRateIngestionService` | `Europe/Prague`, unchanged | **Justified exception**, entry KEPT with a decided reason |

### sanctions — a real defect, not a style question

`isDueForScheduledRefresh` compares `now` (from the injected clock, UTC in production) with
`lastUpdatedAt` read in `ZoneId.systemDefault()`. The comparison is a same-minute equality on
`(year, dayOfYear, hour, minute)` — meaningful only if both sides are in one zone. Off UTC it was
wrong in **both** directions: a just-completed run reads as not-yet-run (the list re-imports on the
next tick inside the due minute), and an unrelated run offset by exactly the zone offset reads as
already-run (a due refresh is skipped). Taking the zone from `now` makes both sides one zone by
construction. No zone was chosen.

### transaction — same value, one owner

`BANK_ZONE` was a second copy of `Europe/Prague`. The booking date *is* an accounting date, so it
must be the day the ledger and the year-close also think it is; a locally restated zone is exactly
what let two components in `openbank-ledger-service` disagree for two hours a day. The substitution
is value-identical, so **no booking or value date moves**. The 16:00 cut-off is deliberately not
`AccountingClock.cutoff`: that is the accounting-day rollover, this is a submission deadline.

The issue flagged this as entangled with #1302 item 3 (reconciliation false drift). It still is —
and nothing here touches it, precisely because the change moves no dates. #1302 item 3 stays open.

### fx — the question the issue asked, answered

The issue asked whether the ČNB fixing day means the accounting day or the publication day. It is
the **publication** day: a fixing is declared by the ČNB for a named ČNB business day and published
at 14:30 Prague, so the boundaries that bound `validFrom`/`validTo` are the publisher's, not the
bank's books. It equals `AccountingClock.BANK_ZONE` today only because the ČNB is a Prague
institution and this entity keeps its books in Prague; binding it to `AccountingClock` would encode
a coincidence as a dependency and make a future divergence (a non-Czech entity consuming the ČNB
fixing) silent. The allowlist entry is kept and its reason rewritten from an open question to a
decision, with the same reasoning stated in the file.

## What I proved

- **The gate is falsifiable in both directions, by reintroducing each pattern and reading the
  error** — not by trusting the green. `ZoneId.systemDefault()` back into `SanctionsListService`:
  `::error::...:165: ZoneId.systemDefault()`, exit 1. `ZoneId.of("Europe/Prague")` back into
  `SettlementDateResolver`: `::error::...:44: ZoneId.of(...)`, exit 1. Restored: exit 0.
- **Both new sanctions tests fail against the pre-change code.** They force the JVM default zone to
  `Europe/Prague` and restore it in a `finally` — the defect is invisible on a UTC host, which is
  why nothing caught it in a UTC container. Reverting the one-line fix: both FAILED.
- **A vacuous assertion was caught and fixed mid-review.** The first version of the "skips a list
  already refreshed this minute" test passed against the broken code, because an unstubbed
  `repo.findByListType` made mockk throw inside `refresh()`, `scheduledRefresh()` swallowed it, and
  `importList` was never reached — the assertion held for the wrong reason. Stubbing the whole
  refresh path so a wrongly-due list would *succeed* makes it red against the old code.
- **The settlement zone test uses a literal instant**, not one derived from `BANK_ZONE`. Deriving
  both sides moves input and expectation together and asserts nothing. `2026-06-03T22:30:00Z` is
  already 2026-06-04 in Prague; with the cut-off widened to end-of-day (so the zone is the only
  variable) the two zones book different days, asserted explicitly as unequal. Flipping `BANK_ZONE`
  to UTC: both new tests FAILED.
- `--rerun-tasks :<svc>:ktlintCheck :<svc>:detekt :<svc>:test` green for all three services, with
  `ktlintCheck`, `detekt` and `test` each appearing as executed (not `UP-TO-DATE`) in the output.

## What I did NOT verify — read this before approving

- **The transaction change is untestable by construction.** `ZoneId.of("Europe/Prague")` and
  `AccountingClock.BANK_ZONE` are the same value, so no test can distinguish the old code from the
  new by its output, and none here claims to. The added equality assertion catches a *future*
  divergence, not this change. If you want evidence this PR is safe for transaction-service, the
  evidence is that it is a no-op — read the diff, not the tests.
- **The fx zone choice is a decision, not a measurement.** I did not confirm against ČNB
  documentation that the fixing's business-day boundaries are Prague-local, nor consult anyone on
  whether this entity would ever consume the ČNB fixing from a non-Czech book. If the intended
  reading is "the accounting day, and ČNB happens to publish in Prague", then the right change is
  the opposite of the one here and the entry should go. I have stated my reading in the file so it
  can be disagreed with.
- **The fx path remains untested end-to-end**, and this PR does not change that. `#2963`'s ČNB site
  had a dead-URL incident where the feed 404'd for the service's whole life with every layer green;
  nothing here probes the feed, and I deliberately added no fx test rather than add one that would
  be equally vacuous.
- **No integration test.** The sanctions fix is covered by unit tests against a mocked repository.
  The scheduled path itself (`@Scheduled` + Vert.x context) is not exercised here.
- **`ZoneId.systemDefault()` elsewhere.** Scope is the three allowlisted money-path sites. The gate
  covers `domain/`+`application/` of money-path services only; infrastructure and non-money-path
  services are out of scope by design and I did not sweep them.
- **No threat-model update.** I judged none needed — the change removes a host-dependent value and
  moves no money — but that is my judgement and a reviewer may disagree.
- **Blast radius of a re-release.** This touches `src/main` in sanctions and transaction, so
  release-please will cut releases for both. The transaction one carries no behaviour change.

## Merge expectation

Money-path: two human approvals required. This PR is **not** expected to auto-merge, and that is the
correct final state. No override flag was or will be used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
