### PR TITLE
fix(ci): record-deployment must not fabricate a broker version it cannot verify

### DIFF
--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -1549,6 +1549,21 @@ gates:
     run: |
       python3 .github/scripts/check-pacticipant-matches-module.py
 
+  # The resolver decides what record-deployment writes into the broker's environment record
+  # (#3223). Its core is a pure path classifier, so the self-test drives every branch — including
+  # the prefix-sibling near-miss (openbank-ledger vs openbank-ledger-service) and the
+  # "no exclude-paths declared" case, where src/test must COUNT rather than be assumed excluded.
+  # Falsified both ways before wiring in: breaking the exclusion makes it exit 1 with 4 failures.
+  - id: record-deployment-version-resolver
+    name: "record-deployment version resolver (issue #3223, enforced)"
+    group: api
+    mode: enforced
+    selftest: |
+      bash .github/scripts/resolve-record-deployment-version.sh --self-test
+    selftest_expect: pass
+    run: |
+      bash .github/scripts/resolve-record-deployment-version.sh --self-test
+
   - id: pact-provider-replay-coverage
     name: "Pact provider-replay coverage (issue #2338, enforced)"
     group: api

--- a/.github/scripts/resolve-record-deployment-version.sh
+++ b/.github/scripts/resolve-record-deployment-version.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+# See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+#
+# ---------------------------------------------------------------------------------------
+# Decide WHICH VERSION record-deployment should record as deployed (issue #3223).
+#
+# THE DEFECT THIS REMOVES
+# record-deployment-on-merge.yml resolved each `openbank-<svc>:sandbox-<short>` image tag to a
+# full sha and recorded THAT as deployed. Path-scoped CI skips most services on most commits, so
+# for most (service, sha) pairs the broker has no such version — and the workflow created one:
+#
+#     if [ "$ver_code" = "404" ]; then
+#       curl -X PUT ... -d '{}' ".../pacticipants/${svc}/versions/${SHA}"
+#     fi
+#
+# That version carries no pacts and no verifications, and nothing can ever give it any: the
+# publishing lane is keyed on the shas it actually built. It then becomes the counterpart every
+# consumer's `can-i-deploy --to-environment sandbox` asks about, and the answer can never be yes.
+#
+# MEASURED on the live broker 2026-08-07, before this change:
+#   56 currently-deployed versions, 11 with pacts or verifications, 45 CONTENTLESS
+#   19 providers with a deployed version, 13 of them at a version with ZERO verifications
+#   last 40 auto-deploy runs: 24 failure / 15 success, 12 of 12 sampled failures at can-i-deploy
+#
+# WHY NOT SIMPLY SKIP THE PUT
+# Then the environment record has a gap rather than a lie, which is better but still wrong: the
+# artifact IS deployed and the broker would not know. The honest record exists — some published
+# version whose source is byte-identical for this service — and this script finds it.
+#
+# THE EQUIVALENCE ARGUMENT, AND WHY IT IS NOT NEW
+# #3432 already established it for the ASKING side (resolve-can-i-deploy-selector.sh): if every
+# build input of <svc> is identical between two commits, a question about one is a question about
+# the same source, not about a different commit. Recording is the symmetric case. This script is
+# the recording half of that decision; the two halves disagreeing is the state #3223 describes.
+#
+# WHY VIA THE GITHUB API AND NOT git
+# resolve-can-i-deploy-selector.sh compares git tree objects, which needs a checkout with full
+# history. The `record-deployment` job has NO `actions/checkout` at all — one step, api-only, by
+# design (see GH_REPO in that workflow). Adding a full-history checkout to every gitops merge to
+# answer "did anything under <svc>/ change" is a large cost for a question the compare API answers
+# directly. So the proof is the same; the evidence source differs.
+#
+# WHAT COUNTS AS A BUILD INPUT
+# Everything under `<svc>/` except that package's release-please `exclude-paths` — `<svc>/src/test`
+# for every service (and `openbank-admin-ui/e2e`). Those are the paths release-please already
+# declares cannot change the shipped artifact, so reusing them keeps one definition rather than a
+# second copy that drifts (this repo's "never let a second hand-maintained copy exist" rule).
+#
+# OUTPUT — exactly one line on stdout:
+#   exact:<sha>        the broker already has this version; record it unchanged
+#   equivalent:<sha>   no version for the deployed sha, but <sha> is published and byte-identical
+#                      in every build input of this service; record <sha>
+#   none               neither — the caller MUST record nothing and warn. Never fabricate.
+#
+# The caller decides what `none` costs. It is deliberately not an error: a service genuinely
+# deployed from a source no lane ever published is a real state, and a gap in the environment
+# record is honest about it where a `PUT {}` is not.
+
+set -uo pipefail
+
+# ── the testable core ────────────────────────────────────────────────────────────────────
+# True when a changed path is a build input of <svc>: under `<svc>/` and not under one of that
+# package's exclude-paths. Pure, no network — the self-test drives every branch through it.
+path_is_build_input() {
+  local svc="$1" path="$2" excludes="$3" ex
+  case "$path" in
+    "$svc"/*) ;;
+    *) return 1 ;;
+  esac
+  # `excludes` is newline-separated; a path under any of them is not a build input.
+  while IFS= read -r ex; do
+    [ -n "$ex" ] || continue
+    case "$path" in
+      "$ex"/*|"$ex") return 1 ;;
+    esac
+  done <<EOF
+$excludes
+EOF
+  return 0
+}
+
+# True when NONE of the changed paths is a build input of <svc>.
+trees_equivalent() {
+  local svc="$1" excludes="$2" p
+  while IFS= read -r p; do
+    [ -n "$p" ] || continue
+    if path_is_build_input "$svc" "$p" "$excludes"; then
+      return 1
+    fi
+  done
+  return 0
+}
+
+# Read a package's exclude-paths out of release-please-config.json, one per line.
+# Absent config or absent package yields an empty list, which is the safe direction: with no
+# excludes every changed path under `<svc>/` counts, so equivalence is harder to claim.
+excludes_for() {
+  local svc="$1" cfg="${2:-release-please-config.json}"
+  [ -f "$cfg" ] || return 0
+  python3 - "$cfg" "$svc" <<'PY'
+import json, sys
+cfg, svc = sys.argv[1], sys.argv[2]
+try:
+    pkg = json.load(open(cfg)).get("packages", {}).get(svc, {})
+except Exception:
+    sys.exit(0)
+for p in pkg.get("exclude-paths") or []:
+    print(p)
+PY
+}
+
+# ── self-test ────────────────────────────────────────────────────────────────────────────
+# Feeds the core the cases it MUST flag and the near-misses it must NOT, per this repo's rule
+# that a check which has only ever seen correct input is unfalsified.
+self_test() {
+  local fails=0
+  check() { # name expected_rc actual_rc
+    if [ "$2" -eq "$3" ]; then echo "  ok   $1"; else echo "  FAIL $1 (want rc=$2, got rc=$3)"; fails=1; fi
+  }
+  local EX="openbank-ledger-service/src/test"
+
+  path_is_build_input openbank-ledger-service openbank-ledger-service/src/main/kotlin/A.kt "$EX"; check "src/main is a build input" 0 $?
+  path_is_build_input openbank-ledger-service openbank-ledger-service/build.gradle.kts "$EX"; check "build.gradle.kts is a build input" 0 $?
+  path_is_build_input openbank-ledger-service openbank-ledger-service/Dockerfile "$EX"; check "Dockerfile is a build input" 0 $?
+  path_is_build_input openbank-ledger-service openbank-ledger-service/src/test/kotlin/T.kt "$EX"; check "src/test is excluded" 1 $?
+  path_is_build_input openbank-ledger-service openbank-ledger-service/src/test "$EX"; check "the exclude dir itself is excluded" 1 $?
+  path_is_build_input openbank-ledger-service openbank-fx-service/src/main/kotlin/A.kt "$EX"; check "another service is not our input" 1 $?
+  path_is_build_input openbank-ledger-service docs/adr/0001.md "$EX"; check "a doc is not our input" 1 $?
+  # PREFIX TRAP: a sibling whose name starts with ours must not match.
+  path_is_build_input openbank-ledger openbank-ledger-service/src/main/kotlin/A.kt "$EX"; check "prefix sibling does not match" 1 $?
+
+  printf 'openbank-ledger-service/src/test/kotlin/T.kt\ndocs/adr/0001.md\n' \
+    | trees_equivalent openbank-ledger-service "$EX"; check "test-only + docs change IS equivalent" 0 $?
+  printf 'openbank-ledger-service/src/test/kotlin/T.kt\nopenbank-ledger-service/src/main/kotlin/A.kt\n' \
+    | trees_equivalent openbank-ledger-service "$EX"; check "one main change is NOT equivalent" 1 $?
+  printf '' | trees_equivalent openbank-ledger-service "$EX"; check "empty diff IS equivalent" 0 $?
+  # A service with no exclude-paths declared: src/test then counts, which is the safe direction.
+  printf 'openbank-x/src/test/T.kt\n' | trees_equivalent openbank-x ""; check "no excludes => src/test counts" 1 $?
+
+  [ "$fails" -eq 0 ] && { echo "resolve-record-deployment-version: self-test PASS"; return 0; }
+  echo "resolve-record-deployment-version: self-test FAIL"; return 1
+}
+
+# ── resolution ───────────────────────────────────────────────────────────────────────────
+main() {
+  local svc="$1" deployed="$2"
+  : "${PACT_BROKER_URL:?}" "${PACT_BROKER_USERNAME:?}" "${PACT_BROKER_PASSWORD:?}" "${GH_REPO:?}"
+
+  local code
+  code="$(curl -s -o /dev/null -w '%{http_code}' \
+    -u "${PACT_BROKER_USERNAME}:${PACT_BROKER_PASSWORD}" \
+    "${PACT_BROKER_URL}/pacticipants/${svc}/versions/${deployed}")"
+  if [ "$code" = "200" ]; then
+    echo "exact:${deployed}"
+    return 0
+  fi
+
+  # Newest published version for this pacticipant. `latest` is the broker's own ordering, so we
+  # inherit its definition of newest rather than inventing one.
+  local published
+  published="$(curl -s -u "${PACT_BROKER_USERNAME}:${PACT_BROKER_PASSWORD}" \
+    "${PACT_BROKER_URL}/pacticipants/${svc}/latest-version" \
+    | python3 -c 'import json,sys;
+try: print(json.load(sys.stdin).get("number",""))
+except Exception: print("")' 2>/dev/null)"
+  case "$published" in
+    [0-9a-f]*) ;;
+    *) echo "none"; return 0 ;;
+  esac
+  [ "$published" != "$deployed" ] || { echo "none"; return 0; }
+
+  local files excludes
+  files="$(gh api "repos/${GH_REPO}/compare/${published}...${deployed}" \
+    --jq '.files[].filename' 2>/dev/null)" || { echo "none"; return 0; }
+  excludes="$(excludes_for "$svc")"
+
+  if printf '%s\n' "$files" | trees_equivalent "$svc" "$excludes"; then
+    echo "equivalent:${published}"
+  else
+    echo "none"
+  fi
+}
+
+case "${1:-}" in
+  --self-test) self_test ;;
+  "") echo "usage: $0 <pacticipant> <deployed-sha> | --self-test" >&2; exit 2 ;;
+  *) main "$1" "${2:?deployed sha required}" ;;
+esac

--- a/.github/workflows/record-deployment-on-merge.yml
+++ b/.github/workflows/record-deployment-on-merge.yml
@@ -56,12 +56,22 @@ jobs:
       HEAD_REF: ${{ github.event.pull_request.head.ref }}
       PR_NUMBER: ${{ github.event.pull_request.number }}
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      # `gh pr diff` shells out to git and needs either a checkout or an explicit repo. This job
-      # has no checkout, so without --repo it dies "not a git repository", returns nothing, and
+      # `gh pr diff` shells out to git and needs either a checkout or an explicit repo. Everything
+      # here is API-only, so without --repo it dies "not a git repository", returns nothing, and
       # every run silently records zero services ("nothing to record") — the deploy tracking then
       # goes stale with no error. Pass the repo explicitly so it works API-only.
       GH_REPO: ${{ github.repository }}
     steps:
+      # SHALLOW on purpose. The only things needed from the repo are two files —
+      # .github/scripts/resolve-record-deployment-version.sh and release-please-config.json —
+      # and the equivalence proof is made through the compare API, not through git history
+      # (#3223). A full-history checkout on every gitops merge would buy nothing here.
+      - name: Check out the resolver and the exclude-paths it reads
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5.0.1
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
       - name: Record deployed services in the broker
         if: ${{ vars.PACT_BROKER_URL != '' }}
         run: |
@@ -135,23 +145,23 @@ jobs:
             SHA="${FULL[$short]:-}"
             [ -n "$SHA" ] || continue  # unresolvable tag already counted via resolve_failed
             echo "==> record-deployment ${svc} @ ${short} → sandbox"
-            # record-deployment needs the version to exist in the broker. A version that CI
-            # never published (path-scoped build skipped this service on that sha) 404s; create
-            # it idempotently first, matching the old in-gitops-pr behaviour.
-            ver_code="$(curl -s -o /dev/null -w '%{http_code}' \
-              -u "${PACT_BROKER_USERNAME}:${PACT_BROKER_PASSWORD}" \
-              "${PACT_BROKER_URL}/pacticipants/${svc}/versions/${SHA}")"
-            if [ "$ver_code" = "404" ]; then
-              echo "  version not in broker yet — creating it via REST (idempotent PUT)"
-              curl -s -o /dev/null -w '  PUT version → HTTP %{http_code}\n' \
-                -X PUT -u "${PACT_BROKER_USERNAME}:${PACT_BROKER_PASSWORD}" \
-                -H "Content-Type: application/json" -d '{}' \
-                "${PACT_BROKER_URL}/pacticipants/${svc}/versions/${SHA}"
-            fi
+            # WHICH version to record is decided by resolve-record-deployment-version.sh (#3223).
+            # It never fabricates: `exact` when the broker has this sha, `equivalent:<sha>` when a
+            # published version is byte-identical in every build input of this service, `none`
+            # otherwise. The old code PUT an empty version on 404, which made 45 of 56 deployed
+            # versions unverifiable and left 13 of 19 providers permanently blocking consumers.
+            sel="$(bash .github/scripts/resolve-record-deployment-version.sh "$svc" "$SHA")"
+            case "$sel" in
+              exact:*)      REC_VER="${sel#exact:}" ;;
+              equivalent:*) REC_VER="${sel#equivalent:}"
+                            echo "  no version for ${SHA:0:8}; ${REC_VER:0:8} is byte-identical in every build input — recording that (#3223, #3432)" ;;
+              *)            echo "::warning::${svc}: no published version for ${SHA:0:8} and none provably equivalent — recording NOTHING rather than a version nothing can verify (#3223). can-i-deploy for its consumers will report no deployed version, which is the honest state."
+                            continue ;;
+            esac
             ok=0
             for attempt in 1 2 3; do
               if "$CLI" record-deployment \
-                   --pacticipant "$svc" --version "$SHA" --environment sandbox \
+                   --pacticipant "$svc" --version "$REC_VER" --environment sandbox \
                    --broker-base-url "$PACT_BROKER_URL" \
                    --broker-username "$PACT_BROKER_USERNAME" \
                    --broker-password "$PACT_BROKER_PASSWORD"; then


### PR DESCRIPTION
## What

`record-deployment-on-merge.yml` created an empty pacticipant version whenever the broker had none
for the deployed sha, then recorded that as deployed:

```bash
if [ "$ver_code" = "404" ]; then
  curl -X PUT … -d '{}' "${PACT_BROKER_URL}/pacticipants/${svc}/versions/${SHA}"
fi
```

Path-scoped CI skips most services on most commits, so this was the common path, not the edge case.

## Measured on the live broker before this change

```
56  currently-deployed versions in sandbox
11  with pacts or verifications
45  CONTENTLESS

19  providers with a deployed version
13  at a version with ZERO verifications
    balance · delegation · fraud · fx · ledger · party · pid · product-catalog
    sanctions · sca · swift · tpp-registry · transaction

last 40 auto-deploy runs: 24 failure / 15 success
12 of 12 sampled failures fail at can-i-deploy
```

A contentless version is worse than an absent one: it asserts something is deployed that nothing can
ever verify, so every consumer of those 13 is permanently blocked. That is the mechanism behind the
failure rate.

## The change

`resolve-record-deployment-version.sh` decides what to record and never invents one:

| output | meaning |
|---|---|
| `exact:<sha>` | the broker already has this version — record it unchanged |
| `equivalent:<sha>` | no version for the deployed sha, but a published one is byte-identical in every build input of this service — record that |
| `none` | neither — **record nothing and warn** |

Equivalence is the same argument #3432 already accepted for the *asking* side
(`resolve-can-i-deploy-selector.sh`): if every build input is identical between two commits, a
statement about one is a statement about the same source. This is the recording half; the two halves
disagreeing is what #3223 describes.

"Build input" = everything under `<svc>/` except that package's release-please `exclude-paths`
(`<svc>/src/test`, plus `openbank-admin-ui/e2e`) — reusing the existing declaration rather than
keeping a second copy that drifts.

**Proof via the compare API, not git trees.** `resolve-can-i-deploy-selector.sh` compares git tree
objects, which needs full history. This job is API-only by design (see the `GH_REPO` comment in the
workflow) and had no checkout at all. `repos/{o}/{r}/compare/{published}...{deployed}` answers the same
question directly, so the added checkout is `fetch-depth: 1` and exists only to read two files.

## What this changes about what the gate asserts

After this, *"openbank-ledger-service is deployed at version X"* means **the source that produced the
running image is X**, not *the image is tagged X*. That is a deliberate decoupling of the broker's
environment record from the image tag — the same decoupling #3432 made for the asking side.

The `none` branch is also a behaviour change worth naming: a service deployed from a source no lane
ever published now leaves a **gap** in the environment record instead of a fabricated entry. Its
consumers' `can-i-deploy` will report no deployed version rather than an unverifiable one. That is the
honest state, and it is diagnosable; the previous state was not.

## Verification

- `resolve-record-deployment-version.sh --self-test` — 12 assertions, all passing.
- **Falsified both ways**: breaking the exclusion check makes the self-test exit 1 with 4 failures;
  restoring it returns 0. A self-test that has only ever passed is unfalsified.
- Covers the prefix-sibling near-miss (`openbank-ledger` must not match
  `openbank-ledger-service/...`) and the no-`exclude-paths` case, where `src/test` must **count**
  rather than be assumed excluded — the safe direction.
- Registered in `.github/gates/gates.yaml` as `record-deployment-version-resolver`, `mode: enforced`;
  `run-gates.py --only record-deployment-version-resolver` passes.
- `actionlint` and `shellcheck -S warning` clean; `check-workflow-run-step-size.py` unaffected
  (this run step is 5197 chars).
- `actions/checkout` pinned to the sha the other 79 call sites use.

## Not done here, deliberately

The 45 contentless versions already in the broker are **not** cleaned up by this PR — it stops new
ones. Whether to purge or leave them is a separate operational call on #3223, and doing it in the same
change would mix a code fix with a data migration against a money-path gate.

Refs #3223, #3306
