### PR TITLE
fix(observability): set alerting.absent=false on the four new standing-order/psd2 SLOs

### DIFF
--- a/openbank-infra/gitops/components/observability/pyrra-slo-money-path.yaml
+++ b/openbank-infra/gitops/components/observability/pyrra-slo-money-path.yaml
@@ -1060,6 +1060,8 @@ metadata:
 spec:
   target: "99.9"
   window: 30d
+  alerting:
+    absent: false
   description: "openbank-standing-order-service availability — non-error span ratio (issue #669, rules.yaml: slo.availability_target)."
   indicator:
     ratio:
@@ -1082,6 +1084,8 @@ metadata:
 spec:
   target: "99"
   window: 30d
+  alerting:
+    absent: false
   description: "openbank-standing-order-service latency — share of requests faster than 1s (issue #669, rules.yaml: slo.latency_threshold_seconds)."
   indicator:
     latency:
@@ -1104,6 +1108,8 @@ metadata:
 spec:
   target: "99.9"
   window: 30d
+  alerting:
+    absent: false
   description: "openbank-psd2-service availability — non-error span ratio (issue #669, rules.yaml: slo.availability_target)."
   indicator:
     ratio:
@@ -1126,6 +1132,8 @@ metadata:
 spec:
   target: "99"
   window: 30d
+  alerting:
+    absent: false
   description: "openbank-psd2-service latency — share of requests faster than 1s (issue #669, rules.yaml: slo.latency_threshold_seconds)."
   indicator:
     latency:


### PR DESCRIPTION
## `main` is red, and this unblocks it

`slo-registry-consistency` is failing on `origin/main` at `389f5ff73`. Reproduced on a clean
detached checkout of `origin/main`, so it is repo state, not a branch artifact:

```
SLO registry consistency gate (issue #669, rules.yaml: slo)
  money-path services: 23
  SLO objects found:   46  (expected 46)
  VIOLATIONS:
    - openbank-standing-order-availability: spec.alerting.absent must be explicitly false (issue #3333)
    - openbank-standing-order-latency:      spec.alerting.absent must be explicitly false (issue #3333)
    - openbank-psd2-availability:           spec.alerting.absent must be explicitly false (issue #3333)
    - openbank-psd2-latency:                spec.alerting.absent must be explicitly false (issue #3333)
```

The gate is `mode: enforced` in the `registry` shard, and that shard aggregates into
**`Validate manifests`** — one of the five required contexts. So every open PR in the repo is
currently unable to satisfy a required check, regardless of its own content. Found while watching
#3932, which is blocked by this and nothing else.

## Cause

#3688 classified `openbank-standing-order-service` and `openbank-psd2-service` as money-path and
correctly landed the three things that classification pulls in — `rules.yaml`, the threat model, and
an availability + latency SLO pair per service. The four new SLO objects were written without
`alerting.absent: false`, which `check-slo-registry.py` requires on every money-path SLO. The object
count is right (46 = 23 x 2); only the flag is missing.

## Why the flag, and why it is not a coverage downgrade

The file's own header block already states it, from #3795: Pyrra defaults `absent` to **true**, which
emits a critical `SLOMetricAbsent` on `absent(<span-metric>)`. An **idle** service satisfies that
condition permanently, because Tempo span-metrics only exist while traffic flows — so the default
produces a resting critical alert rather than a signal. Liveness for these services is carried by the
`up == 0` rules in `prometheus-rules-tier1.yaml`. Burn-rate alerting is untouched: a real SLO breach
still pages.

## Diff

Four insertions of the same two lines, after `window: 30d`, matching the shape every other
money-path SLO object in the file already uses. No other change.

## Verification

- `run-gates.py --only slo-registry-consistency`: **FAIL on `origin/main` -> PASS on this branch**,
  with the same command in both trees.
- `run-gates.py --group registry`: 15 PASS / 1 WARN. The WARN is `operator-write-naming`, an
  **advisory** gate that is already failing on `main` for an unrelated `rest.rego` rule
  (`operator-mcp-session`) — it prints `::error` and exits 0, so it is not what reddens the shard.
  Untouched here.
- yamllint finding count on the file: **152 before, 152 after** — the insertion adds no new lint debt
  (the existing findings are long `description:` lines, all pre-existing).

Refs #669, #3333, #3688
