### PR TITLE
feat(campaign): enrol a party the moment a product event says they qualify

### DIFF
--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/port/out/Ports.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/port/out/Ports.kt
@@ -18,6 +18,16 @@ interface CampaignRepository {
     suspend fun findById(id: UUID): Campaign?
     suspend fun list(): List<Campaign>
     suspend fun save(campaign: Campaign): Campaign
+
+    /**
+     * ACTIVE campaigns waiting on [trigger] — the only ones a product event may enrol into.
+     *
+     * A query rather than a filter over `list()`: this runs once per matching product event, and
+     * loading every campaign in the estate to discard almost all of them would put the whole table
+     * on the hot path of a Kafka consumer. The ACTIVE filter is in SQL for the same reason it is a
+     * guard in the service — a DRAFT campaign has not passed four-eyes and must not enrol anyone.
+     */
+    suspend fun findActiveByTrigger(trigger: String): List<Campaign>
 }
 
 interface EnrolmentRepository {
@@ -132,6 +142,16 @@ interface SegmentRegistry {
 /** ADR-0210: evaluates a segment against the silver layer and returns matching party ids. */
 interface SegmentEvaluationPort {
     suspend fun evaluate(segment: Segment): List<UUID>
+
+    /**
+     * Whether [partyId] is in [segment] right now — the membership check on the trigger path.
+     *
+     * Its own method rather than `evaluate(segment).contains(partyId)`: that would pull an entire
+     * audience out of ClickHouse to answer a yes/no question, once per product event. The
+     * implementation adds one predicate to the same generated WHERE clause, so the two can never
+     * disagree about what the segment means.
+     */
+    suspend fun matches(segment: Segment, partyId: UUID): Boolean
 }
 
 /** ADR-0198/0195: live per-call consent check — a cached consent survives its own revocation. */

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/usecase/CampaignService.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/usecase/CampaignService.kt
@@ -20,6 +20,7 @@ import com.openbank.campaign.domain.model.EnrolmentState
 import com.openbank.campaign.domain.model.ScheduleCatalog
 import com.openbank.campaign.domain.model.SegmentRef
 import com.openbank.campaign.domain.model.StopCondition
+import com.openbank.campaign.domain.model.TriggerCatalog
 import com.openbank.libs.domain.identifiers.Ids
 import jakarta.enterprise.context.ApplicationScoped
 import org.jboss.logging.Logger
@@ -61,6 +62,7 @@ class CampaignService(
         stopCondition: StopCondition? = null,
         conversionRule: String? = null,
         schedule: CampaignSchedule? = null,
+        trigger: String? = null,
     ): Campaign {
         val segment = segments.load(segmentRef.name, segmentRef.version)
             ?: throw NoSuchElementException("segment ${segmentRef.name}@${segmentRef.version} not found")
@@ -69,6 +71,11 @@ class CampaignService(
         // asked why it converted zero people (ADR-0245 D1).
         require(conversionRule == null || ConversionCatalog.exists(conversionRule)) {
             "unknown conversion rule '$conversionRule' — must be one of ${ConversionCatalog.ALL.keys.sorted()}"
+        }
+        // Same reasoning as the conversion rule: a key nobody watches would be approved, run, and
+        // never enrol anyone, and the first person to notice would ask why the campaign was empty.
+        require(trigger == null || TriggerCatalog.exists(trigger)) {
+            "unknown trigger '$trigger' — must be one of ${TriggerCatalog.ALL.keys.sorted()}"
         }
         val campaign = Campaign(
             id = Ids.newId(),
@@ -82,6 +89,7 @@ class CampaignService(
             // firing against a campaign that has not passed four-eyes would enrol real people into
             // an unapproved journey (ADR-0200 D5).
             schedule = schedule,
+            trigger = trigger,
             state = CampaignState.DRAFT,
             createdBy = createdBy,
             approvedBy = null,

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/usecase/TriggeredEnrolmentService.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/usecase/TriggeredEnrolmentService.kt
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.campaign.application.usecase
+
+import com.openbank.campaign.application.port.out.CampaignRepository
+import com.openbank.campaign.application.port.out.EnrolmentRepository
+import com.openbank.campaign.application.port.out.JourneySignaller
+import com.openbank.campaign.application.port.out.SegmentEvaluationPort
+import com.openbank.campaign.application.port.out.SegmentRegistry
+import com.openbank.campaign.domain.model.CampaignState
+import com.openbank.campaign.domain.model.Enrolment
+import com.openbank.campaign.domain.model.EnrolmentState
+import com.openbank.libs.domain.identifiers.Ids
+import jakarta.enterprise.context.ApplicationScoped
+import org.jboss.logging.Logger
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * Enrols ONE party because a product event said they qualify — the trigger path.
+ *
+ * Its own use case rather than a method on `CampaignService`, for two reasons that agree. The
+ * mechanical one: that class sits exactly at detekt's `TooManyFunctions` threshold of 11, which
+ * fires AT the limit. The real one: every other entry point there is operator-driven and answers to
+ * a REST call, while this one is driven by Kafka and must return outcomes instead of throwing,
+ * because its caller is a consumer that would otherwise retry perfectly ordinary answers.
+ */
+@ApplicationScoped
+class TriggeredEnrolmentService(
+    private val campaigns: CampaignRepository,
+    private val enrolments: EnrolmentRepository,
+    private val segments: SegmentRegistry,
+    private val segmentEvaluation: SegmentEvaluationPort,
+    private val journeys: JourneySignaller,
+) {
+
+    private val log = Logger.getLogger(TriggeredEnrolmentService::class.java)
+
+    /**
+     * The guards run cheapest-first, but the segment check is the one that matters:
+     * **a trigger decides when, the segment decides who.** Without it any party who performed the
+     * action would enter a campaign whose audience was approved as something narrower, which would
+     * make a trigger a way around the versioned-segment rule (ADR-0201 D1) that nobody reviewing
+     * the campaign definition would see.
+     */
+    suspend fun enrol(campaignId: UUID, partyId: UUID): TriggeredEnrolment {
+        val campaign = campaigns.findById(campaignId) ?: return TriggeredEnrolment.CAMPAIGN_GONE
+        if (campaign.state != CampaignState.ACTIVE) return TriggeredEnrolment.NOT_ACTIVE
+        // Cheap and decisive: a party already enrolled is the common case on a redelivered Kafka
+        // record, and re-enrolling would start a second journey and a second set of sends.
+        if (enrolments.findByCampaignAndParty(campaignId, partyId) != null) {
+            return TriggeredEnrolment.ALREADY_ENROLLED
+        }
+
+        val segment = segments.load(campaign.segmentRef.name, campaign.segmentRef.version)
+            ?: return TriggeredEnrolment.SEGMENT_GONE
+        if (!segmentEvaluation.matches(segment, partyId)) return TriggeredEnrolment.NOT_IN_SEGMENT
+
+        // Same order as the sweep, for the same reason (#2953): start the journey first, persist on
+        // success. A crash between the two costs a duplicate start, which the workflow id makes a
+        // no-op; the reverse order costs the party forever, because the committed row makes every
+        // later attempt skip them.
+        journeys.startJourney(campaignId, partyId)
+        enrolments.save(
+            Enrolment(
+                id = Ids.newId(),
+                campaignId = campaignId,
+                partyId = partyId,
+                state = EnrolmentState.ACTIVE,
+                currentStep = 0,
+                startedAt = Instant.now(),
+                completedAt = null,
+            ),
+        )
+        log.infof("Triggered enrolment: campaign=%s party=%s trigger=%s", campaignId, partyId, campaign.trigger)
+        return TriggeredEnrolment.ENROLLED
+    }
+}
+
+/**
+ * What one triggered enrolment did. Every value except [ENROLLED] is a normal outcome, not a fault:
+ * a product event arrives for every party in the bank, and almost none of them are in any given
+ * campaign's segment.
+ */
+enum class TriggeredEnrolment {
+    ENROLLED,
+    ALREADY_ENROLLED,
+    NOT_IN_SEGMENT,
+    NOT_ACTIVE,
+    SEGMENT_GONE,
+    CAMPAIGN_GONE,
+}

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/domain/model/Campaign.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/domain/model/Campaign.kt
@@ -31,6 +31,12 @@ data class Campaign(
      * until now. Null means `POST /{id}/enrol` is the only way in, exactly as before.
      */
     val schedule: CampaignSchedule? = null,
+    /**
+     * Key from [TriggerCatalog], or null. When set, a matching product event enrols the party at
+     * once — but only if the segment still contains them: the trigger decides when, the segment
+     * decides who.
+     */
+    val trigger: String? = null,
     val state: CampaignState,
     val createdBy: String,
     val approvedBy: String?,

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/domain/model/TriggerCatalog.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/domain/model/TriggerCatalog.kt
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.campaign.domain.model
+
+/**
+ * What can start a party's journey, other than a human pressing enrol.
+ *
+ * A campaign had two ways in: `POST /{id}/enrol` and, since the scheduling slice, a cadence. Both
+ * are *pulls* — they ask the segment who qualifies right now. A trigger is the push: the platform
+ * says a party just did something, and any campaign waiting for that event enrols them within
+ * seconds instead of at 09:00 tomorrow. "Welcome someone who just opened an account" is only
+ * honest as a trigger; as a daily sweep it arrives a day late.
+ *
+ * **A trigger decides WHEN, never WHO.** The segment still decides who: an event only enrols a
+ * party that is also in the campaign's segment at that moment. Skipping that check would let any
+ * party who performed the action into a campaign whose audience was approved as something
+ * narrower — the segment is the approved audience (ADR-0201 D1), and a trigger must not be a way
+ * around it.
+ *
+ * **The same catalogue discipline as everywhere else** ([ConversionCatalog], [SegmentCatalog],
+ * [TemplateCatalog], [ScheduleCatalog]): a closed set in reviewed code, extended by pull request.
+ * A topic nobody publishes would look configured and fire never.
+ *
+ * **Why the entries mirror [ConversionCatalog]'s topics.** The same product events that prove a
+ * campaign worked are the ones worth reacting to, so the two catalogues name the same streams
+ * today. They are deliberately separate types rather than one shared enum: a conversion is an
+ * outcome being *measured* and can only ever append a row, while a trigger *causes* a send. Fusing
+ * them would make it a one-word edit to turn a measurement into an outbound message.
+ */
+object TriggerCatalog {
+
+    /**
+     * @param topic the Kafka topic the event arrives on.
+     * @param eventTypes accepted identifiers, matched against the `ce-type` header OR the payload's
+     *   own `eventType` field. Both, for the reason [ConversionCatalog] documents: `AccountCreated`
+     *   carries its type in the payload, `CardIssued` only in the outbox header, and
+     *   `openbank.cards.events` is a shared topic where matching the topic alone would enrol a
+     *   party on a limit change.
+     */
+    data class Trigger(val topic: String, val eventTypes: Set<String>)
+
+    val ALL: Map<String, Trigger> = mapOf(
+        "ACCOUNT_OPENED" to Trigger(
+            topic = "openbank.accounts.account.created",
+            eventTypes = setOf("AccountCreated", "account.created.v1"),
+        ),
+        "CARD_ISSUED" to Trigger(
+            topic = "openbank.cards.events",
+            eventTypes = setOf("card.issued.v1", "CardIssued"),
+        ),
+    )
+
+    fun exists(trigger: String): Boolean = trigger in ALL
+
+    operator fun get(trigger: String): Trigger? = ALL[trigger]
+
+    /** Triggers watching [topic] whose accepted types include [eventType]. */
+    fun matching(topic: String, eventType: String?): Set<String> =
+        ALL.filterValues { it.topic == topic && eventType != null && eventType in it.eventTypes }.keys
+}

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/kafka/EnrolmentTriggerConsumer.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/kafka/EnrolmentTriggerConsumer.kt
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.campaign.infrastructure.kafka
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.campaign.application.port.out.CampaignRepository
+import com.openbank.campaign.application.usecase.TriggeredEnrolment
+import com.openbank.campaign.application.usecase.TriggeredEnrolmentService
+import com.openbank.campaign.domain.model.TriggerCatalog
+import io.smallrye.reactive.messaging.kafka.api.IncomingKafkaRecordMetadata
+import jakarta.enterprise.context.ApplicationScoped
+import org.eclipse.microprofile.reactive.messaging.Incoming
+import org.eclipse.microprofile.reactive.messaging.Message
+import org.jboss.logging.Logger
+import java.util.UUID
+
+/**
+ * Enrols a party into a waiting campaign the moment a product event says they qualify.
+ *
+ * The third way into a campaign, after the manual endpoint and the cadence, and the only one that
+ * reacts rather than polls: "welcome someone who just opened an account" is a day late as a nightly
+ * sweep.
+ *
+ * **A separate consumer from [ConversionConsumer], on the same two topics.** They look alike and
+ * are deliberately not merged. A conversion is a measurement that can only ever append a row —
+ * that consumer's KDoc says its failure mode is "a missing conversion, never a wrong send". This
+ * one *causes* sends. Fusing them would put an outbound-message path behind a class documented as
+ * unable to produce one, and would tie their consumer offsets together, so a lag in measurement
+ * would delay real customer contact. The cost is reading each topic twice, which is a cheap price
+ * for keeping the blast radius of the two apart.
+ *
+ * **Everything a normal journey enforces still applies.** This only creates the enrolment; the
+ * Temporal journey then runs the same steps, with the same ADR-0219 contact gate — suppression,
+ * send caps, quiet hours and the live consent pull — before anything reaches a customer. A trigger
+ * cannot skip a gate, only decide when the journey starts.
+ */
+@ApplicationScoped
+class EnrolmentTriggerConsumer(
+    private val campaigns: CampaignRepository,
+    private val triggered: TriggeredEnrolmentService,
+    private val mapper: ObjectMapper,
+) {
+    private val log = Logger.getLogger(EnrolmentTriggerConsumer::class.java)
+
+    @Incoming("account-triggers-in")
+    suspend fun onAccountEvent(message: Message<String>) = handle(message, "openbank.accounts.account.created")
+
+    @Incoming("card-triggers-in")
+    suspend fun onCardEvent(message: Message<String>) = handle(message, "openbank.cards.events")
+
+    @Suppress("TooGenericExceptionCaught")
+    private suspend fun handle(message: Message<String>, topic: String) {
+        try {
+            val event = try {
+                mapper.readTree(message.payload)
+            } catch (e: Exception) {
+                log.errorf(e, "Unparseable %s event — dropped", topic)
+                return
+            }
+
+            val partyId = event.path("partyId").takeIf { !it.isMissingNode && !it.isNull }
+                ?.let { runCatching { UUID.fromString(it.asText()) }.getOrNull() }
+                ?: return
+
+            // Header first, payload second — the two producers put the type in different places
+            // (see TriggerCatalog). `openbank.cards.events` is shared, so without this a limit
+            // change would enrol the party into a card-issuance campaign.
+            val eventType = headerEventType(message) ?: event.path("eventType").asText().ifBlank { null }
+            val triggers = TriggerCatalog.matching(topic, eventType)
+            if (triggers.isEmpty()) return
+
+            for (trigger in triggers) {
+                for (campaign in campaigns.findActiveByTrigger(trigger)) {
+                    enrol(campaign.id, partyId, trigger)
+                }
+            }
+        } finally {
+            // Acked in every case, including the failures logged below. A poison event that cannot
+            // enrol anyone would otherwise be redelivered forever and stall the partition, blocking
+            // every later party's trigger behind it. The cost of the alternative is worse than the
+            // event being lost: this consumer starts journeys, so a wedged partition is silent
+            // non-delivery for everyone.
+            message.ack()
+        }
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    private suspend fun enrol(campaignId: UUID, partyId: UUID, trigger: String) {
+        try {
+            when (val outcome = triggered.enrol(campaignId, partyId)) {
+                TriggeredEnrolment.ENROLLED ->
+                    log.infof("Trigger %s enrolled party=%s into campaign=%s", trigger, partyId, campaignId)
+                // The ordinary answers. A product event arrives for every party in the bank and
+                // almost none are in any given segment, so these are logged at debug — at info they
+                // would be the loudest thing in the service and would bury the enrolments.
+                TriggeredEnrolment.NOT_IN_SEGMENT,
+                TriggeredEnrolment.ALREADY_ENROLLED,
+                TriggeredEnrolment.NOT_ACTIVE,
+                ->
+                    log.debugf("Trigger %s: campaign=%s party=%s -> %s", trigger, campaignId, partyId, outcome)
+                // These two mean the definition is broken rather than the party unqualified.
+                TriggeredEnrolment.SEGMENT_GONE,
+                TriggeredEnrolment.CAMPAIGN_GONE,
+                ->
+                    log.warnf("Trigger %s: campaign=%s party=%s -> %s", trigger, campaignId, partyId, outcome)
+            }
+        } catch (e: Exception) {
+            // One campaign's failure must not cost the others their enrolment of this same party.
+            log.errorf(e, "Trigger %s failed for campaign=%s party=%s", trigger, campaignId, partyId)
+        }
+    }
+
+    /** The outbox `ce-type` header, when the record carries Kafka metadata at all. */
+    private fun headerEventType(message: Message<String>): String? =
+        message.getMetadata(IncomingKafkaRecordMetadata::class.java)
+            .orElse(null)
+            ?.headers
+            ?.lastHeader("ce-type")
+            ?.value()
+            ?.toString(Charsets.UTF_8)
+}

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/persistence/Persistence.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/persistence/Persistence.kt
@@ -88,6 +88,10 @@ class CampaignEntity : PanacheEntityBase() {
     @Column
     var scheduleEndAt: Instant? = null
 
+    /** TriggerCatalog key (V7). Column is `trigger_event`: `trigger` is a reserved SQL word. */
+    @Column(name = "trigger_event", length = 64)
+    var triggerEvent: String? = null
+
     @Column(nullable = false)
     lateinit var state: String
 
@@ -193,6 +197,12 @@ class PanacheCampaignRepository(private val mapper: ObjectMapper) :
     override suspend fun list(): List<Campaign> =
         Panache.withSession { listAll() }.awaitSuspending().map { it.toDomain() }
 
+    // Filtered in SQL, not in Kotlin: this runs once per matching product event, so loading every
+    // campaign to discard almost all of them would put the whole table on a consumer's hot path.
+    override suspend fun findActiveByTrigger(trigger: String): List<Campaign> = Panache.withSession {
+        list("triggerEvent = ?1 and state = ?2", trigger, CampaignState.ACTIVE.name)
+    }.awaitSuspending().map { it.toDomain() }
+
     // merge, not persist: application-assigned @Id, so persist() would INSERT on every lifecycle
     // transition and fail on the PK (the fleet's standard upsert, cf. consent-service).
     override suspend fun save(campaign: Campaign): Campaign = Panache.withTransaction {
@@ -210,6 +220,7 @@ class PanacheCampaignRepository(private val mapper: ObjectMapper) :
         conversionRule = this@toEntity.conversionRule
         scheduleCadence = this@toEntity.schedule?.cadence
         scheduleEndAt = this@toEntity.schedule?.endAt
+        triggerEvent = this@toEntity.trigger
         state = this@toEntity.state.name
         createdBy = this@toEntity.createdBy
         approvedBy = this@toEntity.approvedBy
@@ -228,6 +239,7 @@ class PanacheCampaignRepository(private val mapper: ObjectMapper) :
         // Reconstructed only when a cadence is present: an end instant on its own would be a
         // schedule with nothing to fire, so the cadence is what decides whether one exists.
         schedule = scheduleCadence?.let { CampaignSchedule(it, scheduleEndAt) },
+        trigger = triggerEvent,
         state = CampaignState.valueOf(state),
         createdBy = createdBy,
         approvedBy = approvedBy,

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/rest/CampaignResource.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/rest/CampaignResource.kt
@@ -33,6 +33,11 @@ data class CreateCampaignRequest(
     val conversionRule: String? = null,
     /** Absent means one-shot: enrolment happens only on POST /{id}/enrol, as it always has. */
     val schedule: ScheduleRequest? = null,
+    /**
+     * A TriggerCatalog key, or absent. When set, a matching product event enrols a party at once —
+     * but only one the segment still contains: the trigger decides when, the segment decides who.
+     */
+    val trigger: String? = null,
 )
 
 /** Optional on create (ADR-0200 D1, #3585): absent means the journey runs every step, as before. */
@@ -130,6 +135,7 @@ class CampaignResource(private val service: CampaignService, private val jwt: Js
             request.stopCondition?.let { StopCondition(it.maxSendsPerParty) },
             request.conversionRule,
             request.schedule?.let { CampaignSchedule(it.cadence, it.endAt) },
+            request.trigger,
         )
         return Response.status(Response.Status.CREATED).entity(campaign).build()
     }

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/segment/SilverSegmentEvaluator.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/segment/SilverSegmentEvaluator.kt
@@ -44,6 +44,45 @@ class SilverSegmentEvaluator(
     private val log = Logger.getLogger(SilverSegmentEvaluator::class.java)
     private val http: HttpClient = HttpClient.newHttpClient()
 
+    /**
+     * One-party membership: the same generated WHERE clause plus an `aggregate_id` predicate.
+     *
+     * Built from [evaluate]'s own query rather than a second hand-written one — the whole risk here
+     * is the two drifting, so that a trigger enrols someone the segment would not have returned.
+     * `LIMIT 1` because the answer is a boolean; the party id travels as a bound parameter like
+     * every other rule value, so it cannot become SQL.
+     */
+    override suspend fun matches(segment: Segment, partyId: UUID): Boolean {
+        val (where, params) = segment.toWhereClause()
+        val sql = buildString {
+            append("SELECT 1 FROM ").append(database).append(".silver_current_state")
+            append(" WHERE ").append(where)
+            append(" AND aggregate_id = {p_party:String} LIMIT 1 FORMAT JSONEachRow")
+        }
+        val bound = params + mapOf("p_party" to partyId.toString())
+        val query = bound.entries.joinToString("&") { (k, v) ->
+            "param_$k=" + URLEncoder.encode(v.toString(), StandardCharsets.UTF_8)
+        }
+        val requestBuilder = HttpRequest.newBuilder(URI.create("$clickHouseUrl?$query"))
+            .POST(HttpRequest.BodyPublishers.ofString(sql))
+            .header("Content-Type", "text/plain")
+        clickHouseUser.filter { it.isNotBlank() }.ifPresent { requestBuilder.header("X-ClickHouse-User", it) }
+        clickHousePassword.filter { it.isNotBlank() }.ifPresent { requestBuilder.header("X-ClickHouse-Key", it) }
+
+        val response = http.send(requestBuilder.build(), HttpResponse.BodyHandlers.ofString())
+        if (response.statusCode() != HTTP_OK) {
+            // Throw rather than answer false: a ClickHouse outage answered as "not a member" would
+            // silently drop every triggered enrolment while looking like an empty segment. The
+            // consumer decides what to do with a failure; this layer must not decide it by
+            // returning the safe-looking value.
+            error(
+                "segment membership query failed (${response.statusCode()}): " +
+                    response.body().take(ERROR_PREVIEW_CHARS),
+            )
+        }
+        return response.body().isNotBlank()
+    }
+
     override suspend fun evaluate(segment: Segment): List<UUID> {
         val (where, params) = segment.toWhereClause()
         val sql = buildString {
@@ -94,6 +133,9 @@ class SilverSegmentEvaluator(
 
     companion object {
         private const val HTTP_OK = 200
+
+        /** Enough of a ClickHouse error to identify it, short enough not to dump a page into a log. */
+        private const val ERROR_PREVIEW_CHARS = 200
         private val AGGREGATE_ID = Regex("\"aggregate_id\"\\s*:\\s*\"([0-9a-fA-F-]{36})\"")
     }
 }

--- a/openbank-campaign-service/src/main/resources/application.yaml
+++ b/openbank-campaign-service/src/main/resources/application.yaml
@@ -144,6 +144,33 @@ mp:
         auto:
           offset:
             reset: latest
+      # Enrolment triggers. SAME two topics as the *-conversions-in channels above, deliberately
+      # on their own consumer groups: a conversion only appends a row, a trigger starts a journey
+      # and can reach a customer, so their offsets and their lag must not be tied together.
+      #
+      # `reset: latest` is a safety property here, not a default worth copying casually. On
+      # `earliest` the first deploy would replay the entire history of account openings and card
+      # issuances and enrol every party who ever qualified — a mass send, from a config line.
+      account-triggers-in:
+        connector: smallrye-kafka
+        topic: openbank.accounts.account.created
+        value:
+          deserializer: org.apache.kafka.common.serialization.StringDeserializer
+        group:
+          id: openbank-campaign-service-account-triggers
+        auto:
+          offset:
+            reset: latest
+      card-triggers-in:
+        connector: smallrye-kafka
+        topic: openbank.cards.events
+        value:
+          deserializer: org.apache.kafka.common.serialization.StringDeserializer
+        group:
+          id: openbank-campaign-service-card-triggers
+        auto:
+          offset:
+            reset: latest
       consent-events-in:
         connector: smallrye-kafka
         topic: openbank.consent.events

--- a/openbank-campaign-service/src/main/resources/db/migration/V7__campaign_trigger.sql
+++ b/openbank-campaign-service/src/main/resources/db/migration/V7__campaign_trigger.sql
@@ -1,0 +1,18 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+-- A campaign may declare a product event that enrols a party the moment it happens, instead of
+-- waiting for the next manual enrol or scheduled sweep. A TriggerCatalog key, not a topic name and
+-- not a filter expression: the topic, the accepted event types and the matching rule live in domain
+-- code, so a trigger is reviewed and diffable, and one naming a stream nobody publishes cannot be
+-- stored.
+--
+-- The trigger decides WHEN. The segment still decides WHO — an event only enrols a party the
+-- campaign's segment currently contains, so a trigger is never a way past the approved audience.
+--
+-- Nullable: every existing campaign has none and behaves exactly as before, enrolling on POST
+-- /{id}/enrol or on its cadence.
+--
+-- Rollback: ALTER TABLE campaigns DROP COLUMN trigger_event;
+-- Note "trigger" is a reserved word in SQL, hence the column name.
+ALTER TABLE campaigns ADD COLUMN trigger_event varchar(64);

--- a/openbank-campaign-service/src/main/resources/openapi.yaml
+++ b/openbank-campaign-service/src/main/resources/openapi.yaml
@@ -4,7 +4,7 @@ openapi: 3.1.0
 info:
   title: Campaign Service API
   # major == openbank.api.version == URL /api/v1 (ADR-0048).
-  version: 1.14.0
+  version: 1.15.0
   description: >-
     Campaign management first slice (ADR-0200 / ADR-0209 D3): deterministic, versioned segments;
     per-enrolment Temporal journeys; consent-gated delivery through notification-service.
@@ -433,6 +433,17 @@ components:
           $ref: '#/components/schemas/StopCondition'
         schedule:
           $ref: '#/components/schemas/CampaignSchedule'
+        trigger:
+          type: string
+          enum: [ACCOUNT_OPENED, CARD_ISSUED]
+          nullable: true
+          description: >-
+            Optional product event that enrols a party the moment it happens (1.15.0), instead of
+            waiting for the next manual enrol or scheduled sweep. A TriggerCatalog key, never a
+            topic name or a filter expression — an uncatalogued value is rejected with 400, since a
+            campaign waiting on a stream nobody publishes would look event-driven and wait forever.
+            The trigger decides WHEN; the campaign's segment still decides WHO, so an event only
+            enrols a party the segment currently contains. Absent means no event enrolment.
         conversionRule:
           description: >-
             Optional conversion rule (ADR-0245, added 1.13.0). A key from the service's own
@@ -507,6 +518,17 @@ components:
           $ref: '#/components/schemas/StopCondition'
         schedule:
           $ref: '#/components/schemas/CampaignSchedule'
+        trigger:
+          type: string
+          enum: [ACCOUNT_OPENED, CARD_ISSUED]
+          nullable: true
+          description: >-
+            Optional product event that enrols a party the moment it happens (1.15.0), instead of
+            waiting for the next manual enrol or scheduled sweep. A TriggerCatalog key, never a
+            topic name or a filter expression — an uncatalogued value is rejected with 400, since a
+            campaign waiting on a stream nobody publishes would look event-driven and wait forever.
+            The trigger decides WHEN; the campaign's segment still decides WHO, so an event only
+            enrols a party the segment currently contains. Absent means no event enrolment.
         conversionRule:
           description: >-
             Optional conversion rule (ADR-0245, added 1.13.0). A key from the service's own

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/CampaignEnrolmentFailureTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/CampaignEnrolmentFailureTest.kt
@@ -97,6 +97,7 @@ class CampaignEnrolmentFailureTest {
             override suspend fun findById(id: UUID): Campaign? = campaign.takeIf { it.id == id }
             override suspend fun list(): List<Campaign> = listOf(campaign)
             override suspend fun save(campaign: Campaign): Campaign = campaign
+            override suspend fun findActiveByTrigger(trigger: String): List<Campaign> = emptyList()
         },
         enrolments = enrolments,
         segments = object : SegmentRegistry {
@@ -106,6 +107,7 @@ class CampaignEnrolmentFailureTest {
         },
         segmentEvaluation = object : SegmentEvaluationPort {
             override suspend fun evaluate(segment: Segment): List<UUID> = parties
+            override suspend fun matches(segment: Segment, partyId: UUID): Boolean = true
         },
         journeys = journeys,
         // Enrolment never touches the scheduler — a stub that throws proves it, and would fail

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/CampaignScheduleLifecycleTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/CampaignScheduleLifecycleTest.kt
@@ -94,6 +94,7 @@ class CampaignScheduleLifecycleTest {
                 override suspend fun findById(id: UUID): Campaign? = stored.takeIf { it.id == id }
                 override suspend fun list(): List<Campaign> = listOf(stored)
                 override suspend fun save(campaign: Campaign): Campaign = campaign
+                override suspend fun findActiveByTrigger(trigger: String): List<Campaign> = emptyList()
             },
             enrolments = object : EnrolmentRepository {
                 override suspend fun findByCampaignAndParty(campaignId: UUID, partyId: UUID): Enrolment? = null
@@ -109,6 +110,7 @@ class CampaignScheduleLifecycleTest {
             },
             segmentEvaluation = object : SegmentEvaluationPort {
                 override suspend fun evaluate(segment: Segment): List<UUID> = emptyList()
+                override suspend fun matches(segment: Segment, partyId: UUID): Boolean = true
             },
             journeys = object : JourneySignaller {
                 override fun signalConsentRevoked(campaignId: UUID, partyId: UUID) = Unit

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/SegmentQueryTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/SegmentQueryTest.kt
@@ -31,6 +31,8 @@ class SegmentQueryTest {
             evaluated = segment
             return cohort
         }
+
+        override suspend fun matches(segment: Segment, partyId: UUID): Boolean = partyId in cohort
     }
 
     private val query = SegmentQuery(evaluation, Clock.fixed(fixedNow, ZoneOffset.UTC))

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/TriggeredEnrolmentTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/TriggeredEnrolmentTest.kt
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.campaign.application
+
+import com.openbank.campaign.application.port.out.CampaignEnrolmentCount
+import com.openbank.campaign.application.port.out.CampaignRepository
+import com.openbank.campaign.application.port.out.EnrolmentRepository
+import com.openbank.campaign.application.port.out.JourneySignaller
+import com.openbank.campaign.application.port.out.SegmentEvaluationPort
+import com.openbank.campaign.application.port.out.SegmentRegistry
+import com.openbank.campaign.application.usecase.TriggeredEnrolment
+import com.openbank.campaign.application.usecase.TriggeredEnrolmentService
+import com.openbank.campaign.domain.model.Campaign
+import com.openbank.campaign.domain.model.CampaignState
+import com.openbank.campaign.domain.model.CampaignStep
+import com.openbank.campaign.domain.model.Channel
+import com.openbank.campaign.domain.model.Enrolment
+import com.openbank.campaign.domain.model.Segment
+import com.openbank.campaign.domain.model.SegmentRef
+import com.openbank.campaign.domain.model.SegmentRule
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * A trigger decides WHEN a party is enrolled. The segment still decides WHO.
+ *
+ * That separation is the whole security property of this path. A product event arrives for every
+ * party in the bank; if the segment check were missing, any of them who performed the action would
+ * enter a campaign whose audience was approved as something much narrower — a way around the
+ * versioned-segment rule (ADR-0201 D1) that no reviewer of the campaign definition would see.
+ */
+class TriggeredEnrolmentTest {
+
+    private val campaignId = UUID.randomUUID()
+    private val inSegment = UUID.randomUUID()
+    private val outOfSegment = UUID.randomUUID()
+    private val segment = Segment("new-customers", 1, listOf(SegmentRule.PartyStatusIs("ACTIVE")))
+
+    private fun campaign(state: CampaignState = CampaignState.ACTIVE, trigger: String? = "ACCOUNT_OPENED") = Campaign(
+        id = campaignId,
+        name = "welcome",
+        goal = "greet a new account holder",
+        segmentRef = SegmentRef("new-customers", 1),
+        steps = listOf(CampaignStep(1, "MARKETING_PRODUCT_OFFER", Channel.EMAIL, emptyMap(), 0)),
+        trigger = trigger,
+        state = state,
+        createdBy = "maker@openbank.test",
+        approvedBy = "checker@openbank.test",
+        createdAt = Instant.parse("2026-08-01T09:00:00Z"),
+        updatedAt = Instant.parse("2026-08-01T09:00:00Z"),
+    )
+
+    private class Journeys : JourneySignaller {
+        val started = mutableListOf<UUID>()
+        override fun signalConsentRevoked(campaignId: UUID, partyId: UUID) = Unit
+        override fun startJourney(campaignId: UUID, partyId: UUID) {
+            started += partyId
+        }
+    }
+
+    private class Enrolments(seed: List<Enrolment> = emptyList()) : EnrolmentRepository {
+        val saved = seed.toMutableList()
+        override suspend fun findByCampaignAndParty(campaignId: UUID, partyId: UUID) =
+            saved.firstOrNull { it.campaignId == campaignId && it.partyId == partyId }
+        override suspend fun listByCampaign(campaignId: UUID) = saved.filter { it.campaignId == campaignId }
+        override suspend fun listByParty(partyId: UUID) = saved.filter { it.partyId == partyId }
+        override suspend fun countAllByCampaign() = emptyList<CampaignEnrolmentCount>()
+        override suspend fun save(enrolment: Enrolment) = enrolment.also { saved += it }
+    }
+
+    private fun service(
+        stored: Campaign?,
+        enrolments: EnrolmentRepository,
+        journeys: JourneySignaller,
+        members: Set<UUID> = setOf(inSegment),
+        segmentPresent: Boolean = true,
+    ) = TriggeredEnrolmentService(
+        campaigns = object : CampaignRepository {
+            override suspend fun findById(id: UUID) = stored?.takeIf { it.id == id }
+            override suspend fun list() = listOfNotNull(stored)
+            override suspend fun save(campaign: Campaign) = campaign
+            override suspend fun findActiveByTrigger(trigger: String) =
+                listOfNotNull(stored?.takeIf { it.trigger == trigger && it.state == CampaignState.ACTIVE })
+        },
+        enrolments = enrolments,
+        segments = object : SegmentRegistry {
+            override suspend fun load(name: String, version: Int) = segment.takeIf { segmentPresent }
+            override suspend fun save(segment: Segment) = segment
+            override suspend fun list() = listOf(segment)
+        },
+        segmentEvaluation = object : SegmentEvaluationPort {
+            override suspend fun evaluate(segment: Segment) = members.toList()
+            override suspend fun matches(segment: Segment, partyId: UUID) = partyId in members
+        },
+        journeys = journeys,
+    )
+
+    @Test
+    fun `a party in the segment is enrolled and their journey starts`(): Unit = runBlocking {
+        val enrolments = Enrolments()
+        val journeys = Journeys()
+
+        val outcome = service(campaign(), enrolments, journeys).enrol(campaignId, inSegment)
+
+        assertThat(outcome).isEqualTo(TriggeredEnrolment.ENROLLED)
+        assertThat(journeys.started).containsExactly(inSegment)
+        assertThat(enrolments.saved.map { it.partyId }).containsExactly(inSegment)
+    }
+
+    @Test
+    fun `a party outside the segment is never enrolled, however the event qualified them`(): Unit = runBlocking {
+        val enrolments = Enrolments()
+        val journeys = Journeys()
+
+        val outcome = service(campaign(), enrolments, journeys).enrol(campaignId, outOfSegment)
+
+        assertThat(outcome).isEqualTo(TriggeredEnrolment.NOT_IN_SEGMENT)
+        assertThat(journeys.started)
+            .describedAs("the trigger decides when, the segment decides who — this is the audience boundary")
+            .isEmpty()
+        assertThat(enrolments.saved).isEmpty()
+    }
+
+    @Test
+    fun `a redelivered event does not start a second journey`(): Unit = runBlocking {
+        // Kafka is at-least-once, so the same account-opened event will arrive twice sooner or
+        // later. Without this guard the party gets two journeys and two sets of sends.
+        val existing = Enrolment(
+            id = UUID.randomUUID(),
+            campaignId = campaignId,
+            partyId = inSegment,
+            state = com.openbank.campaign.domain.model.EnrolmentState.ACTIVE,
+            currentStep = 0,
+            startedAt = Instant.parse("2026-08-01T10:00:00Z"),
+            completedAt = null,
+        )
+        val journeys = Journeys()
+
+        val outcome = service(campaign(), Enrolments(listOf(existing)), journeys)
+            .enrol(campaignId, inSegment)
+
+        assertThat(outcome).isEqualTo(TriggeredEnrolment.ALREADY_ENROLLED)
+        assertThat(journeys.started).isEmpty()
+    }
+
+    @Test
+    fun `a campaign that has not passed four-eyes enrols nobody`(): Unit = runBlocking {
+        val journeys = Journeys()
+
+        val outcome = service(campaign(state = CampaignState.DRAFT), Enrolments(), journeys)
+            .enrol(campaignId, inSegment)
+
+        assertThat(outcome).isEqualTo(TriggeredEnrolment.NOT_ACTIVE)
+        assertThat(journeys.started)
+            .describedAs("a trigger must not be a way to run an unapproved campaign (ADR-0200 D5)")
+            .isEmpty()
+    }
+
+    @Test
+    fun `a paused campaign stops reacting to events`(): Unit = runBlocking {
+        val journeys = Journeys()
+
+        val outcome = service(campaign(state = CampaignState.PAUSED), Enrolments(), journeys)
+            .enrol(campaignId, inSegment)
+
+        assertThat(outcome).isEqualTo(TriggeredEnrolment.NOT_ACTIVE)
+        assertThat(journeys.started).isEmpty()
+    }
+
+    @Test
+    fun `a campaign whose segment has vanished enrols nobody rather than everybody`(): Unit = runBlocking {
+        val journeys = Journeys()
+
+        val outcome = service(campaign(), Enrolments(), journeys, segmentPresent = false)
+            .enrol(campaignId, inSegment)
+
+        // The safe direction. A missing segment read as "no restriction" would turn a campaign
+        // with a deleted audience into one that contacts everyone the event fires for.
+        assertThat(outcome).isEqualTo(TriggeredEnrolment.SEGMENT_GONE)
+        assertThat(journeys.started).isEmpty()
+    }
+
+    @Test
+    fun `an event for a campaign that no longer exists is an outcome, not a crash`(): Unit = runBlocking {
+        val outcome = service(null, Enrolments(), Journeys()).enrol(campaignId, inSegment)
+
+        assertThat(outcome).isEqualTo(TriggeredEnrolment.CAMPAIGN_GONE)
+    }
+}

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/usecase/CampaignSummaryQueryTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/usecase/CampaignSummaryQueryTest.kt
@@ -94,6 +94,7 @@ class CampaignSummaryQueryTest {
         override suspend fun findById(id: UUID) = items.firstOrNull { it.id == id }
         override suspend fun list() = items
         override suspend fun save(campaign: Campaign) = campaign
+        override suspend fun findActiveByTrigger(trigger: String) = emptyList<Campaign>()
     }
 
     @Test

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/workflow/CampaignJourneyActivitiesTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/workflow/CampaignJourneyActivitiesTest.kt
@@ -74,6 +74,7 @@ class CampaignJourneyActivitiesTest {
             override suspend fun findById(id: UUID) = if (id == campaignId) campaign else null
             override suspend fun list() = listOf(campaign)
             override suspend fun save(campaign: Campaign) = campaign
+            override suspend fun findActiveByTrigger(trigger: String) = emptyList<Campaign>()
         }
         val enrolments = object : EnrolmentRepository {
             override suspend fun findByCampaignAndParty(campaignId: UUID, partyId: UUID): Enrolment? = null

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/integration/CampaignRestContractIT.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/integration/CampaignRestContractIT.kt
@@ -316,6 +316,60 @@ class CampaignRestContractIT {
         }
     }
 
+    /** A trigger key survives the round trip, so a campaign can declare what wakes it. */
+    @Test
+    fun `a campaign can declare a trigger and reads it back`() {
+        val body = """
+            {"name":"trig-${UUID.randomUUID()}","goal":"prove the trigger round trip",
+             "segmentName":"actives","segmentVersion":1,"trigger":"ACCOUNT_OPENED",
+             "steps":[{"order":1,"template":"MARKETING_PRODUCT_OFFER",
+                       "variables":{"offerTitle":"T","offerText":"X","ctaText":"Go"},"delaySeconds":0}]}
+        """.trimIndent()
+
+        val id = Given {
+            contentType("application/json")
+            body(body)
+        } When {
+            post("/api/v1/campaigns")
+        } Then {
+            statusCode(201)
+        } Extract {
+            path<String>("id")
+        }
+
+        When {
+            get("/api/v1/campaigns/$id")
+        } Then {
+            statusCode(200)
+            body("trigger", org.hamcrest.Matchers.equalTo("ACCOUNT_OPENED"))
+        }
+    }
+
+    /**
+     * An uncatalogued trigger is a 400.
+     *
+     * Stored, it would be a campaign that looks event-driven and waits forever, because no consumer
+     * watches a topic nobody named — the same dead-capability shape as an unknown cadence.
+     */
+    @Test
+    fun `an unknown trigger is rejected rather than stored`() {
+        val body = """
+            {"name":"badtrig-${UUID.randomUUID()}","goal":"prove the catalogue rejects invented triggers",
+             "segmentName":"actives","segmentVersion":1,"trigger":"CUSTOMER_SNEEZED",
+             "steps":[{"order":1,"template":"MARKETING_PRODUCT_OFFER",
+                       "variables":{"offerTitle":"T","offerText":"X","ctaText":"Go"},"delaySeconds":0}]}
+        """.trimIndent()
+
+        Given {
+            contentType("application/json")
+            body(body)
+        } When {
+            post("/api/v1/campaigns")
+        } Then {
+            statusCode(400)
+        }
+    }
+
     @Test
     fun `the segment catalogue is served over HTTP with its rules in words`() {
         When {


### PR DESCRIPTION
## Summary

A campaign had two ways in, and both were *pulls*: `POST /{id}/enrol`, and the cadence added in #4051. Each asks the segment who qualifies right now, so "welcome someone who just opened an account" arrived up to a day late. This adds the push — a campaign declares a trigger, and a matching product event enrols the party within seconds.

## Type of change

- [x] feat (new functionality)
- [ ] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [ ] docs
- [ ] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change

## Linked issues

Refs #3585

## The security property, stated first because it is the point

**A trigger decides WHEN. The segment still decides WHO.** An event only enrols a party the campaign's segment currently contains. Without that check, any party who performed the action would enter a campaign whose audience was approved as something much narrower — a way around the versioned-segment rule (ADR-0201 D1) that nobody reviewing the campaign definition would ever see.

That test is falsified, not just written. Deleting the one line reddens exactly it:

```
TriggeredEnrolmentTest > a party outside the segment is never enrolled, however the event qualified them() FAILED
```

Everything a normal journey enforces still applies: this only creates the enrolment, and the Temporal journey then runs the same steps behind the same ADR-0219 contact gate — suppression, send caps, quiet hours, live consent pull. A trigger cannot skip a gate, only decide when the journey starts.

## Changes

- **`TriggerCatalog`** — closed set (`ACCOUNT_OPENED`, `CARD_ISSUED`), naming topics that exist today. Deliberately a *separate type* from `ConversionCatalog` even though they name the same streams: a conversion is an outcome being measured and can only append a row, a trigger causes a send. Fusing them would make it a one-word edit to turn a measurement into an outbound message.
- **`SegmentEvaluationPort.matches(segment, partyId)`** — one-party membership. Its own method rather than `evaluate(segment).contains(partyId)`, which would pull an entire audience out of ClickHouse to answer a boolean, once per product event. Built from the same generated WHERE clause so the two cannot disagree about what the segment means.
- **`TriggeredEnrolmentService`** — its own use case. `CampaignService` sits at detekt's `TooManyFunctions` threshold of 11 (fires AT the limit), and this entry point answers to Kafka rather than REST, so it returns outcomes instead of throwing — a consumer would otherwise retry perfectly ordinary answers like "not in this segment".
- **`EnrolmentTriggerConsumer`** — own consumer groups on the two topics.
- Migration `V7` (column `trigger_event` — `trigger` is reserved SQL); openapi `1.14.0 -> 1.15.0`.

## Two operational decisions worth a second look

**`auto.offset.reset: latest` is a safety property here, not a copied default.** On `earliest` the first deploy would replay the entire history of account openings and card issuances and enrol every party who ever qualified — a mass send, caused by a config line.

**A separate consumer from `ConversionConsumer`, on the same two topics.** They look mergeable and are not. That consumer's KDoc promises its failure mode is "a missing conversion, never a wrong send"; this one starts journeys. Merging would put an outbound-message path behind a class documented as unable to produce one, and tie their offsets together so measurement lag delayed customer contact. The cost is reading each topic twice — cheap for keeping the blast radius apart.

**A ClickHouse fault throws rather than answering "not a member".** An outage read as an empty segment would silently drop every triggered enrolment while looking exactly like a campaign nobody qualifies for.

## Definition of Done

- [x] Hexagonal layering preserved (`TriggerCatalog` is pure Kotlin).
- [x] Unit tests added/updated — 7 in `TriggeredEnrolmentTest`, one per outcome.
- [x] Integration tests added/updated — 2 REST tests (round trip, uncatalogued trigger rejected).
- [ ] Contract tests updated. — N/A, no consumer pact covers campaign create.
- [x] `./gradlew detekt ktlintCheck koverVerify build` passes — 130 tests, 0 failures.
- [x] No new lint warnings.
- [x] OpenAPI spec updated.
- [x] Flyway migration added + rollback note.
- [ ] Avro schema versioned backward-compatibly. — N/A, consumes existing topics, publishes nothing new.
- [x] Docs updated — reasoning lives in the catalogue, the migration and the consumer.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs — the consumer logs party ids at debug and never payload contents.
- [x] No new `@SuppressWarnings` / `@Suppress` without justification — two `TooGenericExceptionCaught` on the consumer, both stated: a poison event must not wedge a partition, and one campaign's failure must not cost the others.
- [x] No new third-party dependency.
- [ ] Auth / crypto / payment code changed? — no.
- [x] **PII path changed?** — yes, in the sense that a new path can cause customer contact. It is gated by the segment check above and by the unchanged contact gate; no new personal data is read, stored or logged.
- [ ] Cardholder data path changed? — no. `openbank.cards.events` is consumed for the issuance *fact* only; no card data is read from it.

## Compliance impact

- [x] None

Marketing consent is unchanged — every send still passes the live consent pull, and a trigger cannot enrol a party twice.

## Rollout / Rollback

- Deployment strategy: rolling. No existing campaign has a trigger; the column is null for all of them and behaviour is identical until someone sets one.
- Rollback plan: revert plus `ALTER TABLE campaigns DROP COLUMN trigger_event`. No Temporal or external state to unwind — unlike the schedule, a trigger owns nothing outside this service.
- Data migration reversible: yes.

## Reviewer notes

**Kafka is at-least-once**, so the same account-opened event will arrive twice eventually. The already-enrolled guard is what stops that becoming two journeys and two sets of sends; it is asserted directly rather than relied upon.

**The consumer acks even on failure.** Deliberate: a poison event that cannot enrol anyone would otherwise be redelivered forever and stall the partition, blocking every later party's trigger behind it. For a consumer that *starts journeys*, a wedged partition is silent non-delivery for everyone — worse than losing one event, which is logged at error.

**On the branch.** This was cherry-picked onto a fresh `main` after #4051 merged, so the history is one commit and the diff is only the trigger work. The old `feat/campaign-cron-scheduling` branch is deleted.
