### PR TITLE
chore(admin-ui): regenerate app-status.json from openbank-app source

### DIFF
--- a/openbank-admin-ui/app-status.json
+++ b/openbank-admin-ui/app-status.json
@@ -12,7 +12,7 @@
   "asOf": "2026-07-29",
   "appRepo": "JiRaska/openbank-app",
   "derived": {
-    "version": "0.18.0",
+    "version": "0.19.0",
     "useFakeData": false,
     "edgeBaseUrl": "https://customer.open-bank.tech",
     "keycloakIssuer": "https://kc.open-bank.tech/realms/openbank-customers",


### PR DESCRIPTION
## What

Regenerates the derived `openbank-admin-ui/app-status.json` block from the `openbank-app` source. One field: `derived.version` `0.18.0` -> `0.19.0`.

## Why

The `Customer-app dossier` job's `Regenerate & diff derived block` step is failing on **every open PR**, and is not caused by any of them:

```
##[error]the committed app-status.json no longer matches openbank-app source (1 field(s)). Regenerate & publish.
  derived-block drift:
    version: committed="0.18.0" -> regenerated="0.19.0"
```

Confirmed red on #4163, #4161, #4158, #4156, #4155; last green on #4153. `openbank-app` moved to 0.19.0 and the committed copy was left behind.

## How

Not hand-edited — derived data (ADR-0074). Ran the same command the workflow runs, in write mode:

```
node scripts/generate-app-status.mjs --app-repo <openbank-app checkout>
```

against a fresh clone of `JiRaska/openbank-app` default branch @ `4293b9b5b` (`version.txt` = `0.19.0`).

## Verification

- Before the regen, the workflow's exact enforce command reproduced the failure locally (exit 1, identical drift line).
- After, `node scripts/generate-app-status.mjs --app-repo <checkout> --against app-status.json --enforce --check` prints `derived block matches the committed app-status.json` and exits 0.
- `asOf`, capabilities (18: live=13, partial=4, planned=1) and every other derived field are unchanged — the generator rewrote only the one drifted field.

Precedent: 6a7d8f4da `chore(admin-ui): regenerate app-status.json from openbank-app source (#3917)`.

`chore` type is release-hidden, so this cuts no admin-ui release.
