### PR TITLE
fix(copilot): capture the erasure identity at write time so PARTY_ERASED actually deletes

### DIFF
--- a/openbank-copilot-service/CLAUDE.md
+++ b/openbank-copilot-service/CLAUDE.md
@@ -66,9 +66,25 @@ Free-text chat is where the least predictable personal data lands, so the retent
   and no `PARTY_ERASED` consumer "yet". It is deliberately NOT corrected: Flyway checksums the whole
   file including comments, so editing an applied migration fails the service at boot. Believe this
   file, not that one.
-- **Known gap:** the event carries `partyId`, but history is keyed on the OIDC `sub`. The customers
-  realm also defines a separate `party_id` claim, so where those differ the erasure matches nothing.
-  Tracked separately — do not read the consumer as complete coverage.
+- **The erasure identity is captured at WRITE time, and must stay that way (#3881).** `PARTY_ERASED`
+  carries `partyId`; history is keyed on the OIDC `sub`, and those are not the same value — measured
+  against the deployed customers realm, `sub` equalled `party_id` for **0 of 35** users, because
+  `WebAuthnKeycloakClient.ensureUser` never sets the Keycloak user `id`, so Keycloak mints a random
+  UUID and `party_id` survives as a separate attribute. Keyed on `sub`, the consumer received the
+  event, deleted nothing, and logged `erased 0 copilot conversation(s)` at INFO — a GDPR Art. 17
+  control reporting coverage it did not have, provable wrong only by querying the table. It cannot be
+  fixed in the consumer: by erasure time the Keycloak user is gone, so nothing maps `partyId` back to
+  a `sub`. So `CopilotChatResource.erasureIdentity()` (the `party_id` claim, `sub` as fallback — the
+  resolution customer-edge already uses) writes `conversation_history.party_id` (migration V2), and
+  `deleteForParty` matches **either** column. Do not "simplify" that `or` away.
+- **`party_id` is never a lookup key.** `customerId` alone still decides which conversation a
+  customer resumes; changing that would silently move every customer to a different history and
+  orphan every existing row. Rows written before V2 carry no party id and are reachable only by the
+  `customer_id` arm; they pick one up on that customer's next message.
+- **An erasure test whose two identities are the same string cannot see this class of bug.** Every
+  test in `ConversationErasureIT` erases using the id it seeded with, so all four passed against the
+  broken code. `PartyErasureIdentityIT` deliberately seeds `sub != partyId` and asserts by direct
+  JDBC — measured red on the unfixed behaviour with `expected: 2L but was: 0L`.
 
 ## Build
 

--- a/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/application/CopilotChatService.kt
+++ b/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/application/CopilotChatService.kt
@@ -50,7 +50,7 @@ class CopilotChatService(
 ) : CopilotChatUseCase {
     private val log = Logger.getLogger(CopilotChatService::class.java)
 
-    override suspend fun handle(turn: ChatTurn, customerId: String): ChatOutcome {
+    override suspend fun handle(turn: ChatTurn, customerId: String, partyId: String?): ChatOutcome {
         if (!enabled) return ChatOutcome.Disabled
 
         guard.scanUserInput(customerId, turn.message)?.let {
@@ -67,7 +67,7 @@ class CopilotChatService(
 
         val outcome = converse(turn.conversationId, messages, customerId)
         if (outcome is ChatOutcome.Replied && outcome.reply.reply.isNotBlank()) {
-            persistTurn(customerId, turn.conversationId, turn.message, outcome.reply.reply)
+            persistTurn(customerId, turn.conversationId, turn.message, outcome.reply.reply, partyId)
         }
         return outcome
     }
@@ -82,7 +82,12 @@ class CopilotChatService(
      * context and the customer bearer for downstream tool calls are propagated correctly.
      */
     @Suppress("TooGenericExceptionCaught", "LongMethod")
-    override suspend fun handleStream(turn: ChatTurn, customerId: String, onChunk: suspend (String) -> Unit) {
+    override suspend fun handleStream(
+        turn: ChatTurn,
+        customerId: String,
+        partyId: String?,
+        onChunk: suspend (String) -> Unit,
+    ) {
         if (!enabled) {
             onChunk(DISABLED_MESSAGE)
             return
@@ -138,7 +143,7 @@ class CopilotChatService(
             if (response.stopReason != StopReason.TOOL_USE || response.toolInvocations.isEmpty()) {
                 emitThemeSentinel(themeSpecs, onChunk)
                 emitProposalSentinel(proposals, onChunk)
-                persistTurn(customerId, turn.conversationId, turn.message, finalText.toString())
+                persistTurn(customerId, turn.conversationId, turn.message, finalText.toString(), partyId)
                 return
             }
 
@@ -162,7 +167,13 @@ class CopilotChatService(
      * conversation memory so the next turn has context. No-op for a blank reply or a non-persistable
      * conversation id (a stateless turn where the client sent no id) — [ConversationStore] guards both.
      */
-    private fun persistTurn(customerId: String, conversationId: String, userMessage: String, assistantText: String) {
+    private fun persistTurn(
+        customerId: String,
+        conversationId: String,
+        userMessage: String,
+        assistantText: String,
+        partyId: String?,
+    ) {
         if (assistantText.isBlank()) return
         conversations.append(
             customerId,
@@ -171,6 +182,7 @@ class CopilotChatService(
                 ChatMessage(ChatRole.USER, userMessage),
                 ChatMessage(ChatRole.ASSISTANT, assistantText),
             ),
+            partyId,
         )
     }
 

--- a/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/application/port/in/CopilotChatUseCase.kt
+++ b/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/application/port/in/CopilotChatUseCase.kt
@@ -13,16 +13,26 @@ import com.openbank.copilot.domain.ChatTurn
  *
  * [customerId] is always the authenticated subject the resource resolved from the bearer — never a
  * value the request body carried, so a turn can never be attributed to another customer.
+ *
+ * `partyId` is the same token's `party_id` claim (`sub` as fallback — the resolution customer-edge
+ * already uses). It is recorded with the conversation purely so `PARTY_ERASED` can find it later,
+ * and never participates in lookup: which conversation a customer resumes is still decided by
+ * [customerId] alone. See `ConversationStore.deleteForParty` for why the two must both be kept.
  */
 interface CopilotChatUseCase {
 
     /** Run the turn and return the complete outcome (disabled, refused, or replied). */
-    suspend fun handle(turn: ChatTurn, customerId: String): ChatOutcome
+    suspend fun handle(turn: ChatTurn, customerId: String, partyId: String? = null): ChatOutcome
 
     /**
      * Same governed loop, streaming: [onChunk] receives each text chunk of the final answer as it
      * arrives, plus the `[PROGRESS:…]` / `[THEME_SPEC:…]` / `[PROPOSAL_END:…]` control markers the
      * client parses. Tool-call rounds emit no text, so nothing is streamed for them.
      */
-    suspend fun handleStream(turn: ChatTurn, customerId: String, onChunk: suspend (String) -> Unit)
+    suspend fun handleStream(
+        turn: ChatTurn,
+        customerId: String,
+        partyId: String? = null,
+        onChunk: suspend (String) -> Unit,
+    )
 }

--- a/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/application/port/out/ConversationStore.kt
+++ b/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/application/port/out/ConversationStore.kt
@@ -34,12 +34,26 @@ interface ConversationStore {
     /**
      * Append [newTurns] (typically the current USER message + the final ASSISTANT reply) to the
      * conversation, trimming to the most recent [MAX_MESSAGES] and (re)setting the TTL.
+     *
+     * [partyId] is the ERASURE identity, recorded alongside the row and never used for lookup —
+     * [customerId] alone still decides which conversation a customer resumes, so this changes no
+     * read behaviour. It exists because `PARTY_ERASED` carries `partyId` while [customerId] is the
+     * OIDC `sub`, and those are not the same value (see [deleteForParty]). Null when the caller
+     * could not resolve one; such a row remains reachable by [customerId].
      */
-    fun append(customerId: String, conversationId: String, newTurns: List<ChatMessage>)
+    fun append(customerId: String, conversationId: String, newTurns: List<ChatMessage>, partyId: String? = null)
 
     /**
-     * Erase every conversation held for [customerId], returning how many were removed (GDPR Art. 17 /
-     * ADR-0117). Called by the `PARTY_ERASED` consumer.
+     * Erase every conversation held for the erased party, returning how many were removed
+     * (GDPR Art. 17 / ADR-0117). Called by the `PARTY_ERASED` consumer.
+     *
+     * **Matches EITHER identity** — the stored `party_id` or the `customer_id` (OIDC `sub`).
+     * That is not belt-and-braces: measured against the deployed customers realm, `sub` equals
+     * `partyId` for 0 of 35 users, so deleting on `customer_id` alone erases nothing for anybody
+     * while logging success. Rows written before the party id was captured have no `party_id`, and
+     * the `customer_id` arm is the only thing that can still reach them where ADR-0069 happens to
+     * hold. Both arms are UUID-valued identity columns for the same person, so the union can never
+     * widen across customers.
      *
      * This is a **hard delete**, not the read-side `expires_at` filter [load] applies: an expired
      * conversation stops being *served* but its free-text message bodies stay on disk (and in every
@@ -50,7 +64,7 @@ interface ConversationStore {
      * on a Vert.x context, where the blocking `VertxContextSupport.subscribeAndAwait` bridge the
      * read/write path uses would throw. Keeping erasure suspending means it never needs that bridge.
      */
-    suspend fun deleteForCustomer(customerId: String): Long
+    suspend fun deleteForParty(partyId: String): Long
 
     /** Erase one conversation. Scoped by [customerId], so it can never remove another customer's row. */
     suspend fun deleteConversation(customerId: String, conversationId: String): Long

--- a/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/infrastructure/kafka/PartyErasureConsumer.kt
+++ b/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/infrastructure/kafka/PartyErasureConsumer.kt
@@ -26,13 +26,19 @@ import java.util.UUID
  * Vert.x duplicated context and the reactive Panache delete below runs correctly; poison-pill safe,
  * so any parse or delete failure is logged and the message acked rather than wedging the group.
  *
- * ## Identity caveat — read before trusting this as complete
+ * ## Identity — why the delete is not keyed on the storage key (#3881)
  *
- * The event carries only `partyId`. Copilot keys conversation history on the OIDC `sub`
- * (`CopilotChatResource.customerSubject()`), and the customers realm additionally defines a separate
- * `party_id` claim backed by a user attribute, which customer-edge falls back to `sub` for only when
- * that attribute is unset. Where the attribute IS set and differs from `sub`, the delete below
- * matches nothing. That join is not fixed here — see the PR body and the follow-up issue.
+ * The event carries only `partyId`; copilot keys conversation history on the OIDC `sub`. Those are
+ * not the same value: measured against the deployed customers realm, `sub` equalled `party_id` for
+ * **0 of 35** users, because `WebAuthnKeycloakClient.ensureUser` never sets the Keycloak user `id`,
+ * so Keycloak mints a random UUID and `party_id` survives as a separate attribute. Keyed on `sub`
+ * this consumer would receive the event, delete nothing, and log success — a GDPR control reporting
+ * coverage it does not have, detectable only by querying the table.
+ *
+ * It cannot be resolved here either: by erasure time the Keycloak user is gone, so there is nothing
+ * left to map `partyId` back to a `sub`. So the identity is captured at WRITE time
+ * (`CopilotChatResource.erasureIdentity()` -> `conversation_history.party_id`, migration V2) and
+ * [ConversationStore.deleteForParty] matches either column.
  */
 @ApplicationScoped
 class PartyErasureConsumer {
@@ -64,7 +70,7 @@ class PartyErasureConsumer {
         }
 
         try {
-            val erased = conversationStore.deleteForCustomer(partyId.toString())
+            val erased = conversationStore.deleteForParty(partyId.toString())
             log.infof(
                 "[party-events-in] GDPR Art. 17: erased %d copilot conversation(s) for party %s",
                 erased,

--- a/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/infrastructure/persistence/InMemoryConversationStore.kt
+++ b/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/infrastructure/persistence/InMemoryConversationStore.kt
@@ -22,7 +22,7 @@ import java.util.concurrent.ConcurrentHashMap
 class InMemoryConversationStore(private val clock: Clock) : ConversationStore {
     private val log = Logger.getLogger(InMemoryConversationStore::class.java)
 
-    private data class Entry(val messages: List<ChatMessage>, val expiresAt: Instant)
+    private data class Entry(val messages: List<ChatMessage>, val expiresAt: Instant, val partyId: String? = null)
 
     private val store = ConcurrentHashMap<String, Entry>()
 
@@ -36,7 +36,7 @@ class InMemoryConversationStore(private val clock: Clock) : ConversationStore {
         return entry.messages
     }
 
-    override fun append(customerId: String, conversationId: String, newTurns: List<ChatMessage>) {
+    override fun append(customerId: String, conversationId: String, newTurns: List<ChatMessage>, partyId: String?) {
         if (!ConversationStore.persistable(conversationId) || newTurns.isEmpty()) return
         evictExpired()
         val k = key(customerId, conversationId)
@@ -44,13 +44,21 @@ class InMemoryConversationStore(private val clock: Clock) : ConversationStore {
         val merged = (load(customerId, conversationId) + newTurns)
             .map { ChatMessage(it.role, it.content) }
             .takeLast(ConversationStore.MAX_MESSAGES)
-        store[k] = Entry(merged, Instant.now(clock).plusSeconds(ConversationStore.TTL_SECONDS))
+        store[k] = Entry(
+            merged,
+            Instant.now(clock).plusSeconds(ConversationStore.TTL_SECONDS),
+            partyId ?: store[k]?.partyId,
+        )
         log.debugf("InMemoryConversationStore: appended %d turn(s) key=%s", newTurns.size, k)
     }
 
-    override suspend fun deleteForCustomer(customerId: String): Long {
-        val prefix = "$customerId|"
-        val victims = store.keys.filter { it.startsWith(prefix) }
+    // Either identity, mirroring PostgresConversationStore: the stored party id, or the key prefix
+    // (the OIDC `sub`) for the ADR-0069 case and for entries written without one.
+    override suspend fun deleteForParty(partyId: String): Long {
+        val prefix = "$partyId|"
+        val victims = store.entries
+            .filter { it.key.startsWith(prefix) || it.value.partyId == partyId }
+            .map { it.key }
         victims.forEach { store.remove(it) }
         return victims.size.toLong()
     }

--- a/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/infrastructure/persistence/PostgresConversationStore.kt
+++ b/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/infrastructure/persistence/PostgresConversationStore.kt
@@ -44,6 +44,12 @@ class ConversationHistoryEntity : PanacheEntityBase() {
     @Column(nullable = false, name = "conversation_id")
     lateinit var conversationId: String
 
+    // Erasure identity captured at write time (#3881, V2 migration). Nullable: rows predating the
+    // migration have none, and a turn whose token carried neither a `party_id` claim nor a subject
+    // cannot invent one. NEVER used for lookup — `customerId` alone decides what a customer resumes.
+    @Column(name = "party_id")
+    var partyId: String? = null
+
     // text not jsonb: the Vert.x PG client returns JsonArray for jsonb columns, which cannot be
     // cast to String — the same V2 lesson from campaign-service and copilot's RedisConversationStore.
     @Column(nullable = false, columnDefinition = "text", name = "messages_json")
@@ -107,7 +113,7 @@ class PostgresConversationStore(private val mapper: ObjectMapper) :
         } ?: emptyList()
     }
 
-    override fun append(customerId: String, conversationId: String, newTurns: List<ChatMessage>) {
+    override fun append(customerId: String, conversationId: String, newTurns: List<ChatMessage>, partyId: String?) {
         if (!ConversationStore.persistable(conversationId) || newTurns.isEmpty()) return
         vtx {
             Panache.withTransaction {
@@ -130,6 +136,10 @@ class PostgresConversationStore(private val mapper: ObjectMapper) :
                         this.conversationId = conversationId
                         createdAt = now
                     }
+                    // Refresh on every append, not only on insert: a row created before V2 (or by a
+                    // turn whose token carried no claim) picks the party id up on the customer's
+                    // next message, which is the only backfill that needs no offline job.
+                    if (partyId != null) upsert.partyId = partyId
                     upsert.messagesJson = mapper.writeValueAsString(merged)
                     upsert.lastMessageAt = now
                     upsert.expiresAt = now.plusSeconds(T1_TTL_SECONDS)
@@ -146,8 +156,11 @@ class PostgresConversationStore(private val mapper: ObjectMapper) :
     // event loop. A DELETE also removes the row outright — unlike `load`, which merely stops serving
     // it once `expires_at` passes.
 
-    override suspend fun deleteForCustomer(customerId: String): Long =
-        Panache.withTransaction { delete("customerId = ?1", customerId) }.awaitSuspending()
+    // Either identity: the party id captured at write time, or the OIDC `sub` for the ADR-0069 case
+    // and for rows written before V2. Deleting on `customerId` alone matched 0 of 35 deployed users.
+    override suspend fun deleteForParty(partyId: String): Long = Panache.withTransaction {
+        delete("partyId = ?1 or customerId = ?1", partyId)
+    }.awaitSuspending()
 
     override suspend fun deleteConversation(customerId: String, conversationId: String): Long =
         Panache.withTransaction {

--- a/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/infrastructure/persistence/RedisConversationStore.kt
+++ b/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/infrastructure/persistence/RedisConversationStore.kt
@@ -50,7 +50,7 @@ class RedisConversationStore @Inject constructor(
         }
     }
 
-    override fun append(customerId: String, conversationId: String, newTurns: List<ChatMessage>) {
+    override fun append(customerId: String, conversationId: String, newTurns: List<ChatMessage>, partyId: String?) {
         if (!ConversationStore.persistable(conversationId) || newTurns.isEmpty()) return
         runBlocking {
             val existing = load(customerId, conversationId)
@@ -60,6 +60,16 @@ class RedisConversationStore @Inject constructor(
             val json = mapper.writeValueAsString(merged)
             values.set(key(customerId, conversationId), json, SetArgs().ex(ConversationStore.TTL_SECONDS))
                 .awaitSuspending()
+            // Erasure index (#3881): PARTY_ERASED carries partyId, the history key carries `sub`,
+            // and those are not the same value. Without this pointer an erasure scans a prefix that
+            // matches nothing and reports success. Same TTL, so it cannot outlive what it points at.
+            if (partyId != null && partyId != customerId) {
+                values.set(
+                    partyIndexKey(partyId, conversationId),
+                    customerId,
+                    SetArgs().ex(ConversationStore.TTL_SECONDS),
+                ).awaitSuspending()
+            }
         }
         log.debugf(
             "RedisConversationStore: appended %d turn(s) customer=%s conversation=%s ttl=%ds",
@@ -72,19 +82,32 @@ class RedisConversationStore @Inject constructor(
 
     // ---- Erasure (GDPR Art. 17 / ADR-0117, #3870) --------------------------------------------
 
-    override suspend fun deleteForCustomer(customerId: String): Long {
-        val prefix = "copilot:conv:$customerId:"
+    override suspend fun deleteForParty(partyId: String): Long {
+        // Follow the erasure index first: history is keyed by `sub`, the event carries `partyId`.
+        val idxPrefix = "copilot:conv:party:$partyId:"
+        val indexKeys = keys.keys("$idxPrefix*").awaitSuspending().filter { it.startsWith(idxPrefix) }
+        var viaIndex = 0L
+        indexKeys.forEach { idx ->
+            val subject = values.get(idx).awaitSuspending()
+            val conversationId = idx.removePrefix(idxPrefix)
+            if (subject != null && ConversationStore.persistable(conversationId)) {
+                viaIndex += keys.del(key(subject, conversationId)).awaitSuspending().toLong()
+            }
+            keys.del(idx).awaitSuspending()
+        }
+        // …then the ADR-0069 case, where `sub` IS the party id and no index entry was written.
+        val prefix = "copilot:conv:$partyId:"
         // KEYS takes a glob, and customerId is caller-derived, so a metacharacter in it could widen
         // the pattern across customers. The returned keys are therefore re-filtered on the LITERAL
         // prefix before anything is deleted — the glob only narrows the scan, it never authorises.
         val matched = keys.keys("$prefix*").awaitSuspending()
-            .filter { it.startsWith(prefix) }
-        if (matched.isEmpty()) return 0L
+            .filter { it.startsWith(prefix) && !it.startsWith("copilot:conv:party:") }
+        if (matched.isEmpty()) return viaIndex
         // Deleted one key at a time rather than with a spread vararg: an erasure set is tiny (a
         // customer's open conversations), and the spread would copy the array on every call.
         matched.forEach { keys.del(it).awaitSuspending() }
-        log.infof("RedisConversationStore: erased %d conversation(s) for a customer", matched.size)
-        return matched.size.toLong()
+        log.infof("RedisConversationStore: erased %d conversation(s) for a party", matched.size + viaIndex)
+        return matched.size.toLong() + viaIndex
     }
 
     override suspend fun deleteConversation(customerId: String, conversationId: String): Long {
@@ -101,4 +124,7 @@ class RedisConversationStore @Inject constructor(
     // customerId precedes conversationId, so a crafted conversationId can only ever land inside the
     // SAME customer's namespace — it can never escape to another customer's history.
     private fun key(customerId: String, conversationId: String) = "copilot:conv:$customerId:$conversationId"
+
+    /** Erasure pointer partyId -> the `sub` the history is keyed under. Holds no message content. */
+    private fun partyIndexKey(partyId: String, conversationId: String) = "copilot:conv:party:$partyId:$conversationId"
 }

--- a/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/infrastructure/rest/CopilotChatResource.kt
+++ b/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/infrastructure/rest/CopilotChatResource.kt
@@ -65,7 +65,7 @@ class CopilotChatResource {
             message = request.message,
             currentThemeSpec = request.themeSpec,
         )
-        when (val outcome = chat.handle(turn, customerId)) {
+        when (val outcome = chat.handle(turn, customerId, erasureIdentity())) {
             is ChatOutcome.Disabled -> {
                 metrics.recordChatRequest(CopilotMetricsAdapter.OUTCOME_DISABLED)
                 Response.status(Response.Status.NOT_IMPLEMENTED)
@@ -84,6 +84,21 @@ class CopilotChatResource {
         val principal = identity.principal
         return (principal as? JsonWebToken)?.subject?.takeIf { it.isNotBlank() }
             ?: principal?.name?.takeIf { it.isNotBlank() }
+    }
+
+    /**
+     * The identity `PARTY_ERASED` will arrive with: the `party_id` claim, falling back to `sub`
+     * (the resolution customer-edge's `RateLimitFilter` and `WebAuthnKeycloakClient` already use).
+     *
+     * Recorded on the conversation row so erasure can find it; it is NOT the storage key, so this
+     * changes nothing about which conversation a customer resumes. Resolving it here rather than in
+     * the consumer is the whole point: at erasure time the Keycloak user is gone, so the `sub` ->
+     * `party_id` mapping no longer exists to be looked up. Measured against the deployed customers
+     * realm, `sub` equalled `party_id` for 0 of 35 users (#3881) — this is not a corner case.
+     */
+    private fun erasureIdentity(): String? {
+        val jwt = identity.principal as? JsonWebToken ?: return customerSubject()
+        return jwt.getClaim<String>("party_id")?.takeIf { it.isNotBlank() } ?: customerSubject()
     }
 
     /**
@@ -107,6 +122,7 @@ class CopilotChatResource {
     @Authorize(action = "copilot.chat")
     fun chatStream(request: ChatRequest): Multi<String> {
         val customerId = customerSubject() ?: return Multi.createFrom().empty()
+        val partyId = erasureIdentity()
         val turn = ChatTurn(
             conversationId = request.conversationId ?: "new",
             message = request.message,
@@ -115,7 +131,7 @@ class CopilotChatResource {
         return Multi.createFrom().emitter<String> { emitter ->
             try {
                 runBlocking {
-                    chat.handleStream(turn, customerId) { chunk ->
+                    chat.handleStream(turn, customerId, partyId) { chunk ->
                         emitter.emit(chunk)
                     }
                 }

--- a/openbank-copilot-service/src/main/resources/db/migration/V2__conversation_history_party_id.sql
+++ b/openbank-copilot-service/src/main/resources/db/migration/V2__conversation_history_party_id.sql
@@ -1,0 +1,27 @@
+-- SPDX-License-Identifier: AGPL-3.0-only
+-- Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+
+-- Store the erasure identity AT WRITE TIME (#3881, GDPR Art. 17 / ADR-0117).
+--
+-- WHY: `customer_id` is the OIDC `sub` (CopilotChatResource.customerSubject()). The PARTY_ERASED
+-- event carries `partyId`. Measured against the deployed customers realm (35 users) those two are
+-- equal for ZERO of them: 9 users carry a `party_id` attribute that differs from `sub`, and the
+-- remaining 26 carry none whose `sub` is a real party id. The ADR-0069 `sub == partyId` invariant
+-- holds for nobody, because WebAuthnKeycloakClient.ensureUser never sets the Keycloak user `id`,
+-- so Keycloak mints a random UUID and `party_id` lives on as a separate attribute.
+--
+-- So a consumer that deletes on `customer_id = partyId` receives the event, deletes nothing, and
+-- logs success — a GDPR control that reports coverage it does not have. Resolving the identity at
+-- DELETE time cannot be made reliable (it would need a Keycloak lookup for a user that erasure has
+-- just removed); resolving it at WRITE time can, because the JWT carries both.
+--
+-- Nullable on purpose: rows written before this migration have no party id and nothing can infer
+-- one for them. They stay reachable by `customer_id` (the delete matches either column), and a
+-- backfill is a separate decision, not a blocker.
+--
+-- Rollback:
+--   DROP INDEX IF EXISTS idx_conversation_history_party;
+--   ALTER TABLE conversation_history DROP COLUMN party_id;
+ALTER TABLE conversation_history ADD COLUMN party_id VARCHAR(255);
+
+CREATE INDEX idx_conversation_history_party ON conversation_history (party_id);

--- a/openbank-copilot-service/src/test/kotlin/com/openbank/copilot/infrastructure/kafka/PartyErasureConsumerTest.kt
+++ b/openbank-copilot-service/src/test/kotlin/com/openbank/copilot/infrastructure/kafka/PartyErasureConsumerTest.kt
@@ -35,11 +35,11 @@ class PartyErasureConsumerTest {
     @Test
     fun `PARTY_ERASED erases the party's conversation history`(): Unit = runBlocking {
         val partyId = UUID.randomUUID()
-        coEvery { conversationStore.deleteForCustomer(partyId.toString()) } returns 3L
+        coEvery { conversationStore.deleteForParty(partyId.toString()) } returns 3L
 
         consumer.consume("""{"eventType":"PARTY_ERASED","partyId":"$partyId"}""")
 
-        coVerify(exactly = 1) { conversationStore.deleteForCustomer(partyId.toString()) }
+        coVerify(exactly = 1) { conversationStore.deleteForParty(partyId.toString()) }
     }
 
     @Test
@@ -47,7 +47,7 @@ class PartyErasureConsumerTest {
         consumer.consume("""{"eventType":"PARTY_CREATED","partyId":"${UUID.randomUUID()}"}""")
         consumer.consume("""{"eventType":"PARTY_UPDATED","partyId":"${UUID.randomUUID()}"}""")
 
-        coVerify(exactly = 0) { conversationStore.deleteForCustomer(any()) }
+        coVerify(exactly = 0) { conversationStore.deleteForParty(any()) }
     }
 
     @Test
@@ -56,16 +56,16 @@ class PartyErasureConsumerTest {
         consumer.consume("""{"eventType":"PARTY_ERASED"}""")
         consumer.consume("""{"eventType":"PARTY_ERASED","partyId":"not-a-uuid"}""")
 
-        coVerify(exactly = 0) { conversationStore.deleteForCustomer(any()) }
+        coVerify(exactly = 0) { conversationStore.deleteForParty(any()) }
     }
 
     @Test
     fun `a store failure is swallowed so one bad message cannot wedge the consumer group`(): Unit = runBlocking {
         val partyId = UUID.randomUUID()
-        coEvery { conversationStore.deleteForCustomer(partyId.toString()) } throws IllegalStateException("db down")
+        coEvery { conversationStore.deleteForParty(partyId.toString()) } throws IllegalStateException("db down")
 
         consumer.consume("""{"eventType":"PARTY_ERASED","partyId":"$partyId"}""")
 
-        coVerify(exactly = 1) { conversationStore.deleteForCustomer(partyId.toString()) }
+        coVerify(exactly = 1) { conversationStore.deleteForParty(partyId.toString()) }
     }
 }

--- a/openbank-copilot-service/src/test/kotlin/com/openbank/copilot/it/ConversationErasureIT.kt
+++ b/openbank-copilot-service/src/test/kotlin/com/openbank/copilot/it/ConversationErasureIT.kt
@@ -32,7 +32,7 @@ import java.util.UUID
  * pre-fix code, where nothing ever deleted anything. So the fixtures are written through the store
  * (the real production write path) and every verdict is read straight out of `conversation_history`.
  *
- * RED against the code before this change: `deleteForCustomer` / `deleteConversation` did not exist
+ * RED against the code before this change: `deleteForParty` / `deleteConversation` did not exist
  * on the port at all, so these tests did not compile — and once stubbed to no-ops they fail on the
  * row count, which is the assertion that matters.
  *
@@ -81,7 +81,7 @@ class ConversationErasureIT {
             .describedAs("fixture must exist before erasure, or the test proves nothing")
             .isEqualTo(2)
 
-        val erased = onEventLoop { store.deleteForCustomer(customer) }
+        val erased = onEventLoop { store.deleteForParty(customer) }
 
         assertThat(erased).isEqualTo(2L)
         assertThat(rowsFor(customer))
@@ -98,7 +98,7 @@ class ConversationErasureIT {
         seed(customer, "conv-a")
         seed(other, "conv-a")
 
-        onEventLoop { store.deleteForCustomer(customer) }
+        onEventLoop { store.deleteForParty(customer) }
 
         assertThat(rowsFor(customer)).isZero()
         assertThat(rowsFor(other))

--- a/openbank-copilot-service/src/test/kotlin/com/openbank/copilot/it/PartyErasureIdentityIT.kt
+++ b/openbank-copilot-service/src/test/kotlin/com/openbank/copilot/it/PartyErasureIdentityIT.kt
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+package com.openbank.copilot.it
+
+import com.openbank.copilot.application.port.out.ConversationStore
+import com.openbank.copilot.domain.model.ChatMessage
+import com.openbank.copilot.domain.model.ChatRole
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.vertx.VertxContextSupport
+import io.smallrye.mutiny.coroutines.uni
+import jakarta.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import org.assertj.core.api.Assertions.assertThat
+import org.eclipse.microprofile.config.ConfigProvider
+import org.junit.jupiter.api.Test
+import java.sql.DriverManager
+import java.util.UUID
+
+/**
+ * The half of #3881 that [ConversationErasureIT] cannot see: erasure keyed on an identity that is
+ * **not** the storage key.
+ *
+ * `PARTY_ERASED` carries `partyId`; copilot stores history under the OIDC `sub`. Measured against
+ * the deployed customers realm those are equal for 0 of 35 users, so a consumer that deletes on
+ * `customer_id = partyId` receives the event, deletes zero rows, and logs
+ * `erased 0 copilot conversation(s)` at INFO. Every test in [ConversationErasureIT] passes against
+ * that code, because each of them erases using the very id it seeded with — the mismatch is
+ * invisible to any test whose two identities are the same string.
+ *
+ * So the fixtures here deliberately use `sub != partyId`, and every verdict is a direct JDBC query:
+ * reading through the store cannot distinguish "deleted" from "filtered by `expires_at`", which is
+ * the distinction the whole issue turns on.
+ *
+ * RED against the unfixed code: with `party_id` neither stored nor matched,
+ * `an erasure keyed on partyId removes history stored under a different sub` fails on
+ * `expected 0 but was 1` — the row survives its own erasure.
+ *
+ * No real conversation content appears here; the fixtures are literal placeholder strings.
+ */
+@QuarkusTest
+@QuarkusTestResource(CopilotPostgresTestResource::class)
+class PartyErasureIdentityIT {
+
+    @Inject
+    lateinit var store: ConversationStore
+
+    /** The Keycloak-minted `sub` copilot keys history on. */
+    private val subject = "sub-${UUID.randomUUID()}"
+
+    /** The party id the erasure event will carry — a different value, as it is for every live user. */
+    private val partyId = UUID.randomUUID().toString()
+
+    private fun <T> onEventLoop(block: suspend () -> T): T =
+        VertxContextSupport.subscribeAndAwait { uni(CoroutineScope(Dispatchers.Unconfined)) { block() } }
+
+    private fun <T> query(sql: String, arg: String, read: (java.sql.ResultSet) -> T): T {
+        val config = ConfigProvider.getConfig()
+        DriverManager.getConnection(
+            config.getValue("quarkus.datasource.jdbc.url", String::class.java),
+            config.getValue("quarkus.datasource.username", String::class.java),
+            config.getValue("quarkus.datasource.password", String::class.java),
+        ).use { conn ->
+            conn.prepareStatement(sql).use { ps ->
+                ps.setString(1, arg)
+                ps.executeQuery().use { rs ->
+                    rs.next()
+                    return read(rs)
+                }
+            }
+        }
+    }
+
+    private fun rowsForSubject(sub: String): Int =
+        query("SELECT count(*) FROM conversation_history WHERE customer_id = ?", sub) { it.getInt(1) }
+
+    private fun storedPartyId(sub: String): String? =
+        query("SELECT party_id FROM conversation_history WHERE customer_id = ?", sub) { it.getString(1) }
+
+    @Test
+    fun `the party id is captured on the row at write time, not resolved at delete time`() {
+        store.append(subject, "conv-a", listOf(ChatMessage(ChatRole.USER, "placeholder-turn")), partyId)
+
+        assertThat(storedPartyId(subject))
+            .describedAs(
+                "the erasure identity must be on the row: at erasure time the Keycloak user is " +
+                    "gone, so nothing can map partyId back to this sub afterwards",
+            )
+            .isEqualTo(partyId)
+    }
+
+    @Test
+    fun `an erasure keyed on partyId removes history stored under a different sub`() {
+        store.append(subject, "conv-a", listOf(ChatMessage(ChatRole.USER, "placeholder-turn")), partyId)
+        store.append(subject, "conv-b", listOf(ChatMessage(ChatRole.USER, "placeholder-turn")), partyId)
+        assertThat(rowsForSubject(subject))
+            .describedAs("fixture must exist before erasure, or the test proves nothing")
+            .isEqualTo(2)
+
+        val erased = onEventLoop { store.deleteForParty(partyId) }
+
+        assertThat(erased)
+            .describedAs("a count of 0 here IS the bug — the consumer logs that as success")
+            .isEqualTo(2L)
+        assertThat(rowsForSubject(subject))
+            .describedAs(
+                "GDPR Art. 17: no conversation_history row may survive erasure of the party that " +
+                    "wrote it, even though the row is keyed on sub and the event carried partyId",
+            )
+            .isZero()
+    }
+
+    @Test
+    fun `a row written with no party id is still erasable where sub is the party id (ADR-0069)`() {
+        val adr0069Subject = UUID.randomUUID().toString()
+        store.append(adr0069Subject, "conv-a", listOf(ChatMessage(ChatRole.USER, "placeholder-turn")))
+        assertThat(storedPartyId(adr0069Subject)).isNull()
+
+        val erased = onEventLoop { store.deleteForParty(adr0069Subject) }
+
+        assertThat(erased).isEqualTo(1L)
+        assertThat(rowsForSubject(adr0069Subject)).isZero()
+    }
+
+    @Test
+    fun `erasing one party never reaches another party's rows`() {
+        val otherSubject = "sub-${UUID.randomUUID()}"
+        val otherParty = UUID.randomUUID().toString()
+        store.append(subject, "conv-a", listOf(ChatMessage(ChatRole.USER, "placeholder-turn")), partyId)
+        store.append(otherSubject, "conv-a", listOf(ChatMessage(ChatRole.USER, "placeholder-turn")), otherParty)
+
+        onEventLoop { store.deleteForParty(partyId) }
+
+        assertThat(rowsForSubject(subject)).isZero()
+        assertThat(rowsForSubject(otherSubject))
+            .describedAs("matching either identity column must not widen erasure across parties")
+            .isEqualTo(1)
+    }
+}


### PR DESCRIPTION
## What this fixes

Item 2 of #3881 — the half the issue called "the more dangerous half", and the one that survived
#3885.

`PARTY_ERASED` carries `partyId`. Copilot keyed conversation history on the OIDC `sub`
(`CopilotChatResource.customerSubject()`). Those are not the same value: measured against the
deployed customers realm and reported on the issue, `sub` equalled `party_id` for **0 of 35** users,
because `WebAuthnKeycloakClient.ensureUser` never sets the Keycloak user `id`, so Keycloak mints a
random UUID and `party_id` survives as a separate attribute.

So since #3885 wired the Kafka half, the consumer subscribes, receives the event, runs the delete,
deletes nothing, and logs `erased 0 copilot conversation(s)` at INFO. That is worse than the
originally-filed unwired state: it is a GDPR Art. 17 control that reports success while free-text
transcripts stay on disk and in every base backup, detectable only by querying the table.

## Why the fix is on the write path, not in the consumer

Resolving `partyId` -> `sub` at delete time cannot be made to work: by erasure time the Keycloak user
is gone, so the mapping no longer exists to be looked up. The JWT carries both values at write time,
which is the only moment they are both available.

- `CopilotChatResource.erasureIdentity()` — the `party_id` claim, `sub` as fallback (the resolution
  `RateLimitFilter` and `WebAuthnKeycloakClient` in customer-edge already use).
- `V2__conversation_history_party_id.sql` — nullable `party_id` column + index, with a rollback note.
- `ConversationStore.deleteForParty(partyId)` (renamed from `deleteForCustomer`, whose name asserted
  the very equality that does not hold) matches **either** identity column:
  `partyId = ?1 or customerId = ?1`. The `customerId` arm is not belt-and-braces — it is the only
  thing that reaches rows written before V2, and the ADR-0069 `sub == partyId` case. Both are
  UUID-valued identity columns for the same person, so the union cannot widen across customers.

**`party_id` is never a lookup key.** `customerId` alone still decides which conversation a customer
resumes. The issue explicitly ruled out re-keying history on `party_id` as an identity decision
needing its own PR — this change deliberately does not make it, and moves or orphans nothing.
Pre-V2 rows pick a party id up on that customer's next message; no backfill job is needed and none
is claimed.

The other two adapters follow: `InMemoryConversationStore` records it on the entry, and
`RedisConversationStore` writes a content-free `copilot:conv:party:<partyId>:<conversationId>`
pointer under the same TTL rather than shipping a knowingly-broken erasure in a non-default adapter.

## Red then green — measured, not asserted

The four tests in `ConversationErasureIT` all passed against the broken code, because each erases
using the very id it seeded with. **An erasure test whose two identities are the same string cannot
see this class of bug at all.** So `PartyErasureIdentityIT` seeds `sub != partyId` deliberately, and
every verdict is a direct JDBC query — reading through the store cannot distinguish "deleted" from
"filtered by `expires_at`", which is the distinction the issue turns on (item 3).

RED was produced by reverting only the *behaviour* and keeping the signatures, so the failure is
about the defect and not about compilation. From the JUnit XML, not the console:

```
tests=4 failures=3 errors=0 skipped=0
 - an erasure keyed on partyId removes history stored under a different sub
     FAIL: expected 2L but was 0L      <- the "erased 0, logged success" defect
 - the party id is captured on the row at write time
     FAIL: expected party id on the row, was null
 - erasing one party never reaches another party's rows
     FAIL: expected 0 but was 1
 - a row written with no party id is still erasable where sub is the party id  PASS
```

GREEN, whole module:

```
TOTAL tests=132 failures=0 errors=0 skipped=0
```

Local gate ran all three tasks (Gradle stops at the first failure, so this is the task list that
actually executed): `:openbank-copilot-service:test` + `ktlintCheck` (main and test source sets) +
`detekt`, all green.

## Kafka config: no replay is possible from this PR

This change touches **no** Kafka configuration. `group.id` / `auto.offset.reset` for
`party-events-in` were set by #3885 in `copilot-service-msg-override.yaml` via `override.properties`
+ `config_ordinal=500` — the shape that avoids the dotted-YAML-key trap — and are untouched here.
No consumer group is created, renamed, or re-pointed, and `auto.offset.reset` is not forced onto any
existing group, so **this PR cannot cause a topic replay.**

## Scope and what is still open

- No AWS or cluster mutation; the measurements quoted are from the issue thread, read-only.
- `openbank-engagement-service` and `openbank-admin-ui` untouched.
- Still open and deliberately not addressed here: none of the 9 live `party_id` attribute values
  matches a row in party-service's `parties` table either (noted on the issue as unexplained). This
  change is unaffected by that — it stores whatever identity the token carries and erases on either
  key — but it means the upstream identity question is still worth resolving on its own.
- No API change, so no `openapi.yaml` bump. `version.txt` is left to release-please.

Closes #3881
