### PR TITLE
feat(customer-edge): resolve a directory hit to a payable target without disclosing the account

### DIFF
--- a/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
+++ b/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
@@ -1389,6 +1389,108 @@ class CustomerEdgeResource(
         )
     }
 
+    /**
+     * Turn a directory hit into something payable, WITHOUT ever telling the payer the payee's
+     * account. Body: {"phoneHash":"<hex sha-256>"}.
+     *
+     * This closes pay-to-phone. Until now the directory resolved a number to a partyId and nothing
+     * could be done with it: the customer still typed the account number by hand, so a lookup
+     * bought them a name and nothing else (issue #3176).
+     *
+     * **Why a session token and not an IBAN.** Answering with the payee's account number would turn
+     * this route into a harvester: phone numbers are guessable in a way account numbers are not, so
+     * anyone could walk a range of numbers and collect IBANs. Instead the edge resolves the account
+     * privately and hands back the SAME opaque token the nearby-pay rail already uses (ADR-0087):
+     * the payer sees a name and a masked account, signs SCA against that masked form, and
+     * [createDomesticPayment] resolves the token back to the real account inside the edge. The
+     * payee's account number never reaches another customer's device.
+     *
+     * **Why the hash and not the partyId.** The caller must prove they already know the number, not
+     * merely an id they saw once. Taking a partyId from the body would let anyone with a party id —
+     * ids appear in shared payloads and delegation offers — mint a payment target for a stranger.
+     *
+     * **Opt-in is re-checked here, at payment time.** The lookup that produced the hit may be
+     * minutes or days old; someone who has since turned findability off must stop being payable
+     * immediately. A non-discoverable party is reported exactly like a number nobody holds — 404
+     * with the same body — so this route cannot be used as an existence oracle either.
+     */
+    @POST
+    @Path("/directory/payee")
+    @Authorize(action = "customer.directory.lookup")
+    @Blocking
+    fun directoryPayee(body: String): Response {
+        val customer = customer()
+        val phoneHash = extractTextField(objectMapper, body, "phoneHash")
+            ?.takeIf { it.matches(SHA256_HEX) }
+            ?: return badRequest("phoneHash (hex sha-256) is required")
+
+        // Re-run the directory lookup rather than trusting anything the caller carried over. This is
+        // the opt-in gate: party-service answers only for parties who are currently discoverable.
+        val lookup = upstream.post(
+            "$partyServiceUrl/api/v1/parties/directory/lookup",
+            customer.partyId.toString(),
+            """{"phoneHashes":["$phoneHash"]}""",
+        )
+        if (lookup.status != 200) return notFoundPayee()
+        val match = runCatching { objectMapper.readTree(lookup.entity?.toString() ?: "") }.getOrNull()
+            ?.path("matches")?.takeIf { it.isArray && it.size() > 0 }?.get(0)
+            ?: return notFoundPayee()
+        val payeePartyId = match.path("partyId").asText(null) ?: return notFoundPayee()
+        val payeeName = match.path("legalName").asText(null) ?: return notFoundPayee()
+
+        // Paying yourself through the contact picker is a mistake, not a feature: it would create a
+        // self-transfer that looks like a payment to someone else in the history.
+        if (payeePartyId == customer.partyId.toString()) return badRequest("That is your own number")
+
+        val target = resolvePayableAccount(payeePartyId) ?: return notFoundPayee()
+        val token = sessions.create(
+            creditorAccountId = target.first,
+            creditorPartyId = payeePartyId,
+            displayName = payeeName,
+            requestedAmount = null,
+            creditorMasked = PaymentSessionStore.maskIban(target.second),
+        )
+        val out = objectMapper.createObjectNode()
+        out.put("paymentSessionToken", token)
+        out.put("displayName", payeeName)
+        out.put("creditorMasked", PaymentSessionStore.maskIban(target.second))
+        out.put("expiresInSeconds", PaymentSessionStore.TTL_MS / MILLIS_PER_SECOND)
+        return Response.ok(objectMapper.writeValueAsString(out)).type(MediaType.APPLICATION_JSON).build()
+    }
+
+    /** Same answer for "no such number", "not discoverable" and "nothing payable" — see [directoryPayee]. */
+    private fun notFoundPayee(): Response = Response.status(Response.Status.NOT_FOUND)
+        .entity("""{"error":"no payee for that number"}""")
+        .type(MediaType.APPLICATION_JSON).build()
+
+    /**
+     * The account a contact payment lands on, as (accountId, iban), or null when the party has none
+     * worth crediting.
+     *
+     * Deterministic on purpose: a payee with several accounts must always receive on the same one,
+     * or the payer's history and the payee's expectations drift apart. The rule is the narrowest
+     * that can be stated honestly — an ACTIVE, CURRENT, CZK account, oldest first, since the account
+     * someone has held longest is the one they think of as theirs. SAVINGS is deliberately excluded:
+     * crediting a savings account from a stranger's payment is not what either side means, and some
+     * savings products restrict inbound transfers.
+     */
+    private fun resolvePayableAccount(payeePartyId: String): Pair<String, String>? {
+        val resp = upstream.get("$accountServiceUrl/api/v1/accounts?partyId=$payeePartyId", payeePartyId)
+        if (resp.status != 200) return null
+        val accounts = runCatching { objectMapper.readTree(resp.entity?.toString() ?: "") }.getOrNull()
+            ?.takeIf { it.isArray } ?: return null
+        return accounts
+            .filter { it.path("status").asText() == "ACTIVE" }
+            .filter { it.path("accountType").asText() == "CURRENT" }
+            .filter { it.path("currencyCode").asText() == "CZK" }
+            .sortedBy { it.path("openedAt").asText("") }
+            .firstNotNullOfOrNull { node ->
+                val id = node.path("id").asText(null) ?: return@firstNotNullOfOrNull null
+                val iban = node.path("accountNumber").asText(null) ?: return@firstNotNullOfOrNull null
+                id to iban
+            }
+    }
+
     // --- Transactions ---
 
     /**
@@ -3489,6 +3591,11 @@ class CustomerEdgeResource(
 
         /** Upper bound on address-book hashes forwarded in one directory lookup. */
         internal const val MAX_DIRECTORY_HASHES = 500
+
+        /** A directory hash is a hex sha-256 and nothing else — anything looser is a bad request. */
+        internal val SHA256_HEX = Regex("^[0-9a-f]{64}$")
+
+        private const val MILLIS_PER_SECOND = 1000L
 
         internal const val CARD_TYPE_VIRTUAL = "VIRTUAL"
         internal const val CARD_TYPE_SINGLE_USE = "SINGLE_USE"

--- a/openbank-customer-edge/src/main/resources/openapi.yaml
+++ b/openbank-customer-edge/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: Customer Edge API
-  version: 1.28.0
+  version: 1.29.0
   description: >-
     Customer-facing edge proxy (ADR-0065). Single internet-facing entry point for the
     retail customer app. Validates JWTs from the openbank-customers Keycloak realm,
@@ -205,6 +205,43 @@ paths:
                 $ref: '#/components/schemas/DiscoverableRequest'
         '400':
           description: discoverable missing or not a boolean
+
+  /directory/payee:
+    post:
+      tags: [Directory]
+      summary: Turn a directory hit into a payable target, without disclosing the payee's account
+      description: >
+        Takes the SHA-256 hash of a phone number the caller already holds and returns an opaque
+        payment-session token (the same rail nearby-pay uses, ADR-0087) plus a display name and a
+        MASKED account. The payee's real account number never leaves the edge: the token is
+        resolved back to it inside POST /domestic-payments, and SCA is signed against the masked
+        form. Answering with an account number would make this a harvester, since phone numbers
+        are enumerable in a way account numbers are not.
+
+        Opt-in is re-checked here rather than trusted from the caller's earlier lookup — someone
+        who has since turned findability off stops being payable immediately. "No such number",
+        "not discoverable" and "no creditable account" all return the SAME 404 body, so this route
+        cannot be used as an existence oracle.
+      operationId: directoryPayee
+      security:
+        - customerOidc: [accounts:read]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DirectoryPayeeRequest'
+      responses:
+        '200':
+          description: A payment-session token bound to the payee's account
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DirectoryPayeeResponse'
+        '400':
+          description: phoneHash missing/malformed, or the hash resolves to the caller themselves
+        '404':
+          description: No payee for that number — indistinguishable from opted-out or not creditable
 
   /accounts:
     get:
@@ -1647,6 +1684,31 @@ components:
       properties:
         discoverable:
           type: boolean
+    DirectoryPayeeRequest:
+      type: object
+      required: [phoneHash]
+      properties:
+        phoneHash:
+          type: string
+          pattern: '^[0-9a-f]{64}$'
+          description: Lowercase hex SHA-256 of an E.164 number the caller already holds.
+    DirectoryPayeeResponse:
+      type: object
+      description: >
+        Everything a payer is told about the payee. Deliberately no account number and no party
+        id — the token is the only handle, and only the edge can resolve it.
+      properties:
+        paymentSessionToken:
+          type: string
+          description: Opaque, single-payee, short-lived. Pass as paymentSessionToken on POST /domestic-payments.
+        displayName:
+          type: string
+          description: The payee's legal name, as the bank holds it.
+        creditorMasked:
+          type: string
+          description: Country code + last four ("CZ…5399"). The only account form a payer ever sees.
+        expiresInSeconds:
+          type: integer
     AccessLogEntry:
       type: object
       description: One audit event whose aggregate is the caller's party (metadata only,

--- a/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/DirectoryPayeeTest.kt
+++ b/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/DirectoryPayeeTest.kt
@@ -1,0 +1,208 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.customeredge
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.customeredge.infrastructure.rest.CustomerEdgeResource
+import com.openbank.customeredge.infrastructure.rest.PaymentSessionStore
+import com.openbank.customeredge.infrastructure.rest.UpstreamClient
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import jakarta.ws.rs.core.Response
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.util.UUID
+
+/**
+ * `POST /customer/v1/directory/payee` — turning a directory hit into something payable.
+ *
+ * The properties worth pinning are the ones whose failure is silent and harmful: leaking a
+ * payee's account number, answering differently for "not a customer" and "chose not to be
+ * found", and trusting a stale opt-in.
+ */
+class DirectoryPayeeTest {
+
+    private val sessions = PaymentSessionStore()
+
+    private fun resourceFor(upstream: UpstreamClient, caller: UUID): CustomerEdgeResource = CustomerEdgeResource(
+        upstream,
+        mockk(relaxed = true),
+        sessions,
+        mockk(relaxed = true),
+        mockk(relaxed = true),
+        Clock.systemUTC(),
+    ).apply {
+        partyMergeResolver = mockk { every { resolve(any()) } answers { firstArg() } }
+        jwt = mockk {
+            every { getClaim<String>("party_id") } returns caller.toString()
+            every { subject } returns caller.toString()
+        }
+        objectMapper = ObjectMapper()
+        accountServiceUrl = "http://account"
+        partyServiceUrl = "http://party"
+    }
+
+    private val hash = "a".repeat(64)
+    private fun body(h: String = hash) = """{"phoneHash":"$h"}"""
+
+    private fun matchJson(partyId: UUID, name: String = "Jarmila Nováková") =
+        Response.ok("""{"matches":[{"phoneHash":"$hash","partyId":"$partyId","legalName":"$name"}]}""").build()
+
+    private fun accountsJson(vararg rows: String) = Response.ok("[${rows.joinToString(",")}]").build()
+
+    private fun acct(
+        id: UUID,
+        iban: String = "CZ6508000000192000145399",
+        type: String = "CURRENT",
+        status: String = "ACTIVE",
+        cur: String = "CZK",
+        openedAt: String = "2024-01-01T00:00:00Z",
+    ) = """
+        {"id":"$id","accountNumber":"$iban","accountType":"$type","status":"$status",
+        "currencyCode":"$cur","openedAt":"$openedAt"}
+    """.trimIndent().replace("\n", "")
+
+    @Test
+    fun `the payee's account number never reaches the caller — only a mask and a token`() {
+        val caller = UUID.randomUUID()
+        val payee = UUID.randomUUID()
+        val acctId = UUID.randomUUID()
+        val upstream = mockk<UpstreamClient>()
+        every { upstream.post(match { it.contains("/directory/lookup") }, any(), any()) } returns matchJson(payee)
+        every { upstream.get(match { it.contains("partyId=$payee") }, any()) } returns
+            accountsJson(acct(acctId, iban = "CZ6508000000192000145399"))
+
+        val resp = resourceFor(upstream, caller).directoryPayee(body())
+
+        assertThat(resp.status).isEqualTo(200)
+        val out = resp.entity.toString()
+        assertThat(out).doesNotContain("192000145399")
+        assertThat(out).doesNotContain(acctId.toString())
+        assertThat(out).contains("CZ…5399")
+        assertThat(out).contains("paymentSessionToken")
+    }
+
+    @Test
+    fun `the token resolves inside the edge to the real account, which is how the payment lands`() {
+        val caller = UUID.randomUUID()
+        val payee = UUID.randomUUID()
+        val acctId = UUID.randomUUID()
+        val upstream = mockk<UpstreamClient>()
+        every { upstream.post(match { it.contains("/directory/lookup") }, any(), any()) } returns matchJson(payee)
+        every { upstream.get(match { it.contains("partyId=$payee") }, any()) } returns accountsJson(acct(acctId))
+
+        val resp = resourceFor(upstream, caller).directoryPayee(body())
+        val token = ObjectMapper().readTree(resp.entity.toString()).path("paymentSessionToken").asText()
+
+        val session = sessions.resolve(token)
+        assertThat(session).isNotNull
+        assertThat(session!!.creditorAccountId).isEqualTo(acctId.toString())
+        assertThat(session.creditorPartyId).isEqualTo(payee.toString())
+    }
+
+    @Test
+    fun `a party who is not discoverable is answered exactly like a number nobody holds`() {
+        val caller = UUID.randomUUID()
+        val upstream = mockk<UpstreamClient>()
+        // party-service returns no match for a party who opted out — the same empty answer it
+        // gives for a number that belongs to no customer at all.
+        every { upstream.post(match { it.contains("/directory/lookup") }, any(), any()) } returns
+            Response.ok("""{"matches":[]}""").build()
+
+        val resp = resourceFor(upstream, caller).directoryPayee(body())
+
+        assertThat(resp.status).isEqualTo(404)
+        assertThat(resp.entity.toString()).isEqualTo("""{"error":"no payee for that number"}""")
+    }
+
+    @Test
+    fun `a discoverable party with nothing creditable is answered the same way — no oracle`() {
+        val caller = UUID.randomUUID()
+        val payee = UUID.randomUUID()
+        val upstream = mockk<UpstreamClient>()
+        every { upstream.post(match { it.contains("/directory/lookup") }, any(), any()) } returns matchJson(payee)
+        every { upstream.get(match { it.contains("partyId=$payee") }, any()) } returns accountsJson()
+
+        val resp = resourceFor(upstream, caller).directoryPayee(body())
+
+        // Identical status AND body to the not-discoverable case above: the difference between
+        // "no such person" and "person with no current account" is not the caller's business.
+        assertThat(resp.status).isEqualTo(404)
+        assertThat(resp.entity.toString()).isEqualTo("""{"error":"no payee for that number"}""")
+    }
+
+    @Test
+    fun `opt-in is re-checked here rather than trusted from the caller's earlier lookup`() {
+        val caller = UUID.randomUUID()
+        val upstream = mockk<UpstreamClient>()
+        every { upstream.post(any(), any(), any()) } returns Response.ok("""{"matches":[]}""").build()
+
+        resourceFor(upstream, caller).directoryPayee(body())
+
+        // The route must go back to party-service every time; a hit the app carried over from a
+        // lookup days ago says nothing about whether the person is still findable today.
+        verify { upstream.post(match { it.contains("/parties/directory/lookup") }, any(), any()) }
+    }
+
+    @Test
+    fun `a malformed hash is rejected before anything upstream is asked`() {
+        val caller = UUID.randomUUID()
+        val upstream = mockk<UpstreamClient>()
+
+        val r = resourceFor(upstream, caller)
+        assertThat(r.directoryPayee("""{"phoneHash":"nope"}""").status).isEqualTo(400)
+        assertThat(r.directoryPayee("""{"phoneHash":"${"A".repeat(64)}"}""").status).isEqualTo(400)
+        assertThat(r.directoryPayee("{}").status).isEqualTo(400)
+        verify(exactly = 0) { upstream.post(any(), any(), any()) }
+    }
+
+    @Test
+    fun `paying your own number is refused rather than booked as a self-transfer`() {
+        val caller = UUID.randomUUID()
+        val upstream = mockk<UpstreamClient>()
+        every { upstream.post(match { it.contains("/directory/lookup") }, any(), any()) } returns matchJson(caller)
+
+        val resp = resourceFor(upstream, caller).directoryPayee(body())
+
+        assertThat(resp.status).isEqualTo(400)
+        verify(exactly = 0) { upstream.get(any(), any()) }
+    }
+
+    @Test
+    fun `account choice is deterministic — active, current, CZK, oldest first`() {
+        val caller = UUID.randomUUID()
+        val payee = UUID.randomUUID()
+        val oldest = UUID.randomUUID()
+        val newer = UUID.randomUUID()
+        val upstream = mockk<UpstreamClient>()
+        every { upstream.post(match { it.contains("/directory/lookup") }, any(), any()) } returns matchJson(payee)
+        every { upstream.get(match { it.contains("partyId=$payee") }, any()) } returns accountsJson(
+            acct(UUID.randomUUID(), type = "SAVINGS", openedAt = "2020-01-01T00:00:00Z"),
+            acct(UUID.randomUUID(), status = "CLOSED", openedAt = "2021-01-01T00:00:00Z"),
+            acct(UUID.randomUUID(), cur = "EUR", openedAt = "2022-01-01T00:00:00Z"),
+            acct(newer, openedAt = "2025-01-01T00:00:00Z"),
+            acct(oldest, openedAt = "2023-01-01T00:00:00Z"),
+        )
+
+        val resp = resourceFor(upstream, caller).directoryPayee(body())
+        val token = ObjectMapper().readTree(resp.entity.toString()).path("paymentSessionToken").asText()
+
+        assertThat(sessions.resolve(token)!!.creditorAccountId).isEqualTo(oldest.toString())
+    }
+
+    @Test
+    fun `a savings-only payee is not credited on their savings account`() {
+        val caller = UUID.randomUUID()
+        val payee = UUID.randomUUID()
+        val upstream = mockk<UpstreamClient>()
+        every { upstream.post(match { it.contains("/directory/lookup") }, any(), any()) } returns matchJson(payee)
+        every { upstream.get(match { it.contains("partyId=$payee") }, any()) } returns
+            accountsJson(acct(UUID.randomUUID(), type = "SAVINGS"))
+
+        assertThat(resourceFor(upstream, caller).directoryPayee(body()).status).isEqualTo(404)
+    }
+}


### PR DESCRIPTION
Closes #3176.

## Proč

Pay-to-phone byla půlka funkce: adresář rozliší číslo na `partyId` a s tím se nedalo dělat nic. Zákazník tedy stejně opisoval číslo účtu ručně a vyhledání mu ušetřilo jméno.

## Co

`POST /customer/v1/directory/payee` vezme hash čísla, které volající už zná, a vrátí **neprůhledný payment-session token**, jméno a **maskovaný** účet.

**Žádná nová platební cesta.** Token je ten, který už používá nearby-pay rail (ADR-0087), takže `createDomesticPayment` si ho uvnitř edge přeloží zpět na skutečný účet a SCA se podepisuje proti maskované formě. Platební kód zůstal nedotčený.

## Čtyři rozhodnutí, na kterých to stojí

**Token, ne IBAN.** Odpovědět číslem účtu z toho udělá sklízeč — telefonní čísla se dají procházet po řadě, čísla účtů ne. Účet neopustí edge.

**Hash, ne partyId.** Volající musí prokázat, že číslo už zná. Kdyby se `partyId` bralo z těla, stačilo by id zahlédnuté ve sdíleném payloadu nebo v nabídce dispozice a máš platební cíl na cizího člověka.

**Opt-in se ověřuje tady, v momentě platby.** Lookup mohl proběhnout před týdnem; kdo si mezitím dohledatelnost vypnul, musí okamžitě přestat být platitelný. Proto se lookup pouští znovu proti party-service, místo aby se věřilo klientovi.

**Není to oracle.** „Číslo nikdo nemá", „nechce být dohledatelný" a „nemá kam připsat" vracejí **identické** 404 tělo. Jinak by ta routa odpověděla na otázku, kterou `/directory/lookup` záměrně nezodpovídá.

## Výběr účtu

Deterministický — ACTIVE, CURRENT, CZK, nejstarší první. Příjemce s více účty musí dostávat pořád na stejný, jinak se historie plátce a očekávání příjemce rozejdou. SAVINGS vyloučeno: připsat cizí platbu na spořicí účet není, co kterákoli strana myslí, a některé produkty příchozí převody omezují. Platba na vlastní číslo se odmítá, ne zabookuje jako self-transfer, který v historii vypadá jako platba někomu jinému.

## Ověření

9 unit testů, 0 selhání — doloženo v report XML, ne jen návratovým kódem. `ktlintCheck` + `detekt` čisté. Routa doplněná do `openapi.yaml`, `info.version` → 1.27.0.

Klientská strana: openbank-app#401 (výběr z kontaktů). Po zmergování obojího zmizí z appky věta o ručním doplnění účtu.