### PR TITLE
fix(ci): make the outbox-writer SQL strip string-aware

### DIFF
--- a/.github/scripts/check-outbox-has-writer.py
+++ b/.github/scripts/check-outbox-has-writer.py
@@ -108,21 +108,56 @@ def strip_comments_only(src: str) -> str:
     The SQL predicate needs this: an INSERT lives inside a string literal, which
     strip_comments_and_strings() blanks. Prose describing an insert must still not count, so the
     comments still go.
+
+    STRING-AWARE, and it has to be. Its sibling above states the invariant this function must also
+    honour — "a `\"/*\"` inside a literal must not open a comment" — and gets it for free by
+    blanking literals first. This one cannot blank them (the SQL *is* a literal), so it has to
+    track them, which makes a regex the wrong tool: comment and string openers alias each other.
+    The first version walked `/*` blind to literals, so `val a = "/*"` opened a comment that
+    swallowed every following INSERT and reported a real writer as writerless — measured, and the
+    one case in the self-test below that separates the two implementations (#4240). Raw strings are
+    consumed first: otherwise the opening `\"\"` of a `\"\"\"…\"\"\"` reads as an empty literal.
+
+    No service in the tree trips this today — the fleet verdict is byte-identical before and after
+    (33 dispatchers, 8 baselined, 0 new, 0 stale). This is a latent-defect fix, so the self-test is
+    the only thing that can hold it: there is no failing service to point at.
     """
-    src = re.sub(r"//[^\n]*", "", src)
     out: list[str] = []
-    depth = i = 0
-    while i < len(src):
+    i, n, depth = 0, len(src), 0
+    while i < n:
+        if depth:
+            if src.startswith("/*", i):
+                depth += 1
+                i += 2
+            elif src.startswith("*/", i):
+                depth -= 1
+                i += 2
+            else:
+                i += 1
+            continue
         if src.startswith("/*", i):
-            depth += 1
+            depth = 1
             i += 2
             continue
-        if src.startswith("*/", i) and depth:
-            depth -= 1
-            i += 2
+        if src.startswith("//", i):
+            while i < n and src[i] != "\n":
+                i += 1
             continue
-        if not depth:
-            out.append(src[i])
+        if src.startswith('"""', i):
+            end = src.find('"""', i + 3)
+            end = n if end == -1 else end + 3
+            out.append(src[i:end])
+            i = end
+            continue
+        if src[i] == '"':
+            j = i + 1
+            while j < n and src[j] != '"':
+                j += 2 if src[j] == "\\" else 1
+            j = min(j + 1, n)
+            out.append(src[i:j])
+            i = j
+            continue
+        out.append(src[i])
         i += 1
     return "".join(out)
 
@@ -230,6 +265,32 @@ def self_test() -> int:
     sql_kdoc = disp + "\n/** Historically this did INSERT INTO case_outbox directly. */\n"
     expect("a KDoc describing an INSERT is NOT a writer",
            classify_service({"a.kt": sql_kdoc}), (True, False))
+
+    # The SQL strip must honour the same `"/*"` invariant its sibling states. Exactly ONE of the
+    # three below was measured failing against the regex-plus-blind-walk version this replaced —
+    # the first. The other two pass either way and are regression tests, not evidence of a defect;
+    # saying so here because a comment claiming three failures where one was measured is the kind
+    # of unverified evidence this file's own header exists to warn about.
+    #
+    # A false negative is the dangerous direction for all three: the gate reports a service that
+    # DOES write its outbox as writerless, which reads as a clean finding rather than a broken
+    # probe — the shape that put this gate on main's critical path in the first place (#4240).
+    slash_star_literal = disp + '\nval a = "/*"\nval s = """INSERT INTO case_outbox (id)"""\n'
+    expect('a "/*" inside a literal must not open a comment and swallow the INSERT',
+           classify_service({"a.kt": slash_star_literal}), (True, True))
+    # Regression: `//` stripped to end-of-line must not reach inside a literal and take a
+    # following INSERT with it.
+    url_in_sql = (
+        disp + '\nval s = """\n-- see http://wiki/outbox\nINSERT INTO case_outbox (id)\n"""\n'
+    )
+    expect("a // inside the SQL literal does not hide the INSERT",
+           classify_service({"a.kt": url_in_sql}), (True, True))
+    # Regression: a quote inside a comment must not open a string and swallow the SQL after it.
+    raw_after_comment = (
+        disp + '\n/* the "outbox" table */\nval s = """INSERT INTO case_outbox"""\n'
+    )
+    expect("a quote inside a comment does not swallow the following SQL",
+           classify_service({"a.kt": raw_after_comment}), (True, True))
 
     # …and the stripper must not swallow real code that merely follows a comment.
     after = disp + "\n/* note */\n" + write


### PR DESCRIPTION
## What

Makes the outbox-writer gate's SQL strip **string-aware**. Narrow follow-up to #4233, which landed the SQL write predicate independently while this was being written — this PR is only the part #4233 does not have.

## The defect

#4233 added `strip_comments_only()` to feed the new SQL predicate, because the INSERT lives inside a string literal that `strip_comments_and_strings()` blanks. That new function walks `/*` without tracking literals, so it loses the invariant its sibling states two definitions above:

> Strings first: a `"/*"` inside a literal must not open a comment.

Concretely, `val a = "/*"` opens a comment that swallows every following INSERT:

```
val a = "/*"
val s = """INSERT INTO case_outbox (id)"""     <- invisible; service reported writerless
```

False-negative direction, which is the dangerous one for this gate: it prints *"the dispatcher will poll a table nothing writes to"* about a table that is written to, and that reads as a clean finding rather than as a broken probe — the exact shape that put this gate on `main`'s critical path (#4240).

## Fix

A scanner that tracks raw strings, normal strings with escapes, line comments and nested block comments. Comment and string openers alias each other, so a regex is the wrong tool. Raw strings are consumed first, or the opening `""` of a `"""…"""` reads as an empty literal and the SQL inside is scanned as code.

## Measured

Fleet verdict **byte-identical** before and after:

```
33 service(s) ship a dispatcher; 8 without a writer (8 baselined, 0 new, 0 stale)
```

No service in the tree trips this today. It is a **latent** defect, so the self-test is the only thing that can hold it — there is no failing service to point at.

## Self-test 12 to 15, and an honest count

Exactly **one** of the three new cases fails against the implementation it replaces:

| case | main (#4233) | this PR |
|---|---|---|
| `"/*"` inside a literal | **False** (wrong) | True |
| `//` inside the SQL literal | True | True |
| quote inside a preceding comment | True | True |

The other two pass either way. They are labelled in the code as regression tests rather than as evidence — I first wrote a comment claiming all three were measured failing, which was wrong, and that is the unverified-evidence habit this file's own header warns about.

## Relationship to #4233

Same diagnosis, same approach, arrived at in parallel; #4233 merged at 21:05Z. Its predicate and its baseline are untouched here — only the stripper is replaced. My original wider diff (#4243) was closed rather than re-litigated, so there is one authoring of the SQL predicate in this file, not two.

## Linked issues

Refs #4240

## References

- #4233 (`2f23b4d16`), #4007 (the gate's origin), #4102
