### PR TITLE
fix(ci): re-align case-coordinator-agent's Dockerfile FROM with the deploy recipe

### DIFF
--- a/openbank-case-coordinator-agent/Dockerfile
+++ b/openbank-case-coordinator-agent/Dockerfile
@@ -16,7 +16,7 @@
 # .github/scripts/check-dockerfile-no-build-stage.py, which also fails if the FROM above
 # drifts from Dockerfile.deploy — the runtime base is stated in exactly one place (#3354).
 
-FROM eclipse-temurin:25-jre@sha256:681c543d6f36c50f45e9b5226930a46203dcfa351d3670e9d0bdf0dabae53539
+FROM eclipse-temurin:25-jre@sha256:f19dbf0a22d0b3658fda48ce7d7181df05ad14bda151dd5ad12cc09d1451c70e
 WORKDIR /app
 RUN groupadd --system --gid 101 openbank \
  && useradd --system --uid 100 --gid 101 --no-create-home --shell /usr/sbin/nologin openbank


### PR DESCRIPTION
## What's red on `main`

`dockerfile-runtime-only` (#3016/#3354, enforced) fails on the current tip:

```
::warning::openbank-case-coordinator-agent/Dockerfile: FROM eclipse-temurin:25-jre@sha256:681c543d…
does not match .github/workflows/Dockerfile.deploy
```

`openbank-case-coordinator-agent/Dockerfile` still pins the old digest. `Dockerfile.deploy` — the one recipe every service image is actually built from — was bumped to `sha256:f19dbf0a…` by #4303. #4236 (this service's gitops rollout) merged before #4303's bump, and its Dockerfile was never touched by that bump's sweep because the file did not exist yet when it ran over the fleet.

## Verified

Before the fix, on `origin/main`:
```
run-gates.py --only dockerfile-runtime-only   FAIL=1
```
After the one-line change:
```
check-dockerfile-no-build-stage: OK — 55 Dockerfiles, runtime-only, all with EXPOSE
run-gates.py --only dockerfile-runtime-only   PASS=1
```

## Why this is worth fixing rather than waiting for the next fleet-wide sweep

The Dockerfile is declaration-only (#3016) — the container is actually built from `Dockerfile.deploy` — so this changes what the fleet *claims*, not what runs. But `openbank-admin-ui/scripts/generate-cluster-topology.mjs`'s `imageFacts()` parses this exact file for the `/docs/cluster` dossier and falls back to a hardcoded `eclipse-temurin:25-jre-alpine` literal when it cannot parse a `FROM`. A stale digest here was one bump away from becoming a second source of truth disagreeing with the real one.

Found while landing #3813 — its `Validate manifests` inherited this red from `main`, unrelated to that PR's own diff.
