### PR TITLE
fix(ci): teach the outbox-writer gate the raw-SQL write idiom

### DIFF
--- a/.github/scripts/check-outbox-has-writer.py
+++ b/.github/scripts/check-outbox-has-writer.py
@@ -68,6 +68,30 @@ BASELINE = {
 DISPATCHER_RE = re.compile(r"class\s+\w*OutboxDispatcher\b")
 DECLARATION_RE = re.compile(r"(data\s+)?class\s+OutboxMessage\s*\(")
 
+# THE SECOND WRITE IDIOM — raw SQL (#4240).
+#
+# There are two ways to write an outbox row in this fleet, and the first version of this gate could
+# see only one. `openbank-case-coordinator-agent` writes with a plain JDBC `INSERT INTO case_outbox`
+# because Temporal activity threads are bare worker threads with no Vert.x context, where reactive
+# Panache throws HR000068 — the same reason agent-service keeps `JdbcAgentProposalRepository`. It is
+# deliberate, documented in `CaseActivitiesImpl`'s KDoc, and the dispatch side still reads through
+# the Panache entity.
+#
+# The gate reported it as "polls a table nothing writes to", which was not a close call: the writer
+# is a string literal, and `strip_comments_and_strings` removes string literals BEFORE matching, so
+# the JDBC idiom was structurally invisible — no input could ever have made it visible. That is a
+# fact about the probe, not about the service, and it went red on `main` for every PR (#4240).
+#
+# So the SQL check runs over a comment-stripped body that KEEPS strings, while the
+# `OutboxMessage(` check keeps its original strings-stripped body — the two idioms need opposite
+# treatment of literals, which is exactly why one pass could not serve both. The table-name shape is
+# `<something>outbox`, matching every outbox table in the tree (`case_outbox`, `security_outbox`,
+# `outbox_message`), and an INSERT into any OTHER table is not a writer.
+SQL_WRITE_RE = re.compile(
+    r"INSERT\s+INTO\s+[\"'`]?(?:\w+\.)?\w*outbox\w*",
+    re.IGNORECASE,
+)
+
 
 def strip_comments_and_strings(src: str) -> str:
     """Remove string literals, line comments and NESTED block comments.
@@ -95,6 +119,59 @@ def strip_comments_and_strings(src: str) -> str:
     return "".join(out)
 
 
+def strip_comments_keep_strings(src: str) -> str:
+    """Remove line and NESTED block comments while PRESERVING string literals.
+
+    The sibling stripper above cannot be reused for the SQL check: it deletes literals, and the SQL
+    write IS a literal. Comments must still go — a KDoc saying `INSERT INTO x_outbox` is prose, and
+    this repo has been burnt in both directions by guards that could not tell code from code-about-
+    code (#2450, #3072).
+
+    Scanning rather than regex, because comment and string openers alias each other: a `//` inside a
+    string must not start a comment, and a `"` inside a comment must not open a string. Kotlin raw
+    strings (`\"\"\"…\"\"\"`) are handled first — every SQL literal in this fleet is one, and a
+    naive scanner reads the opening `\"\"` as an empty string and then treats the SQL as code.
+    """
+    out: list[str] = []
+    i, n, depth = 0, len(src), 0
+    while i < n:
+        if depth:
+            if src.startswith("/*", i):
+                depth += 1
+                i += 2
+            elif src.startswith("*/", i):
+                depth -= 1
+                i += 2
+            else:
+                i += 1
+            continue
+        if src.startswith("/*", i):
+            depth = 1
+            i += 2
+            continue
+        if src.startswith("//", i):
+            while i < n and src[i] != "\n":
+                i += 1
+            continue
+        if src.startswith('"""', i):
+            end = src.find('"""', i + 3)
+            end = n if end == -1 else end + 3
+            out.append(src[i:end])
+            i = end
+            continue
+        if src[i] == '"':
+            j = i + 1
+            while j < n and src[j] != '"':
+                j += 2 if src[j] == "\\" else 1
+            j = min(j + 1, n)
+            out.append(src[i:j])
+            i = j
+            continue
+        out.append(src[i])
+        i += 1
+    return "".join(out)
+
+
 def classify_service(files: dict[str, str]) -> tuple[bool, bool]:
     """(ships_a_dispatcher, constructs_a_message) for one service's RAW `src/main` sources.
 
@@ -110,6 +187,9 @@ def classify_service(files: dict[str, str]) -> tuple[bool, bool]:
         if DISPATCHER_RE.search(body):
             dispatcher = True
         if "OutboxMessage(" in body and not DECLARATION_RE.search(body):
+            writes = True
+        # Second idiom, opposite treatment of literals — see SQL_WRITE_RE.
+        if SQL_WRITE_RE.search(strip_comments_keep_strings(raw)):
             writes = True
     return dispatcher, writes
 
@@ -179,6 +259,48 @@ def self_test() -> int:
     after = disp + "\n/* note */\n" + write
     expect("a real construction AFTER a comment still counts",
            classify_service({"a.kt": after}), (True, True))
+
+    # ── The raw-SQL write idiom (#4240) ────────────────────────────────────────────────────────
+    # Built from the shape that broke this gate on main, not invented: a Kotlin raw string holding
+    # the INSERT, which the strings-stripped body can never contain.
+    sql = (
+        'private val INSERT = """\n'
+        "    INSERT INTO case_outbox\n"
+        "        (event_id, aggregate_id, event_type, payload, status, created_at, updated_at)\n"
+        "    VALUES (?, ?, ?, ?, ?, ?, ?)\n"
+        '""".trimIndent()\n'
+    )
+    expect("a raw-string INSERT INTO <x>_outbox IS a writer",
+           classify_service({"a.kt": disp, "b.kt": sql}), (True, True))
+    single = disp + '\nval s = "insert into outbox_message (id) values (?)"\n'
+    expect("a single-quoted-style literal and lower case also count",
+           classify_service({"a.kt": single}), (True, True))
+
+    # The negatives matter more than the positive: a widened regex that matches any INSERT would
+    # mark all eight baselined services as fixed and quietly retire the gate.
+    other_table = disp + '\nval s = """INSERT INTO party_events (id) VALUES (?)"""\n'
+    expect("an INSERT into a NON-outbox table is NOT a writer",
+           classify_service({"a.kt": other_table}), (True, False))
+    sql_in_kdoc = disp + "\n/** Drains rows an INSERT INTO case_outbox put there. */\n"
+    expect("SQL named in a KDoc is NOT a writer",
+           classify_service({"a.kt": sql_in_kdoc}), (True, False))
+    sql_in_line_comment = disp + "\n// INSERT INTO case_outbox (id) VALUES (?)\n"
+    expect("a commented-out INSERT is NOT a writer",
+           classify_service({"a.kt": sql_in_line_comment}), (True, False))
+    sql_in_nested = disp + "\n/* outer /* inner */ INSERT INTO case_outbox */\n"
+    expect("an INSERT inside a NESTED comment is NOT a writer",
+           classify_service({"a.kt": sql_in_nested}), (True, False))
+    # A `//` inside the SQL literal must not be read as a comment opener and eat the rest.
+    url_in_sql = (
+        disp + '\nval s = """\n-- see http://wiki/outbox\nINSERT INTO case_outbox (id)\n"""\n'
+    )
+    expect("a // inside the SQL literal does not hide the INSERT",
+           classify_service({"a.kt": url_in_sql}), (True, True))
+    # …and the mirror: a real INSERT after a comment that contains a quote still counts, which is
+    # what breaks if the scanner lets a `"` inside a comment open a string.
+    quote_in_comment = disp + '\n/* the "outbox" table */\nval s = """INSERT INTO case_outbox"""\n'
+    expect("a quote inside a comment does not swallow the following SQL",
+           classify_service({"a.kt": quote_in_comment}), (True, True))
 
     if fails:
         print("check-outbox-has-writer: self-test FAIL")


### PR DESCRIPTION
## What

Teaches `check-outbox-has-writer.py` the second outbox write idiom in this fleet: a raw-SQL `INSERT INTO <x>_outbox`. One of the three enforced gates currently red on `main`.

## Why this was a blind spot, not a miss

The gate detected a writer solely by the substring `OutboxMessage(`, matched against a body produced by `strip_comments_and_strings()`. The other idiom lives **entirely inside a string literal**, which that function removes before matching — so no input could ever have made it visible. `grep -ci 'insert into|jdbc|preparedstatement'` over the old script: **0**.

`openbank-case-coordinator-agent` writes its row with plain JDBC:

```
INSERT INTO case_outbox
    (event_id, aggregate_id, event_type, payload, status, created_at, updated_at)
```

and `CaseActivitiesImpl`'s KDoc says why, in advance:

> Temporal activity threads are plain worker threads with no Vert.x context, and reactive Panache would throw HR000068 there — the same reason agent-service keeps `JdbcAgentProposalRepository`. The outbox DISPATCH side (`CaseOutboxDispatcher`) runs on the Quarkus scheduler with a Vert.x context and reads through the Panache entity as usual.

The gate reported "the dispatcher will poll a table nothing writes to" about a table that is written to, on every PR since `4405a74fa`. Same shape as the repo's own note that grepping for a JSON key finds hand-built maps and never a serialised data class — a probe that knows one idiom reports the other as absent, and the answer reads as a finding rather than as a fact about the probe.

## How

The two idioms need **opposite** treatment of literals, which is why one pass cannot serve both:

- `OutboxMessage(` → the original strings-stripped body, **untouched** (its 9 self-tests still pass unchanged).
- `INSERT INTO …outbox` → a new comment-stripped body that **keeps** strings.

`strip_comments_keep_strings` is a scanner rather than a regex because comment and string openers alias each other: a `//` inside SQL must not start a comment, a `"` inside a comment must not open a string, and Kotlin raw strings must be consumed first or the opening `""` reads as an empty string and the SQL is treated as code. Each of those three is a self-test case.

## Measured, not asserted

Old logic vs new, on the real tree, diffing the per-service violation sets:

```
flipped violation -> writer: ['openbank-case-coordinator-agent']
flipped writer -> violation: none
```

```
old:  33 service(s) ship a dispatcher; 9 without a writer (8 baselined, 1 new, 0 stale)
new:  33 service(s) ship a dispatcher; 8 without a writer (8 baselined, 0 new, 0 stale)
```

Exactly one service flips. **All 8 baselined services remain violations** — that is the number that matters here, because the obvious way to get this wrong is a regex broad enough to match any `INSERT`, which would mark the whole baseline as fixed and silently retire the gate. It would show up above as baseline entries going stale; none did.

## Self-test: 9 → 17

The 8 new cases are deliberately weighted toward **negatives**, since those are what keep the widening honest:

| case | expected |
|---|---|
| raw-string `INSERT INTO case_outbox` | writer |
| lower-case `insert into outbox_message` | writer |
| `INSERT INTO party_events` (non-outbox table) | **not** a writer |
| SQL named in a KDoc | **not** a writer |
| commented-out INSERT | **not** a writer |
| INSERT inside a NESTED block comment | **not** a writer |
| `//` inside the SQL literal | writer (not swallowed) |
| quote inside a preceding comment | writer (not swallowed) |

The positive case is built from the shape that actually broke the gate, not invented.

`run-gates.py --only outbox-has-writer` → PASS (the gate's `run:` executes both the self-test and the real scan).

## Scope

This fixes **one** of the three enforced gates red on `main`. The other two are real gaps in case-coordinator and are not touched here:

- `event-consumer-liveness` — `proposal-events` has no consumer in the fleet
- `event-contract-coverage-ratchet` — no `openbank-contracts/openbank-case-coordinator-agent/asyncapi.yaml`

So `main` stays red after this merges. #4240 tracks all three plus the governance question of how #4215 merged past a failing required check.

## Linked issues

Refs #4240

## References

- #4007 (the gate's origin), #4215 / `4405a74fa` (the commit that exposed the blind spot)
- `openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/infrastructure/workflow/CaseActivitiesImpl.kt`
