### PR TITLE
fix(ci): let a provider verification target the DEPLOYED sha, not just the tip

### DIFF
--- a/.github/workflows/_service-ci.yml
+++ b/.github/workflows/_service-ci.yml
@@ -24,6 +24,17 @@ on:
         description: "Service directory, e.g. openbank-ledger-service"
         required: true
         type: string
+      ref:
+        # #3306: a provider verification is published against the sha the build ran on
+        # (-Dpact.provider.version below), and a dispatch runs on the tip of main. On a repo
+        # merging this often the tip is almost never the sha a counterpart has DEPLOYED, so
+        # can-i-deploy asks about a version no verification will ever target. Passing the
+        # deployed sha here makes the verification land where the gate looks. Empty keeps the
+        # previous behaviour exactly: check out whatever ref triggered the run.
+        description: "Commit to check out and publish the verification against. Blank = the triggering ref."
+        required: false
+        default: ""
+        type: string
     secrets:
       PACT_BROKER_PASSWORD:
         # Must be declared here for the caller to pass it explicitly: an undeclared
@@ -125,6 +136,28 @@ jobs:
       # egress at the infra layer (egress-only SG in an isolated VPC, ADR-0027), a
       # stronger control, so the shim is redundant (and unsupported on this host).
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Blank resolves to the triggering ref, so the default path is byte-identical to before.
+          ref: ${{ inputs.ref }}
+          # A verification published for a sha is a claim about code; it must be code that is ON
+          # main, never an arbitrary branch tip. fetch-depth 0 so the ancestry check below can run.
+          fetch-depth: ${{ inputs.ref == '' && 1 || 0 }}
+
+      - name: Refuse a ref that is not an ancestor of main
+        if: inputs.ref != ''
+        env:
+          REF: ${{ inputs.ref }}
+        run: |
+          # Publishing a verification says "this provider version satisfies the consumer contract",
+          # and can-i-deploy then lets a deploy through on it. Allowing an off-main sha would let a
+          # branch that never merged authorise a production deploy, so this is a gate, not a nicety.
+          git fetch --quiet origin main
+          if ! git merge-base --is-ancestor "$REF" origin/main; then
+            echo "::error::$REF is not an ancestor of origin/main. A verification may only be" \
+                 "published for a commit that is on main (#3306)."
+            exit 1
+          fi
+          echo "$REF is on main — publishing the verification against it."
 
       # Resolve GRADLE_USER_HOME by runner class:
       #  - ARC ephemeral (GRADLE_USER_HOME_NODE_CACHE set by arc-runners.tf): node-local
@@ -446,6 +479,9 @@ jobs:
           # Publish provider verification results only from the main push (the SHA
           # auto-deploy will gate on). PR builds verify but don't publish results.
           PUBLISH_RESULTS: ${{ github.ref == 'refs/heads/main' }}
+          # #3306: must be the sha that was CHECKED OUT, not the sha the workflow was dispatched
+          # on — otherwise the verification is published against a commit whose code never ran.
+          PACT_PROVIDER_VERSION: ${{ inputs.ref != '' && inputs.ref || github.sha }}
         run: |
           # Pact Broker config (ADR-0092) is forwarded as -D system properties; the
           # provider build.gradle.kts copies these into the forked test JVM. Empty
@@ -481,7 +517,7 @@ jobs:
             -Dpactbroker.enablePending=true \
             -Dpactbroker.providerBranch="${BRANCH}" \
             -Dpact.verifier.publishResults="${PUBLISH_RESULTS}" \
-            -Dpact.provider.version="${GITHUB_SHA}" \
+            -Dpact.provider.version="${PACT_PROVIDER_VERSION}" \
             -Dpact.provider.branch="${BRANCH}" \
             -Dpact.provider.tag="${BRANCH}"
 
@@ -535,6 +571,9 @@ jobs:
         env:
           BRANCH: ${{ github.head_ref || github.ref_name }}
           PUBLISH_RESULTS: ${{ github.ref == 'refs/heads/main' }}
+          # #3306: must be the sha that was CHECKED OUT, not the sha the workflow was dispatched
+          # on — otherwise the verification is published against a commit whose code never ran.
+          PACT_PROVIDER_VERSION: ${{ inputs.ref != '' && inputs.ref || github.sha }}
         run: |
           ./gradlew :${{ inputs.service }}:koverXmlReport --build-cache --console=plain \
             -Dpactbroker.url="${PACT_BROKER_URL:-}" \
@@ -543,7 +582,7 @@ jobs:
             -Dpactbroker.enablePending=true \
             -Dpactbroker.providerBranch="${BRANCH}" \
             -Dpact.verifier.publishResults="${PUBLISH_RESULTS}" \
-            -Dpact.provider.version="${GITHUB_SHA}" \
+            -Dpact.provider.version="${PACT_PROVIDER_VERSION}" \
             -Dpact.provider.branch="${BRANCH}" \
             -Dpact.provider.tag="${BRANCH}"
 

--- a/.github/workflows/verify-provider.yml
+++ b/.github/workflows/verify-provider.yml
@@ -16,6 +16,16 @@ on:
         description: "Provider service dir, e.g. openbank-swift-service"
         required: true
         type: string
+      ref:
+        # #3306: without this the verification is always published against the tip of main, while
+        # can-i-deploy asks about the version the counterpart has DEPLOYED. On a repo merging this
+        # often those are different shas nearly always, so a consumer can be blocked indefinitely
+        # with no move available. Pass the deployed sha to publish where the gate actually looks.
+        # Must be on main — _service-ci.yml refuses anything else.
+        description: "Commit to verify and publish against, e.g. a counterpart's deployed sha. Blank = tip of main."
+        required: false
+        default: ""
+        type: string
 
 permissions:
   contents: read
@@ -47,7 +57,7 @@ permissions:
 # assumption to avoid re-making: "superseding is free" is only true when the thing being
 # superseded was making progress.
 concurrency:
-  group: verify-provider-${{ inputs.service }}
+  group: verify-provider-${{ inputs.service }}-${{ inputs.ref }}
   cancel-in-progress: false
 
 jobs:
@@ -55,5 +65,6 @@ jobs:
     uses: ./.github/workflows/_service-ci.yml
     with:
       service: ${{ inputs.service }}
+      ref: ${{ inputs.ref }}
     secrets:
       PACT_BROKER_PASSWORD: ${{ secrets.PACT_BROKER_PASSWORD }}


### PR DESCRIPTION
## The bug

`can-i-deploy` asks whether the consumer's pact is verified against the provider version
**currently deployed**. A verification is published against the sha its build ran on, and every
lane that produces one runs on the tip of `main`. On a repo merging this often, those two shas are
different nearly always — so a consumer can be blocked with no move available to anyone.

## Measured today

`openbank-delegation-service` spent the entire day undeployable. Money-path; the pod is on
`sandbox-6261040e` while `main` advanced hundreds of commits. Four lanes, four different refusals:

| lane | why it cannot close the gap |
| --- | --- |
| `auto-deploy` `workflow_dispatch` | `NOT_ASKED` — builds **the tip**, where delegation published nothing (no recent commit touches it) |
| re-run the push-lane deploy at `841d20e7` (a sha that *does* carry delegation's pacts) | still blocked — the counterparts' **deployed** versions carry no verification |
| `services-ci` full-fleet dispatch | queued over an hour behind the ARC pool (#2039) while `main` advanced twice; even on success it verifies a sha that is no longer current |
| `verify-provider.yml` | **cannot help by construction** — took only a `service` input and ran on `main`, so it always published against the tip |

That last row is this issue restated as a workflow signature, and is why I fixed it rather than
working around it a fifth time.

## The change

`verify-provider.yml` and `_service-ci.yml` take an optional `ref`. It drives **both** the checkout
and `-Dpact.provider.version`, which had been hardcoded to `GITHUB_SHA` — i.e. publishing against a
commit whose code did not necessarily run. Blank keeps today's behaviour byte-for-byte.

So the fix for a stuck consumer becomes: dispatch `verify-provider` for the blocking provider with
`ref` = the sha that provider currently has deployed. The verification then lands where the gate
looks.

**The ref must be an ancestor of `origin/main`, enforced in the workflow.** This is the part worth
reviewing carefully: publishing a verification is what lets `can-i-deploy` release a deploy, so an
off-main sha would let a branch that never merged authorise one. It is a gate, not input validation.

Concurrency is now keyed on the ref too — two dispatches for the same provider at different shas are
different work, and the old group would have collapsed one away silently.

## Verification

- The ancestry guard was falsified **in both directions**, using the script **extracted from the
  YAML** rather than a retyped copy: a sha on `main` exits 0, an off-main commit exits 1 with the
  error. (A transcription is a different program — that mistake is already in this repo's notes.)
- `actionlint` clean on both files; both parse.
- `check-workflow-run-step-size`: 18955 chars, unchanged from `main` — the largest step is not one
  of these two files. Worth flagging separately that the ceiling is 19000, so there is 45 chars of
  headroom somewhere else in the tree.

**Not verified, and it cannot be pre-merge:** the publish path itself. `verify-provider` only
publishes when `github.ref` is `refs/heads/main`, so the first real exercise is a dispatch after
this lands. The default path is unchanged, so the blast radius of being wrong is confined to the new
input.

## Linked issues

Closes #3306. Refs #2039, #3223.
