### PR TITLE
docs(engagement): correct a stale adverse-state note that blamed the wrong service

### DIFF
--- a/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/application/usecase/ResolveSurfaceUseCase.kt
+++ b/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/application/usecase/ResolveSurfaceUseCase.kt
@@ -55,12 +55,23 @@ class ResolveSurfaceUseCase(
         val recent = events.recentForPartyAndSlot(partyId, slot, Instant.now().minus(DISMISSAL_LOOKBACK))
         if (DismissalRule.shouldSuppress(recent)) return Result.Suppressed
 
-        // Half-real (issue #2749): ARREARS (LendingArrearsEventConsumer, openbank.lending.events)
-        // and ERASURE_REQUESTED (PartyErasureConsumer, openbank.party.events) are materialised.
-        // FRAUD_HOLD and DISPUTE_OPENED are NOT — neither signal is published as an event
-        // anywhere in this fleet today (fraud-service has no persisted hold state; dispute-service
-        // emits only on resolution, never on open). That is still an honest gap for those two, not
-        // a silent one — a party with an open dispute or fraud hold is NOT currently excluded.
+        // Three of four adverse states are materialised (issue #2749): ARREARS
+        // (LendingArrearsEventConsumer, openbank.lending.events), ERASURE_REQUESTED
+        // (PartyErasureConsumer, openbank.party.events) and FRAUD_HOLD (FraudHoldEventConsumer,
+        // fraud-hold-events-in). DISPUTE_OPENED is the one gap: a party with an open dispute is
+        // NOT currently excluded.
+        //
+        // The previous version of this note was wrong on all three of its factual claims, and is
+        // corrected rather than deleted so the next reader learns it was superseded rather than
+        // that it never existed. It said neither signal is published anywhere in the fleet,
+        // "fraud-service has no persisted hold state" and "dispute-service emits only on
+        // resolution, never on open". Measured on this sha: fraud-service persists holds
+        // (FraudHoldEntity/FraudHoldService) and dispute-service does emit `dispute.opened`
+        // (DisputeService.openedOutboxMessage, landed #4087).
+        //
+        // So the REASON DISPUTE_OPENED is missing is not the producer — it exists — but that this
+        // service has no @Incoming for openbank.dispute.events. A note that blames the wrong layer
+        // sends the next person to fix a service that is already correct.
         val eligibility = EligibilitySnapshot(
             partyId = partyId,
             adverseState = adverseState.activeStates(partyId),

--- a/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/application/usecase/ResolveSurfaceUseCase.kt
+++ b/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/application/usecase/ResolveSurfaceUseCase.kt
@@ -55,23 +55,23 @@ class ResolveSurfaceUseCase(
         val recent = events.recentForPartyAndSlot(partyId, slot, Instant.now().minus(DISMISSAL_LOOKBACK))
         if (DismissalRule.shouldSuppress(recent)) return Result.Suppressed
 
-        // Three of four adverse states are materialised (issue #2749): ARREARS
-        // (LendingArrearsEventConsumer, openbank.lending.events), ERASURE_REQUESTED
-        // (PartyErasureConsumer, openbank.party.events) and FRAUD_HOLD (FraudHoldEventConsumer,
-        // fraud-hold-events-in). DISPUTE_OPENED is the one gap: a party with an open dispute is
-        // NOT currently excluded.
+        // WHICH adverse states are materialised is NOT restated here (issue #2749). The answer is
+        // the set of @Incoming consumers in this service's infrastructure/kafka package, and
+        // AdverseState's own KDoc in Eligibility.kt tracks it. A second copy of that list in a
+        // comment is what went stale last time, and would go stale again the moment a consumer is
+        // added — which is exactly what #4297 does.
         //
-        // The previous version of this note was wrong on all three of its factual claims, and is
-        // corrected rather than deleted so the next reader learns it was superseded rather than
-        // that it never existed. It said neither signal is published anywhere in the fleet,
-        // "fraud-service has no persisted hold state" and "dispute-service emits only on
-        // resolution, never on open". Measured on this sha: fraud-service persists holds
-        // (FraudHoldEntity/FraudHoldService) and dispute-service does emit `dispute.opened`
+        // What is worth keeping in place, because it is timeless and a deletion would erase it:
+        // the note that used to stand here was wrong on all three of its factual claims. It said
+        // neither the fraud nor the dispute signal is published anywhere in the fleet, that
+        // "fraud-service has no persisted hold state", and that "dispute-service emits only on
+        // resolution, never on open". Measured 2026-08-09: fraud-service persists holds
+        // (FraudHoldEntity/FraudHoldService), and dispute-service emits `dispute.opened`
         // (DisputeService.openedOutboxMessage, landed #4087).
         //
-        // So the REASON DISPUTE_OPENED is missing is not the producer — it exists — but that this
-        // service has no @Incoming for openbank.dispute.events. A note that blames the wrong layer
-        // sends the next person to fix a service that is already correct.
+        // The lesson that survives the fix: a signal missing HERE is not evidence the producer is
+        // missing. That note blamed the producing services, and a reader acting on it would have
+        // gone to fix two services that were already correct. The gap was always the consumer end.
         val eligibility = EligibilitySnapshot(
             partyId = partyId,
             adverseState = adverseState.activeStates(partyId),


### PR DESCRIPTION
## What

The comment above the `EligibilitySnapshot` construction in `ResolveSurfaceUseCase` made three
factual claims. All three are false on this sha.

| Claim in the note | Measured on `origin/main` |
|---|---|
| "neither signal is published as an event anywhere in this fleet today" | both are |
| "fraud-service has no persisted hold state" | 4 files matching `FraudHold` under `src/main` — `FraudHoldEntity`, `FraudHoldService`, … |
| "dispute-service emits only on resolution, never on open" | 4 occurrences of `dispute.opened` in `DisputeService.kt` (#4087) |

And the count it gave is wrong in this service too: engagement has consumed fraud holds since
#4252 (`FraudHoldEventConsumer`, channel `fraud-hold-events-in`), so **three** of the four
adverse states are materialised, not two.

## Why it matters more than a typo

The one real gap — `DISPUTE_OPENED` — is missing for a **different reason** than the note gave.
The producer exists; this service simply declares no `@Incoming` for the dispute topic. A note
that blames the wrong layer sends the next reader to fix a service that is already correct.

It also contradicted `Eligibility.kt`'s own KDoc, in the same service, which already lists
`FRAUD_HOLD` as materialised — so the two documents disagreed with each other and the reader had
no way to tell which was current.

## Corrected, not deleted

Per the repo's own rule: *"when you fix a defect whose comment predicted it, correct the comment
in place rather than deleting it, so the next reader learns the note was wrong rather than that it
was never there."* The new note quotes what the old one said and states what was measured against
it.

Comment-only change. `ktlintCheck` + `detekt` green on `:openbank-engagement-service`.

Refs #2749, #4262
