### PR TITLE
security(governance): promote shared_m2m_write_prohibition to a top-level key

### DIFF
--- a/.github/scripts/gen-rules-opa-data.py
+++ b/.github/scripts/gen-rules-opa-data.py
@@ -206,14 +206,12 @@ def build() -> tuple[str, list[str]]:
 #
 # So: today's one occurrence is declared with its reason and its issue, and anything NEW fails. A
 # declaration that becomes resolvable is reported too, so this cannot quietly become permanent.
-UNRESOLVABLE_DECLARED: dict[str, str] = {
-    "shared_m2m_write_prohibition": (
-        "nested under `change_requirements:` in rules.yaml, so it cannot be selected as a top-level "
-        "key. Promoting it is a POLICY DECISION, not an edit: 128 currently-reachable writes depend "
-        "on the very reasons the register names, so promotion denies live money-path callers. "
-        "Tracked in #3765/#3734 — remove this entry in the same change that promotes the key."
-    ),
-}
+# Emptied 2026-08-07: `shared_m2m_write_prohibition` was promoted to a top-level key in the same
+# change, so it is now selected into rules-opa-data.yaml and the declaration above it is history
+# rather than debt. The registry stays in place — a NEW referenced-but-unselectable key still
+# fails, and a declaration that becomes resolvable is still reported, which is what forced this
+# entry to be removed here rather than left to rot.
+UNRESOLVABLE_DECLARED: dict[str, str] = {}
 
 
 def report_missing(missing: list[str]) -> int:

--- a/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: account-service
     app.kubernetes.io/part-of: accounts
   annotations:
-    openbank.tech/policy-checksum: "bb5f1cb65aa5c2c3"
+    openbank.tech/policy-checksum: "6f67742d3aba3c74"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2048,5 +2048,52 @@ data:
             - lending.collateralDecide
             - lending.approval.read
             - lending.approval.decide
+
+    shared_m2m_write_prohibition:
+      # GHSA-58jq-9hq3-66jr. rest.rego denies the shared M2M identity
+      # (`service-account-openbank-services`, which carries ROLE_OPERATOR in the realm) when the
+      # ONLY reasons admitting it are the role-only write reasons listed here.
+      #
+      # OPT-IN, and the reason a name pattern was rejected: matching every `operator-*-write`
+      # would have 403'd transaction.create from six live callers (account-service's
+      # welcome-bonus credit, sepa-instant, domestic-payment, swift, interest, sdd) and
+      # settlement.create — both AUTHZ_ENFORCE=true money paths whose services have no
+      # identity-scoped rule to fall back on. transaction-service's rego states the exposure
+      # itself ("RESIDUAL RISK — shared identity, no per-caller narrowing"), which is precisely
+      # why removing its only path is not the fix.
+      #
+      # A reason joins this list once its service carries a rule that NAMES the caller and
+      # enumerates its actions, so denying the role-only path removes an over-grant rather than
+      # the only path. Each entry below was verified to have such a rule.
+      reasons:
+        - operator-consent-write        # service-consent-m2m + service-consent-m2m-marketing
+        - operator-ledger-write         # service-ledger-post / service-ledger-reverse
+        - operator-balance-write        # service-balance-m2m
+        - operator-fraud-write          # service-fraud-scoring
+        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
+        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m
+      # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
+      # adding it here before that is a money-path outage, not a test failure.
+      deferred:
+        operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
+        operator-settlement-write: "settlement.create is resourceless with no alternative rule"
+        operator-swift-write: "no identity-scoped rule; callers unverified"
+        operator-sepa-instant-write: "no identity-scoped rule; callers unverified"
+        operator-billing-write: "no identity-scoped rule; callers unverified"
+        operator-interest-write: "no identity-scoped rule; callers unverified"
+        operator-lending-write: "no identity-scoped rule; callers unverified"
+        operator-sanctions-write: "no identity-scoped rule; m2m-sanctions-screening covers create only"
+        operator-identity-write: "no identity-scoped rule; callers unverified"
+        operator-card-write: "no identity-scoped rule; callers unverified"
+        # These DO carry an identity-pinned rule, but "a rule exists" is not "the rule covers the
+        # actions the role-only path was serving". Listing them on that basis would repeat, one
+        # level down, the guess that made the first revision break transaction.create. Each needs
+        # its identity-scoped rule read against its real callers before it moves up.
+        operator-fx-write: "2 identity-pinned rules; action coverage vs real callers unverified"
+        operator-account-write: "2 identity-pinned rules; action coverage unverified"
+        operator-clearing-write: "1 identity-pinned rule; action coverage unverified"
+        operator-domestic-payment-write: "1 identity-pinned rule; action coverage unverified"
+        operator-party-write: "1 identity-pinned rule, but onboarding-service PUTs party.kyc-status via the shared client (latent: AUTHZ_ENFORCE=false there today)"
+      adr: ADR-0034
   manifest.json: |
     {"roots": ["openbank/agents", "openbank/copilot", "openbank/rest", "agents", "rules"]}

--- a/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: account-service
     app.kubernetes.io/part-of: accounts
   annotations:
-    openbank.tech/policy-checksum: "6f67742d3aba3c74"
+    openbank.tech/policy-checksum: "80f3715117ac96a2"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2070,11 +2070,21 @@ data:
         - operator-ledger-write         # service-ledger-post / service-ledger-reverse
         - operator-balance-write        # service-balance-m2m
         - operator-fraud-write          # service-fraud-scoring
-        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
-        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m
+        # SAFE TODAY ONLY BY CO-ADMISSION, not by the rule named here: that rule covers
+        # sepaPayment.handleReturn alone, but ROLE_OPERATOR also grants sepaPayment.create /
+        # .transitionStatus / .approval.decide, so `matrix-allows` co-admits and this reason
+        # never becomes the only one. standing-order POSTs sepaPayment.create via the shared
+        # client. When ADR-0223 D2(b) retires those matrix grants, this entry starts denying it.
+        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m (see note above)
       # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
       # adding it here before that is a money-path outage, not a test failure.
       deferred:
+        operator-sca-write: "service-sca-shared-client-m2m covers scaChallenge.read ONLY, while
+          sca-service exposes consume/decide/initiate/verify and device.enroll. document-service
+          calls POST /challenges/{id}/consume through the shared client (ScaChallengeClient carries
+          OidcClientRequestReactiveFilter with oidc-client.client-id openbank-services) and
+          sca-service runs AUTHZ_ENFORCE=true, so listing this reason 403s the document-signing
+          gate. Needs #3748 (scaChallenge.consume for the shared client) to land first."
         operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
         operator-settlement-write: "settlement.create is resourceless with no alternative rule"
         operator-swift-write: "no identity-scoped rule; callers unverified"

--- a/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: account-service
     app.kubernetes.io/part-of: accounts
   annotations:
-    openbank.tech/policy-checksum: "80f3715117ac96a2"
+    openbank.tech/policy-checksum: "d82f62f8a6a61090"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2076,15 +2076,16 @@ data:
         # never becomes the only one. standing-order POSTs sepaPayment.create via the shared
         # client. When ADR-0223 D2(b) retires those matrix grants, this entry starts denying it.
         - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m (see note above)
+        # Restored once #3748 landed: service-sca-shared-client-m2m now admits the shared client
+        # for scaChallenge.read AND scaChallenge.consume, so document-service's consume call
+        # (ScaChallengeClient, oidc-client.client-id openbank-services) keeps an identity-scoped
+        # reason and this entry no longer 403s the document-signing gate. device.list is covered
+        # by matrix-allows. Still uncovered for the shared client: decide/initiate/verify and
+        # device.enroll — no in-repo caller invokes them on that principal.
+        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
       # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
       # adding it here before that is a money-path outage, not a test failure.
       deferred:
-        operator-sca-write: "service-sca-shared-client-m2m covers scaChallenge.read ONLY, while
-          sca-service exposes consume/decide/initiate/verify and device.enroll. document-service
-          calls POST /challenges/{id}/consume through the shared client (ScaChallengeClient carries
-          OidcClientRequestReactiveFilter with oidc-client.client-id openbank-services) and
-          sca-service runs AUTHZ_ENFORCE=true, so listing this reason 403s the document-signing
-          gate. Needs #3748 (scaChallenge.consume for the shared client) to land first."
         operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
         operator-settlement-write: "settlement.create is resourceless with no alternative rule"
         operator-swift-write: "no identity-scoped rule; callers unverified"

--- a/openbank-infra/gitops/components/accounts/account-service.yaml
+++ b/openbank-infra/gitops/components/accounts/account-service.yaml
@@ -37,7 +37,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-account-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "80f3715117ac96a2"
+        openbank.tech/policy-checksum: "d82f62f8a6a61090"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/accounts/account-service.yaml
+++ b/openbank-infra/gitops/components/accounts/account-service.yaml
@@ -37,7 +37,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-account-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "6f67742d3aba3c74"
+        openbank.tech/policy-checksum: "80f3715117ac96a2"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/accounts/account-service.yaml
+++ b/openbank-infra/gitops/components/accounts/account-service.yaml
@@ -37,7 +37,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-account-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "bb5f1cb65aa5c2c3"
+        openbank.tech/policy-checksum: "6f67742d3aba3c74"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/aml/aml-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/aml/aml-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: aml-service
     app.kubernetes.io/part-of: aml
   annotations:
-    openbank.tech/policy-checksum: "7fb87b986a717ebb"
+    openbank.tech/policy-checksum: "9bec374f836b0728"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2043,11 +2043,21 @@ data:
         - operator-ledger-write         # service-ledger-post / service-ledger-reverse
         - operator-balance-write        # service-balance-m2m
         - operator-fraud-write          # service-fraud-scoring
-        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
-        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m
+        # SAFE TODAY ONLY BY CO-ADMISSION, not by the rule named here: that rule covers
+        # sepaPayment.handleReturn alone, but ROLE_OPERATOR also grants sepaPayment.create /
+        # .transitionStatus / .approval.decide, so `matrix-allows` co-admits and this reason
+        # never becomes the only one. standing-order POSTs sepaPayment.create via the shared
+        # client. When ADR-0223 D2(b) retires those matrix grants, this entry starts denying it.
+        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m (see note above)
       # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
       # adding it here before that is a money-path outage, not a test failure.
       deferred:
+        operator-sca-write: "service-sca-shared-client-m2m covers scaChallenge.read ONLY, while
+          sca-service exposes consume/decide/initiate/verify and device.enroll. document-service
+          calls POST /challenges/{id}/consume through the shared client (ScaChallengeClient carries
+          OidcClientRequestReactiveFilter with oidc-client.client-id openbank-services) and
+          sca-service runs AUTHZ_ENFORCE=true, so listing this reason 403s the document-signing
+          gate. Needs #3748 (scaChallenge.consume for the shared client) to land first."
         operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
         operator-settlement-write: "settlement.create is resourceless with no alternative rule"
         operator-swift-write: "no identity-scoped rule; callers unverified"

--- a/openbank-infra/gitops/components/aml/aml-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/aml/aml-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: aml-service
     app.kubernetes.io/part-of: aml
   annotations:
-    openbank.tech/policy-checksum: "e1f32675cb5bb7cb"
+    openbank.tech/policy-checksum: "7fb87b986a717ebb"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2021,5 +2021,52 @@ data:
             - lending.collateralDecide
             - lending.approval.read
             - lending.approval.decide
+
+    shared_m2m_write_prohibition:
+      # GHSA-58jq-9hq3-66jr. rest.rego denies the shared M2M identity
+      # (`service-account-openbank-services`, which carries ROLE_OPERATOR in the realm) when the
+      # ONLY reasons admitting it are the role-only write reasons listed here.
+      #
+      # OPT-IN, and the reason a name pattern was rejected: matching every `operator-*-write`
+      # would have 403'd transaction.create from six live callers (account-service's
+      # welcome-bonus credit, sepa-instant, domestic-payment, swift, interest, sdd) and
+      # settlement.create — both AUTHZ_ENFORCE=true money paths whose services have no
+      # identity-scoped rule to fall back on. transaction-service's rego states the exposure
+      # itself ("RESIDUAL RISK — shared identity, no per-caller narrowing"), which is precisely
+      # why removing its only path is not the fix.
+      #
+      # A reason joins this list once its service carries a rule that NAMES the caller and
+      # enumerates its actions, so denying the role-only path removes an over-grant rather than
+      # the only path. Each entry below was verified to have such a rule.
+      reasons:
+        - operator-consent-write        # service-consent-m2m + service-consent-m2m-marketing
+        - operator-ledger-write         # service-ledger-post / service-ledger-reverse
+        - operator-balance-write        # service-balance-m2m
+        - operator-fraud-write          # service-fraud-scoring
+        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
+        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m
+      # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
+      # adding it here before that is a money-path outage, not a test failure.
+      deferred:
+        operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
+        operator-settlement-write: "settlement.create is resourceless with no alternative rule"
+        operator-swift-write: "no identity-scoped rule; callers unverified"
+        operator-sepa-instant-write: "no identity-scoped rule; callers unverified"
+        operator-billing-write: "no identity-scoped rule; callers unverified"
+        operator-interest-write: "no identity-scoped rule; callers unverified"
+        operator-lending-write: "no identity-scoped rule; callers unverified"
+        operator-sanctions-write: "no identity-scoped rule; m2m-sanctions-screening covers create only"
+        operator-identity-write: "no identity-scoped rule; callers unverified"
+        operator-card-write: "no identity-scoped rule; callers unverified"
+        # These DO carry an identity-pinned rule, but "a rule exists" is not "the rule covers the
+        # actions the role-only path was serving". Listing them on that basis would repeat, one
+        # level down, the guess that made the first revision break transaction.create. Each needs
+        # its identity-scoped rule read against its real callers before it moves up.
+        operator-fx-write: "2 identity-pinned rules; action coverage vs real callers unverified"
+        operator-account-write: "2 identity-pinned rules; action coverage unverified"
+        operator-clearing-write: "1 identity-pinned rule; action coverage unverified"
+        operator-domestic-payment-write: "1 identity-pinned rule; action coverage unverified"
+        operator-party-write: "1 identity-pinned rule, but onboarding-service PUTs party.kyc-status via the shared client (latent: AUTHZ_ENFORCE=false there today)"
+      adr: ADR-0034
   manifest.json: |
     {"roots": ["openbank/agents", "openbank/copilot", "openbank/rest", "agents", "rules"]}

--- a/openbank-infra/gitops/components/aml/aml-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/aml/aml-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: aml-service
     app.kubernetes.io/part-of: aml
   annotations:
-    openbank.tech/policy-checksum: "9bec374f836b0728"
+    openbank.tech/policy-checksum: "cf4821f6fd8dec68"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2049,15 +2049,16 @@ data:
         # never becomes the only one. standing-order POSTs sepaPayment.create via the shared
         # client. When ADR-0223 D2(b) retires those matrix grants, this entry starts denying it.
         - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m (see note above)
+        # Restored once #3748 landed: service-sca-shared-client-m2m now admits the shared client
+        # for scaChallenge.read AND scaChallenge.consume, so document-service's consume call
+        # (ScaChallengeClient, oidc-client.client-id openbank-services) keeps an identity-scoped
+        # reason and this entry no longer 403s the document-signing gate. device.list is covered
+        # by matrix-allows. Still uncovered for the shared client: decide/initiate/verify and
+        # device.enroll — no in-repo caller invokes them on that principal.
+        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
       # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
       # adding it here before that is a money-path outage, not a test failure.
       deferred:
-        operator-sca-write: "service-sca-shared-client-m2m covers scaChallenge.read ONLY, while
-          sca-service exposes consume/decide/initiate/verify and device.enroll. document-service
-          calls POST /challenges/{id}/consume through the shared client (ScaChallengeClient carries
-          OidcClientRequestReactiveFilter with oidc-client.client-id openbank-services) and
-          sca-service runs AUTHZ_ENFORCE=true, so listing this reason 403s the document-signing
-          gate. Needs #3748 (scaChallenge.consume for the shared client) to land first."
         operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
         operator-settlement-write: "settlement.create is resourceless with no alternative rule"
         operator-swift-write: "no identity-scoped rule; callers unverified"

--- a/openbank-infra/gitops/components/aml/aml-service.yaml
+++ b/openbank-infra/gitops/components/aml/aml-service.yaml
@@ -31,7 +31,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-aml-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "e1f32675cb5bb7cb"
+        openbank.tech/policy-checksum: "7fb87b986a717ebb"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/aml/aml-service.yaml
+++ b/openbank-infra/gitops/components/aml/aml-service.yaml
@@ -31,7 +31,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-aml-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "7fb87b986a717ebb"
+        openbank.tech/policy-checksum: "9bec374f836b0728"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/aml/aml-service.yaml
+++ b/openbank-infra/gitops/components/aml/aml-service.yaml
@@ -31,7 +31,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-aml-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "9bec374f836b0728"
+        openbank.tech/policy-checksum: "cf4821f6fd8dec68"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: anacredit-service
     app.kubernetes.io/part-of: anacredit
   annotations:
-    openbank.tech/policy-checksum: "f9856a010df6ef54"
+    openbank.tech/policy-checksum: "0bad21e7a390cdb2"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2019,15 +2019,16 @@ data:
         # never becomes the only one. standing-order POSTs sepaPayment.create via the shared
         # client. When ADR-0223 D2(b) retires those matrix grants, this entry starts denying it.
         - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m (see note above)
+        # Restored once #3748 landed: service-sca-shared-client-m2m now admits the shared client
+        # for scaChallenge.read AND scaChallenge.consume, so document-service's consume call
+        # (ScaChallengeClient, oidc-client.client-id openbank-services) keeps an identity-scoped
+        # reason and this entry no longer 403s the document-signing gate. device.list is covered
+        # by matrix-allows. Still uncovered for the shared client: decide/initiate/verify and
+        # device.enroll — no in-repo caller invokes them on that principal.
+        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
       # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
       # adding it here before that is a money-path outage, not a test failure.
       deferred:
-        operator-sca-write: "service-sca-shared-client-m2m covers scaChallenge.read ONLY, while
-          sca-service exposes consume/decide/initiate/verify and device.enroll. document-service
-          calls POST /challenges/{id}/consume through the shared client (ScaChallengeClient carries
-          OidcClientRequestReactiveFilter with oidc-client.client-id openbank-services) and
-          sca-service runs AUTHZ_ENFORCE=true, so listing this reason 403s the document-signing
-          gate. Needs #3748 (scaChallenge.consume for the shared client) to land first."
         operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
         operator-settlement-write: "settlement.create is resourceless with no alternative rule"
         operator-swift-write: "no identity-scoped rule; callers unverified"

--- a/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: anacredit-service
     app.kubernetes.io/part-of: anacredit
   annotations:
-    openbank.tech/policy-checksum: "be05f1daa4c0f1ae"
+    openbank.tech/policy-checksum: "b0c92ca56859a8cb"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1991,5 +1991,52 @@ data:
             - lending.collateralDecide
             - lending.approval.read
             - lending.approval.decide
+
+    shared_m2m_write_prohibition:
+      # GHSA-58jq-9hq3-66jr. rest.rego denies the shared M2M identity
+      # (`service-account-openbank-services`, which carries ROLE_OPERATOR in the realm) when the
+      # ONLY reasons admitting it are the role-only write reasons listed here.
+      #
+      # OPT-IN, and the reason a name pattern was rejected: matching every `operator-*-write`
+      # would have 403'd transaction.create from six live callers (account-service's
+      # welcome-bonus credit, sepa-instant, domestic-payment, swift, interest, sdd) and
+      # settlement.create — both AUTHZ_ENFORCE=true money paths whose services have no
+      # identity-scoped rule to fall back on. transaction-service's rego states the exposure
+      # itself ("RESIDUAL RISK — shared identity, no per-caller narrowing"), which is precisely
+      # why removing its only path is not the fix.
+      #
+      # A reason joins this list once its service carries a rule that NAMES the caller and
+      # enumerates its actions, so denying the role-only path removes an over-grant rather than
+      # the only path. Each entry below was verified to have such a rule.
+      reasons:
+        - operator-consent-write        # service-consent-m2m + service-consent-m2m-marketing
+        - operator-ledger-write         # service-ledger-post / service-ledger-reverse
+        - operator-balance-write        # service-balance-m2m
+        - operator-fraud-write          # service-fraud-scoring
+        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
+        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m
+      # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
+      # adding it here before that is a money-path outage, not a test failure.
+      deferred:
+        operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
+        operator-settlement-write: "settlement.create is resourceless with no alternative rule"
+        operator-swift-write: "no identity-scoped rule; callers unverified"
+        operator-sepa-instant-write: "no identity-scoped rule; callers unverified"
+        operator-billing-write: "no identity-scoped rule; callers unverified"
+        operator-interest-write: "no identity-scoped rule; callers unverified"
+        operator-lending-write: "no identity-scoped rule; callers unverified"
+        operator-sanctions-write: "no identity-scoped rule; m2m-sanctions-screening covers create only"
+        operator-identity-write: "no identity-scoped rule; callers unverified"
+        operator-card-write: "no identity-scoped rule; callers unverified"
+        # These DO carry an identity-pinned rule, but "a rule exists" is not "the rule covers the
+        # actions the role-only path was serving". Listing them on that basis would repeat, one
+        # level down, the guess that made the first revision break transaction.create. Each needs
+        # its identity-scoped rule read against its real callers before it moves up.
+        operator-fx-write: "2 identity-pinned rules; action coverage vs real callers unverified"
+        operator-account-write: "2 identity-pinned rules; action coverage unverified"
+        operator-clearing-write: "1 identity-pinned rule; action coverage unverified"
+        operator-domestic-payment-write: "1 identity-pinned rule; action coverage unverified"
+        operator-party-write: "1 identity-pinned rule, but onboarding-service PUTs party.kyc-status via the shared client (latent: AUTHZ_ENFORCE=false there today)"
+      adr: ADR-0034
   manifest.json: |
     {"roots": ["openbank/agents", "openbank/copilot", "openbank/rest", "agents", "rules"]}

--- a/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: anacredit-service
     app.kubernetes.io/part-of: anacredit
   annotations:
-    openbank.tech/policy-checksum: "b0c92ca56859a8cb"
+    openbank.tech/policy-checksum: "f9856a010df6ef54"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2013,11 +2013,21 @@ data:
         - operator-ledger-write         # service-ledger-post / service-ledger-reverse
         - operator-balance-write        # service-balance-m2m
         - operator-fraud-write          # service-fraud-scoring
-        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
-        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m
+        # SAFE TODAY ONLY BY CO-ADMISSION, not by the rule named here: that rule covers
+        # sepaPayment.handleReturn alone, but ROLE_OPERATOR also grants sepaPayment.create /
+        # .transitionStatus / .approval.decide, so `matrix-allows` co-admits and this reason
+        # never becomes the only one. standing-order POSTs sepaPayment.create via the shared
+        # client. When ADR-0223 D2(b) retires those matrix grants, this entry starts denying it.
+        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m (see note above)
       # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
       # adding it here before that is a money-path outage, not a test failure.
       deferred:
+        operator-sca-write: "service-sca-shared-client-m2m covers scaChallenge.read ONLY, while
+          sca-service exposes consume/decide/initiate/verify and device.enroll. document-service
+          calls POST /challenges/{id}/consume through the shared client (ScaChallengeClient carries
+          OidcClientRequestReactiveFilter with oidc-client.client-id openbank-services) and
+          sca-service runs AUTHZ_ENFORCE=true, so listing this reason 403s the document-signing
+          gate. Needs #3748 (scaChallenge.consume for the shared client) to land first."
         operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
         operator-settlement-write: "settlement.create is resourceless with no alternative rule"
         operator-swift-write: "no identity-scoped rule; callers unverified"

--- a/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
@@ -42,7 +42,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-anacredit-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "f9856a010df6ef54"
+        openbank.tech/policy-checksum: "0bad21e7a390cdb2"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
@@ -42,7 +42,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-anacredit-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "b0c92ca56859a8cb"
+        openbank.tech/policy-checksum: "f9856a010df6ef54"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
@@ -42,7 +42,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-anacredit-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "be05f1daa4c0f1ae"
+        openbank.tech/policy-checksum: "b0c92ca56859a8cb"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/ap2/ap2-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/ap2/ap2-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: mcp-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "39e046dcedf7cddf"
+    openbank.tech/policy-checksum: "b2647a2bbbc7d423"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1981,11 +1981,21 @@ data:
         - operator-ledger-write         # service-ledger-post / service-ledger-reverse
         - operator-balance-write        # service-balance-m2m
         - operator-fraud-write          # service-fraud-scoring
-        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
-        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m
+        # SAFE TODAY ONLY BY CO-ADMISSION, not by the rule named here: that rule covers
+        # sepaPayment.handleReturn alone, but ROLE_OPERATOR also grants sepaPayment.create /
+        # .transitionStatus / .approval.decide, so `matrix-allows` co-admits and this reason
+        # never becomes the only one. standing-order POSTs sepaPayment.create via the shared
+        # client. When ADR-0223 D2(b) retires those matrix grants, this entry starts denying it.
+        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m (see note above)
       # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
       # adding it here before that is a money-path outage, not a test failure.
       deferred:
+        operator-sca-write: "service-sca-shared-client-m2m covers scaChallenge.read ONLY, while
+          sca-service exposes consume/decide/initiate/verify and device.enroll. document-service
+          calls POST /challenges/{id}/consume through the shared client (ScaChallengeClient carries
+          OidcClientRequestReactiveFilter with oidc-client.client-id openbank-services) and
+          sca-service runs AUTHZ_ENFORCE=true, so listing this reason 403s the document-signing
+          gate. Needs #3748 (scaChallenge.consume for the shared client) to land first."
         operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
         operator-settlement-write: "settlement.create is resourceless with no alternative rule"
         operator-swift-write: "no identity-scoped rule; callers unverified"

--- a/openbank-infra/gitops/components/ap2/ap2-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/ap2/ap2-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: mcp-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "b2647a2bbbc7d423"
+    openbank.tech/policy-checksum: "495f4aaec4237b8f"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1987,15 +1987,16 @@ data:
         # never becomes the only one. standing-order POSTs sepaPayment.create via the shared
         # client. When ADR-0223 D2(b) retires those matrix grants, this entry starts denying it.
         - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m (see note above)
+        # Restored once #3748 landed: service-sca-shared-client-m2m now admits the shared client
+        # for scaChallenge.read AND scaChallenge.consume, so document-service's consume call
+        # (ScaChallengeClient, oidc-client.client-id openbank-services) keeps an identity-scoped
+        # reason and this entry no longer 403s the document-signing gate. device.list is covered
+        # by matrix-allows. Still uncovered for the shared client: decide/initiate/verify and
+        # device.enroll — no in-repo caller invokes them on that principal.
+        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
       # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
       # adding it here before that is a money-path outage, not a test failure.
       deferred:
-        operator-sca-write: "service-sca-shared-client-m2m covers scaChallenge.read ONLY, while
-          sca-service exposes consume/decide/initiate/verify and device.enroll. document-service
-          calls POST /challenges/{id}/consume through the shared client (ScaChallengeClient carries
-          OidcClientRequestReactiveFilter with oidc-client.client-id openbank-services) and
-          sca-service runs AUTHZ_ENFORCE=true, so listing this reason 403s the document-signing
-          gate. Needs #3748 (scaChallenge.consume for the shared client) to land first."
         operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
         operator-settlement-write: "settlement.create is resourceless with no alternative rule"
         operator-swift-write: "no identity-scoped rule; callers unverified"

--- a/openbank-infra/gitops/components/ap2/ap2-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/ap2/ap2-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: mcp-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "899d182785c99f54"
+    openbank.tech/policy-checksum: "39e046dcedf7cddf"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1959,5 +1959,52 @@ data:
             - lending.collateralDecide
             - lending.approval.read
             - lending.approval.decide
+
+    shared_m2m_write_prohibition:
+      # GHSA-58jq-9hq3-66jr. rest.rego denies the shared M2M identity
+      # (`service-account-openbank-services`, which carries ROLE_OPERATOR in the realm) when the
+      # ONLY reasons admitting it are the role-only write reasons listed here.
+      #
+      # OPT-IN, and the reason a name pattern was rejected: matching every `operator-*-write`
+      # would have 403'd transaction.create from six live callers (account-service's
+      # welcome-bonus credit, sepa-instant, domestic-payment, swift, interest, sdd) and
+      # settlement.create — both AUTHZ_ENFORCE=true money paths whose services have no
+      # identity-scoped rule to fall back on. transaction-service's rego states the exposure
+      # itself ("RESIDUAL RISK — shared identity, no per-caller narrowing"), which is precisely
+      # why removing its only path is not the fix.
+      #
+      # A reason joins this list once its service carries a rule that NAMES the caller and
+      # enumerates its actions, so denying the role-only path removes an over-grant rather than
+      # the only path. Each entry below was verified to have such a rule.
+      reasons:
+        - operator-consent-write        # service-consent-m2m + service-consent-m2m-marketing
+        - operator-ledger-write         # service-ledger-post / service-ledger-reverse
+        - operator-balance-write        # service-balance-m2m
+        - operator-fraud-write          # service-fraud-scoring
+        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
+        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m
+      # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
+      # adding it here before that is a money-path outage, not a test failure.
+      deferred:
+        operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
+        operator-settlement-write: "settlement.create is resourceless with no alternative rule"
+        operator-swift-write: "no identity-scoped rule; callers unverified"
+        operator-sepa-instant-write: "no identity-scoped rule; callers unverified"
+        operator-billing-write: "no identity-scoped rule; callers unverified"
+        operator-interest-write: "no identity-scoped rule; callers unverified"
+        operator-lending-write: "no identity-scoped rule; callers unverified"
+        operator-sanctions-write: "no identity-scoped rule; m2m-sanctions-screening covers create only"
+        operator-identity-write: "no identity-scoped rule; callers unverified"
+        operator-card-write: "no identity-scoped rule; callers unverified"
+        # These DO carry an identity-pinned rule, but "a rule exists" is not "the rule covers the
+        # actions the role-only path was serving". Listing them on that basis would repeat, one
+        # level down, the guess that made the first revision break transaction.create. Each needs
+        # its identity-scoped rule read against its real callers before it moves up.
+        operator-fx-write: "2 identity-pinned rules; action coverage vs real callers unverified"
+        operator-account-write: "2 identity-pinned rules; action coverage unverified"
+        operator-clearing-write: "1 identity-pinned rule; action coverage unverified"
+        operator-domestic-payment-write: "1 identity-pinned rule; action coverage unverified"
+        operator-party-write: "1 identity-pinned rule, but onboarding-service PUTs party.kyc-status via the shared client (latent: AUTHZ_ENFORCE=false there today)"
+      adr: ADR-0034
   manifest.json: |
     {"roots": ["openbank/agents", "openbank/copilot", "openbank/rest", "agents", "rules"]}

--- a/openbank-infra/gitops/components/ap2/ap2-service.yaml
+++ b/openbank-infra/gitops/components/ap2/ap2-service.yaml
@@ -39,7 +39,7 @@ spec:
       annotations:
         # Roll the pod when the OPA policy bundle changes (subPath mounts don't hot-reload).
         # Kept in sync by gen-ap2-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "899d182785c99f54"
+        openbank.tech/policy-checksum: "39e046dcedf7cddf"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/ap2/ap2-service.yaml
+++ b/openbank-infra/gitops/components/ap2/ap2-service.yaml
@@ -39,7 +39,7 @@ spec:
       annotations:
         # Roll the pod when the OPA policy bundle changes (subPath mounts don't hot-reload).
         # Kept in sync by gen-ap2-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "39e046dcedf7cddf"
+        openbank.tech/policy-checksum: "b2647a2bbbc7d423"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/ap2/ap2-service.yaml
+++ b/openbank-infra/gitops/components/ap2/ap2-service.yaml
@@ -39,7 +39,7 @@ spec:
       annotations:
         # Roll the pod when the OPA policy bundle changes (subPath mounts don't hot-reload).
         # Kept in sync by gen-ap2-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "b2647a2bbbc7d423"
+        openbank.tech/policy-checksum: "495f4aaec4237b8f"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/audit/audit-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/audit/audit-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: audit-service
     app.kubernetes.io/part-of: audit
   annotations:
-    openbank.tech/policy-checksum: "52124e4189c36362"
+    openbank.tech/policy-checksum: "b16cada983078cfb"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2031,15 +2031,16 @@ data:
         # never becomes the only one. standing-order POSTs sepaPayment.create via the shared
         # client. When ADR-0223 D2(b) retires those matrix grants, this entry starts denying it.
         - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m (see note above)
+        # Restored once #3748 landed: service-sca-shared-client-m2m now admits the shared client
+        # for scaChallenge.read AND scaChallenge.consume, so document-service's consume call
+        # (ScaChallengeClient, oidc-client.client-id openbank-services) keeps an identity-scoped
+        # reason and this entry no longer 403s the document-signing gate. device.list is covered
+        # by matrix-allows. Still uncovered for the shared client: decide/initiate/verify and
+        # device.enroll — no in-repo caller invokes them on that principal.
+        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
       # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
       # adding it here before that is a money-path outage, not a test failure.
       deferred:
-        operator-sca-write: "service-sca-shared-client-m2m covers scaChallenge.read ONLY, while
-          sca-service exposes consume/decide/initiate/verify and device.enroll. document-service
-          calls POST /challenges/{id}/consume through the shared client (ScaChallengeClient carries
-          OidcClientRequestReactiveFilter with oidc-client.client-id openbank-services) and
-          sca-service runs AUTHZ_ENFORCE=true, so listing this reason 403s the document-signing
-          gate. Needs #3748 (scaChallenge.consume for the shared client) to land first."
         operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
         operator-settlement-write: "settlement.create is resourceless with no alternative rule"
         operator-swift-write: "no identity-scoped rule; callers unverified"

--- a/openbank-infra/gitops/components/audit/audit-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/audit/audit-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: audit-service
     app.kubernetes.io/part-of: audit
   annotations:
-    openbank.tech/policy-checksum: "84abf3ec069e414f"
+    openbank.tech/policy-checksum: "2328fba157c6b039"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2003,5 +2003,52 @@ data:
             - lending.collateralDecide
             - lending.approval.read
             - lending.approval.decide
+
+    shared_m2m_write_prohibition:
+      # GHSA-58jq-9hq3-66jr. rest.rego denies the shared M2M identity
+      # (`service-account-openbank-services`, which carries ROLE_OPERATOR in the realm) when the
+      # ONLY reasons admitting it are the role-only write reasons listed here.
+      #
+      # OPT-IN, and the reason a name pattern was rejected: matching every `operator-*-write`
+      # would have 403'd transaction.create from six live callers (account-service's
+      # welcome-bonus credit, sepa-instant, domestic-payment, swift, interest, sdd) and
+      # settlement.create — both AUTHZ_ENFORCE=true money paths whose services have no
+      # identity-scoped rule to fall back on. transaction-service's rego states the exposure
+      # itself ("RESIDUAL RISK — shared identity, no per-caller narrowing"), which is precisely
+      # why removing its only path is not the fix.
+      #
+      # A reason joins this list once its service carries a rule that NAMES the caller and
+      # enumerates its actions, so denying the role-only path removes an over-grant rather than
+      # the only path. Each entry below was verified to have such a rule.
+      reasons:
+        - operator-consent-write        # service-consent-m2m + service-consent-m2m-marketing
+        - operator-ledger-write         # service-ledger-post / service-ledger-reverse
+        - operator-balance-write        # service-balance-m2m
+        - operator-fraud-write          # service-fraud-scoring
+        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
+        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m
+      # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
+      # adding it here before that is a money-path outage, not a test failure.
+      deferred:
+        operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
+        operator-settlement-write: "settlement.create is resourceless with no alternative rule"
+        operator-swift-write: "no identity-scoped rule; callers unverified"
+        operator-sepa-instant-write: "no identity-scoped rule; callers unverified"
+        operator-billing-write: "no identity-scoped rule; callers unverified"
+        operator-interest-write: "no identity-scoped rule; callers unverified"
+        operator-lending-write: "no identity-scoped rule; callers unverified"
+        operator-sanctions-write: "no identity-scoped rule; m2m-sanctions-screening covers create only"
+        operator-identity-write: "no identity-scoped rule; callers unverified"
+        operator-card-write: "no identity-scoped rule; callers unverified"
+        # These DO carry an identity-pinned rule, but "a rule exists" is not "the rule covers the
+        # actions the role-only path was serving". Listing them on that basis would repeat, one
+        # level down, the guess that made the first revision break transaction.create. Each needs
+        # its identity-scoped rule read against its real callers before it moves up.
+        operator-fx-write: "2 identity-pinned rules; action coverage vs real callers unverified"
+        operator-account-write: "2 identity-pinned rules; action coverage unverified"
+        operator-clearing-write: "1 identity-pinned rule; action coverage unverified"
+        operator-domestic-payment-write: "1 identity-pinned rule; action coverage unverified"
+        operator-party-write: "1 identity-pinned rule, but onboarding-service PUTs party.kyc-status via the shared client (latent: AUTHZ_ENFORCE=false there today)"
+      adr: ADR-0034
   manifest.json: |
     {"roots": ["openbank/agents", "openbank/copilot", "openbank/rest", "agents", "rules"]}

--- a/openbank-infra/gitops/components/audit/audit-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/audit/audit-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: audit-service
     app.kubernetes.io/part-of: audit
   annotations:
-    openbank.tech/policy-checksum: "2328fba157c6b039"
+    openbank.tech/policy-checksum: "52124e4189c36362"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2025,11 +2025,21 @@ data:
         - operator-ledger-write         # service-ledger-post / service-ledger-reverse
         - operator-balance-write        # service-balance-m2m
         - operator-fraud-write          # service-fraud-scoring
-        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
-        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m
+        # SAFE TODAY ONLY BY CO-ADMISSION, not by the rule named here: that rule covers
+        # sepaPayment.handleReturn alone, but ROLE_OPERATOR also grants sepaPayment.create /
+        # .transitionStatus / .approval.decide, so `matrix-allows` co-admits and this reason
+        # never becomes the only one. standing-order POSTs sepaPayment.create via the shared
+        # client. When ADR-0223 D2(b) retires those matrix grants, this entry starts denying it.
+        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m (see note above)
       # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
       # adding it here before that is a money-path outage, not a test failure.
       deferred:
+        operator-sca-write: "service-sca-shared-client-m2m covers scaChallenge.read ONLY, while
+          sca-service exposes consume/decide/initiate/verify and device.enroll. document-service
+          calls POST /challenges/{id}/consume through the shared client (ScaChallengeClient carries
+          OidcClientRequestReactiveFilter with oidc-client.client-id openbank-services) and
+          sca-service runs AUTHZ_ENFORCE=true, so listing this reason 403s the document-signing
+          gate. Needs #3748 (scaChallenge.consume for the shared client) to land first."
         operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
         operator-settlement-write: "settlement.create is resourceless with no alternative rule"
         operator-swift-write: "no identity-scoped rule; callers unverified"

--- a/openbank-infra/gitops/components/audit/audit-service.yaml
+++ b/openbank-infra/gitops/components/audit/audit-service.yaml
@@ -31,7 +31,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-audit-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "84abf3ec069e414f"
+        openbank.tech/policy-checksum: "2328fba157c6b039"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/audit/audit-service.yaml
+++ b/openbank-infra/gitops/components/audit/audit-service.yaml
@@ -31,7 +31,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-audit-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "2328fba157c6b039"
+        openbank.tech/policy-checksum: "52124e4189c36362"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/audit/audit-service.yaml
+++ b/openbank-infra/gitops/components/audit/audit-service.yaml
@@ -31,7 +31,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-audit-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "52124e4189c36362"
+        openbank.tech/policy-checksum: "b16cada983078cfb"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: balance-service
     app.kubernetes.io/part-of: balances
   annotations:
-    openbank.tech/policy-checksum: "9ff0513a6a20c9c0"
+    openbank.tech/policy-checksum: "da581a1869dbd56d"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2092,5 +2092,52 @@ data:
             - lending.collateralDecide
             - lending.approval.read
             - lending.approval.decide
+
+    shared_m2m_write_prohibition:
+      # GHSA-58jq-9hq3-66jr. rest.rego denies the shared M2M identity
+      # (`service-account-openbank-services`, which carries ROLE_OPERATOR in the realm) when the
+      # ONLY reasons admitting it are the role-only write reasons listed here.
+      #
+      # OPT-IN, and the reason a name pattern was rejected: matching every `operator-*-write`
+      # would have 403'd transaction.create from six live callers (account-service's
+      # welcome-bonus credit, sepa-instant, domestic-payment, swift, interest, sdd) and
+      # settlement.create — both AUTHZ_ENFORCE=true money paths whose services have no
+      # identity-scoped rule to fall back on. transaction-service's rego states the exposure
+      # itself ("RESIDUAL RISK — shared identity, no per-caller narrowing"), which is precisely
+      # why removing its only path is not the fix.
+      #
+      # A reason joins this list once its service carries a rule that NAMES the caller and
+      # enumerates its actions, so denying the role-only path removes an over-grant rather than
+      # the only path. Each entry below was verified to have such a rule.
+      reasons:
+        - operator-consent-write        # service-consent-m2m + service-consent-m2m-marketing
+        - operator-ledger-write         # service-ledger-post / service-ledger-reverse
+        - operator-balance-write        # service-balance-m2m
+        - operator-fraud-write          # service-fraud-scoring
+        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
+        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m
+      # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
+      # adding it here before that is a money-path outage, not a test failure.
+      deferred:
+        operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
+        operator-settlement-write: "settlement.create is resourceless with no alternative rule"
+        operator-swift-write: "no identity-scoped rule; callers unverified"
+        operator-sepa-instant-write: "no identity-scoped rule; callers unverified"
+        operator-billing-write: "no identity-scoped rule; callers unverified"
+        operator-interest-write: "no identity-scoped rule; callers unverified"
+        operator-lending-write: "no identity-scoped rule; callers unverified"
+        operator-sanctions-write: "no identity-scoped rule; m2m-sanctions-screening covers create only"
+        operator-identity-write: "no identity-scoped rule; callers unverified"
+        operator-card-write: "no identity-scoped rule; callers unverified"
+        # These DO carry an identity-pinned rule, but "a rule exists" is not "the rule covers the
+        # actions the role-only path was serving". Listing them on that basis would repeat, one
+        # level down, the guess that made the first revision break transaction.create. Each needs
+        # its identity-scoped rule read against its real callers before it moves up.
+        operator-fx-write: "2 identity-pinned rules; action coverage vs real callers unverified"
+        operator-account-write: "2 identity-pinned rules; action coverage unverified"
+        operator-clearing-write: "1 identity-pinned rule; action coverage unverified"
+        operator-domestic-payment-write: "1 identity-pinned rule; action coverage unverified"
+        operator-party-write: "1 identity-pinned rule, but onboarding-service PUTs party.kyc-status via the shared client (latent: AUTHZ_ENFORCE=false there today)"
+      adr: ADR-0034
   manifest.json: |
     {"roots": ["openbank/agents", "openbank/copilot", "openbank/rest", "agents", "rules"]}

--- a/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: balance-service
     app.kubernetes.io/part-of: balances
   annotations:
-    openbank.tech/policy-checksum: "682e3c51826f5c84"
+    openbank.tech/policy-checksum: "32a43e1487b92cc1"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2120,15 +2120,16 @@ data:
         # never becomes the only one. standing-order POSTs sepaPayment.create via the shared
         # client. When ADR-0223 D2(b) retires those matrix grants, this entry starts denying it.
         - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m (see note above)
+        # Restored once #3748 landed: service-sca-shared-client-m2m now admits the shared client
+        # for scaChallenge.read AND scaChallenge.consume, so document-service's consume call
+        # (ScaChallengeClient, oidc-client.client-id openbank-services) keeps an identity-scoped
+        # reason and this entry no longer 403s the document-signing gate. device.list is covered
+        # by matrix-allows. Still uncovered for the shared client: decide/initiate/verify and
+        # device.enroll — no in-repo caller invokes them on that principal.
+        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
       # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
       # adding it here before that is a money-path outage, not a test failure.
       deferred:
-        operator-sca-write: "service-sca-shared-client-m2m covers scaChallenge.read ONLY, while
-          sca-service exposes consume/decide/initiate/verify and device.enroll. document-service
-          calls POST /challenges/{id}/consume through the shared client (ScaChallengeClient carries
-          OidcClientRequestReactiveFilter with oidc-client.client-id openbank-services) and
-          sca-service runs AUTHZ_ENFORCE=true, so listing this reason 403s the document-signing
-          gate. Needs #3748 (scaChallenge.consume for the shared client) to land first."
         operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
         operator-settlement-write: "settlement.create is resourceless with no alternative rule"
         operator-swift-write: "no identity-scoped rule; callers unverified"

--- a/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: balance-service
     app.kubernetes.io/part-of: balances
   annotations:
-    openbank.tech/policy-checksum: "da581a1869dbd56d"
+    openbank.tech/policy-checksum: "682e3c51826f5c84"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2114,11 +2114,21 @@ data:
         - operator-ledger-write         # service-ledger-post / service-ledger-reverse
         - operator-balance-write        # service-balance-m2m
         - operator-fraud-write          # service-fraud-scoring
-        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
-        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m
+        # SAFE TODAY ONLY BY CO-ADMISSION, not by the rule named here: that rule covers
+        # sepaPayment.handleReturn alone, but ROLE_OPERATOR also grants sepaPayment.create /
+        # .transitionStatus / .approval.decide, so `matrix-allows` co-admits and this reason
+        # never becomes the only one. standing-order POSTs sepaPayment.create via the shared
+        # client. When ADR-0223 D2(b) retires those matrix grants, this entry starts denying it.
+        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m (see note above)
       # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
       # adding it here before that is a money-path outage, not a test failure.
       deferred:
+        operator-sca-write: "service-sca-shared-client-m2m covers scaChallenge.read ONLY, while
+          sca-service exposes consume/decide/initiate/verify and device.enroll. document-service
+          calls POST /challenges/{id}/consume through the shared client (ScaChallengeClient carries
+          OidcClientRequestReactiveFilter with oidc-client.client-id openbank-services) and
+          sca-service runs AUTHZ_ENFORCE=true, so listing this reason 403s the document-signing
+          gate. Needs #3748 (scaChallenge.consume for the shared client) to land first."
         operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
         operator-settlement-write: "settlement.create is resourceless with no alternative rule"
         operator-swift-write: "no identity-scoped rule; callers unverified"

--- a/openbank-infra/gitops/components/balances/balance-service.yaml
+++ b/openbank-infra/gitops/components/balances/balance-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-balance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "da581a1869dbd56d"
+        openbank.tech/policy-checksum: "682e3c51826f5c84"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/balances/balance-service.yaml
+++ b/openbank-infra/gitops/components/balances/balance-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-balance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "682e3c51826f5c84"
+        openbank.tech/policy-checksum: "32a43e1487b92cc1"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/balances/balance-service.yaml
+++ b/openbank-infra/gitops/components/balances/balance-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-balance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "9ff0513a6a20c9c0"
+        openbank.tech/policy-checksum: "da581a1869dbd56d"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: billing-service
     app.kubernetes.io/part-of: billing
   annotations:
-    openbank.tech/policy-checksum: "2d119fbf8dcc877c"
+    openbank.tech/policy-checksum: "915b227e4eb39823"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1997,5 +1997,52 @@ data:
             - lending.collateralDecide
             - lending.approval.read
             - lending.approval.decide
+
+    shared_m2m_write_prohibition:
+      # GHSA-58jq-9hq3-66jr. rest.rego denies the shared M2M identity
+      # (`service-account-openbank-services`, which carries ROLE_OPERATOR in the realm) when the
+      # ONLY reasons admitting it are the role-only write reasons listed here.
+      #
+      # OPT-IN, and the reason a name pattern was rejected: matching every `operator-*-write`
+      # would have 403'd transaction.create from six live callers (account-service's
+      # welcome-bonus credit, sepa-instant, domestic-payment, swift, interest, sdd) and
+      # settlement.create — both AUTHZ_ENFORCE=true money paths whose services have no
+      # identity-scoped rule to fall back on. transaction-service's rego states the exposure
+      # itself ("RESIDUAL RISK — shared identity, no per-caller narrowing"), which is precisely
+      # why removing its only path is not the fix.
+      #
+      # A reason joins this list once its service carries a rule that NAMES the caller and
+      # enumerates its actions, so denying the role-only path removes an over-grant rather than
+      # the only path. Each entry below was verified to have such a rule.
+      reasons:
+        - operator-consent-write        # service-consent-m2m + service-consent-m2m-marketing
+        - operator-ledger-write         # service-ledger-post / service-ledger-reverse
+        - operator-balance-write        # service-balance-m2m
+        - operator-fraud-write          # service-fraud-scoring
+        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
+        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m
+      # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
+      # adding it here before that is a money-path outage, not a test failure.
+      deferred:
+        operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
+        operator-settlement-write: "settlement.create is resourceless with no alternative rule"
+        operator-swift-write: "no identity-scoped rule; callers unverified"
+        operator-sepa-instant-write: "no identity-scoped rule; callers unverified"
+        operator-billing-write: "no identity-scoped rule; callers unverified"
+        operator-interest-write: "no identity-scoped rule; callers unverified"
+        operator-lending-write: "no identity-scoped rule; callers unverified"
+        operator-sanctions-write: "no identity-scoped rule; m2m-sanctions-screening covers create only"
+        operator-identity-write: "no identity-scoped rule; callers unverified"
+        operator-card-write: "no identity-scoped rule; callers unverified"
+        # These DO carry an identity-pinned rule, but "a rule exists" is not "the rule covers the
+        # actions the role-only path was serving". Listing them on that basis would repeat, one
+        # level down, the guess that made the first revision break transaction.create. Each needs
+        # its identity-scoped rule read against its real callers before it moves up.
+        operator-fx-write: "2 identity-pinned rules; action coverage vs real callers unverified"
+        operator-account-write: "2 identity-pinned rules; action coverage unverified"
+        operator-clearing-write: "1 identity-pinned rule; action coverage unverified"
+        operator-domestic-payment-write: "1 identity-pinned rule; action coverage unverified"
+        operator-party-write: "1 identity-pinned rule, but onboarding-service PUTs party.kyc-status via the shared client (latent: AUTHZ_ENFORCE=false there today)"
+      adr: ADR-0034
   manifest.json: |
     {"roots": ["openbank/agents", "openbank/copilot", "openbank/rest", "agents", "rules"]}

--- a/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: billing-service
     app.kubernetes.io/part-of: billing
   annotations:
-    openbank.tech/policy-checksum: "915b227e4eb39823"
+    openbank.tech/policy-checksum: "88019305f8664697"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2019,11 +2019,21 @@ data:
         - operator-ledger-write         # service-ledger-post / service-ledger-reverse
         - operator-balance-write        # service-balance-m2m
         - operator-fraud-write          # service-fraud-scoring
-        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
-        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m
+        # SAFE TODAY ONLY BY CO-ADMISSION, not by the rule named here: that rule covers
+        # sepaPayment.handleReturn alone, but ROLE_OPERATOR also grants sepaPayment.create /
+        # .transitionStatus / .approval.decide, so `matrix-allows` co-admits and this reason
+        # never becomes the only one. standing-order POSTs sepaPayment.create via the shared
+        # client. When ADR-0223 D2(b) retires those matrix grants, this entry starts denying it.
+        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m (see note above)
       # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
       # adding it here before that is a money-path outage, not a test failure.
       deferred:
+        operator-sca-write: "service-sca-shared-client-m2m covers scaChallenge.read ONLY, while
+          sca-service exposes consume/decide/initiate/verify and device.enroll. document-service
+          calls POST /challenges/{id}/consume through the shared client (ScaChallengeClient carries
+          OidcClientRequestReactiveFilter with oidc-client.client-id openbank-services) and
+          sca-service runs AUTHZ_ENFORCE=true, so listing this reason 403s the document-signing
+          gate. Needs #3748 (scaChallenge.consume for the shared client) to land first."
         operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
         operator-settlement-write: "settlement.create is resourceless with no alternative rule"
         operator-swift-write: "no identity-scoped rule; callers unverified"

--- a/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: billing-service
     app.kubernetes.io/part-of: billing
   annotations:
-    openbank.tech/policy-checksum: "88019305f8664697"
+    openbank.tech/policy-checksum: "fcb7f5c4c84e1fa1"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2025,15 +2025,16 @@ data:
         # never becomes the only one. standing-order POSTs sepaPayment.create via the shared
         # client. When ADR-0223 D2(b) retires those matrix grants, this entry starts denying it.
         - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m (see note above)
+        # Restored once #3748 landed: service-sca-shared-client-m2m now admits the shared client
+        # for scaChallenge.read AND scaChallenge.consume, so document-service's consume call
+        # (ScaChallengeClient, oidc-client.client-id openbank-services) keeps an identity-scoped
+        # reason and this entry no longer 403s the document-signing gate. device.list is covered
+        # by matrix-allows. Still uncovered for the shared client: decide/initiate/verify and
+        # device.enroll — no in-repo caller invokes them on that principal.
+        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
       # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
       # adding it here before that is a money-path outage, not a test failure.
       deferred:
-        operator-sca-write: "service-sca-shared-client-m2m covers scaChallenge.read ONLY, while
-          sca-service exposes consume/decide/initiate/verify and device.enroll. document-service
-          calls POST /challenges/{id}/consume through the shared client (ScaChallengeClient carries
-          OidcClientRequestReactiveFilter with oidc-client.client-id openbank-services) and
-          sca-service runs AUTHZ_ENFORCE=true, so listing this reason 403s the document-signing
-          gate. Needs #3748 (scaChallenge.consume for the shared client) to land first."
         operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
         operator-settlement-write: "settlement.create is resourceless with no alternative rule"
         operator-swift-write: "no identity-scoped rule; callers unverified"

--- a/openbank-infra/gitops/components/billing/billing-service.yaml
+++ b/openbank-infra/gitops/components/billing/billing-service.yaml
@@ -36,7 +36,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-billing-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "88019305f8664697"
+        openbank.tech/policy-checksum: "fcb7f5c4c84e1fa1"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/billing/billing-service.yaml
+++ b/openbank-infra/gitops/components/billing/billing-service.yaml
@@ -36,7 +36,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-billing-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "915b227e4eb39823"
+        openbank.tech/policy-checksum: "88019305f8664697"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/billing/billing-service.yaml
+++ b/openbank-infra/gitops/components/billing/billing-service.yaml
@@ -36,7 +36,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-billing-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "2d119fbf8dcc877c"
+        openbank.tech/policy-checksum: "915b227e4eb39823"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/campaign/campaign-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/campaign/campaign-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: campaign-service
     app.kubernetes.io/part-of: campaign
   annotations:
-    openbank.tech/policy-checksum: "43bd5b74468d56e7"
+    openbank.tech/policy-checksum: "0206a9cbcc3868bc"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2040,11 +2040,21 @@ data:
         - operator-ledger-write         # service-ledger-post / service-ledger-reverse
         - operator-balance-write        # service-balance-m2m
         - operator-fraud-write          # service-fraud-scoring
-        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
-        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m
+        # SAFE TODAY ONLY BY CO-ADMISSION, not by the rule named here: that rule covers
+        # sepaPayment.handleReturn alone, but ROLE_OPERATOR also grants sepaPayment.create /
+        # .transitionStatus / .approval.decide, so `matrix-allows` co-admits and this reason
+        # never becomes the only one. standing-order POSTs sepaPayment.create via the shared
+        # client. When ADR-0223 D2(b) retires those matrix grants, this entry starts denying it.
+        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m (see note above)
       # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
       # adding it here before that is a money-path outage, not a test failure.
       deferred:
+        operator-sca-write: "service-sca-shared-client-m2m covers scaChallenge.read ONLY, while
+          sca-service exposes consume/decide/initiate/verify and device.enroll. document-service
+          calls POST /challenges/{id}/consume through the shared client (ScaChallengeClient carries
+          OidcClientRequestReactiveFilter with oidc-client.client-id openbank-services) and
+          sca-service runs AUTHZ_ENFORCE=true, so listing this reason 403s the document-signing
+          gate. Needs #3748 (scaChallenge.consume for the shared client) to land first."
         operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
         operator-settlement-write: "settlement.create is resourceless with no alternative rule"
         operator-swift-write: "no identity-scoped rule; callers unverified"

--- a/openbank-infra/gitops/components/campaign/campaign-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/campaign/campaign-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: campaign-service
     app.kubernetes.io/part-of: campaign
   annotations:
-    openbank.tech/policy-checksum: "b6e69f879ca5f533"
+    openbank.tech/policy-checksum: "43bd5b74468d56e7"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2018,5 +2018,52 @@ data:
             - lending.collateralDecide
             - lending.approval.read
             - lending.approval.decide
+
+    shared_m2m_write_prohibition:
+      # GHSA-58jq-9hq3-66jr. rest.rego denies the shared M2M identity
+      # (`service-account-openbank-services`, which carries ROLE_OPERATOR in the realm) when the
+      # ONLY reasons admitting it are the role-only write reasons listed here.
+      #
+      # OPT-IN, and the reason a name pattern was rejected: matching every `operator-*-write`
+      # would have 403'd transaction.create from six live callers (account-service's
+      # welcome-bonus credit, sepa-instant, domestic-payment, swift, interest, sdd) and
+      # settlement.create — both AUTHZ_ENFORCE=true money paths whose services have no
+      # identity-scoped rule to fall back on. transaction-service's rego states the exposure
+      # itself ("RESIDUAL RISK — shared identity, no per-caller narrowing"), which is precisely
+      # why removing its only path is not the fix.
+      #
+      # A reason joins this list once its service carries a rule that NAMES the caller and
+      # enumerates its actions, so denying the role-only path removes an over-grant rather than
+      # the only path. Each entry below was verified to have such a rule.
+      reasons:
+        - operator-consent-write        # service-consent-m2m + service-consent-m2m-marketing
+        - operator-ledger-write         # service-ledger-post / service-ledger-reverse
+        - operator-balance-write        # service-balance-m2m
+        - operator-fraud-write          # service-fraud-scoring
+        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
+        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m
+      # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
+      # adding it here before that is a money-path outage, not a test failure.
+      deferred:
+        operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
+        operator-settlement-write: "settlement.create is resourceless with no alternative rule"
+        operator-swift-write: "no identity-scoped rule; callers unverified"
+        operator-sepa-instant-write: "no identity-scoped rule; callers unverified"
+        operator-billing-write: "no identity-scoped rule; callers unverified"
+        operator-interest-write: "no identity-scoped rule; callers unverified"
+        operator-lending-write: "no identity-scoped rule; callers unverified"
+        operator-sanctions-write: "no identity-scoped rule; m2m-sanctions-screening covers create only"
+        operator-identity-write: "no identity-scoped rule; callers unverified"
+        operator-card-write: "no identity-scoped rule; callers unverified"
+        # These DO carry an identity-pinned rule, but "a rule exists" is not "the rule covers the
+        # actions the role-only path was serving". Listing them on that basis would repeat, one
+        # level down, the guess that made the first revision break transaction.create. Each needs
+        # its identity-scoped rule read against its real callers before it moves up.
+        operator-fx-write: "2 identity-pinned rules; action coverage vs real callers unverified"
+        operator-account-write: "2 identity-pinned rules; action coverage unverified"
+        operator-clearing-write: "1 identity-pinned rule; action coverage unverified"
+        operator-domestic-payment-write: "1 identity-pinned rule; action coverage unverified"
+        operator-party-write: "1 identity-pinned rule, but onboarding-service PUTs party.kyc-status via the shared client (latent: AUTHZ_ENFORCE=false there today)"
+      adr: ADR-0034
   manifest.json: |
     {"roots": ["openbank/agents", "openbank/copilot", "openbank/rest", "agents", "rules"]}

--- a/openbank-infra/gitops/components/campaign/campaign-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/campaign/campaign-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: campaign-service
     app.kubernetes.io/part-of: campaign
   annotations:
-    openbank.tech/policy-checksum: "0206a9cbcc3868bc"
+    openbank.tech/policy-checksum: "4cccadaf273c26e4"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2046,15 +2046,16 @@ data:
         # never becomes the only one. standing-order POSTs sepaPayment.create via the shared
         # client. When ADR-0223 D2(b) retires those matrix grants, this entry starts denying it.
         - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m (see note above)
+        # Restored once #3748 landed: service-sca-shared-client-m2m now admits the shared client
+        # for scaChallenge.read AND scaChallenge.consume, so document-service's consume call
+        # (ScaChallengeClient, oidc-client.client-id openbank-services) keeps an identity-scoped
+        # reason and this entry no longer 403s the document-signing gate. device.list is covered
+        # by matrix-allows. Still uncovered for the shared client: decide/initiate/verify and
+        # device.enroll — no in-repo caller invokes them on that principal.
+        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
       # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
       # adding it here before that is a money-path outage, not a test failure.
       deferred:
-        operator-sca-write: "service-sca-shared-client-m2m covers scaChallenge.read ONLY, while
-          sca-service exposes consume/decide/initiate/verify and device.enroll. document-service
-          calls POST /challenges/{id}/consume through the shared client (ScaChallengeClient carries
-          OidcClientRequestReactiveFilter with oidc-client.client-id openbank-services) and
-          sca-service runs AUTHZ_ENFORCE=true, so listing this reason 403s the document-signing
-          gate. Needs #3748 (scaChallenge.consume for the shared client) to land first."
         operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
         operator-settlement-write: "settlement.create is resourceless with no alternative rule"
         operator-swift-write: "no identity-scoped rule; callers unverified"

--- a/openbank-infra/gitops/components/campaign/campaign-service.yaml
+++ b/openbank-infra/gitops/components/campaign/campaign-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-campaign-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "b6e69f879ca5f533"
+        openbank.tech/policy-checksum: "43bd5b74468d56e7"
       labels:
         app.kubernetes.io/name: campaign-service
         app.kubernetes.io/part-of: campaign

--- a/openbank-infra/gitops/components/campaign/campaign-service.yaml
+++ b/openbank-infra/gitops/components/campaign/campaign-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-campaign-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "0206a9cbcc3868bc"
+        openbank.tech/policy-checksum: "4cccadaf273c26e4"
       labels:
         app.kubernetes.io/name: campaign-service
         app.kubernetes.io/part-of: campaign

--- a/openbank-infra/gitops/components/campaign/campaign-service.yaml
+++ b/openbank-infra/gitops/components/campaign/campaign-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-campaign-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "43bd5b74468d56e7"
+        openbank.tech/policy-checksum: "0206a9cbcc3868bc"
       labels:
         app.kubernetes.io/name: campaign-service
         app.kubernetes.io/part-of: campaign

--- a/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: consent-service
     app.kubernetes.io/part-of: consent
   annotations:
-    openbank.tech/policy-checksum: "429b7a9f1946a64a"
+    openbank.tech/policy-checksum: "b6ef850388543e36"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2089,11 +2089,21 @@ data:
         - operator-ledger-write         # service-ledger-post / service-ledger-reverse
         - operator-balance-write        # service-balance-m2m
         - operator-fraud-write          # service-fraud-scoring
-        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
-        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m
+        # SAFE TODAY ONLY BY CO-ADMISSION, not by the rule named here: that rule covers
+        # sepaPayment.handleReturn alone, but ROLE_OPERATOR also grants sepaPayment.create /
+        # .transitionStatus / .approval.decide, so `matrix-allows` co-admits and this reason
+        # never becomes the only one. standing-order POSTs sepaPayment.create via the shared
+        # client. When ADR-0223 D2(b) retires those matrix grants, this entry starts denying it.
+        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m (see note above)
       # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
       # adding it here before that is a money-path outage, not a test failure.
       deferred:
+        operator-sca-write: "service-sca-shared-client-m2m covers scaChallenge.read ONLY, while
+          sca-service exposes consume/decide/initiate/verify and device.enroll. document-service
+          calls POST /challenges/{id}/consume through the shared client (ScaChallengeClient carries
+          OidcClientRequestReactiveFilter with oidc-client.client-id openbank-services) and
+          sca-service runs AUTHZ_ENFORCE=true, so listing this reason 403s the document-signing
+          gate. Needs #3748 (scaChallenge.consume for the shared client) to land first."
         operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
         operator-settlement-write: "settlement.create is resourceless with no alternative rule"
         operator-swift-write: "no identity-scoped rule; callers unverified"

--- a/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: consent-service
     app.kubernetes.io/part-of: consent
   annotations:
-    openbank.tech/policy-checksum: "b6ef850388543e36"
+    openbank.tech/policy-checksum: "a2d376635b5e6dc0"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2095,15 +2095,16 @@ data:
         # never becomes the only one. standing-order POSTs sepaPayment.create via the shared
         # client. When ADR-0223 D2(b) retires those matrix grants, this entry starts denying it.
         - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m (see note above)
+        # Restored once #3748 landed: service-sca-shared-client-m2m now admits the shared client
+        # for scaChallenge.read AND scaChallenge.consume, so document-service's consume call
+        # (ScaChallengeClient, oidc-client.client-id openbank-services) keeps an identity-scoped
+        # reason and this entry no longer 403s the document-signing gate. device.list is covered
+        # by matrix-allows. Still uncovered for the shared client: decide/initiate/verify and
+        # device.enroll — no in-repo caller invokes them on that principal.
+        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
       # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
       # adding it here before that is a money-path outage, not a test failure.
       deferred:
-        operator-sca-write: "service-sca-shared-client-m2m covers scaChallenge.read ONLY, while
-          sca-service exposes consume/decide/initiate/verify and device.enroll. document-service
-          calls POST /challenges/{id}/consume through the shared client (ScaChallengeClient carries
-          OidcClientRequestReactiveFilter with oidc-client.client-id openbank-services) and
-          sca-service runs AUTHZ_ENFORCE=true, so listing this reason 403s the document-signing
-          gate. Needs #3748 (scaChallenge.consume for the shared client) to land first."
         operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
         operator-settlement-write: "settlement.create is resourceless with no alternative rule"
         operator-swift-write: "no identity-scoped rule; callers unverified"

--- a/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: consent-service
     app.kubernetes.io/part-of: consent
   annotations:
-    openbank.tech/policy-checksum: "0e2f2ab37d34251f"
+    openbank.tech/policy-checksum: "429b7a9f1946a64a"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2067,5 +2067,52 @@ data:
             - lending.collateralDecide
             - lending.approval.read
             - lending.approval.decide
+
+    shared_m2m_write_prohibition:
+      # GHSA-58jq-9hq3-66jr. rest.rego denies the shared M2M identity
+      # (`service-account-openbank-services`, which carries ROLE_OPERATOR in the realm) when the
+      # ONLY reasons admitting it are the role-only write reasons listed here.
+      #
+      # OPT-IN, and the reason a name pattern was rejected: matching every `operator-*-write`
+      # would have 403'd transaction.create from six live callers (account-service's
+      # welcome-bonus credit, sepa-instant, domestic-payment, swift, interest, sdd) and
+      # settlement.create — both AUTHZ_ENFORCE=true money paths whose services have no
+      # identity-scoped rule to fall back on. transaction-service's rego states the exposure
+      # itself ("RESIDUAL RISK — shared identity, no per-caller narrowing"), which is precisely
+      # why removing its only path is not the fix.
+      #
+      # A reason joins this list once its service carries a rule that NAMES the caller and
+      # enumerates its actions, so denying the role-only path removes an over-grant rather than
+      # the only path. Each entry below was verified to have such a rule.
+      reasons:
+        - operator-consent-write        # service-consent-m2m + service-consent-m2m-marketing
+        - operator-ledger-write         # service-ledger-post / service-ledger-reverse
+        - operator-balance-write        # service-balance-m2m
+        - operator-fraud-write          # service-fraud-scoring
+        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
+        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m
+      # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
+      # adding it here before that is a money-path outage, not a test failure.
+      deferred:
+        operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
+        operator-settlement-write: "settlement.create is resourceless with no alternative rule"
+        operator-swift-write: "no identity-scoped rule; callers unverified"
+        operator-sepa-instant-write: "no identity-scoped rule; callers unverified"
+        operator-billing-write: "no identity-scoped rule; callers unverified"
+        operator-interest-write: "no identity-scoped rule; callers unverified"
+        operator-lending-write: "no identity-scoped rule; callers unverified"
+        operator-sanctions-write: "no identity-scoped rule; m2m-sanctions-screening covers create only"
+        operator-identity-write: "no identity-scoped rule; callers unverified"
+        operator-card-write: "no identity-scoped rule; callers unverified"
+        # These DO carry an identity-pinned rule, but "a rule exists" is not "the rule covers the
+        # actions the role-only path was serving". Listing them on that basis would repeat, one
+        # level down, the guess that made the first revision break transaction.create. Each needs
+        # its identity-scoped rule read against its real callers before it moves up.
+        operator-fx-write: "2 identity-pinned rules; action coverage vs real callers unverified"
+        operator-account-write: "2 identity-pinned rules; action coverage unverified"
+        operator-clearing-write: "1 identity-pinned rule; action coverage unverified"
+        operator-domestic-payment-write: "1 identity-pinned rule; action coverage unverified"
+        operator-party-write: "1 identity-pinned rule, but onboarding-service PUTs party.kyc-status via the shared client (latent: AUTHZ_ENFORCE=false there today)"
+      adr: ADR-0034
   manifest.json: |
     {"roots": ["openbank/agents", "openbank/copilot", "openbank/rest", "agents", "rules"]}

--- a/openbank-infra/gitops/components/consent/consent-service.yaml
+++ b/openbank-infra/gitops/components/consent/consent-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-consent-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "b6ef850388543e36"
+        openbank.tech/policy-checksum: "a2d376635b5e6dc0"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/consent/consent-service.yaml
+++ b/openbank-infra/gitops/components/consent/consent-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-consent-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "429b7a9f1946a64a"
+        openbank.tech/policy-checksum: "b6ef850388543e36"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/consent/consent-service.yaml
+++ b/openbank-infra/gitops/components/consent/consent-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-consent-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "0e2f2ab37d34251f"
+        openbank.tech/policy-checksum: "429b7a9f1946a64a"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: copilot-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "4c17ea6282ae21c2"
+    openbank.tech/policy-checksum: "3128e16f5e0e8bf2"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2105,11 +2105,21 @@ data:
         - operator-ledger-write         # service-ledger-post / service-ledger-reverse
         - operator-balance-write        # service-balance-m2m
         - operator-fraud-write          # service-fraud-scoring
-        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
-        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m
+        # SAFE TODAY ONLY BY CO-ADMISSION, not by the rule named here: that rule covers
+        # sepaPayment.handleReturn alone, but ROLE_OPERATOR also grants sepaPayment.create /
+        # .transitionStatus / .approval.decide, so `matrix-allows` co-admits and this reason
+        # never becomes the only one. standing-order POSTs sepaPayment.create via the shared
+        # client. When ADR-0223 D2(b) retires those matrix grants, this entry starts denying it.
+        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m (see note above)
       # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
       # adding it here before that is a money-path outage, not a test failure.
       deferred:
+        operator-sca-write: "service-sca-shared-client-m2m covers scaChallenge.read ONLY, while
+          sca-service exposes consume/decide/initiate/verify and device.enroll. document-service
+          calls POST /challenges/{id}/consume through the shared client (ScaChallengeClient carries
+          OidcClientRequestReactiveFilter with oidc-client.client-id openbank-services) and
+          sca-service runs AUTHZ_ENFORCE=true, so listing this reason 403s the document-signing
+          gate. Needs #3748 (scaChallenge.consume for the shared client) to land first."
         operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
         operator-settlement-write: "settlement.create is resourceless with no alternative rule"
         operator-swift-write: "no identity-scoped rule; callers unverified"

--- a/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: copilot-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "b75b1c0ef9364722"
+    openbank.tech/policy-checksum: "4c17ea6282ae21c2"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2083,5 +2083,52 @@ data:
             - lending.collateralDecide
             - lending.approval.read
             - lending.approval.decide
+
+    shared_m2m_write_prohibition:
+      # GHSA-58jq-9hq3-66jr. rest.rego denies the shared M2M identity
+      # (`service-account-openbank-services`, which carries ROLE_OPERATOR in the realm) when the
+      # ONLY reasons admitting it are the role-only write reasons listed here.
+      #
+      # OPT-IN, and the reason a name pattern was rejected: matching every `operator-*-write`
+      # would have 403'd transaction.create from six live callers (account-service's
+      # welcome-bonus credit, sepa-instant, domestic-payment, swift, interest, sdd) and
+      # settlement.create — both AUTHZ_ENFORCE=true money paths whose services have no
+      # identity-scoped rule to fall back on. transaction-service's rego states the exposure
+      # itself ("RESIDUAL RISK — shared identity, no per-caller narrowing"), which is precisely
+      # why removing its only path is not the fix.
+      #
+      # A reason joins this list once its service carries a rule that NAMES the caller and
+      # enumerates its actions, so denying the role-only path removes an over-grant rather than
+      # the only path. Each entry below was verified to have such a rule.
+      reasons:
+        - operator-consent-write        # service-consent-m2m + service-consent-m2m-marketing
+        - operator-ledger-write         # service-ledger-post / service-ledger-reverse
+        - operator-balance-write        # service-balance-m2m
+        - operator-fraud-write          # service-fraud-scoring
+        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
+        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m
+      # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
+      # adding it here before that is a money-path outage, not a test failure.
+      deferred:
+        operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
+        operator-settlement-write: "settlement.create is resourceless with no alternative rule"
+        operator-swift-write: "no identity-scoped rule; callers unverified"
+        operator-sepa-instant-write: "no identity-scoped rule; callers unverified"
+        operator-billing-write: "no identity-scoped rule; callers unverified"
+        operator-interest-write: "no identity-scoped rule; callers unverified"
+        operator-lending-write: "no identity-scoped rule; callers unverified"
+        operator-sanctions-write: "no identity-scoped rule; m2m-sanctions-screening covers create only"
+        operator-identity-write: "no identity-scoped rule; callers unverified"
+        operator-card-write: "no identity-scoped rule; callers unverified"
+        # These DO carry an identity-pinned rule, but "a rule exists" is not "the rule covers the
+        # actions the role-only path was serving". Listing them on that basis would repeat, one
+        # level down, the guess that made the first revision break transaction.create. Each needs
+        # its identity-scoped rule read against its real callers before it moves up.
+        operator-fx-write: "2 identity-pinned rules; action coverage vs real callers unverified"
+        operator-account-write: "2 identity-pinned rules; action coverage unverified"
+        operator-clearing-write: "1 identity-pinned rule; action coverage unverified"
+        operator-domestic-payment-write: "1 identity-pinned rule; action coverage unverified"
+        operator-party-write: "1 identity-pinned rule, but onboarding-service PUTs party.kyc-status via the shared client (latent: AUTHZ_ENFORCE=false there today)"
+      adr: ADR-0034
   manifest.json: |
     {"roots": ["openbank/agents", "openbank/copilot", "openbank/rest", "agents", "rules"]}

--- a/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: copilot-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "3128e16f5e0e8bf2"
+    openbank.tech/policy-checksum: "b129b6f88e7dcb4a"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2111,15 +2111,16 @@ data:
         # never becomes the only one. standing-order POSTs sepaPayment.create via the shared
         # client. When ADR-0223 D2(b) retires those matrix grants, this entry starts denying it.
         - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m (see note above)
+        # Restored once #3748 landed: service-sca-shared-client-m2m now admits the shared client
+        # for scaChallenge.read AND scaChallenge.consume, so document-service's consume call
+        # (ScaChallengeClient, oidc-client.client-id openbank-services) keeps an identity-scoped
+        # reason and this entry no longer 403s the document-signing gate. device.list is covered
+        # by matrix-allows. Still uncovered for the shared client: decide/initiate/verify and
+        # device.enroll — no in-repo caller invokes them on that principal.
+        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
       # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
       # adding it here before that is a money-path outage, not a test failure.
       deferred:
-        operator-sca-write: "service-sca-shared-client-m2m covers scaChallenge.read ONLY, while
-          sca-service exposes consume/decide/initiate/verify and device.enroll. document-service
-          calls POST /challenges/{id}/consume through the shared client (ScaChallengeClient carries
-          OidcClientRequestReactiveFilter with oidc-client.client-id openbank-services) and
-          sca-service runs AUTHZ_ENFORCE=true, so listing this reason 403s the document-signing
-          gate. Needs #3748 (scaChallenge.consume for the shared client) to land first."
         operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
         operator-settlement-write: "settlement.create is resourceless with no alternative rule"
         operator-swift-write: "no identity-scoped rule; callers unverified"

--- a/openbank-infra/gitops/components/copilot/copilot-service.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-service.yaml
@@ -39,7 +39,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-copilot-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "4c17ea6282ae21c2"
+        openbank.tech/policy-checksum: "3128e16f5e0e8bf2"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/copilot/copilot-service.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-service.yaml
@@ -39,7 +39,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-copilot-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "b75b1c0ef9364722"
+        openbank.tech/policy-checksum: "4c17ea6282ae21c2"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/copilot/copilot-service.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-service.yaml
@@ -39,7 +39,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-copilot-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "3128e16f5e0e8bf2"
+        openbank.tech/policy-checksum: "b129b6f88e7dcb4a"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: customer-edge
     app.kubernetes.io/part-of: customer-edge
   annotations:
-    openbank.tech/policy-checksum: "1b5a85b0af2c058a"
+    openbank.tech/policy-checksum: "9e6b95854986a6c1"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1091,11 +1091,21 @@ data:
         - operator-ledger-write         # service-ledger-post / service-ledger-reverse
         - operator-balance-write        # service-balance-m2m
         - operator-fraud-write          # service-fraud-scoring
-        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
-        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m
+        # SAFE TODAY ONLY BY CO-ADMISSION, not by the rule named here: that rule covers
+        # sepaPayment.handleReturn alone, but ROLE_OPERATOR also grants sepaPayment.create /
+        # .transitionStatus / .approval.decide, so `matrix-allows` co-admits and this reason
+        # never becomes the only one. standing-order POSTs sepaPayment.create via the shared
+        # client. When ADR-0223 D2(b) retires those matrix grants, this entry starts denying it.
+        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m (see note above)
       # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
       # adding it here before that is a money-path outage, not a test failure.
       deferred:
+        operator-sca-write: "service-sca-shared-client-m2m covers scaChallenge.read ONLY, while
+          sca-service exposes consume/decide/initiate/verify and device.enroll. document-service
+          calls POST /challenges/{id}/consume through the shared client (ScaChallengeClient carries
+          OidcClientRequestReactiveFilter with oidc-client.client-id openbank-services) and
+          sca-service runs AUTHZ_ENFORCE=true, so listing this reason 403s the document-signing
+          gate. Needs #3748 (scaChallenge.consume for the shared client) to land first."
         operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
         operator-settlement-write: "settlement.create is resourceless with no alternative rule"
         operator-swift-write: "no identity-scoped rule; callers unverified"

--- a/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: customer-edge
     app.kubernetes.io/part-of: customer-edge
   annotations:
-    openbank.tech/policy-checksum: "9e6b95854986a6c1"
+    openbank.tech/policy-checksum: "af2491131f1b36de"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1097,15 +1097,16 @@ data:
         # never becomes the only one. standing-order POSTs sepaPayment.create via the shared
         # client. When ADR-0223 D2(b) retires those matrix grants, this entry starts denying it.
         - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m (see note above)
+        # Restored once #3748 landed: service-sca-shared-client-m2m now admits the shared client
+        # for scaChallenge.read AND scaChallenge.consume, so document-service's consume call
+        # (ScaChallengeClient, oidc-client.client-id openbank-services) keeps an identity-scoped
+        # reason and this entry no longer 403s the document-signing gate. device.list is covered
+        # by matrix-allows. Still uncovered for the shared client: decide/initiate/verify and
+        # device.enroll — no in-repo caller invokes them on that principal.
+        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
       # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
       # adding it here before that is a money-path outage, not a test failure.
       deferred:
-        operator-sca-write: "service-sca-shared-client-m2m covers scaChallenge.read ONLY, while
-          sca-service exposes consume/decide/initiate/verify and device.enroll. document-service
-          calls POST /challenges/{id}/consume through the shared client (ScaChallengeClient carries
-          OidcClientRequestReactiveFilter with oidc-client.client-id openbank-services) and
-          sca-service runs AUTHZ_ENFORCE=true, so listing this reason 403s the document-signing
-          gate. Needs #3748 (scaChallenge.consume for the shared client) to land first."
         operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
         operator-settlement-write: "settlement.create is resourceless with no alternative rule"
         operator-swift-write: "no identity-scoped rule; callers unverified"

--- a/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: customer-edge
     app.kubernetes.io/part-of: customer-edge
   annotations:
-    openbank.tech/policy-checksum: "caa4315947012bae"
+    openbank.tech/policy-checksum: "1b5a85b0af2c058a"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1069,6 +1069,53 @@ data:
             - lending.collateralDecide
             - lending.approval.read
             - lending.approval.decide
+
+    shared_m2m_write_prohibition:
+      # GHSA-58jq-9hq3-66jr. rest.rego denies the shared M2M identity
+      # (`service-account-openbank-services`, which carries ROLE_OPERATOR in the realm) when the
+      # ONLY reasons admitting it are the role-only write reasons listed here.
+      #
+      # OPT-IN, and the reason a name pattern was rejected: matching every `operator-*-write`
+      # would have 403'd transaction.create from six live callers (account-service's
+      # welcome-bonus credit, sepa-instant, domestic-payment, swift, interest, sdd) and
+      # settlement.create — both AUTHZ_ENFORCE=true money paths whose services have no
+      # identity-scoped rule to fall back on. transaction-service's rego states the exposure
+      # itself ("RESIDUAL RISK — shared identity, no per-caller narrowing"), which is precisely
+      # why removing its only path is not the fix.
+      #
+      # A reason joins this list once its service carries a rule that NAMES the caller and
+      # enumerates its actions, so denying the role-only path removes an over-grant rather than
+      # the only path. Each entry below was verified to have such a rule.
+      reasons:
+        - operator-consent-write        # service-consent-m2m + service-consent-m2m-marketing
+        - operator-ledger-write         # service-ledger-post / service-ledger-reverse
+        - operator-balance-write        # service-balance-m2m
+        - operator-fraud-write          # service-fraud-scoring
+        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
+        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m
+      # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
+      # adding it here before that is a money-path outage, not a test failure.
+      deferred:
+        operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
+        operator-settlement-write: "settlement.create is resourceless with no alternative rule"
+        operator-swift-write: "no identity-scoped rule; callers unverified"
+        operator-sepa-instant-write: "no identity-scoped rule; callers unverified"
+        operator-billing-write: "no identity-scoped rule; callers unverified"
+        operator-interest-write: "no identity-scoped rule; callers unverified"
+        operator-lending-write: "no identity-scoped rule; callers unverified"
+        operator-sanctions-write: "no identity-scoped rule; m2m-sanctions-screening covers create only"
+        operator-identity-write: "no identity-scoped rule; callers unverified"
+        operator-card-write: "no identity-scoped rule; callers unverified"
+        # These DO carry an identity-pinned rule, but "a rule exists" is not "the rule covers the
+        # actions the role-only path was serving". Listing them on that basis would repeat, one
+        # level down, the guess that made the first revision break transaction.create. Each needs
+        # its identity-scoped rule read against its real callers before it moves up.
+        operator-fx-write: "2 identity-pinned rules; action coverage vs real callers unverified"
+        operator-account-write: "2 identity-pinned rules; action coverage unverified"
+        operator-clearing-write: "1 identity-pinned rule; action coverage unverified"
+        operator-domestic-payment-write: "1 identity-pinned rule; action coverage unverified"
+        operator-party-write: "1 identity-pinned rule, but onboarding-service PUTs party.kyc-status via the shared client (latent: AUTHZ_ENFORCE=false there today)"
+      adr: ADR-0034
   agents-data.yaml: |
     # SPDX-License-Identifier: Apache-2.0
     # Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.

--- a/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
@@ -65,7 +65,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-customer-edge-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "1b5a85b0af2c058a"
+        openbank.tech/policy-checksum: "9e6b95854986a6c1"
     spec:
       # Dedicated SA so EKS Pod Identity can hand the edge (and ONLY the edge) the
       # feedback-screenshots S3 role — ADR-0192, openbank-infra/aws/envs/sandbox-platform/

--- a/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
@@ -65,7 +65,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-customer-edge-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "9e6b95854986a6c1"
+        openbank.tech/policy-checksum: "af2491131f1b36de"
     spec:
       # Dedicated SA so EKS Pod Identity can hand the edge (and ONLY the edge) the
       # feedback-screenshots S3 role — ADR-0192, openbank-infra/aws/envs/sandbox-platform/

--- a/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
@@ -65,7 +65,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-customer-edge-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "caa4315947012bae"
+        openbank.tech/policy-checksum: "1b5a85b0af2c058a"
     spec:
       # Dedicated SA so EKS Pod Identity can hand the edge (and ONLY the edge) the
       # feedback-screenshots S3 role — ADR-0192, openbank-infra/aws/envs/sandbox-platform/

--- a/openbank-infra/gitops/components/delegation/delegation-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/delegation/delegation-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: delegation-service
     app.kubernetes.io/part-of: delegation
   annotations:
-    openbank.tech/policy-checksum: "02435ff78e9cb325"
+    openbank.tech/policy-checksum: "d6648acfcca231eb"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2066,15 +2066,16 @@ data:
         # never becomes the only one. standing-order POSTs sepaPayment.create via the shared
         # client. When ADR-0223 D2(b) retires those matrix grants, this entry starts denying it.
         - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m (see note above)
+        # Restored once #3748 landed: service-sca-shared-client-m2m now admits the shared client
+        # for scaChallenge.read AND scaChallenge.consume, so document-service's consume call
+        # (ScaChallengeClient, oidc-client.client-id openbank-services) keeps an identity-scoped
+        # reason and this entry no longer 403s the document-signing gate. device.list is covered
+        # by matrix-allows. Still uncovered for the shared client: decide/initiate/verify and
+        # device.enroll — no in-repo caller invokes them on that principal.
+        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
       # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
       # adding it here before that is a money-path outage, not a test failure.
       deferred:
-        operator-sca-write: "service-sca-shared-client-m2m covers scaChallenge.read ONLY, while
-          sca-service exposes consume/decide/initiate/verify and device.enroll. document-service
-          calls POST /challenges/{id}/consume through the shared client (ScaChallengeClient carries
-          OidcClientRequestReactiveFilter with oidc-client.client-id openbank-services) and
-          sca-service runs AUTHZ_ENFORCE=true, so listing this reason 403s the document-signing
-          gate. Needs #3748 (scaChallenge.consume for the shared client) to land first."
         operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
         operator-settlement-write: "settlement.create is resourceless with no alternative rule"
         operator-swift-write: "no identity-scoped rule; callers unverified"

--- a/openbank-infra/gitops/components/delegation/delegation-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/delegation/delegation-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: delegation-service
     app.kubernetes.io/part-of: delegation
   annotations:
-    openbank.tech/policy-checksum: "799cf7e8bbfafdc4"
+    openbank.tech/policy-checksum: "b71dae798e5451cb"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2038,5 +2038,52 @@ data:
             - lending.collateralDecide
             - lending.approval.read
             - lending.approval.decide
+
+    shared_m2m_write_prohibition:
+      # GHSA-58jq-9hq3-66jr. rest.rego denies the shared M2M identity
+      # (`service-account-openbank-services`, which carries ROLE_OPERATOR in the realm) when the
+      # ONLY reasons admitting it are the role-only write reasons listed here.
+      #
+      # OPT-IN, and the reason a name pattern was rejected: matching every `operator-*-write`
+      # would have 403'd transaction.create from six live callers (account-service's
+      # welcome-bonus credit, sepa-instant, domestic-payment, swift, interest, sdd) and
+      # settlement.create — both AUTHZ_ENFORCE=true money paths whose services have no
+      # identity-scoped rule to fall back on. transaction-service's rego states the exposure
+      # itself ("RESIDUAL RISK — shared identity, no per-caller narrowing"), which is precisely
+      # why removing its only path is not the fix.
+      #
+      # A reason joins this list once its service carries a rule that NAMES the caller and
+      # enumerates its actions, so denying the role-only path removes an over-grant rather than
+      # the only path. Each entry below was verified to have such a rule.
+      reasons:
+        - operator-consent-write        # service-consent-m2m + service-consent-m2m-marketing
+        - operator-ledger-write         # service-ledger-post / service-ledger-reverse
+        - operator-balance-write        # service-balance-m2m
+        - operator-fraud-write          # service-fraud-scoring
+        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
+        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m
+      # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
+      # adding it here before that is a money-path outage, not a test failure.
+      deferred:
+        operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
+        operator-settlement-write: "settlement.create is resourceless with no alternative rule"
+        operator-swift-write: "no identity-scoped rule; callers unverified"
+        operator-sepa-instant-write: "no identity-scoped rule; callers unverified"
+        operator-billing-write: "no identity-scoped rule; callers unverified"
+        operator-interest-write: "no identity-scoped rule; callers unverified"
+        operator-lending-write: "no identity-scoped rule; callers unverified"
+        operator-sanctions-write: "no identity-scoped rule; m2m-sanctions-screening covers create only"
+        operator-identity-write: "no identity-scoped rule; callers unverified"
+        operator-card-write: "no identity-scoped rule; callers unverified"
+        # These DO carry an identity-pinned rule, but "a rule exists" is not "the rule covers the
+        # actions the role-only path was serving". Listing them on that basis would repeat, one
+        # level down, the guess that made the first revision break transaction.create. Each needs
+        # its identity-scoped rule read against its real callers before it moves up.
+        operator-fx-write: "2 identity-pinned rules; action coverage vs real callers unverified"
+        operator-account-write: "2 identity-pinned rules; action coverage unverified"
+        operator-clearing-write: "1 identity-pinned rule; action coverage unverified"
+        operator-domestic-payment-write: "1 identity-pinned rule; action coverage unverified"
+        operator-party-write: "1 identity-pinned rule, but onboarding-service PUTs party.kyc-status via the shared client (latent: AUTHZ_ENFORCE=false there today)"
+      adr: ADR-0034
   manifest.json: |
     {"roots": ["openbank/agents", "openbank/copilot", "openbank/rest", "agents", "rules"]}

--- a/openbank-infra/gitops/components/delegation/delegation-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/delegation/delegation-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: delegation-service
     app.kubernetes.io/part-of: delegation
   annotations:
-    openbank.tech/policy-checksum: "b71dae798e5451cb"
+    openbank.tech/policy-checksum: "02435ff78e9cb325"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2060,11 +2060,21 @@ data:
         - operator-ledger-write         # service-ledger-post / service-ledger-reverse
         - operator-balance-write        # service-balance-m2m
         - operator-fraud-write          # service-fraud-scoring
-        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
-        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m
+        # SAFE TODAY ONLY BY CO-ADMISSION, not by the rule named here: that rule covers
+        # sepaPayment.handleReturn alone, but ROLE_OPERATOR also grants sepaPayment.create /
+        # .transitionStatus / .approval.decide, so `matrix-allows` co-admits and this reason
+        # never becomes the only one. standing-order POSTs sepaPayment.create via the shared
+        # client. When ADR-0223 D2(b) retires those matrix grants, this entry starts denying it.
+        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m (see note above)
       # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
       # adding it here before that is a money-path outage, not a test failure.
       deferred:
+        operator-sca-write: "service-sca-shared-client-m2m covers scaChallenge.read ONLY, while
+          sca-service exposes consume/decide/initiate/verify and device.enroll. document-service
+          calls POST /challenges/{id}/consume through the shared client (ScaChallengeClient carries
+          OidcClientRequestReactiveFilter with oidc-client.client-id openbank-services) and
+          sca-service runs AUTHZ_ENFORCE=true, so listing this reason 403s the document-signing
+          gate. Needs #3748 (scaChallenge.consume for the shared client) to land first."
         operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
         operator-settlement-write: "settlement.create is resourceless with no alternative rule"
         operator-swift-write: "no identity-scoped rule; callers unverified"

--- a/openbank-infra/gitops/components/delegation/delegation-service.yaml
+++ b/openbank-infra/gitops/components/delegation/delegation-service.yaml
@@ -42,7 +42,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-delegation-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "799cf7e8bbfafdc4"
+        openbank.tech/policy-checksum: "b71dae798e5451cb"
       labels:
         app.kubernetes.io/name: delegation-service
         app.kubernetes.io/part-of: delegation

--- a/openbank-infra/gitops/components/delegation/delegation-service.yaml
+++ b/openbank-infra/gitops/components/delegation/delegation-service.yaml
@@ -42,7 +42,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-delegation-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "b71dae798e5451cb"
+        openbank.tech/policy-checksum: "02435ff78e9cb325"
       labels:
         app.kubernetes.io/name: delegation-service
         app.kubernetes.io/part-of: delegation

--- a/openbank-infra/gitops/components/delegation/delegation-service.yaml
+++ b/openbank-infra/gitops/components/delegation/delegation-service.yaml
@@ -42,7 +42,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-delegation-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "02435ff78e9cb325"
+        openbank.tech/policy-checksum: "d6648acfcca231eb"
       labels:
         app.kubernetes.io/name: delegation-service
         app.kubernetes.io/part-of: delegation

--- a/openbank-infra/gitops/components/dispute-service/dispute-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/dispute-service/dispute-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: dispute-service
     app.kubernetes.io/part-of: dispute
   annotations:
-    openbank.tech/policy-checksum: "c05ecd973bc33428"
+    openbank.tech/policy-checksum: "f4f8aaff555ecb24"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2133,5 +2133,52 @@ data:
             - lending.collateralDecide
             - lending.approval.read
             - lending.approval.decide
+
+    shared_m2m_write_prohibition:
+      # GHSA-58jq-9hq3-66jr. rest.rego denies the shared M2M identity
+      # (`service-account-openbank-services`, which carries ROLE_OPERATOR in the realm) when the
+      # ONLY reasons admitting it are the role-only write reasons listed here.
+      #
+      # OPT-IN, and the reason a name pattern was rejected: matching every `operator-*-write`
+      # would have 403'd transaction.create from six live callers (account-service's
+      # welcome-bonus credit, sepa-instant, domestic-payment, swift, interest, sdd) and
+      # settlement.create — both AUTHZ_ENFORCE=true money paths whose services have no
+      # identity-scoped rule to fall back on. transaction-service's rego states the exposure
+      # itself ("RESIDUAL RISK — shared identity, no per-caller narrowing"), which is precisely
+      # why removing its only path is not the fix.
+      #
+      # A reason joins this list once its service carries a rule that NAMES the caller and
+      # enumerates its actions, so denying the role-only path removes an over-grant rather than
+      # the only path. Each entry below was verified to have such a rule.
+      reasons:
+        - operator-consent-write        # service-consent-m2m + service-consent-m2m-marketing
+        - operator-ledger-write         # service-ledger-post / service-ledger-reverse
+        - operator-balance-write        # service-balance-m2m
+        - operator-fraud-write          # service-fraud-scoring
+        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
+        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m
+      # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
+      # adding it here before that is a money-path outage, not a test failure.
+      deferred:
+        operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
+        operator-settlement-write: "settlement.create is resourceless with no alternative rule"
+        operator-swift-write: "no identity-scoped rule; callers unverified"
+        operator-sepa-instant-write: "no identity-scoped rule; callers unverified"
+        operator-billing-write: "no identity-scoped rule; callers unverified"
+        operator-interest-write: "no identity-scoped rule; callers unverified"
+        operator-lending-write: "no identity-scoped rule; callers unverified"
+        operator-sanctions-write: "no identity-scoped rule; m2m-sanctions-screening covers create only"
+        operator-identity-write: "no identity-scoped rule; callers unverified"
+        operator-card-write: "no identity-scoped rule; callers unverified"
+        # These DO carry an identity-pinned rule, but "a rule exists" is not "the rule covers the
+        # actions the role-only path was serving". Listing them on that basis would repeat, one
+        # level down, the guess that made the first revision break transaction.create. Each needs
+        # its identity-scoped rule read against its real callers before it moves up.
+        operator-fx-write: "2 identity-pinned rules; action coverage vs real callers unverified"
+        operator-account-write: "2 identity-pinned rules; action coverage unverified"
+        operator-clearing-write: "1 identity-pinned rule; action coverage unverified"
+        operator-domestic-payment-write: "1 identity-pinned rule; action coverage unverified"
+        operator-party-write: "1 identity-pinned rule, but onboarding-service PUTs party.kyc-status via the shared client (latent: AUTHZ_ENFORCE=false there today)"
+      adr: ADR-0034
   manifest.json: |
     {"roots": ["openbank/agents", "openbank/copilot", "openbank/rest", "agents", "rules"]}

--- a/openbank-infra/gitops/components/dispute-service/dispute-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/dispute-service/dispute-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: dispute-service
     app.kubernetes.io/part-of: dispute
   annotations:
-    openbank.tech/policy-checksum: "f4f8aaff555ecb24"
+    openbank.tech/policy-checksum: "add3e37a0049482a"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2155,11 +2155,21 @@ data:
         - operator-ledger-write         # service-ledger-post / service-ledger-reverse
         - operator-balance-write        # service-balance-m2m
         - operator-fraud-write          # service-fraud-scoring
-        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
-        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m
+        # SAFE TODAY ONLY BY CO-ADMISSION, not by the rule named here: that rule covers
+        # sepaPayment.handleReturn alone, but ROLE_OPERATOR also grants sepaPayment.create /
+        # .transitionStatus / .approval.decide, so `matrix-allows` co-admits and this reason
+        # never becomes the only one. standing-order POSTs sepaPayment.create via the shared
+        # client. When ADR-0223 D2(b) retires those matrix grants, this entry starts denying it.
+        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m (see note above)
       # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
       # adding it here before that is a money-path outage, not a test failure.
       deferred:
+        operator-sca-write: "service-sca-shared-client-m2m covers scaChallenge.read ONLY, while
+          sca-service exposes consume/decide/initiate/verify and device.enroll. document-service
+          calls POST /challenges/{id}/consume through the shared client (ScaChallengeClient carries
+          OidcClientRequestReactiveFilter with oidc-client.client-id openbank-services) and
+          sca-service runs AUTHZ_ENFORCE=true, so listing this reason 403s the document-signing
+          gate. Needs #3748 (scaChallenge.consume for the shared client) to land first."
         operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
         operator-settlement-write: "settlement.create is resourceless with no alternative rule"
         operator-swift-write: "no identity-scoped rule; callers unverified"

--- a/openbank-infra/gitops/components/dispute-service/dispute-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/dispute-service/dispute-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: dispute-service
     app.kubernetes.io/part-of: dispute
   annotations:
-    openbank.tech/policy-checksum: "add3e37a0049482a"
+    openbank.tech/policy-checksum: "86808f0351d1bac2"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2161,15 +2161,16 @@ data:
         # never becomes the only one. standing-order POSTs sepaPayment.create via the shared
         # client. When ADR-0223 D2(b) retires those matrix grants, this entry starts denying it.
         - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m (see note above)
+        # Restored once #3748 landed: service-sca-shared-client-m2m now admits the shared client
+        # for scaChallenge.read AND scaChallenge.consume, so document-service's consume call
+        # (ScaChallengeClient, oidc-client.client-id openbank-services) keeps an identity-scoped
+        # reason and this entry no longer 403s the document-signing gate. device.list is covered
+        # by matrix-allows. Still uncovered for the shared client: decide/initiate/verify and
+        # device.enroll — no in-repo caller invokes them on that principal.
+        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
       # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
       # adding it here before that is a money-path outage, not a test failure.
       deferred:
-        operator-sca-write: "service-sca-shared-client-m2m covers scaChallenge.read ONLY, while
-          sca-service exposes consume/decide/initiate/verify and device.enroll. document-service
-          calls POST /challenges/{id}/consume through the shared client (ScaChallengeClient carries
-          OidcClientRequestReactiveFilter with oidc-client.client-id openbank-services) and
-          sca-service runs AUTHZ_ENFORCE=true, so listing this reason 403s the document-signing
-          gate. Needs #3748 (scaChallenge.consume for the shared client) to land first."
         operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
         operator-settlement-write: "settlement.create is resourceless with no alternative rule"
         operator-swift-write: "no identity-scoped rule; callers unverified"

--- a/openbank-infra/gitops/components/dispute-service/dispute-service.yaml
+++ b/openbank-infra/gitops/components/dispute-service/dispute-service.yaml
@@ -24,7 +24,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-dispute-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "c05ecd973bc33428"
+        openbank.tech/policy-checksum: "f4f8aaff555ecb24"
       labels: {app.kubernetes.io/name: dispute-service, app.kubernetes.io/part-of: dispute}
     spec:
       securityContext:

--- a/openbank-infra/gitops/components/dispute-service/dispute-service.yaml
+++ b/openbank-infra/gitops/components/dispute-service/dispute-service.yaml
@@ -24,7 +24,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-dispute-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "f4f8aaff555ecb24"
+        openbank.tech/policy-checksum: "add3e37a0049482a"
       labels: {app.kubernetes.io/name: dispute-service, app.kubernetes.io/part-of: dispute}
     spec:
       securityContext:

--- a/openbank-infra/gitops/components/dispute-service/dispute-service.yaml
+++ b/openbank-infra/gitops/components/dispute-service/dispute-service.yaml
@@ -24,7 +24,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-dispute-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "add3e37a0049482a"
+        openbank.tech/policy-checksum: "86808f0351d1bac2"
       labels: {app.kubernetes.io/name: dispute-service, app.kubernetes.io/part-of: dispute}
     spec:
       securityContext:

--- a/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: document-service
     app.kubernetes.io/part-of: documents
   annotations:
-    openbank.tech/policy-checksum: "9e6b95854986a6c1"
+    openbank.tech/policy-checksum: "af2491131f1b36de"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1097,15 +1097,16 @@ data:
         # never becomes the only one. standing-order POSTs sepaPayment.create via the shared
         # client. When ADR-0223 D2(b) retires those matrix grants, this entry starts denying it.
         - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m (see note above)
+        # Restored once #3748 landed: service-sca-shared-client-m2m now admits the shared client
+        # for scaChallenge.read AND scaChallenge.consume, so document-service's consume call
+        # (ScaChallengeClient, oidc-client.client-id openbank-services) keeps an identity-scoped
+        # reason and this entry no longer 403s the document-signing gate. device.list is covered
+        # by matrix-allows. Still uncovered for the shared client: decide/initiate/verify and
+        # device.enroll — no in-repo caller invokes them on that principal.
+        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
       # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
       # adding it here before that is a money-path outage, not a test failure.
       deferred:
-        operator-sca-write: "service-sca-shared-client-m2m covers scaChallenge.read ONLY, while
-          sca-service exposes consume/decide/initiate/verify and device.enroll. document-service
-          calls POST /challenges/{id}/consume through the shared client (ScaChallengeClient carries
-          OidcClientRequestReactiveFilter with oidc-client.client-id openbank-services) and
-          sca-service runs AUTHZ_ENFORCE=true, so listing this reason 403s the document-signing
-          gate. Needs #3748 (scaChallenge.consume for the shared client) to land first."
         operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
         operator-settlement-write: "settlement.create is resourceless with no alternative rule"
         operator-swift-write: "no identity-scoped rule; callers unverified"

--- a/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: document-service
     app.kubernetes.io/part-of: documents
   annotations:
-    openbank.tech/policy-checksum: "caa4315947012bae"
+    openbank.tech/policy-checksum: "1b5a85b0af2c058a"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1069,6 +1069,53 @@ data:
             - lending.collateralDecide
             - lending.approval.read
             - lending.approval.decide
+
+    shared_m2m_write_prohibition:
+      # GHSA-58jq-9hq3-66jr. rest.rego denies the shared M2M identity
+      # (`service-account-openbank-services`, which carries ROLE_OPERATOR in the realm) when the
+      # ONLY reasons admitting it are the role-only write reasons listed here.
+      #
+      # OPT-IN, and the reason a name pattern was rejected: matching every `operator-*-write`
+      # would have 403'd transaction.create from six live callers (account-service's
+      # welcome-bonus credit, sepa-instant, domestic-payment, swift, interest, sdd) and
+      # settlement.create — both AUTHZ_ENFORCE=true money paths whose services have no
+      # identity-scoped rule to fall back on. transaction-service's rego states the exposure
+      # itself ("RESIDUAL RISK — shared identity, no per-caller narrowing"), which is precisely
+      # why removing its only path is not the fix.
+      #
+      # A reason joins this list once its service carries a rule that NAMES the caller and
+      # enumerates its actions, so denying the role-only path removes an over-grant rather than
+      # the only path. Each entry below was verified to have such a rule.
+      reasons:
+        - operator-consent-write        # service-consent-m2m + service-consent-m2m-marketing
+        - operator-ledger-write         # service-ledger-post / service-ledger-reverse
+        - operator-balance-write        # service-balance-m2m
+        - operator-fraud-write          # service-fraud-scoring
+        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
+        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m
+      # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
+      # adding it here before that is a money-path outage, not a test failure.
+      deferred:
+        operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
+        operator-settlement-write: "settlement.create is resourceless with no alternative rule"
+        operator-swift-write: "no identity-scoped rule; callers unverified"
+        operator-sepa-instant-write: "no identity-scoped rule; callers unverified"
+        operator-billing-write: "no identity-scoped rule; callers unverified"
+        operator-interest-write: "no identity-scoped rule; callers unverified"
+        operator-lending-write: "no identity-scoped rule; callers unverified"
+        operator-sanctions-write: "no identity-scoped rule; m2m-sanctions-screening covers create only"
+        operator-identity-write: "no identity-scoped rule; callers unverified"
+        operator-card-write: "no identity-scoped rule; callers unverified"
+        # These DO carry an identity-pinned rule, but "a rule exists" is not "the rule covers the
+        # actions the role-only path was serving". Listing them on that basis would repeat, one
+        # level down, the guess that made the first revision break transaction.create. Each needs
+        # its identity-scoped rule read against its real callers before it moves up.
+        operator-fx-write: "2 identity-pinned rules; action coverage vs real callers unverified"
+        operator-account-write: "2 identity-pinned rules; action coverage unverified"
+        operator-clearing-write: "1 identity-pinned rule; action coverage unverified"
+        operator-domestic-payment-write: "1 identity-pinned rule; action coverage unverified"
+        operator-party-write: "1 identity-pinned rule, but onboarding-service PUTs party.kyc-status via the shared client (latent: AUTHZ_ENFORCE=false there today)"
+      adr: ADR-0034
   agents-data.yaml: |
     # SPDX-License-Identifier: Apache-2.0
     # Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.

--- a/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: document-service
     app.kubernetes.io/part-of: documents
   annotations:
-    openbank.tech/policy-checksum: "1b5a85b0af2c058a"
+    openbank.tech/policy-checksum: "9e6b95854986a6c1"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1091,11 +1091,21 @@ data:
         - operator-ledger-write         # service-ledger-post / service-ledger-reverse
         - operator-balance-write        # service-balance-m2m
         - operator-fraud-write          # service-fraud-scoring
-        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
-        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m
+        # SAFE TODAY ONLY BY CO-ADMISSION, not by the rule named here: that rule covers
+        # sepaPayment.handleReturn alone, but ROLE_OPERATOR also grants sepaPayment.create /
+        # .transitionStatus / .approval.decide, so `matrix-allows` co-admits and this reason
+        # never becomes the only one. standing-order POSTs sepaPayment.create via the shared
+        # client. When ADR-0223 D2(b) retires those matrix grants, this entry starts denying it.
+        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m (see note above)
       # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
       # adding it here before that is a money-path outage, not a test failure.
       deferred:
+        operator-sca-write: "service-sca-shared-client-m2m covers scaChallenge.read ONLY, while
+          sca-service exposes consume/decide/initiate/verify and device.enroll. document-service
+          calls POST /challenges/{id}/consume through the shared client (ScaChallengeClient carries
+          OidcClientRequestReactiveFilter with oidc-client.client-id openbank-services) and
+          sca-service runs AUTHZ_ENFORCE=true, so listing this reason 403s the document-signing
+          gate. Needs #3748 (scaChallenge.consume for the shared client) to land first."
         operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
         operator-settlement-write: "settlement.create is resourceless with no alternative rule"
         operator-swift-write: "no identity-scoped rule; callers unverified"

--- a/openbank-infra/gitops/components/document-service/document-service-service.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-service.yaml
@@ -52,7 +52,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-document-service-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "caa4315947012bae"
+        openbank.tech/policy-checksum: "1b5a85b0af2c058a"
     spec:
       # ADR-0162 D4 (continued): a dedicated SA (not `default`) is what OpenBao's Kubernetes-auth
       # role `document-service-signing` is bound to — least-privilege, one identity per consumer.

--- a/openbank-infra/gitops/components/document-service/document-service-service.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-service.yaml
@@ -52,7 +52,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-document-service-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "1b5a85b0af2c058a"
+        openbank.tech/policy-checksum: "9e6b95854986a6c1"
     spec:
       # ADR-0162 D4 (continued): a dedicated SA (not `default`) is what OpenBao's Kubernetes-auth
       # role `document-service-signing` is bound to — least-privilege, one identity per consumer.

--- a/openbank-infra/gitops/components/document-service/document-service-service.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-service.yaml
@@ -52,7 +52,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-document-service-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "9e6b95854986a6c1"
+        openbank.tech/policy-checksum: "af2491131f1b36de"
     spec:
       # ADR-0162 D4 (continued): a dedicated SA (not `default`) is what OpenBao's Kubernetes-auth
       # role `document-service-signing` is bound to — least-privilege, one identity per consumer.

--- a/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fraud-service
     app.kubernetes.io/part-of: fraud
   annotations:
-    openbank.tech/policy-checksum: "f8371c47911847fd"
+    openbank.tech/policy-checksum: "fe1e8e9813569279"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2008,5 +2008,52 @@ data:
             - lending.collateralDecide
             - lending.approval.read
             - lending.approval.decide
+
+    shared_m2m_write_prohibition:
+      # GHSA-58jq-9hq3-66jr. rest.rego denies the shared M2M identity
+      # (`service-account-openbank-services`, which carries ROLE_OPERATOR in the realm) when the
+      # ONLY reasons admitting it are the role-only write reasons listed here.
+      #
+      # OPT-IN, and the reason a name pattern was rejected: matching every `operator-*-write`
+      # would have 403'd transaction.create from six live callers (account-service's
+      # welcome-bonus credit, sepa-instant, domestic-payment, swift, interest, sdd) and
+      # settlement.create — both AUTHZ_ENFORCE=true money paths whose services have no
+      # identity-scoped rule to fall back on. transaction-service's rego states the exposure
+      # itself ("RESIDUAL RISK — shared identity, no per-caller narrowing"), which is precisely
+      # why removing its only path is not the fix.
+      #
+      # A reason joins this list once its service carries a rule that NAMES the caller and
+      # enumerates its actions, so denying the role-only path removes an over-grant rather than
+      # the only path. Each entry below was verified to have such a rule.
+      reasons:
+        - operator-consent-write        # service-consent-m2m + service-consent-m2m-marketing
+        - operator-ledger-write         # service-ledger-post / service-ledger-reverse
+        - operator-balance-write        # service-balance-m2m
+        - operator-fraud-write          # service-fraud-scoring
+        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
+        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m
+      # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
+      # adding it here before that is a money-path outage, not a test failure.
+      deferred:
+        operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
+        operator-settlement-write: "settlement.create is resourceless with no alternative rule"
+        operator-swift-write: "no identity-scoped rule; callers unverified"
+        operator-sepa-instant-write: "no identity-scoped rule; callers unverified"
+        operator-billing-write: "no identity-scoped rule; callers unverified"
+        operator-interest-write: "no identity-scoped rule; callers unverified"
+        operator-lending-write: "no identity-scoped rule; callers unverified"
+        operator-sanctions-write: "no identity-scoped rule; m2m-sanctions-screening covers create only"
+        operator-identity-write: "no identity-scoped rule; callers unverified"
+        operator-card-write: "no identity-scoped rule; callers unverified"
+        # These DO carry an identity-pinned rule, but "a rule exists" is not "the rule covers the
+        # actions the role-only path was serving". Listing them on that basis would repeat, one
+        # level down, the guess that made the first revision break transaction.create. Each needs
+        # its identity-scoped rule read against its real callers before it moves up.
+        operator-fx-write: "2 identity-pinned rules; action coverage vs real callers unverified"
+        operator-account-write: "2 identity-pinned rules; action coverage unverified"
+        operator-clearing-write: "1 identity-pinned rule; action coverage unverified"
+        operator-domestic-payment-write: "1 identity-pinned rule; action coverage unverified"
+        operator-party-write: "1 identity-pinned rule, but onboarding-service PUTs party.kyc-status via the shared client (latent: AUTHZ_ENFORCE=false there today)"
+      adr: ADR-0034
   manifest.json: |
     {"roots": ["openbank/agents", "openbank/copilot", "openbank/rest", "agents", "rules"]}

--- a/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fraud-service
     app.kubernetes.io/part-of: fraud
   annotations:
-    openbank.tech/policy-checksum: "fe1e8e9813569279"
+    openbank.tech/policy-checksum: "5aafa5d7497e4897"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2030,11 +2030,21 @@ data:
         - operator-ledger-write         # service-ledger-post / service-ledger-reverse
         - operator-balance-write        # service-balance-m2m
         - operator-fraud-write          # service-fraud-scoring
-        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
-        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m
+        # SAFE TODAY ONLY BY CO-ADMISSION, not by the rule named here: that rule covers
+        # sepaPayment.handleReturn alone, but ROLE_OPERATOR also grants sepaPayment.create /
+        # .transitionStatus / .approval.decide, so `matrix-allows` co-admits and this reason
+        # never becomes the only one. standing-order POSTs sepaPayment.create via the shared
+        # client. When ADR-0223 D2(b) retires those matrix grants, this entry starts denying it.
+        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m (see note above)
       # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
       # adding it here before that is a money-path outage, not a test failure.
       deferred:
+        operator-sca-write: "service-sca-shared-client-m2m covers scaChallenge.read ONLY, while
+          sca-service exposes consume/decide/initiate/verify and device.enroll. document-service
+          calls POST /challenges/{id}/consume through the shared client (ScaChallengeClient carries
+          OidcClientRequestReactiveFilter with oidc-client.client-id openbank-services) and
+          sca-service runs AUTHZ_ENFORCE=true, so listing this reason 403s the document-signing
+          gate. Needs #3748 (scaChallenge.consume for the shared client) to land first."
         operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
         operator-settlement-write: "settlement.create is resourceless with no alternative rule"
         operator-swift-write: "no identity-scoped rule; callers unverified"

--- a/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fraud-service
     app.kubernetes.io/part-of: fraud
   annotations:
-    openbank.tech/policy-checksum: "5aafa5d7497e4897"
+    openbank.tech/policy-checksum: "1d6e27da662904f3"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2036,15 +2036,16 @@ data:
         # never becomes the only one. standing-order POSTs sepaPayment.create via the shared
         # client. When ADR-0223 D2(b) retires those matrix grants, this entry starts denying it.
         - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m (see note above)
+        # Restored once #3748 landed: service-sca-shared-client-m2m now admits the shared client
+        # for scaChallenge.read AND scaChallenge.consume, so document-service's consume call
+        # (ScaChallengeClient, oidc-client.client-id openbank-services) keeps an identity-scoped
+        # reason and this entry no longer 403s the document-signing gate. device.list is covered
+        # by matrix-allows. Still uncovered for the shared client: decide/initiate/verify and
+        # device.enroll — no in-repo caller invokes them on that principal.
+        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
       # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
       # adding it here before that is a money-path outage, not a test failure.
       deferred:
-        operator-sca-write: "service-sca-shared-client-m2m covers scaChallenge.read ONLY, while
-          sca-service exposes consume/decide/initiate/verify and device.enroll. document-service
-          calls POST /challenges/{id}/consume through the shared client (ScaChallengeClient carries
-          OidcClientRequestReactiveFilter with oidc-client.client-id openbank-services) and
-          sca-service runs AUTHZ_ENFORCE=true, so listing this reason 403s the document-signing
-          gate. Needs #3748 (scaChallenge.consume for the shared client) to land first."
         operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
         operator-settlement-write: "settlement.create is resourceless with no alternative rule"
         operator-swift-write: "no identity-scoped rule; callers unverified"

--- a/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
@@ -23,7 +23,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fraud-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "fe1e8e9813569279"
+        openbank.tech/policy-checksum: "5aafa5d7497e4897"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
@@ -23,7 +23,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fraud-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "5aafa5d7497e4897"
+        openbank.tech/policy-checksum: "1d6e27da662904f3"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
@@ -23,7 +23,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fraud-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "f8371c47911847fd"
+        openbank.tech/policy-checksum: "fe1e8e9813569279"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fx-service
     app.kubernetes.io/part-of: fx
   annotations:
-    openbank.tech/policy-checksum: "8f340b68b488ce6e"
+    openbank.tech/policy-checksum: "011a905efc56760f"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2081,11 +2081,21 @@ data:
         - operator-ledger-write         # service-ledger-post / service-ledger-reverse
         - operator-balance-write        # service-balance-m2m
         - operator-fraud-write          # service-fraud-scoring
-        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
-        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m
+        # SAFE TODAY ONLY BY CO-ADMISSION, not by the rule named here: that rule covers
+        # sepaPayment.handleReturn alone, but ROLE_OPERATOR also grants sepaPayment.create /
+        # .transitionStatus / .approval.decide, so `matrix-allows` co-admits and this reason
+        # never becomes the only one. standing-order POSTs sepaPayment.create via the shared
+        # client. When ADR-0223 D2(b) retires those matrix grants, this entry starts denying it.
+        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m (see note above)
       # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
       # adding it here before that is a money-path outage, not a test failure.
       deferred:
+        operator-sca-write: "service-sca-shared-client-m2m covers scaChallenge.read ONLY, while
+          sca-service exposes consume/decide/initiate/verify and device.enroll. document-service
+          calls POST /challenges/{id}/consume through the shared client (ScaChallengeClient carries
+          OidcClientRequestReactiveFilter with oidc-client.client-id openbank-services) and
+          sca-service runs AUTHZ_ENFORCE=true, so listing this reason 403s the document-signing
+          gate. Needs #3748 (scaChallenge.consume for the shared client) to land first."
         operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
         operator-settlement-write: "settlement.create is resourceless with no alternative rule"
         operator-swift-write: "no identity-scoped rule; callers unverified"

--- a/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fx-service
     app.kubernetes.io/part-of: fx
   annotations:
-    openbank.tech/policy-checksum: "011a905efc56760f"
+    openbank.tech/policy-checksum: "42cb151bc59fd8fb"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2087,15 +2087,16 @@ data:
         # never becomes the only one. standing-order POSTs sepaPayment.create via the shared
         # client. When ADR-0223 D2(b) retires those matrix grants, this entry starts denying it.
         - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m (see note above)
+        # Restored once #3748 landed: service-sca-shared-client-m2m now admits the shared client
+        # for scaChallenge.read AND scaChallenge.consume, so document-service's consume call
+        # (ScaChallengeClient, oidc-client.client-id openbank-services) keeps an identity-scoped
+        # reason and this entry no longer 403s the document-signing gate. device.list is covered
+        # by matrix-allows. Still uncovered for the shared client: decide/initiate/verify and
+        # device.enroll — no in-repo caller invokes them on that principal.
+        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
       # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
       # adding it here before that is a money-path outage, not a test failure.
       deferred:
-        operator-sca-write: "service-sca-shared-client-m2m covers scaChallenge.read ONLY, while
-          sca-service exposes consume/decide/initiate/verify and device.enroll. document-service
-          calls POST /challenges/{id}/consume through the shared client (ScaChallengeClient carries
-          OidcClientRequestReactiveFilter with oidc-client.client-id openbank-services) and
-          sca-service runs AUTHZ_ENFORCE=true, so listing this reason 403s the document-signing
-          gate. Needs #3748 (scaChallenge.consume for the shared client) to land first."
         operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
         operator-settlement-write: "settlement.create is resourceless with no alternative rule"
         operator-swift-write: "no identity-scoped rule; callers unverified"

--- a/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fx-service
     app.kubernetes.io/part-of: fx
   annotations:
-    openbank.tech/policy-checksum: "9dd0bf7beff85161"
+    openbank.tech/policy-checksum: "8f340b68b488ce6e"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2059,5 +2059,52 @@ data:
             - lending.collateralDecide
             - lending.approval.read
             - lending.approval.decide
+
+    shared_m2m_write_prohibition:
+      # GHSA-58jq-9hq3-66jr. rest.rego denies the shared M2M identity
+      # (`service-account-openbank-services`, which carries ROLE_OPERATOR in the realm) when the
+      # ONLY reasons admitting it are the role-only write reasons listed here.
+      #
+      # OPT-IN, and the reason a name pattern was rejected: matching every `operator-*-write`
+      # would have 403'd transaction.create from six live callers (account-service's
+      # welcome-bonus credit, sepa-instant, domestic-payment, swift, interest, sdd) and
+      # settlement.create — both AUTHZ_ENFORCE=true money paths whose services have no
+      # identity-scoped rule to fall back on. transaction-service's rego states the exposure
+      # itself ("RESIDUAL RISK — shared identity, no per-caller narrowing"), which is precisely
+      # why removing its only path is not the fix.
+      #
+      # A reason joins this list once its service carries a rule that NAMES the caller and
+      # enumerates its actions, so denying the role-only path removes an over-grant rather than
+      # the only path. Each entry below was verified to have such a rule.
+      reasons:
+        - operator-consent-write        # service-consent-m2m + service-consent-m2m-marketing
+        - operator-ledger-write         # service-ledger-post / service-ledger-reverse
+        - operator-balance-write        # service-balance-m2m
+        - operator-fraud-write          # service-fraud-scoring
+        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
+        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m
+      # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
+      # adding it here before that is a money-path outage, not a test failure.
+      deferred:
+        operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
+        operator-settlement-write: "settlement.create is resourceless with no alternative rule"
+        operator-swift-write: "no identity-scoped rule; callers unverified"
+        operator-sepa-instant-write: "no identity-scoped rule; callers unverified"
+        operator-billing-write: "no identity-scoped rule; callers unverified"
+        operator-interest-write: "no identity-scoped rule; callers unverified"
+        operator-lending-write: "no identity-scoped rule; callers unverified"
+        operator-sanctions-write: "no identity-scoped rule; m2m-sanctions-screening covers create only"
+        operator-identity-write: "no identity-scoped rule; callers unverified"
+        operator-card-write: "no identity-scoped rule; callers unverified"
+        # These DO carry an identity-pinned rule, but "a rule exists" is not "the rule covers the
+        # actions the role-only path was serving". Listing them on that basis would repeat, one
+        # level down, the guess that made the first revision break transaction.create. Each needs
+        # its identity-scoped rule read against its real callers before it moves up.
+        operator-fx-write: "2 identity-pinned rules; action coverage vs real callers unverified"
+        operator-account-write: "2 identity-pinned rules; action coverage unverified"
+        operator-clearing-write: "1 identity-pinned rule; action coverage unverified"
+        operator-domestic-payment-write: "1 identity-pinned rule; action coverage unverified"
+        operator-party-write: "1 identity-pinned rule, but onboarding-service PUTs party.kyc-status via the shared client (latent: AUTHZ_ENFORCE=false there today)"
+      adr: ADR-0034
   manifest.json: |
     {"roots": ["openbank/agents", "openbank/copilot", "openbank/rest", "agents", "rules"]}

--- a/openbank-infra/gitops/components/fx-service/fx-service.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fx-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "011a905efc56760f"
+        openbank.tech/policy-checksum: "42cb151bc59fd8fb"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/fx-service/fx-service.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fx-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "9dd0bf7beff85161"
+        openbank.tech/policy-checksum: "8f340b68b488ce6e"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/fx-service/fx-service.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fx-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "8f340b68b488ce6e"
+        openbank.tech/policy-checksum: "011a905efc56760f"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: interest-service
     app.kubernetes.io/part-of: interest
   annotations:
-    openbank.tech/policy-checksum: "a1aa2f2bc6d8f5ae"
+    openbank.tech/policy-checksum: "398a7e93ce653728"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2015,11 +2015,21 @@ data:
         - operator-ledger-write         # service-ledger-post / service-ledger-reverse
         - operator-balance-write        # service-balance-m2m
         - operator-fraud-write          # service-fraud-scoring
-        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
-        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m
+        # SAFE TODAY ONLY BY CO-ADMISSION, not by the rule named here: that rule covers
+        # sepaPayment.handleReturn alone, but ROLE_OPERATOR also grants sepaPayment.create /
+        # .transitionStatus / .approval.decide, so `matrix-allows` co-admits and this reason
+        # never becomes the only one. standing-order POSTs sepaPayment.create via the shared
+        # client. When ADR-0223 D2(b) retires those matrix grants, this entry starts denying it.
+        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m (see note above)
       # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
       # adding it here before that is a money-path outage, not a test failure.
       deferred:
+        operator-sca-write: "service-sca-shared-client-m2m covers scaChallenge.read ONLY, while
+          sca-service exposes consume/decide/initiate/verify and device.enroll. document-service
+          calls POST /challenges/{id}/consume through the shared client (ScaChallengeClient carries
+          OidcClientRequestReactiveFilter with oidc-client.client-id openbank-services) and
+          sca-service runs AUTHZ_ENFORCE=true, so listing this reason 403s the document-signing
+          gate. Needs #3748 (scaChallenge.consume for the shared client) to land first."
         operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
         operator-settlement-write: "settlement.create is resourceless with no alternative rule"
         operator-swift-write: "no identity-scoped rule; callers unverified"

--- a/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: interest-service
     app.kubernetes.io/part-of: interest
   annotations:
-    openbank.tech/policy-checksum: "398a7e93ce653728"
+    openbank.tech/policy-checksum: "e4742ff1fd3deca1"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2021,15 +2021,16 @@ data:
         # never becomes the only one. standing-order POSTs sepaPayment.create via the shared
         # client. When ADR-0223 D2(b) retires those matrix grants, this entry starts denying it.
         - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m (see note above)
+        # Restored once #3748 landed: service-sca-shared-client-m2m now admits the shared client
+        # for scaChallenge.read AND scaChallenge.consume, so document-service's consume call
+        # (ScaChallengeClient, oidc-client.client-id openbank-services) keeps an identity-scoped
+        # reason and this entry no longer 403s the document-signing gate. device.list is covered
+        # by matrix-allows. Still uncovered for the shared client: decide/initiate/verify and
+        # device.enroll — no in-repo caller invokes them on that principal.
+        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
       # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
       # adding it here before that is a money-path outage, not a test failure.
       deferred:
-        operator-sca-write: "service-sca-shared-client-m2m covers scaChallenge.read ONLY, while
-          sca-service exposes consume/decide/initiate/verify and device.enroll. document-service
-          calls POST /challenges/{id}/consume through the shared client (ScaChallengeClient carries
-          OidcClientRequestReactiveFilter with oidc-client.client-id openbank-services) and
-          sca-service runs AUTHZ_ENFORCE=true, so listing this reason 403s the document-signing
-          gate. Needs #3748 (scaChallenge.consume for the shared client) to land first."
         operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
         operator-settlement-write: "settlement.create is resourceless with no alternative rule"
         operator-swift-write: "no identity-scoped rule; callers unverified"

--- a/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: interest-service
     app.kubernetes.io/part-of: interest
   annotations:
-    openbank.tech/policy-checksum: "078eb174fcf61e86"
+    openbank.tech/policy-checksum: "a1aa2f2bc6d8f5ae"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1993,5 +1993,52 @@ data:
             - lending.collateralDecide
             - lending.approval.read
             - lending.approval.decide
+
+    shared_m2m_write_prohibition:
+      # GHSA-58jq-9hq3-66jr. rest.rego denies the shared M2M identity
+      # (`service-account-openbank-services`, which carries ROLE_OPERATOR in the realm) when the
+      # ONLY reasons admitting it are the role-only write reasons listed here.
+      #
+      # OPT-IN, and the reason a name pattern was rejected: matching every `operator-*-write`
+      # would have 403'd transaction.create from six live callers (account-service's
+      # welcome-bonus credit, sepa-instant, domestic-payment, swift, interest, sdd) and
+      # settlement.create — both AUTHZ_ENFORCE=true money paths whose services have no
+      # identity-scoped rule to fall back on. transaction-service's rego states the exposure
+      # itself ("RESIDUAL RISK — shared identity, no per-caller narrowing"), which is precisely
+      # why removing its only path is not the fix.
+      #
+      # A reason joins this list once its service carries a rule that NAMES the caller and
+      # enumerates its actions, so denying the role-only path removes an over-grant rather than
+      # the only path. Each entry below was verified to have such a rule.
+      reasons:
+        - operator-consent-write        # service-consent-m2m + service-consent-m2m-marketing
+        - operator-ledger-write         # service-ledger-post / service-ledger-reverse
+        - operator-balance-write        # service-balance-m2m
+        - operator-fraud-write          # service-fraud-scoring
+        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
+        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m
+      # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
+      # adding it here before that is a money-path outage, not a test failure.
+      deferred:
+        operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
+        operator-settlement-write: "settlement.create is resourceless with no alternative rule"
+        operator-swift-write: "no identity-scoped rule; callers unverified"
+        operator-sepa-instant-write: "no identity-scoped rule; callers unverified"
+        operator-billing-write: "no identity-scoped rule; callers unverified"
+        operator-interest-write: "no identity-scoped rule; callers unverified"
+        operator-lending-write: "no identity-scoped rule; callers unverified"
+        operator-sanctions-write: "no identity-scoped rule; m2m-sanctions-screening covers create only"
+        operator-identity-write: "no identity-scoped rule; callers unverified"
+        operator-card-write: "no identity-scoped rule; callers unverified"
+        # These DO carry an identity-pinned rule, but "a rule exists" is not "the rule covers the
+        # actions the role-only path was serving". Listing them on that basis would repeat, one
+        # level down, the guess that made the first revision break transaction.create. Each needs
+        # its identity-scoped rule read against its real callers before it moves up.
+        operator-fx-write: "2 identity-pinned rules; action coverage vs real callers unverified"
+        operator-account-write: "2 identity-pinned rules; action coverage unverified"
+        operator-clearing-write: "1 identity-pinned rule; action coverage unverified"
+        operator-domestic-payment-write: "1 identity-pinned rule; action coverage unverified"
+        operator-party-write: "1 identity-pinned rule, but onboarding-service PUTs party.kyc-status via the shared client (latent: AUTHZ_ENFORCE=false there today)"
+      adr: ADR-0034
   manifest.json: |
     {"roots": ["openbank/agents", "openbank/copilot", "openbank/rest", "agents", "rules"]}

--- a/openbank-infra/gitops/components/interest-service/interest-service.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-service.yaml
@@ -25,7 +25,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-interest-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "398a7e93ce653728"
+        openbank.tech/policy-checksum: "e4742ff1fd3deca1"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/interest-service/interest-service.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-service.yaml
@@ -25,7 +25,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-interest-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "a1aa2f2bc6d8f5ae"
+        openbank.tech/policy-checksum: "398a7e93ce653728"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/interest-service/interest-service.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-service.yaml
@@ -25,7 +25,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-interest-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "078eb174fcf61e86"
+        openbank.tech/policy-checksum: "a1aa2f2bc6d8f5ae"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/kyc/kyc-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/kyc/kyc-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: kyc-service
     app.kubernetes.io/part-of: kyc
   annotations:
-    openbank.tech/policy-checksum: "18b96aa159eac334"
+    openbank.tech/policy-checksum: "ee680f2d010151bf"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2021,5 +2021,52 @@ data:
             - lending.collateralDecide
             - lending.approval.read
             - lending.approval.decide
+
+    shared_m2m_write_prohibition:
+      # GHSA-58jq-9hq3-66jr. rest.rego denies the shared M2M identity
+      # (`service-account-openbank-services`, which carries ROLE_OPERATOR in the realm) when the
+      # ONLY reasons admitting it are the role-only write reasons listed here.
+      #
+      # OPT-IN, and the reason a name pattern was rejected: matching every `operator-*-write`
+      # would have 403'd transaction.create from six live callers (account-service's
+      # welcome-bonus credit, sepa-instant, domestic-payment, swift, interest, sdd) and
+      # settlement.create — both AUTHZ_ENFORCE=true money paths whose services have no
+      # identity-scoped rule to fall back on. transaction-service's rego states the exposure
+      # itself ("RESIDUAL RISK — shared identity, no per-caller narrowing"), which is precisely
+      # why removing its only path is not the fix.
+      #
+      # A reason joins this list once its service carries a rule that NAMES the caller and
+      # enumerates its actions, so denying the role-only path removes an over-grant rather than
+      # the only path. Each entry below was verified to have such a rule.
+      reasons:
+        - operator-consent-write        # service-consent-m2m + service-consent-m2m-marketing
+        - operator-ledger-write         # service-ledger-post / service-ledger-reverse
+        - operator-balance-write        # service-balance-m2m
+        - operator-fraud-write          # service-fraud-scoring
+        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
+        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m
+      # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
+      # adding it here before that is a money-path outage, not a test failure.
+      deferred:
+        operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
+        operator-settlement-write: "settlement.create is resourceless with no alternative rule"
+        operator-swift-write: "no identity-scoped rule; callers unverified"
+        operator-sepa-instant-write: "no identity-scoped rule; callers unverified"
+        operator-billing-write: "no identity-scoped rule; callers unverified"
+        operator-interest-write: "no identity-scoped rule; callers unverified"
+        operator-lending-write: "no identity-scoped rule; callers unverified"
+        operator-sanctions-write: "no identity-scoped rule; m2m-sanctions-screening covers create only"
+        operator-identity-write: "no identity-scoped rule; callers unverified"
+        operator-card-write: "no identity-scoped rule; callers unverified"
+        # These DO carry an identity-pinned rule, but "a rule exists" is not "the rule covers the
+        # actions the role-only path was serving". Listing them on that basis would repeat, one
+        # level down, the guess that made the first revision break transaction.create. Each needs
+        # its identity-scoped rule read against its real callers before it moves up.
+        operator-fx-write: "2 identity-pinned rules; action coverage vs real callers unverified"
+        operator-account-write: "2 identity-pinned rules; action coverage unverified"
+        operator-clearing-write: "1 identity-pinned rule; action coverage unverified"
+        operator-domestic-payment-write: "1 identity-pinned rule; action coverage unverified"
+        operator-party-write: "1 identity-pinned rule, but onboarding-service PUTs party.kyc-status via the shared client (latent: AUTHZ_ENFORCE=false there today)"
+      adr: ADR-0034
   manifest.json: |
     {"roots": ["openbank/agents", "openbank/copilot", "openbank/rest", "agents", "rules"]}

--- a/openbank-infra/gitops/components/kyc/kyc-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/kyc/kyc-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: kyc-service
     app.kubernetes.io/part-of: kyc
   annotations:
-    openbank.tech/policy-checksum: "ee680f2d010151bf"
+    openbank.tech/policy-checksum: "ec436a468f542a98"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2043,11 +2043,21 @@ data:
         - operator-ledger-write         # service-ledger-post / service-ledger-reverse
         - operator-balance-write        # service-balance-m2m
         - operator-fraud-write          # service-fraud-scoring
-        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
-        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m
+        # SAFE TODAY ONLY BY CO-ADMISSION, not by the rule named here: that rule covers
+        # sepaPayment.handleReturn alone, but ROLE_OPERATOR also grants sepaPayment.create /
+        # .transitionStatus / .approval.decide, so `matrix-allows` co-admits and this reason
+        # never becomes the only one. standing-order POSTs sepaPayment.create via the shared
+        # client. When ADR-0223 D2(b) retires those matrix grants, this entry starts denying it.
+        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m (see note above)
       # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
       # adding it here before that is a money-path outage, not a test failure.
       deferred:
+        operator-sca-write: "service-sca-shared-client-m2m covers scaChallenge.read ONLY, while
+          sca-service exposes consume/decide/initiate/verify and device.enroll. document-service
+          calls POST /challenges/{id}/consume through the shared client (ScaChallengeClient carries
+          OidcClientRequestReactiveFilter with oidc-client.client-id openbank-services) and
+          sca-service runs AUTHZ_ENFORCE=true, so listing this reason 403s the document-signing
+          gate. Needs #3748 (scaChallenge.consume for the shared client) to land first."
         operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
         operator-settlement-write: "settlement.create is resourceless with no alternative rule"
         operator-swift-write: "no identity-scoped rule; callers unverified"

--- a/openbank-infra/gitops/components/kyc/kyc-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/kyc/kyc-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: kyc-service
     app.kubernetes.io/part-of: kyc
   annotations:
-    openbank.tech/policy-checksum: "ec436a468f542a98"
+    openbank.tech/policy-checksum: "3ac3209b789d0a04"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2049,15 +2049,16 @@ data:
         # never becomes the only one. standing-order POSTs sepaPayment.create via the shared
         # client. When ADR-0223 D2(b) retires those matrix grants, this entry starts denying it.
         - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m (see note above)
+        # Restored once #3748 landed: service-sca-shared-client-m2m now admits the shared client
+        # for scaChallenge.read AND scaChallenge.consume, so document-service's consume call
+        # (ScaChallengeClient, oidc-client.client-id openbank-services) keeps an identity-scoped
+        # reason and this entry no longer 403s the document-signing gate. device.list is covered
+        # by matrix-allows. Still uncovered for the shared client: decide/initiate/verify and
+        # device.enroll — no in-repo caller invokes them on that principal.
+        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
       # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
       # adding it here before that is a money-path outage, not a test failure.
       deferred:
-        operator-sca-write: "service-sca-shared-client-m2m covers scaChallenge.read ONLY, while
-          sca-service exposes consume/decide/initiate/verify and device.enroll. document-service
-          calls POST /challenges/{id}/consume through the shared client (ScaChallengeClient carries
-          OidcClientRequestReactiveFilter with oidc-client.client-id openbank-services) and
-          sca-service runs AUTHZ_ENFORCE=true, so listing this reason 403s the document-signing
-          gate. Needs #3748 (scaChallenge.consume for the shared client) to land first."
         operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
         operator-settlement-write: "settlement.create is resourceless with no alternative rule"
         operator-swift-write: "no identity-scoped rule; callers unverified"

--- a/openbank-infra/gitops/components/kyc/kyc-service.yaml
+++ b/openbank-infra/gitops/components/kyc/kyc-service.yaml
@@ -48,7 +48,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-kyc-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "18b96aa159eac334"
+        openbank.tech/policy-checksum: "ee680f2d010151bf"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/kyc/kyc-service.yaml
+++ b/openbank-infra/gitops/components/kyc/kyc-service.yaml
@@ -48,7 +48,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-kyc-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "ec436a468f542a98"
+        openbank.tech/policy-checksum: "3ac3209b789d0a04"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/kyc/kyc-service.yaml
+++ b/openbank-infra/gitops/components/kyc/kyc-service.yaml
@@ -48,7 +48,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-kyc-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "ee680f2d010151bf"
+        openbank.tech/policy-checksum: "ec436a468f542a98"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: ledger-service
     app.kubernetes.io/part-of: ledger
   annotations:
-    openbank.tech/policy-checksum: "6efa6f1f9ec41558"
+    openbank.tech/policy-checksum: "682afddc41361e1f"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2106,5 +2106,52 @@ data:
             - lending.collateralDecide
             - lending.approval.read
             - lending.approval.decide
+
+    shared_m2m_write_prohibition:
+      # GHSA-58jq-9hq3-66jr. rest.rego denies the shared M2M identity
+      # (`service-account-openbank-services`, which carries ROLE_OPERATOR in the realm) when the
+      # ONLY reasons admitting it are the role-only write reasons listed here.
+      #
+      # OPT-IN, and the reason a name pattern was rejected: matching every `operator-*-write`
+      # would have 403'd transaction.create from six live callers (account-service's
+      # welcome-bonus credit, sepa-instant, domestic-payment, swift, interest, sdd) and
+      # settlement.create — both AUTHZ_ENFORCE=true money paths whose services have no
+      # identity-scoped rule to fall back on. transaction-service's rego states the exposure
+      # itself ("RESIDUAL RISK — shared identity, no per-caller narrowing"), which is precisely
+      # why removing its only path is not the fix.
+      #
+      # A reason joins this list once its service carries a rule that NAMES the caller and
+      # enumerates its actions, so denying the role-only path removes an over-grant rather than
+      # the only path. Each entry below was verified to have such a rule.
+      reasons:
+        - operator-consent-write        # service-consent-m2m + service-consent-m2m-marketing
+        - operator-ledger-write         # service-ledger-post / service-ledger-reverse
+        - operator-balance-write        # service-balance-m2m
+        - operator-fraud-write          # service-fraud-scoring
+        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
+        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m
+      # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
+      # adding it here before that is a money-path outage, not a test failure.
+      deferred:
+        operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
+        operator-settlement-write: "settlement.create is resourceless with no alternative rule"
+        operator-swift-write: "no identity-scoped rule; callers unverified"
+        operator-sepa-instant-write: "no identity-scoped rule; callers unverified"
+        operator-billing-write: "no identity-scoped rule; callers unverified"
+        operator-interest-write: "no identity-scoped rule; callers unverified"
+        operator-lending-write: "no identity-scoped rule; callers unverified"
+        operator-sanctions-write: "no identity-scoped rule; m2m-sanctions-screening covers create only"
+        operator-identity-write: "no identity-scoped rule; callers unverified"
+        operator-card-write: "no identity-scoped rule; callers unverified"
+        # These DO carry an identity-pinned rule, but "a rule exists" is not "the rule covers the
+        # actions the role-only path was serving". Listing them on that basis would repeat, one
+        # level down, the guess that made the first revision break transaction.create. Each needs
+        # its identity-scoped rule read against its real callers before it moves up.
+        operator-fx-write: "2 identity-pinned rules; action coverage vs real callers unverified"
+        operator-account-write: "2 identity-pinned rules; action coverage unverified"
+        operator-clearing-write: "1 identity-pinned rule; action coverage unverified"
+        operator-domestic-payment-write: "1 identity-pinned rule; action coverage unverified"
+        operator-party-write: "1 identity-pinned rule, but onboarding-service PUTs party.kyc-status via the shared client (latent: AUTHZ_ENFORCE=false there today)"
+      adr: ADR-0034
   manifest.json: |
     {"roots": ["openbank/agents", "openbank/copilot", "openbank/rest", "agents", "rules"]}

--- a/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: ledger-service
     app.kubernetes.io/part-of: ledger
   annotations:
-    openbank.tech/policy-checksum: "e750930c14c05cae"
+    openbank.tech/policy-checksum: "5aa4227761c9392d"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2134,15 +2134,16 @@ data:
         # never becomes the only one. standing-order POSTs sepaPayment.create via the shared
         # client. When ADR-0223 D2(b) retires those matrix grants, this entry starts denying it.
         - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m (see note above)
+        # Restored once #3748 landed: service-sca-shared-client-m2m now admits the shared client
+        # for scaChallenge.read AND scaChallenge.consume, so document-service's consume call
+        # (ScaChallengeClient, oidc-client.client-id openbank-services) keeps an identity-scoped
+        # reason and this entry no longer 403s the document-signing gate. device.list is covered
+        # by matrix-allows. Still uncovered for the shared client: decide/initiate/verify and
+        # device.enroll — no in-repo caller invokes them on that principal.
+        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
       # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
       # adding it here before that is a money-path outage, not a test failure.
       deferred:
-        operator-sca-write: "service-sca-shared-client-m2m covers scaChallenge.read ONLY, while
-          sca-service exposes consume/decide/initiate/verify and device.enroll. document-service
-          calls POST /challenges/{id}/consume through the shared client (ScaChallengeClient carries
-          OidcClientRequestReactiveFilter with oidc-client.client-id openbank-services) and
-          sca-service runs AUTHZ_ENFORCE=true, so listing this reason 403s the document-signing
-          gate. Needs #3748 (scaChallenge.consume for the shared client) to land first."
         operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
         operator-settlement-write: "settlement.create is resourceless with no alternative rule"
         operator-swift-write: "no identity-scoped rule; callers unverified"

--- a/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: ledger-service
     app.kubernetes.io/part-of: ledger
   annotations:
-    openbank.tech/policy-checksum: "682afddc41361e1f"
+    openbank.tech/policy-checksum: "e750930c14c05cae"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2128,11 +2128,21 @@ data:
         - operator-ledger-write         # service-ledger-post / service-ledger-reverse
         - operator-balance-write        # service-balance-m2m
         - operator-fraud-write          # service-fraud-scoring
-        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
-        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m
+        # SAFE TODAY ONLY BY CO-ADMISSION, not by the rule named here: that rule covers
+        # sepaPayment.handleReturn alone, but ROLE_OPERATOR also grants sepaPayment.create /
+        # .transitionStatus / .approval.decide, so `matrix-allows` co-admits and this reason
+        # never becomes the only one. standing-order POSTs sepaPayment.create via the shared
+        # client. When ADR-0223 D2(b) retires those matrix grants, this entry starts denying it.
+        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m (see note above)
       # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
       # adding it here before that is a money-path outage, not a test failure.
       deferred:
+        operator-sca-write: "service-sca-shared-client-m2m covers scaChallenge.read ONLY, while
+          sca-service exposes consume/decide/initiate/verify and device.enroll. document-service
+          calls POST /challenges/{id}/consume through the shared client (ScaChallengeClient carries
+          OidcClientRequestReactiveFilter with oidc-client.client-id openbank-services) and
+          sca-service runs AUTHZ_ENFORCE=true, so listing this reason 403s the document-signing
+          gate. Needs #3748 (scaChallenge.consume for the shared client) to land first."
         operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
         operator-settlement-write: "settlement.create is resourceless with no alternative rule"
         operator-swift-write: "no identity-scoped rule; callers unverified"

--- a/openbank-infra/gitops/components/ledger/ledger-service.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-service.yaml
@@ -38,7 +38,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-ledger-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "682afddc41361e1f"
+        openbank.tech/policy-checksum: "e750930c14c05cae"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/ledger/ledger-service.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-service.yaml
@@ -38,7 +38,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-ledger-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "e750930c14c05cae"
+        openbank.tech/policy-checksum: "5aa4227761c9392d"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/ledger/ledger-service.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-service.yaml
@@ -38,7 +38,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-ledger-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "6efa6f1f9ec41558"
+        openbank.tech/policy-checksum: "682afddc41361e1f"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: lending-service
     app.kubernetes.io/part-of: lending
   annotations:
-    openbank.tech/policy-checksum: "1211983c4a419a54"
+    openbank.tech/policy-checksum: "82ab58091df01c75"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2123,11 +2123,21 @@ data:
         - operator-ledger-write         # service-ledger-post / service-ledger-reverse
         - operator-balance-write        # service-balance-m2m
         - operator-fraud-write          # service-fraud-scoring
-        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
-        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m
+        # SAFE TODAY ONLY BY CO-ADMISSION, not by the rule named here: that rule covers
+        # sepaPayment.handleReturn alone, but ROLE_OPERATOR also grants sepaPayment.create /
+        # .transitionStatus / .approval.decide, so `matrix-allows` co-admits and this reason
+        # never becomes the only one. standing-order POSTs sepaPayment.create via the shared
+        # client. When ADR-0223 D2(b) retires those matrix grants, this entry starts denying it.
+        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m (see note above)
       # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
       # adding it here before that is a money-path outage, not a test failure.
       deferred:
+        operator-sca-write: "service-sca-shared-client-m2m covers scaChallenge.read ONLY, while
+          sca-service exposes consume/decide/initiate/verify and device.enroll. document-service
+          calls POST /challenges/{id}/consume through the shared client (ScaChallengeClient carries
+          OidcClientRequestReactiveFilter with oidc-client.client-id openbank-services) and
+          sca-service runs AUTHZ_ENFORCE=true, so listing this reason 403s the document-signing
+          gate. Needs #3748 (scaChallenge.consume for the shared client) to land first."
         operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
         operator-settlement-write: "settlement.create is resourceless with no alternative rule"
         operator-swift-write: "no identity-scoped rule; callers unverified"

--- a/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: lending-service
     app.kubernetes.io/part-of: lending
   annotations:
-    openbank.tech/policy-checksum: "8592c7ef864525f6"
+    openbank.tech/policy-checksum: "1211983c4a419a54"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2101,5 +2101,52 @@ data:
             - lending.collateralDecide
             - lending.approval.read
             - lending.approval.decide
+
+    shared_m2m_write_prohibition:
+      # GHSA-58jq-9hq3-66jr. rest.rego denies the shared M2M identity
+      # (`service-account-openbank-services`, which carries ROLE_OPERATOR in the realm) when the
+      # ONLY reasons admitting it are the role-only write reasons listed here.
+      #
+      # OPT-IN, and the reason a name pattern was rejected: matching every `operator-*-write`
+      # would have 403'd transaction.create from six live callers (account-service's
+      # welcome-bonus credit, sepa-instant, domestic-payment, swift, interest, sdd) and
+      # settlement.create — both AUTHZ_ENFORCE=true money paths whose services have no
+      # identity-scoped rule to fall back on. transaction-service's rego states the exposure
+      # itself ("RESIDUAL RISK — shared identity, no per-caller narrowing"), which is precisely
+      # why removing its only path is not the fix.
+      #
+      # A reason joins this list once its service carries a rule that NAMES the caller and
+      # enumerates its actions, so denying the role-only path removes an over-grant rather than
+      # the only path. Each entry below was verified to have such a rule.
+      reasons:
+        - operator-consent-write        # service-consent-m2m + service-consent-m2m-marketing
+        - operator-ledger-write         # service-ledger-post / service-ledger-reverse
+        - operator-balance-write        # service-balance-m2m
+        - operator-fraud-write          # service-fraud-scoring
+        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
+        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m
+      # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
+      # adding it here before that is a money-path outage, not a test failure.
+      deferred:
+        operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
+        operator-settlement-write: "settlement.create is resourceless with no alternative rule"
+        operator-swift-write: "no identity-scoped rule; callers unverified"
+        operator-sepa-instant-write: "no identity-scoped rule; callers unverified"
+        operator-billing-write: "no identity-scoped rule; callers unverified"
+        operator-interest-write: "no identity-scoped rule; callers unverified"
+        operator-lending-write: "no identity-scoped rule; callers unverified"
+        operator-sanctions-write: "no identity-scoped rule; m2m-sanctions-screening covers create only"
+        operator-identity-write: "no identity-scoped rule; callers unverified"
+        operator-card-write: "no identity-scoped rule; callers unverified"
+        # These DO carry an identity-pinned rule, but "a rule exists" is not "the rule covers the
+        # actions the role-only path was serving". Listing them on that basis would repeat, one
+        # level down, the guess that made the first revision break transaction.create. Each needs
+        # its identity-scoped rule read against its real callers before it moves up.
+        operator-fx-write: "2 identity-pinned rules; action coverage vs real callers unverified"
+        operator-account-write: "2 identity-pinned rules; action coverage unverified"
+        operator-clearing-write: "1 identity-pinned rule; action coverage unverified"
+        operator-domestic-payment-write: "1 identity-pinned rule; action coverage unverified"
+        operator-party-write: "1 identity-pinned rule, but onboarding-service PUTs party.kyc-status via the shared client (latent: AUTHZ_ENFORCE=false there today)"
+      adr: ADR-0034
   manifest.json: |
     {"roots": ["openbank/agents", "openbank/copilot", "openbank/rest", "agents", "rules"]}

--- a/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: lending-service
     app.kubernetes.io/part-of: lending
   annotations:
-    openbank.tech/policy-checksum: "82ab58091df01c75"
+    openbank.tech/policy-checksum: "5a76a661b652eda3"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2129,15 +2129,16 @@ data:
         # never becomes the only one. standing-order POSTs sepaPayment.create via the shared
         # client. When ADR-0223 D2(b) retires those matrix grants, this entry starts denying it.
         - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m (see note above)
+        # Restored once #3748 landed: service-sca-shared-client-m2m now admits the shared client
+        # for scaChallenge.read AND scaChallenge.consume, so document-service's consume call
+        # (ScaChallengeClient, oidc-client.client-id openbank-services) keeps an identity-scoped
+        # reason and this entry no longer 403s the document-signing gate. device.list is covered
+        # by matrix-allows. Still uncovered for the shared client: decide/initiate/verify and
+        # device.enroll — no in-repo caller invokes them on that principal.
+        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
       # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
       # adding it here before that is a money-path outage, not a test failure.
       deferred:
-        operator-sca-write: "service-sca-shared-client-m2m covers scaChallenge.read ONLY, while
-          sca-service exposes consume/decide/initiate/verify and device.enroll. document-service
-          calls POST /challenges/{id}/consume through the shared client (ScaChallengeClient carries
-          OidcClientRequestReactiveFilter with oidc-client.client-id openbank-services) and
-          sca-service runs AUTHZ_ENFORCE=true, so listing this reason 403s the document-signing
-          gate. Needs #3748 (scaChallenge.consume for the shared client) to land first."
         operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
         operator-settlement-write: "settlement.create is resourceless with no alternative rule"
         operator-swift-write: "no identity-scoped rule; callers unverified"

--- a/openbank-infra/gitops/components/lending/lending-service.yaml
+++ b/openbank-infra/gitops/components/lending/lending-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-lending-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "1211983c4a419a54"
+        openbank.tech/policy-checksum: "82ab58091df01c75"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/lending/lending-service.yaml
+++ b/openbank-infra/gitops/components/lending/lending-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-lending-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "8592c7ef864525f6"
+        openbank.tech/policy-checksum: "1211983c4a419a54"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/lending/lending-service.yaml
+++ b/openbank-infra/gitops/components/lending/lending-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-lending-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "82ab58091df01c75"
+        openbank.tech/policy-checksum: "5a76a661b652eda3"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/mcp/mcp-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/mcp/mcp-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: mcp-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "39e046dcedf7cddf"
+    openbank.tech/policy-checksum: "b2647a2bbbc7d423"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1981,11 +1981,21 @@ data:
         - operator-ledger-write         # service-ledger-post / service-ledger-reverse
         - operator-balance-write        # service-balance-m2m
         - operator-fraud-write          # service-fraud-scoring
-        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
-        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m
+        # SAFE TODAY ONLY BY CO-ADMISSION, not by the rule named here: that rule covers
+        # sepaPayment.handleReturn alone, but ROLE_OPERATOR also grants sepaPayment.create /
+        # .transitionStatus / .approval.decide, so `matrix-allows` co-admits and this reason
+        # never becomes the only one. standing-order POSTs sepaPayment.create via the shared
+        # client. When ADR-0223 D2(b) retires those matrix grants, this entry starts denying it.
+        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m (see note above)
       # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
       # adding it here before that is a money-path outage, not a test failure.
       deferred:
+        operator-sca-write: "service-sca-shared-client-m2m covers scaChallenge.read ONLY, while
+          sca-service exposes consume/decide/initiate/verify and device.enroll. document-service
+          calls POST /challenges/{id}/consume through the shared client (ScaChallengeClient carries
+          OidcClientRequestReactiveFilter with oidc-client.client-id openbank-services) and
+          sca-service runs AUTHZ_ENFORCE=true, so listing this reason 403s the document-signing
+          gate. Needs #3748 (scaChallenge.consume for the shared client) to land first."
         operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
         operator-settlement-write: "settlement.create is resourceless with no alternative rule"
         operator-swift-write: "no identity-scoped rule; callers unverified"

--- a/openbank-infra/gitops/components/mcp/mcp-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/mcp/mcp-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: mcp-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "b2647a2bbbc7d423"
+    openbank.tech/policy-checksum: "495f4aaec4237b8f"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1987,15 +1987,16 @@ data:
         # never becomes the only one. standing-order POSTs sepaPayment.create via the shared
         # client. When ADR-0223 D2(b) retires those matrix grants, this entry starts denying it.
         - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m (see note above)
+        # Restored once #3748 landed: service-sca-shared-client-m2m now admits the shared client
+        # for scaChallenge.read AND scaChallenge.consume, so document-service's consume call
+        # (ScaChallengeClient, oidc-client.client-id openbank-services) keeps an identity-scoped
+        # reason and this entry no longer 403s the document-signing gate. device.list is covered
+        # by matrix-allows. Still uncovered for the shared client: decide/initiate/verify and
+        # device.enroll — no in-repo caller invokes them on that principal.
+        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
       # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
       # adding it here before that is a money-path outage, not a test failure.
       deferred:
-        operator-sca-write: "service-sca-shared-client-m2m covers scaChallenge.read ONLY, while
-          sca-service exposes consume/decide/initiate/verify and device.enroll. document-service
-          calls POST /challenges/{id}/consume through the shared client (ScaChallengeClient carries
-          OidcClientRequestReactiveFilter with oidc-client.client-id openbank-services) and
-          sca-service runs AUTHZ_ENFORCE=true, so listing this reason 403s the document-signing
-          gate. Needs #3748 (scaChallenge.consume for the shared client) to land first."
         operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
         operator-settlement-write: "settlement.create is resourceless with no alternative rule"
         operator-swift-write: "no identity-scoped rule; callers unverified"

--- a/openbank-infra/gitops/components/mcp/mcp-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/mcp/mcp-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: mcp-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "899d182785c99f54"
+    openbank.tech/policy-checksum: "39e046dcedf7cddf"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1959,5 +1959,52 @@ data:
             - lending.collateralDecide
             - lending.approval.read
             - lending.approval.decide
+
+    shared_m2m_write_prohibition:
+      # GHSA-58jq-9hq3-66jr. rest.rego denies the shared M2M identity
+      # (`service-account-openbank-services`, which carries ROLE_OPERATOR in the realm) when the
+      # ONLY reasons admitting it are the role-only write reasons listed here.
+      #
+      # OPT-IN, and the reason a name pattern was rejected: matching every `operator-*-write`
+      # would have 403'd transaction.create from six live callers (account-service's
+      # welcome-bonus credit, sepa-instant, domestic-payment, swift, interest, sdd) and
+      # settlement.create — both AUTHZ_ENFORCE=true money paths whose services have no
+      # identity-scoped rule to fall back on. transaction-service's rego states the exposure
+      # itself ("RESIDUAL RISK — shared identity, no per-caller narrowing"), which is precisely
+      # why removing its only path is not the fix.
+      #
+      # A reason joins this list once its service carries a rule that NAMES the caller and
+      # enumerates its actions, so denying the role-only path removes an over-grant rather than
+      # the only path. Each entry below was verified to have such a rule.
+      reasons:
+        - operator-consent-write        # service-consent-m2m + service-consent-m2m-marketing
+        - operator-ledger-write         # service-ledger-post / service-ledger-reverse
+        - operator-balance-write        # service-balance-m2m
+        - operator-fraud-write          # service-fraud-scoring
+        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
+        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m
+      # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
+      # adding it here before that is a money-path outage, not a test failure.
+      deferred:
+        operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
+        operator-settlement-write: "settlement.create is resourceless with no alternative rule"
+        operator-swift-write: "no identity-scoped rule; callers unverified"
+        operator-sepa-instant-write: "no identity-scoped rule; callers unverified"
+        operator-billing-write: "no identity-scoped rule; callers unverified"
+        operator-interest-write: "no identity-scoped rule; callers unverified"
+        operator-lending-write: "no identity-scoped rule; callers unverified"
+        operator-sanctions-write: "no identity-scoped rule; m2m-sanctions-screening covers create only"
+        operator-identity-write: "no identity-scoped rule; callers unverified"
+        operator-card-write: "no identity-scoped rule; callers unverified"
+        # These DO carry an identity-pinned rule, but "a rule exists" is not "the rule covers the
+        # actions the role-only path was serving". Listing them on that basis would repeat, one
+        # level down, the guess that made the first revision break transaction.create. Each needs
+        # its identity-scoped rule read against its real callers before it moves up.
+        operator-fx-write: "2 identity-pinned rules; action coverage vs real callers unverified"
+        operator-account-write: "2 identity-pinned rules; action coverage unverified"
+        operator-clearing-write: "1 identity-pinned rule; action coverage unverified"
+        operator-domestic-payment-write: "1 identity-pinned rule; action coverage unverified"
+        operator-party-write: "1 identity-pinned rule, but onboarding-service PUTs party.kyc-status via the shared client (latent: AUTHZ_ENFORCE=false there today)"
+      adr: ADR-0034
   manifest.json: |
     {"roots": ["openbank/agents", "openbank/copilot", "openbank/rest", "agents", "rules"]}

--- a/openbank-infra/gitops/components/mcp/mcp-service.yaml
+++ b/openbank-infra/gitops/components/mcp/mcp-service.yaml
@@ -39,7 +39,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-mcp-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "39e046dcedf7cddf"
+        openbank.tech/policy-checksum: "b2647a2bbbc7d423"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/mcp/mcp-service.yaml
+++ b/openbank-infra/gitops/components/mcp/mcp-service.yaml
@@ -39,7 +39,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-mcp-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "899d182785c99f54"
+        openbank.tech/policy-checksum: "39e046dcedf7cddf"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/mcp/mcp-service.yaml
+++ b/openbank-infra/gitops/components/mcp/mcp-service.yaml
@@ -39,7 +39,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-mcp-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "b2647a2bbbc7d423"
+        openbank.tech/policy-checksum: "495f4aaec4237b8f"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: notification-service
     app.kubernetes.io/part-of: notifications
   annotations:
-    openbank.tech/policy-checksum: "1b5a85b0af2c058a"
+    openbank.tech/policy-checksum: "9e6b95854986a6c1"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1091,11 +1091,21 @@ data:
         - operator-ledger-write         # service-ledger-post / service-ledger-reverse
         - operator-balance-write        # service-balance-m2m
         - operator-fraud-write          # service-fraud-scoring
-        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
-        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m
+        # SAFE TODAY ONLY BY CO-ADMISSION, not by the rule named here: that rule covers
+        # sepaPayment.handleReturn alone, but ROLE_OPERATOR also grants sepaPayment.create /
+        # .transitionStatus / .approval.decide, so `matrix-allows` co-admits and this reason
+        # never becomes the only one. standing-order POSTs sepaPayment.create via the shared
+        # client. When ADR-0223 D2(b) retires those matrix grants, this entry starts denying it.
+        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m (see note above)
       # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
       # adding it here before that is a money-path outage, not a test failure.
       deferred:
+        operator-sca-write: "service-sca-shared-client-m2m covers scaChallenge.read ONLY, while
+          sca-service exposes consume/decide/initiate/verify and device.enroll. document-service
+          calls POST /challenges/{id}/consume through the shared client (ScaChallengeClient carries
+          OidcClientRequestReactiveFilter with oidc-client.client-id openbank-services) and
+          sca-service runs AUTHZ_ENFORCE=true, so listing this reason 403s the document-signing
+          gate. Needs #3748 (scaChallenge.consume for the shared client) to land first."
         operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
         operator-settlement-write: "settlement.create is resourceless with no alternative rule"
         operator-swift-write: "no identity-scoped rule; callers unverified"

--- a/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: notification-service
     app.kubernetes.io/part-of: notifications
   annotations:
-    openbank.tech/policy-checksum: "caa4315947012bae"
+    openbank.tech/policy-checksum: "1b5a85b0af2c058a"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1069,6 +1069,53 @@ data:
             - lending.collateralDecide
             - lending.approval.read
             - lending.approval.decide
+
+    shared_m2m_write_prohibition:
+      # GHSA-58jq-9hq3-66jr. rest.rego denies the shared M2M identity
+      # (`service-account-openbank-services`, which carries ROLE_OPERATOR in the realm) when the
+      # ONLY reasons admitting it are the role-only write reasons listed here.
+      #
+      # OPT-IN, and the reason a name pattern was rejected: matching every `operator-*-write`
+      # would have 403'd transaction.create from six live callers (account-service's
+      # welcome-bonus credit, sepa-instant, domestic-payment, swift, interest, sdd) and
+      # settlement.create — both AUTHZ_ENFORCE=true money paths whose services have no
+      # identity-scoped rule to fall back on. transaction-service's rego states the exposure
+      # itself ("RESIDUAL RISK — shared identity, no per-caller narrowing"), which is precisely
+      # why removing its only path is not the fix.
+      #
+      # A reason joins this list once its service carries a rule that NAMES the caller and
+      # enumerates its actions, so denying the role-only path removes an over-grant rather than
+      # the only path. Each entry below was verified to have such a rule.
+      reasons:
+        - operator-consent-write        # service-consent-m2m + service-consent-m2m-marketing
+        - operator-ledger-write         # service-ledger-post / service-ledger-reverse
+        - operator-balance-write        # service-balance-m2m
+        - operator-fraud-write          # service-fraud-scoring
+        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
+        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m
+      # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
+      # adding it here before that is a money-path outage, not a test failure.
+      deferred:
+        operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
+        operator-settlement-write: "settlement.create is resourceless with no alternative rule"
+        operator-swift-write: "no identity-scoped rule; callers unverified"
+        operator-sepa-instant-write: "no identity-scoped rule; callers unverified"
+        operator-billing-write: "no identity-scoped rule; callers unverified"
+        operator-interest-write: "no identity-scoped rule; callers unverified"
+        operator-lending-write: "no identity-scoped rule; callers unverified"
+        operator-sanctions-write: "no identity-scoped rule; m2m-sanctions-screening covers create only"
+        operator-identity-write: "no identity-scoped rule; callers unverified"
+        operator-card-write: "no identity-scoped rule; callers unverified"
+        # These DO carry an identity-pinned rule, but "a rule exists" is not "the rule covers the
+        # actions the role-only path was serving". Listing them on that basis would repeat, one
+        # level down, the guess that made the first revision break transaction.create. Each needs
+        # its identity-scoped rule read against its real callers before it moves up.
+        operator-fx-write: "2 identity-pinned rules; action coverage vs real callers unverified"
+        operator-account-write: "2 identity-pinned rules; action coverage unverified"
+        operator-clearing-write: "1 identity-pinned rule; action coverage unverified"
+        operator-domestic-payment-write: "1 identity-pinned rule; action coverage unverified"
+        operator-party-write: "1 identity-pinned rule, but onboarding-service PUTs party.kyc-status via the shared client (latent: AUTHZ_ENFORCE=false there today)"
+      adr: ADR-0034
   agents-data.yaml: |
     # SPDX-License-Identifier: Apache-2.0
     # Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.

--- a/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: notification-service
     app.kubernetes.io/part-of: notifications
   annotations:
-    openbank.tech/policy-checksum: "9e6b95854986a6c1"
+    openbank.tech/policy-checksum: "af2491131f1b36de"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1097,15 +1097,16 @@ data:
         # never becomes the only one. standing-order POSTs sepaPayment.create via the shared
         # client. When ADR-0223 D2(b) retires those matrix grants, this entry starts denying it.
         - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m (see note above)
+        # Restored once #3748 landed: service-sca-shared-client-m2m now admits the shared client
+        # for scaChallenge.read AND scaChallenge.consume, so document-service's consume call
+        # (ScaChallengeClient, oidc-client.client-id openbank-services) keeps an identity-scoped
+        # reason and this entry no longer 403s the document-signing gate. device.list is covered
+        # by matrix-allows. Still uncovered for the shared client: decide/initiate/verify and
+        # device.enroll — no in-repo caller invokes them on that principal.
+        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
       # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
       # adding it here before that is a money-path outage, not a test failure.
       deferred:
-        operator-sca-write: "service-sca-shared-client-m2m covers scaChallenge.read ONLY, while
-          sca-service exposes consume/decide/initiate/verify and device.enroll. document-service
-          calls POST /challenges/{id}/consume through the shared client (ScaChallengeClient carries
-          OidcClientRequestReactiveFilter with oidc-client.client-id openbank-services) and
-          sca-service runs AUTHZ_ENFORCE=true, so listing this reason 403s the document-signing
-          gate. Needs #3748 (scaChallenge.consume for the shared client) to land first."
         operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
         operator-settlement-write: "settlement.create is resourceless with no alternative rule"
         operator-swift-write: "no identity-scoped rule; callers unverified"

--- a/openbank-infra/gitops/components/notifications/notification-service.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service.yaml
@@ -48,7 +48,7 @@ spec:
       annotations:
         # Rolls the Deployment when the OPA policy bundle changes (subPath mounts don't
         # hot-reload). Kept in sync by gen-notification-opa-bundle.sh.
-        openbank.tech/policy-checksum: "caa4315947012bae"
+        openbank.tech/policy-checksum: "1b5a85b0af2c058a"
       labels:
         app.kubernetes.io/name: notification-service
         app.kubernetes.io/part-of: notifications

--- a/openbank-infra/gitops/components/notifications/notification-service.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service.yaml
@@ -48,7 +48,7 @@ spec:
       annotations:
         # Rolls the Deployment when the OPA policy bundle changes (subPath mounts don't
         # hot-reload). Kept in sync by gen-notification-opa-bundle.sh.
-        openbank.tech/policy-checksum: "1b5a85b0af2c058a"
+        openbank.tech/policy-checksum: "9e6b95854986a6c1"
       labels:
         app.kubernetes.io/name: notification-service
         app.kubernetes.io/part-of: notifications

--- a/openbank-infra/gitops/components/notifications/notification-service.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service.yaml
@@ -48,7 +48,7 @@ spec:
       annotations:
         # Rolls the Deployment when the OPA policy bundle changes (subPath mounts don't
         # hot-reload). Kept in sync by gen-notification-opa-bundle.sh.
-        openbank.tech/policy-checksum: "9e6b95854986a6c1"
+        openbank.tech/policy-checksum: "af2491131f1b36de"
       labels:
         app.kubernetes.io/name: notification-service
         app.kubernetes.io/part-of: notifications

--- a/openbank-infra/gitops/components/party/party-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/party/party-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: party-service
     app.kubernetes.io/part-of: party
   annotations:
-    openbank.tech/policy-checksum: "d8f52b5114a39627"
+    openbank.tech/policy-checksum: "e1e0e77e5bb964de"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2030,5 +2030,52 @@ data:
             - lending.collateralDecide
             - lending.approval.read
             - lending.approval.decide
+
+    shared_m2m_write_prohibition:
+      # GHSA-58jq-9hq3-66jr. rest.rego denies the shared M2M identity
+      # (`service-account-openbank-services`, which carries ROLE_OPERATOR in the realm) when the
+      # ONLY reasons admitting it are the role-only write reasons listed here.
+      #
+      # OPT-IN, and the reason a name pattern was rejected: matching every `operator-*-write`
+      # would have 403'd transaction.create from six live callers (account-service's
+      # welcome-bonus credit, sepa-instant, domestic-payment, swift, interest, sdd) and
+      # settlement.create — both AUTHZ_ENFORCE=true money paths whose services have no
+      # identity-scoped rule to fall back on. transaction-service's rego states the exposure
+      # itself ("RESIDUAL RISK — shared identity, no per-caller narrowing"), which is precisely
+      # why removing its only path is not the fix.
+      #
+      # A reason joins this list once its service carries a rule that NAMES the caller and
+      # enumerates its actions, so denying the role-only path removes an over-grant rather than
+      # the only path. Each entry below was verified to have such a rule.
+      reasons:
+        - operator-consent-write        # service-consent-m2m + service-consent-m2m-marketing
+        - operator-ledger-write         # service-ledger-post / service-ledger-reverse
+        - operator-balance-write        # service-balance-m2m
+        - operator-fraud-write          # service-fraud-scoring
+        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
+        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m
+      # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
+      # adding it here before that is a money-path outage, not a test failure.
+      deferred:
+        operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
+        operator-settlement-write: "settlement.create is resourceless with no alternative rule"
+        operator-swift-write: "no identity-scoped rule; callers unverified"
+        operator-sepa-instant-write: "no identity-scoped rule; callers unverified"
+        operator-billing-write: "no identity-scoped rule; callers unverified"
+        operator-interest-write: "no identity-scoped rule; callers unverified"
+        operator-lending-write: "no identity-scoped rule; callers unverified"
+        operator-sanctions-write: "no identity-scoped rule; m2m-sanctions-screening covers create only"
+        operator-identity-write: "no identity-scoped rule; callers unverified"
+        operator-card-write: "no identity-scoped rule; callers unverified"
+        # These DO carry an identity-pinned rule, but "a rule exists" is not "the rule covers the
+        # actions the role-only path was serving". Listing them on that basis would repeat, one
+        # level down, the guess that made the first revision break transaction.create. Each needs
+        # its identity-scoped rule read against its real callers before it moves up.
+        operator-fx-write: "2 identity-pinned rules; action coverage vs real callers unverified"
+        operator-account-write: "2 identity-pinned rules; action coverage unverified"
+        operator-clearing-write: "1 identity-pinned rule; action coverage unverified"
+        operator-domestic-payment-write: "1 identity-pinned rule; action coverage unverified"
+        operator-party-write: "1 identity-pinned rule, but onboarding-service PUTs party.kyc-status via the shared client (latent: AUTHZ_ENFORCE=false there today)"
+      adr: ADR-0034
   manifest.json: |
     {"roots": ["openbank/agents", "openbank/copilot", "openbank/rest", "agents", "rules"]}

--- a/openbank-infra/gitops/components/party/party-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/party/party-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: party-service
     app.kubernetes.io/part-of: party
   annotations:
-    openbank.tech/policy-checksum: "e1e0e77e5bb964de"
+    openbank.tech/policy-checksum: "cacb495e5e6cf34e"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2052,11 +2052,21 @@ data:
         - operator-ledger-write         # service-ledger-post / service-ledger-reverse
         - operator-balance-write        # service-balance-m2m
         - operator-fraud-write          # service-fraud-scoring
-        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
-        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m
+        # SAFE TODAY ONLY BY CO-ADMISSION, not by the rule named here: that rule covers
+        # sepaPayment.handleReturn alone, but ROLE_OPERATOR also grants sepaPayment.create /
+        # .transitionStatus / .approval.decide, so `matrix-allows` co-admits and this reason
+        # never becomes the only one. standing-order POSTs sepaPayment.create via the shared
+        # client. When ADR-0223 D2(b) retires those matrix grants, this entry starts denying it.
+        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m (see note above)
       # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
       # adding it here before that is a money-path outage, not a test failure.
       deferred:
+        operator-sca-write: "service-sca-shared-client-m2m covers scaChallenge.read ONLY, while
+          sca-service exposes consume/decide/initiate/verify and device.enroll. document-service
+          calls POST /challenges/{id}/consume through the shared client (ScaChallengeClient carries
+          OidcClientRequestReactiveFilter with oidc-client.client-id openbank-services) and
+          sca-service runs AUTHZ_ENFORCE=true, so listing this reason 403s the document-signing
+          gate. Needs #3748 (scaChallenge.consume for the shared client) to land first."
         operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
         operator-settlement-write: "settlement.create is resourceless with no alternative rule"
         operator-swift-write: "no identity-scoped rule; callers unverified"

--- a/openbank-infra/gitops/components/party/party-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/party/party-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: party-service
     app.kubernetes.io/part-of: party
   annotations:
-    openbank.tech/policy-checksum: "cacb495e5e6cf34e"
+    openbank.tech/policy-checksum: "1f15b209b3f624cb"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2058,15 +2058,16 @@ data:
         # never becomes the only one. standing-order POSTs sepaPayment.create via the shared
         # client. When ADR-0223 D2(b) retires those matrix grants, this entry starts denying it.
         - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m (see note above)
+        # Restored once #3748 landed: service-sca-shared-client-m2m now admits the shared client
+        # for scaChallenge.read AND scaChallenge.consume, so document-service's consume call
+        # (ScaChallengeClient, oidc-client.client-id openbank-services) keeps an identity-scoped
+        # reason and this entry no longer 403s the document-signing gate. device.list is covered
+        # by matrix-allows. Still uncovered for the shared client: decide/initiate/verify and
+        # device.enroll — no in-repo caller invokes them on that principal.
+        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
       # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
       # adding it here before that is a money-path outage, not a test failure.
       deferred:
-        operator-sca-write: "service-sca-shared-client-m2m covers scaChallenge.read ONLY, while
-          sca-service exposes consume/decide/initiate/verify and device.enroll. document-service
-          calls POST /challenges/{id}/consume through the shared client (ScaChallengeClient carries
-          OidcClientRequestReactiveFilter with oidc-client.client-id openbank-services) and
-          sca-service runs AUTHZ_ENFORCE=true, so listing this reason 403s the document-signing
-          gate. Needs #3748 (scaChallenge.consume for the shared client) to land first."
         operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
         operator-settlement-write: "settlement.create is resourceless with no alternative rule"
         operator-swift-write: "no identity-scoped rule; callers unverified"

--- a/openbank-infra/gitops/components/party/party-service.yaml
+++ b/openbank-infra/gitops/components/party/party-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-party-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "e1e0e77e5bb964de"
+        openbank.tech/policy-checksum: "cacb495e5e6cf34e"
       labels:
         app.kubernetes.io/name: party-service
         app.kubernetes.io/part-of: party

--- a/openbank-infra/gitops/components/party/party-service.yaml
+++ b/openbank-infra/gitops/components/party/party-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-party-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "cacb495e5e6cf34e"
+        openbank.tech/policy-checksum: "1f15b209b3f624cb"
       labels:
         app.kubernetes.io/name: party-service
         app.kubernetes.io/part-of: party

--- a/openbank-infra/gitops/components/party/party-service.yaml
+++ b/openbank-infra/gitops/components/party/party-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-party-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "d8f52b5114a39627"
+        openbank.tech/policy-checksum: "e1e0e77e5bb964de"
       labels:
         app.kubernetes.io/name: party-service
         app.kubernetes.io/part-of: party

--- a/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: card-issuance-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "f8f84d73f9905b4d"
+    openbank.tech/policy-checksum: "d54a9cf49cb126d4"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2036,11 +2036,21 @@ data:
         - operator-ledger-write         # service-ledger-post / service-ledger-reverse
         - operator-balance-write        # service-balance-m2m
         - operator-fraud-write          # service-fraud-scoring
-        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
-        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m
+        # SAFE TODAY ONLY BY CO-ADMISSION, not by the rule named here: that rule covers
+        # sepaPayment.handleReturn alone, but ROLE_OPERATOR also grants sepaPayment.create /
+        # .transitionStatus / .approval.decide, so `matrix-allows` co-admits and this reason
+        # never becomes the only one. standing-order POSTs sepaPayment.create via the shared
+        # client. When ADR-0223 D2(b) retires those matrix grants, this entry starts denying it.
+        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m (see note above)
       # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
       # adding it here before that is a money-path outage, not a test failure.
       deferred:
+        operator-sca-write: "service-sca-shared-client-m2m covers scaChallenge.read ONLY, while
+          sca-service exposes consume/decide/initiate/verify and device.enroll. document-service
+          calls POST /challenges/{id}/consume through the shared client (ScaChallengeClient carries
+          OidcClientRequestReactiveFilter with oidc-client.client-id openbank-services) and
+          sca-service runs AUTHZ_ENFORCE=true, so listing this reason 403s the document-signing
+          gate. Needs #3748 (scaChallenge.consume for the shared client) to land first."
         operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
         operator-settlement-write: "settlement.create is resourceless with no alternative rule"
         operator-swift-write: "no identity-scoped rule; callers unverified"

--- a/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: card-issuance-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "30c8b09275e65d61"
+    openbank.tech/policy-checksum: "f8f84d73f9905b4d"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2014,5 +2014,52 @@ data:
             - lending.collateralDecide
             - lending.approval.read
             - lending.approval.decide
+
+    shared_m2m_write_prohibition:
+      # GHSA-58jq-9hq3-66jr. rest.rego denies the shared M2M identity
+      # (`service-account-openbank-services`, which carries ROLE_OPERATOR in the realm) when the
+      # ONLY reasons admitting it are the role-only write reasons listed here.
+      #
+      # OPT-IN, and the reason a name pattern was rejected: matching every `operator-*-write`
+      # would have 403'd transaction.create from six live callers (account-service's
+      # welcome-bonus credit, sepa-instant, domestic-payment, swift, interest, sdd) and
+      # settlement.create — both AUTHZ_ENFORCE=true money paths whose services have no
+      # identity-scoped rule to fall back on. transaction-service's rego states the exposure
+      # itself ("RESIDUAL RISK — shared identity, no per-caller narrowing"), which is precisely
+      # why removing its only path is not the fix.
+      #
+      # A reason joins this list once its service carries a rule that NAMES the caller and
+      # enumerates its actions, so denying the role-only path removes an over-grant rather than
+      # the only path. Each entry below was verified to have such a rule.
+      reasons:
+        - operator-consent-write        # service-consent-m2m + service-consent-m2m-marketing
+        - operator-ledger-write         # service-ledger-post / service-ledger-reverse
+        - operator-balance-write        # service-balance-m2m
+        - operator-fraud-write          # service-fraud-scoring
+        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
+        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m
+      # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
+      # adding it here before that is a money-path outage, not a test failure.
+      deferred:
+        operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
+        operator-settlement-write: "settlement.create is resourceless with no alternative rule"
+        operator-swift-write: "no identity-scoped rule; callers unverified"
+        operator-sepa-instant-write: "no identity-scoped rule; callers unverified"
+        operator-billing-write: "no identity-scoped rule; callers unverified"
+        operator-interest-write: "no identity-scoped rule; callers unverified"
+        operator-lending-write: "no identity-scoped rule; callers unverified"
+        operator-sanctions-write: "no identity-scoped rule; m2m-sanctions-screening covers create only"
+        operator-identity-write: "no identity-scoped rule; callers unverified"
+        operator-card-write: "no identity-scoped rule; callers unverified"
+        # These DO carry an identity-pinned rule, but "a rule exists" is not "the rule covers the
+        # actions the role-only path was serving". Listing them on that basis would repeat, one
+        # level down, the guess that made the first revision break transaction.create. Each needs
+        # its identity-scoped rule read against its real callers before it moves up.
+        operator-fx-write: "2 identity-pinned rules; action coverage vs real callers unverified"
+        operator-account-write: "2 identity-pinned rules; action coverage unverified"
+        operator-clearing-write: "1 identity-pinned rule; action coverage unverified"
+        operator-domestic-payment-write: "1 identity-pinned rule; action coverage unverified"
+        operator-party-write: "1 identity-pinned rule, but onboarding-service PUTs party.kyc-status via the shared client (latent: AUTHZ_ENFORCE=false there today)"
+      adr: ADR-0034
   manifest.json: |
     {"roots": ["openbank/agents", "openbank/copilot", "openbank/rest", "agents", "rules"]}

--- a/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: card-issuance-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "d54a9cf49cb126d4"
+    openbank.tech/policy-checksum: "7e600c6823fc1d28"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2042,15 +2042,16 @@ data:
         # never becomes the only one. standing-order POSTs sepaPayment.create via the shared
         # client. When ADR-0223 D2(b) retires those matrix grants, this entry starts denying it.
         - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m (see note above)
+        # Restored once #3748 landed: service-sca-shared-client-m2m now admits the shared client
+        # for scaChallenge.read AND scaChallenge.consume, so document-service's consume call
+        # (ScaChallengeClient, oidc-client.client-id openbank-services) keeps an identity-scoped
+        # reason and this entry no longer 403s the document-signing gate. device.list is covered
+        # by matrix-allows. Still uncovered for the shared client: decide/initiate/verify and
+        # device.enroll — no in-repo caller invokes them on that principal.
+        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
       # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
       # adding it here before that is a money-path outage, not a test failure.
       deferred:
-        operator-sca-write: "service-sca-shared-client-m2m covers scaChallenge.read ONLY, while
-          sca-service exposes consume/decide/initiate/verify and device.enroll. document-service
-          calls POST /challenges/{id}/consume through the shared client (ScaChallengeClient carries
-          OidcClientRequestReactiveFilter with oidc-client.client-id openbank-services) and
-          sca-service runs AUTHZ_ENFORCE=true, so listing this reason 403s the document-signing
-          gate. Needs #3748 (scaChallenge.consume for the shared client) to land first."
         operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
         operator-settlement-write: "settlement.create is resourceless with no alternative rule"
         operator-swift-write: "no identity-scoped rule; callers unverified"

--- a/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: clearing-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "01bfd56bd86208af"
+    openbank.tech/policy-checksum: "7d476c49dfac5ec9"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2079,15 +2079,16 @@ data:
         # never becomes the only one. standing-order POSTs sepaPayment.create via the shared
         # client. When ADR-0223 D2(b) retires those matrix grants, this entry starts denying it.
         - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m (see note above)
+        # Restored once #3748 landed: service-sca-shared-client-m2m now admits the shared client
+        # for scaChallenge.read AND scaChallenge.consume, so document-service's consume call
+        # (ScaChallengeClient, oidc-client.client-id openbank-services) keeps an identity-scoped
+        # reason and this entry no longer 403s the document-signing gate. device.list is covered
+        # by matrix-allows. Still uncovered for the shared client: decide/initiate/verify and
+        # device.enroll — no in-repo caller invokes them on that principal.
+        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
       # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
       # adding it here before that is a money-path outage, not a test failure.
       deferred:
-        operator-sca-write: "service-sca-shared-client-m2m covers scaChallenge.read ONLY, while
-          sca-service exposes consume/decide/initiate/verify and device.enroll. document-service
-          calls POST /challenges/{id}/consume through the shared client (ScaChallengeClient carries
-          OidcClientRequestReactiveFilter with oidc-client.client-id openbank-services) and
-          sca-service runs AUTHZ_ENFORCE=true, so listing this reason 403s the document-signing
-          gate. Needs #3748 (scaChallenge.consume for the shared client) to land first."
         operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
         operator-settlement-write: "settlement.create is resourceless with no alternative rule"
         operator-swift-write: "no identity-scoped rule; callers unverified"

--- a/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: clearing-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "bb259c4ebf2de153"
+    openbank.tech/policy-checksum: "adb4bf0df846a239"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2051,5 +2051,52 @@ data:
             - lending.collateralDecide
             - lending.approval.read
             - lending.approval.decide
+
+    shared_m2m_write_prohibition:
+      # GHSA-58jq-9hq3-66jr. rest.rego denies the shared M2M identity
+      # (`service-account-openbank-services`, which carries ROLE_OPERATOR in the realm) when the
+      # ONLY reasons admitting it are the role-only write reasons listed here.
+      #
+      # OPT-IN, and the reason a name pattern was rejected: matching every `operator-*-write`
+      # would have 403'd transaction.create from six live callers (account-service's
+      # welcome-bonus credit, sepa-instant, domestic-payment, swift, interest, sdd) and
+      # settlement.create — both AUTHZ_ENFORCE=true money paths whose services have no
+      # identity-scoped rule to fall back on. transaction-service's rego states the exposure
+      # itself ("RESIDUAL RISK — shared identity, no per-caller narrowing"), which is precisely
+      # why removing its only path is not the fix.
+      #
+      # A reason joins this list once its service carries a rule that NAMES the caller and
+      # enumerates its actions, so denying the role-only path removes an over-grant rather than
+      # the only path. Each entry below was verified to have such a rule.
+      reasons:
+        - operator-consent-write        # service-consent-m2m + service-consent-m2m-marketing
+        - operator-ledger-write         # service-ledger-post / service-ledger-reverse
+        - operator-balance-write        # service-balance-m2m
+        - operator-fraud-write          # service-fraud-scoring
+        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
+        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m
+      # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
+      # adding it here before that is a money-path outage, not a test failure.
+      deferred:
+        operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
+        operator-settlement-write: "settlement.create is resourceless with no alternative rule"
+        operator-swift-write: "no identity-scoped rule; callers unverified"
+        operator-sepa-instant-write: "no identity-scoped rule; callers unverified"
+        operator-billing-write: "no identity-scoped rule; callers unverified"
+        operator-interest-write: "no identity-scoped rule; callers unverified"
+        operator-lending-write: "no identity-scoped rule; callers unverified"
+        operator-sanctions-write: "no identity-scoped rule; m2m-sanctions-screening covers create only"
+        operator-identity-write: "no identity-scoped rule; callers unverified"
+        operator-card-write: "no identity-scoped rule; callers unverified"
+        # These DO carry an identity-pinned rule, but "a rule exists" is not "the rule covers the
+        # actions the role-only path was serving". Listing them on that basis would repeat, one
+        # level down, the guess that made the first revision break transaction.create. Each needs
+        # its identity-scoped rule read against its real callers before it moves up.
+        operator-fx-write: "2 identity-pinned rules; action coverage vs real callers unverified"
+        operator-account-write: "2 identity-pinned rules; action coverage unverified"
+        operator-clearing-write: "1 identity-pinned rule; action coverage unverified"
+        operator-domestic-payment-write: "1 identity-pinned rule; action coverage unverified"
+        operator-party-write: "1 identity-pinned rule, but onboarding-service PUTs party.kyc-status via the shared client (latent: AUTHZ_ENFORCE=false there today)"
+      adr: ADR-0034
   manifest.json: |
     {"roots": ["openbank/agents", "openbank/copilot", "openbank/rest", "agents", "rules"]}

--- a/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: clearing-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "adb4bf0df846a239"
+    openbank.tech/policy-checksum: "01bfd56bd86208af"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2073,11 +2073,21 @@ data:
         - operator-ledger-write         # service-ledger-post / service-ledger-reverse
         - operator-balance-write        # service-balance-m2m
         - operator-fraud-write          # service-fraud-scoring
-        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
-        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m
+        # SAFE TODAY ONLY BY CO-ADMISSION, not by the rule named here: that rule covers
+        # sepaPayment.handleReturn alone, but ROLE_OPERATOR also grants sepaPayment.create /
+        # .transitionStatus / .approval.decide, so `matrix-allows` co-admits and this reason
+        # never becomes the only one. standing-order POSTs sepaPayment.create via the shared
+        # client. When ADR-0223 D2(b) retires those matrix grants, this entry starts denying it.
+        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m (see note above)
       # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
       # adding it here before that is a money-path outage, not a test failure.
       deferred:
+        operator-sca-write: "service-sca-shared-client-m2m covers scaChallenge.read ONLY, while
+          sca-service exposes consume/decide/initiate/verify and device.enroll. document-service
+          calls POST /challenges/{id}/consume through the shared client (ScaChallengeClient carries
+          OidcClientRequestReactiveFilter with oidc-client.client-id openbank-services) and
+          sca-service runs AUTHZ_ENFORCE=true, so listing this reason 403s the document-signing
+          gate. Needs #3748 (scaChallenge.consume for the shared client) to land first."
         operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
         operator-settlement-write: "settlement.create is resourceless with no alternative rule"
         operator-swift-write: "no identity-scoped rule; callers unverified"

--- a/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: domestic-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "a889bcf33b99b8b6"
+    openbank.tech/policy-checksum: "1b477a08c631ffce"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2064,15 +2064,16 @@ data:
         # never becomes the only one. standing-order POSTs sepaPayment.create via the shared
         # client. When ADR-0223 D2(b) retires those matrix grants, this entry starts denying it.
         - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m (see note above)
+        # Restored once #3748 landed: service-sca-shared-client-m2m now admits the shared client
+        # for scaChallenge.read AND scaChallenge.consume, so document-service's consume call
+        # (ScaChallengeClient, oidc-client.client-id openbank-services) keeps an identity-scoped
+        # reason and this entry no longer 403s the document-signing gate. device.list is covered
+        # by matrix-allows. Still uncovered for the shared client: decide/initiate/verify and
+        # device.enroll — no in-repo caller invokes them on that principal.
+        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
       # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
       # adding it here before that is a money-path outage, not a test failure.
       deferred:
-        operator-sca-write: "service-sca-shared-client-m2m covers scaChallenge.read ONLY, while
-          sca-service exposes consume/decide/initiate/verify and device.enroll. document-service
-          calls POST /challenges/{id}/consume through the shared client (ScaChallengeClient carries
-          OidcClientRequestReactiveFilter with oidc-client.client-id openbank-services) and
-          sca-service runs AUTHZ_ENFORCE=true, so listing this reason 403s the document-signing
-          gate. Needs #3748 (scaChallenge.consume for the shared client) to land first."
         operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
         operator-settlement-write: "settlement.create is resourceless with no alternative rule"
         operator-swift-write: "no identity-scoped rule; callers unverified"

--- a/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: domestic-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "33c40ea53b865dd0"
+    openbank.tech/policy-checksum: "a889bcf33b99b8b6"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2058,11 +2058,21 @@ data:
         - operator-ledger-write         # service-ledger-post / service-ledger-reverse
         - operator-balance-write        # service-balance-m2m
         - operator-fraud-write          # service-fraud-scoring
-        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
-        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m
+        # SAFE TODAY ONLY BY CO-ADMISSION, not by the rule named here: that rule covers
+        # sepaPayment.handleReturn alone, but ROLE_OPERATOR also grants sepaPayment.create /
+        # .transitionStatus / .approval.decide, so `matrix-allows` co-admits and this reason
+        # never becomes the only one. standing-order POSTs sepaPayment.create via the shared
+        # client. When ADR-0223 D2(b) retires those matrix grants, this entry starts denying it.
+        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m (see note above)
       # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
       # adding it here before that is a money-path outage, not a test failure.
       deferred:
+        operator-sca-write: "service-sca-shared-client-m2m covers scaChallenge.read ONLY, while
+          sca-service exposes consume/decide/initiate/verify and device.enroll. document-service
+          calls POST /challenges/{id}/consume through the shared client (ScaChallengeClient carries
+          OidcClientRequestReactiveFilter with oidc-client.client-id openbank-services) and
+          sca-service runs AUTHZ_ENFORCE=true, so listing this reason 403s the document-signing
+          gate. Needs #3748 (scaChallenge.consume for the shared client) to land first."
         operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
         operator-settlement-write: "settlement.create is resourceless with no alternative rule"
         operator-swift-write: "no identity-scoped rule; callers unverified"

--- a/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: domestic-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "cb91ae113c049e27"
+    openbank.tech/policy-checksum: "33c40ea53b865dd0"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2036,5 +2036,52 @@ data:
             - lending.collateralDecide
             - lending.approval.read
             - lending.approval.decide
+
+    shared_m2m_write_prohibition:
+      # GHSA-58jq-9hq3-66jr. rest.rego denies the shared M2M identity
+      # (`service-account-openbank-services`, which carries ROLE_OPERATOR in the realm) when the
+      # ONLY reasons admitting it are the role-only write reasons listed here.
+      #
+      # OPT-IN, and the reason a name pattern was rejected: matching every `operator-*-write`
+      # would have 403'd transaction.create from six live callers (account-service's
+      # welcome-bonus credit, sepa-instant, domestic-payment, swift, interest, sdd) and
+      # settlement.create — both AUTHZ_ENFORCE=true money paths whose services have no
+      # identity-scoped rule to fall back on. transaction-service's rego states the exposure
+      # itself ("RESIDUAL RISK — shared identity, no per-caller narrowing"), which is precisely
+      # why removing its only path is not the fix.
+      #
+      # A reason joins this list once its service carries a rule that NAMES the caller and
+      # enumerates its actions, so denying the role-only path removes an over-grant rather than
+      # the only path. Each entry below was verified to have such a rule.
+      reasons:
+        - operator-consent-write        # service-consent-m2m + service-consent-m2m-marketing
+        - operator-ledger-write         # service-ledger-post / service-ledger-reverse
+        - operator-balance-write        # service-balance-m2m
+        - operator-fraud-write          # service-fraud-scoring
+        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
+        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m
+      # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
+      # adding it here before that is a money-path outage, not a test failure.
+      deferred:
+        operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
+        operator-settlement-write: "settlement.create is resourceless with no alternative rule"
+        operator-swift-write: "no identity-scoped rule; callers unverified"
+        operator-sepa-instant-write: "no identity-scoped rule; callers unverified"
+        operator-billing-write: "no identity-scoped rule; callers unverified"
+        operator-interest-write: "no identity-scoped rule; callers unverified"
+        operator-lending-write: "no identity-scoped rule; callers unverified"
+        operator-sanctions-write: "no identity-scoped rule; m2m-sanctions-screening covers create only"
+        operator-identity-write: "no identity-scoped rule; callers unverified"
+        operator-card-write: "no identity-scoped rule; callers unverified"
+        # These DO carry an identity-pinned rule, but "a rule exists" is not "the rule covers the
+        # actions the role-only path was serving". Listing them on that basis would repeat, one
+        # level down, the guess that made the first revision break transaction.create. Each needs
+        # its identity-scoped rule read against its real callers before it moves up.
+        operator-fx-write: "2 identity-pinned rules; action coverage vs real callers unverified"
+        operator-account-write: "2 identity-pinned rules; action coverage unverified"
+        operator-clearing-write: "1 identity-pinned rule; action coverage unverified"
+        operator-domestic-payment-write: "1 identity-pinned rule; action coverage unverified"
+        operator-party-write: "1 identity-pinned rule, but onboarding-service PUTs party.kyc-status via the shared client (latent: AUTHZ_ENFORCE=false there today)"
+      adr: ADR-0034
   manifest.json: |
     {"roots": ["openbank/agents", "openbank/copilot", "openbank/rest", "agents", "rules"]}

--- a/openbank-infra/gitops/components/payments/payments-services.yaml
+++ b/openbank-infra/gitops/components/payments/payments-services.yaml
@@ -42,7 +42,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-transaction-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "95507cf598bafc4f" # transaction-opa-bundle
+        openbank.tech/policy-checksum: "7c800f18b73edc61" # transaction-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -375,7 +375,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-payment-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "689438f481302d5d"
+        openbank.tech/policy-checksum: "6a7481be8fea262c"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -729,7 +729,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-domestic-payment-opa-bundle.sh via the trailing marker
         # comment (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "a889bcf33b99b8b6" # domestic-payment-opa-bundle
+        openbank.tech/policy-checksum: "1b477a08c631ffce" # domestic-payment-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1053,7 +1053,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-instant-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "4fea808f20166a6a"
+        openbank.tech/policy-checksum: "0451603652418486"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1369,7 +1369,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-clearing-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "01bfd56bd86208af" # clearing-opa-bundle
+        openbank.tech/policy-checksum: "7d476c49dfac5ec9" # clearing-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1667,7 +1667,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (ADR-0034). Value is stamped by
         # gen-standing-order-opa-bundle.sh — do not hand-edit.
-        openbank.tech/policy-checksum: "dbdf0fde74f58ffa" # standing-order-opa-bundle
+        openbank.tech/policy-checksum: "d5494dbaafb3019a" # standing-order-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1929,7 +1929,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-card-issuance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "d54a9cf49cb126d4"
+        openbank.tech/policy-checksum: "7e600c6823fc1d28"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2199,7 +2199,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-settlement-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "869680b02dc97b41" # settlement-opa-bundle
+        openbank.tech/policy-checksum: "f5abcf7008f85299" # settlement-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2614,7 +2614,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-swift-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "228646a848af0c91"
+        openbank.tech/policy-checksum: "e46c26e6a4619427"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2928,7 +2928,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-vop-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "42b0070784b83ba1"
+        openbank.tech/policy-checksum: "8e96f4ca114b5e4b"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/payments/payments-services.yaml
+++ b/openbank-infra/gitops/components/payments/payments-services.yaml
@@ -42,7 +42,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-transaction-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "db0fd25f3c6cc7ce" # transaction-opa-bundle
+        openbank.tech/policy-checksum: "e342c76362451b0b" # transaction-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -375,7 +375,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-payment-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "3109a168a31a6da6"
+        openbank.tech/policy-checksum: "76c28b6fccc91789"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -729,7 +729,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-domestic-payment-opa-bundle.sh via the trailing marker
         # comment (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "cb91ae113c049e27" # domestic-payment-opa-bundle
+        openbank.tech/policy-checksum: "33c40ea53b865dd0" # domestic-payment-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1053,7 +1053,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-instant-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "6c3cd0538533986d"
+        openbank.tech/policy-checksum: "afe7f47bd33be54a"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1369,7 +1369,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-clearing-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "bb259c4ebf2de153" # clearing-opa-bundle
+        openbank.tech/policy-checksum: "adb4bf0df846a239" # clearing-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1667,7 +1667,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (ADR-0034). Value is stamped by
         # gen-standing-order-opa-bundle.sh — do not hand-edit.
-        openbank.tech/policy-checksum: "b3446cfd050f3b6b" # standing-order-opa-bundle
+        openbank.tech/policy-checksum: "06a1ed6dd44971e9" # standing-order-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1929,7 +1929,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-card-issuance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "30c8b09275e65d61"
+        openbank.tech/policy-checksum: "f8f84d73f9905b4d"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2199,7 +2199,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-settlement-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "980eb49e19a37c53" # settlement-opa-bundle
+        openbank.tech/policy-checksum: "922d62a8e2230d52" # settlement-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2614,7 +2614,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-swift-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "e90ec0a03058de5e"
+        openbank.tech/policy-checksum: "a58af91137312cab"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2928,7 +2928,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-vop-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "ff1d488571b0c025"
+        openbank.tech/policy-checksum: "6afe1a7778655f2e"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/payments/payments-services.yaml
+++ b/openbank-infra/gitops/components/payments/payments-services.yaml
@@ -42,7 +42,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-transaction-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "e342c76362451b0b" # transaction-opa-bundle
+        openbank.tech/policy-checksum: "95507cf598bafc4f" # transaction-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -375,7 +375,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-payment-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "76c28b6fccc91789"
+        openbank.tech/policy-checksum: "689438f481302d5d"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -729,7 +729,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-domestic-payment-opa-bundle.sh via the trailing marker
         # comment (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "33c40ea53b865dd0" # domestic-payment-opa-bundle
+        openbank.tech/policy-checksum: "a889bcf33b99b8b6" # domestic-payment-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1053,7 +1053,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-instant-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "afe7f47bd33be54a"
+        openbank.tech/policy-checksum: "4fea808f20166a6a"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1369,7 +1369,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-clearing-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "adb4bf0df846a239" # clearing-opa-bundle
+        openbank.tech/policy-checksum: "01bfd56bd86208af" # clearing-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1667,7 +1667,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (ADR-0034). Value is stamped by
         # gen-standing-order-opa-bundle.sh — do not hand-edit.
-        openbank.tech/policy-checksum: "06a1ed6dd44971e9" # standing-order-opa-bundle
+        openbank.tech/policy-checksum: "dbdf0fde74f58ffa" # standing-order-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1929,7 +1929,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-card-issuance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "f8f84d73f9905b4d"
+        openbank.tech/policy-checksum: "d54a9cf49cb126d4"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2199,7 +2199,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-settlement-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "922d62a8e2230d52" # settlement-opa-bundle
+        openbank.tech/policy-checksum: "869680b02dc97b41" # settlement-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2614,7 +2614,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-swift-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "a58af91137312cab"
+        openbank.tech/policy-checksum: "228646a848af0c91"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2928,7 +2928,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-vop-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "6afe1a7778655f2e"
+        openbank.tech/policy-checksum: "42b0070784b83ba1"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-instant
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "afe7f47bd33be54a"
+    openbank.tech/policy-checksum: "4fea808f20166a6a"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2031,11 +2031,21 @@ data:
         - operator-ledger-write         # service-ledger-post / service-ledger-reverse
         - operator-balance-write        # service-balance-m2m
         - operator-fraud-write          # service-fraud-scoring
-        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
-        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m
+        # SAFE TODAY ONLY BY CO-ADMISSION, not by the rule named here: that rule covers
+        # sepaPayment.handleReturn alone, but ROLE_OPERATOR also grants sepaPayment.create /
+        # .transitionStatus / .approval.decide, so `matrix-allows` co-admits and this reason
+        # never becomes the only one. standing-order POSTs sepaPayment.create via the shared
+        # client. When ADR-0223 D2(b) retires those matrix grants, this entry starts denying it.
+        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m (see note above)
       # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
       # adding it here before that is a money-path outage, not a test failure.
       deferred:
+        operator-sca-write: "service-sca-shared-client-m2m covers scaChallenge.read ONLY, while
+          sca-service exposes consume/decide/initiate/verify and device.enroll. document-service
+          calls POST /challenges/{id}/consume through the shared client (ScaChallengeClient carries
+          OidcClientRequestReactiveFilter with oidc-client.client-id openbank-services) and
+          sca-service runs AUTHZ_ENFORCE=true, so listing this reason 403s the document-signing
+          gate. Needs #3748 (scaChallenge.consume for the shared client) to land first."
         operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
         operator-settlement-write: "settlement.create is resourceless with no alternative rule"
         operator-swift-write: "no identity-scoped rule; callers unverified"

--- a/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-instant
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "4fea808f20166a6a"
+    openbank.tech/policy-checksum: "0451603652418486"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2037,15 +2037,16 @@ data:
         # never becomes the only one. standing-order POSTs sepaPayment.create via the shared
         # client. When ADR-0223 D2(b) retires those matrix grants, this entry starts denying it.
         - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m (see note above)
+        # Restored once #3748 landed: service-sca-shared-client-m2m now admits the shared client
+        # for scaChallenge.read AND scaChallenge.consume, so document-service's consume call
+        # (ScaChallengeClient, oidc-client.client-id openbank-services) keeps an identity-scoped
+        # reason and this entry no longer 403s the document-signing gate. device.list is covered
+        # by matrix-allows. Still uncovered for the shared client: decide/initiate/verify and
+        # device.enroll — no in-repo caller invokes them on that principal.
+        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
       # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
       # adding it here before that is a money-path outage, not a test failure.
       deferred:
-        operator-sca-write: "service-sca-shared-client-m2m covers scaChallenge.read ONLY, while
-          sca-service exposes consume/decide/initiate/verify and device.enroll. document-service
-          calls POST /challenges/{id}/consume through the shared client (ScaChallengeClient carries
-          OidcClientRequestReactiveFilter with oidc-client.client-id openbank-services) and
-          sca-service runs AUTHZ_ENFORCE=true, so listing this reason 403s the document-signing
-          gate. Needs #3748 (scaChallenge.consume for the shared client) to land first."
         operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
         operator-settlement-write: "settlement.create is resourceless with no alternative rule"
         operator-swift-write: "no identity-scoped rule; callers unverified"

--- a/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-instant
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "6c3cd0538533986d"
+    openbank.tech/policy-checksum: "afe7f47bd33be54a"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2009,5 +2009,52 @@ data:
             - lending.collateralDecide
             - lending.approval.read
             - lending.approval.decide
+
+    shared_m2m_write_prohibition:
+      # GHSA-58jq-9hq3-66jr. rest.rego denies the shared M2M identity
+      # (`service-account-openbank-services`, which carries ROLE_OPERATOR in the realm) when the
+      # ONLY reasons admitting it are the role-only write reasons listed here.
+      #
+      # OPT-IN, and the reason a name pattern was rejected: matching every `operator-*-write`
+      # would have 403'd transaction.create from six live callers (account-service's
+      # welcome-bonus credit, sepa-instant, domestic-payment, swift, interest, sdd) and
+      # settlement.create — both AUTHZ_ENFORCE=true money paths whose services have no
+      # identity-scoped rule to fall back on. transaction-service's rego states the exposure
+      # itself ("RESIDUAL RISK — shared identity, no per-caller narrowing"), which is precisely
+      # why removing its only path is not the fix.
+      #
+      # A reason joins this list once its service carries a rule that NAMES the caller and
+      # enumerates its actions, so denying the role-only path removes an over-grant rather than
+      # the only path. Each entry below was verified to have such a rule.
+      reasons:
+        - operator-consent-write        # service-consent-m2m + service-consent-m2m-marketing
+        - operator-ledger-write         # service-ledger-post / service-ledger-reverse
+        - operator-balance-write        # service-balance-m2m
+        - operator-fraud-write          # service-fraud-scoring
+        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
+        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m
+      # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
+      # adding it here before that is a money-path outage, not a test failure.
+      deferred:
+        operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
+        operator-settlement-write: "settlement.create is resourceless with no alternative rule"
+        operator-swift-write: "no identity-scoped rule; callers unverified"
+        operator-sepa-instant-write: "no identity-scoped rule; callers unverified"
+        operator-billing-write: "no identity-scoped rule; callers unverified"
+        operator-interest-write: "no identity-scoped rule; callers unverified"
+        operator-lending-write: "no identity-scoped rule; callers unverified"
+        operator-sanctions-write: "no identity-scoped rule; m2m-sanctions-screening covers create only"
+        operator-identity-write: "no identity-scoped rule; callers unverified"
+        operator-card-write: "no identity-scoped rule; callers unverified"
+        # These DO carry an identity-pinned rule, but "a rule exists" is not "the rule covers the
+        # actions the role-only path was serving". Listing them on that basis would repeat, one
+        # level down, the guess that made the first revision break transaction.create. Each needs
+        # its identity-scoped rule read against its real callers before it moves up.
+        operator-fx-write: "2 identity-pinned rules; action coverage vs real callers unverified"
+        operator-account-write: "2 identity-pinned rules; action coverage unverified"
+        operator-clearing-write: "1 identity-pinned rule; action coverage unverified"
+        operator-domestic-payment-write: "1 identity-pinned rule; action coverage unverified"
+        operator-party-write: "1 identity-pinned rule, but onboarding-service PUTs party.kyc-status via the shared client (latent: AUTHZ_ENFORCE=false there today)"
+      adr: ADR-0034
   manifest.json: |
     {"roots": ["openbank/agents", "openbank/copilot", "openbank/rest", "agents", "rules"]}

--- a/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "3109a168a31a6da6"
+    openbank.tech/policy-checksum: "76c28b6fccc91789"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2030,5 +2030,52 @@ data:
             - lending.collateralDecide
             - lending.approval.read
             - lending.approval.decide
+
+    shared_m2m_write_prohibition:
+      # GHSA-58jq-9hq3-66jr. rest.rego denies the shared M2M identity
+      # (`service-account-openbank-services`, which carries ROLE_OPERATOR in the realm) when the
+      # ONLY reasons admitting it are the role-only write reasons listed here.
+      #
+      # OPT-IN, and the reason a name pattern was rejected: matching every `operator-*-write`
+      # would have 403'd transaction.create from six live callers (account-service's
+      # welcome-bonus credit, sepa-instant, domestic-payment, swift, interest, sdd) and
+      # settlement.create — both AUTHZ_ENFORCE=true money paths whose services have no
+      # identity-scoped rule to fall back on. transaction-service's rego states the exposure
+      # itself ("RESIDUAL RISK — shared identity, no per-caller narrowing"), which is precisely
+      # why removing its only path is not the fix.
+      #
+      # A reason joins this list once its service carries a rule that NAMES the caller and
+      # enumerates its actions, so denying the role-only path removes an over-grant rather than
+      # the only path. Each entry below was verified to have such a rule.
+      reasons:
+        - operator-consent-write        # service-consent-m2m + service-consent-m2m-marketing
+        - operator-ledger-write         # service-ledger-post / service-ledger-reverse
+        - operator-balance-write        # service-balance-m2m
+        - operator-fraud-write          # service-fraud-scoring
+        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
+        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m
+      # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
+      # adding it here before that is a money-path outage, not a test failure.
+      deferred:
+        operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
+        operator-settlement-write: "settlement.create is resourceless with no alternative rule"
+        operator-swift-write: "no identity-scoped rule; callers unverified"
+        operator-sepa-instant-write: "no identity-scoped rule; callers unverified"
+        operator-billing-write: "no identity-scoped rule; callers unverified"
+        operator-interest-write: "no identity-scoped rule; callers unverified"
+        operator-lending-write: "no identity-scoped rule; callers unverified"
+        operator-sanctions-write: "no identity-scoped rule; m2m-sanctions-screening covers create only"
+        operator-identity-write: "no identity-scoped rule; callers unverified"
+        operator-card-write: "no identity-scoped rule; callers unverified"
+        # These DO carry an identity-pinned rule, but "a rule exists" is not "the rule covers the
+        # actions the role-only path was serving". Listing them on that basis would repeat, one
+        # level down, the guess that made the first revision break transaction.create. Each needs
+        # its identity-scoped rule read against its real callers before it moves up.
+        operator-fx-write: "2 identity-pinned rules; action coverage vs real callers unverified"
+        operator-account-write: "2 identity-pinned rules; action coverage unverified"
+        operator-clearing-write: "1 identity-pinned rule; action coverage unverified"
+        operator-domestic-payment-write: "1 identity-pinned rule; action coverage unverified"
+        operator-party-write: "1 identity-pinned rule, but onboarding-service PUTs party.kyc-status via the shared client (latent: AUTHZ_ENFORCE=false there today)"
+      adr: ADR-0034
   manifest.json: |
     {"roots": ["openbank/agents", "openbank/copilot", "openbank/rest", "agents", "rules"]}

--- a/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "76c28b6fccc91789"
+    openbank.tech/policy-checksum: "689438f481302d5d"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2052,11 +2052,21 @@ data:
         - operator-ledger-write         # service-ledger-post / service-ledger-reverse
         - operator-balance-write        # service-balance-m2m
         - operator-fraud-write          # service-fraud-scoring
-        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
-        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m
+        # SAFE TODAY ONLY BY CO-ADMISSION, not by the rule named here: that rule covers
+        # sepaPayment.handleReturn alone, but ROLE_OPERATOR also grants sepaPayment.create /
+        # .transitionStatus / .approval.decide, so `matrix-allows` co-admits and this reason
+        # never becomes the only one. standing-order POSTs sepaPayment.create via the shared
+        # client. When ADR-0223 D2(b) retires those matrix grants, this entry starts denying it.
+        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m (see note above)
       # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
       # adding it here before that is a money-path outage, not a test failure.
       deferred:
+        operator-sca-write: "service-sca-shared-client-m2m covers scaChallenge.read ONLY, while
+          sca-service exposes consume/decide/initiate/verify and device.enroll. document-service
+          calls POST /challenges/{id}/consume through the shared client (ScaChallengeClient carries
+          OidcClientRequestReactiveFilter with oidc-client.client-id openbank-services) and
+          sca-service runs AUTHZ_ENFORCE=true, so listing this reason 403s the document-signing
+          gate. Needs #3748 (scaChallenge.consume for the shared client) to land first."
         operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
         operator-settlement-write: "settlement.create is resourceless with no alternative rule"
         operator-swift-write: "no identity-scoped rule; callers unverified"

--- a/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "689438f481302d5d"
+    openbank.tech/policy-checksum: "6a7481be8fea262c"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2058,15 +2058,16 @@ data:
         # never becomes the only one. standing-order POSTs sepaPayment.create via the shared
         # client. When ADR-0223 D2(b) retires those matrix grants, this entry starts denying it.
         - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m (see note above)
+        # Restored once #3748 landed: service-sca-shared-client-m2m now admits the shared client
+        # for scaChallenge.read AND scaChallenge.consume, so document-service's consume call
+        # (ScaChallengeClient, oidc-client.client-id openbank-services) keeps an identity-scoped
+        # reason and this entry no longer 403s the document-signing gate. device.list is covered
+        # by matrix-allows. Still uncovered for the shared client: decide/initiate/verify and
+        # device.enroll — no in-repo caller invokes them on that principal.
+        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
       # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
       # adding it here before that is a money-path outage, not a test failure.
       deferred:
-        operator-sca-write: "service-sca-shared-client-m2m covers scaChallenge.read ONLY, while
-          sca-service exposes consume/decide/initiate/verify and device.enroll. document-service
-          calls POST /challenges/{id}/consume through the shared client (ScaChallengeClient carries
-          OidcClientRequestReactiveFilter with oidc-client.client-id openbank-services) and
-          sca-service runs AUTHZ_ENFORCE=true, so listing this reason 403s the document-signing
-          gate. Needs #3748 (scaChallenge.consume for the shared client) to land first."
         operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
         operator-settlement-write: "settlement.create is resourceless with no alternative rule"
         operator-swift-write: "no identity-scoped rule; callers unverified"

--- a/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: settlement-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "922d62a8e2230d52"
+    openbank.tech/policy-checksum: "869680b02dc97b41"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2032,11 +2032,21 @@ data:
         - operator-ledger-write         # service-ledger-post / service-ledger-reverse
         - operator-balance-write        # service-balance-m2m
         - operator-fraud-write          # service-fraud-scoring
-        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
-        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m
+        # SAFE TODAY ONLY BY CO-ADMISSION, not by the rule named here: that rule covers
+        # sepaPayment.handleReturn alone, but ROLE_OPERATOR also grants sepaPayment.create /
+        # .transitionStatus / .approval.decide, so `matrix-allows` co-admits and this reason
+        # never becomes the only one. standing-order POSTs sepaPayment.create via the shared
+        # client. When ADR-0223 D2(b) retires those matrix grants, this entry starts denying it.
+        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m (see note above)
       # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
       # adding it here before that is a money-path outage, not a test failure.
       deferred:
+        operator-sca-write: "service-sca-shared-client-m2m covers scaChallenge.read ONLY, while
+          sca-service exposes consume/decide/initiate/verify and device.enroll. document-service
+          calls POST /challenges/{id}/consume through the shared client (ScaChallengeClient carries
+          OidcClientRequestReactiveFilter with oidc-client.client-id openbank-services) and
+          sca-service runs AUTHZ_ENFORCE=true, so listing this reason 403s the document-signing
+          gate. Needs #3748 (scaChallenge.consume for the shared client) to land first."
         operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
         operator-settlement-write: "settlement.create is resourceless with no alternative rule"
         operator-swift-write: "no identity-scoped rule; callers unverified"

--- a/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: settlement-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "869680b02dc97b41"
+    openbank.tech/policy-checksum: "f5abcf7008f85299"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2038,15 +2038,16 @@ data:
         # never becomes the only one. standing-order POSTs sepaPayment.create via the shared
         # client. When ADR-0223 D2(b) retires those matrix grants, this entry starts denying it.
         - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m (see note above)
+        # Restored once #3748 landed: service-sca-shared-client-m2m now admits the shared client
+        # for scaChallenge.read AND scaChallenge.consume, so document-service's consume call
+        # (ScaChallengeClient, oidc-client.client-id openbank-services) keeps an identity-scoped
+        # reason and this entry no longer 403s the document-signing gate. device.list is covered
+        # by matrix-allows. Still uncovered for the shared client: decide/initiate/verify and
+        # device.enroll — no in-repo caller invokes them on that principal.
+        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
       # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
       # adding it here before that is a money-path outage, not a test failure.
       deferred:
-        operator-sca-write: "service-sca-shared-client-m2m covers scaChallenge.read ONLY, while
-          sca-service exposes consume/decide/initiate/verify and device.enroll. document-service
-          calls POST /challenges/{id}/consume through the shared client (ScaChallengeClient carries
-          OidcClientRequestReactiveFilter with oidc-client.client-id openbank-services) and
-          sca-service runs AUTHZ_ENFORCE=true, so listing this reason 403s the document-signing
-          gate. Needs #3748 (scaChallenge.consume for the shared client) to land first."
         operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
         operator-settlement-write: "settlement.create is resourceless with no alternative rule"
         operator-swift-write: "no identity-scoped rule; callers unverified"

--- a/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: settlement-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "980eb49e19a37c53"
+    openbank.tech/policy-checksum: "922d62a8e2230d52"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2010,5 +2010,52 @@ data:
             - lending.collateralDecide
             - lending.approval.read
             - lending.approval.decide
+
+    shared_m2m_write_prohibition:
+      # GHSA-58jq-9hq3-66jr. rest.rego denies the shared M2M identity
+      # (`service-account-openbank-services`, which carries ROLE_OPERATOR in the realm) when the
+      # ONLY reasons admitting it are the role-only write reasons listed here.
+      #
+      # OPT-IN, and the reason a name pattern was rejected: matching every `operator-*-write`
+      # would have 403'd transaction.create from six live callers (account-service's
+      # welcome-bonus credit, sepa-instant, domestic-payment, swift, interest, sdd) and
+      # settlement.create — both AUTHZ_ENFORCE=true money paths whose services have no
+      # identity-scoped rule to fall back on. transaction-service's rego states the exposure
+      # itself ("RESIDUAL RISK — shared identity, no per-caller narrowing"), which is precisely
+      # why removing its only path is not the fix.
+      #
+      # A reason joins this list once its service carries a rule that NAMES the caller and
+      # enumerates its actions, so denying the role-only path removes an over-grant rather than
+      # the only path. Each entry below was verified to have such a rule.
+      reasons:
+        - operator-consent-write        # service-consent-m2m + service-consent-m2m-marketing
+        - operator-ledger-write         # service-ledger-post / service-ledger-reverse
+        - operator-balance-write        # service-balance-m2m
+        - operator-fraud-write          # service-fraud-scoring
+        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
+        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m
+      # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
+      # adding it here before that is a money-path outage, not a test failure.
+      deferred:
+        operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
+        operator-settlement-write: "settlement.create is resourceless with no alternative rule"
+        operator-swift-write: "no identity-scoped rule; callers unverified"
+        operator-sepa-instant-write: "no identity-scoped rule; callers unverified"
+        operator-billing-write: "no identity-scoped rule; callers unverified"
+        operator-interest-write: "no identity-scoped rule; callers unverified"
+        operator-lending-write: "no identity-scoped rule; callers unverified"
+        operator-sanctions-write: "no identity-scoped rule; m2m-sanctions-screening covers create only"
+        operator-identity-write: "no identity-scoped rule; callers unverified"
+        operator-card-write: "no identity-scoped rule; callers unverified"
+        # These DO carry an identity-pinned rule, but "a rule exists" is not "the rule covers the
+        # actions the role-only path was serving". Listing them on that basis would repeat, one
+        # level down, the guess that made the first revision break transaction.create. Each needs
+        # its identity-scoped rule read against its real callers before it moves up.
+        operator-fx-write: "2 identity-pinned rules; action coverage vs real callers unverified"
+        operator-account-write: "2 identity-pinned rules; action coverage unverified"
+        operator-clearing-write: "1 identity-pinned rule; action coverage unverified"
+        operator-domestic-payment-write: "1 identity-pinned rule; action coverage unverified"
+        operator-party-write: "1 identity-pinned rule, but onboarding-service PUTs party.kyc-status via the shared client (latent: AUTHZ_ENFORCE=false there today)"
+      adr: ADR-0034
   manifest.json: |
     {"roots": ["openbank/agents", "openbank/copilot", "openbank/rest", "agents", "rules"]}

--- a/openbank-infra/gitops/components/payments/standing-order-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/standing-order-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: standing-order-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "06a1ed6dd44971e9"
+    openbank.tech/policy-checksum: "dbdf0fde74f58ffa"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2017,11 +2017,21 @@ data:
         - operator-ledger-write         # service-ledger-post / service-ledger-reverse
         - operator-balance-write        # service-balance-m2m
         - operator-fraud-write          # service-fraud-scoring
-        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
-        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m
+        # SAFE TODAY ONLY BY CO-ADMISSION, not by the rule named here: that rule covers
+        # sepaPayment.handleReturn alone, but ROLE_OPERATOR also grants sepaPayment.create /
+        # .transitionStatus / .approval.decide, so `matrix-allows` co-admits and this reason
+        # never becomes the only one. standing-order POSTs sepaPayment.create via the shared
+        # client. When ADR-0223 D2(b) retires those matrix grants, this entry starts denying it.
+        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m (see note above)
       # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
       # adding it here before that is a money-path outage, not a test failure.
       deferred:
+        operator-sca-write: "service-sca-shared-client-m2m covers scaChallenge.read ONLY, while
+          sca-service exposes consume/decide/initiate/verify and device.enroll. document-service
+          calls POST /challenges/{id}/consume through the shared client (ScaChallengeClient carries
+          OidcClientRequestReactiveFilter with oidc-client.client-id openbank-services) and
+          sca-service runs AUTHZ_ENFORCE=true, so listing this reason 403s the document-signing
+          gate. Needs #3748 (scaChallenge.consume for the shared client) to land first."
         operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
         operator-settlement-write: "settlement.create is resourceless with no alternative rule"
         operator-swift-write: "no identity-scoped rule; callers unverified"

--- a/openbank-infra/gitops/components/payments/standing-order-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/standing-order-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: standing-order-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "b3446cfd050f3b6b"
+    openbank.tech/policy-checksum: "06a1ed6dd44971e9"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1995,5 +1995,52 @@ data:
             - lending.collateralDecide
             - lending.approval.read
             - lending.approval.decide
+
+    shared_m2m_write_prohibition:
+      # GHSA-58jq-9hq3-66jr. rest.rego denies the shared M2M identity
+      # (`service-account-openbank-services`, which carries ROLE_OPERATOR in the realm) when the
+      # ONLY reasons admitting it are the role-only write reasons listed here.
+      #
+      # OPT-IN, and the reason a name pattern was rejected: matching every `operator-*-write`
+      # would have 403'd transaction.create from six live callers (account-service's
+      # welcome-bonus credit, sepa-instant, domestic-payment, swift, interest, sdd) and
+      # settlement.create — both AUTHZ_ENFORCE=true money paths whose services have no
+      # identity-scoped rule to fall back on. transaction-service's rego states the exposure
+      # itself ("RESIDUAL RISK — shared identity, no per-caller narrowing"), which is precisely
+      # why removing its only path is not the fix.
+      #
+      # A reason joins this list once its service carries a rule that NAMES the caller and
+      # enumerates its actions, so denying the role-only path removes an over-grant rather than
+      # the only path. Each entry below was verified to have such a rule.
+      reasons:
+        - operator-consent-write        # service-consent-m2m + service-consent-m2m-marketing
+        - operator-ledger-write         # service-ledger-post / service-ledger-reverse
+        - operator-balance-write        # service-balance-m2m
+        - operator-fraud-write          # service-fraud-scoring
+        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
+        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m
+      # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
+      # adding it here before that is a money-path outage, not a test failure.
+      deferred:
+        operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
+        operator-settlement-write: "settlement.create is resourceless with no alternative rule"
+        operator-swift-write: "no identity-scoped rule; callers unverified"
+        operator-sepa-instant-write: "no identity-scoped rule; callers unverified"
+        operator-billing-write: "no identity-scoped rule; callers unverified"
+        operator-interest-write: "no identity-scoped rule; callers unverified"
+        operator-lending-write: "no identity-scoped rule; callers unverified"
+        operator-sanctions-write: "no identity-scoped rule; m2m-sanctions-screening covers create only"
+        operator-identity-write: "no identity-scoped rule; callers unverified"
+        operator-card-write: "no identity-scoped rule; callers unverified"
+        # These DO carry an identity-pinned rule, but "a rule exists" is not "the rule covers the
+        # actions the role-only path was serving". Listing them on that basis would repeat, one
+        # level down, the guess that made the first revision break transaction.create. Each needs
+        # its identity-scoped rule read against its real callers before it moves up.
+        operator-fx-write: "2 identity-pinned rules; action coverage vs real callers unverified"
+        operator-account-write: "2 identity-pinned rules; action coverage unverified"
+        operator-clearing-write: "1 identity-pinned rule; action coverage unverified"
+        operator-domestic-payment-write: "1 identity-pinned rule; action coverage unverified"
+        operator-party-write: "1 identity-pinned rule, but onboarding-service PUTs party.kyc-status via the shared client (latent: AUTHZ_ENFORCE=false there today)"
+      adr: ADR-0034
   manifest.json: |
     {"roots": ["openbank/agents", "openbank/copilot", "openbank/rest", "agents", "rules"]}

--- a/openbank-infra/gitops/components/payments/standing-order-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/standing-order-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: standing-order-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "dbdf0fde74f58ffa"
+    openbank.tech/policy-checksum: "d5494dbaafb3019a"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2023,15 +2023,16 @@ data:
         # never becomes the only one. standing-order POSTs sepaPayment.create via the shared
         # client. When ADR-0223 D2(b) retires those matrix grants, this entry starts denying it.
         - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m (see note above)
+        # Restored once #3748 landed: service-sca-shared-client-m2m now admits the shared client
+        # for scaChallenge.read AND scaChallenge.consume, so document-service's consume call
+        # (ScaChallengeClient, oidc-client.client-id openbank-services) keeps an identity-scoped
+        # reason and this entry no longer 403s the document-signing gate. device.list is covered
+        # by matrix-allows. Still uncovered for the shared client: decide/initiate/verify and
+        # device.enroll — no in-repo caller invokes them on that principal.
+        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
       # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
       # adding it here before that is a money-path outage, not a test failure.
       deferred:
-        operator-sca-write: "service-sca-shared-client-m2m covers scaChallenge.read ONLY, while
-          sca-service exposes consume/decide/initiate/verify and device.enroll. document-service
-          calls POST /challenges/{id}/consume through the shared client (ScaChallengeClient carries
-          OidcClientRequestReactiveFilter with oidc-client.client-id openbank-services) and
-          sca-service runs AUTHZ_ENFORCE=true, so listing this reason 403s the document-signing
-          gate. Needs #3748 (scaChallenge.consume for the shared client) to land first."
         operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
         operator-settlement-write: "settlement.create is resourceless with no alternative rule"
         operator-swift-write: "no identity-scoped rule; callers unverified"

--- a/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: swift-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "e90ec0a03058de5e"
+    openbank.tech/policy-checksum: "a58af91137312cab"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2013,5 +2013,52 @@ data:
             - lending.collateralDecide
             - lending.approval.read
             - lending.approval.decide
+
+    shared_m2m_write_prohibition:
+      # GHSA-58jq-9hq3-66jr. rest.rego denies the shared M2M identity
+      # (`service-account-openbank-services`, which carries ROLE_OPERATOR in the realm) when the
+      # ONLY reasons admitting it are the role-only write reasons listed here.
+      #
+      # OPT-IN, and the reason a name pattern was rejected: matching every `operator-*-write`
+      # would have 403'd transaction.create from six live callers (account-service's
+      # welcome-bonus credit, sepa-instant, domestic-payment, swift, interest, sdd) and
+      # settlement.create — both AUTHZ_ENFORCE=true money paths whose services have no
+      # identity-scoped rule to fall back on. transaction-service's rego states the exposure
+      # itself ("RESIDUAL RISK — shared identity, no per-caller narrowing"), which is precisely
+      # why removing its only path is not the fix.
+      #
+      # A reason joins this list once its service carries a rule that NAMES the caller and
+      # enumerates its actions, so denying the role-only path removes an over-grant rather than
+      # the only path. Each entry below was verified to have such a rule.
+      reasons:
+        - operator-consent-write        # service-consent-m2m + service-consent-m2m-marketing
+        - operator-ledger-write         # service-ledger-post / service-ledger-reverse
+        - operator-balance-write        # service-balance-m2m
+        - operator-fraud-write          # service-fraud-scoring
+        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
+        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m
+      # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
+      # adding it here before that is a money-path outage, not a test failure.
+      deferred:
+        operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
+        operator-settlement-write: "settlement.create is resourceless with no alternative rule"
+        operator-swift-write: "no identity-scoped rule; callers unverified"
+        operator-sepa-instant-write: "no identity-scoped rule; callers unverified"
+        operator-billing-write: "no identity-scoped rule; callers unverified"
+        operator-interest-write: "no identity-scoped rule; callers unverified"
+        operator-lending-write: "no identity-scoped rule; callers unverified"
+        operator-sanctions-write: "no identity-scoped rule; m2m-sanctions-screening covers create only"
+        operator-identity-write: "no identity-scoped rule; callers unverified"
+        operator-card-write: "no identity-scoped rule; callers unverified"
+        # These DO carry an identity-pinned rule, but "a rule exists" is not "the rule covers the
+        # actions the role-only path was serving". Listing them on that basis would repeat, one
+        # level down, the guess that made the first revision break transaction.create. Each needs
+        # its identity-scoped rule read against its real callers before it moves up.
+        operator-fx-write: "2 identity-pinned rules; action coverage vs real callers unverified"
+        operator-account-write: "2 identity-pinned rules; action coverage unverified"
+        operator-clearing-write: "1 identity-pinned rule; action coverage unverified"
+        operator-domestic-payment-write: "1 identity-pinned rule; action coverage unverified"
+        operator-party-write: "1 identity-pinned rule, but onboarding-service PUTs party.kyc-status via the shared client (latent: AUTHZ_ENFORCE=false there today)"
+      adr: ADR-0034
   manifest.json: |
     {"roots": ["openbank/agents", "openbank/copilot", "openbank/rest", "agents", "rules"]}

--- a/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: swift-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "a58af91137312cab"
+    openbank.tech/policy-checksum: "228646a848af0c91"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2035,11 +2035,21 @@ data:
         - operator-ledger-write         # service-ledger-post / service-ledger-reverse
         - operator-balance-write        # service-balance-m2m
         - operator-fraud-write          # service-fraud-scoring
-        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
-        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m
+        # SAFE TODAY ONLY BY CO-ADMISSION, not by the rule named here: that rule covers
+        # sepaPayment.handleReturn alone, but ROLE_OPERATOR also grants sepaPayment.create /
+        # .transitionStatus / .approval.decide, so `matrix-allows` co-admits and this reason
+        # never becomes the only one. standing-order POSTs sepaPayment.create via the shared
+        # client. When ADR-0223 D2(b) retires those matrix grants, this entry starts denying it.
+        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m (see note above)
       # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
       # adding it here before that is a money-path outage, not a test failure.
       deferred:
+        operator-sca-write: "service-sca-shared-client-m2m covers scaChallenge.read ONLY, while
+          sca-service exposes consume/decide/initiate/verify and device.enroll. document-service
+          calls POST /challenges/{id}/consume through the shared client (ScaChallengeClient carries
+          OidcClientRequestReactiveFilter with oidc-client.client-id openbank-services) and
+          sca-service runs AUTHZ_ENFORCE=true, so listing this reason 403s the document-signing
+          gate. Needs #3748 (scaChallenge.consume for the shared client) to land first."
         operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
         operator-settlement-write: "settlement.create is resourceless with no alternative rule"
         operator-swift-write: "no identity-scoped rule; callers unverified"

--- a/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: swift-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "228646a848af0c91"
+    openbank.tech/policy-checksum: "e46c26e6a4619427"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2041,15 +2041,16 @@ data:
         # never becomes the only one. standing-order POSTs sepaPayment.create via the shared
         # client. When ADR-0223 D2(b) retires those matrix grants, this entry starts denying it.
         - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m (see note above)
+        # Restored once #3748 landed: service-sca-shared-client-m2m now admits the shared client
+        # for scaChallenge.read AND scaChallenge.consume, so document-service's consume call
+        # (ScaChallengeClient, oidc-client.client-id openbank-services) keeps an identity-scoped
+        # reason and this entry no longer 403s the document-signing gate. device.list is covered
+        # by matrix-allows. Still uncovered for the shared client: decide/initiate/verify and
+        # device.enroll — no in-repo caller invokes them on that principal.
+        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
       # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
       # adding it here before that is a money-path outage, not a test failure.
       deferred:
-        operator-sca-write: "service-sca-shared-client-m2m covers scaChallenge.read ONLY, while
-          sca-service exposes consume/decide/initiate/verify and device.enroll. document-service
-          calls POST /challenges/{id}/consume through the shared client (ScaChallengeClient carries
-          OidcClientRequestReactiveFilter with oidc-client.client-id openbank-services) and
-          sca-service runs AUTHZ_ENFORCE=true, so listing this reason 403s the document-signing
-          gate. Needs #3748 (scaChallenge.consume for the shared client) to land first."
         operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
         operator-settlement-write: "settlement.create is resourceless with no alternative rule"
         operator-swift-write: "no identity-scoped rule; callers unverified"

--- a/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: transaction-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "e342c76362451b0b"
+    openbank.tech/policy-checksum: "95507cf598bafc4f"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2088,11 +2088,21 @@ data:
         - operator-ledger-write         # service-ledger-post / service-ledger-reverse
         - operator-balance-write        # service-balance-m2m
         - operator-fraud-write          # service-fraud-scoring
-        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
-        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m
+        # SAFE TODAY ONLY BY CO-ADMISSION, not by the rule named here: that rule covers
+        # sepaPayment.handleReturn alone, but ROLE_OPERATOR also grants sepaPayment.create /
+        # .transitionStatus / .approval.decide, so `matrix-allows` co-admits and this reason
+        # never becomes the only one. standing-order POSTs sepaPayment.create via the shared
+        # client. When ADR-0223 D2(b) retires those matrix grants, this entry starts denying it.
+        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m (see note above)
       # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
       # adding it here before that is a money-path outage, not a test failure.
       deferred:
+        operator-sca-write: "service-sca-shared-client-m2m covers scaChallenge.read ONLY, while
+          sca-service exposes consume/decide/initiate/verify and device.enroll. document-service
+          calls POST /challenges/{id}/consume through the shared client (ScaChallengeClient carries
+          OidcClientRequestReactiveFilter with oidc-client.client-id openbank-services) and
+          sca-service runs AUTHZ_ENFORCE=true, so listing this reason 403s the document-signing
+          gate. Needs #3748 (scaChallenge.consume for the shared client) to land first."
         operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
         operator-settlement-write: "settlement.create is resourceless with no alternative rule"
         operator-swift-write: "no identity-scoped rule; callers unverified"

--- a/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: transaction-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "db0fd25f3c6cc7ce"
+    openbank.tech/policy-checksum: "e342c76362451b0b"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2066,5 +2066,52 @@ data:
             - lending.collateralDecide
             - lending.approval.read
             - lending.approval.decide
+
+    shared_m2m_write_prohibition:
+      # GHSA-58jq-9hq3-66jr. rest.rego denies the shared M2M identity
+      # (`service-account-openbank-services`, which carries ROLE_OPERATOR in the realm) when the
+      # ONLY reasons admitting it are the role-only write reasons listed here.
+      #
+      # OPT-IN, and the reason a name pattern was rejected: matching every `operator-*-write`
+      # would have 403'd transaction.create from six live callers (account-service's
+      # welcome-bonus credit, sepa-instant, domestic-payment, swift, interest, sdd) and
+      # settlement.create — both AUTHZ_ENFORCE=true money paths whose services have no
+      # identity-scoped rule to fall back on. transaction-service's rego states the exposure
+      # itself ("RESIDUAL RISK — shared identity, no per-caller narrowing"), which is precisely
+      # why removing its only path is not the fix.
+      #
+      # A reason joins this list once its service carries a rule that NAMES the caller and
+      # enumerates its actions, so denying the role-only path removes an over-grant rather than
+      # the only path. Each entry below was verified to have such a rule.
+      reasons:
+        - operator-consent-write        # service-consent-m2m + service-consent-m2m-marketing
+        - operator-ledger-write         # service-ledger-post / service-ledger-reverse
+        - operator-balance-write        # service-balance-m2m
+        - operator-fraud-write          # service-fraud-scoring
+        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
+        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m
+      # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
+      # adding it here before that is a money-path outage, not a test failure.
+      deferred:
+        operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
+        operator-settlement-write: "settlement.create is resourceless with no alternative rule"
+        operator-swift-write: "no identity-scoped rule; callers unverified"
+        operator-sepa-instant-write: "no identity-scoped rule; callers unverified"
+        operator-billing-write: "no identity-scoped rule; callers unverified"
+        operator-interest-write: "no identity-scoped rule; callers unverified"
+        operator-lending-write: "no identity-scoped rule; callers unverified"
+        operator-sanctions-write: "no identity-scoped rule; m2m-sanctions-screening covers create only"
+        operator-identity-write: "no identity-scoped rule; callers unverified"
+        operator-card-write: "no identity-scoped rule; callers unverified"
+        # These DO carry an identity-pinned rule, but "a rule exists" is not "the rule covers the
+        # actions the role-only path was serving". Listing them on that basis would repeat, one
+        # level down, the guess that made the first revision break transaction.create. Each needs
+        # its identity-scoped rule read against its real callers before it moves up.
+        operator-fx-write: "2 identity-pinned rules; action coverage vs real callers unverified"
+        operator-account-write: "2 identity-pinned rules; action coverage unverified"
+        operator-clearing-write: "1 identity-pinned rule; action coverage unverified"
+        operator-domestic-payment-write: "1 identity-pinned rule; action coverage unverified"
+        operator-party-write: "1 identity-pinned rule, but onboarding-service PUTs party.kyc-status via the shared client (latent: AUTHZ_ENFORCE=false there today)"
+      adr: ADR-0034
   manifest.json: |
     {"roots": ["openbank/agents", "openbank/copilot", "openbank/rest", "agents", "rules"]}

--- a/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: transaction-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "95507cf598bafc4f"
+    openbank.tech/policy-checksum: "7c800f18b73edc61"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2094,15 +2094,16 @@ data:
         # never becomes the only one. standing-order POSTs sepaPayment.create via the shared
         # client. When ADR-0223 D2(b) retires those matrix grants, this entry starts denying it.
         - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m (see note above)
+        # Restored once #3748 landed: service-sca-shared-client-m2m now admits the shared client
+        # for scaChallenge.read AND scaChallenge.consume, so document-service's consume call
+        # (ScaChallengeClient, oidc-client.client-id openbank-services) keeps an identity-scoped
+        # reason and this entry no longer 403s the document-signing gate. device.list is covered
+        # by matrix-allows. Still uncovered for the shared client: decide/initiate/verify and
+        # device.enroll — no in-repo caller invokes them on that principal.
+        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
       # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
       # adding it here before that is a money-path outage, not a test failure.
       deferred:
-        operator-sca-write: "service-sca-shared-client-m2m covers scaChallenge.read ONLY, while
-          sca-service exposes consume/decide/initiate/verify and device.enroll. document-service
-          calls POST /challenges/{id}/consume through the shared client (ScaChallengeClient carries
-          OidcClientRequestReactiveFilter with oidc-client.client-id openbank-services) and
-          sca-service runs AUTHZ_ENFORCE=true, so listing this reason 403s the document-signing
-          gate. Needs #3748 (scaChallenge.consume for the shared client) to land first."
         operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
         operator-settlement-write: "settlement.create is resourceless with no alternative rule"
         operator-swift-write: "no identity-scoped rule; callers unverified"

--- a/openbank-infra/gitops/components/payments/vop-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/vop-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: vop-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "42b0070784b83ba1"
+    openbank.tech/policy-checksum: "8e96f4ca114b5e4b"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2045,15 +2045,16 @@ data:
         # never becomes the only one. standing-order POSTs sepaPayment.create via the shared
         # client. When ADR-0223 D2(b) retires those matrix grants, this entry starts denying it.
         - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m (see note above)
+        # Restored once #3748 landed: service-sca-shared-client-m2m now admits the shared client
+        # for scaChallenge.read AND scaChallenge.consume, so document-service's consume call
+        # (ScaChallengeClient, oidc-client.client-id openbank-services) keeps an identity-scoped
+        # reason and this entry no longer 403s the document-signing gate. device.list is covered
+        # by matrix-allows. Still uncovered for the shared client: decide/initiate/verify and
+        # device.enroll — no in-repo caller invokes them on that principal.
+        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
       # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
       # adding it here before that is a money-path outage, not a test failure.
       deferred:
-        operator-sca-write: "service-sca-shared-client-m2m covers scaChallenge.read ONLY, while
-          sca-service exposes consume/decide/initiate/verify and device.enroll. document-service
-          calls POST /challenges/{id}/consume through the shared client (ScaChallengeClient carries
-          OidcClientRequestReactiveFilter with oidc-client.client-id openbank-services) and
-          sca-service runs AUTHZ_ENFORCE=true, so listing this reason 403s the document-signing
-          gate. Needs #3748 (scaChallenge.consume for the shared client) to land first."
         operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
         operator-settlement-write: "settlement.create is resourceless with no alternative rule"
         operator-swift-write: "no identity-scoped rule; callers unverified"

--- a/openbank-infra/gitops/components/payments/vop-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/vop-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: vop-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "6afe1a7778655f2e"
+    openbank.tech/policy-checksum: "42b0070784b83ba1"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2039,11 +2039,21 @@ data:
         - operator-ledger-write         # service-ledger-post / service-ledger-reverse
         - operator-balance-write        # service-balance-m2m
         - operator-fraud-write          # service-fraud-scoring
-        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
-        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m
+        # SAFE TODAY ONLY BY CO-ADMISSION, not by the rule named here: that rule covers
+        # sepaPayment.handleReturn alone, but ROLE_OPERATOR also grants sepaPayment.create /
+        # .transitionStatus / .approval.decide, so `matrix-allows` co-admits and this reason
+        # never becomes the only one. standing-order POSTs sepaPayment.create via the shared
+        # client. When ADR-0223 D2(b) retires those matrix grants, this entry starts denying it.
+        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m (see note above)
       # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
       # adding it here before that is a money-path outage, not a test failure.
       deferred:
+        operator-sca-write: "service-sca-shared-client-m2m covers scaChallenge.read ONLY, while
+          sca-service exposes consume/decide/initiate/verify and device.enroll. document-service
+          calls POST /challenges/{id}/consume through the shared client (ScaChallengeClient carries
+          OidcClientRequestReactiveFilter with oidc-client.client-id openbank-services) and
+          sca-service runs AUTHZ_ENFORCE=true, so listing this reason 403s the document-signing
+          gate. Needs #3748 (scaChallenge.consume for the shared client) to land first."
         operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
         operator-settlement-write: "settlement.create is resourceless with no alternative rule"
         operator-swift-write: "no identity-scoped rule; callers unverified"

--- a/openbank-infra/gitops/components/payments/vop-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/vop-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: vop-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "ff1d488571b0c025"
+    openbank.tech/policy-checksum: "6afe1a7778655f2e"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2017,5 +2017,52 @@ data:
             - lending.collateralDecide
             - lending.approval.read
             - lending.approval.decide
+
+    shared_m2m_write_prohibition:
+      # GHSA-58jq-9hq3-66jr. rest.rego denies the shared M2M identity
+      # (`service-account-openbank-services`, which carries ROLE_OPERATOR in the realm) when the
+      # ONLY reasons admitting it are the role-only write reasons listed here.
+      #
+      # OPT-IN, and the reason a name pattern was rejected: matching every `operator-*-write`
+      # would have 403'd transaction.create from six live callers (account-service's
+      # welcome-bonus credit, sepa-instant, domestic-payment, swift, interest, sdd) and
+      # settlement.create — both AUTHZ_ENFORCE=true money paths whose services have no
+      # identity-scoped rule to fall back on. transaction-service's rego states the exposure
+      # itself ("RESIDUAL RISK — shared identity, no per-caller narrowing"), which is precisely
+      # why removing its only path is not the fix.
+      #
+      # A reason joins this list once its service carries a rule that NAMES the caller and
+      # enumerates its actions, so denying the role-only path removes an over-grant rather than
+      # the only path. Each entry below was verified to have such a rule.
+      reasons:
+        - operator-consent-write        # service-consent-m2m + service-consent-m2m-marketing
+        - operator-ledger-write         # service-ledger-post / service-ledger-reverse
+        - operator-balance-write        # service-balance-m2m
+        - operator-fraud-write          # service-fraud-scoring
+        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
+        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m
+      # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
+      # adding it here before that is a money-path outage, not a test failure.
+      deferred:
+        operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
+        operator-settlement-write: "settlement.create is resourceless with no alternative rule"
+        operator-swift-write: "no identity-scoped rule; callers unverified"
+        operator-sepa-instant-write: "no identity-scoped rule; callers unverified"
+        operator-billing-write: "no identity-scoped rule; callers unverified"
+        operator-interest-write: "no identity-scoped rule; callers unverified"
+        operator-lending-write: "no identity-scoped rule; callers unverified"
+        operator-sanctions-write: "no identity-scoped rule; m2m-sanctions-screening covers create only"
+        operator-identity-write: "no identity-scoped rule; callers unverified"
+        operator-card-write: "no identity-scoped rule; callers unverified"
+        # These DO carry an identity-pinned rule, but "a rule exists" is not "the rule covers the
+        # actions the role-only path was serving". Listing them on that basis would repeat, one
+        # level down, the guess that made the first revision break transaction.create. Each needs
+        # its identity-scoped rule read against its real callers before it moves up.
+        operator-fx-write: "2 identity-pinned rules; action coverage vs real callers unverified"
+        operator-account-write: "2 identity-pinned rules; action coverage unverified"
+        operator-clearing-write: "1 identity-pinned rule; action coverage unverified"
+        operator-domestic-payment-write: "1 identity-pinned rule; action coverage unverified"
+        operator-party-write: "1 identity-pinned rule, but onboarding-service PUTs party.kyc-status via the shared client (latent: AUTHZ_ENFORCE=false there today)"
+      adr: ADR-0034
   manifest.json: |
     {"roots": ["openbank/agents", "openbank/copilot", "openbank/rest", "agents", "rules"]}

--- a/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: pid-service
     app.kubernetes.io/part-of: pid
   annotations:
-    openbank.tech/policy-checksum: "a81c109f90403d09"
+    openbank.tech/policy-checksum: "8e5fca4620202784"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2019,5 +2019,52 @@ data:
             - lending.collateralDecide
             - lending.approval.read
             - lending.approval.decide
+
+    shared_m2m_write_prohibition:
+      # GHSA-58jq-9hq3-66jr. rest.rego denies the shared M2M identity
+      # (`service-account-openbank-services`, which carries ROLE_OPERATOR in the realm) when the
+      # ONLY reasons admitting it are the role-only write reasons listed here.
+      #
+      # OPT-IN, and the reason a name pattern was rejected: matching every `operator-*-write`
+      # would have 403'd transaction.create from six live callers (account-service's
+      # welcome-bonus credit, sepa-instant, domestic-payment, swift, interest, sdd) and
+      # settlement.create — both AUTHZ_ENFORCE=true money paths whose services have no
+      # identity-scoped rule to fall back on. transaction-service's rego states the exposure
+      # itself ("RESIDUAL RISK — shared identity, no per-caller narrowing"), which is precisely
+      # why removing its only path is not the fix.
+      #
+      # A reason joins this list once its service carries a rule that NAMES the caller and
+      # enumerates its actions, so denying the role-only path removes an over-grant rather than
+      # the only path. Each entry below was verified to have such a rule.
+      reasons:
+        - operator-consent-write        # service-consent-m2m + service-consent-m2m-marketing
+        - operator-ledger-write         # service-ledger-post / service-ledger-reverse
+        - operator-balance-write        # service-balance-m2m
+        - operator-fraud-write          # service-fraud-scoring
+        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
+        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m
+      # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
+      # adding it here before that is a money-path outage, not a test failure.
+      deferred:
+        operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
+        operator-settlement-write: "settlement.create is resourceless with no alternative rule"
+        operator-swift-write: "no identity-scoped rule; callers unverified"
+        operator-sepa-instant-write: "no identity-scoped rule; callers unverified"
+        operator-billing-write: "no identity-scoped rule; callers unverified"
+        operator-interest-write: "no identity-scoped rule; callers unverified"
+        operator-lending-write: "no identity-scoped rule; callers unverified"
+        operator-sanctions-write: "no identity-scoped rule; m2m-sanctions-screening covers create only"
+        operator-identity-write: "no identity-scoped rule; callers unverified"
+        operator-card-write: "no identity-scoped rule; callers unverified"
+        # These DO carry an identity-pinned rule, but "a rule exists" is not "the rule covers the
+        # actions the role-only path was serving". Listing them on that basis would repeat, one
+        # level down, the guess that made the first revision break transaction.create. Each needs
+        # its identity-scoped rule read against its real callers before it moves up.
+        operator-fx-write: "2 identity-pinned rules; action coverage vs real callers unverified"
+        operator-account-write: "2 identity-pinned rules; action coverage unverified"
+        operator-clearing-write: "1 identity-pinned rule; action coverage unverified"
+        operator-domestic-payment-write: "1 identity-pinned rule; action coverage unverified"
+        operator-party-write: "1 identity-pinned rule, but onboarding-service PUTs party.kyc-status via the shared client (latent: AUTHZ_ENFORCE=false there today)"
+      adr: ADR-0034
   manifest.json: |
     {"roots": ["openbank/agents", "openbank/copilot", "openbank/rest", "agents", "rules"]}

--- a/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: pid-service
     app.kubernetes.io/part-of: pid
   annotations:
-    openbank.tech/policy-checksum: "e6363dccd1d7ad08"
+    openbank.tech/policy-checksum: "09a0ebc9ff513789"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2047,15 +2047,16 @@ data:
         # never becomes the only one. standing-order POSTs sepaPayment.create via the shared
         # client. When ADR-0223 D2(b) retires those matrix grants, this entry starts denying it.
         - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m (see note above)
+        # Restored once #3748 landed: service-sca-shared-client-m2m now admits the shared client
+        # for scaChallenge.read AND scaChallenge.consume, so document-service's consume call
+        # (ScaChallengeClient, oidc-client.client-id openbank-services) keeps an identity-scoped
+        # reason and this entry no longer 403s the document-signing gate. device.list is covered
+        # by matrix-allows. Still uncovered for the shared client: decide/initiate/verify and
+        # device.enroll — no in-repo caller invokes them on that principal.
+        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
       # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
       # adding it here before that is a money-path outage, not a test failure.
       deferred:
-        operator-sca-write: "service-sca-shared-client-m2m covers scaChallenge.read ONLY, while
-          sca-service exposes consume/decide/initiate/verify and device.enroll. document-service
-          calls POST /challenges/{id}/consume through the shared client (ScaChallengeClient carries
-          OidcClientRequestReactiveFilter with oidc-client.client-id openbank-services) and
-          sca-service runs AUTHZ_ENFORCE=true, so listing this reason 403s the document-signing
-          gate. Needs #3748 (scaChallenge.consume for the shared client) to land first."
         operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
         operator-settlement-write: "settlement.create is resourceless with no alternative rule"
         operator-swift-write: "no identity-scoped rule; callers unverified"

--- a/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: pid-service
     app.kubernetes.io/part-of: pid
   annotations:
-    openbank.tech/policy-checksum: "8e5fca4620202784"
+    openbank.tech/policy-checksum: "e6363dccd1d7ad08"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2041,11 +2041,21 @@ data:
         - operator-ledger-write         # service-ledger-post / service-ledger-reverse
         - operator-balance-write        # service-balance-m2m
         - operator-fraud-write          # service-fraud-scoring
-        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
-        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m
+        # SAFE TODAY ONLY BY CO-ADMISSION, not by the rule named here: that rule covers
+        # sepaPayment.handleReturn alone, but ROLE_OPERATOR also grants sepaPayment.create /
+        # .transitionStatus / .approval.decide, so `matrix-allows` co-admits and this reason
+        # never becomes the only one. standing-order POSTs sepaPayment.create via the shared
+        # client. When ADR-0223 D2(b) retires those matrix grants, this entry starts denying it.
+        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m (see note above)
       # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
       # adding it here before that is a money-path outage, not a test failure.
       deferred:
+        operator-sca-write: "service-sca-shared-client-m2m covers scaChallenge.read ONLY, while
+          sca-service exposes consume/decide/initiate/verify and device.enroll. document-service
+          calls POST /challenges/{id}/consume through the shared client (ScaChallengeClient carries
+          OidcClientRequestReactiveFilter with oidc-client.client-id openbank-services) and
+          sca-service runs AUTHZ_ENFORCE=true, so listing this reason 403s the document-signing
+          gate. Needs #3748 (scaChallenge.consume for the shared client) to land first."
         operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
         operator-settlement-write: "settlement.create is resourceless with no alternative rule"
         operator-swift-write: "no identity-scoped rule; callers unverified"

--- a/openbank-infra/gitops/components/pid/pid-service.yaml
+++ b/openbank-infra/gitops/components/pid/pid-service.yaml
@@ -32,7 +32,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-pid-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "8e5fca4620202784"
+        openbank.tech/policy-checksum: "e6363dccd1d7ad08"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/pid/pid-service.yaml
+++ b/openbank-infra/gitops/components/pid/pid-service.yaml
@@ -32,7 +32,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-pid-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "a81c109f90403d09"
+        openbank.tech/policy-checksum: "8e5fca4620202784"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/pid/pid-service.yaml
+++ b/openbank-infra/gitops/components/pid/pid-service.yaml
@@ -32,7 +32,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-pid-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "e6363dccd1d7ad08"
+        openbank.tech/policy-checksum: "09a0ebc9ff513789"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/psd2-service/psd2-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/psd2-service/psd2-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: psd2-service
     app.kubernetes.io/part-of: psd2
   annotations:
-    openbank.tech/policy-checksum: "9e59dd70562565a7"
+    openbank.tech/policy-checksum: "bc1111a6f679511b"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2092,5 +2092,52 @@ data:
             - lending.collateralDecide
             - lending.approval.read
             - lending.approval.decide
+
+    shared_m2m_write_prohibition:
+      # GHSA-58jq-9hq3-66jr. rest.rego denies the shared M2M identity
+      # (`service-account-openbank-services`, which carries ROLE_OPERATOR in the realm) when the
+      # ONLY reasons admitting it are the role-only write reasons listed here.
+      #
+      # OPT-IN, and the reason a name pattern was rejected: matching every `operator-*-write`
+      # would have 403'd transaction.create from six live callers (account-service's
+      # welcome-bonus credit, sepa-instant, domestic-payment, swift, interest, sdd) and
+      # settlement.create — both AUTHZ_ENFORCE=true money paths whose services have no
+      # identity-scoped rule to fall back on. transaction-service's rego states the exposure
+      # itself ("RESIDUAL RISK — shared identity, no per-caller narrowing"), which is precisely
+      # why removing its only path is not the fix.
+      #
+      # A reason joins this list once its service carries a rule that NAMES the caller and
+      # enumerates its actions, so denying the role-only path removes an over-grant rather than
+      # the only path. Each entry below was verified to have such a rule.
+      reasons:
+        - operator-consent-write        # service-consent-m2m + service-consent-m2m-marketing
+        - operator-ledger-write         # service-ledger-post / service-ledger-reverse
+        - operator-balance-write        # service-balance-m2m
+        - operator-fraud-write          # service-fraud-scoring
+        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
+        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m
+      # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
+      # adding it here before that is a money-path outage, not a test failure.
+      deferred:
+        operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
+        operator-settlement-write: "settlement.create is resourceless with no alternative rule"
+        operator-swift-write: "no identity-scoped rule; callers unverified"
+        operator-sepa-instant-write: "no identity-scoped rule; callers unverified"
+        operator-billing-write: "no identity-scoped rule; callers unverified"
+        operator-interest-write: "no identity-scoped rule; callers unverified"
+        operator-lending-write: "no identity-scoped rule; callers unverified"
+        operator-sanctions-write: "no identity-scoped rule; m2m-sanctions-screening covers create only"
+        operator-identity-write: "no identity-scoped rule; callers unverified"
+        operator-card-write: "no identity-scoped rule; callers unverified"
+        # These DO carry an identity-pinned rule, but "a rule exists" is not "the rule covers the
+        # actions the role-only path was serving". Listing them on that basis would repeat, one
+        # level down, the guess that made the first revision break transaction.create. Each needs
+        # its identity-scoped rule read against its real callers before it moves up.
+        operator-fx-write: "2 identity-pinned rules; action coverage vs real callers unverified"
+        operator-account-write: "2 identity-pinned rules; action coverage unverified"
+        operator-clearing-write: "1 identity-pinned rule; action coverage unverified"
+        operator-domestic-payment-write: "1 identity-pinned rule; action coverage unverified"
+        operator-party-write: "1 identity-pinned rule, but onboarding-service PUTs party.kyc-status via the shared client (latent: AUTHZ_ENFORCE=false there today)"
+      adr: ADR-0034
   manifest.json: |
     {"roots": ["openbank/agents", "openbank/copilot", "openbank/rest", "agents", "rules"]}

--- a/openbank-infra/gitops/components/psd2-service/psd2-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/psd2-service/psd2-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: psd2-service
     app.kubernetes.io/part-of: psd2
   annotations:
-    openbank.tech/policy-checksum: "1b7af038710fe1c7"
+    openbank.tech/policy-checksum: "a40dbb1067991400"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2120,15 +2120,16 @@ data:
         # never becomes the only one. standing-order POSTs sepaPayment.create via the shared
         # client. When ADR-0223 D2(b) retires those matrix grants, this entry starts denying it.
         - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m (see note above)
+        # Restored once #3748 landed: service-sca-shared-client-m2m now admits the shared client
+        # for scaChallenge.read AND scaChallenge.consume, so document-service's consume call
+        # (ScaChallengeClient, oidc-client.client-id openbank-services) keeps an identity-scoped
+        # reason and this entry no longer 403s the document-signing gate. device.list is covered
+        # by matrix-allows. Still uncovered for the shared client: decide/initiate/verify and
+        # device.enroll — no in-repo caller invokes them on that principal.
+        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
       # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
       # adding it here before that is a money-path outage, not a test failure.
       deferred:
-        operator-sca-write: "service-sca-shared-client-m2m covers scaChallenge.read ONLY, while
-          sca-service exposes consume/decide/initiate/verify and device.enroll. document-service
-          calls POST /challenges/{id}/consume through the shared client (ScaChallengeClient carries
-          OidcClientRequestReactiveFilter with oidc-client.client-id openbank-services) and
-          sca-service runs AUTHZ_ENFORCE=true, so listing this reason 403s the document-signing
-          gate. Needs #3748 (scaChallenge.consume for the shared client) to land first."
         operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
         operator-settlement-write: "settlement.create is resourceless with no alternative rule"
         operator-swift-write: "no identity-scoped rule; callers unverified"

--- a/openbank-infra/gitops/components/psd2-service/psd2-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/psd2-service/psd2-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: psd2-service
     app.kubernetes.io/part-of: psd2
   annotations:
-    openbank.tech/policy-checksum: "bc1111a6f679511b"
+    openbank.tech/policy-checksum: "1b7af038710fe1c7"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2114,11 +2114,21 @@ data:
         - operator-ledger-write         # service-ledger-post / service-ledger-reverse
         - operator-balance-write        # service-balance-m2m
         - operator-fraud-write          # service-fraud-scoring
-        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
-        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m
+        # SAFE TODAY ONLY BY CO-ADMISSION, not by the rule named here: that rule covers
+        # sepaPayment.handleReturn alone, but ROLE_OPERATOR also grants sepaPayment.create /
+        # .transitionStatus / .approval.decide, so `matrix-allows` co-admits and this reason
+        # never becomes the only one. standing-order POSTs sepaPayment.create via the shared
+        # client. When ADR-0223 D2(b) retires those matrix grants, this entry starts denying it.
+        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m (see note above)
       # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
       # adding it here before that is a money-path outage, not a test failure.
       deferred:
+        operator-sca-write: "service-sca-shared-client-m2m covers scaChallenge.read ONLY, while
+          sca-service exposes consume/decide/initiate/verify and device.enroll. document-service
+          calls POST /challenges/{id}/consume through the shared client (ScaChallengeClient carries
+          OidcClientRequestReactiveFilter with oidc-client.client-id openbank-services) and
+          sca-service runs AUTHZ_ENFORCE=true, so listing this reason 403s the document-signing
+          gate. Needs #3748 (scaChallenge.consume for the shared client) to land first."
         operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
         operator-settlement-write: "settlement.create is resourceless with no alternative rule"
         operator-swift-write: "no identity-scoped rule; callers unverified"

--- a/openbank-infra/gitops/components/psd2-service/psd2-service.yaml
+++ b/openbank-infra/gitops/components/psd2-service/psd2-service.yaml
@@ -27,7 +27,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-psd2-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "9e59dd70562565a7"
+        openbank.tech/policy-checksum: "bc1111a6f679511b"
       labels: {app.kubernetes.io/name: psd2-service, app.kubernetes.io/part-of: psd2}
     spec:
       securityContext:

--- a/openbank-infra/gitops/components/psd2-service/psd2-service.yaml
+++ b/openbank-infra/gitops/components/psd2-service/psd2-service.yaml
@@ -27,7 +27,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-psd2-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "1b7af038710fe1c7"
+        openbank.tech/policy-checksum: "a40dbb1067991400"
       labels: {app.kubernetes.io/name: psd2-service, app.kubernetes.io/part-of: psd2}
     spec:
       securityContext:

--- a/openbank-infra/gitops/components/psd2-service/psd2-service.yaml
+++ b/openbank-infra/gitops/components/psd2-service/psd2-service.yaml
@@ -27,7 +27,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-psd2-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "bc1111a6f679511b"
+        openbank.tech/policy-checksum: "1b7af038710fe1c7"
       labels: {app.kubernetes.io/name: psd2-service, app.kubernetes.io/part-of: psd2}
     spec:
       securityContext:

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sanctions-service
     app.kubernetes.io/part-of: sanctions
   annotations:
-    openbank.tech/policy-checksum: "6d8115554340cfad"
+    openbank.tech/policy-checksum: "c5a76ce594be513e"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2019,11 +2019,21 @@ data:
         - operator-ledger-write         # service-ledger-post / service-ledger-reverse
         - operator-balance-write        # service-balance-m2m
         - operator-fraud-write          # service-fraud-scoring
-        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
-        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m
+        # SAFE TODAY ONLY BY CO-ADMISSION, not by the rule named here: that rule covers
+        # sepaPayment.handleReturn alone, but ROLE_OPERATOR also grants sepaPayment.create /
+        # .transitionStatus / .approval.decide, so `matrix-allows` co-admits and this reason
+        # never becomes the only one. standing-order POSTs sepaPayment.create via the shared
+        # client. When ADR-0223 D2(b) retires those matrix grants, this entry starts denying it.
+        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m (see note above)
       # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
       # adding it here before that is a money-path outage, not a test failure.
       deferred:
+        operator-sca-write: "service-sca-shared-client-m2m covers scaChallenge.read ONLY, while
+          sca-service exposes consume/decide/initiate/verify and device.enroll. document-service
+          calls POST /challenges/{id}/consume through the shared client (ScaChallengeClient carries
+          OidcClientRequestReactiveFilter with oidc-client.client-id openbank-services) and
+          sca-service runs AUTHZ_ENFORCE=true, so listing this reason 403s the document-signing
+          gate. Needs #3748 (scaChallenge.consume for the shared client) to land first."
         operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
         operator-settlement-write: "settlement.create is resourceless with no alternative rule"
         operator-swift-write: "no identity-scoped rule; callers unverified"

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sanctions-service
     app.kubernetes.io/part-of: sanctions
   annotations:
-    openbank.tech/policy-checksum: "c5a76ce594be513e"
+    openbank.tech/policy-checksum: "10ed6ea72e66cc2f"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2025,15 +2025,16 @@ data:
         # never becomes the only one. standing-order POSTs sepaPayment.create via the shared
         # client. When ADR-0223 D2(b) retires those matrix grants, this entry starts denying it.
         - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m (see note above)
+        # Restored once #3748 landed: service-sca-shared-client-m2m now admits the shared client
+        # for scaChallenge.read AND scaChallenge.consume, so document-service's consume call
+        # (ScaChallengeClient, oidc-client.client-id openbank-services) keeps an identity-scoped
+        # reason and this entry no longer 403s the document-signing gate. device.list is covered
+        # by matrix-allows. Still uncovered for the shared client: decide/initiate/verify and
+        # device.enroll — no in-repo caller invokes them on that principal.
+        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
       # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
       # adding it here before that is a money-path outage, not a test failure.
       deferred:
-        operator-sca-write: "service-sca-shared-client-m2m covers scaChallenge.read ONLY, while
-          sca-service exposes consume/decide/initiate/verify and device.enroll. document-service
-          calls POST /challenges/{id}/consume through the shared client (ScaChallengeClient carries
-          OidcClientRequestReactiveFilter with oidc-client.client-id openbank-services) and
-          sca-service runs AUTHZ_ENFORCE=true, so listing this reason 403s the document-signing
-          gate. Needs #3748 (scaChallenge.consume for the shared client) to land first."
         operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
         operator-settlement-write: "settlement.create is resourceless with no alternative rule"
         operator-swift-write: "no identity-scoped rule; callers unverified"

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sanctions-service
     app.kubernetes.io/part-of: sanctions
   annotations:
-    openbank.tech/policy-checksum: "0f8e3d72ed3a2d84"
+    openbank.tech/policy-checksum: "6d8115554340cfad"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1997,5 +1997,52 @@ data:
             - lending.collateralDecide
             - lending.approval.read
             - lending.approval.decide
+
+    shared_m2m_write_prohibition:
+      # GHSA-58jq-9hq3-66jr. rest.rego denies the shared M2M identity
+      # (`service-account-openbank-services`, which carries ROLE_OPERATOR in the realm) when the
+      # ONLY reasons admitting it are the role-only write reasons listed here.
+      #
+      # OPT-IN, and the reason a name pattern was rejected: matching every `operator-*-write`
+      # would have 403'd transaction.create from six live callers (account-service's
+      # welcome-bonus credit, sepa-instant, domestic-payment, swift, interest, sdd) and
+      # settlement.create — both AUTHZ_ENFORCE=true money paths whose services have no
+      # identity-scoped rule to fall back on. transaction-service's rego states the exposure
+      # itself ("RESIDUAL RISK — shared identity, no per-caller narrowing"), which is precisely
+      # why removing its only path is not the fix.
+      #
+      # A reason joins this list once its service carries a rule that NAMES the caller and
+      # enumerates its actions, so denying the role-only path removes an over-grant rather than
+      # the only path. Each entry below was verified to have such a rule.
+      reasons:
+        - operator-consent-write        # service-consent-m2m + service-consent-m2m-marketing
+        - operator-ledger-write         # service-ledger-post / service-ledger-reverse
+        - operator-balance-write        # service-balance-m2m
+        - operator-fraud-write          # service-fraud-scoring
+        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
+        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m
+      # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
+      # adding it here before that is a money-path outage, not a test failure.
+      deferred:
+        operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
+        operator-settlement-write: "settlement.create is resourceless with no alternative rule"
+        operator-swift-write: "no identity-scoped rule; callers unverified"
+        operator-sepa-instant-write: "no identity-scoped rule; callers unverified"
+        operator-billing-write: "no identity-scoped rule; callers unverified"
+        operator-interest-write: "no identity-scoped rule; callers unverified"
+        operator-lending-write: "no identity-scoped rule; callers unverified"
+        operator-sanctions-write: "no identity-scoped rule; m2m-sanctions-screening covers create only"
+        operator-identity-write: "no identity-scoped rule; callers unverified"
+        operator-card-write: "no identity-scoped rule; callers unverified"
+        # These DO carry an identity-pinned rule, but "a rule exists" is not "the rule covers the
+        # actions the role-only path was serving". Listing them on that basis would repeat, one
+        # level down, the guess that made the first revision break transaction.create. Each needs
+        # its identity-scoped rule read against its real callers before it moves up.
+        operator-fx-write: "2 identity-pinned rules; action coverage vs real callers unverified"
+        operator-account-write: "2 identity-pinned rules; action coverage unverified"
+        operator-clearing-write: "1 identity-pinned rule; action coverage unverified"
+        operator-domestic-payment-write: "1 identity-pinned rule; action coverage unverified"
+        operator-party-write: "1 identity-pinned rule, but onboarding-service PUTs party.kyc-status via the shared client (latent: AUTHZ_ENFORCE=false there today)"
+      adr: ADR-0034
   manifest.json: |
     {"roots": ["openbank/agents", "openbank/copilot", "openbank/rest", "agents", "rules"]}

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
@@ -49,7 +49,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sanctions-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "c5a76ce594be513e"
+        openbank.tech/policy-checksum: "10ed6ea72e66cc2f"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
@@ -49,7 +49,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sanctions-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "0f8e3d72ed3a2d84"
+        openbank.tech/policy-checksum: "6d8115554340cfad"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
@@ -49,7 +49,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sanctions-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "6d8115554340cfad"
+        openbank.tech/policy-checksum: "c5a76ce594be513e"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sca-service
     app.kubernetes.io/part-of: sca
   annotations:
-    openbank.tech/policy-checksum: "3987b45e5d0ebffd"
+    openbank.tech/policy-checksum: "c0b59bd40d18039b"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2080,15 +2080,16 @@ data:
         # never becomes the only one. standing-order POSTs sepaPayment.create via the shared
         # client. When ADR-0223 D2(b) retires those matrix grants, this entry starts denying it.
         - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m (see note above)
+        # Restored once #3748 landed: service-sca-shared-client-m2m now admits the shared client
+        # for scaChallenge.read AND scaChallenge.consume, so document-service's consume call
+        # (ScaChallengeClient, oidc-client.client-id openbank-services) keeps an identity-scoped
+        # reason and this entry no longer 403s the document-signing gate. device.list is covered
+        # by matrix-allows. Still uncovered for the shared client: decide/initiate/verify and
+        # device.enroll — no in-repo caller invokes them on that principal.
+        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
       # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
       # adding it here before that is a money-path outage, not a test failure.
       deferred:
-        operator-sca-write: "service-sca-shared-client-m2m covers scaChallenge.read ONLY, while
-          sca-service exposes consume/decide/initiate/verify and device.enroll. document-service
-          calls POST /challenges/{id}/consume through the shared client (ScaChallengeClient carries
-          OidcClientRequestReactiveFilter with oidc-client.client-id openbank-services) and
-          sca-service runs AUTHZ_ENFORCE=true, so listing this reason 403s the document-signing
-          gate. Needs #3748 (scaChallenge.consume for the shared client) to land first."
         operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
         operator-settlement-write: "settlement.create is resourceless with no alternative rule"
         operator-swift-write: "no identity-scoped rule; callers unverified"

--- a/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sca-service
     app.kubernetes.io/part-of: sca
   annotations:
-    openbank.tech/policy-checksum: "924b1cf14d2c90a9"
+    openbank.tech/policy-checksum: "3987b45e5d0ebffd"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2074,11 +2074,21 @@ data:
         - operator-ledger-write         # service-ledger-post / service-ledger-reverse
         - operator-balance-write        # service-balance-m2m
         - operator-fraud-write          # service-fraud-scoring
-        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
-        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m
+        # SAFE TODAY ONLY BY CO-ADMISSION, not by the rule named here: that rule covers
+        # sepaPayment.handleReturn alone, but ROLE_OPERATOR also grants sepaPayment.create /
+        # .transitionStatus / .approval.decide, so `matrix-allows` co-admits and this reason
+        # never becomes the only one. standing-order POSTs sepaPayment.create via the shared
+        # client. When ADR-0223 D2(b) retires those matrix grants, this entry starts denying it.
+        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m (see note above)
       # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
       # adding it here before that is a money-path outage, not a test failure.
       deferred:
+        operator-sca-write: "service-sca-shared-client-m2m covers scaChallenge.read ONLY, while
+          sca-service exposes consume/decide/initiate/verify and device.enroll. document-service
+          calls POST /challenges/{id}/consume through the shared client (ScaChallengeClient carries
+          OidcClientRequestReactiveFilter with oidc-client.client-id openbank-services) and
+          sca-service runs AUTHZ_ENFORCE=true, so listing this reason 403s the document-signing
+          gate. Needs #3748 (scaChallenge.consume for the shared client) to land first."
         operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
         operator-settlement-write: "settlement.create is resourceless with no alternative rule"
         operator-swift-write: "no identity-scoped rule; callers unverified"

--- a/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sca-service
     app.kubernetes.io/part-of: sca
   annotations:
-    openbank.tech/policy-checksum: "7e456af3f69dc2f2"
+    openbank.tech/policy-checksum: "924b1cf14d2c90a9"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2052,5 +2052,52 @@ data:
             - lending.collateralDecide
             - lending.approval.read
             - lending.approval.decide
+
+    shared_m2m_write_prohibition:
+      # GHSA-58jq-9hq3-66jr. rest.rego denies the shared M2M identity
+      # (`service-account-openbank-services`, which carries ROLE_OPERATOR in the realm) when the
+      # ONLY reasons admitting it are the role-only write reasons listed here.
+      #
+      # OPT-IN, and the reason a name pattern was rejected: matching every `operator-*-write`
+      # would have 403'd transaction.create from six live callers (account-service's
+      # welcome-bonus credit, sepa-instant, domestic-payment, swift, interest, sdd) and
+      # settlement.create — both AUTHZ_ENFORCE=true money paths whose services have no
+      # identity-scoped rule to fall back on. transaction-service's rego states the exposure
+      # itself ("RESIDUAL RISK — shared identity, no per-caller narrowing"), which is precisely
+      # why removing its only path is not the fix.
+      #
+      # A reason joins this list once its service carries a rule that NAMES the caller and
+      # enumerates its actions, so denying the role-only path removes an over-grant rather than
+      # the only path. Each entry below was verified to have such a rule.
+      reasons:
+        - operator-consent-write        # service-consent-m2m + service-consent-m2m-marketing
+        - operator-ledger-write         # service-ledger-post / service-ledger-reverse
+        - operator-balance-write        # service-balance-m2m
+        - operator-fraud-write          # service-fraud-scoring
+        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
+        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m
+      # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
+      # adding it here before that is a money-path outage, not a test failure.
+      deferred:
+        operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
+        operator-settlement-write: "settlement.create is resourceless with no alternative rule"
+        operator-swift-write: "no identity-scoped rule; callers unverified"
+        operator-sepa-instant-write: "no identity-scoped rule; callers unverified"
+        operator-billing-write: "no identity-scoped rule; callers unverified"
+        operator-interest-write: "no identity-scoped rule; callers unverified"
+        operator-lending-write: "no identity-scoped rule; callers unverified"
+        operator-sanctions-write: "no identity-scoped rule; m2m-sanctions-screening covers create only"
+        operator-identity-write: "no identity-scoped rule; callers unverified"
+        operator-card-write: "no identity-scoped rule; callers unverified"
+        # These DO carry an identity-pinned rule, but "a rule exists" is not "the rule covers the
+        # actions the role-only path was serving". Listing them on that basis would repeat, one
+        # level down, the guess that made the first revision break transaction.create. Each needs
+        # its identity-scoped rule read against its real callers before it moves up.
+        operator-fx-write: "2 identity-pinned rules; action coverage vs real callers unverified"
+        operator-account-write: "2 identity-pinned rules; action coverage unverified"
+        operator-clearing-write: "1 identity-pinned rule; action coverage unverified"
+        operator-domestic-payment-write: "1 identity-pinned rule; action coverage unverified"
+        operator-party-write: "1 identity-pinned rule, but onboarding-service PUTs party.kyc-status via the shared client (latent: AUTHZ_ENFORCE=false there today)"
+      adr: ADR-0034
   manifest.json: |
     {"roots": ["openbank/agents", "openbank/copilot", "openbank/rest", "agents", "rules"]}

--- a/openbank-infra/gitops/components/sca/sca-service.yaml
+++ b/openbank-infra/gitops/components/sca/sca-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sca-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "3987b45e5d0ebffd"
+        openbank.tech/policy-checksum: "c0b59bd40d18039b"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/sca/sca-service.yaml
+++ b/openbank-infra/gitops/components/sca/sca-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sca-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "924b1cf14d2c90a9"
+        openbank.tech/policy-checksum: "3987b45e5d0ebffd"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/sca/sca-service.yaml
+++ b/openbank-infra/gitops/components/sca/sca-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sca-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "7e456af3f69dc2f2"
+        openbank.tech/policy-checksum: "924b1cf14d2c90a9"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/statements/statement-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/statements/statement-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: statement-service
     app.kubernetes.io/part-of: statements
   annotations:
-    openbank.tech/policy-checksum: "a93c9b76d8f9a4b7"
+    openbank.tech/policy-checksum: "ca385b1be8a81163"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2085,11 +2085,21 @@ data:
         - operator-ledger-write         # service-ledger-post / service-ledger-reverse
         - operator-balance-write        # service-balance-m2m
         - operator-fraud-write          # service-fraud-scoring
-        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
-        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m
+        # SAFE TODAY ONLY BY CO-ADMISSION, not by the rule named here: that rule covers
+        # sepaPayment.handleReturn alone, but ROLE_OPERATOR also grants sepaPayment.create /
+        # .transitionStatus / .approval.decide, so `matrix-allows` co-admits and this reason
+        # never becomes the only one. standing-order POSTs sepaPayment.create via the shared
+        # client. When ADR-0223 D2(b) retires those matrix grants, this entry starts denying it.
+        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m (see note above)
       # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
       # adding it here before that is a money-path outage, not a test failure.
       deferred:
+        operator-sca-write: "service-sca-shared-client-m2m covers scaChallenge.read ONLY, while
+          sca-service exposes consume/decide/initiate/verify and device.enroll. document-service
+          calls POST /challenges/{id}/consume through the shared client (ScaChallengeClient carries
+          OidcClientRequestReactiveFilter with oidc-client.client-id openbank-services) and
+          sca-service runs AUTHZ_ENFORCE=true, so listing this reason 403s the document-signing
+          gate. Needs #3748 (scaChallenge.consume for the shared client) to land first."
         operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
         operator-settlement-write: "settlement.create is resourceless with no alternative rule"
         operator-swift-write: "no identity-scoped rule; callers unverified"

--- a/openbank-infra/gitops/components/statements/statement-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/statements/statement-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: statement-service
     app.kubernetes.io/part-of: statements
   annotations:
-    openbank.tech/policy-checksum: "09a7cab8157b2904"
+    openbank.tech/policy-checksum: "a93c9b76d8f9a4b7"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2063,5 +2063,52 @@ data:
             - lending.collateralDecide
             - lending.approval.read
             - lending.approval.decide
+
+    shared_m2m_write_prohibition:
+      # GHSA-58jq-9hq3-66jr. rest.rego denies the shared M2M identity
+      # (`service-account-openbank-services`, which carries ROLE_OPERATOR in the realm) when the
+      # ONLY reasons admitting it are the role-only write reasons listed here.
+      #
+      # OPT-IN, and the reason a name pattern was rejected: matching every `operator-*-write`
+      # would have 403'd transaction.create from six live callers (account-service's
+      # welcome-bonus credit, sepa-instant, domestic-payment, swift, interest, sdd) and
+      # settlement.create — both AUTHZ_ENFORCE=true money paths whose services have no
+      # identity-scoped rule to fall back on. transaction-service's rego states the exposure
+      # itself ("RESIDUAL RISK — shared identity, no per-caller narrowing"), which is precisely
+      # why removing its only path is not the fix.
+      #
+      # A reason joins this list once its service carries a rule that NAMES the caller and
+      # enumerates its actions, so denying the role-only path removes an over-grant rather than
+      # the only path. Each entry below was verified to have such a rule.
+      reasons:
+        - operator-consent-write        # service-consent-m2m + service-consent-m2m-marketing
+        - operator-ledger-write         # service-ledger-post / service-ledger-reverse
+        - operator-balance-write        # service-balance-m2m
+        - operator-fraud-write          # service-fraud-scoring
+        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
+        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m
+      # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
+      # adding it here before that is a money-path outage, not a test failure.
+      deferred:
+        operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
+        operator-settlement-write: "settlement.create is resourceless with no alternative rule"
+        operator-swift-write: "no identity-scoped rule; callers unverified"
+        operator-sepa-instant-write: "no identity-scoped rule; callers unverified"
+        operator-billing-write: "no identity-scoped rule; callers unverified"
+        operator-interest-write: "no identity-scoped rule; callers unverified"
+        operator-lending-write: "no identity-scoped rule; callers unverified"
+        operator-sanctions-write: "no identity-scoped rule; m2m-sanctions-screening covers create only"
+        operator-identity-write: "no identity-scoped rule; callers unverified"
+        operator-card-write: "no identity-scoped rule; callers unverified"
+        # These DO carry an identity-pinned rule, but "a rule exists" is not "the rule covers the
+        # actions the role-only path was serving". Listing them on that basis would repeat, one
+        # level down, the guess that made the first revision break transaction.create. Each needs
+        # its identity-scoped rule read against its real callers before it moves up.
+        operator-fx-write: "2 identity-pinned rules; action coverage vs real callers unverified"
+        operator-account-write: "2 identity-pinned rules; action coverage unverified"
+        operator-clearing-write: "1 identity-pinned rule; action coverage unverified"
+        operator-domestic-payment-write: "1 identity-pinned rule; action coverage unverified"
+        operator-party-write: "1 identity-pinned rule, but onboarding-service PUTs party.kyc-status via the shared client (latent: AUTHZ_ENFORCE=false there today)"
+      adr: ADR-0034
   manifest.json: |
     {"roots": ["openbank/agents", "openbank/copilot", "openbank/rest", "agents", "rules"]}

--- a/openbank-infra/gitops/components/statements/statement-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/statements/statement-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: statement-service
     app.kubernetes.io/part-of: statements
   annotations:
-    openbank.tech/policy-checksum: "ca385b1be8a81163"
+    openbank.tech/policy-checksum: "f7b7bdc821f43c4c"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2091,15 +2091,16 @@ data:
         # never becomes the only one. standing-order POSTs sepaPayment.create via the shared
         # client. When ADR-0223 D2(b) retires those matrix grants, this entry starts denying it.
         - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m (see note above)
+        # Restored once #3748 landed: service-sca-shared-client-m2m now admits the shared client
+        # for scaChallenge.read AND scaChallenge.consume, so document-service's consume call
+        # (ScaChallengeClient, oidc-client.client-id openbank-services) keeps an identity-scoped
+        # reason and this entry no longer 403s the document-signing gate. device.list is covered
+        # by matrix-allows. Still uncovered for the shared client: decide/initiate/verify and
+        # device.enroll — no in-repo caller invokes them on that principal.
+        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
       # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
       # adding it here before that is a money-path outage, not a test failure.
       deferred:
-        operator-sca-write: "service-sca-shared-client-m2m covers scaChallenge.read ONLY, while
-          sca-service exposes consume/decide/initiate/verify and device.enroll. document-service
-          calls POST /challenges/{id}/consume through the shared client (ScaChallengeClient carries
-          OidcClientRequestReactiveFilter with oidc-client.client-id openbank-services) and
-          sca-service runs AUTHZ_ENFORCE=true, so listing this reason 403s the document-signing
-          gate. Needs #3748 (scaChallenge.consume for the shared client) to land first."
         operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
         operator-settlement-write: "settlement.create is resourceless with no alternative rule"
         operator-swift-write: "no identity-scoped rule; callers unverified"

--- a/openbank-infra/gitops/components/statements/statement-service.yaml
+++ b/openbank-infra/gitops/components/statements/statement-service.yaml
@@ -35,7 +35,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-statement-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "ca385b1be8a81163"
+        openbank.tech/policy-checksum: "f7b7bdc821f43c4c"
       labels:
         app.kubernetes.io/name: statement-service
         app.kubernetes.io/part-of: statements

--- a/openbank-infra/gitops/components/statements/statement-service.yaml
+++ b/openbank-infra/gitops/components/statements/statement-service.yaml
@@ -35,7 +35,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-statement-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "09a7cab8157b2904"
+        openbank.tech/policy-checksum: "a93c9b76d8f9a4b7"
       labels:
         app.kubernetes.io/name: statement-service
         app.kubernetes.io/part-of: statements

--- a/openbank-infra/gitops/components/statements/statement-service.yaml
+++ b/openbank-infra/gitops/components/statements/statement-service.yaml
@@ -35,7 +35,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-statement-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "a93c9b76d8f9a4b7"
+        openbank.tech/policy-checksum: "ca385b1be8a81163"
       labels:
         app.kubernetes.io/name: statement-service
         app.kubernetes.io/part-of: statements

--- a/openbank-infra/gitops/components/tpp-registry/tpp-registry-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/tpp-registry/tpp-registry-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: tpp-registry-service
     app.kubernetes.io/part-of: tpp-registry
   annotations:
-    openbank.tech/policy-checksum: "fd2a3b498e890c32"
+    openbank.tech/policy-checksum: "5720252999bb9395"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2028,15 +2028,16 @@ data:
         # never becomes the only one. standing-order POSTs sepaPayment.create via the shared
         # client. When ADR-0223 D2(b) retires those matrix grants, this entry starts denying it.
         - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m (see note above)
+        # Restored once #3748 landed: service-sca-shared-client-m2m now admits the shared client
+        # for scaChallenge.read AND scaChallenge.consume, so document-service's consume call
+        # (ScaChallengeClient, oidc-client.client-id openbank-services) keeps an identity-scoped
+        # reason and this entry no longer 403s the document-signing gate. device.list is covered
+        # by matrix-allows. Still uncovered for the shared client: decide/initiate/verify and
+        # device.enroll — no in-repo caller invokes them on that principal.
+        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
       # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
       # adding it here before that is a money-path outage, not a test failure.
       deferred:
-        operator-sca-write: "service-sca-shared-client-m2m covers scaChallenge.read ONLY, while
-          sca-service exposes consume/decide/initiate/verify and device.enroll. document-service
-          calls POST /challenges/{id}/consume through the shared client (ScaChallengeClient carries
-          OidcClientRequestReactiveFilter with oidc-client.client-id openbank-services) and
-          sca-service runs AUTHZ_ENFORCE=true, so listing this reason 403s the document-signing
-          gate. Needs #3748 (scaChallenge.consume for the shared client) to land first."
         operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
         operator-settlement-write: "settlement.create is resourceless with no alternative rule"
         operator-swift-write: "no identity-scoped rule; callers unverified"

--- a/openbank-infra/gitops/components/tpp-registry/tpp-registry-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/tpp-registry/tpp-registry-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: tpp-registry-service
     app.kubernetes.io/part-of: tpp-registry
   annotations:
-    openbank.tech/policy-checksum: "134e97bf752b0e02"
+    openbank.tech/policy-checksum: "fd2a3b498e890c32"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2022,11 +2022,21 @@ data:
         - operator-ledger-write         # service-ledger-post / service-ledger-reverse
         - operator-balance-write        # service-balance-m2m
         - operator-fraud-write          # service-fraud-scoring
-        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
-        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m
+        # SAFE TODAY ONLY BY CO-ADMISSION, not by the rule named here: that rule covers
+        # sepaPayment.handleReturn alone, but ROLE_OPERATOR also grants sepaPayment.create /
+        # .transitionStatus / .approval.decide, so `matrix-allows` co-admits and this reason
+        # never becomes the only one. standing-order POSTs sepaPayment.create via the shared
+        # client. When ADR-0223 D2(b) retires those matrix grants, this entry starts denying it.
+        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m (see note above)
       # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
       # adding it here before that is a money-path outage, not a test failure.
       deferred:
+        operator-sca-write: "service-sca-shared-client-m2m covers scaChallenge.read ONLY, while
+          sca-service exposes consume/decide/initiate/verify and device.enroll. document-service
+          calls POST /challenges/{id}/consume through the shared client (ScaChallengeClient carries
+          OidcClientRequestReactiveFilter with oidc-client.client-id openbank-services) and
+          sca-service runs AUTHZ_ENFORCE=true, so listing this reason 403s the document-signing
+          gate. Needs #3748 (scaChallenge.consume for the shared client) to land first."
         operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
         operator-settlement-write: "settlement.create is resourceless with no alternative rule"
         operator-swift-write: "no identity-scoped rule; callers unverified"

--- a/openbank-infra/gitops/components/tpp-registry/tpp-registry-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/tpp-registry/tpp-registry-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: tpp-registry-service
     app.kubernetes.io/part-of: tpp-registry
   annotations:
-    openbank.tech/policy-checksum: "dd38de878fd2f78c"
+    openbank.tech/policy-checksum: "134e97bf752b0e02"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2000,5 +2000,52 @@ data:
             - lending.collateralDecide
             - lending.approval.read
             - lending.approval.decide
+
+    shared_m2m_write_prohibition:
+      # GHSA-58jq-9hq3-66jr. rest.rego denies the shared M2M identity
+      # (`service-account-openbank-services`, which carries ROLE_OPERATOR in the realm) when the
+      # ONLY reasons admitting it are the role-only write reasons listed here.
+      #
+      # OPT-IN, and the reason a name pattern was rejected: matching every `operator-*-write`
+      # would have 403'd transaction.create from six live callers (account-service's
+      # welcome-bonus credit, sepa-instant, domestic-payment, swift, interest, sdd) and
+      # settlement.create — both AUTHZ_ENFORCE=true money paths whose services have no
+      # identity-scoped rule to fall back on. transaction-service's rego states the exposure
+      # itself ("RESIDUAL RISK — shared identity, no per-caller narrowing"), which is precisely
+      # why removing its only path is not the fix.
+      #
+      # A reason joins this list once its service carries a rule that NAMES the caller and
+      # enumerates its actions, so denying the role-only path removes an over-grant rather than
+      # the only path. Each entry below was verified to have such a rule.
+      reasons:
+        - operator-consent-write        # service-consent-m2m + service-consent-m2m-marketing
+        - operator-ledger-write         # service-ledger-post / service-ledger-reverse
+        - operator-balance-write        # service-balance-m2m
+        - operator-fraud-write          # service-fraud-scoring
+        - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
+        - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m
+      # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
+      # adding it here before that is a money-path outage, not a test failure.
+      deferred:
+        operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
+        operator-settlement-write: "settlement.create is resourceless with no alternative rule"
+        operator-swift-write: "no identity-scoped rule; callers unverified"
+        operator-sepa-instant-write: "no identity-scoped rule; callers unverified"
+        operator-billing-write: "no identity-scoped rule; callers unverified"
+        operator-interest-write: "no identity-scoped rule; callers unverified"
+        operator-lending-write: "no identity-scoped rule; callers unverified"
+        operator-sanctions-write: "no identity-scoped rule; m2m-sanctions-screening covers create only"
+        operator-identity-write: "no identity-scoped rule; callers unverified"
+        operator-card-write: "no identity-scoped rule; callers unverified"
+        # These DO carry an identity-pinned rule, but "a rule exists" is not "the rule covers the
+        # actions the role-only path was serving". Listing them on that basis would repeat, one
+        # level down, the guess that made the first revision break transaction.create. Each needs
+        # its identity-scoped rule read against its real callers before it moves up.
+        operator-fx-write: "2 identity-pinned rules; action coverage vs real callers unverified"
+        operator-account-write: "2 identity-pinned rules; action coverage unverified"
+        operator-clearing-write: "1 identity-pinned rule; action coverage unverified"
+        operator-domestic-payment-write: "1 identity-pinned rule; action coverage unverified"
+        operator-party-write: "1 identity-pinned rule, but onboarding-service PUTs party.kyc-status via the shared client (latent: AUTHZ_ENFORCE=false there today)"
+      adr: ADR-0034
   manifest.json: |
     {"roots": ["openbank/agents", "openbank/copilot", "openbank/rest", "agents", "rules"]}

--- a/openbank-infra/gitops/components/tpp-registry/tpp-registry-service.yaml
+++ b/openbank-infra/gitops/components/tpp-registry/tpp-registry-service.yaml
@@ -32,7 +32,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-tpp-registry-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "fd2a3b498e890c32"
+        openbank.tech/policy-checksum: "5720252999bb9395"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/tpp-registry/tpp-registry-service.yaml
+++ b/openbank-infra/gitops/components/tpp-registry/tpp-registry-service.yaml
@@ -32,7 +32,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-tpp-registry-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "dd38de878fd2f78c"
+        openbank.tech/policy-checksum: "134e97bf752b0e02"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/tpp-registry/tpp-registry-service.yaml
+++ b/openbank-infra/gitops/components/tpp-registry/tpp-registry-service.yaml
@@ -32,7 +32,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-tpp-registry-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "134e97bf752b0e02"
+        openbank.tech/policy-checksum: "fd2a3b498e890c32"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-libs/governance/rules-opa-data.yaml
+++ b/openbank-libs/governance/rules-opa-data.yaml
@@ -411,15 +411,16 @@ shared_m2m_write_prohibition:
     # never becomes the only one. standing-order POSTs sepaPayment.create via the shared
     # client. When ADR-0223 D2(b) retires those matrix grants, this entry starts denying it.
     - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m (see note above)
+    # Restored once #3748 landed: service-sca-shared-client-m2m now admits the shared client
+    # for scaChallenge.read AND scaChallenge.consume, so document-service's consume call
+    # (ScaChallengeClient, oidc-client.client-id openbank-services) keeps an identity-scoped
+    # reason and this entry no longer 403s the document-signing gate. device.list is covered
+    # by matrix-allows. Still uncovered for the shared client: decide/initiate/verify and
+    # device.enroll — no in-repo caller invokes them on that principal.
+    - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
   # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
   # adding it here before that is a money-path outage, not a test failure.
   deferred:
-    operator-sca-write: "service-sca-shared-client-m2m covers scaChallenge.read ONLY, while
-      sca-service exposes consume/decide/initiate/verify and device.enroll. document-service
-      calls POST /challenges/{id}/consume through the shared client (ScaChallengeClient carries
-      OidcClientRequestReactiveFilter with oidc-client.client-id openbank-services) and
-      sca-service runs AUTHZ_ENFORCE=true, so listing this reason 403s the document-signing
-      gate. Needs #3748 (scaChallenge.consume for the shared client) to land first."
     operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
     operator-settlement-write: "settlement.create is resourceless with no alternative rule"
     operator-swift-write: "no identity-scoped rule; callers unverified"

--- a/openbank-libs/governance/rules-opa-data.yaml
+++ b/openbank-libs/governance/rules-opa-data.yaml
@@ -405,11 +405,21 @@ shared_m2m_write_prohibition:
     - operator-ledger-write         # service-ledger-post / service-ledger-reverse
     - operator-balance-write        # service-balance-m2m
     - operator-fraud-write          # service-fraud-scoring
-    - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
-    - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m
+    # SAFE TODAY ONLY BY CO-ADMISSION, not by the rule named here: that rule covers
+    # sepaPayment.handleReturn alone, but ROLE_OPERATOR also grants sepaPayment.create /
+    # .transitionStatus / .approval.decide, so `matrix-allows` co-admits and this reason
+    # never becomes the only one. standing-order POSTs sepaPayment.create via the shared
+    # client. When ADR-0223 D2(b) retires those matrix grants, this entry starts denying it.
+    - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m (see note above)
   # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
   # adding it here before that is a money-path outage, not a test failure.
   deferred:
+    operator-sca-write: "service-sca-shared-client-m2m covers scaChallenge.read ONLY, while
+      sca-service exposes consume/decide/initiate/verify and device.enroll. document-service
+      calls POST /challenges/{id}/consume through the shared client (ScaChallengeClient carries
+      OidcClientRequestReactiveFilter with oidc-client.client-id openbank-services) and
+      sca-service runs AUTHZ_ENFORCE=true, so listing this reason 403s the document-signing
+      gate. Needs #3748 (scaChallenge.consume for the shared client) to land first."
     operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
     operator-settlement-write: "settlement.create is resourceless with no alternative rule"
     operator-swift-write: "no identity-scoped rule; callers unverified"

--- a/openbank-libs/governance/rules-opa-data.yaml
+++ b/openbank-libs/governance/rules-opa-data.yaml
@@ -383,3 +383,50 @@ authz:
         - lending.collateralDecide
         - lending.approval.read
         - lending.approval.decide
+
+shared_m2m_write_prohibition:
+  # GHSA-58jq-9hq3-66jr. rest.rego denies the shared M2M identity
+  # (`service-account-openbank-services`, which carries ROLE_OPERATOR in the realm) when the
+  # ONLY reasons admitting it are the role-only write reasons listed here.
+  #
+  # OPT-IN, and the reason a name pattern was rejected: matching every `operator-*-write`
+  # would have 403'd transaction.create from six live callers (account-service's
+  # welcome-bonus credit, sepa-instant, domestic-payment, swift, interest, sdd) and
+  # settlement.create — both AUTHZ_ENFORCE=true money paths whose services have no
+  # identity-scoped rule to fall back on. transaction-service's rego states the exposure
+  # itself ("RESIDUAL RISK — shared identity, no per-caller narrowing"), which is precisely
+  # why removing its only path is not the fix.
+  #
+  # A reason joins this list once its service carries a rule that NAMES the caller and
+  # enumerates its actions, so denying the role-only path removes an over-grant rather than
+  # the only path. Each entry below was verified to have such a rule.
+  reasons:
+    - operator-consent-write        # service-consent-m2m + service-consent-m2m-marketing
+    - operator-ledger-write         # service-ledger-post / service-ledger-reverse
+    - operator-balance-write        # service-balance-m2m
+    - operator-fraud-write          # service-fraud-scoring
+    - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
+    - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m
+  # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
+  # adding it here before that is a money-path outage, not a test failure.
+  deferred:
+    operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
+    operator-settlement-write: "settlement.create is resourceless with no alternative rule"
+    operator-swift-write: "no identity-scoped rule; callers unverified"
+    operator-sepa-instant-write: "no identity-scoped rule; callers unverified"
+    operator-billing-write: "no identity-scoped rule; callers unverified"
+    operator-interest-write: "no identity-scoped rule; callers unverified"
+    operator-lending-write: "no identity-scoped rule; callers unverified"
+    operator-sanctions-write: "no identity-scoped rule; m2m-sanctions-screening covers create only"
+    operator-identity-write: "no identity-scoped rule; callers unverified"
+    operator-card-write: "no identity-scoped rule; callers unverified"
+    # These DO carry an identity-pinned rule, but "a rule exists" is not "the rule covers the
+    # actions the role-only path was serving". Listing them on that basis would repeat, one
+    # level down, the guess that made the first revision break transaction.create. Each needs
+    # its identity-scoped rule read against its real callers before it moves up.
+    operator-fx-write: "2 identity-pinned rules; action coverage vs real callers unverified"
+    operator-account-write: "2 identity-pinned rules; action coverage unverified"
+    operator-clearing-write: "1 identity-pinned rule; action coverage unverified"
+    operator-domestic-payment-write: "1 identity-pinned rule; action coverage unverified"
+    operator-party-write: "1 identity-pinned rule, but onboarding-service PUTs party.kyc-status via the shared client (latent: AUTHZ_ENFORCE=false there today)"
+  adr: ADR-0034

--- a/openbank-libs/governance/rules.yaml
+++ b/openbank-libs/governance/rules.yaml
@@ -2526,15 +2526,16 @@ shared_m2m_write_prohibition:
     # never becomes the only one. standing-order POSTs sepaPayment.create via the shared
     # client. When ADR-0223 D2(b) retires those matrix grants, this entry starts denying it.
     - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m (see note above)
+    # Restored once #3748 landed: service-sca-shared-client-m2m now admits the shared client
+    # for scaChallenge.read AND scaChallenge.consume, so document-service's consume call
+    # (ScaChallengeClient, oidc-client.client-id openbank-services) keeps an identity-scoped
+    # reason and this entry no longer 403s the document-signing gate. device.list is covered
+    # by matrix-allows. Still uncovered for the shared client: decide/initiate/verify and
+    # device.enroll — no in-repo caller invokes them on that principal.
+    - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
   # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
   # adding it here before that is a money-path outage, not a test failure.
   deferred:
-    operator-sca-write: "service-sca-shared-client-m2m covers scaChallenge.read ONLY, while
-      sca-service exposes consume/decide/initiate/verify and device.enroll. document-service
-      calls POST /challenges/{id}/consume through the shared client (ScaChallengeClient carries
-      OidcClientRequestReactiveFilter with oidc-client.client-id openbank-services) and
-      sca-service runs AUTHZ_ENFORCE=true, so listing this reason 403s the document-signing
-      gate. Needs #3748 (scaChallenge.consume for the shared client) to land first."
     operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
     operator-settlement-write: "settlement.create is resourceless with no alternative rule"
     operator-swift-write: "no identity-scoped rule; callers unverified"

--- a/openbank-libs/governance/rules.yaml
+++ b/openbank-libs/governance/rules.yaml
@@ -2520,11 +2520,21 @@ shared_m2m_write_prohibition:
     - operator-ledger-write         # service-ledger-post / service-ledger-reverse
     - operator-balance-write        # service-balance-m2m
     - operator-fraud-write          # service-fraud-scoring
-    - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
-    - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m
+    # SAFE TODAY ONLY BY CO-ADMISSION, not by the rule named here: that rule covers
+    # sepaPayment.handleReturn alone, but ROLE_OPERATOR also grants sepaPayment.create /
+    # .transitionStatus / .approval.decide, so `matrix-allows` co-admits and this reason
+    # never becomes the only one. standing-order POSTs sepaPayment.create via the shared
+    # client. When ADR-0223 D2(b) retires those matrix grants, this entry starts denying it.
+    - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m (see note above)
   # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
   # adding it here before that is a money-path outage, not a test failure.
   deferred:
+    operator-sca-write: "service-sca-shared-client-m2m covers scaChallenge.read ONLY, while
+      sca-service exposes consume/decide/initiate/verify and device.enroll. document-service
+      calls POST /challenges/{id}/consume through the shared client (ScaChallengeClient carries
+      OidcClientRequestReactiveFilter with oidc-client.client-id openbank-services) and
+      sca-service runs AUTHZ_ENFORCE=true, so listing this reason 403s the document-signing
+      gate. Needs #3748 (scaChallenge.consume for the shared client) to land first."
     operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
     operator-settlement-write: "settlement.create is resourceless with no alternative rule"
     operator-swift-write: "no identity-scoped rule; callers unverified"

--- a/openbank-libs/governance/rules.yaml
+++ b/openbank-libs/governance/rules.yaml
@@ -485,52 +485,6 @@ change_requirements:
     # all, so check-gate-graduation.sh could not see it and it had no deadline. That class is now
     # itself gated by .github/scripts/check-advisory-gate-registration.py.
     ci_producer: ".github/scripts/check-dotted-mp-messaging-keys.sh"
-  shared_m2m_write_prohibition:
-    # GHSA-58jq-9hq3-66jr. rest.rego denies the shared M2M identity
-    # (`service-account-openbank-services`, which carries ROLE_OPERATOR in the realm) when the
-    # ONLY reasons admitting it are the role-only write reasons listed here.
-    #
-    # OPT-IN, and the reason a name pattern was rejected: matching every `operator-*-write`
-    # would have 403'd transaction.create from six live callers (account-service's
-    # welcome-bonus credit, sepa-instant, domestic-payment, swift, interest, sdd) and
-    # settlement.create — both AUTHZ_ENFORCE=true money paths whose services have no
-    # identity-scoped rule to fall back on. transaction-service's rego states the exposure
-    # itself ("RESIDUAL RISK — shared identity, no per-caller narrowing"), which is precisely
-    # why removing its only path is not the fix.
-    #
-    # A reason joins this list once its service carries a rule that NAMES the caller and
-    # enumerates its actions, so denying the role-only path removes an over-grant rather than
-    # the only path. Each entry below was verified to have such a rule.
-    reasons:
-      - operator-consent-write        # service-consent-m2m + service-consent-m2m-marketing
-      - operator-ledger-write         # service-ledger-post / service-ledger-reverse
-      - operator-balance-write        # service-balance-m2m
-      - operator-fraud-write          # service-fraud-scoring
-      - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
-      - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m
-    # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
-    # adding it here before that is a money-path outage, not a test failure.
-    deferred:
-      operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
-      operator-settlement-write: "settlement.create is resourceless with no alternative rule"
-      operator-swift-write: "no identity-scoped rule; callers unverified"
-      operator-sepa-instant-write: "no identity-scoped rule; callers unverified"
-      operator-billing-write: "no identity-scoped rule; callers unverified"
-      operator-interest-write: "no identity-scoped rule; callers unverified"
-      operator-lending-write: "no identity-scoped rule; callers unverified"
-      operator-sanctions-write: "no identity-scoped rule; m2m-sanctions-screening covers create only"
-      operator-identity-write: "no identity-scoped rule; callers unverified"
-      operator-card-write: "no identity-scoped rule; callers unverified"
-      # These DO carry an identity-pinned rule, but "a rule exists" is not "the rule covers the
-      # actions the role-only path was serving". Listing them on that basis would repeat, one
-      # level down, the guess that made the first revision break transaction.create. Each needs
-      # its identity-scoped rule read against its real callers before it moves up.
-      operator-fx-write: "2 identity-pinned rules; action coverage vs real callers unverified"
-      operator-account-write: "2 identity-pinned rules; action coverage unverified"
-      operator-clearing-write: "1 identity-pinned rule; action coverage unverified"
-      operator-domestic-payment-write: "1 identity-pinned rule; action coverage unverified"
-      operator-party-write: "1 identity-pinned rule, but onboarding-service PUTs party.kyc-status via the shared client (latent: AUTHZ_ENFORCE=false there today)"
-    adr: ADR-0034
   role_only_write_rule_naming:
     # GHSA-58jq-9hq3-66jr. `service-account-openbank-services` — the identity nearly every
     # backend service authenticates as — carries ROLE_OPERATOR in the realm, and
@@ -2538,3 +2492,56 @@ authz:
         - lending.collateralDecide
         - lending.approval.read
         - lending.approval.decide
+
+# PROMOTED TO A TOP-LEVEL KEY (2026-08-07). rest.rego reads this as
+# `data.rules.shared_m2m_write_prohibition.reasons`, and gen-rules-opa-data.py selects only
+# TOP-LEVEL keys of this file into the derived rules-opa-data.yaml that OPA actually mounts.
+# Nested under `change_requirements:` it was never emitted, so `role_only_write_reason` was
+# never true, `prohibited`'s `every` clause was false, and the guard had never once fired in
+# the cluster. gen-rules-opa-data.py had been warning about exactly this on every run.
+shared_m2m_write_prohibition:
+  # GHSA-58jq-9hq3-66jr. rest.rego denies the shared M2M identity
+  # (`service-account-openbank-services`, which carries ROLE_OPERATOR in the realm) when the
+  # ONLY reasons admitting it are the role-only write reasons listed here.
+  #
+  # OPT-IN, and the reason a name pattern was rejected: matching every `operator-*-write`
+  # would have 403'd transaction.create from six live callers (account-service's
+  # welcome-bonus credit, sepa-instant, domestic-payment, swift, interest, sdd) and
+  # settlement.create — both AUTHZ_ENFORCE=true money paths whose services have no
+  # identity-scoped rule to fall back on. transaction-service's rego states the exposure
+  # itself ("RESIDUAL RISK — shared identity, no per-caller narrowing"), which is precisely
+  # why removing its only path is not the fix.
+  #
+  # A reason joins this list once its service carries a rule that NAMES the caller and
+  # enumerates its actions, so denying the role-only path removes an over-grant rather than
+  # the only path. Each entry below was verified to have such a rule.
+  reasons:
+    - operator-consent-write        # service-consent-m2m + service-consent-m2m-marketing
+    - operator-ledger-write         # service-ledger-post / service-ledger-reverse
+    - operator-balance-write        # service-balance-m2m
+    - operator-fraud-write          # service-fraud-scoring
+    - operator-sca-write            # service-sca-edge-m2m + service-sca-shared-client-m2m
+    - operator-sepa-payment-write   # service-sepa-payment-shared-client-m2m
+  # NOT listed, and why. Each needs an identity-scoped rule for its real callers FIRST;
+  # adding it here before that is a money-path outage, not a test failure.
+  deferred:
+    operator-transaction-write: "6 verified callers of transaction.create via the shared client; no identity-scoped rule exists"
+    operator-settlement-write: "settlement.create is resourceless with no alternative rule"
+    operator-swift-write: "no identity-scoped rule; callers unverified"
+    operator-sepa-instant-write: "no identity-scoped rule; callers unverified"
+    operator-billing-write: "no identity-scoped rule; callers unverified"
+    operator-interest-write: "no identity-scoped rule; callers unverified"
+    operator-lending-write: "no identity-scoped rule; callers unverified"
+    operator-sanctions-write: "no identity-scoped rule; m2m-sanctions-screening covers create only"
+    operator-identity-write: "no identity-scoped rule; callers unverified"
+    operator-card-write: "no identity-scoped rule; callers unverified"
+    # These DO carry an identity-pinned rule, but "a rule exists" is not "the rule covers the
+    # actions the role-only path was serving". Listing them on that basis would repeat, one
+    # level down, the guess that made the first revision break transaction.create. Each needs
+    # its identity-scoped rule read against its real callers before it moves up.
+    operator-fx-write: "2 identity-pinned rules; action coverage vs real callers unverified"
+    operator-account-write: "2 identity-pinned rules; action coverage unverified"
+    operator-clearing-write: "1 identity-pinned rule; action coverage unverified"
+    operator-domestic-payment-write: "1 identity-pinned rule; action coverage unverified"
+    operator-party-write: "1 identity-pinned rule, but onboarding-service PUTs party.kyc-status via the shared client (latent: AUTHZ_ENFORCE=false there today)"
+  adr: ADR-0034


### PR DESCRIPTION
## What this changes

`rest.rego:482` reads `data.rules.shared_m2m_write_prohibition.reasons`. The key sat under `change_requirements:`, and `gen-rules-opa-data.py` selects only **top-level** keys of `rules.yaml` into `rules-opa-data.yaml` — the derived file OPA actually mounts. So the register was undefined in-cluster: `role_only_write_reason` never true, `prohibited`'s `every` clause always false, and the rule that mitigates **GHSA-58jq-9hq3-66jr** had never denied anything.

Measured on `origin/main` before the change:

```
shared_m2m_write_prohibition top-level in rules.yaml : False
                    under change_requirements:       : True
occurrences in derived rules-opa-data.yaml           : 0     <- what OPA reads
referenced by rest.rego                              : line 482
```

and after:

```
present in rules-opa-data.yaml : True
reasons emitted                : operator-consent-write, operator-ledger-write,
                                 operator-balance-write, operator-fraud-write,
                                 operator-sca-write, operator-sepa-payment-write
```

The block moves **verbatim** — `reasons` (6) and `deferred` (15) both preserved, `adr: ADR-0034` kept with it. Verified structurally, not by eye: parsing both revisions and comparing shows the only difference is the key's location, with `rest of file identical: True`.

`UNRESOLVABLE_DECLARED` in `gen-rules-opa-data.py` is emptied in the same commit — the generator refuses to pass otherwise (`::error:: … is declared unresolvable but IS now selectable — the debt is paid`), which is exactly the both-directions check that stopped this becoming permanent. The registry itself stays, so a *new* referenced-but-unselectable key still fails.

## Blast radius — measured, and narrower than the declaration assumed

The retired declaration warned that "128 currently-reachable writes depend on the very reasons the register names, so promotion denies live money-path callers". That is the right instinct but it over-states what this change can do, because `prohibited` requires **every** admitting reason to be in the register — and `matrix-allows` is not, and cannot be.

So the guard can only bite where `matrix-allows` does **not** co-admit. Checking each active reason's domain against `authz.role_action_matrix.ROLE_OPERATOR.grant`:

| reason | matrix grants non-read actions? | effect of this change |
|---|---|---|
| operator-consent-write | none | **guard now fires** |
| operator-sca-write | none | **guard now fires** |
| operator-sepa-payment-write | none | **guard now fires** |
| operator-ledger-write | `ledger.create/replay/reverse/trigger` | inert — `matrix-allows` co-admits |
| operator-balance-write | `balance.credit/debit/hold/holdRelease/initialize/reconciliation.run` | inert — same |
| operator-fraud-write | `fraud.score` | inert — same |

**Three of six become live; three remain inert.** For the three that fire, the register's own entry criterion is that the service already carries a rule naming the caller and enumerating its actions, so denying the role-only path removes an over-grant rather than the only path — `service-consent-m2m`, `service-sca-edge-m2m` / `service-sca-shared-client-m2m`, and `service-sepa-payment-shared-client-m2m` respectively. That is the claim to check hardest before merging; it is the whole safety argument.

## Why the green test suite is not evidence

`opa test` reports **168/168 PASS** — before and after, and it would pass either way. `rest_test.rego` supplies the register it tests against:

```rego
with data.rules.shared_m2m_write_prohibition.reasons as ["operator-ledger-write"]
```

so it is green about a rule given data production has never had. The generator's own header says this. The evidence that this change works is the derived artifact, not the test run.

## Regeneration

`gen-rules-opa-data.py` re-run, then every `gen-*opa-bundle*.sh`, as the last step before pushing. 72 files: the two governance artifacts, the generator, and 69 bundle/annotation files across the fleet. Verified **idempotent** (second run produces no further diff).

## Not merged deliberately

This is governance + authz on money paths. It is also a **policy decision**, as the retired declaration said — it starts denying callers on three domains. Leaving it for human review rather than arming auto-merge.

Refs #3765, Refs #3734. Related: #3812 argues `shared_m2m_write_prohibition` cannot address the `matrix-allows` layer — that is correct and this change does not claim otherwise; the two are complementary, and the table above marks exactly where this one stops.
