### PR TITLE
test(finrep): assert the management interface BINDS, not just that its config resolves

### DIFF
--- a/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/ManagementInterfaceSocketTest.kt
+++ b/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/ManagementInterfaceSocketTest.kt
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.finrep
+
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.junit.QuarkusTestProfile
+import io.quarkus.test.junit.TestProfile
+import io.restassured.RestAssured
+import org.assertj.core.api.Assertions.assertThat
+import org.eclipse.microprofile.config.ConfigProvider
+import org.junit.jupiter.api.Test
+
+/**
+ * Does the management interface actually BIND and SERVE on the config the shared base supplies —
+ * or do we only know the values resolve?
+ *
+ * WHY THIS EXISTS
+ *
+ * #3686 moved `quarkus.management.*` out of this service's `application.yaml` and into
+ * `openbank-libs-runtime`'s shared base. `FinrepBootSmokeTest` then asserted that
+ * `quarkus.management.port`, `.root-path` and `.enabled` RESOLVE — which is a claim about config
+ * lookup, not about a listening socket. #4017 relied on that to teach
+ * `check-probe-port-listener.py` that 8085 is open, and #4030 disputes it and re-declares the
+ * block in this service. Neither side had observed the interface actually serving.
+ *
+ * This test closes the half that a JVM test can close: with the interface enabled, the management
+ * HTTP server binds using the base-supplied `root-path` and answers a health request. If the base
+ * stopped contributing management config, or the interface stopped serving `/q/health` on it, this
+ * goes red — and it cannot pass by reading a value nothing acts on.
+ *
+ * WHAT IT DELIBERATELY DOES NOT PROVE, so nobody reads more into a green than is there:
+ *
+ *  - **That production gets `enabled: true` from the base.** This service's own `%test` block sets
+ *    `quarkus.management.enabled: false`, so a JVM test must override it to observe anything at
+ *    all. The profile below overrides ONLY `enabled`, and deliberately leaves `port` and
+ *    `root-path` to come from the base — so a green here does say the base reaches the bound
+ *    interface, and does not say the base's `enabled` survives augmentation in the packaged
+ *    fast-jar. That question is answerable only by booting the built artifact (a
+ *    `@QuarkusIntegrationTest`, or the in-image probe `check-probe-port-listener.py` performs).
+ *  - **The literal port 8085.** `@QuarkusTest` assigns a management TEST port, so asserting 8085
+ *    here would assert Quarkus's test-port machinery, not the deployed configuration. The port is
+ *    read from config at request time instead.
+ */
+@QuarkusTest
+@TestProfile(ManagementInterfaceSocketTest.ManagementEnabled::class)
+class ManagementInterfaceSocketTest {
+
+    /**
+     * Re-enables the management interface, and nothing else. Literals only: a [QuarkusTestProfile]
+     * is loaded in a different classloader from the test class, so anything computed here would be
+     * computed twice and the two copies need not agree.
+     */
+    class ManagementEnabled : QuarkusTestProfile {
+        override fun getConfigOverrides(): Map<String, String> = mapOf(
+            "quarkus.management.enabled" to "true",
+        )
+    }
+
+    @Test
+    fun `the management interface binds and serves health on the base-supplied root path`() {
+        val config = ConfigProvider.getConfig()
+
+        // Both come from openbank-libs-runtime's application.yaml — this service declares neither.
+        val rootPath = config.getValue("quarkus.management.root-path", String::class.java)
+        assertThat(rootPath)
+            .describedAs("root-path must come from the shared base; this service declares no management block")
+            .isEqualTo("/q")
+
+        // The management server runs on its own port, which Quarkus randomises for tests.
+        val managementPort = config.getValue("quarkus.management.test-port", Int::class.javaObjectType)
+
+        val body = RestAssured.given()
+            .port(managementPort)
+            .get("$rootPath/health/ready")
+            .then()
+            .statusCode(200)
+            .extract().body().asString()
+
+        assertThat(body)
+            .describedAs("a bound management interface must actually answer, not merely be configured")
+            .contains("UP")
+    }
+}


### PR DESCRIPTION
## What this settles, and what it does not

**#4017** (merged) taught `check-probe-port-listener.py` that finrep's management port 8085 is open, on the grounds that #3686 moved `quarkus.management.*` into `openbank-libs-runtime`'s shared `application.yaml`. **#4030** disputes that, says the interface was never enabled, and re-declares the block in finrep.

The evidence both sides were using was `FinrepBootSmokeTest`, which asserts that `quarkus.management.port`, `.root-path` and `.enabled` **resolve**. That is a claim about config lookup. Neither PR had evidence that anything *listens*.

This adds the missing half: with the interface enabled, the management server binds using the **base-supplied** `root-path` and answers `/q/health/ready`.

### Falsified in both directions, not assumed

```
base root-path /q -> /broken      AssertionFailedError  (config half fires)
management interface disabled     java.net.ConnectException: Connection refused
```

The second is the one that earns the test. It proves the assertion cannot be satisfied by reading a value nothing acts on — which is precisely what the existing smoke test could do, and why it could not settle the dispute.

### What it deliberately does not prove

Stated in the test's own header so a future reader does not over-read a green:

- **That production gets `enabled: true` from the base.** finrep's `%test` block sets `quarkus.management.enabled: false`, so any JVM test must override it to observe anything. The profile overrides **only** `enabled`, leaving `port` and `root-path` to come from the base — so a green says *base config reaches a bound interface*, not *the base's `enabled` survives augmentation in the packaged fast-jar*. That needs `@QuarkusIntegrationTest` against the built artifact, or the in-image probe. There is no `@QuarkusIntegrationTest` precedent in this repo yet.
- **The literal port 8085.** `@QuarkusTest` assigns a management *test* port; asserting 8085 would test Quarkus's test-port machinery, not the deployed config. The port is read from config at request time.

### Bearing on #4030

This does not close #4030, and I would not close it on this. It removes the part of the disagreement that was resolvable in-JVM — the base's management config does reach a real bound socket — and leaves the genuinely open question, which is whether `enabled: true` propagates through augmentation in the packaged image. The honest next step for that is the in-image check, not a re-declared block: re-declaring restores the duplication #3686 removed and hands the next service adopting the base the same false red on an enforced gate.

`ktlintCheck` and `detekt` green locally.

Refs #3686, #4017, #4030
