### PR TITLE
fix(engagement): remove the duplicate %test authz key that regressed onto main

### DIFF
--- a/openbank-engagement-service/src/main/resources/application.yaml
+++ b/openbank-engagement-service/src/main/resources/application.yaml
@@ -93,13 +93,6 @@ mp:
       enabled: false
     oidc-client:
       enabled: false
-  # `authz.enforce` has no key elsewhere in this file, so the interceptor's safe default (true)
-  # applies — and with no PolicyDecisionPoint bean in a test JVM every @Authorize call fails
-  # closed (503) before the handler runs. Advisory HERE ONLY, same pattern and same reasoning as
-  # campaign-service's application.yaml: SurfaceRestContractIT is about the HTTP contract, not
-  # about who may call what — that's the OPA gate + rego tests' job, neither needs the app running.
-  authz:
-    enforce: false
   openbank:
     outbox:
       dispatch-enabled: false


### PR DESCRIPTION
## `main` is red on `duplicate-yaml-key-guard` again

The `%test` profile of `openbank-engagement-service` carries two `authz:` mappings. SmallRye/SnakeYAML keep only the **last** and drop the rest with no error — the entire reason that gate exists.

## This is a regression, and the mechanism is the point

```
fac75d19e   0 keys
93429152b   1 key
75ed48229   2 keys   <- introduced   (#4128, 05:01Z)
d0af48b68   1 key    <- fixed        (#4160, 06:25Z)
fb5c455bc   2 keys   <- REINTRODUCED (#4106, 12:38Z)
```

**#4106 merged with no failing checks.** It added 22 lines to this file and deleted none, because its branch was cut *before* #4160 landed — so its CI was evaluated against its own creation-time base, where the second block was still the only one. Nothing was wrong anywhere: the gate cannot catch a defect absent from the tree it ran against. The merge simply restored what a later commit had removed.

That is the frozen `base.sha` race this repo already documents (#481 × #524). The lever that prevents it is `strict_required_status_checks_policy` — require branches up to date before merging — which is also the only one available here, since merge queue returns `422 Invalid rule 'merge_queue'` on a personal-account repo.

**So expect a third occurrence.** Any open PR whose branch predates this fix and touches this file will do it again. Worth checking #3702 in particular.

## What was removed

The **second** block — the one #4160 removed and #4106 restored. Its comment asserts, directly above itself:

> `authz.enforce` has no key elsewhere in this file

The surviving block above **is** that key. The survivor's comment is also the better of the two: it cites the #4128 measurement ("removing this key alone turns all four of those tests red with 503") and the #4068 sidecar decision.

Effective value is unchanged — `enforce: false` either way. That is why no test can see this and only the gate can, and why the damage is deferred: the next edit to the *first* block would have had no effect at all, silently.

## Verified

| check | result |
|---|---|
| `authz:` keys | 1 |
| `run-gates.py --only duplicate-yaml-key-guard` | **PASS** |
| `:openbank-engagement-service:test` | **32 tests, 0 failures, 0 errors** (JUnit XML, not console) |

Supersedes my #4161, which was closed as a duplicate of #4160 — correctly, since #4160 was first and landed.
