### PR TITLE
fix(ledger): make the ČNB fixing's age observable at the point of revaluation

### DIFF
--- a/docs/threat-models/openbank-ledger-service.md
+++ b/docs/threat-models/openbank-ledger-service.md
@@ -260,3 +260,24 @@ set) apply equally to the new `ledger.approval.decide` action.
   existing `ExceptionMappers.kt`. STRIDE supplement added in §7 above. **`authz.four-eyes.enforce`
   stays `false`** — no behavior change to any existing request; this PR only wires the mechanism.
   Rollback: revert the commit (no DB/schema change; `ApprovalStore` records live in Redis with a TTL).
+- **2026-08-08** — **The ČNB fixing's `validFrom` now crosses the fx-service seam** (issue #3921).
+  `CnbRateProvider` returned a bare `BigDecimal?`, and `FxServiceClient`'s DTO declared only
+  `baseCurrency/quoteCurrency/bidRate/askRate` — fx-service was already serving `validFrom`, and
+  `@JsonIgnoreProperties(ignoreUnknown = true)` silently dropped it. The port now returns
+  `CnbFixing(rate, validFrom)` and `FxServiceCnbRateAdapter` carries it through. **Risk class =
+  information disclosure**, and it is a bounded *decrease* in blind trust rather than an increase:
+  no new endpoint, no new caller, no authorization or NetworkPolicy change, and the field was
+  already on the wire — this side simply stops discarding it. It is a published reference rate, so
+  it discloses nothing about any customer or position. The only new outbound artifact is a metric,
+  `openbank.fx.fixing.age_seconds{currency}`, which carries a currency label and an age in seconds
+  and no amount, account or party.
+  **Why it matters here**: nothing anywhere compared a fixing's age to now. The service-side bound
+  is date-blind (`CNB_VALIDITY_DAYS = 3`, `validTo > :now`), so a stale rate revalues silently, and
+  the one alert meant to catch the silent case — `FxRevaluationSkippedAllLegs` — selected
+  `{namespace="fx"}` while the log line it matches is emitted only by this service, deployed to
+  namespace `ledger`. It could never fire. That selector is corrected in the same change.
+  **Explicitly NOT addressed**: a late or corrected fixing still cannot be incorporated.
+  `idempotencyKey = "fx-reval-{date}"` carries no rate identity, so a re-run returns the existing
+  entry and reports success while every position marked that day keeps the superseded rate's CZK
+  counter-value. That needs a correcting-entry decision, not a patch, and #3921 stays open for it.
+  Rollback: revert; the field is read-only on this side and nothing persists it.

--- a/openbank-infra/gitops/components/observability/loki-rules-silent-failures.yaml
+++ b/openbank-infra/gitops/components/observability/loki-rules-silent-failures.yaml
@@ -103,20 +103,32 @@ data:
 
           # A job that completed successfully having done nothing. The hardest class to alert on,
           # because every metric it touches reports a healthy run.
+          # The selector is `ledger`, not `fx`, and that one word was the whole rule (#3921).
+          # "skipping its revaluation leg" is emitted from exactly one place in service code —
+          # openbank-ledger-service .../usecase/FxRevaluationService.kt — and the ledger workload
+          # deploys to namespace `ledger` (gitops/apps/ledger.yaml). Selecting `fx` matched the
+          # namespace holding fx-service, fx-db and redis, where that string is never logged, so
+          # the only rule claiming to cover the skipped-leg path could not fire at all. The label
+          # vocabulary was never in doubt: this same file selects namespace=~"ledger|accounts|…"
+          # elsewhere. Companion signal, and the one that catches the quieter failure: the
+          # openbank_fx_fixing_age_seconds gauge in prometheus-rules-fx-fixing.yaml, which sees a
+          # rate that is stale-but-valid — a case that logs nothing at all.
           - alert: FxRevaluationSkippedAllLegs
             expr: |
               sum by (namespace) (
-                count_over_time({namespace="fx"} |= "skipping its revaluation leg" [1h])
+                count_over_time({namespace="ledger"} |= "skipping its revaluation leg" [1h])
               ) > 0
             for: 15m
             labels:
               severity: warning
               team: platform
             annotations:
-              summary: "fx-service revalued nothing — no valid rate available"
+              summary: "ledger-service revalued nothing — no valid ČNB rate available"
               description: >-
-                FxRevaluationService found no usable rate and returned posted=false. The run looks
-                successful from every angle: no exception, no failed counter, a green job. The only
-                other evidence is a table that stops growing, and nothing alerts on that. Check the
-                ČNB feed first (check-external-feeds.py probes the URL's payload SHAPE, not its
-                status code — a 404 HTML page is a perfectly valid HTTP response).
+                FxRevaluationService (openbank-ledger-service) found no usable rate and returned
+                posted=false. The run looks successful from every angle: no exception, no failed
+                counter, a green job, and a workflow-liveness heartbeat that records the run as a
+                success. The only other evidence is a table that stops growing, and nothing alerts
+                on that. Check the ČNB feed first — it is ingested by fx-service, one namespace
+                over (check-external-feeds.py probes the URL's payload SHAPE, not its status code
+                — a 404 HTML page is a perfectly valid HTTP response).

--- a/openbank-infra/gitops/components/observability/prometheus-rules-fx-fixing.yaml
+++ b/openbank-infra/gitops/components/observability/prometheus-rules-fx-fixing.yaml
@@ -1,0 +1,82 @@
+# ČNB fixing freshness at the point of use (issue #3921, ADR-0237 point 2).
+#
+# openbank-ledger-service publishes openbank_fx_fixing_age_seconds{currency} — the
+# scrape-time age of the fixing its daily FX revaluation last marked positions at,
+# per currency (FxFixingFreshnessGauge). It is deliberately NOT the same signal as
+# the two rules already covering this job:
+#
+#   * openbank_workflow_last_success_age_seconds{workflow="ledger-fx-revaluation"}
+#     answers "did the job run". A run that marked every position at a three-day-old
+#     fixing calls recordSuccess() and is indistinguishable from a healthy one.
+#   * FxRevaluationSkippedAllLegs (loki-rules-silent-failures.yaml) answers "was any
+#     rate available at all". A stale-but-valid rate logs nothing — fx-service's
+#     validity window is three days and date-blind, so a Friday fixing marking a
+#     Monday position is silent on every existing signal.
+#
+# Boot-safe by construction: the gauge's holder is seeded at registration, not at
+# Instant.EPOCH, so a fresh pod reads as old as itself rather than as decades. That
+# is what allows a plain threshold here with no pod-uptime guard — the trap the
+# workflow-liveness KDoc documents at length (#2239 Gap 2).
+#
+# severity: warning throughout, per ADR-0237 point 3 and #3346: a stale valuation is
+# a correctness gap to work in hours, not a page. Note what this rule does NOT do —
+# a corrected fixing arriving after the run can never be incorporated, because the
+# revaluation's idempotency key is the business date alone with no rate identity, so
+# a re-run returns the original entry and reports success. This alert makes that
+# condition visible; it does not fix it (#3921, still open).
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: openbank-fx-fixing-freshness
+  namespace: observability
+  labels:
+    app.kubernetes.io/part-of: observability
+spec:
+  groups:
+    - name: openbank.fx.fixing
+      interval: 5m
+      rules:
+        # 1. The series is gone fleet-wide. Not "all rates fresh" — either ledger
+        # stopped being scraped or the revaluation never reached a currency loop, and
+        # in both cases every freshness verdict below is void. 25h so a single missed
+        # daily run does not trip it on its own; that is rule 2's job.
+        - alert: FxFixingAgeAbsent
+          expr: absent(openbank_fx_fixing_age_seconds)
+          for: 25h
+          labels:
+            severity: warning
+            team: platform
+          annotations:
+            summary: "No FX fixing-age series from ledger-service for 25h"
+            description: >-
+              openbank_fx_fixing_age_seconds is absent. The daily FX revaluation
+              reports one sample per currency per run, including currencies it could
+              not resolve, so an absent series means the run itself is not reaching
+              that code — check WorkflowLivenessStale for workflow="ledger-fx-revaluation"
+              and the ledger pod log for HR000068 before reading any other FX signal.
+
+        # 2. A position is being valued at a fixing older than two ČNB publication
+        # cycles. 60h absorbs a normal weekend (a Friday fixing is legitimately ~63h
+        # old by Monday morning, so the threshold sits just above one weekend and
+        # below two) plus a public holiday. for: 1h keeps a single stale scrape during
+        # ingestion from firing.
+        - alert: FxFixingStale
+          expr: openbank_fx_fixing_age_seconds > 60 * 3600
+          for: 1h
+          labels:
+            severity: warning
+            team: platform
+          annotations:
+            summary: "{{ $labels.currency }} positions valued at a fixing {{ $value | humanizeDuration }} old"
+            description: >-
+              The last FX revaluation marked {{ $labels.currency }} positions at a ČNB
+              fixing older than 60h, or could not resolve one at all (an unresolved
+              attempt deliberately leaves the age climbing rather than blanking the
+              series). fx-service serves any fixing inside a three-day validity window
+              without regard to the date being revalued, so this is silent everywhere
+              else. Check the ČNB ingestion in namespace fx first
+              (workflow="fx-cnb-ingestion"), then the fx→ledger call. Positions in this
+              currency carry a valuation from a superseded rate until a run succeeds
+              with a current one — and a re-run for a date already posted returns the
+              original entry unchanged (#3921), so a correcting entry is a manual
+              decision, not a retry.

--- a/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/application/port/out/CnbRateProvider.kt
+++ b/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/application/port/out/CnbRateProvider.kt
@@ -5,14 +5,33 @@
 package com.openbank.ledger.application.port.out
 
 import java.math.BigDecimal
+import java.time.Instant
+
+/**
+ * A ČNB fixing as the revaluation consumes it: the statutory CZK-per-unit [rate] **and** the moment
+ * that fixing became valid.
+ *
+ * [validFrom] is the whole point of this type (#3921). The port used to return a bare [BigDecimal],
+ * so no time at all crossed the fx→ledger seam — fx-service persists and serves `validFrom`, and
+ * ledger threw it away on the wire. With no date on this side there was nowhere a staleness check
+ * or a freshness metric could even be *written*: a Friday fixing marked a Monday position with no
+ * warning, no metric and no alert, bounded only by fx-service's own date-blind three-day validity
+ * window. Carrying the instant does not by itself reject anything — it makes the age observable,
+ * which is the prerequisite for everything else in #3921.
+ *
+ * Nullable on purpose: an fx-service that does not send `validFrom` (an older deploy, or a stored
+ * row without one) must degrade to "age unknown", never to "age zero". A silent zero would read as
+ * a perfectly fresh fixing on the very dashboards this exists to populate.
+ */
+data class CnbFixing(val rate: BigDecimal, val validFrom: Instant?)
 
 /**
  * Outbound port for reading the ČNB central-bank fixing from `openbank-fx-service` (FX rates are
  * that service's bounded context — ADR-0046). Returns the statutory CZK-per-unit rate used for the
- * daily mark-to-ČNB revaluation.
+ * daily mark-to-ČNB revaluation, together with the fixing's own validity start.
  */
 interface CnbRateProvider {
 
     /** Latest ČNB fixing as CZK per 1 unit of [base] (against CZK), or `null` if none is published. */
-    suspend fun cnbRate(base: String): BigDecimal?
+    suspend fun cnbRate(base: String): CnbFixing?
 }

--- a/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/application/port/out/FxFixingFreshnessPort.kt
+++ b/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/application/port/out/FxFixingFreshnessPort.kt
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.ledger.application.port.out
+
+import java.time.Instant
+
+/**
+ * Outbound port for publishing **how old the ČNB fixing used by the last revaluation attempt is**
+ * (#3921, ADR-0237 point 2 — "the job ran" and "the feed delivered" must be separate signals).
+ *
+ * ### Why this is not covered by the workflow-liveness gauge
+ *
+ * `FxRevaluationScheduler` already registers ADR-0160 mechanism 3, which answers *did the job run*.
+ * A run that marked every position at a three-day-old fixing calls `recordSuccess()` and is
+ * indistinguishable from a healthy one — as is a run where no rate was available at all, which
+ * returns `posted = false` after a single WARN. That is the exact shape of the ČNB-404 history: a
+ * successful-looking run of a job that revalued nothing, whose only evidence anywhere was a table
+ * that stopped growing, and nothing alerts on a table not growing.
+ *
+ * A **counter** would not close it either. "Revaluations attempted" rises identically whether the
+ * rate was minutes or a week old, and a counter of stale runs only moves once someone has already
+ * chosen a staleness threshold in code. The signal that carries the information is the *age of the
+ * last value actually used*, sampled at scrape time — the same primitive shape as
+ * `openbank_workflow_last_success_age_seconds`, one level down: not "when did the job last
+ * succeed" but "how old is the number it succeeded with".
+ */
+interface FxFixingFreshnessPort {
+
+    /**
+     * Report the outcome of resolving the fixing for [currency] on one revaluation attempt.
+     *
+     * Call on **every** attempt, for **every** currency in scope — including the ones that could
+     * not be resolved. That is what makes a feed going quiet visible: passing `null` deliberately
+     * leaves the currency's last known fixing instant in place, so its published age keeps growing
+     * rather than the series vanishing. An absent series reads as "nothing to see" on every
+     * dashboard and in most alert expressions; a growing age reads as the problem it is.
+     *
+     * @param currency  ISO-4217 code of the position's currency — low cardinality, three values
+     * @param validFrom the instant the fixing became valid, or `null` when no fixing (or no fixing
+     *                  date) was available for this attempt
+     */
+    fun fixingObserved(currency: String, validFrom: Instant?)
+}

--- a/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/application/usecase/FxRevaluationService.kt
+++ b/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/application/usecase/FxRevaluationService.kt
@@ -13,12 +13,14 @@ import com.openbank.ledger.application.port.`in`.LedgerUseCase
 import com.openbank.ledger.application.port.`in`.PostJournalCommand
 import com.openbank.ledger.application.port.`in`.RevalueFxCommand
 import com.openbank.ledger.application.port.out.CnbRateProvider
+import com.openbank.ledger.application.port.out.FxFixingFreshnessPort
 import com.openbank.ledger.application.port.out.GlAccountRepository
 import com.openbank.ledger.domain.event.FxRevaluedEvent
 import com.openbank.ledger.domain.model.FxRevaluationInput
 import com.openbank.ledger.domain.model.FxRevaluationPosting
 import com.openbank.ledger.domain.model.JournalEntry
 import com.openbank.ledger.domain.model.JournalLine
+import com.openbank.ledger.domain.model.TrialBalanceLine
 import com.openbank.libs.persistence.outbox.OutboxMessage
 import jakarta.enterprise.context.ApplicationScoped
 import org.jboss.logging.Logger
@@ -39,6 +41,22 @@ import java.util.UUID
  * commits in the SAME transaction as the `JournalPosted`/`AccountBookedChanged` rows the post
  * itself writes (#1201 proposed fix 3) — not a separate post-commit publish that a crash between
  * the two could lose.
+ *
+ * ### Fixing freshness, and what is still open (#3921)
+ *
+ * Every attempt reports the resolved fixing's age through [FxFixingFreshnessPort], and the posting
+ * records which fixing it used in its description. Both exist because a revaluation cannot fail
+ * loudly here: with no rate it returns `posted = false` after one WARN, and with a stale-but-valid
+ * rate it returns a perfectly ordinary success. fx-service's validity window is three days and
+ * date-blind, so a Friday fixing marking a Monday position is, to every other signal, a healthy run.
+ *
+ * **The correctness half of #3921 is NOT addressed here.** `idempotencyKey = "fx-reval-{date}"`
+ * keys on the business day alone, with no rate identity, and `LedgerService.postJournal` returns
+ * the existing entry on a key hit. So a re-run after a corrected or belated fixing lands returns
+ * the ORIGINAL entry, emits no new event and reports `posted = true` — a success that changed
+ * nothing, leaving the position valued at the superseded rate indefinitely. Fixing that needs a
+ * decision about correcting entries (a rate-identity component in the key, or an explicit reversing
+ * entry), not a smaller patch; the age gauge above is what makes the condition visible meanwhile.
  */
 @ApplicationScoped
 class FxRevaluationService(
@@ -47,6 +65,7 @@ class FxRevaluationService(
     private val cnbRates: CnbRateProvider,
     private val objectMapper: ObjectMapper,
     private val clock: Clock,
+    private val fixingFreshness: FxFixingFreshnessPort,
 ) : FxRevaluationUseCase {
 
     private val log: Logger = Logger.getLogger(FxRevaluationService::class.java)
@@ -57,28 +76,13 @@ class FxRevaluationService(
 
         val inputs = mutableListOf<FxRevaluationInput>()
         val movements = mutableMapOf<String, BigDecimal>()
+        val fixings = linkedMapOf<String, Instant>()
 
         for ((currency, codes) in CURRENCIES) {
-            val rate = cnbRates.cnbRate(currency)
-            if (rate == null) {
-                log.warnf("No ČNB rate for %s/CZK on %s — skipping its revaluation leg", currency, command.date)
-                continue
-            }
-            val counterValue = glAccounts.findByCode(codes.counterValueCode)
-                ?: error("Counter-value GL account ${codes.counterValueCode} missing — is migration V6 applied?")
-
-            // 199x is credited when the bank acquires the currency, so credit − debit is the long position.
-            val positionLine = byCode[codes.positionCode]
-            val positionForeign = positionLine?.let { it.totalCredit.subtract(it.totalDebit) } ?: BigDecimal.ZERO
-            // Counter-value is a normal ASSET: its net (debit − credit) is the CZK already marked.
-            val carryCzk = byCode[codes.counterValueCode]?.net ?: BigDecimal.ZERO
-
-            val input = FxRevaluationInput(currency, counterValue.id, positionForeign, rate, carryCzk)
-            val movement = FxRevaluationPosting.movement(input)
-            if (movement.signum() != 0) {
-                inputs += input
-                movements[currency] = movement
-            }
+            val leg = resolveLeg(currency, codes, byCode, command.date) ?: continue
+            inputs += leg.input
+            movements[currency] = leg.movement
+            leg.validFrom?.let { fixings[currency] = it }
         }
 
         if (inputs.isEmpty()) {
@@ -98,17 +102,65 @@ class FxRevaluationService(
                 transactionId = UUID.nameUUIDFromBytes("fx-reval-${command.date}".toByteArray()),
                 entryDate = command.date,
                 valueDate = command.date,
-                description = "Daily FX revaluation at ČNB fixing ${command.date}",
+                description = "Daily FX revaluation at ČNB fixing ${command.date}${fixingSuffix(fixings)}",
                 lines = lines.map { it.toRequest() },
                 postedBy = SYSTEM_USER,
                 additionalOutboxMessages = { posted -> listOf(fxRevaluedMessage(posted, command.date, movements)) },
             ),
         )
 
-        log.infof("FX revaluation %s posted as %s: %s", command.date, entry.id, movements)
+        log.infof("FX revaluation %s posted as %s: %s (fixings %s)", command.date, entry.id, movements, fixings)
 
         return FxRevaluationResult(command.date, posted = true, journalId = entry.id, movements = movements)
     }
+
+    /**
+     * One currency's revaluation leg, or `null` when there is nothing to post for it — either no
+     * ČNB fixing was available, or the position has not moved since the last mark.
+     *
+     * The freshness report happens here, unconditionally, **before** either null return. Reporting
+     * only the resolved legs would publish an age exclusively for the currencies that are working,
+     * which is the inverse of what the signal is for.
+     */
+    private suspend fun resolveLeg(
+        currency: String,
+        codes: AccountCodes,
+        byCode: Map<String, TrialBalanceLine>,
+        date: LocalDate,
+    ): RevaluationLeg? {
+        val fixing = cnbRates.cnbRate(currency)
+        // Report EVERY attempt, resolved or not — a null here deliberately leaves the currency's
+        // published age climbing instead of blanking the series (#3921).
+        fixingFreshness.fixingObserved(currency, fixing?.validFrom)
+        if (fixing == null) {
+            log.warnf("No ČNB rate for %s/CZK on %s — skipping its revaluation leg", currency, date)
+            return null
+        }
+        val counterValue = glAccounts.findByCode(codes.counterValueCode)
+            ?: error("Counter-value GL account ${codes.counterValueCode} missing — is migration V6 applied?")
+
+        // 199x is credited when the bank acquires the currency, so credit − debit is the long position.
+        val positionLine = byCode[codes.positionCode]
+        val positionForeign = positionLine?.let { it.totalCredit.subtract(it.totalDebit) } ?: BigDecimal.ZERO
+        // Counter-value is a normal ASSET: its net (debit − credit) is the CZK already marked.
+        val carryCzk = byCode[codes.counterValueCode]?.net ?: BigDecimal.ZERO
+
+        val input = FxRevaluationInput(currency, counterValue.id, positionForeign, fixing.rate, carryCzk)
+        val movement = FxRevaluationPosting.movement(input)
+        return if (movement.signum() == 0) null else RevaluationLeg(input, movement, fixing.validFrom)
+    }
+
+    /**
+     * Renders the fixings the posting was actually built from, e.g. ` [fixings EUR@2026-08-07T13:15:00Z]`.
+     *
+     * The entry used to record only the business day it marked, never the rate it marked at, so
+     * "which fixing valued this position" was unanswerable from the ledger — and it is the question
+     * that matters when a corrected fixing arrives after the run (#3921). Empty when no leg carried
+     * a fixing date, so an fx-service that does not send `validFrom` leaves the description exactly
+     * as it was rather than adding an empty bracket.
+     */
+    private fun fixingSuffix(fixings: Map<String, Instant>): String =
+        if (fixings.isEmpty()) "" else fixings.entries.joinToString(", ", " [fixings ", "]") { "${it.key}@${it.value}" }
 
     private fun fxRevaluedMessage(entry: JournalEntry, date: LocalDate, movements: Map<String, BigDecimal>) =
         OutboxMessage(
@@ -136,6 +188,9 @@ class FxRevaluationService(
     )
 
     private data class AccountCodes(val positionCode: String, val counterValueCode: String)
+
+    /** A leg that will contribute to the posting, with the fixing instant it was valued at. */
+    private data class RevaluationLeg(val input: FxRevaluationInput, val movement: BigDecimal, val validFrom: Instant?)
 
     private companion object {
         const val EXCHANGE_DIFF_CODE = "5900"

--- a/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/client/FxServiceClient.kt
+++ b/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/client/FxServiceClient.kt
@@ -16,6 +16,7 @@ import jakarta.ws.rs.core.MediaType
 import org.eclipse.microprofile.rest.client.annotation.RegisterProvider
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient
 import java.math.BigDecimal
+import java.time.Instant
 
 /**
  * RestClient binding to `openbank-fx-service` for reading the ČNB central-bank fixing
@@ -37,11 +38,21 @@ interface FxServiceClient {
     ): Uni<FxRateResponse>
 }
 
-/** Subset of the fx-service FxRate payload we need; a CNB fixing has bid == ask == mid. */
+/**
+ * Subset of the fx-service FxRate payload we need; a CNB fixing has bid == ask == mid.
+ *
+ * [validFrom] is read because the revaluation has to know **how old the fixing it is about to mark
+ * positions at actually is** (#3921). fx-service has always served it — it is a column on
+ * `fx_rates` and a field of that service's own `FxRateResponse` — and this DTO simply did not
+ * declare it, so `@JsonIgnoreProperties(ignoreUnknown = true)` dropped it on the floor and the
+ * ledger side had no time value to reason about at all. Nullable so a payload without it degrades
+ * to "age unknown" rather than to a fabricated "just now".
+ */
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class FxRateResponse(
     val baseCurrency: String? = null,
     val quoteCurrency: String? = null,
     val bidRate: BigDecimal? = null,
     val askRate: BigDecimal? = null,
+    val validFrom: Instant? = null,
 )

--- a/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/client/FxServiceCnbRateAdapter.kt
+++ b/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/client/FxServiceCnbRateAdapter.kt
@@ -4,6 +4,7 @@
 
 package com.openbank.ledger.infrastructure.client
 
+import com.openbank.ledger.application.port.out.CnbFixing
 import com.openbank.ledger.application.port.out.CnbRateProvider
 import io.smallrye.mutiny.coroutines.awaitSuspending
 import jakarta.enterprise.context.ApplicationScoped
@@ -13,7 +14,6 @@ import org.eclipse.microprofile.faulttolerance.CircuitBreaker
 import org.eclipse.microprofile.faulttolerance.Retry
 import org.eclipse.microprofile.faulttolerance.Timeout
 import org.eclipse.microprofile.rest.client.inject.RestClient
-import java.math.BigDecimal
 
 /**
  * Resilient adapter over [FxServiceClient]. Wraps the cross-service call in the same fault-tolerance
@@ -27,15 +27,17 @@ class FxServiceCnbRateAdapter(@RestClient private val client: FxServiceClient) :
     @Inject
     lateinit var self: FxServiceCnbRateAdapter
 
-    override suspend fun cnbRate(base: String): BigDecimal? = self.fetchWithResilience(base)
+    override suspend fun cnbRate(base: String): CnbFixing? = self.fetchWithResilience(base)
 
     @CircuitBreaker(requestVolumeThreshold = 4, failureRatio = 0.5, delay = 10_000, successThreshold = 2)
     @Retry(maxRetries = 3, delay = 500, jitter = 200, retryOn = [Exception::class])
     @Timeout(8_000)
-    open suspend fun fetchWithResilience(base: String): BigDecimal? = try {
+    open suspend fun fetchWithResilience(base: String): CnbFixing? = try {
         val rate = client.getRate(base, QUOTE, SOURCE_CNB).awaitSuspending()
         // CNB fixing stores bid == ask == mid; either is the per-unit CZK rate.
-        rate.bidRate ?: rate.askRate
+        // `validFrom` rides along unchanged, including when absent — see CnbFixing's KDoc for why a
+        // missing fixing date must not become Instant.now() here (#3921).
+        (rate.bidRate ?: rate.askRate)?.let { CnbFixing(it, rate.validFrom) }
     } catch (ex: WebApplicationException) {
         if (ex.response?.status == 404) null else throw ex
     }

--- a/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/observability/FxFixingFreshnessGauge.kt
+++ b/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/observability/FxFixingFreshnessGauge.kt
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.ledger.infrastructure.observability
+
+import com.openbank.ledger.application.port.out.FxFixingFreshnessPort
+import io.micrometer.core.instrument.Gauge
+import io.micrometer.core.instrument.MeterRegistry
+import jakarta.enterprise.context.ApplicationScoped
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * Micrometer adapter for [FxFixingFreshnessPort]: publishes [FIXING_AGE_SECONDS] tagged by
+ * `currency` — the scrape-time age of the ČNB fixing the FX revaluation last used for that
+ * currency (#3921).
+ *
+ * ### Two design choices that are the whole value of the gauge
+ *
+ * **Seeded at registration, not at [Instant.EPOCH].** A fresh pod that has not yet run a
+ * revaluation publishes an age counted from its own start, so it reads as old as the pod rather
+ * than as decades. That is ADR-0237 point 3's boot-safety property, and it is what makes this
+ * gauge safe to alert on with a plain threshold: an EPOCH seed makes every deploy fire the alert
+ * continuously until the next successful run, which for a daily job is up to 24h of noise that no
+ * `for:` duration can absorb, because the condition genuinely persists. The cost of the
+ * registration seed is that a pod restarted more often than the feed publishes can mask staleness;
+ * the daily job's 2-day threshold is far longer than the pod's restart cadence, so a mask requires
+ * a restart storm, which has its own alerts.
+ *
+ * **A resolution failure does not clear the holder.** [fixingObserved] with a `null` instant leaves
+ * the last known fixing time in place, so the published age keeps climbing. Clearing it (or simply
+ * not publishing) would make the series flat-line or disappear at exactly the moment the feed
+ * stopped delivering — the "table that stopped growing" failure, restated as a metric.
+ *
+ * Registration is lazy per currency and idempotent: [ConcurrentHashMap.computeIfAbsent] registers
+ * the gauge once on first sight, matching `DomainMetrics.recordReconciliationDrift`'s shape for the
+ * same reason (the tag set is only known once the workload runs).
+ */
+@ApplicationScoped
+class FxFixingFreshnessGauge(private val registry: MeterRegistry, private val clock: Clock) :
+    FxFixingFreshnessPort {
+
+    private val lastFixing = ConcurrentHashMap<String, AtomicReference<Instant>>()
+
+    override fun fixingObserved(currency: String, validFrom: Instant?) {
+        val holder = lastFixing.computeIfAbsent(currency) { code ->
+            val ref = AtomicReference(clock.instant())
+            Gauge.builder(FIXING_AGE_SECONDS) { Duration.between(ref.get(), clock.instant()).seconds.toDouble() }
+                .tag(CURRENCY_TAG, code)
+                .strongReference(true)
+                .register(registry)
+            ref
+        }
+        if (validFrom != null) holder.set(validFrom)
+    }
+
+    companion object {
+        /**
+         * Meter name (Micrometer, dotted). Prometheus scrapes it as
+         * `openbank_fx_fixing_age_seconds` — the series
+         * `openbank-infra/gitops/components/observability/prometheus-rules-fx-fixing.yaml` alerts
+         * on. Written down once here rather than spelled at both ends, the #2187 lesson: the
+         * producer and the consumer each hardcoding their own literal is how a metric ends up
+         * emitted under a name nothing queries, and both sides' tests still pass.
+         */
+        const val FIXING_AGE_SECONDS: String = "openbank.fx.fixing.age_seconds"
+
+        /** Tag carrying the position currency — ISO-4217, three values in ADR-0046 scope. */
+        const val CURRENCY_TAG: String = "currency"
+    }
+}

--- a/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/application/usecase/FxRevaluationServiceTest.kt
+++ b/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/application/usecase/FxRevaluationServiceTest.kt
@@ -11,6 +11,7 @@ import com.openbank.ledger.application.port.`in`.GetTrialBalanceQuery
 import com.openbank.ledger.application.port.`in`.LedgerUseCase
 import com.openbank.ledger.application.port.`in`.PostJournalCommand
 import com.openbank.ledger.application.port.`in`.RevalueFxCommand
+import com.openbank.ledger.application.port.out.CnbFixing
 import com.openbank.ledger.application.port.out.CnbRateProvider
 import com.openbank.ledger.application.port.out.GlAccountRepository
 import com.openbank.ledger.domain.model.GlAccount
@@ -21,8 +22,10 @@ import com.openbank.ledger.domain.model.JournalSide
 import com.openbank.ledger.domain.model.JournalStatus
 import com.openbank.ledger.domain.model.TrialBalance
 import com.openbank.ledger.domain.model.TrialBalanceLine
+import com.openbank.ledger.infrastructure.observability.FxFixingFreshnessGauge
 import com.openbank.libs.domain.money.CurrencyCode
 import com.openbank.libs.domain.money.Money
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
@@ -32,6 +35,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.math.BigDecimal
 import java.time.Clock
+import java.time.Duration
 import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneOffset
@@ -50,9 +54,25 @@ class FxRevaluationServiceTest {
     private val objectMapper = ObjectMapper()
         .registerModule(JavaTimeModule())
         .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
-    private val clock = Clock.fixed(Instant.parse("2026-05-30T15:00:00Z"), ZoneOffset.UTC)
+    private val now = Instant.parse("2026-05-30T15:00:00Z")
+    private val clock = Clock.fixed(now, ZoneOffset.UTC)
 
-    private val service = FxRevaluationService(ledger, glAccounts, cnbRates, objectMapper, clock)
+    // The REAL Micrometer adapter over a SimpleMeterRegistry, not a mock port: the assertions
+    // below are on published gauge values, and a mock would only prove the call was made — which
+    // says nothing about what an alert would read at scrape time (#3921).
+    private val registry = SimpleMeterRegistry()
+    private val freshness = FxFixingFreshnessGauge(registry, clock)
+
+    private val service = FxRevaluationService(ledger, glAccounts, cnbRates, objectMapper, clock, freshness)
+
+    /** ČNB publishes the fixing early afternoon Prague time; the date is what matters. */
+    private fun fixing(rate: String, validFrom: Instant? = Instant.parse("2026-05-30T13:15:00Z")) =
+        CnbFixing(BigDecimal(rate), validFrom)
+
+    private fun age(currency: String): Double? = registry.find(FxFixingFreshnessGauge.FIXING_AGE_SECONDS)
+        .tag(FxFixingFreshnessGauge.CURRENCY_TAG, currency)
+        .gauge()
+        ?.value()
 
     private val eurCvId = UUID.randomUUID()
     private val pnlId = UUID.randomUUID()
@@ -121,7 +141,7 @@ class FxRevaluationServiceTest {
             asOf = date,
             lines = listOf(position("1991", debit = "0", credit = "1000000")),
         )
-        coEvery { cnbRates.cnbRate("EUR") } returns BigDecimal("25.145")
+        coEvery { cnbRates.cnbRate("EUR") } returns fixing("25.145")
         coEvery { cnbRates.cnbRate("USD") } returns null
         coEvery { cnbRates.cnbRate("GBP") } returns null
         coEvery { glAccounts.findByCode("1995") } returns gl(eurCvId, "1995")
@@ -178,7 +198,7 @@ class FxRevaluationServiceTest {
                 ),
             ),
         )
-        coEvery { cnbRates.cnbRate("EUR") } returns BigDecimal("25.145")
+        coEvery { cnbRates.cnbRate("EUR") } returns fixing("25.145")
         coEvery { cnbRates.cnbRate("USD") } returns null
         coEvery { cnbRates.cnbRate("GBP") } returns null
         coEvery { glAccounts.findByCode("1995") } returns gl(eurCvId, "1995")
@@ -189,4 +209,84 @@ class FxRevaluationServiceTest {
         assertThat(result.movements).isEmpty()
         coVerify(exactly = 0) { ledger.postJournal(any()) }
     }
+
+    // ── #3921: the fixing's age is observable, and the entry says which fixing it used ────────
+
+    @Test
+    fun `publishes the age of the fixing each leg was marked at, and records it on the entry`() = runBlocking<Unit> {
+        // A Friday fixing marking a Monday position: three days old, inside fx-service's
+        // date-blind three-day validity window, so nothing else on the run reports a problem.
+        val friday = now.minus(Duration.ofDays(3))
+        coEvery { ledger.getTrialBalance(GetTrialBalanceQuery(date)) } returns TrialBalance(
+            asOf = date,
+            lines = listOf(position("1991", debit = "0", credit = "1000000")),
+        )
+        coEvery { cnbRates.cnbRate("EUR") } returns fixing("25.145", validFrom = friday)
+        coEvery { cnbRates.cnbRate("USD") } returns null
+        coEvery { cnbRates.cnbRate("GBP") } returns null
+        coEvery { glAccounts.findByCode("1995") } returns gl(eurCvId, "1995")
+        coEvery { glAccounts.findByCode("5900") } returns gl(pnlId, "5900")
+        val cmd = slot<PostJournalCommand>()
+        coEvery { ledger.postJournal(capture(cmd)) } returns stubEntry()
+
+        val result = service.revalue(RevalueFxCommand(date))
+
+        // The run itself is a perfectly ordinary success — that is the point.
+        assertThat(result.posted).isTrue()
+        // The age is the FIXING's, not the run's: 3 days, not ~0.
+        assertThat(age("EUR")).isEqualTo(Duration.ofDays(3).seconds.toDouble())
+        // And the posting now answers "which rate valued this position", which the ledger
+        // could not answer at all before — the question that matters the moment a corrected
+        // fixing arrives after the run.
+        assertThat(cmd.captured.description)
+            .isEqualTo("Daily FX revaluation at ČNB fixing 2026-05-30 [fixings EUR@2026-05-27T15:00:00Z]")
+    }
+
+    @Test
+    fun `a currency with no fixing still publishes an age, so a quiet feed is visible`() = runBlocking<Unit> {
+        coEvery { ledger.getTrialBalance(GetTrialBalanceQuery(date)) } returns TrialBalance(
+            asOf = date,
+            lines = listOf(position("1991", debit = "0", credit = "1000000")),
+        )
+        coEvery { cnbRates.cnbRate("EUR") } returns fixing("25.145")
+        coEvery { cnbRates.cnbRate("USD") } returns null
+        coEvery { cnbRates.cnbRate("GBP") } returns null
+        coEvery { glAccounts.findByCode("1995") } returns gl(eurCvId, "1995")
+        coEvery { glAccounts.findByCode("5900") } returns gl(pnlId, "5900")
+        coEvery { ledger.postJournal(any()) } returns stubEntry()
+
+        service.revalue(RevalueFxCommand(date))
+
+        // USD and GBP resolved to nothing, and each still has a series. An absent series is
+        // how "no rate for two days" reads as "nothing to see" on every dashboard.
+        assertThat(age("USD")).isNotNull()
+        assertThat(age("GBP")).isNotNull()
+        assertThat(
+            registry.find(FxFixingFreshnessGauge.FIXING_AGE_SECONDS).gauges().map { it.id.getTag("currency") },
+        ).containsExactlyInAnyOrder("EUR", "USD", "GBP")
+    }
+
+    @Test
+    fun `an fx-service answer without a fixing date leaves the description and the age untouched`() =
+        runBlocking<Unit> {
+            coEvery { ledger.getTrialBalance(GetTrialBalanceQuery(date)) } returns TrialBalance(
+                asOf = date,
+                lines = listOf(position("1991", debit = "0", credit = "1000000")),
+            )
+            coEvery { cnbRates.cnbRate("EUR") } returns fixing("25.145", validFrom = null)
+            coEvery { cnbRates.cnbRate("USD") } returns null
+            coEvery { cnbRates.cnbRate("GBP") } returns null
+            coEvery { glAccounts.findByCode("1995") } returns gl(eurCvId, "1995")
+            coEvery { glAccounts.findByCode("5900") } returns gl(pnlId, "5900")
+            val cmd = slot<PostJournalCommand>()
+            coEvery { ledger.postJournal(capture(cmd)) } returns stubEntry()
+
+            service.revalue(RevalueFxCommand(date))
+
+            // "Age unknown" must never render as "just now" — the holder is seeded at
+            // registration, so EUR reads as pod-age (0 under the fixed clock), and the
+            // description gains no empty bracket.
+            assertThat(cmd.captured.description).isEqualTo("Daily FX revaluation at ČNB fixing 2026-05-30")
+            assertThat(age("EUR")).isEqualTo(0.0)
+        }
 }

--- a/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/infrastructure/observability/FxFixingFreshnessGaugeTest.kt
+++ b/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/infrastructure/observability/FxFixingFreshnessGaugeTest.kt
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.ledger.infrastructure.observability
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.time.ZoneId
+import java.time.ZoneOffset
+
+/**
+ * Pins the three properties that make `openbank.fx.fixing.age_seconds` worth alerting on (#3921).
+ *
+ * Every assertion here is on the gauge's **value**, never on its presence. `isNotNull()` on an age
+ * gauge passes against a holder still sitting at 1970 — the exact way an `Instant.EPOCH` default
+ * survives a full test suite (the `AuditEvent.timestamp` class of bug, #3882). A freshness signal
+ * that is only asserted to exist is not asserted at all.
+ */
+class FxFixingFreshnessGaugeTest {
+
+    private val t0: Instant = Instant.parse("2026-05-30T15:00:00Z")
+    private val registry = SimpleMeterRegistry()
+    private val clock = MutableClock(t0)
+    private val gauge = FxFixingFreshnessGauge(registry, clock)
+
+    private fun age(currency: String): Double? = registry.find(FxFixingFreshnessGauge.FIXING_AGE_SECONDS)
+        .tag(FxFixingFreshnessGauge.CURRENCY_TAG, currency)
+        .gauge()
+        ?.value()
+
+    @Test
+    fun `a currency never observed ages from registration, not from the epoch`() {
+        gauge.fixingObserved("EUR", validFrom = null)
+
+        clock.advance(Duration.ofSeconds(90))
+
+        // 90, not ~1.77e9. An Instant.EPOCH seed would make every fresh pod fire a staleness
+        // alert continuously until the next daily run — up to 24h of noise no `for:` absorbs,
+        // because the condition genuinely holds (ADR-0237 point 3 boot-safety).
+        assertThat(age("EUR")).isEqualTo(90.0)
+    }
+
+    @Test
+    fun `the published age is the age of the fixing, not of the run that used it`() {
+        gauge.fixingObserved("EUR", validFrom = t0.minus(Duration.ofDays(3)))
+
+        // Three days exactly — a Friday fixing marking a Monday position. Every other signal
+        // (workflow liveness, the posted journal, the job's own log) reports this run as healthy.
+        assertThat(age("EUR")).isEqualTo(Duration.ofDays(3).seconds.toDouble())
+    }
+
+    @Test
+    fun `a failed resolution keeps the age climbing rather than blanking the series`() {
+        gauge.fixingObserved("USD", validFrom = t0)
+        assertThat(age("USD")).isEqualTo(0.0)
+
+        clock.advance(Duration.ofDays(2))
+        gauge.fixingObserved("USD", validFrom = null)
+
+        // The feed went quiet and the series says so. Clearing the holder — or simply not
+        // reporting a failed attempt — would flat-line or drop the series at exactly the moment
+        // it matters, which is "a table that stopped growing" restated as a metric.
+        assertThat(age("USD")).isEqualTo(Duration.ofDays(2).seconds.toDouble())
+    }
+
+    @Test
+    fun `each currency ages independently and re-observation is not a re-registration`() {
+        gauge.fixingObserved("EUR", validFrom = t0.minus(Duration.ofDays(1)))
+        gauge.fixingObserved("GBP", validFrom = t0)
+        gauge.fixingObserved("EUR", validFrom = t0)
+
+        assertThat(age("EUR")).isEqualTo(0.0)
+        assertThat(age("GBP")).isEqualTo(0.0)
+        assertThat(
+            registry.find(FxFixingFreshnessGauge.FIXING_AGE_SECONDS).gauges(),
+        ).hasSize(2)
+    }
+
+    /** Test clock the gauge's scrape-time supplier can be moved against. */
+    private class MutableClock(private var now: Instant) : Clock() {
+        fun advance(by: Duration) {
+            now = now.plus(by)
+        }
+
+        override fun getZone(): ZoneId = ZoneOffset.UTC
+
+        override fun withZone(zone: ZoneId): Clock = this
+
+        override fun instant(): Instant = now
+    }
+}


### PR DESCRIPTION
## What this changes

`#3921` names two problems and only one of them is bounded. This PR does that one, and states
plainly what the other one costs so it is not mistaken for done.

**(a) Staleness was unobservable — fixed here.** The fx→ledger seam carried no time at all
(`CnbRateProvider.cnbRate(base): BigDecimal?`), so there was nowhere in `FxRevaluationService` a
freshness check or metric could even be *written*. The port now returns `CnbFixing(rate,
validFrom)`, and every revaluation attempt publishes `openbank.fx.fixing.age_seconds{currency}` —
the age of the fixing the positions were actually marked at.

**(b) A late fixing can never be incorporated — NOT fixed here, and it is the one with money
consequences.** `idempotencyKey = "fx-reval-{date}"` keys on the business day alone, and
`LedgerService.postJournal` returns the existing entry on a key hit. So once a day has been
revalued, a re-run after a corrected or belated ČNB fixing lands returns the **original** entry,
emits no new event, and reports `posted = true`. A success that changed nothing.

Concretely: every EUR/USD/GBP position marked on that business day keeps a CZK counter-value
computed from the superseded rate, in the general ledger, **indefinitely** — there is no
correcting entry, no versioned key and no expiry. The next day's revaluation marks *that* day
from the current carry, so the error does not self-heal; it is absorbed into the exchange-rate
differences account as a permanent misstatement of the earlier day. Closing that needs a decision
about correcting entries (rate identity in the key, or an explicit reversing entry), not a smaller
patch. The gauge below is what makes the condition visible in the meantime.

## Why a gauge and not a counter

A counter of "revaluations attempted" rises identically whether the rate was minutes or a week
old, and a counter of "stale runs" only moves once someone has picked a threshold in code. The
signal that carries the information is the **age of the last value actually used**, sampled at
scrape time — the same primitive shape as `openbank_workflow_last_success_age_seconds`, one level
down: not "when did the job last succeed" but "how old is the number it succeeded with".

That distinction is the whole point, because the three signals this job already has cannot express
it:

| signal | what a 3-day-old fixing looks like |
|---|---|
| `WorkflowLivenessStale` (`workflow="ledger-fx-revaluation"`) | healthy — `recordSuccess()` is called |
| the posted journal entry | healthy — a normal entry, and it never recorded which rate it used |
| `FxRevaluationSkippedAllLegs` | silent — nothing is skipped, a valid rate *was* found |

fx-service's validity window is three days and **date-blind** (`CNB_VALIDITY_DAYS = 3`;
`FxRepositories` selects the latest row with `validTo > :now`), so a Friday fixing marking a Monday
position is, to everything else, an ordinary successful run.

Two design choices make the gauge alertable rather than decorative:

- **Seeded at registration, not `Instant.EPOCH`.** A fresh pod ages from its own start. An EPOCH
  seed makes every deploy fire the alert continuously until the next daily run — up to 24h of
  noise no `for:` can absorb, because the condition genuinely holds. This is the trap
  `DomainMetrics.registerWorkflowLiveness`'s KDoc documents at length (#2239 Gap 2) and ADR-0237
  point 3 decides against.
- **A failed resolution does not clear the holder.** `fixingObserved(currency, null)` leaves the
  last known instant in place so the published age keeps climbing. Blanking the series — or simply
  not reporting a failed attempt — reads as "nothing to see" on every dashboard and in most alert
  expressions. That is "a table that stopped growing", restated as a metric.

## `FxRevaluationSkippedAllLegs` could not fire

Confirmed on the committed evidence, in both directions:

- `"skipping its revaluation leg"` is emitted from exactly one place in service code —
  `openbank-ledger-service/src/main/kotlin/com/openbank/ledger/application/usecase/FxRevaluationService.kt:64`
  on `origin/main`
  (verified: it is the only `.kt` hit fleet-wide).
- The ledger workload deploys to namespace `ledger` (`openbank-infra/gitops/apps/ledger.yaml:21`).
- The rule selected `{namespace="fx"}`.

The label vocabulary was never in doubt — the same file selects
`namespace=~"ledger|accounts|balances|…"` elsewhere. So the only rule claiming to cover the
skipped-leg path could not match, and its `summary`/`description` attributed the condition to
fx-service, which would have misdirected whoever it eventually paged. Both are fixed; it is a
one-line change independent of everything else here.

## Files

| file | what |
|---|---|
| `application/port/out/CnbRateProvider.kt` | `cnbRate` returns `CnbFixing(rate, validFrom)`; `validFrom` nullable so a payload without it degrades to "age unknown", never to "just now" |
| `infrastructure/client/FxServiceClient.kt` | declares `validFrom` — fx-service has always sent it, this DTO's `@JsonIgnoreProperties(ignoreUnknown = true)` was dropping it |
| `infrastructure/client/FxServiceCnbRateAdapter.kt` | maps it through unchanged |
| `application/port/out/FxFixingFreshnessPort.kt` | new out-port: report the fixing age of every attempt, for every currency, resolved or not |
| `infrastructure/observability/FxFixingFreshnessGauge.kt` | Micrometer adapter, `openbank.fx.fixing.age_seconds{currency}` |
| `application/usecase/FxRevaluationService.kt` | reports every attempt; the journal description now records **which fixing** each leg was marked at |
| `gitops/…/prometheus-rules-fx-fixing.yaml` | new: `FxFixingAgeAbsent` + `FxFixingStale` (60h — just above one weekend, below two), both `severity: warning` per ADR-0237 point 3 |
| `gitops/…/loki-rules-silent-failures.yaml` | `{namespace="fx"}` → `{namespace="ledger"}` + attribution |

A metric nobody alerts on is the same gap one level up, so the `PrometheusRule` ships in this PR
rather than as a follow-up.

## Red then green

`FxFixingFreshnessGaugeTest` and the three new cases in `FxRevaluationServiceTest` assert the
gauge's **value**, never `isNotNull()` — an age gauge asserted only to exist passes against a
holder still sitting at 1970, which is exactly how an `Instant.EPOCH` default survives a full
suite (#3882).

Falsification, per assertion, against the head of this branch with the one behaviour under test
removed:

```
GREEN  (branch head, unmodified)
  FxRevaluationServiceTest      tests=5 failures=0 errors=0 skipped=0
  FxFixingFreshnessGaugeTest    tests=4 failures=0 errors=0 skipped=0

RED  m1 — delete `fixingFreshness.fixingObserved(currency, fixing?.validFrom)`
  tests=9 failures=3
    FxRevaluationServiceTest :: publishes the age of the fixing each leg was marked at, and records it on the entry
    FxRevaluationServiceTest :: a currency with no fixing still publishes an age, so a quiet feed is visible
    FxRevaluationServiceTest :: an fx-service answer without a fixing date leaves the description and the age untouched

RED  m2 — seed the gauge holder at `Instant.EPOCH` instead of `clock.instant()`
  tests=9 failures=2
    FxFixingFreshnessGaugeTest :: a currency never observed ages from registration, not from the epoch
    FxRevaluationServiceTest :: an fx-service answer without a fixing date leaves the description and the age untouched

RED  m3 — drop `${fixingSuffix(fixings)}` from the journal description
  tests=9 failures=1
    FxRevaluationServiceTest :: publishes the age of the fixing each leg was marked at, and records it on the entry
```

Counts are read out of `build/test-results/test/TEST-*.xml`, not off the console. Each mutation
was applied on its own and reverted before the next, and the two pre-existing
`FxRevaluationServiceTest` cases stay green under all three — the new assertions are sensitive to
the new behaviour and to nothing else. m2 is the one worth noting: it is the EPOCH-seed variant,
and without that case a boot-noisy gauge would have shipped looking identical to this one.

## Still open (why `Refs`, not `Closes`)

1. **The late-fixing correctness gap above.** Needs a correcting-entry decision.
2. **Backfill still uses today's rate.** `cnbRate(base)` ignores `command.date`, so a manual run
   for an older date marks that date at the latest fixing. Widening the port to take an `asOf`
   would be a lie until fx-service can answer as-of a date — the `/history` endpoint bounds on
   `validFrom` but the CNB path does not — so that is fx-side work, not a parameter to add here.
3. **fx-service's `openapi.yaml` does not describe the payload it serves.** `ExchangeRateResponse`
   declares `rate`, `spread`, `validAt`; the code serializes `bidRate`, `askRate`, `rateType`,
   `source`, `validFrom`, `validTo`, `createdAt`, `pair`, `midRate`. Ledger has always depended on
   the undocumented `bidRate`/`askRate` and now also on `validFrom`. Correcting it is an fx-side
   spec change (ADR-0048 minor bump; the two fictional properties want deprecating rather than
   removing, since removal classifies as breaking) and belongs in an `fx`-scoped PR — the scope
   selects the released component, so it cannot ride in this one.
4. **`ADR-0237` point 2 (`feed-cnb-fixing` liveness in fx-service) is still `planned`.** No
   `feed-`prefixed workflow exists in code today. That is the complementary signal — "the feed
   delivered" as measured at ingestion, versus this PR's "the value in use is this old" as measured
   at consumption.

Refs #3921
Refs #1302

🤖 Generated with [Claude Code](https://claude.com/claude-code)
