### PR TITLE
feat(statement-service): add customer-facing statement download endpoint

### DIFF
--- a/docs/threat-models/statement-service.md
+++ b/docs/threat-models/statement-service.md
@@ -1,0 +1,69 @@
+# Threat model — Statement Service (ADR-0035 / ADR-0248)
+
+**Surface:** `openbank-statement-service` — owns the per-pocket statement lifecycle (period-close,
+fail-closed reconciliation, on-demand camt.053/MT940/PDF render, ad-hoc export) and, as of ADR-0248,
+a synchronous customer-facing styled-document download that calls out to document-service.
+**Posture:** NOT on the `money_path_services` list (`rules.yaml`), so the 2-approval / money-path
+regime does not apply — but ADR-0248 is a **trust-boundary change** regardless: it adds a new
+outbound synchronous call into document-service, statement-service's first (`rules.yaml:
+trust_boundary_diff_change`), which is why this document exists.
+
+## Assets
+- **Statement correctness** — every rendered format (camt.053, MT940, PDF, and now the styled
+  document) is a pure projection of the same `StatementModel`; a wrong figure on any of them is a
+  regulatory (PSD2 Art. 58(2)) and customer-trust failure.
+- **Legal/electronic sequence integrity** — the per-pocket sequence assigned at close is the
+  document's identity; it must never be reused, skipped, or assignable by an unauthenticated caller.
+- **Fail-closed reconciliation boundary** — a period whose computed closing balance disagrees with
+  balance-service's independently-reported one must never close (`ReconciliationException` → 409).
+- **Booked-entry / balance confidentiality** — every render path (existing and new) exposes an
+  account's transaction history and balances; unauthorized access is a PII/financial-data leak.
+
+## Trust boundaries
+- Caller (operator / in-cluster service / customer-facing edge, OIDC bearer,
+  `ROLE_VIEWER`/`ROLE_OPERATOR`/`ROLE_ADMIN`/`ROLE_AUDITOR`/`ROLE_API`) → statement-service REST
+  (`/api/v1/statements/**`).
+- statement-service → transaction-service (booked entries), balance-service (reconciliation
+  closing balance), account-service + party-service (pocket identity, holder name) — all pre-existing
+  reactive REST-client reads (`infrastructure/client/RestClients.kt`).
+- statement-service → the scheduled period-close job (`ClosePeriodUseCase`, self-healing catch-up,
+  ADR-0069 D3) — an in-process trigger, no external trust boundary of its own.
+- **NEW (ADR-0248): statement-service → document-service**, synchronous, on customer download
+  request only. Calls `GET /api/v1/documents/templates` (list, to resolve the PUBLISHED
+  `MESICNI_VYPIS_CS`/`MESICNI_VYPIS_EN` template body — there is no get-by-code route) then
+  `POST /api/v1/documents/templates/preview` (merge `StatementModel`-derived data into that body).
+  Both calls are non-persisting on the document-service side (ADR-0248) — the response is streamed
+  straight back to the caller and never stored or cached by statement-service either.
+
+## Threats & mitigations (STRIDE)
+| Threat | Mitigation |
+| --- | --- |
+| **Spoofing the caller** | Every `/api/v1/statements/**` endpoint (including the new `/document` one) requires a valid OIDC bearer via the class-level `@RolesAllowed`; unauthenticated calls are 401. `StatementSecurityTest` guards against an unannotated endpoint. |
+| **Tampering — wrong statement served for the wrong account** | `#accountId`/`#currency`/`#legalSequence` are path parameters resolved against `StatementPeriodRepository.findBySequence`, which looks the closed period up by exactly that composite key; there is no ambient/session-derived account context to confuse. The new `/document` endpoint reuses the identical lookup (`StatementModelUseCase.statementModel`, factored out of `RenderStatementUseCase.render` specifically so both paths share one reconciliation/lookup implementation rather than risk drifting). |
+| **Tampering — a malicious/buggy caller requests another customer's statement** | **Gap, not new**: `@Authorize(action = "statement.read", resource = "#accountId")` is enforced at the OPA policy layer, but `rules.yaml`'s `role_action_matrix` grants `statement.read` to `ROLE_OPERATOR`/`ROLE_ADMIN`/`ROLE_COMPLIANCE`/`ROLE_API` — all machine/staff roles — with no per-request check that the caller's own identity owns `accountId`. Statement-service trusts its caller (ADR-0248: "the customer-facing edge calling it") to have already scoped the request to the authenticated customer's own account, the same design `render()` already relies on. The new `/document` endpoint inherits this exactly — it adds no new exposure, but it does add a second callable surface with the same gap, which is worth closing once (e.g. an OPA rule comparing `input.principal.id`'s linked party/account set against `accountId`) rather than twice. |
+| **Tampering — SSTI via the Handlebars data map** | Every value statement-service sends into `document.*`/`party.*`/`account.*` is a projection of `StatementModel` (booked entries, balances, IBAN, holder name) — no caller-supplied string reaches document-service's template engine as anything but a data value; the template body itself is document-service's own, published-only, and out of statement-service's control (document-service's own threat model owns SSTI on the engine side). |
+| **Repudiation** | Period-close and restatement already emit outbox events (`account.statement.period.closed.v1`) atomically with the persisted record. The new download path renders and discards — it is read-only and mints no new record, so it has nothing to repudiate; it does not need (and per ADR-0248 must not have) an audit trail beyond normal access logging. |
+| **Information disclosure** | Rendered output (all formats, including the new styled document) carries booked-entry detail and balances — the same class of data `render()`/`export()` already expose. The new call to document-service travels over the same in-cluster mTLS/OIDC path as the other four outbound REST clients (transaction/balance/account/party); no new plaintext egress. |
+| **Denial of service — the new outbound call degrades only this one endpoint** | `DocumentTemplateRestAdapter` wraps every failure (list call, preview call, template not found) in a single `DocumentServiceException`, mapped by `StatementResource.document()` to `502 Bad Gateway`. A slow or unreachable document-service therefore fails closed on `/document` only — period-close, camt.053/MT940/PDF render, ad-hoc export, list, and restate are all on independent code paths and untouched. There is no retry/circuit-breaker on this new client today (matching the existing four REST clients, none of which have one either) — a sustained document-service outage means every `/document` call times out at the HTTP client default rather than failing fast; a tracked follow-up if this endpoint's traffic grows past occasional customer downloads. |
+| **Elevation / cluster pivot** | Unchanged posture: restricted PSS, non-root, OPA authz (`@Authorize`, ADR-0034), and an egress NetworkPolicy that must now also allow statement-service → document-service (previously not a peer) — `openbank-infra` gitops owns that allow-list and needs the corresponding entry when this ships (out of scope for this PR: `openbank-infra/` is untouched here). |
+
+## Residual risk / follow-ups
+- **Account-ownership check is missing at the statement-service layer, fleet-wide, not just on the
+  new endpoint** (see the Tampering row above). Tracked as a gap to close once, not per-endpoint.
+- **No circuit breaker / timeout tuning on the new document-service client** — it inherits whatever
+  the shared Quarkus REST-client default connect/read timeout is, same as the other four adapters in
+  `infrastructure/client/`. Worth revisiting together, not singled out for this one client.
+- **The rendered "document" is HTML, not PDF, today.** document-service's non-persisting `preview`
+  endpoint (`PreviewTemplateRequest`/`PreviewTemplateResponse`) merges Handlebars data into a
+  template body and returns `renderedHtml` — it does not run the HTML→PDF step that the persisting
+  `/api/v1/documents/render` endpoint does. ADR-0248 deliberately excludes `/render` from this flow
+  (it persists a `Document` row + outbox event, which the ADR rejects for a customer-download click).
+  So today's `/document` endpoint streams back `text/html` with the `MESICNI_VYPIS_CS`/`_EN` body
+  merged in; a byte-identical PDF requires either a PDF-capable variant of `preview` in
+  document-service or a client-side HTML→PDF step — both out of scope for `openbank-statement-service/`
+  and left as an explicit follow-up, not silently deferred.
+- **Template existence is not verified at deploy time.** `DocumentTemplateRestAdapter` fails a single
+  request with `502` if `MESICNI_VYPIS_CS`/`MESICNI_VYPIS_EN` is not yet PUBLISHED in document-service
+  (e.g. before the seed from the companion ADR-0248 work lands) — there is no boot-time check. This is
+  consistent with how the four existing REST-client dependencies are treated (no boot-time reachability
+  probe either) but is worth naming explicitly since it is a new, request-time-only failure mode.

--- a/openbank-statement-service/src/main/kotlin/com/openbank/statement/application/port/in/StatementUseCases.kt
+++ b/openbank-statement-service/src/main/kotlin/com/openbank/statement/application/port/in/StatementUseCases.kt
@@ -3,7 +3,9 @@
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 package com.openbank.statement.application.port.`in`
 
+import com.openbank.statement.application.port.out.RenderedDocument
 import com.openbank.statement.domain.model.StatementFormat
+import com.openbank.statement.domain.model.StatementModel
 import com.openbank.statement.domain.model.StatementPeriod
 import com.openbank.statement.domain.render.StatementRenderer
 import io.smallrye.mutiny.Uni
@@ -49,6 +51,25 @@ interface RenderStatementUseCase {
         legalSequence: Long,
         format: StatementFormat,
     ): Uni<StatementRenderer.Rendered>
+}
+
+/**
+ * Replays an already-closed period into its canonical [StatementModel] — the same lookup
+ * [RenderStatementUseCase.render] uses internally, exposed so a second consumer (the customer-facing
+ * styled document, ADR-0248) can reuse the reconciliation/lookup logic without duplicating it.
+ */
+interface StatementModelUseCase {
+    fun statementModel(accountId: UUID, currency: String, legalSequence: Long): Uni<StatementModel>
+}
+
+/**
+ * Renders the customer-facing styled statement document (ADR-0248) — synchronous, on customer
+ * request only. Assembles [StatementModel] into document-service's Handlebars data shape and calls
+ * its non-persisting `/api/v1/documents/templates/preview` endpoint; nothing is stored on either
+ * side.
+ */
+interface RenderStatementDocumentUseCase {
+    fun renderDocument(accountId: UUID, currency: String, legalSequence: Long, locale: String): Uni<RenderedDocument>
 }
 
 /** Lists the retained period-close records for an account. */

--- a/openbank-statement-service/src/main/kotlin/com/openbank/statement/application/port/out/DocumentTemplatePort.kt
+++ b/openbank-statement-service/src/main/kotlin/com/openbank/statement/application/port/out/DocumentTemplatePort.kt
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+package com.openbank.statement.application.port.out
+
+import io.smallrye.mutiny.Uni
+
+/** A document rendered by document-service and streamed straight back to the caller — never stored. */
+data class RenderedDocument(val contentType: String, val body: String)
+
+/**
+ * Renders a PUBLISHED document-service template against a Handlebars data map (ADR-0248) via
+ * document-service's non-persisting `/api/v1/documents/templates/preview` endpoint. A new outbound
+ * synchronous trust-boundary edge (`rules.yaml: trust_boundary_diff_change`) — statement-service was
+ * not previously a caller of document-service.
+ */
+interface DocumentTemplatePort {
+    fun renderTemplate(templateCode: String, data: Map<String, Any?>): Uni<RenderedDocument>
+}
+
+/**
+ * Raised when document-service cannot produce the requested document — the template isn't found /
+ * PUBLISHED, or the call itself failed (timeout, 5xx, network). Degrades only this one endpoint;
+ * the rest of statement-service (period close, camt.053/MT940/PDF render) is unaffected.
+ */
+class DocumentServiceException(message: String, cause: Throwable? = null) : RuntimeException(message, cause)

--- a/openbank-statement-service/src/main/kotlin/com/openbank/statement/application/usecase/StatementDocumentService.kt
+++ b/openbank-statement-service/src/main/kotlin/com/openbank/statement/application/usecase/StatementDocumentService.kt
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+package com.openbank.statement.application.usecase
+
+import com.openbank.statement.application.port.`in`.RenderStatementDocumentUseCase
+import com.openbank.statement.application.port.`in`.StatementModelUseCase
+import com.openbank.statement.application.port.out.DocumentTemplatePort
+import com.openbank.statement.application.port.out.RenderedDocument
+import com.openbank.statement.domain.model.CreditDebit
+import com.openbank.statement.domain.model.StatementEntry
+import com.openbank.statement.domain.model.StatementModel
+import io.smallrye.mutiny.Uni
+import jakarta.enterprise.context.ApplicationScoped
+import java.math.BigDecimal
+import java.util.UUID
+
+/**
+ * Orchestrates the customer-facing styled statement download (ADR-0248): replays the same
+ * [StatementModel] the camt.053/MT940/PDF render path uses (via [StatementModelUseCase], so the
+ * reconciliation/lookup logic is not duplicated), maps it into the `MESICNI_VYPIS_CS`/
+ * `MESICNI_VYPIS_EN` Handlebars data shape, and calls document-service's non-persisting preview
+ * endpoint. Synchronous, on customer request only — no pre-generation, no Kafka, nothing persisted
+ * on either side.
+ */
+@ApplicationScoped
+class StatementDocumentService(
+    private val statementModel: StatementModelUseCase,
+    private val documentTemplates: DocumentTemplatePort,
+) : RenderStatementDocumentUseCase {
+
+    override fun renderDocument(
+        accountId: UUID,
+        currency: String,
+        legalSequence: Long,
+        locale: String,
+    ): Uni<RenderedDocument> = statementModel.statementModel(accountId, currency, legalSequence).flatMap { model ->
+        documentTemplates.renderTemplate(templateCodeFor(locale), model.toDocumentData())
+    }
+
+    private fun templateCodeFor(locale: String): String =
+        if (locale.equals("cs", ignoreCase = true)) TEMPLATE_CODE_CS else TEMPLATE_CODE_EN
+
+    private companion object {
+        const val TEMPLATE_CODE_CS = "MESICNI_VYPIS_CS"
+        const val TEMPLATE_CODE_EN = "MESICNI_VYPIS_EN"
+    }
+}
+
+/**
+ * Maps [StatementModel] into the `document.*` / `party.*` / `account.*` Handlebars data shape the
+ * `MESICNI_VYPIS_CS`/`MESICNI_VYPIS_EN` templates expect (ADR-0248). `document.generatedAt` is taken
+ * from [StatementModel.closedAt] — never the wall clock — so a re-render stays byte-identical, the
+ * same determinism guarantee [com.openbank.statement.domain.render.StatementRenderer] upholds.
+ */
+internal fun StatementModel.toDocumentData(): Map<String, Any?> = mapOf(
+    "document" to mapOf(
+        "periodFrom" to periodFrom.toString(),
+        "periodTo" to periodTo.toString(),
+        "openingBalance" to openingBalance.amount,
+        "closingBalance" to closingBalance.amount,
+        "entries" to entries.map { it.toDocumentData() },
+        "legalSequenceNumber" to legalSequenceNumber,
+        "electronicSequenceNumber" to electronicSequenceNumber,
+        "generatedAt" to closedAt.toString(),
+    ),
+    "party" to mapOf("name" to holderName),
+    "account" to mapOf("iban" to iban, "currency" to currency),
+)
+
+private fun StatementEntry.toDocumentData(): Map<String, Any?> = mapOf(
+    "bookingDate" to bookingDate.toString(),
+    "valueDate" to valueDate.toString(),
+    "amount" to signedAmount(),
+    "currency" to currency,
+    "counterparty" to counterparty,
+    "description" to description,
+)
+
+/** [StatementEntry.amount] is always non-negative (sign carried by [StatementEntry.creditDebit]) —
+ *  the document template expects a signed amount (credit positive, debit negative). */
+private fun StatementEntry.signedAmount(): BigDecimal = when (creditDebit) {
+    CreditDebit.CRDT -> amount
+    CreditDebit.DBIT -> amount.negate()
+}

--- a/openbank-statement-service/src/main/kotlin/com/openbank/statement/application/usecase/StatementService.kt
+++ b/openbank-statement-service/src/main/kotlin/com/openbank/statement/application/usecase/StatementService.kt
@@ -8,6 +8,7 @@ import com.openbank.statement.application.port.`in`.ClosePeriodUseCase
 import com.openbank.statement.application.port.`in`.ClosePocketUseCase
 import com.openbank.statement.application.port.`in`.ListStatementsUseCase
 import com.openbank.statement.application.port.`in`.RenderStatementUseCase
+import com.openbank.statement.application.port.`in`.StatementModelUseCase
 import com.openbank.statement.application.port.out.AccountInfoPort
 import com.openbank.statement.application.port.out.BalancePort
 import com.openbank.statement.application.port.out.BookedEntryPort
@@ -41,6 +42,11 @@ import java.util.UUID
  * The reconciliation/sequence/projection logic lives in the (framework-free) domain; this use case
  * only wires the ports together.
  */
+// TooManyFunctions: this is the single lifecycle orchestrator for close/render/export/list (see
+// KDoc above) — ADR-0248 added statementModel() as the shared lookup both render() and the new
+// customer-facing document use case (StatementDocumentService) replay, so it belongs here rather
+// than duplicating the reconciliation/lookup logic in a second class.
+@Suppress("TooManyFunctions")
 @ApplicationScoped
 class StatementService(
     private val accountInfo: AccountInfoPort,
@@ -50,6 +56,7 @@ class StatementService(
 ) : ClosePeriodUseCase,
     ClosePocketUseCase,
     RenderStatementUseCase,
+    StatementModelUseCase,
     ListStatementsUseCase,
     AdHocExportUseCase {
 
@@ -152,18 +159,20 @@ class StatementService(
         currency: String,
         legalSequence: Long,
         format: StatementFormat,
-    ): Uni<StatementRenderer.Rendered> = periods.findBySequence(accountId, currency, legalSequence).flatMap { period ->
-        if (period == null) {
-            Uni.createFrom().failure(StatementNotFoundException(accountId, currency, legalSequence))
-        } else {
-            accountInfo.pocketAccount(accountId).flatMap { account ->
-                bookedEntries.bookedEntries(accountId, currency, period.periodFrom, period.periodTo)
-                    .map { entries ->
-                        StatementRenderer.render(modelFromPeriod(account, period, entries), format)
-                    }
+    ): Uni<StatementRenderer.Rendered> =
+        statementModel(accountId, currency, legalSequence).map { model -> StatementRenderer.render(model, format) }
+
+    override fun statementModel(accountId: UUID, currency: String, legalSequence: Long): Uni<StatementModel> =
+        periods.findBySequence(accountId, currency, legalSequence).flatMap { period ->
+            if (period == null) {
+                Uni.createFrom().failure(StatementNotFoundException(accountId, currency, legalSequence))
+            } else {
+                accountInfo.pocketAccount(accountId).flatMap { account ->
+                    bookedEntries.bookedEntries(accountId, currency, period.periodFrom, period.periodTo)
+                        .map { entries -> modelFromPeriod(account, period, entries) }
+                }
             }
         }
-    }
 
     override fun export(
         accountId: UUID,

--- a/openbank-statement-service/src/main/kotlin/com/openbank/statement/infrastructure/client/DocumentRestClients.kt
+++ b/openbank-statement-service/src/main/kotlin/com/openbank/statement/infrastructure/client/DocumentRestClients.kt
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+package com.openbank.statement.infrastructure.client
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import io.quarkus.oidc.client.reactive.filter.OidcClientRequestReactiveFilter
+import io.smallrye.mutiny.Uni
+import jakarta.ws.rs.Consumes
+import jakarta.ws.rs.GET
+import jakarta.ws.rs.POST
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.Produces
+import jakarta.ws.rs.QueryParam
+import jakarta.ws.rs.core.MediaType
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient
+
+// document-service's `/api/v1/documents/templates/preview` endpoint is reused as-is (ADR-0248): it
+// only accepts a literal `bodyHtml`, not a `templateCode` lookup, and there is no get-by-code route —
+// only the bounded `GET /templates` list. So rendering a document by code is two calls: list (find
+// the PUBLISHED template's bodyHtml), then preview (merge data into it). Neither call persists
+// anything.
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class DocumentTemplateDto(
+    val code: String? = null,
+    val version: String? = null,
+    val bodyHtml: String? = null,
+    val locale: String? = null,
+    val status: String? = null,
+)
+
+data class PreviewTemplateRequestDto(val bodyHtml: String, val data: Map<String, Any?>)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class PreviewTemplateResponseDto(val renderedHtml: String? = null)
+
+@RegisterProvider(OidcClientRequestReactiveFilter::class)
+@RegisterRestClient(configKey = "document-api")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+interface DocumentRestClient {
+    @GET
+    @Path("/api/v1/documents/templates")
+    fun listTemplates(@QueryParam("limit") limit: Int): Uni<List<DocumentTemplateDto>>
+
+    @POST
+    @Path("/api/v1/documents/templates/preview")
+    fun preview(request: PreviewTemplateRequestDto): Uni<PreviewTemplateResponseDto>
+}

--- a/openbank-statement-service/src/main/kotlin/com/openbank/statement/infrastructure/client/RestPortAdapters.kt
+++ b/openbank-statement-service/src/main/kotlin/com/openbank/statement/infrastructure/client/RestPortAdapters.kt
@@ -6,7 +6,10 @@ package com.openbank.statement.infrastructure.client
 import com.openbank.statement.application.port.out.AccountInfoPort
 import com.openbank.statement.application.port.out.BalancePort
 import com.openbank.statement.application.port.out.BookedEntryPort
+import com.openbank.statement.application.port.out.DocumentServiceException
+import com.openbank.statement.application.port.out.DocumentTemplatePort
 import com.openbank.statement.application.port.out.PocketAccountInfo
+import com.openbank.statement.application.port.out.RenderedDocument
 import com.openbank.statement.application.usecase.NotViableAccountException
 import com.openbank.statement.domain.model.BalanceAnchor
 import com.openbank.statement.domain.model.CreditDebit
@@ -157,5 +160,51 @@ class AccountInfoRestAdapter @Inject constructor(
         partyClient.party(partyId)
             .map { it.legalName ?: "" }
             .onFailure().recoverWithItem("")
+    }
+}
+
+/**
+ * Calls document-service's non-persisting template preview flow (ADR-0248): list the PUBLISHED
+ * templates to find the requested code's `bodyHtml` (there is no get-by-code route), then merge the
+ * Handlebars data into it via `/api/v1/documents/templates/preview`. Neither call persists anything;
+ * a failure at either step degrades only the caller's one endpoint, never the rest of
+ * statement-service (fail-closed reconciliation, camt.053/MT940/PDF render are unaffected).
+ */
+@ApplicationScoped
+class DocumentTemplateRestAdapter @Inject constructor(@RestClient private val client: DocumentRestClient) :
+    DocumentTemplatePort {
+
+    override fun renderTemplate(templateCode: String, data: Map<String, Any?>): Uni<RenderedDocument> =
+        client.listTemplates(TEMPLATE_LIST_LIMIT)
+            .onFailure().transform { e ->
+                DocumentServiceException("document-service template list call failed for $templateCode", e)
+            }
+            .flatMap { templates -> renderFromTemplate(templateCode, data, templates) }
+
+    private fun renderFromTemplate(
+        templateCode: String,
+        data: Map<String, Any?>,
+        templates: List<DocumentTemplateDto>,
+    ): Uni<RenderedDocument> {
+        val bodyHtml = templates.firstOrNull { it.code == templateCode && it.status == "PUBLISHED" }?.bodyHtml
+        return if (bodyHtml == null) {
+            Uni.createFrom().failure(
+                DocumentServiceException("no PUBLISHED document-service template found for code=$templateCode"),
+            )
+        } else {
+            client.preview(PreviewTemplateRequestDto(bodyHtml, data))
+                .onFailure().transform { e ->
+                    DocumentServiceException("document-service preview call failed for $templateCode", e)
+                }
+                .map { resp ->
+                    RenderedDocument(contentType = "text/html; charset=utf-8", body = resp.renderedHtml.orEmpty())
+                }
+        }
+    }
+
+    private companion object {
+        /** The API max (`GET /templates` is bounded, not cursor-paginated) — plenty for the small,
+         *  fixed set of PUBLISHED templates this platform seeds. */
+        const val TEMPLATE_LIST_LIMIT = 200
     }
 }

--- a/openbank-statement-service/src/main/kotlin/com/openbank/statement/infrastructure/rest/StatementResource.kt
+++ b/openbank-statement-service/src/main/kotlin/com/openbank/statement/infrastructure/rest/StatementResource.kt
@@ -7,8 +7,10 @@ import com.openbank.libs.authz.Authorize
 import com.openbank.statement.application.port.`in`.AdHocExportUseCase
 import com.openbank.statement.application.port.`in`.ClosePeriodUseCase
 import com.openbank.statement.application.port.`in`.ListStatementsUseCase
+import com.openbank.statement.application.port.`in`.RenderStatementDocumentUseCase
 import com.openbank.statement.application.port.`in`.RenderStatementUseCase
 import com.openbank.statement.application.port.`in`.RestatePeriodUseCase
+import com.openbank.statement.application.port.out.DocumentServiceException
 import com.openbank.statement.application.usecase.NoClosedPeriodToRestateException
 import com.openbank.statement.application.usecase.ReconciliationException
 import com.openbank.statement.application.usecase.StatementNotFoundException
@@ -41,6 +43,7 @@ class StatementResource(
     private val listStatements: ListStatementsUseCase,
     private val adHocExport: AdHocExportUseCase,
     private val restatePeriod: RestatePeriodUseCase,
+    private val renderStatementDocument: RenderStatementDocumentUseCase,
 ) {
 
     @POST
@@ -105,6 +108,34 @@ class StatementResource(
         .onFailure(StatementNotFoundException::class.java)
         .recoverWithItem { e ->
             Response.status(Response.Status.NOT_FOUND).entity(mapOf("error" to e.message)).build()
+        }
+
+    @GET
+    @Path("/{accountId}/{currency}/{legalSequence}/document")
+    // Reuses the "statement.read" action (not a new "statement.document" one): rules.yaml's
+    // role_action_matrix only registers statement.list/statement.read, and this endpoint is the same
+    // authorization decision as render() — read access to this account's closed statements — just a
+    // different output format. A new action string would need its own matrix registration
+    // (out of scope: only openbank-statement-service/ and this PR's threat model may change).
+    @Authorize(action = "statement.read", resource = "#accountId")
+    @Operation(
+        summary = "Render the customer-facing styled statement via document-service's non-persisting " +
+            "preview endpoint (ADR-0248) — synchronous, on customer request only; nothing is stored",
+    )
+    fun document(
+        @PathParam("accountId") accountId: UUID,
+        @PathParam("currency") currency: String,
+        @PathParam("legalSequence") legalSequence: Long,
+        @QueryParam("locale") @DefaultValue("cs") locale: String,
+    ): Uni<Response> = renderStatementDocument.renderDocument(accountId, currency, legalSequence, locale)
+        .map { rendered -> Response.ok(rendered.body).type(rendered.contentType).build() }
+        .onFailure(StatementNotFoundException::class.java)
+        .recoverWithItem { e ->
+            Response.status(Response.Status.NOT_FOUND).entity(mapOf("error" to e.message)).build()
+        }
+        .onFailure(DocumentServiceException::class.java)
+        .recoverWithItem { e ->
+            Response.status(Response.Status.BAD_GATEWAY).entity(mapOf("error" to e.message)).build()
         }
 
     @GET

--- a/openbank-statement-service/src/main/resources/application.yaml
+++ b/openbank-statement-service/src/main/resources/application.yaml
@@ -72,6 +72,11 @@ quarkus:
     party-api:
       url: ${PARTY_SERVICE_URL:http://localhost:8111}
       scope: jakarta.inject.Singleton
+    # ADR-0248: synchronous, on-demand call to document-service's non-persisting preview endpoint —
+    # a new outbound trust-boundary edge (rules.yaml: trust_boundary_diff_change).
+    document-api:
+      url: ${DOCUMENT_SERVICE_URL:http://localhost:8143}
+      scope: jakarta.inject.Singleton
   shutdown:
     timeout: 30S
   log:

--- a/openbank-statement-service/src/main/resources/openapi.yaml
+++ b/openbank-statement-service/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: Statement Service API
-  version: 1.1.0
+  version: 1.2.0
   description: >-
     Account statements for the multi-currency current account (ADR-0035). The unit is the per-pocket
     (IBAN + currency) statement: each pocket has its own camt.053.001.08 / MT940 with an independent
@@ -115,6 +115,30 @@ paths:
           description: Rendered statement (application/xml for camt.053, text/plain for MT940/PDF)
         '404':
           description: No closed statement with that sequence
+
+  /api/v1/statements/{accountId}/{currency}/{legalSequence}/document:
+    get:
+      tags: [Statements]
+      summary: Render the customer-facing styled statement document (ADR-0248)
+      description: >-
+        Synchronous, on customer request only. Calls document-service's non-persisting template
+        preview endpoint with data assembled from the same closed period the camt.053/MT940/PDF
+        render path uses; nothing is stored on either side.
+      operationId: renderStatementDocument
+      parameters:
+        - { name: accountId, in: path, required: true, schema: { type: string, format: uuid } }
+        - { name: currency, in: path, required: true, schema: { type: string, minLength: 3, maxLength: 3 } }
+        - { name: legalSequence, in: path, required: true, schema: { type: integer, format: int64 } }
+        - name: locale
+          in: query
+          schema: { type: string, enum: [cs, en], default: cs }
+      responses:
+        '200':
+          description: Rendered styled statement document
+        '404':
+          description: No closed statement with that sequence
+        '502':
+          description: document-service could not render the template (unreachable, or template not PUBLISHED)
 
   /api/v1/statements/{accountId}/{currency}/export:
     get:

--- a/openbank-statement-service/src/test/kotlin/com/openbank/statement/application/usecase/StatementDocumentServiceTest.kt
+++ b/openbank-statement-service/src/test/kotlin/com/openbank/statement/application/usecase/StatementDocumentServiceTest.kt
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+package com.openbank.statement.application.usecase
+
+import com.openbank.statement.Fixtures
+import com.openbank.statement.application.port.`in`.StatementModelUseCase
+import com.openbank.statement.application.port.out.DocumentServiceException
+import com.openbank.statement.application.port.out.DocumentTemplatePort
+import com.openbank.statement.application.port.out.RenderedDocument
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import io.smallrye.mutiny.Uni
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+
+class StatementDocumentServiceTest {
+
+    private val statementModel = mockk<StatementModelUseCase>()
+    private val documentTemplates = mockk<DocumentTemplatePort>()
+    private val service = StatementDocumentService(statementModel, documentTemplates)
+
+    @Test
+    fun `renderDocument replays the statement model and calls the CS template for a cs locale`() {
+        every { statementModel.statementModel(Fixtures.ACCOUNT_ID, "CZK", 7L) } returns
+            Uni.createFrom().item(Fixtures.model())
+        every { documentTemplates.renderTemplate(any(), any()) } returns
+            Uni.createFrom().item(RenderedDocument("text/html; charset=utf-8", "<html></html>"))
+
+        val result = service.renderDocument(Fixtures.ACCOUNT_ID, "CZK", 7L, "cs").await().indefinitely()
+
+        assertThat(result.body).isEqualTo("<html></html>")
+        verify(exactly = 1) { documentTemplates.renderTemplate("MESICNI_VYPIS_CS", any()) }
+    }
+
+    @Test
+    fun `renderDocument calls the EN template for any non-cs locale`() {
+        every { statementModel.statementModel(any(), any(), any()) } returns Uni.createFrom().item(Fixtures.model())
+        every { documentTemplates.renderTemplate(any(), any()) } returns
+            Uni.createFrom().item(RenderedDocument("text/html; charset=utf-8", "<html></html>"))
+
+        service.renderDocument(Fixtures.ACCOUNT_ID, "CZK", 7L, "en").await().indefinitely()
+        verify(exactly = 1) { documentTemplates.renderTemplate("MESICNI_VYPIS_EN", any()) }
+    }
+
+    @Test
+    fun `a missing closed period fails before any document-service call is made`() {
+        every { statementModel.statementModel(any(), any(), any()) } returns
+            Uni.createFrom().failure(StatementNotFoundException(Fixtures.ACCOUNT_ID, "CZK", 99L))
+
+        assertThatThrownBy {
+            service.renderDocument(Fixtures.ACCOUNT_ID, "CZK", 99L, "cs").await().indefinitely()
+        }.isInstanceOf(StatementNotFoundException::class.java)
+        verify(exactly = 0) { documentTemplates.renderTemplate(any(), any()) }
+    }
+
+    @Test
+    fun `a document-service failure propagates as DocumentServiceException`() {
+        every { statementModel.statementModel(any(), any(), any()) } returns Uni.createFrom().item(Fixtures.model())
+        every { documentTemplates.renderTemplate(any(), any()) } returns
+            Uni.createFrom().failure(DocumentServiceException("preview call failed"))
+
+        assertThatThrownBy {
+            service.renderDocument(Fixtures.ACCOUNT_ID, "CZK", 7L, "cs").await().indefinitely()
+        }.isInstanceOf(DocumentServiceException::class.java)
+    }
+
+    @Test
+    fun `toDocumentData maps the statement model into the document, party and account namespaces`() {
+        val model = Fixtures.model()
+
+        val data = model.toDocumentData()
+
+        @Suppress("UNCHECKED_CAST")
+        val document = data["document"] as Map<String, Any?>
+
+        @Suppress("UNCHECKED_CAST")
+        val party = data["party"] as Map<String, Any?>
+
+        @Suppress("UNCHECKED_CAST")
+        val account = data["account"] as Map<String, Any?>
+
+        assertThat(document["periodFrom"]).isEqualTo("2026-01-01")
+        assertThat(document["periodTo"]).isEqualTo("2026-01-31")
+        assertThat(document["openingBalance"]).isEqualTo(BigDecimal("1000.00"))
+        assertThat(document["closingBalance"]).isEqualTo(BigDecimal("1075.00"))
+        assertThat(document["legalSequenceNumber"]).isEqualTo(7L)
+        assertThat(document["electronicSequenceNumber"]).isEqualTo(7L)
+        // closedAt, never wall clock (ADR-0035 determinism guarantee extended to this template).
+        assertThat(document["generatedAt"]).isEqualTo("2026-02-01T02:30:00Z")
+        assertThat(party["name"]).isEqualTo("Jan Novak")
+        assertThat(account["iban"]).isEqualTo("CZ6508000000192000145399")
+        assertThat(account["currency"]).isEqualTo("CZK")
+
+        @Suppress("UNCHECKED_CAST")
+        val entries = document["entries"] as List<Map<String, Any?>>
+        assertThat(entries).hasSize(2)
+        // TX-1 is a credit -> positive; TX-2 is a debit -> negative (the domain amount is always
+        // non-negative, the sign is carried separately by creditDebit).
+        assertThat(entries[0]["amount"]).isEqualTo(BigDecimal("100.00"))
+        assertThat(entries[1]["amount"]).isEqualTo(BigDecimal("-25.00"))
+        assertThat(entries[0]["bookingDate"]).isEqualTo("2026-01-15")
+        assertThat(entries[0]["currency"]).isEqualTo("CZK")
+        assertThat(entries[1]["description"]).isEqualTo("Fee")
+    }
+}


### PR DESCRIPTION
## Summary

Adds a customer-facing statement download endpoint on `openbank-statement-service`
(`GET /api/v1/statements/{accountId}/{currency}/{legalSequence}/document`) that replays the same
closed `StatementPeriod` the existing `render()` endpoint uses, maps it into the Handlebars data
shape the `MESICNI_VYPIS_CS`/`MESICNI_VYPIS_EN` document-service templates expect, and streams
back document-service's non-persisting template preview response (ADR-0248). Synchronous, only on
customer request — no pre-generation, no Kafka, nothing persisted on either side.

## Type of change

- [x] feat (new functionality)
- [ ] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [ ] docs
- [ ] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change

## Linked issues

Refs #4109, Refs ADR-0248

## Changes

- New `StatementModelUseCase` port + `StatementService.statementModel(...)`: the period lookup +
  `StatementModel` assembly factored out of `render()` so both the existing camt.053/MT940/PDF path
  and the new document path share one implementation (no duplicated reconciliation/lookup logic).
- New `RenderStatementDocumentUseCase` / `StatementDocumentService` (`application/usecase`):
  orchestrates replay of the statement model, maps it into `document.*`/`party.*`/`account.*`
  Handlebars data (`document.generatedAt` taken from `StatementModel.closedAt`, never wall clock —
  same determinism guarantee as the other renderers), and selects `MESICNI_VYPIS_CS`/
  `MESICNI_VYPIS_EN` by the `locale` query param.
- New `DocumentTemplatePort` / `DocumentTemplateRestAdapter` (`infrastructure/client`): calls
  document-service's `GET /api/v1/documents/templates` (list, to resolve the PUBLISHED template's
  `bodyHtml` — there is no get-by-code route) then `POST /api/v1/documents/templates/preview`
  (merge data into it). Neither call persists anything on document-service's side. Every failure
  (list, preview, template not PUBLISHED) is wrapped in one `DocumentServiceException`.
- New `GET .../{legalSequence}/document` endpoint on `StatementResource`, mirroring `render()`'s
  error-handling shape: `StatementNotFoundException` → 404, `DocumentServiceException` → 502. Reuses
  the existing `statement.read` OPA action (no new action string, since `rules.yaml`'s
  `role_action_matrix` is out of scope for this PR).
- `application.yaml`: new `document-api` REST-client config (`DOCUMENT_SERVICE_URL`, default
  `http://localhost:8143`).
- `openapi.yaml`: documents the new endpoint; `info.version` 1.1.0 → 1.2.0 (additive).
- New `docs/threat-models/statement-service.md` (did not exist before this PR).

## Trust-boundary change (`rules.yaml: trust_boundary_diff_change`)

This PR adds a **new outbound synchronous call edge**: `openbank-statement-service` did not
previously call `openbank-document-service`. `docs/threat-models/statement-service.md` (new file,
this PR) documents it: the call is on-path only for the one new endpoint (a document-service outage
or timeout returns `502` there and does not affect period-close, camt.053/MT940/PDF render, export,
list, or restate); it carries no new data class beyond what `render()` already exposes to callers;
and it surfaces — rather than introduces — an existing gap noted in the threat model: statement-service
has no account-ownership check of its own and trusts the caller (the customer-facing edge) to have
already scoped `accountId` to the authenticated customer, exactly as `render()` already does today.

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports) — the new orchestration
      lives in `application/usecase`, the REST client in `infrastructure/client`.
- [x] Unit tests added/updated (`StatementDocumentServiceTest`: locale → template-code selection,
      not-found propagation, document-service-failure propagation, and the
      `StatementModel.toDocumentData()` mapping).
- [ ] Integration tests added/updated — not added; the existing `render()` endpoint has no
      dedicated `@QuarkusTest` REST-layer test either (only the contract test + unit-level
      `StatementServiceTest`), so this follows the same convention.
- [x] Contract tests updated (if public API changed) — `openapi.yaml` documents the new endpoint;
      `StatementContractTest`'s existing invariants are unchanged and stay green.
- [x] `./gradlew :openbank-statement-service:ktlintCheck :openbank-statement-service:detekt
      :openbank-statement-service:test` — `ktlintCheck` and `detekt` are clean. `test`: 71/72 pass;
      the 1 failure (`StatementOutboxClaimIT`) is a pre-existing `@QuarkusTest` integration test
      that fails to boot locally with `RuntimeException: OIDC Server is not available` — it needs a
      live Keycloak that isn't running in this sandbox, and it is unrelated to this change (outbox
      claim-locking, no reference to document-service or anything touched here). It runs against a
      real OIDC server in CI.
- [x] No new lint warnings — `detekt`'s `TooManyFunctions` on `StatementService` (12 functions after
      adding `statementModel()`, threshold 11) is suppressed with an inline justification (see
      Security checklist below); everything else is clean.
- [x] OpenAPI spec regenerated (if REST API changed).
- [ ] Flyway migration added + rollback note — N/A, no DB change.
- [ ] Avro schema versioned backward-compatibly — N/A, no event change.
- [x] Docs updated — new threat model added.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] New `@Suppress("TooManyFunctions")` on `StatementService`, justified inline in the source:
      it is the single lifecycle orchestrator for close/render/export/list, and ADR-0248 added
      `statementModel()` as the shared lookup both `render()` and the new
      `StatementDocumentService` replay — splitting it into a second class to dodge the threshold
      would duplicate the reconciliation/lookup logic instead of sharing it.
- [x] No new third-party dependency (reuses the existing `quarkus-oidc-client-reactive-filter` /
      MicroProfile REST Client already on the classpath for the other four adapters).
- [ ] Auth / crypto / payment code changed? → N/A.
- [ ] PII path changed? → statement content already flows through `render()`/`export()`; this is
      the same class of data over a new transport hop to document-service, not a new PII surface.
- [ ] Cardholder data path changed? → N/A.

## Compliance impact

- [x] PSD2 / SCA / RTS — ADR-0248 implements the PSD2 Art. 58(2) statement-availability duty via a
      styled document layer on top of the existing on-demand render (unchanged legal basis).
- [ ] PCI DSS
- [ ] DORA
- [ ] GDPR
- [ ] AML / 5AMLD
- [ ] CNB reporting
- [ ] None

## Rollout / Rollback

- Deployment strategy: rolling (standard for this service).
- Rollback plan: revert the PR — nothing is persisted by this feature (nothing to migrate back),
  and the new endpoint is additive (no existing path changed shape).
- Data migration reversible: N/A (no migration).

## Reviewer notes

- document-service's non-persisting `/api/v1/documents/templates/preview` endpoint (already
  implemented, not touched by this PR) takes a literal `bodyHtml` + `data`, not a `templateCode` —
  there is no get-by-code route today, only the bounded `GET /templates` list. So rendering by code
  is two calls (list, then preview); see `DocumentTemplateRestAdapter` for the reasoning. It also
  returns `renderedHtml` (JSON-wrapped HTML), not a converted PDF — so today this endpoint streams
  back `text/html`. A byte-identical PDF needs either a PDF-capable `preview` variant in
  document-service or a client-side HTML→PDF step; called out explicitly as a follow-up in the new
  threat model rather than silently deferred.
- `MESICNI_VYPIS_CS`/`MESICNI_VYPIS_EN` are expected to be seeded in document-service by a companion
  ADR-0248 PR; until that template is `PUBLISHED`, this endpoint returns 502 for both locales (no
  boot-time reachability check, consistent with the other four REST-client dependencies).
