### PR TITLE
feat(domestic-payment): add customer-facing payment confirmation download endpoint

### DIFF
--- a/docs/threat-models/openbank-domestic-payment.md
+++ b/docs/threat-models/openbank-domestic-payment.md
@@ -23,6 +23,8 @@ to a beneficiary — a primary fraud target.
                                                                                   +--> [fraud-service] (shadow, OIDC CC / mTLS, fail-open)
                                                                                   |
                                                                                   +--> [clearing-simulator] (pacs.008 out / pacs.002 in; OIDC CC; ADR-0104 D4; flag-gated)
+                                                                                  |
+                                                                                  +--> [document-service] (GET .../templates, POST .../templates/preview; OIDC CC; ADR-0248 #3; synchronous, on customer request only)
 ```
 
 - **External entities:** payment-initiating channels/operators, downstream clearing & ledger,
@@ -84,6 +86,36 @@ not change any existing request's outcome until explicitly flipped.
   need an additional store; not implemented in this PR.
 
 ## 6. Change log
+
+- **2026-08-07** — ADR-0248 #3: new outbound trust boundary, `domestic-payment-service →
+  document-service (GET /api/v1/documents/templates, POST /api/v1/documents/templates/preview,
+  OIDC client-credentials)`, plus a new customer-facing endpoint
+  `GET /api/v1/domestic-payments/{paymentId}/confirmation` (`@RolesAllowed("ROLE_VIEWER",
+  "ROLE_OPERATOR","ROLE_ADMIN","ROLE_PAYMENTS")`, `@Authorize(action=
+  "domestic-payment.confirmation.read", resource="#paymentId")`). Renders the payment
+  confirmation document **synchronously, only on explicit customer request** — no
+  pre-generation off `DomesticPaymentStatusChangedEvent`, no Kafka consumer, nothing cached or
+  persisted a second time here or in document-service (document-service's `preview` endpoint is
+  the existing non-persisting one; no `Document` row or `document.generated` outbox event is ever
+  created for this call). `PaymentConfirmationService` reads the payment's own already-persisted
+  record via `DomesticPaymentRepository.findById` and calls neither `save` nor `update` — it
+  cannot affect payment status, and 409s (via `PaymentNotSettledMapper`) unless the payment has
+  reached `SETTLED`. `PaymentConfirmationRenderAdapter` resolves the current PUBLISHED
+  `POTVRZENI_O_PLATBE_CS`/`_EN` template body via `listTemplates`, then merges the payment's own
+  data into it via `previewTemplate` — both document-service calls are read-only/non-persisting on
+  the document-service side, so a retry can never double-render or double-persist anything.
+  **Risk class = availability** (a document-service outage fails only the download itself — never
+  payment initiation, status transition, or clearing/settlement — retryable by the customer, no
+  data lost) and **confidentiality** (payment amount, debtor/creditor account numbers/bank codes,
+  creditor name, and remittance info cross the boundary to document-service in the preview
+  request; mitigated by OIDC client-credentials + cluster-internal-only document-service ingress,
+  same posture as the existing `fraud-service`/`transaction-service` edges above). **New STRIDE
+  rows**: Info disclosure (payment data sent to document-service for a one-shot render, never
+  stored there) and Spoofing (a caller other than the payment's own viewer/operator requesting a
+  confirmation) — mitigated by the same `@RolesAllowed`/`@Authorize` gate as every other read
+  endpoint on this resource. `openapi.yaml` bumped `1.3.0` → `1.4.0` (additive). No DB schema
+  change; rollback = revert the endpoint/use-case/adapter commit (document-service's `preview`
+  endpoint and its own threat model are unaffected either way).
 
 - **2026-08-03** — Missing required query/header parameter answered 500, not 400 (#3104). A required `@QueryParam`/`@HeaderParam` declared with a non-nullable Kotlin type was fed `null` by JAX-RS when the caller omitted it, and answered **500** rather than 400 (#3104). Kotlin's null-safety is compile-time only, so the declared type only decided where the failure landed: a non-suspend handler threw `Intrinsics.checkNotNullParameter` at the method boundary, and a **suspend** handler got no intrinsic at all, so the null flowed into the body. `Idempotency-Key` on createPayment. The existing guard `require(idempotencyKey.isNotBlank())` could not run for an ABSENT header: this handler is `suspend`, so no intrinsic was emitted and `null.isNotBlank()` threw NPE — the replay control answered 500 in exactly the case it was written for, while a BLANK header correctly gave 400. Now `require(!idempotencyKey.isNullOrBlank())`. This is a control that was partially inoperative, not a new one. No new caller or boundary. Rollback: revert.
 - **2026-07-24** — Retire the legacy in-service orchestration; Temporal is the sole orchestrator

--- a/openbank-domestic-payment/ktlint-baseline.xml
+++ b/openbank-domestic-payment/ktlint-baseline.xml
@@ -11,6 +11,9 @@
         <error line="38" column="27" source="standard:trailing-comma-on-declaration-site" />
         <error line="61" column="20" source="standard:trailing-comma-on-declaration-site" />
     </file>
+    <file name="src/main/kotlin/com/openbank/domestic/application/port/in/PaymentConfirmationPorts.kt">
+        <error line="5" column="9" source="standard:package-name" />
+    </file>
     <file name="src/main/kotlin/com/openbank/domestic/application/port/out/ScreeningPorts.kt">
         <error line="37" column="31" source="standard:trailing-comma-on-declaration-site" />
     </file>

--- a/openbank-domestic-payment/src/main/kotlin/com/openbank/domestic/application/port/in/PaymentConfirmationPorts.kt
+++ b/openbank-domestic-payment/src/main/kotlin/com/openbank/domestic/application/port/in/PaymentConfirmationPorts.kt
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.domestic.application.port.`in`
+
+import java.util.UUID
+
+/**
+ * Inbound port for the customer-facing "download confirmation" action (ADR-0248 #3). Strictly
+ * additive and read-only: never touches [com.openbank.domestic.domain.model.DomesticPayment]
+ * state, never persists anything.
+ */
+interface PaymentConfirmationUseCase {
+    /**
+     * @param lang `"en"` for [com.openbank.domestic.application.usecase.PaymentConfirmationMapper.TEMPLATE_CODE_EN],
+     * anything else (including null) for the CS template.
+     * @return the rendered confirmation HTML.
+     * @throws com.openbank.domestic.application.usecase.DomesticPaymentNotFoundException if [paymentId] does not exist.
+     * @throws PaymentNotSettledException if the payment has not reached SETTLED.
+     */
+    suspend fun getConfirmation(paymentId: UUID, lang: String?): String
+}
+
+class PaymentNotSettledException(message: String) : RuntimeException(message)

--- a/openbank-domestic-payment/src/main/kotlin/com/openbank/domestic/application/port/out/PaymentConfirmationPorts.kt
+++ b/openbank-domestic-payment/src/main/kotlin/com/openbank/domestic/application/port/out/PaymentConfirmationPorts.kt
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.domestic.application.port.out
+
+/**
+ * Outbound port for rendering a payment confirmation document (ADR-0248 #3) via
+ * `openbank-document-service`'s non-persisting `POST /api/v1/documents/templates/preview` endpoint.
+ * Synchronous, on customer request only — never pre-generated, never cached, never persisted a
+ * second time here or in document-service.
+ */
+interface PaymentConfirmationRenderPort {
+
+    /**
+     * Render [templateCode] with [data] and return the resulting HTML. Throws
+     * [PaymentConfirmationRenderException] if document-service is unreachable or answers an
+     * unexpected status — the caller (the confirmation download endpoint) has no fallback: a
+     * failed render is a failed download, retryable by the customer, and never blocks anything
+     * upstream (ADR-0248 Negative consequences).
+     */
+    suspend fun renderConfirmation(templateCode: String, data: Map<String, Any?>): String
+}
+
+class PaymentConfirmationRenderException(message: String, cause: Throwable? = null) : RuntimeException(message, cause)

--- a/openbank-domestic-payment/src/main/kotlin/com/openbank/domestic/application/usecase/PaymentConfirmationMapper.kt
+++ b/openbank-domestic-payment/src/main/kotlin/com/openbank/domestic/application/usecase/PaymentConfirmationMapper.kt
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.domestic.application.usecase
+
+import com.openbank.domestic.domain.model.DomesticPayment
+import com.openbank.domestic.domain.model.DomesticPaymentStatus
+
+/**
+ * Maps a [DomesticPayment] onto the Handlebars `document.*` data shape the
+ * `POTVRZENI_O_PLATBE_CS`/`POTVRZENI_O_PLATBE_EN` document-service templates expect (ADR-0248 #3).
+ *
+ * Pure — zero framework imports, so it is unit-testable without a running service. The payment's
+ * own already-persisted record is the sole data source (ADR-0248 Decision §3: "the originating
+ * payment service ... invokes document-service's non-persisting preview endpoint at request time
+ * with data read from its own already-persisted payment record").
+ */
+object PaymentConfirmationMapper {
+
+    const val TEMPLATE_CODE_CS = "POTVRZENI_O_PLATBE_CS"
+    const val TEMPLATE_CODE_EN = "POTVRZENI_O_PLATBE_EN"
+
+    private const val EN_LANG = "en"
+    private const val IBAN_BANK_DIGITS = 4
+    private const val IBAN_ACCOUNT_DIGITS = 16
+    private const val MOD_97 = 97
+    private const val MOD_97_COMPLEMENT = 98
+    private const val RADIX_10 = 10
+
+    /** `lang` query param -> template code. Anything other than `en` (case-insensitive) is CS. */
+    fun templateCodeFor(lang: String?): String =
+        if (lang?.trim()?.lowercase() == EN_LANG) TEMPLATE_CODE_EN else TEMPLATE_CODE_CS
+
+    /**
+     * A confirmation is only meaningful for a [DomesticPaymentStatus.SETTLED] payment — the caller
+     * must check [DomesticPayment.status] before calling this (it throws [IllegalArgumentException]
+     * otherwise, so a caller cannot accidentally render a confirmation for a payment that hasn't
+     * settled, or has since REJECTED/RETURNED/CANCELLED).
+     */
+    fun toConfirmationData(payment: DomesticPayment): Map<String, Any?> {
+        require(payment.status == DomesticPaymentStatus.SETTLED) {
+            "Payment confirmation is only available for a SETTLED payment (was ${payment.status})"
+        }
+        val executedAt = payment.settledAt ?: payment.updatedAt
+        val remittanceInfo = payment.variableSymbol?.takeIf { it.isNotBlank() }
+            ?: payment.messageForPayee?.takeIf { it.isNotBlank() }
+            ?: ""
+
+        return mapOf(
+            "document" to mapOf(
+                "paymentReference" to payment.id.toString(),
+                "endToEndId" to payment.endToEndId,
+                "executedAt" to executedAt.toString(),
+                "amount" to payment.amount.toPlainString(),
+                "currency" to payment.currency,
+                "debtorIban" to toCzIban(payment.debtorAccountNumber, payment.debtorBankCode),
+                "creditorIban" to toCzIban(payment.creditorAccountNumber, payment.creditorBankCode),
+                "creditorName" to payment.creditorName,
+                "remittanceInfo" to remittanceInfo,
+                "status" to payment.status.name,
+                // No SCA-evidence-reference field exists on the DomesticPayment aggregate today —
+                // never fabricate one; the template renders this slot conditionally (Handlebars
+                // `{{#if document.scaEvidenceRef}}`).
+                "scaEvidenceRef" to null,
+            ),
+        )
+    }
+
+    /**
+     * Build a Czech IBAN (`CZkk BBBB` + 16-digit account part, ISO 13616 mod-97 check digits) from
+     * an account number + bank code, for DISPLAY on the confirmation only — this is a presentation
+     * transform, not part of the settlement/clearing path (mirrors, but does not share code with,
+     * [com.openbank.domestic.infrastructure.client.SettlementAdapter]'s identical private helper,
+     * which stays untouched).
+     */
+    private fun toCzIban(accountNumber: String, bankCode: String): String {
+        val raw = accountNumber.replace(" ", "").uppercase()
+        if (raw.startsWith("CZ")) return raw
+        val acct = raw.filter { it.isDigit() }.padStart(IBAN_ACCOUNT_DIGITS, '0')
+        val bank = bankCode.filter { it.isDigit() }.padStart(IBAN_BANK_DIGITS, '0')
+        val bban = bank + acct
+        var mod = 0
+        for (ch in bban + "123500") mod = (mod * RADIX_10 + (ch - '0')) % MOD_97
+        val check = (MOD_97_COMPLEMENT - mod).toString().padStart(2, '0')
+        return "CZ$check$bban"
+    }
+}

--- a/openbank-domestic-payment/src/main/kotlin/com/openbank/domestic/application/usecase/PaymentConfirmationService.kt
+++ b/openbank-domestic-payment/src/main/kotlin/com/openbank/domestic/application/usecase/PaymentConfirmationService.kt
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.domestic.application.usecase
+
+import com.openbank.domestic.application.port.`in`.PaymentConfirmationUseCase
+import com.openbank.domestic.application.port.`in`.PaymentNotSettledException
+import com.openbank.domestic.application.port.out.DomesticPaymentRepository
+import com.openbank.domestic.application.port.out.PaymentConfirmationRenderPort
+import com.openbank.domestic.domain.model.DomesticPaymentStatus
+import jakarta.enterprise.context.ApplicationScoped
+import java.util.UUID
+
+/**
+ * Renders a payment confirmation on demand (ADR-0248 #3) — synchronous, customer-request-only,
+ * never persisted. Read-only against [DomesticPaymentRepository]: no [DomesticPaymentRepository.save]
+ * or [DomesticPaymentRepository.update] call anywhere in this class, so this use case cannot affect
+ * payment state.
+ */
+@ApplicationScoped
+class PaymentConfirmationService(
+    private val paymentRepository: DomesticPaymentRepository,
+    private val renderPort: PaymentConfirmationRenderPort,
+) : PaymentConfirmationUseCase {
+
+    override suspend fun getConfirmation(paymentId: UUID, lang: String?): String {
+        val payment = paymentRepository.findById(paymentId)
+            ?: throw DomesticPaymentNotFoundException(paymentId)
+
+        if (payment.status != DomesticPaymentStatus.SETTLED) {
+            throw PaymentNotSettledException(
+                "Payment confirmation is only available once a payment has SETTLED " +
+                    "(payment $paymentId is ${payment.status})",
+            )
+        }
+
+        val templateCode = PaymentConfirmationMapper.templateCodeFor(lang)
+        val data = PaymentConfirmationMapper.toConfirmationData(payment)
+        return renderPort.renderConfirmation(templateCode, data)
+    }
+}

--- a/openbank-domestic-payment/src/main/kotlin/com/openbank/domestic/infrastructure/client/DocumentServiceClient.kt
+++ b/openbank-domestic-payment/src/main/kotlin/com/openbank/domestic/infrastructure/client/DocumentServiceClient.kt
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.domestic.infrastructure.client
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import io.quarkus.oidc.client.reactive.filter.OidcClientRequestReactiveFilter
+import io.smallrye.mutiny.Uni
+import jakarta.ws.rs.Consumes
+import jakarta.ws.rs.GET
+import jakarta.ws.rs.POST
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.Produces
+import jakarta.ws.rs.QueryParam
+import jakarta.ws.rs.core.MediaType
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient
+
+/**
+ * RestClient binding to `openbank-document-service`'s template surface (ADR-0248 #3). Only two
+ * calls are used, both read-only / non-persisting on the document-service side:
+ *  - [listTemplates] to resolve the PUBLISHED `bodyHtml` for a `templateCode` — document-service's
+ *    `preview` endpoint takes a raw `bodyHtml`, not a `templateCode` (it merges an UNSAVED template
+ *    body, by design — see `PreviewTemplateRequest`/`DocumentResource.previewTemplate`), so the
+ *    caller resolves the current published body first.
+ *  - [previewTemplate] to merge [PreviewTemplateRequest.data] into that body and get back HTML.
+ *    Never persisted: no `Document` row, no `document.generated` outbox event, on either call.
+ */
+@RegisterRestClient(configKey = "document-service")
+@RegisterProvider(OidcClientRequestReactiveFilter::class)
+@Path("/api/v1/documents")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+interface DocumentServiceClient {
+
+    @GET
+    @Path("/templates")
+    fun listTemplates(@QueryParam("limit") limit: Int): Uni<List<DocumentTemplateSummary>>
+
+    @POST
+    @Path("/templates/preview")
+    fun previewTemplate(request: PreviewTemplateRequest): Uni<PreviewTemplateResponse>
+}
+
+/** Mirror of document-service's `PreviewTemplateRequest`. */
+data class PreviewTemplateRequest(val bodyHtml: String, val data: Map<String, Any?> = emptyMap())
+
+/** Mirror of document-service's `PreviewTemplateResponse`. */
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class PreviewTemplateResponse(val renderedHtml: String)
+
+/** Mirror of document-service's `TemplateResponse` — only the fields this adapter needs. */
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class DocumentTemplateSummary(val code: String, val status: String, val bodyHtml: String)

--- a/openbank-domestic-payment/src/main/kotlin/com/openbank/domestic/infrastructure/client/PaymentConfirmationRenderAdapter.kt
+++ b/openbank-domestic-payment/src/main/kotlin/com/openbank/domestic/infrastructure/client/PaymentConfirmationRenderAdapter.kt
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.domestic.infrastructure.client
+
+import com.openbank.domestic.application.port.out.PaymentConfirmationRenderException
+import com.openbank.domestic.application.port.out.PaymentConfirmationRenderPort
+import io.smallrye.mutiny.coroutines.awaitSuspending
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.inject.Inject
+import org.eclipse.microprofile.faulttolerance.Retry
+import org.eclipse.microprofile.faulttolerance.Timeout
+import org.eclipse.microprofile.rest.client.inject.RestClient
+import org.jboss.logging.Logger
+
+/**
+ * Adapter over [DocumentServiceClient] — the synchronous, non-persisting render path for a
+ * customer-requested payment confirmation (ADR-0248 #3). Resolves the current PUBLISHED body for
+ * `templateCode`, then merges [data] into it via document-service's `preview` endpoint. Neither
+ * call writes anything: `listTemplates`/`previewTemplate` are both read-only on the document-service
+ * side, so a retry here can never double-render or double-persist anything.
+ */
+@ApplicationScoped
+class PaymentConfirmationRenderAdapter(@RestClient private val client: DocumentServiceClient) :
+    PaymentConfirmationRenderPort {
+
+    @Inject
+    lateinit var self: PaymentConfirmationRenderAdapter
+
+    private val log = Logger.getLogger(PaymentConfirmationRenderAdapter::class.java)
+
+    @Suppress("TooGenericExceptionCaught")
+    override suspend fun renderConfirmation(templateCode: String, data: Map<String, Any?>): String = try {
+        self.renderWithResilience(templateCode, data)
+    } catch (ex: PaymentConfirmationRenderException) {
+        throw ex
+    } catch (ex: Exception) {
+        log.warnf(ex, "document-service unavailable while rendering confirmation template=%s", templateCode)
+        throw PaymentConfirmationRenderException("document-service unavailable for template $templateCode", ex)
+    }
+
+    @Retry(maxRetries = 2, delay = 300, jitter = 150, retryOn = [Exception::class])
+    @Timeout(RENDER_TIMEOUT_MS)
+    open suspend fun renderWithResilience(templateCode: String, data: Map<String, Any?>): String {
+        val templates = client.listTemplates(LIST_LIMIT).awaitSuspending()
+        val template = templates.firstOrNull { it.code == templateCode && it.status == PUBLISHED_STATUS }
+            ?: throw PaymentConfirmationRenderException(
+                "No PUBLISHED document-service template for code $templateCode",
+            )
+
+        val preview = client.previewTemplate(PreviewTemplateRequest(bodyHtml = template.bodyHtml, data = data))
+            .awaitSuspending()
+        return preview.renderedHtml
+    }
+
+    private companion object {
+        const val RENDER_TIMEOUT_MS = 8_000L
+        const val LIST_LIMIT = 200
+        const val PUBLISHED_STATUS = "PUBLISHED"
+    }
+}

--- a/openbank-domestic-payment/src/main/kotlin/com/openbank/domestic/infrastructure/rest/DomesticPaymentResource.kt
+++ b/openbank-domestic-payment/src/main/kotlin/com/openbank/domestic/infrastructure/rest/DomesticPaymentResource.kt
@@ -7,6 +7,7 @@ package com.openbank.domestic.infrastructure.rest
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.openbank.domestic.application.port.`in`.DomesticPaymentUseCase
 import com.openbank.domestic.application.port.`in`.ListDomesticPaymentsQuery
+import com.openbank.domestic.application.port.`in`.PaymentConfirmationUseCase
 import com.openbank.domestic.domain.model.DomesticPaymentStatus
 import com.openbank.domestic.infrastructure.rest.dto.CreateDomesticPaymentRequest
 import com.openbank.domestic.infrastructure.rest.dto.TransitionDomesticPaymentStatusRequest
@@ -40,6 +41,7 @@ import java.util.UUID
 @Tag(name = "Domestic Payments", description = "Domestic CZK payment lifecycle")
 class DomesticPaymentResource(
     private val paymentUseCase: DomesticPaymentUseCase,
+    private val confirmationUseCase: PaymentConfirmationUseCase,
     private val idempotencyStore: IdempotencyStore,
     private val objectMapper: ObjectMapper,
 ) {
@@ -113,6 +115,23 @@ class DomesticPaymentResource(
             ),
         )
         return Response.ok(payments.map { it.toResponse() }).build()
+    }
+
+    /**
+     * Customer-facing "download confirmation" action (ADR-0248 #3). Strictly additive and
+     * read-only: renders synchronously, on request only, off the payment's own persisted status
+     * record — no pre-generation, no caching, nothing written here or in document-service. Only
+     * meaningful once a payment has SETTLED (409 otherwise, mapped from [PaymentNotSettledMapper]).
+     */
+    @GET
+    @Path("/{paymentId}/confirmation")
+    @Produces(MediaType.TEXT_HTML)
+    @RolesAllowed("ROLE_VIEWER", "ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_PAYMENTS")
+    @Authorize(action = "domestic-payment.confirmation.read", resource = "#paymentId")
+    @Operation(summary = "Download the payment confirmation document for a SETTLED payment")
+    suspend fun getConfirmation(@PathParam("paymentId") paymentId: UUID, @QueryParam("lang") lang: String?): Response {
+        val html = confirmationUseCase.getConfirmation(paymentId, lang)
+        return Response.ok(html, MediaType.TEXT_HTML_TYPE).build()
     }
 
     @PATCH

--- a/openbank-domestic-payment/src/main/kotlin/com/openbank/domestic/infrastructure/rest/ExceptionMappers.kt
+++ b/openbank-domestic-payment/src/main/kotlin/com/openbank/domestic/infrastructure/rest/ExceptionMappers.kt
@@ -4,6 +4,8 @@
 
 package com.openbank.domestic.infrastructure.rest
 
+import com.openbank.domestic.application.port.`in`.PaymentNotSettledException
+import com.openbank.domestic.application.port.out.PaymentConfirmationRenderException
 import com.openbank.domestic.application.usecase.DomesticPaymentNotFoundException
 import com.openbank.domestic.application.usecase.InvalidDomesticPaymentStateTransitionException
 import com.openbank.libs.api.error.ApiError
@@ -25,6 +27,42 @@ class InvalidDomesticPaymentStateTransitionMapper : ExceptionMapper<InvalidDomes
     override fun toResponse(exception: InvalidDomesticPaymentStateTransitionException): Response = Response.status(409)
         .entity(ApiError(UUID.randomUUID().toString(), 409, ErrorCode.CONFLICT.code, exception.message ?: "Conflict"))
         .build()
+}
+
+@Provider
+class PaymentNotSettledMapper : ExceptionMapper<PaymentNotSettledException> {
+    override fun toResponse(exception: PaymentNotSettledException): Response = Response.status(HTTP_CONFLICT)
+        .entity(
+            ApiError(
+                UUID.randomUUID().toString(),
+                HTTP_CONFLICT,
+                ErrorCode.CONFLICT.code,
+                exception.message ?: "Conflict",
+            ),
+        )
+        .build()
+
+    private companion object {
+        const val HTTP_CONFLICT = 409
+    }
+}
+
+@Provider
+class PaymentConfirmationRenderMapper : ExceptionMapper<PaymentConfirmationRenderException> {
+    override fun toResponse(exception: PaymentConfirmationRenderException): Response = Response.status(HTTP_BAD_GATEWAY)
+        .entity(
+            ApiError(
+                UUID.randomUUID().toString(),
+                HTTP_BAD_GATEWAY,
+                "DOCUMENT_SERVICE_UNAVAILABLE",
+                exception.message ?: "Confirmation rendering is temporarily unavailable",
+            ),
+        )
+        .build()
+
+    private companion object {
+        const val HTTP_BAD_GATEWAY = 502
+    }
 }
 
 // SelfApprovalNotAllowedMapper / InvalidApprovalStateMapper (403/409) moved to

--- a/openbank-domestic-payment/src/main/kotlin/com/openbank/domestic/infrastructure/rest/ExceptionMappers.kt
+++ b/openbank-domestic-payment/src/main/kotlin/com/openbank/domestic/infrastructure/rest/ExceptionMappers.kt
@@ -10,6 +10,7 @@ import com.openbank.domestic.application.usecase.DomesticPaymentNotFoundExceptio
 import com.openbank.domestic.application.usecase.InvalidDomesticPaymentStateTransitionException
 import com.openbank.libs.api.error.ApiError
 import com.openbank.libs.api.error.ErrorCode
+import com.openbank.libs.domain.identifiers.Ids
 import jakarta.ws.rs.core.Response
 import jakarta.ws.rs.ext.ExceptionMapper
 import jakarta.ws.rs.ext.Provider
@@ -34,7 +35,7 @@ class PaymentNotSettledMapper : ExceptionMapper<PaymentNotSettledException> {
     override fun toResponse(exception: PaymentNotSettledException): Response = Response.status(HTTP_CONFLICT)
         .entity(
             ApiError(
-                UUID.randomUUID().toString(),
+                Ids.randomId().toString(),
                 HTTP_CONFLICT,
                 ErrorCode.CONFLICT.code,
                 exception.message ?: "Conflict",
@@ -52,7 +53,7 @@ class PaymentConfirmationRenderMapper : ExceptionMapper<PaymentConfirmationRende
     override fun toResponse(exception: PaymentConfirmationRenderException): Response = Response.status(HTTP_BAD_GATEWAY)
         .entity(
             ApiError(
-                UUID.randomUUID().toString(),
+                Ids.randomId().toString(),
                 HTTP_BAD_GATEWAY,
                 "DOCUMENT_SERVICE_UNAVAILABLE",
                 exception.message ?: "Confirmation rendering is temporarily unavailable",

--- a/openbank-domestic-payment/src/main/resources/application.yaml
+++ b/openbank-domestic-payment/src/main/resources/application.yaml
@@ -77,6 +77,9 @@ quarkus:
     account-service:
       url: ${ACCOUNT_SERVICE_URL:http://account-service.accounts.svc:8100}
       scope: jakarta.inject.Singleton
+    document-service:
+      url: ${DOCUMENT_SERVICE_URL:http://localhost:8143}
+      scope: jakarta.inject.Singleton
   redis:
     hosts: redis://localhost:6379
   smallrye-reactive-messaging:

--- a/openbank-domestic-payment/src/main/resources/openapi.yaml
+++ b/openbank-domestic-payment/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: Domestic Payment Service API
-  version: 1.3.0
+  version: 1.4.0
   description: >-
     Czech domestic payment lifecycle (CZ-specific rails, SIPO). On create, debtor and creditor names
     are synchronously screened against the sanctions lists (ADR-0032): a clean payment is returned
@@ -100,6 +100,46 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '404':
           $ref: '#/components/responses/NotFound'
+
+  /api/v1/domestic-payments/{paymentId}/confirmation:
+    get:
+      tags: [Domestic Payments]
+      summary: Download the payment confirmation document (ADR-0248) — customer-request-only, synchronous, never persisted
+      description: >-
+        Renders on demand from the payment's own persisted status record via document-service's
+        non-persisting preview endpoint (ADR-0248 #3). Only available once the payment has reached
+        SETTLED — a payment in any other status answers 409.
+      operationId: getDomesticPaymentConfirmation
+      parameters:
+        - $ref: '#/components/parameters/paymentId'
+        - name: lang
+          in: query
+          description: '`en` for the English template; anything else (including omitted) renders the Czech one.'
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Rendered confirmation HTML
+          content:
+            text/html:
+              schema:
+                type: string
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          description: Payment has not reached SETTLED
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        '502':
+          description: document-service unreachable or has no PUBLISHED confirmation template
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
 
   /api/v1/domestic-payments/{paymentId}/status:
     patch:

--- a/openbank-domestic-payment/src/test/kotlin/com/openbank/domestic/application/usecase/PaymentConfirmationMapperTest.kt
+++ b/openbank-domestic-payment/src/test/kotlin/com/openbank/domestic/application/usecase/PaymentConfirmationMapperTest.kt
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.domestic.application.usecase
+
+import com.openbank.domestic.domain.model.DomesticPayment
+import com.openbank.domestic.domain.model.DomesticPaymentPriority
+import com.openbank.domestic.domain.model.DomesticPaymentStatus
+import com.openbank.domestic.domain.model.DomesticTransferScope
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.math.BigInteger
+import java.time.Instant
+import java.util.UUID
+
+class PaymentConfirmationMapperTest {
+
+    @Test
+    fun `templateCodeFor selects the EN code only for a case-insensitive en`() {
+        assertThat(PaymentConfirmationMapper.templateCodeFor("en"))
+            .isEqualTo(PaymentConfirmationMapper.TEMPLATE_CODE_EN)
+        assertThat(PaymentConfirmationMapper.templateCodeFor("EN"))
+            .isEqualTo(PaymentConfirmationMapper.TEMPLATE_CODE_EN)
+        assertThat(PaymentConfirmationMapper.templateCodeFor(" en "))
+            .isEqualTo(PaymentConfirmationMapper.TEMPLATE_CODE_EN)
+        assertThat(
+            PaymentConfirmationMapper.templateCodeFor("cs"),
+        ).isEqualTo(PaymentConfirmationMapper.TEMPLATE_CODE_CS)
+        assertThat(
+            PaymentConfirmationMapper.templateCodeFor(null),
+        ).isEqualTo(PaymentConfirmationMapper.TEMPLATE_CODE_CS)
+        assertThat(PaymentConfirmationMapper.templateCodeFor("garbage"))
+            .isEqualTo(PaymentConfirmationMapper.TEMPLATE_CODE_CS)
+    }
+
+    @Test
+    fun `toConfirmationData rejects a payment that has not SETTLED`() {
+        assertThatThrownBy {
+            PaymentConfirmationMapper.toConfirmationData(payment(status = DomesticPaymentStatus.SENT_TO_CLEARING))
+        }.isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("SETTLED")
+    }
+
+    @Test
+    fun `toConfirmationData maps every required field under the document namespace`() {
+        val settledAt = Instant.parse("2026-08-01T10:15:30Z")
+        val p = payment(
+            status = DomesticPaymentStatus.SETTLED,
+            settledAt = settledAt,
+            variableSymbol = "123456",
+        )
+
+        val data = PaymentConfirmationMapper.toConfirmationData(p)
+
+        @Suppress("UNCHECKED_CAST")
+        val document = data["document"] as Map<String, Any?>
+        assertThat(document["paymentReference"]).isEqualTo(p.id.toString())
+        assertThat(document["endToEndId"]).isEqualTo(p.endToEndId)
+        assertThat(document["executedAt"]).isEqualTo(settledAt.toString())
+        assertThat(document["amount"]).isEqualTo("20.00")
+        assertThat(document["currency"]).isEqualTo("CZK")
+        assertThat(document["creditorName"]).isEqualTo(p.creditorName)
+        assertThat(document["remittanceInfo"]).isEqualTo("123456")
+        assertThat(document["status"]).isEqualTo("SETTLED")
+        assertThat(document["scaEvidenceRef"]).isNull()
+    }
+
+    @Test
+    fun `remittanceInfo falls back to messageForPayee when there is no variable symbol`() {
+        val p = payment(
+            status = DomesticPaymentStatus.SETTLED,
+            variableSymbol = null,
+            messageForPayee = "Rent August",
+        )
+
+        @Suppress("UNCHECKED_CAST")
+        val document = PaymentConfirmationMapper.toConfirmationData(p)["document"] as Map<String, Any?>
+        assertThat(document["remittanceInfo"]).isEqualTo("Rent August")
+    }
+
+    @Test
+    fun `remittanceInfo is blank when neither variable symbol nor message is present`() {
+        val p = payment(status = DomesticPaymentStatus.SETTLED, variableSymbol = null, messageForPayee = null)
+
+        @Suppress("UNCHECKED_CAST")
+        val document = PaymentConfirmationMapper.toConfirmationData(p)["document"] as Map<String, Any?>
+        assertThat(document["remittanceInfo"]).isEqualTo("")
+    }
+
+    @Test
+    fun `debtor and creditor IBANs are valid ISO 13616 mod-97 checksums`() {
+        val p = payment(status = DomesticPaymentStatus.SETTLED)
+
+        @Suppress("UNCHECKED_CAST")
+        val document = PaymentConfirmationMapper.toConfirmationData(p)["document"] as Map<String, Any?>
+        val debtorIban = document["debtorIban"] as String
+        val creditorIban = document["creditorIban"] as String
+
+        assertThat(debtorIban).startsWith("CZ").hasSize(24)
+        assertThat(creditorIban).startsWith("CZ").hasSize(24)
+        assertThat(ibanChecksumValid(debtorIban)).describedAs("debtorIban=%s", debtorIban).isTrue()
+        assertThat(ibanChecksumValid(creditorIban)).describedAs("creditorIban=%s", creditorIban).isTrue()
+    }
+
+    /** Standard IBAN validation (ISO 7064 MOD 97-10): rearrange, letters -> digits, mod 97 == 1. */
+    private fun ibanChecksumValid(iban: String): Boolean {
+        val rearranged = iban.substring(4) + iban.substring(0, 4)
+        val numeric = rearranged.map { ch ->
+            if (ch.isDigit()) ch.toString() else (ch.uppercaseChar() - 'A' + 10).toString()
+        }
+            .joinToString("")
+        return BigInteger(numeric).mod(BigInteger.valueOf(97)) == BigInteger.ONE
+    }
+
+    private fun payment(
+        status: DomesticPaymentStatus,
+        settledAt: Instant? = Instant.parse("2026-08-01T10:00:00Z"),
+        variableSymbol: String? = null,
+        messageForPayee: String? = null,
+    ) = DomesticPayment(
+        id = UUID.randomUUID(),
+        idempotencyKey = "idem-${UUID.randomUUID()}",
+        status = status,
+        debtorAccountId = UUID.randomUUID(),
+        debtorAccountNumber = "1234567890",
+        debtorBankCode = "0800",
+        debtorName = "Debtor",
+        creditorAccountNumber = "0987654321",
+        creditorBankCode = "2010",
+        creditorName = "Creditor Name",
+        amount = BigDecimal("20.00"),
+        currency = "CZK",
+        variableSymbol = variableSymbol,
+        specificSymbol = null,
+        constantSymbol = null,
+        messageForPayee = messageForPayee,
+        priority = DomesticPaymentPriority.STANDARD,
+        transferScope = DomesticTransferScope.EXTERNAL,
+        technicalAccountCode = null,
+        statementLabel = null,
+        endToEndId = "DOMS1234567890",
+        rejectReason = null,
+        rejectDetail = null,
+        submittedAt = Instant.parse("2026-08-01T09:00:00Z"),
+        settledAt = settledAt,
+        createdAt = Instant.parse("2026-08-01T08:00:00Z"),
+        updatedAt = Instant.parse("2026-08-01T10:00:00Z"),
+    )
+}

--- a/openbank-domestic-payment/src/test/kotlin/com/openbank/domestic/application/usecase/PaymentConfirmationServiceTest.kt
+++ b/openbank-domestic-payment/src/test/kotlin/com/openbank/domestic/application/usecase/PaymentConfirmationServiceTest.kt
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.domestic.application.usecase
+
+import com.openbank.domestic.application.port.`in`.PaymentNotSettledException
+import com.openbank.domestic.application.port.out.DomesticPaymentRepository
+import com.openbank.domestic.application.port.out.PaymentConfirmationRenderPort
+import com.openbank.domestic.domain.model.DomesticPayment
+import com.openbank.domestic.domain.model.DomesticPaymentPriority
+import com.openbank.domestic.domain.model.DomesticPaymentStatus
+import com.openbank.domestic.domain.model.DomesticTransferScope
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * Coverage for [PaymentConfirmationService] — the "download confirmation" use case (ADR-0248 #3).
+ * Never calls [DomesticPaymentRepository.save]/[DomesticPaymentRepository.update]: this is a
+ * read-only view over the payment's own persisted status record.
+ */
+class PaymentConfirmationServiceTest {
+
+    private lateinit var paymentRepository: DomesticPaymentRepository
+    private lateinit var renderPort: PaymentConfirmationRenderPort
+    private lateinit var service: PaymentConfirmationService
+
+    @BeforeEach
+    fun setUp() {
+        paymentRepository = mockk()
+        renderPort = mockk()
+        service = PaymentConfirmationService(paymentRepository, renderPort)
+    }
+
+    @Test
+    fun `unknown payment id raises DomesticPaymentNotFoundException`() {
+        val paymentId = UUID.randomUUID()
+        coEvery { paymentRepository.findById(paymentId) } returns null
+
+        assertThatThrownBy {
+            runBlocking { service.getConfirmation(paymentId, lang = null) }
+        }.isInstanceOf(DomesticPaymentNotFoundException::class.java)
+    }
+
+    @Test
+    fun `a payment that has not SETTLED raises PaymentNotSettledException`() {
+        val payment = payment(status = DomesticPaymentStatus.SENT_TO_CLEARING)
+        coEvery { paymentRepository.findById(payment.id) } returns payment
+
+        assertThatThrownBy {
+            runBlocking { service.getConfirmation(payment.id, lang = null) }
+        }.isInstanceOf(PaymentNotSettledException::class.java)
+    }
+
+    @Test
+    fun `a SETTLED payment renders via the CS template by default`() {
+        val payment = payment(status = DomesticPaymentStatus.SETTLED)
+        coEvery { paymentRepository.findById(payment.id) } returns payment
+        coEvery {
+            renderPort.renderConfirmation(PaymentConfirmationMapper.TEMPLATE_CODE_CS, any())
+        } returns "<html>ok</html>"
+
+        val html = runBlocking { service.getConfirmation(payment.id, lang = null) }
+
+        assertThat(html).isEqualTo("<html>ok</html>")
+        coVerify(exactly = 1) { renderPort.renderConfirmation(PaymentConfirmationMapper.TEMPLATE_CODE_CS, any()) }
+    }
+
+    @Test
+    fun `lang=en renders via the EN template`() {
+        val payment = payment(status = DomesticPaymentStatus.SETTLED)
+        coEvery { paymentRepository.findById(payment.id) } returns payment
+        coEvery {
+            renderPort.renderConfirmation(PaymentConfirmationMapper.TEMPLATE_CODE_EN, any())
+        } returns "<html>en</html>"
+
+        val html = runBlocking { service.getConfirmation(payment.id, lang = "en") }
+
+        assertThat(html).isEqualTo("<html>en</html>")
+    }
+
+    @Test
+    fun `never calls save or update - strictly read-only`() {
+        val payment = payment(status = DomesticPaymentStatus.SETTLED)
+        coEvery { paymentRepository.findById(payment.id) } returns payment
+        coEvery { renderPort.renderConfirmation(any(), any()) } returns "<html/>"
+
+        runBlocking { service.getConfirmation(payment.id, lang = null) }
+
+        coVerify(exactly = 0) { paymentRepository.save(any(), any()) }
+        coVerify(exactly = 0) { paymentRepository.update(any(), any()) }
+    }
+
+    private fun payment(status: DomesticPaymentStatus) = DomesticPayment(
+        id = UUID.randomUUID(),
+        idempotencyKey = "idem-${UUID.randomUUID()}",
+        status = status,
+        debtorAccountId = UUID.randomUUID(),
+        debtorAccountNumber = "1234567890",
+        debtorBankCode = "0800",
+        debtorName = "Debtor",
+        creditorAccountNumber = "0987654321",
+        creditorBankCode = "2010",
+        creditorName = "Creditor Name",
+        amount = BigDecimal("20.00"),
+        currency = "CZK",
+        variableSymbol = "123456",
+        specificSymbol = null,
+        constantSymbol = null,
+        messageForPayee = null,
+        priority = DomesticPaymentPriority.STANDARD,
+        transferScope = DomesticTransferScope.EXTERNAL,
+        technicalAccountCode = null,
+        statementLabel = null,
+        endToEndId = "DOMS1234567890",
+        rejectReason = null,
+        rejectDetail = null,
+        submittedAt = Instant.parse("2026-08-01T09:00:00Z"),
+        settledAt = Instant.parse("2026-08-01T10:00:00Z"),
+        createdAt = Instant.parse("2026-08-01T08:00:00Z"),
+        updatedAt = Instant.parse("2026-08-01T10:00:00Z"),
+    )
+}

--- a/openbank-domestic-payment/src/test/kotlin/com/openbank/domestic/infrastructure/client/FakePaymentConfirmationRenderPort.kt
+++ b/openbank-domestic-payment/src/test/kotlin/com/openbank/domestic/infrastructure/client/FakePaymentConfirmationRenderPort.kt
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.domestic.infrastructure.client
+
+import com.openbank.domestic.application.port.out.PaymentConfirmationRenderPort
+import jakarta.annotation.Priority
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.enterprise.inject.Alternative
+
+/**
+ * Test double for [PaymentConfirmationRenderPort] — replaces [PaymentConfirmationRenderAdapter]
+ * (which would otherwise call a real document-service over HTTP) in `@QuarkusTest`, mirroring
+ * [com.openbank.domestic.infrastructure.temporal.WorkflowClientTestProducer]'s
+ * `@Alternative @Priority(1)` CDI-override pattern. Tests set [renderedHtml] and read
+ * [lastTemplateCode]/[lastData] to assert on what the use case asked for, without a running
+ * document-service. Both are plain `var`s (no `private set`): the Quarkus Kotlin all-open plugin
+ * makes every property of an `@ApplicationScoped` bean `open` for CDI proxying, and ktlint/kotlinc
+ * reject a `private set` on an `open` property.
+ */
+@ApplicationScoped
+@Alternative
+@Priority(1)
+class FakePaymentConfirmationRenderPort : PaymentConfirmationRenderPort {
+
+    var renderedHtml: String = "<html>fake-confirmation</html>"
+    var lastTemplateCode: String? = null
+    var lastData: Map<String, Any?>? = null
+
+    override suspend fun renderConfirmation(templateCode: String, data: Map<String, Any?>): String {
+        lastTemplateCode = templateCode
+        lastData = data
+        return renderedHtml
+    }
+}

--- a/openbank-domestic-payment/src/test/kotlin/com/openbank/domestic/infrastructure/client/PaymentConfirmationRenderAdapterTest.kt
+++ b/openbank-domestic-payment/src/test/kotlin/com/openbank/domestic/infrastructure/client/PaymentConfirmationRenderAdapterTest.kt
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.domestic.infrastructure.client
+
+import com.openbank.domestic.application.port.out.PaymentConfirmationRenderException
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import io.smallrye.mutiny.Uni
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+
+/**
+ * Coverage for [PaymentConfirmationRenderAdapter]'s list-then-preview flow: document-service's
+ * `preview` endpoint takes a raw `bodyHtml`, not a `templateCode`, so the adapter resolves the
+ * current PUBLISHED template body first (ADR-0248 #3).
+ */
+class PaymentConfirmationRenderAdapterTest {
+
+    private val client: DocumentServiceClient = mockk()
+
+    private fun adapter(): PaymentConfirmationRenderAdapter =
+        PaymentConfirmationRenderAdapter(client).also { it.self = it }
+
+    @Test
+    fun `resolves the PUBLISHED template body then merges data via preview`(): Unit = runBlocking {
+        every { client.listTemplates(any()) } returns Uni.createFrom().item(
+            listOf(
+                DocumentTemplateSummary(code = "POTVRZENI_O_PLATBE_CS", status = "DRAFT", bodyHtml = "<old/>"),
+                DocumentTemplateSummary(
+                    code = "POTVRZENI_O_PLATBE_CS",
+                    status = "PUBLISHED",
+                    bodyHtml = "<b>{{document.status}}</b>",
+                ),
+                DocumentTemplateSummary(code = "OTHER_TEMPLATE", status = "PUBLISHED", bodyHtml = "<other/>"),
+            ),
+        )
+        every { client.previewTemplate(any()) } returns
+            Uni.createFrom().item(PreviewTemplateResponse(renderedHtml = "<b>SETTLED</b>"))
+
+        val html = adapter().renderConfirmation(
+            "POTVRZENI_O_PLATBE_CS",
+            mapOf(
+                "document" to mapOf("status" to "SETTLED"),
+            ),
+        )
+
+        assertThat(html).isEqualTo("<b>SETTLED</b>")
+        verify(exactly = 1) {
+            client.previewTemplate(
+                PreviewTemplateRequest(
+                    bodyHtml = "<b>{{document.status}}</b>",
+                    data = mapOf("document" to mapOf("status" to "SETTLED")),
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun `throws PaymentConfirmationRenderException when no PUBLISHED template exists for the code`(): Unit =
+        runBlocking {
+            every { client.listTemplates(any()) } returns Uni.createFrom().item(emptyList())
+
+            assertThatThrownBy {
+                runBlocking { adapter().renderConfirmation("POTVRZENI_O_PLATBE_CS", emptyMap()) }
+            }.isInstanceOf(PaymentConfirmationRenderException::class.java)
+                .hasMessageContaining("POTVRZENI_O_PLATBE_CS")
+        }
+
+    @Test
+    fun `wraps a downstream failure in PaymentConfirmationRenderException`(): Unit = runBlocking {
+        every { client.listTemplates(any()) } returns Uni.createFrom().failure(RuntimeException("connection refused"))
+
+        assertThatThrownBy {
+            runBlocking { adapter().renderConfirmation("POTVRZENI_O_PLATBE_CS", emptyMap()) }
+        }.isInstanceOf(PaymentConfirmationRenderException::class.java)
+    }
+}

--- a/openbank-domestic-payment/src/test/kotlin/com/openbank/domestic/infrastructure/rest/PaymentConfirmationResourceIT.kt
+++ b/openbank-domestic-payment/src/test/kotlin/com/openbank/domestic/infrastructure/rest/PaymentConfirmationResourceIT.kt
@@ -1,0 +1,199 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.domestic.infrastructure.rest
+
+import com.openbank.domestic.application.port.out.DomesticPaymentRepository
+import com.openbank.domestic.domain.model.DomesticPayment
+import com.openbank.domestic.domain.model.DomesticPaymentPriority
+import com.openbank.domestic.domain.model.DomesticPaymentStatus
+import com.openbank.domestic.domain.model.DomesticTransferScope
+import com.openbank.domestic.infrastructure.client.FakePaymentConfirmationRenderPort
+import com.openbank.domestic.integration.DomesticPaymentBootSmokeIT
+import com.openbank.domestic.it.PostgresRedisTestResource
+import com.openbank.libs.persistence.outbox.OutboxMessage
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.security.TestSecurity
+import io.quarkus.vertx.VertxContextSupport
+import io.restassured.RestAssured
+import io.restassured.module.kotlin.extensions.Given
+import io.restassured.module.kotlin.extensions.Then
+import io.restassured.module.kotlin.extensions.When
+import io.smallrye.mutiny.coroutines.uni
+import jakarta.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import org.hamcrest.Matchers.equalTo
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.Clock
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * Integration coverage for `GET /api/v1/domestic-payments/{paymentId}/confirmation` (ADR-0248 #3)
+ * — the customer-facing "download confirmation" action. [FakePaymentConfirmationRenderPort] (an
+ * `@Alternative @Priority(1)` CDI override) replaces the real document-service call, so this
+ * exercises the REST layer + use case + repository against a real Postgres, without a running
+ * document-service.
+ */
+@QuarkusTest
+@QuarkusTestResource(DomesticPaymentBootSmokeIT.InMemoryKafkaResource::class)
+@QuarkusTestResource(PostgresRedisTestResource::class)
+class PaymentConfirmationResourceIT {
+
+    @Inject
+    lateinit var repository: DomesticPaymentRepository
+
+    @Inject
+    lateinit var fakeRenderPort: FakePaymentConfirmationRenderPort
+
+    private fun <T> onEventLoop(block: suspend () -> T): T =
+        VertxContextSupport.subscribeAndAwait { uni(CoroutineScope(Dispatchers.Unconfined)) { block() } }
+
+    @BeforeEach
+    fun setUp() {
+        fakeRenderPort.renderedHtml = "<html>fake-confirmation</html>"
+    }
+
+    private fun newReceivedPayment(clock: Clock): DomesticPayment {
+        val now = Instant.now(clock)
+        return DomesticPayment(
+            id = UUID.randomUUID(),
+            idempotencyKey = "confirmation-it-${UUID.randomUUID()}",
+            status = DomesticPaymentStatus.RECEIVED,
+            debtorAccountId = UUID.randomUUID(),
+            debtorAccountNumber = "1234567890",
+            debtorBankCode = "0800",
+            debtorName = "Debtor",
+            creditorAccountNumber = "0987654321",
+            creditorBankCode = "2010",
+            creditorName = "Creditor Name",
+            amount = BigDecimal("42.50"),
+            currency = "CZK",
+            variableSymbol = "999888",
+            specificSymbol = null,
+            constantSymbol = null,
+            messageForPayee = null,
+            priority = DomesticPaymentPriority.STANDARD,
+            transferScope = DomesticTransferScope.EXTERNAL,
+            technicalAccountCode = null,
+            statementLabel = null,
+            endToEndId = "DOMS${clock.millis()}",
+            rejectReason = null,
+            rejectDetail = null,
+            submittedAt = null,
+            settledAt = null,
+            createdAt = now,
+            updatedAt = now,
+        )
+    }
+
+    private fun pathTo(status: DomesticPaymentStatus): List<DomesticPaymentStatus> = when (status) {
+        DomesticPaymentStatus.RECEIVED -> emptyList()
+        DomesticPaymentStatus.VALIDATED -> listOf(DomesticPaymentStatus.VALIDATED)
+        DomesticPaymentStatus.SENT_TO_CLEARING -> listOf(
+            DomesticPaymentStatus.VALIDATED,
+            DomesticPaymentStatus.SENT_TO_CLEARING,
+        )
+        DomesticPaymentStatus.SETTLED -> listOf(
+            DomesticPaymentStatus.VALIDATED,
+            DomesticPaymentStatus.SENT_TO_CLEARING,
+            DomesticPaymentStatus.SETTLED,
+        )
+        else -> error("Unsupported seed status in this test: $status")
+    }
+
+    private fun seedPayment(status: DomesticPaymentStatus): DomesticPayment {
+        val clock = Clock.systemUTC()
+        val received = newReceivedPayment(clock)
+
+        var payment = onEventLoop {
+            repository.save(
+                received,
+                OutboxMessage(aggregateId = received.id, eventType = "test.confirmation.seed", payload = "{}"),
+            )
+        }
+
+        pathTo(status).forEach { target ->
+            val transitioned = payment.transitionTo(target, clock = clock)
+            payment = onEventLoop {
+                repository.update(
+                    transitioned,
+                    OutboxMessage(
+                        aggregateId = transitioned.id,
+                        eventType = "test.confirmation.seed",
+                        payload = "{}",
+                    ),
+                )
+            }
+        }
+        return payment
+    }
+
+    @Test
+    @TestSecurity(user = "00000000-0000-0000-0000-000000000099", roles = ["ROLE_OPERATOR"])
+    fun `SETTLED payment returns the rendered confirmation HTML`() {
+        val payment = seedPayment(DomesticPaymentStatus.SETTLED)
+        fakeRenderPort.renderedHtml = "<html>settled-confirmation</html>"
+
+        Given { this } When {
+            get("/api/v1/domestic-payments/${payment.id}/confirmation")
+        } Then {
+            statusCode(200)
+            contentType(org.hamcrest.Matchers.containsString("text/html"))
+            body(equalTo("<html>settled-confirmation</html>"))
+        }
+
+        assert(fakeRenderPort.lastTemplateCode == "POTVRZENI_O_PLATBE_CS") {
+            "expected the CS template by default, got ${fakeRenderPort.lastTemplateCode}"
+        }
+    }
+
+    @Test
+    @TestSecurity(user = "00000000-0000-0000-0000-000000000099", roles = ["ROLE_OPERATOR"])
+    fun `lang=en asks the render port for the EN template`() {
+        val payment = seedPayment(DomesticPaymentStatus.SETTLED)
+
+        RestAssured.given()
+            .queryParam("lang", "en")
+            .`when`().get("/api/v1/domestic-payments/${payment.id}/confirmation")
+            .then().statusCode(200)
+
+        assert(fakeRenderPort.lastTemplateCode == "POTVRZENI_O_PLATBE_EN")
+    }
+
+    @Test
+    @TestSecurity(user = "00000000-0000-0000-0000-000000000099", roles = ["ROLE_OPERATOR"])
+    fun `a payment that has not SETTLED is rejected with 409`() {
+        val payment = seedPayment(DomesticPaymentStatus.SENT_TO_CLEARING)
+
+        Given { this } When {
+            get("/api/v1/domestic-payments/${payment.id}/confirmation")
+        } Then {
+            statusCode(409)
+        }
+    }
+
+    @Test
+    @TestSecurity(user = "00000000-0000-0000-0000-000000000099", roles = ["ROLE_OPERATOR"])
+    fun `an unknown payment id answers 404`() {
+        Given { this } When {
+            get("/api/v1/domestic-payments/${UUID.randomUUID()}/confirmation")
+        } Then {
+            statusCode(404)
+        }
+    }
+
+    @Test
+    fun `anonymous request is rejected before the use case runs`() {
+        Given { this } When {
+            get("/api/v1/domestic-payments/${UUID.randomUUID()}/confirmation")
+        } Then {
+            statusCode(401)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds `GET /api/v1/domestic-payments/{paymentId}/confirmation` — the customer-facing "download
confirmation" action for a SETTLED domestic payment (ADR-0248 #3). Renders synchronously, only on
explicit customer request, off the payment's own already-persisted status record, via
document-service's existing non-persisting `templates/preview` endpoint. Nothing is pre-generated,
cached, or persisted a second time anywhere.

## Type of change

- [x] feat (new functionality)
- [ ] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [ ] docs
- [ ] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change

## Linked issues

Refs #4109
Refs ADR-0248

## Changes

- New `GET /api/v1/domestic-payments/{paymentId}/confirmation` on `DomesticPaymentResource`
  (`@Authorize(action = "domestic-payment.confirmation.read")`), 409 unless the payment is
  `SETTLED`, returns rendered `text/html`.
- `PaymentConfirmationService` (new use case) — strictly read-only: calls
  `DomesticPaymentRepository.findById` only, never `save`/`update`, so it cannot affect payment
  state.
- `PaymentConfirmationMapper` (pure, zero framework imports) — maps the persisted
  `DomesticPayment` onto the `document.*` Handlebars data shape the
  `POTVRZENI_O_PLATBE_CS`/`POTVRZENI_O_PLATBE_EN` document-service templates expect.
- `DocumentServiceClient` + `PaymentConfirmationRenderAdapter` — resolves the current PUBLISHED
  template body via document-service's `listTemplates` (the `preview` endpoint takes a raw
  `bodyHtml`, not a `templateCode`, by design), then merges payment data into it via
  `previewTemplate`. Both document-service calls are read-only/non-persisting on that side.
- `openapi.yaml` `1.3.0` → `1.4.0` (additive).
- `docs/threat-models/openbank-domestic-payment.md` — new outbound trust edge to document-service
  documented in the DFD and change log.

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports; `PaymentConfirmationMapper`
      is a pure application-layer transform).
- [x] Unit tests added/updated (`PaymentConfirmationMapperTest`, `PaymentConfirmationServiceTest`,
      `PaymentConfirmationRenderAdapterTest`).
- [x] Integration tests added/updated (`PaymentConfirmationResourceIT` — real Postgres, document-service
      client replaced by an `@Alternative` CDI test double; covers SETTLED success, `lang=en`,
      non-SETTLED 409, unknown-payment 404, anonymous 401).
- [x] Contract tests updated (if public API changed) — N/A, no consumer pact exists for this
      service's own API surface; `openapi.yaml` updated directly.
- [x] `./gradlew :openbank-domestic-payment:ktlintCheck :openbank-domestic-payment:detekt :openbank-domestic-payment:test` passes.
- [x] No new lint warnings (one pre-existing-pattern `ktlint-baseline.xml` entry added for the
      `port.\`in\`` package-name rule — same accepted style already baselined for the sibling
      `DomesticPaymentPorts.kt` in that package).
- [x] OpenAPI spec regenerated (if REST API changed) — hand-updated (no REST API changed on
      document-service; this service's own spec was updated).
- [ ] Flyway migration added + rollback note (if DB changed) — N/A, no DB change.
- [ ] Avro schema versioned backward-compatibly (if event changed) — N/A, no event change.
- [x] Docs updated (README, ADR if architectural) — threat model updated; ADR-0248 itself already
      merged and unchanged by this PR.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings`, `as Any`, `@Suppress("...")` without justification.
- [ ] No new third-party dependency, OR: dependency review attached (license, CVE, source) — no new
      dependency added.
- [x] Auth / crypto / payment code changed? → tag `security-review-required`. **This is a
      money-path service change** — see note below.
- [ ] PII path changed? → payment amount/account/creditor data crosses to document-service for a
      one-shot, non-persisted render; covered in the threat model's confidentiality row rather than
      a new GDPR lawful basis.
- [ ] Cardholder data path changed? — N/A.

## Compliance impact

- [x] PSD2 / SCA / RTS — Art. 45/48 post-execution payment information (ADR-0248 legal basis).
- [ ] PCI DSS / DORA / GDPR / AML / CNB reporting / None — see threat-model change log entry for
      the full compliance discussion (GDPR data-minimisation rationale for render-and-discard).

## Rollout / Rollback

- Deployment strategy: rolling (no flag; strictly additive endpoint).
- Rollback plan: revert this commit. The endpoint/use-case/adapter are net-new — reverting removes
  them cleanly with no data or schema to unwind.
- Data migration reversible: N/A — no migration.

## Reviewer notes

**Money-path service change — `openbank-domestic-payment` is on `rules.yaml:
money_path_services`. This needs 2 human approvals and a threat-model diff per repo governance
(ADR-0030) and is explicitly not self-mergeable — I will not merge this myself, and will not use
`--admin`/any override on `gh pr merge`/`gh pr review`.**

Scoped strictly to a new, read-only, additive endpoint: `PaymentConfirmationService` never calls
`DomesticPaymentRepository.save`/`update`, so it structurally cannot affect payment
initiation/status transition/clearing/settlement — see `PaymentConfirmationServiceTest`'s explicit
"never calls save or update" assertion. Please double-check:

1. The document-service `preview` endpoint contract I relied on (`bodyHtml`+`data` in,
   `renderedHtml` out — no `templateCode` field) — confirmed against
   `openbank-document-service/src/main/resources/openapi.yaml` and
   `DocumentResource.previewTemplate`, since the ADR's prose reads as if `preview` accepted a
   `templateCode` directly, which it does not.
2. The `PaymentConfirmationRenderAdapter`'s list-then-preview flow is read-only on both calls, so a
   `@Retry` on it cannot double-render or double-persist anything.
