### PR TITLE
feat(libs): ADR-0252 phase 1 — the synthetic taint primitive

### DIFF
--- a/openbank-libs-domain/src/main/kotlin/com/openbank/libs/synthetic/SyntheticTaint.kt
+++ b/openbank-libs-domain/src/main/kotlin/com/openbank/libs/synthetic/SyntheticTaint.kt
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.libs.synthetic
+
+/**
+ * The synthetic taint (ADR-0252 phase 1, issue #4348).
+ *
+ * ONE flag, carried end to end, marking activity produced by a bank-owned synthetic customer
+ * rather than a real one. It is the primitive the whole synthetic-customer fleet rests on, and
+ * it is deliberately tiny: a header name, a baggage key, and a parse with one strongly-argued
+ * default.
+ *
+ * ## Why a taint at all
+ *
+ * A synthetic customer that does not touch the real code path proves nothing about the real
+ * code path. So the canary's payment IS a real payment: it hits the ledger, the screening
+ * engine and the event streams. That is the point, and it is also the risk — those movements
+ * must never reach a regulatory aggregate. The taint is what lets both be true at once.
+ *
+ * ## The asymmetry, which is easy to get backwards
+ *
+ * Two rules, and they point in opposite directions:
+ *
+ *  - **Regulatory aggregates and analytics baselines must EXCLUDE tainted activity.** FINREP,
+ *    COREP, AnaCredit, statistical returns, AML baseline scoring. A synthetic movement in a
+ *    regulatory return is a misstatement.
+ *  - **Control paths must INCLUDE it, always.** Sanctions screening, Verification of Payee,
+ *    SCA, limits, fraud scoring. The canary exists to prove those controls are alive; a
+ *    control that skips synthetic traffic is a control the canary cannot test, and excluding
+ *    synthetic payments from screening would manufacture a screening blind spot — a worse
+ *    defect than the one the fleet is built to catch.
+ *
+ * There is no `mayBypassControl` helper here on purpose. A call site that wants to skip work
+ * for synthetic traffic is asking the wrong question, and the absence of an API to answer it
+ * is the cheapest possible way to say so.
+ *
+ * ## Fail-to-REAL, never fail-to-synthetic
+ *
+ * [isTainted] treats anything that is not an exact, case-insensitive `true` as REAL — absent,
+ * empty, malformed, `1`, `yes`, all of it. The two failure directions are not symmetric:
+ *
+ *  - real activity misread as synthetic ⇒ it is dropped from FINREP/COREP/AnaCredit and from
+ *    the AML baseline. A regulatory return that silently omits real customer money.
+ *  - synthetic activity misread as real ⇒ a canary's own movements land in those aggregates.
+ *    Wrong, visible, and bounded by how much the canaries do — which the platform sets.
+ *
+ * The first is unbounded and silent, so the default leans away from it. `1`/`yes`/`on` are
+ * rejected rather than accepted for the same reason: a permissive parser turns any stray value
+ * in a header into a suppression.
+ */
+object SyntheticTaint {
+
+    /**
+     * Kafka record header. Lower-case and hyphenated to match the fleet's other transport
+     * headers, and NOT a payload field: a taint that lives in the body can only be read by a
+     * consumer that already deserialises that body, while every consumer, bridge and dead-letter
+     * tool can read a header.
+     */
+    const val KAFKA_HEADER: String = "x-openbank-synthetic"
+
+    /**
+     * OpenTelemetry baggage key. Dotted, per OTel convention, and distinct from [KAFKA_HEADER]
+     * on purpose — they travel different rails and a shared constant would imply one hop
+     * carries the other.
+     */
+    const val BAGGAGE_KEY: String = "openbank.synthetic"
+
+    /** The only value that means "synthetic". See the fail-to-real note in the class KDoc. */
+    const val TRUE_VALUE: String = "true"
+
+    /**
+     * True only for an exact, case-insensitive [TRUE_VALUE], after trimming surrounding
+     * whitespace. Everything else — null, blank, `1`, `yes`, `TRUE!`, a stray byte — is REAL.
+     */
+    fun isTainted(value: String?): Boolean = value?.trim()?.equals(TRUE_VALUE, ignoreCase = true) == true
+
+    /**
+     * True when [headers] carries the taint. The lookup is case-insensitive because header
+     * casing survives no transport reliably: Kafka preserves it, HTTP/2 lower-cases it, and a
+     * bridge between them may do either. A case-sensitive lookup here would make the taint
+     * silently disappear at exactly one hop, which is the failure this whole ADR is about.
+     */
+    fun isTainted(headers: Map<String, String?>): Boolean =
+        headers.entries.firstOrNull { it.key.equals(KAFKA_HEADER, ignoreCase = true) }
+            ?.value
+            ?.let(::isTainted)
+            ?: false
+
+    /** The header value to stamp. Only ever [TRUE_VALUE] — an untainted record carries no header. */
+    fun headerValue(): String = TRUE_VALUE
+
+    /**
+     * Whether a regulatory aggregate, statistical return or analytics baseline may count this
+     * record. Named for the decision rather than the flag so a reader of the call site sees the
+     * rule, not a boolean whose polarity they have to reconstruct.
+     */
+    fun admittedToRegulatoryAggregate(tainted: Boolean): Boolean = !tainted
+
+    /** [admittedToRegulatoryAggregate] straight from a header map, for a consumer that has one. */
+    fun admittedToRegulatoryAggregate(headers: Map<String, String?>): Boolean = !isTainted(headers)
+}

--- a/openbank-libs-domain/src/test/kotlin/com/openbank/libs/synthetic/SyntheticTaintTest.kt
+++ b/openbank-libs-domain/src/test/kotlin/com/openbank/libs/synthetic/SyntheticTaintTest.kt
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.libs.synthetic
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * ADR-0252 phase 1. These assertions are about the DEFAULT, not about parsing: the parse is four
+ * lines and could not plausibly be wrong, while the direction it fails in decides whether a
+ * regulatory return can silently omit real customer money.
+ */
+class SyntheticTaintTest {
+
+    @Test
+    fun `only an exact true means synthetic`() {
+        assertThat(SyntheticTaint.isTainted("true")).isTrue()
+        assertThat(SyntheticTaint.isTainted("TRUE")).isTrue()
+        assertThat(SyntheticTaint.isTainted("  true  ")).isTrue()
+    }
+
+    @Test
+    fun `everything else is REAL, including the values a permissive parser would accept`() {
+        // The dangerous direction is real-read-as-synthetic: that drops real money out of
+        // FINREP/COREP/AnaCredit and the AML baseline, silently and without bound. So a stray
+        // value in a header must never be able to suppress a record.
+        for (value in listOf(null, "", "   ", "1", "yes", "on", "TRUE!", "synthetic", "false", "0")) {
+            assertThat(SyntheticTaint.isTainted(value))
+                .withFailMessage("%s must be read as REAL, not synthetic", value)
+                .isFalse()
+        }
+    }
+
+    @Test
+    fun `header lookup is case-insensitive because casing does not survive every hop`() {
+        // Kafka preserves header casing, HTTP/2 lower-cases it, and a bridge may do either. A
+        // case-sensitive lookup would drop the taint at exactly one hop and nowhere else.
+        assertThat(SyntheticTaint.isTainted(mapOf("X-OpenBank-Synthetic" to "true"))).isTrue()
+        assertThat(SyntheticTaint.isTainted(mapOf("x-openbank-synthetic" to "true"))).isTrue()
+        assertThat(SyntheticTaint.isTainted(mapOf("X-OPENBANK-SYNTHETIC" to "true"))).isTrue()
+    }
+
+    @Test
+    fun `an absent or differently-named header is REAL`() {
+        assertThat(SyntheticTaint.isTainted(emptyMap())).isFalse()
+        assertThat(SyntheticTaint.isTainted(mapOf("x-openbank-synthetics" to "true"))).isFalse()
+        assertThat(SyntheticTaint.isTainted(mapOf("x-openbank-synthetic" to null))).isFalse()
+    }
+
+    @Test
+    fun `regulatory aggregates admit real activity and exclude synthetic`() {
+        assertThat(SyntheticTaint.admittedToRegulatoryAggregate(tainted = false)).isTrue()
+        assertThat(SyntheticTaint.admittedToRegulatoryAggregate(tainted = true)).isFalse()
+        assertThat(SyntheticTaint.admittedToRegulatoryAggregate(mapOf(SyntheticTaint.KAFKA_HEADER to "true")))
+            .isFalse()
+        assertThat(SyntheticTaint.admittedToRegulatoryAggregate(emptyMap())).isTrue()
+    }
+
+    @Test
+    fun `the stamped value round-trips`() {
+        assertThat(SyntheticTaint.isTainted(SyntheticTaint.headerValue())).isTrue()
+    }
+
+    @Test
+    fun `there is no API for bypassing a control on synthetic traffic`() {
+        // Not a tautology test: it pins the API SURFACE. Controls (screening, VoP, SCA, limits)
+        // must run for synthetic traffic — that is what the canary exists to prove — so the
+        // absence of a `mayBypassControl`-shaped helper is a deliberate design property, and a
+        // future addition should have to delete this assertion and explain itself.
+        val members = SyntheticTaint::class.java.methods.map { it.name }
+        assertThat(members).noneMatch { it.contains("bypass", ignoreCase = true) }
+        assertThat(members).noneMatch { it.contains("skip", ignoreCase = true) }
+    }
+}


### PR DESCRIPTION
ADR-0252 phase 1, first slice. Additive, unwired, no service touches it yet — everything else in
phase 1 (canary personas, the ledger dimension, exclusion from the regulatory aggregates) rests on
this, so it lands on its own where it can be argued about in isolation.

## What is actually being decided

The file is a header name, a baggage key and a four-line parse. The load-bearing part is the
**default**, and it is not symmetric:

- **Real read as synthetic** ⇒ dropped from FINREP / COREP / AnaCredit and the AML baseline. A
  regulatory return that silently omits real customer money. Unbounded and invisible.
- **Synthetic read as real** ⇒ canary movements land in those aggregates. Wrong, but visible, and
  bounded by how much the canaries do — which the platform sets.

So `isTainted()` reads anything that is not an exact, case-insensitive `true` as REAL. `1`, `yes`,
`on` are **rejected** rather than accepted for the same reason: a permissive parser turns any stray
value in a header into a suppression.

The header lookup is case-insensitive because casing survives no transport reliably — Kafka
preserves it, HTTP/2 lower-cases it, a bridge between them may do either. A case-sensitive lookup
would drop the taint at exactly one hop and nowhere else, which is the failure mode this whole ADR
is about.

It is a **header**, not a payload field: a taint in the body can only be read by a consumer that
already deserialises that body, while every consumer, bridge and dead-letter tool can read a header.

## The asymmetry, encoded rather than described

Two rules pointing in opposite directions, and the second is the one that gets built backwards:

- regulatory aggregates and analytics baselines **exclude** tainted activity;
- control paths — sanctions screening, Verification of Payee, SCA, limits, fraud scoring — **always
  include** it. A canary that skips the controls proves nothing about them, and excluding synthetic
  payments from screening would manufacture a screening blind spot: a worse defect than the one the
  fleet exists to catch.

So there is deliberately **no bypass-shaped helper**, and a test pins that absence by reflecting over
the object's methods. A future addition has to delete an assertion and explain itself. The test
inspects the method list rather than the file text, so the word "bypass" appearing in the KDoc that
explains the rule cannot satisfy it — the check-matches-its-own-comment trap (#3072).

## Verification

- `:openbank-libs-domain:test ktlintCheck detekt` green. Verdict read from the test XML: 7 tests,
  **0 failures, 0 skipped**.
- **The API-surface test is falsified, not assumed:** adding a `mayBypassControl` method makes the
  suite exit 1; removing it exits 0. Both measured.
- The default is tested against the values a permissive parser would have accepted (`1`, `yes`, `on`,
  `TRUE!`) rather than only against `true`/`false`, since that is where the decision lives.

## Scope

Nothing consumes this yet. Wiring it into producers and consumers, the ledger dimension, and the
exclusion in the regulatory aggregates are separate PRs — several of them money-path, so they need
two human approvals by rule. Tracked in #4348.

Refs #4348, ADR-0252.
