### PR TITLE
fix(settlement): dial balance/ledger/party at their real in-cluster Services, enforce the gate

### DIFF
--- a/.github/asvs-l3-baseline.txt
+++ b/.github/asvs-l3-baseline.txt
@@ -205,6 +205,12 @@ V9.1 openbank-infra/gitops/components/billing/billing-service.yaml:70: plaintext
 V9.1 openbank-infra/gitops/components/billing/billing-service.yaml:78: plaintext http:// env value http://ledger-service.ledger.svc:8101
 V9.1 openbank-infra/gitops/components/billing/billing-service.yaml:97: plaintext http:// env value http://tempo.observability.svc:4317
 V9.1 openbank-infra/gitops/components/onboarding/onboarding-service.yaml:134: plaintext http:// env value http://tempo.observability.svc:4317
+# onboarding -> party-service (issue #3931). Genuinely a NEW plaintext edge and declared as
+# such: the rest-client existed but its URL default named `openbank-party-service`, a hostname
+# no Service has, so the call never left the pod. Making it resolve turns a dead edge into a
+# live one, on the same plaintext in-cluster transport as the other 200+ lines here — deleting
+# this line is the mesh-mTLS work (baseline Layer 1), not a per-service change.
+V9.1 openbank-infra/gitops/components/onboarding/onboarding-service.yaml:138: plaintext http:// env value http://party-service.party.svc:8111
 V9.1 openbank-infra/gitops/components/analytics/analytics-sink.yaml:79: plaintext http:// env value http://clickhouse.analytics.svc:8123
 # analytics-sink -> Apicurio schema registry (issue #1916). Same declared debt as every other
 # in-cluster edge here: the Service exposes exactly one port, named `http`, on 8080

--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -431,14 +431,20 @@ gates:
   # "schema-registry:8081" for the life of the service; the Service is apicurio-registry:8080 in
   # `messaging` (issue #1916). Needs no network: the resolvable set is fully declared in gitops.
   #
-  # ADVISORY (rules.yaml: incluster_hostnames, target_enforce_date 2026-10-31) — 6 pre-existing
-  # findings, all bare `openbank-<svc>` rest-client defaults on services whose pods override them
-  # by env. Four of the owners are money-path, so that cleanup takes the two-approval path rather
-  # than riding along with the guard that found it.
+  # ENFORCED since #3931, which drained the 6 pre-existing findings. The advisory note that stood
+  # here claimed all six were dead defaults "on services whose pods override them by env" — that
+  # was true of only THREE (account-service ×2, card-issuance ×1). The other three were live:
+  # settlement-service's Rollout and onboarding-service's Deployment carried no *_SERVICE_URL at
+  # all, so `openbank-balance-service:8080` / `openbank-ledger-service:8080` /
+  # `openbank-party-service:8090` were the EFFECTIVE values in the cluster — names that resolve
+  # nowhere, on wrong ports (8103 / 8101 / 8111). The triage note was written from the shape of
+  # the findings rather than from the deployed manifests, and being advisory is what let it sit.
+  # Generalize: an advisory gate's "these are all benign" note is itself an unverified claim, and
+  # advisory mode removes the pressure that would have checked it.
   - id: incluster-hostname-resolution
-    name: "in-cluster hostnames resolve to a declared Service (issue #1916, advisory)"
+    name: "in-cluster hostnames resolve to a declared Service (issue #1916, enforced)"
     group: gitops
-    mode: advisory
+    mode: enforced
     selftest: |
       python3 .github/scripts/check-incluster-hostnames.py --self-test
     selftest_expect: pass

--- a/docs/threat-models/openbank-account-service.md
+++ b/docs/threat-models/openbank-account-service.md
@@ -86,6 +86,21 @@ not change any existing request's outcome until explicitly flipped.
 
 ## 6. Change log
 
+- **2026-08-07** — No trust boundary moved: the `sanctions-service` and `product-catalog`
+  rest-client **defaults** in `application.yaml` were changed from `http://openbank-sanctions-service:8123`
+  and `http://openbank-product-catalog:8080` to `http://localhost:8123` / `http://localhost:8104`
+  (issue #3931). Neither `openbank-` name is a Service in any namespace, and the product-catalog
+  port was wrong as well (the Service is `product-catalog:8104` in `accounts`). **These defaults
+  were dead in every deployed environment** — the account-service Deployment sets
+  `SANCTIONS_SERVICE_URL` and `PRODUCT_CATALOG_SERVICE_URL` (the latter at the KEDA HTTP
+  interceptor, with `PRODUCT_CATALOG_API_HOST_OVERRIDE`) — so no deployed request path changes,
+  and both edges keep their existing postures (sanctions fails **closed**, product-catalog fails
+  **open**, §6 2026-07-09 and 2026-06-06 entries). The change matters for local dev, where the
+  screening gate previously failed closed against a name that could never resolve, and it clears
+  the last findings blocking `incluster-hostname-resolution` from `mode: advisory` to `enforced`.
+  Sibling services on the same edges (`fx`, `kyc`, `sepa-payment`, `billing`, `document-service`)
+  already used these localhost defaults; account-service was the outlier.
+
 - **2026-07-09** — Account opening validates against product-catalog (ADR-0158, issue #668).
   New outbound trust boundary: `account-service → product-catalog` (`GET /api/v1/products/{id}`,
   unauthenticated, sync). `openAccount` now rejects a `productId` product-catalog confirms does

--- a/docs/threat-models/openbank-settlement-service.md
+++ b/docs/threat-models/openbank-settlement-service.md
@@ -148,6 +148,26 @@ replacing the former in-memory stub), so settlement state is durable across rest
 4. **2-approval gate** — money-path rule requires 2 approvals. This PR has 1 (automated review).
    Second approval from a human committer required before merge per rules.yaml.
 
+5. **Both outbound money-path edges were pointed at unresolvable hostnames for the life of the
+   service (#3931).** The Rollout carried no `BALANCE_SERVICE_URL` / `LEDGER_SERVICE_URL`, so the
+   debit, credit and ledger-book adapters (`BalanceDebitAdapter`, `BalanceCreditAdapter`,
+   `LedgerBookAdapter`) used `application.yaml`'s defaults `http://openbank-balance-service:8080`
+   and `http://openbank-ledger-service:8080`. No Service of either name is declared in any
+   namespace, and the ports were wrong for the real Services too (`balance-service:8103` in
+   `balances`, `ledger-service:8101` in `ledger`). **This is an availability, not a confidentiality
+   or integrity, finding**: the trust boundary itself did not move — the same two edges to the same
+   two services, over the same NetworkPolicy (`payments` was already permitted to both) — the
+   requests simply never left the pod. It does not change any STRIDE row above; every mitigation
+   listed for S2/T1/R2 applies unchanged once the calls actually arrive.
+
+   Worth recording as a residual risk because of *how it survived*: no test layer in this repo can
+   observe a hostname (the unit tests stub both ports, an IT serves localhost, a consumer pact
+   answers whatever path the client asks for), and the failure mode of a settlement whose debit
+   activity cannot connect is a Temporal retry loop, not a visible integrity breach. The
+   `incluster-hostname-resolution` gate is the only control that can see it, and it is enforced as
+   of #3931. Config is now the fleet shape: localhost dev default in `application.yaml`, real URL
+   from the workload env in gitops.
+
 ---
 
 ## DORA / PSD2 / PCI alignment

--- a/openbank-account-service/src/main/resources/application.yaml
+++ b/openbank-account-service/src/main/resources/application.yaml
@@ -90,12 +90,20 @@ quarkus:
       # ever exercised account-service + sanctions-service together (issue #669 load-benchmark
       # setup() was the first) — sanctions screening fails closed, so every local account
       # creation was silently blocked, not just slow.
-      url: ${SANCTIONS_SERVICE_URL:http://openbank-sanctions-service:8123}
+      # `openbank-sanctions-service` was never a resolvable name — the Service is
+      # `sanctions-service` in namespace `sanctions`. Harmless in the cluster (the Deployment
+      # sets SANCTIONS_SERVICE_URL) but wrong for local dev and unresolvable if the env is ever
+      # dropped; localhost:8123 is what fx/kyc/sepa-payment already default to (issue #3931).
+      url: ${SANCTIONS_SERVICE_URL:http://localhost:8123}
       connect-timeout: 3000
       read-timeout: 5000
     # Issue #668: unauthenticated read of product-catalog reference data at account-open time.
     "product-catalog-api":
-      url: ${PRODUCT_CATALOG_SERVICE_URL:http://openbank-product-catalog:8080}
+      # `openbank-product-catalog:8080` resolved to nothing and named the wrong port — the
+      # Service is `product-catalog` on 8104 in namespace `accounts`. Overridden in the cluster
+      # (PRODUCT_CATALOG_SERVICE_URL points at the KEDA interceptor); localhost:8104 matches
+      # billing/document-service (issue #3931).
+      url: ${PRODUCT_CATALOG_SERVICE_URL:http://localhost:8104}
       connect-timeout: 3000
       read-timeout: 5000
 

--- a/openbank-card-issuance-service/src/main/resources/application.yaml
+++ b/openbank-card-issuance-service/src/main/resources/application.yaml
@@ -64,7 +64,11 @@ quarkus:
     # fail-open (see CardProductCatalogPort) — waiting on a cold start would delay every issue
     # for a rule that is allowed to be skipped.
     "product-catalog-api":
-      url: ${PRODUCT_CATALOG_SERVICE_URL:http://openbank-product-catalog:8080}
+      # `openbank-product-catalog:8080` resolved to nothing and named the wrong port — the
+      # Service is `product-catalog` on 8104 in namespace `accounts`. Overridden in the cluster
+      # (PRODUCT_CATALOG_SERVICE_URL points at the KEDA interceptor); localhost:8104 matches
+      # billing/document-service (issue #3931).
+      url: ${PRODUCT_CATALOG_SERVICE_URL:http://localhost:8104}
       connect-timeout: 3000
       read-timeout: 5000
   redis:

--- a/openbank-infra/gitops/components/onboarding/onboarding-service.yaml
+++ b/openbank-infra/gitops/components/onboarding/onboarding-service.yaml
@@ -130,6 +130,12 @@ spec:
                 secretKeyRef:
                   name: onboarding-service-oidc
                   key: OIDC_CLIENT_SECRET
+            # party-service in-cluster URL (issue #3931). This Deployment carried no override,
+            # so AbandonedRegistrationCleaner's PartyServiceClient used application.yaml's
+            # default `openbank-party-service:8090` — a hostname no Service in this cluster has
+            # ever had, on the wrong port. Same shape as customer-edge / statement-service.
+            - name: PARTY_SERVICE_URL
+              value: http://party-service.party.svc:8111
             - name: QUARKUS_OTEL_EXPORTER_OTLP_ENDPOINT
               value: "http://tempo.observability.svc:4317"
             - name: OTEL_TRACES_SAMPLER_ARG

--- a/openbank-infra/gitops/components/party/network-policies.yaml
+++ b/openbank-infra/gitops/components/party/network-policies.yaml
@@ -50,6 +50,9 @@ spec:
               kubernetes.io/metadata.name: documents
         - namespaceSelector:
             matchLabels:
+              kubernetes.io/metadata.name: onboarding
+        - namespaceSelector:
+            matchLabels:
               kubernetes.io/metadata.name: security-scanner
         - namespaceSelector:
             matchLabels:

--- a/openbank-infra/gitops/components/payments/payments-services.yaml
+++ b/openbank-infra/gitops/components/payments/payments-services.yaml
@@ -2256,6 +2256,16 @@ spec:
                 secretKeyRef:
                   name: settlement-service-oidc
                   key: OIDC_CLIENT_SECRET
+            # Downstream money-path dependencies (issue #3931). Until now this Rollout carried
+            # NEITHER, so both rest-clients fell back to application.yaml's defaults — which
+            # named `openbank-balance-service:8080` / `openbank-ledger-service:8080`, hostnames
+            # no Service in this cluster has ever had. Every settlement debit/credit and every
+            # GL posting therefore dialled an unresolvable name. Same shape and same values as
+            # transaction-service above.
+            - name: BALANCE_SERVICE_URL
+              value: http://balance-service.balances.svc:8103
+            - name: LEDGER_SERVICE_URL
+              value: http://ledger-service.ledger.svc:8101
             # Temporal go-live (ADR-0101 P3, runbook 0006 Gate 1): settlement now runs its
             # durable workflow. Namespace openbank-default + SERVER_URL + the temporal-platform
             # NetworkPolicy are already in place; rollback = set this back to "false".

--- a/openbank-libs/governance/rules.yaml
+++ b/openbank-libs/governance/rules.yaml
@@ -1612,14 +1612,35 @@ incluster_hostnames:
   # yaml.safe_load_all output, which drops comments by construction, and --self-test pins it with
   # a fixture whose only bogus host is in a comment.
   #
-  # ADVISORY while the 6 pre-existing findings are triaged. All six are bare `openbank-<svc>` rest
-  # client defaults (account, card-issuance, onboarding, settlement) that name no Service in any
-  # namespace — the deployed pods override them by env, so they are dead defaults rather than a
-  # live outage, but each is a hostname nobody could dial. They are NOT fixed in the PR that
-  # introduced this gate: four of the owning services are money-path, so a default-URL change
-  # there needs the two-approval path rather than riding along with a CI guard.
-  enforced: advisory
-  target_enforce_date: "2026-10-31"   # ADR-0144
+  # ENFORCED since #3931 (ahead of the 2026-10-31 target), which drained all 6 findings to zero.
+  #
+  # The triage note that stood here graded every finding as a dead default "the deployed pods
+  # override by env". Checked against the deployed manifests, that held for three of the six —
+  # account-service's sanctions + product-catalog clients and card-issuance's product-catalog
+  # client. The other three were LIVE: settlement-service's Rollout and onboarding-service's
+  # Deployment carried no *_SERVICE_URL env at all, so `openbank-balance-service:8080`,
+  # `openbank-ledger-service:8080` and `openbank-party-service:8090` were the values those pods
+  # actually dialled — names that resolve in no namespace, on ports that are wrong even for the
+  # right name (balance-service is 8103, ledger-service 8101, party-service 8111). Every
+  # settlement debit/credit, every settlement GL posting, and onboarding's abandoned-registration
+  # party lookup were pointed at nothing.
+  #
+  # THE LESSON, which is why this text stays rather than being deleted with the findings: an
+  # advisory gate's "all of these are benign" note is itself an unverified claim, and advisory
+  # mode is exactly what removes the pressure to verify it. Grading a finding by the SHAPE of the
+  # config line (a bare `openbank-<svc>` default that some peers do override) instead of by the
+  # deployed manifest gets the benign cases right and the live ones wrong, silently. Same class as
+  # the "gate that has only ever passed is unfalsified" rule in root CLAUDE.md, one level up: here
+  # the gate fired correctly and the TRIAGE was the unfalsified artifact.
+  #
+  # The fix follows the fleet convention rather than inventing one: application.yaml keeps a
+  # localhost dev default (what transaction/billing/statement/lending/fx/kyc already do), and the
+  # in-cluster URL is supplied by the workload's env in openbank-infra/gitops. NetworkPolicies are
+  # derived from those env URLs, so gen-network-policies.py was re-run (onboarding gained ingress
+  # to party; payments already had balances/ledger).
+  enforced: enforced
+  enforced_since: "2026-08-07"        # #3931
+  original_target_enforce_date: "2026-10-31"   # ADR-0144 — met early
   ci_producer: .github/scripts/check-incluster-hostnames.py
 
 kafka_dotted_keys:

--- a/openbank-onboarding-service/src/main/resources/application.yaml
+++ b/openbank-onboarding-service/src/main/resources/application.yaml
@@ -43,8 +43,15 @@ quarkus:
     tls:
       verification: none
   rest-client:
+    # Local-dev default ONLY — the in-cluster URL comes from PARTY_SERVICE_URL on the Deployment
+    # (openbank-infra/gitops/components/onboarding/onboarding-service.yaml), as customer-edge,
+    # statement-service and document-service already do. The previous default named
+    # `openbank-party-service:8090`: no Service of that name exists in any namespace, and the
+    # port was wrong too (party-service is 8111 in namespace `party`). The Deployment carried no
+    # override, so that was the EFFECTIVE value and AbandonedRegistrationCleaner's party lookup
+    # could never resolve (issue #3931).
     "party-service":
-      url: ${PARTY_SERVICE_URL:http://openbank-party-service:8090}
+      url: ${PARTY_SERVICE_URL:http://localhost:8111}
       connect-timeout: 3000
       read-timeout: 5000
   smallrye-reactive-messaging:

--- a/openbank-settlement-service/src/main/resources/application.yaml
+++ b/openbank-settlement-service/src/main/resources/application.yaml
@@ -28,11 +28,20 @@ quarkus:
       "com.openbank":
         level: DEBUG
   rest-client:
+    # Local-dev defaults ONLY. The in-cluster URLs are supplied by the Rollout's env
+    # (BALANCE_SERVICE_URL / LEDGER_SERVICE_URL in
+    # openbank-infra/gitops/components/payments/payments-services.yaml), which is the fleet
+    # convention every other consumer of these two services follows (transaction, billing,
+    # statement, lending). The previous defaults named `openbank-balance-service:8080` and
+    # `openbank-ledger-service:8080` — no Service of either name exists in any namespace, and
+    # the ports were wrong too (balance is 8103, ledger is 8101). Because the Rollout carried
+    # no env override, those were the EFFECTIVE values in the cluster, so every settlement
+    # debit/credit and every GL posting dialled a name that cannot resolve (issue #3931).
     balance-api:
-      url: "${BALANCE_SERVICE_URL:http://openbank-balance-service:8080}"
+      url: "${BALANCE_SERVICE_URL:http://localhost:8103}"
       scope: jakarta.inject.Singleton
     ledger-api:
-      url: "${LEDGER_SERVICE_URL:http://openbank-ledger-service:8080}"
+      url: "${LEDGER_SERVICE_URL:http://localhost:8101}"
       scope: jakarta.inject.Singleton
 
 openbank:


### PR DESCRIPTION
Closes #3931

## What this is

The `incluster-hostname-resolution` gate (added advisory in #1916's follow-up) reported 6 findings. Its triage note in both `gates.yaml` and `rules.yaml` graded all six as dead defaults "on services whose pods override them by env".

That was true of **three**. The other three were live.

## Verification (2026-08-07, sandbox cluster, `origin/main` @ `98a385f68`)

`kubectl get svc -A` — no Service is named `openbank-balance-service`, `openbank-ledger-service`, `openbank-party-service`, `openbank-sanctions-service` or `openbank-product-catalog` in any namespace. The real ones:

| claimed default | real Service | real port |
|---|---|---|
| `openbank-balance-service:8080` | `balance-service` (ns `balances`) | 8103 |
| `openbank-ledger-service:8080` | `ledger-service` (ns `ledger`) | 8101 |
| `openbank-party-service:8090` | `party-service` (ns `party`) | 8111 |
| `openbank-sanctions-service:8123` | `sanctions-service` (ns `sanctions`) | 8123 |
| `openbank-product-catalog:8080` | `product-catalog` (ns `accounts`) | 8104 |

Then, per service, whether the workload overrides the default:

| finding | override present? | verdict |
|---|---|---|
| account-service -> sanctions | `SANCTIONS_SERVICE_URL` on the Deployment | dead default |
| account-service -> product-catalog | `PRODUCT_CATALOG_SERVICE_URL` (+ `_HOST_OVERRIDE`) | dead default |
| card-issuance -> product-catalog | `PRODUCT_CATALOG_SERVICE_URL` (+ `_HOST_OVERRIDE`) | dead default |
| **settlement -> balance** | **none** | **live** |
| **settlement -> ledger** | **none** | **live** |
| **onboarding -> party** | **none** | **live** |

`kubectl -n payments get pod -l app.kubernetes.io/name=settlement-service` carries only `QUARKUS_DATASOURCE_*`, `QUARKUS_OIDC_AUTH_SERVER_URL`, `OPENBANK_TEMPORAL_SERVER_URL`, `SETTLEMENT_GL_*` — no `*_SERVICE_URL`. `kubectl -n onboarding get pod -l app.kubernetes.io/name=onboarding-service` carries no `*_SERVICE_URL` at all.

The clients on the live side are live code: `BalanceDebitAdapter`, `BalanceCreditAdapter`, `LedgerBookAdapter` (all `@RestClient`), and `AbandonedRegistrationCleaner`'s `PartyServiceClient`. So **every settlement debit/credit and every settlement GL posting, plus onboarding's abandoned-registration party lookup, dialled a hostname that resolves nowhere.**

The `LEDGER_SERVICE_URL` / `BALANCE_SERVICE_URL` pair that does exist in `payments-services.yaml` belongs to **transaction-service**, not settlement — that is the shape that makes this easy to misread from a grep.

## The fix

Follows the fleet convention rather than inventing one — a localhost dev default in `application.yaml`, the in-cluster URL from the workload env in gitops. transaction, billing, statement, lending, fx, kyc, sepa-payment, document-service all already do this; the four services here were the outliers.

- **settlement** (`fix`): `BALANCE_SERVICE_URL` / `LEDGER_SERVICE_URL` added to the Rollout, values copied from transaction-service; defaults to `localhost:8103` / `localhost:8101`.
- **onboarding** (`fix`): `PARTY_SERVICE_URL` added to the Deployment; default to `localhost:8111`.
- **account** and **card-issuance** (`refactor`): defaults corrected to `localhost:8123` / `localhost:8104`. No deployed behaviour changes, so deliberately not a releasing type — these only fix local dev and clear the gate.

NetworkPolicies are derived from those env URLs, so `gen-network-policies.py` was re-run: party's ingress allow-list gains `onboarding` (one 3-line hunk). `payments` was already permitted to `balances` and `ledger`, so nothing there changed.

Note the ordering property: the env override lands with the ArgoCD sync, so **the live fix does not wait for a settlement/onboarding image rebuild** — the `application.yaml` half only matters for local dev and for the day someone drops the env.

## Gate graduation

`mode: advisory` -> `enforced` (ahead of its ADR-0144 target of 2026-10-31), with both copies of the triage note corrected to what was measured. `rules.yaml` keeps the lesson rather than deleting it with the findings:

> an advisory gate's "these are all benign" triage is itself an unverified claim, and advisory mode is exactly what removes the pressure to check it.

Grading a finding by the **shape** of the config line instead of by the deployed manifest gets the benign cases right and the live ones wrong, silently. Same class as "a gate that has only ever passed is unfalsified" one level up: here the gate fired correctly and the *triage* was the unfalsified artifact.

**Falsified against a real counter-example, not only the fixture harness**: re-introducing `openbank-ledger-service:8080` into settlement's `application.yaml` on this branch takes the gate from exit 0 to exit 1 with exactly that one finding, and reverting returns it to 0. `--self-test` is 19/19.

`rules-opa-data.yaml` is unchanged — no `.rego` reads `data.rules.incluster_hostnames` — so no OPA bundle restamps.

## Money-path

settlement and account are `rules.yaml: money_path_services`, so **2 approvals** are required. The enforced `threat-model-updated-on-trust-boundary-change` gate fired on both; both threat models are updated in this PR and are explicit that **no trust boundary moved** — same edges, same services, same NetworkPolicies, so no STRIDE row changes. The settlement finding is availability, not confidentiality or integrity: the requests never left the pod.

## ASVS baseline

`V9.1` counts a new plaintext `http://` inter-service env value as new debt, and onboarding -> party genuinely is one (a dead edge becoming a live one). Declared in `.github/asvs-l3-baseline.txt` with the reason; deleting it is the mesh-mTLS work (security baseline Layer 1), not a per-service change. The settlement additions needed no entry — V9.1's identity is `(file, value)` with the line fragment normalised away, and `payments-services.yaml` already carries both URLs.

## Local verification

`run-gates.py --all`: 112 gates, **109 PASS**, 2 WARN, 1 FAIL.

- Both WARNs are advisory and pre-existing on `main` (`release-scope-mismatch` needs `PR_TITLE`; `operator-write naming` flags `rest.rego`'s `operator-mcp-session`, untouched here).
- The FAIL is `api-contract-gate`, which cannot run locally (`sudo: a password is required` installing `oasdiff`). No `openapi.yaml` is in this diff, so there is nothing for it to classify.
- `loki-rule-load-test` needed `BASE_REF` and passes once it is set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
