### PR TITLE
docs: add AGENTS.md as a symlink to CLAUDE.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md


### PR DESCRIPTION
`AGENTS.md` -> `CLAUDE.md`, as a symlink.

Non-Claude agent harnesses (opencode / Sisyphus) are briefed to read `AGENTS.md` first, as the
authoritative in-repo rule file. It has never existed:

```
$ git cat-file -e origin/main:AGENTS.md
fatal: path 'AGENTS.md' does not exist in 'origin/main'
```

So such a harness loads none of root `CLAUDE.md` (1054 lines of fleet rules) and runs on
`rules.yaml` alone — the machine-checkable subset. Two PRs authored that way are already merged on
`main` (#3300, #3319); both came out correct, and #3319 even regenerated all three `agents.yaml`
derived tails. That is a good outcome reached without the rule file being readable, which makes it
luck, not a procedure. Detail and evidence in #4312.

## Why a symlink rather than a second document

One file, one source of truth, structurally incapable of drifting. A parallel `AGENTS.md` carrying
its own copy of the rules would reproduce the failure the repo already knows well — a published doc
keeping its own copy of a list that lives elsewhere **is** the drift (#2280, where the AGPL module
count read 12 / 10 / 4 across four places). Aiming that defect at the harness least able to notice
it is the worst available placement.

## Release axis

Type `docs`, and the only path touched is a root-level symlink — no `<service>/` file outside any
`exclude-paths`. Neither release axis fires, which is correct: nothing shipped changes.

## Verification

- `python3 .github/scripts/check-license-headers.py` -> `OK: multi-license tree is self-consistent`,
  exit 0. A symlink is not a file the SPDX scanner needs to stamp, and the gate agrees.
- `readlink AGENTS.md` -> `CLAUDE.md`; git stores it as mode 120000, so the two can never diverge.

## Linked issues

Closes #4312
