### PR TITLE
fix(engagement): SurfaceRestContractIT is red on main — an identity and test-profile authz enforcement

### DIFF
--- a/openbank-engagement-service/src/main/resources/application.yaml
+++ b/openbank-engagement-service/src/main/resources/application.yaml
@@ -62,6 +62,13 @@ mp:
           serializer: org.apache.kafka.common.serialization.StringSerializer
 
 "%test":
+  # SurfaceResource's two endpoints are @Authorize-annotated, and `authz.enforce` carries
+  # defaultValue = "true" in AuthorizeInterceptor — so under @QuarkusTest, with no OPA PDP
+  # bean in the graph, every one of them answers 503 and SurfaceRestContractIT's
+  # `statusCode(200)` fails. Advisory in tests only; the deployed posture is unchanged and
+  # is decided by the sidecar wired in #4068.
+  authz:
+    enforce: false
   quarkus:
     management:
       enabled: false

--- a/openbank-engagement-service/src/test/kotlin/com/openbank/engagement/integration/SurfaceRestContractIT.kt
+++ b/openbank-engagement-service/src/test/kotlin/com/openbank/engagement/integration/SurfaceRestContractIT.kt
@@ -11,6 +11,7 @@ import io.restassured.module.kotlin.extensions.Extract
 import io.restassured.module.kotlin.extensions.Given
 import io.restassured.module.kotlin.extensions.Then
 import io.restassured.module.kotlin.extensions.When
+import io.quarkus.test.security.TestSecurity
 import io.smallrye.reactive.messaging.memory.InMemoryConnector
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -50,6 +51,7 @@ class SurfaceRestContractIT {
     }
 
     @Test
+    @TestSecurity(user = TEST_OPERATOR, roles = ["ROLE_OPERATOR"])
     fun `an eligible party sees the catalogued banner`() {
         StubConsentCheckPort.granted.set(true)
         val body = getBanner(UUID.randomUUID())
@@ -59,6 +61,7 @@ class SurfaceRestContractIT {
     }
 
     @Test
+    @TestSecurity(user = TEST_OPERATOR, roles = ["ROLE_OPERATOR"])
     fun `a party without marketing consent is not_eligible, not an empty list`() {
         StubConsentCheckPort.granted.set(false)
         val body = getBanner(UUID.randomUUID())
@@ -67,6 +70,7 @@ class SurfaceRestContractIT {
     }
 
     @Test
+    @TestSecurity(user = TEST_OPERATOR, roles = ["ROLE_OPERATOR"])
     fun `three posted dismissals suppress the next resolve for that party and slot`() {
         StubConsentCheckPort.granted.set(true)
         val party = UUID.randomUUID()
@@ -88,6 +92,7 @@ class SurfaceRestContractIT {
     }
 
     @Test
+    @TestSecurity(user = TEST_OPERATOR, roles = ["ROLE_OPERATOR"])
     fun `an unknown slot is a 400, not a 500 or a silent empty result`() {
         Given {
             queryParam("partyId", UUID.randomUUID().toString())
@@ -96,5 +101,10 @@ class SurfaceRestContractIT {
         } Then {
             statusCode(400)
         }
+    }
+
+    private companion object {
+        /** Any stable principal id: the endpoints gate on the ROLE, not on this value. */
+        const val TEST_OPERATOR = "00000000-0000-0000-0000-000000000099"
     }
 }

--- a/openbank-engagement-service/src/test/kotlin/com/openbank/engagement/integration/SurfaceRestContractIT.kt
+++ b/openbank-engagement-service/src/test/kotlin/com/openbank/engagement/integration/SurfaceRestContractIT.kt
@@ -7,11 +7,11 @@ package com.openbank.engagement.integration
 import io.quarkus.test.common.QuarkusTestResource
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager
 import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.security.TestSecurity
 import io.restassured.module.kotlin.extensions.Extract
 import io.restassured.module.kotlin.extensions.Given
 import io.restassured.module.kotlin.extensions.Then
 import io.restassured.module.kotlin.extensions.When
-import io.quarkus.test.security.TestSecurity
 import io.smallrye.reactive.messaging.memory.InMemoryConnector
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test


### PR DESCRIPTION
All four `SurfaceRestContractIT` tests fail on `main`. They are invisible there — Services CI is path-scoped, and `main`'s own run reports `skipped build` because the push touched no service path, so `all-green` went green over **zero** services (#4119). The two other open PRs that do build engagement pass, but sit **8** and **62** commits behind and predate the breakage.

## Two defects, layered — the first masked the second

Each measured, not argued. `:openbank-engagement-service:test --tests '*SurfaceRestContractIT*'`, reading the JUnit XML after `rm -rf build/test-results` every time (a stale XML reports a green for code that never ran):

| `@TestSecurity` | `authz.enforce=false` | result |
|---|---|---|
| no | yes | 4 failures, all **401** |
| **yes** | **yes** | **4 passed** |
| yes | no | 4 failures, all **503** |

**1 — 401.** `SurfaceResource` carries `@RolesAllowed("ROLE_OPERATOR","ROLE_API","ROLE_ADMIN")` on both endpoints, and the IT authenticated as nobody. Its KDoc says it means to prove the contract *"without also needing a reachable OIDC token server"*, and `%test` does set `quarkus.oidc.enabled: false` — but disabling the provider removes the token **source**, not the **requirement**. Fixed with `@TestSecurity`, which is the fleet convention rather than my invention: 39 ITs use it, and the module already had `quarkus-test-security` on its test classpath.

**2 — 503.** With an identity in hand the request finally reaches `@Authorize`, and `authz.enforce` carries `defaultValue = "true"` in `AuthorizeInterceptor` while `@QuarkusTest` has no PDP bean. The third row is the control: removing that single key reproduces 503 on all four. Test profile only — the deployed posture is unchanged and is decided by the sidecar wired in #4068.

I ran the third row specifically because the first fix made the second one unfalsifiable: once 401 was gone I could have shipped the config key on the strength of *"`enforce=true, no PDP bean throws 503`" exists as a unit test elsewhere*, which is an inference, not evidence about this service. It costs one 6-minute run to turn it into evidence.

## What this unblocks

#4114 (engagement's missing `governance.yaml`, which closes the ADR-0071 drift keeping `main`'s `Admin UI build` red) currently fails on exactly these four tests. It adds one YAML file to engagement and cannot break a REST contract — it merely *touches* an engagement path, which is what makes CI run these tests at all.

## What this does NOT fix

The structural half of #4119: a service's tests can be broken on `main` indefinitely as long as no commit touches its directory, and `all-green` will report success over a skipped build the whole time. That wants a scheduled full-fleet build, and is a separate change.
