### PR TITLE
fix(ci): auto-close deploy-drift trackers when nothing drifts anymore

### DIFF
--- a/.github/workflows/deploy-drift-watch.yml
+++ b/.github/workflows/deploy-drift-watch.yml
@@ -98,8 +98,14 @@ jobs:
                exit "$code" ;;
           esac
 
+      # Runs on a clean scan (code 0) too: the auto-close half of this step is the
+      # only thing that closes a tracker whose drift has resolved. Gating on drift
+      # alone meant the LAST open deploy-drift issue was never auto-closed — with
+      # zero drifted services the step was skipped and the issue sat open forever
+      # (measured 2026-08-08: run 31277854742 reported 56 in sync / 0 drifted and
+      # #3366 stayed open; it was closed by hand).
       - name: Escalate drift per service
-        if: ${{ github.event_name != 'pull_request' && steps.probe.outputs.code == '2' }}
+        if: ${{ github.event_name != 'pull_request' && (steps.probe.outputs.code == '0' || steps.probe.outputs.code == '2') }}
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |


### PR DESCRIPTION
## Problem

The `Escalate drift per service` step carries **both** halves of the drift-issue lifecycle:

1. escalate/refresh/reopen trackers for drifted services,
2. **auto-close** trackers whose service caught up with main.

But the step was gated on `steps.probe.outputs.code == '2'` (at least one service drifting). With a fully in-sync fleet (`code == '0'`) the step was skipped entirely — including the auto-close half — so **the last remaining open `deploy-drift` tracker could never be closed by the watch**.

Measured today: run [31277854742](https://github.com/JiRaska/open-bank-oss/actions/runs/31277854742) (workflow_dispatch) reported `56 in sync, 0 drifted/unverifiable` and #3366 (sepa-payment, drift resolved by deploy PR #4222) stayed OPEN; it was closed by hand with a comment citing the run. Yesterday's auto-close of #3363 only fired because sepa-payment was still drifting and kept the step alive.

## Fix

Run the step on a clean scan (`code == '0'`) too. With an empty `drifted` list the escalate half is a no-op (the `for` loop iterates nothing, no issue is created or reopened) and the auto-close half closes whatever caught up. Behaviour with drift present is unchanged.

## Testing

- This PR touches `deploy-drift-watch.yml`, so the PR lane (declaration gate + scanner self-test) runs on it.
- The zero-drift path executes the same github-script with an empty `drifted` array; the only new behaviour is the auto-close loop running — verified by reading, since the sandbox currently has no open drift tracker to close (the next real exercise is the daily cron once a tracker outlives its drift).

Refs #3344
