### PR TITLE
fix(audit): record whether occurred_at is event time or ingest time

### DIFF
--- a/openbank-audit-service/src/main/kotlin/com/openbank/audit/application/AuditConsumer.kt
+++ b/openbank-audit-service/src/main/kotlin/com/openbank/audit/application/AuditConsumer.kt
@@ -7,7 +7,9 @@ package com.openbank.audit.application
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.openbank.audit.domain.model.AuditEntry
+import com.openbank.audit.domain.model.OccurredAtSource
 import com.openbank.audit.infrastructure.persistence.AuditRepository
+import io.micrometer.core.instrument.MeterRegistry
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.inject.Inject
 import org.eclipse.microprofile.reactive.messaging.Incoming
@@ -25,12 +27,15 @@ class AuditConsumer {
 
     @Inject lateinit var clock: Clock
 
+    @Inject lateinit var meterRegistry: MeterRegistry
+
     private val log = Logger.getLogger(AuditConsumer::class.java)
 
     @Incoming("audit-events-in")
     suspend fun consume(payload: String) {
         try {
             val node: JsonNode = objectMapper.readTree(payload)
+            val eventTime = eventTime(node)
             val entry = AuditEntry(
                 id = UUID.randomUUID(),
                 // sepa.instant.events (KafkaSctInstEventPublisher) names its discriminator "type",
@@ -46,17 +51,64 @@ class AuditConsumer {
                 payload = payload,
                 sourceService = node["sourceService"]?.asText() ?: "unknown",
                 correlationId = node["correlationId"]?.asText(),
-                occurredAt = node["occurredAt"]?.asText()?.let { Instant.parse(it) } ?: Instant.now(clock),
+                occurredAt = eventTime ?: Instant.now(clock),
                 recordedAt = Instant.now(clock),
+                occurredAtSource = if (eventTime != null) OccurredAtSource.EVENT else OccurredAtSource.INGEST,
                 // ADR-0226: cross-channel dimensions, additive — producers adopt them channel by
                 // channel, so absence stays null (unknown), never a guessed default.
                 channel = node["channel"]?.asText(),
                 actChain = node["actChain"]?.takeIf { it.isArray }?.map { it.asText() } ?: emptyList(),
                 sessionId = node["sessionId"]?.asText(),
             )
+            if (eventTime == null) countMissingEventTime(entry.sourceService)
             repo.save(entry)
         } catch (e: Exception) {
             log.errorf(e, "Failed to record audit entry: %s", payload.take(200))
+        }
+    }
+
+    /**
+     * `openbank.audit.event.time.missing{source_service}` — events stored with ingest time because
+     * their producer sent no usable `occurredAt` (#3883).
+     *
+     * The per-row [OccurredAtSource] flag makes the gap answerable in SQL after the fact; this
+     * makes it answerable as a series, which is what turns "a producer regressed" into something
+     * that can degrade a dashboard instead of waiting for an auditor. Tagged by producing service
+     * only — the tag set is the fixed topic list, so cardinality is bounded.
+     *
+     * Guarded by `isInitialized` because unit tests construct this bean by hand; a missing
+     * registry must never cost an audit row.
+     */
+    private fun countMissingEventTime(sourceService: String) {
+        if (!::meterRegistry.isInitialized) return
+        meterRegistry.counter("openbank.audit.event.time.missing", "source_service", sourceService)
+            .increment()
+    }
+
+    /**
+     * The producer's own event time, or null when the payload does not carry one (#3883).
+     *
+     * `occurredAt` is the fleet's canonical key — it is declared on
+     * `com.openbank.libs.domain.event.DomainEvent`, so every Jackson-of-domain-event producer
+     * lands on it. This reads that key and ONLY that key: a second accepted spelling would be a
+     * second silent path, and a silent path is exactly how the gap below survived unnoticed.
+     *
+     * Two ways to have no event time, both previously invisible:
+     *  - the key is absent. 7 of the 21 consumed topics are in this state today (clearing,
+     *    dispute, statement, sanctions, six of lending's payloads, sepa-payment's Temporal path,
+     *    and document-service which names it `at`). The old code substituted `Instant.now(clock)`
+     *    and the row then asserted, indistinguishably from a real one, that the operation happened
+     *    when the consumer got round to it. Under consumer lag or a replay that is arbitrarily
+     *    wrong, and it is the GDPR Art. 30 "when" dimension and DORA Art. 17 evidence.
+     *  - the key is present but unparseable. That threw out of the constructor into consume()'s
+     *    catch, so the WHOLE audit entry was dropped — one malformed field lost the record of the
+     *    operation entirely. It is now an INGEST-sourced row: a degraded entry beats no entry.
+     */
+    private fun eventTime(node: JsonNode): Instant? {
+        val raw = node["occurredAt"]?.asText() ?: return null
+        return runCatching { Instant.parse(raw) }.getOrElse {
+            log.warnf("Unparseable occurredAt %s; recording ingest time instead", raw.take(MAX_LOGGED_RAW_TIME_CHARS))
+            null
         }
     }
 
@@ -101,5 +153,10 @@ class AuditConsumer {
             if (node.has(field)) return type
         }
         return "UNKNOWN"
+    }
+
+    private companion object {
+        /** Cap on the producer-supplied value echoed into the warning — it is untrusted input. */
+        const val MAX_LOGGED_RAW_TIME_CHARS = 64
     }
 }

--- a/openbank-audit-service/src/main/kotlin/com/openbank/audit/domain/model/AuditEntry.kt
+++ b/openbank-audit-service/src/main/kotlin/com/openbank/audit/domain/model/AuditEntry.kt
@@ -19,6 +19,15 @@ data class AuditEntry(
     val correlationId: String?,
     val occurredAt: Instant,
     val recordedAt: Instant,
+    /**
+     * Whether [occurredAt] is the producer's own event time or a stand-in for it.
+     *
+     * "When it happened" and "when we recorded it" are different facts, and [recordedAt] already
+     * holds the second one. When a producer's payload carries no `occurredAt`, the consumer has
+     * nothing better than ingest time to put here — and a row that says so is worth far more than
+     * one that quietly claims the queue's clock was the event's (#3883).
+     */
+    val occurredAtSource: OccurredAtSource,
     /** Ingress channel the event arrived through — ui|mcp|api (ADR-0226); null = unknown/legacy. */
     val channel: String? = null,
     /** Ordered on-behalf-of delegation chain from the RFC 8693 `act` claim (ADR-0224); empty = direct. */
@@ -26,3 +35,27 @@ data class AuditEntry(
     /** Browser or agent session the action belongs to; groups one sitting's events. */
     val sessionId: String? = null,
 )
+
+/**
+ * Provenance of [AuditEntry.occurredAt] (#3883).
+ *
+ * The fleet's canonical event-time key is `occurredAt` — declared on
+ * `com.openbank.libs.domain.event.DomainEvent` and emitted by 14 of the 21 topics this service
+ * consumes. The remaining producers emit no event time at all (or, in document-service's case,
+ * name it `at`), and for those the consumer used to substitute `Instant.now(clock)` with nothing
+ * anywhere recording that it had done so. This enum is that record.
+ *
+ * Deliberately NOT a second parsing fallback: accepting `at`/`timestamp` too would restore the
+ * silence this exists to end. A producer that emits the wrong key now shows up as [INGEST] rows
+ * and on `openbank.audit.event.time.missing`, and gets fixed at the producer.
+ */
+enum class OccurredAtSource {
+    /** The producer sent a parseable `occurredAt`; [AuditEntry.occurredAt] is the real event time. */
+    EVENT,
+
+    /**
+     * No parseable `occurredAt` in the payload, so [AuditEntry.occurredAt] is ingest time —
+     * an upper bound on when the operation happened, not the operation's own time.
+     */
+    INGEST,
+}

--- a/openbank-audit-service/src/main/kotlin/com/openbank/audit/infrastructure/persistence/AuditRepository.kt
+++ b/openbank-audit-service/src/main/kotlin/com/openbank/audit/infrastructure/persistence/AuditRepository.kt
@@ -5,6 +5,7 @@
 package com.openbank.audit.infrastructure.persistence
 
 import com.openbank.audit.domain.model.AuditEntry
+import com.openbank.audit.domain.model.OccurredAtSource
 import io.quarkus.hibernate.reactive.panache.Panache
 import io.quarkus.hibernate.reactive.panache.kotlin.PanacheEntity
 import io.quarkus.hibernate.reactive.panache.kotlin.PanacheRepository
@@ -53,6 +54,25 @@ class AuditEntryEntity : PanacheEntity() {
 
     @Column(name = "recorded_at", nullable = false)
     lateinit var recordedAt: Instant
+
+    /**
+     * Provenance of [occurredAt] — `EVENT` or `INGEST` ([OccurredAtSource]), NULL on any row
+     * written before V11 (#3883).
+     *
+     * NULL is "unknown", and it has to stay unknown: `audit_entries` carries a
+     * `DO INSTEAD NOTHING` rule on UPDATE (V2), so a backfill would report success and change
+     * nothing — and there is no data to backfill FROM, since the discarded producer key was never
+     * stored in a column. The pre-V11 rows keep whatever `occurred_at` they were given; this
+     * column only stops NEW rows from being ambiguous the same way. Same shape as `hash_version`
+     * (V10): record the boundary rather than rewrite history.
+     *
+     * NOT part of [chainHash] — like the ADR-0226 channel columns, it is derived from the
+     * producer's raw JSON, which the chain already covers via the `payload` hash. Adding it to the
+     * canonical string would change the hash of every future row for no evidential gain and would
+     * split the chain a second time.
+     */
+    @Column(name = "occurred_at_source", length = 8)
+    var occurredAtSource: String? = null
 
     // ── Tamper-evidence (hash chain, ADR-0023 spirit applied to the operational log) ──
     @Column(name = "prev_hash")
@@ -126,6 +146,7 @@ class AuditRepository : PanacheRepository<AuditEntryEntity> {
                 it.correlationId = entry.correlationId
                 it.occurredAt = stored.occurredAt
                 it.recordedAt = stored.recordedAt
+                it.occurredAtSource = entry.occurredAtSource.name
                 it.channel = entry.channel
                 it.actChain = entry.actChain.takeIf { chain -> chain.isNotEmpty() }
                     ?.let { chain -> actChainJson.writeValueAsString(chain) }
@@ -307,6 +328,9 @@ class AuditRepository : PanacheRepository<AuditEntryEntity> {
     private fun AuditEntryEntity.toDomain() = AuditEntry(
         entryId, eventType, aggregateType, aggregateId, actorId, actorType,
         payload, sourceService, correlationId, occurredAt, recordedAt,
+        // NULL (pre-V11) reads back as INGEST: those rows may hold ingest time and cannot prove
+        // otherwise, so the weaker claim is the honest one.
+        occurredAtSource = occurredAtSource?.let { OccurredAtSource.valueOf(it) } ?: OccurredAtSource.INGEST,
         channel = channel,
         actChain = actChain?.let { actChainJson.readValue(it, stringListType) } ?: emptyList(),
         sessionId = sessionId,

--- a/openbank-audit-service/src/main/resources/db/migration/V11__occurred_at_source.sql
+++ b/openbank-audit-service/src/main/resources/db/migration/V11__occurred_at_source.sql
@@ -1,0 +1,46 @@
+-- Records WHETHER `occurred_at` is the producer's own event time or the consumer's ingest time
+-- standing in for it (#3883).
+--
+-- WHY THIS EXISTS. AuditConsumer read the event time as
+--   node["occurredAt"] ?: Instant.now(clock)
+-- with nothing recording which branch had been taken. `occurredAt` IS the fleet's canonical key
+-- (it is declared on com.openbank.libs.domain.event.DomainEvent, and 14 of the 21 consumed topics
+-- emit it), so the read is correct — but 7 topics emit no event time at all, or name it something
+-- else: clearing.batch.event, dispute.events, statement.event, sanctions.screening.event, six of
+-- lending.events' payloads, sepa-payment's Temporal activity path, and documents.document.event
+-- which names it `at`. For every one of those the row asserted, indistinguishably from a real
+-- measurement, that the operation happened when the consumer got round to it. Under consumer lag
+-- or a replay that is arbitrarily wrong, and it is the GDPR Art. 30 "when" dimension and the basis
+-- of DORA Art. 17 reconstruction.
+--
+-- "When it happened" and "when we recorded it" are different facts. `recorded_at` already holds
+-- the second one and is kept — this column says whether the first is real.
+--
+-- WHY NO BACKFILL. Two independent reasons, either sufficient:
+--   * `audit_entries` carries `CREATE RULE no_update_audit ... DO INSTEAD NOTHING` (V2), so an
+--     UPDATE against it succeeds and changes nothing. A backfill migration would look like it had
+--     worked.
+--   * there is nothing to backfill from. The producer key that was or was not present was never
+--     stored in a column, only inside the verbatim `payload` JSON, and re-deriving it row by row
+--     would still be a rewrite of audit data — which is what tamper-evidence exists to prevent.
+-- So pre-V11 rows stay NULL = unknown, and the read side maps NULL to the weaker claim (INGEST):
+-- those rows may hold ingest time and cannot prove otherwise. Same choice as V10's hash_version —
+-- record the boundary, never rewrite history.
+--
+-- TAMPER-EVIDENCE. Not part of chainHash(), so no existing record_hash changes and no future row's
+-- hash is affected: the column is derived from the producer's raw event JSON, which the chain
+-- already covers via the payload hash (same argument as the ADR-0226 channel columns in V9).
+--
+-- Rollback: ALTER TABLE audit_entries DROP COLUMN occurred_at_source;
+--   (safe — no row's record_hash, occurred_at or recorded_at is modified by this migration.)
+ALTER TABLE audit_entries ADD COLUMN IF NOT EXISTS occurred_at_source VARCHAR(8);
+
+COMMENT ON COLUMN audit_entries.occurred_at_source IS
+  'Provenance of occurred_at. EVENT = the producer sent a parseable occurredAt. '
+  'INGEST = it did not, so occurred_at is the time this service received the event (an upper '
+  'bound, not a measurement). NULL = row written before this column existed; treat as INGEST.';
+
+-- Partial index: the operational question is "which rows do NOT carry a real event time", and the
+-- EVENT rows are expected to be the overwhelming and growing majority.
+CREATE INDEX IF NOT EXISTS idx_audit_entries_occurred_at_source
+  ON audit_entries(occurred_at_source) WHERE occurred_at_source <> 'EVENT';

--- a/openbank-audit-service/src/main/resources/docs/04-data.cs.md
+++ b/openbank-audit-service/src/main/resources/docs/04-data.cs.md
@@ -34,8 +34,9 @@
 | `payload` | TEXT, not null | Původní JSON události, doslovně |
 | `source_service` | VARCHAR(100) | Zdrojová služba |
 | `correlation_id` | VARCHAR(100), null | Trace correlation |
-| `occurred_at` | TIMESTAMPTZ | Business čas |
+| `occurred_at` | TIMESTAMPTZ | Business čas — skutečný jen když `occurred_at_source = 'EVENT'` |
 | `recorded_at` | TIMESTAMPTZ, default NOW() | Čas ingestu |
+| `occurred_at_source` | VARCHAR(8), null | (V11) `EVENT` = producent poslal `occurredAt`; `INGEST` = neposlal, takže `occurred_at` je čas příjmu (horní mez); NULL = řádek před V11, ber jako `INGEST` |
 | `session_id` | VARCHAR(100), null | (V2) |
 | `user_agent` | VARCHAR(500), null | (V2) |
 | `ip_address` | VARCHAR(45), null | (V2) — IPv4/IPv6 |

--- a/openbank-audit-service/src/main/resources/docs/04-data.en.md
+++ b/openbank-audit-service/src/main/resources/docs/04-data.en.md
@@ -34,8 +34,9 @@
 | `payload` | TEXT, not null | Original event JSON, verbatim |
 | `source_service` | VARCHAR(100) | Originating service |
 | `correlation_id` | VARCHAR(100), null | Trace correlation |
-| `occurred_at` | TIMESTAMPTZ | Business time |
+| `occurred_at` | TIMESTAMPTZ | Business time — real only when `occurred_at_source = 'EVENT'` |
 | `recorded_at` | TIMESTAMPTZ, default NOW() | Ingest time |
+| `occurred_at_source` | VARCHAR(8), null | (V11) `EVENT` = producer sent `occurredAt`; `INGEST` = it did not, so `occurred_at` is ingest time (an upper bound); NULL = pre-V11 row, treat as `INGEST` |
 | `session_id` | VARCHAR(100), null | (V2) |
 | `user_agent` | VARCHAR(500), null | (V2) |
 | `ip_address` | VARCHAR(45), null | (V2) — IPv4/IPv6 |

--- a/openbank-audit-service/src/test/kotlin/com/openbank/audit/application/AuditConsumerTest.kt
+++ b/openbank-audit-service/src/test/kotlin/com/openbank/audit/application/AuditConsumerTest.kt
@@ -2,11 +2,14 @@
 package com.openbank.audit.application
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.openbank.audit.domain.model.OccurredAtSource
 import com.openbank.audit.infrastructure.persistence.AuditRepository
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatCode
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -19,6 +22,8 @@ class AuditConsumerTest {
 
     private val repo = mockk<AuditRepository>()
 
+    private val registry = SimpleMeterRegistry()
+
     private lateinit var consumer: AuditConsumer
 
     @BeforeEach
@@ -27,7 +32,8 @@ class AuditConsumerTest {
             it.repo = repo
             it.objectMapper = jacksonObjectMapper().findAndRegisterModules()
             // ADR-0100: recordedAt is stamped via Instant.now(clock); fix it for determinism.
-            it.clock = Clock.fixed(Instant.parse("2026-05-27T12:00:00Z"), ZoneOffset.UTC)
+            it.clock = Clock.fixed(INGEST_TIME, ZoneOffset.UTC)
+            it.meterRegistry = registry
         }
     }
 
@@ -351,5 +357,88 @@ class AuditConsumerTest {
         }.doesNotThrowAnyException()
 
         coVerify(exactly = 0) { repo.save(any()) }
+    }
+
+    // ── #3883: event time vs ingest time ──────────────────────────────────────────────────────
+    //
+    // `occurredAt` is the fleet's canonical event-time key (declared on DomainEvent), so the
+    // consumer's read of it is right and stays. What was missing is any record of the OTHER
+    // branch: 7 of the 21 consumed topics send no event time, and their rows silently claimed
+    // ingest time as business time. These pin both halves.
+
+    @Test
+    fun `consume keeps the producer's event time and marks it as the producer's (EVENT)`(): Unit = runBlocking {
+        // Deliberately far from the fixed ingest clock: an assertion using a value equal to
+        // Instant.now(clock) would pass against the bug, which is how this survived.
+        val eventTime = Instant.parse("2026-05-27T09:15:30Z")
+        val payload = """{"eventType":"X","accountId":"${UUID.randomUUID()}","occurredAt":"$eventTime"}"""
+        coEvery { repo.save(any()) } returns Unit
+
+        consumer.consume(payload)
+
+        coVerify {
+            repo.save(
+                match {
+                    it.occurredAt == eventTime &&
+                        it.occurredAtSource == OccurredAtSource.EVENT &&
+                        it.recordedAt == INGEST_TIME
+                },
+            )
+        }
+        assertThat(registry.find("openbank.audit.event.time.missing").counters()).isEmpty()
+    }
+
+    @Test
+    fun `consume marks an entry INGEST-sourced when the producer sends no occurredAt`(): Unit = runBlocking {
+        // A real statement-service payload shape: it carries closedAt, never occurredAt.
+        val payload = """
+            {"eventType":"account.statement.period.closed.v1","accountId":"${UUID.randomUUID()}",
+             "sourceService":"statement-service","closedAt":"2026-05-27T09:15:30Z"}
+        """.trimIndent()
+        coEvery { repo.save(any()) } returns Unit
+
+        consumer.consume(payload)
+
+        coVerify {
+            repo.save(
+                match { it.occurredAt == INGEST_TIME && it.occurredAtSource == OccurredAtSource.INGEST },
+            )
+        }
+        assertThat(
+            registry.counter("openbank.audit.event.time.missing", "source_service", "statement-service").count(),
+        ).isEqualTo(1.0)
+    }
+
+    @Test
+    fun `consume does NOT accept a differently-named event-time key`(): Unit = runBlocking {
+        // document-service emits `at`, the canonical audit envelope names the field `timestamp`.
+        // Accepting either here would be a second silent path; the producer is the thing to fix,
+        // and an INGEST row plus a counter is what makes that visible.
+        val payload = """{"eventType":"DOCUMENT_GENERATED","documentId":"${UUID.randomUUID()}",
+            "sourceService":"document-service","at":"2026-05-27T09:15:30Z","timestamp":"2026-05-27T09:15:30Z"}"""
+        coEvery { repo.save(any()) } returns Unit
+
+        consumer.consume(payload)
+
+        coVerify { repo.save(match { it.occurredAtSource == OccurredAtSource.INGEST }) }
+    }
+
+    @Test
+    fun `consume keeps the entry when occurredAt is unparseable, rather than dropping it`(): Unit = runBlocking {
+        // Before #3883 this threw out of the AuditEntry constructor into consume()'s catch, so one
+        // malformed field discarded the entire audit record. RED against that code: repo.save was
+        // never called.
+        val payload = """{"eventType":"X","accountId":"${UUID.randomUUID()}","occurredAt":"not-a-timestamp"}"""
+        coEvery { repo.save(any()) } returns Unit
+
+        consumer.consume(payload)
+
+        coVerify {
+            repo.save(match { it.occurredAt == INGEST_TIME && it.occurredAtSource == OccurredAtSource.INGEST })
+        }
+    }
+
+    private companion object {
+        val INGEST_TIME: Instant = Instant.parse("2026-05-27T12:00:00Z")
     }
 }

--- a/openbank-audit-service/src/test/kotlin/com/openbank/audit/infrastructure/persistence/AuditChainHashTest.kt
+++ b/openbank-audit-service/src/test/kotlin/com/openbank/audit/infrastructure/persistence/AuditChainHashTest.kt
@@ -28,6 +28,7 @@ class AuditChainHashTest {
         correlationId = "corr-1",
         occurredAt = Instant.parse("2026-06-12T10:00:00Z"),
         recordedAt = Instant.parse("2026-06-12T10:00:01Z"),
+        occurredAtSource = com.openbank.audit.domain.model.OccurredAtSource.EVENT,
     )
 
     private val genesis = "0".repeat(64)

--- a/openbank-audit-service/src/test/kotlin/com/openbank/audit/integration/AuditChainRoundTripIT.kt
+++ b/openbank-audit-service/src/test/kotlin/com/openbank/audit/integration/AuditChainRoundTripIT.kt
@@ -57,6 +57,7 @@ class AuditChainRoundTripIT {
         // 123456789 ns and 987654321 ns — both lose their last three digits to TIMESTAMPTZ.
         occurredAt = Instant.ofEpochSecond(OCCURRED_EPOCH_SECOND, OCCURRED_NANOS),
         recordedAt = Instant.ofEpochSecond(RECORDED_EPOCH_SECOND, RECORDED_NANOS),
+        occurredAtSource = com.openbank.audit.domain.model.OccurredAtSource.EVENT,
     )
 
     /**


### PR DESCRIPTION
Closes #3883

## The premise, corrected

The issue says the consumer reads `occurredAt` while "the canonical envelope names it `timestamp`", so event time is dropped on every message. **The first half is right, the conclusion is not**, and the real defect is a different, larger one.

`AuditConsumer` never sees a `com.openbank.libs.audit.AuditEvent`. Nothing in the fleet serialises that class to Kafka — the only implementation of `AuditEventPublisher` is `LoggingAuditEventPublisher`, and the `audit-events-out` Kafka publisher in its KDoc is an example, not a shipped bean. The consumer's input is 21 **domain-event** topics, and the canonical *domain-event* envelope (`openbank-libs-domain/.../domain/event/DomainEvent.kt`) names the field **`occurredAt`**. So the consumer's read is correct for 14 of 21 topics; renaming it to `timestamp` would have broken all 14 and fixed nothing.

The real gap: **7 topics send no event time under any name**, so the `?: Instant.now(clock)` fallback fires for them, and the row then claims ingest time as business time in a form indistinguishable from a real measurement — which is exactly the harm the issue describes.

| topic | event-time key |
|---|---|
| accounts.account.created, transactions.transaction.initiated, balance.events, party.events, kyc.events, consent.events, customer.audit, security.ict.incident, cards.events, domestic.payment.events, sepa.payment.events (non-Temporal), sepa.instant.events, fx.conversion.completed, payments.swift.event | `occurredAt` |
| clearing.batch.event, dispute.events, statement.event, sanctions.screening.event | none (`settledAt` / `resolvedAt` / `closedAt` / `checkedAt` only) |
| lending.events | mixed — 6 of 8 payloads have none |
| sepa.payment.events (Temporal activity path) | none |
| documents.document.event | **`at`** |
| security.scan.event | no producer at all (outbox never written) |

## The contract decision: producers win, and the losing name fails loudly

`occurredAt` stays the single accepted key. `at` and `timestamp` are **not** accepted — a second spelling would be a second silent path, and a silent path is precisely how this survived. Instead the absence is made loud in two places:

- `audit_entries.occurred_at_source` (V11, `EVENT` | `INGEST`) — per row, answerable in SQL.
- `openbank.audit.event.time.missing{source_service}` — a counter, so a producer regression degrades a series instead of waiting for an auditor.

A producer that emits the wrong key now shows up in both and gets fixed at the producer. Follow-up for the 7 producers is deliberately **not** in this PR: it is 8 services and a per-event-shape decision each.

**Is ingest time still worth a separate column? Yes, and `recorded_at` is kept.** "When it happened" and "when we recorded it" are different facts; conflating them is what produced this bug. What was missing was not a column but the flag saying which fact `occurred_at` currently holds.

Also fixed, found while writing the tests: an **unparseable** `occurredAt` threw out of the `AuditEntry` constructor into `consume()`'s `catch`, discarding the **entire** audit entry. One malformed field lost the record of the operation. It is now an `INGEST`-sourced row — a degraded entry beats no entry.

## Proof (RED first)

The runtime-red run against unmodified `main`:

```
RedProofTest > an unparseable occurredAt must not discard the whole audit entry() FAILED
    java.lang.AssertionError at RedProofTest.kt:31
1 test completed, 1 failed
```

(`coVerify { repo.save(any()) }` — `save` was never called.) That harness was deleted; the same case ships as `consume keeps the entry when occurredAt is unparseable, rather than dropping it`.

Four tests in `AuditConsumerTest`:
1. event time far from the fixed ingest clock (`09:15:30Z` vs `12:00:00Z`) survives to the row, source `EVENT`, `recordedAt` still ingest time, counter not touched. Using a value equal to `Instant.now(clock)` — which the pre-existing first test does — passes against the bug; that is why this one uses a distinct value.
2. a real statement-service payload (`closedAt`, no `occurredAt`) → `INGEST` + counter = 1.
3. a payload carrying **both** `at` and `timestamp` → still `INGEST`. This is the test that keeps the losing names from quietly coming back.
4. the unparseable case above.

Green: `:openbank-audit-service:detekt ktlintCheck koverVerify build quarkusBuild`.

## Hash chain: does not move

`chainHash()` covers `occurredAt` and `recordedAt`, so this had to be checked rather than assumed. `occurred_at_source` is **not** added to the canonical string — same argument as the ADR-0226 `channel`/`act_chain` columns in V9: it is derived from the producer's raw JSON, which the chain already covers via the payload SHA-256. No `record_hash` changes, past or future; `verifyChain` is unaffected. What DOES change for future rows is the *value* landing in `occurred_at` for the 7 gap topics — but only from "ingest time" to "ingest time, labelled" (identical value, so identical hash); a real fix at those producers will change the value, and that is a normal new-row event, not a re-base.

## Already-written rows: untouched, and cannot be fixed

`audit_entries` carries `RULE no_update_audit ... DO INSTEAD NOTHING` (V2), so a backfill UPDATE would report success and change nothing. It is moot anyway: which key the producer sent was never stored in a column, only inside the verbatim `payload` JSON, and re-deriving audit rows is what tamper-evidence exists to prevent. Pre-V11 rows stay `NULL` and the read side maps `NULL` → `INGEST` — the weaker, honest claim ("may hold ingest time, cannot prove otherwise"). Same choice as V10's `hash_version`.

Side effect worth naming: `retention_until = occurred_at + 10y` (V2 trigger) is computed from a possibly-ingest `occurred_at`, so affected rows are retained slightly *longer*, never shorter. Not corrected here.

## What I did NOT verify — and where this could be wrong

- **The producer survey is largely delegated.** I verified by hand: no Kafka `AuditEvent` producer exists; document-service really uses `at`; statement-service's payload really has no `occurredAt`; `DomainEvent` declares `occurredAt`. The other ~17 rows of the table come from a sub-agent sweep I did not re-derive line by line. If one of the "none" rows is wrong, the fix is still correct — that topic simply lands `EVENT` instead of `INGEST` — but the count "7 of 21" would be off.
- **No integration test against a real database.** `AuditChainRoundTripIT` was updated to compile but I did not run it (needs Postgres), so V11 applying cleanly and the column round-tripping are unproven here; CI is the first place that runs.
- **The migration was not applied anywhere.** `migrate-at-start: true` is set for this service, so it applies on next boot. `V11` was the next number against live `main` at push time and must be re-checked if this sits behind another audit-service PR.
- **Could my tests pass against the old code?** Tests 1–3 do not compile against it — the `OccurredAtSource` distinction does not exist there, which IS the defect. Only test 4 is a runtime-red, and that is the output quoted above. I am not claiming a runtime-red for the main defect, because there was nothing in the old data model capable of expressing it.
- **No alert rule is added** for the new counter, so today it is a series nobody watches. That is weaker than it sounds — this repo's own history says an unwatched metric is close to no metric — but an alert threshold is meaningless until the 7 producers are fixed, since it would fire constantly on day one.
- I did not check `docs/asyncapi/openbank-events.yaml` for agreement with the actual producers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
