### PR TITLE
fix(gitops): register the ArgoCD Application for engagement-service

### DIFF
--- a/openbank-infra/gitops/apps/engagement.yaml
+++ b/openbank-infra/gitops/apps/engagement.yaml
@@ -1,0 +1,47 @@
+# engagement domain: engagement-service + single-owner CNPG Postgres (ADR-0037 domain=namespace).
+# Onboarded so the ADR-0220 D1/D3.5 in-app engagement surface (impression/click/dismiss/conversion
+# feedback + AdverseState-driven eligibility, consuming openbank.lending.events/party.events/
+# fraud.hold.changed) actually runs somewhere — the gitops component was complete and the service
+# was already in auto-deploy.yml's ALL_SERVICES, but with no Application here nothing ever
+# reconciled it (issue #4268).
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: engagement
+  namespace: argocd
+  annotations:
+    # Server-Side Diff must run the Kyverno verify-images mutation in its dry-run, otherwise the
+    # digest-pinning annotation it injects reads as a permanent OutOfSync diff (issue #856).
+    argocd.argoproj.io/compare-options: IncludeMutationWebhook=true
+  finalizers: [resources-finalizer.argocd.argoproj.io]
+spec:
+  project: default
+  source:
+    repoURL: git@github.com:JiRaska/open-bank-oss.git
+    targetRevision: main
+    path: openbank-infra/gitops/components/engagement
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: engagement
+  syncPolicy:
+    # ServerSideApply: the OPA bundle ConfigMap can exceed the 262144-byte last-applied-
+    # configuration annotation cap under client-side apply (issue #856's fraud.yaml precedent).
+    syncOptions:
+      - ServerSideApply=true
+    automated:
+      prune: true
+      selfHeal: true
+    retry:
+      limit: 10
+      backoff:
+        duration: 15s
+        factor: 2
+        maxDuration: 5m
+  # Argo Rollouts (ADR-0098) sets spec.selector.rollouts-pod-template-hash on the stable/canary
+  # Services at runtime; git holds only the base selector, so without this every Rollout-backed
+  # Service reads as permanently OutOfSync (same fraud.yaml precedent, issue #856).
+  ignoreDifferences:
+    - group: ""
+      kind: Service
+      jqPathExpressions:
+        - .spec.selector."rollouts-pod-template-hash"


### PR DESCRIPTION
## Summary
- Adds `openbank-infra/gitops/apps/engagement.yaml` — the missing ArgoCD `Application` for `openbank-engagement-service` (issue #4268).
- Its gitops component (`components/engagement/`) has existed complete for a while and the service has been in `auto-deploy.yml`'s `ALL_SERVICES`, but with no `Application` manifest ArgoCD never watched it — verified empty in sandbox while diagnosing #4252's rollout (`kubectl get ns engagement` → NotFound, no `Application` named `engagement`).
- Same shape as `fraud.yaml` (`ServerSideApply` for the OPA bundle ConfigMap size, `rollouts-pod-template-hash` ignoreDifferences — both issue #856 precedents).

## Test plan
- [x] `check-msg-channel-image-parity.py` — clean.
- [x] `check-network-policy-code-edges.py` — clean.
- [ ] After merge: `kubectl get application engagement -n argocd` reaches `Synced`/`Healthy`, `kubectl -n engagement get pods` shows `engagement-service` Running/Ready. Will verify live post-merge.

Closes #4268.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
