### PR TITLE
fix(ci): match qualified and quoted outbox tables in the writer gate

### DIFF
--- a/.github/scripts/check-outbox-has-writer.py
+++ b/.github/scripts/check-outbox-has-writer.py
@@ -73,7 +73,30 @@ DECLARATION_RE = re.compile(r"(data\s+)?class\s+OutboxMessage\s*\(")
 # instead (case-coordinator-agent's CaseActivitiesImpl.emitProposal, agent-service's
 # JdbcAgentProposalRepository). Matching only `OutboxMessage(` called those services writerless
 # and was wrong about them.
-SQL_INSERT_RE = re.compile(r"INSERT\s+INTO\s+\w*outbox\w*", re.IGNORECASE)
+#
+# The table reference is matched in the three forms Postgres accepts, not just the bare one:
+# `case_outbox`, schema-qualified `cc.case_outbox`, and quoted `"case_outbox"` (or backticked, for
+# a copy-pasted MySQL-ism). Neither of the extra two appears in the tree today and schema-qualified
+# INSERT is not an idiom here at all — this is latent, and it is written down because the failure
+# is a FALSE NEGATIVE: a service that does write its outbox gets reported as writerless, which
+# reads as a clean finding rather than as a gap in the pattern (#4240).
+#
+# The `\w*outbox\w*` on the table NAME is what keeps this narrow. Widening to any INSERT would
+# mark all eight baselined services as fixed and silently retire the gate, so the negatives in the
+# self-test are the cases that matter here, not the positives.
+#
+# The trailing `(?!\w*\s*\.)` is not decoration and was measured, not reasoned: because the schema
+# group is OPTIONAL, `INSERT INTO outbox_schema.events` otherwise backtracks into matching
+# `outbox_schema` as the TABLE and reports a writer for an insert into `events`. A false positive
+# here is the opposite failure — it would let a genuinely writerless service off — so the lookahead
+# says "this name is the table only if no dot follows it".
+SQL_INSERT_RE = re.compile(
+    r"INSERT\s+INTO\s+"
+    r"(?:[\"`]?\w+[\"`]?\s*\.\s*)?"  # optional schema qualifier, quoted or bare
+    r"[\"`]?\w*outbox\w*[\"`]?"
+    r"(?!\w*\s*\.)",  # ...and it must not itself be a qualifier
+    re.IGNORECASE,
+)
 
 
 def strip_comments_and_strings(src: str) -> str:
@@ -258,6 +281,31 @@ def self_test() -> int:
 '''
     expect("a direct SQL INSERT into the outbox table IS a writer",
            classify_service({"a.kt": sql}), (True, True))
+
+    # ── Qualified and quoted table references (#4240 follow-up) ────────────────────────────────
+    # Latent: neither form appears in the tree today, and schema-qualified INSERT is not an idiom
+    # here at all. Covered because the failure direction is a FALSE NEGATIVE — a service that does
+    # write its outbox reported as writerless, which reads as a clean finding.
+    schema_qualified = disp + '\nval s = """INSERT INTO cc.case_outbox (id) VALUES (?)"""\n'
+    expect("a schema-qualified INSERT IS a writer",
+           classify_service({"a.kt": schema_qualified}), (True, True))
+    quoted = disp + '\nval s = """INSERT INTO "case_outbox" (id) VALUES (?)"""\n'
+    expect("a quoted table name IS a writer",
+           classify_service({"a.kt": quoted}), (True, True))
+    both = disp + '\nval s = """INSERT INTO "cc"."case_outbox" (id) VALUES (?)"""\n'
+    expect("quoted schema AND quoted table IS a writer",
+           classify_service({"a.kt": both}), (True, True))
+
+    # The negative that pays for the optional schema group. Because that group is OPTIONAL, the
+    # pattern otherwise backtracks into reading `outbox_schema` as the TABLE and calls an insert
+    # into `events` a writer — which would let a genuinely writerless service off. Measured
+    # failing without the trailing lookahead.
+    schema_named_outbox = disp + '\nval s = """INSERT INTO outbox_schema.events (id) VALUES (?)"""\n'
+    expect("a SCHEMA named *outbox* with a non-outbox table is NOT a writer",
+           classify_service({"a.kt": schema_named_outbox}), (True, False))
+    qualified_other = disp + '\nval s = """INSERT INTO cc.party_events (id) VALUES (?)"""\n'
+    expect("a schema-qualified NON-outbox table is NOT a writer",
+           classify_service({"a.kt": qualified_other}), (True, False))
     # …but prose describing one is not — the same code-about-code rule as the constructor case.
     sql_prose = disp + "\n// we should INSERT INTO case_outbox here one day\n"
     expect("a comment describing an INSERT is NOT a writer",


### PR DESCRIPTION
## What

`SQL_INSERT_RE` matched only a bare table reference. Matching an optional schema qualifier (quoted or bare) and anchoring the table name fixes the gate in **both** directions.

## Two defects, opposite directions

**False negative** — a qualified or quoted name does not match, so a service that *does* write its outbox is reported writerless:

```
INSERT INTO cc.case_outbox      -> no match
INSERT INTO "case_outbox"       -> no match
```

The gate then prints *"the dispatcher will poll a table nothing writes to"* about a table that is written to. Same shape as #4240.

**False positive** — and this one I did not anticipate. `\w*outbox\w*` matches the **schema** as happily as the table:

```
>>> re.search(r'INSERT\s+INTO\s+\w*outbox\w*', 'INSERT INTO outbox_schema.events (id)')
<match: 'INSERT INTO outbox_schema'>
```

So an insert into `events` reports a writer. That direction lets a genuinely writerless service off — the failure the gate exists to prevent.

## Fix

```
INSERT\s+INTO\s+
(?:["`]?\w+["`]?\s*\.\s*)?     # optional schema qualifier, quoted or bare
["`]?\w*outbox\w*["`]?
(?!\w*\s*\.)                   # ...and it must not itself be a qualifier
```

The trailing lookahead is load-bearing, and was measured rather than reasoned: because the schema group is optional, the pattern otherwise backtracks into reading `outbox_schema` as the table. My first draft had exactly that bug and the self-test case caught it before the commit.

`\w*outbox\w*` on the table name is what keeps this narrow. Widening to any `INSERT` would mark all eight baselined services as fixed and silently retire the gate.

## Measured

| case | main | this PR | want |
|---|---|---|---|
| `INSERT INTO cc.case_outbox` | False | True | True |
| `INSERT INTO "case_outbox"` | False | True | True |
| `INSERT INTO "cc"."case_outbox"` | False | True | True |
| `INSERT INTO outbox_schema.events` | **True** | False | False |
| `INSERT INTO cc.party_events` | False | False | False |

Four of five differ, all four being the current implementation getting it wrong.

Fleet verdict **byte-identical** before and after:

```
34 service(s) ship a dispatcher; 8 without a writer (8 baselined, 0 new, 0 stale)
```

## Latent, and said so in the code

Neither qualified nor quoted outbox inserts appear anywhere in `src/main`, and schema-qualified `INSERT` is not an idiom in this tree at all (`grep -rniE 'INSERT[[:space:]]+INTO[[:space:]]+\w+\.\w+' openbank-*/src/main` → nothing). So there is no failing service to point at and the self-test is the only thing that can hold this. The header says that outright rather than implying a live defect.

## Self-test 15 → 20

Three positives and two negatives. The two negatives are what pay for the optional schema group — without them the widening is unfalsified, and the `outbox_schema.events` case is the one my own first draft failed.

## Provenance

These two forms were in #4243, which I closed as a duplicate of #4233 before noticing it carried something #4233 did not. Reconstructed here with the false-positive fix and the self-tests that #4243 lacked, rather than resurrecting the branch.

## Linked issues

Refs #4240

## References

- #4240, #4233, #4245 (the string-aware strip), #4007 (the gate's origin)
