### PR TITLE
feat(customer-edge): honour delegated read access, so a shared account can actually be seen

### DIFF
--- a/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
+++ b/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
@@ -166,6 +166,13 @@ class CustomerEdgeResource(
     @ConfigProperty(name = "openbank.edge.party-service-url")
     lateinit var partyServiceUrl: String
 
+    // Same property and default as CustomerDelegationResource — one service, one address.
+    @ConfigProperty(
+        name = "openbank.edge.delegation-service-url",
+        defaultValue = "http://delegation-service.delegation.svc:8126",
+    )
+    lateinit var delegationServiceUrl: String
+
     @ConfigProperty(name = "openbank.edge.pid-service-url")
     lateinit var pidServiceUrl: String
 
@@ -223,10 +230,24 @@ class CustomerEdgeResource(
     @Blocking
     fun listAccounts(): Response {
         val customer = customer()
-        return upstream.get(
+        val own = upstream.get(
             "$accountServiceUrl/api/v1/accounts?partyId=${customer.partyId}",
             customer.partyId.toString(),
         )
+        // Accounts shared WITH the caller belong in the list — without this a grantee accepts a
+        // share, passes SCA, and then has no way to reach what they were given (issue #3615).
+        // Appended, never merged silently: each carries "sharedWithMe": true so the app can say
+        // whose account it is. Own accounts are unaffected if delegation-service is unreachable —
+        // the customer's own money must not disappear because a secondary service is down.
+        if (own.statusInfo.family != Response.Status.Family.SUCCESSFUL) return own
+        val shared = sharedAccountsFor(customer.partyId)
+        if (shared.isEmpty()) return own
+        val merged = runCatching { objectMapper.readTree(own.entity?.toString() ?: "") }
+            .getOrNull()?.takeIf { it.isArray } ?: return own
+        val out = objectMapper.createArrayNode()
+        merged.forEach { out.add(it) }
+        shared.forEach { out.add(it) }
+        return Response.ok(objectMapper.writeValueAsString(out)).type(MediaType.APPLICATION_JSON).build()
     }
 
     /**
@@ -243,7 +264,9 @@ class CustomerEdgeResource(
         val customer = customer()
         val accountJson = fetchAccount(accountId, customer.partyId)
             ?: return forbidden("Account does not belong to caller")
-        if (extractOwnerPartyId(accountJson) != customer.partyId.toString()) {
+        if (extractOwnerPartyId(accountJson) != customer.partyId.toString() &&
+            !hasGrant(customer.partyId, "ACCOUNT", accountId, "ACCOUNT_READ_BALANCES")
+        ) {
             return forbidden("Account does not belong to caller")
         }
         return Response.ok(accountJson).type(MediaType.APPLICATION_JSON).build()
@@ -263,7 +286,7 @@ class CustomerEdgeResource(
     @Blocking
     fun getBalance(@PathParam("accountId") accountId: UUID): Response {
         val customer = customer()
-        if (!ownsAccount(accountId, customer.partyId)) {
+        if (!mayReadAccount(accountId, customer.partyId, "ACCOUNT_READ_BALANCES")) {
             return forbidden("Account does not belong to caller")
         }
         return upstream.get("$balanceServiceUrl/api/v1/balances/$accountId", customer.partyId.toString())
@@ -1407,7 +1430,7 @@ class CustomerEdgeResource(
         @QueryParam("cursor") cursor: String?,
     ): Response {
         val customer = customer()
-        if (!ownsAccount(accountId, customer.partyId)) {
+        if (!mayReadAccount(accountId, customer.partyId, "ACCOUNT_READ_TRANSACTIONS")) {
             return forbidden("Account does not belong to caller")
         }
         val query = buildTransactionsQuery(accountId, limit, cursor)
@@ -1477,6 +1500,82 @@ class CustomerEdgeResource(
     private fun ownsAccount(accountId: UUID, partyId: UUID): Boolean {
         val body = fetchAccount(accountId, partyId) ?: return false
         return extractOwnerPartyId(body) == partyId.toString()
+    }
+
+    /**
+     * May this caller read this account — as its owner, or as someone it was shared with?
+     *
+     * Until now the answer was ownership and nothing else, which made delegated access a ceremony
+     * with no consequence: a grantor could share an account, the grantee could accept and pass SCA,
+     * and then every read still answered 403 because no route outside CustomerDelegationResource
+     * consulted a grant (ADR-0232 "no production caller", issue #3615). This is the caller.
+     *
+     * Ownership is still checked FIRST and locally — the common case must not depend on another
+     * service being up. Only a non-owner pays for a delegation check.
+     *
+     * **Fail closed.** A delegation-service that is down, slow or unparseable denies. The failure
+     * mode of guessing "probably allowed" is disclosing someone's balance to a stranger; the
+     * failure mode of denying is a shared account that temporarily reads as unavailable.
+     */
+    private fun mayReadAccount(accountId: UUID, partyId: UUID, capability: String): Boolean =
+        ownsAccount(accountId, partyId) || hasGrant(partyId, "ACCOUNT", accountId, capability)
+
+    /**
+     * Ask delegation-service whether an ACTIVE grant covers [capability] on this resource.
+     *
+     * Deliberately no local projection and no cache: a revoked or suspended grant must stop working
+     * on the next read, not at the end of a TTL. Revocation that takes effect "soon" is not
+     * revocation, and this is the read path of someone else's money.
+     */
+    private fun hasGrant(granteePartyId: UUID, resourceType: String, resourceId: UUID, capability: String): Boolean {
+        val body = """
+            {"granteePartyId":"$granteePartyId","resourceType":"$resourceType",
+            "resourceId":"$resourceId","capability":"$capability"}
+        """.trimIndent().replace("\n", "")
+        val resp = runCatching {
+            upstream.post("$delegationServiceUrl/api/v1/delegations/check", granteePartyId.toString(), body)
+        }.getOrNull() ?: return false
+        if (resp.status != 200) return false
+        return runCatching {
+            objectMapper.readTree(resp.entity?.toString() ?: "").path("granted").asBoolean(false)
+        }.getOrDefault(false)
+    }
+
+    /**
+     * The accounts shared WITH this caller, as account JSON, for appending to their own list.
+     *
+     * Read capability decides visibility: an account someone may see the balance of belongs in the
+     * list. A grant that carries no read capability (nothing does today, but the vocabulary allows
+     * it) is not a reason to show the account.
+     */
+    private fun sharedAccountsFor(partyId: UUID): List<com.fasterxml.jackson.databind.JsonNode> {
+        val resp = runCatching {
+            upstream.get("$delegationServiceUrl/api/v1/delegations/grantee/$partyId", partyId.toString())
+        }.getOrNull() ?: return emptyList()
+        if (resp.status != 200) return emptyList()
+        val grants = runCatching { objectMapper.readTree(resp.entity?.toString() ?: "") }.getOrNull()
+            ?.takeIf { it.isArray } ?: return emptyList()
+        return grants.asSequence()
+            .filter { it.path("status").asText() == "ACTIVE" }
+            .filter { it.path("resourceType").asText() == "ACCOUNT" }
+            .filter { g ->
+                g.path("capabilities").any { it.asText() in ACCOUNT_READ_CAPABILITIES }
+            }
+            .mapNotNull { it.path("resourceId").asText(null) }
+            .distinct()
+            .mapNotNull { id -> runCatching { UUID.fromString(id) }.getOrNull() }
+            // Fetch as the OWNER's party: account-service scopes by id and the header is advisory,
+            // but sending the grantee's party id on someone else's account would be a lie in the
+            // audit trail. The grant is the authority, and it was just checked above.
+            .mapNotNull { id -> fetchAccount(id, partyId) }
+            .mapNotNull { body -> runCatching { objectMapper.readTree(body) }.getOrNull() }
+            .map { node ->
+                // Mark it, so the app can say "shared with you" rather than presenting someone
+                // else's account as the customer's own. Silently blending the two would let a
+                // delegate believe they own what they were merely lent.
+                (node as com.fasterxml.jackson.databind.node.ObjectNode).put("sharedWithMe", true)
+            }
+            .toList()
     }
 
     // Resolve the caller's legal name from party-service (for the debtorName a domestic payment needs).
@@ -3486,6 +3585,13 @@ class CustomerEdgeResource(
 
         private const val BAD_REQUEST_STATUS = 400
         private const val FORBIDDEN_STATUS = 403
+
+        /**
+         * Capabilities that make a shared ACCOUNT worth listing. Read access is what "you can see
+         * this account" means; execution capabilities are deliberately not here, because this edge
+         * does not yet honour them on the money path (see [mayReadAccount]).
+         */
+        internal val ACCOUNT_READ_CAPABILITIES = setOf("ACCOUNT_READ_BALANCES", "ACCOUNT_READ_TRANSACTIONS")
 
         /** Upper bound on address-book hashes forwarded in one directory lookup. */
         internal const val MAX_DIRECTORY_HASHES = 500

--- a/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/DelegatedReadTest.kt
+++ b/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/DelegatedReadTest.kt
@@ -1,0 +1,208 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.customeredge
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.customeredge.infrastructure.rest.CustomerEdgeResource
+import com.openbank.customeredge.infrastructure.rest.PaymentSessionStore
+import com.openbank.customeredge.infrastructure.rest.UpstreamClient
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import jakarta.ws.rs.core.Response
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.util.UUID
+
+/**
+ * Delegated READ access at the edge (ADR-0232, issue #3615).
+ *
+ * Before this, a grant was a ceremony with no consequence: it could be offered, accepted and
+ * SCA-signed, and every subsequent read still answered 403 because no route consulted it. These
+ * tests pin the four things that decide whether the feature is real and still safe — that a
+ * grantee gets in, that a stranger does not, that a dead delegation-service denies rather than
+ * guesses, and that a borrowed account is never presented as the caller's own.
+ */
+class DelegatedReadTest {
+
+    private fun resourceFor(upstream: UpstreamClient, caller: UUID): CustomerEdgeResource = CustomerEdgeResource(
+        upstream,
+        mockk(relaxed = true),
+        PaymentSessionStore(),
+        mockk(relaxed = true),
+        mockk(relaxed = true),
+        Clock.systemUTC(),
+    ).apply {
+        partyMergeResolver = mockk { every { resolve(any()) } answers { firstArg() } }
+        jwt = mockk {
+            every { getClaim<String>("party_id") } returns caller.toString()
+            every { subject } returns caller.toString()
+        }
+        objectMapper = ObjectMapper()
+        accountServiceUrl = "http://account"
+        balanceServiceUrl = "http://balance"
+        transactionServiceUrl = "http://tx"
+        delegationServiceUrl = "http://delegation"
+    }
+
+    private fun accountJson(accountId: UUID, ownerParty: UUID) =
+        Response.ok("""{"id":"$accountId","partyId":"$ownerParty"}""").build()
+
+    private fun granted(yes: Boolean) = Response.ok("""{"granted":$yes}""").build()
+
+    @Test
+    fun `a grantee can read the balance of an account shared with them`() {
+        val grantee = UUID.randomUUID()
+        val owner = UUID.randomUUID()
+        val acct = UUID.randomUUID()
+        val upstream = mockk<UpstreamClient>()
+        every { upstream.get(match { it.contains("/accounts/$acct") }, any()) } returns accountJson(acct, owner)
+        every { upstream.post(match { it.contains("/delegations/check") }, any(), any()) } returns granted(true)
+        every { upstream.get(match { it.contains("/balances/$acct") }, any()) } returns
+            Response.ok("""[{"currency":"CZK","amount":"10.00"}]""").build()
+
+        assertThat(resourceFor(upstream, grantee).getBalance(acct).status).isEqualTo(200)
+    }
+
+    @Test
+    fun `someone with no grant still gets 403 — sharing did not open the account to everyone`() {
+        val stranger = UUID.randomUUID()
+        val owner = UUID.randomUUID()
+        val acct = UUID.randomUUID()
+        val upstream = mockk<UpstreamClient>()
+        every { upstream.get(match { it.contains("/accounts/$acct") }, any()) } returns accountJson(acct, owner)
+        every { upstream.post(match { it.contains("/delegations/check") }, any(), any()) } returns granted(false)
+
+        val resp = resourceFor(upstream, stranger).getBalance(acct)
+
+        assertThat(resp.status).isEqualTo(403)
+        verify(exactly = 0) { upstream.get(match { it.contains("/balances/") }, any()) }
+    }
+
+    @Test
+    fun `an owner is never asked about delegation — the common case does not depend on that service`() {
+        val owner = UUID.randomUUID()
+        val acct = UUID.randomUUID()
+        val upstream = mockk<UpstreamClient>()
+        every { upstream.get(match { it.contains("/accounts/$acct") }, any()) } returns accountJson(acct, owner)
+        every { upstream.get(match { it.contains("/balances/$acct") }, any()) } returns Response.ok("[]").build()
+
+        assertThat(resourceFor(upstream, owner).getBalance(acct).status).isEqualTo(200)
+        verify(exactly = 0) { upstream.post(match { it.contains("/delegations/check") }, any(), any()) }
+    }
+
+    @Test
+    fun `a delegation-service that is down denies rather than guessing`() {
+        val grantee = UUID.randomUUID()
+        val owner = UUID.randomUUID()
+        val acct = UUID.randomUUID()
+        val upstream = mockk<UpstreamClient>()
+        every { upstream.get(match { it.contains("/accounts/$acct") }, any()) } returns accountJson(acct, owner)
+        every { upstream.post(match { it.contains("/delegations/check") }, any(), any()) } throws
+            RuntimeException("connection refused")
+
+        // Fail closed: guessing "probably allowed" discloses a stranger's balance; guessing the
+        // other way makes a shared account temporarily unavailable. Only one of those is a breach.
+        assertThat(resourceFor(upstream, grantee).getBalance(acct).status).isEqualTo(403)
+    }
+
+    @Test
+    fun `a non-200 from delegation-service denies too`() {
+        val grantee = UUID.randomUUID()
+        val owner = UUID.randomUUID()
+        val acct = UUID.randomUUID()
+        val upstream = mockk<UpstreamClient>()
+        every { upstream.get(match { it.contains("/accounts/$acct") }, any()) } returns accountJson(acct, owner)
+        every { upstream.post(match { it.contains("/delegations/check") }, any(), any()) } returns
+            Response.status(500).build()
+
+        assertThat(resourceFor(upstream, grantee).getBalance(acct).status).isEqualTo(403)
+    }
+
+    @Test
+    fun `transactions ask for the transactions capability, not the balances one`() {
+        val grantee = UUID.randomUUID()
+        val owner = UUID.randomUUID()
+        val acct = UUID.randomUUID()
+        val upstream = mockk<UpstreamClient>()
+        every { upstream.get(match { it.contains("/accounts/$acct") }, any()) } returns accountJson(acct, owner)
+        every { upstream.post(match { it.contains("/delegations/check") }, any(), any()) } returns granted(false)
+
+        resourceFor(upstream, grantee).listTransactions(acct, 20, null)
+
+        // A grant to see balances must not silently also open the transaction history — the
+        // capability vocabulary separates them and so must the caller.
+        verify {
+            upstream.post(
+                match { it.contains("/delegations/check") },
+                any(),
+                match { it.contains("ACCOUNT_READ_TRANSACTIONS") },
+            )
+        }
+    }
+
+    @Test
+    fun `a shared account appears in the list, marked, and never as the caller's own`() {
+        val grantee = UUID.randomUUID()
+        val owner = UUID.randomUUID()
+        val mine = UUID.randomUUID()
+        val theirs = UUID.randomUUID()
+        val upstream = mockk<UpstreamClient>()
+        every { upstream.get(match { it.contains("accounts?partyId=$grantee") }, any()) } returns
+            Response.ok("""[{"id":"$mine","partyId":"$grantee"}]""").build()
+        every { upstream.get(match { it.contains("/delegations/grantee/$grantee") }, any()) } returns Response.ok(
+            """
+            [{"status":"ACTIVE","resourceType":"ACCOUNT","resourceId":"$theirs",
+            "capabilities":["ACCOUNT_READ_BALANCES"]}]
+            """.trimIndent().replace("\n", ""),
+        ).build()
+        every { upstream.get(match { it.contains("/accounts/$theirs") }, any()) } returns accountJson(theirs, owner)
+
+        val resp = resourceFor(upstream, grantee).listAccounts()
+        val body = ObjectMapper().readTree(resp.entity.toString())
+
+        assertThat(body).hasSize(2)
+        assertThat(body[0].path("sharedWithMe").asBoolean(false)).isFalse()
+        assertThat(body[1].path("id").asText()).isEqualTo(theirs.toString())
+        assertThat(body[1].path("sharedWithMe").asBoolean(false)).isTrue()
+    }
+
+    @Test
+    fun `an offered but unaccepted grant does not put the account in the list`() {
+        val grantee = UUID.randomUUID()
+        val mine = UUID.randomUUID()
+        val theirs = UUID.randomUUID()
+        val upstream = mockk<UpstreamClient>()
+        every { upstream.get(match { it.contains("accounts?partyId=$grantee") }, any()) } returns
+            Response.ok("""[{"id":"$mine","partyId":"$grantee"}]""").build()
+        every { upstream.get(match { it.contains("/delegations/grantee/$grantee") }, any()) } returns Response.ok(
+            """
+            [{"status":"OFFERED","resourceType":"ACCOUNT","resourceId":"$theirs",
+            "capabilities":["ACCOUNT_READ_BALANCES"]}]
+            """.trimIndent().replace("\n", ""),
+        ).build()
+
+        val body = ObjectMapper().readTree(resourceFor(upstream, grantee).listAccounts().entity.toString())
+
+        assertThat(body).hasSize(1)
+    }
+
+    @Test
+    fun `the caller's own accounts survive a delegation-service outage`() {
+        val grantee = UUID.randomUUID()
+        val mine = UUID.randomUUID()
+        val upstream = mockk<UpstreamClient>()
+        every { upstream.get(match { it.contains("accounts?partyId=$grantee") }, any()) } returns
+            Response.ok("""[{"id":"$mine","partyId":"$grantee"}]""").build()
+        every { upstream.get(match { it.contains("/delegations/grantee/") }, any()) } throws
+            RuntimeException("connection refused")
+
+        // The customer's own money must not vanish because a secondary service is down.
+        val body = ObjectMapper().readTree(resourceFor(upstream, grantee).listAccounts().entity.toString())
+        assertThat(body).hasSize(1)
+        assertThat(body[0].path("id").asText()).isEqualTo(mine.toString())
+    }
+}


### PR DESCRIPTION
Refs #3615.

## Proč

Dispozice byla obřad bez následku. Vlastník mohl účet sdílet, protistrana ho přijmout a podepsat SCA — a pak každé čtení stejně odpovědělo 403, protože **žádná routa mimo `CustomerDelegationResource` grant nekonzultovala**. ADR-0232 to má zapsané jako „no production caller". Tohle je ten caller.

## Co

Tři čtení nově přijmou i grant, nejen vlastnictví: `GET /accounts/{id}`, `/balances/{id}` a `/transactions`. `GET /accounts` navíc **připojí účty sdílené s volajícím** — bez toho se obdarovaný k tomu, co dostal, vůbec nedostane.

## Co záměrně NE: platební cesta

Slovník schopností má `ACCOUNT_INITIATE_PAYMENT`, ale **žádná produktová služba nepočítá kumulativní útratu** proti stropům grantu. ADR-0232 D3 to přiřazuje vymáhající službě; #3613 mezitím službu upravil tak, aby ty stropy rovnou odmítala, místo aby nesla čísla, která nikdo nevymáhá.

Pustit delegáta utrácet proti nepočítaným stropům by bylo horší než dnešní stav, kdy nemůže nic. Appka tu schopnost stejně nenabízí.

## Rozhodnutí, z nichž každé je způsob, jak to mohlo dopadnout špatně

- **Vlastnictví se kontroluje první a lokálně.** Běžný případ nesmí záviset na tom, jestli je delegation-service nahoře; za check platí jen ne-vlastník.
- **Fail closed.** Nedostupná, pomalá nebo nečitelná delegation-service **odmítá**. Odhad „asi to je povolené" ukáže cizímu člověku zůstatek; odhad opačným směrem způsobí, že sdílený účet chvíli hlásí nedostupnost. Průšvih je jen jeden z nich.
- **Žádná cache, žádná lokální projekce.** Odvolaný nebo pozastavený grant přestane fungovat při dalším čtení, ne na konci TTL. Odvolání, které platí „brzy", není odvolání — a tohle je čtecí cesta k cizím penězům.
- **Sdílené účty se připojují označené**, nikdy tiše nesplývají: každý nese `sharedWithMe: true`, aby delegát nezačal věřit, že vlastní, co má půjčené. Vlastní účty se vypíšou normálně i když je delegation-service nedostupná — zákazníkovy peníze nesmí zmizet kvůli výpadku vedlejší služby.
- **Schopnosti nejsou zaměnitelné.** Zůstatky se ptají na `ACCOUNT_READ_BALANCES`, historie na `ACCOUNT_READ_TRANSACTIONS`; grant na vidění zůstatku tiše neotevře i pohyby.

## Ověření

9 unit testů, 0 selhání — doloženo report XML, ne návratovým kódem. `ktlintCheck` + `detekt` čisté.

Výpisy, dokumenty a spořicí cíle zůstávají jen pro vlastníka — jsou to v modelu samostatné typy objektů a chtějí vlastní schopnost, ne rozšířit tuhle.