### PR TITLE
fix(iam): declare the mcp-service service account in the realm template

### DIFF
--- a/openbank-infra/gitops/components/keycloak/realm-template.json
+++ b/openbank-infra/gitops/components/keycloak/realm-template.json
@@ -446,6 +446,12 @@
       "realmRoles": [
         "ROLE_API"
       ]
+    },
+    {
+      "username": "service-account-openbank-mcp-service",
+      "enabled": true,
+      "serviceAccountClientId": "openbank-mcp-service",
+      "realmRoles": []
     }
   ]
 }


### PR DESCRIPTION
## What

Declares `service-account-openbank-mcp-service` in `realm-template.json` — the one live-vs-template gap left after triaging [#2540](https://github.com/JiRaska/open-bank-oss/issues/2540) that was actionable without owner-gated infra mutation.

## Why it's safe

- Verified live via a throwaway read-only pod (deleted after use) using the same `keycloak-bootstrap` credential the `keycloak-realm-drift` CronJob already uses daily: the account holds **only** Keycloak's own built-ins (`default-roles-openbank`, `offline_access`, `uma_authorization`) — zero realm role grants, zero client role grants (404 on client-role-mappings).
- Matches the client's stated purpose: `openbank-mcp-service` is an OBO audience target for RFC 8693 token exchange (ADR-0224) — not a caller that authenticates as itself. The service-account user is a structural byproduct of `serviceAccountsEnabled: true`, never intentionally granted privilege.
- Added with `realmRoles: []`, mirroring the existing `service-account-openbank-edge` / `service-account-openbank-services` entries' shape.

## Verified

- `realm-template-importable` gate: PASS (7 users, up from 6, no known-fatal shape).
- `rolesallowed-realm-parity` gate: PASS.
- Replayed the measured live snapshot through `check-realm-user-role-parity.py` directly: `undeclaredUsers` drops this principal to `[]`. Confirms the fix closes exactly the gap, not just "looks right."

## Not in scope here

- `demo@openbank.local`'s broader grant is confirmed intentional (showcases admin capabilities, deliberately scoped) — no change needed.
- `service-account-openbank-services` / `ROLE_OPERATOR` over-grant predates this PR (#2442) and is unrelated to mcp-service — left alone.
- No live Keycloak or Vault mutation. Template-only, additive.

Refs #2540

🤖 Generated with [Claude Code](https://claude.com/claude-code)
