### PR TITLE
ci(governance): drop the identifier-intent-guard debt entry its self-test made stale

### DIFF
--- a/.github/scripts/check-gate-selftest-declaration.py
+++ b/.github/scripts/check-gate-selftest-declaration.py
@@ -352,7 +352,6 @@ DEBT = {
     "gate-graduation-guard": DEBT_MARKER,
     "gen-network-policies-drift-gate": DEBT_MARKER,
     "gitops-ref-integrity-guard": DEBT_MARKER,
-    "identifier-intent-guard": DEBT_MARKER,
     "mcp-charter-data-scope-binding": DEBT_MARKER,
     "mcp-real-port-requires-caller-auth-first": DEBT_MARKER,
     "no-dead-code-service-principal-rego-rule": DEBT_MARKER,


### PR DESCRIPTION
## `main` is red

`gates (lint)` fails on `origin/main` right now, reproduced in a clean detached worktree with no
local changes:

```
::error::stale baseline — identifier-intent-guard: now declares a self-test — remove it from the debt list
gate failed: every gate's falsifiability is declared, not inline (enforced)
```

That gate is part of the enforced `Validate manifests` shard, so **every open PR inherits the red**
until this lands — #4366 and #4367 already show it.

## Why neither PR could see it

#4311 gave `identifier-intent-guard` a real self-test, so it stopped being debt. But #4311's branch
predates #4336 — the PR that *created* `.github/scripts/check-gate-selftest-declaration.py` — so
there was no debt list on that branch to remove itself from. Each PR was correct and green in
isolation; the defect exists only in their merge order.

Worth recording because it defeated my own first check: grepping #4311's branch for the entry
returned nothing, and I read that as "the line was deleted". It was not — **the file was absent**.
A no-hits grep cannot distinguish a removed line from a missing file.

## The change

One line removed, asserted by count rather than trusted to the edit.

| | `gate-selftest-declaration` |
|---|---|
| `origin/main` | **FAIL=1** |
| this branch | **PASS=1** |

Refs #1699, #4311, #4336
