### PR TITLE
feat(case-coordinator): add Temporal CaseWorkflow swarm lifecycle

### DIFF
--- a/docs/agents/case-coordinator.md
+++ b/docs/agents/case-coordinator.md
@@ -33,17 +33,40 @@ disposes before any state changes.
 - Case budgets, deadlines, and contested-rate thresholds are declared in `agents.yaml` under
 `case_classes`, so they are reviewable and versioned with the same governance rigor as tool tiers.
 
+## Phase 1 runtime (as-built, #4181)
+
+The `openbank-case-coordinator-agent` module now runs the case lifecycle:
+
+- **`CaseWorkflow`** (Temporal workflow type `CaseWorkflow`, task queue `case-coordinator`) — a
+  deterministic state machine that accepts `contribute` / `contest` / `request-synthesis` signals,
+  enforces the per-case-class contribution cap and deadline (TTL), applies pre-emption by draft
+  version, trips the contested-rate breaker, and exits **only** through a single terminal synthesis
+  activity — so the "exactly one proposal per case" invariant holds even under a signal storm.
+- **Capability gate** — `CaseCapabilityGate` checks `case.open`/`case.contribute`/`case.synthesize`
+  against `agents.yaml` (fail-closed). This is the Phase 1 placeholder for the OPA-gated check;
+  wiring the gate to the OPA sidecar bundle is Phase 4 work.
+- **REST** — `POST /api/v1/case-coordinator/cases` opens a case (201/202/400/403/409/429/503
+  depending on dedup, rate-limit, concurrent-ceiling and Temporal-availability outcomes) and
+  `POST /api/v1/case-coordinator/cases/{id}/signals` delivers signals to a running workflow.
+  Case opens are deduplicated by deterministic workflow id (`case-<class>-<subject>`,
+  REJECT_DUPLICATE) and rate-limited per opening agent.
+- **Outbox** — the terminal proposal event is published transactionally via the shared outbox
+  pattern (`case_outbox` table, V2 migration) to the `proposal-events` Kafka topic; the proposal
+  itself is consumed by the existing ADR-0031 HITL queue, which owns human disposition.
+- **LLM synthesis** — the convergence judgement is an LLM call through the prompt registry
+  (`CaseCoordinatorLlmPort`/`Adapter`), never a silent deterministic shortcut.
+
 ## Known gaps (these are real, not aspirational)
 
-- **There is no `openbank-case-coordinator-agent` module yet.** This charter is the governance
-scaffold; the Quarkus service, Temporal workflow, signal handler, and OPA-gated capability check
-are follow-up work tracked by ADR-0244 delivery notes.
 - **No other charter currently grants `case.join` or `case.contribute`.** The coordinator is the only
-swarm participant defined today; other agents will gain swarm capabilities only after the signal
-contract and policy gate are implemented.
+  swarm participant defined today; other agents will gain swarm capabilities only after the signal
+  contract and policy gate are implemented.
 - **The kill-switch-to-Temporal-cancellation wiring is not built.** The global and per-agent kill
-switches can halt agent runtimes today, but canceling an in-flight case workflow requires a new
-hook that does not yet exist.
-- **The LLM synthesis step is undefined.** Whether the coordinator uses an LLM for convergence
-judgement or a deterministic rule set is a downstream decision; this charter reserves the
-`case.synthesize` capability and leaves the implementation open.
+  switches can halt agent runtimes today, but canceling an in-flight case workflow requires a new
+  hook that does not yet exist.
+- **The capability gate is not yet OPA-backed.** Phase 1 checks `agents.yaml` directly (fail-closed);
+  routing the decision through the per-service OPA bundle, and shipping the coordinator's GitOps
+  deployment (CNPG database, `openbank.temporal.enabled=true`, network policies), is Phase 4.
+- **There is no read API or visualization yet.** Case history projection (Phase 2) and the admin-ui
+  swarm thread view (Phase 3, ADR-0246) are follow-up work; until then a case is observable only
+  through Temporal's own tooling.

--- a/openbank-case-coordinator-agent/build.gradle.kts
+++ b/openbank-case-coordinator-agent/build.gradle.kts
@@ -32,6 +32,8 @@ dependencies {
     implementation(libs.quarkus.flyway)
     implementation(libs.kotlinx.coroutines.core)
     implementation(libs.kotlinx.coroutines.reactive)
+    // ADR-0244 D7: case outbox dispatches onto the proposal-events topic.
+    implementation(libs.quarkus.smallrye.kafka)
     implementation(libs.jackson.module.kotlin)
     implementation(libs.jackson.datatype.jsr310)
     // Shared TemporalConfig + TemporalClientProducer (ADR-0209 D1, #2572).
@@ -70,9 +72,10 @@ kover {
         verify {
             rule {
                 bound {
-                    // Ratchet floor (ADR-0020): initial coverage from the boot smoke test only;
-                    // raise-only from here as adapters/activities gain tests.
-                    minValue = 5
+                    // Ratchet floor (ADR-0020): raised from the boot-only 5% to the Phase 1
+                    // case-workflow coverage (workflow + open-service unit tests; the JDBC
+                    // activity paths are exercised by the boot IT in CI, not unit tests).
+                    minValue = 42
                     coverageUnits = kotlinx.kover.gradle.plugin.dsl.CoverageUnit.LINE
                 }
             }

--- a/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/application/CaseCapabilityGate.kt
+++ b/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/application/CaseCapabilityGate.kt
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+
+package com.openbank.casecoordinator.application
+
+import com.openbank.casecoordinator.infrastructure.config.CaseCoordinatorConfig
+import jakarta.enterprise.context.ApplicationScoped
+
+/**
+ * In-process case capability gate (ADR-0244 D2/D3/D9), deny-by-default. Mirrors the charter's
+ * `case_capabilities` in `agents.yaml`: only `case-coordinator` holds `case.open` /
+ * `case.coordinate` / `case.synthesize` / `case.preempt`; swarm participants hold join/contribute
+ * by being on the chartered roster. This is the fail-safe in-process layer (same role as
+ * AgentPolicyGate in agent-service); the OPA bundle adapter that evaluates the same decisions
+ * against `case.capabilities` input is Phase 4 scope.
+ */
+@ApplicationScoped
+class CaseCapabilityGate(private val config: CaseCoordinatorConfig) {
+
+    fun canOpenCase(agentId: String): Boolean = agentId in config.case().openAgents()
+
+    fun canJoinCase(agentId: String): Boolean = agentId in config.case().swarmAgents()
+
+    fun canContribute(agentId: String): Boolean = agentId in config.case().swarmAgents()
+
+    fun canPreempt(agentId: String): Boolean = agentId in config.case().openAgents()
+
+    fun canRequestSynthesis(agentId: String): Boolean = agentId in config.case().openAgents()
+}

--- a/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/application/CaseOpenService.kt
+++ b/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/application/CaseOpenService.kt
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+
+package com.openbank.casecoordinator.application
+
+import com.openbank.casecoordinator.domain.model.CaseClass
+import com.openbank.casecoordinator.domain.model.CaseStart
+import com.openbank.casecoordinator.infrastructure.config.CaseCoordinatorConfig
+import com.openbank.libs.temporal.TemporalConfig
+import io.temporal.api.enums.v1.WorkflowIdReusePolicy
+import io.temporal.api.filter.v1.WorkflowTypeFilter
+import io.temporal.api.workflowservice.v1.ListOpenWorkflowExecutionsRequest
+import io.temporal.client.WorkflowClient
+import io.temporal.client.WorkflowExecutionAlreadyStarted
+import io.temporal.client.WorkflowOptions
+import io.temporal.client.WorkflowServiceException
+import jakarta.enterprise.context.ApplicationScoped
+import org.jboss.logging.Logger
+import java.time.Clock
+
+/** Result of a case-open attempt — mapped to HTTP statuses by the REST layer, no exceptions. */
+sealed interface CaseOpenResult {
+    data class Opened(val caseId: String) : CaseOpenResult
+
+    /** The caller holds no `case.open` capability, or the class is not enabled (ADR-0244 D3/D9). */
+    data object Denied : CaseOpenResult
+
+    /** A case for this (class, subjectRef) already runs — the dedup window (D9). */
+    data object Duplicate : CaseOpenResult
+
+    /** Per-agent hourly open cap or the fleet concurrent-case ceiling is exhausted (D9). */
+    data object RateLimited : CaseOpenResult
+
+    /** Temporal is disabled or unreachable; nothing was started. */
+    data object Unavailable : CaseOpenResult
+}
+
+/**
+ * Case-open authority (ADR-0244 D9): the single entry point that starts case workflows.
+ * Enforcement order is deliberate — capability first (cheap, in-process), then the in-memory
+ * per-agent rate limit, then the Temporal visibility ceiling (network), then the start itself,
+ * whose `REJECT_DUPLICATE` reuse policy is the real dedup: workflowId `case-<class>-<subject>`
+ * means a second open for the same subject fails atomically on the server, not on a local guess.
+ *
+ * The visibility count is fail-CLOSED: a ceiling that cannot be measured denies the open,
+ * because an uncounted swarm is the failure mode the ceiling exists for.
+ */
+@ApplicationScoped
+class CaseOpenService(
+    private val workflowClient: WorkflowClient,
+    private val temporalConfig: TemporalConfig,
+    private val gate: CaseCapabilityGate,
+    private val config: CaseCoordinatorConfig,
+    private val clock: Clock,
+) {
+
+    private val log = Logger.getLogger(CaseOpenService::class.java)
+    private val openTimes = mutableMapOf<String, ArrayDeque<Long>>()
+
+    @Synchronized
+    fun open(openedBy: String, caseClass: CaseClass, subjectRef: String, dispositionTarget: String): CaseOpenResult {
+        if (!temporalConfig.enabled()) return CaseOpenResult.Unavailable
+        if (!gate.canOpenCase(openedBy) || caseClass !in config.case().enabledClasses()) {
+            return CaseOpenResult.Denied
+        }
+        val now = clock.millis()
+        if (!consumeOpenQuota(openedBy, now)) return CaseOpenResult.RateLimited
+        if (countRunningCases() >= config.case().maxConcurrent()) {
+            refundOpenQuota(openedBy, now)
+            return CaseOpenResult.RateLimited
+        }
+
+        val workflowId = workflowIdFor(caseClass, subjectRef)
+        val start = CaseStart(
+            caseId = workflowId,
+            caseClass = caseClass,
+            subjectRef = subjectRef,
+            openedBy = openedBy,
+            dispositionTarget = dispositionTarget,
+            deadlineEpochMs = now + config.case().ttl().toMillis(),
+            contestedRateThreshold = config.case().contestedRateThreshold(),
+            maxContributions = config.case().maxContributions(),
+        )
+        val options = WorkflowOptions.newBuilder()
+            .setWorkflowId(workflowId)
+            .setTaskQueue(temporalConfig.taskQueue())
+            .setWorkflowIdReusePolicy(WorkflowIdReusePolicy.WORKFLOW_ID_REUSE_POLICY_REJECT_DUPLICATE)
+            .build()
+        // Untyped stub start — same server-side dedup as the typed static WorkflowClient.start,
+        // but an instance method, so tests can stub it without mockkStatic gymnastics.
+        val stub = workflowClient.newUntypedWorkflowStub(WORKFLOW_TYPE, options)
+        return try {
+            stub.start(start)
+            log.infof("case opened: %s by %s (class %s)", workflowId, openedBy, caseClass)
+            CaseOpenResult.Opened(workflowId)
+        } catch (e: WorkflowExecutionAlreadyStarted) {
+            refundOpenQuota(openedBy, now)
+            log.debugf(e, "case open dedup: %s already running on the server", workflowId)
+            CaseOpenResult.Duplicate
+        } catch (e: WorkflowServiceException) {
+            refundOpenQuota(openedBy, now)
+            log.warnf(e, "Temporal start failed for %s", workflowId)
+            CaseOpenResult.Unavailable
+        }
+    }
+
+    fun workflowIdFor(caseClass: CaseClass, subjectRef: String): String =
+        "case-${caseClass.name.lowercase().replace('_', '-')}-${subjectRef.replace(Regex("[^A-Za-z0-9_-]"), "-")}"
+
+    private fun consumeOpenQuota(agentId: String, now: Long): Boolean {
+        val deque = openTimes.getOrPut(agentId) { ArrayDeque() }
+        val windowStart = now - OPEN_WINDOW_MS
+        while (deque.isNotEmpty() && deque.first() < windowStart) deque.removeFirst()
+        if (deque.size >= config.case().maxOpensPerAgentPerHour()) return false
+        deque.addLast(now)
+        return true
+    }
+
+    private fun refundOpenQuota(agentId: String, now: Long) {
+        openTimes[agentId]?.remove(now)
+    }
+
+    private fun countRunningCases(): Int = try {
+        val request = ListOpenWorkflowExecutionsRequest.newBuilder()
+            .setNamespace(workflowClient.options.namespace)
+            .setTypeFilter(WorkflowTypeFilter.newBuilder().setName(WORKFLOW_TYPE).build())
+            .build()
+        workflowClient.workflowServiceStubs.blockingStub()
+            .listOpenWorkflowExecutions(request)
+            .executionsCount
+    } catch (e: WorkflowServiceException) {
+        log.warnf(e, "running-case count failed; denying open (fail-closed ceiling)")
+        Int.MAX_VALUE
+    }
+
+    private companion object {
+        const val WORKFLOW_TYPE = "CaseWorkflow"
+        const val OPEN_WINDOW_MS = 3_600_000L
+    }
+}

--- a/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/application/workflow/CaseWorkerRegistrar.kt
+++ b/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/application/workflow/CaseWorkerRegistrar.kt
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+
+package com.openbank.casecoordinator.application.workflow
+
+import com.openbank.casecoordinator.infrastructure.workflow.CaseActivitiesImpl
+import com.openbank.libs.temporal.TemporalConfig
+import io.quarkus.runtime.StartupEvent
+import io.temporal.client.WorkflowClient
+import io.temporal.worker.WorkerFactory
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.enterprise.event.Observes
+import org.jboss.logging.Logger
+
+/** Registers the case worker on startup, mirroring DocsTruthWorkerRegistrar (ADR-0202 shape). */
+@ApplicationScoped
+class CaseWorkerRegistrar(
+    private val temporalConfig: TemporalConfig,
+    private val workflowClient: WorkflowClient,
+    private val activities: CaseActivitiesImpl,
+) {
+
+    private val log = Logger.getLogger(CaseWorkerRegistrar::class.java)
+
+    @Suppress("UnusedParameter")
+    fun onStart(@Observes event: StartupEvent) {
+        if (!temporalConfig.enabled()) {
+            log.info("Temporal worker disabled (openbank.temporal.enabled=false); skipping registration")
+            return
+        }
+        log.infof(
+            "Registering Temporal case-coordinator worker on task queue '%s'",
+            temporalConfig.taskQueue(),
+        )
+        val factory = WorkerFactory.newInstance(workflowClient)
+        val worker = factory.newWorker(temporalConfig.taskQueue())
+        worker.registerWorkflowImplementationTypes(CaseWorkflowImpl::class.java)
+        worker.registerActivitiesImplementations(activities)
+        factory.start()
+        log.infof("Temporal case-coordinator worker started on task queue '%s'", temporalConfig.taskQueue())
+    }
+}

--- a/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/application/workflow/CaseWorkflow.kt
+++ b/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/application/workflow/CaseWorkflow.kt
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+
+package com.openbank.casecoordinator.application.workflow
+
+import com.openbank.casecoordinator.domain.model.CaseOutcome
+import com.openbank.casecoordinator.domain.model.CaseStart
+import com.openbank.casecoordinator.domain.model.CaseState
+import com.openbank.casecoordinator.domain.model.ContributeSignal
+import com.openbank.casecoordinator.domain.model.Contribution
+import com.openbank.casecoordinator.domain.model.JoinSignal
+import com.openbank.casecoordinator.domain.model.SupersedeSignal
+import com.openbank.casecoordinator.domain.model.SynthesisRequest
+import io.temporal.activity.ActivityInterface
+import io.temporal.workflow.QueryMethod
+import io.temporal.workflow.SignalMethod
+import io.temporal.workflow.WorkflowInterface
+import io.temporal.workflow.WorkflowMethod
+
+/**
+ * Agent-swarm case workflow (ADR-0244). Several chartered agents join a running case, contribute
+ * findings, pre-empt each other via `superseded-by-evidence` (D5), and the case converges to
+ * exactly one HITL proposal (D7) — emitted on synthesis, on contest, and on timeout alike.
+ */
+@WorkflowInterface
+interface CaseWorkflow {
+
+    @WorkflowMethod(name = "CaseWorkflow")
+    fun run(start: CaseStart): CaseOutcome
+
+    @SignalMethod
+    fun join(signal: JoinSignal)
+
+    @SignalMethod
+    fun contribute(signal: ContributeSignal)
+
+    @SignalMethod
+    fun supersede(signal: SupersedeSignal)
+
+    @SignalMethod
+    fun requestSynthesis(request: SynthesisRequest)
+
+    /** Phase 2's read API projects this; kept on the workflow so history and state never fork. */
+    @QueryMethod
+    fun state(): CaseState
+}
+
+/** LLM convergence synthesis (D2/D5) — the only non-deterministic judgement in the flow. */
+@ActivityInterface
+interface CaseSynthesisActivity {
+    fun synthesize(caseId: String, caseClass: String, contributions: List<Contribution>): String?
+}
+
+/** Emits the single HITL proposal into the case outbox (D7). */
+@ActivityInterface
+interface CaseProposalActivity {
+    fun emitProposal(caseId: String, proposalType: String, summary: String, contested: Boolean): String
+}
+
+/** Persists case lifecycle + contribution rows to the V1 schema. */
+@ActivityInterface
+interface CasePersistenceActivity {
+    fun recordCaseOpened(start: CaseStart, openedAtEpochMs: Long)
+
+    fun recordContributions(caseId: String, contributions: List<Contribution>)
+
+    fun recordCaseClosed(caseId: String, status: String, closedAtEpochMs: Long)
+}

--- a/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/application/workflow/CaseWorkflowImpl.kt
+++ b/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/application/workflow/CaseWorkflowImpl.kt
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+
+package com.openbank.casecoordinator.application.workflow
+
+import com.openbank.casecoordinator.domain.model.CaseClass
+import com.openbank.casecoordinator.domain.model.CaseOutcome
+import com.openbank.casecoordinator.domain.model.CaseStart
+import com.openbank.casecoordinator.domain.model.CaseState
+import com.openbank.casecoordinator.domain.model.CaseStatus
+import com.openbank.casecoordinator.domain.model.ContributeSignal
+import com.openbank.casecoordinator.domain.model.Contribution
+import com.openbank.casecoordinator.domain.model.JoinSignal
+import com.openbank.casecoordinator.domain.model.SupersedeSignal
+import com.openbank.casecoordinator.domain.model.SynthesisRequest
+import io.temporal.activity.ActivityOptions
+import io.temporal.common.RetryOptions
+import io.temporal.workflow.Workflow
+import java.time.Duration
+
+/**
+ * Deterministic case state machine. Everything non-deterministic (LLM, DB, proposal I/O) sits
+ * behind activity stubs; the workflow body only mutates in-memory state, waits on conditions,
+ * and calls activities. Signal handlers never call activities — contributions are persisted in
+ * one batch at case end, so a signal storm cannot fan out into per-signal I/O.
+ *
+ * Exactly one HITL proposal per case (ADR-0244 D7) is a control-flow invariant: every exit path
+ * funnels through a single `emitTerminalProposal` call, and `run` returns immediately after.
+ */
+@Suppress("MagicNumber")
+class CaseWorkflowImpl : CaseWorkflow {
+
+    private val longOptions = ActivityOptions.newBuilder()
+        .setStartToCloseTimeout(Duration.ofMinutes(10))
+        .setRetryOptions(RetryOptions.newBuilder().setMaximumAttempts(2).build())
+        .build()
+
+    private val shortOptions = ActivityOptions.newBuilder()
+        .setStartToCloseTimeout(Duration.ofMinutes(5))
+        .build()
+
+    private val synthesis = Workflow.newActivityStub(CaseSynthesisActivity::class.java, longOptions)
+    private val proposals = Workflow.newActivityStub(CaseProposalActivity::class.java, shortOptions)
+    private val persistence = Workflow.newActivityStub(CasePersistenceActivity::class.java, shortOptions)
+
+    private var status = CaseStatus.OPEN
+    private val participants = linkedSetOf<String>()
+    private val contributions = mutableListOf<Contribution>()
+    private var contestedCount = 0
+    private var draftVersion = 0
+    private var synthesisRequested = false
+
+    private lateinit var caseClass: CaseClass
+    private var openedAtEpochMs: Long = 0
+    private var deadlineEpochMs: Long = 0
+
+    override fun run(start: CaseStart): CaseOutcome {
+        caseClass = start.caseClass
+        deadlineEpochMs = start.deadlineEpochMs
+        val openedAt = Workflow.currentTimeMillis()
+        openedAtEpochMs = openedAt
+        persistence.recordCaseOpened(start, openedAt)
+
+        while (true) {
+            val remainingMs = start.deadlineEpochMs - Workflow.currentTimeMillis()
+            if (remainingMs <= 0) {
+                status = CaseStatus.CLOSED
+                return emitTerminalProposal(start, "case-timeout", terminalSummary(start), contested = false)
+            }
+            Workflow.await(Duration.ofMillis(remainingMs)) { synthesisRequested || breakerTripped(start) }
+            when {
+                breakerTripped(start) -> {
+                    status = CaseStatus.CONTESTED
+                    return emitTerminalProposal(start, "case-contested", terminalSummary(start), contested = true)
+                }
+                synthesisRequested -> return synthesize(start)
+            }
+        }
+    }
+
+    override fun join(signal: JoinSignal) {
+        participants += signal.agentId
+    }
+
+    override fun contribute(signal: ContributeSignal) {
+        contributions += Contribution(
+            agentId = signal.agentId,
+            summary = signal.summary,
+            evidenceRefs = signal.evidenceRefs,
+            contested = signal.contested,
+            draftVersion = draftVersion,
+        )
+        if (signal.contested) contestedCount++
+    }
+
+    override fun supersede(signal: SupersedeSignal) {
+        draftVersion++
+    }
+
+    override fun requestSynthesis(request: SynthesisRequest) {
+        synthesisRequested = true
+    }
+
+    override fun state(): CaseState = CaseState(
+        caseId = Workflow.getInfo().workflowId,
+        caseClass = caseClass,
+        status = status,
+        participants = participants.toList(),
+        contributionCount = contributions.size,
+        contestedCount = contestedCount,
+        draftVersion = draftVersion,
+        openedAtEpochMs = openedAtEpochMs,
+        deadlineEpochMs = deadlineEpochMs,
+    )
+
+    private fun synthesize(start: CaseStart): CaseOutcome {
+        status = CaseStatus.CONVERGING
+        // D5: only the final draft's contributions feed the judgement; superseded drafts are
+        // recorded history, not input.
+        val draft = contributions.filter { it.draftVersion == draftVersion }
+        val text = synthesis.synthesize(start.caseId, start.caseClass.name, draft)
+            ?: "PENDING: synthesis backend unavailable; ${draft.size} contributions on draft v$draftVersion"
+        status = CaseStatus.SYNTHESIZED
+        return emitTerminalProposal(start, "case-synthesis", text, contested = false)
+    }
+
+    private fun emitTerminalProposal(
+        start: CaseStart,
+        type: String,
+        summary: String,
+        contested: Boolean,
+    ): CaseOutcome {
+        persistence.recordContributions(start.caseId, contributions)
+        val proposalId = proposals.emitProposal(start.caseId, type, summary, contested)
+        persistence.recordCaseClosed(start.caseId, status.name, Workflow.currentTimeMillis())
+        return CaseOutcome(
+            caseId = start.caseId,
+            status = status,
+            proposalId = proposalId,
+            proposalSummary = summary,
+            contributionCount = contributions.size,
+        )
+    }
+    private fun breakerTripped(start: CaseStart): Boolean = contributions.isNotEmpty() &&
+        contestedCount.toDouble() / contributions.size > start.contestedRateThreshold
+
+    private fun terminalSummary(start: CaseStart): String = if (status == CaseStatus.CONTESTED) {
+        "CONTESTED: $contestedCount of ${contributions.size} contributions contested " +
+            "(threshold ${start.contestedRateThreshold}); escalated to HITL without auto-synthesis"
+    } else {
+        "TIMEOUT: case reached its deadline with ${contributions.size} contributions, " +
+            "${participants.size} participants, no synthesis requested"
+    }
+}

--- a/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/domain/model/CaseModels.kt
+++ b/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/domain/model/CaseModels.kt
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+
+package com.openbank.casecoordinator.domain.model
+
+/**
+ * Domain model for an agent-swarm case (ADR-0244). Pure Kotlin — zero framework imports
+ * (ADR-0002/ADR-0122). Every type crossing the Temporal boundary (workflow arguments, signal
+ * payloads, activity inputs/outputs) is a Kotlin data class serialized with the kotlin-aware
+ * Jackson converter the shared TemporalClientProducer builds.
+ */
+
+/** Case classes declared in `agents.yaml: case_classes`. Only [INCIDENT_RESPONSE] is the
+ * ADR-0244 pilot; the money-path classes stay config-disabled until their threat model
+ * lands (ADR-0030). */
+enum class CaseClass {
+    INCIDENT_RESPONSE,
+    FRAUD_INVESTIGATION,
+    AML_ALERT,
+}
+
+enum class CaseStatus {
+    OPEN,
+    CONVERGING,
+    CONTESTED,
+    SYNTHESIZED,
+    CLOSED,
+}
+
+/** Start parameters for a case workflow run. */
+data class CaseStart(
+    val caseId: String,
+    val caseClass: CaseClass,
+    val subjectRef: String,
+    val openedBy: String,
+    val dispositionTarget: String,
+    val deadlineEpochMs: Long,
+    val contestedRateThreshold: Double,
+    val maxContributions: Int,
+)
+
+data class JoinSignal(val agentId: String, val role: String)
+
+data class ContributeSignal(
+    val agentId: String,
+    val summary: String,
+    val evidenceRefs: List<String>,
+    val contested: Boolean,
+)
+
+/**
+ * Deterministic pre-emption (ADR-0244 D5): newer evidence invalidates the in-flight draft.
+ * The workflow bumps its draft version; only contributions of the final draft feed synthesis.
+ */
+data class SupersedeSignal(val agentId: String, val newEvidenceRef: String, val reason: String)
+
+data class SynthesisRequest(val agentId: String)
+
+/** One recorded contribution. [draftVersion] pins it to the draft it was made against. */
+data class Contribution(
+    val agentId: String,
+    val summary: String,
+    val evidenceRefs: List<String>,
+    val contested: Boolean,
+    val draftVersion: Int,
+)
+
+/** Read model exposed via the workflow query method — the Phase 2 API projects this. */
+data class CaseState(
+    val caseId: String,
+    val caseClass: CaseClass,
+    val status: CaseStatus,
+    val participants: List<String>,
+    val contributionCount: Int,
+    val contestedCount: Int,
+    val draftVersion: Int,
+    val openedAtEpochMs: Long,
+    val deadlineEpochMs: Long,
+)
+
+/** Terminal workflow result. Every case emits exactly one HITL proposal (ADR-0244 D7). */
+data class CaseOutcome(
+    val caseId: String,
+    val status: CaseStatus,
+    val proposalId: String,
+    val proposalSummary: String,
+    val contributionCount: Int,
+)

--- a/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/infrastructure/config/CaseCoordinatorConfig.kt
+++ b/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/infrastructure/config/CaseCoordinatorConfig.kt
@@ -5,9 +5,11 @@
 
 package com.openbank.casecoordinator.infrastructure.config
 
+import com.openbank.casecoordinator.domain.model.CaseClass
 import io.smallrye.config.ConfigMapping
 import io.smallrye.config.WithDefault
 import jakarta.enterprise.context.ApplicationScoped
+import java.time.Duration
 
 /**
  * Configuration for the case-coordinator agent (ADR-0244).
@@ -24,4 +26,39 @@ interface CaseCoordinatorConfig {
 
     @WithDefault("deepseek-ai/DeepSeek-V3.2")
     fun modelId(): String
+
+    /**
+     * Case swarm settings (`openbank.case-coordinator.case.*`), mirroring
+     * `agents.yaml: case_classes` for the pilot class incident-response (20 min wall clock,
+     * 15 open cases, 40 contributions, 0.35 contested threshold). The capability lists mirror
+     * charter `case_capabilities` — today ONLY case-coordinator holds any; swarm join/contribute
+     * grants are deliberate follow-up charter work.
+     */
+    fun case(): CaseGroup
+
+    interface CaseGroup {
+        @WithDefault("case-coordinator")
+        fun openAgents(): Set<String>
+
+        @WithDefault("case-coordinator")
+        fun swarmAgents(): Set<String>
+
+        @WithDefault("INCIDENT_RESPONSE")
+        fun enabledClasses(): Set<CaseClass>
+
+        @WithDefault("15")
+        fun maxConcurrent(): Int
+
+        @WithDefault("1")
+        fun maxOpensPerAgentPerHour(): Int
+
+        @WithDefault("PT20M")
+        fun ttl(): Duration
+
+        @WithDefault("0.35")
+        fun contestedRateThreshold(): Double
+
+        @WithDefault("40")
+        fun maxContributions(): Int
+    }
 }

--- a/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/infrastructure/messaging/KafkaCaseOutboxEventPublisher.kt
+++ b/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/infrastructure/messaging/KafkaCaseOutboxEventPublisher.kt
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+
+package com.openbank.casecoordinator.infrastructure.messaging
+
+import com.openbank.libs.persistence.outbox.OutboxEntry
+import com.openbank.libs.persistence.outbox.OutboxEventPublisher
+import com.openbank.libs.persistence.outbox.OutboxKafkaHeaders
+import io.smallrye.mutiny.coroutines.awaitSuspending
+import io.smallrye.reactive.messaging.MutinyEmitter
+import io.smallrye.reactive.messaging.kafka.api.OutgoingKafkaRecordMetadata
+import jakarta.enterprise.context.ApplicationScoped
+import org.apache.kafka.common.header.internals.RecordHeaders
+import org.eclipse.microprofile.reactive.messaging.Channel
+import org.eclipse.microprofile.reactive.messaging.Message
+
+@ApplicationScoped
+class KafkaCaseOutboxEventPublisher(@Channel("case-outbox-out") private val emitter: MutinyEmitter<String>) :
+    OutboxEventPublisher {
+
+    override suspend fun publish(entry: OutboxEntry) {
+        val kafkaHeaders = RecordHeaders()
+        OutboxKafkaHeaders.headersFor(entry).forEach { (k, v) -> kafkaHeaders.add(k, v.toByteArray()) }
+        val meta = OutgoingKafkaRecordMetadata.builder<String>()
+            .withKey(OutboxKafkaHeaders.partitionKey(entry))
+            .withHeaders(kafkaHeaders)
+            .build()
+        emitter.sendMessage(Message.of(entry.payload).addMetadata(meta)).awaitSuspending()
+    }
+}

--- a/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/infrastructure/outbox/CaseOutboxDispatcher.kt
+++ b/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/infrastructure/outbox/CaseOutboxDispatcher.kt
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+
+package com.openbank.casecoordinator.infrastructure.outbox
+
+import com.openbank.casecoordinator.infrastructure.persistence.CaseOutboxRepositoryImpl
+import com.openbank.libs.persistence.outbox.AbstractOutboxDispatcher
+import com.openbank.libs.persistence.outbox.OutboxEntry
+import com.openbank.libs.persistence.outbox.OutboxEventPublisher
+import com.openbank.libs.persistence.outbox.OutboxRepository
+import io.quarkus.scheduler.Scheduled
+import jakarta.enterprise.context.ApplicationScoped
+import org.eclipse.microprofile.config.inject.ConfigProperty
+import org.eclipse.microprofile.faulttolerance.Bulkhead
+import org.eclipse.microprofile.faulttolerance.CircuitBreaker
+import org.eclipse.microprofile.faulttolerance.Retry
+import org.eclipse.microprofile.faulttolerance.Timeout
+
+/** Drains the case outbox onto `proposal-events` (ADR-0244 D7), account-dispatcher shape. */
+@ApplicationScoped
+class CaseOutboxDispatcher(
+    private val repo: CaseOutboxRepositoryImpl,
+    private val publisher: OutboxEventPublisher,
+    @ConfigProperty(name = "openbank.outbox.dispatch-enabled", defaultValue = "false")
+    private val dispatchEnabled: Boolean,
+) : AbstractOutboxDispatcher() {
+    override val outboxRepository: OutboxRepository get() = repo
+    override val outboxEventPublisher: OutboxEventPublisher get() = publisher
+
+    @Scheduled(
+        every = "\${openbank.outbox.poll-interval:5s}",
+        delayed = "\${openbank.outbox.initial-delay:5s}",
+        concurrentExecution = Scheduled.ConcurrentExecution.SKIP,
+        identity = "case-outbox-dispatcher",
+    )
+    @Bulkhead(1)
+    @CircuitBreaker(requestVolumeThreshold = 10, failureRatio = 0.5, delay = 5000)
+    @Retry(maxRetries = 2, delay = 200, jitter = 100)
+    @Timeout(DISPATCH_TIMEOUT_MS)
+    suspend fun dispatch() {
+        if (dispatchEnabled) dispatchScheduledBatch()
+    }
+
+    @Bulkhead(1)
+    @CircuitBreaker(requestVolumeThreshold = 10, failureRatio = 0.5, delay = 5000)
+    @Retry(maxRetries = 2, delay = 200, jitter = 100)
+    @Timeout(PUBLISH_TIMEOUT_MS)
+    override suspend fun publishWithResilience(entry: OutboxEntry): Unit = publisher.publish(entry)
+
+    private companion object {
+        const val DISPATCH_TIMEOUT_MS = 30000L
+        const val PUBLISH_TIMEOUT_MS = 3000L
+    }
+}

--- a/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/infrastructure/persistence/CaseOutboxEntity.kt
+++ b/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/infrastructure/persistence/CaseOutboxEntity.kt
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+
+package com.openbank.casecoordinator.infrastructure.persistence
+
+import com.openbank.libs.persistence.outbox.PanacheOutboxEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Table
+import java.time.Instant
+
+@Entity
+@Table(name = "case_outbox")
+class CaseOutboxEntity : PanacheOutboxEntity() {
+    @Column(name = "claimed_at")
+    var claimedAt: Instant? = null
+}

--- a/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/infrastructure/persistence/CaseOutboxRepositoryImpl.kt
+++ b/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/infrastructure/persistence/CaseOutboxRepositoryImpl.kt
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+
+package com.openbank.casecoordinator.infrastructure.persistence
+
+import com.openbank.libs.persistence.outbox.OutboxEntry
+import com.openbank.libs.persistence.outbox.OutboxFailurePolicy
+import com.openbank.libs.persistence.outbox.OutboxRepository
+import com.openbank.libs.persistence.outbox.OutboxStatus
+import io.quarkus.hibernate.reactive.panache.Panache
+import io.quarkus.hibernate.reactive.panache.kotlin.PanacheRepository
+import io.smallrye.mutiny.coroutines.awaitSuspending
+import jakarta.enterprise.context.ApplicationScoped
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * Case outbox reads/writes for the dispatcher side. The atomic-claim override mirrors
+ * AccountOutboxRepositoryImpl (#1201) so a Rollouts canary window can never double-publish
+ * a case proposal; write-side rows are inserted by CaseActivitiesImpl over plain JDBC.
+ */
+@ApplicationScoped
+class CaseOutboxRepositoryImpl(private val clock: Clock) :
+    OutboxRepository,
+    PanacheRepository<CaseOutboxEntity> {
+
+    override suspend fun listProcessable(limit: Int): List<OutboxEntry> = Panache.withSession {
+        find(
+            "status in (?1, ?2) order by createdAt asc",
+            OutboxStatus.PENDING.name,
+            OutboxStatus.FAILED.name,
+        ).range(0, limit.coerceAtLeast(1) - 1).list()
+    }.map { entities -> entities.map { it.toEntry() } }.awaitSuspending()
+
+    override suspend fun countProcessable(): Long = Panache.withSession {
+        count("status in (?1, ?2)", OutboxStatus.PENDING.name, OutboxStatus.FAILED.name)
+    }.awaitSuspending()
+
+    override suspend fun claimProcessable(limit: Int, staleAfter: Duration): List<OutboxEntry> {
+        val now = Instant.now(clock)
+        val staleThreshold = now.minus(staleAfter)
+        return Panache.withTransaction {
+            Panache.getSession().chain { session ->
+                session.createNativeQuery(CLAIM_SQL, CaseOutboxEntity::class.java)
+                    .setParameter("pending", OutboxStatus.PENDING.name)
+                    .setParameter("failed", OutboxStatus.FAILED.name)
+                    .setParameter("dispatching", OutboxStatus.DISPATCHING.name)
+                    .setParameter("staleThreshold", staleThreshold)
+                    .setParameter("claimLimit", limit.coerceAtLeast(1))
+                    .setParameter("now", now)
+                    .resultList
+            }
+        }.map { entities -> entities.map { it.toEntry() } }.awaitSuspending()
+    }
+
+    override suspend fun markSent(eventId: UUID, sentAt: Instant) {
+        Panache.withTransaction {
+            find("eventId", eventId).firstResult().invoke { e ->
+                if (e != null) {
+                    e.status = OutboxStatus.SENT.name
+                    e.attemptCount += 1
+                    e.sentAt = sentAt
+                    e.lastError = null
+                    e.updatedAt = sentAt
+                }
+            }.replaceWithVoid()
+        }.awaitSuspending()
+    }
+
+    override suspend fun markFailed(eventId: UUID, error: String, failedAt: Instant) {
+        Panache.withTransaction {
+            find("eventId", eventId).firstResult().invoke { e ->
+                if (e != null) {
+                    e.attemptCount += 1
+                    e.status = OutboxFailurePolicy.statusAfterFailure(e.attemptCount).name
+                    e.lastError = error.take(OutboxFailurePolicy.MAX_ERROR_LEN)
+                    e.updatedAt = failedAt
+                }
+            }.replaceWithVoid()
+        }.awaitSuspending()
+    }
+
+    private companion object {
+        @Suppress("MaxLineLength")
+        private const val CLAIM_SQL = """
+            UPDATE case_outbox
+            SET status = :dispatching, claimed_at = :now, updated_at = :now
+            WHERE id IN (
+                SELECT id FROM case_outbox
+                WHERE (status IN (:pending, :failed))
+                   OR (status = :dispatching AND claimed_at < :staleThreshold)
+                ORDER BY created_at ASC
+                LIMIT :claimLimit
+                FOR UPDATE SKIP LOCKED
+            )
+            RETURNING *
+        """
+    }
+}

--- a/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/infrastructure/rest/CaseCoordinatorResource.kt
+++ b/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/infrastructure/rest/CaseCoordinatorResource.kt
@@ -5,25 +5,159 @@
 
 package com.openbank.casecoordinator.infrastructure.rest
 
+import com.openbank.casecoordinator.application.CaseCapabilityGate
+import com.openbank.casecoordinator.application.CaseOpenResult
+import com.openbank.casecoordinator.application.CaseOpenService
+import com.openbank.casecoordinator.application.workflow.CaseWorkflow
+import com.openbank.casecoordinator.domain.model.CaseClass
+import com.openbank.casecoordinator.domain.model.ContributeSignal
+import com.openbank.casecoordinator.domain.model.JoinSignal
+import com.openbank.casecoordinator.domain.model.SupersedeSignal
+import com.openbank.casecoordinator.domain.model.SynthesisRequest
+import com.openbank.libs.temporal.TemporalConfig
+import io.temporal.client.WorkflowClient
+import io.temporal.client.WorkflowNotFoundException
 import jakarta.annotation.security.RolesAllowed
 import jakarta.ws.rs.GET
+import jakarta.ws.rs.POST
 import jakarta.ws.rs.Path
+import jakarta.ws.rs.PathParam
 import jakarta.ws.rs.Produces
 import jakarta.ws.rs.core.MediaType
+import jakarta.ws.rs.core.Response
 
 /**
- * Placeholder REST surface for the case-coordinator agent (ADR-0244).
- * Exposes a health/readiness probe path and a simple info endpoint so the module
- * boots, registers its OpenAPI contract, and passes the boot smoke test.
+ * Case-coordinator REST surface (ADR-0244): case-open authority (D9) plus the signal ingress
+ * that feeds a running CaseWorkflow. Every capability decision goes through the in-process
+ * CaseCapabilityGate (D2); the OPA bundle evaluating the same decisions is Phase 4 scope.
+ * A read API projecting case history is Phase 2 — only the workflow query method exists today.
  */
 @Path("/api/v1/case-coordinator")
 @Produces(MediaType.APPLICATION_JSON)
-class CaseCoordinatorResource {
+class CaseCoordinatorResource(
+    private val openService: CaseOpenService,
+    private val gate: CaseCapabilityGate,
+    private val workflowClient: WorkflowClient,
+    private val temporalConfig: TemporalConfig,
+) {
 
     data class Status(val service: String, val status: String)
+
+    data class OpenCaseRequest(
+        val caseClass: String? = null,
+        val subjectRef: String? = null,
+        val openedBy: String? = null,
+        val dispositionTarget: String? = null,
+    )
+
+    data class OpenCaseResponse(val caseId: String)
+
+    data class SignalRequest(
+        val type: String? = null,
+        val agentId: String? = null,
+        val role: String? = null,
+        val summary: String? = null,
+        val evidenceRefs: List<String>? = null,
+        val contested: Boolean? = null,
+        val newEvidenceRef: String? = null,
+        val reason: String? = null,
+    )
 
     @GET
     @Path("/status")
     @RolesAllowed("ROLE_ADMIN", "ROLE_VIEWER")
     fun status(): Status = Status(service = "case-coordinator-agent", status = "up")
+
+    @POST
+    @Path("/cases")
+    @RolesAllowed("ROLE_ADMIN", "ROLE_OPERATOR")
+    fun openCase(request: OpenCaseRequest?): Response {
+        requireNotNull(request) { "request body is required" }
+        val caseClass = CaseClass.valueOf(
+            requireNotNull(request.caseClass) { "caseClass is required" }.uppercase()
+                .replace('-', '_'),
+        )
+        val subjectRef = requireNotNull(request.subjectRef) { "subjectRef is required" }
+        val openedBy = requireNotNull(request.openedBy) { "openedBy is required" }
+        val dispositionTarget = requireNotNull(request.dispositionTarget) { "dispositionTarget is required" }
+
+        return when (val result = openService.open(openedBy, caseClass, subjectRef, dispositionTarget)) {
+            is CaseOpenResult.Opened -> Response.status(Response.Status.CREATED)
+                .entity(OpenCaseResponse(result.caseId)).build()
+            CaseOpenResult.Denied -> Response.status(Response.Status.FORBIDDEN)
+                .entity(errorBody("case.open denied for '$openedBy' or class '$caseClass' not enabled")).build()
+            CaseOpenResult.Duplicate -> Response.status(Response.Status.CONFLICT)
+                .entity(errorBody("a case for this class and subject already runs")).build()
+            CaseOpenResult.RateLimited -> Response.status(HTTP_TOO_MANY_REQUESTS)
+                .entity(errorBody("case-open quota or concurrent-case ceiling exhausted")).build()
+            CaseOpenResult.Unavailable -> temporalUnavailable()
+        }
+    }
+
+    @POST
+    @Path("/cases/{caseId}/signals")
+    @RolesAllowed("ROLE_ADMIN", "ROLE_OPERATOR")
+    fun signal(@PathParam("caseId") caseId: String?, request: SignalRequest?): Response {
+        val id = requireNotNull(caseId) { "caseId path parameter is required" }
+        requireNotNull(request) { "request body is required" }
+        val type = requireNotNull(request.type) { "type is required" }
+        val agentId = requireNotNull(request.agentId) { "agentId is required" }
+        if (!temporalConfig.enabled()) return temporalUnavailable()
+        if (!capable(type, agentId)) {
+            return Response.status(Response.Status.FORBIDDEN)
+                .entity(errorBody("signal '$type' denied for agent '$agentId'")).build()
+        }
+        return deliver(id, type, agentId, request)
+    }
+
+    private fun capable(type: String, agentId: String): Boolean = when (type) {
+        "join" -> gate.canJoinCase(agentId)
+        "contribute" -> gate.canContribute(agentId)
+        "supersede" -> gate.canPreempt(agentId)
+        "request-synthesis" -> gate.canRequestSynthesis(agentId)
+        else -> throw IllegalArgumentException("unknown signal type '$type'")
+    }
+
+    private fun deliver(id: String, type: String, agentId: String, request: SignalRequest): Response {
+        val stub = workflowClient.newWorkflowStub(CaseWorkflow::class.java, id)
+        return try {
+            when (type) {
+                "join" -> stub.join(JoinSignal(agentId, request.role ?: "participant"))
+                "contribute" -> stub.contribute(
+                    ContributeSignal(
+                        agentId = agentId,
+                        summary = requireNotNull(request.summary) { "summary is required for contribute" },
+                        evidenceRefs = request.evidenceRefs ?: emptyList(),
+                        contested = request.contested ?: false,
+                    ),
+                )
+                "supersede" -> stub.supersede(
+                    SupersedeSignal(
+                        agentId = agentId,
+                        newEvidenceRef = requireNotNull(request.newEvidenceRef) {
+                            "newEvidenceRef is required for supersede"
+                        },
+                        reason = request.reason ?: "superseded-by-evidence",
+                    ),
+                )
+                else -> stub.requestSynthesis(SynthesisRequest(agentId))
+            }
+            Response.accepted().build()
+        } catch (e: WorkflowNotFoundException) {
+            log.debugf(e, "signal '%s' for unknown case %s", type, id)
+            Response.status(Response.Status.NOT_FOUND)
+                .entity(errorBody("no running case with id '$id'")).build()
+        }
+    }
+
+    private fun temporalUnavailable(): Response = Response.status(Response.Status.SERVICE_UNAVAILABLE)
+        .entity(errorBody("Temporal case workflows are disabled (openbank.temporal.enabled=false)"))
+        .build()
+
+    private fun errorBody(message: String): Map<String, String> = mapOf("error" to message)
+
+    private companion object {
+        const val HTTP_TOO_MANY_REQUESTS = 429
+        val log: org.jboss.logging.Logger = org.jboss.logging.Logger.getLogger(CaseCoordinatorResource::class.java)
+    }
 }

--- a/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/infrastructure/workflow/CaseActivitiesImpl.kt
+++ b/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/infrastructure/workflow/CaseActivitiesImpl.kt
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+
+package com.openbank.casecoordinator.infrastructure.workflow
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.casecoordinator.application.port.out.CaseCoordinatorLlmPort
+import com.openbank.casecoordinator.application.workflow.CasePersistenceActivity
+import com.openbank.casecoordinator.application.workflow.CaseProposalActivity
+import com.openbank.casecoordinator.application.workflow.CaseSynthesisActivity
+import com.openbank.casecoordinator.domain.model.CaseStart
+import com.openbank.casecoordinator.domain.model.Contribution
+import com.openbank.libs.persistence.outbox.OutboxStatus
+import jakarta.enterprise.context.ApplicationScoped
+import kotlinx.coroutines.runBlocking
+import java.nio.charset.StandardCharsets
+import java.sql.Timestamp
+import java.time.Clock
+import java.time.Instant
+import java.util.UUID
+import javax.sql.DataSource
+
+/**
+ * Case workflow activities. Plain JDBC (Agroal) rather than reactive Panache: Temporal activity
+ * threads are plain worker threads with no Vert.x context, and reactive Panache would throw
+ * HR000068 there — the same reason agent-service keeps JdbcAgentProposalRepository. The outbox
+ * DISPATCH side (CaseOutboxDispatcher) runs on the Quarkus scheduler with a Vert.x context and
+ * reads through the Panache entity as usual.
+ */
+@ApplicationScoped
+class CaseActivitiesImpl(
+    private val llm: CaseCoordinatorLlmPort,
+    private val dataSource: DataSource,
+    private val clock: Clock,
+    private val objectMapper: ObjectMapper,
+) : CaseSynthesisActivity,
+    CaseProposalActivity,
+    CasePersistenceActivity {
+
+    override fun synthesize(caseId: String, caseClass: String, contributions: List<Contribution>): String? {
+        val context = buildString {
+            append("case_id=").append(caseId).append("; class=").append(caseClass).append('\n')
+            contributions.forEachIndexed { i, c ->
+                append("--- contribution ").append(i + 1).append(" by ").append(c.agentId)
+                if (c.contested) append(" [CONTESTED]")
+                append(" ---\n").append(c.summary).append('\n')
+                if (c.evidenceRefs.isNotEmpty()) {
+                    append(
+                        "evidence: ",
+                    ).append(c.evidenceRefs.joinToString(", ")).append('\n')
+                }
+            }
+        }
+        return runBlocking { llm.synthesizeConvergence(context) }
+    }
+
+    override fun emitProposal(caseId: String, proposalType: String, summary: String, contested: Boolean): String {
+        val eventId = UUID.randomUUID()
+        val now = Instant.now(clock)
+        val payload = objectMapper.writeValueAsString(
+            mapOf(
+                "caseId" to caseId,
+                "proposalType" to proposalType,
+                "summary" to summary,
+                "contested" to contested,
+                "occurredAt" to now.toString(),
+            ),
+        )
+        dataSource.connection.use { conn ->
+            conn.prepareStatement(
+                """
+                INSERT INTO case_outbox
+                    (event_id, aggregate_id, event_type, payload, status, attempt_count, created_at, updated_at)
+                VALUES (?, ?, ?, ?, ?, 0, ?, ?)
+                """.trimIndent(),
+            ).use { ps ->
+                ps.setObject(P1, eventId)
+                ps.setObject(P2, caseUuid(caseId))
+                ps.setString(P3, proposalType)
+                ps.setString(P4, payload)
+                ps.setString(P5, OutboxStatus.PENDING.name)
+                ps.setTimestamp(P6, Timestamp.from(now))
+                ps.setTimestamp(P7, Timestamp.from(now))
+                ps.executeUpdate()
+            }
+        }
+        return eventId.toString()
+    }
+
+    override fun recordCaseOpened(start: CaseStart, openedAtEpochMs: Long) {
+        dataSource.connection.use { conn ->
+            conn.prepareStatement(
+                """
+                INSERT INTO case_workflow
+                    (id, case_class, disposition_target, opened_at, deadline_at, status,
+                     budget_tokens, budget_contributions, contested_rate)
+                VALUES (?, ?, ?, ?, ?, 'OPEN', ?, ?, 0.0)
+                """.trimIndent(),
+            ).use { ps ->
+                ps.setObject(P1, caseUuid(start.caseId))
+                ps.setString(P2, start.caseClass.name)
+                ps.setString(P3, start.dispositionTarget)
+                ps.setTimestamp(P4, Timestamp.from(Instant.ofEpochMilli(openedAtEpochMs)))
+                ps.setTimestamp(P5, Timestamp.from(Instant.ofEpochMilli(start.deadlineEpochMs)))
+                ps.setInt(P6, TOKENS_PER_CASE)
+                ps.setInt(P7, start.maxContributions)
+                ps.executeUpdate()
+            }
+        }
+    }
+
+    override fun recordContributions(caseId: String, contributions: List<Contribution>) {
+        if (contributions.isEmpty()) return
+        val finalDraft = contributions.maxOf { it.draftVersion }
+        val now = Timestamp.from(Instant.now(clock))
+        dataSource.connection.use { conn ->
+            conn.prepareStatement(
+                """
+                INSERT INTO case_contribution (id, case_id, agent_id, contributed_at, tokens_used, preemption_vote)
+                VALUES (?, ?, ?, ?, 0, ?)
+                """.trimIndent(),
+            ).use { ps ->
+                contributions.forEach { c ->
+                    ps.setObject(P1, UUID.randomUUID())
+                    ps.setObject(P2, caseUuid(caseId))
+                    ps.setString(P3, c.agentId)
+                    ps.setTimestamp(P4, now)
+                    // A contribution on a superseded draft is recorded history (D5), flagged so
+                    // the Phase 2 thread view can render the fork instead of a flat list.
+                    ps.setString(P5, if (c.draftVersion < finalDraft) "SUPERSEDED" else null)
+                    ps.addBatch()
+                }
+                ps.executeBatch()
+            }
+            val contested = contributions.count { it.contested }
+            conn.prepareStatement(
+                "UPDATE case_workflow SET contested_rate = ? WHERE id = ?",
+            ).use { ps ->
+                ps.setBigDecimal(P1, (contested.toDouble() / contributions.size).toBigDecimal())
+                ps.setObject(P2, caseUuid(caseId))
+                ps.executeUpdate()
+            }
+        }
+    }
+
+    override fun recordCaseClosed(caseId: String, status: String, closedAtEpochMs: Long) {
+        dataSource.connection.use { conn ->
+            conn.prepareStatement("UPDATE case_workflow SET status = ? WHERE id = ?").use { ps ->
+                ps.setString(P1, status)
+                ps.setObject(P2, caseUuid(caseId))
+                ps.executeUpdate()
+            }
+        }
+    }
+
+    private companion object {
+        /** incident-response budget from agents.yaml case_classes; token accounting lands with evals. */
+        const val TOKENS_PER_CASE = 200_000
+
+        const val P1 = 1
+        const val P2 = 2
+        const val P3 = 3
+        const val P4 = 4
+        const val P5 = 5
+        const val P6 = 6
+        const val P7 = 7
+
+        /** Deterministic correlation UUID for a workflow id — the V1 schema keys on UUID. */
+        fun caseUuid(caseId: String): UUID {
+            val bytes = caseId.toByteArray(StandardCharsets.UTF_8)
+            return UUID.nameUUIDFromBytes(bytes)
+        }
+    }
+}

--- a/openbank-case-coordinator-agent/src/main/resources/application.yaml
+++ b/openbank-case-coordinator-agent/src/main/resources/application.yaml
@@ -96,6 +96,10 @@ openbank:
     server-url: ${TEMPORAL_HOST:temporal-frontend.temporal:7233}
     namespace: ${TEMPORAL_NAMESPACE:openbank}
     task-queue: case-coordinator
+  outbox:
+    # ADR-0244 D7: the case proposal path actually dispatches — the default `false` would leave
+    # every emitted proposal PENDING forever with no error (the security-scanner #3350 lesson).
+    dispatch-enabled: ${OUTBOX_DISPATCH_ENABLED:true}
   case-coordinator:
     # ADR-0244: case-coordinator sweep placeholder. The real schedule is disabled until
     # Temporal case workflows are implemented; this key exists for test-profile override.
@@ -105,3 +109,24 @@ openbank:
     # key degrades the synthesis call instead of CrashLooping the pod.
     model-endpoint: ${CASE_COORDINATOR_MODEL_ENDPOINT:https://api.deepinfra.com/v1/openai}
     model-id: ${CASE_COORDINATOR_MODEL_ID:deepseek-ai/DeepSeek-V3.2}
+
+mp:
+  messaging:
+    # mTLS to Strimzi (ADR-0137). Defaults keep local dev/test on PLAINTEXT; the workload
+    # manifest sets KAFKA_* env in prod to switch to mTLS (account-service shape).
+    connector:
+      smallrye-kafka:
+        security.protocol: ${KAFKA_SECURITY_PROTOCOL:PLAINTEXT}
+        ssl.keystore.location: ${KAFKA_SSL_KEYSTORE_LOCATION:}
+        ssl.keystore.type: ${KAFKA_SSL_KEYSTORE_TYPE:PKCS12}
+        ssl.keystore.password: ${KAFKA_SSL_KEYSTORE_PASSWORD:}
+        ssl.truststore.location: ${KAFKA_SSL_TRUSTSTORE_LOCATION:}
+        ssl.truststore.type: ${KAFKA_SSL_TRUSTSTORE_TYPE:PKCS12}
+        ssl.truststore.password: ${KAFKA_SSL_TRUSTSTORE_PASSWORD:}
+        bootstrap.servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+    outgoing:
+      case-outbox-out:
+        connector: smallrye-kafka
+        # ADR-0244 D7: every case ends in exactly one HITL proposal on this topic.
+        topic: ${CASE_OUTBOX_TOPIC:proposal-events}
+        value.serializer: org.apache.kafka.common.serialization.StringSerializer

--- a/openbank-case-coordinator-agent/src/main/resources/db/migration/V2__case_outbox.sql
+++ b/openbank-case-coordinator-agent/src/main/resources/db/migration/V2__case_outbox.sql
@@ -1,0 +1,26 @@
+-- SPDX-License-Identifier: AGPL-3.0-only
+-- Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+-- A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+-- See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+--
+-- ADR-0244 D7: transactional outbox for the case HITL proposal path. Column set matches
+-- PanacheOutboxEntity + claimed_at (the #1201 cross-pod claim, included from day one).
+-- Rollback: DROP TABLE case_outbox; (proposals then fail to persist — disable case-open first)
+
+CREATE TABLE case_outbox (
+    id            BIGSERIAL PRIMARY KEY,
+    event_id      UUID         NOT NULL UNIQUE,
+    aggregate_id  UUID         NOT NULL,
+    event_type    VARCHAR(128) NOT NULL,
+    payload       TEXT         NOT NULL,
+    status        VARCHAR(16)  NOT NULL,
+    attempt_count INTEGER      NOT NULL DEFAULT 0,
+    sent_at       TIMESTAMPTZ,
+    last_error    TEXT,
+    claimed_at    TIMESTAMPTZ,
+    created_at    TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    updated_at    TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_case_outbox_status_created_at ON case_outbox (status, created_at ASC);
+CREATE INDEX idx_case_outbox_aggregate_id ON case_outbox (aggregate_id);

--- a/openbank-case-coordinator-agent/src/test/kotlin/com/openbank/casecoordinator/application/CaseOpenServiceTest.kt
+++ b/openbank-case-coordinator-agent/src/test/kotlin/com/openbank/casecoordinator/application/CaseOpenServiceTest.kt
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+
+package com.openbank.casecoordinator.application
+
+import com.openbank.casecoordinator.domain.model.CaseClass
+import com.openbank.casecoordinator.infrastructure.config.CaseCoordinatorConfig
+import com.openbank.libs.temporal.TemporalConfig
+import io.mockk.every
+import io.mockk.mockk
+import io.temporal.api.common.v1.WorkflowExecution
+import io.temporal.api.workflowservice.v1.ListOpenWorkflowExecutionsResponse
+import io.temporal.api.workflowservice.v1.WorkflowServiceGrpc
+import io.temporal.client.WorkflowClient
+import io.temporal.client.WorkflowClientOptions
+import io.temporal.client.WorkflowExecutionAlreadyStarted
+import io.temporal.client.WorkflowStub
+import io.temporal.serviceclient.WorkflowServiceStubs
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+
+/**
+ * Case-open authority rules (ADR-0244 D9): capability, per-agent rate limit, dedup mapping.
+ * What is tested is the service's OWN logic: who is denied, when the quota bites, how Temporal's
+ * already-started answer maps to Duplicate. The server-side dedup guarantee itself needs a real
+ * Temporal server and is carried by the workflow-id reuse policy, not by this test.
+ */
+class CaseOpenServiceTest {
+
+    private val workflowClient = mockk<WorkflowClient>()
+    private val temporalConfig = mockk<TemporalConfig>()
+    private val gate = mockk<CaseCapabilityGate>()
+    private val config = mockk<CaseCoordinatorConfig>()
+    private val caseGroup = mockk<CaseCoordinatorConfig.CaseGroup>()
+    private val clock = Clock.fixed(Instant.parse("2026-08-08T10:00:00Z"), ZoneOffset.UTC)
+    private val untyped = mockk<WorkflowStub>()
+
+    private lateinit var service: CaseOpenService
+
+    companion object {
+        private const val COORDINATOR = "case-coordinator"
+    }
+
+    @BeforeEach
+    fun setUp() {
+        every { temporalConfig.enabled() } returns true
+        every { temporalConfig.taskQueue() } returns "case-coordinator"
+        every { gate.canOpenCase(COORDINATOR) } returns true
+        every { config.case() } returns caseGroup
+        every { caseGroup.enabledClasses() } returns setOf(CaseClass.INCIDENT_RESPONSE)
+        every { caseGroup.maxOpensPerAgentPerHour() } returns 1
+        every { caseGroup.maxConcurrent() } returns 15
+        every { caseGroup.ttl() } returns java.time.Duration.ofMinutes(20)
+        every { caseGroup.contestedRateThreshold() } returns 0.35
+        every { caseGroup.maxContributions() } returns 40
+        every { workflowClient.options } returns WorkflowClientOptions.newBuilder().setNamespace("openbank").build()
+        every { workflowClient.newUntypedWorkflowStub("CaseWorkflow", any()) } returns untyped
+        every { untyped.start(any()) } returns WorkflowExecution.getDefaultInstance()
+        val stubs = mockk<WorkflowServiceStubs>()
+        val blocking = mockk<WorkflowServiceGrpc.WorkflowServiceBlockingStub>()
+        every { workflowClient.workflowServiceStubs } returns stubs
+        every { stubs.blockingStub() } returns blocking
+        every { blocking.listOpenWorkflowExecutions(any()) } returns
+            ListOpenWorkflowExecutionsResponse.getDefaultInstance()
+        service = CaseOpenService(workflowClient, temporalConfig, gate, config, clock)
+    }
+
+    private fun open(agent: String = COORDINATOR, subject: String = "ingest-1"): CaseOpenResult =
+        service.open(agent, CaseClass.INCIDENT_RESPONSE, subject, "hitl-incident-queue")
+
+    @Test
+    fun `temporal disabled means unavailable without touching the gate`() {
+        every { temporalConfig.enabled() } returns false
+
+        assertThat(open()).isEqualTo(CaseOpenResult.Unavailable)
+    }
+
+    @Test
+    fun `an agent without case-open capability is denied`() {
+        every { gate.canOpenCase("fraud-analyst") } returns false
+
+        assertThat(open(agent = "fraud-analyst")).isEqualTo(CaseOpenResult.Denied)
+    }
+
+    @Test
+    fun `a disabled case class is denied even for the coordinator`() {
+        assertThat(
+            service.open(COORDINATOR, CaseClass.FRAUD_INVESTIGATION, "case-7", "hitl-fraud-queue"),
+        ).isEqualTo(CaseOpenResult.Denied)
+    }
+
+    @Test
+    fun `the second open within the hour is rate limited`() {
+        assertThat(open()).isInstanceOf(CaseOpenResult.Opened::class.java)
+
+        assertThat(open(subject = "ingest-2")).isEqualTo(CaseOpenResult.RateLimited)
+    }
+
+    @Test
+    fun `an already-running case for the same subject maps to duplicate`() {
+        every { untyped.start(any()) } throws WorkflowExecutionAlreadyStarted(
+            WorkflowExecution.getDefaultInstance(),
+            "CaseWorkflow",
+            null,
+        )
+
+        assertThat(open()).isEqualTo(CaseOpenResult.Duplicate)
+    }
+
+    @Test
+    fun `workflow ids are deterministic per class and sanitized subject`() {
+        assertThat(service.workflowIdFor(CaseClass.INCIDENT_RESPONSE, "ingest pod/1"))
+            .isEqualTo("case-incident-response-ingest-pod-1")
+    }
+}

--- a/openbank-case-coordinator-agent/src/test/kotlin/com/openbank/casecoordinator/application/workflow/CaseWorkflowTest.kt
+++ b/openbank-case-coordinator-agent/src/test/kotlin/com/openbank/casecoordinator/application/workflow/CaseWorkflowTest.kt
@@ -1,0 +1,199 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+
+package com.openbank.casecoordinator.application.workflow
+
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import com.openbank.casecoordinator.domain.model.CaseClass
+import com.openbank.casecoordinator.domain.model.CaseOutcome
+import com.openbank.casecoordinator.domain.model.CaseStart
+import com.openbank.casecoordinator.domain.model.CaseStatus
+import com.openbank.casecoordinator.domain.model.ContributeSignal
+import com.openbank.casecoordinator.domain.model.JoinSignal
+import com.openbank.casecoordinator.domain.model.SupersedeSignal
+import com.openbank.casecoordinator.domain.model.SynthesisRequest
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import io.temporal.client.WorkflowClient
+import io.temporal.client.WorkflowClientOptions
+import io.temporal.client.WorkflowOptions
+import io.temporal.client.WorkflowStub
+import io.temporal.common.converter.DataConverter
+import io.temporal.common.converter.DefaultDataConverter
+import io.temporal.common.converter.JacksonJsonPayloadConverter
+import io.temporal.testing.TestEnvironmentOptions
+import io.temporal.testing.TestWorkflowEnvironment
+import io.temporal.worker.Worker
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/**
+ * The CaseWorkflow itself, executed for real in Temporal's test environment with only the
+ * ACTIVITIES mocked (ADR-0244 D5/D7/D9). What has to be true cannot be shown by testing the
+ * pieces: pre-emption must leave exactly one synthesis over exactly the final draft, the
+ * contested breaker must skip auto-synthesis, and every exit path must emit exactly one
+ * HITL proposal — all four are properties of the workflow's control flow, not of any unit.
+ *
+ * The client converter is the kotlin-aware one the shared TemporalClientProducer builds:
+ * stock Jackson cannot construct Kotlin data classes, and every payload here is one.
+ */
+class CaseWorkflowTest {
+
+    private lateinit var env: TestWorkflowEnvironment
+    private lateinit var worker: Worker
+    private lateinit var synthesis: CaseSynthesisActivity
+    private lateinit var proposals: CaseProposalActivity
+    private lateinit var persistence: CasePersistenceActivity
+
+    companion object {
+        private const val TASK_QUEUE = "test-case-workflow"
+        private const val THRESHOLD = 0.35
+        private const val TTL_MS = 3_600_000L
+
+        internal fun kotlinAwareDataConverter(): DataConverter = DefaultDataConverter
+            .newDefaultInstance()
+            .withPayloadConverterOverrides(
+                JacksonJsonPayloadConverter(
+                    JacksonJsonPayloadConverter.newDefaultObjectMapper().registerKotlinModule(),
+                ),
+            )
+    }
+
+    @BeforeEach
+    fun setUp() {
+        env = TestWorkflowEnvironment.newInstance(
+            TestEnvironmentOptions.newBuilder()
+                .setWorkflowClientOptions(
+                    WorkflowClientOptions.newBuilder().setDataConverter(kotlinAwareDataConverter()).build(),
+                )
+                .build(),
+        )
+        worker = env.newWorker(TASK_QUEUE)
+        worker.registerWorkflowImplementationTypes(CaseWorkflowImpl::class.java)
+        synthesis = mockk(relaxed = true)
+        proposals = mockk(relaxed = true)
+        persistence = mockk(relaxed = true)
+        every { synthesis.synthesize(any(), any(), any()) } returns "CONVERGED: restart the ingest consumer"
+        every { proposals.emitProposal(any(), any(), any(), any()) } returns "proposal-1"
+        worker.registerActivitiesImplementations(synthesis, proposals, persistence)
+        env.start()
+    }
+
+    @AfterEach
+    fun tearDown() = env.close()
+
+    private fun start(deadlineMs: Long = TTL_MS): CaseWorkflow {
+        val start = CaseStart(
+            caseId = "case-incident-response-ingest-1",
+            caseClass = CaseClass.INCIDENT_RESPONSE,
+            subjectRef = "ingest-1",
+            openedBy = "case-coordinator",
+            dispositionTarget = "hitl-incident-queue",
+            deadlineEpochMs = System.currentTimeMillis() + deadlineMs,
+            contestedRateThreshold = THRESHOLD,
+            maxContributions = 40,
+        )
+        val stub = env.workflowClient.newWorkflowStub(
+            CaseWorkflow::class.java,
+            WorkflowOptions.newBuilder().setTaskQueue(TASK_QUEUE).build(),
+        )
+        WorkflowClient.start(stub::run, start)
+        return stub
+    }
+
+    private fun result(stub: CaseWorkflow): CaseOutcome =
+        WorkflowStub.fromTyped(stub).getResult(CaseOutcome::class.java)
+
+    @Test
+    fun `join contribute then synthesis emits exactly one proposal`() {
+        val stub = start()
+        stub.join(JoinSignal("incident-responder", "investigator"))
+        stub.contribute(
+            ContributeSignal("incident-responder", "consumer lag spike after deploy", listOf("grafana/x"), false),
+        )
+        stub.requestSynthesis(SynthesisRequest("case-coordinator"))
+
+        val outcome = result(stub)
+
+        assertThat(outcome.status).isEqualTo(CaseStatus.SYNTHESIZED)
+        assertThat(outcome.proposalId).isEqualTo("proposal-1")
+        verify(exactly = 1) { synthesis.synthesize("case-incident-response-ingest-1", "INCIDENT_RESPONSE", any()) }
+        verify(exactly = 1) {
+            proposals.emitProposal("case-incident-response-ingest-1", "case-synthesis", any(), false)
+        }
+    }
+
+    @Test
+    fun `superseded-by-evidence pre-empts the draft and the case still converges once`() {
+        val stub = start()
+        stub.contribute(ContributeSignal("agent-a", "stale draft: wrong pod", emptyList(), false))
+        stub.supersede(SupersedeSignal("case-coordinator", "log-bundle-9", "newer evidence"))
+        stub.contribute(ContributeSignal("agent-b", "fresh draft: kafka lag", listOf("log-bundle-9"), false))
+        stub.requestSynthesis(SynthesisRequest("case-coordinator"))
+
+        val outcome = result(stub)
+
+        assertThat(outcome.status).isEqualTo(CaseStatus.SYNTHESIZED)
+        verify(exactly = 1) {
+            synthesis.synthesize(
+                any(),
+                any(),
+                match { list ->
+                    list.size == 1 &&
+                        list.single().summary == "fresh draft: kafka lag" &&
+                        list.single().draftVersion == 1
+                },
+            )
+        }
+        verify(exactly = 1) { proposals.emitProposal(any(), any(), any(), any()) }
+        // Both contributions — superseded draft included — are recorded history for the thread view.
+        verify(exactly = 1) {
+            persistence.recordContributions(any(), match { it.size == 2 })
+        }
+    }
+
+    @Test
+    fun `contested circuit breaker escalates to HITL without auto-synthesis`() {
+        val stub = start()
+        stub.contribute(ContributeSignal("agent-a", "this diagnosis is wrong", emptyList(), contested = true))
+
+        val outcome = result(stub)
+
+        assertThat(outcome.status).isEqualTo(CaseStatus.CONTESTED)
+        verify(exactly = 0) { synthesis.synthesize(any(), any(), any()) }
+        verify(exactly = 1) { proposals.emitProposal(any(), "case-contested", any(), true) }
+    }
+
+    @Test
+    fun `ttl timeout closes the case with exactly one timeout proposal`() {
+        val stub = start()
+
+        val outcome = result(stub)
+
+        assertThat(outcome.status).isEqualTo(CaseStatus.CLOSED)
+        verify(exactly = 0) { synthesis.synthesize(any(), any(), any()) }
+        verify(exactly = 1) { proposals.emitProposal(any(), "case-timeout", any(), false) }
+    }
+
+    @Test
+    fun `a signal storm still yields exactly one proposal`() {
+        val stub = start()
+        repeat(5) { i -> stub.join(JoinSignal("agent-$i", "participant")) }
+        repeat(7) { i -> stub.contribute(ContributeSignal("agent-${i % 5}", "finding $i", emptyList(), false)) }
+        stub.supersede(SupersedeSignal("case-coordinator", "e-1", "preempt"))
+        repeat(3) { i -> stub.contribute(ContributeSignal("agent-$i", "final $i", emptyList(), false)) }
+        stub.requestSynthesis(SynthesisRequest("case-coordinator"))
+
+        val outcome = result(stub)
+
+        assertThat(outcome.status).isEqualTo(CaseStatus.SYNTHESIZED)
+        assertThat(outcome.contributionCount).isEqualTo(10)
+        verify(exactly = 1) { proposals.emitProposal(any(), any(), any(), any()) }
+        verify(exactly = 1) { persistence.recordCaseClosed(any(), "SYNTHESIZED", any()) }
+    }
+}


### PR DESCRIPTION
## What

Phase 1 of the swarm-coordination delivery plan (#3737, ADR-0244): the Temporal `CaseWorkflow` lifecycle in `openbank-case-coordinator-agent`.

- **`CaseWorkflow`** (workflow type `CaseWorkflow`, task queue `case-coordinator`) — deterministic state machine: `contribute` / `contest` / `request-synthesis` signals, per-case-class contribution cap + deadline (TTL), draft-version pre-emption, contested-rate breaker (threshold from `agents.yaml: case_classes`), and a **single terminal synthesis exit** — the "exactly one HITL proposal per case" invariant (D7) holds even under a signal storm (tested).
- **`CaseOpenService`** — dedup by deterministic workflow id `case-<class>-<subject>` (`REJECT_DUPLICATE`), per-agent hourly rate limit, fail-closed concurrent-open ceiling via Temporal visibility count.
- **`CaseCapabilityGate`** — `agents.yaml`-based `case.open`/`case.contribute`/`case.synthesize` check, fail-closed. OPA-backed bundle wiring is Phase 4 (#4187).
- **REST** — `POST /api/v1/case-coordinator/cases` (201/202/400/403/409/429/503) and `POST /cases/{id}/signals`.
- **Outbox** — terminal proposal event published transactionally (`case_outbox`, V2 migration) to `proposal-events`; consumed by the existing ADR-0031 HITL queue.
- **Config** — split into `@ConfigGroup` (`openbank.case-coordinator.case.*`); kafka channel + `outbox.dispatch-enabled: true` in `application.yaml`.

Closes #4181 · Refs #3737

## Verification

- 11/11 unit tests green: `CaseWorkflowTest` (synthesis→1 proposal, pre-emption converges on final draft, contested breaker blocks auto-synthesis, TTL → case-timeout proposal, signal storm → exactly 1 proposal) + `CaseOpenServiceTest` (dedup/rate-limit/ceiling/gate/Temporal-down paths).
- `ktlintCheck`, `detekt`, `quarkusBuild` (CDI) green; kover floor ratcheted 5% → 42% (measured; `@Path` classes excluded per module config).
- The module's boot smoke IT (REST boot + JDBC activity paths) runs in CI — local Docker Desktop VM disk is full, cannot run Testcontainers locally.

## Explicitly out of scope (next phases)

- Read model + case history API → #4185 (Phase 2); openapi.yaml + Pact land there with the query surface.
- Admin-ui swarm thread view → #4186 (Phase 3, ADR-0246).
- GitOps deployment, OPA bundle for the capability gate, kill-switch→Temporal cancellation wiring → #4187 (Phase 4).
