### PR TITLE
fix(engagement): remove the duplicate authz key that reddens main

### DIFF
--- a/openbank-engagement-service/src/main/resources/application.yaml
+++ b/openbank-engagement-service/src/main/resources/application.yaml
@@ -66,7 +66,10 @@ mp:
   # defaultValue = "true" in AuthorizeInterceptor — so under @QuarkusTest, with no OPA PDP
   # bean in the graph, every one of them answers 503 and SurfaceRestContractIT's
   # `statusCode(200)` fails. Advisory in tests only; the deployed posture is unchanged and
-  # is decided by the sidecar wired in #4068.
+  # is decided by the sidecar wired in #4068. Same pattern and same reasoning as
+  # campaign-service's application.yaml: the contract IT is about the HTTP contract, not about
+  # who may call what — that is the OPA gate plus the rego tests, neither of which needs the
+  # app running.
   authz:
     enforce: false
   quarkus:
@@ -76,13 +79,6 @@ mp:
       enabled: false
     oidc-client:
       enabled: false
-  # `authz.enforce` has no key elsewhere in this file, so the interceptor's safe default (true)
-  # applies — and with no PolicyDecisionPoint bean in a test JVM every @Authorize call fails
-  # closed (503) before the handler runs. Advisory HERE ONLY, same pattern and same reasoning as
-  # campaign-service's application.yaml: SurfaceRestContractIT is about the HTTP contract, not
-  # about who may call what — that's the OPA gate + rego tests' job, neither needs the app running.
-  authz:
-    enforce: false
   openbank:
     outbox:
       dispatch-enabled: false


### PR DESCRIPTION
## What

Removes a duplicate `authz:` key from `openbank-engagement-service`'s `%test` profile. **`main` is currently red on `duplicate-yaml-key-guard` because of it.**

## I introduced this

Resolving the `application.yaml` conflict on #4114, I took `main`'s side of what looked like a prose-only conflict — two different comments explaining the same setting — without noticing the branch already carried an `authz:` block a few lines above. The merge kept both.

My validation was `yaml.safe_load(...)` printing *"YAML parses OK"*. It does parse. A duplicate key is not a parse error, and PyYAML silently keeps the last one — which is the entire reason this gate exists. **A probe that cannot express the failure reports success.**

The removed block's own comment made the point sharper by asserting, directly above the duplicate:

> `authz.enforce` has no key elsewhere in this file

It did.

## Why it matters even though nothing broke

SmallRye/SnakeYAML keep only the **last** of a repeated mapping key and drop the rest with no error. Here both blocks said `enforce: false`, so the effective value is unchanged and no test could see it — only the gate could. The next edit to either block is where that stops being true: changing the first one would have had no effect whatsoever, silently.

## What was kept

The earlier block, because its comment explains the deployed posture and cites the sidecar wired in #4068. Folded into it the one thing the removed comment added — the campaign-service precedent — so nothing was lost with the deletion.

## Falsification

Through the **real runner**, not a hand-rolled probe:

| state | `run-gates.py --only duplicate-yaml-key-guard` |
|---|---|
| duplicate restored | **exit 1**, names `application.yaml:82:3 duplication of key "authz"` |
| one key | **exit 0**, PASS |

Worth recording: my first attempt called the checker script directly and returned `rc=2` with **zero** matches for *both* states. That is a broken probe, not a passing one — it was discarded rather than read as evidence.

Engagement tests after the edit: **24 tests, 0 failures, 0 errors**, from the JUnit XML.
