### PR TITLE
fix(infra): bind transaction-service Temporal env to the openbank.temporal prefix

### DIFF
--- a/openbank-infra/gitops/components/payments/payments-services.yaml
+++ b/openbank-infra/gitops/components/payments/payments-services.yaml
@@ -130,13 +130,16 @@ spec:
             # ADR-0120 Phase 1: Temporal payment orchestration — flag ON.
             # Worker connects to temporal-frontend.temporal.svc:7233 (namespace=openbank-payments,
             # queue=openbank-payment-execution). NetworkPolicy allows payments→temporal:7233.
-            - name: OPENBANK_TRANSACTION_ORCHESTRATION_TEMPORAL_ENABLED
+            # ADR-0209 D1 (#2572) moved the binding prefix to `openbank.temporal` — the
+            # OPENBANK_TRANSACTION_ORCHESTRATION_TEMPORAL_* names below were read by nothing, so the
+            # worker fell back to the @WithDefault localhost:7233 and the pod died at StartupEvent.
+            - name: OPENBANK_TEMPORAL_ENABLED
               value: "true"
-            - name: OPENBANK_TRANSACTION_ORCHESTRATION_TEMPORAL_SERVER_URL
+            - name: OPENBANK_TEMPORAL_SERVER_URL
               value: temporal-frontend.temporal.svc.cluster.local:7233
-            - name: OPENBANK_TRANSACTION_ORCHESTRATION_TEMPORAL_NAMESPACE
+            - name: OPENBANK_TEMPORAL_NAMESPACE
               value: openbank-payments
-            - name: OPENBANK_TRANSACTION_ORCHESTRATION_TEMPORAL_TASK_QUEUE
+            - name: OPENBANK_TEMPORAL_TASK_QUEUE
               value: openbank-payment-execution
             # OPA sidecar is deployed (ADR-0034 Phase 5, issue #266). AUTHZ_ENFORCE=true
             # enables the @Authorize HTTP interceptor to enforce decisions from


### PR DESCRIPTION
## Incident

`transaction-service` has been in `CrashLoopBackOff` since ~06:59Z today (70+ restarts). Blast radius:

- every domestic payment strands in `SENT_TO_CLEARING` — `SettlementAdapter` calls transaction-service, and `DomesticPaymentActivitiesImpl` logs `Settlement unavailable ...; holding in SENT_TO_CLEARING`, then the workflow **completes** on that terminal status. Live example: payment `2691ef92-2ff5-49cc-a53b-dc016b089b93`, 700 CZK, 11:35:03Z. No ledger entry, so no money moved (ledger `max(entry_number)` still 280).
- transaction history is empty for **all** customers.

## Causal chain

1. `TemporalConfig` is `@ConfigMapping(prefix = "openbank.temporal")` (`openbank-libs-temporal`). ADR-0209 D1 (#2572) moved the in-repo `application.yaml` keys to that prefix. The Rollout kept `OPENBANK_TRANSACTION_ORCHESTRATION_TEMPORAL_*` — read by nothing.
2. So `serverUrl()` resolved to the `@WithDefault("localhost:7233")`. `PaymentWorkerRegistrar.onStart` runs `WorkerFactory.start` at `StartupEvent`, which fails `Connection refused: localhost/127.0.0.1:7233` and kills the boot.
3. That aborted the revision-89 canary (`RolloutAborted: Rollout aborted update to revision 89`) — but only **after** the canary had applied Flyway `V16__create_merchant_catalog` at 02:10Z.
4. The stable ReplicaSet runs `sandbox-a5e5d32a`, an image without V16, so it now fails validation too: `Detected applied migration not resolved locally: 16`. Forward-only migrations make the rollback target unbootable — both sides dead, no self-healing path.

Every other Temporal consumer in this file already uses `OPENBANK_TEMPORAL_*`; transaction-service was the only holdout, and it is the only one whose worker registers at boot rather than lazily.

## Change

Rename the four env vars to the prefix that is actually bound. No image change — `sandbox-93429152` (already the desired image, and it contains V16) boots once the URL resolves.

## Verification

- `@ConfigMapping(prefix = "openbank.temporal")` read off `origin/main`, not a local snapshot.
- `git merge-base --is-ancestor 78139e03d 93429152b` — desired image contains V16; the same check against `a5e5d32a0` fails, which is exactly why stable cannot boot.
- Post-merge: watch the Rollout reach `Healthy`, then re-drive the stranded payment through Temporal (not `PATCH /status`, which flips state without a ledger entry).

## Follow-ups (not in this PR)

- Nothing gates that a `@ConfigMapping` prefix rename is mirrored in the GitOps env vars — the rename shipped in #2572 and this manifest kept the dead names for weeks with no signal.
- `SettlementUnavailableException` produces a **Completed** workflow on a non-terminal business state. A stranded payment needs a retry timer or a compensating path, not a green workflow.
- `FraudScoringAdapter` logs `Connection refused: localhost/127.0.0.1:8133` and degrades to shadow ALLOW — same "localhost default in a cluster" shape, separate service.

Refs #4010
