### PR TITLE
chore(governance): regenerate the EU AI Act inventory and AI-governance snapshot

### DIFF
--- a/docs/compliance/eu-ai-act.md
+++ b/docs/compliance/eu-ai-act.md
@@ -41,6 +41,7 @@ it can move past *Proposed*.
 | `docs-truth-agent` | control | Limited / minimal risk | — | produces proposals only; a human dispositions every effect (not autonomous decision-making on a natural person). |
 | `authz-policy-auditor` | control | Limited / minimal risk | — | produces proposals only; a human dispositions every effect (not autonomous decision-making on a natural person). |
 | `flaky-test-hunter` | development | Limited / minimal risk | — | produces proposals only; a human dispositions every effect (not autonomous decision-making on a natural person). |
+| `case-coordinator` | control | Limited / minimal risk | — | produces proposals only; a human dispositions every effect (not autonomous decision-making on a natural person). |
 
 ### Non-agent ML and statistical systems
 
@@ -107,7 +108,7 @@ not deployed.
 
 ## Provenance
 
-- Source: `openbank-libs/governance/agents.yaml` (sha256 `7feff1674a83d5ea…`, 15 charters)
+- Source: `openbank-libs/governance/agents.yaml` (sha256 `bfc4b4639efd5846…`, 16 charters)
 - Source: `openbank-libs/governance/ml-systems.yaml` (sha256 `9cd5cb5b20918520…`, 4 non-agent systems)
 - Related: ADR-0031 (agent governance), ADR-0084 (fraud scoring plane), ADR-0139/0140
   (ML decisioning platform), ADR-0141 (model registry), ADR-0142 (credit decisioning),

--- a/openbank-admin-ui/ai-governance-snapshot.json
+++ b/openbank-admin-ui/ai-governance-snapshot.json
@@ -142,8 +142,8 @@
   "facts": {
     "agentCharters": {
       "source": "openbank-libs/governance/agents.yaml",
-      "sha256": "7feff1674a83d5ea",
-      "count": 15,
+      "sha256": "bfc4b4639efd5846",
+      "count": 16,
       "ids": [
         "compliance-officer",
         "ledger-domain-engineer",
@@ -159,10 +159,11 @@
         "release-steward",
         "docs-truth-agent",
         "authz-policy-auditor",
-        "flaky-test-hunter"
+        "flaky-test-hunter",
+        "case-coordinator"
       ],
       "byPlane": {
-        "control": 10,
+        "control": 11,
         "development": 2,
         "customer": 3
       },
@@ -173,11 +174,11 @@
     },
     "promptRegistryCoverage": {
       "source": "openbank-libs/governance/prompts/registry.yaml",
-      "sha256": "7b03a0fa5c08758f",
+      "sha256": "48f2f75ee17aa764",
       "counts": {
         "external": 2,
         "not-applicable": 2,
-        "pending": 1,
+        "pending": 2,
         "registered": 10
       },
       "idsByStatus": {
@@ -190,7 +191,8 @@
           "ap2-anonymous"
         ],
         "pending": [
-          "authz-policy-auditor"
+          "authz-policy-auditor",
+          "case-coordinator"
         ],
         "registered": [
           "compliance-officer",


### PR DESCRIPTION
## main is red

#3771 added the ADR-0244 `case-coordinator` charter to `agents.yaml` without regenerating the two
artifacts derived from it. Both enforced drift gates now fail **on main itself**:

```
gate failed: EU AI Act inventory drift (ADR-0148 rule #7, enforced)
gate failed: AI governance snapshot drift (ADR-0029 D3 / ADR-0031, enforced)
```

`Validate manifests` is a required status check and aggregates those shards, so it fails with them.
Confirmed red on both `3208109c` (#3771's own push) and `d16dc102` (the release commit after it).

Every PR that merges main in inherits this. The three open PRs that are still green are green only
because they predate #3771 — the first rebase turns them red.

## What is here

Regenerated by `gen-eu-ai-act.py` and `gen-ai-governance-snapshot.py`, not hand-edited (rule 6).
The whole diff is the one new agent:

- inventory: one row for `case-coordinator`
- snapshot: the two content hashes, control agents `10 -> 11`, total `15 -> 16`, pending-eval `1 -> 2`

## Not included, on purpose

`check-operator-write-naming` also prints an error on main, for `rest.rego`'s `operator-mcp-session`
(GHSA-58jq-9hq3-66jr). That gate is `mode: advisory`, so it is **not** why main is red — I initially
read its `::error::` output as a blocking failure and that was wrong; the gate manifest is what
settles it, not the log line. The fix is a security decision between renaming the rule, pinning
`input.principal.id`, or a declared exception with a reason, and belongs in its own PR.

Refs #3771
