### PR TITLE
feat(card-issuance): make the card controls real, and add category rules (D3)

### DIFF
--- a/docs/threat-models/openbank-card-issuance-service.md
+++ b/docs/threat-models/openbank-card-issuance-service.md
@@ -59,6 +59,37 @@ All mutations require `Idempotency-Key` or `X-Operator-Id` header; resource-leve
 | **E**oP | Viewer escalates to issue or block | Distinct roles enforced at JAX-RS layer (`@RolesAllowed`) + OPA; deny-by-default |
 | **T**ampering | Race between `suspend` and `block` on same card | Domain `require` guards throw `IllegalArgumentException` on illegal state; a concurrent block on a SUSPENDED card is valid by design; concurrent suspend+block both succeed on ACTIVE → last writer wins idempotently (both move toward frozen state) — acceptable; optimistic locking would make this exact (see §5) |
 
+## 4a. Card authorization decision point (D3) — STRIDE supplement
+
+Three new surfaces: `GET /api/v1/cards/category-taxonomy`, `GET|PUT /api/v1/cards/{id}/category-limits`,
+and `POST /api/v1/cards/{id}/authorizations` — the decision that answers whether one card
+authorisation is approved.
+
+**The pre-existing defect this closes.** The channel controls (`contactlessEnabled`,
+`onlineEnabled`, `atmEnabled`, `abroadEnabled`) have been stored on `cards` and returned by the API
+since V5, and **no code anywhere read them to decide anything**. A customer who switched off
+"payments abroad" changed a boolean, got a 200, and their card kept working abroad. That is worse
+than not offering the control: a security control that reports success without acting invites the
+customer to stop taking other precautions. Everything below exists to make those toggles real.
+
+| STRIDE | Threat | Mitigation |
+|---|---|---|
+| **E**oP | A caller obtains approvals for a card it does not own | `@RolesAllowed(ROLE_API, ROLE_OPERATOR, ROLE_ADMIN)` + `@Authorize(action = "card.authorization.decide", resource = "#id")`; the customer-facing path reaches this only through the edge, which already enforces card ownership against the JWT party |
+| **T**ampering | The caller supplies its own spend totals, so a compromised caller could under-report and slip past a limit | Accepted and explicit: the totals are inputs, because this service holds no authorisation history. The trust boundary is that only trusted rails may call it (no `ROLE_CUSTOMER`). When spend tracking lands, the totals become server-derived and this row narrows — flagged in the response today as `spendTracking: false` so no client presents them as measured |
+| **S**poofing | An unknown card id is used to fish for a permissive default | An unknown card **declines** (`CARD_NOT_ACTIVE`) rather than 404s. The acquirer needs an answer, and the safe answer to "may this unknown card spend" is no; it also avoids an existence oracle on card ids |
+| **D**oS | A customer locks themselves out of every rail | `CHIP_AND_PIN` deliberately has no toggle. A customer able to disable every channel could not pay at any terminal and could not recover from one either |
+| **T**ampering | A category block is bypassed by sending an MCC the taxonomy does not know | Unknown, malformed and absent MCCs all resolve to `OTHER`, which is **limitable but never blockable**. That asymmetry is deliberate: making OTHER blockable would let one unclassified code decline arbitrary legitimate spend as the acquirer estate changes, while leaving it unblockable means a customer's gambling block cannot be dodged by a merchant miscoding — because a miscoded gambling merchant is not in the gambling range for any control, including ours |
+| **R**epudiation | A decline cannot be explained to the customer | The decision returns a specific `declineReason`, and the evaluation order is card state, then customer switches, then amounts — so the reason shown is the one the customer can act on ("you turned gambling off"), not a downstream limit they never set |
+| **I**nfo disclosure | The taxonomy leaks something sensitive | It is public bank policy — category ids, labels and MCC ranges. Serving it is the point: a client that hardcoded MCC sets would keep enforcing a stale policy on every installed build |
+
+**DFD update:** adds `acquirer rail → POST /cards/{id}/authorizations → decision` and
+`customer (via edge) → PUT /cards/{id}/category-limits`. No new downstream dependency; the decision
+reads only this service's own tables.
+**Risk class:** integrity of a money-path control (an authorisation approve/decline).
+**Rollback:** revert. Card behaviour returns to what it is today — controls stored and unenforced —
+which is the defect, so a rollback should be paired with disabling the customer-facing toggles
+rather than leaving them visibly ineffective.
+
 ## 5. Residual risks / assumptions
 
 - **No optimistic locking today.** `Card` lacks a `version` column; two concurrent lifecycle
@@ -78,6 +109,8 @@ All mutations require `Idempotency-Key` or `X-Operator-Id` header; resource-leve
   is implemented, erasure is manual.
 
 ## 6. Change log
+
+- **2026-08-07** — Card authorization decision point (D3). New `CardAuthorizationPolicy` (pure, 15 unit tests) plus `POST /cards/{id}/authorizations`, `GET|PUT /cards/{id}/category-limits` and `GET /cards/category-taxonomy`; new `card_category_rules` table. STRIDE supplement in §4a. **This closes a live defect, not just a missing feature:** the channel controls stored since V5 were read by nothing, so a customer switching off "payments abroad" got a 200 and no protection. The policy is deliberately pure — no repository, no clock — so every branch of a money-path decision is reachable in a unit test rather than only against a live acquirer. Per-category spend is not yet tracked; the response says `spendTracking: false` so a client shows "no data" instead of a progress ring against a zero that looks measured. Rollback: revert, but pair it with hiding the customer-facing toggles rather than leaving controls that visibly do nothing.
 
 - **2026-06-30** — Initial threat model authored (ADR-0113 delivery gate).
   Sandbox: maskedPan synthetic, no real PAN stored, PCI DSS CHD scope not triggered.

--- a/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/domain/model/CardAuthorization.kt
+++ b/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/domain/model/CardAuthorization.kt
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.cardissuance.domain.model
+
+/** How the card was presented. Mirrors the channel toggles the customer already controls. */
+enum class AuthorizationChannel { CONTACTLESS, ONLINE, ATM, CHIP_AND_PIN }
+
+/** Why an authorisation was refused. Surfaced to the customer, so each value must be explainable. */
+enum class DeclineReason {
+    CARD_NOT_ACTIVE,
+    CHANNEL_DISABLED,
+    ABROAD_DISABLED,
+    CATEGORY_BLOCKED,
+    CATEGORY_LIMIT_EXCEEDED,
+    DAILY_LIMIT_EXCEEDED,
+    MONTHLY_LIMIT_EXCEEDED,
+}
+
+/**
+ * One authorisation request as the acquirer presents it.
+ *
+ * [amountMinorUnits] is the amount being authorised; the spend figures are what has already been
+ * authorised in the relevant window and are supplied by the caller, because this object is a pure
+ * decision input with no database of its own.
+ */
+data class AuthorizationRequest(
+    val amountMinorUnits: Long,
+    val channel: AuthorizationChannel,
+    val mcc: String?,
+    val countryCode: String?,
+    val spentTodayMinorUnits: Long = 0,
+    val spentThisMonthMinorUnits: Long = 0,
+    val spentThisMonthInCategoryMinorUnits: Long = 0,
+)
+
+/** Per-category configuration the customer set for a card. */
+data class CategoryRule(val category: String, val blocked: Boolean = false, val monthlyLimitMinorUnits: Long? = null)
+
+data class AuthorizationDecision(
+    val approved: Boolean,
+    val reason: DeclineReason? = null,
+    /** The category the request was judged as — returned even on approval, so the ledger can keep it. */
+    val category: String = MerchantCategoryTaxonomy.UNMAPPED,
+)
+
+/**
+ * Decides whether a card authorisation is approved.
+ *
+ * **This is the enforcement point.** Until it existed, the channel toggles a customer set in the
+ * app — contactless, online, ATM, abroad — were stored, returned by the API and never consulted by
+ * anything: turning off "payments abroad" changed a boolean and nothing else. A control that
+ * answers 200 and does not control is worse than an absent one, because the customer believes they
+ * are protected.
+ *
+ * Pure by construction: no repository, no clock, no I/O. Everything it needs — the card, the
+ * customer's category rules, and the spend already authorised — arrives as arguments, so every
+ * branch below is reachable in a unit test. A money-path decision that can only be exercised
+ * against a live acquirer is a decision nobody checks.
+ *
+ * Order matters and is deliberate: the card's own state first, then what the customer switched
+ * off, then the amounts. The first failing rule wins, so the reason the customer is shown is the
+ * one they can act on — "you turned gambling off", not "you are over a limit you did not set".
+ */
+object CardAuthorizationPolicy {
+    /** Statuses that may authorise. Everything else — including PENDING — declines. */
+    private val AUTHORIZABLE = setOf(CardStatus.ACTIVE)
+
+    /** ISO-3166 alpha-2 of the issuing market; see the note at the abroad check. */
+    const val HOME_COUNTRY: String = "CZ"
+
+    fun decide(card: Card, request: AuthorizationRequest, rules: List<CategoryRule>): AuthorizationDecision {
+        val category = MerchantCategoryTaxonomy.categoryOf(request.mcc)
+        fun decline(reason: DeclineReason) = AuthorizationDecision(false, reason, category)
+
+        if (card.status !in AUTHORIZABLE) return decline(DeclineReason.CARD_NOT_ACTIVE)
+        if (isChannelDisabled(card, request.channel)) return decline(DeclineReason.CHANNEL_DISABLED)
+
+        // Absent country is treated as domestic. An acquirer that omits it is far more often a
+        // domestic terminal with a sparse message than a foreign one, and declining on missing data
+        // would break ordinary spend to enforce a control the customer may not even have set.
+        //
+        // "Home" is the bank's market rather than a per-card field, because no such field exists on
+        // the card: a Czech bank's cards are issued in CZ. When the bank issues outside CZ this
+        // becomes a card attribute, and this constant is where that change starts.
+        val abroad = request.countryCode != null && !request.countryCode.equals(HOME_COUNTRY, ignoreCase = true)
+        if (abroad && !card.abroadEnabled) return decline(DeclineReason.ABROAD_DISABLED)
+
+        val rule = rules.firstOrNull { it.category == category }
+        categoryDecline(rule, category, request)?.let { return decline(it) }
+        amountDecline(card, request)?.let { return decline(it) }
+
+        return AuthorizationDecision(approved = true, category = category)
+    }
+
+    private fun isChannelDisabled(card: Card, channel: AuthorizationChannel): Boolean = when (channel) {
+        AuthorizationChannel.CONTACTLESS -> !card.contactlessEnabled
+        AuthorizationChannel.ONLINE -> !card.onlineEnabled
+        AuthorizationChannel.ATM -> !card.atmEnabled
+        // Chip and PIN is the fallback rail; there is no toggle for it, and inventing one would let
+        // a customer lock themselves out of every terminal with no way back.
+        AuthorizationChannel.CHIP_AND_PIN -> false
+    }
+
+    /** A block the customer set, or their cap for this category, whichever bites first. */
+    private fun categoryDecline(rule: CategoryRule?, category: String, request: AuthorizationRequest): DeclineReason? {
+        if (rule == null) return null
+        if (rule.blocked && MerchantCategoryTaxonomy.isBlockable(category)) return DeclineReason.CATEGORY_BLOCKED
+        val limit = rule.monthlyLimitMinorUnits ?: return null
+        val after = request.spentThisMonthInCategoryMinorUnits + request.amountMinorUnits
+        return if (after > limit) DeclineReason.CATEGORY_LIMIT_EXCEEDED else null
+    }
+
+    /** The card's own daily and monthly ceilings, checked last. */
+    private fun amountDecline(card: Card, request: AuthorizationRequest): DeclineReason? = when {
+        request.spentTodayMinorUnits + request.amountMinorUnits > card.dailyLimitMinorUnits ->
+            DeclineReason.DAILY_LIMIT_EXCEEDED
+        request.spentThisMonthMinorUnits + request.amountMinorUnits > card.monthlyLimitMinorUnits ->
+            DeclineReason.MONTHLY_LIMIT_EXCEEDED
+        else -> null
+    }
+}

--- a/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/domain/model/MerchantCategoryTaxonomy.kt
+++ b/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/domain/model/MerchantCategoryTaxonomy.kt
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.cardissuance.domain.model
+
+/**
+ * Maps an ISO-18245 merchant category code to the category a customer can block or cap.
+ *
+ * The bank owns this mapping, deliberately. If a client hardcoded "gambling is MCC 7995", adding
+ * a code to the gambling set would need an app release, and every customer on an older build would
+ * keep spending against a block they believe is on. Served over the API so the enforcement point
+ * and the display agree by construction.
+ *
+ * Codes with no mapping fall into [UNMAPPED]. That category is deliberately **not** blockable:
+ * blocking "everything I haven't classified" would decline arbitrary legitimate spend as the
+ * acquirer estate changes, and the customer could never learn what they had turned off.
+ */
+object MerchantCategoryTaxonomy {
+    /** Where an unrecognised MCC lands. Limitable — you may cap it — but never blockable. */
+    const val UNMAPPED: String = "OTHER"
+
+    data class Category(
+        val id: String,
+        val label: String,
+        val mccRanges: List<String>,
+        val blockable: Boolean,
+        val limitable: Boolean,
+    )
+
+    /**
+     * `7800-7802` style ranges are inclusive on both ends; a bare code is a range of one. Kept as
+     * strings because that is the shape the API publishes, and one source avoids the two drifting.
+     */
+    private data class Range(val from: Int, val to: Int)
+
+    val CATEGORIES: List<Category> = listOf(
+        // Gambling is the reason the whole feature exists: it is the one category where a customer
+        // asking to be stopped is asking for protection, not budgeting.
+        Category("GAMBLING", "Hazard", listOf("7800-7802", "7995", "9754"), blockable = true, limitable = true),
+        Category("GROCERIES", "Potraviny", listOf("5411", "5422", "5441", "5451", "5462", "5499"), true, true),
+        Category("DINING", "Restaurace", listOf("5811-5814"), true, true),
+        Category("TRANSPORT", "Doprava", listOf("4111-4131", "4121", "5541-5542", "7523"), true, true),
+        Category("TRAVEL", "Cestování", listOf("3000-3999", "4511-4722", "7011"), true, true),
+        Category("SHOPPING", "Nákupy", listOf("5200-5399", "5611-5699", "5712-5722", "5940-5999"), true, true),
+        Category("ENTERTAINMENT", "Zábava", listOf("7832-7841", "7911-7999"), true, true),
+        Category("HEALTH", "Zdraví", listOf("5912", "5975-5977", "8011-8099"), true, true),
+        Category("SERVICES", "Služby", listOf("4812-4816", "4899-4900", "7210-7299"), true, true),
+        Category("CASH", "Výběry hotovosti", listOf("6010-6012"), true, true),
+        // Unmapped: limitable, never blockable — see the class KDoc.
+        Category(UNMAPPED, "Ostatní", emptyList(), blockable = false, limitable = true),
+    )
+
+    private val RANGES: Map<String, List<Range>> = CATEGORIES.associate { c ->
+        c.id to c.mccRanges.map { spec ->
+            val parts = spec.split("-")
+            Range(parts.first().toInt(), parts.last().toInt())
+        }
+    }
+
+    private val BY_ID: Map<String, Category> = CATEGORIES.associateBy { it.id }
+
+    /**
+     * The category for [mcc], or [UNMAPPED] when the code is unknown, malformed or absent.
+     *
+     * Never throws: an authorisation decision must not fail because an acquirer sent a code we do
+     * not recognise. An unrecognised code becomes OTHER and is judged on OTHER's rules.
+     */
+    fun categoryOf(mcc: String?): String {
+        val code = mcc?.trim()?.toIntOrNull() ?: return UNMAPPED
+        return CATEGORIES.firstOrNull { c ->
+            RANGES[c.id].orEmpty().any { code >= it.from && code <= it.to }
+        }?.id ?: UNMAPPED
+    }
+
+    fun isKnown(categoryId: String): Boolean = categoryId in BY_ID
+
+    fun isBlockable(categoryId: String): Boolean = BY_ID[categoryId]?.blockable ?: false
+}

--- a/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/infrastructure/persistence/entity/CardCategoryRuleEntity.kt
+++ b/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/infrastructure/persistence/entity/CardCategoryRuleEntity.kt
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.cardissuance.infrastructure.persistence.entity
+
+import io.quarkus.hibernate.reactive.panache.kotlin.PanacheEntityBase
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.IdClass
+import jakarta.persistence.Table
+import java.io.Serializable
+import java.time.Instant
+import java.util.UUID
+
+/** Composite key: one rule per (card, category). */
+data class CardCategoryRuleId(var cardId: UUID = UUID(0, 0), var category: String = "") : Serializable {
+    companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}
+
+@Entity
+@Table(name = "card_category_rules")
+@IdClass(CardCategoryRuleId::class)
+class CardCategoryRuleEntity : PanacheEntityBase {
+    @Id
+    @Column(name = "card_id")
+    var cardId: UUID = UUID(0, 0)
+
+    @Id
+    @Column(name = "category")
+    var category: String = ""
+
+    @Column(name = "blocked", nullable = false)
+    var blocked: Boolean = false
+
+    /** Null means uncapped. Zero is a real cap of nothing, which is a different statement. */
+    @Column(name = "monthly_limit_minor_units")
+    var monthlyLimitMinorUnits: Long? = null
+
+    @Column(name = "updated_at", nullable = false)
+    var updatedAt: Instant = Instant.EPOCH
+}

--- a/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/infrastructure/persistence/repository/CardCategoryRuleRepository.kt
+++ b/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/infrastructure/persistence/repository/CardCategoryRuleRepository.kt
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.cardissuance.infrastructure.persistence.repository
+
+import com.openbank.cardissuance.domain.model.CategoryRule
+import com.openbank.cardissuance.infrastructure.persistence.entity.CardCategoryRuleEntity
+import io.quarkus.hibernate.reactive.panache.Panache
+import io.quarkus.hibernate.reactive.panache.kotlin.PanacheRepositoryBase
+import io.smallrye.mutiny.coroutines.awaitSuspending
+import jakarta.enterprise.context.ApplicationScoped
+import java.time.Clock
+import java.time.Instant
+import java.util.UUID
+
+@ApplicationScoped
+class CardCategoryRuleRepository(private val clock: Clock) : PanacheRepositoryBase<CardCategoryRuleEntity, UUID> {
+
+    suspend fun findByCard(cardId: UUID): List<CategoryRule> = Panache.withSession {
+        find("cardId", cardId).list()
+    }.awaitSuspending().map { CategoryRule(it.category, it.blocked, it.monthlyLimitMinorUnits) }
+
+    /**
+     * Replaces the card's rules with [rules] wholesale.
+     *
+     * Replace rather than patch, deliberately: the payload is the complete desired state, so the
+     * client is never in a read-modify-write race with itself, and a category the customer removed
+     * from the screen genuinely stops being enforced rather than lingering server-side where they
+     * cannot see it.
+     *
+     * Rules that say nothing — not blocked, no cap — are not stored at all. An unblocked, uncapped
+     * category is the absence of a rule; keeping a row for it would grow the table with entries
+     * that can never change a decision.
+     */
+    suspend fun replaceForCard(cardId: UUID, rules: List<CategoryRule>): List<CategoryRule> {
+        val meaningful = rules.filter { it.blocked || it.monthlyLimitMinorUnits != null }
+        val now = Instant.now(clock)
+        Panache.withTransaction {
+            delete("cardId", cardId).flatMap {
+                val entities = meaningful.map { r ->
+                    CardCategoryRuleEntity().also { e ->
+                        e.cardId = cardId
+                        e.category = r.category
+                        e.blocked = r.blocked
+                        e.monthlyLimitMinorUnits = r.monthlyLimitMinorUnits
+                        e.updatedAt = now
+                    }
+                }
+                if (entities.isEmpty()) {
+                    io.smallrye.mutiny.Uni.createFrom().voidItem()
+                } else {
+                    persist(entities)
+                }
+            }
+        }.awaitSuspending()
+        return meaningful
+    }
+}

--- a/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/infrastructure/rest/CardAuthorizationResource.kt
+++ b/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/infrastructure/rest/CardAuthorizationResource.kt
@@ -1,0 +1,217 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.cardissuance.infrastructure.rest
+
+import com.openbank.cardissuance.application.port.`in`.CardUseCase
+import com.openbank.cardissuance.domain.model.AuthorizationChannel
+import com.openbank.cardissuance.domain.model.AuthorizationRequest
+import com.openbank.cardissuance.domain.model.CardAuthorizationPolicy
+import com.openbank.cardissuance.domain.model.CategoryRule
+import com.openbank.cardissuance.domain.model.MerchantCategoryTaxonomy
+import com.openbank.cardissuance.infrastructure.persistence.repository.CardCategoryRuleRepository
+import com.openbank.libs.authz.Authorize
+import jakarta.annotation.security.RolesAllowed
+import jakarta.ws.rs.Consumes
+import jakarta.ws.rs.GET
+import jakarta.ws.rs.POST
+import jakarta.ws.rs.PUT
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.PathParam
+import jakarta.ws.rs.Produces
+import jakarta.ws.rs.core.MediaType
+import jakarta.ws.rs.core.Response
+import org.eclipse.microprofile.openapi.annotations.Operation
+import java.util.UUID
+
+/**
+ * The card authorisation decision point, and the per-category rules it enforces.
+ *
+ * Separate resource class from [CardResource] because these are a different job: that one manages
+ * a card's lifecycle for an operator, this one answers "may this payment go through" for the
+ * acquirer path and lets the customer configure what it answers.
+ */
+@Path("/api/v1/cards")
+@Produces(MediaType.APPLICATION_JSON)
+class CardAuthorizationResource(
+    private val cardUseCase: CardUseCase,
+    private val categoryRules: CardCategoryRuleRepository,
+) {
+
+    /**
+     * The category taxonomy, served rather than hardcoded in clients.
+     *
+     * A client that hardcoded "gambling is 7995" would keep letting spend through after the bank
+     * added a code, on every build already installed. Publishing it means the enforcement point and
+     * the screen agree by construction.
+     */
+    @GET
+    @Path("/category-taxonomy")
+    @RolesAllowed("ROLE_API", "ROLE_OPERATOR", "ROLE_ADMIN")
+    @Authorize(action = "card.taxonomy.read", resource = "")
+    @Operation(summary = "Merchant category taxonomy — ids, labels, MCC ranges, what may be blocked")
+    fun taxonomy(): Response = Response.ok(
+        TaxonomyResponse(
+            categories = MerchantCategoryTaxonomy.CATEGORIES.map {
+                TaxonomyCategory(it.id, it.label, it.mccRanges, it.blockable, it.limitable)
+            },
+            unmappedMccCategory = MerchantCategoryTaxonomy.UNMAPPED,
+        ),
+    ).build()
+
+    @GET
+    @Path("/{id}/category-limits")
+    @RolesAllowed("ROLE_API", "ROLE_OPERATOR", "ROLE_ADMIN")
+    @Authorize(action = "card.category-limits.read", resource = "#id")
+    @Operation(summary = "A card's per-category blocks and monthly caps")
+    suspend fun listCategoryLimits(@PathParam("id") id: UUID): Response {
+        val rules = categoryRules.findByCard(id)
+        return Response.ok(
+            CategoryLimitsResponse(
+                limits = rules.map { CategoryLimit(it.category, it.monthlyLimitMinorUnits, it.blocked) },
+                // Honest about what we cannot yet show: per-category spend needs authorisation
+                // history this service does not keep. The flag exists so a UI renders "no data"
+                // instead of a progress ring against a zero that looks measured.
+                spendTracking = false,
+            ),
+        ).build()
+    }
+
+    /**
+     * Replaces the card's category rules with the payload.
+     *
+     * Whole-state replacement, not a patch: the caller sends what it wants to be true, so it can
+     * never be in a read-modify-write race with itself, and a rule the customer removed from the
+     * screen genuinely stops being enforced.
+     *
+     * SCA is enforced at the edge, which is where the customer's challenge lives — raising a cap or
+     * unblocking a category is a step-up there. This service is reached only by trusted callers.
+     */
+    @PUT
+    @Path("/{id}/category-limits")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @RolesAllowed("ROLE_API", "ROLE_OPERATOR", "ROLE_ADMIN")
+    @Authorize(action = "card.category-limits.update", resource = "#id")
+    @Operation(summary = "Replace a card's per-category blocks and monthly caps")
+    suspend fun replaceCategoryLimits(@PathParam("id") id: UUID, req: CategoryLimitsRequest): Response {
+        val unknown = req.limits.map { it.category }.filterNot { MerchantCategoryTaxonomy.isKnown(it) }
+        if (unknown.isNotEmpty()) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                .entity(ErrorResponse("Unknown category: ${unknown.joinToString()}", "CATEGORY_UNKNOWN"))
+                .build()
+        }
+        val notBlockable = req.limits.filter { it.blocked }.map { it.category }
+            .filterNot { MerchantCategoryTaxonomy.isBlockable(it) }
+        if (notBlockable.isNotEmpty()) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                .entity(
+                    ErrorResponse(
+                        "Category cannot be blocked: ${notBlockable.joinToString()}",
+                        "CATEGORY_NOT_BLOCKABLE",
+                    ),
+                )
+                .build()
+        }
+        val saved = categoryRules.replaceForCard(
+            id,
+            req.limits.map { CategoryRule(it.category, it.blocked, it.monthlyLimitMinorUnits) },
+        )
+        return Response.ok(
+            CategoryLimitsResponse(
+                limits = saved.map { CategoryLimit(it.category, it.monthlyLimitMinorUnits, it.blocked) },
+                spendTracking = false,
+            ),
+        ).build()
+    }
+
+    /**
+     * Decides one card authorisation.
+     *
+     * **This is the enforcement point the channel controls never had.** Before it, a customer who
+     * turned off "payments abroad" changed a stored boolean that nothing read. The decision itself
+     * is [CardAuthorizationPolicy] — pure, and unit-tested branch by branch; this method only
+     * gathers the card and its rules and hands them over.
+     *
+     * A card that does not exist declines rather than 404s: an acquirer needs an answer, and the
+     * safe answer to "may this unknown card spend" is no.
+     */
+    @POST
+    @Path("/{id}/authorizations")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @RolesAllowed("ROLE_API", "ROLE_OPERATOR", "ROLE_ADMIN")
+    @Authorize(action = "card.authorization.decide", resource = "#id")
+    @Operation(summary = "Decide a card authorization against status, channel controls and category rules")
+    suspend fun authorize(@PathParam("id") id: UUID, req: AuthorizationDecisionRequest): Response {
+        val card = cardUseCase.getCard(id)
+            ?: return Response.ok(
+                AuthorizationDecisionResponse(
+                    approved = false,
+                    declineReason = "CARD_NOT_ACTIVE",
+                    category = MerchantCategoryTaxonomy.UNMAPPED,
+                ),
+            ).build()
+
+        val channel = runCatching { AuthorizationChannel.valueOf(req.channel.uppercase()) }.getOrNull()
+            ?: return Response.status(Response.Status.BAD_REQUEST)
+                .entity(ErrorResponse("Unknown channel: ${req.channel}", "CHANNEL_UNKNOWN"))
+                .build()
+
+        val decision = CardAuthorizationPolicy.decide(
+            card = card,
+            request = AuthorizationRequest(
+                amountMinorUnits = req.amountMinorUnits,
+                channel = channel,
+                mcc = req.mcc,
+                countryCode = req.countryCode,
+                spentTodayMinorUnits = req.spentTodayMinorUnits,
+                spentThisMonthMinorUnits = req.spentThisMonthMinorUnits,
+                spentThisMonthInCategoryMinorUnits = req.spentThisMonthInCategoryMinorUnits,
+            ),
+            rules = categoryRules.findByCard(id),
+        )
+        return Response.ok(
+            AuthorizationDecisionResponse(
+                approved = decision.approved,
+                declineReason = decision.reason?.name,
+                category = decision.category,
+            ),
+        ).build()
+    }
+}
+
+data class TaxonomyCategory(
+    val id: String,
+    val label: String,
+    val mccRanges: List<String>,
+    val blockable: Boolean,
+    val limitable: Boolean,
+)
+
+data class TaxonomyResponse(val categories: List<TaxonomyCategory>, val unmappedMccCategory: String)
+
+data class CategoryLimit(val category: String, val monthlyLimitMinorUnits: Long?, val blocked: Boolean)
+
+data class CategoryLimitsResponse(val limits: List<CategoryLimit>, val spendTracking: Boolean)
+
+data class CategoryLimitsRequest(val limits: List<CategoryLimitInput> = emptyList())
+
+data class CategoryLimitInput(
+    val category: String = "",
+    val monthlyLimitMinorUnits: Long? = null,
+    val blocked: Boolean = false,
+)
+
+data class AuthorizationDecisionRequest(
+    val amountMinorUnits: Long = 0,
+    val channel: String = "",
+    val mcc: String? = null,
+    val countryCode: String? = null,
+    val spentTodayMinorUnits: Long = 0,
+    val spentThisMonthMinorUnits: Long = 0,
+    val spentThisMonthInCategoryMinorUnits: Long = 0,
+)
+
+data class AuthorizationDecisionResponse(val approved: Boolean, val declineReason: String?, val category: String)
+
+data class ErrorResponse(val error: String, val code: String)

--- a/openbank-card-issuance-service/src/main/resources/db/migration/V8__card_category_rules.sql
+++ b/openbank-card-issuance-service/src/main/resources/db/migration/V8__card_category_rules.sql
@@ -1,0 +1,29 @@
+-- D3: per-category spending rules for a card — a monthly cap, a block, or both.
+--
+-- Separate table rather than columns on `cards` because the category taxonomy is expected to grow:
+-- adding a category must not be a schema change, and a customer sets rules for a handful of
+-- categories at most, so the table stays small and sparse.
+--
+-- Enforcement is in CardAuthorizationPolicy, in the authorisation path. Storing a rule the
+-- authorisation path did not read is the failure this whole change exists to end: before it, the
+-- channel toggles on `cards` were written, returned by the API, and consulted by nothing.
+CREATE TABLE card_category_rules (
+    card_id                   UUID        NOT NULL,
+    -- Taxonomy id (GAMBLING, GROCERIES, …). Not an enum type: the taxonomy is served by the API
+    -- and grows without a migration, and a Postgres enum would make each addition a schema change
+    -- in lock-step with a deploy.
+    category                  VARCHAR(40) NOT NULL,
+    blocked                   BOOLEAN     NOT NULL DEFAULT FALSE,
+    -- NULL = no cap for this category. Zero is a real value meaning "nothing at all", which is
+    -- distinct from "uncapped" — hence nullable rather than a 0 default.
+    monthly_limit_minor_units BIGINT,
+    updated_at                TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (card_id, category),
+    CONSTRAINT card_category_rules_limit_non_negative
+        CHECK (monthly_limit_minor_units IS NULL OR monthly_limit_minor_units >= 0)
+);
+
+CREATE INDEX idx_card_category_rules_card ON card_category_rules (card_id);
+
+COMMENT ON TABLE card_category_rules IS
+    'Per-card, per-category blocks and monthly caps. Enforced by CardAuthorizationPolicy in the authorization path (D3).';

--- a/openbank-card-issuance-service/src/main/resources/openapi.yaml
+++ b/openbank-card-issuance-service/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: Card Issuance Service API
-  version: 1.4.0
+  version: 1.5.0
   description: Debit/credit card lifecycle — issue, activate, block, suspend, resume, cancel;
     synthetic PAN vault and product-catalog entitlements.
   license:
@@ -324,6 +324,155 @@ paths:
               schema:
                 $ref: '#/components/schemas/CardResponse'
 
+  /api/v1/cards/category-taxonomy:
+    get:
+      tags: [Cards]
+      summary: Merchant category taxonomy — ids, labels, MCC ranges, what may be blocked
+      description: >
+        Served rather than hardcoded in clients. A client that hardcoded "gambling is MCC 7995"
+        would keep letting spend through after the bank added a code, on every build already
+        installed; publishing the taxonomy makes the enforcement point and the screen agree by
+        construction.
+      operationId: getCardCategoryTaxonomy
+      responses:
+        '200':
+          description: Taxonomy
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  categories:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id: { type: string }
+                        label: { type: string }
+                        mccRanges:
+                          type: array
+                          items: { type: string }
+                          description: 'Inclusive ranges ("7800-7802") or single codes ("7995").'
+                        blockable:
+                          type: boolean
+                          description: >
+                            False for OTHER — blocking everything unclassified would decline
+                            arbitrary legitimate spend as the acquirer estate changes, and the
+                            customer could never see what they had turned off.
+                        limitable: { type: boolean }
+                  unmappedMccCategory:
+                    type: string
+                    description: Category an unrecognised or absent MCC falls into.
+  /api/v1/cards/{id}/category-limits:
+    get:
+      tags: [Cards]
+      summary: A card's per-category blocks and monthly caps
+      operationId: getCardCategoryLimits
+      parameters:
+        - $ref: '#/components/parameters/cardId'
+      responses:
+        '200':
+          description: Category rules
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CategoryLimits'
+    put:
+      tags: [Cards]
+      summary: Replace a card's per-category blocks and monthly caps
+      description: >
+        Whole-state replacement, not a patch: the payload is what the caller wants to be true, so a
+        client is never in a read-modify-write race with itself, and a rule removed from the screen
+        genuinely stops being enforced. SCA for raising a cap or unblocking a category is enforced
+        at the customer edge, where the challenge lives.
+      operationId: replaceCardCategoryLimits
+      parameters:
+        - $ref: '#/components/parameters/cardId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                limits:
+                  type: array
+                  items:
+                    type: object
+                    required: [category]
+                    properties:
+                      category: { type: string }
+                      monthlyLimitMinorUnits:
+                        type: integer
+                        format: int64
+                        nullable: true
+                        description: 'Null = uncapped. Zero is a real cap of nothing, which is different.'
+                      blocked: { type: boolean }
+      responses:
+        '200':
+          description: Rules replaced
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CategoryLimits'
+        '400':
+          description: 'CATEGORY_UNKNOWN or CATEGORY_NOT_BLOCKABLE'
+  /api/v1/cards/{id}/authorizations:
+    post:
+      tags: [Cards]
+      summary: Decide a card authorization against status, channel controls and category rules
+      description: >
+        The card authorization decision point. Until it existed the channel controls
+        (contactless / online / ATM / abroad) were stored, returned by the API and read by nothing —
+        a customer who switched off payments abroad changed a boolean and nothing else. An unknown
+        card is DECLINED rather than 404: an acquirer needs an answer, and the safe answer to "may
+        this unknown card spend" is no.
+      operationId: decideCardAuthorization
+      parameters:
+        - $ref: '#/components/parameters/cardId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [amountMinorUnits, channel]
+              properties:
+                amountMinorUnits: { type: integer, format: int64 }
+                channel:
+                  type: string
+                  enum: [CONTACTLESS, ONLINE, ATM, CHIP_AND_PIN]
+                  description: >
+                    CHIP_AND_PIN has no customer toggle by design — a customer able to disable every
+                    rail could lock themselves out of every terminal with no way back.
+                mcc: { type: string, nullable: true }
+                countryCode:
+                  type: string
+                  nullable: true
+                  description: >
+                    ISO-3166 alpha-2 of the acquirer. Absent counts as domestic: declining on
+                    missing data would break ordinary spend at terminals with sparse messages.
+                spentTodayMinorUnits: { type: integer, format: int64 }
+                spentThisMonthMinorUnits: { type: integer, format: int64 }
+                spentThisMonthInCategoryMinorUnits: { type: integer, format: int64 }
+      responses:
+        '200':
+          description: Decision (an approved and a declined authorization both answer 200)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  approved: { type: boolean }
+                  declineReason:
+                    type: string
+                    nullable: true
+                    enum: [CARD_NOT_ACTIVE, CHANNEL_DISABLED, ABROAD_DISABLED, CATEGORY_BLOCKED, CATEGORY_LIMIT_EXCEEDED, DAILY_LIMIT_EXCEEDED, MONTHLY_LIMIT_EXCEEDED]
+                  category:
+                    type: string
+                    description: Category the request was judged as — present on approval too.
+        '400':
+          description: CHANNEL_UNKNOWN
   /api/v1/cards/{id}/controls:
     put:
       tags: [Cards]
@@ -417,6 +566,23 @@ components:
             $ref: '#/components/schemas/ApiError'
 
   schemas:
+    CategoryLimits:
+      type: object
+      properties:
+        limits:
+          type: array
+          items:
+            type: object
+            properties:
+              category: { type: string }
+              monthlyLimitMinorUnits: { type: integer, format: int64, nullable: true }
+              blocked: { type: boolean }
+        spendTracking:
+          type: boolean
+          description: >
+            False while per-category spend is not tracked. Present so a client renders "no data"
+            rather than a progress ring against a zero that looks measured.
+
     IssueCardRequest:
       type: object
       required: [partyId, accountId, cardType, cardNetwork]

--- a/openbank-card-issuance-service/src/test/kotlin/com/openbank/cardissuance/domain/model/CardAuthorizationPolicyTest.kt
+++ b/openbank-card-issuance-service/src/test/kotlin/com/openbank/cardissuance/domain/model/CardAuthorizationPolicyTest.kt
@@ -1,0 +1,208 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.cardissuance.domain.model
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.time.LocalDate
+import java.util.UUID
+
+class CardAuthorizationPolicyTest {
+    private fun card(
+        status: CardStatus = CardStatus.ACTIVE,
+        contactless: Boolean = true,
+        online: Boolean = true,
+        atm: Boolean = true,
+        abroad: Boolean = true,
+        daily: Long = 500_000,
+        monthly: Long = 5_000_000,
+    ) = Card(
+        id = UUID.randomUUID(),
+        idempotencyKey = "k",
+        partyId = UUID.randomUUID(),
+        accountId = UUID.randomUUID(),
+        productCode = "P",
+        cardType = CardType.DEBIT,
+        network = CardNetwork.VISA,
+        maskedPan = "**** 1234",
+        cardholderName = "J R",
+        embossedName = "J R",
+        expiryDate = LocalDate.of(2030, 1, 1),
+        status = status,
+        dailyLimitMinorUnits = daily,
+        monthlyLimitMinorUnits = monthly,
+        currency = "CZK",
+        deliveryAddress = null,
+        activatedAt = null,
+        blockedAt = null,
+        blockedReason = null,
+        createdAt = Instant.EPOCH,
+        updatedAt = Instant.EPOCH,
+        contactlessEnabled = contactless,
+        onlineEnabled = online,
+        atmEnabled = atm,
+        abroadEnabled = abroad,
+    )
+
+    private fun req(
+        amount: Long = 10_000,
+        channel: AuthorizationChannel = AuthorizationChannel.CHIP_AND_PIN,
+        mcc: String? = "5411",
+        country: String? = "CZ",
+        today: Long = 0,
+        month: Long = 0,
+        monthCategory: Long = 0,
+    ) = AuthorizationRequest(amount, channel, mcc, country, today, month, monthCategory)
+
+    @Test
+    fun `an ordinary purchase on an active card is approved`() {
+        val d = CardAuthorizationPolicy.decide(card(), req(), emptyList())
+        assertThat(d.approved).isTrue()
+        assertThat(d.reason).isNull()
+        assertThat(d.category).isEqualTo("GROCERIES")
+    }
+
+    @Test
+    fun `a card that is not active never authorises`() {
+        for (s in CardStatus.entries.filter { it != CardStatus.ACTIVE }) {
+            val d = CardAuthorizationPolicy.decide(card(status = s), req(), emptyList())
+            assertThat(d.approved).describedAs("status $s").isFalse()
+            assertThat(d.reason).isEqualTo(DeclineReason.CARD_NOT_ACTIVE)
+        }
+    }
+
+    @Test
+    fun `each channel toggle declines only its own channel`() {
+        val contactless = req(channel = AuthorizationChannel.CONTACTLESS)
+        assertThat(CardAuthorizationPolicy.decide(card(contactless = false), contactless, emptyList()).reason)
+            .isEqualTo(DeclineReason.CHANNEL_DISABLED)
+        assertThat(CardAuthorizationPolicy.decide(card(online = false), contactless, emptyList()).approved).isTrue()
+
+        val online = req(channel = AuthorizationChannel.ONLINE)
+        assertThat(CardAuthorizationPolicy.decide(card(online = false), online, emptyList()).reason)
+            .isEqualTo(DeclineReason.CHANNEL_DISABLED)
+
+        val atm = req(channel = AuthorizationChannel.ATM)
+        assertThat(CardAuthorizationPolicy.decide(card(atm = false), atm, emptyList()).reason)
+            .isEqualTo(DeclineReason.CHANNEL_DISABLED)
+    }
+
+    @Test
+    fun `chip and pin has no toggle so it cannot be switched off`() {
+        // Deliberate: a customer who could disable every rail would lock themselves out with no
+        // way back in from a terminal.
+        val d = CardAuthorizationPolicy.decide(
+            card(contactless = false, online = false, atm = false),
+            req(channel = AuthorizationChannel.CHIP_AND_PIN),
+            emptyList(),
+        )
+        assertThat(d.approved).isTrue()
+    }
+
+    @Test
+    fun `abroad is judged against the issuing market`() {
+        assertThat(CardAuthorizationPolicy.decide(card(abroad = false), req(country = "DE"), emptyList()).reason)
+            .isEqualTo(DeclineReason.ABROAD_DISABLED)
+        assertThat(CardAuthorizationPolicy.decide(card(abroad = false), req(country = "CZ"), emptyList()).approved)
+            .isTrue()
+        // Case is the acquirer's business, not the customer's.
+        assertThat(CardAuthorizationPolicy.decide(card(abroad = false), req(country = "cz"), emptyList()).approved)
+            .isTrue()
+    }
+
+    @Test
+    fun `a missing country counts as domestic`() {
+        // Declining on absent data would break ordinary spend at terminals with sparse messages,
+        // to enforce a control the customer may never have set.
+        val d = CardAuthorizationPolicy.decide(card(abroad = false), req(country = null), emptyList())
+        assertThat(d.approved).isTrue()
+    }
+
+    @Test
+    fun `a blocked category declines`() {
+        val rules = listOf(CategoryRule("GAMBLING", blocked = true))
+        val d = CardAuthorizationPolicy.decide(card(), req(mcc = "7995"), rules)
+        assertThat(d.reason).isEqualTo(DeclineReason.CATEGORY_BLOCKED)
+        assertThat(d.category).isEqualTo("GAMBLING")
+    }
+
+    @Test
+    fun `blocking one category leaves the others alone`() {
+        val rules = listOf(CategoryRule("GAMBLING", blocked = true))
+        assertThat(CardAuthorizationPolicy.decide(card(), req(mcc = "5411"), rules).approved).isTrue()
+    }
+
+    @Test
+    fun `the unmapped category cannot be blocked`() {
+        // Blocking "everything I have not classified" would decline arbitrary legitimate spend as
+        // the acquirer estate shifts, and the customer could never see what they had turned off.
+        val rules = listOf(CategoryRule(MerchantCategoryTaxonomy.UNMAPPED, blocked = true))
+        val d = CardAuthorizationPolicy.decide(card(), req(mcc = "9999"), rules)
+        assertThat(d.category).isEqualTo(MerchantCategoryTaxonomy.UNMAPPED)
+        assertThat(d.approved).isTrue()
+    }
+
+    @Test
+    fun `a category limit counts the spend already made in that category`() {
+        val rules = listOf(CategoryRule("GROCERIES", monthlyLimitMinorUnits = 100_000))
+        // Exactly at the limit is allowed; one minor unit past it is not.
+        assertThat(
+            CardAuthorizationPolicy.decide(card(), req(amount = 40_000, monthCategory = 60_000), rules).approved,
+        ).isTrue()
+        assertThat(
+            CardAuthorizationPolicy.decide(card(), req(amount = 40_001, monthCategory = 60_000), rules).reason,
+        ).isEqualTo(DeclineReason.CATEGORY_LIMIT_EXCEEDED)
+    }
+
+    @Test
+    fun `a category limit on another category does not apply`() {
+        val rules = listOf(CategoryRule("GAMBLING", monthlyLimitMinorUnits = 1))
+        assertThat(CardAuthorizationPolicy.decide(card(), req(mcc = "5411", amount = 400_000), rules).approved)
+            .isTrue()
+    }
+
+    @Test
+    fun `daily and monthly card limits still apply`() {
+        assertThat(CardAuthorizationPolicy.decide(card(daily = 50_000), req(amount = 50_001), emptyList()).reason)
+            .isEqualTo(DeclineReason.DAILY_LIMIT_EXCEEDED)
+        assertThat(
+            CardAuthorizationPolicy.decide(
+                card(daily = 1_000_000, monthly = 100_000),
+                req(amount = 100_001),
+                emptyList(),
+            ).reason,
+        ).isEqualTo(DeclineReason.MONTHLY_LIMIT_EXCEEDED)
+    }
+
+    @Test
+    fun `the reason shown is the one the customer can act on`() {
+        // A blocked category on an over-limit request reports the block: the customer switched that
+        // on themselves and can switch it off. Reporting the limit would send them to the wrong dial.
+        val rules = listOf(CategoryRule("GAMBLING", blocked = true))
+        val d = CardAuthorizationPolicy.decide(
+            card(daily = 1),
+            req(mcc = "7995", amount = 999_999),
+            rules,
+        )
+        assertThat(d.reason).isEqualTo(DeclineReason.CATEGORY_BLOCKED)
+    }
+
+    @Test
+    fun `card state outranks everything the customer configured`() {
+        val rules = listOf(CategoryRule("GAMBLING", blocked = true))
+        val d = CardAuthorizationPolicy.decide(
+            card(status = CardStatus.BLOCKED),
+            req(mcc = "7995"),
+            rules,
+        )
+        assertThat(d.reason).isEqualTo(DeclineReason.CARD_NOT_ACTIVE)
+    }
+
+    @Test
+    fun `a zero amount is judged like any other`() {
+        assertThat(CardAuthorizationPolicy.decide(card(), req(amount = 0), emptyList()).approved).isTrue()
+    }
+}

--- a/openbank-card-issuance-service/src/test/kotlin/com/openbank/cardissuance/domain/model/MerchantCategoryTaxonomyTest.kt
+++ b/openbank-card-issuance-service/src/test/kotlin/com/openbank/cardissuance/domain/model/MerchantCategoryTaxonomyTest.kt
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.cardissuance.domain.model
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class MerchantCategoryTaxonomyTest {
+    @Test
+    fun `a single code and a range both classify`() {
+        assertThat(MerchantCategoryTaxonomy.categoryOf("7995")).isEqualTo("GAMBLING")
+        assertThat(MerchantCategoryTaxonomy.categoryOf("7801")).isEqualTo("GAMBLING")
+        assertThat(MerchantCategoryTaxonomy.categoryOf("5411")).isEqualTo("GROCERIES")
+    }
+
+    @Test
+    fun `range ends are inclusive`() {
+        assertThat(MerchantCategoryTaxonomy.categoryOf("7800")).isEqualTo("GAMBLING")
+        assertThat(MerchantCategoryTaxonomy.categoryOf("7802")).isEqualTo("GAMBLING")
+        // Just outside must not be swept in — an off-by-one here blocks or frees real spend.
+        assertThat(MerchantCategoryTaxonomy.categoryOf("7799")).isNotEqualTo("GAMBLING")
+        assertThat(MerchantCategoryTaxonomy.categoryOf("7803")).isNotEqualTo("GAMBLING")
+    }
+
+    @Test
+    fun `an unknown or malformed code lands in OTHER instead of throwing`() {
+        // An authorisation must never fail because an acquirer sent something unexpected.
+        assertThat(MerchantCategoryTaxonomy.categoryOf("9999")).isEqualTo(MerchantCategoryTaxonomy.UNMAPPED)
+        assertThat(MerchantCategoryTaxonomy.categoryOf("abcd")).isEqualTo(MerchantCategoryTaxonomy.UNMAPPED)
+        assertThat(MerchantCategoryTaxonomy.categoryOf("")).isEqualTo(MerchantCategoryTaxonomy.UNMAPPED)
+        assertThat(MerchantCategoryTaxonomy.categoryOf(null)).isEqualTo(MerchantCategoryTaxonomy.UNMAPPED)
+    }
+
+    @Test
+    fun `OTHER is limitable but never blockable`() {
+        assertThat(MerchantCategoryTaxonomy.isBlockable(MerchantCategoryTaxonomy.UNMAPPED)).isFalse()
+        assertThat(MerchantCategoryTaxonomy.CATEGORIES.single { it.id == MerchantCategoryTaxonomy.UNMAPPED }.limitable)
+            .isTrue()
+    }
+
+    @Test
+    fun `gambling is blockable — the reason the feature exists`() {
+        assertThat(MerchantCategoryTaxonomy.isBlockable("GAMBLING")).isTrue()
+    }
+
+    @Test
+    fun `an unknown category id is not treated as blockable`() {
+        assertThat(MerchantCategoryTaxonomy.isBlockable("NOT_A_CATEGORY")).isFalse()
+        assertThat(MerchantCategoryTaxonomy.isKnown("NOT_A_CATEGORY")).isFalse()
+    }
+
+    @Test
+    fun `every published range parses and is well formed`() {
+        // The ranges are strings because that is what the API serves; a typo would otherwise only
+        // surface as a silently mis-classified payment.
+        for (c in MerchantCategoryTaxonomy.CATEGORIES) {
+            for (spec in c.mccRanges) {
+                val parts = spec.split("-")
+                assertThat(parts.size).describedAs("range %s in %s", spec, c.id).isBetween(1, 2)
+                val from = parts.first().toIntOrNull()
+                val to = parts.last().toIntOrNull()
+                assertThat(from).describedAs("range %s in %s", spec, c.id).isNotNull()
+                assertThat(to).describedAs("range %s in %s", spec, c.id).isNotNull()
+                assertThat(from!!).describedAs("range %s in %s", spec, c.id).isLessThanOrEqualTo(to!!)
+            }
+        }
+    }
+
+    @Test
+    fun `category ids are unique`() {
+        val ids = MerchantCategoryTaxonomy.CATEGORIES.map { it.id }
+        assertThat(ids).doesNotHaveDuplicates()
+    }
+}


### PR DESCRIPTION
D3 (per-category limits + gambling block) from openbank-app#396, plus the thing that had to exist first.

**Found while implementing:** the channel controls shipped since V5 — contactless / online / ATM / abroad — are stored, returned by the API, and **read by nothing**. There is no card authorization path in the repo at all. A customer switching off "payments abroad" gets a 200 and no protection.

This adds the decision point: `CardAuthorizationPolicy` (pure, 15 unit tests, every branch reachable without an acquirer) behind `POST /cards/{id}/authorizations`, plus `GET|PUT /cards/{id}/category-limits` and a served `GET /cards/category-taxonomy` so no client hardcodes MCC sets.

Deliberate calls, argue with any of them: OTHER is limitable but never blockable; CHIP_AND_PIN has no toggle (lock-out); missing acquirer country = domestic; unknown card declines rather than 404s; `spendTracking: false` because per-category spend is not tracked yet and a zero must not render as a measured ring.

Spend totals are caller-supplied (no authorization history here) — that boundary is in the threat model §4a, not implicit. Service tests, detekt, ktlint and route-conformance green locally.