### PR TITLE
docs(compliance): correct false evidence in the OpenSSF Gold gap doc and gate it

### DIFF
--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -1218,6 +1218,27 @@ gates:
     run: |
       python3 .github/scripts/check-compliance-matrix.py --enforce
 
+  # docs/compliance/openssf-gold-gap.md feeds the OpenSSF BadgeApp form -- a public
+  # attestation to a third party. It shipped scoring crypto_used_network/crypto_tls12 as
+  # met on the justification "TLS + Istio mTLS", while the live cluster has zero Istio
+  # CRDs and zero Istio namespaces (#1914 is open for exactly that), and nine other rows
+  # were scored met on justifications naming nothing checkable at all ("Attest"). An
+  # assessor checks the evidence, not the tick. Nothing read this file before #3884.
+  #
+  # Structural, not a word deny-list: a met row must cite a resolvable anchor (existing
+  # repo path / issue ref / URL), and every path-shaped citation must resolve. Partial and
+  # not-met rows are exempt, so the prose explaining the mesh gap cannot trip it -- the
+  # gate-over-prose trap. Falsified both ways against the real pre-fix document: 10
+  # findings before, 0 after. Prints the row count, so a green cannot mean "never opened".
+  - id: openssf-gold-evidence
+    name: "OpenSSF Gold gap-doc evidence citations (#3884, enforced)"
+    group: registry
+    mode: enforced
+    selftest: |
+      python3 .github/scripts/check-openssf-gold-evidence.py --self-test
+    run: |
+      python3 .github/scripts/check-openssf-gold-evidence.py
+
   # rules.yaml' shared_m2m_write_prohibition names this script as its own `ci_producer`, and
   # nothing invoked it — so reading rules.yaml gave every impression the rule was enforced
   # while the check had never executed (#3240). The surrounding rule is not a small one: it

--- a/.github/scripts/check-openssf-gold-evidence.py
+++ b/.github/scripts/check-openssf-gold-evidence.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Evidence discipline for docs/compliance/openssf-gold-gap.md (#3884).
+
+WHY THIS EXISTS
+---------------
+That document feeds the OpenSSF BadgeApp form -- a public attestation to a third party.
+It shipped with `crypto_used_network` / `crypto_tls12` scored met on the justification
+"TLS + Istio mTLS", while the live cluster has ZERO Istio CRDs and ZERO Istio namespaces
+(#1914 is open for exactly that). Three other rows were scored met on justifications that
+named no checkable thing at all: "Attest", "Falco, NetworkPolicies, OPA, seccomp,
+PSS-restricted", "Owner attests GitHub 2FA is enforced". An assessor checks the EVIDENCE,
+not the tick, so a justification naming a control that does not exist is worse than an
+honest gap. Hand-corrected conformance rows rot exactly the way the originals did --
+`check-compliance-matrix.py` exists for the admin-ui page for the same reason. Nothing
+read this file before this gate.
+
+WHY IT IS STRUCTURAL, NOT A WORD DENY-LIST
+------------------------------------------
+The obvious design -- ban the string "Istio" -- is the classic gate-over-prose failure:
+it matches the sentence EXPLAINING that no mesh is deployed just as readily as a false
+citation, and the corrected document necessarily contains that sentence. So this gate
+never reasons about what a word means. It asserts a structural property instead:
+
+  R1  A row scored met must cite at least one RESOLVABLE ANCHOR -- a repo path that
+      exists, an issue reference, or a URL. "TLS + Istio mTLS" contains none of those
+      and fails; so do "Attest" and the bare control-name list. The corrected rows pass
+      because they name files. A row scored partial or not-met is EXEMPT: describing a
+      gap is what those rows are for, and demanding evidence for a confessed gap would
+      be nonsense.
+
+  R2  Every path-shaped citation ANYWHERE in the tables must resolve on disk (globs
+      allowed). This is the actual rot mechanism -- a cited file gets renamed and the
+      justification silently becomes fiction.
+
+Scope is the CONSTRUCT, not the file: only 3-cell markdown table rows whose first cell
+begins with a backticked criterion id are parsed, and only the third cell is read. Body
+prose, blockquotes and headings are never examined, so the note explaining the mesh gap
+cannot trip anything.
+
+The row count is printed on every run: a green that says "0 rows" is a gate that never
+opened the file, and that must be visible.
+"""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import re
+import sys
+import tempfile
+
+REPO = pathlib.Path(__file__).resolve().parents[2]
+DOC_REL = "docs/compliance/openssf-gold-gap.md"
+
+MET = "✅"  # white heavy check mark -- "met, with measured evidence"
+
+# A table row we care about: exactly three cells, first cell opens with a backtick.
+ROW_RE = re.compile(r"^\|([^|]*)\|([^|]*)\|([^|]*)\|\s*$")
+BACKTICKED = re.compile(r"`([^`]+)`")
+ISSUE_REF = re.compile(r"#\d+")
+URL_REF = re.compile(r"https?://")
+
+
+def looks_like_path(token: str) -> bool:
+    """A backticked token we should try to resolve against the working tree.
+
+    Deliberately narrow. A token qualifies only if it contains a path separator and
+    nothing that marks it as prose, a URL, config syntax or markup -- otherwise
+    `<verify-signatures>false</verify-signatures>` and `https://open-bank.tech` would be
+    treated as filenames.
+    """
+    if not token or " " in token or "\t" in token:
+        return False
+    if token.startswith(("http://", "https://")):
+        return False
+    if any(c in token for c in "<>=:()\"'"):
+        return False
+    return "/" in token
+
+
+def resolve_path(repo: pathlib.Path, token: str) -> bool:
+    token = token.rstrip("/")
+    if not token:
+        return False
+    if "*" in token or "?" in token:
+        return any(repo.glob(token))
+    return (repo / token).exists()
+
+
+def parse_rows(text: str) -> list[tuple[int, str, str, str]]:
+    """Yield (lineno, criterion, state, evidence) for criterion table rows only."""
+    rows = []
+    for i, line in enumerate(text.splitlines(), start=1):
+        m = ROW_RE.match(line)
+        if not m:
+            continue
+        crit, state, evidence = (c.strip() for c in m.groups())
+        # Header rows ("| Criterion | State | ... |") and separators never start with a
+        # backtick; requiring one is what keeps this scoped to real criterion rows.
+        if not crit.startswith("`"):
+            continue
+        rows.append((i, crit, state, evidence))
+    return rows
+
+
+def check(repo: pathlib.Path, doc_rel: str) -> tuple[list[str], int]:
+    doc = repo / doc_rel
+    if not doc.is_file():
+        return ([f"{doc_rel}: not found"], 0)
+
+    text = doc.read_text(encoding="utf-8")
+    rows = parse_rows(text)
+    problems: list[str] = []
+
+    if not rows:
+        problems.append(f"{doc_rel}: no criterion rows parsed -- the table shape changed")
+        return (problems, 0)
+
+    for lineno, crit, state, evidence in rows:
+        # R2 applies to every row: a cited path must exist.
+        for token in BACKTICKED.findall(evidence):
+            if looks_like_path(token) and not resolve_path(repo, token):
+                problems.append(
+                    f"{doc_rel}:{lineno}: {crit} cites `{token}`, which does not exist"
+                )
+
+        # R1 applies only to rows scored met.
+        if MET not in state:
+            continue
+
+        has_path = any(
+            looks_like_path(t) and resolve_path(repo, t)
+            for t in BACKTICKED.findall(evidence)
+        )
+        if has_path or ISSUE_REF.search(evidence) or URL_REF.search(evidence):
+            continue
+        problems.append(
+            f"{doc_rel}:{lineno}: {crit} is scored {MET} but its justification cites no "
+            f"resolvable evidence (no existing repo path, issue ref or URL): "
+            f"{evidence!r}. Cite a checkable artefact, or downgrade the row."
+        )
+
+    return (problems, len(rows))
+
+
+# --------------------------------------------------------------------------- self-test
+
+_HEADER = "| Criterion | State | Evidence / action |\n|---|---|---|\n"
+
+
+def _self_test() -> int:
+    """Falsify in BOTH directions: it must flag what is false and pass what is true."""
+    cases: list[tuple[str, str, bool]] = [
+        # (name, table body, expect_problem)
+        (
+            "the real #3884 defect: met, justification names only a control",
+            "| `crypto_tls12` | ✅ | TLS + Istio mTLS |\n",
+            True,
+        ),
+        (
+            "met with bare 'Attest' as the justification",
+            "| `test_invocation` | ✅ | Attest |\n",
+            True,
+        ),
+        (
+            "met on a list of control names with no artefact",
+            "| `hardening` | ✅ | Falco, NetworkPolicies, OPA, seccomp, PSS-restricted |\n",
+            True,
+        ),
+        (
+            "met citing a repo path that does not exist",
+            "| `dynamic_analysis` | ✅ | `.github/workflows/nope-does-not-exist.yml` |\n",
+            True,
+        ),
+        (
+            "TRUE ROW must not be flagged: met citing an existing path",
+            "| `dynamic_analysis` | ✅ | `.github/scripts/check-openssf-gold-evidence.py` |\n",
+            False,
+        ),
+        (
+            "TRUE ROW must not be flagged: met citing an issue",
+            "| `crypto_tls12` | ✅ | Edge TLS via cert-manager; not mesh mTLS, see #1914 |\n",
+            False,
+        ),
+        (
+            "TRUE ROW must not be flagged: met citing a URL",
+            "| `hardened_site` | ✅ | HSTS+CSP measured on https://open-bank.tech |\n",
+            False,
+        ),
+        (
+            "PROSE-VS-THING: a NOT-MET row may name a mesh freely",
+            "| `crypto_tls12` | ❌ | No Istio mesh mTLS is deployed |\n",
+            False,
+        ),
+        (
+            "PROSE-VS-THING: a PARTIAL row needs no anchor",
+            "| `achieve_silver` | ⚠️ | Not verifiable from this repo |\n",
+            False,
+        ),
+    ]
+
+    failures = 0
+    with tempfile.TemporaryDirectory() as d:
+        tmp = pathlib.Path(d)
+        # Give the sandbox the one real file the "true row" cases cite.
+        real = tmp / ".github/scripts"
+        real.mkdir(parents=True)
+        (real / "check-openssf-gold-evidence.py").write_text("x", encoding="utf-8")
+        rel = "doc.md"
+
+        for name, body, expect_problem in cases:
+            # Prose that would trip a naive word deny-list, present in every case.
+            prose = (
+                "> No service mesh is deployed. There are zero Istio CRDs; the "
+                "istio.yaml manifest is referenced by no ArgoCD Application (#1914).\n\n"
+            )
+            (tmp / rel).write_text(prose + _HEADER + body, encoding="utf-8")
+            problems, n_rows = check(tmp, rel)
+            got = bool(problems)
+            if n_rows != 1:
+                print(f"::error::self-test '{name}': parsed {n_rows} rows, expected 1")
+                failures += 1
+                continue
+            if got != expect_problem:
+                verb = "expected a finding, got none" if expect_problem else "false positive"
+                print(f"::error::self-test '{name}': {verb} -- {problems}")
+                failures += 1
+            else:
+                print(f"  ok  [{'flags' if expect_problem else 'passes'}] {name}")
+
+        # Scope guard: a doc with no criterion rows must be reported, never silently green.
+        (tmp / rel).write_text("# nothing here\n", encoding="utf-8")
+        problems, n_rows = check(tmp, rel)
+        if not problems or n_rows != 0:
+            print("::error::self-test: an empty document was not reported")
+            failures += 1
+        else:
+            print("  ok  [flags] a document with zero criterion rows is reported")
+
+    if failures:
+        print(f"::error::self-test: {failures} case(s) failed")
+        return 1
+    print(f"self-test: all {len(cases) + 1} cases passed (both directions)")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--self-test", action="store_true", help="run the built-in cases")
+    args = ap.parse_args()
+
+    if args.self_test:
+        return _self_test()
+
+    problems, n_rows = check(REPO, DOC_REL)
+    # Always print the count: a green claiming 0 rows means the file was never opened.
+    print(f"openssf-gold-evidence: checked {n_rows} criterion row(s) in {DOC_REL}")
+    if problems:
+        for p in problems:
+            print(f"::error::{p}")
+        print(f"::error::{len(problems)} evidence problem(s) in {DOC_REL}")
+        return 1
+    print("openssf-gold-evidence: every row scored met cites resolvable evidence")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/compliance/openssf-gold-gap.md
+++ b/docs/compliance/openssf-gold-gap.md
@@ -3,57 +3,96 @@
 > Assessment of this repository against the [OpenSSF Best Practices Gold criteria](https://www.bestpractices.dev/en/criteria/2),
 > to make the path to Gold concrete. **Positioning, not a submission** — the badge is submitted from
 > the maintainer's BadgeApp account; several criteria are attestations only the maintainer can make.
-> Verified against `origin/main` (SPDX coverage sampled, contributor list from `git log`, coverage
-> floor from the kover config).
+>
+> **Every justification in the tables below must name something measurable — a repo path, an ADR, a
+> live HTTP response, or an issue number — and must have been measured, not assumed.** This document
+> feeds a public attestation to a third party, and an assessor checks the *evidence*, not the tick.
+> A justification naming a control that does not exist is worse than an honest gap.
+> Evidence discipline is enforced by `.github/scripts/check-openssf-gold-evidence.py`
+> (gate `openssf-gold-evidence`).
 
 ## Headline
 
 The platform **already meets almost every security and quality-infrastructure Gold criterion** — it
-is a security-heavy codebase (Falco, mesh mTLS, OPA, signed SLSA evidence, an external pentest,
-ZAP + ClusterFuzzLite dynamic analysis). Gold is blocked on **three things that share one root**
-plus a coverage push:
+is a security-heavy codebase (Falco, default-deny NetworkPolicies, OPA, signed SLSA evidence, an
+external pentest, ZAP + ClusterFuzzLite dynamic analysis). Gold is blocked on **three things that
+share one root** plus a coverage push:
 
 1. **bus factor ≥ 2**, 2. **two-person review (≥50% of changes reviewed by a non-author)**,
 3. **two unassociated significant contributors** — all three fail for the same reason: a **single
 maintainer** (`CODEOWNERS` is `@JiRaska` on every path; the git log is JiRaska + bots). Plus
-4. **90% statement / 80% branch coverage** (the current ratchet floor is far lower).
+4. **90% statement / 80% branch coverage** (the current per-service floors are far lower).
 
 **The first three are not solvable in code.** One added external reviewer/maintainer unlocks all
 three at once — it is the single highest-leverage, non-purchasable action for the whole
 credibility roadmap.
 
+> **No service mesh is deployed.** There is an `openbank-infra/k8s/base/istio.yaml` manifest, but the
+> control plane has never been bootstrapped: the live cluster has **zero** Istio CRDs and zero Istio
+> namespaces (measured 2026-08-06), and no ArgoCD Application references the manifest. In-cluster
+> isolation today is **NetworkPolicy-based, not mesh-based** — as `README.md`, `docs/ARCHITECTURE.md`
+> and `docs/strategy/09-roadmap-M1-M7.md` already state. Tracked by **#1914**. No criterion below may
+> cite mesh mTLS as evidence.
+
 ## Criterion-by-criterion
 
+Legend — ✅ met, with measured evidence · ⚠️ partial, or met only by an owner attestation this repo
+cannot verify · ❌ not met.
+
 ### Prerequisites
-| Criterion | State | Action |
+| Criterion | State | Evidence / action |
 |---|---|---|
-| `achieve_silver` | ⚠️ ~84% | Close the remaining Silver criteria (owner, BadgeApp) |
-| `bus_factor` (≥2) | ❌ | **Add a second maintainer / external review pool** (owner) |
-| `contributors_unassociated` (2+ significant) | ❌ | Same root — grow unassociated contribution |
+| `achieve_silver` | ⚠️ | **Not verifiable from this repo** — Silver progress lives in the maintainer's BadgeApp account. Owner to read the current percentage off BadgeApp and close the remainder |
+| `bus_factor` (≥2) | ❌ | Measured: `CODEOWNERS` names `@JiRaska` on every path, 0 lines naming anyone else. **Add a second maintainer / external review pool** (owner) |
+| `contributors_unassociated` (2+ significant) | ❌ | Measured: `git log origin/main` has exactly one human author address; every other author is a bot. Same root — grow unassociated contribution |
 
 ### Basics
-| `copyright_per_file` / `license_per_file` (SPDX) | ✅ | Sampled 52/52 in ledger; confirm fleet-wide, then attest |
+| Criterion | State | Evidence / action |
+|---|---|---|
+| `copyright_per_file` / `license_per_file` (SPDX) | ✅ | Measured fleet-wide: 2893 of 2894 `.kt` files carry `SPDX-License-Identifier`. Enforced continuously by `.github/scripts/check-license-headers.py` (gate `license-header-consistency`), which checks headers against the `agpl_modules` set in `openbank-libs/governance/rules.yaml` |
+| `small_tasks` | ⚠️ | The label exists but is spelled `good-first-issue` in `.github/labels.yml`, and **0 open issues currently carry it** (measured 2026-08-06). The criterion asks the project to *identify* small tasks — label the backlog before claiming this |
 
 ### Change control
-| `repo_distributed` (git) | ✅ | Attest |
-| `small_tasks` | ✅ | `good first issue` label exists |
-| `require_2FA` / `secure_2FA` | ✅ (assumed) | Owner attests GitHub 2FA is enforced (cryptographic, not SMS) |
+| Criterion | State | Evidence / action |
+|---|---|---|
+| `repo_distributed` (git) | ✅ | The project is a public git repository with its full history at https://github.com/JiRaska/open-bank-oss |
+| `require_2FA` / `secure_2FA` | ⚠️ | **Owner attestation only** — GitHub account 2FA settings are not observable from this repository. Previously scored ✅ "(assumed)"; an assumption is not evidence |
 
 ### Quality
-| `code_review_standards` | ⚠️ | CONTRIBUTING.md + GOVERNANCE.md document the flow; point the criterion at them |
+| Criterion | State | Evidence / action |
+|---|---|---|
+| `code_review_standards` | ⚠️ | `CONTRIBUTING.md` and `GOVERNANCE.md` both exist and document the flow; point the criterion at them. Partial only because the review itself has no second human (see `two_person_review`) |
 | `two_person_review` (≥50%) | ❌ | **Bus-factor root** — needs a second human reviewer |
-| `build_reproducible` | ⚠️ | `verification-metadata.xml` byte-pins + fast-jar help; either finish reproducibility or claim N/A with justification |
-| `test_invocation` (`./gradlew test`) | ✅ | Attest |
-| `test_continuous_integration` | ✅ | Extensive CI — attest |
-| `test_statement_coverage90` | ❌ | Ratchet floor ~55%; raise over time (money-path first) |
-| `test_branch_coverage80` | ❌ | Same |
+| `build_reproducible` | ⚠️ | **Artefact present, enforcement pending.** `gradle/verification-metadata.xml` byte-pins dependencies, but `gradle.properties` sets `org.gradle.dependency.verification=lenient` and the metadata sets `<verify-signatures>false</verify-signatures>` — so a checksum mismatch warns rather than fails, and signatures are not checked at all. The lenient→strict flip is tracked by **#1915** (target 2026-09-30). Do not claim this until that lands |
+| `test_invocation` (`./gradlew test`) | ✅ | The Gradle wrapper is committed (`gradle/wrapper/gradle-wrapper.properties`) and `CONTRIBUTING.md` documents the command: "Ensure tests pass locally (`./gradlew test` for JVM, `npm test` for Admin UI)". Scored on the documented entry point, not on a clean fleet-wide run |
+| `test_continuous_integration` | ✅ | `.github/gates/gates.yaml` declares 110 CI gates run per PR, plus per-service build/test workflows under `.github/workflows/` |
+| `test_statement_coverage90` | ❌ | Measured: 60 per-module kover `minValue` floors span 0–90 with a median of 55; **58 of 60 are below 90**. Ratchet upward, money-path first |
+| `test_branch_coverage80` | ❌ | Same ratchet, same floors |
 
 ### Security
-| `crypto_used_network` / `crypto_tls12` | ✅ | TLS + Istio mTLS |
-| `hardened_site` | ⚠️ | Confirm security headers on open-bank.tech (CSP/HSTS) |
-| `security_review` (≤5y) | ✅ | External pentest, ADR-0080 |
-| `hardening` | ✅ | Falco, NetworkPolicies, OPA, seccomp, PSS-restricted |
-| `dynamic_analysis` | ✅ | ZAP baseline + schemathesis + ClusterFuzzLite |
+| Criterion | State | Evidence / action |
+|---|---|---|
+| `crypto_used_network` / `crypto_tls12` | ✅ | **Edge TLS only.** Ingress certificates are issued by cert-manager from `letsencrypt-prod` (`openbank-infra/gitops/components/*/ingress.yaml`); the static site fronts CloudFront with `minimum_protocol_version = "TLSv1.2_2021"` (`openbank-infra/aws/modules/static-site/main.tf`). Verified live: `https://open-bank.tech` and `https://admin.open-bank.tech` both answer over HTTP/2 TLS (2026-08-06). **Not** mesh mTLS — see the note above and **#1914** |
+| `hardened_site` | ✅ | Measured live 2026-08-06: both `https://open-bank.tech` and `https://admin.open-bank.tech` return `strict-transport-security: max-age=63072000; includeSubDomains; preload`, a `content-security-policy` with `object-src 'none'` and `base-uri 'self'`, and an `x-frame-options` header |
+| `security_review` (≤5y) | ✅ | External web pentest of `admin.open-bank.tech`, 2026-06-10, recorded in `docs/adr/0080-pentest-remediation-p0-p2.md`. Note that ADR's own `delivery-status: partial` — the *review* is what this criterion asks for, remediation is tracked separately |
+| `hardening` | ✅ | Measured across `openbank-infra/gitops/`: 64 files declaring `kind: NetworkPolicy` (default-deny fleet-wide), 102 files setting `seccompProfile`, 42 namespaces with `pod-security.kubernetes.io/enforce: restricted`, plus per-service OPA bundles under `openbank-infra/gitops/components/`. Falco is deployed (its namespace is live in the cluster) |
+| `dynamic_analysis` | ✅ | `.github/workflows/dast-zap-baseline.yml` (ZAP baseline), `.github/workflows/api-fuzz.yml` + `api-fuzz-authenticated.yml` (schemathesis), `.clusterfuzzlite/` + `.github/workflows/cflite-pr.yml` (ClusterFuzzLite) |
+
+## What was measured, and what was not
+
+Measured directly for this revision (2026-08-06): the cluster mesh state (`kubectl get crd` / `get ns`),
+the Gradle verification mode, SPDX coverage across all 2894 `.kt` files, the kover floor distribution,
+`CODEOWNERS`, `git log` authorship, the label file and open-issue label counts, the presence of every
+workflow and manifest cited above, and live HTTP response headers for both public sites.
+
+**Taken on trust / not verifiable here:** `achieve_silver` (BadgeApp account state) and
+`require_2FA` / `secure_2FA` (GitHub account settings). Both are now scored ⚠️ rather than ✅ for
+exactly that reason.
+
+**Possible residual overstatement:** `hardening` and `dynamic_analysis` are scored on the *existence
+and wiring* of each named control, not on its runtime efficacy — a NetworkPolicy that exists is not
+proof that it denies the right traffic, and a ZAP job that runs is not proof it has meaningful
+coverage. `test_invocation` is scored on the documented command, not on a clean fleet-wide run.
 
 ## Recommended order
 
@@ -62,4 +101,10 @@ credibility roadmap.
    *and* the OSTIF-style external audit.
 2. **Close Silver to 100%** — small, owner-driven BadgeApp work.
 3. **Attest the already-met security/infra criteria** — most of Gold is a form-fill once (1).
-4. **Coverage ratchet toward 90/80** — the one real engineering effort; sequence money-path first.
+4. **Land #1915** (dependency verification lenient→strict) to convert `build_reproducible`.
+5. **Label a handful of `good-first-issue` items** to convert `small_tasks` — cheap.
+6. **Coverage ratchet toward 90/80** — the one real engineering effort; sequence money-path first.
+
+> **If anything has already been submitted to BadgeApp citing "Istio mTLS" for `crypto_used_network`
+> or `crypto_tls12`, that justification is false and should be replaced with the edge-TLS evidence
+> above.** Submitting or amending the badge is the maintainer's action; this document does not do it.


### PR DESCRIPTION
Closes #3884. Refs #1914, #1915.

## The defect

`docs/compliance/openssf-gold-gap.md` feeds the OpenSSF BadgeApp form — a public attestation to a third party. It scored `crypto_used_network` / `crypto_tls12` as met on the justification **"TLS + Istio mTLS"**, and the headline called this a "mesh mTLS" codebase.

Re-verified independently (2026-08-06):

```
kubectl get crd -o name | grep -ciE 'istio|peerauthentication'  -> 0
kubectl get ns  -o name | grep -ci istio                        -> 0
kubectl get crd -o name | grep -ciE 'linkerd|cilium'            -> 0
```

The criterion itself is almost certainly **met** — edge TLS is real. The defect is that the *stated evidence* is false, and evidence is what an assessor checks. Notably this document was the **sole outlier**: `README.md`, `docs/ARCHITECTURE.md` and `docs/strategy/09-roadmap-M1-M7.md` all already say plainly that the Istio control plane has never been bootstrapped.

## Full row audit

I audited **all 19 rows**, not the two reported. Every ✅ was checked against `origin/main` or the live cluster.

| Criterion | Was | Now | What I measured |
|---|---|---|---|
| `achieve_silver` | ⚠️ ~84% | ⚠️ | **NOT MEASURED** — BadgeApp account state, not observable here. The "~84%" figure was unsourced; removed |
| `bus_factor` | ❌ | ❌ | `CODEOWNERS`: every path `@JiRaska`, 0 lines naming anyone else. Justification accurate |
| `contributors_unassociated` | ❌ | ❌ | `git log origin/main`: 1 human author address, all others bots. Accurate |
| `copyright_per_file` / `license_per_file` | ✅ sample of 52 | ✅ | **Upgraded evidence**: 2893/2894 `.kt` carry SPDX; the enforced `license-header-consistency` gate now backs it instead of a sample |
| `small_tasks` | ✅ | **⚠️** | **WRONG.** Label is `good-first-issue`, not "`good first issue`", and **0 open issues carry it**. Label-exists is not "identifies small tasks" |
| `repo_distributed` | ✅ "Attest" | ✅ | True, but "Attest" is not evidence. Now cites the repo URL |
| `require_2FA` / `secure_2FA` | ✅ (assumed) | **⚠️** | **An assumption is not evidence.** Not observable from this repo; owner attestation |
| `code_review_standards` | ⚠️ | ⚠️ | `CONTRIBUTING.md` + `GOVERNANCE.md` both exist. Accurate |
| `two_person_review` | ❌ | ❌ | Bus-factor root. Accurate |
| `build_reproducible` | ⚠️ | ⚠️ | **Overstated justification.** `gradle.properties:37` = `org.gradle.dependency.verification=lenient`; `verification-metadata.xml:5` = `<verify-signatures>false</verify-signatures>`. Reworded to "artefact present, enforcement pending (#1915)" |
| `test_invocation` | ✅ "Attest" | ✅ | `CONTRIBUTING.md:37` documents it; wrapper committed. Now says it is scored on the documented command, not a clean fleet run |
| `test_continuous_integration` | ✅ "attest" | ✅ | 110 gates in `.github/gates/gates.yaml` + per-service workflows |
| `test_statement_coverage90` | ❌ "floor ~55%" | ❌ | **Imprecise.** There is no single floor: 60 kover `minValue`s spanning **0–90**, median 55, **58 of 60 below 90** |
| `test_branch_coverage80` | ❌ | ❌ | Same |
| `crypto_used_network` / `crypto_tls12` | ✅ Istio mTLS | ✅ | **THE REPORTED DEFECT.** Real evidence: cert-manager `letsencrypt-prod` ingress TLS; CloudFront `minimum_protocol_version = "TLSv1.2_2021"`; both public sites answer over HTTP/2 TLS. Explicitly *not* mesh mTLS |
| `hardened_site` | ⚠️ "confirm headers" | **✅** | **Under-claimed.** Measured live on **both** `open-bank.tech` and `admin.open-bank.tech`: HSTS `max-age=63072000; includeSubDomains; preload`, CSP with `object-src 'none'` + `base-uri 'self'`, X-Frame-Options |
| `security_review` | ✅ | ✅ | ADR-0080 is a real external pentest, 2026-06-10, within 5y. Accurate — I note its own `delivery-status: partial` applies to remediation, not the review |
| `hardening` | ✅ bare list | ✅ | All five verified: 64 NetworkPolicy files, 102 `seccompProfile`, 42 PSS-`restricted` namespaces, `falco` namespace live, per-service OPA bundles |
| `dynamic_analysis` | ✅ bare list | ✅ | All three verified: `dast-zap-baseline.yml`, `api-fuzz{,-authenticated}.yml` (schemathesis), `.clusterfuzzlite/` + `cflite-pr.yml` |

**Net: 3 rows downgraded, 1 upgraded, 1 factually corrected, 14 kept with evidence replaced by something checkable.**

## The gate

New `openssf-gold-evidence` (enforced, group `registry`) — nothing read this file before; `check-compliance-matrix.py` is scoped to the admin-ui page only, so this is not a duplicate.

**It is structural, not a word deny-list.** Banning the string "Istio" is the classic gate-over-prose failure — it would flag the sentence *explaining* that no mesh is deployed, which the corrected document necessarily contains. Instead:

- **R1** — a row scored ✅ must cite a **resolvable anchor**: an existing repo path, an issue ref, or a URL. "TLS + Istio mTLS" has none. Neither does "Attest". Rows scored ⚠️/❌ are **exempt** — describing a gap is what those rows are for.
- **R2** — every path-shaped citation in the tables must resolve on disk (globs allowed). That is the actual rot mechanism.
- Scope is the **construct**: only 3-cell table rows whose first cell opens with a backticked criterion id, and only the third cell. Prose, blockquotes and headings are never read.

**Falsified in both directions, against the real artefact — not just fixtures:**

```
# the ACTUAL pre-fix document from origin/main
checked 19 criterion row(s)  ->  10 findings, exit 1
   (including line 52: `crypto_used_network` / `crypto_tls12` ... 'TLS + Istio mTLS')
# the corrected document
checked 19 criterion row(s)  ->  0 findings, exit 0
```

The self-test covers 9 cases in both directions plus an empty-document guard, including two explicit prose-vs-thing cases (a ❌ row naming Istio, a ⚠️ row with no anchor) that it must **not** flag. It prints the row count on every run, so a green can never mean "the gate never opened the file".

The gate found **three of my own rewritten rows** lacking anchors; I fixed the document rather than weakening the gate.

## Self-evaluation — what I did not measure

Stated plainly, since an audit that quietly skips rows is the same failure being fixed:

- **Taken on trust:** `achieve_silver` (BadgeApp account state) and `require_2FA` / `secure_2FA` (GitHub account settings). Neither is observable from this repository — which is precisely why both are now ⚠️ rather than ✅.
- **Possibly still overstated:** `hardening` and `dynamic_analysis` are scored on the *existence and wiring* of each named control, not its runtime efficacy. A NetworkPolicy that exists is not proof it denies the right traffic; a ZAP job that runs is not proof of meaningful coverage. `test_invocation` is scored on the documented command, not a clean fleet-wide run. All three caveats are written into the document itself.
- **The gate proves citation, not truth.** It can confirm a cited file exists; it cannot confirm the file says what the row claims. A future row could cite a real path that does not support its claim and pass.
- `hardened_site` was measured from this machine at one point in time; headers are served by CloudFront/ingress config and could differ by edge.

## BadgeApp

**Out of scope deliberately** — submitting or amending the badge is the owner's action. But to state it plainly: **if anything has already been submitted to BadgeApp citing "Istio mTLS" for `crypto_used_network` / `crypto_tls12`, that justification is false and needs replacing** with the edge-TLS evidence. I have no visibility into what was submitted. The document now carries this warning in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
