### PR TITLE
chore(governance): regenerate derived artifacts stranded by #3771 (unblocks fleet deploy)

### DIFF
--- a/docs/compliance/eu-ai-act.md
+++ b/docs/compliance/eu-ai-act.md
@@ -41,6 +41,7 @@ it can move past *Proposed*.
 | `docs-truth-agent` | control | Limited / minimal risk | — | produces proposals only; a human dispositions every effect (not autonomous decision-making on a natural person). |
 | `authz-policy-auditor` | control | Limited / minimal risk | — | produces proposals only; a human dispositions every effect (not autonomous decision-making on a natural person). |
 | `flaky-test-hunter` | development | Limited / minimal risk | — | produces proposals only; a human dispositions every effect (not autonomous decision-making on a natural person). |
+| `case-coordinator` | control | Limited / minimal risk | — | produces proposals only; a human dispositions every effect (not autonomous decision-making on a natural person). |
 
 ### Non-agent ML and statistical systems
 
@@ -107,7 +108,7 @@ not deployed.
 
 ## Provenance
 
-- Source: `openbank-libs/governance/agents.yaml` (sha256 `7feff1674a83d5ea…`, 15 charters)
+- Source: `openbank-libs/governance/agents.yaml` (sha256 `bfc4b4639efd5846…`, 16 charters)
 - Source: `openbank-libs/governance/ml-systems.yaml` (sha256 `9cd5cb5b20918520…`, 4 non-agent systems)
 - Related: ADR-0031 (agent governance), ADR-0084 (fraud scoring plane), ADR-0139/0140
   (ML decisioning platform), ADR-0141 (model registry), ADR-0142 (credit decisioning),

--- a/openbank-admin-ui/ai-governance-snapshot.json
+++ b/openbank-admin-ui/ai-governance-snapshot.json
@@ -142,8 +142,8 @@
   "facts": {
     "agentCharters": {
       "source": "openbank-libs/governance/agents.yaml",
-      "sha256": "7feff1674a83d5ea",
-      "count": 15,
+      "sha256": "bfc4b4639efd5846",
+      "count": 16,
       "ids": [
         "compliance-officer",
         "ledger-domain-engineer",
@@ -159,10 +159,11 @@
         "release-steward",
         "docs-truth-agent",
         "authz-policy-auditor",
-        "flaky-test-hunter"
+        "flaky-test-hunter",
+        "case-coordinator"
       ],
       "byPlane": {
-        "control": 10,
+        "control": 11,
         "development": 2,
         "customer": 3
       },
@@ -173,11 +174,11 @@
     },
     "promptRegistryCoverage": {
       "source": "openbank-libs/governance/prompts/registry.yaml",
-      "sha256": "7b03a0fa5c08758f",
+      "sha256": "48f2f75ee17aa764",
       "counts": {
         "external": 2,
         "not-applicable": 2,
-        "pending": 1,
+        "pending": 2,
         "registered": 10
       },
       "idsByStatus": {
@@ -190,7 +191,8 @@
           "ap2-anonymous"
         ],
         "pending": [
-          "authz-policy-auditor"
+          "authz-policy-auditor",
+          "case-coordinator"
         ],
         "registered": [
           "compliance-officer",

--- a/openbank-infra/gitops/components/agent/agent-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/agent/agent-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: agent-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "e0aa410ca8309da1"
+    openbank.tech/policy-checksum: "77e8a1da9b019d1d"
 data:
   agents.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -367,10 +367,58 @@ data:
         - secrets.read.raw
 
     # ---------------------------------------------------------------------------------------
+    # Case classes for agent swarm coordination (ADR-0244). A case is one long-running
+    # Temporal workflow opened for a single disposition target. Default budgets and
+    # convergence thresholds live here; per-class overrides are merged over default.
+    # Every case names exactly one class. The case-coordinator charter owns convergence
+    # judgement and budget enforcement; other charters may be granted case.join (and later
+    # case.contribute) once the signal-handling wiring lands.
+    # ---------------------------------------------------------------------------------------
+    case_classes:
+      default:
+        budget:
+          tokens_per_case: 500000
+          max_contributions: 100
+          wall_clock_minutes: 60
+        concurrency:
+          max_open_cases: 10
+        convergence:
+          contested_rate_threshold: 0.30   # suspend case-open for this class above 30% contested
+      classes:
+        fraud-investigation:
+          budget:
+            tokens_per_case: 1000000
+            max_contributions: 200
+            wall_clock_minutes: 120
+          concurrency:
+            max_open_cases: 5
+          convergence:
+            contested_rate_threshold: 0.25
+        aml-alert:
+          budget:
+            tokens_per_case: 300000
+            max_contributions: 50
+            wall_clock_minutes: 30
+          concurrency:
+            max_open_cases: 20
+          convergence:
+            contested_rate_threshold: 0.40
+        incident-response:
+          budget:
+            tokens_per_case: 200000
+            max_contributions: 40
+            wall_clock_minutes: 20
+          concurrency:
+            max_open_cases: 15
+          convergence:
+            contested_rate_threshold: 0.35
+
+    # ---------------------------------------------------------------------------------------
     # Agents. plane = control (oversight, proposal-only) | development (per-domain engineering)
     #                | customer (customer-facing assistant, ADR-0089 — its own SCA-gated regime).
     # Each charter answers: data_scope (what it reads), tools (what it calls), requires_human
-    # (what must be approved), limits (budget/quota).
+    # (what must be approved), limits (budget/quota). Swarm participants additionally declare
+    # case_capabilities (ADR-0244).
     # ---------------------------------------------------------------------------------------
     agents:
 
@@ -972,5 +1020,66 @@ data:
         compliance:
           eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
           dora: "Art. 9 ICT risk detection; Art. 5 ICT risk management framework — fleet-wide static verification that a test suite's reported green state reflects tests that actually ran"
+
+      - id: case-coordinator
+        plane: control
+        charter: "ADR-0244"
+        description: >
+          Owns a running Temporal case workflow: invites chartered agents to contribute,
+          enforces the per-case-class budget and deadline, judges convergence, and emits
+          exactly one HITL proposal per case. Every swarm is bounded to one disposition
+          target; pre-emption is deterministic and replay-safe. The coordinator never
+          coordinates a case it opened; who detected is never who converged.
+        enabled: true
+        enforcement: block
+        data_scope:
+          read:
+            - case-workflow-history       # Temporal workflow history of cases it coordinates
+            - agent-proposals-readonly    # existing proposal queue metadata (no raw payload)
+            - read.governance             # agents.yaml case classes and charter capabilities
+          pii: masked
+        tools:
+          allow:
+            - tier: read
+              resources: [case-workflow, governance]
+            - tier: write_proposal
+              resources: [agent-proposal]   # emits one HITL proposal per case
+            - tier: execute
+              resources: [case-workflow-signal]  # sends deterministic pre-emption / convergence signals
+          deny:
+            - tier: write
+              resources: ["*"]             # never writes to a business record directly
+            - tier: execute
+              resources: [money.*, gh.pr.*, secrets.*]
+        case_capabilities:
+          # The coordinator is the only charter that may open, coordinate, and synthesize a case.
+          # Other agents may be granted case.join (and later case.contribute) in their own charters.
+          - case.open
+          - case.coordinate
+          - case.synthesize
+          - case.preempt
+        requires_human:
+          - every: proposal               # every synthesized proposal is a HITL proposal
+          - approver_must_differ_from: author
+          - record: reason
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 48                # one per active case hour is common; cap prevents runaway
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - case_id
+            - disposition_target
+            - case_class
+            - contributions_received
+            - synthesis_cited_contribution_ids
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, human disposes; not Annex III high-risk"
+          dora: "ICT change management (Art. 8–10); operational resilience via durable, bounded case coordination"
   manifest.json: |
     {"roots": ["openbank/agents", "openbank/copilot", "openbank/rest", "agents", "rules"]}

--- a/openbank-infra/gitops/components/agent/agent-service.yaml
+++ b/openbank-infra/gitops/components/agent/agent-service.yaml
@@ -43,7 +43,7 @@ spec:
       annotations:
         # Roll the pod when the OPA policy bundle changes (subPath mounts don't hot-reload).
         # Must match agent-opa-bundle's openbank.tech/policy-checksum (CI verifies, no drift).
-        openbank.tech/policy-checksum: "e0aa410ca8309da1"
+        openbank.tech/policy-checksum: "77e8a1da9b019d1d"
     spec:
       securityContext:
         runAsNonRoot: true


### PR DESCRIPTION
## What

Regenerates the four derived artifacts stranded when the case-coordinator charter (ADR-0244, #3771) landed in `agents.yaml`:

- `docs/compliance/eu-ai-act.md` (15 → 16 charters) — gate `eu-ai-act-inventory-drift`
- `openbank-admin-ui/ai-governance-snapshot.json` — gate `ai-governance-snapshot-drift`
- `openbank-infra/gitops/components/agent/agent-opa-bundle.yaml` + `agent-service.yaml` pod-roll annotation — the `OPA policy gate` / "verify bundle, check ConfigMap sync" failure

No hand edits; generator output only. `gen-rules-opa-data.py` verified **unchanged**, so no other service bundle needs a restamp (the fleet-wide restamp in #4002 is unnecessary by that measurement). Regen re-run is idempotent (0 dirty files).

## Why it matters now

These three enforced gates are red on every open PR, including auto-deploy gitops PR #4000 — which carries the ledger accounting-day scheduler deploy (#3984, ADR-0207 increment 2). Until this lands, the fleet cannot deploy.

## Overlap

- #4003 covers the first two files (identical generator output) but not the agent bundle, so the OPA gate stays red with it alone.
- #4002 covers the agent bundle but restamps 34 services' bundles without a `rules-opa-data` change to justify it, misses the snapshot, and is failing its own checks.

Whichever lands first wins; the shared files are byte-identical generator output, so the rest rebase clean.

Refs #3771, #4000

🤖 Generated with [Claude Code](https://claude.com/claude-code)
