### PR TITLE
ci(gitops): make the #3545 gate ask whether a canary is REALISABLE, not merely declared

### DIFF
--- a/.github/canary-rollout-realisable-baseline.txt
+++ b/.github/canary-rollout-realisable-baseline.txt
@@ -1,0 +1,53 @@
+# Declared debt for the canary-realisability half of check-single-replica-rollout-strategy.py
+# (issue #3806, the sharper half of #3545).
+#
+# Every line here is a canary Argo Rollout that declares `setWeight` steps its replica count
+# cannot produce. Without a `trafficRouting` provider Argo realises a canary weight by POD COUNT,
+# so N replicas express only the multiples of 100/N — at N=1 that is 0 or 100 and nothing else.
+# `setWeight: 10` on a one-replica Rollout therefore routes all traffic or none, and the `pause`
+# after it observes a state the weights do not describe.
+#
+# Measured on origin/main and live (`kubectl get rollout -A`) 2026-08-08: 21 Rollouts in the
+# fleet, 21 at `replicas: 1`, 21 canary, 0 with trafficRouting, all reporting `Healthy` and
+# `1/1 READY`. 17 of the 21 are money-path per rules.yaml: money_path_services. There is no
+# unaffected control group — the canary strategy has never run in a shape where it can do
+# anything, which is why nothing ever looked wrong.
+#
+# This file is the ENFORCED ratchet, not an amnesty: a NEW unrealisable canary fails the gate,
+# and a line here that stops matching fails it too (delete the line when the debt is paid, or the
+# file outlives it and starts lying about what is covered).
+#
+# Three ways off this list, and picking between them is an owner decision, not a drive-by:
+#   1. Make the weights match the replica count (at 1 replica: 0/100 only) — free, honest, and
+#      says out loud that progressive delivery is not in force.
+#   2. Wire a trafficRouting provider (ingress-nginx / SMI) — weights become real at any replica
+#      count. This is the only option that makes `setWeight: 10` mean 10%.
+#   3. Raise `replicas` — note this alone does NOT fix it (at 2 replicas `setWeight: 10` means
+#      50%), it costs capacity (+4.62 vCPU / +9.69 GiB to double all 21, ~+9.6% of the `default`
+#      nodepool's declared CPU cap), and for at least lending-service it is a CORRECTNESS change
+#      first: #3467 records per-pod in-memory compliance-pack state, so a second replica arms a
+#      four-eyes divergence. #3644 is the convergence fix and says itself it does not make
+#      lending safe to scale.
+#
+# Refs #3806, #3545, #3805, #3467, #3644.
+openbank-infra/gitops/components/accounts/account-service.yaml: Rollout/account-service canary declares setWeight 10,30 that 1 replica(s) cannot express and has no trafficRouting
+openbank-infra/gitops/components/balances/balance-service.yaml: Rollout/balance-service canary declares setWeight 10,30 that 1 replica(s) cannot express and has no trafficRouting
+openbank-infra/gitops/components/consent/consent-service.yaml: Rollout/consent-service canary declares setWeight 10,30 that 1 replica(s) cannot express and has no trafficRouting
+openbank-infra/gitops/components/customer-edge/customer-edge.yaml: Rollout/customer-edge canary declares setWeight 10,30 that 1 replica(s) cannot express and has no trafficRouting
+openbank-infra/gitops/components/fraud-service/fraud-service.yaml: Rollout/fraud-service canary declares setWeight 10,30 that 1 replica(s) cannot express and has no trafficRouting
+openbank-infra/gitops/components/fx-service/fx-service.yaml: Rollout/fx-service canary declares setWeight 10,30 that 1 replica(s) cannot express and has no trafficRouting
+openbank-infra/gitops/components/kyc/kyc-service.yaml: Rollout/kyc-service canary declares setWeight 10,30 that 1 replica(s) cannot express and has no trafficRouting
+openbank-infra/gitops/components/ledger/ledger-service.yaml: Rollout/ledger-service canary declares setWeight 10,30 that 1 replica(s) cannot express and has no trafficRouting
+openbank-infra/gitops/components/lending/lending-service.yaml: Rollout/lending-service canary declares setWeight 10,30 that 1 replica(s) cannot express and has no trafficRouting
+openbank-infra/gitops/components/onboarding/onboarding-service.yaml: Rollout/onboarding-service canary declares setWeight 10,30 that 1 replica(s) cannot express and has no trafficRouting
+openbank-infra/gitops/components/party/party-service.yaml: Rollout/party-service canary declares setWeight 10,30 that 1 replica(s) cannot express and has no trafficRouting
+openbank-infra/gitops/components/payments/payments-services.yaml: Rollout/transaction-service canary declares setWeight 10,30 that 1 replica(s) cannot express and has no trafficRouting
+openbank-infra/gitops/components/payments/payments-services.yaml: Rollout/sepa-payment canary declares setWeight 10,30 that 1 replica(s) cannot express and has no trafficRouting
+openbank-infra/gitops/components/payments/payments-services.yaml: Rollout/domestic-payment canary declares setWeight 10,30 that 1 replica(s) cannot express and has no trafficRouting
+openbank-infra/gitops/components/payments/payments-services.yaml: Rollout/sepa-instant canary declares setWeight 10,30 that 1 replica(s) cannot express and has no trafficRouting
+openbank-infra/gitops/components/payments/payments-services.yaml: Rollout/clearing-service canary declares setWeight 10,30 that 1 replica(s) cannot express and has no trafficRouting
+openbank-infra/gitops/components/payments/payments-services.yaml: Rollout/settlement-service canary declares setWeight 10,30 that 1 replica(s) cannot express and has no trafficRouting
+openbank-infra/gitops/components/payments/payments-services.yaml: Rollout/swift-service canary declares setWeight 10,30 that 1 replica(s) cannot express and has no trafficRouting
+openbank-infra/gitops/components/payments/payments-services.yaml: Rollout/vop-service canary declares setWeight 10,30 that 1 replica(s) cannot express and has no trafficRouting
+openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml: Rollout/sanctions-service canary declares setWeight 10,30 that 1 replica(s) cannot express and has no trafficRouting
+openbank-infra/gitops/components/sca/sca-service.yaml: Rollout/sca-service canary declares setWeight 10,30 that 1 replica(s) cannot express and has no trafficRouting

--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -250,14 +250,22 @@ gates:
       python3 .github/scripts/check-oidc-secret-convention.py --enforce
 
   - id: single-replica-rollout-strategy
-    name: "one-replica workloads declare their rollout strategy (issue #3545, enforced, baseline-ratcheted)"
+    name: "one-replica workloads declare their rollout strategy AND their canary is realisable (issues #3545/#3806, enforced, baseline-ratcheted)"
     group: gitops
     mode: enforced
     selftest: python3 .github/scripts/check-single-replica-rollout-strategy.py --self-test
     selftest_expect: pass
     run: |
+      # Two independent questions over the same manifests. The first is #3545: did the workload
+      # SAY what it wants, or inherit maxSurge 1 / maxUnavailable 0 by accident. The second is
+      # #3806: a canary block counted as "declared" and stopped there, which is how 21 of 21
+      # canary Rollouts (17 money-path) declaring `setWeight: 10` on ONE replica were never
+      # findings — without trafficRouting a weight is pods-out-of-pods, so one pod expresses 0 or
+      # 100 and nothing else, while status.phase reads Healthy throughout. Separate baselines:
+      # #3545's is empty on purpose and must stay that way.
       python3 .github/scripts/check-single-replica-rollout-strategy.py --enforce \
-        --baseline .github/single-replica-rollout-strategy-baseline.txt
+        --baseline .github/single-replica-rollout-strategy-baseline.txt \
+        --canary-baseline .github/canary-rollout-realisable-baseline.txt
 
   - id: gen-network-policies-drift-gate
     name: "gen-network-policies drift gate (ADR-0081, issue #854)"

--- a/.github/scripts/check-single-replica-rollout-strategy.py
+++ b/.github/scripts/check-single-replica-rollout-strategy.py
@@ -30,9 +30,40 @@ It does not impose an answer, because there isn't one answer:
 So the rule is: *say which one you chose*. An explicit `strategy` block is a decision; the default
 is an accident that reads identically until the day the cluster is full.
 
+The second question: is the declared canary REALISABLE? (issue #3806)
+---------------------------------------------------------------------
+The paragraph above counts a canary block as "declared" and stops there, which is how all 21
+canary Rollouts in this fleet — 17 of them money-path — were never findings. Measured on
+`origin/main` and live (`kubectl get rollout -A`) 2026-08-08: **21 Rollouts, 21 at `replicas: 1`,
+21 canary, 0 with `trafficRouting`, and every one carrying `setWeight` steps of 10/30**.
+
+Without a traffic router, Argo realises a canary weight by POD COUNT. With N replicas the only
+expressible weights are the multiples of 100/N — at N=1 that is {0, 100} and nothing else. So
+`setWeight: 10` on a one-replica Rollout does not send 10% of traffic anywhere: it sends either
+all of it or none, and the `pause` that follows observes a state the weights do not describe.
+Raising `replicas` to 2 does not by itself fix it either — it makes `setWeight: 10` mean 50%.
+
+Nothing in the Rollout object says so. `status.phase` is `Healthy` throughout, and a canary that
+cannot split traffic presents identically to one that is splitting it correctly. That is the
+"green about work it never did" class: a declaration check cannot tell these 21 from a working
+fleet, so it reads as passing rather than as unchecked.
+
+This gate therefore asks a second, independent question of every canary Rollout: can the weights
+it declares actually be produced by the replica count it declares? `trafficRouting` answers it
+outright (weights are then real at any replica count) and short-circuits the check. The findings
+carry their own baseline file so #3545's — deliberately empty — stays that way.
+
+What this gate still does NOT do
+--------------------------------
+It does not raise anybody's `replicas`. That is a capacity decision (+9.6% of the `default`
+nodepool's CPU cap to double all 21) and, for at least `lending-service`, a correctness one first:
+#3467 records per-pod in-memory compliance-pack state, so a second replica ARMS a four-eyes
+divergence. Recording today's set as declared debt is the honest state until an owner picks
+between fixing the weights, wiring a router, or paying for replicas.
+
 Falsifiability
 --------------
-`--self-test` feeds the matcher a workload of each shape and asserts the verdict in both
+`--self-test` feeds both matchers a workload of each shape and asserts the verdict in both
 directions, so a run that reports "clean" has been shown capable of reporting "dirty".
 """
 
@@ -72,6 +103,63 @@ def declares_strategy(doc: dict) -> bool:
     if not isinstance(rolling, dict):
         return False
     return "maxSurge" in rolling or "maxUnavailable" in rolling
+
+
+def unrealisable_weights(doc: dict) -> list[int] | None:
+    """The `setWeight` steps this canary declares that its replica count cannot produce.
+
+    Returns None when the question does not apply (not a canary Rollout, or a `trafficRouting`
+    provider is wired in — a router realises any weight independently of pod count). Returns the
+    offending weights otherwise, empty list meaning "realisable".
+
+    Without a router the canary share is pods-out-of-pods, so with N replicas only the multiples
+    of 100/N exist. `w * N % 100 == 0` is exactly that test: at N=1 it admits only 0 and 100.
+    """
+    if doc.get("kind") != "Rollout":
+        return None
+    canary = ((doc.get("spec") or {}).get("strategy") or {}).get("canary")
+    if not isinstance(canary, dict):
+        return None
+    if canary.get("trafficRouting"):
+        return None
+    replicas = (doc.get("spec") or {}).get("replicas")
+    if not isinstance(replicas, int) or isinstance(replicas, bool) or replicas < 1:
+        replicas = 1  # an absent `replicas` is 1, the same default that makes this bite
+    bad: list[int] = []
+    for step in canary.get("steps") or []:
+        if not isinstance(step, dict) or "setWeight" not in step:
+            continue
+        weight = step["setWeight"]
+        if not isinstance(weight, int) or isinstance(weight, bool):
+            continue
+        if weight * replicas % 100 != 0:
+            bad.append(weight)
+    return bad
+
+
+def canary_findings(root: pathlib.Path) -> list[str]:
+    """One line per canary Rollout whose declared weights its replica count cannot express."""
+    out: list[str] = []
+    for path in sorted(root.rglob("*.yaml")):
+        try:
+            docs = list(yaml.safe_load_all(path.read_text(encoding="utf-8")))
+        except (yaml.YAMLError, UnicodeDecodeError):
+            continue
+        for doc in docs:
+            if not isinstance(doc, dict):
+                continue
+            bad = unrealisable_weights(doc)
+            if not bad:
+                continue
+            rel = path.relative_to(REPO)
+            name = (doc.get("metadata") or {}).get("name", "?")
+            replicas = (doc.get("spec") or {}).get("replicas", 1)
+            weights = ",".join(str(w) for w in bad)
+            out.append(
+                f"{rel}: Rollout/{name} canary declares setWeight {weights} that {replicas} replica(s) "
+                f"cannot express and has no trafficRouting"
+            )
+    return out
 
 
 def findings(root: pathlib.Path) -> list[str]:
@@ -124,6 +212,42 @@ SELF_TEST_CASES = [
 ]
 
 
+def _canary(replicas, weights, routing=False):
+    canary: dict = {"steps": [{"setWeight": w} for w in weights]}
+    if routing:
+        canary["trafficRouting"] = {"nginx": {"stableIngress": "x"}}
+    spec: dict = {"strategy": {"canary": canary}}
+    if replicas is not None:
+        spec["replicas"] = replicas
+    return {"kind": "Rollout", "spec": spec}
+
+
+# (doc, expected offending weights or None, label) — None means "the question does not apply".
+CANARY_SELF_TEST_CASES = [
+    (_canary(1, [10, 30, 100]), [10, 30], "the live fleet shape: 1 replica, 10/30/100"),
+    (_canary(1, [10, 30]), [10, 30], "1 replica, no terminal 100"),
+    (_canary(1, [100]), [], "1 replica, only 0/100 — realisable"),
+    (_canary(1, [0, 100]), [], "1 replica, 0 and 100 — realisable"),
+    (_canary(None, [10]), [10], "absent replicas defaults to 1"),
+    (_canary(2, [10, 30, 100]), [10, 30], "2 replicas still cannot express 10 or 30"),
+    (_canary(2, [50, 100]), [], "2 replicas CAN express 50 — realisable"),
+    (_canary(4, [25, 50, 75, 100]), [], "4 replicas express every quarter — realisable"),
+    (_canary(4, [10]), [10], "4 replicas cannot express 10"),
+    (_canary(1, [10, 30], routing=True), None, "trafficRouting makes any weight real"),
+    ({"kind": "Deployment", "spec": {"replicas": 1}}, None, "a Deployment is not asked"),
+    (
+        {"kind": "Rollout", "spec": {"replicas": 1, "strategy": {"blueGreen": {}}}},
+        None,
+        "blueGreen has no setWeight",
+    ),
+    (
+        {"kind": "Rollout", "spec": {"replicas": 1, "strategy": {"canary": {"steps": [{"pause": {}}]}}}},
+        [],
+        "canary of pauses only — nothing to express",
+    ),
+]
+
+
 def self_test() -> int:
     bad = 0
     for doc, want, label in SELF_TEST_CASES:
@@ -131,11 +255,32 @@ def self_test() -> int:
         if got != want:
             print(f"  SELF-TEST FAIL: {label} — wanted {want}, got {got}")
             bad += 1
+    for doc, want_w, label in CANARY_SELF_TEST_CASES:
+        got_w = unrealisable_weights(doc)
+        if got_w != want_w:
+            print(f"  SELF-TEST FAIL (canary): {label} — wanted {want_w}, got {got_w}")
+            bad += 1
     if bad:
         print(f"::error::check-single-replica-rollout-strategy self-test failed on {bad} case(s)")
         return 1
-    print(f"selftest OK: {len(SELF_TEST_CASES)} cases, both directions.")
+    print(
+        f"selftest OK: {len(SELF_TEST_CASES)} strategy-declaration + {len(CANARY_SELF_TEST_CASES)} "
+        f"canary-realisability cases, both directions."
+    )
     return 0
+
+
+def _load_baseline(path: str | None) -> set[str]:
+    if not path:
+        return set()
+    bp = pathlib.Path(path)
+    if not bp.exists():
+        return set()
+    return {
+        ln.strip()
+        for ln in bp.read_text(encoding="utf-8").splitlines()
+        if ln.strip() and not ln.startswith("#")
+    }
 
 
 def main() -> int:
@@ -147,6 +292,12 @@ def main() -> int:
         "baseline line with no matching finding ALSO fails (the debt was paid — delete the line, "
         "or the file outlives it and starts lying about what is covered).",
     )
+    ap.add_argument(
+        "--canary-baseline",
+        help="declared-debt file for the canary-realisability half (issue #3806). Same two-way "
+        "contract as --baseline: a new unrealisable canary fails, and so does a line that has "
+        "stopped matching. Separate file so #3545's baseline stays empty.",
+    )
     ap.add_argument("--self-test", action="store_true")
     args = ap.parse_args()
 
@@ -155,24 +306,18 @@ def main() -> int:
     if self_test():
         return 1
 
-    hits = findings(GITOPS)
-    baseline: set[str] = set()
-    if args.baseline:
-        bp = pathlib.Path(args.baseline)
-        if bp.exists():
-            baseline = {
-                ln.strip()
-                for ln in bp.read_text(encoding="utf-8").splitlines()
-                if ln.strip() and not ln.startswith("#")
-            }
+    marker = "::error::" if args.enforce else "::warning::"
+    rc = 0
 
+    hits = findings(GITOPS)
+    baseline = _load_baseline(args.baseline)
     new_debt = [h for h in hits if h not in baseline]
     paid_off = sorted(baseline - set(hits))
 
     for h in new_debt:
-        print(f"{'::error::' if args.enforce else '::warning::'}single-replica-rollout-strategy: {h}")
+        print(f"{marker}single-replica-rollout-strategy: {h}")
     for b in paid_off:
-        print(f"{'::error::' if args.enforce else '::warning::'}single-replica-rollout-strategy: baseline line no longer matches anything — delete it: {b}")
+        print(f"{marker}single-replica-rollout-strategy: baseline line no longer matches anything — delete it: {b}")
 
     print(
         f"check-single-replica-rollout-strategy: {len(hits)} one-replica workload(s) inherit the default "
@@ -184,7 +329,36 @@ def main() -> int:
             "no-HA service, or surge stated deliberately. A canary Rollout already counts as declared. "
             "See issue #3545."
         )
-    if not (new_debt or paid_off):
+    if new_debt or paid_off:
+        rc = 1
+
+    canary_hits = canary_findings(GITOPS)
+    canary_baseline = _load_baseline(args.canary_baseline)
+    canary_new = [h for h in canary_hits if h not in canary_baseline]
+    canary_paid = sorted(canary_baseline - set(canary_hits))
+
+    for h in canary_new:
+        print(f"{marker}canary-rollout-realisable: {h}")
+    for b in canary_paid:
+        print(f"{marker}canary-rollout-realisable: baseline line no longer matches anything — delete it: {b}")
+
+    print(
+        f"check-canary-rollout-realisable: {len(canary_hits)} canary Rollout(s) declare a setWeight "
+        f"their replica count cannot express, {len(canary_new)} NEW vs baseline, "
+        f"{len(canary_paid)} stale baseline line(s)."
+    )
+    if canary_new:
+        print(
+            "  Without `trafficRouting` a canary weight is pods-out-of-pods, so N replicas can only "
+            "express multiples of 100/N — at N=1 that is 0 or 100 and nothing else. Either make the "
+            "`setWeight` steps match what the replica count can produce, wire a trafficRouting "
+            "provider, or raise `replicas` (a capacity AND per-pod-state decision — see #3467). "
+            "See issue #3806."
+        )
+    if canary_new or canary_paid:
+        rc = 1
+
+    if not rc:
         return 0
     if not args.enforce:
         print("check-single-replica-rollout-strategy: advisory — no --enforce, so this is a warning.")


### PR DESCRIPTION
## What

Makes the #3545 gate ask a second question of every canary Argo Rollout: **can the weights it
declares actually be produced by the replica count it declares?**

It could not before, and said so in its own docstring — a canary block counted as *declared* and
the check stopped there. That is the "green about work it never did" class: the 21 workloads the
gate most needed to look at were the 21 its scope silently excluded.

## Re-derived counts (issue says 21 / 15)

Measured on `origin/main` at `2f23b4d16` and live, 2026-08-08:

| | manifests | live (`kubectl get rollout -A`) |
|---|---|---|
| Rollouts in the fleet | **21** | **21** |
| `replicas: 1` | **21** | **21** (`spec.replicas=1`, `ready=1`, `available=1`) |
| canary strategy | **21** | 21 |
| canary with `replicas > 1` | **0** | 0 |
| `canary.trafficRouting` set | **0** | 0 |
| explicit `canary.maxSurge` / `maxUnavailable` | **0** / **0** | — |
| `setWeight` step outside {0, 100} | **21** | — |
| `status.phase` | — | **Healthy on all 21** |

**Money-path is 17, not 15.** Cross-checked name by name against
`openbank-libs/governance/rules.yaml: money_path_services`. The issue *title* says 15; the issue
*body* lists 17 names under `money-path:`, so the body was right and the title compressed it.

```
money-path (17): account balance consent fraud fx ledger lending transaction sepa-payment
                 domestic-payment sepa-instant clearing settlement swift vop sanctions sca
not money-path (4): customer-edge kyc onboarding party
```

There is no unaffected control group. The canary strategy has never run in a shape where it can
do anything.

## The title compresses two mechanisms — they are not equally live

**Mechanism 1 — the weight cannot be expressed. Unconditional, biting today, all 21.**
No `trafficRouting` on any of the 21, so Argo realises a canary weight by *pod count*. With N
replicas only the multiples of 100/N exist; at N=1 that is 0 or 100. So `setWeight: 10` routes
everything or nothing, and the `pause: 5m` that follows is wall-clock delay observing a state the
weights do not describe. Evidence: all 21 carry `setWeight` 10 and 30 (13 of them also a terminal
100), and 0 carry a router. This does not depend on the cluster being full — it is true right now,
on an idle cluster, and it is true of every one of the 21.

Raising `replicas` to 2 does **not** fix this. It makes `setWeight: 10` mean 50%.

**Mechanism 2 — the surge pod has nowhere to schedule. Armed on all 21, not biting today.**
All 21 leave `canary.maxSurge` / `maxUnavailable` unset, so they take the Argo defaults —
`maxSurge: 25%` → 1, `maxUnavailable: 25%` → 0. A canary step therefore needs room for a **second**
pod before the stable pod may be released, exactly the #3545 deadlock. **But the honest live
reading is that the pool has headroom right now:**

```
$ kubectl get nodepool -o json
default   limits.cpu 72   status.resources.cpu 36   nodes 13     # 22 nodes cluster-wide
```

36 of 72 vCPU, so Karpenter can still provision and mechanism 2 is **latent, not active**. That
also updates the issue body, which cites a `48` live cap against `72` declared and calls the drift
documented — the live limit now reads 72. Mechanism 2 bit when #3545 was filed (`48/48, 23 nodes`)
and will bite again under load; it is not what is wrong today. **Mechanism 1 is.**

## The gate

`unrealisable_weights(doc)` — `weight * replicas % 100 != 0`, short-circuited by `trafficRouting`
(a router realises any weight at any pod count) and by kind/strategy. Findings get their own
baseline file so #3545's, which is empty on purpose, stays empty.

Both halves keep the same two-way contract: a **new** finding fails, and a baseline line that has
**stopped matching** fails too, so the file cannot outlive the debt it describes.

### Falsified both ways on the real tree — exit codes read directly, not through a pipe

| case | exit | counts |
|---|---|---|
| A. clean, baseline in place | **0** | 21 hits, **0 NEW**, 0 stale |
| B. new one-replica canary added (`setWeight: 20`) | **1** | 22 hits, **1 NEW**, 0 stale — named in the output |
| C. ghost line added to the baseline | **1** | 21 hits, 0 NEW, **1 stale** — named in the output |
| D. restored | **0** | 21 hits, 0 NEW, 0 stale |

Before baselining, the same run reported **21 NEW** — exactly the 21 derived independently above,
so the baseline was written from a gate that had been shown able to report them.

Through the real runner, enforced:

```
$ python3 .github/scripts/run-gates.py --only single-replica-rollout-strategy
PASS [gitops] one-replica workloads declare their rollout strategy AND their canary is realisable
selftest OK: 8 strategy-declaration + 13 canary-realisability cases, both directions.
check-single-replica-rollout-strategy: 0 ... 0 NEW vs baseline, 0 stale baseline line(s).
check-canary-rollout-realisable: 21 ... 0 NEW vs baseline, 0 stale baseline line(s).
```

The 13 new self-test cases include the ones that would let a wrong implementation pass: 2 replicas
still failing on 10/30, 2 replicas *passing* on 50, 4 replicas passing on 25/50/75, `trafficRouting`
short-circuiting, blueGreen and Deployment not being asked, and an absent `replicas` defaulting to 1.

## What this PR deliberately does NOT do

**It changes no replica count.** Three reasons, and the second is the one that would have made this
a correctness regression wearing a capacity fix's costume:

1. Doubling all 21 costs **+4.62 vCPU / +9.69 GiB**, ~**+9.6%** of the `default` nodepool's CPU cap.
   This repo has a recorded incident of a NodePool cap stalling exactly this class of change.
2. **#3467**: `openbank-lending-service` holds compliance-pack activation as per-pod **in-memory**
   state. Its whole reason for not being a live defect is that lending runs one replica — a second
   replica *arms* a four-eyes divergence. #3644 is the convergence fix and says itself that it does
   not make lending safe to scale. The same question is unanswered for the rest of the 21.
3. Replicas alone do not fix mechanism 1 anyway (see above).

**This is an owner decision, and the evidence for it is now in the baseline file.** Three ways off
the list, recorded there in full:
(i) make the weights match the replica count — free, and says out loud that progressive delivery is
not in force; (ii) wire a `trafficRouting` provider (ingress-nginx / SMI) — the only option that
makes `setWeight: 10` mean 10%; (iii) raise `replicas` — costs capacity and needs the per-pod-state
question answered per service first.

No `gitops/` manifest, `.rego` or `rules.yaml` key changed, so no OPA-bundle or pod-roll restamp is
required. Nothing was applied, scaled or rolled — all cluster reads were read-only.

`Refs #3806` rather than `Closes`: this lands the gate half. The issue's acceptance also asks for a
per-service replica/constraint decision and a PDB for anything reaching 2, which are the owner's
calls above.

Refs #3806, #3545, #3805, #3467, #3644
