### PR TITLE
fix(ci): the probe-port gate must read the shared base application.yaml

### DIFF
--- a/.github/scripts/check-probe-port-listener.py
+++ b/.github/scripts/check-probe-port-listener.py
@@ -55,18 +55,51 @@ GITOPS = REPO / "openbank-infra" / "gitops"
 PROBES = ("livenessProbe", "readinessProbe", "startupProbe")
 
 
+# ADR-0122 / #3672: openbank-libs-runtime ships a base application.yaml that every service
+# inherits. Quarkus reads it from the dependency jar at a LOWER ordinal than the service's own
+# file, so a port declared only in the base IS opened at runtime — verified empirically by
+# FinrepBootSmokeTest, not assumed here. Reading a service's file alone therefore under-reports
+# what listens, and the gate blamed finrep for a management port the base already opens (#3686).
+# The failure direction matters: it is a FALSE POSITIVE that grows with adoption, one new red for
+# every service that takes the base.
+BASE_CONFIG = REPO / "openbank-libs-runtime" / "src" / "main" / "resources" / "application.yaml"
+
+
+def _ports_of(doc: dict) -> dict[str, int | None]:
+    quarkus = doc.get("quarkus") or {}
+    return {
+        "http": (quarkus.get("http") or {}).get("port"),
+        "management": (quarkus.get("management") or {}).get("port"),
+    }
+
+
+def _load(path: pathlib.Path) -> dict | None:
+    try:
+        return yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    except (yaml.YAMLError, OSError):
+        return None
+
+
+def base_ports() -> dict[str, int | None]:
+    """Ports the shared openbank-libs-runtime base opens for every service that inherits it."""
+    doc = _load(BASE_CONFIG)
+    return _ports_of(doc) if doc is not None else {"http": None, "management": None}
+
+
 def service_ports() -> dict[str, dict[str, int | None]]:
-    """{service: {"http": port, "management": port}} from each service's application.yaml."""
+    """{service: {"http": port, "management": port}}, service file layered over the shared base."""
+    base = base_ports()
     out: dict[str, dict[str, int | None]] = {}
     for path in sorted(REPO.glob("openbank-*/src/main/resources/application.yaml")):
-        try:
-            doc = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
-        except yaml.YAMLError:
+        if path == BASE_CONFIG:
+            continue  # the base is not a service
+        doc = _load(path)
+        if doc is None:
             continue
-        quarkus = doc.get("quarkus") or {}
+        own = _ports_of(doc)
+        # The service's own value wins where it sets one; the base fills the rest.
         out[path.parts[len(REPO.parts)]] = {
-            "http": (quarkus.get("http") or {}).get("port"),
-            "management": (quarkus.get("management") or {}).get("port"),
+            k: own[k] if own[k] is not None else base[k] for k in ("http", "management")
         }
     return out
 
@@ -205,6 +238,9 @@ def selftest() -> int:
         (8085, 8128, None, True),    # #2870 exactly: no quarkus.management block
         (8085, 8128, 8086, True),    # management enabled, different port
         (8128, 8128, None, False),   # probing the http port needs no management block
+        # #3686: the port comes from the shared base, not the service's own file. Before this,
+        # service_ports() returned management=None here and the gate flagged a healthy service.
+        (8085, 8140, 8085, False),   # base-supplied management port, resolved by layering
     ]
     for probe_port, http, management, must_flag in cases:
         flagged = probe_port not in {http, management}
@@ -212,8 +248,20 @@ def selftest() -> int:
             verb = "missed" if must_flag else "wrongly flagged"
             print(f"selftest FAIL: {verb} probe={probe_port} http={http} management={management}")
             return 1
+    base = base_ports()
+    if base["management"] is None:
+        print("selftest FAIL: the shared base declares no management port — either it moved or "
+              f"{BASE_CONFIG.relative_to(REPO)} no longer parses, and every inheriting service "
+              "would be flagged for a port that is in fact open.")
+        return 1
+    inheritors = [s for s, p in configs.items() if (_load(REPO / s / "src/main/resources/application.yaml")
+                  or {}).get("quarkus", {}).get("management") is None and p["management"] is not None]
+    if not inheritors:
+        print("selftest FAIL: no service resolves its management port from the base, so the "
+              "layering path is untested — it would pass while doing nothing.")
+        return 1
     print(f"selftest OK: {len(cases)} cases, both directions; "
-          f"{len(configs)} service config(s), {len(workloads())} workload(s) parsed.")
+          f"{len(configs)} service config(s) ({len(inheritors)} inheriting management="f"{base['management']} from the shared base), {len(workloads())} workload(s) parsed.")
     return 0
 
 


### PR DESCRIPTION
## main is red, and the finding is false

Enforced gate, red on main since #3686 (`ee974ea3`), and three commits have merged on top of it
since:

```
finrep-service probes or scrapes port 8085, but openbank-finrep-service's application.yaml
opens only http=8140 / management=None
```

Port 8085 **is** open. #3686 moved the management block into `openbank-libs-runtime`'s shared base
`application.yaml`; Quarkus reads that from the dependency jar at a lower ordinal than the service's
own file. That is not an assumption here — #3686 shipped `FinrepBootSmokeTest`, which asserts a
base-supplied value, a service `%test` override beating the base, and an untouched service-local key.

The gate globbed `openbank-*/src/main/resources/application.yaml` only, so an inherited port was
invisible to it.

## Why this is worth fixing properly rather than adding the key back to finrep

#3672 rolls the base out fleet-wide. Re-declaring `quarkus.management` in finrep would clear today's
red and hand the next adopting service the same false red — on an **enforced** gate that blocks every
PR in the repo. The bug is in the reader, not in finrep.

## The fix

Layering: the service's own value wins where it sets one, the base fills the rest. The base file is
excluded from the service scan.

## Falsification

A change to detection logic can go green by going *blind*, so re-running it was not enough:

| case | expected | result |
| --- | --- | --- |
| finrep re-pointed at port 9999 (nothing opens it) | flags, exit 1 | flags, exit 1 |
| base stops declaring a management port | selftest fails, named reason | selftest fails |
| no service actually resolves through the base | selftest fails (dead code path) | guard added |
| unmodified tree | clean | 113 ports checked, clean |

`--selftest`: 5 cases, 57 service configs (2 inheriting `management=8085`), 97 workloads.

Refs #3686, #3672, #2872
