### PR TITLE
fix(engagement): consume dispute.opened so an open dispute suppresses marketing

### DIFF
--- a/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/domain/model/Eligibility.kt
+++ b/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/domain/model/Eligibility.kt
@@ -9,21 +9,20 @@ import java.util.UUID
 
 /**
  * The adverse-state set ADR-0220 D1/D3.5 names verbatim: fraud-hold, arrears, dispute-opened,
- * erasure. Three of the four now have a real event to materialise from (issue #2749, verified
+ * erasure. All four now have a real event to materialise from (issues #2749 and #4262, verified
  * against `origin/main` rather than assumed): [ARREARS] (`loan.stage_changed`),
- * [ERASURE_REQUESTED] (`PARTY_ERASED`), and [FRAUD_HOLD] (`fraud.hold_changed`, a new
- * fraud-service signal — repeated REVIEW verdicts, deliberately not a new DECLINE rule; see
- * `FraudHoldService`'s KDoc for why). [DISPUTE_OPENED] is named here for the shape D1/D3.5
- * specifies, but dispute-service's outbox only emits on *resolution*, never on open, so nothing
- * publishes it yet. Do not assume "named in this enum" means "wired"; check the three consumers
- * (`LendingArrearsEventConsumer`, `PartyErasureConsumer`, `FraudHoldEventConsumer`) for what
- * actually is.
+ * [ERASURE_REQUESTED] (`PARTY_ERASED`), [FRAUD_HOLD] (`fraud.hold_changed`, a new fraud-service
+ * signal — repeated REVIEW verdicts, deliberately not a new DECLINE rule; see `FraudHoldService`'s
+ * KDoc for why), and [DISPUTE_OPENED] (`dispute.opened`/`dispute.resolved`, which bracket the
+ * window a customer is in dispute). Do not assume "named in this enum" means "wired"; check the
+ * four consumers (`LendingArrearsEventConsumer`, `PartyErasureConsumer`, `FraudHoldEventConsumer`,
+ * `DisputeOpenedEventConsumer`) for what actually is.
  */
 enum class AdverseState { FRAUD_HOLD, ARREARS, DISPUTE_OPENED, ERASURE_REQUESTED }
 
 /**
  * A pre-computed eligibility snapshot for one party (ADR-0220 D1), materialised event-driven into
- * `party_adverse_state` for the three signals that exist (see [AdverseState]'s KDoc) — this
+ * `party_adverse_state` for the four signals that exist (see [AdverseState]'s KDoc) — this
  * domain layer only defines the shape and the rule over it, not the materialisation pipeline
  * itself.
  */

--- a/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/infrastructure/kafka/DisputeOpenedEventConsumer.kt
+++ b/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/infrastructure/kafka/DisputeOpenedEventConsumer.kt
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.engagement.infrastructure.kafka
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.engagement.application.port.out.AdverseStateRepository
+import com.openbank.engagement.domain.model.AdverseState
+import jakarta.enterprise.context.ApplicationScoped
+import org.eclipse.microprofile.reactive.messaging.Incoming
+import org.jboss.logging.Logger
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * Consumes `openbank-dispute-service`'s `openbank.dispute.events` and materialises the
+ * [AdverseState.DISPUTE_OPENED] quarter of ADR-0220 D1/D3.5's targeting exclusion — the last of
+ * the four `AdverseState` values to get a real signal (issue #4262, after #4252 wired FRAUD_HOLD).
+ *
+ * The topic is SHARED across every dispute lifecycle event (`dispute.opened`, `dispute.resolved`,
+ * `dispute.remediation_requested`), so this consumer must filter on `eventType` — the same idiom
+ * [PartyErasureConsumer] uses on `openbank.party.events`, and unlike [FraudHoldEventConsumer]
+ * whose topic carries exactly one event type. The two types handled here bracket the window
+ * during which a customer is in dispute: `dispute.opened` applies the exclusion,
+ * `dispute.resolved` lifts it. That pairing is why dispute-service carries `partyId` on BOTH
+ * (see `DisputeService.openedOutboxMessage`/`resolvedOutboxMessage`); without the resolved half an
+ * exclusion applied on open would never lift.
+ *
+ * Known cardinality limitation, deliberate and shared with every other signal here:
+ * `party_adverse_state` is keyed by (party, state) with no per-dispute reference, so a party with
+ * two concurrent disputes has the exclusion lifted by whichever resolves first. Erring towards
+ * fewer suppressed marketing surfaces rather than towards a state that can never be cleared, and
+ * matching the existing FRAUD_HOLD/ARREARS shape rather than introducing a second one.
+ *
+ * Poison-pill safe: parse/handle failures are logged and swallowed so one bad event cannot wedge
+ * the consumer group — dispute-service's outbox remains the source of truth and can be replayed.
+ */
+@ApplicationScoped
+class DisputeOpenedEventConsumer(
+    private val adverseState: AdverseStateRepository,
+    private val objectMapper: ObjectMapper,
+) {
+    private val log = Logger.getLogger(DisputeOpenedEventConsumer::class.java)
+
+    @Incoming("dispute-events-in")
+    @Suppress("TooGenericExceptionCaught")
+    suspend fun consume(payload: String) {
+        try {
+            val node = objectMapper.readTree(payload)
+            val eventType = node.path("eventType").asText()
+            if (eventType != EVENT_OPENED && eventType != EVENT_RESOLVED) return
+
+            val partyId = node.path("partyId").asText(null)?.let(UUID::fromString) ?: run {
+                log.warnf("%s missing/unparseable partyId, skipping: %.300s", eventType, payload)
+                return
+            }
+            if (eventType == EVENT_OPENED) {
+                adverseState.setActive(partyId, AdverseState.DISPUTE_OPENED, Instant.now())
+                log.infof("ADR-0220 D3.5: excluded party %s from targeting (dispute.opened)", partyId)
+            } else {
+                adverseState.clearActive(partyId, AdverseState.DISPUTE_OPENED)
+                log.infof("ADR-0220 D3.5: lifted dispute exclusion for party %s (dispute.resolved)", partyId)
+            }
+        } catch (e: Exception) {
+            log.errorf(e, "Failed to handle dispute lifecycle event: %.300s", payload)
+        }
+    }
+
+    private companion object {
+        const val EVENT_OPENED = "dispute.opened"
+        const val EVENT_RESOLVED = "dispute.resolved"
+    }
+}

--- a/openbank-engagement-service/src/main/resources/application.yaml
+++ b/openbank-engagement-service/src/main/resources/application.yaml
@@ -61,7 +61,7 @@ mp:
         key:
           serializer: org.apache.kafka.common.serialization.StringSerializer
     incoming:
-      # group.id / auto.offset.reset for both channels below are set via the
+      # group.id / auto.offset.reset for the channels below are set via the
       # engagement-service-msg-override ConfigMap (override.properties), NOT here — a dotted leaf
       # map key under mp.messaging.incoming.<channel> in YAML never resolves to the plain
       # MicroProfile Config property name SmallRye reads (issue #686, ADR-0137 pattern).
@@ -78,6 +78,11 @@ mp:
       fraud-hold-events-in:
         connector: smallrye-kafka
         topic: openbank.fraud.hold.changed
+        value.deserializer: org.apache.kafka.common.serialization.StringDeserializer
+        key.deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      dispute-events-in:
+        connector: smallrye-kafka
+        topic: openbank.dispute.events
         value.deserializer: org.apache.kafka.common.serialization.StringDeserializer
         key.deserializer: org.apache.kafka.common.serialization.StringDeserializer
 

--- a/openbank-engagement-service/src/test/kotlin/com/openbank/engagement/infrastructure/kafka/DisputeOpenedEventConsumerTest.kt
+++ b/openbank-engagement-service/src/test/kotlin/com/openbank/engagement/infrastructure/kafka/DisputeOpenedEventConsumerTest.kt
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.engagement.infrastructure.kafka
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.engagement.application.port.out.AdverseStateRepository
+import com.openbank.engagement.domain.model.AdverseState
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+/**
+ * The payloads below are copied from `DisputeService.openedOutboxMessage` /
+ * `resolvedOutboxMessage` in `openbank-dispute-service` (the hand-built JSON strings that are the
+ * actual wire format), not invented — a consumer test written against a payload the producer never
+ * emits is green about nothing.
+ */
+class DisputeOpenedEventConsumerTest {
+
+    private val adverseState = mockk<AdverseStateRepository>(relaxed = true)
+    private val consumer = DisputeOpenedEventConsumer(adverseState, ObjectMapper())
+
+    private fun opened(partyId: UUID) =
+        """{"eventType":"dispute.opened","disputeId":"${UUID.randomUUID()}","reference":"DSP-1",""" +
+            """"partyId":"$partyId","disputeType":"UNAUTHORISED_TRANSACTION","status":"OPEN",""" +
+            """"openedAt":"2026-08-09T10:00:00Z"}"""
+
+    private fun resolved(partyId: UUID) =
+        """{"eventType":"dispute.resolved","disputeId":"${UUID.randomUUID()}","reference":"DSP-1",""" +
+            """"partyId":"$partyId","outcome":"UPHELD","status":"RESOLVED",""" +
+            """"resolvedAt":"2026-08-09T12:00:00Z","occurredAt":"2026-08-09T12:00:00Z"}"""
+
+    @Test
+    fun `dispute opened sets DISPUTE_OPENED active`(): Unit = runBlocking {
+        val partyId = UUID.randomUUID()
+        consumer.consume(opened(partyId))
+        coVerify(exactly = 1) { adverseState.setActive(partyId, AdverseState.DISPUTE_OPENED, any()) }
+    }
+
+    @Test
+    fun `dispute resolved lifts the exclusion`(): Unit = runBlocking {
+        val partyId = UUID.randomUUID()
+        consumer.consume(resolved(partyId))
+        coVerify(exactly = 1) { adverseState.clearActive(partyId, AdverseState.DISPUTE_OPENED) }
+        coVerify(exactly = 0) { adverseState.setActive(any(), any(), any()) }
+    }
+
+    @Test
+    fun `another event type on the shared topic is ignored`(): Unit = runBlocking {
+        // openbank.dispute.events carries three event types; only two of them are ours.
+        consumer.consume(
+            """{"eventType":"dispute.remediation_requested","partyId":"${UUID.randomUUID()}",""" +
+                """"amount":"100.00","currency":"CZK"}""",
+        )
+        coVerify(exactly = 0) { adverseState.setActive(any(), any(), any()) }
+        coVerify(exactly = 0) { adverseState.clearActive(any(), any()) }
+    }
+
+    @Test
+    fun `malformed payload is acked without applying anything or throwing`(): Unit = runBlocking {
+        consumer.consume("not json")
+        consumer.consume("""{"eventType":"dispute.opened"}""") // no partyId
+        consumer.consume("""{"eventType":"dispute.opened","partyId":"not-a-uuid"}""")
+        coVerify(exactly = 0) { adverseState.setActive(any(), any(), any()) }
+        coVerify(exactly = 0) { adverseState.clearActive(any(), any()) }
+    }
+}

--- a/openbank-infra/gitops/components/engagement/kafka-engagement-mtls.yaml
+++ b/openbank-infra/gitops/components/engagement/kafka-engagement-mtls.yaml
@@ -16,6 +16,7 @@
 #   Read  + Describe: openbank.lending.events        (LendingArrearsEventConsumer, ADR-0220 D3.5)
 #   Read  + Describe: openbank.party.events          (PartyErasureConsumer, ADR-0220 D3.5)
 #   Read  + Describe: openbank.fraud.hold.changed    (FraudHoldEventConsumer, ADR-0220 D3.5, #2749)
+#   Read  + Describe: openbank.dispute.events        (DisputeOpenedEventConsumer, ADR-0220 D3.5, #4262)
 #   Read:             group openbank-engagement-service
 #
 # The fraud-hold grant is NOT deferred like the two above were: `fraud-hold-events-in`'s
@@ -23,6 +24,10 @@
 # there is no image/config ordering gap for check-msg-channel-image-parity.py to catch — that
 # guard is about a GitOps *ConfigMap* declaring a channel override ahead of its image, and this
 # is a KafkaUser ACL grant, not a msg-override ConfigMap.
+#
+# The dispute grant (#4262) has the same shape: `dispute-events-in`'s `connector:` and this ACL
+# land in one PR. Its group.id/auto.offset.reset stay OUT of engagement-service-msg-override until
+# the deployed image carries the channel, exactly as fraud-hold-events-in's still do.
 #
 # Cert projection: Strimzi User Operator mints the keystore Secret in `messaging`;
 # the ExternalSecrets below project it into `engagement` via the kafka-messaging-certs
@@ -65,6 +70,12 @@ spec:
       - resource:
           type: topic
           name: openbank.fraud.hold.changed
+          patternType: literal
+        operations: [Read, Describe]
+        host: "*"
+      - resource:
+          type: topic
+          name: openbank.dispute.events
           patternType: literal
         operations: [Read, Describe]
         host: "*"


### PR DESCRIPTION
## What

Wires the last of ADR-0220 D1/D3.5's four `AdverseState` signals. `ARREARS`,
`ERASURE_REQUESTED` and `FRAUD_HOLD` each had a consumer; `DISPUTE_OPENED` existed only as an
enum literal and in comments — no `setActive` call site anywhere — so a party with an open
dispute was **not** excluded from marketing surfaces.

Closes #4262

## Topic and payload, derived from the producer

Read out of `openbank-dispute-service/src/main/kotlin/com/openbank/dispute/application/usecase/DisputeService.kt`
(`openedOutboxMessage` / `resolvedOutboxMessage`, landed by #4087) and its
`application.yaml` outgoing channel `dispute-outbox-out`:

- **Topic**: `openbank.dispute.events` — one topic for the whole dispute lifecycle, carrying
  `dispute.opened`, `dispute.resolved` and `dispute.remediation_requested`. Not a dedicated
  per-event topic like fraud-hold's, so the consumer **must** filter on `eventType`, the
  `PartyErasureConsumer` idiom rather than the `FraudHoldEventConsumer` one.
- **Payload**: a hand-built JSON string, so the field names are literals in the producer source
  (no serialised data class to reason about here):
  `eventType`, `disputeId`, `reference`, `partyId`, `disputeType`, `status`, `openedAt`.
- **Party identifier**: `partyId`, added deliberately alongside `dispute.opened` and mirrored on
  `dispute.resolved` — the producer's own KDoc says the pair brackets the window a customer is in
  dispute so a consumer can both apply and lift the exclusion. This consumer does exactly that:
  `dispute.opened` -> `setActive(DISPUTE_OPENED)`, `dispute.resolved` -> `clearActive`.

The test payloads are copied from those two producer methods rather than invented.

## Falsification — what the test MUST flag, and did

A test that passes against the unwired code proves nothing, so both halves were fed a defect and
run:

| injected defect | expected | measured |
|---|---|---|
| `EVENT_OPENED` literal changed `dispute.opened` -> `DISPUTE_OPENED` (i.e. a guessed event name instead of the producer's) | red | `4 tests completed, 1 failed` — `dispute opened sets DISPUTE_OPENED active` FAILED |
| both `setActive`/`clearActive` calls replaced by `Unit` (the pre-PR state: consumer present, nothing wired) | red | `4 tests completed, 2 failed` |
| ACL half: `openbank.dispute.events` Read/Describe grant removed from the KafkaUser | red | `kafka-acl-coverage` gate FAIL=1 |

Restored, all four test cases green — and all four *ran*, read from the JUnit XML
(`36 tests / 0 failures / 0 skipped` for the module), not from the console, since a
`fun x() = runBlocking {}` is silently ignored by JUnit5. Every test here is `(): Unit = runBlocking`.

## Traps checked explicitly

- **No dotted leaf key introduced.** `group.id` / `auto.offset.reset` are absent from the new
  channel block, matching the three siblings — SmallRye's YAML source quotes a dotted leaf key and
  the connector silently uses its default (#686). They also stay out of
  `engagement-service-msg-override` until the deployed image carries the channel, the same state
  `fraud-hold-events-in` is in — a ConfigMap declaring a channel ahead of its image is what
  `check-msg-channel-image-parity.py` blocks.
- **`application.yaml` duplicate keys**: verified with a strict loader that raises on a repeated
  mapping key, and the loader itself validated against a known-positive first
  (`yaml.safe_load` returned `{'a': {'b': 2}}` for the same input, i.e. proves nothing).
- **detekt `LongParameterList`**: constructor is 2 params, nowhere near the threshold-9 rule.
- **No DB in the test** — it drives the consumer against a mocked `AdverseStateRepository`, so no
  reactive-Panache-on-a-bare-thread problem arises.
- Does not touch `ResolveSurfaceUseCase.kt`, so no conflict with open PR #4294.

## Local gate — tasks that actually ran

```
:openbank-engagement-service:detekt              (executed, then UP-TO-DATE)
:openbank-engagement-service:ktlintCheck         (+ main/test/script source-set checks)
:openbank-engagement-service:test                36 tests, 0 failures, 0 skipped
:openbank-engagement-service:quarkusBuild        (CDI wiring — the new @ApplicationScoped bean)
BUILD SUCCESSFUL — 42 actionable tasks executed
```

Relevant CI gates run locally, all PASS:
`msg-channel-image-parity`, `gitops-duplicate-resources`, `kafka-cert-reader-grant`,
`kafka-topic-existence`, `kafka-acl-coverage`, `duplicate-yaml-key-guard`,
`event-contract-coverage-ratchet`, `kafka-dotted-key-ratchet`.

## Known limitation, documented in the KDoc rather than hidden

`party_adverse_state` is keyed by (party, state) with no per-dispute reference, so a party with
two concurrent disputes has the exclusion lifted by whichever resolves first. Erring towards fewer
suppressed surfaces rather than a state that can never clear, and matching the existing
FRAUD_HOLD/ARREARS shape rather than introducing a second one.
