### PR TITLE
fix(ci): unbreak the default branch — drop the stale gate-selftest debt entry

### DIFF
--- a/.github/scripts/check-gate-selftest-declaration.py
+++ b/.github/scripts/check-gate-selftest-declaration.py
@@ -352,7 +352,6 @@ DEBT = {
     "gate-graduation-guard": DEBT_MARKER,
     "gen-network-policies-drift-gate": DEBT_MARKER,
     "gitops-ref-integrity-guard": DEBT_MARKER,
-    "identifier-intent-guard": DEBT_MARKER,
     "mcp-charter-data-scope-binding": DEBT_MARKER,
     "mcp-real-port-requires-caller-auth-first": DEBT_MARKER,
     "no-dead-code-service-principal-rego-rule": DEBT_MARKER,


### PR DESCRIPTION
`main` has been **red since c40aa316d (#4311)**, and every PR opened against it inherits the failure.

#4311 gave `identifier-intent-guard` a self-test — paying the debt — but left it in the
`DEBT_MARKER` list in `check-gate-selftest-declaration.py`. That gate fails on a stale entry in
**either** direction by design, precisely so a debt list cannot quietly become permanent:

```
stale baseline — identifier-intent-guard: now declares a self-test — remove it from the debt list
```

The gate was right; nothing was wrong with the tree except the list. One line removed.

Caught by `main-red-watch` (#4019), which raised #4191 naming the exact job — the mechanism working
on the one signal in this repo that has no other reader. A red push-triggered run has no PR and no
reviewer, and the next PR opened against that commit inherits a failure it did not cause. Two of
mine did (#4359, #4371).

Verified: `run-gates.py --only gate-selftest-declaration` passes on this branch and fails on the
base commit.

Refs #4191.
