### PR TITLE
feat(engagement): expose a party's active adverse states as a read API

### DIFF
--- a/openbank-admin-ui/src/app/api/svc/[service]/[...path]/route.ts
+++ b/openbank-admin-ui/src/app/api/svc/[service]/[...path]/route.ts
@@ -48,6 +48,7 @@ const SERVICE_MAP: Record<string, { container: string; port: number }> = {
   'dispute-service':        { container: 'openbank-dispute-service',        port: 8135 },
   'sepa-instant':           { container: 'openbank-sepa-instant',           port: 8127 },
   'document-service':       { container: 'openbank-document-service',       port: 8143 },
+  'engagement-service':     { container: 'openbank-engagement-service',     port: 8153 },
   'vop-service':            { container: 'openbank-vop-service',            port: 8149 },
 }
 

--- a/openbank-admin-ui/src/app/customer-360/page.tsx
+++ b/openbank-admin-ui/src/app/customer-360/page.tsx
@@ -11,6 +11,7 @@ import { DataUnavailable, type UnavailableKind } from '@/components/feedback/Dat
 import { PageHeader, StatCard, StatusBadge } from '@/components/ui'
 import type { Customer360 } from '@/app/api/customer-360/[partyId]/route'
 import { PartySearch, partyDisplayName, type PartyHit } from '@/components/party/PartySearch'
+import { AdverseStatePanel } from '@/components/party/AdverseStatePanel'
 
 // ADR-0210: a lookup over the analytics silver layer, not a customer list. There is no
 // crm-service and no "list all customers" surface here — party-service owns that.
@@ -83,6 +84,12 @@ export default function Customer360Page() {
       />
 
       <PartySearch onSelect={load360} selectedId={selected?.id} busy={loading} />
+
+      {/* Issue #4265. Deliberately OUTSIDE every `data`/`loading`/`failure` branch below: this panel
+          reads engagement-service, not ClickHouse, so a silver layer that is down or a party with no
+          projected events must not hide an active fraud hold. Those are independent sources and the
+          page now degrades independently for each. */}
+      {selected && <AdverseStatePanel key={selected.id} partyId={selected.id} />}
 
       {loading && (
         <div style={{ color: 'var(--text-secondary)', padding: '40px', textAlign: 'center' }}>

--- a/openbank-admin-ui/src/components/party/AdverseStatePanel.tsx
+++ b/openbank-admin-ui/src/components/party/AdverseStatePanel.tsx
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+'use client'
+
+import { useEffect, useState } from 'react'
+import { ShieldAlert, ShieldCheck, HelpCircle } from 'lucide-react'
+import { useLanguage } from '@/lib/i18n/LanguageContext'
+import { svcUrl, classifyBffFailure, type BffFailure } from '@/lib/services/bff'
+
+// Issue #4265 item 2 — the operator-visible half of ADR-0220 D3.5. Reads engagement-service's
+// `GET /api/v1/eligibility/adverse-states` through the ADR-0056 BFF proxy, which relays the
+// operator's own Keycloak token, so what an operator may see here is decided by backend RBAC and
+// the shared OPA policy (`operator-read-any`), not by this component.
+//
+// SOURCE, stated because the issue asks for it: `party_adverse_state` in engagement-service —
+// event-materialised, authoritative for the suppression decision itself since it is the very row
+// `ResolveSurfaceUseCase` reads. That is a different source from the rest of this page, which is
+// the analytics silver layer, and the panel says so on screen rather than letting an operator
+// assume one `asOf` covers both.
+//
+// ADR-0210 D3 is not weakened: flag names and a party id, no balance, no transaction row, no KYC
+// content — the exact categories D3 excludes are the ones this endpoint does not carry.
+
+/** Mirrors engagement-service's `AdverseState` enum. Not exhaustive-checked at runtime: an unknown
+ *  value must still render (as its raw name) rather than vanish, since a value this UI has not
+ *  heard of is the case where an operator most needs to see something. */
+const LABELS: Record<string, { cs: string; en: string }> = {
+  FRAUD_HOLD: { cs: 'Podezření na podvod (hold)', en: 'Fraud hold' },
+  ARREARS: { cs: 'Po splatnosti', en: 'In arrears' },
+  DISPUTE_OPENED: { cs: 'Otevřená reklamace', en: 'Open dispute' },
+  ERASURE_REQUESTED: { cs: 'Žádost o výmaz', en: 'Erasure requested' },
+}
+
+interface AdverseStateResponse {
+  partyId: string
+  adverseStates: string[]
+}
+
+type State =
+  | { kind: 'loading' }
+  | { kind: 'ok'; states: string[] }
+  | { kind: 'unknown'; why: BffFailure }
+
+export function AdverseStatePanel({ partyId }: { partyId: string }) {
+  const { t, language } = useLanguage()
+  const [state, setState] = useState<State>({ kind: 'loading' })
+
+  // No `setState({kind:'loading'})` reset here: the parent mounts this panel with `key={partyId}`,
+  // so a new selection is a fresh component whose initial state is already `loading`. Resetting in
+  // the effect body would be a second, cascading render of the same fact (react-hooks/
+  // set-state-in-effect) — and, more to the point, would leave the previous party's badges on
+  // screen for one render if the key were ever dropped.
+  useEffect(() => {
+    let live = true
+    ;(async () => {
+      try {
+        const res = await fetch(svcUrl('engagement-service', '/api/v1/eligibility/adverse-states', { partyId }), {
+          cache: 'no-store',
+        })
+        if (!res.ok) {
+          const why = await classifyBffFailure(res)
+          if (live) setState({ kind: 'unknown', why })
+          return
+        }
+        const body = (await res.json()) as AdverseStateResponse
+        if (live) setState({ kind: 'ok', states: body.adverseStates ?? [] })
+      } catch {
+        if (live) setState({ kind: 'unknown', why: 'unreachable' })
+      }
+    })()
+    return () => {
+      live = false
+    }
+  }, [partyId])
+
+  const label = (s: string) => LABELS[s]?.[language === 'cs' ? 'cs' : 'en'] ?? s
+
+  return (
+    <div className="card" style={{ padding: '16px 20px', marginBottom: '20px' }}>
+      <h2 className="section-title" style={{ marginBottom: '4px' }}>
+        {t('Nepříznivé stavy (vyloučení z marketingu)', 'Adverse states (marketing exclusion)')}
+      </h2>
+      <p style={{ margin: '0 0 12px', fontSize: '11px', color: 'var(--text-secondary)' }}>
+        {t(
+          'Zdroj: engagement-service, tabulka party_adverse_state (ADR-0220 D3.5) — ne silver vrstva, takže „Stav k“ výše se na tento panel nevztahuje.',
+          'Source: engagement-service, party_adverse_state (ADR-0220 D3.5) — not the silver layer, so the "As of" chip above does not describe this panel.',
+        )}
+      </p>
+
+      {state.kind === 'loading' && (
+        <span style={{ fontSize: '12px', color: 'var(--text-secondary)' }}>{t('Načítám…', 'Loading…')}</span>
+      )}
+
+      {/* An empty list is a MEASURED all-clear and says so. It is deliberately worded differently
+          from the unknown state below: "no active flag" and "we could not ask" look identical to an
+          operator if both render as an absence, and only one of them is safe to act on. */}
+      {state.kind === 'ok' && state.states.length === 0 && (
+        <div style={{ display: 'flex', alignItems: 'center', gap: '8px', fontSize: '13px' }}>
+          <ShieldCheck size={16} className="tone-text-success" />
+          <span>{t('Žádné aktivní vyloučení', 'No active exclusion')}</span>
+        </div>
+      )}
+
+      {state.kind === 'ok' && state.states.length > 0 && (
+        <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap', alignItems: 'center' }}>
+          <ShieldAlert size={16} className="tone-text-danger" />
+          {/* Only states the service actually returned are rendered. No badge is drawn for a value
+              that is merely declared in the enum: a permanently dark fourth badge cannot be told
+              apart from "this signal is not wired", which is the reading the issue thread warns
+              about for DISPUTE_OPENED. */}
+          {state.states.map(s => (
+            <span key={s} className="tag" style={{ fontSize: '11px' }} data-testid={`adverse-${s}`}>
+              {label(s)}
+            </span>
+          ))}
+        </div>
+      )}
+
+      {state.kind === 'unknown' && (
+        <div style={{ display: 'flex', alignItems: 'center', gap: '8px', fontSize: '13px', color: 'var(--text-secondary)' }}>
+          <HelpCircle size={16} />
+          <span>
+            {t(
+              `Stav nelze zjistit (engagement-service: ${state.why}). NEJDE o potvrzení, že party žádné vyloučení nemá.`,
+              `State unavailable (engagement-service: ${state.why}). This is NOT a confirmation that the party has no exclusion.`,
+            )}
+          </span>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/openbank-admin-ui/src/test/customer-360-adverse-state.test.tsx
+++ b/openbank-admin-ui/src/test/customer-360-adverse-state.test.tsx
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+// Issue #4265 — an operator on Customer 360 must be able to see that a party is suppressed from
+// marketing, and must never be shown an all-clear the console did not actually measure.
+//
+// The second half is the one worth a test. "No active exclusion" and "we could not reach
+// engagement-service" both end up as an absence of badges if the failure path is written lazily,
+// and an operator cannot tell them apart — which is worse than showing nothing, because the safe
+// reading and the dangerous reading render identically. So this asserts the UNAVAILABLE case
+// explicitly, not just the happy one.
+//
+// It also pins the BFF URL as a LITERAL rather than deriving it from svcUrl(): deriving both the
+// expectation and the request from the same helper is vacuous — they move together, and the
+// assertion would survive the component pointing at a route that does not exist.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import React from 'react'
+import { render, screen, cleanup, waitFor } from '@testing-library/react'
+import { LanguageProvider } from '@/lib/i18n/LanguageContext'
+import { AdverseStatePanel } from '@/components/party/AdverseStatePanel'
+
+const PARTY = '44444444-4444-4444-4444-444444444444'
+
+function json(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } })
+}
+
+function renderPanel() {
+  return render(
+    <LanguageProvider>
+      <AdverseStatePanel partyId={PARTY} />
+    </LanguageProvider>,
+  )
+}
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+})
+
+describe('Customer 360 adverse-state panel', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn(async () => json({ partyId: PARTY, adverseStates: [] })))
+  })
+
+  it('asks engagement-service through the BFF proxy, on the path the service serves', async () => {
+    renderPanel()
+    await waitFor(() => expect(fetch).toHaveBeenCalled())
+    const url = String((fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0])
+    expect(url).toBe(`/api/svc/engagement-service/api/v1/eligibility/adverse-states?partyId=${PARTY}`)
+  })
+
+  it('renders a badge per active state, and only for states the service returned', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => json({ partyId: PARTY, adverseStates: ['ARREARS', 'FRAUD_HOLD'] })))
+    renderPanel()
+
+    await waitFor(() => expect(screen.getByTestId('adverse-FRAUD_HOLD')).toBeTruthy())
+    expect(screen.getByTestId('adverse-ARREARS')).toBeTruthy()
+    // DISPUTE_OPENED was not returned, so no badge exists for it. A permanently dark badge for a
+    // declared-but-unwired enum value is indistinguishable from "no open dispute" — the exact
+    // ambiguity the issue thread flags.
+    expect(screen.queryByTestId('adverse-DISPUTE_OPENED')).toBeNull()
+  })
+
+  it('states an empty result as a measured all-clear', async () => {
+    renderPanel()
+    await waitFor(() => expect(screen.getByText(/No active exclusion/i)).toBeTruthy())
+  })
+
+  // THE load-bearing one. The proxy answers 404 `{error:"Unknown service: …"}` when the service is
+  // not deployed or not discovered — a state much of the fleet is in per environment.
+  it('never reports an unreachable service as "no exclusion"', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => json({ error: 'Unknown service: engagement-service' }, 404)))
+    renderPanel()
+
+    await waitFor(() => expect(screen.getByText(/State unavailable/i)).toBeTruthy())
+    expect(screen.queryByText(/No active exclusion/i)).toBeNull()
+    expect(screen.getByText(/NOT a confirmation/i)).toBeTruthy()
+  })
+
+  it('treats a scaled-to-zero backend the same way — unknown, not clear', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => json({ error: 'scaled_to_zero' }, 503)))
+    renderPanel()
+
+    await waitFor(() => expect(screen.getByText(/scaled_to_zero/i)).toBeTruthy())
+    expect(screen.queryByText(/No active exclusion/i)).toBeNull()
+  })
+})

--- a/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/application/usecase/ReadAdverseStateUseCase.kt
+++ b/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/application/usecase/ReadAdverseStateUseCase.kt
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.engagement.application.usecase
+
+import com.openbank.engagement.application.port.out.AdverseStateRepository
+import com.openbank.engagement.domain.model.AdverseState
+import jakarta.enterprise.context.ApplicationScoped
+import java.util.UUID
+
+/**
+ * The operator-facing read over ADR-0220 D3.5's materialised adverse-state set (issue #4265,
+ * item 1). It adds no rule of its own — [AdverseStateRepository.activeStates] already answers
+ * exactly this question, and has since the table landed; what was missing was only a way to ask
+ * it without a `psql` session.
+ *
+ * Why a use case rather than the resource calling the port: the resource layer here never touches
+ * an out-port directly (`SurfaceResource` goes through `ResolveSurfaceUseCase`/
+ * `RecordEngagementEventUseCase`), and the hexagonal boundary is the thing this service's
+ * `CLAUDE.md` and ADR-0002 actually gate on.
+ *
+ * Deliberately NOT returned: `set_at`. The port exposes the state set only, and widening it to
+ * carry timestamps would mean a new port method, a new repository query and a second shape for
+ * the same fact — for a badge that says "this party is excluded", the set IS the answer. When an
+ * operator needs "since when", that is a separate, justified change, not one smuggled in here.
+ *
+ * ADR-0210 D3 posture is preserved by construction: `party_adverse_state` holds a party id, a flag
+ * name and a timestamp — no balance, no transaction row, no KYC content — so this endpoint cannot
+ * become the leak vector D3 excludes, regardless of who calls it.
+ */
+@ApplicationScoped
+class ReadAdverseStateUseCase(private val adverseState: AdverseStateRepository) {
+
+    /**
+     * Sorted by enum name so the response body is deterministic: the repository returns a `Set`
+     * whose iteration order is an implementation detail, and a contract test that asserts a list
+     * cannot be allowed to depend on it.
+     */
+    suspend fun activeStates(partyId: UUID): List<AdverseState> =
+        adverseState.activeStates(partyId).sortedBy { it.name }
+}

--- a/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/infrastructure/rest/AdverseStateResource.kt
+++ b/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/infrastructure/rest/AdverseStateResource.kt
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.engagement.infrastructure.rest
+
+import com.openbank.engagement.application.usecase.ReadAdverseStateUseCase
+import com.openbank.libs.authz.Authorize
+import jakarta.annotation.security.RolesAllowed
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.ws.rs.GET
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.QueryParam
+import jakarta.ws.rs.core.Response
+import java.util.UUID
+
+/**
+ * The operator-facing read of a party's active adverse states (issue #4265 item 1) — the missing
+ * half of ADR-0220 D3.5. The signals have been durable in `party_adverse_state` and queryable via
+ * `AdverseStateRepository.activeStates` since that table landed; nothing exposed them, so a
+ * support agent fielding "why did I stop getting offers" had no on-screen answer and no way to
+ * spot-check the suppression short of a database session.
+ *
+ * SEPARATE from [SurfaceResource] on purpose, and not merely for tidiness: the surface API is the
+ * customer-app plane reached through the customer edge (`edge-service-engagement` in
+ * `openbank-libs/governance/policies/rest.rego`, scoped to exactly two actions), while this is the
+ * staff plane. Hanging an operator read off `/api/v1/surfaces` would have put it one careless
+ * `input.action` widening away from the edge's grant. Hence a different path, a different action,
+ * and no `ROLE_API`.
+ *
+ * Authorization needs NO new rego rule and deliberately so: `engagement.adverseState.read` ends in
+ * `.read`, which `operator-read-any` (ROLE_OPERATOR/ROLE_ADMIN) and `compliance-read-any`
+ * (ROLE_COMPLIANCE) already grant in the shared policy. Every role in the `@RolesAllowed` below
+ * therefore has a matching OPA reason under enforcement — verified by reading those two rules, not
+ * assumed from the annotation. A new bespoke action name would instead have hit
+ * `default allow := false` and shipped an endpoint that 403s for everyone while looking wired.
+ *
+ * ADR-0210 D3's non-authoritative posture is intact by construction: the row behind this response
+ * is (party id, flag name, timestamp). No balance, no transaction row, no KYC content is newly
+ * reachable, so this is not the drive-by expansion D3 warns about.
+ */
+@Path("/api/v1/eligibility/adverse-states")
+@ApplicationScoped
+class AdverseStateResource(private val read: ReadAdverseStateUseCase) {
+
+    /**
+     * `partyId` is declared NULLABLE, and that is load-bearing rather than defensive. JAX-RS
+     * injects `null` for an absent query parameter; a non-nullable `UUID` here would make the
+     * absent-header case a 500 (`GenericExceptionMapper`), and in a `suspend fun` — which emits no
+     * `Intrinsics.checkNotNullParameter` at all — the null would instead flow silently into the
+     * body. `requireNotNull` only does anything because the declared type admits null; libs-runtime
+     * maps the resulting `IllegalArgumentException` to 400, so no service-local mapper is added.
+     */
+    @GET
+    @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_COMPLIANCE")
+    @Authorize(action = "engagement.adverseState.read", resource = "#partyId")
+    suspend fun activeStates(@QueryParam("partyId") partyId: UUID?): Response {
+        requireNotNull(partyId) { "query parameter 'partyId' is required" }
+        return Response.ok(
+            mapOf(
+                "partyId" to partyId.toString(),
+                "adverseStates" to read.activeStates(partyId).map { it.name },
+            ),
+        ).build()
+    }
+}

--- a/openbank-engagement-service/src/main/resources/openapi.yaml
+++ b/openbank-engagement-service/src/main/resources/openapi.yaml
@@ -15,10 +15,47 @@ info:
     graduates from shadow (D5). No `@Authorize` OPA rule for these actions yet; the shared policy's
     `default allow := false` denies both endpoints fail-closed under enforcement until that rule
     lands.
-  version: 1.0.0
+  version: 1.1.0
 tags:
   - name: Surfaces
+  - name: Eligibility
 paths:
+  /api/v1/eligibility/adverse-states:
+    get:
+      tags: [Eligibility]
+      summary: List a party's active adverse states (ADR-0220 D3.5 targeting exclusions)
+      description: >-
+        The staff-plane read of `party_adverse_state` (issue #4265). Answers "why is this party
+        suppressed from marketing surfaces" with the set of flags currently set for them; an empty
+        list means no exclusion is active, which is a different fact from the endpoint being
+        unreachable and is why this is a list rather than a nullable object.
+
+        Not the customer-app plane: `ROLE_API` is deliberately absent, and the action
+        `engagement.adverseState.read` is outside the two actions the customer edge's
+        `edge-service-engagement` policy reason grants.
+
+        Returns flag names and a party id only — no balance, transaction or KYC content — so the
+        ADR-0210 D3 non-authoritative boundary is unchanged by it.
+      parameters:
+        - name: partyId
+          in: query
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: the party's active adverse states, possibly empty
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AdverseStateResponse"
+        "400":
+          description: partyId absent or not a UUID
+        "401":
+          description: no bearer token
+        "403":
+          description: token lacks ROLE_OPERATOR / ROLE_ADMIN / ROLE_COMPLIANCE
   /api/v1/surfaces/{slot}:
     get:
       tags: [Surfaces]
@@ -65,6 +102,21 @@ paths:
           description: unknown slot or event type
 components:
   schemas:
+    AdverseStateResponse:
+      type: object
+      required: [partyId, adverseStates]
+      properties:
+        partyId: { type: string, format: uuid }
+        adverseStates:
+          type: array
+          description: >-
+            Sorted by name so the body is deterministic. Every value is a member of the enum
+            below; a value being absent from the list means the exclusion is not active for this
+            party, NOT that the signal is unwired — which of the four have a producing consumer is
+            a fact about this service's @Incoming consumers, tracked in AdverseState's KDoc.
+          items:
+            type: string
+            enum: [ARREARS, DISPUTE_OPENED, ERASURE_REQUESTED, FRAUD_HOLD]
     SurfaceContent:
       type: object
       properties:

--- a/openbank-engagement-service/src/test/kotlin/com/openbank/engagement/integration/SurfaceRestContractIT.kt
+++ b/openbank-engagement-service/src/test/kotlin/com/openbank/engagement/integration/SurfaceRestContractIT.kt
@@ -14,7 +14,11 @@ import io.restassured.module.kotlin.extensions.Then
 import io.restassured.module.kotlin.extensions.When
 import io.smallrye.reactive.messaging.memory.InMemoryConnector
 import org.assertj.core.api.Assertions.assertThat
+import org.eclipse.microprofile.config.ConfigProvider
 import org.junit.jupiter.api.Test
+import java.sql.DriverManager
+import java.sql.Timestamp
+import java.time.Instant
 import java.util.UUID
 
 /**
@@ -113,6 +117,109 @@ class SurfaceRestContractIT {
             get("/api/v1/surfaces/NOT_A_REAL_SLOT")
         } Then {
             statusCode(400)
+        }
+    }
+
+    // ── AdverseStateResource (issue #4265 item 1) ──────────────────────────────────────────────
+    //
+    // These live in THIS class rather than a second @QuarkusTest deliberately. A new IT class would
+    // need its own `switchIncomingChannelsToInMemory(...)` list, and that list is exactly the thing
+    // that goes stale: #4297 is adding a fourth consumer (`dispute-events-in`) right now, and a
+    // second copy would silently start reaching for a real broker the day it lands. One boot, one
+    // channel list, one place to update.
+
+    /**
+     * The route is SERVED, not merely compiled. A Kotlin annotation binds to the NEXT declaration,
+     * so a `@Path` that slid onto something other than its class leaves the resource unregistered
+     * and every call 404s while a unit test calling the class directly stays green — the exact
+     * failure `McpEndpointRoutingIT` exists for. Only a real HTTP request can tell 200 from 404
+     * here, which is why this assertion is a status code and not a returned object.
+     */
+    @Test
+    @TestSecurity(user = TEST_OPERATOR, roles = ["ROLE_OPERATOR"])
+    fun `a party with no adverse state gets a served 200 and an empty list, not a 404`() {
+        val body = adverseStates(UUID.randomUUID())
+        assertThat(body.getList<String>("adverseStates")).isEmpty()
+    }
+
+    /**
+     * The read reaches the real table. The row is written with plain JDBC because a Hibernate
+     * Reactive Panache repository cannot be driven from a bare `@QuarkusTest` thread (`No current
+     * Vertx context found`); only the HTTP request carries a Vert.x context, so the write goes
+     * around the repository and the read goes through it — which is what makes this a test of the
+     * endpoint rather than of a mock.
+     */
+    @Test
+    @TestSecurity(user = TEST_OPERATOR, roles = ["ROLE_OPERATOR"])
+    fun `states materialised in party_adverse_state are visible over HTTP, sorted`() {
+        val party = UUID.randomUUID()
+        insertAdverseState(party, "FRAUD_HOLD")
+        insertAdverseState(party, "ARREARS")
+
+        // Sorted by name, not insertion order: the repository hands back a Set, whose iteration
+        // order is an implementation detail no response body may depend on.
+        assertThat(adverseStates(party).getList<String>("adverseStates"))
+            .containsExactly("ARREARS", "FRAUD_HOLD")
+    }
+
+    /**
+     * One party's flags never leak into another's. Cheap to assert, and the only thing standing
+     * between a per-party read and a fleet-wide one is a single `where` clause.
+     */
+    @Test
+    @TestSecurity(user = TEST_OPERATOR, roles = ["ROLE_OPERATOR"])
+    fun `a second party does not see the first party's adverse state`() {
+        val flagged = UUID.randomUUID()
+        insertAdverseState(flagged, "ERASURE_REQUESTED")
+
+        assertThat(adverseStates(UUID.randomUUID()).getList<String>("adverseStates")).isEmpty()
+    }
+
+    /**
+     * An absent `partyId` is a 400, not a 500. This is the assertion the repo's nonnull-JAX-RS rule
+     * exists for: JAX-RS injects null for an absent query parameter, so a non-nullable `UUID` here
+     * would answer 500 — and in a `suspend fun`, which emits no `checkNotNullParameter` intrinsic,
+     * the null would flow into the body instead and the `requireNotNull` guard would be the only
+     * thing catching it. Declared nullable + `requireNotNull` → libs-runtime's
+     * `IllegalArgumentExceptionMapper` → 400.
+     */
+    @Test
+    @TestSecurity(user = TEST_OPERATOR, roles = ["ROLE_OPERATOR"])
+    fun `an absent partyId is a 400, not a 500`() {
+        When {
+            get("/api/v1/eligibility/adverse-states")
+        } Then {
+            statusCode(400)
+        }
+    }
+
+    private fun adverseStates(partyId: UUID) = Given {
+        queryParam("partyId", partyId.toString())
+    } When {
+        get("/api/v1/eligibility/adverse-states")
+    } Then {
+        statusCode(200)
+    } Extract {
+        body().jsonPath()
+    }
+
+    /** The JDBC URL is the one EngagementPostgresTestResource injected — never a second copy. */
+    private fun insertAdverseState(partyId: UUID, state: String) {
+        val config = ConfigProvider.getConfig()
+        DriverManager.getConnection(
+            config.getValue("quarkus.datasource.jdbc.url", String::class.java),
+            config.getValue("quarkus.datasource.username", String::class.java),
+            config.getValue("quarkus.datasource.password", String::class.java),
+        ).use { conn ->
+            conn.prepareStatement(
+                "INSERT INTO party_adverse_state (id, party_id, state, set_at) VALUES (?, ?, ?, ?)",
+            ).use { st ->
+                st.setObject(1, UUID.randomUUID())
+                st.setObject(2, partyId)
+                st.setString(3, state)
+                st.setTimestamp(4, Timestamp.from(Instant.now()))
+                st.executeUpdate()
+            }
         }
     }
 


### PR DESCRIPTION
## What

Item 1 (and, as it turned out affordably, item 2) of #4265: the adverse-state signals that suppress
a party from marketing surfaces are now readable, and visible on Customer 360.

`GET /api/v1/eligibility/adverse-states?partyId=<uuid>` on engagement-service →
`{ "partyId": "...", "adverseStates": ["ARREARS", "FRAUD_HOLD"] }`, sorted by name.

The issue body framed item 1 as an architecture call ("extend the surfaces API, or add adverse-state
to the analytics feed"). The thread's own measurement already answered it and this PR follows that:
the state is durable in `party_adverse_state` and `AdverseStateRepository.activeStates(partyId)` has
been the exact read since the table landed. What was missing was only the REST surface. No new feed,
no new projection, no new table.

## Design decisions worth review

- **A separate resource, not a third path on `SurfaceResource`.** `/api/v1/surfaces` is the
  customer-app plane reached through the customer edge, whose `edge-service-engagement` policy reason
  is scoped to exactly two actions. Hanging a staff read off that path would have put it one careless
  `input.action` widening away from the edge's grant. Hence a different path, a different action, and
  no `ROLE_API` in `@RolesAllowed`.
- **`engagement.adverseState.read` needs no rego change, and that is a measured claim rather than a
  hope.** It ends in `.read`, which `operator-read-any` (ROLE_OPERATOR/ROLE_ADMIN) and
  `compliance-read-any` (ROLE_COMPLIANCE) already grant in the shared `rest.rego` — the same three
  roles the annotation allows. A bespoke action name would have fallen to `default allow := false`
  and shipped an endpoint that 403s for everyone under enforcement while looking wired.
- **`setAt` is deliberately not returned.** The port exposes the state set; widening it would mean a
  new port method, a new query and a second shape for the same fact. "Since when" is a separate,
  justifiable change, not one smuggled in here.
- **ADR-0210 D3 posture intact by construction.** The row behind this response is
  (party id, flag name, timestamp) — no balance, no transaction row, no KYC content, i.e. exactly the
  categories D3 excludes are the ones this table does not carry.
- **No fourth dark badge.** Per the thread: only states the service actually returns get rendered.
  A badge for a declared-but-unwired enum value cannot be told apart from "no open dispute".
  `DISPUTE_OPENED` gets a label ready for #4297 and no permanent placeholder.
- **The UI panel sits outside every ClickHouse branch on Customer 360.** It reads engagement-service,
  not the silver layer, so a silver layer that is down or a party with no projected events must not
  hide an active fraud hold. It also says which source it came from, because the page's `As of` chip
  describes the silver layer and does not describe this panel.

## Falsification — what each new test was fed that it MUST reject

Not "the tests pass". Each assertion was run against the specific defect it exists to catch:

1. **The route is SERVED, not merely compiled.** Inserted a top-level
   `private fun annotationThief(x: String) = x` between `@Path` and `class AdverseStateResource`, the
   Kotlin annotation-binding trap. Result: **4 IT failures, `Expected status code <200> but was
   <404>`** (and the 400 test became `<400> but was <404>`) — RESTEasy never registered the resource.
   Restored → 8/8. A unit test calling the class directly cannot see this; only real HTTP can.
2. **The nullable-`@QueryParam` rule.** Changed `partyId: UUID?` + `requireNotNull` to a
   non-nullable `partyId: UUID`. Result: **`an absent partyId is a 400, not a 500` failed with
   `Expected status code <400> but was <500>`** — exactly the documented defect class. Restored → 400
   via libs-runtime's `IllegalArgumentExceptionMapper`; no service-local mapper added.
3. **The UI must never report an unreachable service as an all-clear.** Changed the panel's `!res.ok`
   branch to `setState({kind:'ok', states: []})` — the lazy failure path. Result: **2 vitest failures**
   (`Unable to find an element with the text: /State unavailable/i`, and the `scaled_to_zero` case).
   Restored → both green.

The IT writes its fixture row with plain JDBC and reads it back over HTTP, so the write goes around
the repository and the read goes through it — a mocked repo could not prove the endpoint reaches the
real table. The consumer-side URL is asserted as a **literal**, not derived from `svcUrl()`:
deriving both sides moves them together and would stay green against a route that does not exist.

## Verification

- `./gradlew :openbank-engagement-service:detekt :ktlintCheck :test :quarkusBuild` — BUILD SUCCESSFUL,
  all four tasks present in the output. `SurfaceRestContractIT` **8 tests / 0 failures / 0 skipped**
  read from the JUnit XML, not the console.
- `npm test` (not bare `npx vitest run`) — **84 files / 1142 tests passed**, including
  `service-registry.guard.test.ts`, which is what validates the new `engagement-service` SERVICE_MAP
  key against the real gitops workload. `tsc --noEmit` clean; `eslint` adds no new warning.
- `openapi.yaml` `info.version` read off live `origin/main` @ `44a3c2c3a` immediately before the bump:
  **1.0.0 → 1.1.0** (additive; major still matches `/api/v1`). `version.txt` untouched —
  release-please owns it, and `feat(engagement)` releases on both axes.

## Conflict surface

Checked both open PRs against this service before starting and touched none of their files:
#4294 (`ResolveSurfaceUseCase.kt`) and #4297 (`Eligibility.kt`, `DisputeOpenedEventConsumer.kt`,
`application.yaml`, the Kafka ACL manifest). The new IT cases were added to the existing
`SurfaceRestContractIT` rather than a second `@QuarkusTest` on purpose: a new class would carry its
own `switchIncomingChannelsToInMemory(...)` copy, and #4297 is adding a fourth channel right now — a
second list would go stale the day it lands.

Refs #4265 (item 1 and item 2; the issue stays open for its remaining acceptance criteria).
