### PR TITLE
fix(audit): stop an explicit JSON null becoming the actor "null"

### DIFF
--- a/openbank-audit-service/src/main/kotlin/com/openbank/audit/application/AuditConsumer.kt
+++ b/openbank-audit-service/src/main/kotlin/com/openbank/audit/application/AuditConsumer.kt
@@ -108,36 +108,34 @@ class AuditConsumer {
                 // `ce-type` is the outbox event type, and it is the LAST resort before the
                 // sentinel: it is the producer's own value, carried by the transport rather than
                 // the body, so it is a recovery of a fact and not an inference (#3994).
-                eventType = node["eventType"]?.asText()
-                    ?: node["type"]?.asText()
+                eventType = node.textOrNull("eventType")
+                    ?: node.textOrNull("type")
                     ?: address.ceType
                     ?: "UNKNOWN",
-                aggregateType = node["aggregateType"]?.asText() ?: inferAggregateType(node),
+                aggregateType = node.textOrNull("aggregateType") ?: inferAggregateType(node),
                 aggregateId = inferAggregateId(node),
-                actorId = node["requestedBy"]?.asText()
-                    ?: node["actorId"]?.asText()
+                actorId = node.textOrNull("requestedBy")
+                    ?: node.textOrNull("actorId")
                     // transaction.initiated events carry the customer identity here (ADR-0021).
-                    ?: node["initiatedByPartyId"]?.asText(),
-                actorType = node["actorType"]?.asText(),
+                    ?: node.textOrNull("initiatedByPartyId"),
+                actorType = node.textOrNull("actorType"),
                 payload = payload,
                 sourceService = resolvedSource.first,
                 sourceServiceSource = resolvedSource.second,
-                correlationId = node["correlationId"]?.asText(),
+                correlationId = node.textOrNull("correlationId"),
                 occurredAt = eventTime ?: Instant.now(clock),
                 recordedAt = Instant.now(clock),
                 occurredAtSource = if (eventTime != null) OccurredAtSource.EVENT else OccurredAtSource.INGEST,
                 // ADR-0226: cross-channel dimensions, additive — producers adopt them channel by
                 // channel, so absence stays null (unknown), never a guessed default.
-                channel = node["channel"]?.asText(),
+                channel = node.textOrNull("channel"),
                 actChain = node["actChain"]?.takeIf { it.isArray }?.map { it.asText() } ?: emptyList(),
-                sessionId = node["sessionId"]?.asText(),
+                sessionId = node.textOrNull("sessionId"),
                 // ADR-0232 D5: a delegated action names the grantor it was taken on behalf of and
                 // the grant that permitted it. customer-edge flattens its audit details into the
                 // event JSON, so both arrive as top-level fields. Absent = a direct action.
-                // (`takeIf { !it.isNull }` because Jackson's asText() on an explicit JSON null
-                // yields the STRING "null", which would index a delegated action that is not one.)
-                onBehalfOf = node["onBehalfOf"]?.takeIf { !it.isNull }?.asText(),
-                delegationId = node["delegationId"]?.takeIf { !it.isNull }?.asText(),
+                onBehalfOf = node.textOrNull("onBehalfOf"),
+                delegationId = node.textOrNull("delegationId"),
             )
             if (eventTime == null) countMissingEventTime(entry.sourceService)
             if (entry.sourceServiceSource != AttributionSource.EVENT) {
@@ -183,7 +181,7 @@ class AuditConsumer {
      * no log line, and 76% of the trail went that way unnoticed.
      */
     private fun resolveSourceService(node: JsonNode, address: EventAddress): Pair<String, AttributionSource> {
-        node["sourceService"]?.asText()?.takeIf { it.isNotBlank() }?.let {
+        node.textOrNull("sourceService")?.let {
             return it to AttributionSource.EVENT
         }
         TopicAttribution.sourceService(address.topic)?.let { return it to AttributionSource.TOPIC }
@@ -230,7 +228,7 @@ class AuditConsumer {
      *    operation entirely. It is now an INGEST-sourced row: a degraded entry beats no entry.
      */
     private fun eventTime(node: JsonNode): Instant? {
-        val raw = node["occurredAt"]?.asText() ?: return null
+        val raw = node.textOrNull("occurredAt") ?: return null
         return runCatching { Instant.parse(raw) }.getOrElse {
             log.warnf("Unparseable occurredAt %s; recording ingest time instead", raw.take(MAX_LOGGED_RAW_TIME_CHARS))
             null
@@ -264,18 +262,23 @@ class AuditConsumer {
         "id" to "SANCTIONS_CHECK",
     )
 
+    // Both halves test the SAME predicate ([textOrNull], not `has`) on purpose. `has` is true for a
+    // field explicitly set to JSON null, so the old pair disagreed on exactly that input: the type
+    // side claimed the aggregate ("accountId": null -> ACCOUNT) while the id side produced the
+    // string "null" — a typed aggregate pointing at an id that identifies nothing. Keeping the
+    // predicate identical is what makes the two sides answer about the same field (#3994).
     private fun inferAggregateId(node: JsonNode): String {
-        node["incident"]?.get("id")?.asText()?.let { return it }
+        node["incident"]?.textOrNull("id")?.let { return it }
         for ((field, _) in aggregateFields) {
-            node[field]?.asText()?.let { return it }
+            node.textOrNull(field)?.let { return it }
         }
         return "unknown"
     }
 
     private fun inferAggregateType(node: JsonNode): String {
-        if (node.has("incident")) return "ICT_INCIDENT"
+        if (node["incident"]?.textOrNull("id") != null) return "ICT_INCIDENT"
         for ((field, type) in aggregateFields) {
-            if (node.has(field)) return type
+            if (node.textOrNull(field) != null) return type
         }
         return "UNKNOWN"
     }
@@ -285,3 +288,32 @@ class AuditConsumer {
         const val MAX_LOGGED_RAW_TIME_CHARS = 64
     }
 }
+
+/**
+ * One string field of a producer's payload, or null when the producer did not supply one (#3994).
+ *
+ * **Why this exists rather than `node[field]?.asText()`.** Jackson's `asText()` on a `NullNode`
+ * returns the four-character STRING `"null"`, so `{"actorId": null}` — a producer explicitly
+ * saying it has no actor — stored `actorId = "null"` as though that were somebody. Measured on the
+ * live audit database: **7 rows carry `actor_id = 'null'`**, all `TransactionInitiated`, all
+ * money-path. That is worse than the NULL it replaces and is why it survived: a NULL actor reads
+ * as a known gap and gets counted, whereas `"null"` reads as an attributed row. It is also
+ * chain-hashed into `record_hash` (`actorId` is in `chainHash`'s canonical string), returned by
+ * the ADR-0226 `findByActorId` cross-channel person query, and served to data subjects by the
+ * GDPR Art. 15 access log — so a query for actor `"null"` returns seven real transactions
+ * belonging to nobody, and a real actor's own access log is missing them.
+ *
+ * The trap was already known here — [AuditConsumer]'s `onBehalfOf`/`delegationId` carried a
+ * hand-written `takeIf { !it.isNull }` guard and a comment explaining precisely this — but the
+ * guard was applied at two of the eleven call sites that needed it. That is the argument for one
+ * shared accessor over eleven guards: a guard that has to be remembered per field is a guard that
+ * documents the defect at the two places it does not occur.
+ *
+ * Blank is folded in with null for the same reason: `""` is not an actor, an event type or a
+ * service name, and letting it through only moves the empty value one layer downstream.
+ *
+ * Free-standing rather than a member so it also reads on the nested `incident` node, and so the
+ * class stays under detekt's function-count threshold.
+ */
+private fun JsonNode.textOrNull(field: String): String? =
+    this[field]?.takeIf { !it.isNull }?.asText()?.takeIf { it.isNotBlank() }

--- a/openbank-audit-service/src/test/kotlin/com/openbank/audit/application/AuditConsumerTest.kt
+++ b/openbank-audit-service/src/test/kotlin/com/openbank/audit/application/AuditConsumerTest.kt
@@ -2,6 +2,7 @@
 package com.openbank.audit.application
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.openbank.audit.domain.model.AttributionSource
 import com.openbank.audit.domain.model.OccurredAtSource
 import com.openbank.audit.infrastructure.persistence.AuditRepository
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
@@ -436,6 +437,117 @@ class AuditConsumerTest {
         coVerify {
             repo.save(match { it.occurredAt == INGEST_TIME && it.occurredAtSource == OccurredAtSource.INGEST })
         }
+    }
+
+    // ── Explicit JSON null must never become the STRING "null" (#3994) ──────────────────────────
+    //
+    // Jackson's asText() on a NullNode returns "null", so `{"actorId": null}` stored an actor
+    // called "null". Measured on the live audit database: 7 rows carry actor_id = 'null', all
+    // TransactionInitiated. Every test below is RED against origin/main.
+    //
+    // Note what is asserted: the exact expected VALUE, never non-nullity. `assertThat(actorId)
+    // .isNotNull()` passes happily against the string "null" — it is the same shape as the
+    // Instant.EPOCH trap, where isNotNull() agreed with 1970-01-01.
+
+    @Test
+    fun `consume stores no actor when the producer explicitly sends a null actor`(): Unit = runBlocking {
+        val partyId = UUID.randomUUID()
+        // The live payload shape: transaction-service emits initiatedByPartyId as an explicit null
+        // for a system-initiated transaction. 22 rows in the live table are exactly this.
+        val payload = """
+            {"eventType":"TransactionInitiated","transactionId":"${UUID.randomUUID()}",
+             "initiatedByPartyId":null,"actorId":null,"actorType":null,"partyId":"$partyId"}
+        """.trimIndent()
+        coEvery { repo.save(any()) } returns Unit
+
+        consumer.consume(payload)
+
+        // origin/main: actorId == "null", actorType == "null".
+        coVerify { repo.save(match { it.actorId == null && it.actorType == null }) }
+    }
+
+    @Test
+    fun `consume prefers a real actor over an explicitly null one earlier in the chain`(): Unit = runBlocking {
+        val partyId = UUID.randomUUID()
+        val payload = """
+            {"eventType":"TransactionInitiated","transactionId":"${UUID.randomUUID()}",
+             "requestedBy":null,"actorId":null,"initiatedByPartyId":"$partyId"}
+        """.trimIndent()
+        coEvery { repo.save(any()) } returns Unit
+
+        consumer.consume(payload)
+
+        // origin/main: the first `?.asText()` yields "null", which is non-null, so the elvis chain
+        // short-circuits and the REAL actor two links down is never reached. The explicit null did
+        // not merely fail to attribute — it actively displaced a known actor.
+        coVerify { repo.save(match { it.actorId == partyId.toString() }) }
+    }
+
+    @Test
+    fun `consume does not attribute a source service the producer explicitly nulled`(): Unit = runBlocking {
+        val payload = """
+            {"eventType":"BALANCE_UPDATED","accountId":"${UUID.randomUUID()}","sourceService":null}
+        """.trimIndent()
+        coEvery { repo.save(any()) } returns Unit
+
+        consumer.consume(payload, EventAddress(topic = "openbank.balance.events"))
+
+        // origin/main: `takeIf { it.isNotBlank() }` passes "null" through, so the row claims
+        // source_service = "null" with provenance EVENT — a consumer-invented value recorded as
+        // the producer's own assertion, which is the exact failure V13's column exists to prevent.
+        coVerify {
+            repo.save(
+                match {
+                    it.sourceService == "balance-service" &&
+                        it.sourceServiceSource == AttributionSource.TOPIC
+                },
+            )
+        }
+    }
+
+    @Test
+    fun `consume keeps aggregate type and id agreeing when a candidate field is null`(): Unit = runBlocking {
+        val transactionId = UUID.randomUUID()
+        val payload = """
+            {"eventType":"TransactionCompleted","accountId":null,"transactionId":"$transactionId"}
+        """.trimIndent()
+        coEvery { repo.save(any()) } returns Unit
+
+        consumer.consume(payload)
+
+        // origin/main: inferAggregateType uses `has` (true for an explicit null) and returns
+        // ACCOUNT, while inferAggregateId uses asText() and returns "null" — a typed aggregate
+        // pointing at an id that identifies nothing. Both sides now test the same predicate.
+        coVerify {
+            repo.save(
+                match { it.aggregateType == "TRANSACTION" && it.aggregateId == transactionId.toString() },
+            )
+        }
+    }
+
+    @Test
+    fun `consume falls back to the ce-type header when eventType is explicitly null`(): Unit = runBlocking {
+        val payload = """{"eventType":null,"accountId":"${UUID.randomUUID()}"}"""
+        coEvery { repo.save(any()) } returns Unit
+
+        consumer.consume(payload, EventAddress(topic = "openbank.balance.events", ceType = "BALANCE_UPDATED"))
+
+        // origin/main: eventType == "null" — and because that is non-null the ce-type header the
+        // transport was carrying is never consulted, so #4270's recovery silently does not apply.
+        coVerify { repo.save(match { it.eventType == "BALANCE_UPDATED" }) }
+    }
+
+    @Test
+    fun `consume records ingest time without a bogus parse warning when occurredAt is null`(): Unit = runBlocking {
+        val payload = """{"eventType":"X","accountId":"${UUID.randomUUID()}","occurredAt":null}"""
+        coEvery { repo.save(any()) } returns Unit
+
+        consumer.consume(payload)
+
+        // Same class, benign outcome by luck: "null" is unparseable, so main already lands on
+        // INGEST — but via the "unparseable occurredAt" warning path, which reports a malformed
+        // producer where there is only an absent field. Asserted so the two stay distinguishable.
+        coVerify { repo.save(match { it.occurredAtSource == OccurredAtSource.INGEST }) }
     }
 
     private companion object {


### PR DESCRIPTION
## Which layer loses the attribution, and how that was established

Measured against the live audit database (read-only) rather than inferred from code, because this
repo builds event payloads two ways and a grep over producers sees only the hand-built maps. The
authoritative enumeration is the stored payloads themselves:

```sql
SELECT event_type, string_agg(DISTINCT k, ',')
FROM (SELECT DISTINCT event_type, jsonb_object_keys(payload::jsonb) k
      FROM audit_entries WHERE actor_id IS NULL) s GROUP BY event_type;
```

That splits the gap cleanly in two:

* **Producer layer, most rows.** `BALANCE_UPDATED`, `HOLD_*`, `AccountCreated`, `KYC_*`, `PARTY_*`
  and the statement events carry **no actor key at all**. The consumer cannot invent one. Not
  fixed here — see below.
* **Consumer layer, and it is actively corrupting.** `TransactionInitiated` *does* carry
  `initiatedByPartyId`, and `AuditConsumer` *does* read it — yet those rows are unattributed. The
  reason is not that the value was missing.

```
SELECT event_type, actor_id, count(*) FROM audit_entries
WHERE payload::jsonb ? 'initiatedByPartyId' GROUP BY 1,2;

 TransactionInitiated |                                      | 26
 TransactionInitiated | null                                 |  7   <-- the STRING "null"
 TransactionInitiated | ec28276d-28b9-4cdb-ac03-097afca855b9 |  6
 TransactionInitiated | 07d13ecc-443b-456e-a504-dd8999078a48 |  5
```

**7 live money-path rows have `actor_id = 'null'`** — four characters of text, not SQL NULL.
Jackson's `asText()` on a `NullNode` returns `"null"`, so a producer explicitly stating it has no
actor was recorded as having one.

This is worse than the NULL it replaces, and that is exactly why it survived: a NULL actor reads as
a known gap and gets counted, whereas `"null"` reads as a fully attributed row. `actorId` is
chain-hashed into `record_hash`, returned by the ADR-0226 `findByActorId` cross-channel person
query, and served to data subjects by the GDPR Art. 15 access log — so a query for actor `"null"`
returns seven real transactions belonging to nobody, and the real actor's own access log omits them.

**Something does read the field**, so this is a live defect rather than a latent trap:
`AuditRepository.findByActorId` (ADR-0226 D3), the delegated-action transparency query, and the
`/audit/customer/{partyId}` access log.

### The trap was already known here, and applied at 2 of 11 sites

`AuditConsumer` guarded `onBehalfOf` and `delegationId` with `takeIf { !it.isNull }` and a comment
naming this precise behaviour. Nine other `?.asText()` reads had no guard. A guard that must be
remembered per field is one that documents the defect at the two places it does not occur — hence
one shared `JsonNode.textOrNull()` accessor rather than nine more copies.

Two further consequences of the same cause, both fixed:

* an explicit null **earlier in the actor elvis chain displaced a real actor further down** —
  `requestedBy: null` yields `"null"`, which is non-null, so `initiatedByPartyId` was never reached;
* `inferAggregateType` (`has`, true for an explicit null) disagreed with `inferAggregateId`
  (`asText()`, `"null"`) on that same input, producing a typed aggregate pointing at an id that
  identifies nothing. Both halves now test the same predicate.

`sourceService` is the one that ties straight back to this issue: `takeIf { it.isNotBlank() }` let
`"null"` through as `AttributionSource.EVENT` — a consumer-invented value recorded as the producer's
own assertion, the exact failure V13's provenance column exists to prevent.

## Was an existing test asserting the defect?

**No.** All 20 existing `AuditConsumerTest` cases cover *present* or *absent* fields; not one sends
an explicit JSON null. No assertions were deleted. The defect survived because the input was never
tested, not because a test encoded it.

Assertions here check the exact expected **value**, never non-nullity —
`assertThat(actorId).isNotNull()` passes happily against the string `"null"`, the same shape as the
`Instant.EPOCH` trap where `isNotNull()` agreed with 1970-01-01.

## Both test runs

**RED — new tests against unmodified `origin/main`** (`e21936d2b`, tests copied onto a clean
worktree):

```
26 tests completed, 5 failed        # JUnit XML: tests=26 failures=5 errors=0 skipped=0
  FAIL consume stores no actor when the producer explicitly sends a null actor()
  FAIL consume prefers a real actor over an explicitly null one earlier in the chain()
  FAIL consume does not attribute a source service the producer explicitly nulled()
  FAIL consume keeps aggregate type and id agreeing when a candidate field is null()
  FAIL consume falls back to the ce-type header when eventType is explicitly null()
```

The sixth new test (`occurredAt: null`) passes on main and is labelled in place as benign-by-luck:
`"null"` is unparseable, so main already lands on INGEST — but via the *"unparseable occurredAt"*
warning path, reporting a malformed producer where there is only an absent field. Asserted so the
two stay distinguishable.

**GREEN — this branch**, `detekt ktlintCheck test` then `quarkusBuild`:

```
BUILD SUCCESSFUL
module JUnit XML totals: tests=87 failures/errors=0 skipped=0
AuditConsumerTest:       tests=26 failures=0  skipped=0
:openbank-audit-service:quarkusBuild BUILD SUCCESSFUL
```

Skipped counts are read from the JUnit XML, not the console, so a Quarkus boot failure reporting
every `@QuarkusTest` as SKIPPED could not read as a pass.

## What this does NOT fix, with counts

Measured now, 1785 rows total:

| Gap | Rows | Why not here |
|---|---|---|
| Producers that emit **no actor key at all** | ~1290 | `BALANCE_UPDATED` (314), `HOLD_*` (228), `KYC_*` (224), `PARTY_*` (64), `AccountCreated`/`AccountStatusChanged` (126), statements (86). The consumer has nothing to read; each needs its own producer change. |
| `sanctions` review carries `reviewedBy`, which the consumer does not read | 51 | **All 51 are JSON null** — sanctions-service never populates the reviewer. Adding the key would recover 0 rows today and add a silent path; the producer is the thing to fix. |
| `source_service = 'unknown'` on existing rows | 1359 | Retired for NEW rows by #4270's topic attribution, already deployed. Not backfillable — see below. |
| `source_service_source IS NULL` on existing rows | 1784 | Same. |
| No provenance enum for **actor** (absent-because-system vs absent-because-omitted) | — | The `OccurredAtSource`/`AttributionSource` treatment applied to the actor is a column + migration + read-path change; worth doing, deliberately not smuggled into this fix. |

**No backfill is proposed, and none is available.** `audit_entries` carries
`CREATE RULE no_update_audit ... DO INSTEAD NOTHING` (V2), so an UPDATE against it *succeeds and
changes nothing* — a backfill migration would look like it had worked and would have done nothing.
The 7 corrupted rows stay as they are; this stops the 8th.

## Deployment note (verified, not assumed)

The issue's premise that the consumer-side fix had not shipped no longer holds. `audit-service` is
running `sandbox-2f2eb227`, and `git merge-base --is-ancestor` confirms that image **does** contain
#4270. Exactly one row has been written since (`EVENT`, customer-edge); the `TOPIC` path is correct
in tests but still unexercised live purely for want of traffic on the other 20 topics.

## Scope

`openbank-audit-service` only. No `openbank-libs` change, so no `@Produces` risk to non-consuming
services. No API change, so no `openapi.yaml` bump. Version left to release-please.

Refs #3994
