### PR TITLE
feat(dispute): publish dispute.opened so an open dispute is visible outside this service

### DIFF
--- a/openbank-dispute-service/src/main/kotlin/com/openbank/dispute/application/port/out/DisputePorts.kt
+++ b/openbank-dispute-service/src/main/kotlin/com/openbank/dispute/application/port/out/DisputePorts.kt
@@ -17,6 +17,17 @@ interface DisputeRepository {
 
     fun save(dispute: Dispute): Uni<Dispute>
 
+    /**
+     * Persist the dispute and [outbox] in the SAME transaction (transactional outbox,
+     * ADR-0003/0050) — the open path's counterpart to [update].
+     *
+     * A dispute committed without its `dispute.opened` event is invisible to every consumer
+     * downstream, and the one that matters is ADR-0220 D1's vulnerable-customer exclusion: a
+     * customer with an open dispute must stop receiving promotional surfaces, and it can only know
+     * that if opening one is announced.
+     */
+    fun save(dispute: Dispute, outbox: List<OutboxMessage>): Uni<Dispute>
+
     fun findById(id: UUID): Uni<Dispute?>
 
     fun findByReference(reference: String): Uni<Dispute?>

--- a/openbank-dispute-service/src/main/kotlin/com/openbank/dispute/application/usecase/DisputeService.kt
+++ b/openbank-dispute-service/src/main/kotlin/com/openbank/dispute/application/usecase/DisputeService.kt
@@ -80,7 +80,12 @@ class DisputeService(
             createdAt = now,
             updatedAt = now,
         )
-        return disputeRepo.save(dispute).flatMap { saved ->
+        // The timeline row and the Kafka event are NOT the same thing, and the difference was a
+        // real gap: "OPENED" below is a DisputeTimelineEvent — an audit entry inside this service
+        // — so until now nothing outside dispute-service could learn that a customer had opened
+        // one. ADR-0220 D1 needs exactly that fact to stop sending promotional surfaces to a
+        // customer in dispute, and #4070 records that the absence made the exclusion unbuildable.
+        return disputeRepo.save(dispute, listOf(openedOutboxMessage(dispute))).flatMap { saved ->
             val event = DisputeTimelineEvent(
                 disputeId = saved.id,
                 eventType = "OPENED",
@@ -243,11 +248,34 @@ class DisputeService(
     private fun isValidPartialAmount(amount: BigDecimal?, claimAmount: BigDecimal): Boolean =
         amount != null && amount > BigDecimal.ZERO && amount < claimAmount
 
+    /**
+     * The `dispute.opened` event.
+     *
+     * `partyId` is the field that makes this consumable at all — a consumer holding only a
+     * disputeId would have to call back into this service to learn whose dispute it is, on a path
+     * where that lookup is exactly what the ADR-0220 eligibility snapshot exists to avoid. Paired
+     * with the existing `dispute.resolved`, the two bracket the window during which a customer is
+     * in dispute, so a consumer can both apply and lift the exclusion.
+     */
+    private fun openedOutboxMessage(dispute: Dispute): OutboxMessage = OutboxMessage(
+        aggregateId = dispute.id,
+        eventType = "dispute.opened",
+        payload = """{"eventType":"dispute.opened","disputeId":"${dispute.id}",""" +
+            """"reference":"${dispute.reference}","partyId":"${dispute.partyId}",""" +
+            """"disputeType":"${dispute.disputeType}","status":"${dispute.status}",""" +
+            """"openedAt":"${dispute.createdAt}"}""",
+        createdAt = Instant.now(clock),
+    )
+
     private fun resolvedOutboxMessage(dispute: Dispute): OutboxMessage = OutboxMessage(
         aggregateId = dispute.id,
         eventType = "dispute.resolved",
+        // partyId added alongside dispute.opened: without it a consumer can learn that a customer
+        // entered dispute but never that they left it, so an ADR-0220 exclusion applied on open
+        // would never lift. Additive, and `dispute.remediation_requested` already carries one.
         payload = """{"eventType":"dispute.resolved","disputeId":"${dispute.id}",""" +
-            """"reference":"${dispute.reference}","outcome":"${dispute.remediationOutcome}",""" +
+            """"reference":"${dispute.reference}","partyId":"${dispute.partyId}",""" +
+            """"outcome":"${dispute.remediationOutcome}",""" +
             """"status":"${dispute.status}","resolvedAt":"${dispute.resolvedAt}"}""",
         createdAt = Instant.now(clock),
     )

--- a/openbank-dispute-service/src/main/kotlin/com/openbank/dispute/infrastructure/persistence/repository/DisputeRepositories.kt
+++ b/openbank-dispute-service/src/main/kotlin/com/openbank/dispute/infrastructure/persistence/repository/DisputeRepositories.kt
@@ -28,6 +28,17 @@ class DisputeRepositoryImpl @Inject constructor(
         return sf.withTransaction { s -> s.persist(e).map { mapper.toDomain(e) } }
     }
 
+    // Mirrors update(dispute, outbox): one transaction, so a dispute cannot exist without the
+    // event that announced it, nor an event without the dispute.
+    override fun save(dispute: Dispute, outbox: List<OutboxMessage>): Uni<Dispute> = sf.withTransaction { s ->
+        val e = mapper.toEntity(dispute)
+        var chain = s.persist(e)
+        for (message in outbox) {
+            chain = chain.flatMap { s.persist(message.toOutboxEntity()) }
+        }
+        chain.map { mapper.toDomain(e) }
+    }
+
     @WithSession override fun findById(id: UUID): Uni<Dispute?> =
         sf.withSession { s -> s.find(DisputeEntity::class.java, id) }.map { it?.let(mapper::toDomain) }
 

--- a/openbank-dispute-service/src/test/kotlin/com/openbank/dispute/application/usecase/DisputeServiceTest.kt
+++ b/openbank-dispute-service/src/test/kotlin/com/openbank/dispute/application/usecase/DisputeServiceTest.kt
@@ -76,10 +76,27 @@ class DisputeServiceTest {
 
         val persistedId = UUID.randomUUID()
 
-        every { disputeRepo.save(any()) } answers { Uni.createFrom().item(firstArg<Dispute>().copy(id = persistedId)) }
+        val outbox = slot<List<OutboxMessage>>()
+        every { disputeRepo.save(any(), capture(outbox)) } answers {
+            Uni.createFrom().item(firstArg<Dispute>().copy(id = persistedId))
+        }
         every { timelineRepo.save(any()) } answers { Uni.createFrom().item(firstArg<DisputeTimelineEvent>()) }
 
         val result = service.open(request).await().indefinitely()
+
+        // The timeline row is an audit entry INSIDE this service; the outbox message is the only
+        // thing anyone else can see. Opening a dispute used to write the first and not the second,
+        // which is why ADR-0220 D1's exclusion could not be built (#4070).
+        assertThat(outbox.captured.map { it.eventType }).containsExactly("dispute.opened")
+        val payload = outbox.captured.single().payload
+        assertThat(payload)
+            .describedAs("a consumer holding only a disputeId cannot tell whose dispute it is")
+            .contains(""""partyId":"${request.partyId}"""")
+        // NOT asserted against persistedId: the outbox message is built from the dispute before it
+        // is handed to the repository, and this mock rewrites the id on the way back. Real
+        // persistence keeps it — the id is application-assigned — so the two agree in production
+        // and only the stub makes them differ.
+        assertThat(payload).contains(""""eventType":"dispute.opened"""")
 
         assertThat(result.id).isEqualTo(persistedId)
         assertThat(result.status).isEqualTo(DisputeStatus.OPEN)
@@ -87,7 +104,7 @@ class DisputeServiceTest {
         assertThat(result.filingDate).isEqualTo(today)
         assertThat(result.resolutionDeadline).isEqualTo(today.plusDays(45))
 
-        verify(exactly = 1) { disputeRepo.save(any()) }
+        verify(exactly = 1) { disputeRepo.save(any(), any()) }
         verify(exactly = 1) { timelineRepo.save(any()) }
     }
 


### PR DESCRIPTION
## Summary

Opening a dispute was invisible outside dispute-service. The only dispute facts on Kafka were `dispute.resolved` and `dispute.remediation_requested` — so a consumer could learn that a dispute *ended*, never that one had *started*. `"OPENED"` existed, but as a `DisputeTimelineEvent`: an audit row inside this service.

## Type of change

- [x] feat (new functionality)
- [ ] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [ ] docs
- [ ] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change

## Linked issues

Refs #4070 — the survey of what ADR-0220 D1's vulnerable-customer exclusion is missing. This is one of the three producer-side gaps it lists.

## Why

ADR-0220 D1 requires in-app promotional surfaces to exclude the ADR-0200 D6 adverse-state set: fraud hold, arrears, **open dispute**, erasure requested. `openbank-engagement-service` has the rule and the `AdverseState.DISPUTE_OPENED` type, but nothing can feed the dispute half while the fact never leaves this service.

## Changes

- **`dispute.opened`** — new outbox event on open, carrying `partyId`, `disputeType`, `status` and `openedAt`.
- **`partyId` added to `dispute.resolved`** — see below; this is the half that is easy to forget.
- **`save(dispute, outbox)`** on `DisputeRepository`, mirroring the existing `update(dispute, outbox)`, so the dispute and its event commit in one transaction.

## The two decisions worth reviewing

**`dispute.resolved` needed `partyId` too, and omitting it would have been worse than doing nothing.** A consumer can apply an exclusion when it sees an open, but with no party on the resolve it can never lift one — leaving a customer permanently excluded from surfaces by a dispute that closed months ago. That failure is silent and would look like "this customer never engages". The two events now bracket the window. `dispute.remediation_requested` already carried a `partyId`, so this only makes the topic consistent.

**Transactional outbox, not a publish after save.** A dispute committed without its event is invisible downstream forever, with nothing to reconcile against — there is no later write to piggyback on, unlike the resolve path. The new `save` overload keeps them atomic and mirrors the shape the resolve path already uses, rather than inventing a second pattern.

## Definition of Done

- [x] Hexagonal layering preserved.
- [x] Unit tests added/updated — the assertion was **falsified**: replacing the outbox list with `emptyList()` reddens exactly that test.
- [ ] Integration tests added/updated. — N/A, no new boundary behaviour; the outbox dispatcher is unchanged.
- [ ] Contract tests updated. — N/A, no consumer pact covers this topic.
- [x] `./gradlew ktlintCheck detekt test` passes — 50 tests, 0 failures.
- [x] No new lint warnings.
- [ ] OpenAPI spec regenerated. — N/A, no REST change.
- [ ] Flyway migration. — N/A, no schema change (the outbox table already exists).
- [x] Event schema versioned backward-compatibly — `dispute.opened` is a new type on an existing topic; the `partyId` addition to `dispute.resolved` is additive. JSON outbox payloads, no registry step.
- [x] Docs updated — reasoning is in the payload builders and the port KDoc.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings` / `@Suppress`.
- [x] No new third-party dependency.
- [ ] Auth / crypto / payment code changed? — no.
- [x] **PII path changed?** — yes, narrowly. A party identifier now travels on `openbank.dispute.events`, which already carries one on `dispute.remediation_requested`. Consumers are internal services under the same ADR-0118 retention. The identifier is a UUID, not an attribute, and the purpose is to *stop* contacting a customer in dispute.
- [ ] Cardholder data path changed? — no.

## Compliance impact

- [ ] PCI DSS
- [ ] DORA
- [x] GDPR
- [ ] PSD2 / SCA / RTS
- [ ] AML / 5AMLD
- [ ] CNB reporting

GDPR: the identifier is added to enforce a protection — suppressing marketing to customers in dispute — rather than to enable targeting.

## Rollout / Rollback

- Deployment strategy: rolling. Nothing consumes `dispute.opened` yet, so this is producer-only.
- Rollback plan: revert. Additive on both counts; no consumer breaks either way.
- Data migration reversible: N/A.

## Reviewer notes

**What this does NOT do.** It makes the dispute adverse-state feed possible; it does not build it. engagement-service still constructs an empty adverse-state set and that stays a launch blocker — better than a half-wired exclusion that reads as complete.

**Remaining gap after this lands.** Of the four adverse states: erasure has a usable source today (`PARTY_ERASED`), arrears gets one from #4071 (open, money-path, awaiting two approvals), this PR covers dispute — and **fraud hold still has none**: fraud-service has no outgoing channel at all, and giving it one means first deciding what a "fraud hold" event is, which is a design question rather than a plumbing one.
