### PR TITLE
fix(gitops): wire FRAUD_SERVICE_URL so shadow fraud scoring actually runs (#4221)

### DIFF
--- a/.github/asvs-l3-baseline.txt
+++ b/.github/asvs-l3-baseline.txt
@@ -244,3 +244,7 @@ V9.1 openbank-infra/gitops/components/engagement/engagement-service.yaml:81: pla
 # instead (https is not an available alternative here, same as analytics-sink -> Apicurio above).
 # Paid off by the Layer 1 mesh-mTLS work, not before, and not by this PR alone.
 V9.1 openbank-infra/gitops/components/fraud-service/fraud-service.yaml:124: plaintext http:// env value http://account-service.accounts.svc:8100
+V9.1 openbank-infra/gitops/components/payments/payments-services.yaml:477: plaintext http:// env value http://fraud-service.fraud.svc:8133
+V9.1 openbank-infra/gitops/components/payments/payments-services.yaml:832: plaintext http:// env value http://fraud-service.fraud.svc:8133
+V9.1 openbank-infra/gitops/components/payments/payments-services.yaml:1160: plaintext http:// env value http://fraud-service.fraud.svc:8133
+V9.1 openbank-infra/gitops/components/fx-service/fx-service.yaml:89: plaintext http:// env value http://fraud-service.fraud.svc:8133

--- a/docs/threat-models/openbank-fraud-service.md
+++ b/docs/threat-models/openbank-fraud-service.md
@@ -69,7 +69,10 @@ Assets protected, in priority order:
                      └────────────────────────────────────────────────────────────────────────────┘
 ```
 
-Trust boundaries crossed: (1) external caller → REST; (3) service → Postgres;
+Trust boundaries crossed: (1) external caller → REST — in a deployed environment this means
+namespaces `payments` (domestic-payment, sepa-payment, sepa-instant) and `fx` (fx-service), which
+is what this service's NetworkPolicy admits; until issue #4221 it was crossed by nothing at all,
+since no workload set `FRAUD_SERVICE_URL`; (3) service → Postgres;
 (4) Kafka (`openbank.transactions.transaction.initiated`) → `TransactionSignalConsumer` → (5)
 `velocity_aggregates` Postgres and (6) `payee_history` Postgres (ADR-0084 §3 v4 — same Kafka signal,
 same trust boundary, no new topic). Domain layer (`FraudRuleEngine`, model) has **zero** framework
@@ -135,6 +138,35 @@ imports (ADR-0002), so verdict logic is unit-testable in isolation.
 
 ## 6. Change log
 
+- **2026-08-09** — Boundary (1) gains its first real callers (issue #4221). No new *kind* of
+  boundary: the inbound REST surface, its `@RolesAllowed`/`@Authorize` gates, the rule engine and
+  every stored artefact are untouched. What changes is that boundary (1) — described above as the
+  "(Phase 2 caller)" — had **never once been crossed in a deployed environment**. All four scoring
+  clients (domestic-payment, sepa-payment, sepa-instant, fx-service) resolved
+  `${FRAUD_SERVICE_URL:http://localhost:8133}` with the variable unset in every workload, so each
+  dialled its own pod, was refused, and the fail-open `FraudScoringAdapter` returned a synthetic
+  ALLOW. `fraud_scores` held 0 rows fleet-wide. Wiring the four workloads to
+  `fraud-service.fraud.svc:8133` makes `gen-network-policies.py` derive the corresponding ingress
+  edge, so this service's NetworkPolicy now admits namespaces `payments` and `fx` (previously
+  `admin-ui` only). Security-relevant in both directions, and worth stating plainly:
+  - **Reduces** a real risk. Every payment on all four rails was scored by a fail-open stub, and
+    the WARN it emitted per payment ("shadow ALLOW") is indistinguishable in aggregate from a
+    genuinely quiet risk engine. The RTS Art. 18 baseline ADR-0084 §4.1 assumes is now actually
+    being collected rather than assumed.
+  - **Adds** exposure worth naming. Two namespaces reach this service's REST surface that could
+    not before, and `fraud_scores` starts receiving live money-path amounts, currencies and
+    account identifiers at payment volume for the first time. Ingress remains least-privilege
+    (derived per-namespace, not opened wildly), callers still present a Keycloak JWT and are still
+    gated by `@RolesAllowed`, and the storage contract is unchanged.
+  - **No verdict is acted on.** Every call site is shadow-only — `shadowFraudScore`
+    (domestic/sepa), `scoreFraudShadow` (sepa-instant) — and logs a non-ALLOW outcome without
+    influencing payment flow. The `*_FRAUD_ENFORCEMENT_ENABLED` flags that would change that have
+    no reader in Kotlin today. Flipping enforcement is a separate, runbook-gated change and needs
+    its own threat-model entry, including the load test §5 already requires before any surface
+    moves to challenge/enforce.
+  - **Rollback**: remove `FRAUD_SERVICE_URL` from the four workloads and regenerate network
+    policies. That restores the fail-open stub, i.e. the state described above — which is a
+    return to unmeasured risk, not to safety.
 - **2026-08-08** — ADR-0220 D3.5 fraud-hold signal (issue #2749): two NEW trust boundaries,
   documented in S3/T5/I3 above. This is fraud-service's **first-ever Kafka producer** (every
   prior grant was Read-only, `openbank.fraud.hold.changed`, `kafka-fraud-mtls.yaml`) and its

--- a/openbank-infra/gitops/components/fraud-service/network-policies.yaml
+++ b/openbank-infra/gitops/components/fraud-service/network-policies.yaml
@@ -44,6 +44,12 @@ spec:
     - from:
         - namespaceSelector:
             matchLabels:
+              kubernetes.io/metadata.name: fx
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: payments
+        - namespaceSelector:
+            matchLabels:
               kubernetes.io/metadata.name: admin-ui
       ports:
         - protocol: TCP

--- a/openbank-infra/gitops/components/fx-service/fx-service.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-service.yaml
@@ -80,6 +80,13 @@ spec:
               value: http://sanctions-service.sanctions.svc:8123
             - name: AML_SERVICE_URL
               value: http://aml-service.aml.svc:8117
+            # Fraud scoring in SHADOW mode (ADR-0084 §4.1, issue #4221). fx-service scores from
+            # two call sites (FxActivitiesImpl and FxService, rail FX) and had no FRAUD_SERVICE_URL,
+            # so both resolved application.yaml's `http://localhost:8133` and the fail-open adapter
+            # logged "shadow ALLOW" on every conversion. Behaviour-neutral to wire — the verdict is
+            # observed and logged, never acted on.
+            - name: FRAUD_SERVICE_URL
+              value: http://fraud-service.fraud.svc:8133
             # NOT optional (#2929). The three rest-clients behind the ADR-0032 screening gate
             # (sanctions, aml, fraud) carry OidcClientRequestReactiveFilter; without this value
             # the default oidc-client is "not initialized" and they send no Authorization header

--- a/openbank-infra/gitops/components/payments/payments-services.yaml
+++ b/openbank-infra/gitops/components/payments/payments-services.yaml
@@ -466,6 +466,15 @@ spec:
               value: http://sanctions-service.sanctions.svc:8123
             - name: AML_SERVICE_URL
               value: http://aml-service.aml.svc:8117
+            # Fraud scoring in SHADOW mode (ADR-0084 §4.1, issue #4221). This Rollout carried no
+            # FRAUD_SERVICE_URL, so SepaPaymentActivitiesImpl's rest-client fell back to
+            # application.yaml's `http://localhost:8133` — nothing listens there, the adapter is
+            # fail-open, and every scoring call logged "shadow ALLOW / Connection refused" and
+            # moved on. `fraud_scores` held 0 rows fleet-wide as a result. Behaviour-neutral to
+            # wire: the verdict is only logged (`SEPA` rail), never acted on, until
+            # SEPA_FRAUD_ENFORCEMENT_ENABLED flips — which is a separate runbook-gated change.
+            - name: FRAUD_SERVICE_URL
+              value: http://fraud-service.fraud.svc:8133
             - name: QUARKUS_OTEL_EXPORTER_OTLP_ENDPOINT
               value: "http://tempo.observability.svc:4317"
             - name: OTEL_TRACES_SAMPLER_ARG
@@ -812,6 +821,15 @@ spec:
             # the lookup hung until the caller timed out ("upstream unavailable"). Declare it.
             - name: ACCOUNT_SERVICE_URL
               value: http://account-service.accounts.svc:8100
+            # Fraud scoring in SHADOW mode (ADR-0084 §4.1, issue #4221). Same omission as the
+            # ACCOUNT_SERVICE_URL edge above and with the same consequence: no FRAUD_SERVICE_URL
+            # here meant DomesticPaymentActivitiesImpl.shadowFraudScore resolved
+            # `http://localhost:8133`, the fail-open adapter swallowed the refusal as
+            # "shadow ALLOW", and the DOMESTIC rail scored nothing for its entire life.
+            # Behaviour-neutral: shadowFraudScore only logs a non-ALLOW verdict. Enforcement is
+            # DOMESTIC_FRAUD_ENFORCEMENT_ENABLED, deliberately left off (and today unread).
+            - name: FRAUD_SERVICE_URL
+              value: http://fraud-service.fraud.svc:8133
             - name: QUARKUS_OTEL_EXPORTER_OTLP_ENDPOINT
               value: "http://tempo.observability.svc:4317"
             - name: OTEL_TRACES_SAMPLER_ARG
@@ -1129,12 +1147,17 @@ spec:
               value: http://sanctions-service.sanctions.svc:8123
             - name: AML_SERVICE_URL
               value: http://aml-service.aml.svc:8117
-            # NOTE: no FRAUD_SERVICE_URL — sepa-instant does not consume fraud scoring yet
-            # (zero `fraud` refs in src). A dangling env pointing at a non-existent "fraud-detection"
-            # Service was removed (#1827; the real service is fraud-service). Re-add FRAUD_SERVICE_URL
-            # pointing at fraud-service (port 8133) WITH the fraud-client code + threat-model update
-            # when instant-rail fraud screening is actually wired — that also lets gen-network-
-            # policies derive the payments→fraud-service ingress edge (least-privilege, ADR-0060).
+            # Fraud scoring in SHADOW mode (ADR-0084 §4.1, issue #4221).
+            # This block previously read "no FRAUD_SERVICE_URL — sepa-instant does not consume
+            # fraud scoring yet (zero `fraud` refs in src)", and named the conditions for re-adding
+            # it. Both halves are now satisfied and the premise had gone stale: the fraud client
+            # DID land (SctInstPaymentService.scoreFraudShadow, rail SCT_INST), so the env was
+            # missing from a consumer rather than absent from a non-consumer — the note stated a
+            # fact about src that had stopped being true, which is why nobody re-checked it. The
+            # dangling "fraud-detection" env removed in #1827 was a different, genuinely wrong host.
+            # Behaviour-neutral: scoreFraudShadow logs a non-ALLOW verdict and enforces nothing.
+            - name: FRAUD_SERVICE_URL
+              value: http://fraud-service.fraud.svc:8133
             # ADR-0104 D4: real ISO 20022 pacs.008 → clearing-simulator → pacs.002 pipeline
             # (shipped in PR #1732). Fail-closed: gateway down ⇒ payment stays PROCESSING.
             - name: CLEARING_SIMULATOR_URL


### PR DESCRIPTION
## Summary

Wires `FRAUD_SERVICE_URL` into the four workloads that consume fraud scoring, so the scoring
that ADR-0084 §4.1 assumes is running actually runs. Closes the live half of #4221.

`fraud_scores` in `openbank_fraud` held **0 rows** across every rail. All four consumers —
domestic-payment, sepa-payment, sepa-instant, fx-service — declare
`url: ${FRAUD_SERVICE_URL:http://localhost:8133}` in their own `application.yaml`, and no
workload set the variable; the only occurrence anywhere under `gitops/` was inside a comment.
Nothing listens on `localhost:8133` in a pod, `FraudScoringAdapter` is fail-open, and the refusal
surfaced once per payment as a WARN reading `shadow ALLOW`.

Verified the zero is a fact and not a broken probe: `SANCTIONS_SERVICE_URL` appears in 5 gitops
files under the same query.

## Behaviour impact: none

Every call site is shadow-only. The domestic activity is literally named `shadowFraudScore` and
only logs a non-ALLOW verdict; sepa-instant's is `scoreFraudShadow`. The
`*_FRAUD_ENFORCEMENT_ENABLED` flags that would change that have **no reader in Kotlin** today.
Flipping enforcement stays a separate, runbook-gated change.

What this restores is the observation itself — the RTS Art. 18 baseline — not a new control.

## Changes

- `FRAUD_SERVICE_URL: http://fraud-service.fraud.svc:8133` on all four workloads. The Service
  exists in namespace `fraud` on port 8133.
- Regenerated network policies. `gen-network-policies.py` derives the ingress edge from exactly
  these env URLs; the only resulting change is fraud-service admitting `payments` and `fx`
  (previously `admin-ui` only), least-privilege per ADR-0060.
- Threat model updated (ADR-0030 D2) — this gives boundary (1) its first real callers.
- Four ASVS V9.1 baseline lines. `https` is not an available alternative: fraud-service publishes
  a single plain `http` port and terminates no TLS, exactly like the already-baselined
  `sanctions-service:8123` and `aml-service:8117` declared two lines above. Closed fleet-wide by
  #1914 (Istio STRICT mTLS), not per-edge.

## A stale comment, corrected in place

sepa-instant carried `# NOTE: no FRAUD_SERVICE_URL — sepa-instant does not consume fraud scoring
yet (zero fraud refs in src)`. That premise had gone stale — `SctInstPaymentService.scoreFraudShadow`
scores the `SCT_INST` rail. The note stated a fact about `src` that stopped being true, which is
why nobody re-checked it. Corrected rather than deleted, so the next reader learns the note was
wrong rather than that it was never there.

## #3978 is already fixed — recommend closing it

This PR was scoped from #3978 + #4221 together. #3978's three findings are all resolved on
`origin/main` already: settlement-service and vop-service carry correct overrides (landed via
#3931 and #3966), onboarding-service has `PARTY_SERVICE_URL`, and the gate it says is advisory is
now `mode: enforced` and passes clean:

```
check-incluster-hostnames: 59 application.yaml files (77 hostnames) + 489 gitops workload env/arg
values (480 hostnames), against 295 declared Services ... across 60 namespaces
OK: every in-cluster hostname resolves — in application.yaml AND in the gitops workload env.
```

## Verification

Full local gate sweep, `PR_DIFF_BASE=origin/main`:

| group | result |
|---|---|
| gitops | PASS=24, WARN=1, UNFALSIFIED=1 |
| security | PASS=12 |
| registry | PASS=21 |
| supplychain | PASS=19, WARN=1 |
| data | PASS=11 |
| api | PASS=6, FAIL=1 |

Every non-PASS was baselined against a clean `origin/main` worktree and reproduces there
identically — `api-contract-gate`, `loki-rule-load-test` (unfalsified), `scheduler-liveness-adoption`
(advisory). None is introduced here.

`gen-network-policies-drift-gate` and `threat-model-updated-on-trust-boundary-change` both failed
first and are green now — the drift gate only after committing, since it diffs the working tree.

## Review note

Money-path scope, so this needs 2 approvals per ADR-0030. Not self-merging.

Refs #4221, #1914
Closes #3978
