### PR TITLE
fix(notification): pin MarketingGateIT to a fixed clock — main fails every night

### DIFF
--- a/openbank-notification-service/src/test/kotlin/com/openbank/notification/integration/MarketingGateIT.kt
+++ b/openbank-notification-service/src/test/kotlin/com/openbank/notification/integration/MarketingGateIT.kt
@@ -156,10 +156,20 @@ class StubContactGateProducer {
         },
         suppression = ContactSuppressionPort { emptyList() },
         policy = ContactPolicy(),
+        // A FIXED clock, at 12:00 UTC. ContactPolicy's defaults are quietHoursStart = 21 and
+        // quietHoursEnd = 8, and ContactPolicyGate reads them against `clock()`, which defaults to
+        // Instant.now(). Without this the outcome of every test here depends on the wall clock of
+        // whatever runs it: the SENT case is SUPPRESSED with reason QUIET_HOURS between 21:00 and
+        // 08:00 in the platform zone, and green the rest of the day. Measured on main at 21:37
+        // local — `expected: "SENT" but was: "SUPPRESSED"`.
+        clock = { FIXED_NOW },
     )
 
     companion object {
         var consented: Boolean = true
         var sendsInWindow: Int = 0
+
+        /** 2026-01-15T12:00:00Z — midday, so outside the 21→8 quiet window in any platform zone. */
+        val FIXED_NOW: Instant = Instant.parse("2026-01-15T12:00:00Z")
     }
 }


### PR DESCRIPTION
## `main` is red on `build (openbank-notification-service)`, and it fails **every night**

Reproduced against pristine `origin/main` in a detached worktree, no branch involved:

```
MarketingGateIT > a consented party's marketing send goes through the gate to SENT
expected: "SENT" but was: "SUPPRESSED"
```

Three open PRs inherit it — #3644, #3880, #4179 — none of which touches notification-service.

## The gate is correct. The test was wall-clock dependent.

- `ContactPolicy` defaults to `quietHoursStart = 21`, `quietHoursEnd = 8`
- `ContactPolicyGate` evaluates them against `clock()`, which defaults to `Instant.now()`
- `StubContactGateProducer` built the gate **without passing a clock**

So between **21:00 and 08:00** in the platform zone the SENT case is denied with `QUIET_HOURS`, and it is green the rest of the day. That is why it passed on the PR that introduced it (#4224, merged 15:35Z) and started failing later the same evening. Nothing in the code changed; the hour did.

The seam already existed — `ContactPolicyGate` takes an injectable clock — the stub simply did not use it. Now pinned to `2026-01-15T12:00:00Z`: midday, outside the 21→8 window in any platform zone.

## Verified at the failing hour, not a convenient one

This matters for a time-dependent bug: a green run at midday proves nothing. Run locally at **21:xx local — the same hour the `main` reproduction failed**:

```
:openbank-notification-service:test  →  130 tests, 0 failures, 0 errors
```

read from the JUnit XML rather than the console. `ktlintCheck` and `detekt` both appear in the executed task list.

## Why this class is worth a second look elsewhere

A test that reads the real clock through a defaulted parameter passes on the PR that adds it and fails later, in a window nobody is watching — and it reads as a flake rather than a defect, because re-running it in the morning makes it green. Any other test constructing `ContactPolicyGate` without a clock has the same property; campaign-service's `ContactGateProducer` is the other production builder of this gate and worth checking.
