### PR TITLE
fix(analytics-sink): point the residency guard and WORM S3 defaults at the estate region

### DIFF
--- a/.github/scripts/check-external-feeds.py
+++ b/.github/scripts/check-external-feeds.py
@@ -152,7 +152,7 @@ NOT_PROBED = [
     ("https://api.groq.com/openai/v1", "authenticated LLM gateway (ADR-0139); needs a key"),
     ("https://api.deepinfra.com/v1/openai", "authenticated LLM gateway; needs a key"),
     ("https://integrate.api.nvidia.com/v1", "authenticated LLM gateway; needs a key"),
-    ("https://s3.eu-central-1.amazonaws.com", "AWS endpoint, reached with SigV4 credentials"),
+    ("https://s3.eu-north-1.amazonaws.com", "AWS endpoint, reached with SigV4 credentials"),
     ("https://kc.open-bank.tech/realms/openbank-customers", "our own Keycloak realm, covered by its own probes"),
     ("https://pid.open-bank.tech", "our own PID issuer, covered by its own probes"),
 ]

--- a/openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/infrastructure/DataResidencyValidator.kt
+++ b/openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/infrastructure/DataResidencyValidator.kt
@@ -18,18 +18,33 @@ import org.jboss.logging.Logger
  * ClickHouse region is not on the allow-list, turning a silent mis-deployment into a deploy-time error.
  *
  * Configuration:
- *  - `openbank.analytics.residency.region` — the region this warehouse runs in (e.g. `eu-central-1`).
- *  - `openbank.analytics.residency.allowed` — comma-separated allow-list (default `eu-central-1,eu-west-1`).
+ *  - `openbank.analytics.residency.region` — the region this warehouse runs in (default `eu-north-1`).
+ *  - `openbank.analytics.residency.allowed` — comma-separated allow-list (default `eu-north-1`).
  *  - `openbank.analytics.residency.enforce` — when true (default), a violation aborts startup; when
  *    false it only logs (useful for local dev / `%dev`).
+ *
+ * `eu-north-1` is the estate region decided by ADR-0175 §Decision 1. It is decided *there* and not in
+ * `openbank-infra/aws/README.md`, whose `eu-central-1` production pin ADR-0175 §Decision 2 names as an
+ * inference from a condition ADR-0027 does not contain, and explicitly does not adopt.
+ *
+ * Until #3962 these defaults were `eu-central-1` with an allow-list of `eu-central-1,eu-west-1`, which
+ * left exactly one bootable configuration and it was the one that misstates where the warehouse is:
+ * the guard passed on `region=eu-central-1` for a warehouse in `eu-north-1`, while configuring the real
+ * region aborted boot (`enforce` defaults to true, and `eu-north-1` was not on the list).
+ *
+ * KNOWN LIMIT (deliberate, not an oversight): this compares a config string to a config string. It
+ * never observes the region it is actually running in (IMDS, `AWS_REGION`, the bucket's
+ * `LocationConstraint`), so it can only detect a self-inconsistent configuration, not a real residency
+ * violation. Nothing else in the service reads `residency.region`; a wrong value is a false assurance
+ * in the log line, not a mis-routed write.
  */
 @ApplicationScoped
 class DataResidencyValidator {
 
-    @ConfigProperty(name = "openbank.analytics.residency.region", defaultValue = "eu-central-1")
+    @ConfigProperty(name = "openbank.analytics.residency.region", defaultValue = "eu-north-1")
     lateinit var region: String
 
-    @ConfigProperty(name = "openbank.analytics.residency.allowed", defaultValue = "eu-central-1,eu-west-1")
+    @ConfigProperty(name = "openbank.analytics.residency.allowed", defaultValue = "eu-north-1")
     lateinit var allowed: String
 
     @ConfigProperty(name = "openbank.analytics.residency.enforce", defaultValue = "true")

--- a/openbank-analytics-sink/src/main/resources/application.yaml
+++ b/openbank-analytics-sink/src/main/resources/application.yaml
@@ -231,8 +231,10 @@ openbank:
       s3:
         # Path-style S3 endpoint, region and Object-Lock-enabled bucket. Credentials should be a
         # narrowly-scoped key that may PutObject (with retention) but NOT bypass governance retention.
-        endpoint: ${ANALYTICS_WORM_S3_ENDPOINT:https://s3.eu-central-1.amazonaws.com}
-        region: ${ANALYTICS_WORM_S3_REGION:eu-central-1}
+        # Region is the estate region (ADR-0175 §Decision 1: eu-north-1); every bucket in the account
+        # is eu-north-1, and nothing overrides these in gitops (issue #3962).
+        endpoint: ${ANALYTICS_WORM_S3_ENDPOINT:https://s3.eu-north-1.amazonaws.com}
+        region: ${ANALYTICS_WORM_S3_REGION:eu-north-1}
         bucket: ${ANALYTICS_WORM_S3_BUCKET:openbank-analytics-worm}
         access-key: ${ANALYTICS_WORM_S3_ACCESS_KEY:}
         secret-key: ${ANALYTICS_WORM_S3_SECRET_KEY:}
@@ -244,6 +246,12 @@ openbank:
       max-dead-letters: ${ANALYTICS_MAX_DEAD_LETTERS:100}
     residency:
       # Data residency guard checked at startup (F9 / GDPR Art. 44). Boot aborts if region not allowed.
-      region: ${ANALYTICS_RESIDENCY_REGION:eu-central-1}
-      allowed: ${ANALYTICS_RESIDENCY_ALLOWED:eu-central-1,eu-west-1}
+      # eu-north-1 is the estate region decided by ADR-0175 §Decision 1 (NOT by any README — §Decision 2
+      # explicitly rejects the eu-central-1 pin openbank-infra/aws/README.md infers from ADR-0027).
+      # These two defaults previously said eu-central-1 / [eu-central-1, eu-west-1], which made the only
+      # bootable configuration one that misstates the region: the guard logged "data residency OK:
+      # region=eu-central-1" for a warehouse in eu-north-1, and setting the region truthfully aborted
+      # boot because eu-north-1 was not on the allow-list (issue #3962).
+      region: ${ANALYTICS_RESIDENCY_REGION:eu-north-1}
+      allowed: ${ANALYTICS_RESIDENCY_ALLOWED:eu-north-1}
       enforce: ${ANALYTICS_RESIDENCY_ENFORCE:true}

--- a/openbank-analytics-sink/src/main/resources/docs/05-operations.cs.md
+++ b/openbank-analytics-sink/src/main/resources/docs/05-operations.cs.md
@@ -27,7 +27,7 @@ Všechny externí závislosti jsou **opt-in** přes env, výchozí jsou offline 
 | Výmaz | `ANALYTICS_ERASURE_BACKEND` (`vault`), `ANALYTICS_VAULT_*` | NoOpCryptoErasure |
 | WORM | `ANALYTICS_WORM_BACKEND` (`s3`), `ANALYTICS_WORM_S3_*` | zrcadlo/logging |
 | Health / RPO | `ANALYTICS_MAX_LAG_SECONDS` (`900`), `ANALYTICS_MAX_DEAD_LETTERS` (`100`) | — |
-| Rezidence | `ANALYTICS_RESIDENCY_REGION` (`eu-central-1`), `..._ALLOWED`, `..._ENFORCE` (`true`) | vynuceno |
+| Rezidence | `ANALYTICS_RESIDENCY_REGION` (`eu-north-1`), `..._ALLOWED`, `..._ENFORCE` (`true`) | vynuceno |
 | Auth | `OIDC_CLIENT_SECRET` | dev placeholder (blokován v prod) |
 
 ## Deploy & FinOps tier

--- a/openbank-analytics-sink/src/main/resources/docs/05-operations.en.md
+++ b/openbank-analytics-sink/src/main/resources/docs/05-operations.en.md
@@ -27,7 +27,7 @@ All external dependencies are **opt-in** via env, defaulting to offline no-op/lo
 | Erasure | `ANALYTICS_ERASURE_BACKEND` (`vault`), `ANALYTICS_VAULT_*` | NoOpCryptoErasure |
 | WORM | `ANALYTICS_WORM_BACKEND` (`s3`), `ANALYTICS_WORM_S3_*` | mirror/logging |
 | Health / RPO | `ANALYTICS_MAX_LAG_SECONDS` (`900`), `ANALYTICS_MAX_DEAD_LETTERS` (`100`) | — |
-| Residency | `ANALYTICS_RESIDENCY_REGION` (`eu-central-1`), `..._ALLOWED`, `..._ENFORCE` (`true`) | enforced |
+| Residency | `ANALYTICS_RESIDENCY_REGION` (`eu-north-1`), `..._ALLOWED`, `..._ENFORCE` (`true`) | enforced |
 | Auth | `OIDC_CLIENT_SECRET` | dev placeholder (blocked in prod) |
 
 ## Deploy & FinOps tier

--- a/openbank-analytics-sink/src/main/resources/docs/06-compliance.cs.md
+++ b/openbank-analytics-sink/src/main/resources/docs/06-compliance.cs.md
@@ -44,7 +44,7 @@ Přímo identifikující PII je maskováno na hranici příjmu (`PayloadMasker`)
 | Přenositelnost (Art. 20) | N/A — analytika není systémem záznamu osobních údajů. |
 
 ### Mezinárodní přenosy (Art. 44)
-`DataResidencyValidator` přeruší boot, pokud region skladu není na allow-listu (výchozí `eu-central-1,eu-west-1`). Žádná osobní data neopouštějí schválené EU regiony.
+`DataResidencyValidator` přeruší boot, pokud region skladu není na allow-listu (výchozí `eu-north-1`, ADR-0175 §1). Žádná osobní data neopouštějí schválené EU regiony.
 
 ### Retence (Art. 5(1)(e))
 
@@ -68,7 +68,7 @@ Přímo identifikující PII je maskováno na hranici příjmu (`PayloadMasker`)
 ## Toky dat ven
 
 - → **BI nástroje (Metabase / Superset):** čtou maskovaný gold/silver v ClickHouse — žádný přístup do provozní DB, žádné surové PII.
-- → **WORM / S3 Object Lock (`eu-central-1`):** integrity kotvy (jen hashe, žádné PII).
+- → **WORM / S3 Object Lock (`eu-north-1`):** integrity kotvy (jen hashe, žádné PII).
 - → **Vault (volitelně):** operace s crypto-erasure klíčem — žádný PII payload.
 
 Žádné surové PII se neukládá ani nepřenáší; žádná data neopouštějí schválený EU region.

--- a/openbank-analytics-sink/src/main/resources/docs/06-compliance.en.md
+++ b/openbank-analytics-sink/src/main/resources/docs/06-compliance.en.md
@@ -44,7 +44,7 @@ Directly-identifying PII is masked at the ingestion boundary (`PayloadMasker`) b
 | Portability (Art. 20) | N/A — analytics is not the system of record for personal data. |
 
 ### International transfers (Art. 44)
-`DataResidencyValidator` aborts boot if the warehouse region is not on the allow-list (default `eu-central-1,eu-west-1`). No personal data leaves the approved EU regions.
+`DataResidencyValidator` aborts boot if the warehouse region is not on the allow-list (default `eu-north-1`, ADR-0175 §1). No personal data leaves the approved EU regions.
 
 ### Retention (Art. 5(1)(e))
 
@@ -68,7 +68,7 @@ Directly-identifying PII is masked at the ingestion boundary (`PayloadMasker`) b
 ## Data flows out
 
 - → **BI tools (Metabase / Superset):** read masked gold/silver in ClickHouse only — no operational DB access, no raw PII.
-- → **WORM / S3 Object Lock (`eu-central-1`):** integrity anchors (hashes only, no PII).
+- → **WORM / S3 Object Lock (`eu-north-1`):** integrity anchors (hashes only, no PII).
 - → **Vault (optional):** crypto-erasure key operations — no PII payload.
 
 No raw PII is stored or transmitted; no data leaves the approved EU region.

--- a/openbank-analytics-sink/src/test/kotlin/com/openbank/analytics/infrastructure/DataResidencyDefaultsTest.kt
+++ b/openbank-analytics-sink/src/test/kotlin/com/openbank/analytics/infrastructure/DataResidencyDefaultsTest.kt
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.analytics.infrastructure
+
+import io.quarkus.runtime.StartupEvent
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatCode
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.eclipse.microprofile.config.inject.ConfigProperty
+import org.junit.jupiter.api.Test
+import java.io.File
+
+/**
+ * The committed defaults must name the estate region, and the estate region must be bootable (#3962).
+ *
+ * `eu-north-1` is established by **ADR-0175 §Decision 1** ("The estate is `eu-north-1` (Stockholm)").
+ * §Decision 2 of the same ADR explicitly does *not* adopt the `eu-central-1` production pin that
+ * `openbank-infra/aws/README.md` infers from a condition ADR-0027 does not contain — so the ADR, not
+ * the README, is the source asserted here.
+ *
+ * Before the fix all four assertions below were red: the defaults were `eu-central-1` with an
+ * allow-list of `eu-central-1,eu-west-1`, so the *only* configuration that booted was the one that
+ * misstated the region, and configuring the true region aborted startup (`enforce` defaults to true).
+ *
+ * Values are asserted literally on purpose. A `isNotNull()`/"is some region" assertion passes against
+ * exactly the wrong value this test exists to reject.
+ */
+class DataResidencyDefaultsTest {
+
+    private companion object {
+        /** ADR-0175 §Decision 1. Not from a README — see the class KDoc. */
+        const val ESTATE_REGION = "eu-north-1"
+        val APPLICATION_YAML = File("src/main/resources/application.yaml")
+    }
+
+    /** Extracts `key: ${ENV_VAR:default}` from application.yaml, returning the committed default. */
+    private fun committedDefault(envVar: String): String {
+        assertThat(APPLICATION_YAML).exists()
+        val pattern = Regex("""\$\{$envVar:([^}]*)}""")
+        val match = pattern.find(APPLICATION_YAML.readText())
+        assertThat(match).describedAs("no default for %s in application.yaml", envVar).isNotNull
+        return match!!.groupValues[1]
+    }
+
+    private fun annotationDefault(field: String): String = DataResidencyValidator::class.java
+        .getDeclaredField(field)
+        .getAnnotation(ConfigProperty::class.java)
+        .defaultValue
+
+    @Test
+    fun `the committed residency defaults name the estate region`() {
+        assertThat(committedDefault("ANALYTICS_RESIDENCY_REGION")).isEqualTo(ESTATE_REGION)
+        assertThat(annotationDefault("region")).isEqualTo(ESTATE_REGION)
+    }
+
+    @Test
+    fun `the estate region is on the committed allow-list`() {
+        val yamlAllowed = committedDefault("ANALYTICS_RESIDENCY_ALLOWED").split(",").map { it.trim() }
+        assertThat(yamlAllowed).contains(ESTATE_REGION)
+        val annotationAllowed = annotationDefault("allowed").split(",").map { it.trim() }
+        assertThat(annotationAllowed).contains(ESTATE_REGION)
+    }
+
+    @Test
+    fun `the committed defaults boot with enforcement on`() {
+        val validator = DataResidencyValidator().apply {
+            region = committedDefault("ANALYTICS_RESIDENCY_REGION")
+            allowed = committedDefault("ANALYTICS_RESIDENCY_ALLOWED")
+            enforce = true
+        }
+        assertThatCode { validator.onStart(StartupEvent()) }.doesNotThrowAnyException()
+    }
+
+    /** Falsification control: the guard must still abort on a region genuinely outside the estate. */
+    @Test
+    fun `a region outside the allow-list still aborts boot`() {
+        val validator = DataResidencyValidator().apply {
+            region = "us-east-1"
+            allowed = committedDefault("ANALYTICS_RESIDENCY_ALLOWED")
+            enforce = true
+        }
+        assertThatThrownBy { validator.onStart(StartupEvent()) }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("data residency violation")
+    }
+
+    @Test
+    fun `the committed WORM S3 defaults name the estate region`() {
+        assertThat(committedDefault("ANALYTICS_WORM_S3_REGION")).isEqualTo(ESTATE_REGION)
+        assertThat(committedDefault("ANALYTICS_WORM_S3_ENDPOINT"))
+            .isEqualTo("https://s3.$ESTATE_REGION.amazonaws.com")
+    }
+}


### PR DESCRIPTION
## What this fixes

`DataResidencyValidator`'s committed defaults were:

```
region:  ${ANALYTICS_RESIDENCY_REGION:eu-central-1}
allowed: ${ANALYTICS_RESIDENCY_ALLOWED:eu-central-1,eu-west-1}
enforce: ${ANALYTICS_RESIDENCY_ENFORCE:true}
```

Nothing in `openbank-infra/` sets any of the three, so both defaults apply in the deployed pod. That
left **exactly one bootable configuration, and it is the one that misstates the region**: the guard
passes on `region=eu-central-1` for a warehouse in `eu-north-1`, while configuring the true region
throws `IllegalStateException` at `StartupEvent` (`enforce` defaults to true and `eu-north-1` was not
on the allow-list). The log line it emits cites GDPR Art. 44.

This PR moves both defaults to `eu-north-1`, and the WORM S3 `endpoint`/`region` defaults in the same
config block with them.

## Which source establishes the region

**`ADR-0175 — Data residency and sovereignty`, §Decision 1**: *"The estate is `eu-north-1`
(Stockholm), AWS account 265175468565. Uniform across bootstrap, sandbox-platform and web-prod."*

Not `openbank-infra/aws/README.md`. §Decision 2 of the same ADR names that README's `eu-central-1`
production pin as an inference from a condition ADR-0027 does not contain, and states it is **"not
adopted by inference"** — D1 is an open action to delete it. The issue thread contains a correction
and a correction-of-the-correction on exactly this point; the ADR is the artefact that settles it, and
it is quoted in the new test's KDoc so the next reader does not have to re-derive it.

## What reads the validated value — and therefore how urgent this is

`git grep` over the tree: `openbank.analytics.residency.region` is read **only by
`DataResidencyValidator` itself**, in the comparison and the log line. No sink, no ClickHouse client,
no S3 adapter consults it; no gitops manifest sets it.

So a wrong value is **a false assurance in a log line, not a mis-routed write** — a latent trap rather
than data corruption. That is why this is a plain `fix`, not an incident. The KDoc now records the
deeper limit as well: this validator compares a config string to a config string and never observes
the region it actually runs in (IMDS, `AWS_REGION`, the bucket's `LocationConstraint`), so it can only
detect a self-inconsistent config. Making it observe reality is a larger change and not attempted here.

## Red-then-green

New `DataResidencyDefaultsTest` asserts the literal region **values** parsed out of the committed
`application.yaml` and read off the `@ConfigProperty` annotation defaults — never `isNotNull()`, which
would pass against precisely the wrong value.

Against the **previous** config (fix stashed, `build/test-results` removed first), from the JUnit XML:

```
TEST-...DataResidencyDefaultsTest.xml tests=5 failures=3 errors=0
   the committed WORM S3 defaults name the estate region()   -> FAIL: expected "eu-north-1" but was "eu-central-1"
   a region outside the allow-list still aborts boot()       -> PASS   (control, must stay green)
   the committed defaults boot with enforcement on()         -> PASS   (this is the point: the wrong config is the bootable one)
   the committed residency defaults name the estate region() -> FAIL: expected "eu-north-1" but was "eu-central-1"
   the estate region is on the committed allow-list()        -> FAIL: ["eu-central-1","eu-west-1"] does not contain "eu-north-1"
```

With the fix:

```
TEST-...DataResidencyDefaultsTest.xml tests=5 failures=0 errors=0   (all five PASS)
MODULE TOTAL: tests=71 failures=0 errors=0 skipped=0
```

Local gate — all three tasks confirmed present in the task list, not inferred from a green tail:

```
> Task :openbank-analytics-sink:detekt
> Task :openbank-analytics-sink:ktlintTestSourceSetCheck
> Task :openbank-analytics-sink:ktlintCheck
> Task :openbank-analytics-sink:test
BUILD SUCCESSFUL
```

## Scope — deliberately not in this PR

- **ADR-0023 F2's untracked deployment** (the issue's other half). Provisioning the Object-Lock bucket,
  flipping `openbank.analytics.worm.backend=s3` (build-time `@IfBuildProperty`, so a gitops env var can
  never activate it) and proving `S3WormArchive`'s SigV4 path against real S3 are deployment work with
  no code change here — and the refutation pass on the issue found a harder blocker than the region
  string: the signer emits no `x-amz-security-token`, so it cannot use any temporary credential, and
  the account has zero IAM users. Adding a tracking marker to the ADR would be half-doing it. The
  general case is already **#3965** (open), which cites this issue as one of its worked examples;
  F2's deployment belongs there or in its own issue with an owner and a bucket, not in a config PR.
- **The rest of ADR-0175 D2.** `eu-central-1` also defaults in `openbank-libs-runtime`'s shared
  `S3ObjectStore`, `openbank-document-service` and `openbank-customer-edge`. That is a fleet-wide
  sweep across four modules with its own review surface; this PR touches only the service the issue
  is filed against. (Note the trap has not fired in production: customer-edge, the one service running
  the S3 backend, overrides `OBJECTSTORE_S3_REGION=eu-north-1` in gitops.)

## Risk

No runtime behaviour change in the deployed pod beyond the log line now naming the region the
warehouse is actually in. `openbank.analytics.worm.backend` stays unset, so the Object Lock path is
still inactive. No migration, no API change, no `openapi.yaml` impact.

Refs #3962 · Refs #3965 · Refs ADR-0175 (§Decision 1, §Decision 2, D2), ADR-0023 (F2, F9)
