### PR TITLE
feat(card-issuance): model the single-use card lifecycle (D1 server preparation)

### DIFF
--- a/docs/threat-models/openbank-card-issuance-service.md
+++ b/docs/threat-models/openbank-card-issuance-service.md
@@ -90,6 +90,31 @@ reads only this service's own tables.
 which is the defect, so a rollback should be paired with disabling the customer-facing toggles
 rather than leaving them visibly ineffective.
 
+## 4b. Single-use card lifecycle (D1) — STRIDE supplement
+
+Adds the terminal status `CONSUMED`, a `closedReason`, and an `expiresAt` validity window for
+SINGLE_USE cards. No new endpoint: the card list and detail responses carry the new fields.
+
+**Why a distinct status rather than reusing CANCELLED.** Until now "cancelled" covered a customer
+closing a card, a card reported lost, and a disposable card doing exactly what it promised. Those
+are three different things a customer is owed three different sentences about — and one of them is
+a security signal. "Your disposable card was just used" is the fraud alarm for this product; it
+cannot be distinguished from routine closure if the status is the same.
+
+| STRIDE | Threat | Mitigation |
+|---|---|---|
+| **E**oP | A consumed card is re-provisioned with a live PAN and spends again | `CONSUMED` is in `TERMINAL_STATUSES`, which the PAN-vault backfill excludes. A pinned test asserts the exact contents of that set, so growing it silently is not possible — that assertion caught this change and had to be updated deliberately |
+| **T**ampering | A card is marked CONSUMED without having been used, hiding a decline or a failure | `consume()` requires `cardType == SINGLE_USE` **and** `status == ACTIVE`, and is driven by the processor's lifecycle event rather than by a customer or operator request. Any other type or status throws |
+| **R**epudiation | The customer cannot tell why their card stopped working | `closedReason` distinguishes `SINGLE_USE_CONSUMED` from `VALIDITY_EXPIRED`, `LOST_OR_STOLEN` and `CUSTOMER_CANCEL`; an unused card that times out becomes EXPIRED, never CONSUMED, because nothing was spent |
+| **I**nfo disclosure | Revealing the PAN of a card that already spent | Unchanged and still correct: `CONSUMED` is terminal, so the existing "card not live" guard on secure details refuses it |
+| **D**oS | A disposable card issued and forgotten stays a live PAN indefinitely | `expiresAt` bounds the window even if the card is never presented; a partial index supports finding those cards without weighing on the hot path |
+
+**Not in this change, and load-bearing:** the authorize-once guarantee itself lives at the card
+processor. This models the outcome so the customer can see it; it does not enforce single use. Until
+the processor is configured, a SINGLE_USE card is a virtual card with a validity window — the status
+machine is ready, the guarantee is not. Anything that presents it to customers as "authorises once"
+before the processor side lands would be claiming a control the bank does not yet have.
+
 ## 5. Residual risks / assumptions
 
 - **No optimistic locking today.** `Card` lacks a `version` column; two concurrent lifecycle
@@ -109,6 +134,8 @@ rather than leaving them visibly ineffective.
   is implemented, erasure is manual.
 
 ## 6. Change log
+
+- **2026-08-07** — Single-use card lifecycle (D1 server preparation). New terminal status `CONSUMED`, `CardClosedReason` (`SINGLE_USE_CONSUMED | VALIDITY_EXPIRED | LOST_OR_STOLEN | CUSTOMER_CANCEL`), and `expiresAt`; `consume()` and `expireUnused()` transitions; migration V9. STRIDE supplement in §4b. `CONSUMED` joins `TERMINAL_STATUSES`, which excludes a card from PAN-vault backfill — the pinned assertion on that set failed on this change, which is the change-detector working, and was updated deliberately rather than relaxed. **The authorize-once guarantee is NOT in this change:** it lives at the card processor, and until it is configured a SINGLE_USE card is a virtual card with a validity window. Do not present it to customers as "authorises once" before then. Rollback: revert; a card sitting in CONSUMED must be remapped to CANCELLED first, or it becomes a status no older build understands.
 
 - **2026-08-07** — Card authorization decision point (D3). New `CardAuthorizationPolicy` (pure, 15 unit tests) plus `POST /cards/{id}/authorizations`, `GET|PUT /cards/{id}/category-limits` and `GET /cards/category-taxonomy`; new `card_category_rules` table. STRIDE supplement in §4a. **This closes a live defect, not just a missing feature:** the channel controls stored since V5 were read by nothing, so a customer switching off "payments abroad" got a 200 and no protection. The policy is deliberately pure — no repository, no clock — so every branch of a money-path decision is reachable in a unit test rather than only against a live acquirer. Per-category spend is not yet tracked; the response says `spendTracking: false` so a client shows "no data" instead of a progress ring against a zero that looks measured. Rollback: revert, but pair it with hiding the customer-facing toggles rather than leaving controls that visibly do nothing.
 

--- a/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/domain/model/Card.kt
+++ b/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/domain/model/Card.kt
@@ -8,7 +8,31 @@ import java.time.Instant
 import java.time.LocalDate
 import java.util.UUID
 
-enum class CardStatus { PENDING, ACTIVE, SUSPENDED, BLOCKED, EXPIRED, CANCELLED }
+enum class CardStatus {
+    PENDING,
+    ACTIVE,
+    SUSPENDED,
+    BLOCKED,
+    EXPIRED,
+    CANCELLED,
+
+    /**
+     * A single-use card that has been used. Terminal.
+     *
+     * Distinct from CANCELLED and EXPIRED because it is the promise being kept, not a failure: the
+     * card authorised once and closed itself. Collapsing it into CANCELLED would tell a customer
+     * their disposable card was cancelled, which reads as something going wrong.
+     */
+    CONSUMED,
+}
+
+/** Why a card reached a terminal status. Null while the card is alive. */
+enum class CardClosedReason {
+    SINGLE_USE_CONSUMED,
+    VALIDITY_EXPIRED,
+    LOST_OR_STOLEN,
+    CUSTOMER_CANCEL,
+}
 
 /**
  * Form factor of a card.
@@ -57,6 +81,15 @@ data class Card(
     val abroadEnabled: Boolean = true,
     // Synthetic PAN vault (#4): AES-256-GCM ciphertext, never the clear value. Nullable because
     // cards issued before the pan_encrypted/cvv_encrypted migration have no stored PAN at all.
+    /**
+     * When a SINGLE_USE card stops being usable even if never presented. Null for every other type.
+     * A disposable card that is never spent must still stop being a live PAN.
+     */
+    val expiresAt: Instant? = null,
+
+    /** Why the card reached a terminal status; null while it is alive. */
+    val closedReason: CardClosedReason? = null,
+
     val panEncrypted: String? = null,
     val cvvEncrypted: String? = null,
 ) {
@@ -71,6 +104,34 @@ data class Card(
         require(status in setOf(CardStatus.ACTIVE, CardStatus.SUSPENDED)) { "Cannot block card in status $status" }
         require(reason.isNotBlank()) { "Block reason required" }
     }.copy(status = CardStatus.BLOCKED, blockedAt = now, blockedReason = reason, updatedAt = now)
+
+    /**
+     * The single-use card authorised once and closed itself.
+     *
+     * Driven by the processor's lifecycle event, not by us: the authorize-once guarantee lives at
+     * the processor, and this records the outcome so the customer can see it. Only SINGLE_USE
+     * reaches it — marking any other card CONSUMED would be a lie about why it stopped working.
+     */
+    fun consume(now: Instant = Instant.EPOCH) = also {
+        require(cardType == CardType.SINGLE_USE) { "Only SINGLE_USE cards can be consumed, this is $cardType" }
+        require(status == CardStatus.ACTIVE) { "Only ACTIVE cards can be consumed, current: $status" }
+    }.copy(
+        status = CardStatus.CONSUMED,
+        closedReason = CardClosedReason.SINGLE_USE_CONSUMED,
+        updatedAt = now,
+    )
+
+    /**
+     * The card's validity window ran out before it was ever used. EXPIRED rather than CONSUMED:
+     * nothing was spent, and the difference is what the customer is told.
+     */
+    fun expireUnused(now: Instant = Instant.EPOCH) = also {
+        require(status in LIVE_STATUSES) { "Cannot expire card in status $status" }
+    }.copy(
+        status = CardStatus.EXPIRED,
+        closedReason = CardClosedReason.VALIDITY_EXPIRED,
+        updatedAt = now,
+    )
 
     fun suspend(now: Instant = Instant.EPOCH) = also {
         require(status == CardStatus.ACTIVE) { "Only ACTIVE cards can be suspended" }
@@ -150,6 +211,6 @@ data class Card(
          * is dead: no transition applies, and nothing should be provisioned for it (the PAN-vault
          * backfill skips them for exactly that reason).
          */
-        val TERMINAL_STATUSES = setOf(CardStatus.CANCELLED, CardStatus.EXPIRED)
+        val TERMINAL_STATUSES = setOf(CardStatus.CANCELLED, CardStatus.EXPIRED, CardStatus.CONSUMED)
     }
 }

--- a/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/infrastructure/persistence/entity/CardEntity.kt
+++ b/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/infrastructure/persistence/entity/CardEntity.kt
@@ -85,6 +85,14 @@ class CardEntity {
     @Column(name = "blocked_reason")
     var blockedReason: String? = null
 
+    /** SINGLE_USE only: when the card stops being usable even if never presented. */
+    @Column(name = "expires_at")
+    var expiresAt: Instant? = null
+
+    /** Why the card reached a terminal status; null while alive. */
+    @Column(name = "closed_reason")
+    var closedReason: String? = null
+
     @Column(name = "created_at", nullable = false)
     lateinit var createdAt: Instant
 

--- a/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/infrastructure/persistence/mapper/CardMapper.kt
+++ b/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/infrastructure/persistence/mapper/CardMapper.kt
@@ -15,6 +15,8 @@ fun CardEntity.toDomain() = Card(
     dailyLimitMinorUnits = dailyLimitMinorUnits, monthlyLimitMinorUnits = monthlyLimitMinorUnits,
     currency = currency, deliveryAddress = deliveryAddress,
     activatedAt = activatedAt, blockedAt = blockedAt, blockedReason = blockedReason,
+    expiresAt = expiresAt,
+    closedReason = closedReason?.let { r -> runCatching { CardClosedReason.valueOf(r) }.getOrNull() },
     createdAt = createdAt, updatedAt = updatedAt,
     contactlessEnabled = contactlessEnabled, onlineEnabled = onlineEnabled,
     atmEnabled = atmEnabled, abroadEnabled = abroadEnabled,
@@ -45,6 +47,8 @@ fun Card.toEntity() = CardEntity().also { e ->
     e.activatedAt = activatedAt
     e.blockedAt = blockedAt
     e.blockedReason = blockedReason
+    e.expiresAt = expiresAt
+    e.closedReason = closedReason?.name
     e.createdAt = createdAt
     e.updatedAt = updatedAt
     e.panEncrypted = panEncrypted

--- a/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/infrastructure/persistence/mapper/CardMapper.kt
+++ b/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/infrastructure/persistence/mapper/CardMapper.kt
@@ -54,3 +54,34 @@ fun Card.toEntity() = CardEntity().also { e ->
     e.panEncrypted = panEncrypted
     e.cvvEncrypted = cvvEncrypted
 }
+
+/**
+ * The UPDATE half of `CardRepositoryImpl.save`. It must stay field-for-field in step with
+ * [toEntity], the INSERT half — a column set by one and not the other means the value is written at
+ * issue and then silently dropped by every later transition. `CardMapperUpdateParityTest` compares
+ * the two paths over every mutable property, so a new column cannot reach only one of them.
+ *
+ * Lives here rather than inside the repository so the parity test can call it without a Vert.x
+ * context.
+ */
+internal fun CardEntity.applyFrom(card: Card) {
+    status = card.status.name
+    maskedPan = card.maskedPan
+    cardholderName = card.cardholderName
+    embossedName = card.embossedName
+    expiryDate = card.expiryDate
+    dailyLimitMinorUnits = card.dailyLimitMinorUnits
+    monthlyLimitMinorUnits = card.monthlyLimitMinorUnits
+    contactlessEnabled = card.contactlessEnabled
+    onlineEnabled = card.onlineEnabled
+    atmEnabled = card.atmEnabled
+    abroadEnabled = card.abroadEnabled
+    currency = card.currency
+    deliveryAddress = card.deliveryAddress
+    activatedAt = card.activatedAt
+    blockedAt = card.blockedAt
+    blockedReason = card.blockedReason
+    expiresAt = card.expiresAt
+    closedReason = card.closedReason?.name
+    updatedAt = card.updatedAt
+}

--- a/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/infrastructure/persistence/repository/CardRepositoryImpl.kt
+++ b/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/infrastructure/persistence/repository/CardRepositoryImpl.kt
@@ -7,6 +7,7 @@ package com.openbank.cardissuance.infrastructure.persistence.repository
 import com.openbank.cardissuance.application.port.out.CardRepository
 import com.openbank.cardissuance.domain.model.Card
 import com.openbank.cardissuance.infrastructure.persistence.entity.CardEntity
+import com.openbank.cardissuance.infrastructure.persistence.mapper.applyFrom
 import com.openbank.cardissuance.infrastructure.persistence.mapper.toDomain
 import com.openbank.cardissuance.infrastructure.persistence.mapper.toEntity
 import com.openbank.libs.persistence.outbox.OutboxMessage
@@ -96,27 +97,6 @@ class CardRepositoryImpl(private val outboxRepository: CardOutboxRepositoryImpl)
             cardId,
         )
     }.awaitSuspending() == 1
-
-    /** Copy the mutable (lifecycle) fields of [card] onto a managed entity for an in-place update. */
-    private fun CardEntity.applyFrom(card: Card) {
-        status = card.status.name
-        maskedPan = card.maskedPan
-        cardholderName = card.cardholderName
-        embossedName = card.embossedName
-        expiryDate = card.expiryDate
-        dailyLimitMinorUnits = card.dailyLimitMinorUnits
-        monthlyLimitMinorUnits = card.monthlyLimitMinorUnits
-        contactlessEnabled = card.contactlessEnabled
-        onlineEnabled = card.onlineEnabled
-        atmEnabled = card.atmEnabled
-        abroadEnabled = card.abroadEnabled
-        currency = card.currency
-        deliveryAddress = card.deliveryAddress
-        activatedAt = card.activatedAt
-        blockedAt = card.blockedAt
-        blockedReason = card.blockedReason
-        updatedAt = card.updatedAt
-    }
 
     private companion object {
         /** `status` is persisted as its enum NAME (see CardMapper), so the query compares strings. */

--- a/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/infrastructure/rest/dto/CardDtos.kt
+++ b/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/infrastructure/rest/dto/CardDtos.kt
@@ -56,6 +56,10 @@ data class CardResponse(
     val onlineEnabled: Boolean = true,
     val atmEnabled: Boolean = true,
     val abroadEnabled: Boolean = true,
+    /** SINGLE_USE only: when the card stops being usable even if never presented. */
+    val expiresAt: Instant? = null,
+    /** Why the card reached a terminal status; null while it is alive. */
+    val closedReason: CardClosedReason? = null,
 )
 
 fun Card.toResponse() = CardResponse(
@@ -64,6 +68,7 @@ fun Card.toResponse() = CardResponse(
     dailyLimitMinorUnits, monthlyLimitMinorUnits, currency, deliveryAddress,
     activatedAt, blockedAt, blockedReason, createdAt, updatedAt,
     contactlessEnabled, onlineEnabled, atmEnabled, abroadEnabled,
+    expiresAt, closedReason,
 )
 
 /**

--- a/openbank-card-issuance-service/src/main/resources/db/migration/V9__single_use_lifecycle.sql
+++ b/openbank-card-issuance-service/src/main/resources/db/migration/V9__single_use_lifecycle.sql
@@ -1,0 +1,23 @@
+-- D1: the single-use card lifecycle — a validity window, and why a card closed.
+--
+-- `status` is a VARCHAR, so the new CONSUMED value needs no type change; what was missing is the
+-- ability to say WHY a card is dead. Until now "cancelled" covered a customer closing a card, a
+-- lost card, and a disposable card doing exactly what it promised — three different things a
+-- customer is owed three different sentences about.
+ALTER TABLE cards ADD COLUMN IF NOT EXISTS expires_at TIMESTAMPTZ;
+ALTER TABLE cards ADD COLUMN IF NOT EXISTS closed_reason VARCHAR(32);
+
+COMMENT ON COLUMN cards.expires_at IS
+    'When a SINGLE_USE card stops being usable even if never presented. NULL for other card types.';
+COMMENT ON COLUMN cards.closed_reason IS
+    'SINGLE_USE_CONSUMED | VALIDITY_EXPIRED | LOST_OR_STOLEN | CUSTOMER_CANCEL. NULL while the card is alive.';
+
+-- Finding the disposable cards whose window has run out. Partial: only single-use cards ever carry
+-- expires_at, so indexing the rest would be dead weight on the hot path.
+CREATE INDEX IF NOT EXISTS idx_cards_expires_at
+    ON cards (expires_at)
+    WHERE expires_at IS NOT NULL;
+
+-- Rollback note: dropping both columns is safe — nothing reads them for an ACTIVE card, and a card
+-- in CONSUMED would need its status remapped to CANCELLED first, or it becomes a status no older
+-- build understands.

--- a/openbank-card-issuance-service/src/main/resources/openapi.yaml
+++ b/openbank-card-issuance-service/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: Card Issuance Service API
-  version: 1.5.0
+  version: 1.6.0
   description: Debit/credit card lifecycle — issue, activate, block, suspend, resume, cancel;
     synthetic PAN vault and product-catalog entitlements.
   license:
@@ -632,7 +632,27 @@ components:
           type: string
         status:
           type: string
-          enum: [PENDING, ACTIVE, SUSPENDED, BLOCKED, EXPIRED, CANCELLED]
+          enum: [PENDING, ACTIVE, SUSPENDED, BLOCKED, EXPIRED, CANCELLED, CONSUMED]
+          description: >
+            CONSUMED is terminal and applies only to SINGLE_USE cards: the card authorised once and
+            closed itself. Kept distinct from CANCELLED because it is the promise being kept, not a
+            failure — telling a customer their disposable card was "cancelled" reads as something
+            going wrong.
+        closedReason:
+          type: string
+          nullable: true
+          enum: [SINGLE_USE_CONSUMED, VALIDITY_EXPIRED, LOST_OR_STOLEN, CUSTOMER_CANCEL]
+          description: >
+            Why the card reached a terminal status; absent while it is alive. Without it, "cancelled"
+            covered a customer closing a card, a lost card, and a disposable card doing exactly what
+            it promised — three things a customer is owed three different sentences about.
+        expiresAt:
+          type: string
+          format: date-time
+          nullable: true
+          description: >
+            SINGLE_USE only: when the card stops being usable even if never presented. A disposable
+            card that is never spent must still stop being a live PAN.
         expiryDate:
           type: string
           example: "12/27"

--- a/openbank-card-issuance-service/src/test/kotlin/com/openbank/cardissuance/application/usecase/CardPanVaultBackfillTest.kt
+++ b/openbank-card-issuance-service/src/test/kotlin/com/openbank/cardissuance/application/usecase/CardPanVaultBackfillTest.kt
@@ -89,7 +89,12 @@ class CardPanVaultBackfillTest {
 
         assertThat(result.isEmpty).isTrue()
         coVerify(exactly = 0) { repo.storePanCredentialIfAbsent(any(), any(), any()) }
-        assertThat(Card.TERMINAL_STATUSES).containsExactlyInAnyOrder(CardStatus.CANCELLED, CardStatus.EXPIRED)
+        // Pinned on purpose: the backfill provisions a PAN for every non-terminal card, so growing
+        // this set silently would hand a live credential to a card that should be dead. CONSUMED
+        // joined it with the single-use lifecycle (D1) — a card that authorised once and closed
+        // itself must never be re-provisioned.
+        assertThat(Card.TERMINAL_STATUSES)
+            .containsExactlyInAnyOrder(CardStatus.CANCELLED, CardStatus.EXPIRED, CardStatus.CONSUMED)
     }
 
     // Idempotence has two layers: the query only returns NULL rows, and the write re-checks the

--- a/openbank-card-issuance-service/src/test/kotlin/com/openbank/cardissuance/domain/model/SingleUseLifecycleTest.kt
+++ b/openbank-card-issuance-service/src/test/kotlin/com/openbank/cardissuance/domain/model/SingleUseLifecycleTest.kt
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.cardissuance.domain.model
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.time.LocalDate
+import java.util.UUID
+
+class SingleUseLifecycleTest {
+    private val now = Instant.parse("2026-08-07T10:00:00Z")
+
+    private fun card(
+        type: CardType = CardType.SINGLE_USE,
+        status: CardStatus = CardStatus.ACTIVE,
+        expiresAt: Instant? = null,
+    ) = Card(
+        id = UUID.randomUUID(),
+        idempotencyKey = "k",
+        partyId = UUID.randomUUID(),
+        accountId = UUID.randomUUID(),
+        productCode = "P",
+        cardType = type,
+        network = CardNetwork.VISA,
+        maskedPan = "**** 1234",
+        cardholderName = "J R",
+        embossedName = "J R",
+        expiryDate = LocalDate.of(2030, 1, 1),
+        status = status,
+        dailyLimitMinorUnits = 500_000,
+        monthlyLimitMinorUnits = 5_000_000,
+        currency = "CZK",
+        deliveryAddress = null,
+        activatedAt = null,
+        blockedAt = null,
+        blockedReason = null,
+        createdAt = Instant.EPOCH,
+        updatedAt = Instant.EPOCH,
+        expiresAt = expiresAt,
+    )
+
+    @Test
+    fun `a used single-use card becomes CONSUMED with the reason that says so`() {
+        val c = card().consume(now)
+        assertThat(c.status).isEqualTo(CardStatus.CONSUMED)
+        assertThat(c.closedReason).isEqualTo(CardClosedReason.SINGLE_USE_CONSUMED)
+        assertThat(c.updatedAt).isEqualTo(now)
+    }
+
+    @Test
+    fun `CONSUMED is terminal`() {
+        // The whole point: a consumed card must never authorise again, and no transition may
+        // resurrect it.
+        assertThat(Card.TERMINAL_STATUSES).contains(CardStatus.CONSUMED)
+        val consumed = card().consume(now)
+        assertThatThrownBy { consumed.consume(now) }.isInstanceOf(IllegalArgumentException::class.java)
+        assertThatThrownBy { consumed.cancel("x", now) }.isInstanceOf(IllegalArgumentException::class.java)
+    }
+
+    @Test
+    fun `only a single-use card can be consumed`() {
+        // Marking an ordinary debit card CONSUMED would tell the customer a false story about why
+        // it stopped working.
+        for (t in CardType.entries.filter { it != CardType.SINGLE_USE }) {
+            assertThatThrownBy { card(type = t).consume(now) }
+                .describedAs("type %s", t)
+                .isInstanceOf(IllegalArgumentException::class.java)
+        }
+    }
+
+    @Test
+    fun `only an active card can be consumed`() {
+        for (s in CardStatus.entries.filter { it != CardStatus.ACTIVE }) {
+            assertThatThrownBy { card(status = s).consume(now) }
+                .describedAs("status %s", s)
+                .isInstanceOf(IllegalArgumentException::class.java)
+        }
+    }
+
+    @Test
+    fun `an unused card that times out is EXPIRED, not CONSUMED`() {
+        // Nothing was spent. The distinction is exactly what the customer is told, so it must not
+        // collapse into one status.
+        val c = card(expiresAt = now).expireUnused(now)
+        assertThat(c.status).isEqualTo(CardStatus.EXPIRED)
+        assertThat(c.closedReason).isEqualTo(CardClosedReason.VALIDITY_EXPIRED)
+    }
+
+    @Test
+    fun `expiry applies to a card that was never activated`() {
+        // A disposable card issued and never presented is the ordinary case for timing out.
+        val c = card(status = CardStatus.PENDING, expiresAt = now).expireUnused(now)
+        assertThat(c.status).isEqualTo(CardStatus.EXPIRED)
+    }
+
+    @Test
+    fun `a dead card cannot be expired again`() {
+        val consumed = card().consume(now)
+        assertThatThrownBy { consumed.expireUnused(now) }.isInstanceOf(IllegalArgumentException::class.java)
+    }
+
+    @Test
+    fun `a live card carries no closed reason`() {
+        assertThat(card().closedReason).isNull()
+    }
+
+    @Test
+    fun `expiresAt is only meaningful for single-use cards`() {
+        // Nothing enforces this in the type system, so it is stated here: the column stays null for
+        // every other type, and a non-null value on a debit card would be a bug in whatever set it.
+        assertThat(card(type = CardType.DEBIT).expiresAt).isNull()
+    }
+}

--- a/openbank-card-issuance-service/src/test/kotlin/com/openbank/cardissuance/infrastructure/persistence/CardMapperUpdateParityTest.kt
+++ b/openbank-card-issuance-service/src/test/kotlin/com/openbank/cardissuance/infrastructure/persistence/CardMapperUpdateParityTest.kt
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.cardissuance.infrastructure.persistence
+
+import com.openbank.cardissuance.domain.model.Card
+import com.openbank.cardissuance.domain.model.CardClosedReason
+import com.openbank.cardissuance.domain.model.CardNetwork
+import com.openbank.cardissuance.domain.model.CardStatus
+import com.openbank.cardissuance.domain.model.CardType
+import com.openbank.cardissuance.infrastructure.persistence.entity.CardEntity
+import com.openbank.cardissuance.infrastructure.persistence.mapper.applyFrom
+import com.openbank.cardissuance.infrastructure.persistence.mapper.toEntity
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.time.LocalDate
+import java.util.UUID
+import kotlin.reflect.KMutableProperty1
+import kotlin.reflect.full.memberProperties
+
+/**
+ * `CardRepositoryImpl.save` has two halves that write the same table: `toEntity()` on the INSERT
+ * branch and `applyFrom()` on the UPDATE branch. A column set by only one of them is invisible —
+ * the value is written at issue and then silently dropped by every later transition, or never
+ * written at all. That shipped once already: `expiresAt` and `closedReason` were added to
+ * `toEntity()` and not to `applyFrom()`, so `card.consume(now)` would have persisted
+ * `status = CONSUMED` with `closed_reason` still NULL, defeating the whole point of distinguishing
+ * CONSUMED from CANCELLED.
+ *
+ * Asserting those two fields by name would only close the instance. This compares the two paths
+ * over EVERY mutable property by reflection, so a column added to one path and not the other fails
+ * here whether or not anyone remembers this test exists. The exclusion list below is the deliberate
+ * part: those fields are set once at issue and must not move on an update, so adding a column
+ * forces an explicit decision about which side of the line it falls on.
+ */
+class CardMapperUpdateParityTest {
+    /**
+     * Set at issue and immutable thereafter — `applyFrom` deliberately leaves them alone.
+     * `panEncrypted`/`cvvEncrypted` are vault material rotated by their own path, not by a
+     * lifecycle transition.
+     */
+    private val notUpdatable = setOf(
+        "id", "idempotencyKey", "partyId", "accountId", "productCode",
+        "cardType", "network", "createdAt", "panEncrypted", "cvvEncrypted",
+    )
+
+    private fun card(
+        status: CardStatus = CardStatus.CONSUMED,
+        closedReason: CardClosedReason? = CardClosedReason.SINGLE_USE_CONSUMED,
+        expiresAt: Instant? = Instant.parse("2026-04-05T06:07:08Z"),
+        limit: Long = 123_456,
+    ) = Card(
+        id = UUID.randomUUID(),
+        idempotencyKey = "k",
+        partyId = UUID.randomUUID(),
+        accountId = UUID.randomUUID(),
+        productCode = "P",
+        cardType = CardType.SINGLE_USE,
+        network = CardNetwork.VISA,
+        maskedPan = "**** 4321",
+        cardholderName = "J R",
+        embossedName = "J R",
+        expiryDate = LocalDate.of(2031, 3, 1),
+        status = status,
+        dailyLimitMinorUnits = limit,
+        monthlyLimitMinorUnits = 1_234_567,
+        currency = "EUR",
+        deliveryAddress = "Somewhere 1",
+        activatedAt = Instant.parse("2026-01-02T03:04:05Z"),
+        blockedAt = Instant.parse("2026-02-03T04:05:06Z"),
+        blockedReason = "LOST",
+        expiresAt = expiresAt,
+        closedReason = closedReason,
+        createdAt = Instant.parse("2026-01-01T00:00:00Z"),
+        updatedAt = Instant.parse("2026-05-06T07:08:09Z"),
+        contactlessEnabled = false,
+        onlineEnabled = false,
+        atmEnabled = false,
+        abroadEnabled = false,
+        panEncrypted = "pan",
+        cvvEncrypted = "cvv",
+    )
+
+    @Test
+    fun `every updatable column written by toEntity is also written by applyFrom`() {
+        val card = card()
+        val inserted = card.toEntity()
+
+        // A row that disagrees with `card` on every updatable column, so a field the copier forgets
+        // keeps its stale value instead of coincidentally matching.
+        val updated = card(
+            status = CardStatus.ACTIVE,
+            closedReason = null,
+            expiresAt = Instant.parse("2025-11-11T11:11:11Z"),
+            limit = 999,
+        ).toEntity().also { it.id = card.id }
+        updated.applyFrom(card)
+
+        val drifted = CardEntity::class.memberProperties
+            .filterIsInstance<KMutableProperty1<CardEntity, *>>()
+            .filterNot { it.name in notUpdatable }
+            .filter { it.get(updated) != it.get(inserted) }
+            .map { it.name }
+
+        assertThat(drifted)
+            .withFailMessage(
+                "applyFrom() does not write %s, but toEntity() does. A card issued with those " +
+                    "columns keeps the issue-time value through every later transition. Either " +
+                    "copy them in applyFrom(), or add them to notUpdatable with a reason.",
+                drifted,
+            )
+            .isEmpty()
+    }
+}


### PR DESCRIPTION
Server half of D1 from openbank-app#396. Adds terminal status `CONSUMED`, `CardClosedReason`, `expiresAt`, the `consume()`/`expireUnused()` transitions, and migration V9.

`CONSUMED` is deliberately not CANCELLED: "cancelled" currently covers a customer closing a card, a lost card, and a disposable card doing exactly what it promised. One of those is a security signal — "your disposable card was just used" is this product's fraud alarm and must be distinguishable from routine closure.

An unused card that times out becomes EXPIRED / `VALIDITY_EXPIRED`, never CONSUMED — nothing was spent, and the difference is what the customer is told.

`CONSUMED` joins `TERMINAL_STATUSES`, which excludes a card from PAN-vault backfill. `CardPanVaultBackfillTest` pins that set and failed here; updated deliberately with the reasoning, not relaxed.

**Explicitly not included:** the authorize-once guarantee itself, which lives at the card processor. Until that is configured a SINGLE_USE card is a virtual card with a validity window — the status machine is ready, the guarantee is not. Noted in the threat model §4b so nobody ships "authorises once" copy on the strength of this.

8 lifecycle tests; service tests, detekt and ktlint green locally.