### PR TITLE
fix(case-coordinator): copy the deploy base digest into the new Dockerfile

### DIFF
--- a/openbank-case-coordinator-agent/Dockerfile
+++ b/openbank-case-coordinator-agent/Dockerfile
@@ -16,7 +16,7 @@
 # .github/scripts/check-dockerfile-no-build-stage.py, which also fails if the FROM above
 # drifts from Dockerfile.deploy — the runtime base is stated in exactly one place (#3354).
 
-FROM eclipse-temurin:25-jre@sha256:681c543d6f36c50f45e9b5226930a46203dcfa351d3670e9d0bdf0dabae53539
+FROM eclipse-temurin:25-jre@sha256:f19dbf0a22d0b3658fda48ce7d7181df05ad14bda151dd5ad12cc09d1451c70e
 WORKDIR /app
 RUN groupadd --system --gid 101 openbank \
  && useradd --system --uid 100 --gid 101 --no-create-home --shell /usr/sbin/nologin openbank


### PR DESCRIPTION
## `main` is red

The enforced `dockerfile-runtime-only` gate fails on `origin/main`, reproduced in a clean detached
worktree with no local changes:

```
openbank-case-coordinator-agent/Dockerfile: FROM eclipse-temurin:25-jre@sha256:681c543d…
does not match .github/workflows/Dockerfile.deploy, which declares …@sha256:f19dbf0a…
```

## Two green PRs, one red main

| PR | what it did |
|---|---|
| #4303 | bumped the pinned base digest across the **56** Dockerfiles that existed — the old pin was a 2026-07-16 build and `Image rescan` had been correctly red on its OS CVEs for four runs |
| #4236 | added a **57th** Dockerfile, carrying the digest that was current when that branch was written |

The merge was textually clean because the two never touched the same file. That is the failure mode
in full: a shared **value** with no single place that holds it, checked only by a gate that runs
after both have landed. Neither author could have seen it.

## The change

One line, copied from the deploy recipe rather than retyped, with the edit asserting it replaced
exactly one `FROM`. I swept the rest of the tree in the same run — every other Dockerfile already
agrees, so this was the only straggler.

| | `dockerfile-runtime-only` |
|---|---|
| `origin/main` | **FAIL=1** |
| this branch | **PASS=1** |

Refs #3016, #3354, #4026
