### PR TITLE
build(case-coordinator): realign the declared runtime base with Dockerfile.deploy (unblocks red main)

### DIFF
--- a/openbank-case-coordinator-agent/Dockerfile
+++ b/openbank-case-coordinator-agent/Dockerfile
@@ -16,7 +16,7 @@
 # .github/scripts/check-dockerfile-no-build-stage.py, which also fails if the FROM above
 # drifts from Dockerfile.deploy — the runtime base is stated in exactly one place (#3354).
 
-FROM eclipse-temurin:25-jre@sha256:681c543d6f36c50f45e9b5226930a46203dcfa351d3670e9d0bdf0dabae53539
+FROM eclipse-temurin:25-jre@sha256:f19dbf0a22d0b3658fda48ce7d7181df05ad14bda151dd5ad12cc09d1451c70e
 WORKDIR /app
 RUN groupadd --system --gid 101 openbank \
  && useradd --system --uid 100 --gid 101 --no-create-home --shell /usr/sbin/nologin openbank


### PR DESCRIPTION
## What

`openbank-case-coordinator-agent/Dockerfile` declared
`eclipse-temurin:25-jre@sha256:681c543d...`; `.github/workflows/Dockerfile.deploy`
declares `@sha256:f19dbf0a...`. This PR makes them agree.

## Why

The enforced gate `dockerfile-runtime-only` (#3016/#3354) fails on that drift:

```
openbank-case-coordinator-agent/Dockerfile: FROM eclipse-temurin:25-jre@sha256:681c543d... does not match .github/workflows/Dockerfile.deploy, which declares FROM eclipse-temurin:25-jre@sha256:f19dbf0a...
```

So `CI` on `main` is red (`gates (registry)` -> `Validate manifests`), and **every
PR opened against `main` inherits a failure it did not cause**. Tracked by the
main-red-watch issue #4191, red since `2946fa3d9` (2026-08-08 13:30Z) and still
refreshing.

The runtime base is stated in exactly one place by design (#3354); the correct
direction of the fix is therefore to take `Dockerfile.deploy`'s digest, not the
other way round.

## Scope — why exactly one file

Enumerated the `FROM` line of every `openbank-*/Dockerfile` on live `origin/main`:

| digest | count |
|---|---|
| `eclipse-temurin:25-jre@sha256:f19dbf0a...` (Dockerfile.deploy) | 51 |
| `eclipse-temurin:25-jre@sha256:681c543d...` | 1 — case-coordinator-agent |
| `alpine:3.24@...`, `nginxinc/nginx-unprivileged:1.31-alpine@...`, `python:3.14-slim@...` | 3 — admin-ui, developer-portal, document-renderer, legitimately different images |

## Verification

```
BASE_REF=main PR_DIFF_BASE=$(git merge-base HEAD origin/main) \
  python3 .github/scripts/run-gates.py --only dockerfile-runtime-only
```

```
--- self-test (must PASS) ---
check-dockerfile-no-build-stage --self-test: OK — rule 3 fires on drift, stays quiet on agreement, covers the non-glob files, exempts SELF_BUILT
--- gate ---
check-dockerfile-no-build-stage: OK — 55 Dockerfiles, runtime-only, all with EXPOSE
1 gates  PASS=1
```

The gate's own self-test asserts rule 3 both ways (fires on drift, quiet on
agreement), so this is not a green from a check that never reached its subject.

## Commit type

`build(...)` — hidden type, no release. The per-service Dockerfile is a
declaration; the deployed image is built from `Dockerfile.deploy`, so no shipped
artifact changes.

Refs #4191
