### PR TITLE
fix(ci): key the JAX-RS param gate to the top-level resource, not a nested type

### DIFF
--- a/.github/scripts/check-nonnull-jaxrs-params.py
+++ b/.github/scripts/check-nonnull-jaxrs-params.py
@@ -154,7 +154,22 @@ def strip_comments(src: str) -> str:
 ANNOTATION_RE = re.compile(
     r"@(" + "|".join(PARAM_ANNOTATIONS) + r")\s*\(\s*\"([^\"]+)\"\s*\)",
 )
-DECL_RE = re.compile(r"^(?:[\w@\s]*?)\b(interface|class|object)\s+(\w+)", re.M)
+# TOP-LEVEL declarations only — the leading `(?![ \t])` is load-bearing, not tidiness.
+#
+# The enclosing declaration supplies the middle field of the BASELINE key, so getting the NAME
+# wrong silently rekeys a handler. The old pattern let `[\w@\s]*?` swallow indentation, so a
+# nested type declared inside a resource became the enclosing declaration for every handler
+# BELOW it. Measured on openbank-customer-edge: a `private sealed interface DelegatedCardParse`
+# with a `data class Bad` member re-keyed `listDisputes` from
+# `openbank-customer-edge|CustomerEdgeResource|accountId` (baselined) to
+# `openbank-customer-edge|Bad|accountId`, which the gate then reported as a NEW occurrence on a
+# PR that had not touched a single JAX-RS parameter.
+#
+# Both directions are possible and the quiet one is worse: a false NEW is at least loud, while a
+# handler re-keyed onto some OTHER baselined key would be waved through. Restricting to column 0
+# keeps the resource-plus-client case working (both are top-level, so "last wins" still resolves
+# correctly) and makes nested types invisible, which is what the key wants.
+DECL_RE = re.compile(r"^(?![ \t])(?:[\w@]+[ \t]+)*?\b(interface|class|object)[ \t]+(\w+)", re.M)
 
 
 def enclosing_type(src: str, offset: int):
@@ -276,6 +291,18 @@ class DemoResource {
 
     fun flaggedAfterNestedObject(@QueryParam("flag_after_object") i: String): Response = TODO()
 
+    // A nested TYPE must not become the enclosing declaration for handlers below it. Being flagged
+    // is not enough here: the enclosing NAME is the middle field of the BASELINE key, so a handler
+    // re-keyed onto a nested type reads as a NEW occurrence forever (or, worse, silently collides
+    // with some other baselined key). SELF_TEST_EXPECTED_KEYS below asserts the key, which is why
+    // the pre-existing `object Headers` fixture could not catch this: it only ever checked which
+    // params were flagged.
+    private sealed interface Parse {
+        data class Bad(val response: Response) : Parse
+    }
+
+    fun flaggedAfterNestedType(@QueryParam("flag_after_nested_type") j: String): Response = TODO()
+
     // A commented-out declaration must not count:
     // fun commentedOut(@QueryParam("comment_only") z: String): Response = TODO()
     fun stringLiteralIsNotADecl(): String = "@QueryParam(\\"literal_only\\") y: String"
@@ -288,7 +315,14 @@ interface DemoClient {
 }
 '''
 
-SELF_TEST_EXPECTED_FLAGGED = {"flag_plain", "flag_header", "flag_enum", "flag_after_object"}
+SELF_TEST_EXPECTED_FLAGGED = {
+    "flag_plain", "flag_header", "flag_enum", "flag_after_object", "flag_after_nested_type",
+}
+
+# Every flagged handler in the fixture belongs to the top-level resource, whatever nested types
+# sit above it. Asserting the KEY and not just the param is the whole point — the key is what
+# BASELINE matches on.
+SELF_TEST_EXPECTED_KEYS = {f"demo|DemoResource|{p}" for p in SELF_TEST_EXPECTED_FLAGGED}
 SELF_TEST_EXPECTED_ALLOWED = {
     "prose_only", "nested_prose", "ok_nullable", "ok_default_ann", "ok_kotlin_default",
     "ok_primitive", "comment_only", "literal_only", "ok_outbound",
@@ -296,7 +330,8 @@ SELF_TEST_EXPECTED_ALLOWED = {
 
 
 def self_test() -> int:
-    flagged = {f["param"] for f in scan_source(strip_comments(SELF_TEST_SOURCE), "demo", "Demo.kt")}
+    found = list(scan_source(strip_comments(SELF_TEST_SOURCE), "demo", "Demo.kt"))
+    flagged = {f["param"] for f in found}
     failures = 0
     for want in sorted(SELF_TEST_EXPECTED_FLAGGED):
         ok = want in flagged
@@ -314,7 +349,15 @@ def self_test() -> int:
     else:
         print("pass  no findings outside the declared fixture set")
 
-    total = len(SELF_TEST_EXPECTED_FLAGGED) + len(SELF_TEST_EXPECTED_ALLOWED) + 1
+    keys = {f["key"] for f in found}
+    if keys == SELF_TEST_EXPECTED_KEYS:
+        print("pass  every finding is keyed to the top-level resource, not a nested type")
+    else:
+        print(f"FAIL  wrong BASELINE keys: {sorted(keys - SELF_TEST_EXPECTED_KEYS)} "
+              f"(missing {sorted(SELF_TEST_EXPECTED_KEYS - keys)})")
+        failures += 1
+
+    total = len(SELF_TEST_EXPECTED_FLAGGED) + len(SELF_TEST_EXPECTED_ALLOWED) + 2
     print(f"\nself-test: {total - failures} passed, {failures} failed")
     return 0 if failures == 0 else 2
 


### PR DESCRIPTION
## What broke

`check-nonnull-jaxrs-params.py` reported a NEW occurrence on #4194 — a PR that does not touch a single JAX-RS parameter.

The gate's `enclosing_type` takes the LAST `class`/`interface`/`object` declaration before the offset, and `DECL_RE`'s leading `[\w@\s]*?` swallowed indentation. So a type declared **inside** a resource became the enclosing declaration for every handler below it.

That name is the middle field of the `BASELINE` key, so the effect is a silent re-keying:

```
demo|DemoResource|flag_after_object   ->  demo|Headers|flag_after_object
```

Measured on the real tree: a `private sealed interface DelegatedCardParse` holding a `data class Bad` re-keyed `listDisputes` from `openbank-customer-edge|CustomerEdgeResource|accountId` (baselined) to `openbank-customer-edge|Bad|accountId`.

Both directions are possible, and the quiet one is worse. A false NEW is at least loud. A handler re-keyed onto some *other* baselined key would simply be waved through — a real 500-on-absent-param shipping green.

## The fix

Restrict `DECL_RE` to column 0. The resource-plus-client case still works, because both are top-level and "last wins" resolves correctly; nested types become invisible to the key, which is what the key wants. Column 0 is a safe discriminator here since ktlint already enforces the indentation.

## Why the self-test could not catch it

It already had a nested `object Headers` above a `flag_after_object` handler — added deliberately, per its comment, to prove a nested declaration does not *disarm* the check. It doesn't. The handler was still flagged, so the fixture passed.

But the fixture only ever asserted **which params were flagged**, never the key. So it passed the whole time while emitting `demo|Headers|flag_after_object`. The bug was sitting inside the falsification fixture itself.

`SELF_TEST_EXPECTED_KEYS` now asserts the key, and the fixture gains a nested sealed interface.

## Falsified in three directions

```
new self-test vs OLD regex   FAIL — names both mis-keyed handlers, including
                             the pre-existing demo|Headers|flag_after_object
main tree, new script        OK — 20 baselined occurrences, 0 new
#4194 branch, new script     OK — 20 baselined, 0 new (its code unchanged)
```

The count staying at 20 on both trees is the part that matters: nothing was lost, only re-keyed correctly.

## Effect

Unblocks #4194, whose red was entirely this. No baseline entry is added or removed.

Refs #3104
