### PR TITLE
fix(finrep): open the management port the probes have always asked for

### DIFF
--- a/openbank-finrep-service/src/main/resources/application.yaml
+++ b/openbank-finrep-service/src/main/resources/application.yaml
@@ -23,6 +23,20 @@ quarkus:
 
   log:
     level: INFO
+
+  # The management interface the Kubernetes probes and the Prometheus scrape target.
+  #
+  # This block was missing, and its absence is why the finrep pod could never become ready: the
+  # gitops manifest probes and scrapes port 8085 (`port: management`), Quarkus never opened it, and
+  # kubelet got connection refused. Without a management port Quarkus keeps /q/health on the main
+  # HTTP port, so nothing was wrong with the probe PATH — only with the port it was asked for.
+  # 8085 matches every other service in the fleet (ledger, transaction, …), so the manifest was
+  # right and the service configuration was the half that never landed.
+  management:
+    enabled: true
+    port: 8085
+    host: 0.0.0.0
+    root-path: /q
   smallrye-openapi:
     path: /q/openapi
   swagger-ui:


### PR DESCRIPTION
finrep-service's pod can never become ready: the gitops manifest probes and scrapes `port: management` (8085), and `application.yaml` never enabled Quarkus's management interface, so kubelet got connection refused.

The probe **path** was fine — without a management port Quarkus keeps `/q/health` on the main HTTP port, so the endpoint exists, just not on 8085. That is why this looks like a healthy service that never passes readiness.

Fixed on the service side, not the manifest side, because the fleet convention (ledger, transaction, …) is `management.enabled: true, port: 8085, root-path: /q` — the manifest was written against it and is right. Retargeting the manifest to 8140 would have made finrep the odd one out and broken the scrape convention to work around four missing lines.

`check-probe-port-listener`: 1 finding → clean across all 113 probed/scraped ports. `%test` already disables management, so tests are unaffected (green locally).

Found while working on #4010, whose gitops gate this was blocking.