### PR TITLE
feat(customer-edge): honour a shared DOCUMENT, so the share button leads somewhere

### DIFF
--- a/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerDocumentResource.kt
+++ b/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerDocumentResource.kt
@@ -35,7 +35,7 @@ import java.util.UUID
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
 @RolesAllowed("ROLE_CUSTOMER")
-class CustomerDocumentResource(private val upstream: UpstreamClient) {
+class CustomerDocumentResource(private val upstream: UpstreamClient, private val grants: DelegationGrants) {
 
     @Inject
     lateinit var jwt: JsonWebToken
@@ -103,10 +103,27 @@ class CustomerDocumentResource(private val upstream: UpstreamClient) {
                 put("createdAt", doc.get("createdAt")?.asText())
             }
         }
-        return Response.ok(json.writeValueAsString(safe)).type(MediaType.APPLICATION_JSON).build()
+        // Documents shared WITH the caller belong in the list too — without this a grantee accepts
+        // a share and then has no way to reach what they were given. Appended and marked, never
+        // blended: "sharedWithMe" is how the app can say whose document it is, so a delegate does
+        // not come to believe they own what they were lent. Own documents are unaffected when
+        // delegation-service is unreachable.
+        val shared = sharedDocuments(upstream, json, documentServiceUrl, grants, partyId)
+        val out = if (shared.isEmpty()) safe else safe + shared
+        return Response.ok(json.writeValueAsString(out)).type(MediaType.APPLICATION_JSON).build()
     }
 
-    /** Stream a document's PDF bytes — only if it belongs to the caller. */
+    /**
+     * Stream a document's PDF bytes — to its owner, or to someone it was shared with.
+     *
+     * Delegated access over a DOCUMENT (ADR-0232) was until now a grant nobody could use: the app
+     * could offer one and this route still answered 404, because ownership was the only question
+     * asked. Same defect as accounts had before #4021, one level down — and reintroduced the
+     * moment the app grew a share button on a document row.
+     *
+     * A non-owner needs an ACTIVE grant carrying OBJECT_READ on THIS document. Anything else is
+     * still 404 rather than 403: a stranger must not learn that a document id exists.
+     */
     @GET
     @Path("/documents/{id}/content")
     @Blocking
@@ -114,7 +131,9 @@ class CustomerDocumentResource(private val upstream: UpstreamClient) {
         val partyId = partyId()
         val meta = upstream.get("$documentServiceUrl/api/v1/documents/$id", partyId)
         if (meta.status != OK) return notFound()
-        if (ownerPartyOf(meta) != partyId) return notFound() // do not leak existence to a non-owner
+        if (ownerPartyOf(meta) != partyId && !grants.has(partyId, "DOCUMENT", id.toString(), "OBJECT_READ")) {
+            return notFound()
+        }
         return upstream.getRaw("$documentServiceUrl/api/v1/documents/$id/content", partyId, MediaType.WILDCARD)
     }
 
@@ -189,3 +208,37 @@ class CustomerDocumentResource(private val upstream: UpstreamClient) {
 
 /** `RAMCOVA_SMLOUVA_CS` and `RAMCOVA_SMLOUVA_EN` are two languages of one contract, not two. */
 private fun templateFamily(templateCode: String): String = templateCode.removeSuffix("_CS").removeSuffix("_EN")
+
+private const val HTTP_OK = 200
+
+/**
+ * Documents someone else shared with this caller, projected onto the same customer-safe field set
+ * the owner's own documents get, plus `sharedWithMe` so the app can say whose document it is.
+ *
+ * File-level rather than a member: it is a pure projection over a grant lookup and a fetch, and the
+ * resource class is already at its function budget.
+ */
+private fun sharedDocuments(
+    upstream: UpstreamClient,
+    json: com.fasterxml.jackson.databind.ObjectMapper,
+    documentServiceUrl: String,
+    grants: DelegationGrants,
+    partyId: String,
+): List<Map<String, Any?>> = grants.activeResourceIds(partyId, "DOCUMENT", "OBJECT_READ")
+    .mapNotNull { id ->
+        upstream.get("$documentServiceUrl/api/v1/documents/$id", partyId)
+            .takeIf { it.status == HTTP_OK }
+    }
+    .mapNotNull { r -> runCatching { json.readTree(r.entity?.toString() ?: "") }.getOrNull() }
+    .map { doc ->
+        buildMap<String, Any?> {
+            put("id", doc.textOrNull("id"))
+            put("templateCode", doc.textOrNull("templateCode"))
+            put("templateVersion", doc.textOrNull("templateVersion"))
+            put("contentType", doc.textOrNull("contentType"))
+            put("sizeBytes", doc.get("sizeBytes")?.asLong())
+            put("status", doc.textOrNull("status"))
+            put("createdAt", doc.textOrNull("createdAt"))
+            put("sharedWithMe", true)
+        }
+    }

--- a/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/DelegationGrants.kt
+++ b/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/DelegationGrants.kt
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.customeredge.infrastructure.rest
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import jakarta.enterprise.context.ApplicationScoped
+import org.eclipse.microprofile.config.inject.ConfigProperty
+
+/**
+ * The one place the edge asks delegation-service "may this person do this to that" (ADR-0232).
+ *
+ * Every route that honours a share funnels through here, so the two properties that make delegated
+ * access safe are decided once instead of per caller:
+ *
+ *  - **Fail closed.** A delegation-service that is down, slow or unparseable DENIES. Guessing
+ *    "probably allowed" discloses someone else's document or balance; guessing the other way makes
+ *    a shared thing briefly unavailable. Only one of those is a breach.
+ *  - **No cache, no local projection.** A revoked or suspended grant stops working on the next
+ *    read, not at the end of a TTL. Revocation that takes effect "soon" is not revocation, and
+ *    this is the read path to someone else's money and papers.
+ */
+@ApplicationScoped
+class DelegationGrants(private val upstream: UpstreamClient) {
+
+    @ConfigProperty(
+        name = "openbank.edge.delegation-service-url",
+        defaultValue = "http://delegation-service.delegation.svc:8126",
+    )
+    lateinit var delegationServiceUrl: String
+
+    private val json = ObjectMapper()
+
+    /** Whether an ACTIVE grant gives [granteePartyId] [capability] over this exact resource. */
+    fun has(granteePartyId: String, resourceType: String, resourceId: String, capability: String): Boolean {
+        val body = """
+            {"granteePartyId":"$granteePartyId","resourceType":"$resourceType",
+            "resourceId":"$resourceId","capability":"$capability"}
+        """.trimIndent().replace("\n", "")
+        val resp = runCatching {
+            upstream.post("$delegationServiceUrl/api/v1/delegations/check", granteePartyId, body)
+        }.getOrNull() ?: return false
+        if (resp.status != HTTP_OK) return false
+        return runCatching {
+            json.readTree(resp.entity?.toString() ?: "").path("granted").asBoolean(false)
+        }.getOrDefault(false)
+    }
+
+    /**
+     * Resource ids of [resourceType] shared WITH this party and carrying [capability].
+     *
+     * OFFERED grants are absent on purpose: an offer nobody accepted is not access, and listing it
+     * would show the grantee something they have not agreed to hold.
+     */
+    fun activeResourceIds(granteePartyId: String, resourceType: String, capability: String): List<String> {
+        val resp = runCatching {
+            upstream.get("$delegationServiceUrl/api/v1/delegations/grantee/$granteePartyId", granteePartyId)
+        }.getOrNull() ?: return emptyList()
+        if (resp.status != HTTP_OK) return emptyList()
+        val grants = runCatching { json.readTree(resp.entity?.toString() ?: "") }.getOrNull()
+            ?.takeIf { it.isArray } ?: return emptyList()
+        return grants.asSequence()
+            .filter { it.path("status").asText() == "ACTIVE" }
+            .filter { it.path("resourceType").asText() == resourceType }
+            .filter { g -> g.path("capabilities").any { it.asText() == capability } }
+            .mapNotNull { it.path("resourceId").asText(null) }
+            .distinct()
+            .toList()
+    }
+
+    /** Read-capabilities that make a shared ACCOUNT worth listing. Execution capabilities are absent. */
+    fun accountReadCapabilities(): Set<String> = ACCOUNT_READ_CAPABILITIES
+
+    private companion object {
+        const val HTTP_OK = 200
+        val ACCOUNT_READ_CAPABILITIES = setOf("ACCOUNT_READ_BALANCES", "ACCOUNT_READ_TRANSACTIONS")
+    }
+}
+
+/** Convenience for the JSON projections that follow a grant lookup. */
+internal fun JsonNode.textOrNull(field: String): String? = this.get(field)?.asText()

--- a/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/CustomerDocumentResourceTest.kt
+++ b/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/CustomerDocumentResourceTest.kt
@@ -5,6 +5,7 @@
 package com.openbank.customeredge
 
 import com.openbank.customeredge.infrastructure.rest.CustomerDocumentResource
+import com.openbank.customeredge.infrastructure.rest.DelegationGrants
 import com.openbank.customeredge.infrastructure.rest.UpstreamClient
 import io.mockk.every
 import io.mockk.mockk
@@ -23,14 +24,19 @@ class CustomerDocumentResourceTest {
     private val caller: UUID = UUID.randomUUID()
     private val docSvc = "http://document-service.documents.svc:8143"
 
-    private fun resource(upstream: UpstreamClient): CustomerDocumentResource =
-        CustomerDocumentResource(upstream).apply {
-            jwt = mockk {
-                every { getClaim<String>("party_id") } returns caller.toString()
-                every { subject } returns caller.toString()
-            }
-            documentServiceUrl = docSvc
+    private fun resource(upstream: UpstreamClient): CustomerDocumentResource = CustomerDocumentResource(
+        upstream,
+        // These tests are about ownership, not delegation; a checker pointed at an
+        // unreachable service denies every share, which is the pre-existing behaviour
+        // each case here asserts.
+        DelegationGrants(upstream).apply { delegationServiceUrl = "http://delegation.invalid" },
+    ).apply {
+        jwt = mockk {
+            every { getClaim<String>("party_id") } returns caller.toString()
+            every { subject } returns caller.toString()
         }
+        documentServiceUrl = docSvc
+    }
 
     @Test
     fun `ensureAgreement forces partyRef to the token and passes the chosen language`() {
@@ -48,12 +54,19 @@ class CustomerDocumentResourceTest {
     @Test
     fun `listDocuments queries upstream with the token party, never a client-supplied one`() {
         val upstream = mockk<UpstreamClient>()
-        val urlSlot = slot<String>()
-        every { upstream.get(capture(urlSlot), any()) } returns Response.ok("[]").build()
+        // Capture ALL urls, not the last one: listDocuments also asks delegation-service which
+        // documents were shared with the caller, so "the last call" is no longer the documents
+        // read. The property under test is unchanged — the party in the documents query is the
+        // token's, never one the client supplied.
+        val urls = mutableListOf<String>()
+        every { upstream.get(capture(urls), any()) } returns Response.ok("[]").build()
 
         resource(upstream).listDocuments()
 
-        assertThat(urlSlot.captured).isEqualTo("$docSvc/api/v1/documents?partyRef=$caller")
+        assertThat(urls).contains("$docSvc/api/v1/documents?partyRef=$caller")
+        assertThat(urls.filter { it.startsWith(docSvc) }).allSatisfy {
+            assertThat(it).contains(caller.toString())
+        }
     }
 
     @Test

--- a/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/SharedDocumentTest.kt
+++ b/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/SharedDocumentTest.kt
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.customeredge
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.customeredge.infrastructure.rest.CustomerDocumentResource
+import com.openbank.customeredge.infrastructure.rest.DelegationGrants
+import com.openbank.customeredge.infrastructure.rest.UpstreamClient
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import jakarta.ws.rs.core.Response
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+/**
+ * A shared DOCUMENT, read by the person it was shared with (ADR-0232, issue #3615).
+ *
+ * Delegated access over a document was a grant nobody could use: the app could offer one and this
+ * resource still answered 404, because ownership was the only question asked. The share button on
+ * a document row made that visible — it produced a grant that led nowhere.
+ */
+class SharedDocumentTest {
+
+    private fun resourceFor(upstream: UpstreamClient, caller: UUID): CustomerDocumentResource {
+        val grants = DelegationGrants(upstream).apply { delegationServiceUrl = "http://delegation" }
+        return CustomerDocumentResource(upstream, grants).apply {
+            jwt = mockk {
+                every { getClaim<String>("party_id") } returns caller.toString()
+                every { subject } returns caller.toString()
+            }
+            documentServiceUrl = "http://documents"
+        }
+    }
+
+    private fun docMeta(id: UUID, owner: UUID) = Response.ok(
+        """{"id":"$id","partyRef":"$owner","templateCode":"RAMCOVA_SMLOUVA","status":"ACTIVE","createdAt":"2026-08-01"}""",
+    ).build()
+
+    private fun granted(yes: Boolean) = Response.ok("""{"granted":$yes}""").build()
+
+    @Test
+    fun `the person a document was shared with can open it`() {
+        val grantee = UUID.randomUUID()
+        val owner = UUID.randomUUID()
+        val doc = UUID.randomUUID()
+        val upstream = mockk<UpstreamClient>()
+        every { upstream.get(match { it.endsWith("/documents/$doc") }, any()) } returns docMeta(doc, owner)
+        every { upstream.post(match { it.contains("/delegations/check") }, any(), any()) } returns granted(true)
+        every { upstream.getRaw(match { it.contains("/content") }, any(), any()) } returns
+            Response.ok("%PDF-1.4").build()
+
+        assertThat(resourceFor(upstream, grantee).documentContent(doc).status).isEqualTo(200)
+    }
+
+    @Test
+    fun `a stranger gets 404, not 403 — a document id must not be confirmed to exist`() {
+        val stranger = UUID.randomUUID()
+        val owner = UUID.randomUUID()
+        val doc = UUID.randomUUID()
+        val upstream = mockk<UpstreamClient>()
+        every { upstream.get(match { it.endsWith("/documents/$doc") }, any()) } returns docMeta(doc, owner)
+        every { upstream.post(match { it.contains("/delegations/check") }, any(), any()) } returns granted(false)
+
+        val resp = resourceFor(upstream, stranger).documentContent(doc)
+
+        assertThat(resp.status).isEqualTo(404)
+        verify(exactly = 0) { upstream.getRaw(match { it.contains("/content") }, any(), any()) }
+    }
+
+    @Test
+    fun `an owner is never asked about delegation`() {
+        val owner = UUID.randomUUID()
+        val doc = UUID.randomUUID()
+        val upstream = mockk<UpstreamClient>()
+        every { upstream.get(match { it.endsWith("/documents/$doc") }, any()) } returns docMeta(doc, owner)
+        every { upstream.getRaw(any(), any(), any()) } returns Response.ok("%PDF-1.4").build()
+
+        assertThat(resourceFor(upstream, owner).documentContent(doc).status).isEqualTo(200)
+        verify(exactly = 0) { upstream.post(match { it.contains("/delegations/check") }, any(), any()) }
+    }
+
+    @Test
+    fun `a delegation-service outage denies rather than guessing`() {
+        val grantee = UUID.randomUUID()
+        val owner = UUID.randomUUID()
+        val doc = UUID.randomUUID()
+        val upstream = mockk<UpstreamClient>()
+        every { upstream.get(match { it.endsWith("/documents/$doc") }, any()) } returns docMeta(doc, owner)
+        every { upstream.post(match { it.contains("/delegations/check") }, any(), any()) } throws
+            RuntimeException("connection refused")
+
+        assertThat(resourceFor(upstream, grantee).documentContent(doc).status).isEqualTo(404)
+    }
+
+    @Test
+    fun `a shared document appears in the list, marked, and after the caller's own`() {
+        val grantee = UUID.randomUUID()
+        val owner = UUID.randomUUID()
+        val mine = UUID.randomUUID()
+        val theirs = UUID.randomUUID()
+        val upstream = mockk<UpstreamClient>()
+        every { upstream.get(match { it.contains("documents?partyRef=$grantee") }, any()) } returns Response.ok(
+            """[{"id":"$mine","partyRef":"$grantee","templateCode":"VOP","status":"ACTIVE","createdAt":"2026-08-02"}]""",
+        ).build()
+        every { upstream.get(match { it.contains("/delegations/grantee/$grantee") }, any()) } returns Response.ok(
+            """[{"status":"ACTIVE","resourceType":"DOCUMENT","resourceId":"$theirs","capabilities":["OBJECT_READ"]}]""",
+        ).build()
+        every { upstream.get(match { it.endsWith("/documents/$theirs") }, any()) } returns docMeta(theirs, owner)
+
+        val body = ObjectMapper().readTree(resourceFor(upstream, grantee).listDocuments().entity.toString())
+
+        assertThat(body).hasSize(2)
+        assertThat(body[0].path("sharedWithMe").asBoolean(false)).isFalse()
+        assertThat(body[1].path("id").asText()).isEqualTo(theirs.toString())
+        assertThat(body[1].path("sharedWithMe").asBoolean(false)).isTrue()
+    }
+
+    @Test
+    fun `the caller's own documents survive a delegation-service outage`() {
+        val grantee = UUID.randomUUID()
+        val mine = UUID.randomUUID()
+        val upstream = mockk<UpstreamClient>()
+        every { upstream.get(match { it.contains("documents?partyRef=$grantee") }, any()) } returns Response.ok(
+            """[{"id":"$mine","partyRef":"$grantee","templateCode":"VOP","status":"ACTIVE","createdAt":"2026-08-02"}]""",
+        ).build()
+        every { upstream.get(match { it.contains("/delegations/grantee/") }, any()) } throws
+            RuntimeException("connection refused")
+
+        val body = ObjectMapper().readTree(resourceFor(upstream, grantee).listDocuments().entity.toString())
+
+        assertThat(body).hasSize(1)
+        assertThat(body[0].path("id").asText()).isEqualTo(mine.toString())
+    }
+
+    @Test
+    fun `an offered but unaccepted share does not put the document in the list`() {
+        val grantee = UUID.randomUUID()
+        val theirs = UUID.randomUUID()
+        val upstream = mockk<UpstreamClient>()
+        every { upstream.get(match { it.contains("documents?partyRef=$grantee") }, any()) } returns
+            Response.ok("[]").build()
+        every { upstream.get(match { it.contains("/delegations/grantee/$grantee") }, any()) } returns Response.ok(
+            """[{"status":"OFFERED","resourceType":"DOCUMENT","resourceId":"$theirs","capabilities":["OBJECT_READ"]}]""",
+        ).build()
+
+        val body = ObjectMapper().readTree(resourceFor(upstream, grantee).listDocuments().entity.toString())
+
+        assertThat(body).isEmpty()
+    }
+}


### PR DESCRIPTION
Navazuje na #4021. Klientská strana: openbank-app#413 (zmergováno).

## Proč

#4021 naučil edge respektovat dispozice nad **účtem** — zůstatky, pohyby, seznam účtů. Tam to skončilo. Dokumenty se dál ptaly jen na vlastnictví, takže grant nad `DOCUMENT` byl grant, který nešel uplatnit. Sdílecí tlačítko u dokumentu to zviditelnilo: nabídka odešla, protistrana ji přijala, a dokument dál vracel 404.

## Co

Dvě routy nově přijmou i grant, nejen vlastnictví:

- `GET /documents/{id}/content` — ACTIVE grant s `OBJECT_READ` na **tenhle** dokument. Pro všechny ostatní pořád **404, ne 403**: cizí člověk se nesmí dozvědět, že to id existuje.
- `GET /documents` — dokumenty sdílené s volajícím se **připojí označené** `sharedWithMe`, aby appka mohla říct, čí dokument to je, místo aby cizí papíry splynuly s vlastními.

## DelegationGrants

Dotazování na granty se přesunulo do vlastního spolupracovníka, kterého může převzít i `CustomerEdgeResource`. Dvě vlastnosti jsou tím rozhodnuté **jednou** místo kopie u každého volajícího:

- **Fail closed.** Nedostupná, pomalá nebo nečitelná delegation-service **odmítá**. Odhad „asi to je povolené" podá cizímu člověku něčí smlouvu; odhad opačným směrem způsobí, že sdílený dokument je chvíli nedostupný. Průšvih je jen jeden z nich.
- **Žádná cache.** Odvolané sdílení přestane fungovat při dalším čtení, ne na konci TTL.

Vlastní dokumenty výpadek delegation-service nepocítí — zákazníkovy papíry nesmí zmizet kvůli vedlejší službě.

## Co tu záměrně není: výpisy

Grant nad `STATEMENT` nese id výpisu, ale statement-service umí hledat jen podle `(accountId, currency, legalSequence)` — **vyhledání podle id neexistuje**. Zprovoznění by vyžadovalo nový upstream endpoint, což patří do vlastní změny, ne propašovat sem.

## Ověření

17 testů, 0 selhání (7 nových + 10 stávajících), ktlint i detekt čisté.

Jeden existující test jsem **přepsal, ne změkčil**: zachytával POSLEDNÍ upstream URL, což už není čtení dokumentů, když se `listDocuments` ptá i na sdílení. Nově tvrdí, že **žádné** volání na document-service nenese cizí party — silnější vlastnost než ta původní.