### PR TITLE
fix(gitops): raise litellm-db volume 2Gi -> 10Gi to clear a 25h crashloop

### DIFF
--- a/openbank-infra/gitops/components/ai-platform/postgres.yaml
+++ b/openbank-infra/gitops/components/ai-platform/postgres.yaml
@@ -49,14 +49,21 @@ spec:
   imageName: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/ghcr/cloudnative-pg/postgresql:18.1
   storage:
     storageClass: gp3
-    size: 2Gi
+    # Raised 2Gi -> 10Gi (#3975). At 2Gi this cluster filled and CNPG parked it in
+    # `phase: "Not enough disk space"` — 301 restarts over 25 h with no recovery point, while the
+    # `litellm` application pod beside it stayed `1/1 Running` with 0 restarts, so every pod-level
+    # health view showed the component as up. gp3 has allowVolumeExpansion=true, so the operator
+    # expands the PVC in place: no data is moved and nothing is recreated.
+    size: 10Gi
   resources:
     requests: {cpu: 100m, memory: 256Mi}
     limits: {cpu: "1", memory: 512Mi}
   postgresql:
     parameters:
       wal_keep_size: "64MB"
-      # Bound WAL so a checkpoint spike cannot fill the 2Gi volume (#1432).
+      # Bound WAL so a checkpoint spike cannot fill the volume (#1432). Kept at 512MB after the
+      # 2Gi -> 10Gi resize (#3975): the cap is cheap and the headroom is the point, not a budget
+      # to spend. Raising it would re-create the failure mode the resize just cleared.
       max_wal_size: "512MB"
   bootstrap:
     initdb:


### PR DESCRIPTION
## What

`openbank-infra/gitops/components/ai-platform/postgres.yaml` — `litellm-db` storage `2Gi` → `10Gi`.

## Why now

The cluster filled its volume and CNPG parked it in `phase: "Not enough disk space"`. Measured three
times today against the live cluster:

```
09:00Z   litellm-db-1   CrashLoopBackOff   209 restarts   17 h
11:00Z                                     253            21 h
14:30Z   litellm-db-1   Error              301            25 h
```

**+92 restarts in 5.5 hours**, and `firstRecoverabilityPoint` is null throughout — so the database is
both down and unrecoverable.

**It is invisible from every pod-level view.** The `litellm` application pod beside it has been
`1/1 Running` with **0 restarts** for 4d21h. Only the database is dead, and nothing surfaces that: a
crashloop nobody stops is the failure mode where the counter is the only thing that moves, and 301 is
no louder than 209.

## Why this is safe

```
$ kubectl get storageclass gp3 -o json
allowVolumeExpansion: True     provisioner: ebs.csi.aws.com

$ kubectl get pvc -n ai-platform litellm-db-1
2Gi   class=gp3   phase=Bound
```

`allowVolumeExpansion` is on, so the CNPG operator expands the PVC in place — **no data is moved and
nothing is recreated**. The pod is already crashlooping, so there is no availability to lose.

## Why gitops and not a patch

The `Cluster` object carries
`argocd.argoproj.io/tracking-id: litellm:postgresql.cnpg.io/Cluster:ai-platform/litellm-db`, so it is
owned by the `litellm` ArgoCD Application. A direct `kubectl patch` would be reverted by self-heal
within about a minute. This is the only durable path.

## One thing deliberately not changed

`max_wal_size` stays at `512MB`. Its comment previously read *"so a checkpoint spike cannot fill the
2Gi volume (#1432)"* — now stale, so I corrected the wording, not the value. The headroom from this
resize is the point; spending it by raising the WAL cap would re-create the failure the resize clears.

## What this does not fix

`litellm-db` is one of **three** clusters with no recovery point. The other two are unaffected by this
change and remain open on #3975:

- `platform/copilot-db` — reports `Ready`, `ContinuousArchiving = False`, has never archived WAL
  segment `000000000000000000000001` (`Unable to locate credentials`).
- `observability/glitchtip-pg` — reports `ContinuousArchiving = True` with **no backup block at all**,
  which is the "green because nothing is configured" shape.

Verification after merge: `kubectl get pvc -n ai-platform litellm-db-1` shows 10Gi, the pod reaches
`1/1 Running`, and — the one that actually matters —
`kubectl get cluster.postgresql.cnpg.io -n ai-platform litellm-db -o jsonpath='{.status.firstRecoverabilityPoint}'`
becomes non-null. A `Ready` pod is not evidence the backup works; that field is.

Refs #3975
