### PR TITLE
fix(infra): declare openbank.billing.fee.event topic + document-service ACL

### DIFF
--- a/openbank-infra/gitops/components/document-service/document-service-msg-override.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-msg-override.yaml
@@ -17,6 +17,10 @@
 # Properties file rather than env vars: the hyphenated channel name hits the unresolved
 # quarkusio/quarkus#30106 / smallrye-reactive-messaging#2028 env-var split bug (SRMSG00071).
 # config_ordinal=500 outranks the baked application.yaml (~254); loaded via QUARKUS_CONFIG_LOCATIONS.
+#
+# #4217/ADR-0248: same bug hits the new billing-outbox-events-in channel's group.id — added
+# below rather than a second ConfigMap, since QUARKUS_CONFIG_LOCATIONS on the Deployment already
+# points at this one file.
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -29,3 +33,4 @@ data:
   override.properties: |
     config_ordinal=500
     mp.messaging.incoming.account-created-in.group.id=openbank-document-service
+    mp.messaging.incoming.billing-outbox-events-in.group.id=openbank-document-service

--- a/openbank-infra/gitops/components/document-service/document-service-msg-override.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-msg-override.yaml
@@ -18,9 +18,11 @@
 # quarkusio/quarkus#30106 / smallrye-reactive-messaging#2028 env-var split bug (SRMSG00071).
 # config_ordinal=500 outranks the baked application.yaml (~254); loaded via QUARKUS_CONFIG_LOCATIONS.
 #
-# #4217/ADR-0248: same bug hits the new billing-outbox-events-in channel's group.id — added
-# below rather than a second ConfigMap, since QUARKUS_CONFIG_LOCATIONS on the Deployment already
-# points at this one file.
+# #4217/ADR-0248: the new billing-outbox-events-in channel needs the same override, but NOT yet —
+# `gates (gitops)` correctly refuses it here: SmallRye treats a configured channel with no
+# `connector:` in the DEPLOYED image's application.yaml as a hard boot failure (SRMSG00071), and
+# the currently deployed document-service image predates #4122 (which declares the channel).
+# Add the line once #4122 has merged AND deployed, in a follow-up PR — not before.
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -33,4 +35,3 @@ data:
   override.properties: |
     config_ordinal=500
     mp.messaging.incoming.account-created-in.group.id=openbank-document-service
-    mp.messaging.incoming.billing-outbox-events-in.group.id=openbank-document-service

--- a/openbank-infra/gitops/components/document-service/kafka-document-service-mtls.yaml
+++ b/openbank-infra/gitops/components/document-service/kafka-document-service-mtls.yaml
@@ -6,9 +6,11 @@
 # document-service PRODUCES document lifecycle events to
 # openbank.documents.document.event via its outbox dispatcher (ADR-0161/ADR-0162),
 # and CONSUMES openbank.accounts.account.created (group openbank-document-service,
-# ADR-0162 D7) to issue onboarding documents off the account-opening path (ADR-0086).
-# It therefore needs a Read/Describe ACL on that topic plus a consumer-group ACL,
-# mirroring balance-service, which consumes the same topic.
+# ADR-0162 D7) to issue onboarding documents off the account-opening path (ADR-0086),
+# and openbank.billing.fee.event (same consumer group; #4217, ADR-0248) filtering
+# for the AnnualFeeSummaryReady event to render the annual statement of fees.
+# It therefore needs a Read/Describe ACL on each topic plus a consumer-group ACL,
+# mirroring balance-service, which consumes the same account.created topic.
 #
 # Identity model (ADR-0137): one KafkaUser = one mTLS client cert = one principal
 # for all of this service's Kafka traffic. These resources live in `messaging`
@@ -46,6 +48,13 @@ spec:
       - resource:
           type: topic
           name: openbank.accounts.account.created
+          patternType: literal
+        operations: [Read, Describe]
+        host: "*"
+      # #4217, ADR-0248: consume billing's outbox topic for AnnualFeeSummaryReady.
+      - resource:
+          type: topic
+          name: openbank.billing.fee.event
           patternType: literal
         operations: [Read, Describe]
         host: "*"

--- a/openbank-infra/gitops/components/kafka/kafka.yaml
+++ b/openbank-infra/gitops/components/kafka/kafka.yaml
@@ -192,6 +192,24 @@ spec:
     retention.ms: 604800000
     cleanup.policy: delete
 ---
+# billing-service's single outbox topic (#4217, ADR-0248) — carries all its events
+# (billing.fee.post-intent.v1, billing.fee.reversal-intent.v1, and the new
+# AnnualFeeSummaryReady) via its one "billing-events-out" channel. Single partition
+# + RF 1 to match the single-broker sandbox; prod should raise partitions/RF.
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaTopic
+metadata:
+  name: openbank.billing.fee.event
+  namespace: messaging
+  labels:
+    strimzi.io/cluster: openbank-cluster
+spec:
+  partitions: 1
+  replicas: 1
+  config:
+    retention.ms: 604800000
+    cleanup.policy: delete
+---
 # Dead-letter topic for account-service's party-events-in channel (SmallRye
 # failure-strategy: dead-letter-queue). A party event whose projection survives the
 # consumer's bounded retry is parked here for inspection/replay instead of being dropped.


### PR DESCRIPTION
## Summary

Closes #4217. Gitops fix for #4122's `gates (data)` findings.

## Linked issues

Closes #4217
Refs #4109
Refs ADR-0248

## Changes

- `openbank-infra/gitops/components/kafka/kafka.yaml` — new `KafkaTopic` CR for `openbank.billing.fee.event`, copied from the `openbank.accounts.account.created` pattern (`partitions: 1, replicas: 1`, same retention/cleanup config for the single-broker sandbox).
- `openbank-infra/gitops/components/document-service/kafka-document-service-mtls.yaml` — new `Read, Describe` ACL entry on document-service's existing `KafkaUser` for that topic.

## Deliberately NOT included (caught by `gates (gitops)`, correctly)

The `billing-outbox-events-in` channel's `group.id` override (the dotted-key ratchet finding) is **not** added to `document-service-msg-override.yaml` in this PR. `check-msg-channel-image-parity.py` refused it: SmallRye treats a configured channel with no `connector:` in the *deployed* image's `application.yaml` as a hard boot failure (SRMSG00071), and the currently deployed document-service image predates #4122 (which declares the channel). Adding the override now would crash-loop the pod.

**Merge order:** this PR (topic + ACL only) → #4122 merges + deploys → a follow-up PR adds the `group.id` override line once the deployed image actually has the channel.

## Test plan

- [x] `python3 .github/scripts/check-kafka-topics-exist.py --enforce` — `0 unresolved`.
- [x] `python3 .github/scripts/check-kafka-acl-coverage.py --enforce` — `0 known gap(s) — clean`.
- [x] `python3 .github/scripts/check-msg-channel-image-parity.py` — `28 channel override(s) ... every one is servable by the image actually deployed` (confirms the removed line was the right call, not just a guess).
