### PR TITLE
docs(governance): event payloads have two idioms, so a key grep under-reports

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -194,8 +194,23 @@ These are real, repeatable gotchas — worth knowing before they cost you a debu
   `FlagExposure` has zero production consumers. Cheap to establish — enumerate the interface's
   implementations, then grep the field name across `src/main` — and it changes the whole PR:
   urgency, blast radius, and whether the honest fix is the value or the wiring. It also surfaces
-  the real bug next door, which here was that `AuditConsumer` keys on `occurredAt`, a field the
-  canonical envelope does not have, so the envelope's time is dropped at ingest (#3883).
+  the real bug next door — here, that `AuditConsumer` substitutes ingest time whenever a producer
+  sends no event time, which 7 of its 21 topics do, so the row asserts business time it never
+  measured (#3883, fixed by #3907). Note what the same rule then did to my own framing: I filed
+  that as "the consumer reads `occurredAt`, the canonical envelope says `timestamp`", and the
+  envelope reaches that topic never — `DomainEvent` declares `occurredAt`, so the consumer was
+  right and only the missing-time case was real.
+- **Event payloads are built two ways here, and grepping for the JSON key finds only one of
+  them.** Hand-built maps spell the key literally (`"settledAt" to batch.settledAt` in
+  `ClearingEventPublisherImpl`) and a string grep sees them; a serialised data class
+  (`objectMapper.writeValueAsString(DocumentGenerated(..., at = now))`) has no literal anywhere,
+  the key existing only at runtime as a Kotlin property name. So `grep '"at"'` over
+  `openbank-document-service` returns **nothing** while all three of its event types put `at` on
+  the wire — a clean-looking no-hits answer about producers the probe structurally cannot observe
+  (#3883). Enumerate event-time keys by reading the serialised TYPE, or a real message's payload,
+  never by grepping quoted field names; and treat "no hits" over a codebase with two idioms as a
+  fact about the probe. Same shape as the Pact bullet below on grepping `src/test` for the word
+  "contract".
 
 ### ktlint
 - Path-scoped CI only lints changed files, so a pre-existing wildcard import or a latent


### PR DESCRIPTION
## What

One new bullet in the root `CLAUDE.md` Kotlin/Quarkus section, plus a correction to the bullet #3898 merged an hour ago.

## The new lesson

This repo builds event payloads two ways, and a grep for the JSON key sees only one:

```kotlin
// hand-built map — the key is a literal, greppable
"settledAt" to batch.settledAt?.toString()                       // ClearingEventPublisherImpl

// serialised data class — no literal anywhere, key exists only at runtime
objectMapper.writeValueAsString(DocumentGenerated(..., at = now)) // DocumentRenderService:89
```

So `grep '"at"'` over `openbank-document-service/src/main` returns **nothing**, while `DocumentGenerated`, `DocumentSigned` and `SignatureCeremonyCompleted` all put `at` on the wire. I hit this while checking a claim in #3907 and reported it as unverified — the claim was right and understated, and my no-hits result was a fact about the probe, not the code.

It matters beyond this instance because the #3883 follow-up work is exactly "enumerate the event-time key for each of 21 topics". Doing that by grepping quoted field names will silently under-report every Jackson-serialised producer.

## The correction

The read-path bullet from #3898 ended by summarising #3883 as "`AuditConsumer` keys on `occurredAt`, a field the canonical envelope does not have, so the envelope's time is dropped at ingest". That framing is mine and it is wrong:

- `openbank-libs-domain/.../domain/event/DomainEvent.kt:10` declares `abstract class DomainEvent(open val occurredAt: Instant)` — `occurredAt` is the canonical key for the producers that actually feed the topic, so the consumer's read was correct.
- The `AuditEvent` envelope reaches that topic never, which #3882 had already established and I failed to carry through.
- The real defect is that 7 of 21 topics send no event time under any name, so the row asserts business time it never measured. #3907 fixes that.

I left the correction visible in the bullet rather than quietly rewriting it, because the rule catching its own author one paragraph later is the part worth reading.

## Scope

Docs only. No code, no gate, no `rules.yaml` key — nothing to regenerate, no release axis touched. Verified the "Pact bullet below" cross-reference actually resolves below (line 212 → 304) rather than trusting memory, and that no added line exceeds the file's 100-char convention.

Not touching #3907 or its branch — it is a live worktree.

Refs #3883
Refs #3907
