### PR TITLE
docs: capture the self-corroborating-evidence lesson from #3974

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -512,6 +512,38 @@ fire from *outside* it, so they stay here:
   `ACCOUNT_SERVICE_URL: …accounts.svc:8101`, where 8101 is ledger's. Both ports transposed, live on
   the pod, invisible to the gate. When a gate's subject can be overridden, either extend it to the
   overriding layer or say in its own header which layer it does not cover.
+- **Evidence cannot corroborate the layer it is DERIVED FROM — extending a gate to that layer
+  silently makes it vacuous, and it still reads as green.** `check-incluster-hostnames.py` widens
+  its known-good set with every host a gitops workload env dials ("if the deployment manifest
+  dials it, the platform believes it exists"), which is sound while the CLAIM comes from
+  `application.yaml` and the CORROBORATION from gitops — two independently-authored places. Point
+  the same gate at the gitops env and that becomes the same statement twice: every host vouches
+  for itself, nothing can ever be flagged, and the output still says OK. The fix is not more
+  cleverness but a parameter — the caller passes what it accepts as existing, so the two layers
+  cannot share a believed-set by accident, and a self-test asserts a corroborated-only host stays
+  clean in one layer and IS flagged in the other (#3966). **Before reusing any "known-good" set on
+  a new input, ask what that set is derived from**; the same shape appears wherever a baseline, an
+  allow-list or a cache is built from the artifact it is about.
+- **The derived alternative to a hand-kept list is not automatically better — measure it against
+  the known cases before preferring it on principle.** This repo rightly distrusts hand-kept lists
+  (a gate whose scope is one reads as PASSING when the list is short). So the instinct for the
+  above was a derived rule: believe a host that ≥2 distinct workloads dial. Measured against the
+  real tree it was wrong in BOTH directions at once — it would have believed two live defects
+  (`tpp-registry-service.tpp.svc` and `sepa-payment-service.payments.svc`, each dialled twice) and
+  flagged three real Helm-provisioned Services dialled only once. A 10-entry list, each entry
+  verified with `kubectl` and **checked both ways** so a stale one fails, beat it outright. The
+  rule that survives is narrower than "never hand-keep a list": never let a gate's SCOPE be
+  hand-kept, because a short list then reads as full coverage — but a hand-kept list of external
+  FACTS is fine when the gate fails on a stale entry, since it can only shrink by being noticed.
+- **A comment that explains away a symptom is worse than no comment — it retires the question.**
+  psd2's manifest annotated its TPP-registry URL "Not yet deployed -> calls 503 until it lands".
+  The service was deployed and serving; the URL named a namespace that has never existed. Anyone
+  who noticed the failing lookup found it already accounted for, so the note survived as long as
+  the bug did. Same family as the stale-prose rule under ktlint/detekt above, but the failure is
+  worse: stale prose merely misinforms, whereas an explanation of a symptom suppresses the
+  investigation. When you write one, name what you VERIFIED and when — and when you fix a defect
+  whose comment predicted it, correct the comment in place rather than deleting it, so the next
+  reader learns the note was wrong rather than that it was never there.
 - **An advisory check over a *generated* artifact is a contradiction.** On a hand-written artifact a
   red advisory check means "someone should look"; on a generated one it means "the committed document
   does not match reality" — there is no judgement left to exercise, so advisory just makes the drift


### PR DESCRIPTION
Refs #3931, #3966

Follow-up to #3967, capturing what building #3974 taught rather than what #3956 found. Three bullets in root `CLAUDE.md`, "CI gates — exercise the failure path before trusting the green", routed per `rules.yaml: knowledge_capture` as operational footguns. Fleet-wide rather than tree-scoped: the first two are about how *any* gate builds a known-good set, the third about any comment anywhere.

**1. Evidence cannot corroborate the layer it is derived from.**

`check-incluster-hostnames.py` widens its known-good set with every host a gitops workload env dials — "if the deployment manifest dials it, the platform believes it exists". That is sound while the **claim** comes from `application.yaml` and the **corroboration** from gitops: two independently-authored places. Point the same gate at the gitops env and it becomes the same statement twice — every host vouches for itself, nothing can ever be flagged, and the output still prints OK.

Generalized deliberately beyond this gate, because the shape recurs wherever a baseline, an allow-list or a cache is built from the artifact it is about: *before reusing any known-good set on a new input, ask what that set is derived from.*

**2. The derived alternative to a hand-kept list is not automatically better.**

This repo rightly distrusts hand-kept lists — a gate whose scope is one reads as PASSING when the list is short. So the instinct for (1) was a derived rule: believe a host that ≥2 distinct workloads dial. **Measured against the real tree it was wrong in both directions at once** — it would have believed two live defects (`tpp-registry-service.tpp.svc` and `sepa-payment-service.payments.svc`, each dialled twice) and flagged three real Helm-provisioned Services dialled once. A 10-entry list, each entry `kubectl`-verified and checked both ways so a stale one fails, beat it outright.

The bullet records the narrower rule that actually survives: never let a gate's **scope** be hand-kept, since a short list then reads as full coverage — but a hand-kept list of external **facts** is fine when the gate fails on a stale entry, because it can only shrink by being noticed.

**3. A comment that explains away a symptom is worse than none.**

psd2's manifest annotated its TPP-registry URL "Not yet deployed → calls 503 until it lands". The service was deployed and serving; the URL named a namespace that has never existed. Anyone who noticed the failing lookup found it already accounted for, so the note survived exactly as long as the bug did.

Distinguished from the existing stale-prose rule under ktlint/detekt: stale prose merely misinforms, whereas an explanation of a symptom *suppresses the investigation*. Hence the guidance to correct such a comment in place when fixing the defect, so the next reader learns the note was wrong rather than that it was never there.

## Verification

Docs-only, one file, 32 added lines. `run-gates.py --group lint`: 6/6 pass. No overlap with #3956, #3968 or #3974 — those touch no `CLAUDE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
