### PR TITLE
feat(statement): build the SUPERSEDED write path for closed-period restatement

### DIFF
--- a/openbank-statement-service/src/main/kotlin/com/openbank/statement/application/port/in/StatementUseCases.kt
+++ b/openbank-statement-service/src/main/kotlin/com/openbank/statement/application/port/in/StatementUseCases.kt
@@ -24,6 +24,23 @@ interface ClosePocketUseCase {
     fun closePocketMonth(accountId: UUID, currency: String, from: LocalDate, to: LocalDate): Uni<StatementPeriod>
 }
 
+/**
+ * Restates an already-closed period after a correction to the underlying booked data (ADR-0035 §D,
+ * issue #1302 item 5).
+ *
+ * A close is **immutable**: this never edits the existing record. It re-reads the booked entries and
+ * balance-service's closing balance, reconciles fail-closed exactly as a first close does, and — if
+ * the figures actually changed — writes a **new** period close with the next legal sequence and
+ * `supersedesSequence` pointing at the record it replaces, flipping that record to
+ * [com.openbank.statement.domain.model.PeriodCloseStatus.SUPERSEDED] in the same transaction.
+ *
+ * Idempotent in the sense that matters for a legal sequence: if the recomputed figures are identical
+ * to the standing close, **no** sequence is burnt and the existing record is returned unchanged.
+ */
+interface RestatePeriodUseCase {
+    fun restatePocketPeriod(accountId: UUID, currency: String, from: LocalDate, to: LocalDate): Uni<StatementPeriod>
+}
+
 /** Renders an already-closed period on demand — nothing is stored (ADR-0035 §F.2). */
 interface RenderStatementUseCase {
     fun render(

--- a/openbank-statement-service/src/main/kotlin/com/openbank/statement/application/port/out/StatementPorts.kt
+++ b/openbank-statement-service/src/main/kotlin/com/openbank/statement/application/port/out/StatementPorts.kt
@@ -49,8 +49,29 @@ interface StatementPeriodRepository {
      */
     fun saveWithOutbox(period: StatementPeriod, event: OutboxMessage): Uni<StatementPeriod>
 
+    /**
+     * The **standing** (non-SUPERSEDED) close for a window, or null. Superseded records stay in the
+     * table for retention and remain reachable by [findBySequence]; they must never be returned here,
+     * or a restated period would look closed-with-the-old-figures to the idempotency check and to
+     * [priorClosing].
+     */
     fun findByPeriod(accountId: UUID, currency: String, from: LocalDate, to: LocalDate): Uni<StatementPeriod?>
+
+    /** Finds by legal sequence **including** superseded records — an issued statement page must stay
+     *  reproducible for its full retention (ADR-0035 §D). */
     fun findBySequence(accountId: UUID, currency: String, legalSequence: Long): Uni<StatementPeriod?>
+
+    /**
+     * Atomically supersede [supersededId] and persist [replacement] plus its [event] in ONE
+     * transaction (ADR-0035 §D). Either the whole restatement lands or none of it does — a
+     * SUPERSEDED record with no replacement would leave the pocket with no standing close, and a
+     * replacement without the status flip would violate the one-active-close-per-window index.
+     */
+    fun supersedeAndReplace(
+        supersededId: UUID,
+        replacement: StatementPeriod,
+        event: OutboxMessage,
+    ): Uni<StatementPeriod>
     fun priorClosing(accountId: UUID, currency: String, before: LocalDate): Uni<BigDecimal?>
     fun listForAccount(accountId: UUID): Uni<List<StatementPeriod>>
 

--- a/openbank-statement-service/src/main/kotlin/com/openbank/statement/application/usecase/StatementRestatementService.kt
+++ b/openbank-statement-service/src/main/kotlin/com/openbank/statement/application/usecase/StatementRestatementService.kt
@@ -1,0 +1,202 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+package com.openbank.statement.application.usecase
+
+import com.openbank.statement.application.port.`in`.RestatePeriodUseCase
+import com.openbank.statement.application.port.out.AccountInfoPort
+import com.openbank.statement.application.port.out.BalancePort
+import com.openbank.statement.application.port.out.BookedEntryPort
+import com.openbank.statement.application.port.out.PocketAccountInfo
+import com.openbank.statement.application.port.out.StatementOutboxMessage
+import com.openbank.statement.application.port.out.StatementPeriodRepository
+import com.openbank.statement.domain.model.CreditDebit
+import com.openbank.statement.domain.model.PeriodCloseStatus
+import com.openbank.statement.domain.model.StatementEntry
+import com.openbank.statement.domain.model.StatementPeriod
+import com.openbank.statement.domain.reconcile.ReconciliationPolicy
+import io.smallrye.mutiny.Uni
+import jakarta.enterprise.context.ApplicationScoped
+import java.math.BigDecimal
+import java.time.Instant
+import java.time.LocalDate
+import java.util.UUID
+
+/**
+ * Sum of credits minus debits over [entries] — the booked net movement (ADR-0035 §E). Shared by the
+ * close and restatement paths so a correction can never compute movement differently from the close
+ * it replaces. BigDecimal throughout: statement figures are exact, never floating point.
+ */
+internal fun netMovementOf(entries: List<StatementEntry>): BigDecimal = entries.fold(BigDecimal.ZERO) { acc, e ->
+    when (e.creditDebit) {
+        CreditDebit.CRDT -> acc.add(e.amount)
+        CreditDebit.DBIT -> acc.subtract(e.amount)
+    }
+}
+
+/**
+ * Restatement of an already-closed statement period (ADR-0035 §D, issue #1302 item 5).
+ *
+ * Split out of [StatementService] rather than folded into it: the two paths share only their
+ * reconciliation rule, and a correction is the one operation in this service that writes two rows.
+ *
+ * **What existed before this class: nothing.** `PeriodCloseStatus.SUPERSEDED` and
+ * `supersedesSequence` were present in the model, the schema, the renderers and the published spec
+ * and had **zero write sites fleet-wide** — so a period closed on wrong data was immutable, and
+ * re-running the close returned the stale record unchanged through the idempotency branch. The only
+ * remediation was hand-written SQL against a legal record.
+ */
+@ApplicationScoped
+class StatementRestatementService(
+    private val accountInfo: AccountInfoPort,
+    private val bookedEntries: BookedEntryPort,
+    private val balance: BalancePort,
+    private val periods: StatementPeriodRepository,
+) : RestatePeriodUseCase {
+
+    /** Clock seam, as in [StatementService]: `closedAt` is stamped once and stored, so renders of the
+     *  superseding page stay deterministic. Overridable in tests; CDI uses the default. */
+    internal var clock: () -> Instant = Instant::now
+
+    /** Opening balance = the prior close's closing, else balance-service's balance the day before.
+     *  `priorClosing` excludes SUPERSEDED rows, so a restated earlier period cannot re-open a later
+     *  one on a figure the bank has already retracted. */
+    private fun openingBalance(accountId: UUID, currency: String, from: LocalDate): Uni<BigDecimal> =
+        periods.priorClosing(accountId, currency, from).flatMap { prior ->
+            if (prior != null) {
+                Uni.createFrom().item(prior)
+            } else {
+                balance.closingBalance(accountId, currency, from.minusDays(1)).map { it.amount }
+            }
+        }
+
+    override fun restatePocketPeriod(
+        accountId: UUID,
+        currency: String,
+        from: LocalDate,
+        to: LocalDate,
+    ): Uni<StatementPeriod> = accountInfo.pocketAccount(accountId).flatMap { account ->
+        periods.findByPeriod(accountId, currency, from, to).flatMap { standing ->
+            if (standing == null) {
+                Uni.createFrom().failure(NoClosedPeriodToRestateException(accountId, currency, from, to))
+            } else {
+                recomputeAndSupersede(account, currency, from, to, standing)
+            }
+        }
+    }
+
+    private fun recomputeAndSupersede(
+        account: PocketAccountInfo,
+        currency: String,
+        from: LocalDate,
+        to: LocalDate,
+        standing: StatementPeriod,
+    ): Uni<StatementPeriod> = bookedEntries.bookedEntries(account.accountId, currency, from, to).flatMap { entries ->
+        openingBalance(account.accountId, currency, from).flatMap { opening ->
+            balance.closingBalance(account.accountId, currency, to).flatMap { reported ->
+                // Fail closed on exactly the same terms as a first close (ADR-0035 §E): a
+                // restatement that cannot itself reconcile must not replace a record that does.
+                when (val r = ReconciliationPolicy.reconcile(opening, netMovementOf(entries), reported.amount)) {
+                    is ReconciliationPolicy.Result.Mismatch ->
+                        Uni.createFrom().failure(
+                            ReconciliationException(account.accountId, currency, from, to, r),
+                        )
+                    is ReconciliationPolicy.Result.Reconciled ->
+                        if (unchanged(standing, opening, r.closingBalance, entries.size)) {
+                            // Nothing to correct — do not burn a legal sequence on a no-op.
+                            Uni.createFrom().item(standing)
+                        } else {
+                            supersede(account, currency, from, to, standing, entries.size, opening, r.closingBalance)
+                        }
+                }
+            }
+        }
+    }
+
+    /** BigDecimal identity by VALUE (`compareTo`), never `equals` — 1075.00 and 1075.0000 are the
+     *  same amount and only `compareTo` says so. */
+    private fun unchanged(
+        standing: StatementPeriod,
+        opening: BigDecimal,
+        closing: BigDecimal,
+        entryCount: Int,
+    ): Boolean = standing.openingBalance.compareTo(opening) == 0 &&
+        standing.closingBalance.compareTo(closing) == 0 &&
+        standing.entryCount == entryCount
+
+    private fun supersede(
+        account: PocketAccountInfo,
+        currency: String,
+        from: LocalDate,
+        to: LocalDate,
+        standing: StatementPeriod,
+        entryCount: Int,
+        opening: BigDecimal,
+        closing: BigDecimal,
+    ): Uni<StatementPeriod> = periods.nextLegalSequence(account.accountId, currency).flatMap { seq ->
+        val replacement = StatementPeriod(
+            id = UUID.randomUUID(),
+            accountId = account.accountId,
+            pocketCurrency = currency,
+            periodFrom = from,
+            periodTo = to,
+            legalSequenceNumber = seq,
+            electronicSequenceNumber = seq,
+            openingBalance = opening,
+            closingBalance = closing,
+            entryCount = entryCount,
+            closedAt = clock(),
+            status = PeriodCloseStatus.CLOSED,
+            supersedesSequence = standing.legalSequenceNumber,
+        )
+        periods.supersedeAndReplace(standing.id, replacement, periodRestatedEvent(account, replacement, standing))
+    }
+
+    /**
+     * `account.statement.period.restated.v1` — a NEW event type, not a v2 of `period.closed`.
+     * Consumers of `period.closed` keep their contract unchanged; a consumer that must react to a
+     * correction opts in explicitly (a silently-widened `period.closed` would have downstream
+     * systems treat a restatement as a first close).
+     */
+    private fun periodRestatedEvent(
+        account: PocketAccountInfo,
+        period: StatementPeriod,
+        superseded: StatementPeriod,
+    ): StatementOutboxMessage {
+        val payload = """
+            {"eventType":"account.statement.period.restated.v1",
+            "accountId":"${account.accountId}",
+            "iban":"${account.iban}",
+            "pocketCurrency":"${period.pocketCurrency}",
+            "periodFrom":"${period.periodFrom}",
+            "periodTo":"${period.periodTo}",
+            "legalSequenceNumber":${period.legalSequenceNumber},
+            "electronicSequenceNumber":${period.electronicSequenceNumber},
+            "supersedesSequence":${period.supersedesSequence},
+            "openingBalance":${period.openingBalance.toPlainString()},
+            "closingBalance":${period.closingBalance.toPlainString()},
+            "supersededClosingBalance":${superseded.closingBalance.toPlainString()},
+            "entryCount":${period.entryCount},
+            "supersededEntryCount":${superseded.entryCount},
+            "closedAt":"${period.closedAt}"}
+        """.trimIndent().replace("\n", "")
+        return StatementOutboxMessage(
+            eventId = UUID.randomUUID(),
+            aggregateId = period.id,
+            eventType = "account.statement.period.restated.v1",
+            payload = payload,
+        )
+    }
+}
+
+/**
+ * Raised when a restatement is requested for a window that has no standing close. A correction is a
+ * *replacement* of an issued legal statement page (ADR-0035 §D) — there is nothing to replace, and
+ * minting a first close through this path would bypass the close orchestrator's accounting.
+ */
+class NoClosedPeriodToRestateException(
+    val accountId: UUID,
+    val currency: String,
+    val from: LocalDate,
+    val to: LocalDate,
+) : RuntimeException("No closed statement period to restate for $accountId/$currency $from..$to")

--- a/openbank-statement-service/src/main/kotlin/com/openbank/statement/application/usecase/StatementRestatementService.kt
+++ b/openbank-statement-service/src/main/kotlin/com/openbank/statement/application/usecase/StatementRestatementService.kt
@@ -3,6 +3,7 @@
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 package com.openbank.statement.application.usecase
 
+import com.openbank.libs.domain.identifiers.Ids
 import com.openbank.statement.application.port.`in`.RestatePeriodUseCase
 import com.openbank.statement.application.port.out.AccountInfoPort
 import com.openbank.statement.application.port.out.BalancePort
@@ -135,7 +136,7 @@ class StatementRestatementService(
         closing: BigDecimal,
     ): Uni<StatementPeriod> = periods.nextLegalSequence(account.accountId, currency).flatMap { seq ->
         val replacement = StatementPeriod(
-            id = UUID.randomUUID(),
+            id = Ids.newId(),
             accountId = account.accountId,
             pocketCurrency = currency,
             periodFrom = from,
@@ -181,7 +182,7 @@ class StatementRestatementService(
             "closedAt":"${period.closedAt}"}
         """.trimIndent().replace("\n", "")
         return StatementOutboxMessage(
-            eventId = UUID.randomUUID(),
+            eventId = Ids.newId(),
             aggregateId = period.id,
             eventType = "account.statement.period.restated.v1",
             payload = payload,

--- a/openbank-statement-service/src/main/kotlin/com/openbank/statement/application/usecase/StatementService.kt
+++ b/openbank-statement-service/src/main/kotlin/com/openbank/statement/application/usecase/StatementService.kt
@@ -15,7 +15,6 @@ import com.openbank.statement.application.port.out.PocketAccountInfo
 import com.openbank.statement.application.port.out.StatementOutboxMessage
 import com.openbank.statement.application.port.out.StatementPeriodRepository
 import com.openbank.statement.domain.model.BalanceAnchor
-import com.openbank.statement.domain.model.CreditDebit
 import com.openbank.statement.domain.model.PeriodCloseStatus
 import com.openbank.statement.domain.model.StatementEntry
 import com.openbank.statement.domain.model.StatementFormat
@@ -96,7 +95,7 @@ class StatementService(
     ): Uni<StatementPeriod> = bookedEntries.bookedEntries(account.accountId, currency, from, to).flatMap { entries ->
         openingBalance(account.accountId, currency, from).flatMap { opening ->
             balance.closingBalance(account.accountId, currency, to).flatMap { reported ->
-                val net = netMovement(entries)
+                val net = netMovementOf(entries)
                 when (val r = ReconciliationPolicy.reconcile(opening, net, reported.amount)) {
                     is ReconciliationPolicy.Result.Mismatch ->
                         Uni.createFrom().failure(
@@ -175,7 +174,7 @@ class StatementService(
     ): Uni<StatementRenderer.Rendered> = accountInfo.pocketAccount(accountId).flatMap { account ->
         bookedEntries.bookedEntries(accountId, currency, from, to).flatMap { entries ->
             openingBalance(accountId, currency, from).map { opening ->
-                val closing = opening.add(netMovement(entries))
+                val closing = opening.add(netMovementOf(entries))
                 // Non-sequenced informational export (legal/electronic sequence = 0).
                 val model = StatementModel(
                     accountId = accountId,
@@ -217,13 +216,6 @@ class StatementService(
         closedAt = period.closedAt,
         supersedesSequence = period.supersedesSequence,
     )
-
-    private fun netMovement(entries: List<StatementEntry>): BigDecimal = entries.fold(BigDecimal.ZERO) { acc, e ->
-        when (e.creditDebit) {
-            CreditDebit.CRDT -> acc.add(e.amount)
-            CreditDebit.DBIT -> acc.subtract(e.amount)
-        }
-    }
 
     private fun periodClosedEvent(account: PocketAccountInfo, period: StatementPeriod): StatementOutboxMessage {
         val payload = """

--- a/openbank-statement-service/src/main/kotlin/com/openbank/statement/infrastructure/persistence/repository/StatementPeriodRepositoryImpl.kt
+++ b/openbank-statement-service/src/main/kotlin/com/openbank/statement/infrastructure/persistence/repository/StatementPeriodRepositoryImpl.kt
@@ -7,6 +7,7 @@ import com.openbank.libs.persistence.outbox.OutboxMessage
 import com.openbank.libs.persistence.outbox.OutboxStatus
 import com.openbank.statement.application.port.out.StatementOutbox
 import com.openbank.statement.application.port.out.StatementPeriodRepository
+import com.openbank.statement.domain.model.PeriodCloseStatus
 import com.openbank.statement.domain.model.StatementPeriod
 import com.openbank.statement.infrastructure.persistence.entity.StatementOutboxEntity
 import com.openbank.statement.infrastructure.persistence.entity.StatementPeriodEntity
@@ -65,6 +66,43 @@ class StatementPeriodRepositoryImpl @Inject constructor(
         }
     }
 
+    @WithTransaction
+    override fun supersedeAndReplace(
+        supersededId: UUID,
+        replacement: StatementPeriod,
+        event: OutboxMessage,
+    ): Uni<StatementPeriod> {
+        val pe = mapper.toEntity(replacement)
+        val now = clock.instant()
+        val oe = StatementOutboxEntity().apply {
+            eventId = event.eventId
+            aggregateId = event.aggregateId
+            eventType = event.eventType
+            payload = event.payload
+            status = OutboxStatus.PENDING.name
+            attemptCount = 0
+            createdAt = now
+            updatedAt = now
+        }
+        return sf.withTransaction { s ->
+            // The superseded row is loaded MANAGED and mutated, so Hibernate issues an UPDATE on
+            // flush. Do NOT round-trip it through persist(): `id` is application-assigned, so a
+            // non-null id cannot distinguish transient from detached and Panache would schedule an
+            // INSERT — the duplicate-key defect that 500'd every consent-service transition.
+            s.find(StatementPeriodEntity::class.java, supersededId)
+                .chain { prior ->
+                    requireNotNull(prior) { "No statement period $supersededId to supersede" }
+                    prior.status = PeriodCloseStatus.SUPERSEDED
+                    // Flip BEFORE inserting the replacement: both rows share the window, and
+                    // ux_statement_period_window_active admits only one non-SUPERSEDED row.
+                    s.flush()
+                }
+                .chain { _ -> s.persist(pe) }
+                .chain { _ -> s.persist(oe) }
+                .replaceWith(mapper.toDomain(pe))
+        }
+    }
+
     @WithSession
     override fun findByPeriod(
         accountId: UUID,
@@ -74,10 +112,11 @@ class StatementPeriodRepositoryImpl @Inject constructor(
     ): Uni<StatementPeriod?> = sf.withSession { s ->
         s.createQuery(
             "FROM StatementPeriodEntity WHERE accountId = :a AND pocketCurrency = :c " +
-                "AND periodFrom = :f AND periodTo = :t",
+                "AND periodFrom = :f AND periodTo = :t AND status <> :sup",
             StatementPeriodEntity::class.java,
         ).setParameter("a", accountId).setParameter("c", currency)
             .setParameter("f", from).setParameter("t", to)
+            .setParameter("sup", PeriodCloseStatus.SUPERSEDED)
             .setMaxResults(1).singleResultOrNull
     }.map { it?.let(mapper::toDomain) }
 
@@ -97,9 +136,10 @@ class StatementPeriodRepositoryImpl @Inject constructor(
         sf.withSession { s ->
             s.createQuery(
                 "FROM StatementPeriodEntity WHERE accountId = :a AND pocketCurrency = :c " +
-                    "AND periodTo < :b ORDER BY periodTo DESC",
+                    "AND periodTo < :b AND status <> :sup ORDER BY periodTo DESC",
                 StatementPeriodEntity::class.java,
             ).setParameter("a", accountId).setParameter("c", currency).setParameter("b", before)
+                .setParameter("sup", PeriodCloseStatus.SUPERSEDED)
                 .setMaxResults(1).singleResultOrNull
         }.map { it?.closingBalance }
 
@@ -118,7 +158,7 @@ class StatementPeriodRepositoryImpl @Inject constructor(
                 "WHERE p.accountId = :a AND p.pocketCurrency = :c AND p.status = :st",
             LocalDate::class.java,
         ).setParameter("a", accountId).setParameter("c", currency)
-            .setParameter("st", com.openbank.statement.domain.model.PeriodCloseStatus.CLOSED)
+            .setParameter("st", PeriodCloseStatus.CLOSED)
             .singleResultOrNull
     }
 }

--- a/openbank-statement-service/src/main/kotlin/com/openbank/statement/infrastructure/rest/StatementResource.kt
+++ b/openbank-statement-service/src/main/kotlin/com/openbank/statement/infrastructure/rest/StatementResource.kt
@@ -8,6 +8,8 @@ import com.openbank.statement.application.port.`in`.AdHocExportUseCase
 import com.openbank.statement.application.port.`in`.ClosePeriodUseCase
 import com.openbank.statement.application.port.`in`.ListStatementsUseCase
 import com.openbank.statement.application.port.`in`.RenderStatementUseCase
+import com.openbank.statement.application.port.`in`.RestatePeriodUseCase
+import com.openbank.statement.application.usecase.NoClosedPeriodToRestateException
 import com.openbank.statement.application.usecase.ReconciliationException
 import com.openbank.statement.application.usecase.StatementNotFoundException
 import com.openbank.statement.domain.model.StatementFormat
@@ -38,6 +40,7 @@ class StatementResource(
     private val renderStatement: RenderStatementUseCase,
     private val listStatements: ListStatementsUseCase,
     private val adHocExport: AdHocExportUseCase,
+    private val restatePeriod: RestatePeriodUseCase,
 ) {
 
     @POST
@@ -55,6 +58,31 @@ class StatementResource(
         .recoverWithItem { e ->
             Response.status(Response.Status.CONFLICT).entity(mapOf("error" to e.message)).build()
         }
+
+    @POST
+    @Path("/{accountId}/{currency}/restate")
+    @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN")
+    @Authorize(action = "statement.restate", resource = "#accountId")
+    @Operation(
+        summary = "Restate a closed period after a data correction (ADR-0035 §D) — issues a NEW " +
+            "sequenced close referencing the superseded one; never edits the existing record",
+    )
+    fun restate(
+        @PathParam("accountId") accountId: UUID,
+        @PathParam("currency") currency: String,
+        @QueryParam("from") from: String,
+        @QueryParam("to") to: String,
+    ): Uni<Response> =
+        restatePeriod.restatePocketPeriod(accountId, currency, LocalDate.parse(from), LocalDate.parse(to))
+            .map { Response.ok(it).build() }
+            .onFailure(NoClosedPeriodToRestateException::class.java)
+            .recoverWithItem { e ->
+                Response.status(Response.Status.NOT_FOUND).entity(mapOf("error" to e.message)).build()
+            }
+            .onFailure(ReconciliationException::class.java)
+            .recoverWithItem { e ->
+                Response.status(Response.Status.CONFLICT).entity(mapOf("error" to e.message)).build()
+            }
 
     @GET
     @Path("/{accountId}")

--- a/openbank-statement-service/src/main/resources/db/migration/V6__statement_period_restatement.sql
+++ b/openbank-statement-service/src/main/resources/db/migration/V6__statement_period_restatement.sql
@@ -1,0 +1,34 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+--
+-- ADR-0035 §D: a correction to a closed period is a NEW period close carrying the next legal
+-- sequence and an explicit `supersedes_sequence` back-reference — never an in-place edit.
+--
+-- V1 made that physically impossible: `ux_statement_period_window` is UNIQUE on
+-- (account_id, pocket_currency, period_from, period_to), so a second close for the same window
+-- violates the index. Restatement therefore could not be implemented without this migration —
+-- `PeriodCloseStatus.SUPERSEDED` had zero write sites fleet-wide (issue #1302 item 5).
+--
+-- The invariant that actually holds is weaker and is what we index for: **at most one
+-- non-SUPERSEDED close per (account, pocket, period)**. Superseded rows stay in the table
+-- forever (10y CNB retention on the reproducible record) and remain renderable by legal
+-- sequence, so an already-issued statement can still be reproduced byte-for-byte.
+--
+-- Rollback:
+--   DROP INDEX ux_statement_period_window_active;
+--   -- only possible once every SUPERSEDED row is removed, since the strict index cannot
+--   -- coexist with a restated window:
+--   DELETE FROM statement_period WHERE status = 'SUPERSEDED';
+--   CREATE UNIQUE INDEX ux_statement_period_window
+--       ON statement_period (account_id, pocket_currency, period_from, period_to);
+
+DROP INDEX IF EXISTS ux_statement_period_window;
+
+CREATE UNIQUE INDEX ux_statement_period_window_active
+    ON statement_period (account_id, pocket_currency, period_from, period_to)
+    WHERE status <> 'SUPERSEDED';
+
+-- Supports the supersession chain lookup (which close replaced which page).
+CREATE INDEX ix_statement_period_supersedes
+    ON statement_period (account_id, pocket_currency, supersedes_sequence)
+    WHERE supersedes_sequence IS NOT NULL;

--- a/openbank-statement-service/src/main/resources/docs/03-api.cs.md
+++ b/openbank-statement-service/src/main/resources/docs/03-api.cs.md
@@ -22,6 +22,18 @@ Uzavře měsíc pro **každou kapsu** účtu. Přidělí další právní/elektr
 - `200` → pole `StatementPeriod` (jeden na kapsu).
 - `409` → fail-closed nesoulad rekonciliace; **žádný výpis se nevydá** (tělo `{ "error": "..." }`).
 
+### `POST /api/v1/statements/{accountId}/{currency}/restate`
+
+Přepracování (restatement) uzavřeného období po opravě podkladových zaúčtovaných dat (ADR-0035 §D). Existující záznam se **nikdy needituje**: služba znovu načte zaúčtované položky i koncový zůstatek z balance-service, provede stejnou fail-closed rekonciliaci jako první uzávěrka a vydá **novou** uzávěrku s dalším právním pořadovým číslem a `supersedesSequence` odkazujícím na nahrazovaný záznam; ten ve stejné transakci přechází do stavu `SUPERSEDED`.
+
+- Role: `ROLE_OPERATOR`, `ROLE_ADMIN` (operátorská akce — záměrně **ne** `ROLE_API`).
+- Query parametry: `from` (datum, povinné), `to` (datum, povinné).
+- Pokud se přepočtené částky nezměnily, **nespotřebuje se žádné pořadové číslo** a vrací se stávající záznam.
+- Nahrazený záznam zůstává uchován a po celou dobu archivace je nadále renderovatelný pod svým právním pořadovým číslem.
+- `200` → platný `StatementPeriod` po přepracování.
+- `404` → pro dané období neexistuje uzavřená uzávěrka; restatement nikdy nevytváří první uzávěrku.
+- `409` → fail-closed neshoda rekonciliace; stávající uzávěrka zůstává **nedotčena**.
+
 ### `GET /api/v1/statements/{accountId}`
 
 Vypíše uchovávané záznamy uzávěrek pro účet. `200` → pole `StatementPeriod`.

--- a/openbank-statement-service/src/main/resources/docs/03-api.en.md
+++ b/openbank-statement-service/src/main/resources/docs/03-api.en.md
@@ -22,6 +22,18 @@ Close a month for **every pocket** of an account. Assigns the next legal/electro
 - `200` → array of `StatementPeriod` (one per pocket).
 - `409` → fail-closed reconciliation mismatch; **no statement is issued** (body `{ "error": "..." }`).
 
+### `POST /api/v1/statements/{accountId}/{currency}/restate`
+
+Restate a closed period after a correction to the underlying booked data (ADR-0035 §D). The existing record is **never edited**: the service re-reads the booked entries and balance-service's closing balance, reconciles fail-closed exactly as a first close does, and issues a **new** close carrying the next legal sequence with `supersedesSequence` pointing at the record it replaces; that record flips to `SUPERSEDED` in the same transaction.
+
+- Roles: `ROLE_OPERATOR`, `ROLE_ADMIN` (an operator action — deliberately **not** `ROLE_API`).
+- Query params: `from` (date, required), `to` (date, required).
+- If the recomputed figures are unchanged, **no sequence is burnt** and the standing record is returned as-is.
+- The superseded record is retained and stays renderable by its own legal sequence for its full retention period.
+- `200` → the standing `StatementPeriod` after the restatement.
+- `404` → no closed period for that window; a restatement never mints a first close.
+- `409` → fail-closed reconciliation mismatch; the standing close is left **untouched**.
+
 ### `GET /api/v1/statements/{accountId}`
 
 List the retained period-close records for an account. `200` → array of `StatementPeriod`.

--- a/openbank-statement-service/src/main/resources/openapi.yaml
+++ b/openbank-statement-service/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: Statement Service API
-  version: 1.0.0
+  version: 1.1.0
   description: >-
     Account statements for the multi-currency current account (ADR-0035). The unit is the per-pocket
     (IBAN + currency) statement: each pocket has its own camt.053.001.08 / MT940 with an independent
@@ -47,6 +47,38 @@ paths:
                   $ref: '#/components/schemas/StatementPeriod'
         '409':
           description: Fail-closed reconciliation mismatch — no statement issued
+
+  /api/v1/statements/{accountId}/{currency}/restate:
+    post:
+      tags: [Statements]
+      summary: Restate a closed period after a correction to the underlying booked data
+      description: >-
+        ADR-0035 §D: a correction is a NEW period close carrying the next legal sequence and an
+        explicit `supersedesSequence` back-reference — the existing record is never edited. Re-reads
+        the booked entries and balance-service's closing balance and reconciles fail-closed exactly
+        as a first close does; a restatement that cannot itself reconcile returns 409 and leaves the
+        standing close untouched. If the recomputed figures are unchanged, no sequence is burnt and
+        the standing record is returned as-is. The superseded record is retained and stays renderable
+        by its own legal sequence for its full retention period.
+      operationId: restateStatementPeriod
+      parameters:
+        - { name: accountId, in: path, required: true, schema: { type: string, format: uuid } }
+        - { name: currency, in: path, required: true, schema: { type: string, minLength: 3, maxLength: 3 } }
+        - { name: from, in: query, required: true, schema: { type: string, format: date } }
+        - { name: to, in: query, required: true, schema: { type: string, format: date } }
+      responses:
+        '200':
+          description: >-
+            The standing period-close record after the restatement — the new superseding close, or
+            the unchanged existing one when the recomputed figures matched.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatementPeriod'
+        '404':
+          description: No closed period for that window — a restatement never mints a first close
+        '409':
+          description: Fail-closed reconciliation mismatch — the standing close is left untouched
 
   /api/v1/statements/{accountId}:
     get:

--- a/openbank-statement-service/src/test/kotlin/com/openbank/statement/application/usecase/StatementServiceTest.kt
+++ b/openbank-statement-service/src/test/kotlin/com/openbank/statement/application/usecase/StatementServiceTest.kt
@@ -38,11 +38,14 @@ class StatementServiceTest {
     private val to = LocalDate.parse("2026-01-31")
 
     private lateinit var service: StatementService
+    private lateinit var restatement: StatementRestatementService
 
     @BeforeEach
     fun setUp() {
         service = StatementService(accountInfo, bookedEntries, balance, periods)
         service.clock = { Fixtures.CLOSED_AT }
+        restatement = StatementRestatementService(accountInfo, bookedEntries, balance, periods)
+        restatement.clock = { Fixtures.CLOSED_AT }
         every { accountInfo.pocketAccount(Fixtures.ACCOUNT_ID) } returns
             Uni.createFrom().item(PocketAccountInfo(Fixtures.ACCOUNT_ID, "CZ65", "Jan Novak", listOf("CZK")))
         every { bookedEntries.bookedEntries(any(), any(), any(), any()) } returns Uni.createFrom().item(
@@ -147,5 +150,107 @@ class StatementServiceTest {
         // Non-sequenced informational export -> legal sequence 0 on the PDF.
         assertThat(rendered.body).contains("Statement no. (legal): 0")
         verify(exactly = 0) { periods.saveWithOutbox(any(), any()) }
+    }
+
+    // ---- Restatement of a closed period (ADR-0035 §D, issue #1302 item 5) -------------------
+    //
+    // Before this, `PeriodCloseStatus.SUPERSEDED` had ZERO write sites fleet-wide: a period closed
+    // on wrong data was immutable, and `closePocketMonth` silently returned the stale record.
+
+    private fun standingClose(
+        seq: Long = 3,
+        opening: String = "1000.00",
+        closing: String = "1075.00",
+        entryCount: Int = 2,
+    ) = StatementPeriod(
+        id = UUID.randomUUID(), accountId = Fixtures.ACCOUNT_ID, pocketCurrency = "CZK",
+        periodFrom = from, periodTo = to, legalSequenceNumber = seq, electronicSequenceNumber = seq,
+        openingBalance = BigDecimal(opening), closingBalance = BigDecimal(closing),
+        entryCount = entryCount, closedAt = Fixtures.CLOSED_AT,
+    )
+
+    @Test
+    fun `restating a corrected period issues a new sequenced close referencing the superseded one`() {
+        // The standing close was built before TX-2 (the 25.00 fee) was booked: it says 1100.00 with
+        // one entry. The corrected truth is 1000 + 100 - 25 = 1075.00 over two entries.
+        val standing = standingClose(seq = 3, closing = "1100.00", entryCount = 1)
+        every { periods.findByPeriod(any(), any(), any(), any()) } returns Uni.createFrom().item(standing)
+        every { balance.closingBalance(Fixtures.ACCOUNT_ID, "CZK", to) } returns
+            Uni.createFrom().item(BalanceAnchor(BigDecimal("1075.00"), "CZK", to))
+        every { periods.nextLegalSequence(Fixtures.ACCOUNT_ID, "CZK") } returns Uni.createFrom().item(4L)
+        every { periods.supersedeAndReplace(any(), any(), any()) } answers {
+            Uni.createFrom().item(secondArg<StatementPeriod>())
+        }
+
+        val restated = restatement.restatePocketPeriod(Fixtures.ACCOUNT_ID, "CZK", from, to).await().indefinitely()
+
+        // The FIGURES are the assertion, not merely that a status changed.
+        assertThat(restated.closingBalance).isEqualByComparingTo("1075.00")
+        assertThat(restated.openingBalance).isEqualByComparingTo("1000.00")
+        assertThat(restated.entryCount).isEqualTo(2)
+        assertThat(restated.legalSequenceNumber).isEqualTo(4L)
+        assertThat(restated.electronicSequenceNumber).isEqualTo(4L)
+        assertThat(restated.supersedesSequence).isEqualTo(3L)
+        assertThat(restated.status).isEqualTo(PeriodCloseStatus.CLOSED)
+        assertThat(restated.id).isNotEqualTo(standing.id)
+
+        // The prior record is superseded in the SAME call (one transaction), and the correction is
+        // announced on its own event type, not silently as another `period.closed`.
+        verify(exactly = 1) {
+            periods.supersedeAndReplace(
+                standing.id,
+                any(),
+                match<StatementOutboxMessage> {
+                    it.eventType == "account.statement.period.restated.v1" &&
+                        it.payload.contains("\"supersedesSequence\":3") &&
+                        it.payload.contains("\"closingBalance\":1075.00") &&
+                        it.payload.contains("\"supersededClosingBalance\":1100.00")
+                },
+            )
+        }
+        // Never an in-place edit, and never a plain close.
+        verify(exactly = 0) { periods.save(any()) }
+        verify(exactly = 0) { periods.saveWithOutbox(any(), any()) }
+    }
+
+    @Test
+    fun `restating a period whose figures are unchanged burns no legal sequence`() {
+        val standing = standingClose(seq = 3, closing = "1075.00", entryCount = 2)
+        every { periods.findByPeriod(any(), any(), any(), any()) } returns Uni.createFrom().item(standing)
+        every { balance.closingBalance(Fixtures.ACCOUNT_ID, "CZK", to) } returns
+            Uni.createFrom().item(BalanceAnchor(BigDecimal("1075.00"), "CZK", to))
+
+        val result = restatement.restatePocketPeriod(Fixtures.ACCOUNT_ID, "CZK", from, to).await().indefinitely()
+
+        assertThat(result).isEqualTo(standing)
+        verify(exactly = 0) { periods.nextLegalSequence(any(), any()) }
+        verify(exactly = 0) { periods.supersedeAndReplace(any(), any(), any()) }
+    }
+
+    @Test
+    fun `a restatement that cannot itself reconcile leaves the standing close untouched - fail closed`() {
+        val standing = standingClose(seq = 3, closing = "1100.00", entryCount = 1)
+        every { periods.findByPeriod(any(), any(), any(), any()) } returns Uni.createFrom().item(standing)
+        // computed = 1000 + (100 - 25) = 1075, balance-service says 9999 -> mismatch
+        every { balance.closingBalance(Fixtures.ACCOUNT_ID, "CZK", to) } returns
+            Uni.createFrom().item(BalanceAnchor(BigDecimal("9999.00"), "CZK", to))
+
+        assertThatThrownBy {
+            restatement.restatePocketPeriod(Fixtures.ACCOUNT_ID, "CZK", from, to).await().indefinitely()
+        }.isInstanceOf(ReconciliationException::class.java)
+
+        verify(exactly = 0) { periods.supersedeAndReplace(any(), any(), any()) }
+    }
+
+    @Test
+    fun `restating a window that was never closed is rejected, not turned into a first close`() {
+        every { periods.findByPeriod(any(), any(), any(), any()) } returns Uni.createFrom().nullItem()
+
+        assertThatThrownBy {
+            restatement.restatePocketPeriod(Fixtures.ACCOUNT_ID, "CZK", from, to).await().indefinitely()
+        }.isInstanceOf(NoClosedPeriodToRestateException::class.java)
+
+        verify(exactly = 0) { periods.nextLegalSequence(any(), any()) }
+        verify(exactly = 0) { periods.supersedeAndReplace(any(), any(), any()) }
     }
 }

--- a/openbank-statement-service/src/test/kotlin/com/openbank/statement/integration/StatementRestatementIT.kt
+++ b/openbank-statement-service/src/test/kotlin/com/openbank/statement/integration/StatementRestatementIT.kt
@@ -1,0 +1,228 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+package com.openbank.statement.integration
+
+import com.openbank.libs.persistence.outbox.OutboxMessage
+import com.openbank.statement.domain.model.PeriodCloseStatus
+import com.openbank.statement.domain.model.StatementPeriod
+import com.openbank.statement.infrastructure.persistence.repository.StatementPeriodRepositoryImpl
+import com.openbank.statement.it.PostgresTestResource
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.common.http.TestHTTPResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.vertx.VertxContextSupport
+import io.smallrye.mutiny.coroutines.awaitSuspending
+import io.smallrye.mutiny.coroutines.uni
+import jakarta.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import org.assertj.core.api.Assertions.assertThat
+import org.eclipse.microprofile.config.inject.ConfigProperty
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.net.URL
+import java.sql.DriverManager
+import java.time.Instant
+import java.time.LocalDate
+import java.util.UUID
+
+/**
+ * Real-DB coverage for the statement restatement path (ADR-0035 §D, issue #1302 item 5).
+ *
+ * This IT exists because **no mocked-repository test can see either defect this path is exposed to**:
+ *
+ *  1. `ux_statement_period_window` (V1) was UNIQUE on (account, pocket, period_from, period_to), so a
+ *     superseding close for the same window is a **duplicate-key violation at flush** — the schema
+ *     made ADR-0035 §D physically impossible. `V6__statement_period_restatement.sql` narrows it to
+ *     the invariant that actually holds (at most one *non-SUPERSEDED* close per window). Removing V6
+ *     turns `restatement writes a second row …` red with a
+ *     `duplicate key value violates unique constraint` — that is this test's known-positive.
+ *  2. The status flip on the prior record must be an **UPDATE**. `StatementPeriodEntity.id` is
+ *     application-assigned, so routing it through `persist()` would schedule an INSERT and fail with
+ *     the same duplicate-key error (the defect that 500'd every consent-service lifecycle
+ *     transition). Only a real session/flush can distinguish the two.
+ *
+ * Rows are read back with a plain JDBC query rather than through the repository, so a mapper or
+ * query-filter mistake cannot hide the persisted truth from the assertion.
+ */
+@QuarkusTest
+@QuarkusTestResource(PostgresTestResource::class)
+class StatementRestatementIT {
+
+    @Inject
+    lateinit var repository: StatementPeriodRepositoryImpl
+
+    @TestHTTPResource("/q/openapi")
+    lateinit var openapiUrl: URL
+
+    @ConfigProperty(name = "quarkus.datasource.jdbc.url")
+    lateinit var jdbcUrl: String
+
+    @ConfigProperty(name = "quarkus.datasource.username")
+    lateinit var dbUser: String
+
+    @ConfigProperty(name = "quarkus.datasource.password")
+    lateinit var dbPassword: String
+
+    private val accountId: UUID = UUID.randomUUID()
+    private val currency = "CZK"
+    private val from: LocalDate = LocalDate.parse("2026-01-01")
+    private val to: LocalDate = LocalDate.parse("2026-01-31")
+
+    private fun <T> onEventLoop(block: suspend () -> T): T =
+        VertxContextSupport.subscribeAndAwait { uni(CoroutineScope(Dispatchers.Unconfined)) { block() } }
+
+    private fun period(
+        seq: Long,
+        opening: String,
+        closing: String,
+        entryCount: Int,
+        supersedes: Long? = null,
+        periodFrom: LocalDate = from,
+        periodTo: LocalDate = to,
+    ) = StatementPeriod(
+        id = UUID.randomUUID(),
+        accountId = accountId,
+        pocketCurrency = currency,
+        periodFrom = periodFrom,
+        periodTo = periodTo,
+        legalSequenceNumber = seq,
+        electronicSequenceNumber = seq,
+        openingBalance = BigDecimal(opening),
+        closingBalance = BigDecimal(closing),
+        entryCount = entryCount,
+        closedAt = Instant.parse("2026-02-01T02:30:00Z"),
+        status = PeriodCloseStatus.CLOSED,
+        supersedesSequence = supersedes,
+    )
+
+    private fun event(aggregateId: UUID, type: String) = OutboxMessage(
+        aggregateId = aggregateId,
+        eventType = type,
+        payload = """{"eventType":"$type"}""",
+        createdAt = Instant.parse("2026-02-01T02:30:00Z"),
+    )
+
+    /** Reads the persisted rows for this account straight out of Postgres — no repository, no mapper. */
+    private fun rowsFromDb(): List<Triple<Long, String, BigDecimal>> =
+        DriverManager.getConnection(jdbcUrl, dbUser, dbPassword).use { c ->
+            c.prepareStatement(
+                "SELECT legal_sequence_number, status, closing_balance, supersedes_sequence, entry_count " +
+                    "FROM statement_period WHERE account_id = ? ORDER BY legal_sequence_number",
+            ).use { ps ->
+                ps.setObject(1, accountId)
+                ps.executeQuery().use { rs ->
+                    generateSequence {
+                        if (rs.next()) {
+                            Triple(rs.getLong(1), rs.getString(2), rs.getBigDecimal(3))
+                        } else {
+                            null
+                        }
+                    }.toList()
+                }
+            }
+        }
+
+    private fun supersedesSequenceOf(seq: Long): Long? = queryLong(
+        "SELECT supersedes_sequence FROM statement_period WHERE account_id = ? AND legal_sequence_number = ?",
+        seq,
+    )
+
+    private fun queryLong(sql: String, seq: Long): Long? =
+        DriverManager.getConnection(jdbcUrl, dbUser, dbPassword).use { c -> firstLong(c, sql, seq) }
+
+    private fun firstLong(c: java.sql.Connection, sql: String, seq: Long): Long? = c.prepareStatement(sql).use { ps ->
+        ps.setObject(1, accountId)
+        ps.setLong(2, seq)
+        ps.executeQuery().use { rs -> if (rs.next()) (rs.getObject(1) as? Number)?.toLong() else null }
+    }
+
+    @Test
+    fun `restatement writes a second row for the same window and flips the prior one to SUPERSEDED`() {
+        val original = period(seq = 1, opening = "1000.00", closing = "1100.00", entryCount = 1)
+        onEventLoop { repository.saveWithOutbox(original, event(original.id, "period.closed")).awaitSuspending() }
+
+        val replacement = period(seq = 2, opening = "1000.00", closing = "1075.00", entryCount = 2, supersedes = 1)
+        onEventLoop {
+            repository.supersedeAndReplace(original.id, replacement, event(replacement.id, "period.restated"))
+                .awaitSuspending()
+        }
+
+        val rows = rowsFromDb()
+        assertThat(rows).hasSize(2)
+
+        // The original page is retained verbatim, only its status changes — the legal record of what
+        // was issued must stay reproducible.
+        val (seq1, status1, closing1) = rows[0]
+        assertThat(seq1).isEqualTo(1L)
+        assertThat(status1).isEqualTo("SUPERSEDED")
+        assertThat(closing1).isEqualByComparingTo("1100.00")
+
+        // The correction carries the next sequence and the exact corrected figures.
+        val (seq2, status2, closing2) = rows[1]
+        assertThat(seq2).isEqualTo(2L)
+        assertThat(status2).isEqualTo("CLOSED")
+        assertThat(closing2).isEqualByComparingTo("1075.00")
+        assertThat(supersedesSequenceOf(2L)).isEqualTo(1L)
+    }
+
+    @Test
+    fun `the standing close for a restated window is the replacement, and the superseded page is still renderable`() {
+        val original = period(seq = 1, opening = "1000.00", closing = "1100.00", entryCount = 1)
+        onEventLoop { repository.saveWithOutbox(original, event(original.id, "period.closed")).awaitSuspending() }
+        val replacement = period(seq = 2, opening = "1000.00", closing = "1075.00", entryCount = 2, supersedes = 1)
+        onEventLoop {
+            repository.supersedeAndReplace(original.id, replacement, event(replacement.id, "period.restated"))
+                .awaitSuspending()
+        }
+
+        // findByPeriod drives close-idempotency: it must resolve to the CORRECTION, never the stale page.
+        val standing = onEventLoop { repository.findByPeriod(accountId, currency, from, to).awaitSuspending() }
+        assertThat(standing).isNotNull
+        assertThat(standing!!.legalSequenceNumber).isEqualTo(2L)
+        assertThat(standing.closingBalance).isEqualByComparingTo("1075.00")
+        assertThat(standing.status).isEqualTo(PeriodCloseStatus.CLOSED)
+
+        // …while the superseded page stays reachable by its legal sequence for its full retention.
+        val issued = onEventLoop { repository.findBySequence(accountId, currency, 1L).awaitSuspending() }
+        assertThat(issued).isNotNull
+        assertThat(issued!!.status).isEqualTo(PeriodCloseStatus.SUPERSEDED)
+        assertThat(issued.closingBalance).isEqualByComparingTo("1100.00")
+    }
+
+    @Test
+    fun `the next period opens on the corrected closing balance, not the superseded one`() {
+        // Both rows share periodTo, so an unfiltered "latest prior close" query picks between them
+        // non-deterministically — and picking the superseded one would silently open February on a
+        // balance the bank has already retracted, propagating the error forward forever.
+        val original = period(seq = 1, opening = "1000.00", closing = "1100.00", entryCount = 1)
+        onEventLoop { repository.saveWithOutbox(original, event(original.id, "period.closed")).awaitSuspending() }
+        val replacement = period(seq = 2, opening = "1000.00", closing = "1075.00", entryCount = 2, supersedes = 1)
+        onEventLoop {
+            repository.supersedeAndReplace(original.id, replacement, event(replacement.id, "period.restated"))
+                .awaitSuspending()
+        }
+
+        val feb = LocalDate.parse("2026-02-01")
+        val opening = onEventLoop { repository.priorClosing(accountId, currency, feb).awaitSuspending() }
+
+        assertThat(opening).isNotNull
+        assertThat(opening!!).isEqualByComparingTo("1075.00")
+    }
+
+    @Test
+    fun `the running app actually serves the restate route`() {
+        // The committed openapi.yaml is a document; this asks the RUNNING app what it registered.
+        // A Kotlin annotation binds to the NEXT declaration, so a `@Path`/`@POST` that silently
+        // failed to attach to the resource method leaves every call 404 while unit tests that
+        // invoke the class directly stay green (the McpEndpoint defect). /q/openapi is generated
+        // from the scanned JAX-RS annotations (NOT from the committed openapi.yaml, which lives
+        // outside META-INF and is never merged), so a missing entry here means an unserved route.
+        val served = openapiUrl.openStream().bufferedReader().use { it.readText() }
+
+        assertThat(served).contains("/api/v1/statements/{accountId}/{currency}/restate")
+        // Known-positive for this assertion: an endpoint that has always been served.
+        assertThat(served).contains("/api/v1/statements/{accountId}/close")
+    }
+}


### PR DESCRIPTION
## What this is

The statement `SUPERSEDED` write path — issue #1302 item 5. Item 5 was the last unbuilt half of that item's first sentence; the byte-identity half of item 5 (`render()` re-queries live data) is **not** addressed here and is called out below.

## What happens today when a closed period must be restated

**Nothing happens — there is no path at all.** This was the question that decided the shape of the work, so it is worth being exact about the three independent layers that each said no:

1. **No entry point.** `git grep 'PeriodCloseStatus.SUPERSEDED'` returns 0 hits fleet-wide (validated against the known positive `PeriodCloseStatus.CLOSED`, which returns hits in `StatementService`, the repository, the simulation scenario and a test). The enum value, `supersedesSequence`, the ER diagram, the lifecycle diagram, both language docs, the published `openapi.yaml` and `customer-edge`'s spec all describe the mechanism. Nothing ever wrote it.
2. **The close path swallows the correction.** `StatementService.closePocket` finds the existing record and returns it through the idempotency branch — so re-running the close after the underlying data is corrected answers `200` with the **stale figures**, and looks like a successful run.
3. **The schema forbade it.** `ux_statement_period_window` (V1) is UNIQUE on `(account_id, pocket_currency, period_from, period_to)`, so a superseding close for the same window is a duplicate-key violation. ADR-0035 §D was not implementable without a migration.

So the fix is to build the path, not to correct one that writes the wrong status. The only remediation available before this PR was hand-written SQL against a legal record.

## What was built

- **`V6__statement_period_restatement.sql`** — replaces the strict window index with a partial unique index on `status <> 'SUPERSEDED'`: at most one *standing* close per window. Superseded rows are retained and stay renderable by their own legal sequence for the full retention. Rollback note in the file, including why the rollback is only possible once superseded rows are removed.
- **`StatementRestatementService`** (new use case, split out of `StatementService` — which was already at detekt's `TooManyFunctions` ceiling). It re-reads booked entries + balance-service's closing balance, reconciles **fail-closed on exactly the same terms as a first close**, and writes the superseding close plus flips the prior record **in one transaction**.
- **`POST /api/v1/statements/{accountId}/{currency}/restate`** — `ROLE_OPERATOR`/`ROLE_ADMIN` only (deliberately not `ROLE_API`: a restatement is an operator action, not something an automated caller should reach). `openapi.yaml` `info.version` 1.0.0 → **1.1.0** (additive), re-read off live `main` immediately before pushing.
- **`account.statement.period.restated.v1`** — a new event type, not a widened `period.closed`. A consumer of `period.closed` keeps its contract; anything that must react to a correction opts in.

Three behaviours that are decisions, not accidents:

| case | behaviour |
| --- | --- |
| recomputed figures identical | returns the standing record, **burns no legal sequence** |
| restatement cannot itself reconcile | `409`, standing close left **untouched** |
| window was never closed | `404` — a restatement never mints a first close |

**Query filters that are part of the fix, not incidental:** `findByPeriod` and `priorClosing` now exclude `SUPERSEDED`. Both rows share `periodTo`, so an unfiltered "latest prior close" picks between them non-deterministically — opening the next period on a balance the bank has already retracted, propagating the error forward forever. There is a dedicated IT for exactly this.

Money arithmetic is `BigDecimal` end to end. The no-op check compares with `compareTo`, never `equals`, so `1075.00` and `1075.0000` are one amount.

## Traps this had to clear

- **`persist()` on an application-assigned `@Id` is INSERT-only.** The status flip loads the row **managed** via `s.find(...)` and mutates it, so Hibernate issues an UPDATE on flush. Routing it through `persist()` would schedule an INSERT and fail with the same duplicate-key error that 500'd every consent-service lifecycle transition. Commented in place.
- **The flip happens *before* the replacement is inserted** — both rows share the window and the partial index admits only one non-superseded row.
- **`audit_entries` is append-only at the DB** (a rule that discards UPDATEs silently). This path writes **no** audit rows: statement-service has no audit writer, and the record of the correction is the retained superseded row plus the outbox event. Nothing here relies on updating an existing audit row, which is the case that would have been silently discarded.
- **A unit test that calls a resource class cannot tell a served route from an unserved one** (the `McpEndpoint` 404 defect). One IT asks the **running app** what it registered via `/q/openapi` — which Quarkus generates from the scanned JAX-RS annotations, not from the committed `openapi.yaml` (that file is outside `META-INF` and is never merged). Includes a known-positive assertion on an endpoint that has always been served.
- Migration number chosen by listing the directory sorted numerically and re-checked against live `main` immediately before pushing (V1–V5 present; V6 free).
- No `ZoneId` / date-zone work was introduced, so the `AccountingClock` gate is not engaged.

## RED first — the actual output

The IT was run against the **pre-V6 schema** (V6 moved aside, everything else in place). All three DB tests failed with the exact expected cause:

```
org.hibernate.exception.ConstraintViolationException: error executing SQL statement
  [ERROR: duplicate key value violates unique constraint "ux_statement_period_window" (23505)]
  [insert into statement_period (...) values ...]
```

That is the known-positive for the migration half. A second, independent falsification for the assertion half: mutating `supersedesSequence = standing.legalSequenceNumber` to `null` in the write path turns the unit test red (`Expecting actual not to be null`) while the other 9 stay green.

Green after: **67 tests, 0 failures**, plus `detekt`, `ktlintCheck`, `koverVerify` and `quarkusBuild` (CDI wiring — the new bean resolves).

Restatement figures are asserted, not just the status: `1000.00 + 100.00 − 25.00 = 1075.00` over 2 entries replacing a stale `1100.00` over 1, with sequence 3 → 4 and `supersedesSequence = 3`. The DB assertions read the rows back with **plain JDBC**, not through the repository or mapper, so a query-filter or mapper mistake cannot hide the persisted truth from the assertion.

## Self-evaluation — what I did NOT verify, and what this does not do

- **Could the tests pass against the old code?** The unit tests could not even compile against `main` (the use case does not exist), so their redness is not evidence of anything; the load-bearing falsification is the IT against the pre-V6 schema, which is real and quoted above. The `/q/openapi` routing test is the one I am least able to falsify cheaply — I confirmed it *passes* with the annotation present and that the path is genuinely absent from the served document's path list before, but I did not run a build with the annotation deliberately detached.
- **Periods already closed are untouched.** V6 only changes indexes; no row is rewritten and no `status` value changes at deploy time. Every existing record stays `CLOSED` and remains the standing close for its window. The new endpoint is opt-in per period. Nothing back-fills or re-examines history — a period that was closed on wrong data stays wrong until an operator restates it, and **nothing in this PR detects that condition**. Deciding *when* a restatement is owed is not built here.
- **No end-to-end HTTP test of the restate endpoint with auth.** The route's registration is proved; its authz behaviour is covered only by the existing reflection-based `StatementSecurityTest` (no endpoint is `@PermitAll`) and not by a live `@TestSecurity` call. The `@Authorize(action = "statement.restate")` action name is **new and has no rego rule**; with `AUTHZ_ENFORCE` off today that is inert, and it will need a policy entry before enforcement is flipped on. I did not add one.
- **The `render()` byte-identity half of item 5 is untouched.** `render()` still re-queries live booked entries at request time, so a re-render of a closed period is still not guaranteed byte-identical — a late-completed entry inside a closed window can still silently change a legal document. Restatement does not fix that; if anything it makes the gap sharper, since there is now a sanctioned way to change the *record* and still no way to freeze the *entries*. Worth its own issue.
- **No concurrency test** on two restatements racing the same window. The partial unique index should serialise them into one winner and one constraint violation, but I did not prove it.
- **Not deployed and not exercised against a real cluster.** No migration has been applied anywhere.
- `openbank-statement-service` is **not** in `rules.yaml: money_path_services` and has no `docs/threat-models/` entry, so the 2-approval + threat-model rule does not mechanically apply. Given this changes how a legal accounting record can be rewritten, it should get human review regardless. **This PR is not expected to self-merge, and that is the correct outcome.**

## Item 4 (FX staleness) is deliberately NOT in this PR

Measured, not assumed — see the separate issue. It is a different service pair (ledger + fx), a different failure mode, and the fix is not additive. Headline measurements:

- `FxRevaluationService`'s port is `suspend fun cnbRate(base: String): BigDecimal?` — **no date, no timestamp**. `FxRateResponse` in `FxServiceClient` deserialises only `baseCurrency/quoteCurrency/bidRate/askRate`, so fx-service's `validFrom`/`validTo` are on the wire and **discarded by ledger before any staleness check could be made**.
- The only bound is server-side and date-blind: `CNB_VALIDITY_DAYS = 3`. Within that window a Friday fixing is used silently for a Monday revaluation. Beyond it the rate is `null` and the leg is skipped — the `posted = false` shape from the ČNB-404 history.
- Idempotency key is `fx-reval-{date}`: date only, no rate identity. A fixing that arrives late for an already-revalued day **can never be incorporated** — re-running returns the original journal entry and reports `posted = true`, a success that changed nothing.
- Backfill always uses the **latest** rate, not the target date's, because `cnbRate(base)` ignores `command.date`.
- **No FX-rate age/freshness metric or alert exists anywhere.** The nearest rule, `FxRevaluationSkippedAllLegs`, matches a log line emitted by **ledger** with a `{namespace="fx"}` selector while the ledger workload deploys to namespace `ledger` — so on the committed evidence it cannot match. I verified that selector and the ledger namespace by hand; I did **not** verify the live Loki label set, so treat it as a strong signal, not proof.
- 2 tests touch `FxRevaluationService`; both stub the rate as a bare value or `null`. **Staleness is untestable at that seam** — which is exactly why adding a test there without first widening the port would be the vacuous kind.

Refs #1302
