### PR TITLE
security(admin-ui): pin nanoid to 3.3.17 for CVE-2026-67213

### DIFF
--- a/openbank-admin-ui/package-lock.json
+++ b/openbank-admin-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openbank-admin-ui",
-  "version": "0.102.0",
+  "version": "0.103.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openbank-admin-ui",
-      "version": "0.102.0",
+      "version": "0.103.1",
       "dependencies": {
         "@hookform/resolvers": "5.5.7",
         "@radix-ui/react-dialog": "1.1.23",
@@ -11484,9 +11484,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "funding": [
         {
           "type": "github",

--- a/openbank-admin-ui/package.json
+++ b/openbank-admin-ui/package.json
@@ -56,7 +56,8 @@
   },
   "overrides": {
     "postcss": "8.5.25",
-    "sharp": "0.35.0"
+    "sharp": "0.35.0",
+    "nanoid": "3.3.17"
   },
   "devDependencies": {
     "@playwright/test": "^1.62.1",


### PR DESCRIPTION
## What

Pins `nanoid` to **3.3.17** to clear **CVE-2026-67213** (HIGH).

## Why it is urgent

**Trivy fails on `main` itself**, so every open PR inherits a red `Trivy` check that has nothing to do with its own diff. Measured on `main`'s own `Security scan` run:

```
Total: 1 (HIGH: 1, CRITICAL: 0)
nanoid  CVE-2026-67213  HIGH  fixed  3.3.16 → 3.3.17, 5.1.6
"nanoid (Nano ID) before 5.1.6 contains an infinite loop"
```

That is why #3880 and #3926 went red on `Trivy` immediately after their engagement-service failure was cleared — the red simply moved to the next inherited fault.

## Why an override, and why 3.3.17 rather than 5.1.6

`nanoid` is **transitive** — no direct dependency declares it — so an override is the only lever, alongside the `postcss` and `sharp` pins already in `overrides`.

3.3.17 is the fix on the 3.x line the tree already resolves. Taking 5.1.6 would be two majors of API risk on a package nothing here calls directly, for the same CVE outcome.

## Verified with the gate's own tool, not inferred from a version string

```
trivy fs --scanners vuln --severity CRITICAL,HIGH --ignore-unfixed  openbank-admin-ui
→ package-lock.json  npm  0
```

and the lockfile now resolves `node_modules/nanoid` to `3.3.17`. A version number in a manifest is a claim; the scanner's verdict is the check.

## One thing in the diff I did not set out to change

The lockfile's **root version was `0.102.0`** while `package.json` and `version.txt` both say `0.103.1`. `npm install --package-lock-only` corrected that drift while regenerating.

Flagging it rather than letting it ride silently: it is a real pre-existing inconsistency, the new value is the correct one, and nothing was enforcing it — the version-sync gate compares `version.txt` to `package.json` and never looks at the lockfile's copy.

Refs #4023
