### PR TITLE
feat(ledger): drive the accounting-day lifecycle automatically (ADR-0207 increment 2)

### DIFF
--- a/docs/adr/0207-business-date-authority-and-the-accounting-day-state-machine.md
+++ b/docs/adr/0207-business-date-authority-and-the-accounting-day-state-machine.md
@@ -196,12 +196,34 @@ rejects a posting that is legal today. Enforcement is a config flip, and its pre
 evidence, not a calendar: `openbank_ledger_day_lock_decisions_total{outcome="would_refuse"}` at zero
 or every hit explained.
 
+**Increment 2 (the two enforcement preconditions above).**
+
+Motivated by measurement, not schedule: on 2026-08-07 the live cluster had **zero** rows in
+`ledger_accounting_day` while postings flowed — every day-lock decision was `no_day_record`
+(confirmed in the shadow counter) and `would_refuse` could structurally never fire, so the
+enforcement evidence gate was green about nothing. A lock whose calendar nobody maintains
+measures nothing.
+
+Shipped:
+- `AccountingDayScheduler` — reconciles the persisted calendar toward the `AccountingClock`
+  every tick (default */15 min, cluster-locked, suspend per #2187): opens the current day,
+  backfills gaps since the latest known row (oldest-first, bounded — history before the
+  scheduler existed is deliberately NOT fabricated), cuts over past `OPEN` days, and advances
+  `CUTOFF → TIED_OUT` only on a tie-out run that is OK **and** recorded after the cutoff — a
+  verdict from while the day could still change proves nothing about its final figures.
+  `TIED_OUT → LOCKED` stays operator-driven: locking is the statement/period-close act, which a
+  timer cannot know.
+- The stuck-`CUTOFF` alert: gauge `openbank_ledger_accounting_day_stuck_cutoff_days`
+  (re-published every tick; threshold `openbank.ledger.accounting-day.stuck-cutoff-hours`,
+  default 8h against a normal ~6h residence) + `AccountingDayStuckInCutoff` in
+  `prometheus-rules-accounting-day.yaml`.
+- Dispatch proven by `LedgerSchedulerVertxContextIT` driving the real cron against a real
+  Postgres, alongside the two #2187 regressions.
+
 Not yet built, and deliberately out of this increment:
-- The stuck-`CUTOFF` alert. The ADR's own Consequences section makes it a precondition of
-  enforcement, not of the state machine — a day stuck in `CUTOFF` blocks nothing while the lock is
-  in shadow. It must exist before the flip.
-- A scheduler that opens each day automatically. Days are opened by an operator for now; the day
-  lock treats an unopened day as *not refused* precisely so that this ordering is safe.
+- The enforce flip itself (`openbank.ledger.day-lock.mode: enforce`). Its evidence gate is now
+  real: with the calendar maintained, `would_refuse` measures actual backdated postings. Read
+  the counter after the scheduler has run in the cluster over at least one full day cycle.
 - #1302 items 3–5 (reconciliation false drift, FX rate staleness, statement correction path), which
   this ADR's Context predicted would "collapse into wiring once this is settled".
 - The three pre-existing accounting-clock sites the new guard surfaced outside ledger-service

--- a/openbank-infra/gitops/components/observability/prometheus-rules-accounting-day.yaml
+++ b/openbank-infra/gitops/components/observability/prometheus-rules-accounting-day.yaml
@@ -1,0 +1,45 @@
+# Stuck-CUTOFF accounting day alert (ADR-0207 increment 2). Picked up by the Prometheus
+# operator automatically (ruleSelectorNilUsesHelmValues=false), same as every other
+# PrometheusRule in this directory.
+#
+# WHY THIS EXISTS: ADR-0207's Consequences section names the failure mode the day state
+# machine introduces — a day stuck in CUTOFF because its tie-out never delivered an OK
+# verdict blocks that day's postings once the day lock enforces — and makes DETECTING it a
+# precondition of flipping openbank.ledger.day-lock.mode to enforce. AccountingDayScheduler
+# (ledger-service) re-publishes this gauge every reconcile tick (default */15 min): the
+# count of days sitting in CUTOFF beyond the configured threshold (default 8h; normal
+# residence is ~6h — midnight cutover -> 06:00 tie-out -> next tick).
+#
+# The gauge resets to zero on pod restart until the first tick re-publishes it — a stuck
+# day, if real, re-appears within minutes, which the `for:` below outlasts. Warning, not
+# critical: while the lock is in shadow a stuck day blocks nothing, and the tie-out's own
+# BREAK page (SubledgerTieOutBreak, critical) already covers the usual root cause; the
+# operator action here is to investigate the 06:00 run and drive the day forward via the
+# accounting-days API once resolved.
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: openbank-accounting-day-alerts
+  namespace: observability
+  labels:
+    app.kubernetes.io/part-of: observability
+spec:
+  groups:
+    - name: openbank.ledger.accounting-day
+      rules:
+        - alert: AccountingDayStuckInCutoff
+          expr: openbank_ledger_accounting_day_stuck_cutoff_days > 0
+          for: 30m
+          labels:
+            severity: warning
+          annotations:
+            summary: "An accounting day has been stuck in CUTOFF beyond the threshold"
+            description: >-
+              openbank_ledger_accounting_day_stuck_cutoff_days is non-zero: at least one
+              accounting day has sat in CUTOFF longer than the configured threshold
+              (openbank.ledger.accounting-day.stuck-cutoff-hours, default 8h) — its tie-out
+              has not delivered an OK verdict recorded after the cutoff (ADR-0207). Consult
+              ledger-service logs for the per-day WARN lines and the ledger_tieout_runs
+              table for the verdict; once the underlying issue is repaired, the next OK
+              tie-out run advances the day automatically, or an operator drives it forward
+              via /api/v1/ledger/accounting-days.

--- a/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/application/port/out/AccountingDayRepository.kt
+++ b/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/application/port/out/AccountingDayRepository.kt
@@ -5,6 +5,7 @@
 package com.openbank.ledger.application.port.out
 
 import com.openbank.ledger.domain.model.AccountingDayRecord
+import com.openbank.ledger.domain.model.AccountingDayStatus
 import com.openbank.libs.persistence.outbox.OutboxMessage
 import java.time.LocalDate
 
@@ -15,6 +16,20 @@ interface AccountingDayRepository {
 
     /** The most recently opened day that still accepts postings — the forward-correction target. */
     suspend fun findLatestOpen(): AccountingDayRecord?
+
+    /**
+     * The day with the highest business date regardless of status — the catch-up anchor for
+     * [com.openbank.ledger.infrastructure.schedule.AccountingDayScheduler]: days after this one
+     * have never been opened. Null only before the very first day is ever opened.
+     */
+    suspend fun findLatest(): AccountingDayRecord?
+
+    /**
+     * Every day currently in [status], ascending by business date. Bounded in practice by the
+     * lifecycle itself: one row exists per calendar day and non-terminal statuses drain daily,
+     * so a large result is itself the stuck-day signal, never a paging problem.
+     */
+    suspend fun findInStatus(status: AccountingDayStatus): List<AccountingDayRecord>
 
     /** Days in `[from, to]`, ascending by business date. */
     suspend fun findRange(from: LocalDate, to: LocalDate): List<AccountingDayRecord>

--- a/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/application/port/out/TieOutRunRepository.kt
+++ b/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/application/port/out/TieOutRunRepository.kt
@@ -5,6 +5,7 @@
 package com.openbank.ledger.application.port.out
 
 import com.openbank.ledger.domain.model.TieOutRunRecord
+import java.time.LocalDate
 
 /** Outbound persistence port for the audit trail of tie-out runs (ADR-0039 Phase B). */
 interface TieOutRunRepository {
@@ -12,4 +13,12 @@ interface TieOutRunRepository {
     suspend fun save(record: TieOutRunRecord): TieOutRunRecord
 
     suspend fun findLatest(): TieOutRunRecord?
+
+    /**
+     * The most recent run that checked [asOf] — the evidence
+     * [com.openbank.ledger.infrastructure.schedule.AccountingDayScheduler] reads before advancing
+     * that day `CUTOFF → TIED_OUT`. Latest by `runAt`, because a day can be re-checked (a BREAK
+     * that was repaired and re-run): the newest verdict is the one that stands.
+     */
+    suspend fun findLatestFor(asOf: LocalDate): TieOutRunRecord?
 }

--- a/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/persistence/repository/PanacheAccountingDayRepository.kt
+++ b/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/persistence/repository/PanacheAccountingDayRepository.kt
@@ -33,6 +33,14 @@ class PanacheAccountingDayRepository(
         find("status = ?1 order by businessDate desc", AccountingDayStatus.OPEN.name).firstResult()
     }.awaitSuspending()?.toDomain()
 
+    override suspend fun findLatest(): AccountingDayRecord? = Panache.withSession {
+        find("order by businessDate desc").firstResult()
+    }.awaitSuspending()?.toDomain()
+
+    override suspend fun findInStatus(status: AccountingDayStatus): List<AccountingDayRecord> = Panache.withSession {
+        find("status = ?1 order by businessDate asc", status.name).list()
+    }.awaitSuspending().map { it.toDomain() }
+
     override suspend fun findRange(from: LocalDate, to: LocalDate): List<AccountingDayRecord> = Panache.withSession {
         find("businessDate >= ?1 and businessDate <= ?2 order by businessDate asc", from, to).list()
     }.awaitSuspending().map { it.toDomain() }

--- a/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/persistence/repository/PanacheTieOutRunRepository.kt
+++ b/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/persistence/repository/PanacheTieOutRunRepository.kt
@@ -12,6 +12,7 @@ import io.quarkus.hibernate.reactive.panache.Panache
 import io.quarkus.hibernate.reactive.panache.kotlin.PanacheRepositoryBase
 import io.smallrye.mutiny.coroutines.awaitSuspending
 import jakarta.enterprise.context.ApplicationScoped
+import java.time.LocalDate
 import java.util.UUID
 
 @ApplicationScoped
@@ -28,6 +29,10 @@ class PanacheTieOutRunRepository :
 
     override suspend fun findLatest(): TieOutRunRecord? = Panache.withSession {
         find("order by runAt desc").firstResult()
+    }.awaitSuspending()?.toDomain()
+
+    override suspend fun findLatestFor(asOf: LocalDate): TieOutRunRecord? = Panache.withSession {
+        find("asOf = ?1 order by runAt desc", asOf).firstResult()
     }.awaitSuspending()?.toDomain()
 
     private fun TieOutRunRecord.toEntity() = TieOutRunEntity().also {

--- a/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/schedule/AccountingDayScheduler.kt
+++ b/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/schedule/AccountingDayScheduler.kt
@@ -1,0 +1,274 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.ledger.infrastructure.schedule
+
+import com.openbank.ledger.application.port.`in`.AccountingDayUseCase
+import com.openbank.ledger.application.port.`in`.OpenAccountingDayCommand
+import com.openbank.ledger.application.port.`in`.TransitionAccountingDayCommand
+import com.openbank.ledger.application.port.out.AccountingDayRepository
+import com.openbank.ledger.application.port.out.TieOutRunRepository
+import com.openbank.ledger.domain.model.AccountingDayRecord
+import com.openbank.ledger.domain.model.AccountingDayStatus
+import com.openbank.ledger.domain.model.TieOutRunStatus
+import com.openbank.libs.domain.calendar.AccountingClock
+import com.openbank.libs.observability.DomainMetrics
+import com.openbank.libs.observability.WorkflowLivenessRecorder
+import com.openbank.libs.persistence.lock.ClusterLock
+import io.micrometer.core.instrument.Gauge
+import io.micrometer.core.instrument.MeterRegistry
+import io.quarkus.runtime.StartupEvent
+import io.quarkus.scheduler.Scheduled
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.enterprise.event.Observes
+import jakarta.inject.Inject
+import org.eclipse.microprofile.config.inject.ConfigProperty
+import org.jboss.logging.Logger
+import java.time.Duration
+import java.time.LocalDate
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Drives the accounting-day lifecycle automatically (ADR-0207 increment 2).
+ *
+ * Increment 1 shipped the state machine (`OPEN → CUTOFF → TIED_OUT → LOCKED`), the operator
+ * surface and the day lock in shadow mode — and deliberately left days **operator-opened**. The
+ * measured consequence on the live cluster (2026-08-07): `ledger_accounting_day` had zero rows
+ * while postings flowed, so every day-lock decision was `no_day_record` and the shadow counter
+ * `openbank_ledger_day_lock_decisions_total{outcome="would_refuse"}` could never fire — the
+ * evidence gate for enforcement was structurally vacuous. A lock whose calendar nobody maintains
+ * measures nothing; this scheduler is what makes the calendar real, and therefore what makes
+ * flipping `openbank.ledger.day-lock.mode` to `enforce` an evidence-backed step instead of a leap.
+ *
+ * Each tick reconciles persisted day state toward what the [AccountingClock] says is true:
+ *
+ * 1. **Open** the current accounting day if it has no row, then backfill any gap since the
+ *    latest known row (oldest first, bounded per tick like [TieOutScheduler]'s catch-up). On the
+ *    very first tick ever there is no anchor and only the current day is opened — history before
+ *    the scheduler existed is deliberately not fabricated: the day lock treats a day with no row
+ *    as not-refusable in every mode, which is exactly right for days that predate the calendar.
+ * 2. **`OPEN → CUTOFF`** for every open day the accounting clock has moved past. The current day
+ *    stays OPEN.
+ * 3. **`CUTOFF → TIED_OUT`** for a day whose *latest* tie-out run is OK **and** ran after the
+ *    day's cutoff — evidence recorded before the day stopped moving proves nothing about its
+ *    final figures. In the normal cadence this holds by construction: a day goes CUTOFF at the
+ *    first tick after midnight, [TieOutScheduler] checks it at 06:00, and this scheduler advances
+ *    it within [Scheduled] cadence of that. A BREAK or ERROR run leaves the day in CUTOFF, where
+ *    the stuck gauge below makes it visible.
+ * 4. **`TIED_OUT → LOCKED` is not automated here.** Locking is the statement/period-close act
+ *    (ADR-0035/ADR-0096 territory), not a timer's: a day becomes evidence when downstream close
+ *    processes have consumed it, which this scheduler cannot know. Operator-driven until that
+ *    wiring exists.
+ *
+ * Every step is idempotent and per-day failures are contained: one day failing to transition is
+ * logged and counted, the rest of the tick proceeds. The whole tick runs under [ClusterLock] for
+ * the same reason [TieOutScheduler] does (#1201): an Argo Rollouts canary window runs two pods
+ * whose ticks would otherwise both reconcile — the transitions are individually race-safe
+ * (version-guarded UPDATE + unique business date), so the lock is about noise, not correctness.
+ *
+ * **Stuck-CUTOFF visibility.** ADR-0207's Consequences name the new failure mode this scheduler
+ * introduces: a day stuck in CUTOFF because its tie-out never passed blocks that day's postings
+ * once the lock enforces — so the ADR makes detection a precondition of enforcement.
+ * `openbank.ledger.accounting_day.stuck_cutoff_days` gauges how many days have sat in CUTOFF
+ * longer than the configured threshold; the paired PrometheusRule
+ * (`openbank-infra/gitops/components/observability/prometheus-rules-accounting-day.yaml`) alerts
+ * on it being non-zero. Normal residence in CUTOFF is ~6h (midnight tick → 06:00 tie-out), so
+ * the default threshold of 8h means "the 06:00 run did not deliver an OK verdict".
+ */
+@ApplicationScoped
+class AccountingDayScheduler(
+    private val accountingDayRepository: AccountingDayRepository,
+    private val tieOutRunRepository: TieOutRunRepository,
+    private val accountingDayUseCase: AccountingDayUseCase,
+    private val accountingClock: AccountingClock,
+    private val clusterLock: ClusterLock,
+    @ConfigProperty(name = "openbank.ledger.accounting-day.max-catchup-days", defaultValue = "7")
+    private val maxCatchUpDays: Int,
+    @ConfigProperty(name = "openbank.ledger.accounting-day.stuck-cutoff-hours", defaultValue = "8")
+    private val stuckCutoffHours: Long,
+) {
+    private val log: Logger = Logger.getLogger(AccountingDayScheduler::class.java)
+
+    // Field-injected to keep the constructor under detekt's LongParameterList threshold, the
+    // same shape as LoanStageEventConsumer and McpEndpoint.
+    @Inject
+    lateinit var domainMetrics: DomainMetrics
+
+    @Inject
+    lateinit var meterRegistry: MeterRegistry
+
+    // Nullable, not `lateinit` — a money-path job must never fail because its observability
+    // wiring was not initialised (same reasoning as TieOutScheduler).
+    private var liveness: WorkflowLivenessRecorder? = null
+
+    /**
+     * Updated every tick; read by the gauge. Starts at zero, which is also the boot state — the
+     * alert rule tolerates that window because the stuck condition, if real, is re-published on
+     * the next tick (minutes), while the alert's `for:` is longer.
+     */
+    private val stuckCutoffDays = AtomicInteger(0)
+
+    fun onStart(@Observes @Suppress("UNUSED_PARAMETER") ev: StartupEvent) {
+        liveness = domainMetrics.registerWorkflowLiveness(WORKFLOW_NAME, EXPECTED_INTERVAL)
+        Gauge.builder(STUCK_GAUGE, stuckCutoffDays) { it.get().toDouble() }
+            .description(
+                "Accounting days sitting in CUTOFF longer than the configured threshold — the " +
+                    "tie-out never delivered an OK verdict for them (ADR-0207). Non-zero pages.",
+            )
+            .strongReference(true)
+            .register(meterRegistry)
+    }
+
+    // `suspend`, never `runBlocking` (#2187/#2148): a plain @Scheduled method runs on a bare
+    // executor-thread with no Vert.x context and the first reactive call dies with HR000068.
+    // The cron is a config expression so LedgerSchedulerVertxContextIT can shrink it and drive
+    // the REAL scheduler dispatch — a direct call supplies the context the scheduler does not.
+    @Scheduled(
+        cron = "{openbank.ledger.accounting-day.cron:0 */15 * * * ?}",
+        timeZone = "Europe/Prague",
+        concurrentExecution = Scheduled.ConcurrentExecution.SKIP,
+    )
+    suspend fun reconcile() {
+        val ran = clusterLock.tryRunExclusively(JOB_NAME) {
+            val today = accountingClock.today()
+            openMissingDays(today)
+            cutOverPastDays(today)
+            tieOutEligibleDays()
+            publishStuckCutoff()
+        }
+        if (ran == null) {
+            log.debugf("Accounting-day reconcile: another pod holds this tick's lock — skipping")
+        } else {
+            liveness?.recordSuccess()
+        }
+    }
+
+    /**
+     * Ensure a row exists for [today] and for every day between the latest known row and today,
+     * oldest first, bounded by [maxCatchUpDays] per tick (forward progress on a long gap, same
+     * shape as [TieOutScheduler.catchUpDates]). First tick ever: open [today] only.
+     */
+    private suspend fun openMissingDays(today: LocalDate) {
+        val latest = accountingDayRepository.findLatest()
+        val toOpen: List<LocalDate> = if (latest == null) {
+            listOf(today)
+        } else {
+            generateSequence(latest.businessDate.plusDays(1)) { it.plusDays(1) }
+                .takeWhile { it <= today }
+                .take(maxCatchUpDays)
+                .toList()
+        }
+        if (latest != null && toOpen.size == maxCatchUpDays && toOpen.last() < today) {
+            log.warnf(
+                "Accounting-day reconcile: gap since %s exceeds %d days — opening oldest-first, " +
+                    "the remainder heals on subsequent ticks",
+                latest.businessDate,
+                maxCatchUpDays,
+            )
+        }
+        toOpen.forEach { date ->
+            runStep("open", date) {
+                accountingDayUseCase.open(OpenAccountingDayCommand(businessDate = date, openedBy = SYSTEM_ACTOR))
+                log.infof("Accounting day %s opened by scheduler", date)
+            }
+        }
+    }
+
+    /** Every OPEN day the clock has moved past goes to CUTOFF; the current day stays OPEN. */
+    private suspend fun cutOverPastDays(today: LocalDate) {
+        accountingDayRepository.findInStatus(AccountingDayStatus.OPEN)
+            .filter { it.businessDate < today }
+            .forEach { day ->
+                runStep("cutoff", day.businessDate) {
+                    accountingDayUseCase.transition(
+                        TransitionAccountingDayCommand(
+                            businessDate = day.businessDate,
+                            to = AccountingDayStatus.CUTOFF,
+                            transitionedBy = SYSTEM_ACTOR,
+                        ),
+                    )
+                    log.infof("Accounting day %s cut off (accounting clock has moved past it)", day.businessDate)
+                }
+            }
+    }
+
+    /**
+     * Advance CUTOFF days whose latest tie-out verdict is OK and was recorded after the cutoff.
+     * The runAt-after-cutoff requirement is what makes TIED_OUT mean something: a verdict
+     * produced while the day could still change is a snapshot, not evidence.
+     */
+    private suspend fun tieOutEligibleDays() {
+        accountingDayRepository.findInStatus(AccountingDayStatus.CUTOFF).forEach { day ->
+            runStep("tie-out", day.businessDate) {
+                val run = tieOutRunRepository.findLatestFor(day.businessDate) ?: return@runStep
+                val cutoffAt = day.cutoffAt ?: return@runStep
+                if (run.status == TieOutRunStatus.OK && !run.runAt.isBefore(cutoffAt)) {
+                    accountingDayUseCase.transition(
+                        TransitionAccountingDayCommand(
+                            businessDate = day.businessDate,
+                            to = AccountingDayStatus.TIED_OUT,
+                            transitionedBy = SYSTEM_ACTOR,
+                        ),
+                    )
+                    log.infof(
+                        "Accounting day %s tied out (tie-out run %s at %s)",
+                        day.businessDate,
+                        run.status,
+                        run.runAt,
+                    )
+                }
+            }
+        }
+    }
+
+    /** Re-publish the count of days sitting in CUTOFF longer than the threshold. */
+    private suspend fun publishStuckCutoff() {
+        val threshold = accountingClock.instant().minus(Duration.ofHours(stuckCutoffHours))
+        val stuck = accountingDayRepository.findInStatus(AccountingDayStatus.CUTOFF)
+            .filter { day -> day.cutoffAt?.isBefore(threshold) == true }
+        stuckCutoffDays.set(stuck.size)
+        stuck.forEach { day: AccountingDayRecord ->
+            log.warnf(
+                "Accounting day %s has been in CUTOFF since %s (over %dh) — its tie-out has not " +
+                    "delivered an OK verdict; investigate the 06:00 run, then drive the day " +
+                    "forward via the operator API once resolved",
+                day.businessDate,
+                day.cutoffAt,
+                stuckCutoffHours,
+            )
+        }
+    }
+
+    /**
+     * One reconcile step for one day: failures are logged and contained so a single bad day
+     * cannot stop the calendar for every other day. Racing pods and operator actions surface
+     * here as conflicts, which the next tick resolves by re-reading state.
+     */
+    @Suppress("TooGenericExceptionCaught") // scheduler must survive any infra failure per tick
+    private suspend fun runStep(step: String, date: LocalDate, block: suspend () -> Unit) {
+        try {
+            block()
+        } catch (ex: Exception) {
+            log.errorf(ex, "Accounting-day reconcile step '%s' failed for %s: %s", step, date, ex.message)
+        }
+    }
+
+    private companion object {
+        const val JOB_NAME = "ledger.accounting-day"
+
+        /** ADR-0160 mechanism 3 workflow tag — stable, low-cardinality. */
+        const val WORKFLOW_NAME = "ledger-accounting-day"
+
+        const val STUCK_GAUGE = "openbank.ledger.accounting_day.stuck_cutoff_days"
+
+        /**
+         * Actor recorded on scheduler-driven transitions. Distinct from any JWT principal so an
+         * audit read can tell automation from an operator at a glance.
+         */
+        const val SYSTEM_ACTOR = "system:accounting-day-scheduler"
+
+        /** The schedule interval the liveness gauge declares (sentinel fires at 2x this). */
+        val EXPECTED_INTERVAL: Duration = Duration.ofMinutes(15)
+    }
+}

--- a/openbank-ledger-service/src/main/resources/application.yaml
+++ b/openbank-ledger-service/src/main/resources/application.yaml
@@ -146,6 +146,18 @@ openbank:
     # postings can be attributed rather than only counted.
     day-lock:
       mode: "${LEDGER_DAY_LOCK_MODE:shadow}"
+    # AccountingDayScheduler (ADR-0207 increment 2): reconciles the persisted day calendar
+    # toward the AccountingClock — opens the current day, cuts over past days, ties out days
+    # whose 06:00 tie-out verdict is OK, and publishes the stuck-CUTOFF gauge. Without it the
+    # day lock's shadow counter is vacuous: measured live 2026-08-07, ledger_accounting_day had
+    # zero rows while postings flowed, so every decision was no_day_record and enforcement had
+    # no evidence to read. LOCKED stays operator-driven (statement/period-close territory).
+    accounting-day:
+      max-catchup-days: 7
+      # Normal CUTOFF residence is ~6h (midnight tick -> 06:00 tie-out -> next tick). Over this
+      # threshold the day counts into openbank_ledger_accounting_day_stuck_cutoff_days, which
+      # pages via prometheus-rules-accounting-day.yaml.
+      stuck-cutoff-hours: 8
     # Period-granular lock (ADR-0096 D1). Modes: off | shadow | enforce. Same staged rollout and
     # the same reason as the day lock above — it ships in SHADOW and refuses nothing until the
     # counter openbank_ledger_period_lock_decisions_total{outcome="would_refuse"} reads zero (or

--- a/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/infrastructure/schedule/AccountingDaySchedulerTest.kt
+++ b/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/infrastructure/schedule/AccountingDaySchedulerTest.kt
@@ -1,0 +1,246 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.ledger.infrastructure.schedule
+
+import com.openbank.ledger.application.port.`in`.AccountingDayUseCase
+import com.openbank.ledger.application.port.`in`.OpenAccountingDayCommand
+import com.openbank.ledger.application.port.`in`.TransitionAccountingDayCommand
+import com.openbank.ledger.application.port.out.AccountingDayRepository
+import com.openbank.ledger.application.port.out.TieOutRunRepository
+import com.openbank.ledger.domain.model.AccountingDayRecord
+import com.openbank.ledger.domain.model.AccountingDayStatus
+import com.openbank.ledger.domain.model.TieOutRunRecord
+import com.openbank.ledger.domain.model.TieOutRunStatus
+import com.openbank.libs.domain.calendar.AccountingClock
+import com.openbank.libs.observability.DomainMetrics
+import com.openbank.libs.testing.lock.NoOpClusterLock
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import jakarta.enterprise.inject.Instance
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneOffset
+import java.util.UUID
+
+/**
+ * Behaviour of the accounting-day reconciler (ADR-0207 increment 2) against a fixed clock.
+ *
+ * These tests call [AccountingDayScheduler.reconcile] directly, which supplies a coroutine
+ * context the real Quarkus scheduler does not — so they prove the RECONCILE LOGIC only, never
+ * that the cron dispatches (#2187's lesson). The dispatch half lives in
+ * LedgerSchedulerVertxContextIT, which shrinks the cron and waits for a scheduler-driven row.
+ */
+class AccountingDaySchedulerTest {
+
+    // 2026-08-07 10:00 Prague (08:00Z) — "today" for every test below is 2026-08-07.
+    private val fixedInstant = Instant.parse("2026-08-07T08:00:00Z")
+    private val accountingClock = AccountingClock.bank(Clock.fixed(fixedInstant, ZoneOffset.UTC))
+    private val today: LocalDate = LocalDate.of(2026, 8, 7)
+
+    private val dayRepository = mockk<AccountingDayRepository>()
+    private val tieOutRuns = mockk<TieOutRunRepository>()
+    private val useCase = mockk<AccountingDayUseCase>(relaxed = true)
+
+    private val scheduler = AccountingDayScheduler(
+        dayRepository,
+        tieOutRuns,
+        useCase,
+        accountingClock,
+        NoOpClusterLock(),
+        maxCatchUpDays = 7,
+        stuckCutoffHours = 8,
+    ).apply {
+        domainMetrics = noOpDomainMetrics()
+        meterRegistry = SimpleMeterRegistry()
+    }
+
+    private fun noOpDomainMetrics(): DomainMetrics {
+        val instance = mockk<Instance<MeterRegistry>>()
+        every { instance.isResolvable } returns false
+        return DomainMetrics().apply { registryInstance = instance }
+    }
+
+    private fun day(date: LocalDate, status: AccountingDayStatus, cutoffAt: Instant? = null) = AccountingDayRecord(
+        id = UUID.randomUUID(),
+        businessDate = date,
+        status = status,
+        openedAt = Instant.parse("2026-08-06T23:00:00Z"),
+        openedBy = "system:accounting-day-scheduler",
+        cutoffAt = cutoffAt,
+        version = if (status == AccountingDayStatus.OPEN) 0 else 1,
+    )
+
+    private fun tieOutRun(asOf: LocalDate, status: TieOutRunStatus, runAt: Instant) = TieOutRunRecord(
+        id = UUID.randomUUID(),
+        asOf = asOf,
+        runAt = runAt,
+        status = status,
+        accountsChecked = 4,
+        breaks = if (status == TieOutRunStatus.BREAK) 1 else 0,
+        errors = if (status == TieOutRunStatus.ERROR) 1 else 0,
+    )
+
+    private fun noDaysInAnyStatus() {
+        coEvery { dayRepository.findInStatus(any()) } returns emptyList()
+    }
+
+    @Test
+    fun `first tick ever opens only the current accounting day`() = runBlocking {
+        coEvery { dayRepository.findLatest() } returns null
+        noDaysInAnyStatus()
+
+        scheduler.reconcile()
+
+        coVerify(exactly = 1) { useCase.open(OpenAccountingDayCommand(today, "system:accounting-day-scheduler")) }
+        coVerify(exactly = 0) { useCase.transition(any()) }
+    }
+
+    @Test
+    fun `gap since the latest known day is opened oldest first and bounded`() = runBlocking {
+        // Latest row is 12 days back — only the OLDEST 7 of the missing days open this tick, so
+        // a long outage heals forward instead of stranding the oldest gap (TieOutScheduler shape).
+        coEvery { dayRepository.findLatest() } returns day(today.minusDays(12), AccountingDayStatus.TIED_OUT)
+        noDaysInAnyStatus()
+
+        scheduler.reconcile()
+
+        val expected = (11 downTo 5).map { today.minusDays(it.toLong()) }
+        expected.forEach { date ->
+            coVerify(exactly = 1) {
+                useCase.open(OpenAccountingDayCommand(date, "system:accounting-day-scheduler"))
+            }
+        }
+        coVerify(exactly = 0) { useCase.open(OpenAccountingDayCommand(today, "system:accounting-day-scheduler")) }
+    }
+
+    @Test
+    fun `open day the clock moved past goes to CUTOFF and today stays OPEN`() = runBlocking {
+        coEvery { dayRepository.findLatest() } returns day(today, AccountingDayStatus.OPEN)
+        coEvery { dayRepository.findInStatus(AccountingDayStatus.OPEN) } returns listOf(
+            day(today.minusDays(1), AccountingDayStatus.OPEN),
+            day(today, AccountingDayStatus.OPEN),
+        )
+        coEvery { dayRepository.findInStatus(AccountingDayStatus.CUTOFF) } returns emptyList()
+
+        scheduler.reconcile()
+
+        coVerify(exactly = 1) {
+            useCase.transition(
+                TransitionAccountingDayCommand(
+                    today.minusDays(1),
+                    AccountingDayStatus.CUTOFF,
+                    "system:accounting-day-scheduler",
+                ),
+            )
+        }
+        coVerify(exactly = 0) {
+            useCase.transition(match { it.businessDate == today })
+        }
+    }
+
+    @Test
+    fun `CUTOFF day with an OK tie-out after its cutoff is tied out`() = runBlocking {
+        val yesterday = today.minusDays(1)
+        val cutoffAt = Instant.parse("2026-08-06T22:05:00Z")
+        coEvery { dayRepository.findLatest() } returns day(today, AccountingDayStatus.OPEN)
+        coEvery { dayRepository.findInStatus(AccountingDayStatus.OPEN) } returns emptyList()
+        coEvery { dayRepository.findInStatus(AccountingDayStatus.CUTOFF) } returns listOf(
+            day(yesterday, AccountingDayStatus.CUTOFF, cutoffAt = cutoffAt),
+        )
+        coEvery { tieOutRuns.findLatestFor(yesterday) } returns
+            tieOutRun(yesterday, TieOutRunStatus.OK, runAt = Instant.parse("2026-08-07T04:00:00Z"))
+
+        scheduler.reconcile()
+
+        coVerify(exactly = 1) {
+            useCase.transition(
+                TransitionAccountingDayCommand(
+                    yesterday,
+                    AccountingDayStatus.TIED_OUT,
+                    "system:accounting-day-scheduler",
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun `CUTOFF day stays put on a BREAK verdict and on a pre-cutoff OK`() = runBlocking {
+        val d1 = today.minusDays(2)
+        val d2 = today.minusDays(1)
+        val cutoffAt = Instant.parse("2026-08-06T22:05:00Z")
+        coEvery { dayRepository.findLatest() } returns day(today, AccountingDayStatus.OPEN)
+        coEvery { dayRepository.findInStatus(AccountingDayStatus.OPEN) } returns emptyList()
+        coEvery { dayRepository.findInStatus(AccountingDayStatus.CUTOFF) } returns listOf(
+            day(d1, AccountingDayStatus.CUTOFF, cutoffAt = cutoffAt),
+            day(d2, AccountingDayStatus.CUTOFF, cutoffAt = cutoffAt),
+        )
+        // d1: latest verdict is BREAK. d2: OK, but recorded BEFORE the cutoff — a verdict from
+        // while the day could still change proves nothing about its final figures.
+        coEvery { tieOutRuns.findLatestFor(d1) } returns
+            tieOutRun(d1, TieOutRunStatus.BREAK, runAt = Instant.parse("2026-08-07T04:00:00Z"))
+        coEvery { tieOutRuns.findLatestFor(d2) } returns
+            tieOutRun(d2, TieOutRunStatus.OK, runAt = Instant.parse("2026-08-06T04:00:00Z"))
+
+        scheduler.reconcile()
+
+        coVerify(exactly = 0) { useCase.transition(any()) }
+    }
+
+    @Test
+    fun `stuck gauge counts only CUTOFF days over the threshold`(): Unit = runBlocking {
+        val registry = SimpleMeterRegistry()
+        scheduler.meterRegistry = registry
+        scheduler.onStart(mockk(relaxed = true))
+
+        val freshCutoff = fixedInstant.minus(Duration.ofHours(2))
+        val staleCutoff = fixedInstant.minus(Duration.ofHours(9))
+        coEvery { dayRepository.findLatest() } returns day(today, AccountingDayStatus.OPEN)
+        coEvery { dayRepository.findInStatus(AccountingDayStatus.OPEN) } returns emptyList()
+        coEvery { dayRepository.findInStatus(AccountingDayStatus.CUTOFF) } returns listOf(
+            day(today.minusDays(1), AccountingDayStatus.CUTOFF, cutoffAt = freshCutoff),
+            day(today.minusDays(2), AccountingDayStatus.CUTOFF, cutoffAt = staleCutoff),
+        )
+        coEvery { tieOutRuns.findLatestFor(any()) } returns null
+
+        scheduler.reconcile()
+
+        val gauge = registry.find("openbank.ledger.accounting_day.stuck_cutoff_days").gauge()
+        assertThat(gauge).isNotNull
+        assertThat(gauge!!.value()).isEqualTo(1.0)
+    }
+
+    @Test
+    fun `one failing day does not stop the rest of the tick`() = runBlocking {
+        val d1 = today.minusDays(2)
+        val d2 = today.minusDays(1)
+        coEvery { dayRepository.findLatest() } returns day(today, AccountingDayStatus.OPEN)
+        coEvery { dayRepository.findInStatus(AccountingDayStatus.OPEN) } returns listOf(
+            day(d1, AccountingDayStatus.OPEN),
+            day(d2, AccountingDayStatus.OPEN),
+        )
+        coEvery { dayRepository.findInStatus(AccountingDayStatus.CUTOFF) } returns emptyList()
+        coEvery {
+            useCase.transition(match { it.businessDate == d1 })
+        } throws IllegalStateException("concurrent transition")
+
+        scheduler.reconcile()
+
+        // d1 failed; d2 still transitioned.
+        coVerify(exactly = 1) {
+            useCase.transition(
+                TransitionAccountingDayCommand(d2, AccountingDayStatus.CUTOFF, "system:accounting-day-scheduler"),
+            )
+        }
+    }
+}

--- a/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/infrastructure/schedule/AccountingDaySchedulerTest.kt
+++ b/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/infrastructure/schedule/AccountingDaySchedulerTest.kt
@@ -96,7 +96,7 @@ class AccountingDaySchedulerTest {
     }
 
     @Test
-    fun `first tick ever opens only the current accounting day`() = runBlocking {
+    fun `first tick ever opens only the current accounting day`(): Unit = runBlocking {
         coEvery { dayRepository.findLatest() } returns null
         noDaysInAnyStatus()
 
@@ -107,7 +107,7 @@ class AccountingDaySchedulerTest {
     }
 
     @Test
-    fun `gap since the latest known day is opened oldest first and bounded`() = runBlocking {
+    fun `gap since the latest known day is opened oldest first and bounded`(): Unit = runBlocking {
         // Latest row is 12 days back — only the OLDEST 7 of the missing days open this tick, so
         // a long outage heals forward instead of stranding the oldest gap (TieOutScheduler shape).
         coEvery { dayRepository.findLatest() } returns day(today.minusDays(12), AccountingDayStatus.TIED_OUT)
@@ -125,7 +125,7 @@ class AccountingDaySchedulerTest {
     }
 
     @Test
-    fun `open day the clock moved past goes to CUTOFF and today stays OPEN`() = runBlocking {
+    fun `open day the clock moved past goes to CUTOFF and today stays OPEN`(): Unit = runBlocking {
         coEvery { dayRepository.findLatest() } returns day(today, AccountingDayStatus.OPEN)
         coEvery { dayRepository.findInStatus(AccountingDayStatus.OPEN) } returns listOf(
             day(today.minusDays(1), AccountingDayStatus.OPEN),
@@ -150,7 +150,7 @@ class AccountingDaySchedulerTest {
     }
 
     @Test
-    fun `CUTOFF day with an OK tie-out after its cutoff is tied out`() = runBlocking {
+    fun `CUTOFF day with an OK tie-out after its cutoff is tied out`(): Unit = runBlocking {
         val yesterday = today.minusDays(1)
         val cutoffAt = Instant.parse("2026-08-06T22:05:00Z")
         coEvery { dayRepository.findLatest() } returns day(today, AccountingDayStatus.OPEN)
@@ -175,7 +175,7 @@ class AccountingDaySchedulerTest {
     }
 
     @Test
-    fun `CUTOFF day stays put on a BREAK verdict and on a pre-cutoff OK`() = runBlocking {
+    fun `CUTOFF day stays put on a BREAK verdict and on a pre-cutoff OK`(): Unit = runBlocking {
         val d1 = today.minusDays(2)
         val d2 = today.minusDays(1)
         val cutoffAt = Instant.parse("2026-08-06T22:05:00Z")
@@ -221,7 +221,7 @@ class AccountingDaySchedulerTest {
     }
 
     @Test
-    fun `one failing day does not stop the rest of the tick`() = runBlocking {
+    fun `one failing day does not stop the rest of the tick`(): Unit = runBlocking {
         val d1 = today.minusDays(2)
         val d2 = today.minusDays(1)
         coEvery { dayRepository.findLatest() } returns day(today, AccountingDayStatus.OPEN)

--- a/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/integration/LedgerSchedulerVertxContextIT.kt
+++ b/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/integration/LedgerSchedulerVertxContextIT.kt
@@ -6,8 +6,10 @@ package com.openbank.ledger.integration
 import com.openbank.ledger.application.port.`in`.FxRevaluationResult
 import com.openbank.ledger.application.port.`in`.FxRevaluationUseCase
 import com.openbank.ledger.application.port.`in`.RevalueFxCommand
+import com.openbank.ledger.application.port.out.AccountingDayRepository
 import com.openbank.ledger.application.port.out.TieOutRunRepository
 import com.openbank.ledger.it.PostgresTestResource
+import com.openbank.libs.domain.calendar.AccountingClock
 import io.quarkus.test.common.QuarkusTestResource
 import io.quarkus.test.junit.QuarkusTest
 import io.quarkus.test.junit.QuarkusTestProfile
@@ -67,6 +69,7 @@ class LedgerSchedulerVertxContextIT {
             "quarkus.scheduler.enabled" to "true",
             "openbank.ledger.tieout.cron" to "*/2 * * * * ?",
             "openbank.ledger.fx-revaluation.cron" to "*/2 * * * * ?",
+            "openbank.ledger.accounting-day.cron" to "*/2 * * * * ?",
             "openbank.outbox.dispatch-enabled" to "false",
         )
 
@@ -91,6 +94,12 @@ class LedgerSchedulerVertxContextIT {
     @Inject
     lateinit var tieOutRuns: TieOutRunRepository
 
+    @Inject
+    lateinit var accountingDays: AccountingDayRepository
+
+    @Inject
+    lateinit var accountingClock: AccountingClock
+
     private fun <T> onEventLoop(block: suspend () -> T): T =
         VertxContextSupport.subscribeAndAwait { uni(CoroutineScope(Dispatchers.Unconfined)) { block() } }
 
@@ -112,6 +121,23 @@ class LedgerSchedulerVertxContextIT {
             .describedAs(
                 "a scheduler-dispatched tie-out must record a run — never recording one means the " +
                     "sweep threw HR000068 off the Vert.x context before the first query (#2187)",
+            )
+            .isTrue()
+    }
+
+    @Test
+    fun `the scheduled accounting-day reconcile opens the current day`() {
+        val opened = await {
+            onEventLoop { accountingDays.findByDate(accountingClock.today()) } != null
+        }
+
+        assertThat(opened)
+            .describedAs(
+                "a scheduler-dispatched reconcile must open the current accounting day — the " +
+                    "cluster lock it acquires first is a reactive Panache transaction, and off " +
+                    "the Vert.x context it would throw HR000068 before the first query (#2187); " +
+                    "measured live 2026-08-07: with nothing opening days, ledger_accounting_day " +
+                    "had zero rows and the ADR-0207 day lock measured nothing",
             )
             .isTrue()
     }


### PR DESCRIPTION
## What

ADR-0207 increment 2 — the two enforcement preconditions the ADR named and deferred:

1. **`AccountingDayScheduler`** — reconciles the persisted `ledger_accounting_day` calendar toward the `AccountingClock` every 15 min (cluster-locked, `suspend` per #2187):
   - opens the current accounting day; backfills gaps since the latest known row oldest-first, bounded per tick (pre-scheduler history is deliberately **not** fabricated — the day lock treats a rowless day as not-refusable, which is right for days that predate the calendar);
   - `OPEN → CUTOFF` for days the clock has moved past;
   - `CUTOFF → TIED_OUT` only on a tie-out verdict that is **OK and recorded after the cutoff** — a verdict from while the day could still change proves nothing about its final figures;
   - `TIED_OUT → LOCKED` stays operator-driven (statement/period-close territory).
2. **Stuck-CUTOFF detection** — gauge `openbank_ledger_accounting_day_stuck_cutoff_days` re-published every tick + `AccountingDayStuckInCutoff` PrometheusRule (warning; normal residence ~6h, threshold 8h, `for: 30m` outlasts the boot-zero window).

## Why now (measured, not assumed)

Live cluster 2026-08-07: `ledger_accounting_day` had **0 rows** while 49 postings flowed in the last 7 days; the shadow counter shows `outcome="no_day_record"` only. So `would_refuse` — the evidence gate ADR-0207 sets for flipping `day-lock.mode` to `enforce` — could structurally never fire. A lock whose calendar nobody maintains measures nothing; this PR is what makes the enforce flip an evidence-backed step instead of a leap.

## Tests

- `AccountingDaySchedulerTest` — 7 unit tests, fixed clock: first-tick behaviour, bounded oldest-first backfill, cutover skips today, TIED_OUT requires OK-after-cutoff (BREAK and pre-cutoff OK both refused), stuck gauge counts only over-threshold days, per-day failure containment.
- `LedgerSchedulerVertxContextIT` — third cron added to the real-dispatch profile: a *scheduler-dispatched* reconcile opens the current day against real Postgres (#2187 class of defect is invisible to direct-call tests).
- Local gate: `ktlintCheck detekt koverVerify quarkusBuild` + `run-gates.py --only accounting-clock-gate|no-runblocking-in-a-scheduled-body|scheduled-trigger-emitted|duplicate-yaml-key-guard|yamllint|gitops-duplicate-resources|threat-model-coverage` all PASS; 286 ledger tests, 0 failures (read from JUnit XML).

## What this is not

- Not the enforce flip. That is the follow-up once the counter has been read over at least one full day cycle with the calendar live.
- No API change (`openapi.yaml` untouched — no new REST surface; the operator API from increment 1 is unchanged).
- No new Flyway migration (V21 table reused).

Refs #1302

🤖 Generated with [Claude Code](https://claude.com/claude-code)
