### PR TITLE
docs(governance): capture ADR-registry regen/commit ordering and renumber footguns

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -851,6 +851,16 @@ Rationale + what does *not* cover it: `rules.yaml: dependencies.pr_time_cve_gate
   squash delta; 2-dot includes main's post-divergence commits and makes stale branches look like
   regressions.
 
+### ADR registry
+- **Order is `gen-index.sh` → COMMIT → `check-adr-registry.sh`, never regen → check → commit.** A
+  failing check restores the three derived files (`README.md`, `DIGEST.md`, `index.json`) to HEAD
+  on exit, so committing after a failed check commits the *restored* content — and the next regen
+  then disagrees with what you committed, failing the gate on content you never wrote (#3983).
+- **`git mv` + a follow-up edit = a PURE RENAME commit — the edit stays unstaged.** When
+  renumbering an ADR after a number collision with main, `git mv` the file, edit the H1, `git add`
+  the file AGAIN, then commit — or the registry gate fails with "H1 says number N but filename is
+  M" on a file that looks correct in your working tree (#3983).
+
 ### gh CLI
 - **Always write a PR/issue body to a file and pass `--body-file`. Never `--body` with an
   inline string.** Not "when it contains backticks" — *always*, because you decide the flag


### PR DESCRIPTION
## Summary

Two knowledge-capture bullets for the ADR-registry workflow, both measured live on PR #3983 today: (1) a failing `check-adr-registry.sh` restores the three derived files to HEAD, so the safe order is regen → commit → check; (2) `git mv` + a follow-up edit produces a pure-rename commit with the edit left unstaged — renumbering an ADR needs a second `git add`.

## Type of change

- [x] docs

## Linked issues

N/A — knowledge-capture bullets per `rules.yaml: knowledge_capture` (operational footguns, no actionable backlog item).

## Changes

- `CLAUDE.md` — new `### ADR registry` subsection with the two bullets.

## Definition of Done

- [x] Docs updated (this IS the docs update).

## Security checklist

- [x] No secrets, tokens, passwords, or PII.
