### PR TITLE
test(fx): pin fx_conversions.rate_id to the stored row on both quote paths

### DIFF
--- a/openbank-fx-service/src/test/kotlin/com/openbank/fx/application/usecase/FxServiceTest.kt
+++ b/openbank-fx-service/src/test/kotlin/com/openbank/fx/application/usecase/FxServiceTest.kt
@@ -162,6 +162,46 @@ class FxServiceTest {
         assertThat(conv.appliedRate).isEqualByComparingTo("0.04016064")
     }
 
+    // --- fx_conversions.rate_id must name a STORED row (#3374) --------------------------------
+    //
+    // `fx_conversions.rate_id` is `NOT NULL REFERENCES fx_rates(id)`. A CZK->foreign pair has no
+    // stored row of its own — the CNB fixing publishes FOREIGN->CZK only — so it is answered by
+    // inverting the stored direction, and whatever id that derived quote carries is what reaches
+    // the column. If it is ever an id with no row, EVERY CZK->foreign conversion fails the insert
+    // on a foreign-key violation, and the audit record cites an id nothing can resolve.
+    //
+    // Today the invariant holds by construction, because `inverted()` carries the source id over.
+    // That is precisely why it is worth pinning: #3374 is a live proposal to give a derived quote
+    // its own identity (#3594 minted a deterministic derived id, #3741 nulls it in the response),
+    // and the money-path property has to survive whichever shape lands. These assert the property
+    // itself — the id written is the STORED row's — not any particular derivation scheme, so they
+    // stay meaningful under both designs and fail the moment a derived id reaches the column.
+
+    @Test
+    fun `a conversion on a derived quote records the stored row id`() = runBlocking<Unit> {
+        val stored = fxRate()
+        coEvery { rateRepo.findLatest("CZK", "EUR", RateType.SPOT) } returns null
+        coEvery { rateRepo.findLatest("EUR", "CZK", RateType.SPOT) } returns stored
+        coEvery { convRepo.saveWithOutbox(any(), any()) } answers { firstArg() }
+        clear()
+
+        val conv = service.convert(convertCommand().copy(fromCurrency = "CZK", toCurrency = "EUR"))
+
+        assertThat(conv.rateId).isEqualTo(stored.id)
+    }
+
+    @Test
+    fun `a conversion on a stored quote records that row's id`() = runBlocking<Unit> {
+        val stored = fxRate()
+        coEvery { rateRepo.findLatest("EUR", "CZK", RateType.SPOT) } returns stored
+        coEvery { convRepo.saveWithOutbox(any(), any()) } answers { firstArg() }
+        clear()
+
+        val conv = service.convert(convertCommand().copy(fromCurrency = "EUR", toCurrency = "CZK"))
+
+        assertThat(conv.rateId).isEqualTo(stored.id)
+    }
+
     @Test
     fun `convert throws when rate is expired`() = runBlocking<Unit> {
         val command = convertCommand()


### PR DESCRIPTION
Two tests, no production change. Ported from #3594, which I closed as superseded by #3741.

## The invariant

`fx_conversions.rate_id` is `NOT NULL REFERENCES fx_rates(id)`. A CZK→foreign pair has no stored row of its own — the ČNB fixing publishes FOREIGN→CZK exclusively — so it is answered by inverting the stored direction, and whatever id that derived quote carries is what reaches the column.

If a derived id ever lands there, **every CZK→foreign conversion fails the insert on a foreign-key violation**, and the audit record cites an id nothing can resolve. fx-service is money-path.

## Why pin something that already passes

It holds today only because `inverted()` carries the source id over. #3374 is a live proposal to change exactly that, and the two candidate fixes disagree on how:

- #3594 (closed) minted a deterministic derived id and guarded the write with `derivedFrom ?: rate.id`.
- #3741 (open) nulls the response `id` and keeps the domain rate on the source id.

Both get the FK right, neither asserts it. These tests assert the **property** — the id written is the stored row's — rather than any derivation scheme, so they stay meaningful under whichever lands, and go red if a future refactor lets a derived id through.

## Falsified, not merely green

A test that has only ever passed proves nothing. Injecting the #3594 shape into `inverted()` without `FxService`'s guard:

```kotlin
fun inverted(): FxRate = copy(
    id = UUID.nameUUIDFromBytes((id.toString() + "|inverse").toByteArray()),
```

```
FxServiceTest > a conversion on a derived quote records the stored row id() FAILED
21 tests completed, 1 failed
```

The stored-quote test stayed green, so the pair discriminates between the two paths rather than both failing on any change. Injection reverted; `git diff --stat` on this branch is the one test file, 40 insertions.

`:openbank-fx-service:test ktlintCheck detekt` all pass.

## Scope

Test-only. `src/test` is in fx-service's `exclude-paths`, so this triggers no release, and there is no API or DB change. Not ported: #3594's 267-line `FxRateApiContractTest`, which asserts that PR's response shape — the thing #3741 changes.

fx-service is in `rules.yaml: money_path_services`, so this wants 2 approvals under ADR-0030 even as a test-only change. Not self-merging.

Refs #3374
Refs #3741
