### PR TITLE
ci(governance): declare every gate's falsifiability instead of hiding it in run:

### DIFF
--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -182,8 +182,9 @@ gates:
     name: "deployed image pins name a commit (issue #3344, enforced)"
     group: gitops
     mode: enforced
+    selftest: python3 .github/scripts/check-deploy-drift.py --self-test
+    selftest_expect: pass
     run: |
-      python3 .github/scripts/check-deploy-drift.py --self-test
       python3 .github/scripts/check-deploy-drift.py --root . --offline
 
   # ADR-0081 / issue #854 step 4: NetworkPolicies are DERIVED data (DO NOT
@@ -198,21 +199,23 @@ gates:
     name: every gateway model declares a per-token price (an unpriced model costs $0 and voids every budget)
     group: gitops
     mode: enforced
+    selftest: python3 .github/scripts/check-litellm-model-costs.py --self-test
+    selftest_expect: pass
     run: |
       # Falsified both ways before wiring in: 4 findings against the unpriced tree, 0 after,
       # 9 self-test cases including an explicit zero (which must NOT be treated as a price).
-      python3 .github/scripts/check-litellm-model-costs.py --self-test
       python3 .github/scripts/check-litellm-model-costs.py --enforce
 
   - id: agent-virtual-keys
     name: every agent authenticates with its OWN LiteLLM virtual key, not the shared master key
     group: gitops
     mode: enforced
+    selftest: python3 .github/scripts/check-agent-virtual-keys.py --self-test
+    selftest_expect: pass
     run: |
       # Falsified in both directions before it was wired in: 4 findings against the
       # pre-fix tree, 0 after, plus 7 self-test cases covering the exemption and the
       # near-misses. A gate that has only ever passed is unfalsified.
-      python3 .github/scripts/check-agent-virtual-keys.py --self-test
       python3 .github/scripts/check-agent-virtual-keys.py --enforce
 
   - id: model-residency-claims
@@ -518,8 +521,9 @@ gates:
     name: "probe/scrape port has a listener (issue #2872, enforced)"
     group: gitops
     mode: enforced
+    selftest: python3 .github/scripts/check-probe-port-listener.py --selftest
+    selftest_expect: pass
     run: |
-      python3 .github/scripts/check-probe-port-listener.py --selftest
       python3 .github/scripts/check-probe-port-listener.py --enforce
 
   # ==== supplychain ====================================================
@@ -830,6 +834,8 @@ gates:
     name: "SLO registry consistency (issue #669, rules.yaml: slo)"
     group: registry
     mode: enforced
+    selftest: python3 .github/scripts/check-slo-registry.py --self-test
+    selftest_expect: pass
     run: |
       python3 .github/scripts/check-slo-registry.py
 
@@ -1024,13 +1030,14 @@ gates:
     name: "agent case-coordination schema invariants (ADR-0244 D3/D6/D9, enforced)"
     group: registry
     mode: enforced
+    selftest: python3 .github/scripts/check-agent-case-schema.py --self-test
+    selftest_expect: pass
     run: |
       # #3771 added case_classes + case_capabilities to agents.yaml with no validator;
       # a threshold of 1.30 or a second charter holding case.coordinate would parse as
       # valid YAML and merge as a governance lie (budgets are the D6 stop-condition,
       # single-coordinator the D3/D9 audit invariant). Falsified both directions by the
       # 15-case self-test; the real file passes.
-      python3 .github/scripts/check-agent-case-schema.py --self-test
       python3 .github/scripts/check-agent-case-schema.py --enforce
 
   # EU AI Act inventory drift (ADR-0148 rule #7, issue #1918).
@@ -1097,8 +1104,9 @@ gates:
     name: "ensure-ecr-repository classification (#3423/#3453, enforced)"
     group: supplychain
     mode: enforced
+    selftest: bash .github/scripts/ensure-ecr-repository.sh --self-test
+    selftest_expect: pass
     run: |
-      bash .github/scripts/ensure-ecr-repository.sh --self-test
 
   # campaign-service's rollout died on `/bundle/rules-data.yaml: merge error` (#2872 defect 4).
   # The sidecar runs `opa run --bundle /bundle` — DIRECTORY mode, where OPA derives a data
@@ -1139,24 +1147,26 @@ gates:
     name: every committed scheduler cron parses (a malformed one is a boot crashloop, not a missed run)
     group: kotlin
     mode: enforced
+    selftest: python3 .github/scripts/check-scheduler-cron-syntax.py --self-test
+    selftest_expect: pass
     run: |
       # Nothing in the test layers parses the PRODUCTION cron: the cron IT overrides it with a
       # fast expression and %test overrides it with a never-fire one, so both run against a
       # different string than the one that ships. Falsified against the real files with three
       # typo classes (bad day name, unix 5-field, both day fields '*'); 12 self-tests.
-      python3 .github/scripts/check-scheduler-cron-syntax.py --self-test
       python3 .github/scripts/check-scheduler-cron-syntax.py --enforce
 
   - id: scheduled-trigger-emitted
     name: a declared SCHEDULED trigger must actually be emitted (an unreachable schedule fails silently)
     group: kotlin
     mode: enforced
+    selftest: python3 .github/scripts/check-scheduled-trigger-emitted.py --self-test
+    selftest_expect: pass
     run: |
       # Falsified in three directions before wiring in: a new unemitted service fails, a
       # baselined service that becomes covered ALSO fails (so the list cannot rot), and the
       # tree as committed passes. 9 self-test cases, including comment-only mentions and
       # Kotlin's NESTED block comments.
-      python3 .github/scripts/check-scheduled-trigger-emitted.py --self-test
       python3 .github/scripts/check-scheduled-trigger-emitted.py --enforce
 
   # On 2026-08-02 PR #3492 squash-merged and silently removed THREE enforced gates from this file
@@ -1518,8 +1528,9 @@ gates:
     name: "non-nullable required JAX-RS param ratchet (issue #3104, enforced)"
     group: kotlin
     mode: enforced
+    selftest: python3 .github/scripts/check-nonnull-jaxrs-params.py --self-test
+    selftest_expect: pass
     run: |
-      python3 .github/scripts/check-nonnull-jaxrs-params.py --self-test
       python3 .github/scripts/check-nonnull-jaxrs-params.py --root .
 
   # openbank.outbox.dispatch-enabled guard (the CLAUDE.md "outbox footgun":
@@ -1843,6 +1854,8 @@ gates:
     name: "ASVS L3 mechanical subset (enforced, baseline-ratcheted)"
     group: api
     mode: enforced
+    selftest: python3 .github/scripts/check-asvs-l3.py --self-test
+    selftest_expect: pass
     run: |
       python3 .github/scripts/check-asvs-l3.py --enforce --baseline .github/asvs-l3-baseline.txt
 
@@ -2050,16 +2063,18 @@ gates:
     name: "kafka dotted-key ratchet (issues #686/#2945, enforced)"
     group: data
     mode: enforced
+    selftest: python3 .github/scripts/check-kafka-dotted-keys.py --self-test
+    selftest_expect: pass
     run: |
-      python3 .github/scripts/check-kafka-dotted-keys.py --self-test
       python3 .github/scripts/check-kafka-dotted-keys.py --root .
 
   - id: external-feed-declaration-drift
     name: "external feed declaration drift (issue #2204, enforced)"
     group: data
     mode: enforced
+    selftest: python3 .github/scripts/check-external-feeds.py --self-test
+    selftest_expect: pass
     run: |
-      python3 .github/scripts/check-external-feeds.py --self-test
       python3 .github/scripts/check-external-feeds.py --root . --offline
 
   # ==== security =======================================================
@@ -2466,3 +2481,31 @@ gates:
     selftest_expect: pass
     run: |
       python3 .github/scripts/agent-review-scope.py --self-test
+
+  # Falsifiability has to be DECLARED, not merely present. `selftest:` is a field run-gates.py
+  # ACTS on — it runs the harness before the gate and skips the gate when the verdict is wrong.
+  # A `--self-test` invoked inside a gate's own `run:` block reads identically to a human and
+  # is invisible to every tool: no ordering, no selftest_expect check, and a harness that
+  # starts failing cannot be told from the gate failing.
+  #
+  # Measured 2026-08-09 over 128 gates: 63 declared one, TWELVE more ran a self-test inline,
+  # and two others (check-slo-registry.py, check-asvs-l3.py) shipped a harness nothing called
+  # at all. Wiring those 13 took no new logic and moved declared falsifiability 63 -> 76.
+  #
+  # Same defect as `mode:` — the repo already learned advisory-vs-enforced must be stated
+  # outright rather than inferred from a step name (#2450, #2392). This is that lesson applied
+  # to the property the whole gate system rests on.
+  #
+  # Rule 1 (an existing harness must be declared) has NO baseline: the harness demonstrably
+  # exists, so nothing is being weighed. Rule 2 is a ratchet — today's 44 undeclared checkers
+  # are baselined as debt rather than fixed, because a gate that fails on its own backlog is
+  # one nobody can merge past. Rule 3 fails on a stale baseline entry in either direction, so
+  # the list cannot rot: it shrinks freely, and growing it needs a reviewer.
+  - id: gate-selftest-declaration
+    name: "every gate's falsifiability is declared, not inline (enforced)"
+    group: lint
+    mode: enforced
+    selftest: python3 .github/scripts/check-gate-selftest-declaration.py --self-test
+    selftest_expect: pass
+    run: |
+      python3 .github/scripts/check-gate-selftest-declaration.py --enforce

--- a/.github/scripts/check-gate-selftest-declaration.py
+++ b/.github/scripts/check-gate-selftest-declaration.py
@@ -1,0 +1,314 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+#
+# FALSIFIABILITY MUST BE DECLARED, NOT MERELY PRESENT.
+#
+# This repo's hardest-won CI rule is that a gate which has only ever passed is unfalsified:
+# its failure path is code nobody has run, and it fails in ways a green/red signal cannot
+# express (#2165, #2154, #2177). `gates.yaml` answers that with a `selftest:` field, and
+# run-gates.py acts on it — it runs the self-test BEFORE the gate and skips the gate entirely
+# when the verdict is wrong.
+#
+# All of which is worth exactly nothing if the self-test is not in that field. Measured on
+# 2026-08-09 across 128 gates: 63 declared one, and **12 more ran a `--self-test` inside
+# their own `run:` block**. To a human reading gates.yaml those twelve look falsified. To
+# run-gates.py they do not exist: no ordering guarantee, no `selftest_expect` verdict check,
+# and a self-test that starts failing is indistinguishable from the gate failing. Two others
+# (`check-slo-registry.py`, `check-asvs-l3.py`) shipped a `--self-test` harness that nothing
+# anywhere called.
+#
+# This is the same defect as `mode:` — the repo already learned that advisory-vs-enforced has
+# to be stated outright rather than inferred, because inferring it from a step name is how
+# the registration gate once flagged itself (#2450, #2392). Falsifiability is the same kind
+# of property: a declared one is enumerable, auditable and acted upon; an undeclared one is a
+# convention that reads as coverage.
+#
+# WHAT THIS ENFORCES
+#   1. HARD, no baseline: a gate whose `run:` invokes `--self-test`/`--selftest` must declare
+#      it in `selftest:`. This is never a judgement call — the harness demonstrably exists,
+#      so there is nothing to weigh. It is also the direction that silently regresses, since
+#      copying an existing gate's shape is how the twelve happened.
+#   2. RATCHET: a NEW gate must declare `selftest:` or be listed in the baseline below with a
+#      reason. Today's 52 undeclared gates are baselined, not fixed — writing 52 harnesses is
+#      a separate piece of work, and a gate that fails on the debt is a gate nobody can merge
+#      past. What this stops is the debt GROWING, which is the property that matters.
+#   3. Both directions: a baseline entry for a gate that now declares a self-test, or for a
+#      gate id that no longer exists, is also an error. A baseline that can only grow is the
+#      hand-kept list this repo already knows reads as passing when it is short.
+#
+# Usage:  check-gate-selftest-declaration.py [--enforce]
+#         check-gate-selftest-declaration.py --self-test
+#
+# (Yes, this checker has a self-test. A gate about falsifiability that could not itself fail
+#  would be the joke writing itself.)
+
+import argparse
+import pathlib
+import re
+import sys
+
+import yaml
+
+MANIFEST = ".github/gates/gates.yaml"
+SELFTEST_RE = re.compile(r"--self-?test\b")
+
+# Gates with no self-test as of 2026-08-09, each with the reason it is acceptable — or, where
+# it is simply debt, saying so in those words. This list may SHRINK freely; growing it needs a
+# reason a reviewer accepts, which is the point (repo rule: make the exclusions the thing a
+# human has to justify).
+#
+# Categories used below:
+#   is-a-test-suite   the `run:` IS a unit-test suite, so it falsifies itself by construction
+#   third-party       the command is an externally maintained linter; we do not own its tests
+#   debt              a real checker with no harness. Not excused, just not fixed today.
+BASELINE = {
+    # --- the run: is itself a test suite -------------------------------------------------
+    "gate-runner-self-test": "is-a-test-suite — the run: IS run-gates.py --self-test",
+    "governance-script-unit-tests": "is-a-test-suite — pytest over the governance scripts",
+    "auto-deploy-reconcile-probe-unit-test": "is-a-test-suite",
+    "can-i-deploy-block-classifier-unit-test": "is-a-test-suite",
+    "can-i-deploy-version-selector-unit-test": "is-a-test-suite",
+    "co-deploy-set-derivation-unit-test": "is-a-test-suite",
+    # --- externally maintained tooling ---------------------------------------------------
+    "yamllint": "third-party — yamllint's own test suite is not ours to run",
+    "shellcheck": "third-party — shellcheck's own test suite is not ours to run",
+}
+
+# Everything else undeclared as of the measurement date is debt, enumerated at import time so
+# the file cannot silently disagree with the manifest. Kept separate from BASELINE so the two
+# reasons never blur: BASELINE is "correct as is", DEBT is "should get a harness eventually".
+DEBT_MARKER = "debt — no self-test harness yet (baselined 2026-08-09, #4335)"
+
+
+def load(root="."):
+    f = pathlib.Path(root) / MANIFEST
+    if not f.exists():
+        raise FileNotFoundError(f"{MANIFEST} not found")
+    doc = yaml.safe_load(f.read_text()) or {}
+    gates = doc.get("gates")
+    if not gates:
+        # Never report a clean verdict about an empty manifest: that is the shape where a
+        # gate over a list reads as passing precisely because it found nothing.
+        raise ValueError(f"{MANIFEST}: no gates found — refusing to report a pass")
+    return gates
+
+
+def analyse(gates, debt, baseline=None):
+    """Return (undeclared_with_harness, new_undeclared, stale_baseline).
+
+    `baseline` is a PARAMETER, not the module global, so the self-test can drive fixtures.
+    An earlier version read the global here and every fixture inherited the real 8-entry
+    exemption list — every case reported 8 stale entries and the self-test could not express
+    any of the behaviours it was written to pin down. The counter-example has to reach the
+    code, and a shared global is one of the ways it quietly does not."""
+    baseline = BASELINE if baseline is None else baseline
+    ids = {g.get("id") for g in gates}
+    known = set(baseline) | set(debt)
+
+    undeclared_with_harness, new_undeclared = [], []
+    for g in gates:
+        gid = g.get("id")
+        declared = bool(g.get("selftest"))
+        runs_selftest = bool(SELFTEST_RE.search(str(g.get("run", ""))))
+        if declared:
+            continue
+        if runs_selftest and gid != "gate-runner-self-test":
+            # Rule 1 — hard. The harness exists; only the declaration is missing.
+            undeclared_with_harness.append(gid)
+        elif gid not in known:
+            # Rule 2 — ratchet.
+            new_undeclared.append(gid)
+
+    # Rule 3 — both directions.
+    stale = []
+    for gid in sorted(known):
+        if gid not in ids:
+            stale.append(f"{gid}: baselined but no such gate exists any more — remove the entry")
+        else:
+            g = next(x for x in gates if x.get("id") == gid)
+            if g.get("selftest") and gid not in baseline:
+                stale.append(f"{gid}: now declares a self-test — remove it from the debt list")
+    return undeclared_with_harness, new_undeclared, stale
+
+
+def report(undeclared_with_harness, new_undeclared, stale, enforce):
+    bad = False
+    for gid in undeclared_with_harness:
+        print(f"::error::{gid}: its run: invokes a --self-test but `selftest:` is not declared. "
+              f"run-gates.py cannot see it, so there is no ordering guarantee, no "
+              f"selftest_expect verdict check, and a broken harness is indistinguishable from "
+              f"a failing gate. Move the command into the `selftest:` field.", file=sys.stderr)
+        bad = True
+    for gid in new_undeclared:
+        print(f"::error::{gid}: a gate with no `selftest:` and no baseline entry. A gate that "
+              f"has only ever passed is unfalsified — add a self-test, or add the id to "
+              f"BASELINE/DEBT in this script with a reason.", file=sys.stderr)
+        bad = True
+    for msg in stale:
+        print(f"::error::stale baseline — {msg}", file=sys.stderr)
+        bad = True
+
+    if bad and not enforce:
+        print("::warning::gate-selftest-declaration found violations (advisory run)")
+        return 0
+    return 1 if bad else 0
+
+
+def self_test():
+    fails = []
+
+    def case(label, gates, debt, want_harness, want_new, want_stale, baseline=None):
+        h, n, s = analyse(gates, debt, baseline if baseline is not None else {})
+        got = (sorted(h), sorted(n), len(s))
+        exp = (sorted(want_harness), sorted(want_new), want_stale)
+        if got != exp:
+            fails.append(f"{label}: expected {exp}, got {got}")
+
+    ok = {"id": "ok", "selftest": "x --self-test", "run": "x"}
+
+    # A properly declared gate is clean — the case that separates this from a gate which
+    # flags everything.
+    case("a declared self-test is clean", [ok], {}, [], [], 0)
+
+    # Rule 1: the harness exists in run: but is not declared. This is the measured defect —
+    # 12 gates on 2026-08-09 — and it must fail even though a human reading gates.yaml would
+    # see a self-test right there.
+    case("an inline --self-test must be flagged",
+         [{"id": "inline", "run": "python3 x.py --self-test\npython3 x.py --enforce"}], {},
+         ["inline"], [], 0)
+    case("the --selftest spelling counts too",
+         [{"id": "inline2", "run": "python3 x.py --selftest"}], {}, ["inline2"], [], 0)
+
+    # ...and being baselined must NOT excuse it. A declaration that exists cannot be waived;
+    # otherwise the baseline becomes a way to hide the one violation that is never a
+    # judgement call.
+    case("a baseline entry does not excuse an existing harness",
+         [{"id": "inline3", "run": "x --self-test"}], {"inline3": "debt"}, ["inline3"], [], 0)
+
+    # Rule 2: ratchet. Unknown and undeclared fails; baselined and undeclared passes.
+    case("a new undeclared gate must be flagged",
+         [{"id": "fresh", "run": "python3 x.py"}], {}, [], ["fresh"], 0)
+    case("a baselined undeclared gate is accepted",
+         [{"id": "old", "run": "python3 x.py"}], {"old": "debt"}, [], [], 0)
+
+    # Rule 3: both directions, so the list cannot rot either way.
+    case("a baseline entry for a vanished gate is stale",
+         [ok], {"gone": "debt"}, [], [], 1)
+    case("a baseline entry that healed is stale",
+         [{"id": "healed", "selftest": "x --self-test", "run": "x"}], {"healed": "debt"}, [], [], 1)
+
+    # gate-runner-self-test is the one legitimate inline case: its run: IS the runner's own
+    # self-test, so there is no separate harness to declare.
+    case("the runner's own self-test is exempt",
+         [{"id": "gate-runner-self-test", "run": "python3 .github/scripts/run-gates.py --self-test"}],
+         {}, [], [], 0, baseline={"gate-runner-self-test": "is-a-test-suite"})
+
+    # An empty manifest must RAISE, never report clean.
+    try:
+        load(root="/nonexistent-root-for-self-test")
+        fails.append("a missing manifest did not raise (would report a false clean)")
+    except (FileNotFoundError, ValueError):
+        pass
+
+    # Exit codes: advisory downgrades to 0, --enforce does not. Silenced — report() prints to
+    # stderr by design, and an ::error line from a PASSING self-test reads as a failure in CI.
+    import contextlib, io
+    sink = io.StringIO()
+    with contextlib.redirect_stderr(sink), contextlib.redirect_stdout(sink):
+        rc_adv = report(["x"], [], [], enforce=False)
+        rc_enf = report(["x"], [], [], enforce=True)
+        rc_ok = report([], [], [], enforce=True)
+    if rc_adv != 0:
+        fails.append("advisory mode did not downgrade a violation to 0")
+    if rc_enf != 1:
+        fails.append("--enforce did not fail on a violation")
+    if rc_ok != 0:
+        fails.append("a clean run did not exit 0 under --enforce")
+
+    if fails:
+        for f in fails:
+            sys.stderr.write(f"::error::self-test: {f}\n")
+        sys.stderr.write(f"self-test FAILED ({len(fails)} case(s))\n")
+        return 1
+    print("self-test ok: gate-selftest-declaration is falsifiable (12 cases)")
+    return 0
+
+
+def main():
+    ap = argparse.ArgumentParser(description="every gate's falsifiability must be DECLARED")
+    ap.add_argument("--enforce", action="store_true")
+    ap.add_argument("--root", default=".")
+    ap.add_argument("--self-test", action="store_true")
+    args = ap.parse_args()
+
+    if args.self_test:
+        return self_test()
+
+    try:
+        gates = load(args.root)
+    except (FileNotFoundError, ValueError) as e:
+        sys.stderr.write(f"::error::{e}\n")
+        return 1
+
+    debt = DEBT
+    h, n, s = analyse(gates, debt)
+    declared = len([g for g in gates if g.get("selftest")])
+    print(f"gate-selftest-declaration: {declared}/{len(gates)} gates declare a self-test; "
+          f"{len(BASELINE)} exempt by kind, {len(DEBT)} baselined as debt.")
+    return report(h, n, s, args.enforce)
+
+
+# The debt list, written out rather than derived, so that shrinking it is a visible diff and
+# growing it needs a reviewer. Derived would have been worse here: a set computed from the
+# manifest agrees with the manifest by construction and could never flag anything (the same
+# self-corroboration trap as widening a known-good set with the layer it is checking).
+DEBT = {
+    "accounting-clock-gate": DEBT_MARKER,
+    "admin-ui-version-sync-guard": DEBT_MARKER,
+    "adr-registry-integrity-check": DEBT_MARKER,
+    "advisory-gate-registration": DEBT_MARKER,
+    "agent-charter-registry-parity": DEBT_MARKER,
+    "ai-act-high-risk-inventory-vs-code": DEBT_MARKER,
+    "ai-governance-snapshot-drift": DEBT_MARKER,
+    "authz-enforce-pdp-sidecar-parity": DEBT_MARKER,
+    "clock-injection-gate": DEBT_MARKER,
+    "critical-alert-egress": DEBT_MARKER,
+    "db-backup-association-gate": DEBT_MARKER,
+    "db-migration-gate": DEBT_MARKER,
+    "deploy-coverage-guard": DEBT_MARKER,
+    "domainevent-occurredat-constructor-guard": DEBT_MARKER,
+    "dotted-mp-messaging-key-guard": DEBT_MARKER,
+    "duplicate-yaml-key-guard": DEBT_MARKER,
+    "eu-ai-act-inventory-drift": DEBT_MARKER,
+    "evals-registry-integrity": DEBT_MARKER,
+    "event-consumer-liveness": DEBT_MARKER,
+    "event-contract-coverage-ratchet": DEBT_MARKER,
+    "feature-flag-governance": DEBT_MARKER,
+    "gate-graduation-guard": DEBT_MARKER,
+    "gen-network-policies-drift-gate": DEBT_MARKER,
+    "gitops-ref-integrity-guard": DEBT_MARKER,
+    "identifier-intent-guard": DEBT_MARKER,
+    "mcp-charter-data-scope-binding": DEBT_MARKER,
+    "mcp-real-port-requires-caller-auth-first": DEBT_MARKER,
+    "no-dead-code-service-principal-rego-rule": DEBT_MARKER,
+    "no-runblocking-in-a-scheduled-body": DEBT_MARKER,
+    "no-service-local-exceptionmapper-collision-with-libs-runtime": DEBT_MARKER,
+    "openapi-route-conformance": DEBT_MARKER,
+    "openapi-server-port": DEBT_MARKER,
+    "operator-write-naming": DEBT_MARKER,
+    "outbox-dispatch-enabled-guard": DEBT_MARKER,
+    "prompt-registry-integrity": DEBT_MARKER,
+    "psd2-anonymous-grant-stays-behind-eidas-mtls": DEBT_MARKER,
+    "quarkus-application-version-override-guard": DEBT_MARKER,
+    "release-registration-consistency": DEBT_MARKER,
+    "release-scope-mismatch-gate": DEBT_MARKER,
+    "rolesallowed-realm-parity": DEBT_MARKER,
+    "schema-compat-gate": DEBT_MARKER,
+    "service-runbook-drift": DEBT_MARKER,
+    "test-runblocking-unit-guard": DEBT_MARKER,
+    "threat-model-coverage": DEBT_MARKER,
+}
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Refs #2165, #2154, #2177

## The gap

`selftest:` is a field **run-gates.py acts on** — it runs the harness before the gate and skips the gate entirely when the verdict is wrong. A `--self-test` invoked inside a gate's own `run:` block reads identically to a human, and is invisible to every tool: no ordering guarantee, no `selftest_expect` verdict check, and a harness that starts failing cannot be told apart from the gate failing.

Measured over all 128 gates:

| | |
|---|---|
| declared `selftest:` | 63 |
| **ran a `--self-test` inline in `run:`** | **12** |
| shipped a `--self-test` harness nothing called at all | 2 (`check-slo-registry.py`, `check-asvs-l3.py`) |
| no falsification of any kind | 51 (6 of them *are* test suites, 2 are third-party linters) |

Someone wrote that falsification and it was not wired. Wiring all 13 took **no new logic** and moved declared falsifiability **63 → 76**.

Each of the 13 harnesses was run first — 12 passed as-is; `check-probe-port-listener.py` uses the `--selftest` spelling and was already invoking itself inline, so it moved rather than appeared.

## Why this is the `mode:` lesson again

The repo already learned that advisory-vs-enforced must be **stated outright** rather than inferred from a step name — inferring it is how the registration gate once flagged itself (#2450, #2392). Falsifiability is the same kind of property: declared, it is enumerable, auditable and acted upon; undeclared, it is a convention that reads as coverage.

## The ratchet

`check-gate-selftest-declaration.py`, gate `gate-selftest-declaration`, enforced:

1. **No baseline.** A `run:` invoking a `--self-test` must declare it. Nothing is weighed — the harness demonstrably exists. This is also the direction that silently regresses, since copying an existing gate's shape is how the twelve happened.
2. **Ratchet.** A new gate declares a self-test or carries a baseline entry with a reason. Today's 44 undeclared checkers are baselined **as debt, not fixed** — a gate that fails on its own backlog is one nobody can merge past. What this stops is the debt growing.
3. **Both directions.** A baseline entry for a gate that has since gained a self-test, or for a gate id that no longer exists, is an error too. The list shrinks freely; growing it needs a reviewer.

Falsified **against the real manifest**, not only fixtures: adding an undeclared gate fails rule 2, and moving a declared self-test back into a `run:` fails rule 1 with its own distinct message. 12 fixture cases cover the rest, including that an empty manifest must **raise** rather than report a clean.

## Two defects of my own, both of which had passed

- The debt baseline was **hand-copied from a listing truncated at 40 rows**, so 21 gates were missing. The checker caught it on its first run against the real manifest. It is now derived from the manifest once and frozen, rather than typed.
- A falsification case I described as testing rule 1 was actually failing on **rule 2** — red, but for a different reason than claimed. Only re-running it against a gate genuinely in the baseline exercised the rule I meant.

Both are the same shape as what this PR is about: something that looked verified and was not.

## Local verification

`lint 11/11 · registry 22/22 · supplychain 20/20 · security 12/12 · data 11/11`. `api` fails only on `sudo` for an `oasdiff` install (environmental — `sudo: a terminal is required to read the password`). The 13 newly-declared self-tests now run **as self-tests**, so the runner skips their gate if a verdict is wrong — that is the behaviour change worth watching in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
