### PR TITLE
ci(app-status): scope the dossier check to drift a PR could have caused

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -450,12 +450,51 @@ jobs:
       APP_RO_TOKEN: ${{ secrets.OPENBANK_APP_RO_TOKEN }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      # Does THIS PR touch the dossier or its generator?
+      #
+      # Drift between the committed app-status.json and openbank-app's source is caused by
+      # openbank-app SHIPPING, never by a PR here. Comparing on every PR therefore reports a
+      # real defect to whoever happened to open one next: measured 2026-08-07, openbank-app
+      # released three times in twelve hours (0.16.1, 0.17.0, 0.18.0) against a daily refresh
+      # tick, and 10 of 55 open PRs were red on a file none of them touched. It has recurred
+      # five times in six days (#3212, #3552, #3818, #2101, #3053 — all closed by regenerating).
+      #
+      # Freshness is already owned, and already loud: app-status-refresh.yml regenerates daily
+      # and opens its own PR (#3747, #3867, #3917, #3952 are those PRs). What that job CANNOT
+      # see is a PR that hand-edits app-status.json or changes the generator — which is exactly
+      # what stays checked below. So this narrows the scope to the only drift a PR can author,
+      # and loses no coverage (#3988).
+      #
+      # The JOB stays unconditional on purpose. A gate behind a conditional job is absent
+      # rather than skipped, the aggregate check goes green, and nothing says a gate was not
+      # consulted (#3629). Only the comparison is scoped; the context always reports.
+      - name: Could this PR have caused drift
+        id: scope
+        shell: bash
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          set -euo pipefail
+          git fetch origin "${BASE_REF}:refs/remotes/origin/${BASE_REF}" --no-tags
+          N=$(git diff --name-only "origin/${BASE_REF}...HEAD" -- \
+                openbank-admin-ui/app-status.json \
+                openbank-admin-ui/scripts/generate-app-status.mjs | wc -l | tr -d ' ')
+          echo "owns=$( [ "$N" -gt 0 ] && echo true || echo false )" >> "$GITHUB_OUTPUT"
+          echo "files this PR changes in the dossier's own scope: $N"
+
+      - name: Not this PR's drift
+        if: steps.scope.outputs.owns == 'false'
+        run: |
+          echo "::notice title=app-status::This PR touches neither app-status.json nor its generator, so it cannot have caused dossier drift. Freshness against openbank-app is owned by app-status-refresh.yml, which opens its own regeneration PR (#3988)."
 
       # Read-only checkout of the customer-app source so the generator can derive
       # facts (AppConfig.kt + version.txt + app-status.yaml). openbank-app pins no
       # ref → its default branch, the published state the committed copy should match.
       - name: Checkout customer-app source
-        if: env.APP_RO_TOKEN != ''
+        if: env.APP_RO_TOKEN != '' && steps.scope.outputs.owns == 'true'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: JiRaska/openbank-app
@@ -468,7 +507,7 @@ jobs:
         run: echo "::notice title=app-status::OPENBANK_APP_RO_TOKEN not set — skipping customer-app dossier content check (ADR-0074)."
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        if: env.APP_RO_TOKEN != ''
+        if: env.APP_RO_TOKEN != '' && steps.scope.outputs.owns == 'true'
         with:
           # Matches the runtime image (openbank-admin-ui/Dockerfile: node:26-alpine). Pinned at 20
           # it was three majors behind what ships, and #3569's jsdom bump made that fatal:
@@ -481,7 +520,7 @@ jobs:
           cache-dependency-path: openbank-admin-ui/package-lock.json
 
       - name: Install (admin-ui, for the yaml parser)
-        if: env.APP_RO_TOKEN != ''
+        if: env.APP_RO_TOKEN != '' && steps.scope.outputs.owns == 'true'
         working-directory: openbank-admin-ui
         run: npm ci --no-audit --no-fund
 
@@ -495,7 +534,7 @@ jobs:
       # This step carried a comment claiming pipefail propagation for as long as it has existed, so
       # the check was documented as enforcing, believed to be enforcing, and was not (#3053).
       - name: Regenerate & diff derived block
-        if: env.APP_RO_TOKEN != ''
+        if: env.APP_RO_TOKEN != '' && steps.scope.outputs.owns == 'true'
         working-directory: openbank-admin-ui
         shell: bash
         run: |
@@ -508,7 +547,7 @@ jobs:
 
       # Sticky PR comment ONLY when drift is detected, so a clean PR stays quiet.
       - name: Comment on drift
-        if: env.APP_RO_TOKEN != ''
+        if: env.APP_RO_TOKEN != '' && steps.scope.outputs.owns == 'true'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |


### PR DESCRIPTION
## Linked issues

Closes #3988

## What is wrong

`Customer-app dossier` regenerates `app-status.json` from `openbank-app`'s source and fails on drift — on **every** pull request.

That drift is caused by `openbank-app` shipping. It is never caused by a PR in this repository. So the check reports a real defect to whoever happened to open a PR next.

Measured 2026-08-07:

```
openbank-app releases      0.16.1  08-06 14:42
                           0.17.0  08-06 22:22
                           0.18.0  08-07 03:01      three in ~12 h
open-bank-oss refresh      cron "37 4 * * *"        once daily

result                     10 of 55 open PRs red on a file none of them touched
```

The class has recurred five times in six days. Each recurrence got its own issue, was fixed by regenerating, and was closed — so it reads as solved five times over:

```
#3212  #3552  #3818  #2101  #3053     all CLOSED
```

Regenerations on `main`, all the same edit:

```
08-01 22:15   08-03 06:09   08-05 11:44   08-06 11:09   08-06 16:48   08-07 06:48
```

## Why this loses no coverage

Freshness is already owned, and already loud. `app-status-refresh.yml` regenerates daily and **opens its own PR** on drift — #3747, #3867, #3917 and #3952 are those PRs. The automation is not broken; its cadence simply differs from `openbank-app`'s by an order of magnitude.

What that scheduled job cannot see is a PR that hand-edits `app-status.json` or changes `generate-app-status.mjs`. That is precisely what stays checked here.

So the split is: drift the PR could have authored → checked at PR time; drift the PR cannot have authored → checked on a schedule, by a job that fails on its own behalf and raises a PR someone can merge.

This does not weaken what #3053 established. That issue's point was that advisory-over-generated makes drift *mergeable*. Nothing here becomes advisory — the comparison still exits 1 on drift, `--enforce` and the `set -o pipefail` are untouched.

## The job stays unconditional

Deliberately. A gate behind a conditional job is **absent**, not skipped: the aggregate check goes green and nothing says a gate was not consulted (#3629, where `check-dockerfile-no-build-stage.py` could not run on a Dockerfile-only PR for exactly this reason).

Only the comparison steps are gated. The `Customer-app dossier` context always reports.

## Verification

Four cases, run in a throwaway worktree against the real tree:

| PR touches | expected `owns` | got |
|---|---|---|
| an unrelated `.rego` (the ten red today) | false | false |
| `openbank-admin-ui/app-status.json` | true | true |
| `openbank-admin-ui/scripts/generate-app-status.mjs` | true | true |
| neither | false | false |

The two `true` cases are the ones that make this worth having — a scoping change that only satisfied the "don't fire" half would have turned the check off rather than aimed it.

Also checked:

```
actionlint      branch 0 findings, main 0 findings — identical sets
YAML            parses; app-status job has 9 steps, 5 scope-guarded
run-step size   largest unchanged at 18955 chars
```

## Two things noticed in passing, not changed here

**`BASE_REF` goes through `env:`** rather than being interpolated into the script. The neighbouring `changes-ui` job still interpolates `github.base_ref` directly. That is not exploitable for a base ref, so it is left alone — but new code should not copy the pattern.

**`auto-deploy.yml`'s `can-i-deploy` step is 18955 chars against a 19000 limit.** That is 45 characters of headroom on a gate whose whole purpose is to stop an oversized `run:` making the workflow unparseable — and the real GitHub ceiling is ~20054, at which point the workflow silently stops existing for everyone. One more comment paragraph in that step is enough. Worth a separate look; this PR does not touch it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
