### PR TITLE
ci: detect and escalate merges past an actively failing required check

### DIFF
--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -1307,6 +1307,30 @@ gates:
     run: |
       python3 .github/scripts/check-main-red-watch.py --check-declaration
 
+  # Nothing in this repo has ever read a merged PR's required contexts: before #4240,
+  # `grep -rl 'required_status_checks\|statusCheckRollup' .github/scripts .github/workflows`
+  # returned one hit and it was a comment. A ruleset bypass is recorded only in
+  # `rulesets/rule-suites`, which tells nobody: no PR carries it, no check turns red.
+  #
+  # The binding copy is HERE, not in merged-past-red-check-watch.yml: that workflow is
+  # scheduled and paths-filtered, so it can never be a required context. What this gate holds
+  # is the DECLARATION half — that the watch still queries an explicit non-`day` window (the
+  # default returned 1 row where the true count was 7), still paginates, still keys on the
+  # per-suite `failing` detail rather than `result: bypass` (22 of 29 such rows are benign),
+  # still escalates onto an issue rather than merely going red, and still refuses to report a
+  # window it could not read. The runtime half never gates a merge — a bypass that already
+  # happened is not a defect in the PR at hand.
+  - id: merged-past-red-check-declaration
+    name: "the merged-past-red-check watch keeps its window, its key and its escalation (issue #4240, enforced)"
+    group: registry
+    mode: enforced
+    min_subjects: 6   # D1-D6, applied to the one watch workflow. 0 means the workflow moved.
+    selftest: |
+      python3 .github/scripts/check-merged-past-red-check.py --self-test
+    selftest_expect: pass
+    run: |
+      python3 .github/scripts/check-merged-past-red-check.py --check-declaration
+
   - id: opa-sidecar-bundle-shape
     name: "OPA sidecar data mounts match its .manifest roots (#2872, enforced)"
     group: gitops

--- a/.github/scripts/check-merged-past-red-check.py
+++ b/.github/scripts/check-merged-past-red-check.py
@@ -1,0 +1,564 @@
+#!/usr/bin/env python3
+"""Nothing notices when a PR is merged past an actively FAILING required check (issue #4240).
+
+WHY THIS EXISTS
+---------------
+`main-protection` is a ruleset, and a ruleset can be bypassed. When it is, GitHub records the
+bypass in `repos/<owner>/<repo>/rulesets/rule-suites` and tells nobody else: no PR carries the
+record, no check turns red, no notification is sent, and the merge commit on `main` looks
+exactly like every other merge commit. On 2026-08-08 #4215 merged while `Validate manifests`
+was FAILING and the first anyone knew of it was a human reading the Actions tab.
+
+Before this script, `grep -rl 'required_status_checks\\|statusCheckRollup' .github/scripts
+.github/workflows` returned exactly one hit -- a comment inside agent-review.yml. No workflow in
+this repository has ever read a merged PR's required contexts.
+
+THE MEASUREMENT THAT DEFINES THE SCOPE, and the trap inside it
+--------------------------------------------------------------
+`rulesets/rule-suites` defaults to `time_period=day`. The unparameterised query therefore
+returns ONE row for the incident that prompted #4240, and that single row reads precisely like
+confirmation that the incident was isolated. It is not. Re-measured 2026-08-09 with
+`?time_period=month&per_page=100 --paginate`, deduplicated by suite id:
+
+    2890 raw rows -> 37 distinct `bypass` suites
+    29 of those carry a FAILED `required_status_checks` evaluation
+     7 of those 29 were merged past a check that was actively FAILING:
+
+        pushed_at         head sha    PR     failing required check
+        2026-07-14 09:00  200a6960   #1030   "OPA policy gate" is failing.
+        2026-07-16 10:51  ab245ab3   #1187   "OPA policy gate" is failing.
+        2026-08-07 09:30  0abed33e   #3658   2 of 5 ...: 1 expected and 1 failing.
+        2026-08-07 09:45  3208109c   #3771   2 of 5 required status checks are failing.
+        2026-08-07 10:34  ee974ea3   #3686   2 of 5 required status checks are failing.
+        2026-08-07 17:07  6b3594b2   #4054   2 of 5 required status checks are failing.
+        2026-08-08 17:49  4405a74f   #4215   "Validate manifests" is failing.
+
+    (Suite ids are deliberately not tabulated here: gitleaks' `rod-cislo` rule matches a bare
+    10-digit number, so committing them fails the required Secret-scan check on a shape with no
+    secret in it. The head sha identifies the merge and is greppable.)
+
+Four of the seven landed on 2026-08-07 alone. A detector that reports ONE is not detecting the
+incident, it is reproducing the default-window bug that hid the other six. D1 below makes that
+a property of the committed workflow rather than a thing someone remembered.
+
+WHY `result: bypass` IS THE WRONG KEY -- the noise half
+-------------------------------------------------------
+The other 22 of those 29 are benign and vastly outnumber the signal. A required context that has
+not reported yet is `expected`; one still running is `in progress`. Both are recorded as a FAILED
+`required_status_checks` evaluation on a `bypass` suite, and neither is a merge past a red check:
+
+    "Required status check \"all-green\" is expected."             <- 19 rows, benign
+    "Required status check \"all-green\" is in progress."          <- benign
+    "3 of 5 required status checks have not succeeded: 1 expected."<- benign
+    "Required status check \"Validate manifests\" is failing."     <- SIGNAL
+    "2 of 5 ... have not succeeded: 1 expected and 1 failing."     <- SIGNAL (mixed row)
+
+So the classifier keys on the word `failing` in the per-evaluation `details` string, never on
+`result == "bypass"` and never on the evaluation result alone. A detector that flags all 22
+benign rows is noise, and noise is ignored, which returns the repo to exactly where #4240 found
+it. The mixed row is why the test cannot be `details.endswith("are failing.")`.
+
+ESCALATION, not redness
+-----------------------
+This runs on a schedule and on push to main. A red scheduled workflow is addressed to nobody --
+that is the #4019 lesson this repo already paid for, and reproducing it here would mean the
+detector for an invisible failure is itself an invisible failure. So the runtime lane opens or
+refreshes ONE issue carrying the marker `<!-- merged-past-red-check -->`, reopens it if it was
+hand-closed while offending merges are still inside the window, and closes it itself when the
+window comes back clean. Refreshed in place, never stacked.
+
+The escalation is self-limiting without any stored state: the window is `month`, so a merge
+ages out of the report on its own and the issue closes when the last one does.
+
+TOKEN IDENTITY -- read this before assuming the runtime lane works
+------------------------------------------------------------------
+`rulesets/rule-suites` requires the repository **Administration: read** permission. The Actions
+`permissions:` block has no `administration:` key at all -- there is no way to grant a job's
+`GITHUB_TOKEN` that scope, so the workflow token CANNOT read this endpoint no matter how the job
+is written. The runtime lane therefore needs a PAT (or GitHub App token) in
+`secrets.RULESET_AUDIT_TOKEN`, and the workflow's `capability` step probes the endpoint with the
+plain `GITHUB_TOKEN` on every PR so that this claim is measured under the identity CI actually
+uses, not asserted from documentation. When the secret is absent the runtime lane SKIPS loudly
+rather than reporting a clean window -- a permission-shaped absence is indistinguishable from a
+real one, and it always fails in the direction of a confident wrong answer.
+
+THE TWO LANES
+-------------
+DECLARATION (`--check-declaration`) is a property of the committed workflow file: offline,
+deterministic, and BLOCKING. Its binding copy is the `merged-past-red-check-declaration` gate in
+.github/gates/gates.yaml, which runs unconditionally inside `Validate manifests`. A
+`paths:`-filtered or scheduled workflow can never be a required context here, so the workflow's
+own pull_request lane is only a fast echo. The rules:
+
+  D1  The workflow must pass an EXPLICIT `time_period=` to rule-suites. The default is `day`,
+      which hid six of the seven. `time_period=day` is itself rejected.
+  D2  It must paginate. 37 bypass suites hide inside 2890 rows; one un-paginated page of 100
+      covers roughly nine hours of this repo's push rate.
+  D3  It must classify with THIS script, and this script must key on the `failing` detail.
+      D3 rejects a workflow that decides anything from `result: bypass` in a `run:` block.
+  D4  It must escalate: `issues: write` plus a step that writes an issue. A workflow that only
+      goes red rebuilds the blind spot.
+  D5  It must be scheduled. A push-triggered-only detector cannot notice a bypass on a day
+      nobody pushes, and the bypass is by definition the last push.
+  D6  It must read the ruleset token from a secret and skip loudly when it is unset, never
+      fall back to GITHUB_TOKEN and report an empty window.
+
+WHAT THIS CANNOT DO
+-------------------
+It cannot see a merge that was NOT a ruleset bypass: a check that reported green and was wrong,
+or a required context that was never required, leaves no rule-suite row. It cannot look further
+back than GitHub's retention for the endpoint (`month` is the longest window the API offers,
+and rows age out). And it says nothing about WHY the bypass happened -- an admin merge made
+deliberately and one made by reflex are the same row. It reports; a human judges.
+
+USAGE
+    .github/scripts/check-merged-past-red-check.py --self-test
+    .github/scripts/check-merged-past-red-check.py --check-declaration
+    .github/scripts/check-merged-past-red-check.py --scan --repo O/R --json /tmp/v.json
+    .github/scripts/check-merged-past-red-check.py --scan --from-file suites.json   # offline
+
+EXIT CODES
+    0  clean / declaration holds / self-test passed
+    1  the detector could not answer (a failure of THIS SCRIPT, never a "clean" verdict)
+    2  at least one merge past an actively failing required check was found
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import gatelib  # noqa: E402
+
+REPO = Path(__file__).resolve().parents[2]
+WORKFLOW = ".github/workflows/merged-past-red-check-watch.yml"
+
+# The one classification rule. `failing` appears in every signal detail string and in none of
+# the benign ones; `0 failing` is excluded so a future GitHub phrasing cannot invert the sense.
+FAILING_RE = re.compile(r"\bfailing\b")
+ZERO_FAILING_RE = re.compile(r"\b0 failing\b")
+
+STATUS_RULE = "required_status_checks"
+
+DEFAULT_PERIOD = "month"
+
+
+def list_url(repo: str, period: str) -> str:
+    """The ONE place the rule-suites LIST url is built. D1 exercises this function rather
+    than grepping for `time_period`: the first draft of D1 was a whole-file grep and it
+    flagged its own explanatory prose, the #2450 collision. A grep cannot distinguish the
+    thing from the prose about the thing — so the rule calls the construct instead."""
+    return f"repos/{repo}/rulesets/rule-suites?time_period={period}&per_page=100"
+
+
+def detail_url(repo: str, suite_id: int) -> str:
+    """The per-suite DETAIL endpoint. Takes no window; it is the only source of
+    `rule_evaluations`, which the list endpoint omits entirely."""
+    return f"repos/{repo}/rulesets/rule-suites/{suite_id}"
+
+
+# --------------------------------------------------------------------------------------
+# classifier
+# --------------------------------------------------------------------------------------
+def failing_details(suite: dict[str, Any]) -> list[str]:
+    """Return the required-status-check details that describe an ACTIVELY FAILING check.
+
+    Keys on the per-evaluation `details` string, never on the suite's `result`. See the module
+    header: 22 of 29 failed status-check evaluations in the measured month were `expected` or
+    `in progress` and are not merges past a red check.
+    """
+    out: list[str] = []
+    for ev in suite.get("rule_evaluations") or []:
+        if ev.get("rule_type") != STATUS_RULE:
+            continue
+        if ev.get("result") != "fail":
+            continue
+        details = (ev.get("details") or "").strip()
+        if not details:
+            continue
+        if ZERO_FAILING_RE.search(details):
+            continue
+        if FAILING_RE.search(details):
+            out.append(details)
+    return out
+
+
+def is_merge_past_red(suite: dict[str, Any]) -> bool:
+    """A bypass onto a protected ref that carried an actively failing required check."""
+    if suite.get("result") != "bypass":
+        return False
+    return bool(failing_details(suite))
+
+
+def offenders(suites: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Deduplicate by suite id (the paginated endpoint repeats rows), classify, sort by time."""
+    seen: dict[int, dict[str, Any]] = {}
+    for s in suites:
+        sid = s.get("id")
+        if sid is None:
+            continue
+        # A later copy may carry the detail payload the list endpoint omits.
+        if sid not in seen or (s.get("rule_evaluations") and not seen[sid].get("rule_evaluations")):
+            seen[sid] = s
+    found = []
+    for s in sorted(seen.values(), key=lambda x: (x.get("pushed_at") or "", x.get("id") or 0)):
+        if is_merge_past_red(s):
+            found.append(
+                {
+                    "suite_id": s.get("id"),
+                    "pushed_at": s.get("pushed_at"),
+                    "actor": s.get("actor_name"),
+                    "ref": s.get("ref"),
+                    "head_sha": s.get("after_sha"),
+                    "details": failing_details(s),
+                }
+            )
+    return found
+
+
+# --------------------------------------------------------------------------------------
+# network lane
+# --------------------------------------------------------------------------------------
+def _gh(args: list[str], token: str | None) -> str:
+    env = dict(os.environ)
+    if token:
+        env["GH_TOKEN"] = token
+    p = subprocess.run(["gh", *args], capture_output=True, text=True, env=env)
+    if p.returncode != 0:
+        raise RuntimeError(f"gh {' '.join(args)} failed ({p.returncode}): {p.stderr.strip()[:400]}")
+    return p.stdout
+
+
+def fetch_suites(repo: str, period: str, token: str | None) -> list[dict[str, Any]]:
+    """List every rule suite in the window, then fetch each BYPASS suite's detail payload.
+
+    The list endpoint carries no `rule_evaluations`; only `rule-suites/<id>` does. Fetching
+    details for the bypass rows alone keeps this at ~40 calls rather than ~2900.
+    """
+    raw = _gh(["api", "--paginate", list_url(repo, period)], token)
+    listed = json.loads(raw) if raw.strip().startswith("[") else []
+    ids = sorted({s["id"] for s in listed if s.get("result") == "bypass"})
+    return [json.loads(_gh(["api", detail_url(repo, sid)], token)) for sid in ids]
+
+
+def resolve_pr(repo: str, sha: str, token: str | None) -> int | None:
+    try:
+        data = json.loads(_gh(["api", f"repos/{repo}/commits/{sha}/pulls"], token))
+    except RuntimeError:
+        return None
+    return data[0]["number"] if data else None
+
+
+def scan(args: argparse.Namespace) -> int:
+    if args.from_file:
+        suites = json.loads(Path(args.from_file).read_text())
+        if isinstance(suites, dict):
+            suites = [suites]
+        found = offenders(suites)
+    else:
+        token = os.environ.get(args.token_env) or None
+        if not token and args.require_token:
+            print(
+                f"::error::{args.token_env} is unset. `rulesets/rule-suites` needs the "
+                "Administration:read permission, which a workflow GITHUB_TOKEN cannot hold. "
+                "Refusing to report a window as clean that was never read.",
+                file=sys.stderr,
+            )
+            return 1
+        try:
+            suites = fetch_suites(args.repo, args.period, token)
+        except RuntimeError as exc:
+            print(f"::error::could not read rule suites: {exc}", file=sys.stderr)
+            return 1
+        found = offenders(suites)
+        for f in found:
+            f["pr"] = resolve_pr(args.repo, f["head_sha"], token)
+
+    verdict = {
+        "repo": args.repo,
+        "period": args.period,
+        "suites_examined": len(suites),
+        "offenders": found,
+        "status": "dirty" if found else "clean",
+    }
+    if args.json:
+        Path(args.json).write_text(json.dumps(verdict, indent=2))
+
+    if not found:
+        print(f"clean: no merge past an actively failing required check in the last {args.period}")
+        print(f"       ({len(suites)} bypass suites examined)")
+        return 0
+
+    print(f"{len(found)} merge(s) past an ACTIVELY FAILING required check in the last {args.period}:")
+    for f in found:
+        pr = f"#{f['pr']}" if f.get("pr") else "(no PR)"
+        print(f"  {f['pushed_at']}  suite {f['suite_id']}  {str(f['head_sha'])[:9]}  {pr}")
+        for d in f["details"]:
+            print(f"      {d}")
+    return 2
+
+
+# --------------------------------------------------------------------------------------
+# declaration lane
+# --------------------------------------------------------------------------------------
+def _strip_comments(text: str) -> str:
+    """A whole-file grep matches the PROSE explaining a rule as readily as the rule."""
+    return "\n".join(re.sub(r"(?<!\S)#.*$", "", line) for line in text.splitlines())
+
+
+# The declaration lane's corpus: one workflow file, six rules applied to it. Reported through
+# gatelib.subjects so a vanished workflow reads as "this gate examined nothing" rather than as a
+# pass — the #4339 failure mode, where a moved path turns a gate into a green no-op.
+RULE_IDS = ("D1", "D2", "D3", "D4", "D5", "D6")
+
+
+def check_declaration(root: Path, report_subjects: bool = False) -> tuple[int, list[str]]:
+    path = root / WORKFLOW
+    if not path.exists():
+        if report_subjects:
+            gatelib.subjects(0, "rules applied (the watch workflow is MISSING)")
+        return 1, [f"D0: {WORKFLOW} does not exist — the detector has no runtime lane."]
+    if report_subjects:
+        gatelib.subjects(len(RULE_IDS), "declaration rules applied to the watch workflow")
+    raw = path.read_text()
+    body = _strip_comments(raw)
+    fails: list[str] = []
+
+    # D1a — behavioural, on the construct: the one url builder must carry an explicit,
+    # non-default window. Never a whole-file grep for `time_period`; the first draft of this
+    # rule was exactly that and it flagged its own explanatory prose (the #2450 collision).
+    built = list_url("o/r", DEFAULT_PERIOD)
+    if "time_period=" not in built or re.search(r"time_period=day\b", built):
+        fails.append(
+            "D1: the rule-suites list url carries no explicit window, or carries the default "
+            "`day` — the window that returned 1 row where the true count was 7."
+        )
+
+    # D1b — any INLINE rule-suites call in the workflow. Scoped to lines that actually invoke
+    # the API (`gh api`), so prose about the endpoint cannot match.
+    for line in body.splitlines():
+        if "gh api" not in line or "rule-suites" not in line:
+            continue
+        if "time_period=" not in line or re.search(r"time_period=day\b", line):
+            fails.append(f"D1: inline rule-suites call without an explicit non-day window: {line.strip()[:90]}")
+
+    if "--paginate" not in body and "per_page" not in body:
+        fails.append("D2: no pagination — 37 bypass suites hide inside 2890 rows.")
+
+    if "check-merged-past-red-check.py" not in body:
+        fails.append("D3: the workflow does not call check-merged-past-red-check.py.")
+    if re.search(r"result.{0,6}==.{0,6}[\"']bypass", body):
+        fails.append(
+            "D3: the workflow decides from `result == bypass` — 22 of 29 such rows are benign "
+            "`expected`/`in progress`. Classification belongs in the script's `failing` key."
+        )
+
+    if not re.search(r"^\s*issues:\s*write\s*$", body, re.M):
+        fails.append("D4: no `issues: write` — a workflow that only goes red escalates to nobody.")
+    if "github-script" not in body:
+        fails.append("D4: no escalation step.")
+
+    if not re.search(r"^\s*schedule:\s*$", body, re.M):
+        fails.append("D5: not scheduled — the bypass is by definition the last push.")
+
+    if "RULESET_AUDIT_TOKEN" not in body:
+        fails.append("D6: the ruleset token is not read from a secret.")
+    if "--require-token" not in body:
+        fails.append(
+            "D6: the scan is not run with --require-token, so a missing secret would report "
+            "an unread window as clean."
+        )
+
+    # THIS script must still be the thing that keys on `failing`, not on the suite result.
+    if not FAILING_RE.search("is failing.") or is_merge_past_red(
+        _suite(0, "bypass", 'Required status check "all-green" is expected.')
+    ):
+        fails.append("D3: the classifier no longer keys on the `failing` detail.")
+
+    return (1 if fails else 0), fails
+
+
+# --------------------------------------------------------------------------------------
+# self-test
+# --------------------------------------------------------------------------------------
+def _suite(sid: int, result: str, details: str | None, rule: str = STATUS_RULE) -> dict[str, Any]:
+    evs = [{"rule_type": "required_signatures", "result": "pass"}]
+    if details is not None:
+        evs.append({"rule_type": rule, "result": "fail", "details": details})
+    return {
+        "id": sid,
+        "result": result,
+        "pushed_at": f"2026-08-07T09:{sid % 60:02d}:00+02:00",
+        "after_sha": f"{sid:040x}",
+        "actor_name": "JiRaska",
+        "ref": "refs/heads/main",
+        "rule_evaluations": evs,
+    }
+
+
+# Every SIGNAL detail string observed in the real month window, plus every BENIGN one. Both
+# lists are verbatim API output, not paraphrase: the mixed row ("1 expected and 1 failing")
+# is the case a `.endswith("are failing.")` test gets wrong, and it is a real row (#3658).
+SIGNAL_DETAILS = [
+    'Required status check "OPA policy gate" is failing.',
+    'Required status check "Validate manifests" is failing.',
+    "2 of 5 required status checks are failing.",
+    "2 of 5 required status checks have not succeeded: 1 expected and 1 failing.",
+]
+BENIGN_DETAILS = [
+    'Required status check "all-green" is expected.',
+    'Required status check "all-green" is in progress.',
+    'Required status check "Validate manifests" is in progress.',
+    "4 of 5 required status checks have not succeeded: 2 expected.",
+    "5 of 5 required status checks are expected.",
+    "3 of 5 required status checks have not succeeded: 1 expected.",
+    "2 of 5 required status checks have not succeeded: 0 failing.",
+]
+
+
+def self_test() -> int:
+    bad: list[str] = []
+
+    # 1. Every real signal string is flagged.
+    for i, d in enumerate(SIGNAL_DETAILS):
+        if not is_merge_past_red(_suite(100 + i, "bypass", d)):
+            bad.append(f"signal NOT flagged: {d!r}")
+
+    # 2. Every real benign string is silent. This is the half that decides whether the
+    #    detector is usable: 22 of 29 real rows look like these.
+    for i, d in enumerate(BENIGN_DETAILS):
+        if is_merge_past_red(_suite(200 + i, "bypass", d)):
+            bad.append(f"BENIGN flagged: {d!r}")
+
+    # 3. `result: bypass` alone is not the key — a bypass of the review rule with the status
+    #    checks green is not this defect (real shape: the 2026-07-10 bypass at 5431d982, #1030's neighbour).
+    review_only = {
+        "id": 300,
+        "result": "bypass",
+        "pushed_at": "2026-07-10T09:44:54+02:00",
+        "after_sha": "5431d98",
+        "ref": "refs/heads/main",
+        "rule_evaluations": [
+            {
+                "rule_type": "pull_request",
+                "result": "fail",
+                "details": "1 review requesting changes by reviewers with write access.",
+            },
+            {"rule_type": STATUS_RULE, "result": "pass"},
+        ],
+    }
+    if is_merge_past_red(review_only):
+        bad.append("a review-rule bypass with GREEN status checks was flagged")
+
+    # 4. The word `failing` on a DIFFERENT rule type must not count.
+    if is_merge_past_red(_suite(400, "bypass", "something is failing.", rule="pull_request")):
+        bad.append("a non-status-check rule carrying the word `failing` was flagged")
+
+    # 5. A suite that PASSED, or one that was blocked (`fail`), is not a merge past a red check.
+    for res in ("pass", "fail"):
+        if is_merge_past_red(_suite(500, res, "2 of 5 required status checks are failing.")):
+            bad.append(f"a `{res}` suite was flagged as a bypass")
+
+    # 6. Deduplication: the paginated endpoint repeats rows, and a detail-carrying copy must
+    #    win over a bare list-endpoint copy of the same id.
+    bare = {"id": 600, "result": "bypass", "pushed_at": "2026-08-07T09:00:00+02:00"}
+    rich = _suite(600, "bypass", SIGNAL_DETAILS[0])
+    for order in ([bare, rich], [rich, bare]):
+        got = offenders(order)
+        if len(got) != 1:
+            bad.append(f"dedup produced {len(got)} rows for one suite id (order {order[0] is bare})")
+
+    # 7. Mixed batch: the real ratio. 4 signal + 7 benign in, exactly 4 out, in time order.
+    batch = [_suite(700 + i, "bypass", d) for i, d in enumerate(SIGNAL_DETAILS)]
+    batch += [_suite(800 + i, "bypass", d) for i, d in enumerate(BENIGN_DETAILS)]
+    got = offenders(batch)
+    if len(got) != len(SIGNAL_DETAILS):
+        bad.append(f"mixed batch: expected {len(SIGNAL_DETAILS)} offenders, got {len(got)}")
+
+    # 8. The declaration lane must FAIL on a workflow that reproduces the default-window bug.
+    #    A rule that has only ever passed is unfalsified.
+    import tempfile
+
+    broken = (
+        "on:\n  push:\n    branches: [main]\n"
+        "jobs:\n  x:\n    steps:\n"
+        "      - run: gh api repos/o/r/rulesets/rule-suites\n"
+    )
+    with tempfile.TemporaryDirectory() as td:
+        p = Path(td) / WORKFLOW
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(broken)
+        code, fails = check_declaration(Path(td))
+        if code == 0:
+            bad.append("declaration passed a workflow with no time_period, no pagination, no issue")
+        for want in ("D1", "D2", "D3", "D4", "D5", "D6"):
+            if not any(f.startswith(want) for f in fails):
+                bad.append(f"declaration did not raise {want} against the deliberately broken file")
+
+        # 8b. A workflow whose ONLY defect is the default window must still fail D1 — the
+        #     single-rule falsification, not just the everything-broken one.
+        p.write_text(broken.replace("rule-suites", "rule-suites?time_period=day"))
+        _, fails = check_declaration(Path(td))
+        if not any(f.startswith("D1") for f in fails):
+            bad.append("declaration accepted an explicit `time_period=day`")
+
+        # 8c. Missing workflow is a failure, not a pass.
+        p.unlink()
+        if check_declaration(Path(td))[0] == 0:
+            bad.append("declaration passed with the workflow file absent")
+
+    # 9. The real declaration must hold against the committed tree.
+    code, fails = check_declaration(REPO)
+    if code != 0:
+        bad += [f"committed workflow violates {f}" for f in fails]
+
+    if bad:
+        for b in bad:
+            print(f"self-test FAILED: {b}", file=sys.stderr)
+        return 1
+    print(
+        f"self-test: {len(SIGNAL_DETAILS)} signal + {len(BENIGN_DETAILS)} benign detail strings, "
+        "dedup, rule-type scoping, suite-result scoping and 3 declaration falsifications all "
+        "behaved as required"
+    )
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--self-test", action="store_true")
+    ap.add_argument("--check-declaration", action="store_true")
+    ap.add_argument("--scan", action="store_true")
+    ap.add_argument("--root", default=str(REPO))
+    ap.add_argument("--repo", default=os.environ.get("GH_REPO", "JiRaska/open-bank-oss"))
+    ap.add_argument("--period", default="month", choices=["day", "week", "month"])
+    ap.add_argument("--from-file", help="classify saved suite details offline (falsification)")
+    ap.add_argument("--token-env", default="RULESET_AUDIT_TOKEN")
+    ap.add_argument("--require-token", action="store_true")
+    ap.add_argument("--json", help="write the verdict as JSON here")
+    args = ap.parse_args()
+
+    if args.self_test:
+        return self_test()
+    if args.check_declaration:
+        code, fails = check_declaration(Path(args.root), report_subjects=True)
+        for f in fails:
+            print(f"::error::{f}")
+        if code == 0:
+            print(f"declaration holds: {WORKFLOW} satisfies D1-D6")
+        return code
+    if args.scan:
+        return scan(args)
+    ap.error("pick one of --self-test / --check-declaration / --scan")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/main-red-watch.yml
+++ b/.github/workflows/main-red-watch.yml
@@ -55,6 +55,10 @@ on:
       - "Dependency submission"
       - "Gradle wrapper validation"
       - "Release Please"
+      # Pushes to main unconditionally (issue #4240). Its red is meaningful in a way worth
+      # naming: it means the watch could NOT read the ruleset bypass log — a permission-shaped
+      # absence, not "nothing was bypassed". Exactly the state that must not stay silent.
+      - "merged past red check watch"
       # R2: post-merge guards. Path-filtered, so they do NOT run on every commit —
       # but each is a governance verdict that only ever renders on main, which
       # makes them the LEAST likely reds to be seen and the most likely to rot.

--- a/.github/workflows/merged-past-red-check-watch.yml
+++ b/.github/workflows/merged-past-red-check-watch.yml
@@ -1,0 +1,225 @@
+# -----------------------------------------------------------------------------
+# Merges past an actively FAILING required check (issue #4240).
+#
+# All reasoning lives in .github/scripts/check-merged-past-red-check.py's header,
+# never in a `run:` block: an oversized `run:` step makes the WHOLE workflow
+# unparseable and GitHub reports no size error (#3135, ceiling ~20k chars/step).
+#
+# Short form. `main-protection` can be bypassed; GitHub records the bypass in
+# `rulesets/rule-suites` and tells nobody. That endpoint DEFAULTS to
+# `time_period=day`, so the obvious query returns one row and reads like proof the
+# incident was isolated — with `month` there are 7. And 22 of the 29 failed
+# status-check evaluations in that window are `expected`/`in progress` and benign,
+# so the classifier keys on the per-suite `failing` detail, never on
+# `result: bypass`.
+#
+# ESCALATION, not redness (#4019): a red scheduled workflow is addressed to
+# nobody, which is the very blind spot this closes. One issue, refreshed in place.
+#
+# TOKEN. rule-suites needs Administration:read. The Actions `permissions:` block
+# has no `administration:` key, so a job's GITHUB_TOKEN can NEVER read it — the
+# runtime lane uses secrets.RULESET_AUDIT_TOKEN and skips loudly without it. The
+# `capability` step measures that claim under the CI identity on every PR instead
+# of asserting it from documentation.
+#
+# WHY IT IS NOT A REQUIRED CHECK. Scheduled and paths-filtered workflows cannot be
+# required contexts here. The BINDING copy of the declaration half is the
+# `merged-past-red-check-declaration` gate in .github/gates/gates.yaml, which runs
+# unconditionally inside `Validate manifests`; this file's pull_request lane is a
+# fast echo.
+# -----------------------------------------------------------------------------
+name: merged past red check watch
+
+on:
+  schedule:
+    # D5: the bypass is by definition the last push, so a push-triggered-only
+    # detector cannot notice it on a quiet day. Twice daily.
+    - cron: "17 6,18 * * *"
+  push:
+    branches: [main]
+  pull_request:
+    paths:
+      - ".github/workflows/merged-past-red-check-watch.yml"
+      - ".github/scripts/check-merged-past-red-check.py"
+      - ".github/gates/gates.yaml"
+  workflow_dispatch:
+    inputs:
+      period:
+        description: "rule-suites window (day|week|month). Never leave it defaulted."
+        required: false
+        default: month
+
+permissions:
+  contents: read
+
+concurrency:
+  group: merged-past-red-check-watch
+  cancel-in-progress: false
+
+jobs:
+  # PR lane: offline, cheap, and the only lane that runs on a PR. It proves the
+  # classifier separates the 7 from the 22 and that the workflow still satisfies
+  # D1-D6, then measures what the CI identity can actually read.
+  declaration:
+    name: merged-past-red-check declaration
+    if: ${{ github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Self-test the classifier
+        run: python3 .github/scripts/check-merged-past-red-check.py --self-test
+
+      - name: The watch still satisfies D1-D6
+        run: python3 .github/scripts/check-merged-past-red-check.py --check-declaration
+
+      # Measured, never assumed: can the identity CI runs as read this endpoint?
+      # Never fails the job — it reports a fact about the workflow token.
+      - name: Can the workflow GITHUB_TOKEN read rule-suites?
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TARGET_REPO: ${{ github.repository }}
+        run: |
+          set +e
+          out=$(gh api "repos/${TARGET_REPO}/rulesets/rule-suites?time_period=month&per_page=1" 2>&1)
+          code=$?
+          set -e
+          if [ "$code" -eq 0 ]; then
+            echo "::notice::GITHUB_TOKEN CAN read rule-suites."
+          else
+            echo "::notice::GITHUB_TOKEN CANNOT read rule-suites (exit $code) — this is expected;"
+            echo "::notice::the endpoint needs Administration:read and permissions: has no such key."
+            printf '%s\n' "$out" | head -5
+          fi
+
+  watch:
+    name: merged past red check watch
+    if: ${{ github.event_name != 'pull_request' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # A verdict that has only ever said "clean" is indistinguishable from a
+      # classifier that finds nothing. This step failing voids the run.
+      - name: Self-test the classifier
+        run: python3 .github/scripts/check-merged-past-red-check.py --self-test
+
+      - name: Scan the ruleset bypass log
+        id: verdict
+        env:
+          RULESET_AUDIT_TOKEN: ${{ secrets.RULESET_AUDIT_TOKEN }}
+          TARGET_REPO: ${{ github.repository }}
+          PERIOD: ${{ inputs.period || 'month' }}
+        run: |
+          set +e
+          python3 .github/scripts/check-merged-past-red-check.py --scan \
+            --repo "$TARGET_REPO" --period "$PERIOD" --require-token \
+            --json /tmp/merged-past-red.json | tee /tmp/merged-past-red.txt
+          code=${PIPESTATUS[0]}
+          set -e
+          echo "code=$code" >> "$GITHUB_OUTPUT"
+          case "$code" in
+            0) : ;;
+            1) echo "::error::The watch could not answer. That is a failure of THIS WATCH,"
+               echo "::error::not a 'nothing was bypassed' verdict. Most likely"
+               echo "::error::secrets.RULESET_AUDIT_TOKEN is unset or lacks Administration:read."
+               exit 1 ;;
+            2) echo "::warning::a merge past an actively failing required check — escalating." ;;
+            *) echo "::error::Unexpected exit $code."; exit "$code" ;;
+          esac
+
+      - name: Escalate or stand down
+        if: ${{ github.event_name != 'workflow_dispatch' && steps.verdict.outputs.code != '1' }}
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const fs = require('fs')
+            const v = JSON.parse(fs.readFileSync('/tmp/merged-past-red.json', 'utf8'))
+            const LABEL = 'fleet-health'
+            const marker = '<!-- merged-past-red-check -->'
+            const REOPEN_WINDOW_DAYS = 14
+
+            // Find by MARKER, not by title: the title carries a count and moves.
+            const findByMarker = async (state) => {
+              const issues = await github.paginate(github.rest.issues.listForRepo, {
+                ...context.repo, state, labels: LABEL, per_page: 100,
+                sort: 'updated', direction: 'desc',
+              })
+              return issues.find(i => (i.body || '').includes(marker))
+            }
+
+            if (v.status !== 'dirty') {
+              const open = await findByMarker('open')
+              if (open) {
+                await github.rest.issues.createComment({
+                  ...context.repo, issue_number: open.number,
+                  body: `No merge past an actively failing required check remains in the last \`${v.period}\` — closing. _(\`${context.workflow}\` run ${context.runId})_`,
+                })
+                await github.rest.issues.update({
+                  ...context.repo, issue_number: open.number, state: 'closed',
+                })
+                core.info(`closed #${open.number}`)
+              } else {
+                core.info('clean window; nothing open.')
+              }
+              return
+            }
+
+            const n = v.offenders.length
+            const title = `${n} merge${n === 1 ? '' : 's'} past an actively failing required check (last ${v.period})`
+            const body = [
+              marker,
+              '## A PR was merged while a required check was FAILING',
+              '',
+              'Nothing else would have told you. The bypass is recorded only in',
+              '`rulesets/rule-suites`; no PR carries it, no check turns red, and the merge',
+              'commit looks like every other merge commit.',
+              '',
+              '| when | PR | head | failing required check |',
+              '|---|---|---|---|',
+              ...v.offenders.map(o =>
+                `| \`${o.pushed_at}\` | ${o.pr ? '#' + o.pr : '_none_'} | \`${String(o.head_sha).slice(0, 9)}\` | ${o.details.map(d => d.replace(/\|/g, '\\|')).join('<br>')} |`),
+              '',
+              `Window \`${v.period}\`, ${v.suites_examined} bypass suites examined. The window is`,
+              'explicit on purpose: `rule-suites` defaults to `time_period=day`, which returns one',
+              'row and reads exactly like confirmation that an incident was isolated.',
+              '',
+              'Rows where a required context was merely `expected` or `in progress` are NOT listed —',
+              'those are the common, benign case and flagging them would make this issue noise.',
+              '',
+              'This issue is refreshed in place while offending merges remain in the window and is',
+              'closed by the watch itself when the window comes back clean. Each row ages out on its',
+              'own; closing it by hand does not.',
+              '',
+              `_Automated: \`${context.workflow}\` run ${context.runId} (issue #4240)._`,
+            ].join('\n')
+
+            const open = await findByMarker('open')
+            if (open) {
+              await github.rest.issues.update({ ...context.repo, issue_number: open.number, title, body })
+              core.info(`refreshed #${open.number}`)
+              return
+            }
+            const closed = await findByMarker('closed')
+            const fresh = closed && closed.closed_at &&
+              (Date.now() - Date.parse(closed.closed_at)) < REOPEN_WINDOW_DAYS * 864e5
+            if (fresh) {
+              await github.rest.issues.update({
+                ...context.repo, issue_number: closed.number, title, body, state: 'open',
+              })
+              await github.rest.issues.createComment({
+                ...context.repo, issue_number: closed.number,
+                body: `Another merge past a failing required check — reopening rather than stacking a new issue. _(\`${context.workflow}\` run ${context.runId})_`,
+              })
+              core.info(`reopened #${closed.number}`)
+              return
+            }
+            const created = await github.rest.issues.create({
+              ...context.repo, title, body, labels: [LABEL],
+            })
+            core.info(`opened #${created.data.number}`)


### PR DESCRIPTION
Closes #4240

## The gap

A PR merged past a RED required check and nothing noticed. Verified before building:

```
$ grep -rl 'required_status_checks\|statusCheckRollup' .github/scripts .github/workflows
.github/workflows/agent-review.yml
```

The single hit is a **comment** (line 98, `# documented in admin-ui-deploy.yml — required_status_checks (all-green,`). No workflow in this repository has ever read a merged PR's required contexts. A ruleset bypass is recorded only in `repos/<owner>/<repo>/rulesets/rule-suites`, which tells nobody: no PR carries it, no check turns red, and the merge commit on `main` looks like every other merge commit.

## The scope is bigger than the issue says — and the endpoint hides it

`rulesets/rule-suites` **defaults to `time_period=day`**. The unparameterised query returns exactly one row — #4215 — and reads precisely like confirmation that the incident was isolated.

Re-measured 2026-08-09 with `?time_period=month&per_page=100 --paginate`, deduplicated by suite id:

| | |
|---|---|
| raw rows returned | 2890 |
| distinct `bypass` suites | 37 |
| ...carrying a FAILED `required_status_checks` evaluation | 29 |
| ...where the check was actively **failing** | **7** |

The other 22 are `expected` or `in progress` — benign, and they outnumber the signal 3:1. So the classifier keys on the per-suite `failing` **detail string**, never on `result: bypass` and never on the evaluation result alone.

## Falsification 1 — the real historical data, all 7 by number

Every `bypass` suite in the month window was fetched from the detail endpoint (37 files, `rule-suites/<id>`, since the list endpoint carries no `rule_evaluations`) and fed to the detector offline:

```
$ .github/scripts/check-merged-past-red-check.py --scan --from-file real-month.json
7 merge(s) past an ACTIVELY FAILING required check in the last month:
  2026-07-14T09:00:07+02:00  suite 3327534542  200a69600
      Required status check "OPA policy gate" is failing.
  2026-07-16T10:51:41+02:00  suite 3353753114  ab245ab38
      Required status check "OPA policy gate" is failing.
  2026-08-07T09:30:26+02:00  suite 3591085943  0abed33ed
      2 of 5 required status checks have not succeeded: 1 expected and 1 failing.
  2026-08-07T09:45:52+02:00  suite 3591233684  3208109c3
      2 of 5 required status checks are failing.
  2026-08-07T10:34:09+02:00  suite 3591698225  ee974ea3c
      2 of 5 required status checks are failing.
  2026-08-07T17:07:17+02:00  suite 3596040579  6b3594b2b
      2 of 5 required status checks are failing.
  2026-08-08T17:49:52+02:00  suite 3606045456  4405a74fa
      Required status check "Validate manifests" is failing.
EXIT=2
```

Each head sha resolved via `repos/.../commits/<sha>/pulls`:

| pushed_at | suite | head | PR | failing required check |
|---|---|---|---|---|
| 2026-07-14T09:00:07 | 3327534542 | `200a6960` | **#1030** | `OPA policy gate` |
| 2026-07-16T10:51:41 | 3353753114 | `ab245ab3` | **#1187** | `OPA policy gate` |
| 2026-08-07T09:30:26 | 3591085943 | `0abed33e` | **#3658** | 1 expected **and 1 failing** |
| 2026-08-07T09:45:52 | 3591233684 | `3208109c` | **#3771** | 2 of 5 failing |
| 2026-08-07T10:34:09 | 3591698225 | `ee974ea3` | **#3686** | 2 of 5 failing |
| 2026-08-07T17:07:17 | 3596040579 | `6b3594b2` | **#4054** | 2 of 5 failing |
| 2026-08-08T17:49:52 | 3606045456 | `4405a74f` | **#4215** | `Validate manifests` |

Four on 2026-08-07 alone. A detector that reports 1 is reproducing the default-window bug it exists to fix.

The mixed row (#3658, `1 expected and 1 failing`) is why the test cannot be `details.endswith("are failing.")` — it is a real row, and it is in the self-test verbatim.

## Falsification 2 — the benign bypasses, negative result

The same 37 suites, partitioned; the 30 that carry **no** `failing` detail fed back in:

```
$ .github/scripts/check-merged-past-red-check.py --scan --from-file benign-only.json
clean: no merge past an actively failing required check in the last month
       (30 bypass suites examined)
EXIT=0
```

Zero flagged. That set includes 19 rows of `Required status check "all-green" is expected.`, `... is in progress.`, `3 of 5 required status checks have not succeeded: 1 expected.`, and a pure review-rule bypass (`1 review requesting changes by reviewers with write access.`) whose status checks were green. A detector that flags these is noise, and noise is ignored — which returns the repo to where #4240 found it.

## Falsification 3 — `--self-test`, registered with `selftest_expect: pass`

```
$ .github/scripts/check-merged-past-red-check.py --self-test
self-test: 4 signal + 7 benign detail strings, dedup, rule-type scoping,
suite-result scoping and 3 declaration falsifications all behaved as required
```

Nine cases, all fixtures verbatim from the real API output: every signal string flagged; every benign string silent; a review-rule bypass with green checks not flagged; the word `failing` on a *different* `rule_type` not flagged; `pass` and `fail` suites (a `fail` suite was *blocked*, not merged) not flagged; dedup in both orders with the detail-carrying copy winning; the real 4:7 mixed batch; and three **declaration** falsifications — a workflow with no `time_period` must raise D1–D6, an explicit `time_period=day` must raise D1, and a *missing* workflow must fail rather than pass.

Run as CI runs it:

```
$ BASE_REF=main PR_DIFF_BASE=$(git merge-base HEAD origin/main) \
    python3 .github/scripts/run-gates.py --only merged-past-red-check-declaration
PASS [registry] the merged-past-red-check watch keeps its window, its key and its escalation (issue #4240, enforced)
```

### D1 flagged its own prose first — the #2450 collision, live

The first draft of D1 was a whole-file grep for `time_period`. It failed the committed workflow, matching the sentence *inside the escalation issue body* that explains why `day` is wrong. D1 now keys on the **construct**: it calls the single `list_url()` builder and checks what it produces, plus any inline call scoped to lines containing `gh api`. A whole-file grep cannot distinguish the thing from the prose about the thing.

## Token permission — the runtime lane CANNOT use `GITHUB_TOKEN`

`rulesets/rule-suites` requires the repository **Administration: read** permission. The Actions `permissions:` block **has no `administration` scope at all**, so there is no way to grant it — measured, not assumed:

```
$ actionlint  # on a minimal workflow with `permissions: {administration: read}`
unknown permission scope "administration". all available permission scopes are
"actions", "artifact-metadata", "attestations", "checks", "contents",
"deployments", "discussions", "id-token", "issues", "models", "packages",
"pages", "pull-requests", "repository-projects", "security-events", "statuses"
```

Consequences, all handled explicitly rather than papered over:

- The runtime lane reads `secrets.RULESET_AUDIT_TOKEN` (a PAT or GitHub App token with Administration: read) and runs the scan with `--require-token`. **D6 enforces that.**
- With the secret unset the scan exits **1** — "the watch could not answer" — and never 0. A permission-shaped absence is indistinguishable from a real one and always fails in the direction of a confident wrong answer, so reporting an unread window as clean is the one outcome forbidden.
- **Until the secret is added, this workflow will be red on `main`, and that is the correct state**, not a defect. It is registered in `main-red-watch.yml`'s R1 list, so that redness escalates onto an issue instead of sitting silently in the Actions tab.
- The PR lane carries a **capability probe** step that calls the endpoint with the plain `GITHUB_TOKEN` and prints a `::notice` either way, never failing. That measures the claim under the identity CI actually uses rather than asserting it from documentation. **Measured on this PR** (run `31332983605`, job `93294070149`, read from `.steps[].conclusion` and the annotations API, not from a log grep):

```
notice: GITHUB_TOKEN CANNOT read rule-suites (exit 1) — this is expected;
notice: the endpoint needs Administration:read and permissions: has no such key.
```

  Worth recording how nearly that read wrong: `gh run view --log | grep 'GITHUB_TOKEN'` returned the step's **own `run:` script**, including the `echo "::notice::GITHUB_TOKEN CAN read rule-suites."` branch that never executed. The real line is discriminated by substitution — `##[notice]` with the value expanded, versus `^[[36;1m` script listing.

## Shape

- **`.github/scripts/check-merged-past-red-check.py`** — classifier + `--self-test` + `--check-declaration` + `--scan`. All reasoning is in the module header.
- **`.github/workflows/merged-past-red-check-watch.yml`** — scheduled (twice daily) + push-on-main + a PR echo lane. **Escalates onto one issue** carrying `<!-- merged-past-red-check -->`, refreshed in place, reopened if hand-closed while offenders remain, closed by the watch itself when the window comes back clean — the `main-red-watch.yml` shape, not a new one. Self-limiting without stored state: a row ages out of the `month` window on its own.
- **`.github/gates/gates.yaml`** — `merged-past-red-check-declaration`, `group: registry`, `mode: enforced`, `selftest_expect: pass`. The **binding copy** lives here, in the unconditional `Validate manifests` job: a scheduled/`paths:`-filtered workflow can never be a required context, and a gate written as an inline `run:` in a conditional job silently narrows its scope to something nobody declared.
- **`.github/workflows/main-red-watch.yml`** — the new workflow added to the R1 watched list. The `main-red-watch-declaration` gate failed until it was, which is that gate working correctly.

Prose lives in script headers, never in a `run:` block: the largest `run:` step here is well under the 19000-char limit `check-workflow-run-step-size` enforces, and that gate passes.

GitHub itself was used as the parse oracle — pushing this branch produced **0 workflow runs** (the workflow's triggers exclude non-main branch pushes), which means the file was accepted; an unparseable workflow still produces a failed run.

## Note, out of scope

`gates (registry)` / `Validate manifests` is red on this PR because **`main` is already red on the same gate**, not because of anything here. Measured on both sides:

| run | branch | failing gate |
|---|---|---|
| `31332166682` | `main` | `dockerfile-runtime-only` |
| this PR | `ci/detect-merge-past-red-check` | `dockerfile-runtime-only`, same and only failure |

`openbank-case-coordinator-agent/Dockerfile` pins a base digest that no longer matches `.github/workflows/Dockerfile.deploy`. Untouched by this PR — this is the documented "a PR opened against a red `main` inherits a failure it did not cause" case, and `main-red-watch` should be carrying it.

### Two fixes made after the first CI round, both worth naming

1. **Gitleaks failed on a shape with no secret in it.** The docstring tabulated rule-suite ids; `rod-cislo` (Czech birth number) matches a bare 10-digit number, so three suite ids tripped the required Secret-scan check. The ids were dropped from the table in favour of head shas, which identify the merge just as well. Because gitleaks scans the push **range** and not the tip, the branch was squashed to a single commit and force-pushed with lease — a fixup commit would not have cleared it.
2. **`gate-subject-floor` (#4339) correctly refused the gate.** It had no `min_subjects:`. It now prints `SUBJECTS=6` (D1–D6 applied to the one watch workflow) via `gatelib.subjects`, and **`SUBJECTS=0` when the workflow file is missing**, so a moved path reads as "this gate examined nothing" rather than as a pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
