### PR TITLE
fix(libs): disable the OIDC tenant in tests, not the extension, so JsonWebToken survives

### DIFF
--- a/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/FinrepBootSmokeTest.kt
+++ b/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/FinrepBootSmokeTest.kt
@@ -54,4 +54,35 @@ class FinrepBootSmokeTest {
         assertThat(config.getValue("openbank.service.port", Int::class.javaObjectType))
             .isEqualTo(8140)
     }
+
+    /**
+     * The base file must keep OIDC's *tenant* disabled in tests, never the extension itself.
+     *
+     * This assertion exists because the difference is invisible from finrep, which injects no
+     * `JsonWebToken`, and catastrophic elsewhere: `quarkus.oidc.enabled=false` removes the
+     * `JsonWebToken` bean, so every module whose resource takes one as a constructor parameter
+     * fails CDI validation and its whole `@QuarkusTest` refuses to boot. That is what the first
+     * version of this base file did to campaign-service and mcp-service, and nothing here or in CI
+     * noticed — path-scoped builds do not rebuild a service whose files did not change, so a base
+     * yaml edit is exactly the change that ships without their tests running.
+     *
+     * Asserting the absence of `enabled=false` rather than only the presence of
+     * `tenant-enabled=false` is the point: the two are different properties, so a service setting
+     * one does not override the other, and re-adding the hard switch here would break those modules
+     * again while this file still looked correct.
+     */
+    @Test
+    fun `the base file disables the OIDC tenant in tests, and never the extension itself`() {
+        val config = ConfigProvider.getConfig()
+
+        assertThat(config.getValue("quarkus.oidc.tenant-enabled", Boolean::class.javaObjectType))
+            .describedAs("tests must not reach Keycloak")
+            .isFalse()
+        assertThat(config.getOptionalValue("quarkus.oidc.enabled", Boolean::class.javaObjectType).orElse(true))
+            .describedAs(
+                "quarkus.oidc.enabled=false removes the JsonWebToken bean fleet-wide — every service " +
+                    "whose resource injects one then fails CDI validation and cannot boot its tests",
+            )
+            .isTrue()
+    }
 }

--- a/openbank-libs-runtime/src/main/resources/application.yaml
+++ b/openbank-libs-runtime/src/main/resources/application.yaml
@@ -28,4 +28,20 @@ quarkus:
 "%test":
   quarkus:
     oidc:
-      enabled: false
+      # `tenant-enabled: false`, NEVER `enabled: false`. Both stop a test JVM talking to Keycloak,
+      # and only one of them keeps the JsonWebToken bean: disabling the extension outright removes
+      # it, so every bean that injects one fails CDI validation and the whole @QuarkusTest of that
+      # module refuses to boot with `UnsatisfiedResolutionException`.
+      #
+      # This file is on the classpath of every service, which is what makes the distinction
+      # load-bearing rather than academic. A service carrying its own `enabled: false` overrides
+      # this and is unaffected — 51 of 57 do. The rest inherit whatever is written here, and for
+      # them `enabled: false` was a behaviour change nobody asked for: it broke campaign-service
+      # and mcp-service, whose resources take a JsonWebToken constructor parameter.
+      #
+      # campaign-service's own application.yaml has warned about exactly this since it was written
+      # ("`tenant-enabled: false` and NOT `enabled: false`: turning the extension off removes the
+      # JsonWebToken bean"). The two keys are different properties, so a service-level
+      # `tenant-enabled: false` does not override an inherited `enabled: false` — they simply both
+      # apply, and the harder one wins.
+      tenant-enabled: false


### PR DESCRIPTION
## Summary

The shared base `application.yaml` from #3686 disabled the OIDC **extension** in the test profile. That removes the `JsonWebToken` bean for every service on `openbank-libs-runtime`, so any module whose resource injects one could no longer boot its `@QuarkusTest` suite at all. Switching to `tenant-enabled` keeps tests off Keycloak — the block's only purpose — without removing the bean.

## Type of change

- [ ] feat (new functionality)
- [x] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [ ] docs
- [ ] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change

## Linked issues

Closes #4044
Refs #3686 (the base file this corrects), #3672

## Changes

- `openbank-libs-runtime/.../application.yaml`: `%test` oidc `enabled: false` → `tenant-enabled: false`, with the reasoning inline so the next edit does not undo it.
- `FinrepBootSmokeTest`: asserts both halves — the tenant is off **and** the extension is still on. The second assertion is the load-bearing one and it is written as "not false" rather than only checking `tenant-enabled`, because the two are separate properties.

## Evidence

| revision | `CampaignRestContractIT` |
| --- | --- |
| `ee9708f2c` (before the base file) | passes |
| `06621c299` (main) | `UnsatisfiedResolutionException: JsonWebToken` |
| main + this fix | passes |

Suites run green on this branch: campaign, mcp, finrep, copilot, ap2, customer-edge, ledger. The first two were the confirmed casualties; finrep is the pilot from #3686; ledger is a control from the 51 services that carry their own `enabled: false`, to prove their override still wins.

The new assertion was falsified before being committed — reverting the value to `enabled: false` reddens it:

```
FinrepBootSmokeTest > the base file disables the OIDC tenant in tests, and never the extension itself() FAILED
```

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports).
- [x] Unit tests added/updated.
- [x] Integration tests added/updated (if service boundary involved).
- [ ] Contract tests updated (if public API changed). — N/A, no API change.
- [x] `./gradlew detekt ktlintCheck koverVerify build` passes.
- [x] No new lint warnings.
- [ ] OpenAPI spec regenerated (if REST API changed). — N/A.
- [ ] Flyway migration added + rollback note (if DB changed). — N/A.
- [ ] Avro schema versioned backward-compatibly (if event changed). — N/A.
- [x] Docs updated. — the reasoning lives in the yaml and the test, where the next editor will read it.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings` / `@Suppress`.
- [x] No new third-party dependency.
- [ ] Auth / crypto / payment code changed? — this touches an auth-adjacent **test-profile** switch only. Nothing in a deployed pod changes: `%test` never applies there, and the production OIDC configuration is untouched. It restores the pre-#3686 test posture rather than relaxing anything.
- [ ] PII path changed? — no.
- [ ] Cardholder data path changed? — no.

## Compliance impact

- [x] None

## Rollout / Rollback

- Deployment strategy: rolling; no runtime behaviour change (test profile only).
- Rollback plan: revert. Doing so re-breaks campaign and mcp test boots.
- Data migration reversible: N/A

## Reviewer notes

**Why the original looked safe.** #3686 says the base consolidates a block "services already repeat individually", and for 51 of 57 that is exactly true — their own `enabled: false` overrides it. The sampling was sound; the gap is the six services that had no such block, plus campaign-service, which had deliberately chosen the *other* key.

**Why campaign-service's own setting did not protect it.** `quarkus.oidc.enabled` and `quarkus.oidc.tenant-enabled` are different properties. Setting one does not override the other — both apply, and disabling the extension wins. campaign-service's yaml has warned about precisely this since it was written; the comment was right and nothing enforced it.

**Why CI is green on a broken main.** Path-scoped builds. #3686 touched finrep and libs, so campaign and mcp were never rebuilt and their suites never ran. A base-yaml edit changes every service while triggering almost none of their tests, which makes this class of change worth extra care — it is the "a libs change rebuilds nothing" shape the repo has hit before.

**Production was never affected.** `%test` does not apply in a deployed pod, so this is a broken-tests defect, not an outage. It does mean main has been unbuildable for two services since #3686 merged.
