### PR TITLE
fix(ci): count dependency-submission runs by conclusion, not by status=success

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -155,7 +155,17 @@ jobs:
             exit 0
           fi
 
-          count() { gh api "${runs_api}?head_sha=$1&status=success" --jq '.total_count' 2>/dev/null || echo ""; }
+          # `status=success` is NOT a usable filter on this endpoint: measured on the real API,
+          # `?head_sha=<sha>&status=success` answers total_count 0 for a run whose own JSON reads
+          # status=completed, conclusion=success, while the identical query WITHOUT the filter
+          # answers 1. So this step failed PRs for a condition that was satisfied — #4397 had a
+          # successful submission 22 minutes before the assertion ran and was still told there
+          # was none. Filter on `conclusion` client-side instead, which is the field that
+          # actually carries the verdict.
+          count() {
+            gh api "${runs_api}?head_sha=$1&per_page=100" \
+              --jq '[.workflow_runs[]|select(.conclusion=="success")]|length' 2>/dev/null || echo ""
+          }
           base_runs="$(count "${mb}")"
           head_runs="$(count "${HEAD_SHA}")"
           if [ -z "${base_runs}" ] || [ -z "${head_runs}" ]; then


### PR DESCRIPTION
## A gate failing a PR for a condition that was satisfied

`dependency-review.yml`'s *"Assert the dependency diff had a valid basis"* failed #4397 with

```
head b7ec08da…: 0 successful submission run(s)
::error::No successful dependency-submission run exists for the head b7ec08da…
```

A successful `Dependency submission` run for that exact head had finished **22 minutes earlier**
(`20:44:27Z`; the assertion ran at `21:06:11Z`). So this is not the documented snapshot-indexing
race the step's own comment anticipates — the run existed and was successful, and the step still
said it did not exist.

## Cause, measured against the live API

```
?head_sha=b7ec08da…&status=success   ->  total_count 0
?head_sha=b7ec08da…                  ->  total_count 1
```

and that one run reads `status=completed, conclusion=success`. **`status=success` does not match a
completed run whose verdict lives in `conclusion`.** The step now filters on `conclusion`
client-side.

## Falsified both ways

| input | before | after |
|---|---:|---:|
| head `b7ec08da…` | 0 | **1** |
| merge-base `cd3d010f…` | 0 | **1** |
| an all-zero sha with no submission at all | 0 | **0** |

The last row is the one that matters. This step exists to go RED when no submission was ever
scheduled (#2833), so a "fix" that counted everything would be worse than the bug. It still answers
0 for a sha that never had one.

## Why this is worth saying plainly

It is a control over other controls, and it was wrong in both directions at once: it could fail a PR
for something untrue, and — more quietly — **its green was never evidence of anything**, because the
query it ran returned 0 whatever the world looked like. The comment block above it describes exactly
the failure it was meant to prevent, which is what made the wrong answer look authoritative.

`actionlint` clean; the `workflow-run-step-size` gate passes (prose lives in the step header, well
under the 19000-char ceiling).

Refs #2833
