### PR TITLE
feat(notification): tag push fan-outs by template so an undelivered SCA approval can be alerted on

### DIFF
--- a/openbank-infra/gitops/components/observability/prometheus-rules-push.yaml
+++ b/openbank-infra/gitops/components/observability/prometheus-rules-push.yaml
@@ -90,3 +90,34 @@ spec:
               Almost every PUSH request targets a party with no ACTIVE device token. Suspect the
               device-registration path (POST /api/v1/devices) or a mass token invalidation, not
               the push provider.
+
+        # The ratio rules above are about the channel; this one is about a single message, because
+        # not every push is worth the same alert. SCA_APPROVAL is the prompt telling a customer a
+        # payment waits on their approval — a PSD2 Art. 97 control — so ONE undelivered instance
+        # is worth waking someone, where one lost marketing push is not.
+        #
+        # It is NOT true that the customer cannot then authorise: openbank-app also lists live
+        # challenges at GET /customer/v1/sca/pending, so someone who opens the app can still
+        # approve. What they lose is any notice that they need to. The wording says that, because
+        # an alert that overstates its own severity is one people learn to discount.
+        #
+        # Reads the `template` label added to the fan-out counter for exactly this rule — before
+        # it existed an undeliverable SCA approval was indistinguishable at the metrics layer from
+        # any other push. Measured 2026-08-08: 11 failed SCA_APPROVAL pushes across 6 parties over
+        # two weeks, none of which raised anything.
+        - alert: ScaApprovalPushUndeliverable
+          expr: |
+            increase(openbank_notification_push_fanouts_total{
+              template="SCA_APPROVAL", outcome="FAILED"
+            }[15m]) > 0
+          for: 0m
+          labels:
+            severity: critical
+          annotations:
+            summary: "An SCA approval push could not be delivered"
+            description: >-
+              An SCA_APPROVAL fan-out ended FAILED in the last 15m, so the customer was never
+              prompted that a payment is waiting on them. They can still approve by opening the
+              app (pending-approvals list), but will not know to. devices_bucket="0" means the
+              party has no registered device at all — that is a registration problem, not a
+              provider one.

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/application/NotificationConsumer.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/application/NotificationConsumer.kt
@@ -596,7 +596,7 @@ class NotificationConsumer {
             .chain { tokens ->
                 if (tokens.isEmpty()) {
                     log.infof("PUSH: no active devices for party=%s template=%s", req.partyId, req.template)
-                    pushMetrics.recordFanOut(NotificationOutcome.FAILED, 0)
+                    pushMetrics.recordFanOut(req.template, NotificationOutcome.FAILED, 0)
                     return@chain markStatus(
                         req,
                         entity,
@@ -655,7 +655,7 @@ class NotificationConsumer {
         )
         val outcome = pushOutcomeOf(accepted, skipped)
         val reason = pushReasonOf(accepted, skipped)
-        pushMetrics.recordFanOut(outcome, results.size)
+        pushMetrics.recordFanOut(req.template, outcome, results.size)
         return Panache.withTransaction {
             deviceTokenRepo.invalidate(invalidIds).chain { _ ->
                 notificationRepo.find("notificationId", entity.notificationId).firstResult()

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/application/port/out/PushMetricsPort.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/application/port/out/PushMetricsPort.kt
@@ -5,6 +5,7 @@
 package com.openbank.notification.application.port.out
 
 import com.openbank.notification.domain.model.NotificationOutcome
+import com.openbank.notification.domain.model.NotificationTemplate
 import com.openbank.notification.domain.model.PushPlatform
 import com.openbank.notification.domain.model.PushSendOutcome
 
@@ -38,6 +39,12 @@ interface PushMetricsPort {
      *
      * Emitted for every fan-out including the zero-device case, so "nobody has a device
      * registered" is a visible number rather than an absence.
+     *
+     * [template] is carried because not every push is worth the same alert. A lost
+     * `SCA_APPROVAL` is the prompt telling a customer a payment waits on their approval — a
+     * PSD2 Art. 97 control — and without this label it is indistinguishable at the metrics
+     * layer from a lost marketing message. `NotificationTemplate` is a closed enum, so the
+     * label is bounded by construction and cannot become a cardinality problem.
      */
-    fun recordFanOut(outcome: NotificationOutcome, devices: Int)
+    fun recordFanOut(template: NotificationTemplate, outcome: NotificationOutcome, devices: Int)
 }

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/infrastructure/observability/PushMetricsAdapter.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/infrastructure/observability/PushMetricsAdapter.kt
@@ -6,6 +6,7 @@ package com.openbank.notification.infrastructure.observability
 
 import com.openbank.notification.application.port.out.PushMetricsPort
 import com.openbank.notification.domain.model.NotificationOutcome
+import com.openbank.notification.domain.model.NotificationTemplate
 import com.openbank.notification.domain.model.PushPlatform
 import com.openbank.notification.domain.model.PushSendOutcome
 import io.micrometer.core.instrument.Counter
@@ -60,10 +61,11 @@ class PushMetricsAdapter(private val registry: MeterRegistry?) : PushMetricsPort
         }
     }
 
-    override fun recordFanOut(outcome: NotificationOutcome, devices: Int) {
+    override fun recordFanOut(template: NotificationTemplate, outcome: NotificationOutcome, devices: Int) {
         registry?.let { r ->
             Counter.builder("openbank.notification.push.fanouts")
                 .tag("service", SERVICE)
+                .tag("template", template.name)
                 .tag("outcome", outcome.name)
                 .tag("devices_bucket", deviceBucket(devices))
                 .register(r)

--- a/openbank-notification-service/src/test/kotlin/com/openbank/notification/infrastructure/observability/PushMetricsAdapterTest.kt
+++ b/openbank-notification-service/src/test/kotlin/com/openbank/notification/infrastructure/observability/PushMetricsAdapterTest.kt
@@ -5,6 +5,7 @@
 package com.openbank.notification.infrastructure.observability
 
 import com.openbank.notification.domain.model.NotificationOutcome
+import com.openbank.notification.domain.model.NotificationTemplate
 import com.openbank.notification.domain.model.PushPlatform
 import com.openbank.notification.domain.model.PushSendOutcome
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
@@ -34,18 +35,35 @@ class PushMetricsAdapterTest {
 
     @Test
     fun `a fan-out with no devices is still counted, so zero devices is a number not an absence`() {
-        adapter.recordFanOut(NotificationOutcome.FAILED, 0)
+        adapter.recordFanOut(NotificationTemplate.SCA_APPROVAL, NotificationOutcome.FAILED, 0)
 
         val counter = registry.find("openbank.notification.push.fanouts").counter()
         assertThat(counter?.count()).isEqualTo(1.0)
         assertThat(counter?.id?.getTag("devices_bucket")).isEqualTo("0")
+        // Without this tag an undeliverable SCA approval — a PSD2 Art. 97 prompt — is
+        // indistinguishable from an undeliverable marketing message, and no alert can single
+        // it out. Measured 2026-08-08: 11 failed SCA_APPROVAL pushes across 6 parties.
+        assertThat(counter?.id?.getTag("template")).isEqualTo("SCA_APPROVAL")
+    }
+
+    @Test
+    fun `the template tag distinguishes one template's failures from another's`() {
+        adapter.recordFanOut(NotificationTemplate.SCA_APPROVAL, NotificationOutcome.FAILED, 0)
+        adapter.recordFanOut(NotificationTemplate.TRANSACTION_COMPLETED, NotificationOutcome.FAILED, 0)
+
+        val sca = registry.find("openbank.notification.push.fanouts")
+            .tag("template", "SCA_APPROVAL").counter()
+        val tx = registry.find("openbank.notification.push.fanouts")
+            .tag("template", "TRANSACTION_COMPLETED").counter()
+        assertThat(sca?.count()).isEqualTo(1.0)
+        assertThat(tx?.count()).isEqualTo(1.0)
     }
 
     @Test
     fun `no registry is a no-op rather than a crash`() {
         val inert = PushMetricsAdapter(null)
         inert.recordSend(PushPlatform.FCM, PushSendOutcome.FAILED, "HTTP_410")
-        inert.recordFanOut(NotificationOutcome.SENT, 2)
+        inert.recordFanOut(NotificationTemplate.SCA_APPROVAL, NotificationOutcome.SENT, 2)
     }
 
     @Test


### PR DESCRIPTION
## Why

ADR-0252 phase 0 (#4351) made the push channel observable. Its counters answer *"how is the channel doing"* — but `push_fanouts_total{outcome,devices_bucket}` carries no template, so an undeliverable **SCA approval** is indistinguishable at the metrics layer from an undeliverable marketing message.

They are not worth the same alert. `SCA_APPROVAL` is the prompt telling a customer a payment is waiting on their approval — a PSD2 Art. 97 control. One instance is worth waking someone; one lost marketing push is not. The existing ratio rules are all channel-level, so a handful of failed SCA approvals inside otherwise-healthy traffic never crosses any threshold.

**Measured 2026-08-08: 11 failed `SCA_APPROVAL` pushes across 6 distinct parties, continuously from 2026-07-24 to 2026-08-08.** Nothing raised anything in those two weeks.

## What

- `template` added to the existing fan-out counter, threaded through both call sites (including the zero-device path, which is the one that matters here). **A label, not a second counter** — two counters over one channel in one service are two things to drift apart. `NotificationTemplate` is a closed enum, so cardinality is bounded by construction, and the port KDoc says why the label is there.
- `ScaApprovalPushUndeliverable` added to the ADR-0252 rules file, firing on a single occurrence.

## On the alert's wording

Deliberately narrower than the obvious phrasing. **The customer is not locked out:** `openbank-app` lists live challenges at `GET /customer/v1/sca/pending`, so someone who opens the app can still approve. What they lose is any *notice* that they need to — for a payment they initiated, it simply appears not to complete.

I had written the stronger claim ("the customer cannot authorise their payment") in an earlier draft and corrected it once I checked the app. An alert that overstates its own severity is one people learn to discount, which costs more than the alert is worth.

## Verification

- **The assertions were falsified.** Removing the `template` tag from the adapter fails exactly the two tests that check it, and nothing else: 6 tests, 2 failed. Restored: green.
- **PromQL validated against the live in-cluster Prometheus, probe validated first** — a deliberately malformed expression returns `parse error`, the `up` control returns 265 series, the new rule parses and returns 0 results (correct; the label ships with this PR).
- Local gate green: `test`, `ktlintCheck`, `detekt`.

## Relationship to the other push work

| | |
|---|---|
| #4351 (merged) | the counters — how is the channel doing |
| #4349 | `failure_reason` on the row — why did *this message* fail, durably |
| this PR | the template label + the one alert that needed it |
| openbank-app#432 (merged) | the registration side, where the failures actually originate |

Refs #4353, ADR-0252
