### PR TITLE
fix(libs): an open circuit breaker must not drive outbox rows to terminal DEAD

### DIFF
--- a/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/domain/event/CardEvents.kt
+++ b/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/domain/event/CardEvents.kt
@@ -10,6 +10,19 @@ import java.util.UUID
 
 sealed class CardEvent {
     abstract val cardId: UUID
+
+    /**
+     * Business time of the change, serialized into the outbox payload and read downstream as the
+     * event's business date.
+     *
+     * **Deliberately has no default.** It used to default to `Instant.EPOCH` on all four subtypes —
+     * the same shape as `AuditEvent.timestamp` / `FlagExposure.timestamp` (#3874/#3883) and
+     * `OutboxMessage.createdAt` (#3272/#3338), where the default WAS what every row got. Here it
+     * never fired: all four call sites in `CardService` pass a real clock reading, and the 24 rows
+     * parked in `card_outbox` all carry a real `occurredAt` in their payload. So this is a trap
+     * that had not sprung, and the way to keep it that way is to make omitting it a compile error
+     * rather than a silent 1970 (#4005).
+     */
     abstract val occurredAt: Instant
 }
 data class CardIssued(
@@ -19,7 +32,7 @@ data class CardIssued(
     val cardType: CardType,
     val network: CardNetwork,
     val maskedPan: String,
-    override val occurredAt: Instant = Instant.EPOCH,
+    override val occurredAt: Instant,
 ) : CardEvent()
 data class CardStatusChanged(
     override val cardId: UUID,
@@ -27,14 +40,14 @@ data class CardStatusChanged(
     val newStatus: CardStatus,
     val reason: String?,
     val changedBy: String,
-    override val occurredAt: Instant = Instant.EPOCH,
+    override val occurredAt: Instant,
 ) : CardEvent()
 data class CardLimitsChanged(
     override val cardId: UUID,
     val dailyLimitMinorUnits: Long,
     val monthlyLimitMinorUnits: Long,
     val changedBy: String,
-    override val occurredAt: Instant = Instant.EPOCH,
+    override val occurredAt: Instant,
 ) : CardEvent()
 data class CardControlsChanged(
     override val cardId: UUID,
@@ -43,5 +56,5 @@ data class CardControlsChanged(
     val atmEnabled: Boolean,
     val abroadEnabled: Boolean,
     val changedBy: String,
-    override val occurredAt: Instant = Instant.EPOCH,
+    override val occurredAt: Instant,
 ) : CardEvent()

--- a/openbank-card-issuance-service/src/test/kotlin/com/openbank/cardissuance/integration/CardOutboxBreakerOpenIT.kt
+++ b/openbank-card-issuance-service/src/test/kotlin/com/openbank/cardissuance/integration/CardOutboxBreakerOpenIT.kt
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+package com.openbank.cardissuance.integration
+
+import com.openbank.cardissuance.infrastructure.persistence.entity.CardOutboxEntity
+import com.openbank.cardissuance.infrastructure.persistence.repository.CardOutboxRepositoryImpl
+import com.openbank.libs.persistence.outbox.OutboxDispatch
+import com.openbank.libs.persistence.outbox.OutboxFailurePolicy
+import com.openbank.libs.persistence.outbox.OutboxRepository
+import com.openbank.libs.persistence.outbox.OutboxStatus
+import io.quarkus.hibernate.reactive.panache.Panache
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.vertx.VertxContextSupport
+import io.smallrye.mutiny.coroutines.asUni
+import jakarta.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import org.assertj.core.api.Assertions.assertThat
+import org.eclipse.microprofile.config.ConfigProvider
+import org.eclipse.microprofile.faulttolerance.exceptions.CircuitBreakerOpenException
+import org.junit.jupiter.api.Test
+import java.sql.DriverManager
+import java.time.Duration
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * #4005 — **an open circuit breaker must not drive outbox rows to terminal `DEAD`.**
+ *
+ * What the live table looked like: all 24 `card_outbox` rows `DEAD`, every one at
+ * `attempt_count = 10` (`OutboxFailurePolicy.DEFAULT_MAX_ATTEMPTS`), every one carrying the *same*
+ * `last_error` — `CardOutboxDispatcher#publishWithResilience circuit breaker is open`. So none of
+ * those 240 recorded "attempts" was a delivery attempt: the breaker short-circuited before the
+ * publisher was ever called, each 5 s tick re-claimed the whole batch, and ~50 s of breaker-open was
+ * enough to make every row terminal. `DEAD` is excluded from `listProcessable`, so nothing retried
+ * them again and the breaker's own half-open probe had no work left to probe with.
+ *
+ * ### Why this is an IT and not a unit test
+ * The bookkeeping under test is `markFailed`'s attempt increment plus [OutboxFailurePolicy], which
+ * lives in the repository and commits to Postgres. A mocked repository would assert only that a
+ * method was (not) called — it cannot show the row's committed status or `attempt_count`, which is
+ * the entire claim. So the repository here is the **real** [CardOutboxRepositoryImpl] against the
+ * Testcontainers Postgres, and the assertions are a plain JDBC read on a separate connection —
+ * outside the reactive session, so nothing can be answered out of a first-level cache.
+ *
+ * The publisher is the only stubbed part, because [CircuitBreakerOpenException] is precisely what a
+ * real `@CircuitBreaker` interceptor throws *instead of* invoking the publish. Driving it through
+ * the annotated `CardOutboxDispatcher.publishWithResilience` would need ten real failures plus the
+ * 5 s breaker delay to reach the same exception, i.e. a slower and timing-dependent way of
+ * producing the identical input.
+ */
+@QuarkusTest
+@QuarkusTestResource(CardOutboxDispatchIT.InMemoryKafkaResource::class)
+@QuarkusTestResource(com.openbank.cardissuance.it.PostgresRedisTestResource::class)
+class CardOutboxBreakerOpenIT {
+
+    @Inject
+    lateinit var repository: CardOutboxRepositoryImpl
+
+    private fun <T> onVertxContext(block: suspend () -> T): T = VertxContextSupport.subscribeAndAwait {
+        CoroutineScope(Dispatchers.Unconfined).async { block() }.asUni()
+    }
+
+    private fun persistPending(eventId: UUID, eventType: String) {
+        VertxContextSupport.subscribeAndAwait {
+            Panache.withTransaction {
+                val now = Instant.now()
+                repository.persist(
+                    CardOutboxEntity().apply {
+                        this.eventId = eventId
+                        this.aggregateId = UUID.randomUUID()
+                        this.eventType = eventType
+                        this.payload = """{"cardId":"${UUID.randomUUID()}"}"""
+                        this.status = OutboxStatus.PENDING.name
+                        this.attemptCount = 0
+                        this.createdAt = now
+                        this.updatedAt = now
+                    },
+                )
+            }
+        }
+    }
+
+    /** Committed row state, read over plain JDBC — deliberately not through the reactive session. */
+    private data class Row(val status: String, val attemptCount: Int, val lastError: String?)
+
+    private fun readRow(eventId: UUID): Row {
+        val config = ConfigProvider.getConfig()
+        DriverManager.getConnection(
+            config.getValue("quarkus.datasource.jdbc.url", String::class.java),
+            config.getValue("quarkus.datasource.username", String::class.java),
+            config.getValue("quarkus.datasource.password", String::class.java),
+        ).use { conn ->
+            conn.prepareStatement(
+                "SELECT status, attempt_count, last_error FROM card_outbox WHERE event_id = ?",
+            ).use { ps ->
+                ps.setObject(1, eventId)
+                ps.executeQuery().use { rs ->
+                    check(rs.next()) { "no card_outbox row for event_id=$eventId" }
+                    return Row(rs.getString(1), rs.getInt(2), rs.getString(3))
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `a breaker-open fast-fail burns no attempt and never reaches DEAD`() {
+        val eventId = UUID.randomUUID()
+        persistPending(eventId, "card.issued.v1")
+
+        // Ten ticks — the exact number that took the live rows from PENDING to DEAD.
+        repeat(OutboxFailurePolicy.DEFAULT_MAX_ATTEMPTS) {
+            onVertxContext {
+                OutboxDispatch.dispatchOnce(repository) {
+                    throw CircuitBreakerOpenException(
+                        "CardOutboxDispatcher#publishWithResilience circuit breaker is open",
+                    )
+                }
+            }
+        }
+
+        val row = readRow(eventId)
+        // Before the fix this row was DEAD with attempt_count = 10 and the breaker error stored —
+        // terminal, excluded from listProcessable, unreachable by any retry for the rest of time.
+        assertThat(row.status).isNotEqualTo(OutboxStatus.DEAD.name)
+        assertThat(row.attemptCount).isZero()
+        assertThat(row.lastError).isNull()
+    }
+
+    @Test
+    fun `the row stays reclaimable, so the breaker's half-open probe has work to probe with`() {
+        val eventId = UUID.randomUUID()
+        persistPending(eventId, "card.status_changed.v1")
+
+        // One outage tick claims the row (PENDING -> DISPATCHING) and abandons it untouched.
+        onVertxContext {
+            OutboxDispatch.dispatchOnce(repository) {
+                throw CircuitBreakerOpenException("circuit breaker is open")
+            }
+        }
+        assertThat(readRow(eventId).status).isNotEqualTo(OutboxStatus.DEAD.name)
+
+        // The breaker closes. The stale-claim reclaim — the same path that recovers a pod which
+        // died mid-batch — hands the row straight back. `Duration.ZERO` is the production window
+        // (2 min) collapsed so the test does not have to wait it out; the SQL and the transitions
+        // are the real repository's.
+        val published = mutableListOf<UUID>()
+        onVertxContext {
+            OutboxDispatch.dispatchOnce(ReclaimImmediately(repository)) { entry ->
+                published += entry.eventId
+            }
+        }
+        assertThat(published).contains(eventId)
+
+        val row = readRow(eventId)
+        assertThat(row.status).isEqualTo(OutboxStatus.SENT.name)
+        // One attempt total: the outage tick contributed nothing.
+        assertThat(row.attemptCount).isEqualTo(1)
+    }
+
+    /**
+     * The real repository with only the stale-claim window shortened, so the reclaim a live pod
+     * performs 2 minutes after an abandoned batch happens immediately here. Every statement,
+     * including the `FOR UPDATE SKIP LOCKED` claim itself, is [CardOutboxRepositoryImpl]'s.
+     */
+    private class ReclaimImmediately(private val delegate: CardOutboxRepositoryImpl) : OutboxRepository {
+        override suspend fun listProcessable(limit: Int) = delegate.listProcessable(limit)
+        override suspend fun claimProcessable(limit: Int, staleAfter: Duration) =
+            delegate.claimProcessable(limit, Duration.ZERO)
+        override suspend fun countProcessable() = delegate.countProcessable()
+        override suspend fun markSent(eventId: UUID, sentAt: Instant) = delegate.markSent(eventId, sentAt)
+        override suspend fun markFailed(eventId: UUID, error: String, failedAt: Instant) =
+            delegate.markFailed(eventId, error, failedAt)
+    }
+}

--- a/openbank-libs-domain/src/main/kotlin/com/openbank/libs/persistence/outbox/OutboxDispatch.kt
+++ b/openbank-libs-domain/src/main/kotlin/com/openbank/libs/persistence/outbox/OutboxDispatch.kt
@@ -28,21 +28,90 @@ object OutboxDispatch {
 
     const val DEFAULT_BATCH_SIZE = 25
 
+    /** Guards against a self-referencing or pathological `cause` chain in [isTransportUnavailable]. */
+    private const val MAX_CAUSE_DEPTH = 10
+
+    /**
+     * Fault-tolerance exceptions that are thrown **instead of** invoking the publish, matched by
+     * fully-qualified class name.
+     *
+     * Name matching, not `is CircuitBreakerOpenException`: this module has zero framework imports
+     * (ADR-0002/ADR-0122, `check-domain-purity.py`), and a hard reference would also risk a
+     * `NoClassDefFoundError` in a service that has no fault-tolerance extension on its classpath.
+     *
+     * Both are *system* signals, not row signals. `CircuitBreakerOpenException` means the breaker
+     * is open — the interceptor short-circuits and the publisher is never called;
+     * `BulkheadException` means the concurrency permit was refused, likewise before invocation.
+     * Neither says anything about the row, so neither may consume the row's attempt budget.
+     * `TimeoutException` is deliberately **not** here: a timeout can fire after the record already
+     * reached the broker, so it must keep counting as a real attempt.
+     */
+    val TRANSPORT_UNAVAILABLE_EXCEPTIONS: Set<String> = setOf(
+        "org.eclipse.microprofile.faulttolerance.exceptions.CircuitBreakerOpenException",
+        "org.eclipse.microprofile.faulttolerance.exceptions.BulkheadException",
+    )
+
+    /** True when [error] (or any cause of it) is one of [TRANSPORT_UNAVAILABLE_EXCEPTIONS]. */
+    fun isTransportUnavailable(error: Throwable?): Boolean {
+        var current = error
+        var depth = 0
+        while (current != null && depth < MAX_CAUSE_DEPTH) {
+            if (current.javaClass.name in TRANSPORT_UNAVAILABLE_EXCEPTIONS) return true
+            val next = current.cause
+            if (next === current) return false
+            current = next
+            depth++
+        }
+        return false
+    }
+
+    /**
+     * Publish one claimed batch.
+     *
+     * **A fast-fail from an open breaker is not a delivery attempt (#4005).** `markFailed`
+     * increments `attempt_count` and applies [OutboxFailurePolicy], so counting a
+     * `CircuitBreakerOpenException` against a row lets a broker outage — not a poison payload —
+     * drive rows to terminal `DEAD`. Measured on card-issuance: the breaker opened, every tick
+     * re-claimed the same 24 rows, each fast-failed in microseconds, and 10 ticks (~50 s) later
+     * all 24 were `DEAD` with `last_error = "... circuit breaker is open"` — never once actually
+     * offered to Kafka. `DEAD` is terminal and excluded from `listProcessable`, so nothing ever
+     * retried them again: the breaker healed on the next pod restart, the rows did not, and the
+     * breaker's own half-open probe had no work left to probe with.
+     *
+     * So on that signal the batch is **abandoned untouched**: no `markFailed`, no attempt burned.
+     * The rows a claiming repository already flipped to `DISPATCHING` are picked up again by its
+     * stale-claim reclaim (the same path that recovers a pod which died mid-batch); a repository
+     * on the unclaimed-peek default sees them again on the very next tick. Either way the work
+     * stays processable, which is what lets the breaker close on its own.
+     *
+     * A row still reaches `DEAD` after [OutboxFailurePolicy.DEFAULT_MAX_ATTEMPTS] *real* failed
+     * publishes — that is the poison-row case `DEAD` exists for (ADR-0050 N5) and is unchanged.
+     */
     suspend fun dispatchOnce(
         repository: OutboxRepository,
         batchSize: Int = DEFAULT_BATCH_SIZE,
         publish: suspend (entry: OutboxEntry) -> Unit,
     ) {
-        runCatching { repository.claimProcessable(batchSize) }
+        val claimed = runCatching { repository.claimProcessable(batchSize) }
             .onFailure { ex -> log.log(System.Logger.Level.WARNING, "outbox.claimProcessable failed", ex) }
-            .getOrNull()
-            ?.forEach { entry ->
-                try {
-                    publish(entry)
-                    repository.markSent(entry.eventId)
-                } catch (ex: Exception) {
-                    repository.markFailed(entry.eventId, ex.message ?: ex.javaClass.simpleName)
+            .getOrNull() ?: return
+
+        for ((index, entry) in claimed.withIndex()) {
+            try {
+                publish(entry)
+                repository.markSent(entry.eventId)
+            } catch (ex: Exception) {
+                if (isTransportUnavailable(ex)) {
+                    log.log(
+                        System.Logger.Level.WARNING,
+                        "outbox.dispatch abandoned: transport unavailable (${ex.javaClass.name}), " +
+                            "${claimed.size - index} row(s) left for the next tick — no attempt consumed",
+                        ex,
+                    )
+                    return
                 }
+                repository.markFailed(entry.eventId, ex.message ?: ex.javaClass.simpleName)
             }
+        }
     }
 }

--- a/openbank-libs-domain/src/test/kotlin/com/openbank/libs/persistence/outbox/OutboxDispatchTest.kt
+++ b/openbank-libs-domain/src/test/kotlin/com/openbank/libs/persistence/outbox/OutboxDispatchTest.kt
@@ -116,7 +116,7 @@ class OutboxDispatchTest {
         runBlocking {
             OutboxDispatch.dispatchOnce(repo) { e ->
                 attempted += e.eventId
-                if (e.eventType == "poison") throw IllegalStateException("serialization failed")
+                if (e.eventType == "poison") error("serialization failed")
             }
         }
 

--- a/openbank-libs-domain/src/test/kotlin/com/openbank/libs/persistence/outbox/OutboxDispatchTest.kt
+++ b/openbank-libs-domain/src/test/kotlin/com/openbank/libs/persistence/outbox/OutboxDispatchTest.kt
@@ -68,4 +68,75 @@ class OutboxDispatchTest {
         assertThat(repo.failed.single().first).isEqualTo(row.eventId)
         assertThat(repo.failed.single().second).isEqualTo("kafka down")
     }
+
+    private fun breakerOpen() =
+        org.eclipse.microprofile.faulttolerance.exceptions.CircuitBreakerOpenException("circuit breaker is open")
+
+    @Test
+    fun `an open breaker consumes no attempt and abandons the rest of the batch`() {
+        val rows = listOf(entry("a.created"), entry("b.created"), entry("c.created"))
+        val repo = FakeRepo(rows)
+        val attempted = mutableListOf<UUID>()
+
+        runBlocking {
+            OutboxDispatch.dispatchOnce(repo) { e ->
+                attempted += e.eventId
+                throw breakerOpen()
+            }
+        }
+
+        // The first row is the only one offered; the batch stops there rather than burning an
+        // attempt on every remaining row (#4005: 24 rows x 10 ticks -> all DEAD in ~50 s).
+        assertThat(attempted).containsExactly(rows[0].eventId)
+        assertThat(repo.failed).isEmpty()
+        assertThat(repo.sent).isEmpty()
+    }
+
+    @Test
+    fun `a breaker-open cause nested under another exception is still not an attempt`() {
+        val row = entry("nested")
+        val repo = FakeRepo(listOf(row))
+
+        runBlocking {
+            OutboxDispatch.dispatchOnce(repo) {
+                throw IllegalStateException("wrapped", breakerOpen())
+            }
+        }
+
+        assertThat(repo.failed).isEmpty()
+        assertThat(repo.sent).isEmpty()
+    }
+
+    @Test
+    fun `a real publish failure still counts, so a poison row still reaches DEAD`() {
+        val rows = listOf(entry("poison"), entry("healthy"))
+        val repo = FakeRepo(rows)
+        val attempted = mutableListOf<UUID>()
+
+        runBlocking {
+            OutboxDispatch.dispatchOnce(repo) { e ->
+                attempted += e.eventId
+                if (e.eventType == "poison") throw IllegalStateException("serialization failed")
+            }
+        }
+
+        // Unlike a breaker fast-fail, a genuine failure is recorded AND the batch continues.
+        assertThat(attempted).containsExactly(rows[0].eventId, rows[1].eventId)
+        assertThat(repo.failed.map { it.first }).containsExactly(rows[0].eventId)
+        assertThat(repo.sent).containsExactly(rows[1].eventId)
+    }
+
+    @Test
+    fun `a timeout is NOT treated as transport-unavailable`() {
+        // A @Timeout can fire after the record already reached the broker, so it must keep
+        // counting as a real attempt — otherwise the row is retried and the consumer sees a
+        // duplicate. Deliberately excluded from TRANSPORT_UNAVAILABLE_EXCEPTIONS.
+        assertThat(
+            OutboxDispatch.isTransportUnavailable(
+                java.util.concurrent.TimeoutException("publish timed out"),
+            ),
+        ).isFalse()
+        assertThat(OutboxDispatch.isTransportUnavailable(breakerOpen())).isTrue()
+        assertThat(OutboxDispatch.isTransportUnavailable(null)).isFalse()
+    }
 }

--- a/openbank-libs-domain/src/test/kotlin/org/eclipse/microprofile/faulttolerance/exceptions/CircuitBreakerOpenException.kt
+++ b/openbank-libs-domain/src/test/kotlin/org/eclipse/microprofile/faulttolerance/exceptions/CircuitBreakerOpenException.kt
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package org.eclipse.microprofile.faulttolerance.exceptions
+
+/**
+ * Test-only stand-in for the MicroProfile exception of the same fully-qualified name (#4005).
+ *
+ * `openbank-libs-domain` has zero framework dependencies — not even `compileOnly` ones
+ * (ADR-0002/ADR-0122, enforced by `check-domain-purity.py`) — so the real
+ * `microprofile-fault-tolerance-api` artifact is on no classpath of this module, and there is
+ * nothing here for this declaration to collide with. `OutboxDispatch` classifies by
+ * `javaClass.name`, so the *name* is the whole contract under test: a stand-in in another package
+ * would assert nothing about the real signal.
+ *
+ * The real class is exercised end-to-end, through a real CDI `@CircuitBreaker` interceptor and a
+ * real Postgres, in `openbank-card-issuance-service`'s `CardOutboxBreakerOpenIT`.
+ */
+class CircuitBreakerOpenException(message: String) : RuntimeException(message)


### PR DESCRIPTION
## What this is

`Refs #4005.` The issue names **three** things that had to be separated before anything could be
fixed, because only one of them is a live code defect:

| Claim | Verdict |
|---|---|
| 24 `card_outbox` rows stuck `DEAD`, service has published zero events | **True and still true today.** Re-measured on the live DB (below). |
| An open circuit breaker with no self-healing path | **The breaker is long gone; the parking is permanent.** Breaker state is in-memory, so the fault cleared on the next pod restart. `DEAD` is terminal and excluded from `listProcessable`, so the rows never came back — and the breaker's half-open probe had no work left to probe with. |
| `created_at` stamped 1970 | **The already-fixed `Instant.EPOCH` family (#3272/#3338), not a live defect.** `OutboxMessage.createdAt` and `markSent`/`markFailed`'s timestamps defaulted to `Instant.EPOCH`; `0306c7c81` fixed that in libs on 2026-08-02. All 24 rows were last written on or before 2026-08-01 (`claimed_at`), i.e. they predate the fix. New rows stamp correctly. |

The issue also flags `CardEvents.occurredAt = Instant.EPOCH` as the `#3874`/`#3883` class and predicts
those events will publish with a 1970 business date. **That prediction is wrong, and the check is one
query.** All four call sites in `CardService` pass a real clock reading, and every one of the 24
parked payloads carries a real `occurredAt`:

```
card.controls_changed.v1 | 6 | null occurredAt: 0 | 2026-07-23T20:35:00Z .. 2026-07-30T18:57:15Z
card.issued.v1           | 6 | null occurredAt: 0 | 2026-07-23T18:59:30Z .. 2026-08-01T08:36:16Z
card.limits_changed.v1   | 9 | null occurredAt: 0 | 2026-07-24T10:34:32Z .. 2026-07-25T05:14:25Z
card.status_changed.v1   | 3 | null occurredAt: 0 | 2026-07-25T08:56:50Z .. 2026-07-31T10:17:49Z
```

So it is a **trap that had not sprung**, not corruption — the distinction this repo already insists on
before calling a wrong-looking value a live defect. The fix here is therefore to make omitting it a
compile error, not to chase data.

## The actual defect: a breaker fast-fail was counted as a delivery attempt

Every one of the 24 rows is at `attempt_count = 10` (`OutboxFailurePolicy.DEFAULT_MAX_ATTEMPTS`) with
the *same* `last_error`:

```
com.openbank.cardissuance.infrastructure.outbox.CardOutboxDispatcher#publishWithResilience
  circuit breaker is open
```

`OutboxDispatch.dispatchOnce` caught every `Exception` and called `markFailed`, which increments
`attempt_count` and applies `OutboxFailurePolicy`. But `CircuitBreakerOpenException` is thrown by the
interceptor **instead of** invoking the publisher — nothing was ever offered to Kafka. With a 5 s tick
and a 25-row batch, the whole backlog was re-claimed and re-"failed" every tick, so roughly **50
seconds of an open breaker was enough to make all 24 rows terminal**. `DEAD` is for a poison row that
can never be published (ADR-0050 N5); a broker outage is not that, and it had the entire fleet's
outbox one brief Kafka blip away from permanent loss. `billing_outbox` carries 2 rows in exactly the
same state, same error.

### The change

`OutboxDispatch.dispatchOnce` now classifies `CircuitBreakerOpenException` and `BulkheadException` —
both thrown *before* invocation — as a **system** signal rather than a row signal, and abandons the
batch untouched: no `markFailed`, no attempt consumed. The rows a claiming repository already flipped
to `DISPATCHING` come back via its stale-claim reclaim (the same path that recovers a pod which died
mid-batch); a repository on the unclaimed-peek default sees them again on the next tick. Either way
the work stays processable, which is precisely what gives the breaker's half-open probe something to
probe with. **That is the self-healing path the issue says is missing.**

Deliberately **not** included: `TimeoutException`. A timeout can fire after the record already reached
the broker, so it must keep counting as a real attempt.

Matching is by fully-qualified class name, not `is CircuitBreakerOpenException`: `openbank-libs-domain`
has zero framework dependencies (ADR-0002/ADR-0122, `check-domain-purity.py`), and a hard reference
would also risk `NoClassDefFoundError` in a service with no fault-tolerance extension.

A poison row still reaches `DEAD` after 10 *real* failed publishes. That behaviour is unchanged and is
asserted.

## Can this republish events consumers have already seen?

**No — not from this change.** The two exempted exceptions are thrown *instead of* invoking the
publish, so a row skipped by this branch provably never reached the broker; declining to burn its
attempt cannot produce a duplicate. `TimeoutException`, the one failure mode that *can* leave a record
at the broker, is excluded from the exemption for exactly that reason.

What the change does do is widen the window in which a row is retried: under a long outage rows now
retry indefinitely instead of dying after ~50 s. The pre-existing at-least-once property of the outbox
(a crash between a successful publish and `markSent` replays the row) is unchanged in kind.

**The remediation of the 24 parked rows is a different answer — see below.**

## What is NOT in this PR

**The 24 rows are not fixed by any code change, and I have not touched the database.** They are
terminal; nothing in the system will ever move them. But they are **not lost**: every payload is
intact (24/24 non-empty, 24 distinct `event_id`), so this is a requeue, not a reconstruction.

Proposed one-off remediation, **for the owner to run, not an agent**:

```sql
-- card_outbox: requeue the 24 breaker-killed rows. claimed_at is the honest timestamp —
-- created_at/updated_at are the pre-0306c7c81 epoch default, and left at 1970 these rows
-- sort ahead of every future entry in the ORDER BY created_at ASC claim.
UPDATE card_outbox
   SET status = 'PENDING', attempt_count = 0, last_error = NULL,
       created_at = claimed_at, updated_at = now()
 WHERE status = 'DEAD';
```

Three things the owner should weigh first, which the issue does not raise:

1. **3 of the 24 rows point at an aggregate that no longer exists.** `LEFT JOIN cards` on
   `aggregate_id`: 2 `card.issued.v1` and 1 `card.controls_changed.v1` reference a card that is not in
   the `cards` table (24 rows span 6 aggregates; `cards` holds 4). Replaying a `card.issued.v1` for a
   deleted card creates a downstream projection for a card that does not exist.
2. **These are 6-to-15-day-old lifecycle events published as current.** `limits_changed` /
   `controls_changed` / `status_changed` are last-write-wins state transitions — replaying in
   `claimed_at` order is correct, replaying an old value over a newer one set by another path is not.
3. **Do one row first.** Requeue a single `card.issued.v1`, confirm it reaches `SENT` and that a
   consumer handled it, before releasing the other 23.

Also still open and not addressed here: **`DEAD > 0` on a money-path outbox is silent** — the table is
the only place it shows. That is the general form of #3345 and is what stops this recurring; it needs
its own PR. Hence `Refs`, not `Closes`.

## Tests — red then green

Counts read from the JUnit XML, not the console.

`openbank-libs-domain` `OutboxDispatchTest`, with **only** the new branch disabled in
`dispatchOnce` (same test file, same public API, so this is a behaviour failure and not a compile
failure masquerading as one):

```
RED  : tests=6 failures=2 errors=0 skipped=0
GREEN: tests=6 failures=0 errors=0 skipped=0
```

The two that flip are the ones that describe the defect:

```
OutboxDispatchTest > an open breaker consumes no attempt and abandons the rest of the batch() FAILED
OutboxDispatchTest > a breaker-open cause nested under another exception is still not an attempt() FAILED
```

The other four pass in both variants **by design** — they are the over-reach guards, and a change that
made them flip would be a change that had gone too far: a genuine publish failure must still count (so
a poison row still reaches `DEAD`), and a `TimeoutException` must still not be exempt.

`openbank-card-issuance-service` `CardOutboxBreakerOpenIT` is the half a mocked repository cannot
prove, since the claim under test is the row's *committed* `status` and `attempt_count`. It runs the
**real** `CardOutboxRepositoryImpl` against the Testcontainers Postgres and asserts over a plain JDBC
read on a separate connection, so nothing can be answered out of a first-level cache. It drives ten
breaker-open ticks — the exact count that took the live rows from `PENDING` to `DEAD` — and asserts the
row is not `DEAD`, `attempt_count` is 0 and `last_error` is null; then that the row is reclaimable and
settles `SENT` with exactly one attempt once the breaker closes.

Measured the same way, against a real Postgres:

```
RED  : tests=2 failures=2 errors=0 skipped=0
GREEN: tests=2 failures=0 errors=0 skipped=0
```

and the RED is the live defect reproduced verbatim, not a proxy for it:

```
a breaker-open fast-fail burns no attempt and never reaches DEAD()
  java.lang.AssertionError: Expecting actual: "DEAD" not to be equal to: "DEAD"
the row stays reclaimable, so the breaker's half-open probe has work to probe with()
  org.opentest4j.AssertionFailedError: expected: 1 but was: 2
```

## Local gate

`./gradlew :openbank-libs-domain:test :openbank-libs-domain:ktlintCheck :openbank-libs-domain:detekt
:openbank-card-issuance-service:test :openbank-card-issuance-service:ktlintCheck
:openbank-card-issuance-service:detekt :openbank-card-issuance-service:quarkusBuild` — `BUILD
SUCCESSFUL`, with all eight tasks present in the output (Gradle stops at the first failure, so a
green task list is only worth as much as the tasks that appear in it). `check-domain-purity.py`
reports 0 new violations.

The `Customer-app dossier` check is red on this PR and is **not** caused by it: the committed
`app-status.json` says version 0.18.0 while the openbank-app source is at 0.19.0. It is red on every
other open PR too (#4161, #4158, #4156, #4155; last green on #4153) and needs its own regeneration PR.

## Other changes

`CardEvents.occurredAt` loses its `Instant.EPOCH` default on all four subtypes (see the table above —
no call site relied on it, so this is compile-safe and turns a silent 1970 into a compile error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
