### PR TITLE
feat(campaign): let a caller select the PUSH channel on a campaign step

### DIFF
--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/rest/CampaignResource.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/rest/CampaignResource.kt
@@ -31,9 +31,19 @@ data class CreateCampaignRequest(
 /** Optional on create (ADR-0200 D1, #3585): absent means the journey runs every step, as before. */
 data class StopConditionRequest(val maxSendsPerParty: Int)
 
+/**
+ * A step on the create body.
+ *
+ * [channel] defaults to EMAIL so every body written before PUSH existed keeps its meaning. It was
+ * absent entirely until #3584's PUSH support was reachable only from the domain: the resource
+ * hardcoded `Channel.EMAIL`, so the openapi enum documented a value no caller could ever select.
+ * Validation is the [CampaignStep] init invariant — the template's catalogue channel must agree
+ * with the step channel — not a second edge-level check that could drift from it.
+ */
 data class StepRequest(
     val order: Int,
     val template: String,
+    val channel: Channel = Channel.EMAIL,
     val variables: Map<String, String> = emptyMap(),
     val delaySeconds: Long = 0,
 )
@@ -88,7 +98,7 @@ class CampaignResource(private val service: CampaignService, private val jwt: Js
     suspend fun create(request: CreateCampaignRequest): Response {
         val createdBy = jwt.principalName()
         val steps = request.steps.map {
-            CampaignStep(it.order, it.template, Channel.EMAIL, it.variables, it.delaySeconds)
+            CampaignStep(it.order, it.template, it.channel, it.variables, it.delaySeconds)
         }
         val campaign = service.createDraft(
             request.name,

--- a/openbank-campaign-service/src/main/resources/openapi.yaml
+++ b/openbank-campaign-service/src/main/resources/openapi.yaml
@@ -4,7 +4,7 @@ openapi: 3.1.0
 info:
   title: Campaign Service API
   # major == openbank.api.version == URL /api/v1 (ADR-0048).
-  version: 1.9.0
+  version: 1.11.0
   description: >-
     Campaign management first slice (ADR-0200 / ADR-0209 D3): deterministic, versioned segments;
     per-enrolment Temporal journeys; consent-gated delivery through notification-service.
@@ -424,8 +424,15 @@ components:
           # PUSH added in 1.8.0. SMS and IN_APP are deliberately absent: SMS has no outbound port
           # in the platform, and IN_APP was removed from notification-service's channel enum by
           # #2372 because its dispatch branch dropped every message silently.
+          #
+          # Selectable on create since 1.10.0. Until then the create body had no channel field at
+          # all and the resource hardcoded EMAIL, so PUSH was documented here and unreachable.
           enum: [EMAIL, PUSH]
           default: EMAIL
+          description: >-
+            Optional on create; absent means EMAIL. Must agree with the template's own channel —
+            MARKETING_PRODUCT_OFFER renders on EMAIL, MARKETING_PRODUCT_OFFER_PUSH on PUSH — and a
+            mismatch is rejected with 400.
         variables:
           type: object
           additionalProperties: { type: string }

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/integration/CampaignRestContractIT.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/integration/CampaignRestContractIT.kt
@@ -139,6 +139,88 @@ class CampaignRestContractIT {
         }
     }
 
+    /**
+     * PUSH must be selectable by a caller, not just representable in the domain.
+     *
+     * #3584 added `Channel.PUSH` and the openapi enum lists it, but `StepRequest` had no `channel`
+     * field and the resource hardcoded `Channel.EMAIL` — so the capability was documented and
+     * unreachable, and nothing went red: the domain tests construct `CampaignStep` directly and the
+     * spec is not executed. Only a real create-then-read over HTTP can tell "the enum has PUSH in
+     * it" from "a client can ask for PUSH".
+     */
+    @Test
+    fun `a step can be created on PUSH and reads back as PUSH`() {
+        val body = """
+            {"name":"push-${UUID.randomUUID()}","goal":"prove PUSH is reachable over HTTP",
+             "segmentName":"actives","segmentVersion":1,
+             "steps":[{"order":1,"template":"MARKETING_PRODUCT_OFFER_PUSH","channel":"PUSH",
+                       "variables":{"offerTitle":"T"},"delaySeconds":0}]}
+        """.trimIndent()
+
+        val id = Given {
+            contentType("application/json")
+            body(body)
+        } When {
+            post("/api/v1/campaigns")
+        } Then {
+            statusCode(201)
+            body("steps[0].channel", org.hamcrest.Matchers.equalTo("PUSH"))
+        } Extract {
+            path<String>("id")
+        }
+
+        // Read back through a second request: the create response could be echoing the request DTO
+        // rather than what was persisted, which would pass the assertion above and still mean the
+        // step runs on EMAIL.
+        When {
+            get("/api/v1/campaigns/$id")
+        } Then {
+            statusCode(200)
+            body("steps[0].channel", org.hamcrest.Matchers.equalTo("PUSH"))
+        }
+    }
+
+    /**
+     * The other half: making the channel caller-supplied must not make it caller-*chosen*. The
+     * `CampaignStep` init invariant is the validation — an email template on a PUSH step would put
+     * offer body copy into an APNs payload, the leak #1182 closed — and it has to survive the trip
+     * through the REST layer, where a failed `require()` becomes a 400 via libs' common mappers.
+     */
+    @Test
+    fun `a template that renders on EMAIL is rejected on a PUSH step`() {
+        val body = """
+            {"name":"mismatch-${UUID.randomUUID()}","goal":"prove the invariant reaches HTTP",
+             "segmentName":"actives","segmentVersion":1,
+             "steps":[{"order":1,"template":"MARKETING_PRODUCT_OFFER","channel":"PUSH",
+                       "variables":{"offerTitle":"T","offerText":"X","ctaText":"Go"},"delaySeconds":0}]}
+        """.trimIndent()
+
+        Given {
+            contentType("application/json")
+            body(body)
+        } When {
+            post("/api/v1/campaigns")
+        } Then {
+            statusCode(400)
+        }
+    }
+
+    /**
+     * A body written before `channel` existed must keep its meaning — the field is optional with an
+     * EMAIL default, so every stored campaign and every existing client is unaffected.
+     */
+    @Test
+    fun `a step with no channel field still defaults to EMAIL`() {
+        val id = createDraft()
+
+        When {
+            get("/api/v1/campaigns/$id")
+        } Then {
+            statusCode(200)
+            body("steps[0].channel", org.hamcrest.Matchers.equalTo("EMAIL"))
+        }
+    }
+
     @Test
     fun `the segment catalogue is served over HTTP with its rules in words`() {
         When {


### PR DESCRIPTION
## Summary

`Channel.PUSH` was documented in the campaign openapi spec and implemented in the domain, but no caller could ever select it: `StepRequest` had no `channel` field and `CampaignResource.create` hardcoded `Channel.EMAIL`. This adds the field, passes it through, and covers it at the REST layer — the only layer that can tell "the enum contains PUSH" from "a client can ask for PUSH".

## Type of change

- [x] feat (new functionality)
- [ ] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [ ] docs
- [ ] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change

## Linked issues

Closes #3896
Refs #3584 (added `Channel.PUSH` and `MARKETING_PRODUCT_OFFER_PUSH`, reachable only from Kotlin until now)

## Changes

- `StepRequest` gains `channel: Channel = Channel.EMAIL`, passed through to `CampaignStep`. The default means every request body written before this change keeps its exact meaning, and the field stays optional in the spec.
- No new edge-level validation. The `CampaignStep` init invariant already requires the template's catalogue channel to agree with the step channel — an EMAIL template on a PUSH step would put offer body copy into an APNs payload, the leak #1182 closed. A failed `require()` surfaces as 400 through libs' `CommonExceptionMappers`, so a second check at the edge would only be a copy free to drift.
- Three tests in `CampaignRestContractIT`:
  - a PUSH step created and then read back over a **second** request — the create response could be echoing the request DTO rather than what was persisted, which would pass a single-request assertion while the step still ran on EMAIL;
  - `MARKETING_PRODUCT_OFFER` (an EMAIL template) on a PUSH step rejected with 400;
  - a body with no `channel` field still reading back as EMAIL.
- `openapi.yaml`: `channel` gains a `description` stating it is optional on create and must agree with the template; `info.version` 1.9.0 -> 1.11.0.

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports).
- [x] Unit tests added/updated.
- [x] Integration tests added/updated (if service boundary involved).
- [ ] Contract tests updated (if public API changed). — no consumer pact covers campaign create.
- [x] `./gradlew detekt ktlintCheck koverVerify build` passes.
- [x] No new lint warnings.
- [x] OpenAPI spec regenerated (if REST API changed).
- [ ] Flyway migration added + rollback note (if DB changed). — N/A, steps are serialized to the existing `steps_json` text column, and `channel` is already part of that JSON.
- [ ] Avro schema versioned backward-compatibly (if event changed). — N/A.
- [x] Docs updated (README, ADR if architectural). — spec description only; ADR-0200 D7 already covers the channel set.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings`, `as Any`, `@Suppress("...")` without justification.
- [x] No new third-party dependency.
- [ ] Auth / crypto / payment code changed? — no.
- [ ] PII path changed? — no. The template/channel invariant is what keeps customer-specific content out of an APNs payload, and this PR preserves it rather than relaxing it.
- [ ] Cardholder data path changed? — no.

## Compliance impact

- [ ] PCI DSS
- [ ] DORA
- [ ] GDPR
- [ ] PSD2 / SCA / RTS
- [ ] AML / 5AMLD
- [ ] CNB reporting
- [x] None

Marketing consent is unchanged: per-channel scopes already exist (`MARKETING_COMMS_PUSH`, ADR-0198 D4) and the consent gate runs on the delivery path, not here.

## Rollout / Rollback

- Deployment strategy: rolling
- Rollback plan: revert. The field is additive and optional, so no stored campaign and no existing client depends on it.
- Data migration reversible: N/A

## Reviewer notes

**Version race with #3895 — read before approving.** That PR is open, touches the same two files, and already claims `info.version: 1.10.0`. I took **1.11.0** deliberately: a skipped number is cheaper than a collision, and the api-contract gate classifies against the PR's base, so it cannot see a competing claim. A textual conflict on `StepRequest` and on the `CampaignStep(...)` call site is certain — #3895 adds a 6th `condition` parameter. Both changes are orthogonal and coexist; whoever lands second resolves. I did not touch that branch (it may be a live worktree).

**On the falsifiability of the two new PUSH tests.** Both were run against the pre-fix resource, with the hardcoded `Channel.EMAIL` restored:

```
CampaignRestContractIT > a template that renders on EMAIL is rejected on a PUSH step() FAILED
CampaignRestContractIT > a step can be created on PUSH and reads back as PUSH() FAILED
```

That second failure is the interesting one: before this change, a mismatched template/channel pair was not rejected, it was silently coerced to EMAIL — the caller asked for PUSH and got an email, with no error anywhere.

**Why no domain test was added.** The invariant this relies on is already covered by `TemplateCatalogTest` and the `CampaignStep` init requires. The defect was never in the domain; it was that the domain could not be reached. A fourth domain test would have passed against the broken code, which is precisely how this shipped.
