### PR TITLE
docs(ci): document that all-green covers service builds only, not the gates

### DIFF
--- a/.github/workflows/services-ci.yml
+++ b/.github/workflows/services-ci.yml
@@ -423,6 +423,23 @@ jobs:
           python3 .github/scripts/check-verification-metadata-complete.py \
             --modules "${{ steps.mods.outputs.modules }}" --enforce
 
+  # SCOPE: this job is about SERVICE BUILDS ONLY — despite the name (#3955).
+  #
+  # `needs` is the whole story: `changes`, `build`, `verification-metadata`. It never observes
+  # ci.yml's `gates (*)` shards, and therefore says nothing about `Validate manifests`, which
+  # aggregates them. Both are required contexts in the `main-protection` ruleset, and it is the
+  # PAIR that covers builds + gates — neither half alone is merge-readiness.
+  #
+  # This is not theoretical. On #3932 this job reported SUCCESS at 23:08:08 while
+  # `Validate manifests` had already reported FAILURE at 23:04:58 on the same commit — three
+  # minutes earlier, so not a race. The ruleset held (the PR stayed BLOCKED and merged only once
+  # `Validate manifests` went green), but a reader scanning the checks list for `all-green ✓`
+  # would have called that PR ready, and so would anything keying off this context alone.
+  #
+  # So: do not treat a green here as "the PR is mergeable", and do not add a downstream consumer
+  # that does. The name overpromises and cannot cheaply be fixed — a required context cannot be
+  # renamed in place (see the same warning on issue-hygiene.yml); it takes a two-step ruleset
+  # change. #3955 tracks that decision.
   all-green:
     name: all-green
     needs: [changes, build, verification-metadata]


### PR DESCRIPTION
Implements option 2 from #3955: leave the name, document the scope in place.

## The comment

Added directly above the `all-green` job in `services-ci.yml`. It states four things a reader
cannot get from the checks list:

- the `needs` list **is** the scope — `changes`, `build`, `verification-metadata`, nothing else;
- it never observes `ci.yml`'s `gates (*)` shards, so it says nothing about `Validate manifests`;
- both are required contexts and it is the **pair** that covers builds + gates;
- the measured incident, so the next reader knows this is real rather than hypothetical.

It also says plainly: do not treat a green here as "the PR is mergeable", and do not add a
downstream consumer that does.

## The incident it records

On #3932, on the same commit:

```
23:04:58  failure  Validate manifests
23:08:08  success  all-green      <- 3m 10s later
```

Three minutes apart, so not the "fires before the sibling reports" race — the red required check
was already on the commit. The ruleset held: #3932 stayed `BLOCKED` and merged only once
`Validate manifests` was genuinely green. Not a merge-safety hole, which is exactly why it needs a
comment rather than a fix.

## Why not rename

A required context cannot be renamed in place — `issue-hygiene.yml` already carries that warning
(`required status check in the main-protection ruleset — do not rename it`). It takes a two-step
ruleset change: add the new context, then retire the old. #3955 keeps that option open; this PR
does not foreclose it.

## Why the comment sits above the job, not in the `run:`

Prose inside a `run:` block counts toward the per-step size ceiling that makes an entire workflow
unparseable with no error message (#3135, reverted in #3139 — the first attempt there died of 3240
characters of added comments). The repo rule is that prose belongs outside `run:`. The
`workflow-run-step-size` gate currently reports the largest run script at 18955 chars against a
19000 limit, so there was no room to be casual about this.

## Verification

- **Comment-only**: added lines that are not a comment or blank: **0**.
- **YAML parses**, and `all-green`'s `needs` is unchanged: `['changes', 'build', 'verification-metadata']`.
- **actionlint finding sets identical to `origin/main`** — compared as sets, not by reading the
  output on this branch alone. The one SC2086 it reports is pre-existing (8 lines of output on
  both sides).
- `check-workflow-run-step-size.py` passes; this change adds nothing to any `run:` block.

Refs #3955
