### PR TITLE
fix(analytics-sink): set the session database on ClickHouse reads

### DIFF
--- a/openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/infrastructure/clickhouse/ClickHouseClient.kt
+++ b/openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/infrastructure/clickhouse/ClickHouseClient.kt
@@ -59,9 +59,22 @@ open class ClickHouseClient {
     /** Runs a read [sql] and returns the raw response body. Callers choose the FORMAT and parse it. */
     open suspend fun query(sql: String): String = post(sql, null)
 
-    /** POSTs [sql] (as the `query` parameter) with an optional [body]; throws on a non-2xx response. */
+    /**
+     * POSTs [sql] (as the `query` parameter) with an optional [body]; throws on a non-2xx response.
+     *
+     * The `database` parameter sets the **session default** for the statement, so an unqualified
+     * table reference resolves against [database] and not against ClickHouse's `default`. Without it
+     * every read here (the F4/F5 reconciliation scans, the proposal store, the WORM anchor mirror)
+     * writes qualified and reads unqualified — an asymmetry that answers `HTTP 404 … (UNKNOWN_TABLE)`
+     * on a deployment whose tables live in `openbank_analytics` and whose `default` is empty (#3991).
+     * Setting it here rather than in the SQL strings keeps reads and writes symmetric through one
+     * place and covers every current and future caller.
+     */
     protected open suspend fun post(sql: String, body: String?): String = withContext(Dispatchers.IO) {
-        val uri = URI.create("${url.trimEnd('/')}/?query=${URLEncoder.encode(sql, StandardCharsets.UTF_8)}")
+        val uri = URI.create(
+            "${url.trimEnd('/')}/?database=${URLEncoder.encode(database, StandardCharsets.UTF_8)}" +
+                "&query=${URLEncoder.encode(sql, StandardCharsets.UTF_8)}",
+        )
         val request = HttpRequest.newBuilder(uri)
             .header("X-ClickHouse-User", username)
             .header("X-ClickHouse-Key", password.orElse(""))

--- a/openbank-analytics-sink/src/test/kotlin/com/openbank/analytics/infrastructure/clickhouse/ClickHouseClientDatabaseTest.kt
+++ b/openbank-analytics-sink/src/test/kotlin/com/openbank/analytics/infrastructure/clickhouse/ClickHouseClientDatabaseTest.kt
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.analytics.infrastructure.clickhouse
+
+import com.openbank.analytics.infrastructure.reconcile.ClickHouseWarehouseStateReader
+import com.openbank.libs.analytics.AggregateKey
+import com.sun.net.httpserver.HttpExchange
+import com.sun.net.httpserver.HttpServer
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.net.InetSocketAddress
+import java.net.URLDecoder
+import java.nio.charset.StandardCharsets
+import java.util.Optional
+
+/**
+ * Guards the one thing no other layer in this module can see: **which database the reads resolve
+ * against** (#3991).
+ *
+ * The other ClickHouse tests stub [ClickHouseClient.query], so they never observe the request URI;
+ * the SQL is a `private companion object` constant and the parsers are pure, so a parser test passes
+ * against a query that 404s in production. Only driving the real transport can be wrong out loud —
+ * the same discipline as the external-feed rule.
+ *
+ * [FakeClickHouse] is a JDK [HttpServer] (no new dependency, no ClickHouse) that reproduces the
+ * deployed shape exactly: the tables exist in `openbank_analytics` and **nothing exists in
+ * `default`**, so an unqualified read with no session database answers the real
+ * `404 … Code: 60 … (UNKNOWN_TABLE)` body. Against the pre-fix client — no `database=` on the URI —
+ * every assertion here fails with `ClickHouse query failed: HTTP 404`.
+ */
+class ClickHouseClientDatabaseTest {
+
+    /** Minimal ClickHouse-HTTP stand-in: resolves unqualified tables against the session database. */
+    private class FakeClickHouse(private val tablesIn: String = "openbank_analytics") {
+        private val server: HttpServer = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
+        val requestedDatabases = mutableListOf<String?>()
+
+        val url: String get() = "http://127.0.0.1:${server.address.port}"
+
+        fun start() {
+            server.createContext("/") { exchange -> handle(exchange) }
+            server.start()
+        }
+
+        fun stop() = server.stop(0)
+
+        private fun handle(exchange: HttpExchange) {
+            val params = (exchange.requestURI.rawQuery ?: "").split('&')
+                .filter { it.isNotBlank() }
+                .associate { pair ->
+                    val (k, v) = pair.split('=', limit = 2).let { it[0] to it.getOrElse(1) { "" } }
+                    k to URLDecoder.decode(v, StandardCharsets.UTF_8)
+                }
+            val database = params["database"]
+            requestedDatabases += database
+            val sql = params["query"].orEmpty()
+            // ClickHouse resolves an unqualified `FROM <table>` against the session database, which
+            // defaults to `default` when the request carries no `database` parameter.
+            val effective = database ?: "default"
+            val qualified = QUALIFIED.containsMatchIn(sql)
+            val (status, body) = if (qualified || effective == tablesIn) {
+                200 to ROW
+            } else {
+                404 to UNKNOWN_TABLE_ERROR
+            }
+            val bytes = body.toByteArray(StandardCharsets.UTF_8)
+            exchange.sendResponseHeaders(status, bytes.size.toLong())
+            exchange.responseBody.use { it.write(bytes) }
+        }
+
+        private companion object {
+            // A `db.table` reference resolves without a session database — as `insert()` already does.
+            val QUALIFIED = Regex("""(FROM|INTO)\s+\w+\.\w+""")
+            const val ROW = "ACCOUNT\tacc-1\t5\n"
+            const val UNKNOWN_TABLE_ERROR =
+                "Code: 60. DB::Exception: Unknown table expression identifier 'bronze_events'. (UNKNOWN_TABLE)"
+        }
+    }
+
+    private lateinit var fake: FakeClickHouse
+
+    private fun clientAgainst(fake: FakeClickHouse) = ClickHouseClient().apply {
+        url = fake.url
+        database = "openbank_analytics"
+        username = "analytics"
+        password = Optional.of("")
+    }
+
+    @BeforeEach
+    fun startFake() {
+        fake = FakeClickHouse()
+        fake.start()
+    }
+
+    @AfterEach
+    fun stopFake() = fake.stop()
+
+    @Test
+    fun `the reconciliation read resolves against the configured database, not default`() = runBlocking<Unit> {
+        val reader = ClickHouseWarehouseStateReader().apply { clickhouse = clientAgainst(fake) }
+
+        // Pre-fix this throws IllegalStateException("ClickHouse query failed: HTTP 404 … UNKNOWN_TABLE").
+        val versions = reader.currentVersions()
+
+        assertThat(versions).containsEntry(AggregateKey("ACCOUNT", "acc-1"), 5L)
+        assertThat(fake.requestedDatabases).containsExactly("openbank_analytics")
+    }
+
+    @Test
+    fun `every read primitive carries the session database`() = runBlocking<Unit> {
+        val reader = ClickHouseWarehouseStateReader().apply { clickhouse = clientAgainst(fake) }
+
+        reader.currentVersions()
+        reader.rowCountsByType()
+        reader.versionsByAggregate()
+
+        assertThat(fake.requestedDatabases).hasSize(3).allMatch { it == "openbank_analytics" }
+    }
+
+    @Test
+    fun `an insert still targets the configured database`() = runBlocking<Unit> {
+        clientAgainst(fake).insert("integrity_anchors", """{"anchor_id":"a-1"}""")
+
+        assertThat(fake.requestedDatabases).containsExactly("openbank_analytics")
+    }
+}


### PR DESCRIPTION
## What was wrong

`ClickHouseClient.post(...)` built the request URI with only `?query=`, never `database=`. ClickHouse
resolves an unqualified table against the **session database**, which defaults to `default` when the
HTTP request carries no `database` parameter — and `default` is empty on every deployment, because
`clickhouse-init-configmap.yaml` creates every table in `openbank_analytics`.

Writes were unaffected, which is what hid it: `insert()` qualifies explicitly as
`INSERT INTO $database.$table`. Only the reads were unqualified — the three F4/F5 reconciliation
scans, the proposal store, and the WORM anchor mirror.

## Verified on live main, not inferred

- Pod `analytics-sink-5db846f497-65wts`, cron `0 30 2 * * ?`, run of 2026-08-07 02:30:00.024:
  `ClickHouse query failed: HTTP 404 Code: 60. DB::Exception: Unknown table expression identifier
  'bronze_events' … (UNKNOWN_TABLE)`. The scheduler **does** fire — this is not an unscheduled job,
  it is a job that dies on its first read every night.
- `SELECT count() FROM openbank_analytics.bronze_events` → **719** (the write path works).
- `SHOW TABLES FROM default` → **empty**.
- `SELECT source, count() FROM openbank_analytics.integrity_anchors GROUP BY source` → **no rows**.
  No `RECONCILIATION:*` anchor has ever been sealed, so the check has genuinely never produced a
  result — the two failure modes ("fails silently" vs "never ran") are separated by the log line
  above plus this empty table.

## What reads the output — the smaller defect, stated plainly

Nothing automated. `ReconciliationResult` is consumed by exactly two things: the `ROLE_AUDITOR` /
`ROLE_ADMIN` / `ROLE_COMPLIANCE` endpoint `GET /api/v1/analytics/reconciliation/last` (an on-demand
human pull, which has been answering `204 No Content` since the service was deployed), and the WORM
integrity-anchor chain. `openbank-admin-ui` does not call it, and there is **no PrometheusRule
anywhere in `gitops/` on `openbank_workflow_liveness_last_success_age_seconds`**, so the job's
existing liveness gauge is not wired to an alert either.

So this is **not** a live control silently passing traffic — it is a regulatory tie-out
(ADR-0022/0023 F4 count tie-out, F5 completeness, BCBS 239 audit trail) that has produced no
evidence for its whole life. Corruption of money data is not implied: bronze ingest is a separate
path and is working. What is lost is the ability to *prove* the warehouse agrees with the source of
record.

## The fix

`database=$database` on the URI in `post(...)`, per the issue's own prescription — in the client, not
in the three SQL string constants. That keeps reads and writes symmetric through one place and
covers every current and future caller instead of three constants the next reader copies unqualified
again. `insert()`'s explicit `INSERT INTO $database.$table` is left as is: harmless once the session
default is set, and it is the line that documents the intent.

## Falsification — red, then green

No existing layer could catch this: the SQL is a `private companion object` constant, the parsers are
pure, and every other ClickHouse test stubs `query()` so it never sees the request URI.
`ClickHouseClientDatabaseTest` drives the **real transport** against a JDK `HttpServer` (no new
dependency, no ClickHouse) that reproduces the deployed shape — tables in `openbank_analytics`,
nothing in `default` — and answers the real `Code: 60 … (UNKNOWN_TABLE)` body to an unqualified read
with no session database.

Against the pre-fix `ClickHouseClient` (fix reverted, test kept):

```
ClickHouseClientDatabaseTest > every read primitive carries the session database() FAILED
    java.lang.IllegalStateException at ClickHouseClient.kt:73
3 tests completed, 3 failed
```

Against the fixed client: `3 tests 0 failures 0 errors`, module total **69 tests, 0 failures, 0
errors** (read from the JUnit XML, not the console).

## Local gate

`./gradlew :openbank-analytics-sink:test :openbank-analytics-sink:ktlintCheck
:openbank-analytics-sink:detekt` — BUILD SUCCESSFUL. `detekt` re-run with `--rerun-tasks` to confirm
it actually executed rather than reporting a cached green.

## Deliberately not in this PR

The issue's second, separable item (make "the check did not run" observable) is partly already
there — `ReconciliationJob` registers a `WorkflowLivenessRecorder` and calls `recordSuccess()`. What
is missing is an alert rule on that gauge, which is a `gitops/` change with a different blast radius
and belongs in its own PR.

Closes #3991

🤖 Generated with [Claude Code](https://claude.com/claude-code)
