### PR TITLE
test(document-service): replay the sepa-payment confirmation contract on every PR

### DIFF
--- a/openbank-document-service/build.gradle.kts
+++ b/openbank-document-service/build.gradle.kts
@@ -50,8 +50,15 @@ dependencies {
     implementation(libs.bouncycastle.bcprov)
     implementation(libs.bouncycastle.bcpkix)
     testImplementation(libs.quarkus.junit5)
+    testImplementation(libs.quarkus.test.security)
     testImplementation(libs.assertj)
     testImplementation(libs.mockk)
+    // ADR-0063: document-service is a pact PROVIDER. sepa-payment renders the customer's payment
+    // confirmation through this service's template list + preview endpoints (ADR-0248 #3), and
+    // until DocumentPactProviderVerificationTest nothing replayed that contract — the only cover
+    // was sepa-payment's own WireMock stub, which is written from the client and so cannot
+    // disagree with it (the #2269 shape).
+    testImplementation(libs.pact.provider)
     // AuditEventTime — the ONE copy of the rule openbank-audit-service's AuditConsumer applies to
     // a domain-event payload, so this service's producer tests assert against the real contract
     // rather than a per-service restatement of it (#3914).
@@ -61,6 +68,25 @@ dependencies {
     testImplementation(libs.testcontainers)
     testImplementation(libs.testcontainers.junit)
     testImplementation(libs.testcontainers.postgresql)
+}
+
+// Pact: resolve the git-pact folder and forward broker config for provider verification
+// (ADR-0063). pactbroker.* / pact.provider.* props are injected by CI with -D; on a pull request
+// none of them are set, and DocumentPactProviderVerificationTest is @PactFolder-sourced, so it
+// runs regardless — that is the point (issue #2338).
+tasks.withType<Test> {
+    systemProperty("pact.rootDir", "${rootProject.projectDir}/pacts")
+    listOf(
+        "pactbroker.url",
+        "pactbroker.auth.username",
+        "pactbroker.auth.password",
+        "pactbroker.enablePending",
+        "pactbroker.providerBranch",
+        "pact.verifier.publishResults",
+        "pact.provider.version",
+        "pact.provider.branch",
+        "pact.provider.tag",
+    ).forEach { key -> System.getProperty(key)?.let { systemProperty(key, it) } }
 }
 
 kover {

--- a/openbank-document-service/src/test/kotlin/com/openbank/document/contract/DocumentPactProviderVerificationTest.kt
+++ b/openbank-document-service/src/test/kotlin/com/openbank/document/contract/DocumentPactProviderVerificationTest.kt
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.document.contract
+
+import au.com.dius.pact.provider.junit5.HttpTestTarget
+import au.com.dius.pact.provider.junit5.PactVerificationContext
+import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvider
+import au.com.dius.pact.provider.junitsupport.IgnoreNoPactsToVerify
+import au.com.dius.pact.provider.junitsupport.Provider
+import au.com.dius.pact.provider.junitsupport.State
+import au.com.dius.pact.provider.junitsupport.loader.PactFolder
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.security.TestSecurity
+import org.eclipse.microprofile.config.inject.ConfigProperty
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.TestTemplate
+import org.junit.jupiter.api.extension.ExtendWith
+
+/**
+ * Provider-side Pact verification for the contracts consumers publish against
+ * `openbank-document-service`. The first is `openbank-sepa-payment`'s payment-confirmation render
+ * (ADR-0248 #3): `GET /api/v1/documents/templates` then
+ * `POST /api/v1/documents/templates/preview` — see `SepaPaymentDocumentServicePactConsumerTest`.
+ *
+ * **Why this class is the load-bearing half.** A consumer pact ALONE cannot catch a wrong request
+ * path: the Pact mock server answers whatever path the client asks for, so pointing a client at a
+ * route that does not exist leaves the consumer test green. Only replaying the committed pact
+ * against the real, running provider goes red — the #2269 lesson. sepa-payment's pre-existing cover
+ * for these two calls was `DocumentServiceWireMockResource`, a consumer-authored stub that
+ * hard-codes the same paths the client sends, and a stub written from the client cannot disagree
+ * with it.
+ *
+ * `@PactFolder("../pacts")` and UNGATED, on purpose. A `@PactBroker` class would not do: the PR
+ * lane blanks `PACT_BROKER_URL` (the broker has no public ingress, ADR-0056), so an
+ * `@EnabledIfSystemProperty(pactbroker.url)` gate skips and the contract would be replayed only
+ * after the merge — the state 16 of 27 pacts were in when #2327 was measured.
+ * `check-pact-provider-replay.py` (gate `pact-provider-replay-coverage`) enforces exactly this
+ * shape.
+ *
+ * `@IgnoreNoPactsToVerify(ignoreIoErrors)` makes a missing/unreadable pact folder a skip rather
+ * than a failure, matching every other `@PactFolder` provider class in the fleet.
+ *
+ * IMPORTANT: if `SepaPaymentDocumentServicePactConsumerTest` changes the contract, regenerate
+ * (`./gradlew :openbank-sepa-payment:test --tests "*SepaPaymentDocumentServicePactConsumerTest*"`)
+ * and commit the updated `pacts/openbank-sepa-payment-openbank-document-service.json` in the same
+ * PR, or this test replays a stale contract.
+ */
+@QuarkusTest
+@QuarkusTestResource(com.openbank.document.it.PostgresRedisTestResource::class)
+@TestSecurity(user = "pact-verifier", roles = ["ROLE_API", "ROLE_OPERATOR"])
+@Provider("openbank-document-service")
+@PactFolder("../pacts")
+@IgnoreNoPactsToVerify(ignoreIoErrors = "true")
+class DocumentPactProviderVerificationTest {
+
+    @ConfigProperty(name = "quarkus.http.test-port", defaultValue = "8081")
+    lateinit var testPort: String
+
+    @BeforeEach
+    fun configureTarget(context: PactVerificationContext?) {
+        context?.target = HttpTestTarget("localhost", testPort.toInt())
+        context?.addStateChangeHandlers(this)
+    }
+
+    @TestTemplate
+    @ExtendWith(PactVerificationInvocationContextProvider::class)
+    fun verifyPacts(context: PactVerificationContext?) {
+        context?.verifyInteraction()
+    }
+
+    /**
+     * No seeding needed, and that is a property of the provider rather than an omission:
+     * `DocumentTemplateSeeder` runs on EVERY boot (`@Observes StartupEvent`) and inserts the six
+     * canonical templates — including the `POTVRZENI_O_PLATBE_CS`/`_EN` payment confirmations this
+     * contract is about — into whatever database the service starts against, so the fresh
+     * Testcontainer DB this test boots on already satisfies the state. Seeding again through the
+     * repository would only assert that the fixture works.
+     */
+    @State("the canonical document templates are seeded and published")
+    fun stateTemplatesSeeded() {
+        // Intentionally empty — see the KDoc above.
+    }
+
+    /**
+     * `previewTemplate` is stateless and non-persisting by design (ADR-0248 #3): it merges a
+     * caller-supplied `bodyHtml` with a caller-supplied data map through Handlebars and returns
+     * the result. No `Document` row, no outbox event, nothing to set up.
+     */
+    @State("the template preview renderer is available")
+    fun statePreviewRendererAvailable() {
+        // Intentionally empty — see the KDoc above.
+    }
+}

--- a/openbank-sepa-payment/src/test/kotlin/com/openbank/sepa/contract/SepaPaymentDocumentServicePactConsumerTest.kt
+++ b/openbank-sepa-payment/src/test/kotlin/com/openbank/sepa/contract/SepaPaymentDocumentServicePactConsumerTest.kt
@@ -1,0 +1,234 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.sepa.contract
+
+import au.com.dius.pact.consumer.MockServer
+import au.com.dius.pact.consumer.dsl.LambdaDsl.newJsonArrayMinLike
+import au.com.dius.pact.consumer.dsl.LambdaDsl.newJsonBody
+import au.com.dius.pact.consumer.dsl.PactDslWithProvider
+import au.com.dius.pact.consumer.junit5.PactConsumerTestExt
+import au.com.dius.pact.consumer.junit5.PactTestFor
+import au.com.dius.pact.core.model.PactSpecVersion
+import au.com.dius.pact.core.model.RequestResponsePact
+import au.com.dius.pact.core.model.annotations.Pact
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import com.openbank.sepa.infrastructure.client.DocumentServiceClient
+import com.openbank.sepa.infrastructure.client.DocumentTemplateClientResponse
+import com.openbank.sepa.infrastructure.client.PreviewTemplateClientRequest
+import com.openbank.sepa.infrastructure.client.PreviewTemplateClientResponse
+import io.restassured.RestAssured.given
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.QueryParam
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+/**
+ * Consumer-driven contract for the two `openbank-document-service` calls that render a SEPA
+ * payment confirmation (ADR-0248 #3): `GET /api/v1/documents/templates` to resolve the PUBLISHED
+ * `bodyHtml` for a template code, then `POST /api/v1/documents/templates/preview` to merge the
+ * payment's data into it. Both are driven by
+ * [com.openbank.sepa.infrastructure.client.DocumentPreviewAdapter] on the synchronous,
+ * customer-facing "download my confirmation" click, and the adapter is fail-CLOSED — a
+ * document-service contract break surfaces to the customer as a failed download, immediately.
+ *
+ * **Why this test exists.** Before it, ZERO of the 42 committed pacts named document-service as a
+ * provider, while three merged services held live REST clients calling it. sepa-payment's only
+ * cover was `DocumentServiceWireMockResource` — a CONSUMER-AUTHORED fixture that hard-codes the
+ * very paths and payloads the client sends, so it agrees with the client by construction and can
+ * never disagree with the provider. That is exactly the configuration that let finrep-service ship
+ * a call to `/api/v1/ledger/trial-balance`, a ledger route that has never existed, with green unit
+ * tests (#2269). A stub cannot falsify the client it was written from; only the provider can.
+ *
+ * **The two sides are deliberately sourced differently.** Each interaction declares the contract as
+ * a LITERAL ([TEMPLATES_PATH], [PREVIEW_PATH], [LIMIT_PARAM]); the REQUESTS are issued against
+ * [templatesPath] / [previewPath] / [limitQueryParam], derived by reflection from
+ * [DocumentServiceClient]'s own `@Path` and `@QueryParam` annotations. That asymmetry IS the test:
+ * the pact mock server fails when the production client is annotated with anything other than the
+ * contract path, and the provider-side replay of the committed pact fails if document-service ever
+ * moves the endpoint. Deriving BOTH sides from the annotation is DRY and vacuous — expectation and
+ * request move together, so the test stays green against a client pointing anywhere at all (#2290).
+ *
+ * The provider replay lives in `DocumentPactProviderVerificationTest` (openbank-document-service),
+ * `@PactFolder("../pacts")` and ungated, so it runs on every pull request — a `@PactBroker` class
+ * would not: the PR lane blanks `PACT_BROKER_URL` (ADR-0056), so its
+ * `@EnabledIfSystemProperty(pactbroker.url)` gate skips and the contract would be replayed only
+ * after the merge (#2327).
+ *
+ * IMPORTANT — regenerate on change: if this test's `@Pact` methods change, re-run
+ * (`./gradlew :openbank-sepa-payment:test --tests "*SepaPaymentDocumentServicePactConsumerTest*"`)
+ * and commit the updated `pacts/openbank-sepa-payment-openbank-document-service.json` in the same
+ * PR — an un-regenerated pact silently verifies the OLD contract on the provider side.
+ * `pact-drift-check.yml` enforces this over a scope derived from the `@Pact` annotations.
+ */
+@ExtendWith(PactConsumerTestExt::class)
+@PactTestFor(providerName = "openbank-document-service", pactVersion = PactSpecVersion.V3)
+class SepaPaymentDocumentServicePactConsumerTest {
+
+    private val json = jacksonObjectMapper()
+
+    @Pact(consumer = "openbank-sepa-payment", provider = "openbank-document-service")
+    fun listTemplatesPact(builder: PactDslWithProvider): RequestResponsePact = builder
+        .given("the canonical document templates are seeded and published")
+        .uponReceiving("GET the document templates to resolve a PUBLISHED payment-confirmation body")
+        .path(TEMPLATES_PATH)
+        .query("$LIMIT_PARAM=$TEMPLATE_LIST_LIMIT")
+        .method("GET")
+        .headers(mapOf("Accept" to "application/json"))
+        .willRespondWith()
+        .status(200)
+        .headers(mapOf("Content-Type" to "application/json"))
+        .body(
+            // stringType on every element field, DELIBERATELY (issue #2425): the template list is
+            // HETEROGENEOUS — document-service seeds six templates across three codes and two
+            // locales, in DRAFT / PUBLISHED / RETIRED states. Pinning `code` or `status` to a value
+            // would assert "every template is POTVRZENI_O_PLATBE_EN, and every one is PUBLISHED",
+            // a claim the contract does not make and the provider's own seed data falsifies on the
+            // first run. What the consumer actually needs from the contract is that the three
+            // fields it filters and reads on are PRESENT and are strings — the selection itself is
+            // the adapter's business, covered by DocumentPreviewAdapterTest.
+            newJsonArrayMinLike(1) { a ->
+                a.`object` { t ->
+                    t.stringType("code", "POTVRZENI_O_PLATBE_EN")
+                    t.stringType("status", "PUBLISHED")
+                    t.stringType("bodyHtml", "<p>{{document.status}}</p>")
+                    t.stringType("locale", "en")
+                }
+            }.build(),
+        )
+        .toPact()
+
+    @Pact(consumer = "openbank-sepa-payment", provider = "openbank-document-service")
+    fun previewTemplatePact(builder: PactDslWithProvider): RequestResponsePact = builder
+        .given("the template preview renderer is available")
+        .uponReceiving("POST a template body plus payment data to render the confirmation HTML")
+        .path(PREVIEW_PATH)
+        .method("POST")
+        .headers(mapOf("Content-Type" to "application/json"))
+        .body(json.writeValueAsString(PREVIEW_REQUEST))
+        .willRespondWith()
+        .status(200)
+        .headers(mapOf("Content-Type" to "application/json"))
+        .body(
+            // stringType, NOT stringValue: `renderedHtml` is the Handlebars OUTPUT, so pinning it
+            // would make every whitespace or letterhead change in the renderer a contract break.
+            // The claim under contract is that a non-persisting preview answers 200 with a
+            // `renderedHtml` string — which is the field, and the only field, the adapter returns.
+            newJsonBody { o -> o.stringType("renderedHtml", "<p>COMPLETED</p>") }.build(),
+        )
+        .toPact()
+
+    @Test
+    @PactTestFor(pactMethod = "listTemplatesPact")
+    fun `the template list carries the code, status and body the confirmation adapter reads`(mockServer: MockServer) {
+        // Guards the reflection helpers themselves: were they ever to return an empty or partial
+        // path, the interaction and the request would still agree with each other and both pact
+        // tests would pass against a contract that pins nothing.
+        assertThat(templatesPath).isEqualTo(TEMPLATES_PATH)
+        assertThat(limitQueryParam).isEqualTo(LIMIT_PARAM)
+
+        val body = given()
+            .baseUri(mockServer.getUrl())
+            .accept("application/json")
+            .queryParam(limitQueryParam, TEMPLATE_LIST_LIMIT)
+            .get(templatesPath)
+            .then()
+            .statusCode(200)
+            .extract().body().asString()
+
+        val templates: List<DocumentTemplateClientResponse> = json.readValue(body)
+        assertThat(templates).isNotEmpty()
+        // All three fields DocumentPreviewAdapter touches must deserialize into the client DTO:
+        // it filters on `code` + `status` and then sends `bodyHtml` on to the preview call.
+        val template = templates.first()
+        assertThat(template.code).isNotBlank()
+        assertThat(template.status).isNotBlank()
+        assertThat(template.bodyHtml).isNotBlank()
+    }
+
+    @Test
+    @PactTestFor(pactMethod = "previewTemplatePact")
+    fun `preview returns the rendered confirmation HTML for the template body and payment data`(
+        mockServer: MockServer,
+    ) {
+        assertThat(previewPath).isEqualTo(PREVIEW_PATH)
+
+        val body = given()
+            .baseUri(mockServer.getUrl())
+            .contentType("application/json")
+            .body(json.writeValueAsString(PREVIEW_REQUEST))
+            .post(previewPath)
+            .then()
+            .statusCode(200)
+            .extract().body().asString()
+
+        val response: PreviewTemplateClientResponse = json.readValue(body)
+        assertThat(response.renderedHtml).isNotBlank()
+    }
+
+    private companion object {
+        /**
+         * The contract, written out LITERALLY on purpose: openbank-document-service serves the
+         * bounded template list here (`DocumentResource.listTemplates`, `@Path("/api/v1/documents")`
+         * + `@Path("/templates")`).
+         *
+         * It must NOT be derived from [DocumentServiceClient] like [templatesPath] is. Deriving
+         * both sides from the same annotation makes the interaction and the request move together,
+         * so the pact mock server always sees exactly what it expects and the test passes against a
+         * client pointing anywhere at all. The literal is the fixed point the annotation is
+         * measured against.
+         */
+        const val TEMPLATES_PATH = "/api/v1/documents/templates"
+
+        /** Likewise literal: `DocumentResource.previewTemplate`, the non-persisting render. */
+        const val PREVIEW_PATH = "/api/v1/documents/templates/preview"
+
+        /** document-service's query-parameter name for the list bound — likewise literal. */
+        const val LIMIT_PARAM = "limit"
+
+        /** Mirrors `DocumentPreviewAdapter.TEMPLATE_LIST_LIMIT`, the bound the adapter sends. */
+        const val TEMPLATE_LIST_LIMIT = 200
+
+        /**
+         * The exact body the adapter posts: the PUBLISHED template body it just resolved, plus the
+         * payment data map `PaymentConfirmationMapper` builds. Kept minimal — the contract is the
+         * two-field envelope, not the confirmation's field vocabulary, which is the mapper's own
+         * unit-tested business.
+         */
+        val PREVIEW_REQUEST = PreviewTemplateClientRequest(
+            bodyHtml = "<p>{{document.status}}</p>",
+            data = mapOf("document" to mapOf("status" to "COMPLETED")),
+        )
+
+        private val listTemplatesMethod =
+            DocumentServiceClient::class.java.getDeclaredMethod("listTemplates", Int::class.javaPrimitiveType)
+
+        private val previewMethod =
+            DocumentServiceClient::class.java.getDeclaredMethod("preview", PreviewTemplateClientRequest::class.java)
+
+        private val interfacePath: String =
+            DocumentServiceClient::class.java.getAnnotation(Path::class.java).value
+
+        /**
+         * The interface `@Path` alone — `listTemplates` carries no method-level `@Path`. Read from
+         * the production client so the contract cannot drift from the code that calls it.
+         */
+        val templatesPath: String = "/" + interfacePath.trim('/')
+
+        /** Interface `@Path` + method `@Path`, joined the way JAX-RS resolves them. */
+        val previewPath: String = listOf(
+            interfacePath,
+            previewMethod.getAnnotation(Path::class.java).value,
+        ).joinToString("/") { it.trim('/') }.let { "/$it" }
+
+        /** The query-parameter name the production client sends the list bound under. */
+        val limitQueryParam: String = listTemplatesMethod.parameterAnnotations
+            .flatMap { it.toList() }
+            .filterIsInstance<QueryParam>()
+            .single()
+            .value
+    }
+}

--- a/pacts/openbank-sepa-payment-openbank-document-service.json
+++ b/pacts/openbank-sepa-payment-openbank-document-service.json
@@ -1,0 +1,141 @@
+{
+  "consumer": {
+    "name": "openbank-sepa-payment"
+  },
+  "interactions": [
+    {
+      "description": "GET the document templates to resolve a PUBLISHED payment-confirmation body",
+      "providerStates": [
+        {
+          "name": "the canonical document templates are seeded and published"
+        }
+      ],
+      "request": {
+        "headers": {
+          "Accept": "application/json"
+        },
+        "method": "GET",
+        "path": "/api/v1/documents/templates",
+        "query": {
+          "limit": [
+            "200"
+          ]
+        }
+      },
+      "response": {
+        "body": [
+          {
+            "bodyHtml": "<p>{{document.status}}</p>",
+            "code": "POTVRZENI_O_PLATBE_EN",
+            "locale": "en",
+            "status": "PUBLISHED"
+          }
+        ],
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "matchingRules": {
+          "body": {
+            "$": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type",
+                  "min": 1
+                }
+              ]
+            },
+            "$[*].bodyHtml": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$[*].code": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$[*].locale": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$[*].status": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        },
+        "status": 200
+      }
+    },
+    {
+      "description": "POST a template body plus payment data to render the confirmation HTML",
+      "providerStates": [
+        {
+          "name": "the template preview renderer is available"
+        }
+      ],
+      "request": {
+        "body": {
+          "bodyHtml": "<p>{{document.status}}</p>",
+          "data": {
+            "document": {
+              "status": "COMPLETED"
+            }
+          }
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "method": "POST",
+        "path": "/api/v1/documents/templates/preview"
+      },
+      "response": {
+        "body": {
+          "renderedHtml": "<p>COMPLETED</p>"
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "matchingRules": {
+          "body": {
+            "$.renderedHtml": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        },
+        "status": 200
+      }
+    }
+  ],
+  "metadata": {
+    "pact-jvm": {
+      "version": "4.7.3"
+    },
+    "pactSpecification": {
+      "version": "3.0.0"
+    }
+  },
+  "provider": {
+    "name": "openbank-document-service"
+  }
+}


### PR DESCRIPTION
## The gap, measured

On `origin/main` today: **0 of the 42 committed pacts** name `openbank-document-service` as a
provider, while **three merged services** hold live REST clients calling it synchronously:

| consumer | client | calls |
|---|---|---|
| `openbank-sepa-payment` | `infrastructure/client/DocumentServiceClient.kt` | list templates + preview |
| `openbank-domestic-payment` | `infrastructure/client/DocumentServiceClient.kt` | list templates + preview |
| `openbank-statement-service` | `infrastructure/client/DocumentRestClients.kt` | list templates + preview |

sepa-payment additionally carries `DocumentServiceWireMockResource` — a **consumer-authored**
fixture that hard-codes the same paths and payloads the client sends. It agrees with the client by
construction and can never disagree with the provider. That is precisely the configuration that let
finrep-service ship a call to `/api/v1/ledger/trial-balance`, a ledger path that has never existed,
while its unit tests passed (#2269).

## What this PR wires

One complete contract, not three partial ones. sepa-payment is the pick: it is a
`money_path_services` entry, and its `DocumentPreviewAdapter` is **fail-closed** on the
synchronous, customer-facing "download my payment confirmation" click (ADR-0248 #3) — a
document-service contract break surfaces to the customer immediately, as a failed download.

1. **Consumer pact** — `SepaPaymentDocumentServicePactConsumerTest`
   (`openbank-sepa-payment`), two interactions:
   `GET /api/v1/documents/templates?limit=200` (resolve the PUBLISHED `bodyHtml`) and
   `POST /api/v1/documents/templates/preview` (merge the payment data into it).
2. **Provider replay** — `DocumentPactProviderVerificationTest` (`openbank-document-service`),
   `@PactFolder("../pacts")` and **ungated**, so it runs on a pull request. A `@PactBroker` class
   would not count: the PR lane blanks `PACT_BROKER_URL` (the broker has no public ingress,
   ADR-0056), so its `@EnabledIfSystemProperty(pactbroker.url)` gate skips and the contract would be
   replayed only *after* the merge — the state 16 of 27 pacts were in when #2327 was measured.
   `openbank-document-service/build.gradle.kts` declares no `exclude(...)` /
   `excludeTestsMatching(...)`, so nothing drops it in CI.
3. **Committed pact** — `pacts/openbank-sepa-payment-openbank-document-service.json`.

`openbank-document-service/build.gradle.kts` gains `libs.pact.provider` +
`libs.quarkus.test.security` and the pact system-property forwarding block every provider module
carries.

No provider-state seeding is needed, and that is a property of the provider rather than an
omission: `DocumentTemplateSeeder` runs on **every** boot (`@Observes StartupEvent`), so the fresh
Testcontainer DB the verification boots against already carries the `POTVRZENI_O_PLATBE_CS`/`_EN`
templates this contract is about.

## The design rule: the expected path is a LITERAL

In the consumer test each interaction declares the contract as a string literal
(`TEMPLATES_PATH`, `PREVIEW_PATH`, `LIMIT_PARAM`). Only the **outgoing request** is reflected off
`DocumentServiceClient`'s own `@Path` / `@QueryParam` annotations. Deriving both sides from the
annotation is DRY and vacuous: expectation and request move together, so the test stays green when
the client points at a route that does not exist. **The asymmetry IS the test.**

Two guard assertions (`assertThat(templatesPath).isEqualTo(TEMPLATES_PATH)` and the `previewPath`
twin) cover the reflection helpers themselves — were they to return an empty or partial path, the
interaction and the request would still agree with each other and both pact tests would pass
against a contract that pins nothing.

## Falsification — measured, not asserted

Temporarily repointed the client's interface `@Path` from `/api/v1/documents/templates` to
`/api/v1/documents/template-catalog`, a route document-service does not serve. Verdicts read from
the **JUnit XML**, not the console — pact-jvm prints `Not all of the N were verified` even on a
fully green run.

| # | configuration | consumer test | provider replay |
|---|---|---|---|
| 1 | bad client `@Path` **and** matching literals (the vacuous, symmetric shape) | **GREEN** 2 tests / 0 failures | **RED** 2 tests / **2 failures** |
| 2 | bad client `@Path`, literals restored (the shape in this PR) | **RED** 2 tests / **2 failures** | — |
| 3 | everything restored, pact regenerated | **GREEN** 2 / 0 | **GREEN** 2 tests / 0 failures / 0 skipped |

Row 1 is the whole point, and it reproduces #2269 exactly: a consumer pact **alone cannot** catch a
wrong request path — the Pact mock server answers whatever path the client asks for — and only the
provider replay goes red. Row 2 shows the literal recovering the signal at the consumer layer too:

```
expected: "/api/v1/documents/templates"
 but was: "/api/v1/documents/template-catalog"
```

## Gate output

```
$ python3 .github/scripts/run-gates.py --only pact-provider-replay-coverage
  RUNS  openbank-document-service   .../contract/DocumentPactProviderVerificationTest.kt  [runs]
OK - every committed pact is either replayed on a PR or a declared, still-accurate exception.
1 gates  PASS=1
```

`KNOWN_UNCOVERED` in `check-pact-provider-replay.py` **stays empty** — this PR adds no debt to it.
`check-pacticipant-matches-module.py`: 22 distinct provider names across **43** pacts (42 + this
one), every one a Gradle module directory. `derive-pact-drift-scope.sh` already had
`:openbank-sepa-payment` in scope, so the drift gate regenerates this pact with no workflow edit.

## Local gate

```
:openbank-sepa-payment:detekt :openbank-sepa-payment:ktlintCheck
:openbank-document-service:detekt :openbank-document-service:ktlintCheck   -> BUILD SUCCESSFUL
```

All four tasks appear in the output — a green-looking task list is not a list that ran. Full
suites, counting **skipped**, since a boot failure reports as skipped rather than failed:

- `openbank-document-service`: 119 tests / 0 failures / 0 errors / **0 skipped**, `koverVerify` green
- `openbank-sepa-payment`: 98 tests / 0 failures / 0 errors / **0 skipped**, `koverVerify` green

## Not in scope

`openbank-domestic-payment` and `openbank-statement-service` hold the same two calls and remain
uncovered. Wiring one complete contract beats three partial ones; the provider class added here is
the reusable half, so a second consumer pact needs only a `@State` handler if it introduces a new
state.

Refs #4109
