### PR TITLE
fix(engagement): merge the duplicated %test authz key — main is red on the duplicate-key guard

### DIFF
--- a/openbank-engagement-service/src/main/resources/application.yaml
+++ b/openbank-engagement-service/src/main/resources/application.yaml
@@ -62,11 +62,13 @@ mp:
           serializer: org.apache.kafka.common.serialization.StringSerializer
 
 "%test":
-  # SurfaceResource's two endpoints are @Authorize-annotated, and `authz.enforce` carries
-  # defaultValue = "true" in AuthorizeInterceptor — so under @QuarkusTest, with no OPA PDP
-  # bean in the graph, every one of them answers 503 and SurfaceRestContractIT's
-  # `statusCode(200)` fails. Advisory in tests only; the deployed posture is unchanged and
-  # is decided by the sidecar wired in #4068.
+  # `authz.enforce` carries defaultValue = "true" in AuthorizeInterceptor, and a test JVM has no
+  # PolicyDecisionPoint bean — so every @Authorize call on SurfaceResource's two endpoints fails
+  # closed with 503 before the handler runs, and SurfaceRestContractIT's status assertions fail.
+  # Measured in #4128: removing this key alone turns all four of those tests red with 503.
+  # Advisory HERE ONLY, same pattern and reasoning as campaign-service: that IT is about the HTTP
+  # contract, not about who may call what — the OPA gate and the rego tests own that, and neither
+  # needs the app running. The deployed posture is unchanged, decided by the sidecar (#4068).
   authz:
     enforce: false
   quarkus:
@@ -76,13 +78,6 @@ mp:
       enabled: false
     oidc-client:
       enabled: false
-  # `authz.enforce` has no key elsewhere in this file, so the interceptor's safe default (true)
-  # applies — and with no PolicyDecisionPoint bean in a test JVM every @Authorize call fails
-  # closed (503) before the handler runs. Advisory HERE ONLY, same pattern and same reasoning as
-  # campaign-service's application.yaml: SurfaceRestContractIT is about the HTTP contract, not
-  # about who may call what — that's the OPA gate + rego tests' job, neither needs the app running.
-  authz:
-    enforce: false
   openbank:
     outbox:
       dispatch-enabled: false


### PR DESCRIPTION
`main` is red on the enforced duplicate-YAML-key guard:

```
./openbank-engagement-service/src/main/resources/application.yaml:84:3:
[error] duplication of key "authz" in mapping (key-duplicates)
```

**Cause, and it is mine.** Two PRs added the same `%test` key within minutes: #4128 (the `SurfaceRestContractIT` fix) and #4072. Git merged both cleanly — different lines, no textual overlap — and SnakeYAML keeps only the **last** of a duplicated mapping key, so the effective configuration never changed and nothing except this guard could see it.

I had the information and did not use it: the review I wrote on #4072 explicitly quotes it adding `authz.enforce: false` under `"%test":` to this exact file. I then added the same key myself without re-checking whether #4072 had landed. That is the "another agent is touching the same artifact" check I had been running all evening on other people's PRs, skipped on my own.

**The fix** merges the two blocks into one, keeping what each comment contributed:

- the mechanism — `defaultValue = "true"` in `AuthorizeInterceptor` plus no `PolicyDecisionPoint` bean in a test JVM, so `@Authorize` fails closed with 503 before the handler runs;
- the measurement from #4128 — removing this key alone turns all four tests red with 503;
- the scoping argument — advisory **here only**, same as campaign-service; the OPA gate and the rego tests own who may call what.

Dropped from the surviving comment: *"`authz.enforce` has no key elsewhere in this file"*. True when written, false the moment the second block landed — the kind of claim that rots silently.

**Verified:** `python3 .github/scripts/run-gates.py --only duplicate-yaml-key-guard` passes on this branch, and the parsed `%test` block still resolves to `authz.enforce=false` with `quarkus` and `openbank` intact. No falsification run needed — the guard demonstrably fails on `main` for exactly this input.
