### PR TITLE
fix(audit): recover the producer and event type the transport already carried

### DIFF
--- a/openbank-audit-service/CLAUDE.md
+++ b/openbank-audit-service/CLAUDE.md
@@ -24,3 +24,26 @@
   runner. Note `audit_entries` carries `no_update_audit`/`no_delete_audit` rules (V2), so a test
   cannot clean up after itself — write with fresh `aggregate_id`s and anchor `verifyChain` with
   `fromEntryId` instead of assuming an empty table.
+- **A consumer that takes `payload: String` cannot see the envelope, and its `?:` defaults make the
+  gap look like data.** `AuditConsumer` read the body only, so the outbox `ce-type` header (the
+  event type) and the topic (the producing service) were dropped at ingest and fell through to
+  `?: "UNKNOWN"` / `?: "unknown"`. Measured on the live database: **1353 of 1774 rows** named no
+  source and 131 no event type, with only TWO distinct `source_service` values in the whole table —
+  `unknown` and `customer-edge`, the one producer that populates the field. Nothing could see it:
+  the fallbacks are *successful parses* (no exception, no metric, no log line), and every existing
+  assertion was `isNotNull()`-shaped, which a default satisfies. **Assert the VALUE of an
+  attribution field, never its non-nullity** — same lesson as `Instant.EPOCH` in the root guide.
+  Fixed in #3994 by taking `Message<String>`, exactly as the analytics sink did in #2598.
+- **Do not derive a service name from the topic by convention here — nine of the twenty-one
+  subscribed topics disagree with it.** `openbank.cards.events` is card-issuance-service,
+  `openbank.payments.swift.event` is swift-service, `openbank.customer.audit` is customer-edge,
+  `openbank.security.*` is security-scanner, and accounts/transactions/documents are plural where
+  the module is singular. A convention-based derivation does not under-attribute, it writes a
+  confident FALSE service name into a chain-hashed evidentiary row — worse than the `unknown` it
+  replaces. `TopicAttribution` is a verified table whose COVERAGE (not values) is derived from
+  `application.yaml`, so a newly subscribed topic fails `TopicAttributionCoverageTest` instead of
+  silently defaulting again.
+- **Switching an `@Incoming` from `String` to `Message<String>` switches SmallRye from auto-ack to
+  MANUAL ack.** A missed ack stalls the partition and the audit trail stops dead — worse than the
+  under-attribution being fixed. Ack explicitly, in a `finally`, and test it on the path most
+  likely to skip it (an unparseable payload).

--- a/openbank-audit-service/src/main/kotlin/com/openbank/audit/application/AuditConsumer.kt
+++ b/openbank-audit-service/src/main/kotlin/com/openbank/audit/application/AuditConsumer.kt
@@ -6,13 +6,19 @@ package com.openbank.audit.application
 
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.audit.domain.model.AttributionSource
 import com.openbank.audit.domain.model.AuditEntry
 import com.openbank.audit.domain.model.OccurredAtSource
 import com.openbank.audit.infrastructure.persistence.AuditRepository
+import com.openbank.libs.persistence.outbox.OutboxKafkaHeaders
 import io.micrometer.core.instrument.MeterRegistry
+import io.smallrye.mutiny.Uni
+import io.smallrye.mutiny.coroutines.awaitSuspending
+import io.smallrye.reactive.messaging.kafka.api.IncomingKafkaRecordMetadata
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.inject.Inject
 import org.eclipse.microprofile.reactive.messaging.Incoming
+import org.eclipse.microprofile.reactive.messaging.Message
 import org.jboss.logging.Logger
 import java.time.Clock
 import java.time.Instant
@@ -31,16 +37,81 @@ class AuditConsumer {
 
     private val log = Logger.getLogger(AuditConsumer::class.java)
 
+    /**
+     * Records one audit event.
+     *
+     * **Why `Message<String>` and not `String` (#3994).** The old signature saw the message body
+     * and nothing else, so two facts the transport was already carrying were discarded at ingest:
+     * the outbox `ce-type` header (the event type — the body of an outbox-relayed event is the bare
+     * domain event and usually has no `eventType` key at all) and the topic (which names the
+     * producing service). Both fell through to the `"UNKNOWN"`/`"unknown"` sentinels, and 76% of
+     * the live trail is that `"unknown"`. Same signature, same two defaults and the same fix as the
+     * analytics sink's #2598.
+     *
+     * Body-first ordering is deliberate: broker metadata is consulted ONLY where the body yielded
+     * nothing. A producer that populates the field keeps its own value, so this can only turn a
+     * sentinel into a value — it can never re-attribute a row that is already attributed.
+     *
+     * **Nothing is rejected.** Every message that was stored before is still stored, with the same
+     * or better attribution; a message with no metadata and no body fields still lands on the
+     * sentinels rather than being dropped. An audit path that drops events is worse than one that
+     * under-attributes them, so the fallbacks stay and only become visible ([AttributionSource],
+     * `openbank.audit.attribution.missing`) instead of silent.
+     */
     @Incoming("audit-events-in")
-    suspend fun consume(payload: String) {
+    suspend fun consume(message: Message<String>) {
+        val payload = message.payload
+        try {
+            consume(payload, addressOf(message))
+        } finally {
+            // Switching the signature from `String` to `Message<String>` also switches SmallRye
+            // from auto-ack to MANUAL ack, so the ack must be explicit — and in a `finally`, or an
+            // un-storable message would stall the partition forever and the audit trail would stop
+            // dead. (`consume` already swallows its own exceptions, so this is belt-and-braces.)
+            Uni.createFrom().completionStage(message.ack()).awaitSuspending()
+        }
+    }
+
+    /** Lifts the broker metadata this consumer used to discard. Absent metadata is not an error. */
+    private fun addressOf(message: Message<String>): EventAddress {
+        val meta = message.getMetadata(IncomingKafkaRecordMetadata::class.java).orElse(null)
+            ?: return EventAddress.NONE
+
+        @Suppress("UNCHECKED_CAST")
+        val record = meta as IncomingKafkaRecordMetadata<Any?, String>
+        val ceType = record.headers
+            ?.lastHeader(OutboxKafkaHeaders.HEADER_EVENT_TYPE)
+            ?.value()
+            ?.toString(Charsets.UTF_8)
+            ?.takeIf { it.isNotBlank() }
+        return EventAddress(
+            topic = record.topic?.takeIf { it.isNotBlank() },
+            ceType = ceType,
+        )
+    }
+
+    /**
+     * As above, for a record with no broker addressing to offer. Visible for tests and for any
+     * replay path that has only the stored body.
+     */
+    suspend fun consume(payload: String): Unit = consume(payload, EventAddress.NONE)
+
+    suspend fun consume(payload: String, address: EventAddress) {
         try {
             val node: JsonNode = objectMapper.readTree(payload)
             val eventTime = eventTime(node)
+            val resolvedSource = resolveSourceService(node, address)
             val entry = AuditEntry(
                 id = UUID.randomUUID(),
                 // sepa.instant.events (KafkaSctInstEventPublisher) names its discriminator "type",
                 // not "eventType" — the only #996-consumed producer that does so.
-                eventType = node["eventType"]?.asText() ?: node["type"]?.asText() ?: "UNKNOWN",
+                // `ce-type` is the outbox event type, and it is the LAST resort before the
+                // sentinel: it is the producer's own value, carried by the transport rather than
+                // the body, so it is a recovery of a fact and not an inference (#3994).
+                eventType = node["eventType"]?.asText()
+                    ?: node["type"]?.asText()
+                    ?: address.ceType
+                    ?: "UNKNOWN",
                 aggregateType = node["aggregateType"]?.asText() ?: inferAggregateType(node),
                 aggregateId = inferAggregateId(node),
                 actorId = node["requestedBy"]?.asText()
@@ -49,7 +120,8 @@ class AuditConsumer {
                     ?: node["initiatedByPartyId"]?.asText(),
                 actorType = node["actorType"]?.asText(),
                 payload = payload,
-                sourceService = node["sourceService"]?.asText() ?: "unknown",
+                sourceService = resolvedSource.first,
+                sourceServiceSource = resolvedSource.second,
                 correlationId = node["correlationId"]?.asText(),
                 occurredAt = eventTime ?: Instant.now(clock),
                 recordedAt = Instant.now(clock),
@@ -68,6 +140,9 @@ class AuditConsumer {
                 delegationId = node["delegationId"]?.takeIf { !it.isNull }?.asText(),
             )
             if (eventTime == null) countMissingEventTime(entry.sourceService)
+            if (entry.sourceServiceSource != AttributionSource.EVENT) {
+                countMissingAttribution(entry.sourceService, entry.sourceServiceSource)
+            }
             repo.save(entry)
         } catch (e: Exception) {
             log.errorf(e, "Failed to record audit entry: %s", payload.take(200))
@@ -90,6 +165,49 @@ class AuditConsumer {
         if (!::meterRegistry.isInitialized) return
         meterRegistry.counter("openbank.audit.event.time.missing", "source_service", sourceService)
             .increment()
+    }
+
+    /**
+     * The producing service, and who said so (#3994).
+     *
+     * Ordered strongest claim first:
+     *  1. the producer's own `sourceService` field — [AttributionSource.EVENT];
+     *  2. the Kafka topic, via the verified [TopicAttribution] table — [AttributionSource.TOPIC].
+     *     Sound because the topic is transport addressing rather than anything the producer chose
+     *     to omit, but it identifies the service and is not the service's own assertion;
+     *  3. neither — the `"unknown"` sentinel, [AttributionSource.ABSENT], exactly as before.
+     *
+     * The pair is returned together on purpose: a caller cannot take the value without also taking
+     * the provenance, so a derived attribution cannot be stored as if it were declared. That is
+     * the whole defect — `?: "unknown"` was a *successful parse* with no exception, no metric and
+     * no log line, and 76% of the trail went that way unnoticed.
+     */
+    private fun resolveSourceService(node: JsonNode, address: EventAddress): Pair<String, AttributionSource> {
+        node["sourceService"]?.asText()?.takeIf { it.isNotBlank() }?.let {
+            return it to AttributionSource.EVENT
+        }
+        TopicAttribution.sourceService(address.topic)?.let { return it to AttributionSource.TOPIC }
+        return "unknown" to AttributionSource.ABSENT
+    }
+
+    /**
+     * `openbank.audit.attribution.missing{source_service,provenance}` — rows whose producing
+     * service was not stated by the producer (#3994).
+     *
+     * Counted for TOPIC as well as ABSENT, not only the sentinel. A topic-derived row is a
+     * correctly attributed row AND an outstanding producer gap; folding the two together would
+     * make the gap disappear from the dashboard the moment this fix ships, which is precisely the
+     * kind of silence that let the original defect run to 76%.
+     */
+    private fun countMissingAttribution(sourceService: String, provenance: AttributionSource) {
+        if (!::meterRegistry.isInitialized) return
+        meterRegistry.counter(
+            "openbank.audit.attribution.missing",
+            "source_service",
+            sourceService,
+            "provenance",
+            provenance.name,
+        ).increment()
     }
 
     /**

--- a/openbank-audit-service/src/main/kotlin/com/openbank/audit/application/EventAttribution.kt
+++ b/openbank-audit-service/src/main/kotlin/com/openbank/audit/application/EventAttribution.kt
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.audit.application
+
+/**
+ * Broker-side addressing for one consumed audit record (#3994).
+ *
+ * [AuditConsumer.consume] used to take `payload: String`, so it saw the message BODY and nothing
+ * else. Two facts the transport was already carrying were therefore dropped at ingest:
+ *
+ *  - the **event type**, published as the `ce-type` Kafka header by every outbox-relayed producer
+ *    (`OutboxKafkaHeaders.HEADER_EVENT_TYPE`). The body of an outbox event is the bare domain
+ *    event, which often has no `eventType` key at all — so the discriminator was on the wire and
+ *    unreadable, and the row stored `"UNKNOWN"`.
+ *  - the **topic**, which names the producing domain by the fleet's own convention (ADR-0003 N3).
+ *
+ * Same defect, same cause and the same fix as the analytics sink's #2598 — that consumer had the
+ * identical `consume(payload: String)` signature and the identical pair of `UNKNOWN`/`unknown`
+ * defaults. This is the audit-side counterpart.
+ */
+data class EventAddress(
+    /** Kafka topic the record arrived on, e.g. `openbank.party.events`. */
+    val topic: String? = null,
+    /** `ce-type` header — the outbox event type (`OutboxKafkaHeaders.HEADER_EVENT_TYPE`). */
+    val ceType: String? = null,
+) {
+    companion object {
+        /** No broker metadata available — a hand-constructed or replayed record. */
+        val NONE = EventAddress()
+    }
+}
+
+/**
+ * Topic -> producing service, for the topics this service subscribes to.
+ *
+ * **Why a table and not a derivation.** The sibling sink derives the service from the topic's
+ * domain segment (`openbank.<domain>.…` -> `openbank-<domain>-service`) and that is right for its
+ * purpose, but it is WRONG for nine of the twenty-one topics audited here — `openbank.cards.events`
+ * is produced by card-issuance-service, `openbank.payments.swift.event` by swift-service,
+ * `openbank.customer.audit` by customer-edge, `openbank.security.*` by security-scanner, and
+ * `accounts`/`transactions`/`documents` are plural where the module is singular. A derivation that
+ * is wrong nine times out of twenty-one does not under-attribute: it writes a plausible,
+ * confident, FALSE service name into a tamper-evident evidentiary record, which is strictly worse
+ * than the `"unknown"` it replaces. So every value here is verified against the module that
+ * actually declares the outgoing channel, and [AttributionSource] keeps a derived value
+ * distinguishable from a producer-declared one at every point downstream.
+ *
+ * **Why the scope is still not hand-kept.** A hand-kept table reads as complete when it is short —
+ * the failure this repo has been bitten by repeatedly. `AuditTopicAttributionTest` parses the
+ * subscribed topic list out of `application.yaml` and fails on any topic missing an entry here, and
+ * on any entry here that is no longer subscribed. The VALUES are facts a human verified; the
+ * COVERAGE is derived from the config, so a newly subscribed topic cannot quietly default to
+ * `"unknown"` again.
+ *
+ * Values use the fleet's audit convention — the module directory without the `openbank-` prefix,
+ * which is what `customer-edge` (the one producer that populates the field today) already writes.
+ */
+object TopicAttribution {
+
+    private val TOPIC_TO_SERVICE = mapOf(
+        "openbank.accounts.account.created" to "account-service",
+        "openbank.transactions.transaction.initiated" to "transaction-service",
+        "openbank.balance.events" to "balance-service",
+        "openbank.party.events" to "party-service",
+        "openbank.kyc.events" to "kyc-service",
+        "openbank.consent.events" to "consent-service",
+        "openbank.customer.audit" to "customer-edge",
+        "openbank.clearing.batch.event" to "clearing-service",
+        "openbank.security.ict.incident" to "security-scanner",
+        "openbank.security.scan.event" to "security-scanner",
+        "openbank.cards.events" to "card-issuance-service",
+        "openbank.dispute.events" to "dispute-service",
+        "openbank.domestic.payment.events" to "domestic-payment",
+        "openbank.sepa.payment.events" to "sepa-payment",
+        "openbank.statement.event" to "statement-service",
+        "openbank.sanctions.screening.event" to "sanctions-service",
+        "openbank.sepa.instant.events" to "sepa-instant",
+        "openbank.fx.conversion.completed" to "fx-service",
+        "openbank.documents.document.event" to "document-service",
+        "openbank.payments.swift.event" to "swift-service",
+        "openbank.lending.events" to "lending-service",
+    )
+
+    /** Topics with a verified producer entry. Visible for the coverage test. */
+    val mappedTopics: Set<String> get() = TOPIC_TO_SERVICE.keys
+
+    /**
+     * The service that produces [topic], or null when the topic is not one of ours.
+     *
+     * Null rather than a guess: an unrecognised topic keeps `"unknown"`, which is honest, instead
+     * of acquiring a service name derived from a naming convention it may not follow.
+     */
+    fun sourceService(topic: String?): String? {
+        if (topic.isNullOrBlank()) return null
+        return TOPIC_TO_SERVICE[topic]
+    }
+}

--- a/openbank-audit-service/src/main/kotlin/com/openbank/audit/domain/model/AuditEntry.kt
+++ b/openbank-audit-service/src/main/kotlin/com/openbank/audit/domain/model/AuditEntry.kt
@@ -28,6 +28,14 @@ data class AuditEntry(
      * one that quietly claims the queue's clock was the event's (#3883).
      */
     val occurredAtSource: OccurredAtSource,
+    /**
+     * Whether [sourceService] is the producer's own claim or the broker topic standing in for it.
+     *
+     * The same distinction [occurredAtSource] draws for time, drawn for attribution, and for the
+     * same reason: a value the consumer supplied must never be indistinguishable from one the
+     * producer asserted (#3994).
+     */
+    val sourceServiceSource: AttributionSource = AttributionSource.ABSENT,
     /** Ingress channel the event arrived through — ui|mcp|api (ADR-0226); null = unknown/legacy. */
     val channel: String? = null,
     /** Ordered on-behalf-of delegation chain from the RFC 8693 `act` claim (ADR-0224); empty = direct. */
@@ -63,6 +71,34 @@ data class AuditEntry(
  * silence this exists to end. A producer that emits the wrong key now shows up as [INGEST] rows
  * and on `openbank.audit.event.time.missing`, and gets fixed at the producer.
  */
+/**
+ * Provenance of an attribution field — who says so (#3994).
+ *
+ * `source_service` was `node["sourceService"] ?: "unknown"`, and 76% of the live audit trail is
+ * that `"unknown"`: `customer-edge` is the only producer in the fleet that populates the field.
+ * The consumer can now recover the producer from the Kafka topic for every subscribed topic
+ * (`TopicAttribution`), which retires almost all of that — but a recovered value is a different
+ * kind of claim from a declared one, and an evidentiary store must not blur the two.
+ *
+ * That is the whole point of this enum. Substituting a plausible value silently is exactly the
+ * defect being fixed: it converts a visibly missing attribution into an invisible wrong one, and
+ * the second is far harder to ever notice again. The row now carries who supplied the answer.
+ */
+enum class AttributionSource {
+    /** The producer put the field in its own payload; the strongest claim available. */
+    EVENT,
+
+    /**
+     * Derived from the Kafka topic the record arrived on. Sound — the topic is transport-level
+     * addressing the producer cannot forge by omission — but it identifies the producing SERVICE,
+     * not a producer's own assertion about itself.
+     */
+    TOPIC,
+
+    /** Neither available: the field holds the `"unknown"` sentinel and attributes nothing. */
+    ABSENT,
+}
+
 enum class OccurredAtSource {
     /** The producer sent a parseable `occurredAt`; [AuditEntry.occurredAt] is the real event time. */
     EVENT,

--- a/openbank-audit-service/src/main/kotlin/com/openbank/audit/infrastructure/persistence/AuditRepository.kt
+++ b/openbank-audit-service/src/main/kotlin/com/openbank/audit/infrastructure/persistence/AuditRepository.kt
@@ -4,6 +4,7 @@
 
 package com.openbank.audit.infrastructure.persistence
 
+import com.openbank.audit.domain.model.AttributionSource
 import com.openbank.audit.domain.model.AuditEntry
 import com.openbank.audit.domain.model.OccurredAtSource
 import io.quarkus.hibernate.reactive.panache.Panache
@@ -73,6 +74,19 @@ class AuditEntryEntity : PanacheEntity() {
      */
     @Column(name = "occurred_at_source", length = 8)
     var occurredAtSource: String? = null
+
+    /**
+     * Provenance of [sourceService] — `EVENT`, `TOPIC` or `ABSENT` ([AttributionSource]), NULL on
+     * any row written before V13 (#3994).
+     *
+     * Same contract as [occurredAtSource] above and for the same reasons: NULL stays NULL (the
+     * `DO INSTEAD NOTHING` rule from V2 makes a backfill a silent no-op, and there is nothing to
+     * backfill from — the topic a pre-V13 row arrived on was never stored), and it is NOT part of
+     * [chainHash], because it describes where the consumer got a value rather than asserting a new
+     * evidential fact. `source_service` itself remains chain-hashed exactly as before.
+     */
+    @Column(name = "source_service_source", length = 8)
+    var sourceServiceSource: String? = null
 
     // ── Tamper-evidence (hash chain, ADR-0023 spirit applied to the operational log) ──
     @Column(name = "prev_hash")
@@ -156,6 +170,7 @@ class AuditRepository : PanacheRepository<AuditEntryEntity> {
                 it.occurredAt = stored.occurredAt
                 it.recordedAt = stored.recordedAt
                 it.occurredAtSource = entry.occurredAtSource.name
+                it.sourceServiceSource = entry.sourceServiceSource.name
                 it.channel = entry.channel
                 it.actChain = entry.actChain.takeIf { chain -> chain.isNotEmpty() }
                     ?.let { chain -> actChainJson.writeValueAsString(chain) }
@@ -380,6 +395,9 @@ class AuditRepository : PanacheRepository<AuditEntryEntity> {
         // NULL (pre-V11) reads back as INGEST: those rows may hold ingest time and cannot prove
         // otherwise, so the weaker claim is the honest one.
         occurredAtSource = occurredAtSource?.let { OccurredAtSource.valueOf(it) } ?: OccurredAtSource.INGEST,
+        // NULL (pre-V13) reads back as ABSENT for the same reason: those rows cannot say who
+        // supplied `source_service`, and for 76% of them the answer is that nobody did.
+        sourceServiceSource = sourceServiceSource?.let { AttributionSource.valueOf(it) } ?: AttributionSource.ABSENT,
         channel = channel,
         actChain = actChain?.let { actChainJson.readValue(it, stringListType) } ?: emptyList(),
         sessionId = sessionId,

--- a/openbank-audit-service/src/main/resources/db/migration/V13__source_service_attribution.sql
+++ b/openbank-audit-service/src/main/resources/db/migration/V13__source_service_attribution.sql
@@ -1,0 +1,60 @@
+-- Records WHO supplied `source_service`: the producer itself, or the broker topic standing in for
+-- it (#3994). The attribution counterpart of V11's `occurred_at_source`.
+--
+-- WHY THIS EXISTS. AuditConsumer read the producing service as
+--   node["sourceService"] ?: "unknown"
+-- with nothing recording which branch had been taken. Measured on the live audit database:
+--   SELECT source_service, count(*) FROM audit_entries GROUP BY 1;
+--     unknown       | 1353
+--     customer-edge |  421      <- only TWO distinct values in the entire table
+-- 76% of the evidentiary record cannot name the service that produced it, because customer-edge is
+-- the only producer in the fleet that populates the field. That covers balances, holds,
+-- transactions, KYC decisions, account lifecycle, party merges and consent — and `source_service`
+-- is not decoration: it is chain-hashed into `record_hash`, and it is returned to data subjects by
+-- the GDPR Art. 15 customer access log and to grantors by the ADR-0232 D5 transparency query.
+--
+-- WHAT CHANGES. The consumer now reads the Kafka topic (it took `payload: String`, so it could not
+-- see one) and resolves the producer through a verified topic -> service table. That retires
+-- essentially the whole `unknown` bucket for NEW rows.
+--
+-- WHY THE COLUMN, AND NOT JUST THE BETTER VALUE. A topic-derived attribution is sound but it is
+-- not the producer's own assertion, and writing it into the same column with no marker would make
+-- a consumer-supplied value indistinguishable from a producer-supplied one — converting a visibly
+-- missing attribution into an invisibly derived one. In a tamper-evident store meant to answer
+-- "who did this, from where", that is a worse failure than the gap it closes, and a much harder
+-- one to ever notice again. This column is the record of which it was.
+--
+-- WHY NO BACKFILL. Both reasons from V11 apply unchanged, either sufficient:
+--   * `audit_entries` carries `CREATE RULE no_update_audit ... DO INSTEAD NOTHING` (V2), so an
+--     UPDATE against it succeeds and changes nothing. A backfill migration would look like it had
+--     worked and would have done nothing at all.
+--   * there is nothing to backfill FROM. The topic a row arrived on was never stored in any
+--     column, and re-deriving 1353 rows' provenance would be a rewrite of audit data — which is
+--     what tamper-evidence exists to prevent.
+-- So pre-V13 rows stay NULL, and the read side maps NULL to the weakest claim (ABSENT): those rows
+-- cannot say who supplied `source_service`, and for the overwhelming majority the answer is that
+-- nobody did. Same choice as V10's hash_version and V11 — record the boundary, never rewrite
+-- history.
+--
+-- TAMPER-EVIDENCE. Not part of chainHash(), so no existing record_hash changes and no future row's
+-- hash is affected. `source_service` itself IS chain-hashed and continues to be, unchanged — this
+-- column describes where the consumer obtained that value, it does not assert a new evidential
+-- fact (same argument as the ADR-0226 channel columns in V9 and occurred_at_source in V11).
+--
+-- Rollback: DROP INDEX IF EXISTS idx_audit_entries_source_service_source;
+--           ALTER TABLE audit_entries DROP COLUMN source_service_source;
+--   (safe — no row's record_hash, source_service, occurred_at or recorded_at is modified here.)
+ALTER TABLE audit_entries ADD COLUMN IF NOT EXISTS source_service_source VARCHAR(8);
+
+COMMENT ON COLUMN audit_entries.source_service_source IS
+  'Provenance of source_service. EVENT = the producer sent a sourceService field. '
+  'TOPIC = it did not, so the producing service was resolved from the Kafka topic the record '
+  'arrived on (sound, but not the producer''s own claim). ABSENT = neither, so source_service '
+  'holds the "unknown" sentinel and attributes nothing. NULL = row written before this column '
+  'existed; treat as ABSENT.';
+
+-- Partial index: the operational question is "which rows were NOT attributed by their producer",
+-- and EVENT rows are expected to become the majority as producers are fixed. TOPIC rows are a
+-- correctly attributed row AND an outstanding producer gap, so they must stay queryable.
+CREATE INDEX IF NOT EXISTS idx_audit_entries_source_service_source
+  ON audit_entries(source_service_source) WHERE source_service_source <> 'EVENT';

--- a/openbank-audit-service/src/test/kotlin/com/openbank/audit/application/AuditAttributionTest.kt
+++ b/openbank-audit-service/src/test/kotlin/com/openbank/audit/application/AuditAttributionTest.kt
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.audit.application
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.openbank.audit.domain.model.AttributionSource
+import com.openbank.audit.domain.model.AuditEntry
+import com.openbank.audit.infrastructure.persistence.AuditRepository
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import io.mockk.coEvery
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.eclipse.microprofile.reactive.messaging.Message
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+import java.util.UUID
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionStage
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.function.Supplier
+
+/**
+ * Attribution recovery from the broker address (#3994).
+ *
+ * EVERY assertion here checks the VALUE, never `isNotNull()`. That is the point: the defect under
+ * test is a *default* — `?: "unknown"` and `?: "UNKNOWN"` — so a non-null assertion passes against
+ * the broken code exactly as it does against the fixed code. Non-nullity is what let 76% of the
+ * audit trail go unattributed without a single test going red.
+ */
+class AuditAttributionTest {
+
+    private val repo = mockk<AuditRepository>()
+
+    private val registry = SimpleMeterRegistry()
+
+    private lateinit var consumer: AuditConsumer
+
+    @BeforeEach
+    fun setUp() {
+        consumer = AuditConsumer().also {
+            it.repo = repo
+            it.objectMapper = jacksonObjectMapper().findAndRegisterModules()
+            it.clock = Clock.fixed(Instant.parse("2026-08-09T12:00:00Z"), ZoneOffset.UTC)
+            it.meterRegistry = registry
+        }
+    }
+
+    @Test
+    fun `the ce-type header names the event when the body carries no discriminator`(): Unit = runBlocking {
+        // The body of an outbox-relayed event is the bare domain event, with no eventType key at
+        // all — while the type rides in the `ce-type` header the whole time. RED against the old
+        // consume(payload: String): the header was unreadable, so this stored "UNKNOWN". That is
+        // the live 131-row UNKNOWN bucket, all of it money-path payment settlements.
+        val entry = capturingSave()
+
+        consumer.consume(
+            """{"paymentId":"${UUID.randomUUID()}","status":"SETTLED"}""",
+            EventAddress(topic = "openbank.domestic.payment.events", ceType = "domestic.payment.status-changed"),
+        )
+
+        assertThat(entry.captured.eventType).isEqualTo("domestic.payment.status-changed")
+    }
+
+    @Test
+    fun `the topic names the producing service when the producer does not`(): Unit = runBlocking {
+        // 1353 of 1774 live rows are here: every producer except customer-edge omits sourceService.
+        // RED against the old code, which stored "unknown" with ABSENT-equivalent silence.
+        val entry = capturingSave()
+
+        consumer.consume(
+            """{"partyId":"${UUID.randomUUID()}","eventType":"PARTY_MERGED"}""",
+            EventAddress(topic = "openbank.party.events"),
+        )
+
+        assertThat(entry.captured.sourceService).isEqualTo("party-service")
+        // The value alone is not enough. A derived attribution stored as though the producer had
+        // claimed it is the same class of defect one level up.
+        assertThat(entry.captured.sourceServiceSource).isEqualTo(AttributionSource.TOPIC)
+    }
+
+    @Test
+    fun `the producer's own claim wins over the topic, and is marked as the producer's`(): Unit = runBlocking {
+        // Body-first ordering: this change can only turn a sentinel into a value. It must never
+        // re-attribute a row that is already attributed, or customer-edge's 421 correct rows move.
+        val entry = capturingSave()
+
+        consumer.consume(
+            """{"partyId":"${UUID.randomUUID()}","sourceService":"customer-edge"}""",
+            EventAddress(topic = "openbank.party.events"),
+        )
+
+        assertThat(entry.captured.sourceService).isEqualTo("customer-edge")
+        assertThat(entry.captured.sourceServiceSource).isEqualTo(AttributionSource.EVENT)
+    }
+
+    @Test
+    fun `an unrecognised topic attributes nothing rather than guessing`(): Unit = runBlocking {
+        // The honest failure mode. A convention-based derivation would answer
+        // "openbank-<segment>-service" for anything at all, which is how a confident FALSE service
+        // name gets chain-hashed into an evidentiary record. Unknown stays unknown.
+        val entry = capturingSave()
+
+        consumer.consume(
+            """{"accountId":"${UUID.randomUUID()}"}""",
+            EventAddress(topic = "com.acme.some.other.topic"),
+        )
+
+        assertThat(entry.captured.sourceService).isEqualTo("unknown")
+        assertThat(entry.captured.sourceServiceSource).isEqualTo(AttributionSource.ABSENT)
+    }
+
+    @Test
+    fun `a topic-derived row is still counted as a producer gap`(): Unit = runBlocking {
+        // Folding TOPIC in with EVENT would make the outstanding producer work vanish from the
+        // dashboard the moment this ships — the same silence that let the defect reach 76%.
+        coEvery { repo.save(any()) } returns Unit
+
+        consumer.consume(
+            """{"partyId":"${UUID.randomUUID()}"}""",
+            EventAddress(topic = "openbank.party.events"),
+        )
+
+        assertThat(
+            registry.counter(
+                "openbank.audit.attribution.missing",
+                "source_service",
+                "party-service",
+                "provenance",
+                "TOPIC",
+            ).count(),
+        ).isEqualTo(1.0)
+    }
+
+    @Test
+    fun `a message is always acked, even when it cannot be stored`(): Unit = runBlocking {
+        // The one way this change could be WORSE than the defect it fixes. Taking Message<String>
+        // switches SmallRye from auto-ack to manual ack; an un-acked message stalls the partition
+        // and the audit trail stops dead. Unparseable payload = the path most likely to skip it.
+        val acked = AtomicBoolean(false)
+        val message = Message.of(
+            "this is not json",
+            Supplier<CompletionStage<Void>> {
+                acked.set(true)
+                CompletableFuture.completedFuture(null)
+            },
+        )
+
+        consumer.consume(message)
+
+        assertThat(acked.get()).isTrue()
+    }
+
+    @Test
+    fun `a message with no broker metadata still stores, on the sentinels`(): Unit = runBlocking {
+        // Nothing is rejected: absent metadata is not an error, it is just no extra information.
+        val entry = capturingSave()
+        val message = Message.of(
+            """{"accountId":"${UUID.randomUUID()}"}""",
+            Supplier<CompletionStage<Void>> { CompletableFuture.completedFuture(null) },
+        )
+
+        consumer.consume(message)
+
+        assertThat(entry.captured.sourceService).isEqualTo("unknown")
+        assertThat(entry.captured.sourceServiceSource).isEqualTo(AttributionSource.ABSENT)
+    }
+
+    private fun capturingSave() = slot<AuditEntry>().also {
+        coEvery { repo.save(capture(it)) } returns Unit
+    }
+}

--- a/openbank-audit-service/src/test/kotlin/com/openbank/audit/application/TopicAttributionCoverageTest.kt
+++ b/openbank-audit-service/src/test/kotlin/com/openbank/audit/application/TopicAttributionCoverageTest.kt
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.audit.application
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.io.File
+
+/**
+ * [TopicAttribution]'s VALUES are hand-verified facts; its COVERAGE is derived from the config
+ * (#3994).
+ *
+ * This repo has been bitten repeatedly by a gate whose scope is a hand-kept list of the thing it
+ * checks: a short list reads as full coverage rather than as unchecked. A hand-kept table of
+ * external facts is fine — it can only go stale by being noticed — but only if something fails
+ * when it does. This is that something.
+ *
+ * Both directions are asserted on purpose. A missing entry means a newly subscribed topic silently
+ * defaults to `"unknown"`, which is the original defect returning. A surplus entry means the table
+ * still claims a topic nobody consumes, which is how a stale fact survives long enough to be
+ * trusted.
+ */
+class TopicAttributionCoverageTest {
+
+    @Test
+    fun `every subscribed topic has a verified producer, and every mapped topic is subscribed`() {
+        val subscribed = subscribedTopics()
+
+        // Guard the probe itself: if the parse silently returned nothing, both assertions below
+        // would pass while checking nothing at all.
+        assertThat(subscribed)
+            .describedAs("topics parsed out of application.yaml's audit-events-in channel")
+            .hasSizeGreaterThan(15)
+
+        assertThat(TopicAttribution.mappedTopics)
+            .describedAs("TopicAttribution must name a producer for every topic audit-service consumes")
+            .containsExactlyInAnyOrderElementsOf(subscribed)
+    }
+
+    /**
+     * The `topics:` line of the `audit-events-in` incoming channel, read from the real config —
+     * never a second copy of the list, which would move with the first and keep passing.
+     */
+    private fun subscribedTopics(): Set<String> {
+        val yaml = File("src/main/resources/application.yaml").readText()
+        val line = yaml.lineSequence()
+            .map { it.trim() }
+            .first { it.startsWith("topics:") && it.contains("openbank.") }
+        return line.removePrefix("topics:").trim().split(',').map { it.trim() }.filter { it.isNotEmpty() }.toSet()
+    }
+}


### PR DESCRIPTION
## What this is

`AuditConsumer` took `payload: String`, so it saw the message **body and nothing else**. Two facts
the transport was already carrying were discarded at ingest, and both fell through to a silent
default:

| `AuditConsumer.kt` (on `main`) | substitutes | live rows |
|---|---|---|
| `:52  sourceService = node["sourceService"]?.asText() ?: "unknown"` | the string `"unknown"` | **1353 / 1774** |
| `:43  eventType = node["eventType"] ?: node["type"] ?: "UNKNOWN"` | the string `"UNKNOWN"` | **131** |

Both are *successful parses* — no exception, no metric, no log line. That is the mechanism the
issue names, and it is why this ran to three quarters of the trail without a single test going red:
a default makes `isNotNull()` pass.

## Re-derived against the live database (read-only, today)

```
SELECT count(*), count(*) FILTER (WHERE source_service='unknown'),
       count(*) FILTER (WHERE actor_id IS NULL), count(*) FILTER (WHERE event_type='UNKNOWN')
  FROM audit_entries;
 1774 | 1353 (76.3%) | 1336 (75.3%) | 131
```

Issue says 77% / 76% / 124 against a total of 1692. The **ratios hold** and the absolute counts have
grown — the defect is still accruing. Only two distinct `source_service` values exist in the entire
table: `unknown` and `customer-edge`.

## These fields are read

Established before treating this as a live defect rather than a latent trap:

- **`chainHash()`** (`AuditRepository.kt`) seals `event_type` **and** `source_service` into
  `record_hash` — they are inside the tamper-evident chain.
- **`AuditResource.getCustomerAccessLog`** returns both to a **data subject** (GDPR Art. 15).
- **The ADR-0232 D5 grantor transparency query** returns both to an account owner.

So a customer exercising Art. 15 today is told that an `unknown` service did 76% of the things
recorded about them.

## The fix, and why this one

The same defect, same cause and the same fix already shipped in the sibling consumer: the analytics
sink had the identical `consume(payload: String)` signature and the identical `UNKNOWN`/`unknown`
pair, fixed in **#2598** by reading the broker metadata. This is the audit-side counterpart.

1. `consume` takes `Message<String>` and lifts the topic + the `ce-type` header.
2. **`eventType`** falls back to `ce-type` — the outbox event type, already on the wire
   (`OutboxKafkaHeaders.HEADER_EVENT_TYPE`). This is a *recovery of the producer's own value*, not
   an inference. Retires the 131.
3. **`sourceService`** falls back to the topic, through a table verified one topic at a time
   against the module that declares the outgoing channel. Retires essentially the whole 1353.
4. **`AttributionSource`** (`EVENT` / `TOPIC` / `ABSENT`), new column `source_service_source` (V13),
   records *who supplied the value*.

**Why (3) is a table and not a derivation.** The sink derives `openbank.<domain>.…` →
`openbank-<domain>-service`. That is wrong for **nine of these twenty-one** topics —
`openbank.cards.events` is produced by card-issuance-service, `openbank.payments.swift.event` by
swift-service, `openbank.customer.audit` by customer-edge, `openbank.security.*` by
security-scanner, and accounts/transactions/documents are plural where the module is singular. A
derivation wrong nine times in twenty-one does not under-attribute; it writes a **confident false
service name into a tamper-evident record**, which is strictly worse than the `"unknown"` it
replaces.

**Why (4) exists at all.** A topic-derived value is sound but it is not the producer's own claim.
Storing it in the same column with no marker would convert a *visibly missing* attribution into an
*invisibly derived* one — the same defect one level up, and much harder to notice again. This is
the shape #3907 already established for `occurred_at_source`, applied to attribution.

**Why the scope is not hand-kept.** `TopicAttributionCoverageTest` parses the subscribed topic list
out of `application.yaml` and fails **both ways** — a topic with no entry, and an entry no longer
subscribed. The values are verified facts; the coverage is derived, so a newly subscribed topic
cannot quietly default to `"unknown"` again.

## Blast radius

- **One service, one consumer. No producer changes, no fleet coordination, no envelope change.**
- **Nothing is rejected.** Every message stored before is still stored, with the same or better
  attribution. A message with no metadata and no body fields still lands on the sentinels rather
  than being dropped — an audit path that drops events is worse than one that under-attributes.
  The fallbacks stay; they stop being *silent*.
- **Body-first ordering**, so this can only turn a sentinel into a value. `customer-edge`'s 421
  correctly attributed rows do not move.
- **The one real risk, handled:** taking `Message<String>` switches SmallRye from auto-ack to
  **manual** ack. A missed ack stalls the partition and the audit trail stops dead — worse than the
  defect. The ack is explicit and in a `finally`, and there is a test that drives the
  unparseable-payload path and asserts it.
- **No existing `record_hash` changes** and no future row's hash is affected: `source_service_source`
  is not part of `chainHash()`, and `source_service` itself is hashed exactly as before.

## No backfill — and this is not a matter of preference

`audit_entries` carries `CREATE RULE no_update_audit … DO INSTEAD NOTHING` (V2), so a backfill
UPDATE **succeeds and changes nothing** — it would look like it had worked. Independently, there is
nothing to backfill *from*: the topic a row arrived on was never stored. Pre-V13 rows stay NULL and
read back as the weakest claim, `ABSENT`. Same choice as V10 `hash_version` and V11 — record the
boundary, never rewrite history. **The 1353 existing rows stay unattributed permanently.**

## What this does NOT fix

`actor_id`, the other half of the issue — 1336 / 1774 rows name no actor. No broker metadata can
supply it, and the issue's own point 3 is right that the honest answer is an explicit
`actorType: SYSTEM` at the producers rather than forcing an id. That is a producer-side decision and
a separate change, so this is `Refs`, not `Closes`.

Also unfixed: the direct publishers (`party`, `account`'s lifecycle path, `balance`, and the #4007
four) still attach no `ce-type` header — their **event types** stay `UNKNOWN` where the body omits
one. Their **source** is now recovered regardless, because the topic does not depend on the
publisher attaching anything.

## Possible follow-up spotted in passing

`analytics-sink`'s `TopicAttribution` derives service names by convention for its own store, so the
nine mismatches above likely mean wrong `source_service` values in the analytics bronze layer too.
Not touched here — different store, different convention (`openbank-account-service` full names
vs. audit's short `account-service`), and it deserves its own measurement.

Refs #3994
