### PR TITLE
fix(fraud): register the ADR-0237 liveness heartbeat on the hold-expiry sweep

### DIFF
--- a/openbank-fraud-service/src/main/kotlin/com/openbank/fraud/application/usecase/FraudHoldService.kt
+++ b/openbank-fraud-service/src/main/kotlin/com/openbank/fraud/application/usecase/FraudHoldService.kt
@@ -10,12 +10,16 @@ import com.openbank.fraud.application.port.out.FraudScoreRepository
 import com.openbank.fraud.domain.model.FraudVerdict
 import com.openbank.fraud.infrastructure.persistence.FraudOutboxRepositoryImpl
 import com.openbank.libs.domain.identifiers.Ids
+import com.openbank.libs.observability.DomainMetrics
+import com.openbank.libs.observability.WorkflowLivenessRecorder
 import com.openbank.libs.persistence.outbox.OutboxMessage
 import io.quarkus.hibernate.reactive.panache.Panache
+import io.quarkus.runtime.StartupEvent
 import io.quarkus.scheduler.Scheduled
 import io.smallrye.mutiny.Uni
 import io.smallrye.mutiny.coroutines.awaitSuspending
 import jakarta.enterprise.context.ApplicationScoped
+import jakarta.enterprise.event.Observes
 import jakarta.inject.Inject
 import org.eclipse.microprofile.config.inject.ConfigProperty
 import org.jboss.logging.Logger
@@ -51,6 +55,20 @@ class FraudHoldService @Inject constructor(
     @ConfigProperty(name = "openbank.fraud-hold.ttl-days", defaultValue = "30")
     private val ttlDays: Long,
 ) {
+    @Inject
+    lateinit var domainMetrics: DomainMetrics
+
+    private var liveness: WorkflowLivenessRecorder? = null
+
+    /**
+     * Registered on StartupEvent, not @PostConstruct: @ApplicationScoped is LAZY, so a
+     * @PostConstruct would first run when the cron first fires and the gauge would be ABSENT until
+     * then — and absent is a different signal from stale.
+     */
+    fun registerLiveness(@Observes @Suppress("UNUSED_PARAMETER") event: StartupEvent) {
+        liveness = domainMetrics.registerWorkflowLiveness(WORKFLOW_NAME, EXPECTED_INTERVAL)
+    }
+
     private val log = Logger.getLogger(FraudHoldService::class.java)
 
     /**
@@ -118,6 +136,7 @@ class FraudHoldService @Inject constructor(
             if (expired.isNotEmpty()) {
                 log.infof("fraud-hold expiry sweep cleared=%d", expired.size)
             }
+            liveness?.recordSuccess()
         } catch (ex: Exception) {
             log.warnf(ex, "fraud-hold expiry sweep failed")
         }
@@ -144,6 +163,11 @@ class FraudHoldService @Inject constructor(
     }
 
     private companion object {
+        const val WORKFLOW_NAME = "fraud-hold-expiry-sweep"
+
+        /** Matches the @Scheduled default `openbank.fraud-hold.sweep-interval:1h`. */
+        val EXPECTED_INTERVAL: Duration = Duration.ofHours(1)
+
         const val RULE_VERSION = "fraud-hold-v1"
         const val REASON_REPEATED_REVIEW = "repeated_review"
         const val REASON_EXPIRED = "expired"


### PR DESCRIPTION
## `main` is red on `scheduler-liveness-adoption`

#4180 graduated that gate to enforced and paid off `SavingsProposalExpiryScheduler` — but `FraudHoldService.sweepExpired` was the **other** unregistered job #3345 named, so the graduation landed on a tree that still contained one offender.

Reproduced against pristine `origin/main` in a detached worktree, no branch involved:

```
::error file=…/FraudHoldService.kt::NEW domain @Scheduled job without registerWorkflowLiveness (ADR-0237)
```

That is my sequencing error: I put #4180 in the merge batch without re-running its own gate against the tree it would land on.

## Why this one matters beyond the gate

`sweepExpired` wraps its whole body in `try/catch` and logs a warning. So a permanently broken sweep is **indistinguishable from a healthy quiet one** — no exception escapes, no metric moves, and clearing zero holds is the normal case.

A fraud hold that never expires is a customer left blocked indefinitely, and nothing today would say so.

## Three deliberate choices

- **`recordSuccess()` on the success path only, never in the `catch`.** A heartbeat on the failure branch asserts the very thing it exists to disprove.
- **Registration on `StartupEvent`, not `@PostConstruct`.** `@ApplicationScoped` is lazy, so `@PostConstruct` would first run when the cron first fires and the gauge would be **absent** until then — absent is a different signal from stale.
- **`DomainMetrics` field-injected, not a constructor parameter.** The constructor already takes 8, and detekt's `LongParameterList` fires **at** `constructorThreshold: 9`, not above it. A ninth parameter would have failed the lint gate.

`EXPECTED_INTERVAL` is derived from the `@Scheduled` default (1h) rather than restating a number, so the two cannot drift apart.

## Verification

| check | result |
|---|---|
| `scheduler-liveness-adoption` | **PASS** via the real runner |
| `:openbank-fraud-service:test` | **148 tests, 0 failures, 0 errors** (JUnit XML, not console) |
| `ktlintCheck`, `detekt` | both in the executed task list |
| `quarkusBuild` | **PASS** — included because CDI wiring failures surface only there, and this adds an injection point and an `@Observes` method |

One thing caught on the way: my first patch added `java.time.Duration` next to an existing import and the compiler rejected it as ambiguous. Fixed before pushing — worth noting only because `--console=plain` and reading the `e:` lines is what surfaced it, not the task list.

Refs #3345
