### PR TITLE
fix(governance): regenerate OPA bundles and EU AI Act inventory after agents.yaml change (#3771)

### DIFF
--- a/docs/compliance/eu-ai-act.md
+++ b/docs/compliance/eu-ai-act.md
@@ -41,6 +41,7 @@ it can move past *Proposed*.
 | `docs-truth-agent` | control | Limited / minimal risk | — | produces proposals only; a human dispositions every effect (not autonomous decision-making on a natural person). |
 | `authz-policy-auditor` | control | Limited / minimal risk | — | produces proposals only; a human dispositions every effect (not autonomous decision-making on a natural person). |
 | `flaky-test-hunter` | development | Limited / minimal risk | — | produces proposals only; a human dispositions every effect (not autonomous decision-making on a natural person). |
+| `case-coordinator` | control | Limited / minimal risk | — | produces proposals only; a human dispositions every effect (not autonomous decision-making on a natural person). |
 
 ### Non-agent ML and statistical systems
 
@@ -107,7 +108,7 @@ not deployed.
 
 ## Provenance
 
-- Source: `openbank-libs/governance/agents.yaml` (sha256 `7feff1674a83d5ea…`, 15 charters)
+- Source: `openbank-libs/governance/agents.yaml` (sha256 `bfc4b4639efd5846…`, 16 charters)
 - Source: `openbank-libs/governance/ml-systems.yaml` (sha256 `9cd5cb5b20918520…`, 4 non-agent systems)
 - Related: ADR-0031 (agent governance), ADR-0084 (fraud scoring plane), ADR-0139/0140
   (ML decisioning platform), ADR-0141 (model registry), ADR-0142 (credit decisioning),

--- a/openbank-admin-ui/ai-governance-snapshot.json
+++ b/openbank-admin-ui/ai-governance-snapshot.json
@@ -142,8 +142,8 @@
   "facts": {
     "agentCharters": {
       "source": "openbank-libs/governance/agents.yaml",
-      "sha256": "7feff1674a83d5ea",
-      "count": 15,
+      "sha256": "bfc4b4639efd5846",
+      "count": 16,
       "ids": [
         "compliance-officer",
         "ledger-domain-engineer",
@@ -159,10 +159,11 @@
         "release-steward",
         "docs-truth-agent",
         "authz-policy-auditor",
-        "flaky-test-hunter"
+        "flaky-test-hunter",
+        "case-coordinator"
       ],
       "byPlane": {
-        "control": 10,
+        "control": 11,
         "development": 2,
         "customer": 3
       },
@@ -173,11 +174,11 @@
     },
     "promptRegistryCoverage": {
       "source": "openbank-libs/governance/prompts/registry.yaml",
-      "sha256": "7b03a0fa5c08758f",
+      "sha256": "48f2f75ee17aa764",
       "counts": {
         "external": 2,
         "not-applicable": 2,
-        "pending": 1,
+        "pending": 2,
         "registered": 10
       },
       "idsByStatus": {
@@ -190,7 +191,8 @@
           "ap2-anonymous"
         ],
         "pending": [
-          "authz-policy-auditor"
+          "authz-policy-auditor",
+          "case-coordinator"
         ],
         "registered": [
           "compliance-officer",

--- a/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: account-service
     app.kubernetes.io/part-of: accounts
   annotations:
-    openbank.tech/policy-checksum: "e65546f15e22f41c"
+    openbank.tech/policy-checksum: "bb5f1cb65aa5c2c3"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -948,10 +948,58 @@ data:
         - secrets.read.raw
 
     # ---------------------------------------------------------------------------------------
+    # Case classes for agent swarm coordination (ADR-0244). A case is one long-running
+    # Temporal workflow opened for a single disposition target. Default budgets and
+    # convergence thresholds live here; per-class overrides are merged over default.
+    # Every case names exactly one class. The case-coordinator charter owns convergence
+    # judgement and budget enforcement; other charters may be granted case.join (and later
+    # case.contribute) once the signal-handling wiring lands.
+    # ---------------------------------------------------------------------------------------
+    case_classes:
+      default:
+        budget:
+          tokens_per_case: 500000
+          max_contributions: 100
+          wall_clock_minutes: 60
+        concurrency:
+          max_open_cases: 10
+        convergence:
+          contested_rate_threshold: 0.30   # suspend case-open for this class above 30% contested
+      classes:
+        fraud-investigation:
+          budget:
+            tokens_per_case: 1000000
+            max_contributions: 200
+            wall_clock_minutes: 120
+          concurrency:
+            max_open_cases: 5
+          convergence:
+            contested_rate_threshold: 0.25
+        aml-alert:
+          budget:
+            tokens_per_case: 300000
+            max_contributions: 50
+            wall_clock_minutes: 30
+          concurrency:
+            max_open_cases: 20
+          convergence:
+            contested_rate_threshold: 0.40
+        incident-response:
+          budget:
+            tokens_per_case: 200000
+            max_contributions: 40
+            wall_clock_minutes: 20
+          concurrency:
+            max_open_cases: 15
+          convergence:
+            contested_rate_threshold: 0.35
+
+    # ---------------------------------------------------------------------------------------
     # Agents. plane = control (oversight, proposal-only) | development (per-domain engineering)
     #                | customer (customer-facing assistant, ADR-0089 — its own SCA-gated regime).
     # Each charter answers: data_scope (what it reads), tools (what it calls), requires_human
-    # (what must be approved), limits (budget/quota).
+    # (what must be approved), limits (budget/quota). Swarm participants additionally declare
+    # case_capabilities (ADR-0244).
     # ---------------------------------------------------------------------------------------
     agents:
 
@@ -1553,6 +1601,67 @@ data:
         compliance:
           eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
           dora: "Art. 9 ICT risk detection; Art. 5 ICT risk management framework — fleet-wide static verification that a test suite's reported green state reflects tests that actually ran"
+
+      - id: case-coordinator
+        plane: control
+        charter: "ADR-0244"
+        description: >
+          Owns a running Temporal case workflow: invites chartered agents to contribute,
+          enforces the per-case-class budget and deadline, judges convergence, and emits
+          exactly one HITL proposal per case. Every swarm is bounded to one disposition
+          target; pre-emption is deterministic and replay-safe. The coordinator never
+          coordinates a case it opened; who detected is never who converged.
+        enabled: true
+        enforcement: block
+        data_scope:
+          read:
+            - case-workflow-history       # Temporal workflow history of cases it coordinates
+            - agent-proposals-readonly    # existing proposal queue metadata (no raw payload)
+            - read.governance             # agents.yaml case classes and charter capabilities
+          pii: masked
+        tools:
+          allow:
+            - tier: read
+              resources: [case-workflow, governance]
+            - tier: write_proposal
+              resources: [agent-proposal]   # emits one HITL proposal per case
+            - tier: execute
+              resources: [case-workflow-signal]  # sends deterministic pre-emption / convergence signals
+          deny:
+            - tier: write
+              resources: ["*"]             # never writes to a business record directly
+            - tier: execute
+              resources: [money.*, gh.pr.*, secrets.*]
+        case_capabilities:
+          # The coordinator is the only charter that may open, coordinate, and synthesize a case.
+          # Other agents may be granted case.join (and later case.contribute) in their own charters.
+          - case.open
+          - case.coordinate
+          - case.synthesize
+          - case.preempt
+        requires_human:
+          - every: proposal               # every synthesized proposal is a HITL proposal
+          - approver_must_differ_from: author
+          - record: reason
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 48                # one per active case hour is common; cap prevents runaway
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - case_id
+            - disposition_target
+            - case_class
+            - contributions_received
+            - synthesis_cited_contribution_ids
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, human disposes; not Annex III high-risk"
+          dora: "ICT change management (Art. 8–10); operational resilience via durable, bounded case coordination"
   rules-data.yaml: |
     # GENERATED by .github/scripts/gen-rules-opa-data.py — do not hand-edit.
     #

--- a/openbank-infra/gitops/components/accounts/account-service.yaml
+++ b/openbank-infra/gitops/components/accounts/account-service.yaml
@@ -37,7 +37,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-account-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "e65546f15e22f41c"
+        openbank.tech/policy-checksum: "bb5f1cb65aa5c2c3"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/agent/agent-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/agent/agent-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: agent-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "e0aa410ca8309da1"
+    openbank.tech/policy-checksum: "77e8a1da9b019d1d"
 data:
   agents.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -367,10 +367,58 @@ data:
         - secrets.read.raw
 
     # ---------------------------------------------------------------------------------------
+    # Case classes for agent swarm coordination (ADR-0244). A case is one long-running
+    # Temporal workflow opened for a single disposition target. Default budgets and
+    # convergence thresholds live here; per-class overrides are merged over default.
+    # Every case names exactly one class. The case-coordinator charter owns convergence
+    # judgement and budget enforcement; other charters may be granted case.join (and later
+    # case.contribute) once the signal-handling wiring lands.
+    # ---------------------------------------------------------------------------------------
+    case_classes:
+      default:
+        budget:
+          tokens_per_case: 500000
+          max_contributions: 100
+          wall_clock_minutes: 60
+        concurrency:
+          max_open_cases: 10
+        convergence:
+          contested_rate_threshold: 0.30   # suspend case-open for this class above 30% contested
+      classes:
+        fraud-investigation:
+          budget:
+            tokens_per_case: 1000000
+            max_contributions: 200
+            wall_clock_minutes: 120
+          concurrency:
+            max_open_cases: 5
+          convergence:
+            contested_rate_threshold: 0.25
+        aml-alert:
+          budget:
+            tokens_per_case: 300000
+            max_contributions: 50
+            wall_clock_minutes: 30
+          concurrency:
+            max_open_cases: 20
+          convergence:
+            contested_rate_threshold: 0.40
+        incident-response:
+          budget:
+            tokens_per_case: 200000
+            max_contributions: 40
+            wall_clock_minutes: 20
+          concurrency:
+            max_open_cases: 15
+          convergence:
+            contested_rate_threshold: 0.35
+
+    # ---------------------------------------------------------------------------------------
     # Agents. plane = control (oversight, proposal-only) | development (per-domain engineering)
     #                | customer (customer-facing assistant, ADR-0089 — its own SCA-gated regime).
     # Each charter answers: data_scope (what it reads), tools (what it calls), requires_human
-    # (what must be approved), limits (budget/quota).
+    # (what must be approved), limits (budget/quota). Swarm participants additionally declare
+    # case_capabilities (ADR-0244).
     # ---------------------------------------------------------------------------------------
     agents:
 
@@ -972,5 +1020,66 @@ data:
         compliance:
           eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
           dora: "Art. 9 ICT risk detection; Art. 5 ICT risk management framework — fleet-wide static verification that a test suite's reported green state reflects tests that actually ran"
+
+      - id: case-coordinator
+        plane: control
+        charter: "ADR-0244"
+        description: >
+          Owns a running Temporal case workflow: invites chartered agents to contribute,
+          enforces the per-case-class budget and deadline, judges convergence, and emits
+          exactly one HITL proposal per case. Every swarm is bounded to one disposition
+          target; pre-emption is deterministic and replay-safe. The coordinator never
+          coordinates a case it opened; who detected is never who converged.
+        enabled: true
+        enforcement: block
+        data_scope:
+          read:
+            - case-workflow-history       # Temporal workflow history of cases it coordinates
+            - agent-proposals-readonly    # existing proposal queue metadata (no raw payload)
+            - read.governance             # agents.yaml case classes and charter capabilities
+          pii: masked
+        tools:
+          allow:
+            - tier: read
+              resources: [case-workflow, governance]
+            - tier: write_proposal
+              resources: [agent-proposal]   # emits one HITL proposal per case
+            - tier: execute
+              resources: [case-workflow-signal]  # sends deterministic pre-emption / convergence signals
+          deny:
+            - tier: write
+              resources: ["*"]             # never writes to a business record directly
+            - tier: execute
+              resources: [money.*, gh.pr.*, secrets.*]
+        case_capabilities:
+          # The coordinator is the only charter that may open, coordinate, and synthesize a case.
+          # Other agents may be granted case.join (and later case.contribute) in their own charters.
+          - case.open
+          - case.coordinate
+          - case.synthesize
+          - case.preempt
+        requires_human:
+          - every: proposal               # every synthesized proposal is a HITL proposal
+          - approver_must_differ_from: author
+          - record: reason
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 48                # one per active case hour is common; cap prevents runaway
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - case_id
+            - disposition_target
+            - case_class
+            - contributions_received
+            - synthesis_cited_contribution_ids
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, human disposes; not Annex III high-risk"
+          dora: "ICT change management (Art. 8–10); operational resilience via durable, bounded case coordination"
   manifest.json: |
     {"roots": ["openbank/agents", "openbank/copilot", "openbank/rest", "agents", "rules"]}

--- a/openbank-infra/gitops/components/agent/agent-service.yaml
+++ b/openbank-infra/gitops/components/agent/agent-service.yaml
@@ -43,7 +43,7 @@ spec:
       annotations:
         # Roll the pod when the OPA policy bundle changes (subPath mounts don't hot-reload).
         # Must match agent-opa-bundle's openbank.tech/policy-checksum (CI verifies, no drift).
-        openbank.tech/policy-checksum: "e0aa410ca8309da1"
+        openbank.tech/policy-checksum: "77e8a1da9b019d1d"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/aml/aml-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/aml/aml-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: aml-service
     app.kubernetes.io/part-of: aml
   annotations:
-    openbank.tech/policy-checksum: "2cd3972441cf6ac4"
+    openbank.tech/policy-checksum: "e1f32675cb5bb7cb"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -921,10 +921,58 @@ data:
         - secrets.read.raw
 
     # ---------------------------------------------------------------------------------------
+    # Case classes for agent swarm coordination (ADR-0244). A case is one long-running
+    # Temporal workflow opened for a single disposition target. Default budgets and
+    # convergence thresholds live here; per-class overrides are merged over default.
+    # Every case names exactly one class. The case-coordinator charter owns convergence
+    # judgement and budget enforcement; other charters may be granted case.join (and later
+    # case.contribute) once the signal-handling wiring lands.
+    # ---------------------------------------------------------------------------------------
+    case_classes:
+      default:
+        budget:
+          tokens_per_case: 500000
+          max_contributions: 100
+          wall_clock_minutes: 60
+        concurrency:
+          max_open_cases: 10
+        convergence:
+          contested_rate_threshold: 0.30   # suspend case-open for this class above 30% contested
+      classes:
+        fraud-investigation:
+          budget:
+            tokens_per_case: 1000000
+            max_contributions: 200
+            wall_clock_minutes: 120
+          concurrency:
+            max_open_cases: 5
+          convergence:
+            contested_rate_threshold: 0.25
+        aml-alert:
+          budget:
+            tokens_per_case: 300000
+            max_contributions: 50
+            wall_clock_minutes: 30
+          concurrency:
+            max_open_cases: 20
+          convergence:
+            contested_rate_threshold: 0.40
+        incident-response:
+          budget:
+            tokens_per_case: 200000
+            max_contributions: 40
+            wall_clock_minutes: 20
+          concurrency:
+            max_open_cases: 15
+          convergence:
+            contested_rate_threshold: 0.35
+
+    # ---------------------------------------------------------------------------------------
     # Agents. plane = control (oversight, proposal-only) | development (per-domain engineering)
     #                | customer (customer-facing assistant, ADR-0089 — its own SCA-gated regime).
     # Each charter answers: data_scope (what it reads), tools (what it calls), requires_human
-    # (what must be approved), limits (budget/quota).
+    # (what must be approved), limits (budget/quota). Swarm participants additionally declare
+    # case_capabilities (ADR-0244).
     # ---------------------------------------------------------------------------------------
     agents:
 
@@ -1526,6 +1574,67 @@ data:
         compliance:
           eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
           dora: "Art. 9 ICT risk detection; Art. 5 ICT risk management framework — fleet-wide static verification that a test suite's reported green state reflects tests that actually ran"
+
+      - id: case-coordinator
+        plane: control
+        charter: "ADR-0244"
+        description: >
+          Owns a running Temporal case workflow: invites chartered agents to contribute,
+          enforces the per-case-class budget and deadline, judges convergence, and emits
+          exactly one HITL proposal per case. Every swarm is bounded to one disposition
+          target; pre-emption is deterministic and replay-safe. The coordinator never
+          coordinates a case it opened; who detected is never who converged.
+        enabled: true
+        enforcement: block
+        data_scope:
+          read:
+            - case-workflow-history       # Temporal workflow history of cases it coordinates
+            - agent-proposals-readonly    # existing proposal queue metadata (no raw payload)
+            - read.governance             # agents.yaml case classes and charter capabilities
+          pii: masked
+        tools:
+          allow:
+            - tier: read
+              resources: [case-workflow, governance]
+            - tier: write_proposal
+              resources: [agent-proposal]   # emits one HITL proposal per case
+            - tier: execute
+              resources: [case-workflow-signal]  # sends deterministic pre-emption / convergence signals
+          deny:
+            - tier: write
+              resources: ["*"]             # never writes to a business record directly
+            - tier: execute
+              resources: [money.*, gh.pr.*, secrets.*]
+        case_capabilities:
+          # The coordinator is the only charter that may open, coordinate, and synthesize a case.
+          # Other agents may be granted case.join (and later case.contribute) in their own charters.
+          - case.open
+          - case.coordinate
+          - case.synthesize
+          - case.preempt
+        requires_human:
+          - every: proposal               # every synthesized proposal is a HITL proposal
+          - approver_must_differ_from: author
+          - record: reason
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 48                # one per active case hour is common; cap prevents runaway
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - case_id
+            - disposition_target
+            - case_class
+            - contributions_received
+            - synthesis_cited_contribution_ids
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, human disposes; not Annex III high-risk"
+          dora: "ICT change management (Art. 8–10); operational resilience via durable, bounded case coordination"
   rules-data.yaml: |
     # GENERATED by .github/scripts/gen-rules-opa-data.py — do not hand-edit.
     #

--- a/openbank-infra/gitops/components/aml/aml-service.yaml
+++ b/openbank-infra/gitops/components/aml/aml-service.yaml
@@ -31,7 +31,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-aml-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "2cd3972441cf6ac4"
+        openbank.tech/policy-checksum: "e1f32675cb5bb7cb"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: anacredit-service
     app.kubernetes.io/part-of: anacredit
   annotations:
-    openbank.tech/policy-checksum: "43fc19b11d0e8f93"
+    openbank.tech/policy-checksum: "be05f1daa4c0f1ae"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -891,10 +891,58 @@ data:
         - secrets.read.raw
 
     # ---------------------------------------------------------------------------------------
+    # Case classes for agent swarm coordination (ADR-0244). A case is one long-running
+    # Temporal workflow opened for a single disposition target. Default budgets and
+    # convergence thresholds live here; per-class overrides are merged over default.
+    # Every case names exactly one class. The case-coordinator charter owns convergence
+    # judgement and budget enforcement; other charters may be granted case.join (and later
+    # case.contribute) once the signal-handling wiring lands.
+    # ---------------------------------------------------------------------------------------
+    case_classes:
+      default:
+        budget:
+          tokens_per_case: 500000
+          max_contributions: 100
+          wall_clock_minutes: 60
+        concurrency:
+          max_open_cases: 10
+        convergence:
+          contested_rate_threshold: 0.30   # suspend case-open for this class above 30% contested
+      classes:
+        fraud-investigation:
+          budget:
+            tokens_per_case: 1000000
+            max_contributions: 200
+            wall_clock_minutes: 120
+          concurrency:
+            max_open_cases: 5
+          convergence:
+            contested_rate_threshold: 0.25
+        aml-alert:
+          budget:
+            tokens_per_case: 300000
+            max_contributions: 50
+            wall_clock_minutes: 30
+          concurrency:
+            max_open_cases: 20
+          convergence:
+            contested_rate_threshold: 0.40
+        incident-response:
+          budget:
+            tokens_per_case: 200000
+            max_contributions: 40
+            wall_clock_minutes: 20
+          concurrency:
+            max_open_cases: 15
+          convergence:
+            contested_rate_threshold: 0.35
+
+    # ---------------------------------------------------------------------------------------
     # Agents. plane = control (oversight, proposal-only) | development (per-domain engineering)
     #                | customer (customer-facing assistant, ADR-0089 — its own SCA-gated regime).
     # Each charter answers: data_scope (what it reads), tools (what it calls), requires_human
-    # (what must be approved), limits (budget/quota).
+    # (what must be approved), limits (budget/quota). Swarm participants additionally declare
+    # case_capabilities (ADR-0244).
     # ---------------------------------------------------------------------------------------
     agents:
 
@@ -1496,6 +1544,67 @@ data:
         compliance:
           eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
           dora: "Art. 9 ICT risk detection; Art. 5 ICT risk management framework — fleet-wide static verification that a test suite's reported green state reflects tests that actually ran"
+
+      - id: case-coordinator
+        plane: control
+        charter: "ADR-0244"
+        description: >
+          Owns a running Temporal case workflow: invites chartered agents to contribute,
+          enforces the per-case-class budget and deadline, judges convergence, and emits
+          exactly one HITL proposal per case. Every swarm is bounded to one disposition
+          target; pre-emption is deterministic and replay-safe. The coordinator never
+          coordinates a case it opened; who detected is never who converged.
+        enabled: true
+        enforcement: block
+        data_scope:
+          read:
+            - case-workflow-history       # Temporal workflow history of cases it coordinates
+            - agent-proposals-readonly    # existing proposal queue metadata (no raw payload)
+            - read.governance             # agents.yaml case classes and charter capabilities
+          pii: masked
+        tools:
+          allow:
+            - tier: read
+              resources: [case-workflow, governance]
+            - tier: write_proposal
+              resources: [agent-proposal]   # emits one HITL proposal per case
+            - tier: execute
+              resources: [case-workflow-signal]  # sends deterministic pre-emption / convergence signals
+          deny:
+            - tier: write
+              resources: ["*"]             # never writes to a business record directly
+            - tier: execute
+              resources: [money.*, gh.pr.*, secrets.*]
+        case_capabilities:
+          # The coordinator is the only charter that may open, coordinate, and synthesize a case.
+          # Other agents may be granted case.join (and later case.contribute) in their own charters.
+          - case.open
+          - case.coordinate
+          - case.synthesize
+          - case.preempt
+        requires_human:
+          - every: proposal               # every synthesized proposal is a HITL proposal
+          - approver_must_differ_from: author
+          - record: reason
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 48                # one per active case hour is common; cap prevents runaway
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - case_id
+            - disposition_target
+            - case_class
+            - contributions_received
+            - synthesis_cited_contribution_ids
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, human disposes; not Annex III high-risk"
+          dora: "ICT change management (Art. 8–10); operational resilience via durable, bounded case coordination"
   rules-data.yaml: |
     # GENERATED by .github/scripts/gen-rules-opa-data.py — do not hand-edit.
     #

--- a/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
@@ -42,7 +42,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-anacredit-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "43fc19b11d0e8f93"
+        openbank.tech/policy-checksum: "be05f1daa4c0f1ae"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/ap2/ap2-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/ap2/ap2-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: mcp-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "0b79e3d8d2adf22f"
+    openbank.tech/policy-checksum: "899d182785c99f54"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -859,10 +859,58 @@ data:
         - secrets.read.raw
 
     # ---------------------------------------------------------------------------------------
+    # Case classes for agent swarm coordination (ADR-0244). A case is one long-running
+    # Temporal workflow opened for a single disposition target. Default budgets and
+    # convergence thresholds live here; per-class overrides are merged over default.
+    # Every case names exactly one class. The case-coordinator charter owns convergence
+    # judgement and budget enforcement; other charters may be granted case.join (and later
+    # case.contribute) once the signal-handling wiring lands.
+    # ---------------------------------------------------------------------------------------
+    case_classes:
+      default:
+        budget:
+          tokens_per_case: 500000
+          max_contributions: 100
+          wall_clock_minutes: 60
+        concurrency:
+          max_open_cases: 10
+        convergence:
+          contested_rate_threshold: 0.30   # suspend case-open for this class above 30% contested
+      classes:
+        fraud-investigation:
+          budget:
+            tokens_per_case: 1000000
+            max_contributions: 200
+            wall_clock_minutes: 120
+          concurrency:
+            max_open_cases: 5
+          convergence:
+            contested_rate_threshold: 0.25
+        aml-alert:
+          budget:
+            tokens_per_case: 300000
+            max_contributions: 50
+            wall_clock_minutes: 30
+          concurrency:
+            max_open_cases: 20
+          convergence:
+            contested_rate_threshold: 0.40
+        incident-response:
+          budget:
+            tokens_per_case: 200000
+            max_contributions: 40
+            wall_clock_minutes: 20
+          concurrency:
+            max_open_cases: 15
+          convergence:
+            contested_rate_threshold: 0.35
+
+    # ---------------------------------------------------------------------------------------
     # Agents. plane = control (oversight, proposal-only) | development (per-domain engineering)
     #                | customer (customer-facing assistant, ADR-0089 — its own SCA-gated regime).
     # Each charter answers: data_scope (what it reads), tools (what it calls), requires_human
-    # (what must be approved), limits (budget/quota).
+    # (what must be approved), limits (budget/quota). Swarm participants additionally declare
+    # case_capabilities (ADR-0244).
     # ---------------------------------------------------------------------------------------
     agents:
 
@@ -1464,6 +1512,67 @@ data:
         compliance:
           eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
           dora: "Art. 9 ICT risk detection; Art. 5 ICT risk management framework — fleet-wide static verification that a test suite's reported green state reflects tests that actually ran"
+
+      - id: case-coordinator
+        plane: control
+        charter: "ADR-0244"
+        description: >
+          Owns a running Temporal case workflow: invites chartered agents to contribute,
+          enforces the per-case-class budget and deadline, judges convergence, and emits
+          exactly one HITL proposal per case. Every swarm is bounded to one disposition
+          target; pre-emption is deterministic and replay-safe. The coordinator never
+          coordinates a case it opened; who detected is never who converged.
+        enabled: true
+        enforcement: block
+        data_scope:
+          read:
+            - case-workflow-history       # Temporal workflow history of cases it coordinates
+            - agent-proposals-readonly    # existing proposal queue metadata (no raw payload)
+            - read.governance             # agents.yaml case classes and charter capabilities
+          pii: masked
+        tools:
+          allow:
+            - tier: read
+              resources: [case-workflow, governance]
+            - tier: write_proposal
+              resources: [agent-proposal]   # emits one HITL proposal per case
+            - tier: execute
+              resources: [case-workflow-signal]  # sends deterministic pre-emption / convergence signals
+          deny:
+            - tier: write
+              resources: ["*"]             # never writes to a business record directly
+            - tier: execute
+              resources: [money.*, gh.pr.*, secrets.*]
+        case_capabilities:
+          # The coordinator is the only charter that may open, coordinate, and synthesize a case.
+          # Other agents may be granted case.join (and later case.contribute) in their own charters.
+          - case.open
+          - case.coordinate
+          - case.synthesize
+          - case.preempt
+        requires_human:
+          - every: proposal               # every synthesized proposal is a HITL proposal
+          - approver_must_differ_from: author
+          - record: reason
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 48                # one per active case hour is common; cap prevents runaway
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - case_id
+            - disposition_target
+            - case_class
+            - contributions_received
+            - synthesis_cited_contribution_ids
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, human disposes; not Annex III high-risk"
+          dora: "ICT change management (Art. 8–10); operational resilience via durable, bounded case coordination"
   rules-data.yaml: |
     # GENERATED by .github/scripts/gen-rules-opa-data.py — do not hand-edit.
     #

--- a/openbank-infra/gitops/components/ap2/ap2-service.yaml
+++ b/openbank-infra/gitops/components/ap2/ap2-service.yaml
@@ -39,7 +39,7 @@ spec:
       annotations:
         # Roll the pod when the OPA policy bundle changes (subPath mounts don't hot-reload).
         # Kept in sync by gen-ap2-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "0b79e3d8d2adf22f"
+        openbank.tech/policy-checksum: "899d182785c99f54"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/audit/audit-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/audit/audit-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: audit-service
     app.kubernetes.io/part-of: audit
   annotations:
-    openbank.tech/policy-checksum: "c1615f52b1a4df07"
+    openbank.tech/policy-checksum: "84abf3ec069e414f"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -903,10 +903,58 @@ data:
         - secrets.read.raw
 
     # ---------------------------------------------------------------------------------------
+    # Case classes for agent swarm coordination (ADR-0244). A case is one long-running
+    # Temporal workflow opened for a single disposition target. Default budgets and
+    # convergence thresholds live here; per-class overrides are merged over default.
+    # Every case names exactly one class. The case-coordinator charter owns convergence
+    # judgement and budget enforcement; other charters may be granted case.join (and later
+    # case.contribute) once the signal-handling wiring lands.
+    # ---------------------------------------------------------------------------------------
+    case_classes:
+      default:
+        budget:
+          tokens_per_case: 500000
+          max_contributions: 100
+          wall_clock_minutes: 60
+        concurrency:
+          max_open_cases: 10
+        convergence:
+          contested_rate_threshold: 0.30   # suspend case-open for this class above 30% contested
+      classes:
+        fraud-investigation:
+          budget:
+            tokens_per_case: 1000000
+            max_contributions: 200
+            wall_clock_minutes: 120
+          concurrency:
+            max_open_cases: 5
+          convergence:
+            contested_rate_threshold: 0.25
+        aml-alert:
+          budget:
+            tokens_per_case: 300000
+            max_contributions: 50
+            wall_clock_minutes: 30
+          concurrency:
+            max_open_cases: 20
+          convergence:
+            contested_rate_threshold: 0.40
+        incident-response:
+          budget:
+            tokens_per_case: 200000
+            max_contributions: 40
+            wall_clock_minutes: 20
+          concurrency:
+            max_open_cases: 15
+          convergence:
+            contested_rate_threshold: 0.35
+
+    # ---------------------------------------------------------------------------------------
     # Agents. plane = control (oversight, proposal-only) | development (per-domain engineering)
     #                | customer (customer-facing assistant, ADR-0089 — its own SCA-gated regime).
     # Each charter answers: data_scope (what it reads), tools (what it calls), requires_human
-    # (what must be approved), limits (budget/quota).
+    # (what must be approved), limits (budget/quota). Swarm participants additionally declare
+    # case_capabilities (ADR-0244).
     # ---------------------------------------------------------------------------------------
     agents:
 
@@ -1508,6 +1556,67 @@ data:
         compliance:
           eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
           dora: "Art. 9 ICT risk detection; Art. 5 ICT risk management framework — fleet-wide static verification that a test suite's reported green state reflects tests that actually ran"
+
+      - id: case-coordinator
+        plane: control
+        charter: "ADR-0244"
+        description: >
+          Owns a running Temporal case workflow: invites chartered agents to contribute,
+          enforces the per-case-class budget and deadline, judges convergence, and emits
+          exactly one HITL proposal per case. Every swarm is bounded to one disposition
+          target; pre-emption is deterministic and replay-safe. The coordinator never
+          coordinates a case it opened; who detected is never who converged.
+        enabled: true
+        enforcement: block
+        data_scope:
+          read:
+            - case-workflow-history       # Temporal workflow history of cases it coordinates
+            - agent-proposals-readonly    # existing proposal queue metadata (no raw payload)
+            - read.governance             # agents.yaml case classes and charter capabilities
+          pii: masked
+        tools:
+          allow:
+            - tier: read
+              resources: [case-workflow, governance]
+            - tier: write_proposal
+              resources: [agent-proposal]   # emits one HITL proposal per case
+            - tier: execute
+              resources: [case-workflow-signal]  # sends deterministic pre-emption / convergence signals
+          deny:
+            - tier: write
+              resources: ["*"]             # never writes to a business record directly
+            - tier: execute
+              resources: [money.*, gh.pr.*, secrets.*]
+        case_capabilities:
+          # The coordinator is the only charter that may open, coordinate, and synthesize a case.
+          # Other agents may be granted case.join (and later case.contribute) in their own charters.
+          - case.open
+          - case.coordinate
+          - case.synthesize
+          - case.preempt
+        requires_human:
+          - every: proposal               # every synthesized proposal is a HITL proposal
+          - approver_must_differ_from: author
+          - record: reason
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 48                # one per active case hour is common; cap prevents runaway
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - case_id
+            - disposition_target
+            - case_class
+            - contributions_received
+            - synthesis_cited_contribution_ids
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, human disposes; not Annex III high-risk"
+          dora: "ICT change management (Art. 8–10); operational resilience via durable, bounded case coordination"
   rules-data.yaml: |
     # GENERATED by .github/scripts/gen-rules-opa-data.py — do not hand-edit.
     #

--- a/openbank-infra/gitops/components/audit/audit-service.yaml
+++ b/openbank-infra/gitops/components/audit/audit-service.yaml
@@ -31,7 +31,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-audit-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "c1615f52b1a4df07"
+        openbank.tech/policy-checksum: "84abf3ec069e414f"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: balance-service
     app.kubernetes.io/part-of: balances
   annotations:
-    openbank.tech/policy-checksum: "fb5d9843a6695b09"
+    openbank.tech/policy-checksum: "9ff0513a6a20c9c0"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -992,10 +992,58 @@ data:
         - secrets.read.raw
 
     # ---------------------------------------------------------------------------------------
+    # Case classes for agent swarm coordination (ADR-0244). A case is one long-running
+    # Temporal workflow opened for a single disposition target. Default budgets and
+    # convergence thresholds live here; per-class overrides are merged over default.
+    # Every case names exactly one class. The case-coordinator charter owns convergence
+    # judgement and budget enforcement; other charters may be granted case.join (and later
+    # case.contribute) once the signal-handling wiring lands.
+    # ---------------------------------------------------------------------------------------
+    case_classes:
+      default:
+        budget:
+          tokens_per_case: 500000
+          max_contributions: 100
+          wall_clock_minutes: 60
+        concurrency:
+          max_open_cases: 10
+        convergence:
+          contested_rate_threshold: 0.30   # suspend case-open for this class above 30% contested
+      classes:
+        fraud-investigation:
+          budget:
+            tokens_per_case: 1000000
+            max_contributions: 200
+            wall_clock_minutes: 120
+          concurrency:
+            max_open_cases: 5
+          convergence:
+            contested_rate_threshold: 0.25
+        aml-alert:
+          budget:
+            tokens_per_case: 300000
+            max_contributions: 50
+            wall_clock_minutes: 30
+          concurrency:
+            max_open_cases: 20
+          convergence:
+            contested_rate_threshold: 0.40
+        incident-response:
+          budget:
+            tokens_per_case: 200000
+            max_contributions: 40
+            wall_clock_minutes: 20
+          concurrency:
+            max_open_cases: 15
+          convergence:
+            contested_rate_threshold: 0.35
+
+    # ---------------------------------------------------------------------------------------
     # Agents. plane = control (oversight, proposal-only) | development (per-domain engineering)
     #                | customer (customer-facing assistant, ADR-0089 — its own SCA-gated regime).
     # Each charter answers: data_scope (what it reads), tools (what it calls), requires_human
-    # (what must be approved), limits (budget/quota).
+    # (what must be approved), limits (budget/quota). Swarm participants additionally declare
+    # case_capabilities (ADR-0244).
     # ---------------------------------------------------------------------------------------
     agents:
 
@@ -1597,6 +1645,67 @@ data:
         compliance:
           eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
           dora: "Art. 9 ICT risk detection; Art. 5 ICT risk management framework — fleet-wide static verification that a test suite's reported green state reflects tests that actually ran"
+
+      - id: case-coordinator
+        plane: control
+        charter: "ADR-0244"
+        description: >
+          Owns a running Temporal case workflow: invites chartered agents to contribute,
+          enforces the per-case-class budget and deadline, judges convergence, and emits
+          exactly one HITL proposal per case. Every swarm is bounded to one disposition
+          target; pre-emption is deterministic and replay-safe. The coordinator never
+          coordinates a case it opened; who detected is never who converged.
+        enabled: true
+        enforcement: block
+        data_scope:
+          read:
+            - case-workflow-history       # Temporal workflow history of cases it coordinates
+            - agent-proposals-readonly    # existing proposal queue metadata (no raw payload)
+            - read.governance             # agents.yaml case classes and charter capabilities
+          pii: masked
+        tools:
+          allow:
+            - tier: read
+              resources: [case-workflow, governance]
+            - tier: write_proposal
+              resources: [agent-proposal]   # emits one HITL proposal per case
+            - tier: execute
+              resources: [case-workflow-signal]  # sends deterministic pre-emption / convergence signals
+          deny:
+            - tier: write
+              resources: ["*"]             # never writes to a business record directly
+            - tier: execute
+              resources: [money.*, gh.pr.*, secrets.*]
+        case_capabilities:
+          # The coordinator is the only charter that may open, coordinate, and synthesize a case.
+          # Other agents may be granted case.join (and later case.contribute) in their own charters.
+          - case.open
+          - case.coordinate
+          - case.synthesize
+          - case.preempt
+        requires_human:
+          - every: proposal               # every synthesized proposal is a HITL proposal
+          - approver_must_differ_from: author
+          - record: reason
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 48                # one per active case hour is common; cap prevents runaway
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - case_id
+            - disposition_target
+            - case_class
+            - contributions_received
+            - synthesis_cited_contribution_ids
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, human disposes; not Annex III high-risk"
+          dora: "ICT change management (Art. 8–10); operational resilience via durable, bounded case coordination"
   rules-data.yaml: |
     # GENERATED by .github/scripts/gen-rules-opa-data.py — do not hand-edit.
     #

--- a/openbank-infra/gitops/components/balances/balance-service.yaml
+++ b/openbank-infra/gitops/components/balances/balance-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-balance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "fb5d9843a6695b09"
+        openbank.tech/policy-checksum: "9ff0513a6a20c9c0"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: billing-service
     app.kubernetes.io/part-of: billing
   annotations:
-    openbank.tech/policy-checksum: "322125992d041989"
+    openbank.tech/policy-checksum: "2d119fbf8dcc877c"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -897,10 +897,58 @@ data:
         - secrets.read.raw
 
     # ---------------------------------------------------------------------------------------
+    # Case classes for agent swarm coordination (ADR-0244). A case is one long-running
+    # Temporal workflow opened for a single disposition target. Default budgets and
+    # convergence thresholds live here; per-class overrides are merged over default.
+    # Every case names exactly one class. The case-coordinator charter owns convergence
+    # judgement and budget enforcement; other charters may be granted case.join (and later
+    # case.contribute) once the signal-handling wiring lands.
+    # ---------------------------------------------------------------------------------------
+    case_classes:
+      default:
+        budget:
+          tokens_per_case: 500000
+          max_contributions: 100
+          wall_clock_minutes: 60
+        concurrency:
+          max_open_cases: 10
+        convergence:
+          contested_rate_threshold: 0.30   # suspend case-open for this class above 30% contested
+      classes:
+        fraud-investigation:
+          budget:
+            tokens_per_case: 1000000
+            max_contributions: 200
+            wall_clock_minutes: 120
+          concurrency:
+            max_open_cases: 5
+          convergence:
+            contested_rate_threshold: 0.25
+        aml-alert:
+          budget:
+            tokens_per_case: 300000
+            max_contributions: 50
+            wall_clock_minutes: 30
+          concurrency:
+            max_open_cases: 20
+          convergence:
+            contested_rate_threshold: 0.40
+        incident-response:
+          budget:
+            tokens_per_case: 200000
+            max_contributions: 40
+            wall_clock_minutes: 20
+          concurrency:
+            max_open_cases: 15
+          convergence:
+            contested_rate_threshold: 0.35
+
+    # ---------------------------------------------------------------------------------------
     # Agents. plane = control (oversight, proposal-only) | development (per-domain engineering)
     #                | customer (customer-facing assistant, ADR-0089 — its own SCA-gated regime).
     # Each charter answers: data_scope (what it reads), tools (what it calls), requires_human
-    # (what must be approved), limits (budget/quota).
+    # (what must be approved), limits (budget/quota). Swarm participants additionally declare
+    # case_capabilities (ADR-0244).
     # ---------------------------------------------------------------------------------------
     agents:
 
@@ -1502,6 +1550,67 @@ data:
         compliance:
           eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
           dora: "Art. 9 ICT risk detection; Art. 5 ICT risk management framework — fleet-wide static verification that a test suite's reported green state reflects tests that actually ran"
+
+      - id: case-coordinator
+        plane: control
+        charter: "ADR-0244"
+        description: >
+          Owns a running Temporal case workflow: invites chartered agents to contribute,
+          enforces the per-case-class budget and deadline, judges convergence, and emits
+          exactly one HITL proposal per case. Every swarm is bounded to one disposition
+          target; pre-emption is deterministic and replay-safe. The coordinator never
+          coordinates a case it opened; who detected is never who converged.
+        enabled: true
+        enforcement: block
+        data_scope:
+          read:
+            - case-workflow-history       # Temporal workflow history of cases it coordinates
+            - agent-proposals-readonly    # existing proposal queue metadata (no raw payload)
+            - read.governance             # agents.yaml case classes and charter capabilities
+          pii: masked
+        tools:
+          allow:
+            - tier: read
+              resources: [case-workflow, governance]
+            - tier: write_proposal
+              resources: [agent-proposal]   # emits one HITL proposal per case
+            - tier: execute
+              resources: [case-workflow-signal]  # sends deterministic pre-emption / convergence signals
+          deny:
+            - tier: write
+              resources: ["*"]             # never writes to a business record directly
+            - tier: execute
+              resources: [money.*, gh.pr.*, secrets.*]
+        case_capabilities:
+          # The coordinator is the only charter that may open, coordinate, and synthesize a case.
+          # Other agents may be granted case.join (and later case.contribute) in their own charters.
+          - case.open
+          - case.coordinate
+          - case.synthesize
+          - case.preempt
+        requires_human:
+          - every: proposal               # every synthesized proposal is a HITL proposal
+          - approver_must_differ_from: author
+          - record: reason
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 48                # one per active case hour is common; cap prevents runaway
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - case_id
+            - disposition_target
+            - case_class
+            - contributions_received
+            - synthesis_cited_contribution_ids
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, human disposes; not Annex III high-risk"
+          dora: "ICT change management (Art. 8–10); operational resilience via durable, bounded case coordination"
   rules-data.yaml: |
     # GENERATED by .github/scripts/gen-rules-opa-data.py — do not hand-edit.
     #

--- a/openbank-infra/gitops/components/billing/billing-service.yaml
+++ b/openbank-infra/gitops/components/billing/billing-service.yaml
@@ -36,7 +36,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-billing-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "322125992d041989"
+        openbank.tech/policy-checksum: "2d119fbf8dcc877c"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/campaign/campaign-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/campaign/campaign-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: campaign-service
     app.kubernetes.io/part-of: campaign
   annotations:
-    openbank.tech/policy-checksum: "609f01fbcb6d4680"
+    openbank.tech/policy-checksum: "b6e69f879ca5f533"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -918,10 +918,58 @@ data:
         - secrets.read.raw
 
     # ---------------------------------------------------------------------------------------
+    # Case classes for agent swarm coordination (ADR-0244). A case is one long-running
+    # Temporal workflow opened for a single disposition target. Default budgets and
+    # convergence thresholds live here; per-class overrides are merged over default.
+    # Every case names exactly one class. The case-coordinator charter owns convergence
+    # judgement and budget enforcement; other charters may be granted case.join (and later
+    # case.contribute) once the signal-handling wiring lands.
+    # ---------------------------------------------------------------------------------------
+    case_classes:
+      default:
+        budget:
+          tokens_per_case: 500000
+          max_contributions: 100
+          wall_clock_minutes: 60
+        concurrency:
+          max_open_cases: 10
+        convergence:
+          contested_rate_threshold: 0.30   # suspend case-open for this class above 30% contested
+      classes:
+        fraud-investigation:
+          budget:
+            tokens_per_case: 1000000
+            max_contributions: 200
+            wall_clock_minutes: 120
+          concurrency:
+            max_open_cases: 5
+          convergence:
+            contested_rate_threshold: 0.25
+        aml-alert:
+          budget:
+            tokens_per_case: 300000
+            max_contributions: 50
+            wall_clock_minutes: 30
+          concurrency:
+            max_open_cases: 20
+          convergence:
+            contested_rate_threshold: 0.40
+        incident-response:
+          budget:
+            tokens_per_case: 200000
+            max_contributions: 40
+            wall_clock_minutes: 20
+          concurrency:
+            max_open_cases: 15
+          convergence:
+            contested_rate_threshold: 0.35
+
+    # ---------------------------------------------------------------------------------------
     # Agents. plane = control (oversight, proposal-only) | development (per-domain engineering)
     #                | customer (customer-facing assistant, ADR-0089 — its own SCA-gated regime).
     # Each charter answers: data_scope (what it reads), tools (what it calls), requires_human
-    # (what must be approved), limits (budget/quota).
+    # (what must be approved), limits (budget/quota). Swarm participants additionally declare
+    # case_capabilities (ADR-0244).
     # ---------------------------------------------------------------------------------------
     agents:
 
@@ -1523,6 +1571,67 @@ data:
         compliance:
           eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
           dora: "Art. 9 ICT risk detection; Art. 5 ICT risk management framework — fleet-wide static verification that a test suite's reported green state reflects tests that actually ran"
+
+      - id: case-coordinator
+        plane: control
+        charter: "ADR-0244"
+        description: >
+          Owns a running Temporal case workflow: invites chartered agents to contribute,
+          enforces the per-case-class budget and deadline, judges convergence, and emits
+          exactly one HITL proposal per case. Every swarm is bounded to one disposition
+          target; pre-emption is deterministic and replay-safe. The coordinator never
+          coordinates a case it opened; who detected is never who converged.
+        enabled: true
+        enforcement: block
+        data_scope:
+          read:
+            - case-workflow-history       # Temporal workflow history of cases it coordinates
+            - agent-proposals-readonly    # existing proposal queue metadata (no raw payload)
+            - read.governance             # agents.yaml case classes and charter capabilities
+          pii: masked
+        tools:
+          allow:
+            - tier: read
+              resources: [case-workflow, governance]
+            - tier: write_proposal
+              resources: [agent-proposal]   # emits one HITL proposal per case
+            - tier: execute
+              resources: [case-workflow-signal]  # sends deterministic pre-emption / convergence signals
+          deny:
+            - tier: write
+              resources: ["*"]             # never writes to a business record directly
+            - tier: execute
+              resources: [money.*, gh.pr.*, secrets.*]
+        case_capabilities:
+          # The coordinator is the only charter that may open, coordinate, and synthesize a case.
+          # Other agents may be granted case.join (and later case.contribute) in their own charters.
+          - case.open
+          - case.coordinate
+          - case.synthesize
+          - case.preempt
+        requires_human:
+          - every: proposal               # every synthesized proposal is a HITL proposal
+          - approver_must_differ_from: author
+          - record: reason
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 48                # one per active case hour is common; cap prevents runaway
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - case_id
+            - disposition_target
+            - case_class
+            - contributions_received
+            - synthesis_cited_contribution_ids
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, human disposes; not Annex III high-risk"
+          dora: "ICT change management (Art. 8–10); operational resilience via durable, bounded case coordination"
   rules-data.yaml: |
     # GENERATED by .github/scripts/gen-rules-opa-data.py — do not hand-edit.
     #

--- a/openbank-infra/gitops/components/campaign/campaign-service.yaml
+++ b/openbank-infra/gitops/components/campaign/campaign-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-campaign-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "609f01fbcb6d4680"
+        openbank.tech/policy-checksum: "b6e69f879ca5f533"
       labels:
         app.kubernetes.io/name: campaign-service
         app.kubernetes.io/part-of: campaign

--- a/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: consent-service
     app.kubernetes.io/part-of: consent
   annotations:
-    openbank.tech/policy-checksum: "a59ca0d4439c9591"
+    openbank.tech/policy-checksum: "0e2f2ab37d34251f"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -967,10 +967,58 @@ data:
         - secrets.read.raw
 
     # ---------------------------------------------------------------------------------------
+    # Case classes for agent swarm coordination (ADR-0244). A case is one long-running
+    # Temporal workflow opened for a single disposition target. Default budgets and
+    # convergence thresholds live here; per-class overrides are merged over default.
+    # Every case names exactly one class. The case-coordinator charter owns convergence
+    # judgement and budget enforcement; other charters may be granted case.join (and later
+    # case.contribute) once the signal-handling wiring lands.
+    # ---------------------------------------------------------------------------------------
+    case_classes:
+      default:
+        budget:
+          tokens_per_case: 500000
+          max_contributions: 100
+          wall_clock_minutes: 60
+        concurrency:
+          max_open_cases: 10
+        convergence:
+          contested_rate_threshold: 0.30   # suspend case-open for this class above 30% contested
+      classes:
+        fraud-investigation:
+          budget:
+            tokens_per_case: 1000000
+            max_contributions: 200
+            wall_clock_minutes: 120
+          concurrency:
+            max_open_cases: 5
+          convergence:
+            contested_rate_threshold: 0.25
+        aml-alert:
+          budget:
+            tokens_per_case: 300000
+            max_contributions: 50
+            wall_clock_minutes: 30
+          concurrency:
+            max_open_cases: 20
+          convergence:
+            contested_rate_threshold: 0.40
+        incident-response:
+          budget:
+            tokens_per_case: 200000
+            max_contributions: 40
+            wall_clock_minutes: 20
+          concurrency:
+            max_open_cases: 15
+          convergence:
+            contested_rate_threshold: 0.35
+
+    # ---------------------------------------------------------------------------------------
     # Agents. plane = control (oversight, proposal-only) | development (per-domain engineering)
     #                | customer (customer-facing assistant, ADR-0089 — its own SCA-gated regime).
     # Each charter answers: data_scope (what it reads), tools (what it calls), requires_human
-    # (what must be approved), limits (budget/quota).
+    # (what must be approved), limits (budget/quota). Swarm participants additionally declare
+    # case_capabilities (ADR-0244).
     # ---------------------------------------------------------------------------------------
     agents:
 
@@ -1572,6 +1620,67 @@ data:
         compliance:
           eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
           dora: "Art. 9 ICT risk detection; Art. 5 ICT risk management framework — fleet-wide static verification that a test suite's reported green state reflects tests that actually ran"
+
+      - id: case-coordinator
+        plane: control
+        charter: "ADR-0244"
+        description: >
+          Owns a running Temporal case workflow: invites chartered agents to contribute,
+          enforces the per-case-class budget and deadline, judges convergence, and emits
+          exactly one HITL proposal per case. Every swarm is bounded to one disposition
+          target; pre-emption is deterministic and replay-safe. The coordinator never
+          coordinates a case it opened; who detected is never who converged.
+        enabled: true
+        enforcement: block
+        data_scope:
+          read:
+            - case-workflow-history       # Temporal workflow history of cases it coordinates
+            - agent-proposals-readonly    # existing proposal queue metadata (no raw payload)
+            - read.governance             # agents.yaml case classes and charter capabilities
+          pii: masked
+        tools:
+          allow:
+            - tier: read
+              resources: [case-workflow, governance]
+            - tier: write_proposal
+              resources: [agent-proposal]   # emits one HITL proposal per case
+            - tier: execute
+              resources: [case-workflow-signal]  # sends deterministic pre-emption / convergence signals
+          deny:
+            - tier: write
+              resources: ["*"]             # never writes to a business record directly
+            - tier: execute
+              resources: [money.*, gh.pr.*, secrets.*]
+        case_capabilities:
+          # The coordinator is the only charter that may open, coordinate, and synthesize a case.
+          # Other agents may be granted case.join (and later case.contribute) in their own charters.
+          - case.open
+          - case.coordinate
+          - case.synthesize
+          - case.preempt
+        requires_human:
+          - every: proposal               # every synthesized proposal is a HITL proposal
+          - approver_must_differ_from: author
+          - record: reason
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 48                # one per active case hour is common; cap prevents runaway
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - case_id
+            - disposition_target
+            - case_class
+            - contributions_received
+            - synthesis_cited_contribution_ids
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, human disposes; not Annex III high-risk"
+          dora: "ICT change management (Art. 8–10); operational resilience via durable, bounded case coordination"
   rules-data.yaml: |
     # GENERATED by .github/scripts/gen-rules-opa-data.py — do not hand-edit.
     #

--- a/openbank-infra/gitops/components/consent/consent-service.yaml
+++ b/openbank-infra/gitops/components/consent/consent-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-consent-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "a59ca0d4439c9591"
+        openbank.tech/policy-checksum: "0e2f2ab37d34251f"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: copilot-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "0eb73cb130731327"
+    openbank.tech/policy-checksum: "b75b1c0ef9364722"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -983,10 +983,58 @@ data:
         - secrets.read.raw
 
     # ---------------------------------------------------------------------------------------
+    # Case classes for agent swarm coordination (ADR-0244). A case is one long-running
+    # Temporal workflow opened for a single disposition target. Default budgets and
+    # convergence thresholds live here; per-class overrides are merged over default.
+    # Every case names exactly one class. The case-coordinator charter owns convergence
+    # judgement and budget enforcement; other charters may be granted case.join (and later
+    # case.contribute) once the signal-handling wiring lands.
+    # ---------------------------------------------------------------------------------------
+    case_classes:
+      default:
+        budget:
+          tokens_per_case: 500000
+          max_contributions: 100
+          wall_clock_minutes: 60
+        concurrency:
+          max_open_cases: 10
+        convergence:
+          contested_rate_threshold: 0.30   # suspend case-open for this class above 30% contested
+      classes:
+        fraud-investigation:
+          budget:
+            tokens_per_case: 1000000
+            max_contributions: 200
+            wall_clock_minutes: 120
+          concurrency:
+            max_open_cases: 5
+          convergence:
+            contested_rate_threshold: 0.25
+        aml-alert:
+          budget:
+            tokens_per_case: 300000
+            max_contributions: 50
+            wall_clock_minutes: 30
+          concurrency:
+            max_open_cases: 20
+          convergence:
+            contested_rate_threshold: 0.40
+        incident-response:
+          budget:
+            tokens_per_case: 200000
+            max_contributions: 40
+            wall_clock_minutes: 20
+          concurrency:
+            max_open_cases: 15
+          convergence:
+            contested_rate_threshold: 0.35
+
+    # ---------------------------------------------------------------------------------------
     # Agents. plane = control (oversight, proposal-only) | development (per-domain engineering)
     #                | customer (customer-facing assistant, ADR-0089 — its own SCA-gated regime).
     # Each charter answers: data_scope (what it reads), tools (what it calls), requires_human
-    # (what must be approved), limits (budget/quota).
+    # (what must be approved), limits (budget/quota). Swarm participants additionally declare
+    # case_capabilities (ADR-0244).
     # ---------------------------------------------------------------------------------------
     agents:
 
@@ -1588,6 +1636,67 @@ data:
         compliance:
           eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
           dora: "Art. 9 ICT risk detection; Art. 5 ICT risk management framework — fleet-wide static verification that a test suite's reported green state reflects tests that actually ran"
+
+      - id: case-coordinator
+        plane: control
+        charter: "ADR-0244"
+        description: >
+          Owns a running Temporal case workflow: invites chartered agents to contribute,
+          enforces the per-case-class budget and deadline, judges convergence, and emits
+          exactly one HITL proposal per case. Every swarm is bounded to one disposition
+          target; pre-emption is deterministic and replay-safe. The coordinator never
+          coordinates a case it opened; who detected is never who converged.
+        enabled: true
+        enforcement: block
+        data_scope:
+          read:
+            - case-workflow-history       # Temporal workflow history of cases it coordinates
+            - agent-proposals-readonly    # existing proposal queue metadata (no raw payload)
+            - read.governance             # agents.yaml case classes and charter capabilities
+          pii: masked
+        tools:
+          allow:
+            - tier: read
+              resources: [case-workflow, governance]
+            - tier: write_proposal
+              resources: [agent-proposal]   # emits one HITL proposal per case
+            - tier: execute
+              resources: [case-workflow-signal]  # sends deterministic pre-emption / convergence signals
+          deny:
+            - tier: write
+              resources: ["*"]             # never writes to a business record directly
+            - tier: execute
+              resources: [money.*, gh.pr.*, secrets.*]
+        case_capabilities:
+          # The coordinator is the only charter that may open, coordinate, and synthesize a case.
+          # Other agents may be granted case.join (and later case.contribute) in their own charters.
+          - case.open
+          - case.coordinate
+          - case.synthesize
+          - case.preempt
+        requires_human:
+          - every: proposal               # every synthesized proposal is a HITL proposal
+          - approver_must_differ_from: author
+          - record: reason
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 48                # one per active case hour is common; cap prevents runaway
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - case_id
+            - disposition_target
+            - case_class
+            - contributions_received
+            - synthesis_cited_contribution_ids
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, human disposes; not Annex III high-risk"
+          dora: "ICT change management (Art. 8–10); operational resilience via durable, bounded case coordination"
   rules-data.yaml: |
     # GENERATED by .github/scripts/gen-rules-opa-data.py — do not hand-edit.
     #

--- a/openbank-infra/gitops/components/copilot/copilot-service.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-service.yaml
@@ -39,7 +39,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-copilot-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "0eb73cb130731327"
+        openbank.tech/policy-checksum: "b75b1c0ef9364722"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: customer-edge
     app.kubernetes.io/part-of: customer-edge
   annotations:
-    openbank.tech/policy-checksum: "99a64206f9e9605b"
+    openbank.tech/policy-checksum: "caa4315947012bae"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1246,10 +1246,58 @@ data:
         - secrets.read.raw
 
     # ---------------------------------------------------------------------------------------
+    # Case classes for agent swarm coordination (ADR-0244). A case is one long-running
+    # Temporal workflow opened for a single disposition target. Default budgets and
+    # convergence thresholds live here; per-class overrides are merged over default.
+    # Every case names exactly one class. The case-coordinator charter owns convergence
+    # judgement and budget enforcement; other charters may be granted case.join (and later
+    # case.contribute) once the signal-handling wiring lands.
+    # ---------------------------------------------------------------------------------------
+    case_classes:
+      default:
+        budget:
+          tokens_per_case: 500000
+          max_contributions: 100
+          wall_clock_minutes: 60
+        concurrency:
+          max_open_cases: 10
+        convergence:
+          contested_rate_threshold: 0.30   # suspend case-open for this class above 30% contested
+      classes:
+        fraud-investigation:
+          budget:
+            tokens_per_case: 1000000
+            max_contributions: 200
+            wall_clock_minutes: 120
+          concurrency:
+            max_open_cases: 5
+          convergence:
+            contested_rate_threshold: 0.25
+        aml-alert:
+          budget:
+            tokens_per_case: 300000
+            max_contributions: 50
+            wall_clock_minutes: 30
+          concurrency:
+            max_open_cases: 20
+          convergence:
+            contested_rate_threshold: 0.40
+        incident-response:
+          budget:
+            tokens_per_case: 200000
+            max_contributions: 40
+            wall_clock_minutes: 20
+          concurrency:
+            max_open_cases: 15
+          convergence:
+            contested_rate_threshold: 0.35
+
+    # ---------------------------------------------------------------------------------------
     # Agents. plane = control (oversight, proposal-only) | development (per-domain engineering)
     #                | customer (customer-facing assistant, ADR-0089 — its own SCA-gated regime).
     # Each charter answers: data_scope (what it reads), tools (what it calls), requires_human
-    # (what must be approved), limits (budget/quota).
+    # (what must be approved), limits (budget/quota). Swarm participants additionally declare
+    # case_capabilities (ADR-0244).
     # ---------------------------------------------------------------------------------------
     agents:
 
@@ -1851,5 +1899,66 @@ data:
         compliance:
           eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
           dora: "Art. 9 ICT risk detection; Art. 5 ICT risk management framework — fleet-wide static verification that a test suite's reported green state reflects tests that actually ran"
+
+      - id: case-coordinator
+        plane: control
+        charter: "ADR-0244"
+        description: >
+          Owns a running Temporal case workflow: invites chartered agents to contribute,
+          enforces the per-case-class budget and deadline, judges convergence, and emits
+          exactly one HITL proposal per case. Every swarm is bounded to one disposition
+          target; pre-emption is deterministic and replay-safe. The coordinator never
+          coordinates a case it opened; who detected is never who converged.
+        enabled: true
+        enforcement: block
+        data_scope:
+          read:
+            - case-workflow-history       # Temporal workflow history of cases it coordinates
+            - agent-proposals-readonly    # existing proposal queue metadata (no raw payload)
+            - read.governance             # agents.yaml case classes and charter capabilities
+          pii: masked
+        tools:
+          allow:
+            - tier: read
+              resources: [case-workflow, governance]
+            - tier: write_proposal
+              resources: [agent-proposal]   # emits one HITL proposal per case
+            - tier: execute
+              resources: [case-workflow-signal]  # sends deterministic pre-emption / convergence signals
+          deny:
+            - tier: write
+              resources: ["*"]             # never writes to a business record directly
+            - tier: execute
+              resources: [money.*, gh.pr.*, secrets.*]
+        case_capabilities:
+          # The coordinator is the only charter that may open, coordinate, and synthesize a case.
+          # Other agents may be granted case.join (and later case.contribute) in their own charters.
+          - case.open
+          - case.coordinate
+          - case.synthesize
+          - case.preempt
+        requires_human:
+          - every: proposal               # every synthesized proposal is a HITL proposal
+          - approver_must_differ_from: author
+          - record: reason
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 48                # one per active case hour is common; cap prevents runaway
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - case_id
+            - disposition_target
+            - case_class
+            - contributions_received
+            - synthesis_cited_contribution_ids
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, human disposes; not Annex III high-risk"
+          dora: "ICT change management (Art. 8–10); operational resilience via durable, bounded case coordination"
   manifest.json: |
     {"roots": ["openbank/agents", "openbank/copilot", "openbank/rest", "agents", "rules"]}

--- a/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
@@ -65,7 +65,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-customer-edge-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "99a64206f9e9605b"
+        openbank.tech/policy-checksum: "caa4315947012bae"
     spec:
       # Dedicated SA so EKS Pod Identity can hand the edge (and ONLY the edge) the
       # feedback-screenshots S3 role — ADR-0192, openbank-infra/aws/envs/sandbox-platform/

--- a/openbank-infra/gitops/components/delegation/delegation-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/delegation/delegation-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: delegation-service
     app.kubernetes.io/part-of: delegation
   annotations:
-    openbank.tech/policy-checksum: "3b4f321fc40e98b3"
+    openbank.tech/policy-checksum: "799cf7e8bbfafdc4"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -938,10 +938,58 @@ data:
         - secrets.read.raw
 
     # ---------------------------------------------------------------------------------------
+    # Case classes for agent swarm coordination (ADR-0244). A case is one long-running
+    # Temporal workflow opened for a single disposition target. Default budgets and
+    # convergence thresholds live here; per-class overrides are merged over default.
+    # Every case names exactly one class. The case-coordinator charter owns convergence
+    # judgement and budget enforcement; other charters may be granted case.join (and later
+    # case.contribute) once the signal-handling wiring lands.
+    # ---------------------------------------------------------------------------------------
+    case_classes:
+      default:
+        budget:
+          tokens_per_case: 500000
+          max_contributions: 100
+          wall_clock_minutes: 60
+        concurrency:
+          max_open_cases: 10
+        convergence:
+          contested_rate_threshold: 0.30   # suspend case-open for this class above 30% contested
+      classes:
+        fraud-investigation:
+          budget:
+            tokens_per_case: 1000000
+            max_contributions: 200
+            wall_clock_minutes: 120
+          concurrency:
+            max_open_cases: 5
+          convergence:
+            contested_rate_threshold: 0.25
+        aml-alert:
+          budget:
+            tokens_per_case: 300000
+            max_contributions: 50
+            wall_clock_minutes: 30
+          concurrency:
+            max_open_cases: 20
+          convergence:
+            contested_rate_threshold: 0.40
+        incident-response:
+          budget:
+            tokens_per_case: 200000
+            max_contributions: 40
+            wall_clock_minutes: 20
+          concurrency:
+            max_open_cases: 15
+          convergence:
+            contested_rate_threshold: 0.35
+
+    # ---------------------------------------------------------------------------------------
     # Agents. plane = control (oversight, proposal-only) | development (per-domain engineering)
     #                | customer (customer-facing assistant, ADR-0089 — its own SCA-gated regime).
     # Each charter answers: data_scope (what it reads), tools (what it calls), requires_human
-    # (what must be approved), limits (budget/quota).
+    # (what must be approved), limits (budget/quota). Swarm participants additionally declare
+    # case_capabilities (ADR-0244).
     # ---------------------------------------------------------------------------------------
     agents:
 
@@ -1543,6 +1591,67 @@ data:
         compliance:
           eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
           dora: "Art. 9 ICT risk detection; Art. 5 ICT risk management framework — fleet-wide static verification that a test suite's reported green state reflects tests that actually ran"
+
+      - id: case-coordinator
+        plane: control
+        charter: "ADR-0244"
+        description: >
+          Owns a running Temporal case workflow: invites chartered agents to contribute,
+          enforces the per-case-class budget and deadline, judges convergence, and emits
+          exactly one HITL proposal per case. Every swarm is bounded to one disposition
+          target; pre-emption is deterministic and replay-safe. The coordinator never
+          coordinates a case it opened; who detected is never who converged.
+        enabled: true
+        enforcement: block
+        data_scope:
+          read:
+            - case-workflow-history       # Temporal workflow history of cases it coordinates
+            - agent-proposals-readonly    # existing proposal queue metadata (no raw payload)
+            - read.governance             # agents.yaml case classes and charter capabilities
+          pii: masked
+        tools:
+          allow:
+            - tier: read
+              resources: [case-workflow, governance]
+            - tier: write_proposal
+              resources: [agent-proposal]   # emits one HITL proposal per case
+            - tier: execute
+              resources: [case-workflow-signal]  # sends deterministic pre-emption / convergence signals
+          deny:
+            - tier: write
+              resources: ["*"]             # never writes to a business record directly
+            - tier: execute
+              resources: [money.*, gh.pr.*, secrets.*]
+        case_capabilities:
+          # The coordinator is the only charter that may open, coordinate, and synthesize a case.
+          # Other agents may be granted case.join (and later case.contribute) in their own charters.
+          - case.open
+          - case.coordinate
+          - case.synthesize
+          - case.preempt
+        requires_human:
+          - every: proposal               # every synthesized proposal is a HITL proposal
+          - approver_must_differ_from: author
+          - record: reason
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 48                # one per active case hour is common; cap prevents runaway
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - case_id
+            - disposition_target
+            - case_class
+            - contributions_received
+            - synthesis_cited_contribution_ids
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, human disposes; not Annex III high-risk"
+          dora: "ICT change management (Art. 8–10); operational resilience via durable, bounded case coordination"
   rules-data.yaml: |
     # GENERATED by .github/scripts/gen-rules-opa-data.py — do not hand-edit.
     #

--- a/openbank-infra/gitops/components/delegation/delegation-service.yaml
+++ b/openbank-infra/gitops/components/delegation/delegation-service.yaml
@@ -42,7 +42,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-delegation-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "3b4f321fc40e98b3"
+        openbank.tech/policy-checksum: "799cf7e8bbfafdc4"
       labels:
         app.kubernetes.io/name: delegation-service
         app.kubernetes.io/part-of: delegation

--- a/openbank-infra/gitops/components/dispute-service/dispute-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/dispute-service/dispute-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: dispute-service
     app.kubernetes.io/part-of: dispute
   annotations:
-    openbank.tech/policy-checksum: "09c242d1834d06af"
+    openbank.tech/policy-checksum: "c05ecd973bc33428"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1033,10 +1033,58 @@ data:
         - secrets.read.raw
 
     # ---------------------------------------------------------------------------------------
+    # Case classes for agent swarm coordination (ADR-0244). A case is one long-running
+    # Temporal workflow opened for a single disposition target. Default budgets and
+    # convergence thresholds live here; per-class overrides are merged over default.
+    # Every case names exactly one class. The case-coordinator charter owns convergence
+    # judgement and budget enforcement; other charters may be granted case.join (and later
+    # case.contribute) once the signal-handling wiring lands.
+    # ---------------------------------------------------------------------------------------
+    case_classes:
+      default:
+        budget:
+          tokens_per_case: 500000
+          max_contributions: 100
+          wall_clock_minutes: 60
+        concurrency:
+          max_open_cases: 10
+        convergence:
+          contested_rate_threshold: 0.30   # suspend case-open for this class above 30% contested
+      classes:
+        fraud-investigation:
+          budget:
+            tokens_per_case: 1000000
+            max_contributions: 200
+            wall_clock_minutes: 120
+          concurrency:
+            max_open_cases: 5
+          convergence:
+            contested_rate_threshold: 0.25
+        aml-alert:
+          budget:
+            tokens_per_case: 300000
+            max_contributions: 50
+            wall_clock_minutes: 30
+          concurrency:
+            max_open_cases: 20
+          convergence:
+            contested_rate_threshold: 0.40
+        incident-response:
+          budget:
+            tokens_per_case: 200000
+            max_contributions: 40
+            wall_clock_minutes: 20
+          concurrency:
+            max_open_cases: 15
+          convergence:
+            contested_rate_threshold: 0.35
+
+    # ---------------------------------------------------------------------------------------
     # Agents. plane = control (oversight, proposal-only) | development (per-domain engineering)
     #                | customer (customer-facing assistant, ADR-0089 — its own SCA-gated regime).
     # Each charter answers: data_scope (what it reads), tools (what it calls), requires_human
-    # (what must be approved), limits (budget/quota).
+    # (what must be approved), limits (budget/quota). Swarm participants additionally declare
+    # case_capabilities (ADR-0244).
     # ---------------------------------------------------------------------------------------
     agents:
 
@@ -1638,6 +1686,67 @@ data:
         compliance:
           eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
           dora: "Art. 9 ICT risk detection; Art. 5 ICT risk management framework — fleet-wide static verification that a test suite's reported green state reflects tests that actually ran"
+
+      - id: case-coordinator
+        plane: control
+        charter: "ADR-0244"
+        description: >
+          Owns a running Temporal case workflow: invites chartered agents to contribute,
+          enforces the per-case-class budget and deadline, judges convergence, and emits
+          exactly one HITL proposal per case. Every swarm is bounded to one disposition
+          target; pre-emption is deterministic and replay-safe. The coordinator never
+          coordinates a case it opened; who detected is never who converged.
+        enabled: true
+        enforcement: block
+        data_scope:
+          read:
+            - case-workflow-history       # Temporal workflow history of cases it coordinates
+            - agent-proposals-readonly    # existing proposal queue metadata (no raw payload)
+            - read.governance             # agents.yaml case classes and charter capabilities
+          pii: masked
+        tools:
+          allow:
+            - tier: read
+              resources: [case-workflow, governance]
+            - tier: write_proposal
+              resources: [agent-proposal]   # emits one HITL proposal per case
+            - tier: execute
+              resources: [case-workflow-signal]  # sends deterministic pre-emption / convergence signals
+          deny:
+            - tier: write
+              resources: ["*"]             # never writes to a business record directly
+            - tier: execute
+              resources: [money.*, gh.pr.*, secrets.*]
+        case_capabilities:
+          # The coordinator is the only charter that may open, coordinate, and synthesize a case.
+          # Other agents may be granted case.join (and later case.contribute) in their own charters.
+          - case.open
+          - case.coordinate
+          - case.synthesize
+          - case.preempt
+        requires_human:
+          - every: proposal               # every synthesized proposal is a HITL proposal
+          - approver_must_differ_from: author
+          - record: reason
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 48                # one per active case hour is common; cap prevents runaway
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - case_id
+            - disposition_target
+            - case_class
+            - contributions_received
+            - synthesis_cited_contribution_ids
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, human disposes; not Annex III high-risk"
+          dora: "ICT change management (Art. 8–10); operational resilience via durable, bounded case coordination"
   rules-data.yaml: |
     # GENERATED by .github/scripts/gen-rules-opa-data.py — do not hand-edit.
     #

--- a/openbank-infra/gitops/components/dispute-service/dispute-service.yaml
+++ b/openbank-infra/gitops/components/dispute-service/dispute-service.yaml
@@ -24,7 +24,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-dispute-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "09c242d1834d06af"
+        openbank.tech/policy-checksum: "c05ecd973bc33428"
       labels: {app.kubernetes.io/name: dispute-service, app.kubernetes.io/part-of: dispute}
     spec:
       securityContext:

--- a/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: document-service
     app.kubernetes.io/part-of: documents
   annotations:
-    openbank.tech/policy-checksum: "99a64206f9e9605b"
+    openbank.tech/policy-checksum: "caa4315947012bae"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1246,10 +1246,58 @@ data:
         - secrets.read.raw
 
     # ---------------------------------------------------------------------------------------
+    # Case classes for agent swarm coordination (ADR-0244). A case is one long-running
+    # Temporal workflow opened for a single disposition target. Default budgets and
+    # convergence thresholds live here; per-class overrides are merged over default.
+    # Every case names exactly one class. The case-coordinator charter owns convergence
+    # judgement and budget enforcement; other charters may be granted case.join (and later
+    # case.contribute) once the signal-handling wiring lands.
+    # ---------------------------------------------------------------------------------------
+    case_classes:
+      default:
+        budget:
+          tokens_per_case: 500000
+          max_contributions: 100
+          wall_clock_minutes: 60
+        concurrency:
+          max_open_cases: 10
+        convergence:
+          contested_rate_threshold: 0.30   # suspend case-open for this class above 30% contested
+      classes:
+        fraud-investigation:
+          budget:
+            tokens_per_case: 1000000
+            max_contributions: 200
+            wall_clock_minutes: 120
+          concurrency:
+            max_open_cases: 5
+          convergence:
+            contested_rate_threshold: 0.25
+        aml-alert:
+          budget:
+            tokens_per_case: 300000
+            max_contributions: 50
+            wall_clock_minutes: 30
+          concurrency:
+            max_open_cases: 20
+          convergence:
+            contested_rate_threshold: 0.40
+        incident-response:
+          budget:
+            tokens_per_case: 200000
+            max_contributions: 40
+            wall_clock_minutes: 20
+          concurrency:
+            max_open_cases: 15
+          convergence:
+            contested_rate_threshold: 0.35
+
+    # ---------------------------------------------------------------------------------------
     # Agents. plane = control (oversight, proposal-only) | development (per-domain engineering)
     #                | customer (customer-facing assistant, ADR-0089 — its own SCA-gated regime).
     # Each charter answers: data_scope (what it reads), tools (what it calls), requires_human
-    # (what must be approved), limits (budget/quota).
+    # (what must be approved), limits (budget/quota). Swarm participants additionally declare
+    # case_capabilities (ADR-0244).
     # ---------------------------------------------------------------------------------------
     agents:
 
@@ -1851,5 +1899,66 @@ data:
         compliance:
           eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
           dora: "Art. 9 ICT risk detection; Art. 5 ICT risk management framework — fleet-wide static verification that a test suite's reported green state reflects tests that actually ran"
+
+      - id: case-coordinator
+        plane: control
+        charter: "ADR-0244"
+        description: >
+          Owns a running Temporal case workflow: invites chartered agents to contribute,
+          enforces the per-case-class budget and deadline, judges convergence, and emits
+          exactly one HITL proposal per case. Every swarm is bounded to one disposition
+          target; pre-emption is deterministic and replay-safe. The coordinator never
+          coordinates a case it opened; who detected is never who converged.
+        enabled: true
+        enforcement: block
+        data_scope:
+          read:
+            - case-workflow-history       # Temporal workflow history of cases it coordinates
+            - agent-proposals-readonly    # existing proposal queue metadata (no raw payload)
+            - read.governance             # agents.yaml case classes and charter capabilities
+          pii: masked
+        tools:
+          allow:
+            - tier: read
+              resources: [case-workflow, governance]
+            - tier: write_proposal
+              resources: [agent-proposal]   # emits one HITL proposal per case
+            - tier: execute
+              resources: [case-workflow-signal]  # sends deterministic pre-emption / convergence signals
+          deny:
+            - tier: write
+              resources: ["*"]             # never writes to a business record directly
+            - tier: execute
+              resources: [money.*, gh.pr.*, secrets.*]
+        case_capabilities:
+          # The coordinator is the only charter that may open, coordinate, and synthesize a case.
+          # Other agents may be granted case.join (and later case.contribute) in their own charters.
+          - case.open
+          - case.coordinate
+          - case.synthesize
+          - case.preempt
+        requires_human:
+          - every: proposal               # every synthesized proposal is a HITL proposal
+          - approver_must_differ_from: author
+          - record: reason
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 48                # one per active case hour is common; cap prevents runaway
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - case_id
+            - disposition_target
+            - case_class
+            - contributions_received
+            - synthesis_cited_contribution_ids
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, human disposes; not Annex III high-risk"
+          dora: "ICT change management (Art. 8–10); operational resilience via durable, bounded case coordination"
   manifest.json: |
     {"roots": ["openbank/agents", "openbank/copilot", "openbank/rest", "agents", "rules"]}

--- a/openbank-infra/gitops/components/document-service/document-service-service.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-service.yaml
@@ -52,7 +52,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-document-service-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "99a64206f9e9605b"
+        openbank.tech/policy-checksum: "caa4315947012bae"
     spec:
       # ADR-0162 D4 (continued): a dedicated SA (not `default`) is what OpenBao's Kubernetes-auth
       # role `document-service-signing` is bound to — least-privilege, one identity per consumer.

--- a/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fraud-service
     app.kubernetes.io/part-of: fraud
   annotations:
-    openbank.tech/policy-checksum: "b8502b83529f2a10"
+    openbank.tech/policy-checksum: "f8371c47911847fd"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -908,10 +908,58 @@ data:
         - secrets.read.raw
 
     # ---------------------------------------------------------------------------------------
+    # Case classes for agent swarm coordination (ADR-0244). A case is one long-running
+    # Temporal workflow opened for a single disposition target. Default budgets and
+    # convergence thresholds live here; per-class overrides are merged over default.
+    # Every case names exactly one class. The case-coordinator charter owns convergence
+    # judgement and budget enforcement; other charters may be granted case.join (and later
+    # case.contribute) once the signal-handling wiring lands.
+    # ---------------------------------------------------------------------------------------
+    case_classes:
+      default:
+        budget:
+          tokens_per_case: 500000
+          max_contributions: 100
+          wall_clock_minutes: 60
+        concurrency:
+          max_open_cases: 10
+        convergence:
+          contested_rate_threshold: 0.30   # suspend case-open for this class above 30% contested
+      classes:
+        fraud-investigation:
+          budget:
+            tokens_per_case: 1000000
+            max_contributions: 200
+            wall_clock_minutes: 120
+          concurrency:
+            max_open_cases: 5
+          convergence:
+            contested_rate_threshold: 0.25
+        aml-alert:
+          budget:
+            tokens_per_case: 300000
+            max_contributions: 50
+            wall_clock_minutes: 30
+          concurrency:
+            max_open_cases: 20
+          convergence:
+            contested_rate_threshold: 0.40
+        incident-response:
+          budget:
+            tokens_per_case: 200000
+            max_contributions: 40
+            wall_clock_minutes: 20
+          concurrency:
+            max_open_cases: 15
+          convergence:
+            contested_rate_threshold: 0.35
+
+    # ---------------------------------------------------------------------------------------
     # Agents. plane = control (oversight, proposal-only) | development (per-domain engineering)
     #                | customer (customer-facing assistant, ADR-0089 — its own SCA-gated regime).
     # Each charter answers: data_scope (what it reads), tools (what it calls), requires_human
-    # (what must be approved), limits (budget/quota).
+    # (what must be approved), limits (budget/quota). Swarm participants additionally declare
+    # case_capabilities (ADR-0244).
     # ---------------------------------------------------------------------------------------
     agents:
 
@@ -1513,6 +1561,67 @@ data:
         compliance:
           eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
           dora: "Art. 9 ICT risk detection; Art. 5 ICT risk management framework — fleet-wide static verification that a test suite's reported green state reflects tests that actually ran"
+
+      - id: case-coordinator
+        plane: control
+        charter: "ADR-0244"
+        description: >
+          Owns a running Temporal case workflow: invites chartered agents to contribute,
+          enforces the per-case-class budget and deadline, judges convergence, and emits
+          exactly one HITL proposal per case. Every swarm is bounded to one disposition
+          target; pre-emption is deterministic and replay-safe. The coordinator never
+          coordinates a case it opened; who detected is never who converged.
+        enabled: true
+        enforcement: block
+        data_scope:
+          read:
+            - case-workflow-history       # Temporal workflow history of cases it coordinates
+            - agent-proposals-readonly    # existing proposal queue metadata (no raw payload)
+            - read.governance             # agents.yaml case classes and charter capabilities
+          pii: masked
+        tools:
+          allow:
+            - tier: read
+              resources: [case-workflow, governance]
+            - tier: write_proposal
+              resources: [agent-proposal]   # emits one HITL proposal per case
+            - tier: execute
+              resources: [case-workflow-signal]  # sends deterministic pre-emption / convergence signals
+          deny:
+            - tier: write
+              resources: ["*"]             # never writes to a business record directly
+            - tier: execute
+              resources: [money.*, gh.pr.*, secrets.*]
+        case_capabilities:
+          # The coordinator is the only charter that may open, coordinate, and synthesize a case.
+          # Other agents may be granted case.join (and later case.contribute) in their own charters.
+          - case.open
+          - case.coordinate
+          - case.synthesize
+          - case.preempt
+        requires_human:
+          - every: proposal               # every synthesized proposal is a HITL proposal
+          - approver_must_differ_from: author
+          - record: reason
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 48                # one per active case hour is common; cap prevents runaway
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - case_id
+            - disposition_target
+            - case_class
+            - contributions_received
+            - synthesis_cited_contribution_ids
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, human disposes; not Annex III high-risk"
+          dora: "ICT change management (Art. 8–10); operational resilience via durable, bounded case coordination"
   rules-data.yaml: |
     # GENERATED by .github/scripts/gen-rules-opa-data.py — do not hand-edit.
     #

--- a/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
@@ -23,7 +23,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fraud-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "b8502b83529f2a10"
+        openbank.tech/policy-checksum: "f8371c47911847fd"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fx-service
     app.kubernetes.io/part-of: fx
   annotations:
-    openbank.tech/policy-checksum: "e4a0e534e277dd89"
+    openbank.tech/policy-checksum: "9dd0bf7beff85161"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -959,10 +959,58 @@ data:
         - secrets.read.raw
 
     # ---------------------------------------------------------------------------------------
+    # Case classes for agent swarm coordination (ADR-0244). A case is one long-running
+    # Temporal workflow opened for a single disposition target. Default budgets and
+    # convergence thresholds live here; per-class overrides are merged over default.
+    # Every case names exactly one class. The case-coordinator charter owns convergence
+    # judgement and budget enforcement; other charters may be granted case.join (and later
+    # case.contribute) once the signal-handling wiring lands.
+    # ---------------------------------------------------------------------------------------
+    case_classes:
+      default:
+        budget:
+          tokens_per_case: 500000
+          max_contributions: 100
+          wall_clock_minutes: 60
+        concurrency:
+          max_open_cases: 10
+        convergence:
+          contested_rate_threshold: 0.30   # suspend case-open for this class above 30% contested
+      classes:
+        fraud-investigation:
+          budget:
+            tokens_per_case: 1000000
+            max_contributions: 200
+            wall_clock_minutes: 120
+          concurrency:
+            max_open_cases: 5
+          convergence:
+            contested_rate_threshold: 0.25
+        aml-alert:
+          budget:
+            tokens_per_case: 300000
+            max_contributions: 50
+            wall_clock_minutes: 30
+          concurrency:
+            max_open_cases: 20
+          convergence:
+            contested_rate_threshold: 0.40
+        incident-response:
+          budget:
+            tokens_per_case: 200000
+            max_contributions: 40
+            wall_clock_minutes: 20
+          concurrency:
+            max_open_cases: 15
+          convergence:
+            contested_rate_threshold: 0.35
+
+    # ---------------------------------------------------------------------------------------
     # Agents. plane = control (oversight, proposal-only) | development (per-domain engineering)
     #                | customer (customer-facing assistant, ADR-0089 — its own SCA-gated regime).
     # Each charter answers: data_scope (what it reads), tools (what it calls), requires_human
-    # (what must be approved), limits (budget/quota).
+    # (what must be approved), limits (budget/quota). Swarm participants additionally declare
+    # case_capabilities (ADR-0244).
     # ---------------------------------------------------------------------------------------
     agents:
 
@@ -1564,6 +1612,67 @@ data:
         compliance:
           eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
           dora: "Art. 9 ICT risk detection; Art. 5 ICT risk management framework — fleet-wide static verification that a test suite's reported green state reflects tests that actually ran"
+
+      - id: case-coordinator
+        plane: control
+        charter: "ADR-0244"
+        description: >
+          Owns a running Temporal case workflow: invites chartered agents to contribute,
+          enforces the per-case-class budget and deadline, judges convergence, and emits
+          exactly one HITL proposal per case. Every swarm is bounded to one disposition
+          target; pre-emption is deterministic and replay-safe. The coordinator never
+          coordinates a case it opened; who detected is never who converged.
+        enabled: true
+        enforcement: block
+        data_scope:
+          read:
+            - case-workflow-history       # Temporal workflow history of cases it coordinates
+            - agent-proposals-readonly    # existing proposal queue metadata (no raw payload)
+            - read.governance             # agents.yaml case classes and charter capabilities
+          pii: masked
+        tools:
+          allow:
+            - tier: read
+              resources: [case-workflow, governance]
+            - tier: write_proposal
+              resources: [agent-proposal]   # emits one HITL proposal per case
+            - tier: execute
+              resources: [case-workflow-signal]  # sends deterministic pre-emption / convergence signals
+          deny:
+            - tier: write
+              resources: ["*"]             # never writes to a business record directly
+            - tier: execute
+              resources: [money.*, gh.pr.*, secrets.*]
+        case_capabilities:
+          # The coordinator is the only charter that may open, coordinate, and synthesize a case.
+          # Other agents may be granted case.join (and later case.contribute) in their own charters.
+          - case.open
+          - case.coordinate
+          - case.synthesize
+          - case.preempt
+        requires_human:
+          - every: proposal               # every synthesized proposal is a HITL proposal
+          - approver_must_differ_from: author
+          - record: reason
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 48                # one per active case hour is common; cap prevents runaway
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - case_id
+            - disposition_target
+            - case_class
+            - contributions_received
+            - synthesis_cited_contribution_ids
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, human disposes; not Annex III high-risk"
+          dora: "ICT change management (Art. 8–10); operational resilience via durable, bounded case coordination"
   rules-data.yaml: |
     # GENERATED by .github/scripts/gen-rules-opa-data.py — do not hand-edit.
     #

--- a/openbank-infra/gitops/components/fx-service/fx-service.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fx-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "e4a0e534e277dd89"
+        openbank.tech/policy-checksum: "9dd0bf7beff85161"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: interest-service
     app.kubernetes.io/part-of: interest
   annotations:
-    openbank.tech/policy-checksum: "aef81e896164e05d"
+    openbank.tech/policy-checksum: "078eb174fcf61e86"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -893,10 +893,58 @@ data:
         - secrets.read.raw
 
     # ---------------------------------------------------------------------------------------
+    # Case classes for agent swarm coordination (ADR-0244). A case is one long-running
+    # Temporal workflow opened for a single disposition target. Default budgets and
+    # convergence thresholds live here; per-class overrides are merged over default.
+    # Every case names exactly one class. The case-coordinator charter owns convergence
+    # judgement and budget enforcement; other charters may be granted case.join (and later
+    # case.contribute) once the signal-handling wiring lands.
+    # ---------------------------------------------------------------------------------------
+    case_classes:
+      default:
+        budget:
+          tokens_per_case: 500000
+          max_contributions: 100
+          wall_clock_minutes: 60
+        concurrency:
+          max_open_cases: 10
+        convergence:
+          contested_rate_threshold: 0.30   # suspend case-open for this class above 30% contested
+      classes:
+        fraud-investigation:
+          budget:
+            tokens_per_case: 1000000
+            max_contributions: 200
+            wall_clock_minutes: 120
+          concurrency:
+            max_open_cases: 5
+          convergence:
+            contested_rate_threshold: 0.25
+        aml-alert:
+          budget:
+            tokens_per_case: 300000
+            max_contributions: 50
+            wall_clock_minutes: 30
+          concurrency:
+            max_open_cases: 20
+          convergence:
+            contested_rate_threshold: 0.40
+        incident-response:
+          budget:
+            tokens_per_case: 200000
+            max_contributions: 40
+            wall_clock_minutes: 20
+          concurrency:
+            max_open_cases: 15
+          convergence:
+            contested_rate_threshold: 0.35
+
+    # ---------------------------------------------------------------------------------------
     # Agents. plane = control (oversight, proposal-only) | development (per-domain engineering)
     #                | customer (customer-facing assistant, ADR-0089 — its own SCA-gated regime).
     # Each charter answers: data_scope (what it reads), tools (what it calls), requires_human
-    # (what must be approved), limits (budget/quota).
+    # (what must be approved), limits (budget/quota). Swarm participants additionally declare
+    # case_capabilities (ADR-0244).
     # ---------------------------------------------------------------------------------------
     agents:
 
@@ -1498,6 +1546,67 @@ data:
         compliance:
           eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
           dora: "Art. 9 ICT risk detection; Art. 5 ICT risk management framework — fleet-wide static verification that a test suite's reported green state reflects tests that actually ran"
+
+      - id: case-coordinator
+        plane: control
+        charter: "ADR-0244"
+        description: >
+          Owns a running Temporal case workflow: invites chartered agents to contribute,
+          enforces the per-case-class budget and deadline, judges convergence, and emits
+          exactly one HITL proposal per case. Every swarm is bounded to one disposition
+          target; pre-emption is deterministic and replay-safe. The coordinator never
+          coordinates a case it opened; who detected is never who converged.
+        enabled: true
+        enforcement: block
+        data_scope:
+          read:
+            - case-workflow-history       # Temporal workflow history of cases it coordinates
+            - agent-proposals-readonly    # existing proposal queue metadata (no raw payload)
+            - read.governance             # agents.yaml case classes and charter capabilities
+          pii: masked
+        tools:
+          allow:
+            - tier: read
+              resources: [case-workflow, governance]
+            - tier: write_proposal
+              resources: [agent-proposal]   # emits one HITL proposal per case
+            - tier: execute
+              resources: [case-workflow-signal]  # sends deterministic pre-emption / convergence signals
+          deny:
+            - tier: write
+              resources: ["*"]             # never writes to a business record directly
+            - tier: execute
+              resources: [money.*, gh.pr.*, secrets.*]
+        case_capabilities:
+          # The coordinator is the only charter that may open, coordinate, and synthesize a case.
+          # Other agents may be granted case.join (and later case.contribute) in their own charters.
+          - case.open
+          - case.coordinate
+          - case.synthesize
+          - case.preempt
+        requires_human:
+          - every: proposal               # every synthesized proposal is a HITL proposal
+          - approver_must_differ_from: author
+          - record: reason
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 48                # one per active case hour is common; cap prevents runaway
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - case_id
+            - disposition_target
+            - case_class
+            - contributions_received
+            - synthesis_cited_contribution_ids
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, human disposes; not Annex III high-risk"
+          dora: "ICT change management (Art. 8–10); operational resilience via durable, bounded case coordination"
   rules-data.yaml: |
     # GENERATED by .github/scripts/gen-rules-opa-data.py — do not hand-edit.
     #

--- a/openbank-infra/gitops/components/interest-service/interest-service.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-service.yaml
@@ -25,7 +25,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-interest-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "aef81e896164e05d"
+        openbank.tech/policy-checksum: "078eb174fcf61e86"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/kyc/kyc-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/kyc/kyc-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: kyc-service
     app.kubernetes.io/part-of: kyc
   annotations:
-    openbank.tech/policy-checksum: "7394120ba7abd79e"
+    openbank.tech/policy-checksum: "18b96aa159eac334"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -921,10 +921,58 @@ data:
         - secrets.read.raw
 
     # ---------------------------------------------------------------------------------------
+    # Case classes for agent swarm coordination (ADR-0244). A case is one long-running
+    # Temporal workflow opened for a single disposition target. Default budgets and
+    # convergence thresholds live here; per-class overrides are merged over default.
+    # Every case names exactly one class. The case-coordinator charter owns convergence
+    # judgement and budget enforcement; other charters may be granted case.join (and later
+    # case.contribute) once the signal-handling wiring lands.
+    # ---------------------------------------------------------------------------------------
+    case_classes:
+      default:
+        budget:
+          tokens_per_case: 500000
+          max_contributions: 100
+          wall_clock_minutes: 60
+        concurrency:
+          max_open_cases: 10
+        convergence:
+          contested_rate_threshold: 0.30   # suspend case-open for this class above 30% contested
+      classes:
+        fraud-investigation:
+          budget:
+            tokens_per_case: 1000000
+            max_contributions: 200
+            wall_clock_minutes: 120
+          concurrency:
+            max_open_cases: 5
+          convergence:
+            contested_rate_threshold: 0.25
+        aml-alert:
+          budget:
+            tokens_per_case: 300000
+            max_contributions: 50
+            wall_clock_minutes: 30
+          concurrency:
+            max_open_cases: 20
+          convergence:
+            contested_rate_threshold: 0.40
+        incident-response:
+          budget:
+            tokens_per_case: 200000
+            max_contributions: 40
+            wall_clock_minutes: 20
+          concurrency:
+            max_open_cases: 15
+          convergence:
+            contested_rate_threshold: 0.35
+
+    # ---------------------------------------------------------------------------------------
     # Agents. plane = control (oversight, proposal-only) | development (per-domain engineering)
     #                | customer (customer-facing assistant, ADR-0089 — its own SCA-gated regime).
     # Each charter answers: data_scope (what it reads), tools (what it calls), requires_human
-    # (what must be approved), limits (budget/quota).
+    # (what must be approved), limits (budget/quota). Swarm participants additionally declare
+    # case_capabilities (ADR-0244).
     # ---------------------------------------------------------------------------------------
     agents:
 
@@ -1526,6 +1574,67 @@ data:
         compliance:
           eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
           dora: "Art. 9 ICT risk detection; Art. 5 ICT risk management framework — fleet-wide static verification that a test suite's reported green state reflects tests that actually ran"
+
+      - id: case-coordinator
+        plane: control
+        charter: "ADR-0244"
+        description: >
+          Owns a running Temporal case workflow: invites chartered agents to contribute,
+          enforces the per-case-class budget and deadline, judges convergence, and emits
+          exactly one HITL proposal per case. Every swarm is bounded to one disposition
+          target; pre-emption is deterministic and replay-safe. The coordinator never
+          coordinates a case it opened; who detected is never who converged.
+        enabled: true
+        enforcement: block
+        data_scope:
+          read:
+            - case-workflow-history       # Temporal workflow history of cases it coordinates
+            - agent-proposals-readonly    # existing proposal queue metadata (no raw payload)
+            - read.governance             # agents.yaml case classes and charter capabilities
+          pii: masked
+        tools:
+          allow:
+            - tier: read
+              resources: [case-workflow, governance]
+            - tier: write_proposal
+              resources: [agent-proposal]   # emits one HITL proposal per case
+            - tier: execute
+              resources: [case-workflow-signal]  # sends deterministic pre-emption / convergence signals
+          deny:
+            - tier: write
+              resources: ["*"]             # never writes to a business record directly
+            - tier: execute
+              resources: [money.*, gh.pr.*, secrets.*]
+        case_capabilities:
+          # The coordinator is the only charter that may open, coordinate, and synthesize a case.
+          # Other agents may be granted case.join (and later case.contribute) in their own charters.
+          - case.open
+          - case.coordinate
+          - case.synthesize
+          - case.preempt
+        requires_human:
+          - every: proposal               # every synthesized proposal is a HITL proposal
+          - approver_must_differ_from: author
+          - record: reason
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 48                # one per active case hour is common; cap prevents runaway
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - case_id
+            - disposition_target
+            - case_class
+            - contributions_received
+            - synthesis_cited_contribution_ids
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, human disposes; not Annex III high-risk"
+          dora: "ICT change management (Art. 8–10); operational resilience via durable, bounded case coordination"
   rules-data.yaml: |
     # GENERATED by .github/scripts/gen-rules-opa-data.py — do not hand-edit.
     #

--- a/openbank-infra/gitops/components/kyc/kyc-service.yaml
+++ b/openbank-infra/gitops/components/kyc/kyc-service.yaml
@@ -48,7 +48,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-kyc-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "7394120ba7abd79e"
+        openbank.tech/policy-checksum: "18b96aa159eac334"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: ledger-service
     app.kubernetes.io/part-of: ledger
   annotations:
-    openbank.tech/policy-checksum: "f94cc94ab173fa3f"
+    openbank.tech/policy-checksum: "6efa6f1f9ec41558"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1006,10 +1006,58 @@ data:
         - secrets.read.raw
 
     # ---------------------------------------------------------------------------------------
+    # Case classes for agent swarm coordination (ADR-0244). A case is one long-running
+    # Temporal workflow opened for a single disposition target. Default budgets and
+    # convergence thresholds live here; per-class overrides are merged over default.
+    # Every case names exactly one class. The case-coordinator charter owns convergence
+    # judgement and budget enforcement; other charters may be granted case.join (and later
+    # case.contribute) once the signal-handling wiring lands.
+    # ---------------------------------------------------------------------------------------
+    case_classes:
+      default:
+        budget:
+          tokens_per_case: 500000
+          max_contributions: 100
+          wall_clock_minutes: 60
+        concurrency:
+          max_open_cases: 10
+        convergence:
+          contested_rate_threshold: 0.30   # suspend case-open for this class above 30% contested
+      classes:
+        fraud-investigation:
+          budget:
+            tokens_per_case: 1000000
+            max_contributions: 200
+            wall_clock_minutes: 120
+          concurrency:
+            max_open_cases: 5
+          convergence:
+            contested_rate_threshold: 0.25
+        aml-alert:
+          budget:
+            tokens_per_case: 300000
+            max_contributions: 50
+            wall_clock_minutes: 30
+          concurrency:
+            max_open_cases: 20
+          convergence:
+            contested_rate_threshold: 0.40
+        incident-response:
+          budget:
+            tokens_per_case: 200000
+            max_contributions: 40
+            wall_clock_minutes: 20
+          concurrency:
+            max_open_cases: 15
+          convergence:
+            contested_rate_threshold: 0.35
+
+    # ---------------------------------------------------------------------------------------
     # Agents. plane = control (oversight, proposal-only) | development (per-domain engineering)
     #                | customer (customer-facing assistant, ADR-0089 — its own SCA-gated regime).
     # Each charter answers: data_scope (what it reads), tools (what it calls), requires_human
-    # (what must be approved), limits (budget/quota).
+    # (what must be approved), limits (budget/quota). Swarm participants additionally declare
+    # case_capabilities (ADR-0244).
     # ---------------------------------------------------------------------------------------
     agents:
 
@@ -1611,6 +1659,67 @@ data:
         compliance:
           eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
           dora: "Art. 9 ICT risk detection; Art. 5 ICT risk management framework — fleet-wide static verification that a test suite's reported green state reflects tests that actually ran"
+
+      - id: case-coordinator
+        plane: control
+        charter: "ADR-0244"
+        description: >
+          Owns a running Temporal case workflow: invites chartered agents to contribute,
+          enforces the per-case-class budget and deadline, judges convergence, and emits
+          exactly one HITL proposal per case. Every swarm is bounded to one disposition
+          target; pre-emption is deterministic and replay-safe. The coordinator never
+          coordinates a case it opened; who detected is never who converged.
+        enabled: true
+        enforcement: block
+        data_scope:
+          read:
+            - case-workflow-history       # Temporal workflow history of cases it coordinates
+            - agent-proposals-readonly    # existing proposal queue metadata (no raw payload)
+            - read.governance             # agents.yaml case classes and charter capabilities
+          pii: masked
+        tools:
+          allow:
+            - tier: read
+              resources: [case-workflow, governance]
+            - tier: write_proposal
+              resources: [agent-proposal]   # emits one HITL proposal per case
+            - tier: execute
+              resources: [case-workflow-signal]  # sends deterministic pre-emption / convergence signals
+          deny:
+            - tier: write
+              resources: ["*"]             # never writes to a business record directly
+            - tier: execute
+              resources: [money.*, gh.pr.*, secrets.*]
+        case_capabilities:
+          # The coordinator is the only charter that may open, coordinate, and synthesize a case.
+          # Other agents may be granted case.join (and later case.contribute) in their own charters.
+          - case.open
+          - case.coordinate
+          - case.synthesize
+          - case.preempt
+        requires_human:
+          - every: proposal               # every synthesized proposal is a HITL proposal
+          - approver_must_differ_from: author
+          - record: reason
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 48                # one per active case hour is common; cap prevents runaway
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - case_id
+            - disposition_target
+            - case_class
+            - contributions_received
+            - synthesis_cited_contribution_ids
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, human disposes; not Annex III high-risk"
+          dora: "ICT change management (Art. 8–10); operational resilience via durable, bounded case coordination"
   rules-data.yaml: |
     # GENERATED by .github/scripts/gen-rules-opa-data.py — do not hand-edit.
     #

--- a/openbank-infra/gitops/components/ledger/ledger-service.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-service.yaml
@@ -38,7 +38,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-ledger-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "f94cc94ab173fa3f"
+        openbank.tech/policy-checksum: "6efa6f1f9ec41558"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: lending-service
     app.kubernetes.io/part-of: lending
   annotations:
-    openbank.tech/policy-checksum: "5d79b9c52f3e71e2"
+    openbank.tech/policy-checksum: "8592c7ef864525f6"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1001,10 +1001,58 @@ data:
         - secrets.read.raw
 
     # ---------------------------------------------------------------------------------------
+    # Case classes for agent swarm coordination (ADR-0244). A case is one long-running
+    # Temporal workflow opened for a single disposition target. Default budgets and
+    # convergence thresholds live here; per-class overrides are merged over default.
+    # Every case names exactly one class. The case-coordinator charter owns convergence
+    # judgement and budget enforcement; other charters may be granted case.join (and later
+    # case.contribute) once the signal-handling wiring lands.
+    # ---------------------------------------------------------------------------------------
+    case_classes:
+      default:
+        budget:
+          tokens_per_case: 500000
+          max_contributions: 100
+          wall_clock_minutes: 60
+        concurrency:
+          max_open_cases: 10
+        convergence:
+          contested_rate_threshold: 0.30   # suspend case-open for this class above 30% contested
+      classes:
+        fraud-investigation:
+          budget:
+            tokens_per_case: 1000000
+            max_contributions: 200
+            wall_clock_minutes: 120
+          concurrency:
+            max_open_cases: 5
+          convergence:
+            contested_rate_threshold: 0.25
+        aml-alert:
+          budget:
+            tokens_per_case: 300000
+            max_contributions: 50
+            wall_clock_minutes: 30
+          concurrency:
+            max_open_cases: 20
+          convergence:
+            contested_rate_threshold: 0.40
+        incident-response:
+          budget:
+            tokens_per_case: 200000
+            max_contributions: 40
+            wall_clock_minutes: 20
+          concurrency:
+            max_open_cases: 15
+          convergence:
+            contested_rate_threshold: 0.35
+
+    # ---------------------------------------------------------------------------------------
     # Agents. plane = control (oversight, proposal-only) | development (per-domain engineering)
     #                | customer (customer-facing assistant, ADR-0089 — its own SCA-gated regime).
     # Each charter answers: data_scope (what it reads), tools (what it calls), requires_human
-    # (what must be approved), limits (budget/quota).
+    # (what must be approved), limits (budget/quota). Swarm participants additionally declare
+    # case_capabilities (ADR-0244).
     # ---------------------------------------------------------------------------------------
     agents:
 
@@ -1606,6 +1654,67 @@ data:
         compliance:
           eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
           dora: "Art. 9 ICT risk detection; Art. 5 ICT risk management framework — fleet-wide static verification that a test suite's reported green state reflects tests that actually ran"
+
+      - id: case-coordinator
+        plane: control
+        charter: "ADR-0244"
+        description: >
+          Owns a running Temporal case workflow: invites chartered agents to contribute,
+          enforces the per-case-class budget and deadline, judges convergence, and emits
+          exactly one HITL proposal per case. Every swarm is bounded to one disposition
+          target; pre-emption is deterministic and replay-safe. The coordinator never
+          coordinates a case it opened; who detected is never who converged.
+        enabled: true
+        enforcement: block
+        data_scope:
+          read:
+            - case-workflow-history       # Temporal workflow history of cases it coordinates
+            - agent-proposals-readonly    # existing proposal queue metadata (no raw payload)
+            - read.governance             # agents.yaml case classes and charter capabilities
+          pii: masked
+        tools:
+          allow:
+            - tier: read
+              resources: [case-workflow, governance]
+            - tier: write_proposal
+              resources: [agent-proposal]   # emits one HITL proposal per case
+            - tier: execute
+              resources: [case-workflow-signal]  # sends deterministic pre-emption / convergence signals
+          deny:
+            - tier: write
+              resources: ["*"]             # never writes to a business record directly
+            - tier: execute
+              resources: [money.*, gh.pr.*, secrets.*]
+        case_capabilities:
+          # The coordinator is the only charter that may open, coordinate, and synthesize a case.
+          # Other agents may be granted case.join (and later case.contribute) in their own charters.
+          - case.open
+          - case.coordinate
+          - case.synthesize
+          - case.preempt
+        requires_human:
+          - every: proposal               # every synthesized proposal is a HITL proposal
+          - approver_must_differ_from: author
+          - record: reason
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 48                # one per active case hour is common; cap prevents runaway
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - case_id
+            - disposition_target
+            - case_class
+            - contributions_received
+            - synthesis_cited_contribution_ids
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, human disposes; not Annex III high-risk"
+          dora: "ICT change management (Art. 8–10); operational resilience via durable, bounded case coordination"
   rules-data.yaml: |
     # GENERATED by .github/scripts/gen-rules-opa-data.py — do not hand-edit.
     #

--- a/openbank-infra/gitops/components/lending/lending-service.yaml
+++ b/openbank-infra/gitops/components/lending/lending-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-lending-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "5d79b9c52f3e71e2"
+        openbank.tech/policy-checksum: "8592c7ef864525f6"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/mcp/mcp-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/mcp/mcp-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: mcp-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "0b79e3d8d2adf22f"
+    openbank.tech/policy-checksum: "899d182785c99f54"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -859,10 +859,58 @@ data:
         - secrets.read.raw
 
     # ---------------------------------------------------------------------------------------
+    # Case classes for agent swarm coordination (ADR-0244). A case is one long-running
+    # Temporal workflow opened for a single disposition target. Default budgets and
+    # convergence thresholds live here; per-class overrides are merged over default.
+    # Every case names exactly one class. The case-coordinator charter owns convergence
+    # judgement and budget enforcement; other charters may be granted case.join (and later
+    # case.contribute) once the signal-handling wiring lands.
+    # ---------------------------------------------------------------------------------------
+    case_classes:
+      default:
+        budget:
+          tokens_per_case: 500000
+          max_contributions: 100
+          wall_clock_minutes: 60
+        concurrency:
+          max_open_cases: 10
+        convergence:
+          contested_rate_threshold: 0.30   # suspend case-open for this class above 30% contested
+      classes:
+        fraud-investigation:
+          budget:
+            tokens_per_case: 1000000
+            max_contributions: 200
+            wall_clock_minutes: 120
+          concurrency:
+            max_open_cases: 5
+          convergence:
+            contested_rate_threshold: 0.25
+        aml-alert:
+          budget:
+            tokens_per_case: 300000
+            max_contributions: 50
+            wall_clock_minutes: 30
+          concurrency:
+            max_open_cases: 20
+          convergence:
+            contested_rate_threshold: 0.40
+        incident-response:
+          budget:
+            tokens_per_case: 200000
+            max_contributions: 40
+            wall_clock_minutes: 20
+          concurrency:
+            max_open_cases: 15
+          convergence:
+            contested_rate_threshold: 0.35
+
+    # ---------------------------------------------------------------------------------------
     # Agents. plane = control (oversight, proposal-only) | development (per-domain engineering)
     #                | customer (customer-facing assistant, ADR-0089 — its own SCA-gated regime).
     # Each charter answers: data_scope (what it reads), tools (what it calls), requires_human
-    # (what must be approved), limits (budget/quota).
+    # (what must be approved), limits (budget/quota). Swarm participants additionally declare
+    # case_capabilities (ADR-0244).
     # ---------------------------------------------------------------------------------------
     agents:
 
@@ -1464,6 +1512,67 @@ data:
         compliance:
           eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
           dora: "Art. 9 ICT risk detection; Art. 5 ICT risk management framework — fleet-wide static verification that a test suite's reported green state reflects tests that actually ran"
+
+      - id: case-coordinator
+        plane: control
+        charter: "ADR-0244"
+        description: >
+          Owns a running Temporal case workflow: invites chartered agents to contribute,
+          enforces the per-case-class budget and deadline, judges convergence, and emits
+          exactly one HITL proposal per case. Every swarm is bounded to one disposition
+          target; pre-emption is deterministic and replay-safe. The coordinator never
+          coordinates a case it opened; who detected is never who converged.
+        enabled: true
+        enforcement: block
+        data_scope:
+          read:
+            - case-workflow-history       # Temporal workflow history of cases it coordinates
+            - agent-proposals-readonly    # existing proposal queue metadata (no raw payload)
+            - read.governance             # agents.yaml case classes and charter capabilities
+          pii: masked
+        tools:
+          allow:
+            - tier: read
+              resources: [case-workflow, governance]
+            - tier: write_proposal
+              resources: [agent-proposal]   # emits one HITL proposal per case
+            - tier: execute
+              resources: [case-workflow-signal]  # sends deterministic pre-emption / convergence signals
+          deny:
+            - tier: write
+              resources: ["*"]             # never writes to a business record directly
+            - tier: execute
+              resources: [money.*, gh.pr.*, secrets.*]
+        case_capabilities:
+          # The coordinator is the only charter that may open, coordinate, and synthesize a case.
+          # Other agents may be granted case.join (and later case.contribute) in their own charters.
+          - case.open
+          - case.coordinate
+          - case.synthesize
+          - case.preempt
+        requires_human:
+          - every: proposal               # every synthesized proposal is a HITL proposal
+          - approver_must_differ_from: author
+          - record: reason
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 48                # one per active case hour is common; cap prevents runaway
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - case_id
+            - disposition_target
+            - case_class
+            - contributions_received
+            - synthesis_cited_contribution_ids
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, human disposes; not Annex III high-risk"
+          dora: "ICT change management (Art. 8–10); operational resilience via durable, bounded case coordination"
   rules-data.yaml: |
     # GENERATED by .github/scripts/gen-rules-opa-data.py — do not hand-edit.
     #

--- a/openbank-infra/gitops/components/mcp/mcp-service.yaml
+++ b/openbank-infra/gitops/components/mcp/mcp-service.yaml
@@ -39,7 +39,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-mcp-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "0b79e3d8d2adf22f"
+        openbank.tech/policy-checksum: "899d182785c99f54"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: notification-service
     app.kubernetes.io/part-of: notifications
   annotations:
-    openbank.tech/policy-checksum: "99a64206f9e9605b"
+    openbank.tech/policy-checksum: "caa4315947012bae"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1246,10 +1246,58 @@ data:
         - secrets.read.raw
 
     # ---------------------------------------------------------------------------------------
+    # Case classes for agent swarm coordination (ADR-0244). A case is one long-running
+    # Temporal workflow opened for a single disposition target. Default budgets and
+    # convergence thresholds live here; per-class overrides are merged over default.
+    # Every case names exactly one class. The case-coordinator charter owns convergence
+    # judgement and budget enforcement; other charters may be granted case.join (and later
+    # case.contribute) once the signal-handling wiring lands.
+    # ---------------------------------------------------------------------------------------
+    case_classes:
+      default:
+        budget:
+          tokens_per_case: 500000
+          max_contributions: 100
+          wall_clock_minutes: 60
+        concurrency:
+          max_open_cases: 10
+        convergence:
+          contested_rate_threshold: 0.30   # suspend case-open for this class above 30% contested
+      classes:
+        fraud-investigation:
+          budget:
+            tokens_per_case: 1000000
+            max_contributions: 200
+            wall_clock_minutes: 120
+          concurrency:
+            max_open_cases: 5
+          convergence:
+            contested_rate_threshold: 0.25
+        aml-alert:
+          budget:
+            tokens_per_case: 300000
+            max_contributions: 50
+            wall_clock_minutes: 30
+          concurrency:
+            max_open_cases: 20
+          convergence:
+            contested_rate_threshold: 0.40
+        incident-response:
+          budget:
+            tokens_per_case: 200000
+            max_contributions: 40
+            wall_clock_minutes: 20
+          concurrency:
+            max_open_cases: 15
+          convergence:
+            contested_rate_threshold: 0.35
+
+    # ---------------------------------------------------------------------------------------
     # Agents. plane = control (oversight, proposal-only) | development (per-domain engineering)
     #                | customer (customer-facing assistant, ADR-0089 — its own SCA-gated regime).
     # Each charter answers: data_scope (what it reads), tools (what it calls), requires_human
-    # (what must be approved), limits (budget/quota).
+    # (what must be approved), limits (budget/quota). Swarm participants additionally declare
+    # case_capabilities (ADR-0244).
     # ---------------------------------------------------------------------------------------
     agents:
 
@@ -1851,5 +1899,66 @@ data:
         compliance:
           eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
           dora: "Art. 9 ICT risk detection; Art. 5 ICT risk management framework — fleet-wide static verification that a test suite's reported green state reflects tests that actually ran"
+
+      - id: case-coordinator
+        plane: control
+        charter: "ADR-0244"
+        description: >
+          Owns a running Temporal case workflow: invites chartered agents to contribute,
+          enforces the per-case-class budget and deadline, judges convergence, and emits
+          exactly one HITL proposal per case. Every swarm is bounded to one disposition
+          target; pre-emption is deterministic and replay-safe. The coordinator never
+          coordinates a case it opened; who detected is never who converged.
+        enabled: true
+        enforcement: block
+        data_scope:
+          read:
+            - case-workflow-history       # Temporal workflow history of cases it coordinates
+            - agent-proposals-readonly    # existing proposal queue metadata (no raw payload)
+            - read.governance             # agents.yaml case classes and charter capabilities
+          pii: masked
+        tools:
+          allow:
+            - tier: read
+              resources: [case-workflow, governance]
+            - tier: write_proposal
+              resources: [agent-proposal]   # emits one HITL proposal per case
+            - tier: execute
+              resources: [case-workflow-signal]  # sends deterministic pre-emption / convergence signals
+          deny:
+            - tier: write
+              resources: ["*"]             # never writes to a business record directly
+            - tier: execute
+              resources: [money.*, gh.pr.*, secrets.*]
+        case_capabilities:
+          # The coordinator is the only charter that may open, coordinate, and synthesize a case.
+          # Other agents may be granted case.join (and later case.contribute) in their own charters.
+          - case.open
+          - case.coordinate
+          - case.synthesize
+          - case.preempt
+        requires_human:
+          - every: proposal               # every synthesized proposal is a HITL proposal
+          - approver_must_differ_from: author
+          - record: reason
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 48                # one per active case hour is common; cap prevents runaway
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - case_id
+            - disposition_target
+            - case_class
+            - contributions_received
+            - synthesis_cited_contribution_ids
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, human disposes; not Annex III high-risk"
+          dora: "ICT change management (Art. 8–10); operational resilience via durable, bounded case coordination"
   manifest.json: |
     {"roots": ["openbank/agents", "openbank/copilot", "openbank/rest", "agents", "rules"]}

--- a/openbank-infra/gitops/components/notifications/notification-service.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service.yaml
@@ -48,7 +48,7 @@ spec:
       annotations:
         # Rolls the Deployment when the OPA policy bundle changes (subPath mounts don't
         # hot-reload). Kept in sync by gen-notification-opa-bundle.sh.
-        openbank.tech/policy-checksum: "99a64206f9e9605b"
+        openbank.tech/policy-checksum: "caa4315947012bae"
       labels:
         app.kubernetes.io/name: notification-service
         app.kubernetes.io/part-of: notifications

--- a/openbank-infra/gitops/components/party/party-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/party/party-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: party-service
     app.kubernetes.io/part-of: party
   annotations:
-    openbank.tech/policy-checksum: "bd46c36eb36098eb"
+    openbank.tech/policy-checksum: "d8f52b5114a39627"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -930,10 +930,58 @@ data:
         - secrets.read.raw
 
     # ---------------------------------------------------------------------------------------
+    # Case classes for agent swarm coordination (ADR-0244). A case is one long-running
+    # Temporal workflow opened for a single disposition target. Default budgets and
+    # convergence thresholds live here; per-class overrides are merged over default.
+    # Every case names exactly one class. The case-coordinator charter owns convergence
+    # judgement and budget enforcement; other charters may be granted case.join (and later
+    # case.contribute) once the signal-handling wiring lands.
+    # ---------------------------------------------------------------------------------------
+    case_classes:
+      default:
+        budget:
+          tokens_per_case: 500000
+          max_contributions: 100
+          wall_clock_minutes: 60
+        concurrency:
+          max_open_cases: 10
+        convergence:
+          contested_rate_threshold: 0.30   # suspend case-open for this class above 30% contested
+      classes:
+        fraud-investigation:
+          budget:
+            tokens_per_case: 1000000
+            max_contributions: 200
+            wall_clock_minutes: 120
+          concurrency:
+            max_open_cases: 5
+          convergence:
+            contested_rate_threshold: 0.25
+        aml-alert:
+          budget:
+            tokens_per_case: 300000
+            max_contributions: 50
+            wall_clock_minutes: 30
+          concurrency:
+            max_open_cases: 20
+          convergence:
+            contested_rate_threshold: 0.40
+        incident-response:
+          budget:
+            tokens_per_case: 200000
+            max_contributions: 40
+            wall_clock_minutes: 20
+          concurrency:
+            max_open_cases: 15
+          convergence:
+            contested_rate_threshold: 0.35
+
+    # ---------------------------------------------------------------------------------------
     # Agents. plane = control (oversight, proposal-only) | development (per-domain engineering)
     #                | customer (customer-facing assistant, ADR-0089 — its own SCA-gated regime).
     # Each charter answers: data_scope (what it reads), tools (what it calls), requires_human
-    # (what must be approved), limits (budget/quota).
+    # (what must be approved), limits (budget/quota). Swarm participants additionally declare
+    # case_capabilities (ADR-0244).
     # ---------------------------------------------------------------------------------------
     agents:
 
@@ -1535,6 +1583,67 @@ data:
         compliance:
           eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
           dora: "Art. 9 ICT risk detection; Art. 5 ICT risk management framework — fleet-wide static verification that a test suite's reported green state reflects tests that actually ran"
+
+      - id: case-coordinator
+        plane: control
+        charter: "ADR-0244"
+        description: >
+          Owns a running Temporal case workflow: invites chartered agents to contribute,
+          enforces the per-case-class budget and deadline, judges convergence, and emits
+          exactly one HITL proposal per case. Every swarm is bounded to one disposition
+          target; pre-emption is deterministic and replay-safe. The coordinator never
+          coordinates a case it opened; who detected is never who converged.
+        enabled: true
+        enforcement: block
+        data_scope:
+          read:
+            - case-workflow-history       # Temporal workflow history of cases it coordinates
+            - agent-proposals-readonly    # existing proposal queue metadata (no raw payload)
+            - read.governance             # agents.yaml case classes and charter capabilities
+          pii: masked
+        tools:
+          allow:
+            - tier: read
+              resources: [case-workflow, governance]
+            - tier: write_proposal
+              resources: [agent-proposal]   # emits one HITL proposal per case
+            - tier: execute
+              resources: [case-workflow-signal]  # sends deterministic pre-emption / convergence signals
+          deny:
+            - tier: write
+              resources: ["*"]             # never writes to a business record directly
+            - tier: execute
+              resources: [money.*, gh.pr.*, secrets.*]
+        case_capabilities:
+          # The coordinator is the only charter that may open, coordinate, and synthesize a case.
+          # Other agents may be granted case.join (and later case.contribute) in their own charters.
+          - case.open
+          - case.coordinate
+          - case.synthesize
+          - case.preempt
+        requires_human:
+          - every: proposal               # every synthesized proposal is a HITL proposal
+          - approver_must_differ_from: author
+          - record: reason
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 48                # one per active case hour is common; cap prevents runaway
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - case_id
+            - disposition_target
+            - case_class
+            - contributions_received
+            - synthesis_cited_contribution_ids
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, human disposes; not Annex III high-risk"
+          dora: "ICT change management (Art. 8–10); operational resilience via durable, bounded case coordination"
   rules-data.yaml: |
     # GENERATED by .github/scripts/gen-rules-opa-data.py — do not hand-edit.
     #

--- a/openbank-infra/gitops/components/party/party-service.yaml
+++ b/openbank-infra/gitops/components/party/party-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-party-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "bd46c36eb36098eb"
+        openbank.tech/policy-checksum: "d8f52b5114a39627"
       labels:
         app.kubernetes.io/name: party-service
         app.kubernetes.io/part-of: party

--- a/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: card-issuance-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "48fa347da95613aa"
+    openbank.tech/policy-checksum: "30c8b09275e65d61"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -914,10 +914,58 @@ data:
         - secrets.read.raw
 
     # ---------------------------------------------------------------------------------------
+    # Case classes for agent swarm coordination (ADR-0244). A case is one long-running
+    # Temporal workflow opened for a single disposition target. Default budgets and
+    # convergence thresholds live here; per-class overrides are merged over default.
+    # Every case names exactly one class. The case-coordinator charter owns convergence
+    # judgement and budget enforcement; other charters may be granted case.join (and later
+    # case.contribute) once the signal-handling wiring lands.
+    # ---------------------------------------------------------------------------------------
+    case_classes:
+      default:
+        budget:
+          tokens_per_case: 500000
+          max_contributions: 100
+          wall_clock_minutes: 60
+        concurrency:
+          max_open_cases: 10
+        convergence:
+          contested_rate_threshold: 0.30   # suspend case-open for this class above 30% contested
+      classes:
+        fraud-investigation:
+          budget:
+            tokens_per_case: 1000000
+            max_contributions: 200
+            wall_clock_minutes: 120
+          concurrency:
+            max_open_cases: 5
+          convergence:
+            contested_rate_threshold: 0.25
+        aml-alert:
+          budget:
+            tokens_per_case: 300000
+            max_contributions: 50
+            wall_clock_minutes: 30
+          concurrency:
+            max_open_cases: 20
+          convergence:
+            contested_rate_threshold: 0.40
+        incident-response:
+          budget:
+            tokens_per_case: 200000
+            max_contributions: 40
+            wall_clock_minutes: 20
+          concurrency:
+            max_open_cases: 15
+          convergence:
+            contested_rate_threshold: 0.35
+
+    # ---------------------------------------------------------------------------------------
     # Agents. plane = control (oversight, proposal-only) | development (per-domain engineering)
     #                | customer (customer-facing assistant, ADR-0089 — its own SCA-gated regime).
     # Each charter answers: data_scope (what it reads), tools (what it calls), requires_human
-    # (what must be approved), limits (budget/quota).
+    # (what must be approved), limits (budget/quota). Swarm participants additionally declare
+    # case_capabilities (ADR-0244).
     # ---------------------------------------------------------------------------------------
     agents:
 
@@ -1519,6 +1567,67 @@ data:
         compliance:
           eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
           dora: "Art. 9 ICT risk detection; Art. 5 ICT risk management framework — fleet-wide static verification that a test suite's reported green state reflects tests that actually ran"
+
+      - id: case-coordinator
+        plane: control
+        charter: "ADR-0244"
+        description: >
+          Owns a running Temporal case workflow: invites chartered agents to contribute,
+          enforces the per-case-class budget and deadline, judges convergence, and emits
+          exactly one HITL proposal per case. Every swarm is bounded to one disposition
+          target; pre-emption is deterministic and replay-safe. The coordinator never
+          coordinates a case it opened; who detected is never who converged.
+        enabled: true
+        enforcement: block
+        data_scope:
+          read:
+            - case-workflow-history       # Temporal workflow history of cases it coordinates
+            - agent-proposals-readonly    # existing proposal queue metadata (no raw payload)
+            - read.governance             # agents.yaml case classes and charter capabilities
+          pii: masked
+        tools:
+          allow:
+            - tier: read
+              resources: [case-workflow, governance]
+            - tier: write_proposal
+              resources: [agent-proposal]   # emits one HITL proposal per case
+            - tier: execute
+              resources: [case-workflow-signal]  # sends deterministic pre-emption / convergence signals
+          deny:
+            - tier: write
+              resources: ["*"]             # never writes to a business record directly
+            - tier: execute
+              resources: [money.*, gh.pr.*, secrets.*]
+        case_capabilities:
+          # The coordinator is the only charter that may open, coordinate, and synthesize a case.
+          # Other agents may be granted case.join (and later case.contribute) in their own charters.
+          - case.open
+          - case.coordinate
+          - case.synthesize
+          - case.preempt
+        requires_human:
+          - every: proposal               # every synthesized proposal is a HITL proposal
+          - approver_must_differ_from: author
+          - record: reason
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 48                # one per active case hour is common; cap prevents runaway
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - case_id
+            - disposition_target
+            - case_class
+            - contributions_received
+            - synthesis_cited_contribution_ids
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, human disposes; not Annex III high-risk"
+          dora: "ICT change management (Art. 8–10); operational resilience via durable, bounded case coordination"
   rules-data.yaml: |
     # GENERATED by .github/scripts/gen-rules-opa-data.py — do not hand-edit.
     #

--- a/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: clearing-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "f9a2540634aabf34"
+    openbank.tech/policy-checksum: "bb259c4ebf2de153"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -951,10 +951,58 @@ data:
         - secrets.read.raw
 
     # ---------------------------------------------------------------------------------------
+    # Case classes for agent swarm coordination (ADR-0244). A case is one long-running
+    # Temporal workflow opened for a single disposition target. Default budgets and
+    # convergence thresholds live here; per-class overrides are merged over default.
+    # Every case names exactly one class. The case-coordinator charter owns convergence
+    # judgement and budget enforcement; other charters may be granted case.join (and later
+    # case.contribute) once the signal-handling wiring lands.
+    # ---------------------------------------------------------------------------------------
+    case_classes:
+      default:
+        budget:
+          tokens_per_case: 500000
+          max_contributions: 100
+          wall_clock_minutes: 60
+        concurrency:
+          max_open_cases: 10
+        convergence:
+          contested_rate_threshold: 0.30   # suspend case-open for this class above 30% contested
+      classes:
+        fraud-investigation:
+          budget:
+            tokens_per_case: 1000000
+            max_contributions: 200
+            wall_clock_minutes: 120
+          concurrency:
+            max_open_cases: 5
+          convergence:
+            contested_rate_threshold: 0.25
+        aml-alert:
+          budget:
+            tokens_per_case: 300000
+            max_contributions: 50
+            wall_clock_minutes: 30
+          concurrency:
+            max_open_cases: 20
+          convergence:
+            contested_rate_threshold: 0.40
+        incident-response:
+          budget:
+            tokens_per_case: 200000
+            max_contributions: 40
+            wall_clock_minutes: 20
+          concurrency:
+            max_open_cases: 15
+          convergence:
+            contested_rate_threshold: 0.35
+
+    # ---------------------------------------------------------------------------------------
     # Agents. plane = control (oversight, proposal-only) | development (per-domain engineering)
     #                | customer (customer-facing assistant, ADR-0089 — its own SCA-gated regime).
     # Each charter answers: data_scope (what it reads), tools (what it calls), requires_human
-    # (what must be approved), limits (budget/quota).
+    # (what must be approved), limits (budget/quota). Swarm participants additionally declare
+    # case_capabilities (ADR-0244).
     # ---------------------------------------------------------------------------------------
     agents:
 
@@ -1556,6 +1604,67 @@ data:
         compliance:
           eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
           dora: "Art. 9 ICT risk detection; Art. 5 ICT risk management framework — fleet-wide static verification that a test suite's reported green state reflects tests that actually ran"
+
+      - id: case-coordinator
+        plane: control
+        charter: "ADR-0244"
+        description: >
+          Owns a running Temporal case workflow: invites chartered agents to contribute,
+          enforces the per-case-class budget and deadline, judges convergence, and emits
+          exactly one HITL proposal per case. Every swarm is bounded to one disposition
+          target; pre-emption is deterministic and replay-safe. The coordinator never
+          coordinates a case it opened; who detected is never who converged.
+        enabled: true
+        enforcement: block
+        data_scope:
+          read:
+            - case-workflow-history       # Temporal workflow history of cases it coordinates
+            - agent-proposals-readonly    # existing proposal queue metadata (no raw payload)
+            - read.governance             # agents.yaml case classes and charter capabilities
+          pii: masked
+        tools:
+          allow:
+            - tier: read
+              resources: [case-workflow, governance]
+            - tier: write_proposal
+              resources: [agent-proposal]   # emits one HITL proposal per case
+            - tier: execute
+              resources: [case-workflow-signal]  # sends deterministic pre-emption / convergence signals
+          deny:
+            - tier: write
+              resources: ["*"]             # never writes to a business record directly
+            - tier: execute
+              resources: [money.*, gh.pr.*, secrets.*]
+        case_capabilities:
+          # The coordinator is the only charter that may open, coordinate, and synthesize a case.
+          # Other agents may be granted case.join (and later case.contribute) in their own charters.
+          - case.open
+          - case.coordinate
+          - case.synthesize
+          - case.preempt
+        requires_human:
+          - every: proposal               # every synthesized proposal is a HITL proposal
+          - approver_must_differ_from: author
+          - record: reason
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 48                # one per active case hour is common; cap prevents runaway
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - case_id
+            - disposition_target
+            - case_class
+            - contributions_received
+            - synthesis_cited_contribution_ids
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, human disposes; not Annex III high-risk"
+          dora: "ICT change management (Art. 8–10); operational resilience via durable, bounded case coordination"
   rules-data.yaml: |
     # GENERATED by .github/scripts/gen-rules-opa-data.py — do not hand-edit.
     #

--- a/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: domestic-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "5a14bac86219c8bf"
+    openbank.tech/policy-checksum: "cb91ae113c049e27"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -936,10 +936,58 @@ data:
         - secrets.read.raw
 
     # ---------------------------------------------------------------------------------------
+    # Case classes for agent swarm coordination (ADR-0244). A case is one long-running
+    # Temporal workflow opened for a single disposition target. Default budgets and
+    # convergence thresholds live here; per-class overrides are merged over default.
+    # Every case names exactly one class. The case-coordinator charter owns convergence
+    # judgement and budget enforcement; other charters may be granted case.join (and later
+    # case.contribute) once the signal-handling wiring lands.
+    # ---------------------------------------------------------------------------------------
+    case_classes:
+      default:
+        budget:
+          tokens_per_case: 500000
+          max_contributions: 100
+          wall_clock_minutes: 60
+        concurrency:
+          max_open_cases: 10
+        convergence:
+          contested_rate_threshold: 0.30   # suspend case-open for this class above 30% contested
+      classes:
+        fraud-investigation:
+          budget:
+            tokens_per_case: 1000000
+            max_contributions: 200
+            wall_clock_minutes: 120
+          concurrency:
+            max_open_cases: 5
+          convergence:
+            contested_rate_threshold: 0.25
+        aml-alert:
+          budget:
+            tokens_per_case: 300000
+            max_contributions: 50
+            wall_clock_minutes: 30
+          concurrency:
+            max_open_cases: 20
+          convergence:
+            contested_rate_threshold: 0.40
+        incident-response:
+          budget:
+            tokens_per_case: 200000
+            max_contributions: 40
+            wall_clock_minutes: 20
+          concurrency:
+            max_open_cases: 15
+          convergence:
+            contested_rate_threshold: 0.35
+
+    # ---------------------------------------------------------------------------------------
     # Agents. plane = control (oversight, proposal-only) | development (per-domain engineering)
     #                | customer (customer-facing assistant, ADR-0089 — its own SCA-gated regime).
     # Each charter answers: data_scope (what it reads), tools (what it calls), requires_human
-    # (what must be approved), limits (budget/quota).
+    # (what must be approved), limits (budget/quota). Swarm participants additionally declare
+    # case_capabilities (ADR-0244).
     # ---------------------------------------------------------------------------------------
     agents:
 
@@ -1541,6 +1589,67 @@ data:
         compliance:
           eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
           dora: "Art. 9 ICT risk detection; Art. 5 ICT risk management framework — fleet-wide static verification that a test suite's reported green state reflects tests that actually ran"
+
+      - id: case-coordinator
+        plane: control
+        charter: "ADR-0244"
+        description: >
+          Owns a running Temporal case workflow: invites chartered agents to contribute,
+          enforces the per-case-class budget and deadline, judges convergence, and emits
+          exactly one HITL proposal per case. Every swarm is bounded to one disposition
+          target; pre-emption is deterministic and replay-safe. The coordinator never
+          coordinates a case it opened; who detected is never who converged.
+        enabled: true
+        enforcement: block
+        data_scope:
+          read:
+            - case-workflow-history       # Temporal workflow history of cases it coordinates
+            - agent-proposals-readonly    # existing proposal queue metadata (no raw payload)
+            - read.governance             # agents.yaml case classes and charter capabilities
+          pii: masked
+        tools:
+          allow:
+            - tier: read
+              resources: [case-workflow, governance]
+            - tier: write_proposal
+              resources: [agent-proposal]   # emits one HITL proposal per case
+            - tier: execute
+              resources: [case-workflow-signal]  # sends deterministic pre-emption / convergence signals
+          deny:
+            - tier: write
+              resources: ["*"]             # never writes to a business record directly
+            - tier: execute
+              resources: [money.*, gh.pr.*, secrets.*]
+        case_capabilities:
+          # The coordinator is the only charter that may open, coordinate, and synthesize a case.
+          # Other agents may be granted case.join (and later case.contribute) in their own charters.
+          - case.open
+          - case.coordinate
+          - case.synthesize
+          - case.preempt
+        requires_human:
+          - every: proposal               # every synthesized proposal is a HITL proposal
+          - approver_must_differ_from: author
+          - record: reason
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 48                # one per active case hour is common; cap prevents runaway
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - case_id
+            - disposition_target
+            - case_class
+            - contributions_received
+            - synthesis_cited_contribution_ids
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, human disposes; not Annex III high-risk"
+          dora: "ICT change management (Art. 8–10); operational resilience via durable, bounded case coordination"
   rules-data.yaml: |
     # GENERATED by .github/scripts/gen-rules-opa-data.py — do not hand-edit.
     #

--- a/openbank-infra/gitops/components/payments/payments-services.yaml
+++ b/openbank-infra/gitops/components/payments/payments-services.yaml
@@ -42,7 +42,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-transaction-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "625977bdca7976d4" # transaction-opa-bundle
+        openbank.tech/policy-checksum: "db0fd25f3c6cc7ce" # transaction-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -375,7 +375,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-payment-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "cb3cad3069a09ac5"
+        openbank.tech/policy-checksum: "3109a168a31a6da6"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -729,7 +729,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-domestic-payment-opa-bundle.sh via the trailing marker
         # comment (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "5a14bac86219c8bf" # domestic-payment-opa-bundle
+        openbank.tech/policy-checksum: "cb91ae113c049e27" # domestic-payment-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1053,7 +1053,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-instant-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "0656c4a7e79f4a71"
+        openbank.tech/policy-checksum: "6c3cd0538533986d"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1369,7 +1369,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-clearing-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "f9a2540634aabf34" # clearing-opa-bundle
+        openbank.tech/policy-checksum: "bb259c4ebf2de153" # clearing-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1667,7 +1667,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (ADR-0034). Value is stamped by
         # gen-standing-order-opa-bundle.sh — do not hand-edit.
-        openbank.tech/policy-checksum: "e982df9ebfcb4638" # standing-order-opa-bundle
+        openbank.tech/policy-checksum: "b3446cfd050f3b6b" # standing-order-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1929,7 +1929,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-card-issuance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "48fa347da95613aa"
+        openbank.tech/policy-checksum: "30c8b09275e65d61"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2199,7 +2199,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-settlement-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "dc5ca8618aff01f7" # settlement-opa-bundle
+        openbank.tech/policy-checksum: "980eb49e19a37c53" # settlement-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2614,7 +2614,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-swift-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "b0b561bea5884834"
+        openbank.tech/policy-checksum: "e90ec0a03058de5e"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2928,7 +2928,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-vop-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "966bb3550cbef0e9"
+        openbank.tech/policy-checksum: "ff1d488571b0c025"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-instant
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "0656c4a7e79f4a71"
+    openbank.tech/policy-checksum: "6c3cd0538533986d"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -909,10 +909,58 @@ data:
         - secrets.read.raw
 
     # ---------------------------------------------------------------------------------------
+    # Case classes for agent swarm coordination (ADR-0244). A case is one long-running
+    # Temporal workflow opened for a single disposition target. Default budgets and
+    # convergence thresholds live here; per-class overrides are merged over default.
+    # Every case names exactly one class. The case-coordinator charter owns convergence
+    # judgement and budget enforcement; other charters may be granted case.join (and later
+    # case.contribute) once the signal-handling wiring lands.
+    # ---------------------------------------------------------------------------------------
+    case_classes:
+      default:
+        budget:
+          tokens_per_case: 500000
+          max_contributions: 100
+          wall_clock_minutes: 60
+        concurrency:
+          max_open_cases: 10
+        convergence:
+          contested_rate_threshold: 0.30   # suspend case-open for this class above 30% contested
+      classes:
+        fraud-investigation:
+          budget:
+            tokens_per_case: 1000000
+            max_contributions: 200
+            wall_clock_minutes: 120
+          concurrency:
+            max_open_cases: 5
+          convergence:
+            contested_rate_threshold: 0.25
+        aml-alert:
+          budget:
+            tokens_per_case: 300000
+            max_contributions: 50
+            wall_clock_minutes: 30
+          concurrency:
+            max_open_cases: 20
+          convergence:
+            contested_rate_threshold: 0.40
+        incident-response:
+          budget:
+            tokens_per_case: 200000
+            max_contributions: 40
+            wall_clock_minutes: 20
+          concurrency:
+            max_open_cases: 15
+          convergence:
+            contested_rate_threshold: 0.35
+
+    # ---------------------------------------------------------------------------------------
     # Agents. plane = control (oversight, proposal-only) | development (per-domain engineering)
     #                | customer (customer-facing assistant, ADR-0089 — its own SCA-gated regime).
     # Each charter answers: data_scope (what it reads), tools (what it calls), requires_human
-    # (what must be approved), limits (budget/quota).
+    # (what must be approved), limits (budget/quota). Swarm participants additionally declare
+    # case_capabilities (ADR-0244).
     # ---------------------------------------------------------------------------------------
     agents:
 
@@ -1514,6 +1562,67 @@ data:
         compliance:
           eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
           dora: "Art. 9 ICT risk detection; Art. 5 ICT risk management framework — fleet-wide static verification that a test suite's reported green state reflects tests that actually ran"
+
+      - id: case-coordinator
+        plane: control
+        charter: "ADR-0244"
+        description: >
+          Owns a running Temporal case workflow: invites chartered agents to contribute,
+          enforces the per-case-class budget and deadline, judges convergence, and emits
+          exactly one HITL proposal per case. Every swarm is bounded to one disposition
+          target; pre-emption is deterministic and replay-safe. The coordinator never
+          coordinates a case it opened; who detected is never who converged.
+        enabled: true
+        enforcement: block
+        data_scope:
+          read:
+            - case-workflow-history       # Temporal workflow history of cases it coordinates
+            - agent-proposals-readonly    # existing proposal queue metadata (no raw payload)
+            - read.governance             # agents.yaml case classes and charter capabilities
+          pii: masked
+        tools:
+          allow:
+            - tier: read
+              resources: [case-workflow, governance]
+            - tier: write_proposal
+              resources: [agent-proposal]   # emits one HITL proposal per case
+            - tier: execute
+              resources: [case-workflow-signal]  # sends deterministic pre-emption / convergence signals
+          deny:
+            - tier: write
+              resources: ["*"]             # never writes to a business record directly
+            - tier: execute
+              resources: [money.*, gh.pr.*, secrets.*]
+        case_capabilities:
+          # The coordinator is the only charter that may open, coordinate, and synthesize a case.
+          # Other agents may be granted case.join (and later case.contribute) in their own charters.
+          - case.open
+          - case.coordinate
+          - case.synthesize
+          - case.preempt
+        requires_human:
+          - every: proposal               # every synthesized proposal is a HITL proposal
+          - approver_must_differ_from: author
+          - record: reason
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 48                # one per active case hour is common; cap prevents runaway
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - case_id
+            - disposition_target
+            - case_class
+            - contributions_received
+            - synthesis_cited_contribution_ids
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, human disposes; not Annex III high-risk"
+          dora: "ICT change management (Art. 8–10); operational resilience via durable, bounded case coordination"
   rules-data.yaml: |
     # GENERATED by .github/scripts/gen-rules-opa-data.py — do not hand-edit.
     #

--- a/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "cb3cad3069a09ac5"
+    openbank.tech/policy-checksum: "3109a168a31a6da6"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -930,10 +930,58 @@ data:
         - secrets.read.raw
 
     # ---------------------------------------------------------------------------------------
+    # Case classes for agent swarm coordination (ADR-0244). A case is one long-running
+    # Temporal workflow opened for a single disposition target. Default budgets and
+    # convergence thresholds live here; per-class overrides are merged over default.
+    # Every case names exactly one class. The case-coordinator charter owns convergence
+    # judgement and budget enforcement; other charters may be granted case.join (and later
+    # case.contribute) once the signal-handling wiring lands.
+    # ---------------------------------------------------------------------------------------
+    case_classes:
+      default:
+        budget:
+          tokens_per_case: 500000
+          max_contributions: 100
+          wall_clock_minutes: 60
+        concurrency:
+          max_open_cases: 10
+        convergence:
+          contested_rate_threshold: 0.30   # suspend case-open for this class above 30% contested
+      classes:
+        fraud-investigation:
+          budget:
+            tokens_per_case: 1000000
+            max_contributions: 200
+            wall_clock_minutes: 120
+          concurrency:
+            max_open_cases: 5
+          convergence:
+            contested_rate_threshold: 0.25
+        aml-alert:
+          budget:
+            tokens_per_case: 300000
+            max_contributions: 50
+            wall_clock_minutes: 30
+          concurrency:
+            max_open_cases: 20
+          convergence:
+            contested_rate_threshold: 0.40
+        incident-response:
+          budget:
+            tokens_per_case: 200000
+            max_contributions: 40
+            wall_clock_minutes: 20
+          concurrency:
+            max_open_cases: 15
+          convergence:
+            contested_rate_threshold: 0.35
+
+    # ---------------------------------------------------------------------------------------
     # Agents. plane = control (oversight, proposal-only) | development (per-domain engineering)
     #                | customer (customer-facing assistant, ADR-0089 — its own SCA-gated regime).
     # Each charter answers: data_scope (what it reads), tools (what it calls), requires_human
-    # (what must be approved), limits (budget/quota).
+    # (what must be approved), limits (budget/quota). Swarm participants additionally declare
+    # case_capabilities (ADR-0244).
     # ---------------------------------------------------------------------------------------
     agents:
 
@@ -1535,6 +1583,67 @@ data:
         compliance:
           eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
           dora: "Art. 9 ICT risk detection; Art. 5 ICT risk management framework — fleet-wide static verification that a test suite's reported green state reflects tests that actually ran"
+
+      - id: case-coordinator
+        plane: control
+        charter: "ADR-0244"
+        description: >
+          Owns a running Temporal case workflow: invites chartered agents to contribute,
+          enforces the per-case-class budget and deadline, judges convergence, and emits
+          exactly one HITL proposal per case. Every swarm is bounded to one disposition
+          target; pre-emption is deterministic and replay-safe. The coordinator never
+          coordinates a case it opened; who detected is never who converged.
+        enabled: true
+        enforcement: block
+        data_scope:
+          read:
+            - case-workflow-history       # Temporal workflow history of cases it coordinates
+            - agent-proposals-readonly    # existing proposal queue metadata (no raw payload)
+            - read.governance             # agents.yaml case classes and charter capabilities
+          pii: masked
+        tools:
+          allow:
+            - tier: read
+              resources: [case-workflow, governance]
+            - tier: write_proposal
+              resources: [agent-proposal]   # emits one HITL proposal per case
+            - tier: execute
+              resources: [case-workflow-signal]  # sends deterministic pre-emption / convergence signals
+          deny:
+            - tier: write
+              resources: ["*"]             # never writes to a business record directly
+            - tier: execute
+              resources: [money.*, gh.pr.*, secrets.*]
+        case_capabilities:
+          # The coordinator is the only charter that may open, coordinate, and synthesize a case.
+          # Other agents may be granted case.join (and later case.contribute) in their own charters.
+          - case.open
+          - case.coordinate
+          - case.synthesize
+          - case.preempt
+        requires_human:
+          - every: proposal               # every synthesized proposal is a HITL proposal
+          - approver_must_differ_from: author
+          - record: reason
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 48                # one per active case hour is common; cap prevents runaway
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - case_id
+            - disposition_target
+            - case_class
+            - contributions_received
+            - synthesis_cited_contribution_ids
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, human disposes; not Annex III high-risk"
+          dora: "ICT change management (Art. 8–10); operational resilience via durable, bounded case coordination"
   rules-data.yaml: |
     # GENERATED by .github/scripts/gen-rules-opa-data.py — do not hand-edit.
     #

--- a/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: settlement-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "dc5ca8618aff01f7"
+    openbank.tech/policy-checksum: "980eb49e19a37c53"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -910,10 +910,58 @@ data:
         - secrets.read.raw
 
     # ---------------------------------------------------------------------------------------
+    # Case classes for agent swarm coordination (ADR-0244). A case is one long-running
+    # Temporal workflow opened for a single disposition target. Default budgets and
+    # convergence thresholds live here; per-class overrides are merged over default.
+    # Every case names exactly one class. The case-coordinator charter owns convergence
+    # judgement and budget enforcement; other charters may be granted case.join (and later
+    # case.contribute) once the signal-handling wiring lands.
+    # ---------------------------------------------------------------------------------------
+    case_classes:
+      default:
+        budget:
+          tokens_per_case: 500000
+          max_contributions: 100
+          wall_clock_minutes: 60
+        concurrency:
+          max_open_cases: 10
+        convergence:
+          contested_rate_threshold: 0.30   # suspend case-open for this class above 30% contested
+      classes:
+        fraud-investigation:
+          budget:
+            tokens_per_case: 1000000
+            max_contributions: 200
+            wall_clock_minutes: 120
+          concurrency:
+            max_open_cases: 5
+          convergence:
+            contested_rate_threshold: 0.25
+        aml-alert:
+          budget:
+            tokens_per_case: 300000
+            max_contributions: 50
+            wall_clock_minutes: 30
+          concurrency:
+            max_open_cases: 20
+          convergence:
+            contested_rate_threshold: 0.40
+        incident-response:
+          budget:
+            tokens_per_case: 200000
+            max_contributions: 40
+            wall_clock_minutes: 20
+          concurrency:
+            max_open_cases: 15
+          convergence:
+            contested_rate_threshold: 0.35
+
+    # ---------------------------------------------------------------------------------------
     # Agents. plane = control (oversight, proposal-only) | development (per-domain engineering)
     #                | customer (customer-facing assistant, ADR-0089 — its own SCA-gated regime).
     # Each charter answers: data_scope (what it reads), tools (what it calls), requires_human
-    # (what must be approved), limits (budget/quota).
+    # (what must be approved), limits (budget/quota). Swarm participants additionally declare
+    # case_capabilities (ADR-0244).
     # ---------------------------------------------------------------------------------------
     agents:
 
@@ -1515,6 +1563,67 @@ data:
         compliance:
           eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
           dora: "Art. 9 ICT risk detection; Art. 5 ICT risk management framework — fleet-wide static verification that a test suite's reported green state reflects tests that actually ran"
+
+      - id: case-coordinator
+        plane: control
+        charter: "ADR-0244"
+        description: >
+          Owns a running Temporal case workflow: invites chartered agents to contribute,
+          enforces the per-case-class budget and deadline, judges convergence, and emits
+          exactly one HITL proposal per case. Every swarm is bounded to one disposition
+          target; pre-emption is deterministic and replay-safe. The coordinator never
+          coordinates a case it opened; who detected is never who converged.
+        enabled: true
+        enforcement: block
+        data_scope:
+          read:
+            - case-workflow-history       # Temporal workflow history of cases it coordinates
+            - agent-proposals-readonly    # existing proposal queue metadata (no raw payload)
+            - read.governance             # agents.yaml case classes and charter capabilities
+          pii: masked
+        tools:
+          allow:
+            - tier: read
+              resources: [case-workflow, governance]
+            - tier: write_proposal
+              resources: [agent-proposal]   # emits one HITL proposal per case
+            - tier: execute
+              resources: [case-workflow-signal]  # sends deterministic pre-emption / convergence signals
+          deny:
+            - tier: write
+              resources: ["*"]             # never writes to a business record directly
+            - tier: execute
+              resources: [money.*, gh.pr.*, secrets.*]
+        case_capabilities:
+          # The coordinator is the only charter that may open, coordinate, and synthesize a case.
+          # Other agents may be granted case.join (and later case.contribute) in their own charters.
+          - case.open
+          - case.coordinate
+          - case.synthesize
+          - case.preempt
+        requires_human:
+          - every: proposal               # every synthesized proposal is a HITL proposal
+          - approver_must_differ_from: author
+          - record: reason
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 48                # one per active case hour is common; cap prevents runaway
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - case_id
+            - disposition_target
+            - case_class
+            - contributions_received
+            - synthesis_cited_contribution_ids
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, human disposes; not Annex III high-risk"
+          dora: "ICT change management (Art. 8–10); operational resilience via durable, bounded case coordination"
   rules-data.yaml: |
     # GENERATED by .github/scripts/gen-rules-opa-data.py — do not hand-edit.
     #

--- a/openbank-infra/gitops/components/payments/standing-order-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/standing-order-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: standing-order-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "e982df9ebfcb4638"
+    openbank.tech/policy-checksum: "b3446cfd050f3b6b"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -895,10 +895,58 @@ data:
         - secrets.read.raw
 
     # ---------------------------------------------------------------------------------------
+    # Case classes for agent swarm coordination (ADR-0244). A case is one long-running
+    # Temporal workflow opened for a single disposition target. Default budgets and
+    # convergence thresholds live here; per-class overrides are merged over default.
+    # Every case names exactly one class. The case-coordinator charter owns convergence
+    # judgement and budget enforcement; other charters may be granted case.join (and later
+    # case.contribute) once the signal-handling wiring lands.
+    # ---------------------------------------------------------------------------------------
+    case_classes:
+      default:
+        budget:
+          tokens_per_case: 500000
+          max_contributions: 100
+          wall_clock_minutes: 60
+        concurrency:
+          max_open_cases: 10
+        convergence:
+          contested_rate_threshold: 0.30   # suspend case-open for this class above 30% contested
+      classes:
+        fraud-investigation:
+          budget:
+            tokens_per_case: 1000000
+            max_contributions: 200
+            wall_clock_minutes: 120
+          concurrency:
+            max_open_cases: 5
+          convergence:
+            contested_rate_threshold: 0.25
+        aml-alert:
+          budget:
+            tokens_per_case: 300000
+            max_contributions: 50
+            wall_clock_minutes: 30
+          concurrency:
+            max_open_cases: 20
+          convergence:
+            contested_rate_threshold: 0.40
+        incident-response:
+          budget:
+            tokens_per_case: 200000
+            max_contributions: 40
+            wall_clock_minutes: 20
+          concurrency:
+            max_open_cases: 15
+          convergence:
+            contested_rate_threshold: 0.35
+
+    # ---------------------------------------------------------------------------------------
     # Agents. plane = control (oversight, proposal-only) | development (per-domain engineering)
     #                | customer (customer-facing assistant, ADR-0089 — its own SCA-gated regime).
     # Each charter answers: data_scope (what it reads), tools (what it calls), requires_human
-    # (what must be approved), limits (budget/quota).
+    # (what must be approved), limits (budget/quota). Swarm participants additionally declare
+    # case_capabilities (ADR-0244).
     # ---------------------------------------------------------------------------------------
     agents:
 
@@ -1500,6 +1548,67 @@ data:
         compliance:
           eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
           dora: "Art. 9 ICT risk detection; Art. 5 ICT risk management framework — fleet-wide static verification that a test suite's reported green state reflects tests that actually ran"
+
+      - id: case-coordinator
+        plane: control
+        charter: "ADR-0244"
+        description: >
+          Owns a running Temporal case workflow: invites chartered agents to contribute,
+          enforces the per-case-class budget and deadline, judges convergence, and emits
+          exactly one HITL proposal per case. Every swarm is bounded to one disposition
+          target; pre-emption is deterministic and replay-safe. The coordinator never
+          coordinates a case it opened; who detected is never who converged.
+        enabled: true
+        enforcement: block
+        data_scope:
+          read:
+            - case-workflow-history       # Temporal workflow history of cases it coordinates
+            - agent-proposals-readonly    # existing proposal queue metadata (no raw payload)
+            - read.governance             # agents.yaml case classes and charter capabilities
+          pii: masked
+        tools:
+          allow:
+            - tier: read
+              resources: [case-workflow, governance]
+            - tier: write_proposal
+              resources: [agent-proposal]   # emits one HITL proposal per case
+            - tier: execute
+              resources: [case-workflow-signal]  # sends deterministic pre-emption / convergence signals
+          deny:
+            - tier: write
+              resources: ["*"]             # never writes to a business record directly
+            - tier: execute
+              resources: [money.*, gh.pr.*, secrets.*]
+        case_capabilities:
+          # The coordinator is the only charter that may open, coordinate, and synthesize a case.
+          # Other agents may be granted case.join (and later case.contribute) in their own charters.
+          - case.open
+          - case.coordinate
+          - case.synthesize
+          - case.preempt
+        requires_human:
+          - every: proposal               # every synthesized proposal is a HITL proposal
+          - approver_must_differ_from: author
+          - record: reason
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 48                # one per active case hour is common; cap prevents runaway
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - case_id
+            - disposition_target
+            - case_class
+            - contributions_received
+            - synthesis_cited_contribution_ids
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, human disposes; not Annex III high-risk"
+          dora: "ICT change management (Art. 8–10); operational resilience via durable, bounded case coordination"
   rules-data.yaml: |
     # GENERATED by .github/scripts/gen-rules-opa-data.py — do not hand-edit.
     #

--- a/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: swift-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "b0b561bea5884834"
+    openbank.tech/policy-checksum: "e90ec0a03058de5e"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -913,10 +913,58 @@ data:
         - secrets.read.raw
 
     # ---------------------------------------------------------------------------------------
+    # Case classes for agent swarm coordination (ADR-0244). A case is one long-running
+    # Temporal workflow opened for a single disposition target. Default budgets and
+    # convergence thresholds live here; per-class overrides are merged over default.
+    # Every case names exactly one class. The case-coordinator charter owns convergence
+    # judgement and budget enforcement; other charters may be granted case.join (and later
+    # case.contribute) once the signal-handling wiring lands.
+    # ---------------------------------------------------------------------------------------
+    case_classes:
+      default:
+        budget:
+          tokens_per_case: 500000
+          max_contributions: 100
+          wall_clock_minutes: 60
+        concurrency:
+          max_open_cases: 10
+        convergence:
+          contested_rate_threshold: 0.30   # suspend case-open for this class above 30% contested
+      classes:
+        fraud-investigation:
+          budget:
+            tokens_per_case: 1000000
+            max_contributions: 200
+            wall_clock_minutes: 120
+          concurrency:
+            max_open_cases: 5
+          convergence:
+            contested_rate_threshold: 0.25
+        aml-alert:
+          budget:
+            tokens_per_case: 300000
+            max_contributions: 50
+            wall_clock_minutes: 30
+          concurrency:
+            max_open_cases: 20
+          convergence:
+            contested_rate_threshold: 0.40
+        incident-response:
+          budget:
+            tokens_per_case: 200000
+            max_contributions: 40
+            wall_clock_minutes: 20
+          concurrency:
+            max_open_cases: 15
+          convergence:
+            contested_rate_threshold: 0.35
+
+    # ---------------------------------------------------------------------------------------
     # Agents. plane = control (oversight, proposal-only) | development (per-domain engineering)
     #                | customer (customer-facing assistant, ADR-0089 — its own SCA-gated regime).
     # Each charter answers: data_scope (what it reads), tools (what it calls), requires_human
-    # (what must be approved), limits (budget/quota).
+    # (what must be approved), limits (budget/quota). Swarm participants additionally declare
+    # case_capabilities (ADR-0244).
     # ---------------------------------------------------------------------------------------
     agents:
 
@@ -1518,6 +1566,67 @@ data:
         compliance:
           eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
           dora: "Art. 9 ICT risk detection; Art. 5 ICT risk management framework — fleet-wide static verification that a test suite's reported green state reflects tests that actually ran"
+
+      - id: case-coordinator
+        plane: control
+        charter: "ADR-0244"
+        description: >
+          Owns a running Temporal case workflow: invites chartered agents to contribute,
+          enforces the per-case-class budget and deadline, judges convergence, and emits
+          exactly one HITL proposal per case. Every swarm is bounded to one disposition
+          target; pre-emption is deterministic and replay-safe. The coordinator never
+          coordinates a case it opened; who detected is never who converged.
+        enabled: true
+        enforcement: block
+        data_scope:
+          read:
+            - case-workflow-history       # Temporal workflow history of cases it coordinates
+            - agent-proposals-readonly    # existing proposal queue metadata (no raw payload)
+            - read.governance             # agents.yaml case classes and charter capabilities
+          pii: masked
+        tools:
+          allow:
+            - tier: read
+              resources: [case-workflow, governance]
+            - tier: write_proposal
+              resources: [agent-proposal]   # emits one HITL proposal per case
+            - tier: execute
+              resources: [case-workflow-signal]  # sends deterministic pre-emption / convergence signals
+          deny:
+            - tier: write
+              resources: ["*"]             # never writes to a business record directly
+            - tier: execute
+              resources: [money.*, gh.pr.*, secrets.*]
+        case_capabilities:
+          # The coordinator is the only charter that may open, coordinate, and synthesize a case.
+          # Other agents may be granted case.join (and later case.contribute) in their own charters.
+          - case.open
+          - case.coordinate
+          - case.synthesize
+          - case.preempt
+        requires_human:
+          - every: proposal               # every synthesized proposal is a HITL proposal
+          - approver_must_differ_from: author
+          - record: reason
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 48                # one per active case hour is common; cap prevents runaway
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - case_id
+            - disposition_target
+            - case_class
+            - contributions_received
+            - synthesis_cited_contribution_ids
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, human disposes; not Annex III high-risk"
+          dora: "ICT change management (Art. 8–10); operational resilience via durable, bounded case coordination"
   rules-data.yaml: |
     # GENERATED by .github/scripts/gen-rules-opa-data.py — do not hand-edit.
     #

--- a/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: transaction-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "625977bdca7976d4"
+    openbank.tech/policy-checksum: "db0fd25f3c6cc7ce"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -966,10 +966,58 @@ data:
         - secrets.read.raw
 
     # ---------------------------------------------------------------------------------------
+    # Case classes for agent swarm coordination (ADR-0244). A case is one long-running
+    # Temporal workflow opened for a single disposition target. Default budgets and
+    # convergence thresholds live here; per-class overrides are merged over default.
+    # Every case names exactly one class. The case-coordinator charter owns convergence
+    # judgement and budget enforcement; other charters may be granted case.join (and later
+    # case.contribute) once the signal-handling wiring lands.
+    # ---------------------------------------------------------------------------------------
+    case_classes:
+      default:
+        budget:
+          tokens_per_case: 500000
+          max_contributions: 100
+          wall_clock_minutes: 60
+        concurrency:
+          max_open_cases: 10
+        convergence:
+          contested_rate_threshold: 0.30   # suspend case-open for this class above 30% contested
+      classes:
+        fraud-investigation:
+          budget:
+            tokens_per_case: 1000000
+            max_contributions: 200
+            wall_clock_minutes: 120
+          concurrency:
+            max_open_cases: 5
+          convergence:
+            contested_rate_threshold: 0.25
+        aml-alert:
+          budget:
+            tokens_per_case: 300000
+            max_contributions: 50
+            wall_clock_minutes: 30
+          concurrency:
+            max_open_cases: 20
+          convergence:
+            contested_rate_threshold: 0.40
+        incident-response:
+          budget:
+            tokens_per_case: 200000
+            max_contributions: 40
+            wall_clock_minutes: 20
+          concurrency:
+            max_open_cases: 15
+          convergence:
+            contested_rate_threshold: 0.35
+
+    # ---------------------------------------------------------------------------------------
     # Agents. plane = control (oversight, proposal-only) | development (per-domain engineering)
     #                | customer (customer-facing assistant, ADR-0089 — its own SCA-gated regime).
     # Each charter answers: data_scope (what it reads), tools (what it calls), requires_human
-    # (what must be approved), limits (budget/quota).
+    # (what must be approved), limits (budget/quota). Swarm participants additionally declare
+    # case_capabilities (ADR-0244).
     # ---------------------------------------------------------------------------------------
     agents:
 
@@ -1571,6 +1619,67 @@ data:
         compliance:
           eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
           dora: "Art. 9 ICT risk detection; Art. 5 ICT risk management framework — fleet-wide static verification that a test suite's reported green state reflects tests that actually ran"
+
+      - id: case-coordinator
+        plane: control
+        charter: "ADR-0244"
+        description: >
+          Owns a running Temporal case workflow: invites chartered agents to contribute,
+          enforces the per-case-class budget and deadline, judges convergence, and emits
+          exactly one HITL proposal per case. Every swarm is bounded to one disposition
+          target; pre-emption is deterministic and replay-safe. The coordinator never
+          coordinates a case it opened; who detected is never who converged.
+        enabled: true
+        enforcement: block
+        data_scope:
+          read:
+            - case-workflow-history       # Temporal workflow history of cases it coordinates
+            - agent-proposals-readonly    # existing proposal queue metadata (no raw payload)
+            - read.governance             # agents.yaml case classes and charter capabilities
+          pii: masked
+        tools:
+          allow:
+            - tier: read
+              resources: [case-workflow, governance]
+            - tier: write_proposal
+              resources: [agent-proposal]   # emits one HITL proposal per case
+            - tier: execute
+              resources: [case-workflow-signal]  # sends deterministic pre-emption / convergence signals
+          deny:
+            - tier: write
+              resources: ["*"]             # never writes to a business record directly
+            - tier: execute
+              resources: [money.*, gh.pr.*, secrets.*]
+        case_capabilities:
+          # The coordinator is the only charter that may open, coordinate, and synthesize a case.
+          # Other agents may be granted case.join (and later case.contribute) in their own charters.
+          - case.open
+          - case.coordinate
+          - case.synthesize
+          - case.preempt
+        requires_human:
+          - every: proposal               # every synthesized proposal is a HITL proposal
+          - approver_must_differ_from: author
+          - record: reason
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 48                # one per active case hour is common; cap prevents runaway
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - case_id
+            - disposition_target
+            - case_class
+            - contributions_received
+            - synthesis_cited_contribution_ids
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, human disposes; not Annex III high-risk"
+          dora: "ICT change management (Art. 8–10); operational resilience via durable, bounded case coordination"
   rules-data.yaml: |
     # GENERATED by .github/scripts/gen-rules-opa-data.py — do not hand-edit.
     #

--- a/openbank-infra/gitops/components/payments/vop-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/vop-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: vop-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "966bb3550cbef0e9"
+    openbank.tech/policy-checksum: "ff1d488571b0c025"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -917,10 +917,58 @@ data:
         - secrets.read.raw
 
     # ---------------------------------------------------------------------------------------
+    # Case classes for agent swarm coordination (ADR-0244). A case is one long-running
+    # Temporal workflow opened for a single disposition target. Default budgets and
+    # convergence thresholds live here; per-class overrides are merged over default.
+    # Every case names exactly one class. The case-coordinator charter owns convergence
+    # judgement and budget enforcement; other charters may be granted case.join (and later
+    # case.contribute) once the signal-handling wiring lands.
+    # ---------------------------------------------------------------------------------------
+    case_classes:
+      default:
+        budget:
+          tokens_per_case: 500000
+          max_contributions: 100
+          wall_clock_minutes: 60
+        concurrency:
+          max_open_cases: 10
+        convergence:
+          contested_rate_threshold: 0.30   # suspend case-open for this class above 30% contested
+      classes:
+        fraud-investigation:
+          budget:
+            tokens_per_case: 1000000
+            max_contributions: 200
+            wall_clock_minutes: 120
+          concurrency:
+            max_open_cases: 5
+          convergence:
+            contested_rate_threshold: 0.25
+        aml-alert:
+          budget:
+            tokens_per_case: 300000
+            max_contributions: 50
+            wall_clock_minutes: 30
+          concurrency:
+            max_open_cases: 20
+          convergence:
+            contested_rate_threshold: 0.40
+        incident-response:
+          budget:
+            tokens_per_case: 200000
+            max_contributions: 40
+            wall_clock_minutes: 20
+          concurrency:
+            max_open_cases: 15
+          convergence:
+            contested_rate_threshold: 0.35
+
+    # ---------------------------------------------------------------------------------------
     # Agents. plane = control (oversight, proposal-only) | development (per-domain engineering)
     #                | customer (customer-facing assistant, ADR-0089 — its own SCA-gated regime).
     # Each charter answers: data_scope (what it reads), tools (what it calls), requires_human
-    # (what must be approved), limits (budget/quota).
+    # (what must be approved), limits (budget/quota). Swarm participants additionally declare
+    # case_capabilities (ADR-0244).
     # ---------------------------------------------------------------------------------------
     agents:
 
@@ -1522,6 +1570,67 @@ data:
         compliance:
           eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
           dora: "Art. 9 ICT risk detection; Art. 5 ICT risk management framework — fleet-wide static verification that a test suite's reported green state reflects tests that actually ran"
+
+      - id: case-coordinator
+        plane: control
+        charter: "ADR-0244"
+        description: >
+          Owns a running Temporal case workflow: invites chartered agents to contribute,
+          enforces the per-case-class budget and deadline, judges convergence, and emits
+          exactly one HITL proposal per case. Every swarm is bounded to one disposition
+          target; pre-emption is deterministic and replay-safe. The coordinator never
+          coordinates a case it opened; who detected is never who converged.
+        enabled: true
+        enforcement: block
+        data_scope:
+          read:
+            - case-workflow-history       # Temporal workflow history of cases it coordinates
+            - agent-proposals-readonly    # existing proposal queue metadata (no raw payload)
+            - read.governance             # agents.yaml case classes and charter capabilities
+          pii: masked
+        tools:
+          allow:
+            - tier: read
+              resources: [case-workflow, governance]
+            - tier: write_proposal
+              resources: [agent-proposal]   # emits one HITL proposal per case
+            - tier: execute
+              resources: [case-workflow-signal]  # sends deterministic pre-emption / convergence signals
+          deny:
+            - tier: write
+              resources: ["*"]             # never writes to a business record directly
+            - tier: execute
+              resources: [money.*, gh.pr.*, secrets.*]
+        case_capabilities:
+          # The coordinator is the only charter that may open, coordinate, and synthesize a case.
+          # Other agents may be granted case.join (and later case.contribute) in their own charters.
+          - case.open
+          - case.coordinate
+          - case.synthesize
+          - case.preempt
+        requires_human:
+          - every: proposal               # every synthesized proposal is a HITL proposal
+          - approver_must_differ_from: author
+          - record: reason
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 48                # one per active case hour is common; cap prevents runaway
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - case_id
+            - disposition_target
+            - case_class
+            - contributions_received
+            - synthesis_cited_contribution_ids
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, human disposes; not Annex III high-risk"
+          dora: "ICT change management (Art. 8–10); operational resilience via durable, bounded case coordination"
   rules-data.yaml: |
     # GENERATED by .github/scripts/gen-rules-opa-data.py — do not hand-edit.
     #

--- a/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: pid-service
     app.kubernetes.io/part-of: pid
   annotations:
-    openbank.tech/policy-checksum: "8d877a3cee68303d"
+    openbank.tech/policy-checksum: "a81c109f90403d09"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -919,10 +919,58 @@ data:
         - secrets.read.raw
 
     # ---------------------------------------------------------------------------------------
+    # Case classes for agent swarm coordination (ADR-0244). A case is one long-running
+    # Temporal workflow opened for a single disposition target. Default budgets and
+    # convergence thresholds live here; per-class overrides are merged over default.
+    # Every case names exactly one class. The case-coordinator charter owns convergence
+    # judgement and budget enforcement; other charters may be granted case.join (and later
+    # case.contribute) once the signal-handling wiring lands.
+    # ---------------------------------------------------------------------------------------
+    case_classes:
+      default:
+        budget:
+          tokens_per_case: 500000
+          max_contributions: 100
+          wall_clock_minutes: 60
+        concurrency:
+          max_open_cases: 10
+        convergence:
+          contested_rate_threshold: 0.30   # suspend case-open for this class above 30% contested
+      classes:
+        fraud-investigation:
+          budget:
+            tokens_per_case: 1000000
+            max_contributions: 200
+            wall_clock_minutes: 120
+          concurrency:
+            max_open_cases: 5
+          convergence:
+            contested_rate_threshold: 0.25
+        aml-alert:
+          budget:
+            tokens_per_case: 300000
+            max_contributions: 50
+            wall_clock_minutes: 30
+          concurrency:
+            max_open_cases: 20
+          convergence:
+            contested_rate_threshold: 0.40
+        incident-response:
+          budget:
+            tokens_per_case: 200000
+            max_contributions: 40
+            wall_clock_minutes: 20
+          concurrency:
+            max_open_cases: 15
+          convergence:
+            contested_rate_threshold: 0.35
+
+    # ---------------------------------------------------------------------------------------
     # Agents. plane = control (oversight, proposal-only) | development (per-domain engineering)
     #                | customer (customer-facing assistant, ADR-0089 — its own SCA-gated regime).
     # Each charter answers: data_scope (what it reads), tools (what it calls), requires_human
-    # (what must be approved), limits (budget/quota).
+    # (what must be approved), limits (budget/quota). Swarm participants additionally declare
+    # case_capabilities (ADR-0244).
     # ---------------------------------------------------------------------------------------
     agents:
 
@@ -1524,6 +1572,67 @@ data:
         compliance:
           eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
           dora: "Art. 9 ICT risk detection; Art. 5 ICT risk management framework — fleet-wide static verification that a test suite's reported green state reflects tests that actually ran"
+
+      - id: case-coordinator
+        plane: control
+        charter: "ADR-0244"
+        description: >
+          Owns a running Temporal case workflow: invites chartered agents to contribute,
+          enforces the per-case-class budget and deadline, judges convergence, and emits
+          exactly one HITL proposal per case. Every swarm is bounded to one disposition
+          target; pre-emption is deterministic and replay-safe. The coordinator never
+          coordinates a case it opened; who detected is never who converged.
+        enabled: true
+        enforcement: block
+        data_scope:
+          read:
+            - case-workflow-history       # Temporal workflow history of cases it coordinates
+            - agent-proposals-readonly    # existing proposal queue metadata (no raw payload)
+            - read.governance             # agents.yaml case classes and charter capabilities
+          pii: masked
+        tools:
+          allow:
+            - tier: read
+              resources: [case-workflow, governance]
+            - tier: write_proposal
+              resources: [agent-proposal]   # emits one HITL proposal per case
+            - tier: execute
+              resources: [case-workflow-signal]  # sends deterministic pre-emption / convergence signals
+          deny:
+            - tier: write
+              resources: ["*"]             # never writes to a business record directly
+            - tier: execute
+              resources: [money.*, gh.pr.*, secrets.*]
+        case_capabilities:
+          # The coordinator is the only charter that may open, coordinate, and synthesize a case.
+          # Other agents may be granted case.join (and later case.contribute) in their own charters.
+          - case.open
+          - case.coordinate
+          - case.synthesize
+          - case.preempt
+        requires_human:
+          - every: proposal               # every synthesized proposal is a HITL proposal
+          - approver_must_differ_from: author
+          - record: reason
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 48                # one per active case hour is common; cap prevents runaway
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - case_id
+            - disposition_target
+            - case_class
+            - contributions_received
+            - synthesis_cited_contribution_ids
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, human disposes; not Annex III high-risk"
+          dora: "ICT change management (Art. 8–10); operational resilience via durable, bounded case coordination"
   rules-data.yaml: |
     # GENERATED by .github/scripts/gen-rules-opa-data.py — do not hand-edit.
     #

--- a/openbank-infra/gitops/components/pid/pid-service.yaml
+++ b/openbank-infra/gitops/components/pid/pid-service.yaml
@@ -32,7 +32,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-pid-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "8d877a3cee68303d"
+        openbank.tech/policy-checksum: "a81c109f90403d09"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/psd2-service/psd2-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/psd2-service/psd2-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: psd2-service
     app.kubernetes.io/part-of: psd2
   annotations:
-    openbank.tech/policy-checksum: "d3a8591d24d14a41"
+    openbank.tech/policy-checksum: "9e59dd70562565a7"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -992,10 +992,58 @@ data:
         - secrets.read.raw
 
     # ---------------------------------------------------------------------------------------
+    # Case classes for agent swarm coordination (ADR-0244). A case is one long-running
+    # Temporal workflow opened for a single disposition target. Default budgets and
+    # convergence thresholds live here; per-class overrides are merged over default.
+    # Every case names exactly one class. The case-coordinator charter owns convergence
+    # judgement and budget enforcement; other charters may be granted case.join (and later
+    # case.contribute) once the signal-handling wiring lands.
+    # ---------------------------------------------------------------------------------------
+    case_classes:
+      default:
+        budget:
+          tokens_per_case: 500000
+          max_contributions: 100
+          wall_clock_minutes: 60
+        concurrency:
+          max_open_cases: 10
+        convergence:
+          contested_rate_threshold: 0.30   # suspend case-open for this class above 30% contested
+      classes:
+        fraud-investigation:
+          budget:
+            tokens_per_case: 1000000
+            max_contributions: 200
+            wall_clock_minutes: 120
+          concurrency:
+            max_open_cases: 5
+          convergence:
+            contested_rate_threshold: 0.25
+        aml-alert:
+          budget:
+            tokens_per_case: 300000
+            max_contributions: 50
+            wall_clock_minutes: 30
+          concurrency:
+            max_open_cases: 20
+          convergence:
+            contested_rate_threshold: 0.40
+        incident-response:
+          budget:
+            tokens_per_case: 200000
+            max_contributions: 40
+            wall_clock_minutes: 20
+          concurrency:
+            max_open_cases: 15
+          convergence:
+            contested_rate_threshold: 0.35
+
+    # ---------------------------------------------------------------------------------------
     # Agents. plane = control (oversight, proposal-only) | development (per-domain engineering)
     #                | customer (customer-facing assistant, ADR-0089 — its own SCA-gated regime).
     # Each charter answers: data_scope (what it reads), tools (what it calls), requires_human
-    # (what must be approved), limits (budget/quota).
+    # (what must be approved), limits (budget/quota). Swarm participants additionally declare
+    # case_capabilities (ADR-0244).
     # ---------------------------------------------------------------------------------------
     agents:
 
@@ -1597,6 +1645,67 @@ data:
         compliance:
           eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
           dora: "Art. 9 ICT risk detection; Art. 5 ICT risk management framework — fleet-wide static verification that a test suite's reported green state reflects tests that actually ran"
+
+      - id: case-coordinator
+        plane: control
+        charter: "ADR-0244"
+        description: >
+          Owns a running Temporal case workflow: invites chartered agents to contribute,
+          enforces the per-case-class budget and deadline, judges convergence, and emits
+          exactly one HITL proposal per case. Every swarm is bounded to one disposition
+          target; pre-emption is deterministic and replay-safe. The coordinator never
+          coordinates a case it opened; who detected is never who converged.
+        enabled: true
+        enforcement: block
+        data_scope:
+          read:
+            - case-workflow-history       # Temporal workflow history of cases it coordinates
+            - agent-proposals-readonly    # existing proposal queue metadata (no raw payload)
+            - read.governance             # agents.yaml case classes and charter capabilities
+          pii: masked
+        tools:
+          allow:
+            - tier: read
+              resources: [case-workflow, governance]
+            - tier: write_proposal
+              resources: [agent-proposal]   # emits one HITL proposal per case
+            - tier: execute
+              resources: [case-workflow-signal]  # sends deterministic pre-emption / convergence signals
+          deny:
+            - tier: write
+              resources: ["*"]             # never writes to a business record directly
+            - tier: execute
+              resources: [money.*, gh.pr.*, secrets.*]
+        case_capabilities:
+          # The coordinator is the only charter that may open, coordinate, and synthesize a case.
+          # Other agents may be granted case.join (and later case.contribute) in their own charters.
+          - case.open
+          - case.coordinate
+          - case.synthesize
+          - case.preempt
+        requires_human:
+          - every: proposal               # every synthesized proposal is a HITL proposal
+          - approver_must_differ_from: author
+          - record: reason
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 48                # one per active case hour is common; cap prevents runaway
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - case_id
+            - disposition_target
+            - case_class
+            - contributions_received
+            - synthesis_cited_contribution_ids
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, human disposes; not Annex III high-risk"
+          dora: "ICT change management (Art. 8–10); operational resilience via durable, bounded case coordination"
   rules-data.yaml: |
     # GENERATED by .github/scripts/gen-rules-opa-data.py — do not hand-edit.
     #

--- a/openbank-infra/gitops/components/psd2-service/psd2-service.yaml
+++ b/openbank-infra/gitops/components/psd2-service/psd2-service.yaml
@@ -27,7 +27,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-psd2-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "d3a8591d24d14a41"
+        openbank.tech/policy-checksum: "9e59dd70562565a7"
       labels: {app.kubernetes.io/name: psd2-service, app.kubernetes.io/part-of: psd2}
     spec:
       securityContext:

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sanctions-service
     app.kubernetes.io/part-of: sanctions
   annotations:
-    openbank.tech/policy-checksum: "37e83aab62c22ead"
+    openbank.tech/policy-checksum: "0f8e3d72ed3a2d84"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -897,10 +897,58 @@ data:
         - secrets.read.raw
 
     # ---------------------------------------------------------------------------------------
+    # Case classes for agent swarm coordination (ADR-0244). A case is one long-running
+    # Temporal workflow opened for a single disposition target. Default budgets and
+    # convergence thresholds live here; per-class overrides are merged over default.
+    # Every case names exactly one class. The case-coordinator charter owns convergence
+    # judgement and budget enforcement; other charters may be granted case.join (and later
+    # case.contribute) once the signal-handling wiring lands.
+    # ---------------------------------------------------------------------------------------
+    case_classes:
+      default:
+        budget:
+          tokens_per_case: 500000
+          max_contributions: 100
+          wall_clock_minutes: 60
+        concurrency:
+          max_open_cases: 10
+        convergence:
+          contested_rate_threshold: 0.30   # suspend case-open for this class above 30% contested
+      classes:
+        fraud-investigation:
+          budget:
+            tokens_per_case: 1000000
+            max_contributions: 200
+            wall_clock_minutes: 120
+          concurrency:
+            max_open_cases: 5
+          convergence:
+            contested_rate_threshold: 0.25
+        aml-alert:
+          budget:
+            tokens_per_case: 300000
+            max_contributions: 50
+            wall_clock_minutes: 30
+          concurrency:
+            max_open_cases: 20
+          convergence:
+            contested_rate_threshold: 0.40
+        incident-response:
+          budget:
+            tokens_per_case: 200000
+            max_contributions: 40
+            wall_clock_minutes: 20
+          concurrency:
+            max_open_cases: 15
+          convergence:
+            contested_rate_threshold: 0.35
+
+    # ---------------------------------------------------------------------------------------
     # Agents. plane = control (oversight, proposal-only) | development (per-domain engineering)
     #                | customer (customer-facing assistant, ADR-0089 — its own SCA-gated regime).
     # Each charter answers: data_scope (what it reads), tools (what it calls), requires_human
-    # (what must be approved), limits (budget/quota).
+    # (what must be approved), limits (budget/quota). Swarm participants additionally declare
+    # case_capabilities (ADR-0244).
     # ---------------------------------------------------------------------------------------
     agents:
 
@@ -1502,6 +1550,67 @@ data:
         compliance:
           eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
           dora: "Art. 9 ICT risk detection; Art. 5 ICT risk management framework — fleet-wide static verification that a test suite's reported green state reflects tests that actually ran"
+
+      - id: case-coordinator
+        plane: control
+        charter: "ADR-0244"
+        description: >
+          Owns a running Temporal case workflow: invites chartered agents to contribute,
+          enforces the per-case-class budget and deadline, judges convergence, and emits
+          exactly one HITL proposal per case. Every swarm is bounded to one disposition
+          target; pre-emption is deterministic and replay-safe. The coordinator never
+          coordinates a case it opened; who detected is never who converged.
+        enabled: true
+        enforcement: block
+        data_scope:
+          read:
+            - case-workflow-history       # Temporal workflow history of cases it coordinates
+            - agent-proposals-readonly    # existing proposal queue metadata (no raw payload)
+            - read.governance             # agents.yaml case classes and charter capabilities
+          pii: masked
+        tools:
+          allow:
+            - tier: read
+              resources: [case-workflow, governance]
+            - tier: write_proposal
+              resources: [agent-proposal]   # emits one HITL proposal per case
+            - tier: execute
+              resources: [case-workflow-signal]  # sends deterministic pre-emption / convergence signals
+          deny:
+            - tier: write
+              resources: ["*"]             # never writes to a business record directly
+            - tier: execute
+              resources: [money.*, gh.pr.*, secrets.*]
+        case_capabilities:
+          # The coordinator is the only charter that may open, coordinate, and synthesize a case.
+          # Other agents may be granted case.join (and later case.contribute) in their own charters.
+          - case.open
+          - case.coordinate
+          - case.synthesize
+          - case.preempt
+        requires_human:
+          - every: proposal               # every synthesized proposal is a HITL proposal
+          - approver_must_differ_from: author
+          - record: reason
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 48                # one per active case hour is common; cap prevents runaway
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - case_id
+            - disposition_target
+            - case_class
+            - contributions_received
+            - synthesis_cited_contribution_ids
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, human disposes; not Annex III high-risk"
+          dora: "ICT change management (Art. 8–10); operational resilience via durable, bounded case coordination"
   rules-data.yaml: |
     # GENERATED by .github/scripts/gen-rules-opa-data.py — do not hand-edit.
     #

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
@@ -49,7 +49,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sanctions-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "37e83aab62c22ead"
+        openbank.tech/policy-checksum: "0f8e3d72ed3a2d84"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sca-service
     app.kubernetes.io/part-of: sca
   annotations:
-    openbank.tech/policy-checksum: "db76fec35a301481"
+    openbank.tech/policy-checksum: "7e456af3f69dc2f2"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -952,10 +952,58 @@ data:
         - secrets.read.raw
 
     # ---------------------------------------------------------------------------------------
+    # Case classes for agent swarm coordination (ADR-0244). A case is one long-running
+    # Temporal workflow opened for a single disposition target. Default budgets and
+    # convergence thresholds live here; per-class overrides are merged over default.
+    # Every case names exactly one class. The case-coordinator charter owns convergence
+    # judgement and budget enforcement; other charters may be granted case.join (and later
+    # case.contribute) once the signal-handling wiring lands.
+    # ---------------------------------------------------------------------------------------
+    case_classes:
+      default:
+        budget:
+          tokens_per_case: 500000
+          max_contributions: 100
+          wall_clock_minutes: 60
+        concurrency:
+          max_open_cases: 10
+        convergence:
+          contested_rate_threshold: 0.30   # suspend case-open for this class above 30% contested
+      classes:
+        fraud-investigation:
+          budget:
+            tokens_per_case: 1000000
+            max_contributions: 200
+            wall_clock_minutes: 120
+          concurrency:
+            max_open_cases: 5
+          convergence:
+            contested_rate_threshold: 0.25
+        aml-alert:
+          budget:
+            tokens_per_case: 300000
+            max_contributions: 50
+            wall_clock_minutes: 30
+          concurrency:
+            max_open_cases: 20
+          convergence:
+            contested_rate_threshold: 0.40
+        incident-response:
+          budget:
+            tokens_per_case: 200000
+            max_contributions: 40
+            wall_clock_minutes: 20
+          concurrency:
+            max_open_cases: 15
+          convergence:
+            contested_rate_threshold: 0.35
+
+    # ---------------------------------------------------------------------------------------
     # Agents. plane = control (oversight, proposal-only) | development (per-domain engineering)
     #                | customer (customer-facing assistant, ADR-0089 — its own SCA-gated regime).
     # Each charter answers: data_scope (what it reads), tools (what it calls), requires_human
-    # (what must be approved), limits (budget/quota).
+    # (what must be approved), limits (budget/quota). Swarm participants additionally declare
+    # case_capabilities (ADR-0244).
     # ---------------------------------------------------------------------------------------
     agents:
 
@@ -1557,6 +1605,67 @@ data:
         compliance:
           eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
           dora: "Art. 9 ICT risk detection; Art. 5 ICT risk management framework — fleet-wide static verification that a test suite's reported green state reflects tests that actually ran"
+
+      - id: case-coordinator
+        plane: control
+        charter: "ADR-0244"
+        description: >
+          Owns a running Temporal case workflow: invites chartered agents to contribute,
+          enforces the per-case-class budget and deadline, judges convergence, and emits
+          exactly one HITL proposal per case. Every swarm is bounded to one disposition
+          target; pre-emption is deterministic and replay-safe. The coordinator never
+          coordinates a case it opened; who detected is never who converged.
+        enabled: true
+        enforcement: block
+        data_scope:
+          read:
+            - case-workflow-history       # Temporal workflow history of cases it coordinates
+            - agent-proposals-readonly    # existing proposal queue metadata (no raw payload)
+            - read.governance             # agents.yaml case classes and charter capabilities
+          pii: masked
+        tools:
+          allow:
+            - tier: read
+              resources: [case-workflow, governance]
+            - tier: write_proposal
+              resources: [agent-proposal]   # emits one HITL proposal per case
+            - tier: execute
+              resources: [case-workflow-signal]  # sends deterministic pre-emption / convergence signals
+          deny:
+            - tier: write
+              resources: ["*"]             # never writes to a business record directly
+            - tier: execute
+              resources: [money.*, gh.pr.*, secrets.*]
+        case_capabilities:
+          # The coordinator is the only charter that may open, coordinate, and synthesize a case.
+          # Other agents may be granted case.join (and later case.contribute) in their own charters.
+          - case.open
+          - case.coordinate
+          - case.synthesize
+          - case.preempt
+        requires_human:
+          - every: proposal               # every synthesized proposal is a HITL proposal
+          - approver_must_differ_from: author
+          - record: reason
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 48                # one per active case hour is common; cap prevents runaway
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - case_id
+            - disposition_target
+            - case_class
+            - contributions_received
+            - synthesis_cited_contribution_ids
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, human disposes; not Annex III high-risk"
+          dora: "ICT change management (Art. 8–10); operational resilience via durable, bounded case coordination"
   rules-data.yaml: |
     # GENERATED by .github/scripts/gen-rules-opa-data.py — do not hand-edit.
     #

--- a/openbank-infra/gitops/components/sca/sca-service.yaml
+++ b/openbank-infra/gitops/components/sca/sca-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sca-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "db76fec35a301481"
+        openbank.tech/policy-checksum: "7e456af3f69dc2f2"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/statements/statement-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/statements/statement-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: statement-service
     app.kubernetes.io/part-of: statements
   annotations:
-    openbank.tech/policy-checksum: "fcf07e290f1b0369"
+    openbank.tech/policy-checksum: "09a7cab8157b2904"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -963,10 +963,58 @@ data:
         - secrets.read.raw
 
     # ---------------------------------------------------------------------------------------
+    # Case classes for agent swarm coordination (ADR-0244). A case is one long-running
+    # Temporal workflow opened for a single disposition target. Default budgets and
+    # convergence thresholds live here; per-class overrides are merged over default.
+    # Every case names exactly one class. The case-coordinator charter owns convergence
+    # judgement and budget enforcement; other charters may be granted case.join (and later
+    # case.contribute) once the signal-handling wiring lands.
+    # ---------------------------------------------------------------------------------------
+    case_classes:
+      default:
+        budget:
+          tokens_per_case: 500000
+          max_contributions: 100
+          wall_clock_minutes: 60
+        concurrency:
+          max_open_cases: 10
+        convergence:
+          contested_rate_threshold: 0.30   # suspend case-open for this class above 30% contested
+      classes:
+        fraud-investigation:
+          budget:
+            tokens_per_case: 1000000
+            max_contributions: 200
+            wall_clock_minutes: 120
+          concurrency:
+            max_open_cases: 5
+          convergence:
+            contested_rate_threshold: 0.25
+        aml-alert:
+          budget:
+            tokens_per_case: 300000
+            max_contributions: 50
+            wall_clock_minutes: 30
+          concurrency:
+            max_open_cases: 20
+          convergence:
+            contested_rate_threshold: 0.40
+        incident-response:
+          budget:
+            tokens_per_case: 200000
+            max_contributions: 40
+            wall_clock_minutes: 20
+          concurrency:
+            max_open_cases: 15
+          convergence:
+            contested_rate_threshold: 0.35
+
+    # ---------------------------------------------------------------------------------------
     # Agents. plane = control (oversight, proposal-only) | development (per-domain engineering)
     #                | customer (customer-facing assistant, ADR-0089 — its own SCA-gated regime).
     # Each charter answers: data_scope (what it reads), tools (what it calls), requires_human
-    # (what must be approved), limits (budget/quota).
+    # (what must be approved), limits (budget/quota). Swarm participants additionally declare
+    # case_capabilities (ADR-0244).
     # ---------------------------------------------------------------------------------------
     agents:
 
@@ -1568,6 +1616,67 @@ data:
         compliance:
           eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
           dora: "Art. 9 ICT risk detection; Art. 5 ICT risk management framework — fleet-wide static verification that a test suite's reported green state reflects tests that actually ran"
+
+      - id: case-coordinator
+        plane: control
+        charter: "ADR-0244"
+        description: >
+          Owns a running Temporal case workflow: invites chartered agents to contribute,
+          enforces the per-case-class budget and deadline, judges convergence, and emits
+          exactly one HITL proposal per case. Every swarm is bounded to one disposition
+          target; pre-emption is deterministic and replay-safe. The coordinator never
+          coordinates a case it opened; who detected is never who converged.
+        enabled: true
+        enforcement: block
+        data_scope:
+          read:
+            - case-workflow-history       # Temporal workflow history of cases it coordinates
+            - agent-proposals-readonly    # existing proposal queue metadata (no raw payload)
+            - read.governance             # agents.yaml case classes and charter capabilities
+          pii: masked
+        tools:
+          allow:
+            - tier: read
+              resources: [case-workflow, governance]
+            - tier: write_proposal
+              resources: [agent-proposal]   # emits one HITL proposal per case
+            - tier: execute
+              resources: [case-workflow-signal]  # sends deterministic pre-emption / convergence signals
+          deny:
+            - tier: write
+              resources: ["*"]             # never writes to a business record directly
+            - tier: execute
+              resources: [money.*, gh.pr.*, secrets.*]
+        case_capabilities:
+          # The coordinator is the only charter that may open, coordinate, and synthesize a case.
+          # Other agents may be granted case.join (and later case.contribute) in their own charters.
+          - case.open
+          - case.coordinate
+          - case.synthesize
+          - case.preempt
+        requires_human:
+          - every: proposal               # every synthesized proposal is a HITL proposal
+          - approver_must_differ_from: author
+          - record: reason
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 48                # one per active case hour is common; cap prevents runaway
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - case_id
+            - disposition_target
+            - case_class
+            - contributions_received
+            - synthesis_cited_contribution_ids
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, human disposes; not Annex III high-risk"
+          dora: "ICT change management (Art. 8–10); operational resilience via durable, bounded case coordination"
   rules-data.yaml: |
     # GENERATED by .github/scripts/gen-rules-opa-data.py — do not hand-edit.
     #

--- a/openbank-infra/gitops/components/statements/statement-service.yaml
+++ b/openbank-infra/gitops/components/statements/statement-service.yaml
@@ -35,7 +35,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-statement-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "fcf07e290f1b0369"
+        openbank.tech/policy-checksum: "09a7cab8157b2904"
       labels:
         app.kubernetes.io/name: statement-service
         app.kubernetes.io/part-of: statements

--- a/openbank-infra/gitops/components/tpp-registry/tpp-registry-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/tpp-registry/tpp-registry-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: tpp-registry-service
     app.kubernetes.io/part-of: tpp-registry
   annotations:
-    openbank.tech/policy-checksum: "a000695b99c89b05"
+    openbank.tech/policy-checksum: "dd38de878fd2f78c"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -900,10 +900,58 @@ data:
         - secrets.read.raw
 
     # ---------------------------------------------------------------------------------------
+    # Case classes for agent swarm coordination (ADR-0244). A case is one long-running
+    # Temporal workflow opened for a single disposition target. Default budgets and
+    # convergence thresholds live here; per-class overrides are merged over default.
+    # Every case names exactly one class. The case-coordinator charter owns convergence
+    # judgement and budget enforcement; other charters may be granted case.join (and later
+    # case.contribute) once the signal-handling wiring lands.
+    # ---------------------------------------------------------------------------------------
+    case_classes:
+      default:
+        budget:
+          tokens_per_case: 500000
+          max_contributions: 100
+          wall_clock_minutes: 60
+        concurrency:
+          max_open_cases: 10
+        convergence:
+          contested_rate_threshold: 0.30   # suspend case-open for this class above 30% contested
+      classes:
+        fraud-investigation:
+          budget:
+            tokens_per_case: 1000000
+            max_contributions: 200
+            wall_clock_minutes: 120
+          concurrency:
+            max_open_cases: 5
+          convergence:
+            contested_rate_threshold: 0.25
+        aml-alert:
+          budget:
+            tokens_per_case: 300000
+            max_contributions: 50
+            wall_clock_minutes: 30
+          concurrency:
+            max_open_cases: 20
+          convergence:
+            contested_rate_threshold: 0.40
+        incident-response:
+          budget:
+            tokens_per_case: 200000
+            max_contributions: 40
+            wall_clock_minutes: 20
+          concurrency:
+            max_open_cases: 15
+          convergence:
+            contested_rate_threshold: 0.35
+
+    # ---------------------------------------------------------------------------------------
     # Agents. plane = control (oversight, proposal-only) | development (per-domain engineering)
     #                | customer (customer-facing assistant, ADR-0089 — its own SCA-gated regime).
     # Each charter answers: data_scope (what it reads), tools (what it calls), requires_human
-    # (what must be approved), limits (budget/quota).
+    # (what must be approved), limits (budget/quota). Swarm participants additionally declare
+    # case_capabilities (ADR-0244).
     # ---------------------------------------------------------------------------------------
     agents:
 
@@ -1505,6 +1553,67 @@ data:
         compliance:
           eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
           dora: "Art. 9 ICT risk detection; Art. 5 ICT risk management framework — fleet-wide static verification that a test suite's reported green state reflects tests that actually ran"
+
+      - id: case-coordinator
+        plane: control
+        charter: "ADR-0244"
+        description: >
+          Owns a running Temporal case workflow: invites chartered agents to contribute,
+          enforces the per-case-class budget and deadline, judges convergence, and emits
+          exactly one HITL proposal per case. Every swarm is bounded to one disposition
+          target; pre-emption is deterministic and replay-safe. The coordinator never
+          coordinates a case it opened; who detected is never who converged.
+        enabled: true
+        enforcement: block
+        data_scope:
+          read:
+            - case-workflow-history       # Temporal workflow history of cases it coordinates
+            - agent-proposals-readonly    # existing proposal queue metadata (no raw payload)
+            - read.governance             # agents.yaml case classes and charter capabilities
+          pii: masked
+        tools:
+          allow:
+            - tier: read
+              resources: [case-workflow, governance]
+            - tier: write_proposal
+              resources: [agent-proposal]   # emits one HITL proposal per case
+            - tier: execute
+              resources: [case-workflow-signal]  # sends deterministic pre-emption / convergence signals
+          deny:
+            - tier: write
+              resources: ["*"]             # never writes to a business record directly
+            - tier: execute
+              resources: [money.*, gh.pr.*, secrets.*]
+        case_capabilities:
+          # The coordinator is the only charter that may open, coordinate, and synthesize a case.
+          # Other agents may be granted case.join (and later case.contribute) in their own charters.
+          - case.open
+          - case.coordinate
+          - case.synthesize
+          - case.preempt
+        requires_human:
+          - every: proposal               # every synthesized proposal is a HITL proposal
+          - approver_must_differ_from: author
+          - record: reason
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 48                # one per active case hour is common; cap prevents runaway
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - case_id
+            - disposition_target
+            - case_class
+            - contributions_received
+            - synthesis_cited_contribution_ids
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, human disposes; not Annex III high-risk"
+          dora: "ICT change management (Art. 8–10); operational resilience via durable, bounded case coordination"
   rules-data.yaml: |
     # GENERATED by .github/scripts/gen-rules-opa-data.py — do not hand-edit.
     #

--- a/openbank-infra/gitops/components/tpp-registry/tpp-registry-service.yaml
+++ b/openbank-infra/gitops/components/tpp-registry/tpp-registry-service.yaml
@@ -32,7 +32,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-tpp-registry-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "a000695b99c89b05"
+        openbank.tech/policy-checksum: "dd38de878fd2f78c"
     spec:
       securityContext:
         runAsNonRoot: true


### PR DESCRIPTION
## Summary

#3771 (ADR-0244 case-coordinator charter + case-budget schema) changed `openbank-libs/governance/agents.yaml` without regenerating its derived artifacts. `agents.yaml` is embedded verbatim into 40 OPA bundle ConfigMaps (`rules.yaml: opa_bundle_sync`) and `docs/compliance/eu-ai-act.md` is generated from it (ADR-0148 rule #7) — both enforced gates (`OPA policy gate`, `eu-ai-act-inventory-drift` in `Validate manifests`) fail against current `main`. This PR regenerates everything from the committed source; no hand edits.

## Type of change

- [x] fix

## Linked issues

Refs #3998 (Phase 0 of #3737 — the charter/schema half was delivered by #3771; this completes its derived-artifact tail) · Refs #3771

## Changes

- `docs/compliance/eu-ai-act.md` — regenerated via `python3 .github/scripts/gen-eu-ai-act.py` (16 charters incl. case-coordinator)
- 40 `*-opa-bundle.yaml` + 31 workload `policy-checksum` annotations — regenerated via every `gen-*opa-bundle*.sh` under `openbank-infra/gitops/components`
- `openbank-admin-ui/ai-governance-snapshot.json` — regenerated via `python3 .github/scripts/gen-ai-governance-snapshot.py` (third derived artifact #3771 left stale: prompts/registry.yaml changed with the case-coordinator prompt entry)

## Verification

- `check-eu-ai-act.sh` → OK, in sync
- `check-agent-charter-registry.sh` → OK, 16 agents full parity
- `check-opa-bundle-parses.py` → OK, 40 bundles
- `check-opa-sidecar-bundle-shape.py` → clean
- `check-opa-bundle-apply-size.py` → OK
- Scope: `git diff origin/main...HEAD --name-only` = only the three derived-artifact classes above
- `gen-ai-governance-snapshot.py --check` → in sync

Note for reviewers: `check-eu-ai-act.sh` restores the derived doc to HEAD on a failing run (line 25), the same trap class as `check-adr-registry.sh` (CLAUDE.md `### ADR registry`) — regenerate, commit, THEN check. A CLAUDE.md bullet covering this sibling script follows separately.

## Definition of Done

- [x] Derived data regenerated from source, not hand-edited
- [x] No secrets, tokens, passwords, or PII
