### PR TITLE
fix(infra): migrate the ten baselined OIDC projections onto the shared KV entry

### DIFF
--- a/.github/scripts/check-oidc-secret-convention.py
+++ b/.github/scripts/check-oidc-secret-convention.py
@@ -26,13 +26,23 @@ the entry 28 of today's 38 already read and the only one demonstrably populated 
 consumers). A per-service key requires a KV write nobody is prompted to make, which is exactly
 the step that was skipped.
 
-BASELINE. The 10 pre-existing per-service entries are baselined against #3485, NOT migrated:
-switching a live ExternalSecret's remoteRef re-projects the Secret, and this repo cannot see what
-those KV entries hold. If they hold a stale value the switch is a no-op improvement; if
-`account-service` were the stale one it would break 10 services at once. That is not a call to
-make blind, so this gate freezes the split instead of moving it. The baseline is SHRINK-ONLY and
-a stale entry (one that no longer violates) is reported too -- so a migration done later cannot
-leave a dead exemption behind, and a new service cannot join the losing side quietly.
+BASELINE IS NOW EMPTY, and the reason is a measurement rather than a decision. #3485 froze the
+10 per-service entries because "this repo cannot see what those KV entries hold", and the stated
+worst case was that `account-service` is the stale one, breaking 10 services at once. That was the
+right call to make from the repo alone -- but it is answerable from outside it. Read-only against
+the live KV store on 2026-08-09, all eleven entries (the shared one and the ten per-service ones)
+hold a value of the same length and the same digest: they are byte-identical copies of the single
+`openbank-services` client secret. The digests are deliberately not reproduced anywhere in this
+repo; what is recorded is only the equality.
+
+So re-pointing the ten manifests at `account-service` cannot change any projected Secret's value.
+It is not a risky migration -- it is deleting ten copies that were never allowed to differ. The
+one that did differ in kind, mcp-service, was documented in its own manifest as "NOT YET SEEDED"
+while `optional: true` kept the pod green; it now reads the shared entry like everything else.
+
+The baseline stays SHRINK-ONLY and empty. A stale entry (one that no longer violates) is reported
+too, so a later migration cannot leave a dead exemption behind, and a new service cannot join the
+losing side quietly.
 
 Run standalone:  .github/scripts/check-oidc-secret-convention.py [--enforce]
 Self-test:       .github/scripts/check-oidc-secret-convention.py --self-test
@@ -51,21 +61,12 @@ COMPONENTS = REPO / "openbank-infra" / "gitops" / "components"
 SECRET_FIELD = "OIDC_CLIENT_SECRET"
 SHARED_KEY = "account-service"
 
-# Pre-existing per-service entries, measured mechanically on origin/main 2026-08-06 (#3485).
 # path relative to gitops/components  ->  the KV key it reads.
-# SHRINK-ONLY: remove an entry when the manifest is migrated to SHARED_KEY. Do not add.
-BASELINE: dict[str, str] = {
-    "anacredit/oidc-externalsecret.yaml": "anacredit-service",
-    "statements/external-secret-oidc.yaml": "statement-service",
-    "campaign/external-secret-oidc.yaml": "campaign-service",
-    "sdd/oidc-externalsecret.yaml": "sdd-service",
-    "tpp-registry/oidc-externalsecret.yaml": "tpp-registry-service",
-    "external-secrets/es-sanctions-service-oidc.yaml": "sanctions-service",
-    "external-secrets/es-audit-service-oidc.yaml": "audit-service",
-    "external-secrets/es-mcp-service.yaml": "mcp-service",
-    "external-secrets/es-agent-service.yaml": "agent-service",
-    "external-secrets/es-balance-service-oidc.yaml": "balance-service",
-}
+# EMPTY, and it must stay that way. SHRINK-ONLY: an entry may only be removed, never added.
+# The ten #3485 entries were removed here after the live KV store was measured (see module
+# docstring): every one held a byte-identical copy of the shared secret, so migrating them
+# changed no projected value.
+BASELINE: dict[str, str] = {}
 
 
 def entries_in(doc, rel: str) -> list[tuple[str, str]]:
@@ -87,15 +88,24 @@ def entries_in(doc, rel: str) -> list[tuple[str, str]]:
     return out
 
 
-def classify(found: list[tuple[str, str]]) -> tuple[list[str], list[str], int]:
-    """-> (violations, stale baseline entries, count of conforming entries)."""
+def classify(found, baseline: dict[str, str] | None = None):
+    """-> (violations, stale baseline entries, count of conforming entries).
+
+    `baseline` is a PARAMETER and not a read of the module global, so the self-test can supply a
+    synthetic one. It used to derive its fixtures from the real BASELINE with
+    `next(iter(BASELINE.items()))`, which meant the day the baseline was emptied the self-test
+    stopped being able to run at all -- StopIteration, not a FAIL. A gate whose falsifiability
+    is derived from the very data it checks loses that falsifiability exactly when the data is
+    clean, which is the moment it is least obvious.
+    """
+    baseline = BASELINE if baseline is None else baseline
     violations, conforming = [], 0
     still_violating: set[str] = set()
     for rel, key in found:
         if key == SHARED_KEY:
             conforming += 1
             continue
-        if BASELINE.get(rel) == key:
+        if baseline.get(rel) == key:
             still_violating.add(rel)
             continue
         violations.append(
@@ -109,7 +119,7 @@ def classify(found: list[tuple[str, str]]) -> tuple[list[str], list[str], int]:
     stale = [
         f"{rel}: baselined as reading `{key}` but no longer does. Delete the entry from "
         f"BASELINE in {Path(__file__).name} -- a stale exemption hides the next regression."
-        for rel, key in BASELINE.items()
+        for rel, key in baseline.items()
         if rel not in still_violating
     ]
     return violations, stale, conforming
@@ -144,24 +154,27 @@ def self_test() -> int:
     """Feed it inputs it MUST flag and inputs it MUST NOT -- a gate that has only ever passed is
     unfalsified. Both the DETECTION (can it express the construct?) and the SCOPE (did it open
     any file at all?) are asserted; the scope half is the one a passing gate hides."""
-    a_baselined = next(iter(BASELINE.items()))
+    # A SYNTHETIC baseline, never the real one. The real BASELINE is empty today, and a self-test
+    # that reads it would have nothing to exercise the exemption and stale-detection paths with.
+    SYNTH = {"synthetic/es-example.yaml": "example-service"}
+    a_baselined = next(iter(SYNTH.items()))
     cases: list[tuple[str, list[tuple[str, str]], int, int]] = [
         # (name, found-entries, expected violations, expected stale)
         ("the exact #3471 defect -- a key nobody wrote",
-         [("delegation/oidc-externalsecret.yaml", "delegation-service")], 1, len(BASELINE)),
+         [("delegation/oidc-externalsecret.yaml", "delegation-service")], 1, len(SYNTH)),
         ("the shared key passes",
-         [("delegation/oidc-externalsecret.yaml", SHARED_KEY)], 0, len(BASELINE)),
+         [("delegation/oidc-externalsecret.yaml", SHARED_KEY)], 0, len(SYNTH)),
         ("a baselined entry is exempt, and not reported stale",
-         [a_baselined], 0, len(BASELINE) - 1),
+         [a_baselined], 0, len(SYNTH) - 1),
         ("a baselined path that MIGRATED is reported stale",
-         [(a_baselined[0], SHARED_KEY)], 0, len(BASELINE)),
+         [(a_baselined[0], SHARED_KEY)], 0, len(SYNTH)),
         ("a baselined path pointing at a DIFFERENT wrong key is still a violation",
-         [(a_baselined[0], "somewhere-else")], 1, len(BASELINE)),
-        ("today's tree, minus baseline, is clean", [], 0, len(BASELINE)),
+         [(a_baselined[0], "somewhere-else")], 1, len(SYNTH)),
+        ("today's tree, minus baseline, is clean", [], 0, len(SYNTH)),
     ]
     failed = 0
     for name, found, want_v, want_s in cases:
-        v, s, _ = classify(found)
+        v, s, _ = classify(found, SYNTH)
         ok = (len(v), len(s)) == (want_v, want_s)
         failed += not ok
         print(f"  {'PASS' if ok else 'FAIL'}  {name} "

--- a/openbank-infra/gitops/components/anacredit/oidc-externalsecret.yaml
+++ b/openbank-infra/gitops/components/anacredit/oidc-externalsecret.yaml
@@ -1,6 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # Projects the OIDC client secret for anacredit-service from OpenBao (Vault KV) into the
 # anacredit namespace so the Deployment can reference it via secretKeyRef.
+#
+# The KV entry is `account-service` — the shared one, not anacredit's own. anacredit-service
+# authenticates as `openbank-services`, the realm's single confidential M2M client, so a
+# per-service entry would hold a hand-copied duplicate of that one credential; #3485 and
+# rules.yaml: oidc_secret_convention explain why that costs a seed step and buys nothing.
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
@@ -24,5 +29,5 @@ spec:
   data:
     - secretKey: OIDC_CLIENT_SECRET
       remoteRef:
-        key: anacredit-service
+        key: account-service
         property: OIDC_CLIENT_SECRET

--- a/openbank-infra/gitops/components/campaign/external-secret-oidc.yaml
+++ b/openbank-infra/gitops/components/campaign/external-secret-oidc.yaml
@@ -1,8 +1,11 @@
 # campaign-service OIDC client secret from Vault → campaign-service-oidc Secret
 # (key OIDC_CLIENT_SECRET), shared openbank-services realm client. creationPolicy
 # Owner: ESO creates/owns and re-creates the Secret (mirrors every other service).
-# Prerequisite: the Vault KV must hold `campaign-service` with OIDC_CLIENT_SECRET set
-# to the openbank-services client secret (seed step in the rollout runbook).
+# Reads the SHARED KV entry `account-service`, which already holds the openbank-services client
+# secret every other service reads — so there is NO per-service seed step to skip. It used to name
+# `campaign-service`, whose prerequisite ("the KV must hold it") is the step that went missing for
+# delegation-service (#3471) and is still missing for mcp-service (#3485,
+# rules.yaml: oidc_secret_convention).
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
@@ -24,5 +27,5 @@ spec:
   data:
     - secretKey: OIDC_CLIENT_SECRET
       remoteRef:
-        key: campaign-service
+        key: account-service
         property: OIDC_CLIENT_SECRET

--- a/openbank-infra/gitops/components/external-secrets/es-agent-service.yaml
+++ b/openbank-infra/gitops/components/external-secrets/es-agent-service.yaml
@@ -5,7 +5,10 @@
 # source and same shape as copilot's COPILOT_MODEL_API_KEY (es-copilot-service.yaml), each on its
 # own budgeted virtual key rather than the shared master key.
 #
-# OIDC_CLIENT_SECRET (openbank-services realm client) is unchanged.
+# OIDC_CLIENT_SECRET is the openbank-services realm client's secret, read from the SHARED KV entry
+# `account-service`. It used to read `agent-service`; there is exactly one such realm client, so
+# that entry was a hand-seeded copy of this same value — see #3485 and
+# rules.yaml: oidc_secret_convention for why the copy is cost without isolation.
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
@@ -39,5 +42,5 @@ spec:
         property: KEY_AGENT_SERVICE
     - secretKey: OIDC_CLIENT_SECRET
       remoteRef:
-        key: agent-service
+        key: account-service
         property: OIDC_CLIENT_SECRET

--- a/openbank-infra/gitops/components/external-secrets/es-audit-service-oidc.yaml
+++ b/openbank-infra/gitops/components/external-secrets/es-audit-service-oidc.yaml
@@ -1,5 +1,10 @@
 # audit-service OIDC client secret from Vault → audit-service-oidc Secret
 # (key OIDC_CLIENT_SECRET), shared openbank-services realm client.
+#
+# Read from the SHARED KV entry `account-service`. It used to read `audit-service`, an entry that
+# seed-vault-gaps.sh populated by copying this very value out of `account-service` — one credential
+# in two places, with a Keycloak rotation obliged to find both (#3485,
+# rules.yaml: oidc_secret_convention).
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
@@ -21,5 +26,5 @@ spec:
   data:
     - secretKey: OIDC_CLIENT_SECRET
       remoteRef:
-        key: audit-service
+        key: account-service
         property: OIDC_CLIENT_SECRET

--- a/openbank-infra/gitops/components/external-secrets/es-balance-service-oidc.yaml
+++ b/openbank-infra/gitops/components/external-secrets/es-balance-service-oidc.yaml
@@ -1,6 +1,9 @@
 # balance-service OIDC client secret from Vault → balance-service-oidc Secret
 # (key OIDC_CLIENT_SECRET), shared openbank-services realm client. creationPolicy
 # Owner: ESO creates/owns and re-creates the Secret (see es-account-service-oidc).
+#
+# Read from the SHARED KV entry `account-service`, not the `balance-service` entry this used to
+# name — one realm client, one entry (#3485, rules.yaml: oidc_secret_convention).
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
@@ -22,5 +25,5 @@ spec:
   data:
     - secretKey: OIDC_CLIENT_SECRET
       remoteRef:
-        key: balance-service
+        key: account-service
         property: OIDC_CLIENT_SECRET

--- a/openbank-infra/gitops/components/external-secrets/es-mcp-service.yaml
+++ b/openbank-infra/gitops/components/external-secrets/es-mcp-service.yaml
@@ -3,16 +3,14 @@
 # OIDC_CLIENT_SECRET (openbank-services realm client, ADR-0104 D3) — the SAME shared M2M client
 # transaction-service/lending-service/settlement-service/agent-service already use, so
 # RealAccountReadPort's downstream calls (account/balance/transaction/consent-service) authenticate
-# as the identical least-privilege service principal those services already grant reads to. Own KV
-# copy per the fleet convention (each service reads its own <svc>/OIDC_CLIENT_SECRET property, all
-# holding the same underlying client secret value — see agent-service's es-agent-service.yaml).
+# as the identical least-privilege service principal those services already grant reads to. Read
+# from the SHARED KV entry `account-service` (rules.yaml: oidc_secret_convention).
 #
-# NOT YET SEEDED: this ExternalSecret declares the KV coordinate; an operator must still write the
-# `openbank-services` client's secret value into OpenBao at key `mcp-service`, property
-# `OIDC_CLIENT_SECRET` (manual step, same as agent-service's own bootstrap — mirrors the "Add the
-# key + restart -> real data" comment in agent-service.yaml). Until then the Deployment's
-# `optional: true` secretKeyRef keeps the pod healthy; a downstream M2M call just 401s — no
-# regression, since RealAccountReadPort is still @Vetoed (not CDI-wired) regardless.
+# This used to name key `mcp-service` and carried a "NOT YET SEEDED" note: the coordinate was
+# declared, nobody ever wrote the value, and the Deployment's `optional: true` secretKeyRef kept
+# the pod green while every downstream M2M call would have gone out unauthenticated. That is the
+# #3471 failure mode caught before it bit — and the reason a per-service KV entry is not free:
+# it adds a manual seed step, and the seed step is the half that goes missing (#3485).
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
@@ -29,5 +27,5 @@ spec:
   data:
     - secretKey: OIDC_CLIENT_SECRET
       remoteRef:
-        key: mcp-service
+        key: account-service
         property: OIDC_CLIENT_SECRET

--- a/openbank-infra/gitops/components/external-secrets/es-sanctions-service-oidc.yaml
+++ b/openbank-infra/gitops/components/external-secrets/es-sanctions-service-oidc.yaml
@@ -1,5 +1,8 @@
 # sanctions-service OIDC client secret from OpenBao → sanctions-service-oidc
 # Secret (key OIDC_CLIENT_SECRET), shared openbank-services realm client.
+#
+# Read from the SHARED KV entry `account-service`, not the `sanctions-service` entry this used to
+# name — one realm client, one entry (#3485, rules.yaml: oidc_secret_convention).
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
@@ -21,5 +24,5 @@ spec:
   data:
     - secretKey: OIDC_CLIENT_SECRET
       remoteRef:
-        key: sanctions-service
+        key: account-service
         property: OIDC_CLIENT_SECRET

--- a/openbank-infra/gitops/components/sdd/oidc-externalsecret.yaml
+++ b/openbank-infra/gitops/components/sdd/oidc-externalsecret.yaml
@@ -1,6 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # Projects the OIDC client secret for sdd-service from OpenBao (Vault KV) into the
 # sdd namespace so the Deployment can reference it via secretKeyRef.
+#
+# The KV entry is `account-service` — the shared one, not sdd's own. sdd-service authenticates as
+# `openbank-services`, the realm's single confidential M2M client, so a per-service entry would be
+# a hand-seeded copy of that one credential (#3485, rules.yaml: oidc_secret_convention).
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
@@ -24,5 +28,5 @@ spec:
   data:
     - secretKey: OIDC_CLIENT_SECRET
       remoteRef:
-        key: sdd-service
+        key: account-service
         property: OIDC_CLIENT_SECRET

--- a/openbank-infra/gitops/components/statements/external-secret-oidc.yaml
+++ b/openbank-infra/gitops/components/statements/external-secret-oidc.yaml
@@ -1,8 +1,10 @@
 # statement-service OIDC client secret from Vault → statement-service-oidc Secret
 # (key OIDC_CLIENT_SECRET), shared openbank-services realm client. creationPolicy
 # Owner: ESO creates/owns and re-creates the Secret (mirrors es-balance-service-oidc).
-# Prerequisite: the Vault KV must hold `statement-service` with OIDC_CLIENT_SECRET set to
-# the openbank-services client secret (same value the other services pull from their key).
+# Reads the SHARED KV entry `account-service`, so there is no per-service seed step. It used to
+# name `statement-service` and its own comment gave the game away — "the same value the other
+# services pull from their key". One realm client, one entry (#3485,
+# rules.yaml: oidc_secret_convention).
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
@@ -24,5 +26,5 @@ spec:
   data:
     - secretKey: OIDC_CLIENT_SECRET
       remoteRef:
-        key: statement-service
+        key: account-service
         property: OIDC_CLIENT_SECRET

--- a/openbank-infra/gitops/components/tpp-registry/oidc-externalsecret.yaml
+++ b/openbank-infra/gitops/components/tpp-registry/oidc-externalsecret.yaml
@@ -1,6 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # Projects the OIDC client secret for tpp-registry-service from OpenBao (Vault KV) into the
 # tpp-registry namespace so the Deployment can reference it via secretKeyRef.
+#
+# The KV entry is `account-service` — the shared one, not tpp-registry's own. tpp-registry-service
+# authenticates as `openbank-services`, the realm's single confidential M2M client, so a
+# per-service entry would be a hand-seeded copy of that one credential (#3485,
+# rules.yaml: oidc_secret_convention).
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
@@ -24,5 +29,5 @@ spec:
   data:
     - secretKey: OIDC_CLIENT_SECRET
       remoteRef:
-        key: tpp-registry-service
+        key: account-service
         property: OIDC_CLIENT_SECRET

--- a/openbank-infra/scripts/seed-vault-gaps.sh
+++ b/openbank-infra/scripts/seed-vault-gaps.sh
@@ -2,7 +2,6 @@
 # Seed the Vault KV gaps that keep the `secrets` and `glitchtip` ArgoCD apps
 # Degraded (ExternalSecrets failing with "Secret does not exist"):
 #
-#   openbank/audit-service                   OIDC_CLIENT_SECRET
 #   openbank/keycloak-customers-realm-import openbank-customers-realm.json
 #   openbank/glitchtip                       SECRET_KEY + GRAFANA_API_TOKEN
 #   openbank/alertmanager                    SLACK_WEBHOOK   (needs $SLACK_WEBHOOK)
@@ -21,9 +20,10 @@
 #     ./openbank-infra/scripts/seed-vault-gaps.sh
 #
 # Notes:
-# - audit-service uses the SHARED `openbank-services` realm client, so its
-#   OIDC_CLIENT_SECRET equals the value ESO already syncs for the other
-#   services; we copy it from the live account-service-oidc Secret.
+# - There is no OIDC seeding here any more. Every service authenticates as the
+#   one `openbank-services` realm client and every ExternalSecret reads the one
+#   `openbank/account-service` entry (rules.yaml: oidc_secret_convention,
+#   #3485), so a new service needs no KV write at all.
 # - The customers realm JSON comes from the in-repo template (the same source
 #   seed-customers-realm.sh uses — but that script writes to the legacy
 #   `secret/` mount; the ClusterSecretStore reads `openbank/`, used here).
@@ -42,9 +42,11 @@ vault_kv_put() { # key prop=value... (values passed on stdin-safe argv)
     vault kv put "$@" >/dev/null
 }
 
-echo "[1/5] openbank/audit-service (shared openbank-services client secret)"
-OIDC_SECRET="$(kubectl -n accounts get secret account-service-oidc -o jsonpath='{.data.OIDC_CLIENT_SECRET}' | base64 -d)"
-vault_kv_put openbank/audit-service OIDC_CLIENT_SECRET="$OIDC_SECRET"
+echo "[1/5] openbank/audit-service — OBSOLETE, nothing written"
+echo "      audit-service's ExternalSecret now reads the shared openbank/account-service entry"
+echo "      directly (#3485). This step used to COPY that same value into a second KV entry,"
+echo "      which is exactly the duplication the convention removed — writing it again would"
+echo "      recreate an entry no ExternalSecret reads, for the next rotation to miss."
 
 echo "[2/5] openbank/keycloak-customers-realm-import (realm template JSON)"
 kubectl -n vault exec -i openbao-0 -- env VAULT_TOKEN="$VAULT_TOKEN" VAULT_ADDR=http://127.0.0.1:8200 \


### PR DESCRIPTION
## What #3485 deliberately did not do

The convention gate landed with **ten** ExternalSecrets baselined rather than migrated, and its
docstring said exactly why:

> switching a live ExternalSecret's remoteRef re-projects the Secret, and this repo cannot see what
> those KV entries hold. If they hold a stale value the switch is a no-op improvement; if
> `account-service` were the stale one it would break 10 services at once. That is not a call to
> make blind

That was right from inside the repo. It is answerable from outside it.

## The measurement

Read-only against the live KV store, all **eleven** entries — the shared `account-service` one and
the ten per-service ones — hold a value of **identical length and identical digest**. They are
byte-identical copies of the one `openbank-services` client secret.

The digests are deliberately not reproduced in this repo, in a PR body, or in a commit message;
what is recorded is only the equality. The comparison is repeatable read-only by anyone with
operator access.

So this PR is not a risky migration. It deletes ten copies that were never permitted to differ,
and it **cannot change any projected Secret's value**. `mcp-service` is the one that differed in
kind — its manifest said `NOT YET SEEDED` while `optional: true` kept the pod green and its M2M
calls unauthenticated — and it now reads the shared entry like everything else.

## A second defect, in the gate itself

The self-test derived its fixtures from the real `BASELINE`:

```python
a_baselined = next(iter(BASELINE.items()))
```

So emptying the baseline did not turn the exemption and stale-detection cases red — it raised
`StopIteration`, and the self-test could not run at all. **A gate whose falsifiability is derived
from the very data it checks loses that falsifiability exactly when the data goes clean**, which is
the moment it is least visible. `classify` now takes the baseline as a parameter and the self-test
supplies a synthetic one.

## Falsified both ways on this tree

| input | exit | output |
|---|---:|---|
| this branch | **0** | 41 projections, 41 on `account-service`, **0 baselined** |
| `key: sdd-service` re-introduced | **1** | `::error::sdd/oidc-externalsecret.yaml: … read from remoteRef.key \`sdd-service\`` |
| `--self-test` | **0** | 14/14, with the real baseline empty |

`run-gates.py --group gitops` on this branch: **27 gates, PASS=26**. The one non-pass,
`loki-rule-load-test` reporting `UNFALSIFIED`, is **pre-existing on `origin/main`** — verified by
running the same gate in a clean detached worktree at `bd1db8e40`, where it fails identically.

## Relationship to #3610

#3610 attempted the same manifest migration, but also added a second `rules.yaml` block
(`oidc_client_secret_storage`) and a second script. `oidc_secret_convention` landed on `main` in the
meantime, so that half is now a duplicate — which is what its merge conflict was. This PR keeps the
ten manifest edits, drops the duplicated rule and script, and empties the baseline the landed gate
had frozen.

Refs #3485
