### PR TITLE
fix(fraud): publish a liveness heartbeat from the fraud-hold expiry sweep

### DIFF
--- a/openbank-fraud-service/src/main/kotlin/com/openbank/fraud/application/usecase/FraudHoldService.kt
+++ b/openbank-fraud-service/src/main/kotlin/com/openbank/fraud/application/usecase/FraudHoldService.kt
@@ -10,12 +10,16 @@ import com.openbank.fraud.application.port.out.FraudScoreRepository
 import com.openbank.fraud.domain.model.FraudVerdict
 import com.openbank.fraud.infrastructure.persistence.FraudOutboxRepositoryImpl
 import com.openbank.libs.domain.identifiers.Ids
+import com.openbank.libs.observability.DomainMetrics
+import com.openbank.libs.observability.WorkflowLivenessRecorder
 import com.openbank.libs.persistence.outbox.OutboxMessage
 import io.quarkus.hibernate.reactive.panache.Panache
+import io.quarkus.runtime.StartupEvent
 import io.quarkus.scheduler.Scheduled
 import io.smallrye.mutiny.Uni
 import io.smallrye.mutiny.coroutines.awaitSuspending
 import jakarta.enterprise.context.ApplicationScoped
+import jakarta.enterprise.event.Observes
 import jakarta.inject.Inject
 import org.eclipse.microprofile.config.inject.ConfigProperty
 import org.jboss.logging.Logger
@@ -52,6 +56,24 @@ class FraudHoldService @Inject constructor(
     private val ttlDays: Long,
 ) {
     private val log = Logger.getLogger(FraudHoldService::class.java)
+
+    /**
+     * Field-injected rather than a constructor parameter: the constructor already takes 8, and
+     * detekt's LongParameterList fires AT `constructorThreshold: 9`, not above it.
+     */
+    @Inject
+    lateinit var domainMetrics: DomainMetrics
+
+    private var liveness: WorkflowLivenessRecorder? = null
+
+    /**
+     * Registered from `StartupEvent` rather than an `init` block: `@ApplicationScoped` is LAZY, so
+     * a bean created on first use would publish no gauge until something happened to touch it —
+     * and for a sweep that nothing else calls, that could be never.
+     */
+    fun registerLiveness(@Observes @Suppress("UNUSED_PARAMETER") event: StartupEvent) {
+        liveness = domainMetrics.registerWorkflowLiveness(WORKFLOW_NAME, EXPECTED_INTERVAL)
+    }
 
     /**
      * Checked after every scoring decision, but only ever acts on REVIEW — ALLOW/CHALLENGE/DECLINE
@@ -118,6 +140,11 @@ class FraudHoldService @Inject constructor(
             if (expired.isNotEmpty()) {
                 log.infof("fraud-hold expiry sweep cleared=%d", expired.size)
             }
+            // Only on the path that actually completed. A heartbeat inside (or after) the catch
+            // would assert the very thing it exists to disprove — and this sweep swallows its
+            // exception, so a permanently broken run is otherwise indistinguishable from a healthy
+            // quiet one: no exception escapes, and "cleared=0" is the normal case.
+            liveness?.recordSuccess()
         } catch (ex: Exception) {
             log.warnf(ex, "fraud-hold expiry sweep failed")
         }
@@ -147,5 +174,14 @@ class FraudHoldService @Inject constructor(
         const val RULE_VERSION = "fraud-hold-v1"
         const val REASON_REPEATED_REVIEW = "repeated_review"
         const val REASON_EXPIRED = "expired"
+        const val WORKFLOW_NAME = "fraud-hold-expiry-sweep"
+
+        /**
+         * Matches the `openbank.fraud-hold.sweep-interval` default. The staleness rule bakes in a
+         * 2x multiplier, so this is the schedule, not a tighter SLA — but a deployment that widens
+         * the cron without widening this makes the gauge over-strict rather than lax, which is the
+         * safe direction to be wrong in.
+         */
+        val EXPECTED_INTERVAL: Duration = Duration.ofHours(1)
     }
 }


### PR DESCRIPTION
## What is wrong

`FraudHoldService.sweepExpired` (`@Scheduled`, hourly) clears every fraud hold whose TTL has passed, and catches its own exception:

```kotlin
} catch (ex: Exception) {
    log.warnf(ex, "fraud-hold expiry sweep failed")
}
```

That is right for a schedule — one bad tick must not kill it — but it means a **permanently** broken sweep is indistinguishable from a healthy quiet one. Nothing escapes, no metric moves, and `cleared=0` is the normal case, since most hours legitimately expire nothing. The only evidence anywhere would be holds that stop being released, and nothing alerts on a table that stops shrinking.

That is the ADR-0237 rationale exactly, and why `scheduler-liveness-adoption` exists.

## What this does

Registers the workflow-liveness gauge, following `PartyResolutionScheduler`'s shape. Four details that are each load-bearing:

- **`recordSuccess()` only on the path that completed**, never in or after the `catch`. A heartbeat on the failure path asserts the very thing it exists to disprove.
- **Registration from `@Observes StartupEvent`**, not an `init` block. `@ApplicationScoped` is lazy, so a bean created on first use publishes no gauge until something touches it — and for a sweep nothing else calls, that could be never.
- **`domainMetrics` is field-injected.** The constructor already takes 8 parameters, and detekt's `LongParameterList` fires **at** `constructorThreshold: 9`, not above it, so a ninth constructor parameter would fail the gate.
- **`EXPECTED_INTERVAL` matches the `openbank.fraud-hold.sweep-interval` default of 1h.** The staleness rule bakes in a 2x multiplier, so this is the schedule and not a tighter SLA. A deployment that widens the cron without widening this makes the gauge over-strict rather than lax — the safe direction to be wrong in.

## Why now: it unblocks #4180

#4180 graduates `scheduler-liveness-adoption` from advisory to **enforced**. Measured against current `origin/main`, that gate has **two** violations, and only fails to block because it is still advisory there:

```
MAIN  rc=1  errors=2
  openbank-account-service/.../SavingsProposalExpiryScheduler.kt
  openbank-fraud-service/.../FraudHoldService.kt
```

#4180 fixes the first. The second arrived with #4252 about half an hour after #4180's branch was cut, so that PR cannot see it — and #4180 reads green because its checks predate #4252. Merged as-is it would redden `main`'s own push run, which has no PR to carry it.

```
#4180 alone                        rc=0
#4180 + origin/main                rc=1   (FraudHoldService)
#4180 + origin/main + this change   rc=0
```

**On this branch the gate still reports `errors=1`** — the account-service one, which is #4180's to fix. This PR takes it from two to one; the pair takes it to zero. Sequence: merge this, rebase #4180, merge that promptly (the race re-arms with the next scheduler-adding PR — the intended cost of enforcing).

## Verified

`compileKotlin`, `ktlintCheck` and `detekt` all **ran** — checked in the task list, not inferred from the exit code, since Gradle stops at the first failing task and a green-looking list is not a list that executed. `BUILD SUCCESSFUL`.

The first attempt failed `ktlintMainSourceSetCheck` on import order; fixed with `ktlintFormat` rather than by hand, and its only change was reordering the four new imports.

Refs #3931, #4252
