### PR TITLE
security(engagement): add edge-service-engagement authz policy

### DIFF
--- a/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/infrastructure/rest/SurfaceResource.kt
+++ b/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/infrastructure/rest/SurfaceResource.kt
@@ -10,6 +10,8 @@ import com.openbank.engagement.domain.model.EngagementEvent
 import com.openbank.engagement.domain.model.EngagementEventType
 import com.openbank.engagement.domain.model.SurfaceContent
 import com.openbank.engagement.domain.model.SurfaceSlot
+import com.openbank.libs.authz.Authorize
+import jakarta.annotation.security.RolesAllowed
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.ws.rs.GET
 import jakarta.ws.rs.POST
@@ -21,13 +23,10 @@ import java.time.Instant
 import java.util.UUID
 
 /**
- * The app-facing surface API (ADR-0220 D1/D2). No `@Authorize` policy exists yet for these two
- * actions in the shared `rest.rego` (`openbank-libs/governance/rules.yaml`-derived OPA bundle):
- * editing that file restamps every service's OPA bundle fleet-wide (per this repo's own
- * documented gitops footguns), which is exactly the kind of cross-cutting infra change kept out
- * of this PR alongside the Dockerfile and gitops manifests. Until that rule lands, an OPA sidecar
- * with `AUTHZ_ENFORCE=true` denies both endpoints by the policy's own `default allow := false` —
- * fail-closed, not fail-open, so this gap cannot leak data in the meantime.
+ * The app-facing surface API (ADR-0220 D1/D2), reached through the customer edge
+ * (`edge-service-engagement` in `openbank-libs/governance/policies/rest.rego`) — the edge
+ * injects the caller's authoritative partyId, so a client-supplied partyId never reaches this
+ * service on its own authority.
  */
 @Path("/api/v1/surfaces")
 @ApplicationScoped
@@ -35,6 +34,8 @@ class SurfaceResource(private val resolve: ResolveSurfaceUseCase, private val re
 
     @GET
     @Path("/{slot}")
+    @RolesAllowed("ROLE_OPERATOR", "ROLE_API", "ROLE_ADMIN")
+    @Authorize(action = "engagement.surface.read", resource = "#partyId")
     suspend fun get(@PathParam("slot") slotName: String, @QueryParam("partyId") partyId: UUID?): Response {
         partyId ?: return badRequest("partyId query parameter is required")
         val slot = parseSlot(slotName) ?: return badRequest("unknown slot '$slotName'")
@@ -57,6 +58,8 @@ class SurfaceResource(private val resolve: ResolveSurfaceUseCase, private val re
 
     @POST
     @Path("/events")
+    @RolesAllowed("ROLE_OPERATOR", "ROLE_API", "ROLE_ADMIN")
+    @Authorize(action = "engagement.surface.recordEvent", resource = "#request.partyId")
     suspend fun postEvent(request: EngagementEventRequest): Response {
         val slot = parseSlot(request.slot) ?: return badRequest("unknown slot '${request.slot}'")
         val type = EngagementEventType.entries.find { it.name == request.type }

--- a/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: account-service
     app.kubernetes.io/part-of: accounts
   annotations:
-    openbank.tech/policy-checksum: "d82f62f8a6a61090"
+    openbank.tech/policy-checksum: "c9ff7d84132ee243"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -306,6 +306,18 @@ data:
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
     	input.action in {"consent.list", "consent.revoke"}
+    }
+
+    # The customer-edge proxying the app's in-app engagement surfaces (ADR-0220 D1): the app
+    # resolves what to show in a slot and records the customer's reaction to it. Same edge
+    # principal and same guard as edge-service-consent — the edge injects the caller's
+    # authoritative partyId from the JWT, so a client-supplied partyId never reaches
+    # engagement-service on its own authority. Scoped to the two exact actions the app uses —
+    # NOT an `engagement.` family — least privilege, matching edge-service-consent's shape.
+    allowed_reasons contains "edge-service-engagement" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action in {"engagement.surface.read", "engagement.surface.recordEvent"}
     }
 
     # The customer-edge proxying the app's privacy centre: a customer reads their OWN access log

--- a/openbank-infra/gitops/components/accounts/account-service.yaml
+++ b/openbank-infra/gitops/components/accounts/account-service.yaml
@@ -37,7 +37,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-account-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "d82f62f8a6a61090"
+        openbank.tech/policy-checksum: "c9ff7d84132ee243"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/aml/aml-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/aml/aml-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: aml-service
     app.kubernetes.io/part-of: aml
   annotations:
-    openbank.tech/policy-checksum: "cf4821f6fd8dec68"
+    openbank.tech/policy-checksum: "ed641f074d80d006"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -306,6 +306,18 @@ data:
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
     	input.action in {"consent.list", "consent.revoke"}
+    }
+
+    # The customer-edge proxying the app's in-app engagement surfaces (ADR-0220 D1): the app
+    # resolves what to show in a slot and records the customer's reaction to it. Same edge
+    # principal and same guard as edge-service-consent — the edge injects the caller's
+    # authoritative partyId from the JWT, so a client-supplied partyId never reaches
+    # engagement-service on its own authority. Scoped to the two exact actions the app uses —
+    # NOT an `engagement.` family — least privilege, matching edge-service-consent's shape.
+    allowed_reasons contains "edge-service-engagement" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action in {"engagement.surface.read", "engagement.surface.recordEvent"}
     }
 
     # The customer-edge proxying the app's privacy centre: a customer reads their OWN access log

--- a/openbank-infra/gitops/components/aml/aml-service.yaml
+++ b/openbank-infra/gitops/components/aml/aml-service.yaml
@@ -31,7 +31,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-aml-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "cf4821f6fd8dec68"
+        openbank.tech/policy-checksum: "ed641f074d80d006"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: anacredit-service
     app.kubernetes.io/part-of: anacredit
   annotations:
-    openbank.tech/policy-checksum: "0bad21e7a390cdb2"
+    openbank.tech/policy-checksum: "bea7a2cde61d8dcc"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -306,6 +306,18 @@ data:
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
     	input.action in {"consent.list", "consent.revoke"}
+    }
+
+    # The customer-edge proxying the app's in-app engagement surfaces (ADR-0220 D1): the app
+    # resolves what to show in a slot and records the customer's reaction to it. Same edge
+    # principal and same guard as edge-service-consent — the edge injects the caller's
+    # authoritative partyId from the JWT, so a client-supplied partyId never reaches
+    # engagement-service on its own authority. Scoped to the two exact actions the app uses —
+    # NOT an `engagement.` family — least privilege, matching edge-service-consent's shape.
+    allowed_reasons contains "edge-service-engagement" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action in {"engagement.surface.read", "engagement.surface.recordEvent"}
     }
 
     # The customer-edge proxying the app's privacy centre: a customer reads their OWN access log

--- a/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
@@ -42,7 +42,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-anacredit-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "0bad21e7a390cdb2"
+        openbank.tech/policy-checksum: "bea7a2cde61d8dcc"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/ap2/ap2-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/ap2/ap2-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: mcp-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "495f4aaec4237b8f"
+    openbank.tech/policy-checksum: "ad770789e1de5197"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -306,6 +306,18 @@ data:
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
     	input.action in {"consent.list", "consent.revoke"}
+    }
+
+    # The customer-edge proxying the app's in-app engagement surfaces (ADR-0220 D1): the app
+    # resolves what to show in a slot and records the customer's reaction to it. Same edge
+    # principal and same guard as edge-service-consent — the edge injects the caller's
+    # authoritative partyId from the JWT, so a client-supplied partyId never reaches
+    # engagement-service on its own authority. Scoped to the two exact actions the app uses —
+    # NOT an `engagement.` family — least privilege, matching edge-service-consent's shape.
+    allowed_reasons contains "edge-service-engagement" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action in {"engagement.surface.read", "engagement.surface.recordEvent"}
     }
 
     # The customer-edge proxying the app's privacy centre: a customer reads their OWN access log

--- a/openbank-infra/gitops/components/ap2/ap2-service.yaml
+++ b/openbank-infra/gitops/components/ap2/ap2-service.yaml
@@ -39,7 +39,7 @@ spec:
       annotations:
         # Roll the pod when the OPA policy bundle changes (subPath mounts don't hot-reload).
         # Kept in sync by gen-ap2-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "495f4aaec4237b8f"
+        openbank.tech/policy-checksum: "ad770789e1de5197"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/audit/audit-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/audit/audit-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: audit-service
     app.kubernetes.io/part-of: audit
   annotations:
-    openbank.tech/policy-checksum: "b16cada983078cfb"
+    openbank.tech/policy-checksum: "2afe814b2a70aa65"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -306,6 +306,18 @@ data:
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
     	input.action in {"consent.list", "consent.revoke"}
+    }
+
+    # The customer-edge proxying the app's in-app engagement surfaces (ADR-0220 D1): the app
+    # resolves what to show in a slot and records the customer's reaction to it. Same edge
+    # principal and same guard as edge-service-consent — the edge injects the caller's
+    # authoritative partyId from the JWT, so a client-supplied partyId never reaches
+    # engagement-service on its own authority. Scoped to the two exact actions the app uses —
+    # NOT an `engagement.` family — least privilege, matching edge-service-consent's shape.
+    allowed_reasons contains "edge-service-engagement" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action in {"engagement.surface.read", "engagement.surface.recordEvent"}
     }
 
     # The customer-edge proxying the app's privacy centre: a customer reads their OWN access log

--- a/openbank-infra/gitops/components/audit/audit-service.yaml
+++ b/openbank-infra/gitops/components/audit/audit-service.yaml
@@ -31,7 +31,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-audit-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "b16cada983078cfb"
+        openbank.tech/policy-checksum: "2afe814b2a70aa65"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: balance-service
     app.kubernetes.io/part-of: balances
   annotations:
-    openbank.tech/policy-checksum: "32a43e1487b92cc1"
+    openbank.tech/policy-checksum: "5e1010e19f9165d7"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -306,6 +306,18 @@ data:
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
     	input.action in {"consent.list", "consent.revoke"}
+    }
+
+    # The customer-edge proxying the app's in-app engagement surfaces (ADR-0220 D1): the app
+    # resolves what to show in a slot and records the customer's reaction to it. Same edge
+    # principal and same guard as edge-service-consent — the edge injects the caller's
+    # authoritative partyId from the JWT, so a client-supplied partyId never reaches
+    # engagement-service on its own authority. Scoped to the two exact actions the app uses —
+    # NOT an `engagement.` family — least privilege, matching edge-service-consent's shape.
+    allowed_reasons contains "edge-service-engagement" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action in {"engagement.surface.read", "engagement.surface.recordEvent"}
     }
 
     # The customer-edge proxying the app's privacy centre: a customer reads their OWN access log

--- a/openbank-infra/gitops/components/balances/balance-service.yaml
+++ b/openbank-infra/gitops/components/balances/balance-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-balance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "32a43e1487b92cc1"
+        openbank.tech/policy-checksum: "5e1010e19f9165d7"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: billing-service
     app.kubernetes.io/part-of: billing
   annotations:
-    openbank.tech/policy-checksum: "fcb7f5c4c84e1fa1"
+    openbank.tech/policy-checksum: "458495239f8c9166"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -306,6 +306,18 @@ data:
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
     	input.action in {"consent.list", "consent.revoke"}
+    }
+
+    # The customer-edge proxying the app's in-app engagement surfaces (ADR-0220 D1): the app
+    # resolves what to show in a slot and records the customer's reaction to it. Same edge
+    # principal and same guard as edge-service-consent — the edge injects the caller's
+    # authoritative partyId from the JWT, so a client-supplied partyId never reaches
+    # engagement-service on its own authority. Scoped to the two exact actions the app uses —
+    # NOT an `engagement.` family — least privilege, matching edge-service-consent's shape.
+    allowed_reasons contains "edge-service-engagement" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action in {"engagement.surface.read", "engagement.surface.recordEvent"}
     }
 
     # The customer-edge proxying the app's privacy centre: a customer reads their OWN access log

--- a/openbank-infra/gitops/components/billing/billing-service.yaml
+++ b/openbank-infra/gitops/components/billing/billing-service.yaml
@@ -36,7 +36,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-billing-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "fcb7f5c4c84e1fa1"
+        openbank.tech/policy-checksum: "458495239f8c9166"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/campaign/campaign-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/campaign/campaign-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: campaign-service
     app.kubernetes.io/part-of: campaign
   annotations:
-    openbank.tech/policy-checksum: "4cccadaf273c26e4"
+    openbank.tech/policy-checksum: "a04fc342743c8bd9"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -306,6 +306,18 @@ data:
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
     	input.action in {"consent.list", "consent.revoke"}
+    }
+
+    # The customer-edge proxying the app's in-app engagement surfaces (ADR-0220 D1): the app
+    # resolves what to show in a slot and records the customer's reaction to it. Same edge
+    # principal and same guard as edge-service-consent — the edge injects the caller's
+    # authoritative partyId from the JWT, so a client-supplied partyId never reaches
+    # engagement-service on its own authority. Scoped to the two exact actions the app uses —
+    # NOT an `engagement.` family — least privilege, matching edge-service-consent's shape.
+    allowed_reasons contains "edge-service-engagement" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action in {"engagement.surface.read", "engagement.surface.recordEvent"}
     }
 
     # The customer-edge proxying the app's privacy centre: a customer reads their OWN access log

--- a/openbank-infra/gitops/components/campaign/campaign-service.yaml
+++ b/openbank-infra/gitops/components/campaign/campaign-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-campaign-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "4cccadaf273c26e4"
+        openbank.tech/policy-checksum: "a04fc342743c8bd9"
       labels:
         app.kubernetes.io/name: campaign-service
         app.kubernetes.io/part-of: campaign

--- a/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: consent-service
     app.kubernetes.io/part-of: consent
   annotations:
-    openbank.tech/policy-checksum: "a2d376635b5e6dc0"
+    openbank.tech/policy-checksum: "1adb550684f19972"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -306,6 +306,18 @@ data:
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
     	input.action in {"consent.list", "consent.revoke"}
+    }
+
+    # The customer-edge proxying the app's in-app engagement surfaces (ADR-0220 D1): the app
+    # resolves what to show in a slot and records the customer's reaction to it. Same edge
+    # principal and same guard as edge-service-consent — the edge injects the caller's
+    # authoritative partyId from the JWT, so a client-supplied partyId never reaches
+    # engagement-service on its own authority. Scoped to the two exact actions the app uses —
+    # NOT an `engagement.` family — least privilege, matching edge-service-consent's shape.
+    allowed_reasons contains "edge-service-engagement" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action in {"engagement.surface.read", "engagement.surface.recordEvent"}
     }
 
     # The customer-edge proxying the app's privacy centre: a customer reads their OWN access log

--- a/openbank-infra/gitops/components/consent/consent-service.yaml
+++ b/openbank-infra/gitops/components/consent/consent-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-consent-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "a2d376635b5e6dc0"
+        openbank.tech/policy-checksum: "1adb550684f19972"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: copilot-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "b129b6f88e7dcb4a"
+    openbank.tech/policy-checksum: "193bfe0898e3ef53"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -306,6 +306,18 @@ data:
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
     	input.action in {"consent.list", "consent.revoke"}
+    }
+
+    # The customer-edge proxying the app's in-app engagement surfaces (ADR-0220 D1): the app
+    # resolves what to show in a slot and records the customer's reaction to it. Same edge
+    # principal and same guard as edge-service-consent — the edge injects the caller's
+    # authoritative partyId from the JWT, so a client-supplied partyId never reaches
+    # engagement-service on its own authority. Scoped to the two exact actions the app uses —
+    # NOT an `engagement.` family — least privilege, matching edge-service-consent's shape.
+    allowed_reasons contains "edge-service-engagement" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action in {"engagement.surface.read", "engagement.surface.recordEvent"}
     }
 
     # The customer-edge proxying the app's privacy centre: a customer reads their OWN access log

--- a/openbank-infra/gitops/components/copilot/copilot-service.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-service.yaml
@@ -39,7 +39,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-copilot-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "b129b6f88e7dcb4a"
+        openbank.tech/policy-checksum: "193bfe0898e3ef53"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: customer-edge
     app.kubernetes.io/part-of: customer-edge
   annotations:
-    openbank.tech/policy-checksum: "af2491131f1b36de"
+    openbank.tech/policy-checksum: "207d5deced0ca13e"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -307,6 +307,18 @@ data:
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
     	input.action in {"consent.list", "consent.revoke"}
+    }
+
+    # The customer-edge proxying the app's in-app engagement surfaces (ADR-0220 D1): the app
+    # resolves what to show in a slot and records the customer's reaction to it. Same edge
+    # principal and same guard as edge-service-consent — the edge injects the caller's
+    # authoritative partyId from the JWT, so a client-supplied partyId never reaches
+    # engagement-service on its own authority. Scoped to the two exact actions the app uses —
+    # NOT an `engagement.` family — least privilege, matching edge-service-consent's shape.
+    allowed_reasons contains "edge-service-engagement" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action in {"engagement.surface.read", "engagement.surface.recordEvent"}
     }
 
     # The customer-edge proxying the app's privacy centre: a customer reads their OWN access log

--- a/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
@@ -65,7 +65,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-customer-edge-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "af2491131f1b36de"
+        openbank.tech/policy-checksum: "207d5deced0ca13e"
     spec:
       # Dedicated SA so EKS Pod Identity can hand the edge (and ONLY the edge) the
       # feedback-screenshots S3 role — ADR-0192, openbank-infra/aws/envs/sandbox-platform/

--- a/openbank-infra/gitops/components/delegation/delegation-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/delegation/delegation-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: delegation-service
     app.kubernetes.io/part-of: delegation
   annotations:
-    openbank.tech/policy-checksum: "d6648acfcca231eb"
+    openbank.tech/policy-checksum: "5a9e3709cc8001a5"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -306,6 +306,18 @@ data:
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
     	input.action in {"consent.list", "consent.revoke"}
+    }
+
+    # The customer-edge proxying the app's in-app engagement surfaces (ADR-0220 D1): the app
+    # resolves what to show in a slot and records the customer's reaction to it. Same edge
+    # principal and same guard as edge-service-consent — the edge injects the caller's
+    # authoritative partyId from the JWT, so a client-supplied partyId never reaches
+    # engagement-service on its own authority. Scoped to the two exact actions the app uses —
+    # NOT an `engagement.` family — least privilege, matching edge-service-consent's shape.
+    allowed_reasons contains "edge-service-engagement" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action in {"engagement.surface.read", "engagement.surface.recordEvent"}
     }
 
     # The customer-edge proxying the app's privacy centre: a customer reads their OWN access log

--- a/openbank-infra/gitops/components/delegation/delegation-service.yaml
+++ b/openbank-infra/gitops/components/delegation/delegation-service.yaml
@@ -42,7 +42,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-delegation-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "d6648acfcca231eb"
+        openbank.tech/policy-checksum: "5a9e3709cc8001a5"
       labels:
         app.kubernetes.io/name: delegation-service
         app.kubernetes.io/part-of: delegation

--- a/openbank-infra/gitops/components/dispute-service/dispute-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/dispute-service/dispute-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: dispute-service
     app.kubernetes.io/part-of: dispute
   annotations:
-    openbank.tech/policy-checksum: "86808f0351d1bac2"
+    openbank.tech/policy-checksum: "fe2636be74d71c21"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -306,6 +306,18 @@ data:
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
     	input.action in {"consent.list", "consent.revoke"}
+    }
+
+    # The customer-edge proxying the app's in-app engagement surfaces (ADR-0220 D1): the app
+    # resolves what to show in a slot and records the customer's reaction to it. Same edge
+    # principal and same guard as edge-service-consent — the edge injects the caller's
+    # authoritative partyId from the JWT, so a client-supplied partyId never reaches
+    # engagement-service on its own authority. Scoped to the two exact actions the app uses —
+    # NOT an `engagement.` family — least privilege, matching edge-service-consent's shape.
+    allowed_reasons contains "edge-service-engagement" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action in {"engagement.surface.read", "engagement.surface.recordEvent"}
     }
 
     # The customer-edge proxying the app's privacy centre: a customer reads their OWN access log

--- a/openbank-infra/gitops/components/dispute-service/dispute-service.yaml
+++ b/openbank-infra/gitops/components/dispute-service/dispute-service.yaml
@@ -24,7 +24,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-dispute-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "86808f0351d1bac2"
+        openbank.tech/policy-checksum: "fe2636be74d71c21"
       labels: {app.kubernetes.io/name: dispute-service, app.kubernetes.io/part-of: dispute}
     spec:
       securityContext:

--- a/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: document-service
     app.kubernetes.io/part-of: documents
   annotations:
-    openbank.tech/policy-checksum: "af2491131f1b36de"
+    openbank.tech/policy-checksum: "207d5deced0ca13e"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -307,6 +307,18 @@ data:
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
     	input.action in {"consent.list", "consent.revoke"}
+    }
+
+    # The customer-edge proxying the app's in-app engagement surfaces (ADR-0220 D1): the app
+    # resolves what to show in a slot and records the customer's reaction to it. Same edge
+    # principal and same guard as edge-service-consent — the edge injects the caller's
+    # authoritative partyId from the JWT, so a client-supplied partyId never reaches
+    # engagement-service on its own authority. Scoped to the two exact actions the app uses —
+    # NOT an `engagement.` family — least privilege, matching edge-service-consent's shape.
+    allowed_reasons contains "edge-service-engagement" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action in {"engagement.surface.read", "engagement.surface.recordEvent"}
     }
 
     # The customer-edge proxying the app's privacy centre: a customer reads their OWN access log

--- a/openbank-infra/gitops/components/document-service/document-service-service.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-service.yaml
@@ -52,7 +52,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-document-service-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "af2491131f1b36de"
+        openbank.tech/policy-checksum: "207d5deced0ca13e"
     spec:
       # ADR-0162 D4 (continued): a dedicated SA (not `default`) is what OpenBao's Kubernetes-auth
       # role `document-service-signing` is bound to — least-privilege, one identity per consumer.

--- a/openbank-infra/gitops/components/engagement/engagement-service.yaml
+++ b/openbank-infra/gitops/components/engagement/engagement-service.yaml
@@ -11,9 +11,13 @@
 #     outbox fills, publishes nothing, and no message is silently lost — flipping dispatch on
 #     without also wiring mTLS would just fail every publish attempt, loudly, in the outbox's own
 #     retry/DEAD accounting.
-#   - the OPA sidecar / policy bundle — SurfaceResource carries no @Authorize annotation yet, and
-#     the shared rest.rego has no rule for these two actions, so the platform-wide
-#     `default allow := false` denies them fail-closed under enforcement regardless.
+#   - the OPA sidecar / policy bundle — SurfaceResource now carries @Authorize annotations and
+#     rest.rego has a matching `edge-service-engagement` rule, but no sidecar container is wired
+#     into this Deployment yet (no `gen-engagement-opa-bundle.sh`, unlike lending/pid/sca/etc.).
+#     Same deferred-not-broken shape as the Kafka mTLS gap above: @Authorize's own interceptor
+#     still enforces `@RolesAllowed` at the JAX-RS layer with no sidecar involved, and the
+#     platform's `default allow := false` denies both actions fail-closed the moment enforcement
+#     IS wired in — this just means OPA-level policy isn't consulted yet, not that it's open.
 # Reachable only in-cluster via ClusterIP, no ingress.
 apiVersion: apps/v1
 kind: Deployment

--- a/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fraud-service
     app.kubernetes.io/part-of: fraud
   annotations:
-    openbank.tech/policy-checksum: "1d6e27da662904f3"
+    openbank.tech/policy-checksum: "1cc41b346c7087c9"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -306,6 +306,18 @@ data:
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
     	input.action in {"consent.list", "consent.revoke"}
+    }
+
+    # The customer-edge proxying the app's in-app engagement surfaces (ADR-0220 D1): the app
+    # resolves what to show in a slot and records the customer's reaction to it. Same edge
+    # principal and same guard as edge-service-consent — the edge injects the caller's
+    # authoritative partyId from the JWT, so a client-supplied partyId never reaches
+    # engagement-service on its own authority. Scoped to the two exact actions the app uses —
+    # NOT an `engagement.` family — least privilege, matching edge-service-consent's shape.
+    allowed_reasons contains "edge-service-engagement" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action in {"engagement.surface.read", "engagement.surface.recordEvent"}
     }
 
     # The customer-edge proxying the app's privacy centre: a customer reads their OWN access log

--- a/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
@@ -23,7 +23,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fraud-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "1d6e27da662904f3"
+        openbank.tech/policy-checksum: "1cc41b346c7087c9"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fx-service
     app.kubernetes.io/part-of: fx
   annotations:
-    openbank.tech/policy-checksum: "42cb151bc59fd8fb"
+    openbank.tech/policy-checksum: "70e13eb8de03a7ba"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -306,6 +306,18 @@ data:
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
     	input.action in {"consent.list", "consent.revoke"}
+    }
+
+    # The customer-edge proxying the app's in-app engagement surfaces (ADR-0220 D1): the app
+    # resolves what to show in a slot and records the customer's reaction to it. Same edge
+    # principal and same guard as edge-service-consent — the edge injects the caller's
+    # authoritative partyId from the JWT, so a client-supplied partyId never reaches
+    # engagement-service on its own authority. Scoped to the two exact actions the app uses —
+    # NOT an `engagement.` family — least privilege, matching edge-service-consent's shape.
+    allowed_reasons contains "edge-service-engagement" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action in {"engagement.surface.read", "engagement.surface.recordEvent"}
     }
 
     # The customer-edge proxying the app's privacy centre: a customer reads their OWN access log

--- a/openbank-infra/gitops/components/fx-service/fx-service.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fx-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "42cb151bc59fd8fb"
+        openbank.tech/policy-checksum: "70e13eb8de03a7ba"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: interest-service
     app.kubernetes.io/part-of: interest
   annotations:
-    openbank.tech/policy-checksum: "e4742ff1fd3deca1"
+    openbank.tech/policy-checksum: "3b8a2e1e6a17d189"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -306,6 +306,18 @@ data:
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
     	input.action in {"consent.list", "consent.revoke"}
+    }
+
+    # The customer-edge proxying the app's in-app engagement surfaces (ADR-0220 D1): the app
+    # resolves what to show in a slot and records the customer's reaction to it. Same edge
+    # principal and same guard as edge-service-consent — the edge injects the caller's
+    # authoritative partyId from the JWT, so a client-supplied partyId never reaches
+    # engagement-service on its own authority. Scoped to the two exact actions the app uses —
+    # NOT an `engagement.` family — least privilege, matching edge-service-consent's shape.
+    allowed_reasons contains "edge-service-engagement" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action in {"engagement.surface.read", "engagement.surface.recordEvent"}
     }
 
     # The customer-edge proxying the app's privacy centre: a customer reads their OWN access log

--- a/openbank-infra/gitops/components/interest-service/interest-service.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-service.yaml
@@ -25,7 +25,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-interest-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "e4742ff1fd3deca1"
+        openbank.tech/policy-checksum: "3b8a2e1e6a17d189"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/kyc/kyc-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/kyc/kyc-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: kyc-service
     app.kubernetes.io/part-of: kyc
   annotations:
-    openbank.tech/policy-checksum: "3ac3209b789d0a04"
+    openbank.tech/policy-checksum: "b97bdd521dfd0e38"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -306,6 +306,18 @@ data:
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
     	input.action in {"consent.list", "consent.revoke"}
+    }
+
+    # The customer-edge proxying the app's in-app engagement surfaces (ADR-0220 D1): the app
+    # resolves what to show in a slot and records the customer's reaction to it. Same edge
+    # principal and same guard as edge-service-consent — the edge injects the caller's
+    # authoritative partyId from the JWT, so a client-supplied partyId never reaches
+    # engagement-service on its own authority. Scoped to the two exact actions the app uses —
+    # NOT an `engagement.` family — least privilege, matching edge-service-consent's shape.
+    allowed_reasons contains "edge-service-engagement" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action in {"engagement.surface.read", "engagement.surface.recordEvent"}
     }
 
     # The customer-edge proxying the app's privacy centre: a customer reads their OWN access log

--- a/openbank-infra/gitops/components/kyc/kyc-service.yaml
+++ b/openbank-infra/gitops/components/kyc/kyc-service.yaml
@@ -48,7 +48,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-kyc-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "3ac3209b789d0a04"
+        openbank.tech/policy-checksum: "b97bdd521dfd0e38"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: ledger-service
     app.kubernetes.io/part-of: ledger
   annotations:
-    openbank.tech/policy-checksum: "5f0203cb87c910e3"
+    openbank.tech/policy-checksum: "04f0e48088dedbcb"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -306,6 +306,18 @@ data:
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
     	input.action in {"consent.list", "consent.revoke"}
+    }
+
+    # The customer-edge proxying the app's in-app engagement surfaces (ADR-0220 D1): the app
+    # resolves what to show in a slot and records the customer's reaction to it. Same edge
+    # principal and same guard as edge-service-consent — the edge injects the caller's
+    # authoritative partyId from the JWT, so a client-supplied partyId never reaches
+    # engagement-service on its own authority. Scoped to the two exact actions the app uses —
+    # NOT an `engagement.` family — least privilege, matching edge-service-consent's shape.
+    allowed_reasons contains "edge-service-engagement" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action in {"engagement.surface.read", "engagement.surface.recordEvent"}
     }
 
     # The customer-edge proxying the app's privacy centre: a customer reads their OWN access log

--- a/openbank-infra/gitops/components/ledger/ledger-service.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-service.yaml
@@ -38,7 +38,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-ledger-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "5f0203cb87c910e3"
+        openbank.tech/policy-checksum: "04f0e48088dedbcb"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: lending-service
     app.kubernetes.io/part-of: lending
   annotations:
-    openbank.tech/policy-checksum: "5a76a661b652eda3"
+    openbank.tech/policy-checksum: "c5bfd87224666db7"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -306,6 +306,18 @@ data:
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
     	input.action in {"consent.list", "consent.revoke"}
+    }
+
+    # The customer-edge proxying the app's in-app engagement surfaces (ADR-0220 D1): the app
+    # resolves what to show in a slot and records the customer's reaction to it. Same edge
+    # principal and same guard as edge-service-consent — the edge injects the caller's
+    # authoritative partyId from the JWT, so a client-supplied partyId never reaches
+    # engagement-service on its own authority. Scoped to the two exact actions the app uses —
+    # NOT an `engagement.` family — least privilege, matching edge-service-consent's shape.
+    allowed_reasons contains "edge-service-engagement" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action in {"engagement.surface.read", "engagement.surface.recordEvent"}
     }
 
     # The customer-edge proxying the app's privacy centre: a customer reads their OWN access log

--- a/openbank-infra/gitops/components/lending/lending-service.yaml
+++ b/openbank-infra/gitops/components/lending/lending-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-lending-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "5a76a661b652eda3"
+        openbank.tech/policy-checksum: "c5bfd87224666db7"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/mcp/mcp-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/mcp/mcp-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: mcp-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "495f4aaec4237b8f"
+    openbank.tech/policy-checksum: "ad770789e1de5197"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -306,6 +306,18 @@ data:
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
     	input.action in {"consent.list", "consent.revoke"}
+    }
+
+    # The customer-edge proxying the app's in-app engagement surfaces (ADR-0220 D1): the app
+    # resolves what to show in a slot and records the customer's reaction to it. Same edge
+    # principal and same guard as edge-service-consent — the edge injects the caller's
+    # authoritative partyId from the JWT, so a client-supplied partyId never reaches
+    # engagement-service on its own authority. Scoped to the two exact actions the app uses —
+    # NOT an `engagement.` family — least privilege, matching edge-service-consent's shape.
+    allowed_reasons contains "edge-service-engagement" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action in {"engagement.surface.read", "engagement.surface.recordEvent"}
     }
 
     # The customer-edge proxying the app's privacy centre: a customer reads their OWN access log

--- a/openbank-infra/gitops/components/mcp/mcp-service.yaml
+++ b/openbank-infra/gitops/components/mcp/mcp-service.yaml
@@ -39,7 +39,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-mcp-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "495f4aaec4237b8f"
+        openbank.tech/policy-checksum: "ad770789e1de5197"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: notification-service
     app.kubernetes.io/part-of: notifications
   annotations:
-    openbank.tech/policy-checksum: "af2491131f1b36de"
+    openbank.tech/policy-checksum: "207d5deced0ca13e"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -307,6 +307,18 @@ data:
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
     	input.action in {"consent.list", "consent.revoke"}
+    }
+
+    # The customer-edge proxying the app's in-app engagement surfaces (ADR-0220 D1): the app
+    # resolves what to show in a slot and records the customer's reaction to it. Same edge
+    # principal and same guard as edge-service-consent — the edge injects the caller's
+    # authoritative partyId from the JWT, so a client-supplied partyId never reaches
+    # engagement-service on its own authority. Scoped to the two exact actions the app uses —
+    # NOT an `engagement.` family — least privilege, matching edge-service-consent's shape.
+    allowed_reasons contains "edge-service-engagement" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action in {"engagement.surface.read", "engagement.surface.recordEvent"}
     }
 
     # The customer-edge proxying the app's privacy centre: a customer reads their OWN access log

--- a/openbank-infra/gitops/components/notifications/notification-service.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service.yaml
@@ -48,7 +48,7 @@ spec:
       annotations:
         # Rolls the Deployment when the OPA policy bundle changes (subPath mounts don't
         # hot-reload). Kept in sync by gen-notification-opa-bundle.sh.
-        openbank.tech/policy-checksum: "af2491131f1b36de"
+        openbank.tech/policy-checksum: "207d5deced0ca13e"
       labels:
         app.kubernetes.io/name: notification-service
         app.kubernetes.io/part-of: notifications

--- a/openbank-infra/gitops/components/party/party-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/party/party-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: party-service
     app.kubernetes.io/part-of: party
   annotations:
-    openbank.tech/policy-checksum: "1f15b209b3f624cb"
+    openbank.tech/policy-checksum: "f8a783ed81570dc8"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -306,6 +306,18 @@ data:
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
     	input.action in {"consent.list", "consent.revoke"}
+    }
+
+    # The customer-edge proxying the app's in-app engagement surfaces (ADR-0220 D1): the app
+    # resolves what to show in a slot and records the customer's reaction to it. Same edge
+    # principal and same guard as edge-service-consent — the edge injects the caller's
+    # authoritative partyId from the JWT, so a client-supplied partyId never reaches
+    # engagement-service on its own authority. Scoped to the two exact actions the app uses —
+    # NOT an `engagement.` family — least privilege, matching edge-service-consent's shape.
+    allowed_reasons contains "edge-service-engagement" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action in {"engagement.surface.read", "engagement.surface.recordEvent"}
     }
 
     # The customer-edge proxying the app's privacy centre: a customer reads their OWN access log

--- a/openbank-infra/gitops/components/party/party-service.yaml
+++ b/openbank-infra/gitops/components/party/party-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-party-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "1f15b209b3f624cb"
+        openbank.tech/policy-checksum: "f8a783ed81570dc8"
       labels:
         app.kubernetes.io/name: party-service
         app.kubernetes.io/part-of: party

--- a/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: card-issuance-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "7e600c6823fc1d28"
+    openbank.tech/policy-checksum: "f267ca20ae7606d9"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -306,6 +306,18 @@ data:
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
     	input.action in {"consent.list", "consent.revoke"}
+    }
+
+    # The customer-edge proxying the app's in-app engagement surfaces (ADR-0220 D1): the app
+    # resolves what to show in a slot and records the customer's reaction to it. Same edge
+    # principal and same guard as edge-service-consent — the edge injects the caller's
+    # authoritative partyId from the JWT, so a client-supplied partyId never reaches
+    # engagement-service on its own authority. Scoped to the two exact actions the app uses —
+    # NOT an `engagement.` family — least privilege, matching edge-service-consent's shape.
+    allowed_reasons contains "edge-service-engagement" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action in {"engagement.surface.read", "engagement.surface.recordEvent"}
     }
 
     # The customer-edge proxying the app's privacy centre: a customer reads their OWN access log

--- a/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: clearing-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "7d476c49dfac5ec9"
+    openbank.tech/policy-checksum: "e25e522903a4ef57"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -306,6 +306,18 @@ data:
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
     	input.action in {"consent.list", "consent.revoke"}
+    }
+
+    # The customer-edge proxying the app's in-app engagement surfaces (ADR-0220 D1): the app
+    # resolves what to show in a slot and records the customer's reaction to it. Same edge
+    # principal and same guard as edge-service-consent — the edge injects the caller's
+    # authoritative partyId from the JWT, so a client-supplied partyId never reaches
+    # engagement-service on its own authority. Scoped to the two exact actions the app uses —
+    # NOT an `engagement.` family — least privilege, matching edge-service-consent's shape.
+    allowed_reasons contains "edge-service-engagement" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action in {"engagement.surface.read", "engagement.surface.recordEvent"}
     }
 
     # The customer-edge proxying the app's privacy centre: a customer reads their OWN access log

--- a/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: domestic-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "1b477a08c631ffce"
+    openbank.tech/policy-checksum: "82807f653d0ddbc5"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -306,6 +306,18 @@ data:
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
     	input.action in {"consent.list", "consent.revoke"}
+    }
+
+    # The customer-edge proxying the app's in-app engagement surfaces (ADR-0220 D1): the app
+    # resolves what to show in a slot and records the customer's reaction to it. Same edge
+    # principal and same guard as edge-service-consent — the edge injects the caller's
+    # authoritative partyId from the JWT, so a client-supplied partyId never reaches
+    # engagement-service on its own authority. Scoped to the two exact actions the app uses —
+    # NOT an `engagement.` family — least privilege, matching edge-service-consent's shape.
+    allowed_reasons contains "edge-service-engagement" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action in {"engagement.surface.read", "engagement.surface.recordEvent"}
     }
 
     # The customer-edge proxying the app's privacy centre: a customer reads their OWN access log

--- a/openbank-infra/gitops/components/payments/payments-services.yaml
+++ b/openbank-infra/gitops/components/payments/payments-services.yaml
@@ -42,7 +42,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-transaction-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "7c800f18b73edc61" # transaction-opa-bundle
+        openbank.tech/policy-checksum: "d56f4bd83c15f951" # transaction-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -375,7 +375,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-payment-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "6a7481be8fea262c"
+        openbank.tech/policy-checksum: "cf35d7e824f10c48"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -729,7 +729,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-domestic-payment-opa-bundle.sh via the trailing marker
         # comment (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "1b477a08c631ffce" # domestic-payment-opa-bundle
+        openbank.tech/policy-checksum: "82807f653d0ddbc5" # domestic-payment-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1053,7 +1053,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-instant-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "0451603652418486"
+        openbank.tech/policy-checksum: "d2e709b836e48cfd"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1369,7 +1369,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-clearing-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "7d476c49dfac5ec9" # clearing-opa-bundle
+        openbank.tech/policy-checksum: "e25e522903a4ef57" # clearing-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1667,7 +1667,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (ADR-0034). Value is stamped by
         # gen-standing-order-opa-bundle.sh — do not hand-edit.
-        openbank.tech/policy-checksum: "d5494dbaafb3019a" # standing-order-opa-bundle
+        openbank.tech/policy-checksum: "e30d4d753a025bfc" # standing-order-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1929,7 +1929,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-card-issuance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "7e600c6823fc1d28"
+        openbank.tech/policy-checksum: "f267ca20ae7606d9"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2199,7 +2199,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-settlement-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "f5abcf7008f85299" # settlement-opa-bundle
+        openbank.tech/policy-checksum: "4ff96c65b2221ce5" # settlement-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2614,7 +2614,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-swift-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "e46c26e6a4619427"
+        openbank.tech/policy-checksum: "514debfd4bec0c5c"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2928,7 +2928,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-vop-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "8e96f4ca114b5e4b"
+        openbank.tech/policy-checksum: "9b35cc1fdcfed56f"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-instant
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "0451603652418486"
+    openbank.tech/policy-checksum: "d2e709b836e48cfd"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -306,6 +306,18 @@ data:
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
     	input.action in {"consent.list", "consent.revoke"}
+    }
+
+    # The customer-edge proxying the app's in-app engagement surfaces (ADR-0220 D1): the app
+    # resolves what to show in a slot and records the customer's reaction to it. Same edge
+    # principal and same guard as edge-service-consent — the edge injects the caller's
+    # authoritative partyId from the JWT, so a client-supplied partyId never reaches
+    # engagement-service on its own authority. Scoped to the two exact actions the app uses —
+    # NOT an `engagement.` family — least privilege, matching edge-service-consent's shape.
+    allowed_reasons contains "edge-service-engagement" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action in {"engagement.surface.read", "engagement.surface.recordEvent"}
     }
 
     # The customer-edge proxying the app's privacy centre: a customer reads their OWN access log

--- a/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "6a7481be8fea262c"
+    openbank.tech/policy-checksum: "cf35d7e824f10c48"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -306,6 +306,18 @@ data:
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
     	input.action in {"consent.list", "consent.revoke"}
+    }
+
+    # The customer-edge proxying the app's in-app engagement surfaces (ADR-0220 D1): the app
+    # resolves what to show in a slot and records the customer's reaction to it. Same edge
+    # principal and same guard as edge-service-consent — the edge injects the caller's
+    # authoritative partyId from the JWT, so a client-supplied partyId never reaches
+    # engagement-service on its own authority. Scoped to the two exact actions the app uses —
+    # NOT an `engagement.` family — least privilege, matching edge-service-consent's shape.
+    allowed_reasons contains "edge-service-engagement" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action in {"engagement.surface.read", "engagement.surface.recordEvent"}
     }
 
     # The customer-edge proxying the app's privacy centre: a customer reads their OWN access log

--- a/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: settlement-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "f5abcf7008f85299"
+    openbank.tech/policy-checksum: "4ff96c65b2221ce5"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -306,6 +306,18 @@ data:
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
     	input.action in {"consent.list", "consent.revoke"}
+    }
+
+    # The customer-edge proxying the app's in-app engagement surfaces (ADR-0220 D1): the app
+    # resolves what to show in a slot and records the customer's reaction to it. Same edge
+    # principal and same guard as edge-service-consent — the edge injects the caller's
+    # authoritative partyId from the JWT, so a client-supplied partyId never reaches
+    # engagement-service on its own authority. Scoped to the two exact actions the app uses —
+    # NOT an `engagement.` family — least privilege, matching edge-service-consent's shape.
+    allowed_reasons contains "edge-service-engagement" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action in {"engagement.surface.read", "engagement.surface.recordEvent"}
     }
 
     # The customer-edge proxying the app's privacy centre: a customer reads their OWN access log

--- a/openbank-infra/gitops/components/payments/standing-order-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/standing-order-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: standing-order-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "d5494dbaafb3019a"
+    openbank.tech/policy-checksum: "e30d4d753a025bfc"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -306,6 +306,18 @@ data:
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
     	input.action in {"consent.list", "consent.revoke"}
+    }
+
+    # The customer-edge proxying the app's in-app engagement surfaces (ADR-0220 D1): the app
+    # resolves what to show in a slot and records the customer's reaction to it. Same edge
+    # principal and same guard as edge-service-consent — the edge injects the caller's
+    # authoritative partyId from the JWT, so a client-supplied partyId never reaches
+    # engagement-service on its own authority. Scoped to the two exact actions the app uses —
+    # NOT an `engagement.` family — least privilege, matching edge-service-consent's shape.
+    allowed_reasons contains "edge-service-engagement" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action in {"engagement.surface.read", "engagement.surface.recordEvent"}
     }
 
     # The customer-edge proxying the app's privacy centre: a customer reads their OWN access log

--- a/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: swift-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "e46c26e6a4619427"
+    openbank.tech/policy-checksum: "514debfd4bec0c5c"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -306,6 +306,18 @@ data:
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
     	input.action in {"consent.list", "consent.revoke"}
+    }
+
+    # The customer-edge proxying the app's in-app engagement surfaces (ADR-0220 D1): the app
+    # resolves what to show in a slot and records the customer's reaction to it. Same edge
+    # principal and same guard as edge-service-consent — the edge injects the caller's
+    # authoritative partyId from the JWT, so a client-supplied partyId never reaches
+    # engagement-service on its own authority. Scoped to the two exact actions the app uses —
+    # NOT an `engagement.` family — least privilege, matching edge-service-consent's shape.
+    allowed_reasons contains "edge-service-engagement" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action in {"engagement.surface.read", "engagement.surface.recordEvent"}
     }
 
     # The customer-edge proxying the app's privacy centre: a customer reads their OWN access log

--- a/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: transaction-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "7c800f18b73edc61"
+    openbank.tech/policy-checksum: "d56f4bd83c15f951"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -306,6 +306,18 @@ data:
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
     	input.action in {"consent.list", "consent.revoke"}
+    }
+
+    # The customer-edge proxying the app's in-app engagement surfaces (ADR-0220 D1): the app
+    # resolves what to show in a slot and records the customer's reaction to it. Same edge
+    # principal and same guard as edge-service-consent — the edge injects the caller's
+    # authoritative partyId from the JWT, so a client-supplied partyId never reaches
+    # engagement-service on its own authority. Scoped to the two exact actions the app uses —
+    # NOT an `engagement.` family — least privilege, matching edge-service-consent's shape.
+    allowed_reasons contains "edge-service-engagement" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action in {"engagement.surface.read", "engagement.surface.recordEvent"}
     }
 
     # The customer-edge proxying the app's privacy centre: a customer reads their OWN access log

--- a/openbank-infra/gitops/components/payments/vop-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/vop-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: vop-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "8e96f4ca114b5e4b"
+    openbank.tech/policy-checksum: "9b35cc1fdcfed56f"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -306,6 +306,18 @@ data:
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
     	input.action in {"consent.list", "consent.revoke"}
+    }
+
+    # The customer-edge proxying the app's in-app engagement surfaces (ADR-0220 D1): the app
+    # resolves what to show in a slot and records the customer's reaction to it. Same edge
+    # principal and same guard as edge-service-consent — the edge injects the caller's
+    # authoritative partyId from the JWT, so a client-supplied partyId never reaches
+    # engagement-service on its own authority. Scoped to the two exact actions the app uses —
+    # NOT an `engagement.` family — least privilege, matching edge-service-consent's shape.
+    allowed_reasons contains "edge-service-engagement" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action in {"engagement.surface.read", "engagement.surface.recordEvent"}
     }
 
     # The customer-edge proxying the app's privacy centre: a customer reads their OWN access log

--- a/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: pid-service
     app.kubernetes.io/part-of: pid
   annotations:
-    openbank.tech/policy-checksum: "09a0ebc9ff513789"
+    openbank.tech/policy-checksum: "74a11f0274cef7e2"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -306,6 +306,18 @@ data:
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
     	input.action in {"consent.list", "consent.revoke"}
+    }
+
+    # The customer-edge proxying the app's in-app engagement surfaces (ADR-0220 D1): the app
+    # resolves what to show in a slot and records the customer's reaction to it. Same edge
+    # principal and same guard as edge-service-consent — the edge injects the caller's
+    # authoritative partyId from the JWT, so a client-supplied partyId never reaches
+    # engagement-service on its own authority. Scoped to the two exact actions the app uses —
+    # NOT an `engagement.` family — least privilege, matching edge-service-consent's shape.
+    allowed_reasons contains "edge-service-engagement" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action in {"engagement.surface.read", "engagement.surface.recordEvent"}
     }
 
     # The customer-edge proxying the app's privacy centre: a customer reads their OWN access log

--- a/openbank-infra/gitops/components/pid/pid-service.yaml
+++ b/openbank-infra/gitops/components/pid/pid-service.yaml
@@ -32,7 +32,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-pid-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "09a0ebc9ff513789"
+        openbank.tech/policy-checksum: "74a11f0274cef7e2"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/psd2-service/psd2-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/psd2-service/psd2-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: psd2-service
     app.kubernetes.io/part-of: psd2
   annotations:
-    openbank.tech/policy-checksum: "a40dbb1067991400"
+    openbank.tech/policy-checksum: "bb4b483713900a24"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -306,6 +306,18 @@ data:
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
     	input.action in {"consent.list", "consent.revoke"}
+    }
+
+    # The customer-edge proxying the app's in-app engagement surfaces (ADR-0220 D1): the app
+    # resolves what to show in a slot and records the customer's reaction to it. Same edge
+    # principal and same guard as edge-service-consent — the edge injects the caller's
+    # authoritative partyId from the JWT, so a client-supplied partyId never reaches
+    # engagement-service on its own authority. Scoped to the two exact actions the app uses —
+    # NOT an `engagement.` family — least privilege, matching edge-service-consent's shape.
+    allowed_reasons contains "edge-service-engagement" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action in {"engagement.surface.read", "engagement.surface.recordEvent"}
     }
 
     # The customer-edge proxying the app's privacy centre: a customer reads their OWN access log

--- a/openbank-infra/gitops/components/psd2-service/psd2-service.yaml
+++ b/openbank-infra/gitops/components/psd2-service/psd2-service.yaml
@@ -27,7 +27,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-psd2-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "a40dbb1067991400"
+        openbank.tech/policy-checksum: "bb4b483713900a24"
       labels: {app.kubernetes.io/name: psd2-service, app.kubernetes.io/part-of: psd2}
     spec:
       securityContext:

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sanctions-service
     app.kubernetes.io/part-of: sanctions
   annotations:
-    openbank.tech/policy-checksum: "10ed6ea72e66cc2f"
+    openbank.tech/policy-checksum: "5acb68669d88be4e"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -306,6 +306,18 @@ data:
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
     	input.action in {"consent.list", "consent.revoke"}
+    }
+
+    # The customer-edge proxying the app's in-app engagement surfaces (ADR-0220 D1): the app
+    # resolves what to show in a slot and records the customer's reaction to it. Same edge
+    # principal and same guard as edge-service-consent — the edge injects the caller's
+    # authoritative partyId from the JWT, so a client-supplied partyId never reaches
+    # engagement-service on its own authority. Scoped to the two exact actions the app uses —
+    # NOT an `engagement.` family — least privilege, matching edge-service-consent's shape.
+    allowed_reasons contains "edge-service-engagement" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action in {"engagement.surface.read", "engagement.surface.recordEvent"}
     }
 
     # The customer-edge proxying the app's privacy centre: a customer reads their OWN access log

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
@@ -49,7 +49,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sanctions-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "10ed6ea72e66cc2f"
+        openbank.tech/policy-checksum: "5acb68669d88be4e"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sca-service
     app.kubernetes.io/part-of: sca
   annotations:
-    openbank.tech/policy-checksum: "c0b59bd40d18039b"
+    openbank.tech/policy-checksum: "23bc020461b0ec64"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -306,6 +306,18 @@ data:
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
     	input.action in {"consent.list", "consent.revoke"}
+    }
+
+    # The customer-edge proxying the app's in-app engagement surfaces (ADR-0220 D1): the app
+    # resolves what to show in a slot and records the customer's reaction to it. Same edge
+    # principal and same guard as edge-service-consent — the edge injects the caller's
+    # authoritative partyId from the JWT, so a client-supplied partyId never reaches
+    # engagement-service on its own authority. Scoped to the two exact actions the app uses —
+    # NOT an `engagement.` family — least privilege, matching edge-service-consent's shape.
+    allowed_reasons contains "edge-service-engagement" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action in {"engagement.surface.read", "engagement.surface.recordEvent"}
     }
 
     # The customer-edge proxying the app's privacy centre: a customer reads their OWN access log

--- a/openbank-infra/gitops/components/sca/sca-service.yaml
+++ b/openbank-infra/gitops/components/sca/sca-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sca-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "c0b59bd40d18039b"
+        openbank.tech/policy-checksum: "23bc020461b0ec64"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/statements/statement-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/statements/statement-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: statement-service
     app.kubernetes.io/part-of: statements
   annotations:
-    openbank.tech/policy-checksum: "f7b7bdc821f43c4c"
+    openbank.tech/policy-checksum: "13cfe09011ef4246"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -306,6 +306,18 @@ data:
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
     	input.action in {"consent.list", "consent.revoke"}
+    }
+
+    # The customer-edge proxying the app's in-app engagement surfaces (ADR-0220 D1): the app
+    # resolves what to show in a slot and records the customer's reaction to it. Same edge
+    # principal and same guard as edge-service-consent — the edge injects the caller's
+    # authoritative partyId from the JWT, so a client-supplied partyId never reaches
+    # engagement-service on its own authority. Scoped to the two exact actions the app uses —
+    # NOT an `engagement.` family — least privilege, matching edge-service-consent's shape.
+    allowed_reasons contains "edge-service-engagement" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action in {"engagement.surface.read", "engagement.surface.recordEvent"}
     }
 
     # The customer-edge proxying the app's privacy centre: a customer reads their OWN access log

--- a/openbank-infra/gitops/components/statements/statement-service.yaml
+++ b/openbank-infra/gitops/components/statements/statement-service.yaml
@@ -35,7 +35,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-statement-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "f7b7bdc821f43c4c"
+        openbank.tech/policy-checksum: "13cfe09011ef4246"
       labels:
         app.kubernetes.io/name: statement-service
         app.kubernetes.io/part-of: statements

--- a/openbank-infra/gitops/components/tpp-registry/tpp-registry-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/tpp-registry/tpp-registry-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: tpp-registry-service
     app.kubernetes.io/part-of: tpp-registry
   annotations:
-    openbank.tech/policy-checksum: "5720252999bb9395"
+    openbank.tech/policy-checksum: "9ac1497f73720c4b"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -306,6 +306,18 @@ data:
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
     	input.action in {"consent.list", "consent.revoke"}
+    }
+
+    # The customer-edge proxying the app's in-app engagement surfaces (ADR-0220 D1): the app
+    # resolves what to show in a slot and records the customer's reaction to it. Same edge
+    # principal and same guard as edge-service-consent — the edge injects the caller's
+    # authoritative partyId from the JWT, so a client-supplied partyId never reaches
+    # engagement-service on its own authority. Scoped to the two exact actions the app uses —
+    # NOT an `engagement.` family — least privilege, matching edge-service-consent's shape.
+    allowed_reasons contains "edge-service-engagement" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action in {"engagement.surface.read", "engagement.surface.recordEvent"}
     }
 
     # The customer-edge proxying the app's privacy centre: a customer reads their OWN access log

--- a/openbank-infra/gitops/components/tpp-registry/tpp-registry-service.yaml
+++ b/openbank-infra/gitops/components/tpp-registry/tpp-registry-service.yaml
@@ -32,7 +32,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-tpp-registry-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "5720252999bb9395"
+        openbank.tech/policy-checksum: "9ac1497f73720c4b"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-libs/governance/policies/rest.rego
+++ b/openbank-libs/governance/policies/rest.rego
@@ -294,6 +294,18 @@ allowed_reasons contains "edge-service-consent" if {
 	input.action in {"consent.list", "consent.revoke"}
 }
 
+# The customer-edge proxying the app's in-app engagement surfaces (ADR-0220 D1): the app
+# resolves what to show in a slot and records the customer's reaction to it. Same edge
+# principal and same guard as edge-service-consent — the edge injects the caller's
+# authoritative partyId from the JWT, so a client-supplied partyId never reaches
+# engagement-service on its own authority. Scoped to the two exact actions the app uses —
+# NOT an `engagement.` family — least privilege, matching edge-service-consent's shape.
+allowed_reasons contains "edge-service-engagement" if {
+	input.principal.type == "HUMAN"
+	input.principal.id == "service-account-openbank-edge"
+	input.action in {"engagement.surface.read", "engagement.surface.recordEvent"}
+}
+
 # The customer-edge proxying the app's privacy centre: a customer reads their OWN access log
 # (P2-27). Same edge principal and same guard as edge-service-consent — the edge injects the
 # caller's authoritative partyId from the JWT, so a client-supplied id never reaches


### PR DESCRIPTION
## Summary
- `SurfaceResource` carried no `@Authorize` annotation and `rest.rego` had no matching rule, relying only on the platform's `default allow := false` to fail closed under OPA enforcement — documented as a known gap in the resource's own KDoc (#4048).
- Add `@RolesAllowed` + `@Authorize` to `get`/`postEvent`, and a new `edge-service-engagement` rego rule scoped to the two exact actions (least privilege, mirrors `edge-service-consent`'s shape rather than an open `engagement.` family).
- Regenerates `rules-opa-data.yaml` + every per-service OPA bundle checksum (editing `rest.rego` restamps the fleet-wide derived embed) — no behavioral change to any other service.

## Test plan
- [x] `./gradlew :openbank-engagement-service:compileKotlin`
- [x] `opa test openbank-libs/governance/policies` — same 101/104 pass as on `origin/main` (3 pre-existing unrelated agent-charter-bridge failures)
- [x] Verified `#partyId` / `#request.partyId` resource-expr resolution against `AuthorizeInterceptor`'s reflection logic
