### PR TITLE
fix(ci): pin the kafka dotted-key baseline to explicit channels

### DIFF
--- a/.github/scripts/check-kafka-dotted-keys.py
+++ b/.github/scripts/check-kafka-dotted-keys.py
@@ -40,12 +40,17 @@
 #   green, and a NEW occurrence fails. A baseline entry that becomes covered is also reported, so the
 #   list cannot quietly rot in either direction.
 #
+#   That last property only holds if every baseline entry names ONE channel — see the BASELINE
+#   comment (#3928). A `*` channel makes the ratchet unable to see a channel added later, and the
+#   symptom is a confident `OK`, never a red.
+#
 # EXIT CODES
 #   0  no new occurrences, no stale baseline entries
 #   1  a dotted `group.id` with no override ConfigMap, a dotted `auto.offset.reset` asking for a
 #      non-default value with no override — or a baseline entry that is now covered and should be
 #      removed
-#   2  the check could not run (PyYAML missing, tree not found). Never conflated with 0.
+#   2  the check could not run (PyYAML missing, tree not found) or the BASELINE itself is malformed
+#      (a wildcard channel, an unwatched key). Never conflated with 0.
 #
 # Run:  python3 .github/scripts/check-kafka-dotted-keys.py [--root .] [--self-test]
 
@@ -65,15 +70,35 @@ CONNECTOR_DEFAULT_OFFSET_RESET = "latest"
 
 WATCHED_KEYS = ("group.id", "auto.offset.reset")
 
-# Occurrences that exist today. Each entry is (service, channel, key) -> why it is tolerated.
+# Occurrences that exist today. Each entry is (service, CHANNEL, key) -> why it is tolerated.
 # Adding to this list is a deliberate act that needs a reason; see the ratchet note above.
+#
+# THE CHANNEL IS PINNED, AND `*` IS REJECTED OUTRIGHT (#3928)
+#   This list used to carry six `(service, "*", "auto.offset.reset")` entries. A wildcard channel
+#   makes the baseline a property of the SERVICE, so every channel the service gains later is
+#   pre-absorbed: the ratchet reports "no new ones" about a finding it never looked at, and the
+#   exclusion silently grows past what was ever justified. That is not hypothetical —
+#   `openbank-account-service`'s `delegation-events-in` arrived on 2026-08-02 (#3058), one day
+#   after the baseline was written (#2969), and inherited the exemption with nobody deciding it.
+#   Same repo rule as the pact-drift scope: never let a gate's coverage set be maintained
+#   separately from the artifacts it covers, and never let an exclusion be broader than what was
+#   actually justified. `validate_baseline()` now refuses a `*` channel with exit 2, so the shape
+#   cannot come back by hand.
 BASELINE = {
-    ("openbank-account-service", "*", "auto.offset.reset"): "#2945 — declared earliest, effective default; replay risk makes the fix operational",
-    ("openbank-aml-service", "*", "auto.offset.reset"): "#2945 — same",
-    ("openbank-balance-service", "*", "auto.offset.reset"): "#2945 — same",
-    ("openbank-document-service", "*", "auto.offset.reset"): "#2945 — same",
-    ("openbank-party-service", "*", "auto.offset.reset"): "#2945 — same",
-    ("openbank-statement-service", "*", "auto.offset.reset"): "#2945 — same",
+    ("openbank-account-service", "party-events-in", "auto.offset.reset"): "#2945 — declared earliest, effective default; replay risk makes the fix operational",
+    # NOT part of the #2945 decision. Arrived after the baseline and was absorbed by the `*` channel
+    # (#3058 -> #3928). Pinned here so it is a named, reviewable entry rather than an invisible one;
+    # the operational call (msg-override ConfigMap, i.e. a real replay on openbank.delegation.events)
+    # is still open and is exactly what the wildcard was hiding.
+    ("openbank-account-service", "delegation-events-in", "auto.offset.reset"): "#3928 — post-#2945 arrival, absorbed by the old `*` entry; replay decision still OPEN",
+    ("openbank-aml-service", "party-events-in", "auto.offset.reset"): "#2945 — same",
+    ("openbank-balance-service", "ledger-events-in", "auto.offset.reset"): "#2945 — same",
+    ("openbank-balance-service", "balance-init-in", "auto.offset.reset"): "#2945 — same",
+    ("openbank-document-service", "account-created-in", "auto.offset.reset"): "#2945 — same",
+    ("openbank-party-service", "kyc-events-in", "auto.offset.reset"): "#2945 — same",
+    ("openbank-party-service", "aml-events-in", "auto.offset.reset"): "#2945 — same",
+    ("openbank-party-service", "consent-events-in", "auto.offset.reset"): "#2945 — same",
+    ("openbank-statement-service", "account-events-in", "auto.offset.reset"): "#2945 — same",
 }
 
 
@@ -129,11 +154,31 @@ def load_overrides(root):
 
 
 def baseline_key(service, channel, key):
-    """Baseline entries may pin a channel or use '*' for the whole service."""
-    for candidate in ((service, channel, key), (service, "*", key)):
-        if candidate in BASELINE:
-            return candidate
-    return None
+    """Exact `(service, channel, key)` only — a baseline entry can never span channels (#3928)."""
+    candidate = (service, channel, key)
+    return candidate if candidate in BASELINE else None
+
+
+def validate_baseline(baseline=None):
+    """Reject a baseline shape that would silently widen the exclusion. Returns a list of errors.
+
+    The only shape banned here is the one that caused #3928: a `*` channel. It reads as a small
+    convenience and is in fact an open-ended exemption for every channel the service has not been
+    given yet — the failure lands as a green, so nothing else in the pipeline can notice it.
+    """
+    if baseline is None:
+        baseline = BASELINE
+    errors = []
+    for entry in sorted(baseline):
+        service, channel, key = entry
+        if channel == "*":
+            errors.append(
+                f"baseline entry {entry} uses a wildcard channel. A baseline pins ONE channel, "
+                f"or it pre-absorbs every channel {service} gains later (#3928). Enumerate them.",
+            )
+        if key not in WATCHED_KEYS:
+            errors.append(f"baseline entry {entry} names {key!r}, which is not in WATCHED_KEYS.")
+    return errors
 
 
 def scan(root):
@@ -247,6 +292,84 @@ SELF_TEST_EXPECT = {
 }
 
 
+def _build_self_test_tree(root):
+    """Materialise SELF_TEST_SERVICES under `root`. Shared by both halves of the self-test."""
+    for service, (app_yaml, override) in SELF_TEST_SERVICES.items():
+        res = root / service / "src" / "main" / "resources"
+        res.mkdir(parents=True)
+        (res / "application.yaml").write_text(app_yaml, encoding="utf-8")
+        if override is None:
+            continue
+        short = service[len("openbank-"):]
+        comp = root / "openbank-infra" / "gitops" / "components" / short
+        comp.mkdir(parents=True)
+        (comp / f"{short}-msg-override.yaml").write_text(
+            # The leading comment repeats the property name on purpose: a text guard that does
+            # not strip comments would read this prose as coverage (the silent direction of the
+            # "guard matches the text about the thing" failure).
+            f"# explains mp.messaging.incoming.covered-in.group.id=... and why it is here\n"
+            f"apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: {short}-msg-override\n"
+            f"data:\n  override.properties: |\n    " + override.replace("\n", "\n    "),
+            encoding="utf-8",
+        )
+
+
+def baseline_self_test():
+    """Exercise the BASELINE path itself — the branch #3928 lived in, which had NO coverage.
+
+    Every case here was chosen because the old wildcard code passes it in the WRONG direction:
+    absorbing a channel it was never given, and reporting nothing while doing it. A pinned entry
+    must cover its own channel and NOTHING else, a `*` entry must be refused outright, and an entry
+    matching nothing on the tree must come back as stale.
+    """
+    import tempfile
+
+    global BASELINE
+    saved = BASELINE
+    svc = "openbank-demo-differs-service"
+    cases = []
+    try:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            _build_self_test_tree(root)
+
+            # 1. A pinned entry silences its own channel...
+            BASELINE = {(svc, "asks-for-non-default-in", "auto.offset.reset"): "self-test"}
+            findings, matched = scan(str(root))
+            cases.append((
+                "pinned entry silences its own channel",
+                not any("asks-for-non-default-in" in f for f in findings) and len(matched) == 1,
+            ))
+            # ...and does NOT silence a sibling channel of the same service. This is the whole bug.
+            cases.append((
+                "pinned entry does NOT absorb a sibling channel",
+                any("channel 'differs-in'" in f for f in findings),
+            ))
+
+            # 2. An entry matching nothing on the tree is reported stale (the reverse ratchet).
+            BASELINE = {(svc, "channel-that-does-not-exist", "auto.offset.reset"): "self-test"}
+            _, matched = scan(str(root))
+            cases.append((
+                "baseline entry matching no channel is stale",
+                [k for k in BASELINE if k not in matched] == list(BASELINE),
+            ))
+    finally:
+        BASELINE = saved
+
+    # 3. The shape guard refuses the wildcard that caused #3928, and accepts the real baseline.
+    cases.append((
+        "wildcard channel rejected",
+        len(validate_baseline({(svc, "*", "auto.offset.reset"): "self-test"})) == 1,
+    ))
+    cases.append(("shipped BASELINE is well-formed", validate_baseline() == []))
+
+    failures = 0
+    for label, ok in cases:
+        print(f"{'pass' if ok else 'FAIL'}  {label}")
+        failures += 0 if ok else 1
+    return failures, len(cases)
+
+
 def self_test():
     """Drive the REAL scan() over a synthetic tree, not a retyped copy of its classifier.
 
@@ -262,25 +385,7 @@ def self_test():
     failures = 0
     with tempfile.TemporaryDirectory() as tmp:
         root = pathlib.Path(tmp)
-        for service, (app_yaml, override) in SELF_TEST_SERVICES.items():
-            res = root / service / "src" / "main" / "resources"
-            res.mkdir(parents=True)
-            (res / "application.yaml").write_text(app_yaml, encoding="utf-8")
-            if override is None:
-                continue
-            short = service[len("openbank-"):]
-            comp = root / "openbank-infra" / "gitops" / "components" / short
-            comp.mkdir(parents=True)
-            (comp / f"{short}-msg-override.yaml").write_text(
-                # The leading comment repeats the property name on purpose: a text guard that does
-                # not strip comments would read this prose as coverage (the silent direction of the
-                # "guard matches the text about the thing" failure).
-                f"# explains mp.messaging.incoming.covered-in.group.id=... and why it is here\n"
-                f"apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: {short}-msg-override\n"
-                f"data:\n  override.properties: |\n    " + override.replace("\n", "\n    "),
-                encoding="utf-8",
-            )
-
+        _build_self_test_tree(root)
         findings, _ = scan(str(root))
 
     flagged = {ch for ch in SELF_TEST_EXPECT if any(f"channel '{ch}'" in f for f in findings)}
@@ -297,6 +402,11 @@ def self_test():
     failures += 0 if ok else 1
 
     total = len(SELF_TEST_EXPECT) + 1
+
+    bl_failures, bl_total = baseline_self_test()
+    failures += bl_failures
+    total += bl_total
+
     print(f"\nself-test: {total - failures} passed, {failures} failed")
     return 0 if failures == 0 else 2
 
@@ -312,6 +422,12 @@ def main():
         return 2
     if args.self_test:
         return self_test()
+
+    shape_errors = validate_baseline()
+    if shape_errors:
+        for e in shape_errors:
+            print(f"::error::{e}")
+        return 2
 
     findings, matched = scan(args.root)
     stale = [k for k in BASELINE if k not in matched]


### PR DESCRIPTION
## What

`check-kafka-dotted-keys.py`'s `BASELINE` carried six `("openbank-*-service", "*", "auto.offset.reset")` entries. A wildcard **channel** makes the exclusion a property of the *service*, so every channel that service gains afterwards is pre-absorbed — the ratchet prints `OK — no new ones` about a finding it never looked at, and the exclusion silently grows past what was ever justified.

That is not hypothetical. `openbank-account-service`'s `delegation-events-in` arrived on 2026-08-02 (#3058), one day after the baseline commit (#2969), and inherited the exemption with nobody deciding it.

This is the same repo rule as the pact-drift scope: never let a gate's coverage set be maintained separately from the artifacts it covers, and never let an exclusion be broader than what was actually justified.

## Changes (one file, `.github/scripts/check-kafka-dotted-keys.py`)

- **`BASELINE` names all 10 `(service, channel, key)` triples explicitly.** No `*`. `delegation-events-in` is pinned with its own distinct reason — it was never part of the #2945 decision, and its replay call is still open.
- **`baseline_key()` matches exactly.** The `(service, "*", key)` fallback is gone, so a new channel is a NEW finding, and the existing stale check now works per channel rather than per service (a baselined channel that is fixed or removed is reported).
- **`validate_baseline()` refuses a `*` channel (or an unwatched key) with exit 2**, so the shape cannot be reintroduced by hand.
- **`baseline_self_test()`** — the BASELINE branch had *no* self-test coverage at all, which is why #3928 was invisible to a gate whose self-test passed 5/5. Five new cases, each chosen because the old wildcard code fails it in the silent direction.

## Deliberately NOT in this PR: the underlying config

The defect this gate guards is that SmallRye's YAML source quotes a leaf key containing a literal dot, so `auto.offset.reset: earliest` registers as `…"auto.offset.reset"` and the connector never reads it — the effective value is the connector default, `latest`.

**Fixing that is an operational decision, not a config edit.** Six services look correct on `group.id` only by coincidence (their value happens to equal `quarkus.application.name`, which is what the fallback produces). For `auto.offset.reset` **no such coincidence exists**: making `earliest` actually take effect on a consumer group that has been running as `latest` re-reads the topic from the beginning — a mass replay on money-path channels. That needs a `*-msg-override` ConfigMap and a deliberate per-channel call, as card-issuance did.

**This PR narrows the gate's baseline only.** No `application.yaml` and no gitops manifest is touched. The point is to make the gate *surface* that decision for the next channel instead of absorbing it.

Note the one judgement call: `delegation-events-in` is pinned rather than left to go red. The gate is `mode: enforced` inside the required `Validate manifests` job, so shipping it red would block every PR in the repo on a change this PR is explicitly not making. It is now a named, reviewable baseline entry with its own issue reference — visible, where before it was absorbed.

## Falsification — both ways, on the real tree, exit codes read directly (no pipe)

Every run below is `cmd > file; echo $?` — never `| tail`, which reports `tail`'s status. The old script (`git show origin/main:…`) was run on the *same* mutated tree each time, so the counter-example provably reaches the code.

**Clean tree (control):** new gate `EXIT=0`, `10 baselined occurrence(s), no new ones`. Old gate: `EXIT=0`, `6 baselined occurrence(s)`.

**(a) New dotted key in a channel that is not baselined** — added `zz-falsify-in` with `auto.offset.reset: earliest` to account-service:

```
--- NEW gate (pinned baseline) ---            EXIT=1
NEW  openbank-account-service/.../application.yaml: channel 'zz-falsify-in' sets
     `auto.offset.reset: earliest` as a dotted YAML key with no *-msg-override ConfigMap.
1 new occurrence(s), 0 stale baseline entr(ies).

--- OLD gate (origin/main, wildcard baseline) ---  EXIT=0
kafka dotted keys: OK — 6 baselined occurrence(s), no new ones.
```

Counts: new gate 1 finding / 0 stale (expected 1/0); old gate 0 findings — this is the absorption in #3928, reproduced.

**(b) Baseline entry that no longer matches anything** — removed `auto.offset.reset` from party-service's `consent-events-in`:

```
--- NEW gate ---                              EXIT=1
STALE  baseline entry ('openbank-party-service', 'consent-events-in', 'auto.offset.reset')
       no longer occurs — it is either fixed or the service is gone.
0 new occurrence(s), 1 stale baseline entr(ies).

--- OLD gate ---                              EXIT=0
kafka dotted keys: OK — 6 baselined occurrence(s), no new ones.
```

Counts: new gate 0 findings / 1 stale (expected 0/1); old gate green, because the wildcard entry still matched the service's *other* channel. The reverse ratchet was as broken as the forward one.

Both mutations were reverted from a `cp` backup and the clean-tree run re-confirmed `EXIT=0` before committing (`git status --porcelain` shows only the script modified).

**(c) Shape guard** — reintroducing a `*` entry into a scratch copy of the fixed script: `EXIT=2`, `::error::baseline entry ('openbank-aml-service', '*', 'auto.offset.reset') uses a wildcard channel…`.

**(d) Through the real runner:**

```
python3 .github/scripts/run-gates.py --only kafka-dotted-key-ratchet    RUNNER_EXIT=0
PASS [data] kafka dotted-key ratchet (issues #686/#2945, enforced)  (7.9s)
self-test: 11 passed, 0 failed          (was 6; +5 baseline cases)
kafka dotted keys: OK — 10 baselined occurrence(s), no new ones.
```

## Out of scope, still open

The issue's later comment about `WATCHED_KEYS` being only two keys (anacredit's dotted `client.id` / `value.deserializer`, found by the advisory `dotted-mp-messaging-key-guard`) is a separate scope change to the same gate and is not touched here.

Closes #3928
