### PR TITLE
test(interest): prove the #3104 500-vs-400 defect over real HTTP

### DIFF
--- a/openbank-interest-service/build.gradle.kts
+++ b/openbank-interest-service/build.gradle.kts
@@ -56,6 +56,9 @@ dependencies {
     // capitalization credit leg makes (ADR-0063). interest-service is the fifth ledger-posting
     // consumer; every other one already has a pact with openbank-ledger-service as provider.
     testImplementation(libs.rest.assured.kotlin)
+    // InterestMissingParamStatusIT (#3104) drives `capitalize` over REAL HTTP behind @RolesAllowed —
+    // the only layer at which an omitted @QueryParam can be observed at all.
+    testImplementation(libs.quarkus.test.security)
     testImplementation(libs.pact.consumer)
 }
 

--- a/openbank-interest-service/src/test/kotlin/com/openbank/interest/integration/InterestMissingParamStatusIT.kt
+++ b/openbank-interest-service/src/test/kotlin/com/openbank/interest/integration/InterestMissingParamStatusIT.kt
@@ -66,7 +66,12 @@ class InterestMissingParamStatusIT {
             .statusCode
 
         assertThat(status)
-            .describedAs("with productId supplied the request must get past the #3104 guard")
+            .describedAs(
+                "with productId supplied the request must get past the #3104 guard AND not " +
+                    "crash: `isNotEqualTo(400)` alone is satisfied by a 500, which is the exact " +
+                    "defect this IT exists to catch, so the control could not fail on its own subject",
+            )
+            .isLessThan(500)
             .isNotEqualTo(400)
     }
 

--- a/openbank-interest-service/src/test/kotlin/com/openbank/interest/integration/InterestMissingParamStatusIT.kt
+++ b/openbank-interest-service/src/test/kotlin/com/openbank/interest/integration/InterestMissingParamStatusIT.kt
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+package com.openbank.interest.integration
+
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.security.TestSecurity
+import io.restassured.RestAssured
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+/**
+ * `POST /api/v1/interest/capitalize/{accountId}` with no `?productId=` must answer 400, not 500
+ * (#3104 — this endpoint is the issue's own worked example, and the money-path half fixed by #3625
+ * shipped without a test).
+ *
+ * MECHANISM. `capitalize` is a plain `fun`, not a `suspend fun`, so Kotlin emits
+ * `Intrinsics.checkNotNullParameter` at bytecode offset 0 for the non-nullable `productId: String`.
+ * JAX-RS binds an absent query parameter to null, the intrinsic throws NPE **before the first
+ * statement of the body runs**, and `GenericExceptionMapper` renders 500. Two consequences that are
+ * easy to get wrong: a `requireNotNull(productId)` written inside the body compiles to nothing (the
+ * intrinsic has already thrown), so the parameter MUST be declared nullable for any guard to be
+ * reachable; and the 5xx burns the service's SLO error budget for what is a client mistake.
+ *
+ * WHY ONLY THIS LAYER CAN SEE IT. A unit test that calls `capitalize(...)` directly supplies the
+ * argument JAX-RS does not, so it passes against the broken signature — the defect lives entirely in
+ * the binding step. Only a real HTTP request can omit the parameter.
+ *
+ * The second test is the control: with `productId` present the request gets past the binding and
+ * fails (or succeeds) further downstream, so the first test's redness is attributable to the missing
+ * parameter alone and not to an unrelated 400 on the route.
+ *
+ * `contentType` is not optional here and the omission is silent: the resource declares
+ * `@Consumes(APPLICATION_JSON)`, so a request without a `Content-Type` is rejected with **415
+ * before parameter binding runs at all**. The first draft of this test omitted it and reported 415
+ * where the defect is 500 — a probe weaker than the client it is standing in for, which would have
+ * gone green against the fix for the wrong reason.
+ */
+@QuarkusTest
+@QuarkusTestResource(com.openbank.interest.it.PostgresRedisTestResource::class)
+class InterestMissingParamStatusIT {
+
+    @TestSecurity(user = "tester", roles = ["ROLE_OPERATOR", "ROLE_ADMIN"])
+    @Test
+    fun `capitalize with no productId answers 400, not 500`() {
+        val response = RestAssured.given()
+            .contentType("application/json")
+            .post("/api/v1/interest/capitalize/$ACCOUNT_ID")
+
+        assertThat(response.statusCode)
+            .describedAs(
+                "an absent required @QueryParam is a client error; 500 here is the #3104 defect " +
+                    "(Intrinsics.checkNotNullParameter NPE at offset 0 of a non-suspend handler)",
+            )
+            .isEqualTo(400)
+    }
+
+    @TestSecurity(user = "tester", roles = ["ROLE_OPERATOR", "ROLE_ADMIN"])
+    @Test
+    fun `capitalize with productId present gets past parameter binding`() {
+        val status = RestAssured.given()
+            .contentType("application/json")
+            .post("/api/v1/interest/capitalize/$ACCOUNT_ID?productId=SAVINGS_STANDARD")
+            .statusCode
+
+        assertThat(status)
+            .describedAs("with productId supplied the request must get past the #3104 guard")
+            .isNotEqualTo(400)
+    }
+
+    private companion object {
+        val ACCOUNT_ID: UUID = UUID.fromString("11111111-2222-3333-4444-555555555555")
+    }
+}


### PR DESCRIPTION
## What this adds

One `@QuarkusTest` integration test proving the #3104 defect over real HTTP, on
`POST /api/v1/interest/capitalize/{accountId}` — the endpoint #3104 uses as its own
worked reproduction case.

**Why it is worth a PR of its own:** the money-path half of #3104 is fixed in #3625,
and #3625 touches ten services and adds **no test files at all**. `#3658` and `#3660`
each carry one IT (`Psd2MissingHeaderStatusIT`, `StatementMissingParamStatusIT`); the
money-path half — the part that needs two approvals and a threat model — has none.
This closes that gap without touching any file the three stack branches touch.

Base is `fix/nonnull-queryparam-400` (#3625) because the test needs that PR's fix to
pass. File sets are disjoint: no stack branch touches
`openbank-interest-service/build.gradle.kts` or `openbank-interest-service/src/test/`.

## The mechanism, and why only this layer can see it

`capitalize` is a plain `fun`, not `suspend`, so Kotlin emits
`Intrinsics.checkNotNullParameter` at bytecode **offset 0** for the non-nullable
`productId: String`. JAX-RS binds an absent query parameter to null, the intrinsic throws
NPE before the first statement of the body runs, and `GenericExceptionMapper` renders
**500** for what is a client mistake. A `requireNotNull(productId)` written inside the
body with the old signature would have compiled to nothing — the parameter must be
declared nullable for any guard to be reachable, which is the part most likely to be got
wrong by whoever repeats this.

A unit test that calls `capitalize(...)` directly **supplies the argument JAX-RS does
not**, so it passes against the broken signature. The defect lives entirely in the
binding step. This test is a `@QuarkusTest` issuing a real HTTP request.

## Measured, both directions

Against `origin/main` (`b9d64d5e1`), RED:

```
InterestMissingParamStatusIT > capitalize with no productId answers 400, not 500() FAILED
  org.opentest4j.AssertionFailedError: [an absent required @QueryParam is a client error;
  500 here is the #3104 defect (Intrinsics.checkNotNullParameter NPE at offset 0 of a
  non-suspend handler)] expected: 400 but was: 500
2 tests completed, 1 failed
```

Against #3625's head (`be1cb03f8`), GREEN: `BUILD SUCCESSFUL`.

The second test is the **control** — with `productId` present the request must not be
400 — so the first test's redness is attributable to the missing parameter alone and not
to an unrelated 400 on the route. It passed in both runs.

## A trap this test walked into first, recorded because it is silent

The first draft omitted `contentType` on the request and measured **415, not 500**. The
resource declares `@Consumes(APPLICATION_JSON)`, so a POST without a `Content-Type` is
rejected *before parameter binding runs at all*. That draft would have gone **green
against the fix for the wrong reason** — a probe weaker than the client it stands in for.
The `contentType` call is load-bearing and the KDoc says so in place.

## Re-measurement of #3104's scope

The gate script from #3625 (`--self-test`: 14 passed, 0 failed) against live `main`
`b9d64d5e1` reports **63 findings** — unchanged from the 2026-08-03 measurement in
#3104's comment, so the set has not drifted. Against the stack tip (`f0341b077`, which
has #3625 and #3658 as ancestors) it reports **0 findings with an empty baseline**. The
three-PR stack covers #3104 in full; this PR adds evidence, not coverage.

The issue's headline "57 sites in 22 services" is a grep undercount — the parser-based
figure is 63 inbound sites, plus 52 outbound REST-*client interfaces* that are not a
defect.

## What I did NOT verify

- **Only one of the 24 money-path sites is tested by this PR.** The other 23 are
  reviewed-by-reading, not exercised. I picked `capitalize` because it is #3104's own
  example and is non-suspend, i.e. the unambiguous 500-at-offset-0 shape.
- **The suspend half is untested here.** 43 of the 63 sites are `suspend`, where no
  intrinsic is emitted and the failure is a 500 at first dereference *or a silent null
  flowing through a signature that promised it could not exist*. That second outcome is
  worse than the 500 and this test says nothing about it. `Psd2MissingHeaderStatusIT` in
  #3658 covers a suspend case.
- **Could this test pass against the old code?** No — measured, not assumed: it reports
  500 against `main`. But note it only rules out the old code *for this one handler*.
- **I did not re-verify #3625's per-handler triage.** #3104's comment claims all 24 sites
  are "truly required" (rather than defaulted or optional); I read the interest-service
  fix and agree there, and did not audit the other nine services' judgement calls.
- **No `openapi.yaml` change** in this PR, so no `info.version` question arises. The
  500 → 400 behaviour change lives in #3625.
- **`ApiError` is untouched.** This test asserts the status code only, not the envelope,
  so it is unaffected by #3880 making `ApiError.timestamp` a required constructor
  argument. That was deliberate: asserting the body would have coupled this PR to a
  signature change landing concurrently. The cost is that the `ApiError`/traceId envelope
  is *not* proven here — only the status.
- Ran `:openbank-interest-service:test --tests '*InterestMissingParamStatusIT*'`,
  `ktlintCheck` and `detekt` locally, all green. I did not run the full fleet gate.

## Merge order — please read before merging the stack

`--delete-branch` on a parent **closes every PR targeting it**, and a closed PR whose
base branch is gone can be neither reopened nor retargeted. The repo also sets
`delete_branch_on_merge: true`, so the remote ref goes regardless of the flag.

**Retarget each child to `main` BEFORE merging its parent:**

```
#3625  fix/nonnull-queryparam-400          <- parent of #3658 AND of this PR
#3658  fix/nonnull-params-psd2-cards       <- parent of #3660
#3660  fix/nonnull-params-remaining-seven
this   test/interest-missing-queryparam-400-3104
```

So: retarget #3658 and this PR to `main`, merge #3625; retarget #3660 to `main`, merge
#3658; then #3660; then this one.

Money-path scope — this needs two human approvals and will not auto-merge. That is the
correct final state.

Refs #3104, #3624, #3625, #3658, #3660
