### PR TITLE
feat(engagement): first slice of ADR-0220 in-app surfaces — domain layer only

### DIFF
--- a/docs/runbooks/svc-engagement.md
+++ b/docs/runbooks/svc-engagement.md
@@ -1,0 +1,71 @@
+<!-- Generated starter runbook (generate-service-runbooks.py) from declared
+service facts. Real scaffolding — EXTEND with operational specifics; do not delete.
+Bank-grade ops (prod-readiness C9=3 / C6=3) still needs a real on-call rotation and an
+exercised DR drill, tracked as TTL'd attestations, never faked here. -->
+
+# Runbook — openbank-engagement-service
+
+> Operational runbook for the `engagement` service. Data domain **—**,
+> classification **—**, datastore **—**.
+
+## Service identity
+
+| Field | Value |
+|---|---|
+| Service | `openbank-engagement-service` |
+| HTTP port | `?` |
+| Data domain | — |
+| Datastore | — (database `—`) |
+| Classification | — |
+| Retention | — |
+| Lineage role | — |
+
+## Dependencies
+
+- **Upstream (this service consumes):** _none declared_
+- **Downstream (depends on this service):** _none declared_
+
+A failure here propagates to the downstream services above — check them when
+triaging an incident that starts on `engagement`.
+
+## Health & probes
+
+- Readiness: `GET :?/q/health/ready` · Liveness: `GET :?/q/health/live`
+- Metrics: scraped by the fleet PodMonitor (namespace `engagement`); dashboards in Grafana.
+- Logs: `kubectl logs -n engagement deploy/engagement-service -f`, or Loki
+  `{namespace="engagement"}`.
+
+## Routine operations
+
+- **Restart:** `kubectl rollout restart deploy/engagement-service -n engagement` (rolling, zero-downtime at >1 replica).
+- **Scale:** `kubectl scale deploy/engagement-service -n engagement --replicas=<n>` (or edit the GitOps manifest — GitOps is source of truth, a manual scale is reverted by ArgoCD).
+- **Config/secret change:** edit the GitOps manifest; ArgoCD syncs. Never `kubectl edit` in place.
+
+## Common failure modes
+
+- **Pod CrashLoopBackOff at boot:** usually a missing/invalid config or secret
+  (`ExternalSecret` not synced). Check `kubectl describe pod` events and the
+  first 50 log lines.
+- **Readiness flapping:** this service holds no datastore, so look outward — an
+  upstream dependency below, or the OPA sidecar if `AUTHZ_ENFORCE` is on (with no
+  reachable PDP, `@Authorize` fails closed).
+- **Downstream errors:** verify the upstream dependencies above are healthy before
+  assuming the fault is local.
+
+## Disaster recovery
+
+- **RPO: n/a** — no persistent state. **RTO target:** ≤ 10 min (image pull + rollout).
+- **Mechanism:** none needed — this service declares no primary datastore, so it holds no state to lose. Recovery is a redeploy from the GitOps manifests, which are the source of truth.
+- **Restore:** re-sync the ArgoCD Application (or `kubectl rollout restart` the Deployment). Any state this service reads lives in its upstream services above — recover those first, using their own runbooks.
+- **Verify:** health endpoint green, then re-drive one request end to end against an upstream that is already known-good.
+
+> RPO/RTO above are documented targets. They become **Bank-grade** (prod-readiness
+> C6=3) only once a restore/failover drill has actually been rehearsed and attested
+> (`openbank-libs/governance/attestations.yaml: engagement.dr_drill`).
+
+## Escalation & break-glass
+
+- First responder: the owning squad's on-call (rotation tracked as the
+  `engagement.oncall` attestation — until that is live, escalate via the team channel).
+- Break-glass cluster access is audited; use it only for a declared incident and
+  record the justification.

--- a/openbank-engagement-service/build.gradle.kts
+++ b/openbank-engagement-service/build.gradle.kts
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+// ADR-0220 first slice: domain layer only. No Quarkus plugin, no REST, no persistence, no
+// deployment — deliberately, not by omission. A `version.txt` is what makes a module a released
+// component (ADR-0029 D1); this one has none yet, so release-please and gitops both ignore it.
+// The infrastructure layer (REST resource, Postgres, Kafka outbox, Dockerfile, gitops manifests)
+// is a follow-up PR, scoped separately because it carries its own security review (mTLS certs,
+// OPA policy, network policy) that a domain-only change should not ride in on.
+
+plugins {
+    alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.kover)
+    id("openbank.static-analysis")
+    id("openbank.dependency-vulnerability-pins")
+    `java-library`
+}
+
+group = "com.openbank"
+version = "0.1.0-SNAPSHOT"
+
+repositories {
+    maven("https://maven-central.storage-download.googleapis.com/maven2/")
+    mavenCentral()
+}
+
+dependencies {
+    api(libs.kotlin.stdlib)
+    implementation(project(":openbank-libs-domain"))
+    testImplementation(platform(libs.junit.bom))
+    testImplementation(libs.junit.jupiter)
+    testImplementation(libs.assertj)
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/openbank-engagement-service/build.gradle.kts
+++ b/openbank-engagement-service/build.gradle.kts
@@ -37,3 +37,12 @@ dependencies {
 tasks.test {
     useJUnitPlatform()
 }
+
+// openbank.static-analysis pins detekt's own languageVersion to 21 (JVM-version-detection quirk
+// in its IntelliJ-derived parser) — that is unrelated to the module's compile/runtime toolchain,
+// which openbank-libs-domain fixes at 25. Omitting this here left Gradle pick whatever JVM was on
+// the PATH, which is 21 on the CodeQL tracing runner but not locally, so CodeQL's build step could
+// not resolve against libs-domain's 25 while everything else stayed green.
+kotlin {
+    jvmToolchain(25)
+}

--- a/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/domain/model/Eligibility.kt
+++ b/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/domain/model/Eligibility.kt
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.engagement.domain.model
+
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * The adverse-state set ADR-0220 D1/D3.5 names verbatim: fraud-hold, arrears, dispute-opened,
+ * erasure. The platform already emits domain events for all four elsewhere in the fleet; this
+ * enum names the set this ADR reads, not a new source of truth.
+ */
+enum class AdverseState { FRAUD_HOLD, ARREARS, DISPUTE_OPENED, ERASURE_REQUESTED }
+
+/**
+ * A pre-computed eligibility snapshot for one party (ADR-0220 D1). In the shipped design this is
+ * materialised event-driven into the engagement service's own store; this domain layer only
+ * defines the shape and the rule over it, not the materialisation pipeline (infrastructure,
+ * follow-up PR).
+ */
+data class EligibilitySnapshot(val partyId: UUID, val adverseState: Set<AdverseState>, val asOf: Instant)
+
+/**
+ * ADR-0220 D3.5 — vulnerable customers are excluded from *targeting*, never from the surface
+ * itself. This function answers only "may the platform proactively show this person a promotional
+ * surface" — it says nothing about a customer who opens `rewards_hub` on their own initiative,
+ * which stays available regardless of adverse state.
+ *
+ * This is deliberately a SEPARATE gate from consent and frequency (`ContactPolicyGate`, already
+ * shipped in `openbank-libs-runtime` and reused by campaign-service). Consent answers "may we
+ * contact this person at all"; this answers "is this specific person safe to target with
+ * marketing right now". Collapsing the two would let a fraud-hold party still receive a
+ * promotional surface as long as they happen to have marketing consent, which is exactly the
+ * compliance defect D1 calls out — "a vulnerable-customer exclusion that lags... is a compliance
+ * defect, not a freshness metric."
+ */
+object EligibilityRule {
+    fun isEligibleForPromotionalTargeting(snapshot: EligibilitySnapshot): Boolean = snapshot.adverseState.isEmpty()
+}

--- a/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/domain/model/Engagement.kt
+++ b/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/domain/model/Engagement.kt
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.engagement.domain.model
+
+import java.time.Instant
+import java.util.UUID
+
+/** ADR-0220 D2: the four events the app posts back. */
+enum class EngagementEventType { IMPRESSION, CLICK, DISMISS, CONVERSION }
+
+/**
+ * One posted engagement event (ADR-0220 D2). `conversion` here is deliberately the SAME concept
+ * as ADR-0245's — a real observed product event, never a click proxy — so an `EngagementEventType`
+ * carrying `CONVERSION` must be produced by the same discipline ADR-0245 D5 requires, not invented
+ * by the app client. That wiring is infrastructure (follow-up PR); this domain layer only defines
+ * the shape.
+ */
+data class EngagementEvent(
+    val partyId: UUID,
+    val contentId: String,
+    val slot: SurfaceSlot,
+    val type: EngagementEventType,
+    val occurredAt: Instant,
+)
+
+/**
+ * ADR-0220 D2: "Dismissal is a first-class negative signal: repeated dismissal of a content class
+ * writes a topic-level suppression entry (ADR-0219 D3) rather than merely hiding one card."
+ *
+ * The ADR names the *rule* but not a threshold; [DISMISSALS_BEFORE_SUPPRESSION] is this slice's
+ * own decision, not something quoted from the ADR — stated as a named constant, not a magic
+ * number, precisely so a reviewer can see it is a choice and tune it. Three consecutive
+ * dismissals with no intervening click or impression-then-ignore is the signal: a single dismiss
+ * is often just bad timing, but three in a row with no engagement in between is a customer telling
+ * the platform something.
+ *
+ * Writing the actual suppression entry into `ContactSuppressionPort` (ADR-0219 D3, already shipped
+ * and reused by campaign-service) is infrastructure — this function only decides WHEN to.
+ */
+object DismissalRule {
+    const val DISMISSALS_BEFORE_SUPPRESSION = 3
+
+    /**
+     * [recentEvents] must already be scoped to one party and one content class (e.g. one
+     * `SurfaceSlot`), ordered oldest-first — this function does not do that scoping itself, so it
+     * cannot silently mix signals across parties or slots.
+     */
+    fun shouldSuppress(recentEvents: List<EngagementEvent>): Boolean {
+        var consecutiveDismissals = 0
+        for (event in recentEvents) {
+            consecutiveDismissals = when (event.type) {
+                EngagementEventType.DISMISS -> consecutiveDismissals + 1
+                EngagementEventType.CLICK, EngagementEventType.CONVERSION -> 0
+                EngagementEventType.IMPRESSION -> consecutiveDismissals
+            }
+            if (consecutiveDismissals >= DISMISSALS_BEFORE_SUPPRESSION) return true
+        }
+        return false
+    }
+}

--- a/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/domain/model/Surface.kt
+++ b/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/domain/model/Surface.kt
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.engagement.domain.model
+
+/**
+ * Named slots the app registers to render content into (ADR-0220 D1). A slot has no content of
+ * its own — it is a place, not a message, exactly the distinction that keeps this from being the
+ * removed `IN_APP` notification channel reborn under a new name (issue #2372, ADR-0200 D7).
+ */
+enum class SurfaceSlot { HOME_BANNER, HOME_CAROUSEL, STORIES, PRODUCT_FEED, REWARDS_HUB }
+
+/**
+ * Typed payload kinds. Never free-form markup — an allow-list of shapes is what makes this
+ * auditable; arbitrary server HTML is the phishing-template-with-a-bank-logo risk ADR-0220's own
+ * "Alternatives considered" names and rejects.
+ */
+enum class SurfaceContentType { BANNER, CARD, STORY, CAROUSEL, OFFER }
+
+/**
+ * One catalogue entry: a slot, a content type, and the closed set of variable names it declares.
+ * Same discipline as `TemplateCatalog`/`SegmentCatalog` (ADR-0176 D4, ADR-0201 D1) — a marketer or
+ * an agent cannot invent a payload from a text box, only reference one that was reviewed.
+ *
+ * `OFFER` is declared here as a content type because the type vocabulary is closed and future
+ * proof, but no `OFFER` entries exist in [SurfaceCatalog] yet: ADR-0220 D4 requires every rendered
+ * credit payload to carry the mandatory RPSN/APR representative example from a real ADR-0142
+ * standing decision, and ADR-0142 does not exist in this codebase yet (`decision-status: proposed`).
+ * Adding an `OFFER` entry before that would be exactly the "inauthentic placeholder" ADR-0220 D5
+ * calls worse than a missing feature.
+ */
+data class SurfaceContent(
+    val id: String,
+    val slot: SurfaceSlot,
+    val type: SurfaceContentType,
+    val variables: Set<String>,
+) {
+    init {
+        require(id.isNotBlank()) { "content id must not be blank" }
+        require(type != SurfaceContentType.OFFER) {
+            "OFFER content cannot be catalogued until ADR-0142 exists — see SurfaceContent KDoc"
+        }
+    }
+}
+
+/**
+ * The reviewed catalogue of renderable content. Adding an entry is a pull request, same as
+ * `TemplateCatalog` — never a runtime or admin-ui action.
+ */
+object SurfaceCatalog {
+    val ALL: Map<String, SurfaceContent> = mapOf(
+        "SAVINGS_RATE_BANNER" to SurfaceContent(
+            id = "SAVINGS_RATE_BANNER",
+            slot = SurfaceSlot.HOME_BANNER,
+            type = SurfaceContentType.BANNER,
+            variables = setOf("rateHeadline"),
+        ),
+    )
+
+    fun exists(id: String): Boolean = id in ALL
+
+    fun forSlot(slot: SurfaceSlot): List<SurfaceContent> = ALL.values.filter { it.slot == slot }
+
+    fun unknownVariables(id: String, variables: Map<String, String>): Set<String> =
+        variables.keys - (ALL[id]?.variables ?: emptySet())
+}

--- a/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/domain/model/SurfaceResolver.kt
+++ b/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/domain/model/SurfaceResolver.kt
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.engagement.domain.model
+
+/**
+ * ADR-0220 D1 minus ranking. The full design resolves a slot through
+ * ContactPolicyGate (consent + frequency) → this eligibility exclusion → ADR-0201 NBA ranking →
+ * one typed payload. NBA ranking is explicitly blocked on the model "graduating from shadow"
+ * (D5), so this function returns every catalogue entry eligible for the slot, in catalogue order
+ * — never none by omission, and never a fabricated ranking standing in for the real one.
+ *
+ * [ContactPolicyGate][com.openbank.libs.contact.ContactPolicyGate] (consent, frequency cap, quiet
+ * hours) is NOT invoked here. It already exists in `openbank-libs-runtime` and is reused by
+ * campaign-service — this domain layer cannot depend on it without crossing the domain/runtime
+ * boundary ADR-0002 draws, so that composition is infrastructure's job (follow-up PR), not this
+ * one's.
+ */
+object SurfaceResolver {
+    fun resolve(slot: SurfaceSlot, eligibility: EligibilitySnapshot): List<SurfaceContent> =
+        if (!EligibilityRule.isEligibleForPromotionalTargeting(eligibility)) {
+            emptyList()
+        } else {
+            SurfaceCatalog.forSlot(slot)
+        }
+}

--- a/openbank-engagement-service/src/test/kotlin/com/openbank/engagement/domain/DismissalRuleTest.kt
+++ b/openbank-engagement-service/src/test/kotlin/com/openbank/engagement/domain/DismissalRuleTest.kt
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.engagement.domain
+
+import com.openbank.engagement.domain.model.DismissalRule
+import com.openbank.engagement.domain.model.EngagementEvent
+import com.openbank.engagement.domain.model.EngagementEventType
+import com.openbank.engagement.domain.model.SurfaceSlot
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.UUID
+
+class DismissalRuleTest {
+
+    private val party = UUID.randomUUID()
+
+    private fun event(type: EngagementEventType) = EngagementEvent(
+        partyId = party,
+        contentId = "SAVINGS_RATE_BANNER",
+        slot = SurfaceSlot.HOME_BANNER,
+        type = type,
+        occurredAt = Instant.now(),
+    )
+
+    @Test
+    fun `two dismissals do not suppress`() {
+        val events = listOf(event(EngagementEventType.DISMISS), event(EngagementEventType.DISMISS))
+        assertThat(DismissalRule.shouldSuppress(events)).isFalse
+    }
+
+    @Test
+    fun `three consecutive dismissals suppress`() {
+        val events = List(3) { event(EngagementEventType.DISMISS) }
+        assertThat(DismissalRule.shouldSuppress(events)).isTrue
+    }
+
+    @Test
+    fun `a click resets the dismissal count`() {
+        val events = listOf(
+            event(EngagementEventType.DISMISS),
+            event(EngagementEventType.DISMISS),
+            event(EngagementEventType.CLICK),
+            event(EngagementEventType.DISMISS),
+            event(EngagementEventType.DISMISS),
+        )
+        // Two dismissals, a click, then two more — never three consecutive.
+        assertThat(DismissalRule.shouldSuppress(events)).isFalse
+    }
+
+    @Test
+    fun `a conversion resets the dismissal count`() {
+        val events = listOf(
+            event(EngagementEventType.DISMISS),
+            event(EngagementEventType.DISMISS),
+            event(EngagementEventType.CONVERSION),
+            event(EngagementEventType.DISMISS),
+            event(EngagementEventType.DISMISS),
+        )
+        assertThat(DismissalRule.shouldSuppress(events)).isFalse
+    }
+
+    @Test
+    fun `an impression neither resets nor advances the count`() {
+        val events = listOf(
+            event(EngagementEventType.DISMISS),
+            event(EngagementEventType.IMPRESSION),
+            event(EngagementEventType.DISMISS),
+            event(EngagementEventType.IMPRESSION),
+            event(EngagementEventType.DISMISS),
+        )
+        // Three dismissals total, none adjacent-broken by a click/conversion — still consecutive
+        // in the sense the rule cares about, since impressions are neutral, not resetting.
+        assertThat(DismissalRule.shouldSuppress(events)).isTrue
+    }
+
+    @Test
+    fun `no events do not suppress`() {
+        assertThat(DismissalRule.shouldSuppress(emptyList())).isFalse
+    }
+}

--- a/openbank-engagement-service/src/test/kotlin/com/openbank/engagement/domain/EligibilityRuleTest.kt
+++ b/openbank-engagement-service/src/test/kotlin/com/openbank/engagement/domain/EligibilityRuleTest.kt
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.engagement.domain
+
+import com.openbank.engagement.domain.model.AdverseState
+import com.openbank.engagement.domain.model.EligibilityRule
+import com.openbank.engagement.domain.model.EligibilitySnapshot
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.UUID
+
+class EligibilityRuleTest {
+
+    private fun snapshot(adverseState: Set<AdverseState>) =
+        EligibilitySnapshot(partyId = UUID.randomUUID(), adverseState = adverseState, asOf = Instant.now())
+
+    @Test
+    fun `a party with no adverse state is eligible for targeting`() {
+        assertThat(EligibilityRule.isEligibleForPromotionalTargeting(snapshot(emptySet()))).isTrue
+    }
+
+    @Test
+    fun `a fraud hold alone excludes targeting`() {
+        assertThat(EligibilityRule.isEligibleForPromotionalTargeting(snapshot(setOf(AdverseState.FRAUD_HOLD))))
+            .isFalse
+    }
+
+    @Test
+    fun `every adverse state individually excludes targeting`() {
+        AdverseState.entries.forEach { state ->
+            assertThat(EligibilityRule.isEligibleForPromotionalTargeting(snapshot(setOf(state))))
+                .`as`("state=%s", state)
+                .isFalse
+        }
+    }
+}

--- a/openbank-engagement-service/src/test/kotlin/com/openbank/engagement/domain/SurfaceCatalogTest.kt
+++ b/openbank-engagement-service/src/test/kotlin/com/openbank/engagement/domain/SurfaceCatalogTest.kt
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.engagement.domain
+
+import com.openbank.engagement.domain.model.SurfaceCatalog
+import com.openbank.engagement.domain.model.SurfaceContent
+import com.openbank.engagement.domain.model.SurfaceContentType
+import com.openbank.engagement.domain.model.SurfaceSlot
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+
+class SurfaceCatalogTest {
+
+    @Test
+    fun `an OFFER entry cannot be constructed until ADR-0142 exists`() {
+        assertThatThrownBy {
+            SurfaceContent(
+                id = "FAKE_PRE_APPROVED",
+                slot = SurfaceSlot.HOME_BANNER,
+                type = SurfaceContentType.OFFER,
+                variables = emptySet(),
+            )
+        }.isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("ADR-0142")
+    }
+
+    @Test
+    fun `forSlot returns only entries for that slot`() {
+        assertThat(SurfaceCatalog.forSlot(SurfaceSlot.HOME_BANNER)).isNotEmpty
+        assertThat(SurfaceCatalog.forSlot(SurfaceSlot.REWARDS_HUB)).isEmpty()
+    }
+
+    @Test
+    fun `unknownVariables rejects a variable the entry did not declare`() {
+        assertThat(SurfaceCatalog.unknownVariables("SAVINGS_RATE_BANNER", mapOf("rateHeadline" to "4%")))
+            .isEmpty()
+        assertThat(SurfaceCatalog.unknownVariables("SAVINGS_RATE_BANNER", mapOf("bodyCopy" to "x")))
+            .containsExactly("bodyCopy")
+    }
+
+    @Test
+    fun `an unknown content id declares no variables and matches nothing`() {
+        assertThat(SurfaceCatalog.exists("NOT_IN_THE_CATALOGUE")).isFalse
+        assertThat(SurfaceCatalog.unknownVariables("NOT_IN_THE_CATALOGUE", mapOf("x" to "y")))
+            .containsExactly("x")
+    }
+}

--- a/openbank-engagement-service/src/test/kotlin/com/openbank/engagement/domain/SurfaceResolverTest.kt
+++ b/openbank-engagement-service/src/test/kotlin/com/openbank/engagement/domain/SurfaceResolverTest.kt
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.engagement.domain
+
+import com.openbank.engagement.domain.model.AdverseState
+import com.openbank.engagement.domain.model.EligibilitySnapshot
+import com.openbank.engagement.domain.model.SurfaceResolver
+import com.openbank.engagement.domain.model.SurfaceSlot
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.UUID
+
+class SurfaceResolverTest {
+
+    private fun snapshot(adverseState: Set<AdverseState> = emptySet()) =
+        EligibilitySnapshot(partyId = UUID.randomUUID(), adverseState = adverseState, asOf = Instant.now())
+
+    @Test
+    fun `an eligible party sees the slot's catalogue entries`() {
+        val resolved = SurfaceResolver.resolve(SurfaceSlot.HOME_BANNER, snapshot())
+        assertThat(resolved).extracting("id").containsExactly("SAVINGS_RATE_BANNER")
+    }
+
+    @Test
+    fun `a fraud-hold party sees nothing, not a fallback`() {
+        val resolved = SurfaceResolver.resolve(
+            SurfaceSlot.HOME_BANNER,
+            snapshot(setOf(AdverseState.FRAUD_HOLD)),
+        )
+        assertThat(resolved).isEmpty()
+    }
+
+    @Test
+    fun `a slot with no catalogue entries resolves empty for an eligible party too`() {
+        // Distinguishes "nothing catalogued" from "excluded" — both are empty, but for a different
+        // reason, and neither is a bug: rewards_hub has no first-slice content yet.
+        assertThat(SurfaceResolver.resolve(SurfaceSlot.REWARDS_HUB, snapshot())).isEmpty()
+    }
+}


### PR DESCRIPTION
## What

First slice of ADR-0220: `openbank-engagement-service`, **domain layer only**. No REST, no
persistence, no Dockerfile, no gitops.

## Scope, decided before writing any code

ADR-0220 is a large decision — a new service with three capabilities (surfaces, gamification,
pre-approved offers), full production infra, and a mobile-client integration in a separate repo.
Building all of that in one PR would be the biggest single change of this effort, and several of
its pieces are explicitly blocked by the ADR itself. So this PR is scoped to what is genuinely
buildable and honest right now:

**Built:**
- `SurfaceSlot` / `SurfaceContentType` / `SurfaceCatalog` — the ADR-0176-style allow-list catalogue
  D1 requires, same discipline as `TemplateCatalog`/`SegmentCatalog`.
- `EligibilitySnapshot` / `EligibilityRule` — the D1/D3.5 vulnerable-customer targeting exclusion,
  kept as a *separate* gate from consent/frequency on purpose (see the KDoc on
  `EligibilityRule`): collapsing them would let a fraud-hold party still receive marketing as long
  as they have consent, which is the exact compliance defect D1 names.
- `DismissalRule` — D2's "repeated dismissal is a first-class negative signal". The ADR names the
  rule, not a threshold; `DISMISSALS_BEFORE_SUPPRESSION = 3` is this slice's own decision, stated as
  a named constant so a reviewer can see it is a choice, not a quote.
- `SurfaceResolver` — D1 minus ranking. Returns catalogue entries for a slot in catalogue order,
  never none by omission. No ranking, because NBA ranking is explicitly blocked on ADR-0201
  "graduating from shadow" (D5) — faking a ranking here would misrepresent what D5 already refuses.

**Not built, and why that is a decision rather than a gap:**
- **ContactPolicyGate wiring, REST, persistence, outbox, Dockerfile, gitops.** All infrastructure,
  and gitops in particular (mTLS certs, OPA policy, network policy) deserves its own security
  review rather than riding in on a domain-only change.
- **Gamification (D3).** Large compliance surface (UCPD dark-pattern rules, five hard invariants)
  that deserves its own focused PR rather than being folded in here.
- **Pre-approved offers (D4).** Hard-blocked: it requires ADR-0142 (credit decisioning engine),
  which is `decision-status: proposed` — a document, not code. `SurfaceContent`'s constructor
  refuses to construct an `OFFER` entry at all, with a message naming why, so this cannot silently
  drift into being built by accident later.
- **No `version.txt`.** Release-please and gitops both ignore a module without one (ADR-0029 D1);
  this stays unreleased until the infrastructure PR lands.

## Verification

- `./gradlew :openbank-engagement-service:test` — 16/16 passed, `ktlintCheck` and `detekt` clean.
- Ran every enforced gate group locally against a proper `PR_DIFF_BASE`
  (`kotlin/data/registry/gitops/supplychain/security` all green or advisory-only). One real finding
  along the way: `service-runbook-drift` wanted a generated starter runbook for the new
  `openbank-*-service` directory — generated it via
  `openbank-infra/scripts/generate-service-runbooks.py --force` rather than hand-writing one, since
  the gate's own rule is "never hand-edit a generated runbook". It touched only the one new file.
- `api`/`lint` gate groups show pre-existing, unrelated FAILs in this sandbox: `oasdiff` isn't
  installable on macOS (the gate downloads a linux_amd64 binary) and `lint`'s failures are the
  harness's own self-test fixtures (`an enforced gate that fails`) — both observed identically on
  the previous PR (#3977) tonight, not new here.

Refs #3585
