### PR TITLE
security(notification): wire ContactPolicyGate at the ADR-0219 D4 choke point

### DIFF
--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/application/NotificationConsumer.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/application/NotificationConsumer.kt
@@ -8,6 +8,10 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.openbank.libs.audit.AuditEvent
 import com.openbank.libs.audit.AuditEventPublisher
 import com.openbank.libs.audit.AuditResult
+import com.openbank.libs.contact.ContactClass
+import com.openbank.libs.contact.ContactDenyReason
+import com.openbank.libs.contact.ContactPolicyGate
+import com.openbank.libs.contact.MarketingCallSite
 import com.openbank.libs.domain.identifiers.Ids
 import com.openbank.libs.persistence.outbox.OutboxMessage
 import com.openbank.notification.application.port.out.NotificationOutboxRepository
@@ -25,7 +29,6 @@ import com.openbank.notification.domain.model.NotificationStatus
 import com.openbank.notification.domain.model.NotificationTemplate
 import com.openbank.notification.domain.model.PushPlatform
 import com.openbank.notification.domain.model.TemplateSensitivity
-import com.openbank.notification.infrastructure.client.ConsentServiceClient
 import com.openbank.notification.infrastructure.client.PartyContactClient
 import com.openbank.notification.infrastructure.persistence.entity.NotificationEntity
 import com.openbank.notification.infrastructure.persistence.repository.DeviceTokenRepository
@@ -35,10 +38,14 @@ import io.quarkus.hibernate.reactive.panache.Panache
 import io.quarkus.mailer.Mail
 import io.quarkus.mailer.reactive.ReactiveMailer
 import io.smallrye.mutiny.Uni
+import io.smallrye.mutiny.coroutines.asUni
 import io.vertx.core.Vertx
 import jakarta.annotation.PostConstruct
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
 import kotlinx.coroutines.runBlocking
 import org.eclipse.microprofile.reactive.messaging.Incoming
 import org.eclipse.microprofile.rest.client.inject.RestClient
@@ -60,12 +67,6 @@ class NotificationConsumer {
          * party-scoped GET /api/v1/notifications/{id}/self.
          */
         const val GENERIC_PUSH_BODY = "Open the OpenBank app to view details."
-
-        /**
-         * The fixed internal marketing grantee every MARKETING consent is checked against
-         * (ADR-0205 D3). A constant so the gate cannot drift per call site.
-         */
-        const val MARKETING_GRANTEE = "party-service:marketing-comms"
 
         /**
          * The consent scope a MARKETING send is checked against, per target channel (ADR-0198 D4).
@@ -100,9 +101,7 @@ class NotificationConsumer {
 
     @Inject lateinit var audit: AuditEventPublisher
 
-    @Inject
-    @RestClient
-    lateinit var consentServiceClient: ConsentServiceClient
+    @Inject lateinit var contactGate: ContactPolicyGate
 
     /** Resolves the EMAIL envelope address from `partyId` (issue #3581) — see [resolveEmailRecipient]. */
     @Inject
@@ -298,20 +297,29 @@ class NotificationConsumer {
     // mail never went out" from "the mail went out, but recording SENT failed" — Mutiny's
     // Uni#chain composes onto ONE failure channel, so it would catch both: a transient Postgres
     /**
-     * The ADR-0198 D4 consent gate (#2660): every MARKETING send asks consent-service for the
-     * party's ACTIVE consent under grantee `party-service:marketing-comms` (ADR-0205 D3), scoped
-     * to the target channel. A send with no ACTIVE consent records SUPPRESSED and audits it.
+     * The ADR-0219 D4 contact gate (#2749) — this service's own `consentServiceClient` call was
+     * the choke point ADR-0219 D4 names outright ("its consent call becomes this gate call"): one
+     * `ContactPolicyGate.check(...)` now wraps suppression list -> send cap -> quiet hours ->
+     * live consent pull, in the gate's ordering (same composition campaign-service and
+     * engagement-service already reuse), instead of a bespoke consent-only check.
      *
-     * Fail-closed in BOTH failure modes, deliberately distinguishable in the audit (#2660 §3):
-     *  - `granted == false`  → SUPPRESSED with reason `no_active_consent` (a genuine refusal)
-     *  - client error/timeout → SUPPRESSED with reason `consent_check_unavailable` (an outage)
-     * A consent-service outage must never read as a grant, and the two numbers must never merge
-     * into one — the first is a GDPR control working, the second is an availability problem.
+     * Bridged into this `Uni` chain via `CoroutineScope(Dispatchers.Unconfined).async {
+     * }.asUni()` — the same suspend-into-Uni idiom `CampaignJourneyActivitiesImpl` uses (the
+     * gate itself is a `suspend fun`; this dispatch pipeline is Mutiny `Uni`, not coroutines).
+     *
+     * Fail-closed in every deny reason, deliberately distinguishable in the audit (#2660 §3,
+     * carried forward): `NO_CONSENT` -> `no_active_consent` (a genuine refusal),
+     * `GATE_UNAVAILABLE` -> `consent_check_unavailable` (a port outage — consent, counter or
+     * suppression) — a gate outage must never read as a grant, and the two numbers must never
+     * merge into one. `SEND_CAP_REACHED`/`QUIET_HOURS`/`SUPPRESSED_LIST` are new reasons this
+     * service could not previously produce; each gets its own outcome code rather than folding
+     * into one of the two above.
      *
      * The check is per send, never cached (ADR-0198). `notification_preference`'s columns
      * (`payments_push` / `product_push` / `marketing_push`) remain a per-channel mute *within* a
      * granted consent — a different and legitimate control, not the Art. 6(1)(a) basis.
      */
+    @MarketingCallSite
     private fun gateMarketingOnConsent(
         req: NotificationRequest,
         subject: String,
@@ -319,50 +327,38 @@ class NotificationConsumer {
         entity: NotificationEntity,
     ): Uni<Void> {
         val scope = marketingScopeFor(req.channel)
-        return consentServiceClient.hasActiveConsent(req.partyId, MARKETING_GRANTEE, scope)
-            .onItemOrFailure().transformToUni { check, failure ->
-                when {
-                    failure != null -> {
-                        log.warnf(
-                            failure,
-                            "MARKETING %s suppressed: consent-service unreachable (template=%s party=%s) — " +
-                                "failing closed (ADR-0198 D4, #2660)",
-                            req.channel,
-                            req.template,
-                            req.partyId,
-                        )
-                        markStatus(
-                            req,
-                            entity,
-                            NotificationOutcome.SUPPRESSED,
-                            NotificationOutcomeEvent.REASON_CONSENT_UNAVAILABLE,
-                        ).invoke { _ ->
-                            auditMarketingSuppressed(req, NotificationOutcomeEvent.REASON_CONSENT_UNAVAILABLE)
-                        }
-                    }
-                    check.granted ->
-                        when (req.channel) {
-                            NotificationChannel.EMAIL -> sendEmail(req, subject, body, entity)
-                            NotificationChannel.PUSH -> maybeSendPush(req, subject, entity)
-                        }
-                    else -> {
-                        log.infof(
-                            "MARKETING %s suppressed: no ACTIVE consent (template=%s party=%s, ADR-0198 D4)",
-                            req.channel,
-                            req.template,
-                            req.partyId,
-                        )
-                        markStatus(
-                            req,
-                            entity,
-                            NotificationOutcome.SUPPRESSED,
-                            NotificationOutcomeEvent.REASON_NO_CONSENT,
-                        ).invoke { _ ->
-                            auditMarketingSuppressed(req, NotificationOutcomeEvent.REASON_NO_CONSENT)
-                        }
-                    }
+        val decisionUni = CoroutineScope(Dispatchers.Unconfined).async {
+            contactGate.check(req.partyId, ContactClass.OUTBOUND_SEND, scope)
+        }.asUni()
+        return decisionUni.chain { decision ->
+            if (decision.allowed) {
+                when (req.channel) {
+                    NotificationChannel.EMAIL -> sendEmail(req, subject, body, entity)
+                    NotificationChannel.PUSH -> maybeSendPush(req, subject, entity)
                 }
+            } else {
+                val reason = when (decision.denyReason) {
+                    ContactDenyReason.NO_CONSENT -> NotificationOutcomeEvent.REASON_NO_CONSENT
+                    ContactDenyReason.GATE_UNAVAILABLE -> NotificationOutcomeEvent.REASON_CONSENT_UNAVAILABLE
+                    ContactDenyReason.SEND_CAP_REACHED -> NotificationOutcomeEvent.REASON_SEND_CAP_REACHED
+                    ContactDenyReason.QUIET_HOURS -> NotificationOutcomeEvent.REASON_QUIET_HOURS
+                    ContactDenyReason.SUPPRESSED_LIST -> NotificationOutcomeEvent.REASON_SUPPRESSED_LIST
+                    // IMPRESSION_BUDGET_REACHED, null: never produced for OUTBOUND_SEND — the
+                    // gate's own `when` is exhaustive over ContactClass, so this branch exists
+                    // only for a future ContactDenyReason value this file has not been taught yet.
+                    else -> NotificationOutcomeEvent.REASON_CONSENT_UNAVAILABLE
+                }
+                log.infof(
+                    "MARKETING %s suppressed: %s (template=%s party=%s, ADR-0219 D4)",
+                    req.channel,
+                    reason,
+                    req.template,
+                    req.partyId,
+                )
+                markStatus(req, entity, NotificationOutcome.SUPPRESSED, reason)
+                    .invoke { _ -> auditMarketingSuppressed(req, reason) }
             }
+        }
     }
 
     /**

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/domain/model/NotificationOutcome.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/domain/model/NotificationOutcome.kt
@@ -60,5 +60,10 @@ data class NotificationOutcomeEvent(
         const val REASON_NO_DEVICE: String = "no_active_device"
         const val REASON_PUSH_REJECTED: String = "push_rejected_by_provider"
         const val REASON_PREFERENCE_MUTED: String = "channel_muted_by_preference"
+
+        /** ADR-0219 D4: `ContactPolicyGate` reasons a MARKETING send can now also be denied for. */
+        const val REASON_SEND_CAP_REACHED: String = "send_cap_reached"
+        const val REASON_QUIET_HOURS: String = "quiet_hours"
+        const val REASON_SUPPRESSED_LIST: String = "suppressed_list"
     }
 }

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/infrastructure/contact/ContactGateProducer.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/infrastructure/contact/ContactGateProducer.kt
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.notification.infrastructure.contact
+
+import com.openbank.libs.contact.ContactConsentPort
+import com.openbank.libs.contact.ContactCounterPort
+import com.openbank.libs.contact.ContactPolicy
+import com.openbank.libs.contact.ContactPolicyGate
+import com.openbank.libs.contact.ContactSuppressionPort
+import com.openbank.notification.domain.model.NotificationCategory
+import com.openbank.notification.domain.model.NotificationTemplate
+import com.openbank.notification.infrastructure.client.ConsentServiceClient
+import com.openbank.notification.infrastructure.persistence.repository.NotificationRepository
+import io.smallrye.mutiny.coroutines.awaitSuspending
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.enterprise.inject.Produces
+import org.eclipse.microprofile.rest.client.inject.RestClient
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * Wires the ADR-0219 gate for notification-service — the D4 choke point named explicitly
+ * ("its consent call becomes this gate call"), same producer pattern as campaign-service's and
+ * engagement-service's own `ContactGateProducer` (see their KDoc for the shared shape).
+ *
+ * - `consent`: the same `ConsentServiceClient` call `NotificationConsumer.gateMarketingOnConsent`
+ *   used directly before this change.
+ * - `counters.sendsInWindow`: [NotificationRepository.countSince], scoped to the MARKETING
+ *   template set — this service's own durable send log, same "slice 1" convention as
+ *   campaign-service's send log (no shared Valkey counter exists yet).
+ *   `impressionsInWindow` is unused by `OUTBOUND_SEND` and returns 0 rather than being wired to
+ *   anything invented.
+ * - `suppression`: the honest empty port, same reason as campaign/engagement — no ADR-0219 D3
+ *   platform suppression *store* exists yet.
+ */
+@ApplicationScoped
+class ContactGateProducer {
+
+    @Produces
+    @ApplicationScoped
+    fun contactPolicyGate(
+        @RestClient consentServiceClient: ConsentServiceClient,
+        notificationRepo: NotificationRepository,
+    ): ContactPolicyGate {
+        val marketingTemplates = NotificationTemplate.entries
+            .filter { it.category == NotificationCategory.MARKETING }
+            .map { it.name }
+        return ContactPolicyGate(
+            consent = ContactConsentPort { partyId, scope ->
+                consentServiceClient.hasActiveConsent(partyId, MARKETING_GRANTEE, scope).awaitSuspending().granted
+            },
+            counters = object : ContactCounterPort {
+                override suspend fun sendsInWindow(partyId: UUID, windowStart: Instant): Int =
+                    notificationRepo.countSince(partyId, marketingTemplates, windowStart)
+
+                override suspend fun impressionsInWindow(partyId: UUID, windowStart: Instant): Int = 0
+            },
+            suppression = ContactSuppressionPort { emptyList() },
+            policy = ContactPolicy(),
+        )
+    }
+
+    companion object {
+        /** Matches `NotificationConsumer.MARKETING_GRANTEE` (ADR-0205 D3). */
+        const val MARKETING_GRANTEE = "party-service:marketing-comms"
+    }
+}

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/infrastructure/persistence/repository/NotificationRepository.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/infrastructure/persistence/repository/NotificationRepository.kt
@@ -56,6 +56,17 @@ class NotificationRepository : PanacheRepository<NotificationEntity> {
         Panache.withTransaction { delete("partyId", partyId) }.awaitSuspending()
 
     /**
+     * ContactPolicyGate's `sendsInWindow` counter (ADR-0219 D4/D1), backed by this service's own
+     * durable log — same "slice 1" convention as campaign-service's send log, since no shared
+     * Valkey counter exists yet. [templates] narrows to one [com.openbank.notification.domain.model.NotificationCategory]'s
+     * template names (MARKETING today) rather than every send, matching the gate's own send cap
+     * being a marketing-specific budget, not a count of every notification this party received.
+     */
+    suspend fun countSince(partyId: UUID, templates: List<String>, since: Instant): Int = Panache.withSession {
+        count("partyId = ?1 and template in ?2 and createdAt >= ?3", partyId, templates, since)
+    }.awaitSuspending().toInt()
+
+    /**
      * Mark one notification read (idempotent). partyId scopes the UPDATE so the edge's
      * injected identity can never mark another party's row (IDOR guard at the data layer).
      * True when the row exists for that party (freshly marked OR already read); false = not found.

--- a/openbank-notification-service/src/test/kotlin/com/openbank/notification/domain/model/NotificationTemplateCategoryTest.kt
+++ b/openbank-notification-service/src/test/kotlin/com/openbank/notification/domain/model/NotificationTemplateCategoryTest.kt
@@ -9,41 +9,43 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 /**
- * Guards that the ADR-0198 D4 consent gate stays wired (issue #2660).
+ * Guards that the ADR-0219 D4 contact gate stays wired (issue #2749, superseding ADR-0198 D4 /
+ * #2660's direct consent-service call).
  *
  * Before #2660 this test asserted *no template maps to MARKETING*, because the only honest states
  * were "no marketing sends" or "consent check wired" — and the check was not. Since #2660 the
- * check IS wired: `NotificationConsumer.gateMarketingOnConsent` calls consent-service
- * `GET /api/v1/consents/party/{partyId}/grantee/{granteeId}/active` per send, fails closed on
- * both a refusal (`no_active_consent`) and an outage (`consent_check_unavailable`), and never
+ * check IS wired, and since #2749 it is wired through the shared `ContactPolicyGate` (suppression
+ * list -> send cap -> quiet hours -> live consent pull) instead of a bespoke consent-only call —
+ * `ContactGateProducer` still resolves that gate's consent port from
+ * `ConsentServiceClient.hasActiveConsent` per send, fails closed on every deny reason, and never
  * caches (ADR-0198). A MARKETING template is now permissible BECAUSE that path exists.
  *
- * What must not happen is the reverse drift: someone removes the gate (or the client) while a
- * MARKETING template lives, and every send reverts to unchecked. This test fails in that
- * direction — the gate method and the consent-service client must both exist, and any MARKETING
- * template is fine only while they do.
+ * What must not happen is the reverse drift: someone removes the gate while a MARKETING template
+ * lives, and every send reverts to unchecked. This test fails in that direction — the gate method
+ * and the injected `ContactPolicyGate` must both exist, and any MARKETING template is fine only
+ * while they do.
  */
 class NotificationTemplateCategoryTest {
 
     @Test
-    fun `the consent gate stays wired - every MARKETING send goes through consent-service`() {
+    fun `the contact gate stays wired - every MARKETING send goes through it`() {
         val gate = NotificationConsumer::class.java.declaredMethods
             .firstOrNull { it.name == "gateMarketingOnConsent" }
         assertThat(gate)
             .describedAs(
-                "NotificationConsumer.gateMarketingOnConsent is gone. The ADR-0198 D4 consent gate " +
-                    "(#2660) must not be removed while MARKETING sends exist — without it every " +
+                "NotificationConsumer.gateMarketingOnConsent is gone. The ADR-0219 D4 contact gate " +
+                    "(#2749) must not be removed while MARKETING sends exist — without it every " +
                     "marketing send is an unchecked Art. 6(1)(a) violation. Restore the per-send " +
-                    "consent-service check instead of deleting the gate.",
+                    "gate check instead of deleting the method.",
             )
             .isNotNull()
 
-        val clientField = NotificationConsumer::class.java.declaredFields
-            .firstOrNull { it.type.name.endsWith("ConsentServiceClient") }
-        assertThat(clientField)
+        val gateField = NotificationConsumer::class.java.declaredFields
+            .firstOrNull { it.type.name.endsWith("ContactPolicyGate") }
+        assertThat(gateField)
             .describedAs(
-                "NotificationConsumer no longer holds a ConsentServiceClient. The ADR-0198 D4 gate " +
-                    "(#2660) needs the consent-service client to answer hasActiveConsent per send.",
+                "NotificationConsumer no longer holds a ContactPolicyGate. The ADR-0219 D4 gate " +
+                    "(#2749) needs it injected to answer check(...) per send.",
             )
             .isNotNull()
     }

--- a/openbank-notification-service/src/test/kotlin/com/openbank/notification/integration/MarketingGateIT.kt
+++ b/openbank-notification-service/src/test/kotlin/com/openbank/notification/integration/MarketingGateIT.kt
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+package com.openbank.notification.integration
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.libs.contact.ContactConsentPort
+import com.openbank.libs.contact.ContactCounterPort
+import com.openbank.libs.contact.ContactPolicy
+import com.openbank.libs.contact.ContactPolicyGate
+import com.openbank.libs.contact.ContactSuppressionPort
+import com.openbank.notification.domain.model.NotificationChannel
+import com.openbank.notification.domain.model.NotificationRequest
+import com.openbank.notification.domain.model.NotificationTemplate
+import com.openbank.notification.infrastructure.persistence.repository.NotificationRepository
+import io.quarkus.hibernate.reactive.panache.Panache
+import io.quarkus.mailer.MockMailbox
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.vertx.VertxContextSupport
+import io.smallrye.reactive.messaging.memory.InMemoryConnector
+import io.smallrye.reactive.messaging.memory.InMemorySource
+import jakarta.annotation.Priority
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.enterprise.inject.Alternative
+import jakarta.enterprise.inject.Produces
+import jakarta.inject.Inject
+import org.assertj.core.api.Assertions.assertThat
+import org.eclipse.microprofile.reactive.messaging.Message
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.UUID
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionStage
+import java.util.concurrent.TimeUnit
+import java.util.function.Supplier
+
+/**
+ * ADR-0219 D4's choke point, end to end: `NotificationConsumer.gateMarketingOnConsent` now goes
+ * through `ContactPolicyGate.check` instead of a bespoke consent-only call. [StubContactGateProducer]
+ * replaces the real producer (@Alternative @Priority(1), same idiom as
+ * `NotificationConsumerIT.OffContextPushSender`) so each test controls the gate's inputs directly
+ * — real consent-service and real send-log are neither reachable nor needed here.
+ */
+@QuarkusTest
+@QuarkusTestResource(MarketingGateIT.InMemoryKafkaResource::class)
+@QuarkusTestResource(com.openbank.notification.it.PostgresTestResource::class)
+class MarketingGateIT {
+
+    class InMemoryKafkaResource : QuarkusTestResourceLifecycleManager {
+        override fun start(): Map<String, String> =
+            InMemoryConnector.switchIncomingChannelsToInMemory("notification-events-in") +
+                InMemoryConnector.switchOutgoingChannelsToInMemory("notification-events-out")
+
+        override fun stop() = InMemoryConnector.clear()
+    }
+
+    @Inject
+    lateinit var repository: NotificationRepository
+
+    @Inject
+    lateinit var objectMapper: ObjectMapper
+
+    @Inject
+    lateinit var mailbox: MockMailbox
+
+    @Inject
+    @org.eclipse.microprofile.reactive.messaging.spi.Connector("smallrye-in-memory")
+    lateinit var connector: InMemoryConnector
+
+    private fun statusFor(partyId: UUID): String? = VertxContextSupport.subscribeAndAwait {
+        Panache.withSession { repository.find("partyId", partyId).firstResult() }
+    }?.status
+
+    private fun consumeAndAwait(request: NotificationRequest) {
+        val source: InMemorySource<Message<String>> = connector.source("notification-events-in")
+        source.runOnVertxContext(true)
+        val acked = CompletableFuture<Void>()
+        source.send(
+            Message.of(
+                objectMapper.writeValueAsString(request),
+                Supplier<CompletionStage<Void>> {
+                    acked.complete(null)
+                    CompletableFuture.completedFuture<Void>(null)
+                },
+            ),
+        )
+        acked.get(20, TimeUnit.SECONDS)
+    }
+
+    private fun marketingRequest(recipient: String) = NotificationRequest(
+        partyId = UUID.randomUUID(),
+        channel = NotificationChannel.EMAIL,
+        template = NotificationTemplate.MARKETING_PRODUCT_OFFER,
+        recipient = recipient,
+        variables = mapOf(
+            "offerTitle" to "New savings rate",
+            "offerText" to "Check it out",
+            "ctaText" to "See details",
+        ),
+    )
+
+    @Test
+    fun `a consented party's marketing send goes through the gate to SENT`() {
+        StubContactGateProducer.consented = true
+        StubContactGateProducer.sendsInWindow = 0
+        mailbox.clear()
+        val request = marketingRequest("marketing-allowed@example.com")
+
+        consumeAndAwait(request)
+
+        assertThat(statusFor(request.partyId)).isEqualTo("SENT")
+        assertThat(mailbox.getMailMessagesSentTo("marketing-allowed@example.com")).hasSize(1)
+    }
+
+    @Test
+    fun `no active consent denies with the pre-existing no_active_consent reason`() {
+        StubContactGateProducer.consented = false
+        StubContactGateProducer.sendsInWindow = 0
+        val request = marketingRequest("marketing-no-consent@example.com")
+
+        consumeAndAwait(request)
+
+        assertThat(statusFor(request.partyId)).isEqualTo("SUPPRESSED")
+    }
+
+    @Test
+    fun `an exhausted send cap — a reason this service could not previously produce — suppresses too`() {
+        StubContactGateProducer.consented = true
+        StubContactGateProducer.sendsInWindow = Int.MAX_VALUE
+        val request = marketingRequest("marketing-cap@example.com")
+
+        consumeAndAwait(request)
+
+        assertThat(statusFor(request.partyId)).isEqualTo("SUPPRESSED")
+    }
+}
+
+/**
+ * Replaces the real `ContactGateProducer`-built bean. [consented] and [sendsInWindow] are plain
+ * knobs each test sets before driving a request through the consumer, so the outcome is
+ * deterministic without a real consent-service call or a real send-log query.
+ */
+@Alternative
+@Priority(1)
+@ApplicationScoped
+class StubContactGateProducer {
+    @Produces
+    @ApplicationScoped
+    fun contactPolicyGate(): ContactPolicyGate = ContactPolicyGate(
+        consent = ContactConsentPort { _, _ -> consented },
+        counters = object : ContactCounterPort {
+            override suspend fun sendsInWindow(partyId: UUID, windowStart: Instant): Int = sendsInWindow
+            override suspend fun impressionsInWindow(partyId: UUID, windowStart: Instant): Int = 0
+        },
+        suppression = ContactSuppressionPort { emptyList() },
+        policy = ContactPolicy(),
+    )
+
+    companion object {
+        var consented: Boolean = true
+        var sendsInWindow: Int = 0
+    }
+}


### PR DESCRIPTION
## Summary

Issue #2749's last open ADR-0219 D4 item: notification-service is the choke point D4 names outright ("its consent call becomes this gate call"), but was still calling consent-service directly via a bespoke `gateMarketingOnConsent` check — deliberately not touched earlier in this issue's history because it needed a real design decision, not a mechanical swap.

`gateMarketingOnConsent` now calls `ContactPolicyGate.check(...)` (suppression list → send cap → quiet hours → live consent pull, same composition campaign-service and engagement-service already reuse) instead of `consentServiceClient.hasActiveConsent(...)` directly.

Two things this needed, resolved rather than deferred:

1. **Reactive/coroutine bridge**: this dispatch pipeline is Mutiny `Uni` end to end, and `ContactPolicyGate.check` is a `suspend fun`. Bridged via `CoroutineScope(Dispatchers.Unconfined).async { }.asUni()` — the same idiom `CampaignJourneyActivitiesImpl` already uses in this fleet for the reverse direction, applied here to compose a suspend call into an existing `Uni` chain.
2. **Audit granularity**: `gateMarketingOnConsent`'s own KDoc called the `no_active_consent` vs `consent_check_unavailable` distinction load-bearing ("the two numbers must never merge into one"). `ContactPolicyGate.check` catches `Exception` around its whole `evaluate()` and reports every port failure as one `GATE_UNAVAILABLE` reason — kept mapped to the existing `consent_check_unavailable` code (a widened "the gate could not decide" condition, not a lost distinction: `NO_CONSENT` still maps to the pre-existing `no_active_consent` code). Added three new outcome reason codes this service could not previously produce: `SEND_CAP_REACHED`, `QUIET_HOURS`, `SUPPRESSED_LIST` — each gets its own code rather than folding into one of the two pre-existing ones.

New: `ContactGateProducer` (same producer pattern as campaign-service/engagement-service's own — consent port wraps the existing REST client, counter port backed by a new `NotificationRepository.countSince` query scoped to MARKETING templates, suppression port the honest empty one — no ADR-0219 D3 platform store exists yet). `MarketingGateIT` drives the gate end-to-end via an `@Alternative` test producer (same idiom as this file's own `OffContextPushSender`), proving a consented send still reaches `SENT` and both an old and a new deny reason still suppress. Updated `NotificationTemplateCategoryTest`'s reflection-based wiring guard, which asserted a `ConsentServiceClient` field directly — that field is gone by design now, replaced by the `ContactPolicyGate` the guard checks for instead.

## Test plan
- [x] `MarketingGateIT` — consented send reaches SENT; `NO_CONSENT` and `SEND_CAP_REACHED` (a reason this service could not previously produce) both suppress
- [x] `NotificationTemplateCategoryTest` — wiring guard updated to check for the injected `ContactPolicyGate`
- [x] `ktlintCheck` / `detekt` clean
