### PR TITLE
feat(sepa-payment): add customer-facing payment confirmation download endpoint

### DIFF
--- a/docs/threat-models/openbank-sepa-payment.md
+++ b/docs/threat-models/openbank-sepa-payment.md
@@ -23,13 +23,18 @@ value transfer — a primary fraud target; clears via batch/clearing rather than
                                                                               +--> [fraud-service] (shadow, OIDC CC / mTLS, fail-open)
                                                                               |
                                                                               +--> [clearing-simulator] (pacs.008 out / pacs.002 in; OIDC CC; ADR-0104 D3; flag-gated)
+                                                                              |
+                                                                              +--> [document-service] (GET /templates + POST /templates/preview; OIDC CC; ADR-0248 #3; synchronous, customer-triggered only)
 ```
 
 - **External entities:** payment-initiating channels/operators, downstream clearing & ledger,
-  clearing-simulator (scheme network proxy; swap-point for real SCT scheme connector).
+  clearing-simulator (scheme network proxy; swap-point for real SCT scheme connector),
+  document-service (confirmation-document rendering, non-persisting).
 - **Trust boundaries:** caller↔service (mTLS+OIDC+OPA); service↔Postgres/Kafka;
   service↔fraud-service (OIDC client-credentials + mTLS, internal cluster-only, shadow/read-only);
-  service↔clearing-simulator (OIDC client-credentials; cluster-internal; pilot flag off by default).
+  service↔clearing-simulator (OIDC client-credentials; cluster-internal; pilot flag off by default);
+  service↔document-service (OIDC client-credentials; cluster-internal; synchronous, read-only from
+  this service's perspective — see §5b).
 - **Assets:** payment instructions, amounts, debtor/creditor IBANs.
 
 ## 3. Authn/Authz
@@ -104,8 +109,46 @@ from clearing-simulator (cluster-internal, `ROLE_SERVICE`). New trust boundary:
 **Risk class:** integrity (money-path reversal) + availability (idempotency).
 **Rollback:** feature flag `openbank.sepa.returns.enabled` (off by default); flag OFF = 404 on `/returns`.
 
+## 5b. Payment confirmation download (ADR-0248 #3) — STRIDE supplement
+
+New outbound trust edge: `GET /api/v1/sepa-payments/{paymentId}/confirmation` (customer-facing
+download action) → `sepa-payment-service` → `document-service` (`GET /api/v1/documents/templates`
++ `POST /api/v1/documents/templates/preview`, OIDC client-credentials, cluster-internal). Rendered
+**synchronously, only on this explicit customer request** — no pre-generation on
+`SepaPaymentStatusChangedEvent`, no new Kafka consumer, nothing persisted a second time anywhere:
+the response bytes are read from document-service's non-persisting `preview` endpoint and streamed
+straight back. Only meaningful for a `COMPLETED` payment; every other status is rejected with 409
+before document-service is ever called.
+
+| STRIDE | Threat | Mitigation |
+|---|---|---|
+| **S**poofing | A caller other than the payment's own owner downloads its confirmation | Same `@RolesAllowed("ROLE_VIEWER","ROLE_OPERATOR","ROLE_ADMIN","ROLE_PAYMENTS")` + `@Authorize(action="sepaPayment.downloadConfirmation", resource="#paymentId")` as the existing `sepaPayment.read` endpoint; no new role is introduced |
+| **T**ampering | The rendered document is altered in flight or a stale template is served | document-service call is OIDC client-credentials + cluster-internal only; `DocumentPreviewAdapter` resolves the template by `code` **and** requires `status == PUBLISHED` — a `DRAFT`/`RETIRED` body is never served |
+| **R**epudiation | No record of who downloaded a confirmation | Same request-level audit trail as every other `sepaPayment.*` endpoint (`AuthorizeInterceptor` decision log); this ADR adds no new unaudited path |
+| **I**nfo disclosure | Payment PII (IBANs, amount, counterparty name) sent to a third service | document-service already sits inside the same trust boundary as fraud-service/clearing-simulator (mTLS + OIDC CC, cluster-internal); the confirmation is the ONLY new data this service ever sends it, and nothing sent is persisted there — `preview` is non-persisting by construction, so document-service never becomes a second copy of the payment record |
+| **D**oS | Flooding the download endpoint to exhaust document-service | No new rate-limit surface beyond the existing per-endpoint controls; a document-service fault or timeout fails the single request (502) and does not retry — no amplification |
+| **E**oP | A non-COMPLETED payment's internal state leaks via a confirmation rendered too early | `PaymentConfirmationService` checks `status == COMPLETED` before ever calling `DocumentPreviewPort` — a `RECEIVED`/`VALIDATED`/`PROCESSING`/`REJECTED`/`RETURNED`/`CANCELLED` payment is rejected 409 with document-service never invoked |
+
+**DFD update:** adds `sepa-payment-service → document-service (templates list + preview)` edge,
+customer-facing-edge/operator-initiated only — no service-account/M2M caller is granted this action.
+**Risk class:** confidentiality (payment data sent to a new outbound peer) + availability (a slow or
+unreachable document-service fails only the download, never a payment transition — see §4/§5:
+**payment execution, settlement, and status-transition logic are entirely unchanged** by this ADR).
+**Rollback:** revert the endpoint + adapter commit; no DB schema change, no flag needed (the route
+simply stops existing).
+
 ## 6. Change log
 
+- **2026-08-08** — ADR-0248 #3: payment confirmation download. New endpoint `GET
+  /api/v1/sepa-payments/{paymentId}/confirmation`, new outbound trust edge to
+  `document-service` (STRIDE supplement §5b). Strictly additive and read-only — no change to
+  payment execution, settlement, or status-transition logic; `PaymentConfirmationService` only
+  reads the payment's own already-persisted record via the existing `SepaPaymentUseCase.getPayment`
+  and rejects (409) anything not `COMPLETED` before document-service is ever called. Rendered
+  synchronously on customer request only, via document-service's existing non-persisting `preview`
+  endpoint; nothing is cached or persisted a second time anywhere. Risk class = confidentiality
+  (new outbound peer receiving payment data) + availability (a document-service fault fails only
+  this one download, never a payment transition). Rollback: revert the endpoint + adapter commit.
 - **2026-08-05** — Trust-boundary change (#3734): `operator-sepa-payment-write` now excludes `service-account-*` principals, and a new `prohibited` veto closes `sepaPayment.{transitionStatus, handleReturn, approval.decide}` to `service-account-openbank-edge` (the role_action_matrix grants those to ROLE_OPERATOR, which the edge service-account carries; matrix-allows does not consult the ext exclusion). The edge's verified legitimate access — `sepaPayment.{create, read}` via `service-sepa-payment-edge-m2m` (customer transfer initiation after the edge's own ownership guard + SCA gate, ADR-0021) — is preserved; clearing-simulator keeps `handleReturn` via the shared-client identity rule. Ext moved from generator heredoc to standalone `sepa_payment_rest_ext.rego` with an opa test suite.
 - **2026-08-03** — Missing required query/header parameter answered 500, not 400 (#3104). A required `@QueryParam`/`@HeaderParam` declared with a non-nullable Kotlin type was fed `null` by JAX-RS when the caller omitted it, and answered **500** rather than 400 (#3104). Kotlin's null-safety is compile-time only, so the declared type only decided where the failure landed: a non-suspend handler threw `Intrinsics.checkNotNullParameter` at the method boundary, and a **suspend** handler got no intrinsic at all, so the null flowed into the body. `Idempotency-Key` on createPayment. As in domestic-payment, the existing `require(idempotencyKey.isNotBlank())` could not run for an ABSENT header — this handler is `suspend`, so `null.isNotBlank()` threw NPE and the replay control answered 500 in exactly the case it existed for. A duplicate submission was never at risk (the store is only consulted with a real key), but the caller was told the server had broken when it had not. Now `require(!idempotencyKey.isNullOrBlank())`. No new caller or boundary. Rollback: revert.
 - **2026-07-24** — Retire the legacy in-service orchestration; Temporal is the sole orchestrator

--- a/openbank-sepa-payment/src/main/kotlin/com/openbank/sepa/application/port/in/SepaPaymentPorts.kt
+++ b/openbank-sepa-payment/src/main/kotlin/com/openbank/sepa/application/port/in/SepaPaymentPorts.kt
@@ -49,3 +49,15 @@ interface SepaPaymentUseCase {
     suspend fun transitionStatus(command: TransitionSepaPaymentStatusCommand): SepaPayment
     suspend fun handlePaymentReturn(command: HandlePaymentReturnCommand): SepaPayment
 }
+
+/**
+ * A rendered, never-persisted payment confirmation document (ADR-0248 #3) — rendered synchronously
+ * at the moment the customer requests it and streamed straight back; nothing here is cached or
+ * written to disk anywhere in this service or in document-service.
+ */
+class PaymentConfirmationDocument(val contentType: String, val fileName: String, val bytes: ByteArray)
+
+interface PaymentConfirmationUseCase {
+    /** Only meaningful for a `COMPLETED` payment; throws otherwise (`PaymentNotCompletedException`). */
+    suspend fun getConfirmation(paymentId: UUID, locale: String): PaymentConfirmationDocument
+}

--- a/openbank-sepa-payment/src/main/kotlin/com/openbank/sepa/application/port/out/DocumentPreviewPort.kt
+++ b/openbank-sepa-payment/src/main/kotlin/com/openbank/sepa/application/port/out/DocumentPreviewPort.kt
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.sepa.application.port.out
+
+/**
+ * Outbound port to `openbank-document-service`'s non-persisting template preview (ADR-0248 #3):
+ * renders a PUBLISHED template body against [data] and returns the rendered HTML. Nothing is ever
+ * written to document-service's object store through this port — no `Document` row, no
+ * `document.generated` outbox event — and sepa-payment never caches or persists the result either.
+ */
+interface DocumentPreviewPort {
+    suspend fun renderTemplate(templateCode: String, data: Map<String, Any?>): String
+}
+
+/** The named template has no PUBLISHED version, or document-service could not be reached. */
+class DocumentTemplateUnavailableException(message: String, cause: Throwable? = null) : RuntimeException(message, cause)

--- a/openbank-sepa-payment/src/main/kotlin/com/openbank/sepa/application/usecase/PaymentConfirmationMapper.kt
+++ b/openbank-sepa-payment/src/main/kotlin/com/openbank/sepa/application/usecase/PaymentConfirmationMapper.kt
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.sepa.application.usecase
+
+import com.openbank.sepa.domain.model.SepaPayment
+
+/**
+ * Builds the Handlebars data map the `POTVRZENI_O_PLATBE_CS`/`POTVRZENI_O_PLATBE_EN` document-service
+ * templates expect (ADR-0248 #3), read entirely from the payment's own already-persisted record —
+ * that record is the durable evidentiary copy, so document-service never becomes a second one.
+ * SEPA has no separate SCA-evidence reference field today, so `scaEvidenceRef` is always `null`.
+ */
+fun SepaPayment.toConfirmationData(): Map<String, Any?> = mapOf(
+    "document" to mapOf(
+        "paymentReference" to id.toString(),
+        "endToEndId" to endToEndId,
+        "executedAt" to (completedAt?.toString() ?: ""),
+        "amount" to amount.toPlainString(),
+        "currency" to currency,
+        "debtorIban" to debtorIban,
+        "creditorIban" to creditorIban,
+        "creditorName" to creditorName,
+        "remittanceInfo" to (remittanceInfo ?: ""),
+        "status" to status.name,
+        "scaEvidenceRef" to null,
+    ),
+)

--- a/openbank-sepa-payment/src/main/kotlin/com/openbank/sepa/application/usecase/PaymentConfirmationService.kt
+++ b/openbank-sepa-payment/src/main/kotlin/com/openbank/sepa/application/usecase/PaymentConfirmationService.kt
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.sepa.application.usecase
+
+import com.openbank.sepa.application.port.`in`.PaymentConfirmationDocument
+import com.openbank.sepa.application.port.`in`.PaymentConfirmationUseCase
+import com.openbank.sepa.application.port.`in`.SepaPaymentUseCase
+import com.openbank.sepa.application.port.out.DocumentPreviewPort
+import com.openbank.sepa.domain.model.SepaPaymentStatus
+import jakarta.enterprise.context.ApplicationScoped
+import java.util.Locale
+import java.util.UUID
+
+/** The payment exists but has not reached `COMPLETED` yet — there is nothing to confirm. */
+class PaymentNotCompletedException(paymentId: UUID, status: SepaPaymentStatus) :
+    RuntimeException("SEPA payment $paymentId is $status, not COMPLETED — no confirmation available")
+
+/**
+ * ADR-0248 #3 — payment confirmation, rendered synchronously and only on explicit customer
+ * request. Strictly additive and read-only: it never transitions the payment or touches
+ * settlement/scheme logic, it only reads the payment's own already-persisted status record
+ * (via [SepaPaymentUseCase.getPayment]) and hands it to document-service's non-persisting
+ * preview endpoint through [DocumentPreviewPort]. Nothing is cached or stored anywhere.
+ */
+@ApplicationScoped
+class PaymentConfirmationService(
+    private val paymentUseCase: SepaPaymentUseCase,
+    private val documentPreviewPort: DocumentPreviewPort,
+) : PaymentConfirmationUseCase {
+
+    companion object {
+        private const val TEMPLATE_CODE_CS = "POTVRZENI_O_PLATBE_CS"
+        private const val TEMPLATE_CODE_EN = "POTVRZENI_O_PLATBE_EN"
+        private const val LOCALE_CS = "cs"
+    }
+
+    override suspend fun getConfirmation(paymentId: UUID, locale: String): PaymentConfirmationDocument {
+        val payment = paymentUseCase.getPayment(paymentId)
+        if (payment.status != SepaPaymentStatus.COMPLETED) {
+            throw PaymentNotCompletedException(paymentId, payment.status)
+        }
+
+        val templateCode = if (locale.trim().lowercase(Locale.ROOT) == LOCALE_CS) TEMPLATE_CODE_CS else TEMPLATE_CODE_EN
+        val renderedHtml = documentPreviewPort.renderTemplate(templateCode, payment.toConfirmationData())
+
+        return PaymentConfirmationDocument(
+            contentType = "text/html; charset=UTF-8",
+            fileName = "payment-confirmation-$paymentId.html",
+            bytes = renderedHtml.toByteArray(Charsets.UTF_8),
+        )
+    }
+}

--- a/openbank-sepa-payment/src/main/kotlin/com/openbank/sepa/infrastructure/client/DocumentPreviewAdapter.kt
+++ b/openbank-sepa-payment/src/main/kotlin/com/openbank/sepa/infrastructure/client/DocumentPreviewAdapter.kt
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.sepa.infrastructure.client
+
+import com.openbank.sepa.application.port.out.DocumentPreviewPort
+import com.openbank.sepa.application.port.out.DocumentTemplateUnavailableException
+import io.smallrye.mutiny.coroutines.awaitSuspending
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.inject.Inject
+import org.eclipse.microprofile.faulttolerance.Timeout
+import org.eclipse.microprofile.rest.client.inject.RestClient
+
+private const val TEMPLATE_LIST_LIMIT = 200
+private const val PREVIEW_TIMEOUT_MS = 10_000L
+private const val PUBLISHED_STATUS = "PUBLISHED"
+
+/**
+ * Adapter over [DocumentServiceClient] (ADR-0248 #3). Unlike the fraud-scoring shadow path, this
+ * one is fail-CLOSED: a payment confirmation the customer explicitly requested must not silently
+ * succeed with the wrong (or no) content on a document-service fault. On any failure the download
+ * fails and the customer can retry — no payment state is affected either way (ADR-0248's stated
+ * acceptable failure mode for the synchronous render-on-click path).
+ */
+@ApplicationScoped
+class DocumentPreviewAdapter(@RestClient private val client: DocumentServiceClient) : DocumentPreviewPort {
+
+    // Self-injection so @Timeout below is applied through the CDI proxy (an in-class call bypasses
+    // interceptors) — the same pattern FraudScoringAdapter uses. The outer method catches whatever
+    // the interceptor throws (including its own TimeoutException, which is NOT thrown from inside
+    // the annotated method's try/catch — it is raised by the interceptor wrapping the call) so a
+    // slow document-service always surfaces as the same DocumentTemplateUnavailableException / 502,
+    // never a bare 500.
+    @Inject
+    lateinit var self: DocumentPreviewAdapter
+
+    @Suppress("TooGenericExceptionCaught")
+    override suspend fun renderTemplate(templateCode: String, data: Map<String, Any?>): String = try {
+        self.renderTemplateWithResilience(templateCode, data)
+    } catch (ex: DocumentTemplateUnavailableException) {
+        throw ex
+    } catch (ex: Exception) {
+        throw DocumentTemplateUnavailableException("document-service call failed for code $templateCode", ex)
+    }
+
+    @Timeout(value = PREVIEW_TIMEOUT_MS)
+    open suspend fun renderTemplateWithResilience(templateCode: String, data: Map<String, Any?>): String {
+        val bodyHtml = client.listTemplates(TEMPLATE_LIST_LIMIT).awaitSuspending()
+            .firstOrNull { it.code == templateCode && it.status == PUBLISHED_STATUS }?.bodyHtml
+            ?: throw DocumentTemplateUnavailableException("No PUBLISHED template found for code $templateCode")
+
+        return client.preview(PreviewTemplateClientRequest(bodyHtml = bodyHtml, data = data)).awaitSuspending()
+            .renderedHtml
+    }
+}

--- a/openbank-sepa-payment/src/main/kotlin/com/openbank/sepa/infrastructure/client/DocumentServiceClient.kt
+++ b/openbank-sepa-payment/src/main/kotlin/com/openbank/sepa/infrastructure/client/DocumentServiceClient.kt
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.sepa.infrastructure.client
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import io.quarkus.oidc.client.reactive.filter.OidcClientRequestReactiveFilter
+import io.smallrye.mutiny.Uni
+import jakarta.ws.rs.Consumes
+import jakarta.ws.rs.GET
+import jakarta.ws.rs.POST
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.Produces
+import jakarta.ws.rs.QueryParam
+import jakarta.ws.rs.core.MediaType
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient
+
+/**
+ * RestClient binding to `openbank-document-service`'s template endpoints (ADR-0248 #3).
+ * `GET /api/v1/documents/templates` lists templates (there is no get-by-code endpoint) so the
+ * adapter can resolve a `templateCode` to its current PUBLISHED `bodyHtml`; that body is then
+ * rendered via `POST /api/v1/documents/templates/preview`, document-service's existing
+ * non-persisting preview endpoint (reused as-is, per the ADR — nothing new added there).
+ * Carries the service OIDC token like the other inter-service clients in this module.
+ */
+@RegisterRestClient(configKey = "document-service")
+@RegisterProvider(OidcClientRequestReactiveFilter::class)
+@Path("/api/v1/documents/templates")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+interface DocumentServiceClient {
+
+    @GET
+    fun listTemplates(@QueryParam("limit") limit: Int): Uni<List<DocumentTemplateClientResponse>>
+
+    @POST
+    @Path("/preview")
+    fun preview(request: PreviewTemplateClientRequest): Uni<PreviewTemplateClientResponse>
+}
+
+/** Mirror of document-service `TemplateResponse` (tolerate unknown fields as the contract evolves). */
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class DocumentTemplateClientResponse(
+    val code: String,
+    val bodyHtml: String,
+    val locale: String = "en",
+    val status: String = "DRAFT",
+)
+
+/** Mirror of document-service `PreviewTemplateRequest`. */
+data class PreviewTemplateClientRequest(val bodyHtml: String, val data: Map<String, Any?> = emptyMap())
+
+/** Mirror of document-service `PreviewTemplateResponse` (tolerate unknown fields). */
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class PreviewTemplateClientResponse(val renderedHtml: String)

--- a/openbank-sepa-payment/src/main/kotlin/com/openbank/sepa/infrastructure/rest/ExceptionMappers.kt
+++ b/openbank-sepa-payment/src/main/kotlin/com/openbank/sepa/infrastructure/rest/ExceptionMappers.kt
@@ -6,6 +6,7 @@ package com.openbank.sepa.infrastructure.rest
 
 import com.openbank.libs.api.error.ApiError
 import com.openbank.libs.api.error.ErrorCode
+import com.openbank.libs.domain.identifiers.Ids
 import com.openbank.sepa.application.port.out.DocumentTemplateUnavailableException
 import com.openbank.sepa.application.usecase.InvalidSepaPaymentStateTransitionException
 import com.openbank.sepa.application.usecase.PaymentNotCompletedException
@@ -41,7 +42,7 @@ class PaymentNotCompletedMapper : ExceptionMapper<PaymentNotCompletedException> 
     override fun toResponse(exception: PaymentNotCompletedException): Response = Response.status(HTTP_CONFLICT)
         .entity(
             ApiError(
-                UUID.randomUUID().toString(),
+                Ids.randomId().toString(),
                 HTTP_CONFLICT,
                 ErrorCode.CONFLICT.code,
                 exception.message ?: "Conflict",
@@ -56,7 +57,7 @@ class DocumentTemplateUnavailableMapper : ExceptionMapper<DocumentTemplateUnavai
         Response.status(HTTP_BAD_GATEWAY)
             .entity(
                 ApiError(
-                    UUID.randomUUID().toString(),
+                    Ids.randomId().toString(),
                     HTTP_BAD_GATEWAY,
                     ErrorCode.INTERNAL_ERROR.code,
                     exception.message ?: "Confirmation document unavailable",

--- a/openbank-sepa-payment/src/main/kotlin/com/openbank/sepa/infrastructure/rest/ExceptionMappers.kt
+++ b/openbank-sepa-payment/src/main/kotlin/com/openbank/sepa/infrastructure/rest/ExceptionMappers.kt
@@ -6,12 +6,17 @@ package com.openbank.sepa.infrastructure.rest
 
 import com.openbank.libs.api.error.ApiError
 import com.openbank.libs.api.error.ErrorCode
+import com.openbank.sepa.application.port.out.DocumentTemplateUnavailableException
 import com.openbank.sepa.application.usecase.InvalidSepaPaymentStateTransitionException
+import com.openbank.sepa.application.usecase.PaymentNotCompletedException
 import com.openbank.sepa.application.usecase.SepaPaymentNotFoundException
 import jakarta.ws.rs.core.Response
 import jakarta.ws.rs.ext.ExceptionMapper
 import jakarta.ws.rs.ext.Provider
 import java.util.UUID
+
+private const val HTTP_CONFLICT = 409
+private const val HTTP_BAD_GATEWAY = 502
 
 @Provider
 class SepaPaymentNotFoundMapper : ExceptionMapper<SepaPaymentNotFoundException> {
@@ -30,3 +35,32 @@ class InvalidSepaPaymentStateTransitionMapper : ExceptionMapper<InvalidSepaPayme
 // SelfApprovalNotAllowedMapper / InvalidApprovalStateMapper (403/409) moved to
 // openbank-libs-runtime's CommonExceptionMappers (issue #1394) — a service-local copy of the
 // same exact type would collide non-deterministically with the shared one (issue #526).
+
+@Provider
+class PaymentNotCompletedMapper : ExceptionMapper<PaymentNotCompletedException> {
+    override fun toResponse(exception: PaymentNotCompletedException): Response = Response.status(HTTP_CONFLICT)
+        .entity(
+            ApiError(
+                UUID.randomUUID().toString(),
+                HTTP_CONFLICT,
+                ErrorCode.CONFLICT.code,
+                exception.message ?: "Conflict",
+            ),
+        )
+        .build()
+}
+
+@Provider
+class DocumentTemplateUnavailableMapper : ExceptionMapper<DocumentTemplateUnavailableException> {
+    override fun toResponse(exception: DocumentTemplateUnavailableException): Response =
+        Response.status(HTTP_BAD_GATEWAY)
+            .entity(
+                ApiError(
+                    UUID.randomUUID().toString(),
+                    HTTP_BAD_GATEWAY,
+                    ErrorCode.INTERNAL_ERROR.code,
+                    exception.message ?: "Confirmation document unavailable",
+                ),
+            )
+            .build()
+}

--- a/openbank-sepa-payment/src/main/kotlin/com/openbank/sepa/infrastructure/rest/SepaPaymentResource.kt
+++ b/openbank-sepa-payment/src/main/kotlin/com/openbank/sepa/infrastructure/rest/SepaPaymentResource.kt
@@ -9,6 +9,7 @@ import com.openbank.libs.authz.Authorize
 import com.openbank.libs.idempotency.IdempotencyStore
 import com.openbank.sepa.application.port.`in`.HandlePaymentReturnCommand
 import com.openbank.sepa.application.port.`in`.ListSepaPaymentsQuery
+import com.openbank.sepa.application.port.`in`.PaymentConfirmationUseCase
 import com.openbank.sepa.application.port.`in`.SepaPaymentUseCase
 import com.openbank.sepa.domain.model.SepaPaymentStatus
 import com.openbank.sepa.infrastructure.rest.dto.CreateSepaPaymentRequest
@@ -38,6 +39,7 @@ import java.util.UUID
 @Tag(name = "SEPA Payments", description = "SEPA credit transfer lifecycle")
 class SepaPaymentResource(
     private val paymentUseCase: SepaPaymentUseCase,
+    private val confirmationUseCase: PaymentConfirmationUseCase,
     private val idempotencyStore: IdempotencyStore,
     private val objectMapper: ObjectMapper,
 ) {
@@ -78,6 +80,25 @@ class SepaPaymentResource(
     @Operation(summary = "Get a SEPA payment by ID")
     suspend fun getPayment(@PathParam("paymentId") paymentId: UUID): Response =
         Response.ok(paymentUseCase.getPayment(paymentId).toResponse()).build()
+
+    @GET
+    @Path("/{paymentId}/confirmation")
+    @Produces("text/html")
+    @RolesAllowed("ROLE_VIEWER", "ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_PAYMENTS")
+    @Authorize(action = "sepaPayment.downloadConfirmation", resource = "#paymentId")
+    @Operation(summary = "Download the payment confirmation document for a COMPLETED SEPA payment")
+    suspend fun getConfirmation(
+        @PathParam("paymentId") paymentId: UUID,
+        @QueryParam("locale") @DefaultValue("en") locale: String,
+    ): Response {
+        // ADR-0248 #3: rendered synchronously, on this explicit customer request only — never
+        // pre-generated, never cached, never persisted anywhere (in this service or document-service).
+        val confirmation = confirmationUseCase.getConfirmation(paymentId, locale)
+        return Response.ok(confirmation.bytes)
+            .type(confirmation.contentType)
+            .header("Content-Disposition", "attachment; filename=\"${confirmation.fileName}\"")
+            .build()
+    }
 
     @GET
     @RolesAllowed("ROLE_VIEWER", "ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_PAYMENTS", "ROLE_API")

--- a/openbank-sepa-payment/src/main/resources/application.yaml
+++ b/openbank-sepa-payment/src/main/resources/application.yaml
@@ -76,6 +76,9 @@ quarkus:
     transaction-service:
       url: ${TRANSACTION_SERVICE_URL:http://localhost:8102}
       scope: jakarta.inject.Singleton
+    document-service:
+      url: ${DOCUMENT_SERVICE_URL:http://localhost:8143}
+      scope: jakarta.inject.Singleton
   smallrye-reactive-messaging:
     kafka:
       bootstrap-servers: "${KAFKA_BOOTSTRAP_SERVERS:localhost:29092}"

--- a/openbank-sepa-payment/src/main/resources/openapi.yaml
+++ b/openbank-sepa-payment/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: SEPA Payment Service API
-  version: 1.5.0
+  version: 1.6.0
   description: >-
     SEPA credit transfer lifecycle — create, query, status transitions. On create, debtor and
     creditor names are synchronously screened against the sanctions lists (ADR-0032): a clean payment
@@ -136,6 +136,41 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '404':
           $ref: '#/components/responses/NotFound'
+
+  /api/v1/sepa-payments/{paymentId}/confirmation:
+    get:
+      tags: [SEPA Payments]
+      summary: >-
+        Download the payment confirmation document for a COMPLETED SEPA payment (ADR-0248 #3).
+        Rendered synchronously on this request only, via document-service's non-persisting
+        preview endpoint — never pre-generated, never cached, never persisted anywhere.
+      operationId: getSepaPaymentConfirmation
+      security:
+        - bearerAuth: [ROLE_VIEWER, ROLE_OPERATOR, ROLE_ADMIN, ROLE_PAYMENTS]
+      parameters:
+        - $ref: '#/components/parameters/paymentId'
+        - name: locale
+          in: query
+          schema:
+            type: string
+            enum: [cs, en]
+            default: en
+      responses:
+        '200':
+          description: Rendered confirmation document (HTML)
+          content:
+            text/html:
+              schema:
+                type: string
+                format: binary
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          description: Payment exists but is not COMPLETED — no confirmation available
+        '502':
+          description: document-service unreachable, or no PUBLISHED template for the requested locale
 
   /api/v1/sepa-payments/{paymentId}/status:
     patch:

--- a/openbank-sepa-payment/src/test/kotlin/com/openbank/sepa/application/usecase/PaymentConfirmationMapperTest.kt
+++ b/openbank-sepa-payment/src/test/kotlin/com/openbank/sepa/application/usecase/PaymentConfirmationMapperTest.kt
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.sepa.application.usecase
+
+import com.openbank.sepa.domain.model.SepaPayment
+import com.openbank.sepa.domain.model.SepaPaymentStatus
+import com.openbank.sepa.domain.model.SepaPaymentType
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.Instant
+import java.util.UUID
+
+class PaymentConfirmationMapperTest {
+
+    private fun payment(
+        status: SepaPaymentStatus = SepaPaymentStatus.COMPLETED,
+        completedAt: Instant? = Instant.parse("2026-08-01T10:15:30Z"),
+        remittanceInfo: String? = "Invoice 42",
+    ) = SepaPayment(
+        id = UUID.fromString("00000000-0000-0000-0000-0000000000aa"),
+        idempotencyKey = "idem-conf-1",
+        type = SepaPaymentType.SCT,
+        status = status,
+        debtorAccountId = UUID.randomUUID(),
+        debtorIban = "DE89370400440532013000",
+        debtorName = "Alice Debtor",
+        creditorIban = "FR1420041010050500013M02606",
+        creditorName = "Bob Creditor",
+        creditorBic = "BNPAFRPPXXX",
+        amount = BigDecimal("125.50"),
+        currency = "EUR",
+        remittanceInfo = remittanceInfo,
+        endToEndId = "E2E-CONF-0001",
+        rejectReason = null,
+        rejectDetail = null,
+        submittedAt = Instant.parse("2026-08-01T10:00:00Z"),
+        completedAt = completedAt,
+        createdAt = Instant.parse("2026-08-01T09:59:00Z"),
+        updatedAt = Instant.parse("2026-08-01T10:15:30Z"),
+    )
+
+    @Test
+    fun `maps every ADR-0248 field under the document namespace`() {
+        val data = payment().toConfirmationData()
+
+        @Suppress("UNCHECKED_CAST")
+        val document = data["document"] as Map<String, Any?>
+
+        assertThat(document["paymentReference"]).isEqualTo("00000000-0000-0000-0000-0000000000aa")
+        assertThat(document["endToEndId"]).isEqualTo("E2E-CONF-0001")
+        assertThat(document["executedAt"]).isEqualTo("2026-08-01T10:15:30Z")
+        assertThat(document["amount"]).isEqualTo("125.50")
+        assertThat(document["currency"]).isEqualTo("EUR")
+        assertThat(document["debtorIban"]).isEqualTo("DE89370400440532013000")
+        assertThat(document["creditorIban"]).isEqualTo("FR1420041010050500013M02606")
+        assertThat(document["creditorName"]).isEqualTo("Bob Creditor")
+        assertThat(document["remittanceInfo"]).isEqualTo("Invoice 42")
+        assertThat(document["status"]).isEqualTo("COMPLETED")
+        assertThat(document["scaEvidenceRef"]).isNull()
+    }
+
+    @Test
+    fun `a null remittanceInfo maps to an empty string, not null`() {
+        val data = payment(remittanceInfo = null).toConfirmationData()
+
+        @Suppress("UNCHECKED_CAST")
+        val document = data["document"] as Map<String, Any?>
+        assertThat(document["remittanceInfo"]).isEqualTo("")
+    }
+
+    @Test
+    fun `a null completedAt maps to an empty string, not null`() {
+        val data = payment(completedAt = null).toConfirmationData()
+
+        @Suppress("UNCHECKED_CAST")
+        val document = data["document"] as Map<String, Any?>
+        assertThat(document["executedAt"]).isEqualTo("")
+    }
+}

--- a/openbank-sepa-payment/src/test/kotlin/com/openbank/sepa/application/usecase/PaymentConfirmationServiceTest.kt
+++ b/openbank-sepa-payment/src/test/kotlin/com/openbank/sepa/application/usecase/PaymentConfirmationServiceTest.kt
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.sepa.application.usecase
+
+import com.openbank.sepa.application.port.`in`.SepaPaymentUseCase
+import com.openbank.sepa.application.port.out.DocumentPreviewPort
+import com.openbank.sepa.domain.model.SepaPayment
+import com.openbank.sepa.domain.model.SepaPaymentStatus
+import com.openbank.sepa.domain.model.SepaPaymentType
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * Coverage for [PaymentConfirmationService] with the document-service client mocked out at the
+ * [DocumentPreviewPort] boundary — proves the state gate (only `COMPLETED` renders) and the
+ * locale-to-template-code routing without any network dependency. The real wire contract to
+ * document-service is covered separately by
+ * [com.openbank.sepa.integration.PaymentConfirmationSimulatorIT] against a stubbed HTTP server.
+ */
+class PaymentConfirmationServiceTest {
+
+    private val paymentUseCase = mockk<SepaPaymentUseCase>()
+    private val documentPreviewPort = mockk<DocumentPreviewPort>()
+    private val service = PaymentConfirmationService(paymentUseCase, documentPreviewPort)
+
+    private fun payment(status: SepaPaymentStatus) = SepaPayment(
+        id = UUID.randomUUID(),
+        idempotencyKey = "idem-conf-svc",
+        type = SepaPaymentType.SCT,
+        status = status,
+        debtorAccountId = UUID.randomUUID(),
+        debtorIban = "DE89370400440532013000",
+        debtorName = "Alice Debtor",
+        creditorIban = "FR1420041010050500013M02606",
+        creditorName = "Bob Creditor",
+        creditorBic = "BNPAFRPPXXX",
+        amount = BigDecimal("50.00"),
+        currency = "EUR",
+        remittanceInfo = "Invoice 7",
+        endToEndId = "E2E-SVC-0001",
+        rejectReason = null,
+        rejectDetail = null,
+        submittedAt = Instant.now(),
+        completedAt = if (status == SepaPaymentStatus.COMPLETED) Instant.now() else null,
+        createdAt = Instant.now(),
+        updatedAt = Instant.now(),
+    )
+
+    @Test
+    fun `a COMPLETED payment renders the EN template by default`() {
+        val payment = payment(SepaPaymentStatus.COMPLETED)
+        coEvery { paymentUseCase.getPayment(payment.id) } returns payment
+        coEvery { documentPreviewPort.renderTemplate("POTVRZENI_O_PLATBE_EN", any()) } returns "<html>ok</html>"
+
+        val confirmation = runBlocking { service.getConfirmation(payment.id, "en") }
+
+        assertThat(confirmation.contentType).isEqualTo("text/html; charset=UTF-8")
+        assertThat(confirmation.fileName).isEqualTo("payment-confirmation-${payment.id}.html")
+        assertThat(String(confirmation.bytes, Charsets.UTF_8)).isEqualTo("<html>ok</html>")
+        coVerify(exactly = 1) { documentPreviewPort.renderTemplate("POTVRZENI_O_PLATBE_EN", any()) }
+    }
+
+    @Test
+    fun `a cs locale renders the CS template`() {
+        val payment = payment(SepaPaymentStatus.COMPLETED)
+        coEvery { paymentUseCase.getPayment(payment.id) } returns payment
+        coEvery { documentPreviewPort.renderTemplate("POTVRZENI_O_PLATBE_CS", any()) } returns "<html>ok-cs</html>"
+
+        runBlocking { service.getConfirmation(payment.id, "CS") }
+
+        coVerify(exactly = 1) { documentPreviewPort.renderTemplate("POTVRZENI_O_PLATBE_CS", any()) }
+    }
+
+    @Test
+    fun `a non-COMPLETED payment is rejected without ever calling document-service`() {
+        val payment = payment(SepaPaymentStatus.PROCESSING)
+        coEvery { paymentUseCase.getPayment(payment.id) } returns payment
+
+        assertThatThrownBy { runBlocking { service.getConfirmation(payment.id, "en") } }
+            .isInstanceOf(PaymentNotCompletedException::class.java)
+            .hasMessageContaining("PROCESSING")
+
+        coVerify(exactly = 0) { documentPreviewPort.renderTemplate(any(), any()) }
+    }
+}

--- a/openbank-sepa-payment/src/test/kotlin/com/openbank/sepa/infrastructure/client/DocumentPreviewAdapterTest.kt
+++ b/openbank-sepa-payment/src/test/kotlin/com/openbank/sepa/infrastructure/client/DocumentPreviewAdapterTest.kt
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.sepa.infrastructure.client
+
+import com.openbank.sepa.application.port.out.DocumentTemplateUnavailableException
+import io.mockk.every
+import io.mockk.mockk
+import io.smallrye.mutiny.Uni
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+
+class DocumentPreviewAdapterTest {
+
+    private val client = mockk<DocumentServiceClient>()
+    private val adapter = DocumentPreviewAdapter(client).also { it.self = it }
+
+    private fun template(code: String, status: String, bodyHtml: String = "<p>{{document.status}}</p>") =
+        DocumentTemplateClientResponse(code = code, bodyHtml = bodyHtml, locale = "en", status = status)
+
+    @Test
+    fun `resolves the PUBLISHED template by code and previews it`() {
+        every { client.listTemplates(any()) } returns Uni.createFrom().item(
+            listOf(
+                template("POTVRZENI_O_PLATBE_EN", "DRAFT", bodyHtml = "<p>draft, must be ignored</p>"),
+                template("POTVRZENI_O_PLATBE_EN", "PUBLISHED", bodyHtml = "<p>{{document.status}}</p>"),
+                template("OTHER_TEMPLATE", "PUBLISHED"),
+            ),
+        )
+        every { client.preview(any()) } returns
+            Uni.createFrom().item(PreviewTemplateClientResponse("<p>COMPLETED</p>"))
+
+        val rendered = runBlocking {
+            adapter.renderTemplate("POTVRZENI_O_PLATBE_EN", mapOf("document" to mapOf("status" to "COMPLETED")))
+        }
+
+        assertThat(rendered).isEqualTo("<p>COMPLETED</p>")
+    }
+
+    @Test
+    fun `no PUBLISHED template for the code fails closed`() {
+        every { client.listTemplates(any()) } returns Uni.createFrom().item(
+            listOf(template("POTVRZENI_O_PLATBE_EN", "DRAFT")),
+        )
+
+        assertThatThrownBy { runBlocking { adapter.renderTemplate("POTVRZENI_O_PLATBE_EN", emptyMap()) } }
+            .isInstanceOf(DocumentTemplateUnavailableException::class.java)
+            .hasMessageContaining("POTVRZENI_O_PLATBE_EN")
+    }
+
+    @Test
+    fun `a document-service fault listing templates fails closed, never silently succeeds`() {
+        every { client.listTemplates(any()) } returns Uni.createFrom().failure(RuntimeException("boom"))
+
+        assertThatThrownBy { runBlocking { adapter.renderTemplate("POTVRZENI_O_PLATBE_EN", emptyMap()) } }
+            .isInstanceOf(DocumentTemplateUnavailableException::class.java)
+    }
+
+    @Test
+    fun `a document-service fault rendering the preview fails closed`() {
+        every { client.listTemplates(any()) } returns Uni.createFrom().item(
+            listOf(template("POTVRZENI_O_PLATBE_EN", "PUBLISHED")),
+        )
+        every { client.preview(any()) } returns Uni.createFrom().failure(RuntimeException("boom"))
+
+        assertThatThrownBy { runBlocking { adapter.renderTemplate("POTVRZENI_O_PLATBE_EN", emptyMap()) } }
+            .isInstanceOf(DocumentTemplateUnavailableException::class.java)
+    }
+}

--- a/openbank-sepa-payment/src/test/kotlin/com/openbank/sepa/integration/DocumentServiceWireMockResource.kt
+++ b/openbank-sepa-payment/src/test/kotlin/com/openbank/sepa/integration/DocumentServiceWireMockResource.kt
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.sepa.integration
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock.containing
+import com.github.tomakehurst.wiremock.client.WireMock.get
+import com.github.tomakehurst.wiremock.client.WireMock.okJson
+import com.github.tomakehurst.wiremock.client.WireMock.post
+import com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor
+import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
+import com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration.options
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager
+
+/**
+ * Stands in for `openbank-document-service` over real HTTP (ADR-0248 #3) so
+ * [com.openbank.sepa.infrastructure.client.DocumentPreviewAdapter]'s two real REST-client calls
+ * (list templates, then preview) run for real — the path
+ * [com.openbank.sepa.infrastructure.client.DocumentPreviewAdapterTest] mocks away.
+ */
+class DocumentServiceWireMockResource : QuarkusTestResourceLifecycleManager {
+
+    override fun start(): Map<String, String> {
+        server = WireMockServer(options().dynamicPort())
+        server.start()
+
+        server.stubFor(
+            post(urlEqualTo("/token")).willReturn(
+                okJson("""{"access_token":"test-token","token_type":"Bearer","expires_in":300}"""),
+            ),
+        )
+        stubPublishedTemplate()
+
+        val base = server.baseUrl()
+        return mapOf(
+            "quarkus.rest-client.document-service.url" to base,
+            "quarkus.oidc-client.enabled" to "true",
+            "quarkus.oidc-client.auth-server-url" to base,
+            "quarkus.oidc-client.discovery-enabled" to "false",
+            "quarkus.oidc-client.token-path" to "/token",
+            "quarkus.oidc-client.client-id" to "openbank-services",
+            "quarkus.oidc-client.credentials.secret" to "test-secret",
+            "quarkus.oidc-client.grant.type" to "client",
+        )
+    }
+
+    override fun stop() {
+        if (isStarted()) server.stop()
+    }
+
+    companion object {
+        lateinit var server: WireMockServer
+
+        fun isStarted() = ::server.isInitialized
+
+        const val TEMPLATES_PATH = "/api/v1/documents/templates"
+        const val PREVIEW_PATH = "/api/v1/documents/templates/preview"
+
+        fun stubPublishedTemplate() {
+            server.stubFor(
+                get(urlPathEqualTo(TEMPLATES_PATH)).willReturn(
+                    okJson(
+                        """
+                        [
+                          {"code":"POTVRZENI_O_PLATBE_EN","bodyHtml":"<p>{{document.status}}</p>",
+                           "locale":"en","status":"PUBLISHED"},
+                          {"code":"POTVRZENI_O_PLATBE_CS","bodyHtml":"<p>{{document.status}}</p>",
+                           "locale":"cs","status":"PUBLISHED"}
+                        ]
+                        """.trimIndent(),
+                    ),
+                ),
+            )
+            server.stubFor(
+                post(urlEqualTo(PREVIEW_PATH)).willReturn(
+                    okJson("""{"renderedHtml":"<html><body>rendered confirmation</body></html>"}"""),
+                ),
+            )
+        }
+
+        /** No PUBLISHED templates at all — exercises the adapter's fail-closed "not found" path. */
+        fun stubNoPublishedTemplate() {
+            server.stubFor(get(urlPathEqualTo(TEMPLATES_PATH)).willReturn(okJson("""[]""")))
+        }
+
+        /** Proves the payment's own data actually reached the preview request body. */
+        fun verifyPreviewRequestContained(fragment: String) {
+            server.verify(postRequestedFor(urlEqualTo(PREVIEW_PATH)).withRequestBody(containing(fragment)))
+        }
+    }
+}

--- a/openbank-sepa-payment/src/test/kotlin/com/openbank/sepa/integration/PaymentConfirmationSimulatorIT.kt
+++ b/openbank-sepa-payment/src/test/kotlin/com/openbank/sepa/integration/PaymentConfirmationSimulatorIT.kt
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.sepa.integration
+
+import com.openbank.sepa.application.port.out.SepaPaymentOutboxMessage
+import com.openbank.sepa.application.port.out.SepaPaymentRepository
+import com.openbank.sepa.domain.model.SepaPayment
+import com.openbank.sepa.domain.model.SepaPaymentStatus
+import com.openbank.sepa.domain.model.SepaPaymentType
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.security.TestSecurity
+import io.quarkus.vertx.VertxContextSupport
+import io.restassured.module.kotlin.extensions.Given
+import io.restassured.module.kotlin.extensions.Then
+import io.restassured.module.kotlin.extensions.When
+import io.smallrye.mutiny.coroutines.uni
+import jakarta.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import org.hamcrest.CoreMatchers.equalTo
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * ADR-0248 #3 cross-service IT: drives the REAL `GET /{paymentId}/confirmation` endpoint end to
+ * end — real Postgres-backed payment lookup, real [PaymentConfirmationUseCase] wiring, real
+ * [com.openbank.sepa.infrastructure.client.DocumentPreviewAdapter] REST-client calls — against a
+ * stubbed document-service ([DocumentServiceWireMockResource]). The mocked-boundary version of
+ * this same behavior lives in
+ * [com.openbank.sepa.application.usecase.PaymentConfirmationServiceTest].
+ */
+@QuarkusTest
+@QuarkusTestResource(com.openbank.sepa.it.PostgresRedisTestResource::class)
+@QuarkusTestResource(DocumentServiceWireMockResource::class)
+class PaymentConfirmationSimulatorIT {
+
+    @Inject
+    lateinit var repository: SepaPaymentRepository
+
+    private fun payment(status: SepaPaymentStatus, id: UUID = UUID.randomUUID()) = SepaPayment(
+        id = id,
+        idempotencyKey = "it-conf-$id",
+        type = SepaPaymentType.SCT,
+        status = status,
+        debtorAccountId = UUID.randomUUID(),
+        debtorIban = "DE89370400440532013000",
+        debtorName = "Alice Debtor",
+        creditorIban = "FR1420041010050500013M02606",
+        creditorName = "Bob Creditor",
+        creditorBic = "BNPAFRPPXXX",
+        amount = BigDecimal("99.90"),
+        currency = "EUR",
+        remittanceInfo = "IT confirmation",
+        endToEndId = "E2E-IT-CONF-$id",
+        rejectReason = null,
+        rejectDetail = null,
+        submittedAt = Instant.now(),
+        completedAt = if (status == SepaPaymentStatus.COMPLETED) Instant.now() else null,
+        createdAt = Instant.now(),
+        updatedAt = Instant.now(),
+    )
+
+    // A bare @QuarkusTest thread carries no Vert.x context, and the reactive repository's
+    // Panache.withTransaction needs one — VertxContextSupport bridges it, the same pattern
+    // SepaPaymentOutboxClaimIT already uses to seed rows outside a real HTTP request.
+    private fun <T> onEventLoop(block: suspend () -> T): T =
+        VertxContextSupport.subscribeAndAwait { uni(CoroutineScope(Dispatchers.Unconfined)) { block() } }
+
+    private fun seed(status: SepaPaymentStatus): UUID {
+        val toSave = payment(status)
+        val saved = onEventLoop {
+            repository.save(
+                payment = toSave,
+                outboxMessage = SepaPaymentOutboxMessage(
+                    aggregateId = toSave.id,
+                    eventType = "sepa.payment.created",
+                    payload = "{}",
+                    createdAt = Instant.now(),
+                ),
+            )
+        }
+        return saved.id
+    }
+
+    @Test
+    @TestSecurity(user = "00000000-0000-0000-0000-000000000099", roles = ["ROLE_OPERATOR"])
+    fun `a COMPLETED payment downloads a real rendered confirmation over HTTP`() {
+        DocumentServiceWireMockResource.stubPublishedTemplate()
+        val paymentId = seed(SepaPaymentStatus.COMPLETED)
+
+        Given { this } When {
+            get("/api/v1/sepa-payments/$paymentId/confirmation")
+        } Then {
+            statusCode(200)
+            body(equalTo("<html><body>rendered confirmation</body></html>"))
+        }
+
+        DocumentServiceWireMockResource.verifyPreviewRequestContained("COMPLETED")
+    }
+
+    @Test
+    @TestSecurity(user = "00000000-0000-0000-0000-000000000099", roles = ["ROLE_OPERATOR"])
+    fun `a non-COMPLETED payment is rejected with 409, never calling document-service`() {
+        val paymentId = seed(SepaPaymentStatus.RECEIVED)
+
+        Given { this } When {
+            get("/api/v1/sepa-payments/$paymentId/confirmation")
+        } Then {
+            statusCode(409)
+        }
+    }
+
+    @Test
+    @TestSecurity(user = "00000000-0000-0000-0000-000000000099", roles = ["ROLE_OPERATOR"])
+    fun `an unknown payment id is a 404`() {
+        Given { this } When {
+            get("/api/v1/sepa-payments/${UUID.randomUUID()}/confirmation")
+        } Then {
+            statusCode(404)
+        }
+    }
+
+    @Test
+    @TestSecurity(user = "00000000-0000-0000-0000-000000000099", roles = ["ROLE_OPERATOR"])
+    fun `no PUBLISHED template fails closed with 502, not a silent empty document`() {
+        val paymentId = seed(SepaPaymentStatus.COMPLETED)
+        DocumentServiceWireMockResource.stubNoPublishedTemplate()
+
+        Given { this } When {
+            get("/api/v1/sepa-payments/$paymentId/confirmation")
+        } Then {
+            statusCode(502)
+        }
+
+        DocumentServiceWireMockResource.stubPublishedTemplate()
+    }
+
+    @Test
+    fun `an anonymous request is stopped before it ever reaches the handler`() {
+        Given { this } When {
+            get("/api/v1/sepa-payments/${UUID.randomUUID()}/confirmation")
+        } Then {
+            statusCode(401)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds a customer-facing "download confirmation" endpoint for SEPA payments (ADR-0248 #3):
`GET /api/v1/sepa-payments/{paymentId}/confirmation` renders the confirmation document
synchronously, only when the customer explicitly requests it, via document-service's
existing non-persisting `templates/preview` endpoint — no pre-generation, no Kafka
consumer, no persistence anywhere.

**This is a money-path service change — needs 2 human approvals + threat-model diff per
repo governance; not self-mergeable.**

## Type of change

- [x] feat (new functionality)
- [ ] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [ ] docs
- [ ] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change

## Linked issues

Refs #4109, Refs ADR-0248

## Changes

- New `GET /{paymentId}/confirmation` endpoint on `SepaPaymentResource`: only renders for a
  `COMPLETED` payment (409 otherwise, matching the existing `InvalidSepaPaymentStateTransitionException`
  convention), 404 for an unknown payment, 502 if document-service is unreachable or has no
  `PUBLISHED` template for the requested locale.
- New `PaymentConfirmationUseCase` / `PaymentConfirmationService`: reads the payment's own
  already-persisted record via the existing `SepaPaymentUseCase.getPayment` (read-only — no
  payment execution/settlement/status-transition logic touched) and maps it into the Handlebars
  data shape the `POTVRZENI_O_PLATBE_CS`/`POTVRZENI_O_PLATBE_EN` templates expect.
  `PaymentConfirmationDocument` carries the rendered bytes back to the REST layer; nothing is
  cached or persisted a second time.
- New `DocumentPreviewPort` / `DocumentPreviewAdapter` + `DocumentServiceClient` REST-client
  adapter: document-service's `preview` endpoint takes `bodyHtml` + `data` (not a `templateCode`),
  so the adapter first resolves the code to its current `PUBLISHED` `bodyHtml` via
  `GET /api/v1/documents/templates`, then renders via `POST /api/v1/documents/templates/preview` —
  document-service's endpoint itself is untouched. Fail-**closed**: unlike the fraud-scoring
  shadow adapter, any document-service fault (including timeout) surfaces as a failed download
  the customer can retry, never a silently wrong document.
- `openapi.yaml` bumped 1.5.0 → 1.6.0 (additive: new path only).
- `docs/threat-models/openbank-sepa-payment.md` updated: new §5b STRIDE supplement + DFD/trust-boundary
  updates for the new outbound synchronous edge to document-service, plus a change-log entry.

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports).
- [x] Unit tests added/updated.
- [x] Integration tests added/updated (if service boundary involved).
- [ ] Contract tests updated (if public API changed). — no Pact consumer test added for the new
      document-service client; the WireMock-backed `PaymentConfirmationSimulatorIT` covers the wire
      contract instead (see Reviewer notes).
- [x] `./gradlew detekt ktlintCheck koverVerify build` passes — ran `ktlintCheck`, `detekt`, `test`
      for `:openbank-sepa-payment` locally, all green (kover/full `build` not run locally due to
      machine load; CI will run the full gate).
- [x] No new lint warnings.
- [x] OpenAPI spec regenerated (if REST API changed).
- [ ] Flyway migration added + rollback note (if DB changed). — N/A, no schema change.
- [ ] Avro schema versioned backward-compatibly (if event changed). — N/A, no new event.
- [x] Docs updated (README, ADR if architectural) — threat-model updated; ADR-0248 already merged.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings`, `as Any`, `@Suppress("...")` without justification —
      `@Suppress("TooGenericExceptionCaught")` on `DocumentPreviewAdapter.renderTemplate`, matching
      the existing `FraudScoringAdapter` pattern: the adapter must catch broadly to translate any
      document-service fault into the single `DocumentTemplateUnavailableException` (502), fail-closed.
- [x] No new third-party dependency.
- [x] Auth / crypto / payment code changed? → tag `security-review-required`. (This endpoint is
      read-only over an existing payment record and cannot affect payment state, but it is a new
      money-path-service surface, so flagging per policy.)
- [ ] PII path changed? — the confirmation document carries the same payment PII (IBANs, amount,
      counterparty name) already returned by the existing `GET /{paymentId}` endpoint, sent to
      document-service (already an internal, cluster-only peer) instead of the caller only; see
      threat-model §5b.
- [ ] Cardholder data path changed? → N/A.

## Compliance impact

- [x] PSD2 / SCA / RTS — legal basis is PSD2 Art. 45/48 (post-execution payment information), per
      ADR-0248.
- [ ] PCI DSS / DORA / GDPR / AML / 5AMLD / CNB reporting / None — GDPR Art. 5(1)(c) data
      minimisation is the relevant angle (render-and-discard, no new persisted copy of payment PII);
      no new lawful basis introduced, per ADR-0248's compliance-impact section.

## Rollout / Rollback

- Deployment strategy: rolling (standard for this service).
- Rollback plan: revert this PR — the endpoint simply stops existing; no flag, no DB migration.
- Data migration reversible: N/A — no schema change.

## Reviewer notes

- **Money-path service change — needs 2 human approvals + threat-model diff per repo governance;
  not self-mergeable.** I will not self-merge or use any override flag on `gh pr merge`/`gh pr review`.
- `document-service`'s `POST /api/v1/documents/templates/preview` endpoint takes `bodyHtml` + `data`
  and returns `renderedHtml` (a string) — it does **not** accept a `templateCode` directly, and there
  is no get-by-code endpoint. The adapter therefore makes two calls (list templates, then preview)
  rather than one; this is intentional, not a shortcut — see `DocumentServiceClient`'s KDoc.
- The response `Content-Type` is `text/html`, not a PDF — document-service's `preview` endpoint only
  does Handlebars→HTML merge (PDF conversion is a separate concern of the persisted `/render` path,
  which ADR-0248 explicitly avoids for this template family).
- A parallel PR is expected to seed the `POTVRZENI_O_PLATBE_CS`/`POTVRZENI_O_PLATBE_EN` templates in
  document-service; until that lands, this endpoint's real-environment behavior is a 502 (no
  `PUBLISHED` template found), which is the correct fail-closed outcome — covered by
  `PaymentConfirmationSimulatorIT`'s "no PUBLISHED template" test case.
