### PR TITLE
fix(domestic-payment): make validatePayment re-entrant so a stranded payment can be re-driven

### DIFF
--- a/openbank-domestic-payment/src/main/kotlin/com/openbank/domestic/application/workflow/DomesticPaymentActivitiesImpl.kt
+++ b/openbank-domestic-payment/src/main/kotlin/com/openbank/domestic/application/workflow/DomesticPaymentActivitiesImpl.kt
@@ -129,6 +129,13 @@ open class DomesticPaymentActivitiesImpl(
     override fun validatePayment(paymentId: UUID): Unit = vtx {
         val payment = paymentRepository.findById(paymentId)
             ?: error("Payment $paymentId not found during validate activity")
+        // RECEIVED is the only status that may become VALIDATED, so on a payment that already
+        // moved past this step there is nothing to do. Without the early return a re-drive of a
+        // stranded payment dies here on "Invalid domestic payment status transition" and never
+        // reaches settlePayment — which is the step that would actually recover it, and which is
+        // idempotent (payment-scoped key, 409 = already booked). submitScheme and settlePayment
+        // below both carry the same guard; validate was the one activity that did not (#4182).
+        if (payment.status != DomesticPaymentStatus.RECEIVED) return@vtx Unit
         val updated = payment.transitionTo(DomesticPaymentStatus.VALIDATED, clock = clock)
         paymentRepository.update(
             payment = updated,

--- a/openbank-domestic-payment/src/test/kotlin/com/openbank/domestic/application/workflow/DomesticPaymentActivitiesImplTest.kt
+++ b/openbank-domestic-payment/src/test/kotlin/com/openbank/domestic/application/workflow/DomesticPaymentActivitiesImplTest.kt
@@ -215,6 +215,20 @@ class DomesticPaymentActivitiesImplTest {
     }
 
     @Test
+    fun `validatePayment is a no-op on a payment that already moved past validation`() {
+        // A payment stranded in SENT_TO_CLEARING is recovered by re-driving the workflow, which
+        // replays every activity from the top. Without the guard this call throws "Invalid
+        // domestic payment status transition: SENT_TO_CLEARING -> VALIDATED" and the re-drive
+        // never reaches settlePayment — the step that actually recovers it (#4182).
+        val payment = payment(status = DomesticPaymentStatus.SENT_TO_CLEARING)
+        coEvery { paymentRepository.findById(payment.id) } returns payment
+
+        activities.validatePayment(payment.id)
+
+        coVerify(exactly = 0) { paymentRepository.update(any(), any()) }
+    }
+
+    @Test
     fun `rejectPayment transitions to REJECTED with SANCTIONS_HIT reason`() {
         val payment = payment()
         coEvery { paymentRepository.findById(payment.id) } returns payment


### PR DESCRIPTION
## Why

A live payment (700 CZK, `2691ef92-2ff5-49cc-a53b-dc016b089b93`) is stranded in `SENT_TO_CLEARING` after the transaction-service outage fixed in #4178. It cannot be recovered, and the reason is one missing early return.

Three activities in `DomesticPaymentActivitiesImpl` run in sequence on a re-drive. Two are re-entrant:

```kotlin
// submitScheme:192
if (payment.status != DomesticPaymentStatus.VALIDATED) return@vtx payment.status
// settlePayment:234
if (payment.status != DomesticPaymentStatus.SENT_TO_CLEARING) return@vtx payment.status
```

`validatePayment:129` had no such guard and went straight to `transitionTo(VALIDATED)`. So re-driving the workflow dies at the second activity:

```
Invalid domestic payment status transition: SENT_TO_CLEARING -> VALIDATED
```

— before ever reaching `settlePayment`, which is both the step that recovers the payment and safe to replay: `SettlementAdapter`'s idempotency key is payment-scoped and HTTP 409 is treated as an already-booked success.

Nothing else can recover such a payment. `ScreeningRedriveScheduler` sweeps `RECEIVED` only, and this service has no `@Incoming` consumer at all (dead channels removed in #377). `SENT_TO_CLEARING` is a terminal state in practice with no reader — the gap #4182 describes.

## What

Add the guard its two siblings already carry. `canTransitionTo` allows only `RECEIVED -> VALIDATED`, so this changes nothing on the forward path — it only stops the replay from throwing.

## Verification

The test was falsified before being trusted, not just run green:

- with the guard: 25 tests, 0 failures.
- with the guard temporarily removed: exactly 1 failure, and on the real defect — `java.lang.IllegalArgumentException: Invalid domestic payment status transition: SENT_TO_CLEARING -> VALIDATED`.

Both readings are off the JUnit XML (`tests=`/`failures=` plus the failing testcase name), not off the console.

## What this does NOT do

It does not make a stranded payment recover on its own — a human still has to start the re-drive workflow. The missing sweeper, and the workflow completing `COMPLETED` on a non-terminal business status in the first place, are #4182.

## Deliberately not done

- Rewinding the payment's status to `VALIDATED` in the DB and re-driving: `submitScheme` would submit a **second** item to the clearing scheme.
- `PATCH /api/v1/domestic-payments/{id}/status` to `SETTLED`: flips state without calling `settlementPort.settle()`, producing a settled payment with no ledger entry.

Money-path service: needs 2 approvals and a threat-model review per ADR-0030.

Refs #4182, #4178
