### PR TITLE
security(authz): close the last 4 role-only write grants to the shared M2M identity

### DIFF
--- a/.github/scripts/check-operator-write-naming.py
+++ b/.github/scripts/check-operator-write-naming.py
@@ -57,47 +57,67 @@ DECLARED_EXCEPTIONS = {
     "operator-decide-message-approval": "four-eyes second-approver path (ADR-0155)",
 }
 
-# The 18 role-only WRITE rules that do not follow the operator-*-write convention, and so are
-# invisible as candidates for rules.yaml: shared_m2m_write_prohibition.reasons. This is a DEBT LIST, not an exemption list: each of
-# these is reachable today by the shared openbank-services service-account. Discovered while
-# fixing GHSA-58jq-9hq3-66jr, whose scope was only the ~19 conforming operator-*-write rules.
+# Role-only WRITE rules that do not follow the operator-*-write convention, and so are invisible
+# as candidates for rules.yaml: shared_m2m_write_prohibition.reasons. A DEBT LIST, not an
+# exemption list: every entry was reachable by the shared openbank-services service-account.
+# Discovered while fixing GHSA-58jq-9hq3-66jr, whose scope was only the ~19 conforming
+# operator-*-write rules.
 #
-# They are not fixed in the same change deliberately. The complete fix is to invert the
-# default for the shared identity — deny everything except an explicit (identity, action)
-# allow-list in rules.yaml — and that allow-list cannot be guessed: AUTHZ_ENFORCE is true on
-# most of these services, so a missing entry is a production outage on a money path, not a
-# test failure. Each entry needs its real callers confirmed first.
+# EMPTY as of #4228 (2026-08-09). It held 18 at its widest, then 5, then 4; the per-entry history
+# is kept below because the reasoning is the reusable part, not the names.
 #
-# Shrinking this set is the work. Adding to it is a regression and the guard says so.
-BASELINE = {
-    # Verified individually, not assembled by hand: derived by emptying this set and reading what
-    # the check reports. An earlier revision of this list named 18 rules; 10 of those were NOT
-    # reachable by the shared identity at all — they either bar service-accounts outright
-    # (`not startswith(input.principal.id, "service-account-")`, as statement-close/-export do),
-    # gate on a role the shared account does not hold (ROLE_COMPLIANCE / ROLE_CREDIT_RISK /
-    # ROLE_LENDING_OFFICER), or are reads. Overstating a debt list is not a safe error: it hides
-    # the real entries among noise and invites the whole thing being ignored.
-    # 2026-08-07: operator-fx-trigger and operator-fx-approval-decide removed. #3734 gave both
-    # the `not startswith(input.principal.id, "service-account-")` guard on 2026-08-05
-    # (fx_rest_ext.rego:50 and :96, recorded in docs/threat-models/openbank-fx-service.md), so
-    # the debt was paid and only the list lagged. The gate had been reporting both as stale on
-    # main ever since, in advisory mode, which is why nobody acted.
-    # 2026-08-08: operator-vop-verify removed (#4228). vop_rest_ext.rego now carries the
-    # `not startswith(input.principal.id, "service-account-")` guard. It needed no caller audit —
-    # unlike its siblings here, the legitimate M2M caller already had its OWN identity-pinned
-    # reason (`m2m-vop-verify`) in the same file, so `opa eval` against vop-opa-bundle.yaml showed
-    # the shared account resolving BOTH reasons and the role-only one was pure over-grant. The
-    # extension moved out of the generator heredoc into a real .rego in the same change, which is
-    # what let opa-policy.yml's file-pair discovery cover it (vop_rest_ext_test.rego).
-    "operator-anacredit-create",
-    "operator-party-status",
-    "operator-pid-resolve",       # pid.resolve — a lookup; classified here pending confirmation
-    "operator-standing-order-pause",
-    # `operator-year-close-attest` was here and is GONE (#3765): the ledger ext rule now carries
-    # `not startswith(input.principal.id, "service-account-")`, so it is no longer role-only and
-    # this list must not name it. The removal was surfaced by this script's own stale-entry
-    # ratchet, not by anyone remembering — which is the argument for keeping that ratchet.
-}
+# Shrinking this set was the work. Adding to it is a regression and the guard says so — and with
+# the set empty there is no longer a precedent line to append to, which is the state this list
+# was always meant to reach. A future role-only write is a hard failure at PR time, and the
+# correct response is one of the three remediation paths #4228 worked through (rename if it is
+# not a write; `not startswith(input.principal.id, "service-account-")` if no M2M caller exists;
+# an identity-pinned m2m-<action> rule FIRST if one does), never a new baseline entry.
+BASELINE: set[str] = set()
+# Verified individually, not assembled by hand: derived by emptying this set and reading what
+# the check reports. An earlier revision of this list named 18 rules; 10 of those were NOT
+# reachable by the shared identity at all — they either bar service-accounts outright
+# (`not startswith(input.principal.id, "service-account-")`, as statement-close/-export do),
+# gate on a role the shared account does not hold (ROLE_COMPLIANCE / ROLE_CREDIT_RISK /
+# ROLE_LENDING_OFFICER), or are reads. Overstating a debt list is not a safe error: it hides
+# the real entries among noise and invites the whole thing being ignored.
+# 2026-08-07: operator-fx-trigger and operator-fx-approval-decide removed. #3734 gave both
+# the `not startswith(input.principal.id, "service-account-")` guard on 2026-08-05
+# (fx_rest_ext.rego:50 and :96, recorded in docs/threat-models/openbank-fx-service.md), so
+# the debt was paid and only the list lagged. The gate had been reporting both as stale on
+# main ever since, in advisory mode, which is why nobody acted.
+# 2026-08-08: operator-vop-verify removed (#4228). vop_rest_ext.rego now carries the
+# `not startswith(input.principal.id, "service-account-")` guard. It needed no caller audit —
+# unlike its siblings here, the legitimate M2M caller already had its OWN identity-pinned
+# reason (`m2m-vop-verify`) in the same file, so `opa eval` against vop-opa-bundle.yaml showed
+# the shared account resolving BOTH reasons and the role-only one was pure over-grant. The
+# extension moved out of the generator heredoc into a real .rego in the same change, which is
+# what let opa-policy.yml's file-pair discovery cover it (vop_rest_ext_test.rego).
+# 2026-08-09: the last four removed (#4228), and this set is now EMPTY. Each was resolved on
+# its own evidence, not as a batch — the whole point of the issue was that "role-only write"
+# was three different situations wearing one label:
+#   operator-pid-resolve      -> RENAMED operator-pid-resolve-read. Never a write at all:
+#                                @GET /api/v1/parties/pid/resolve behind @RolesAllowed(API),
+#                                returns {partyId} or 404. The name was the whole defect.
+#   operator-party-status     -> exclusion. A real write (@PATCH .../{id}/status) and LIVE
+#                                (pid runs AUTHZ_ENFORCE=true), but no M2M caller: the
+#                                endpoint is @RolesAllowed(ADMIN) and no service-account holds
+#                                ROLE_ADMIN in any of the three realm JSONs here.
+#   operator-anacredit-create -> exclusion. A real write, latent (AUTHZ_ENFORCE=false), and
+#                                the bundle's own author had already audited "no M2M caller".
+#   operator-standing-order-pause -> path 3, NOT an exclusion alone. It has a real M2M caller
+#                                (customer-edge self-service pause), so an identity-pinned
+#                                m2m-standing-order-pause landed first. The rule's comment had
+#                                named the WRONG client — UpstreamClient authenticates as
+#                                `openbank-edge`, not the shared `openbank-services`.
+#
+# An empty set is not a finished job, it is a claim with a ratchet under it: the stale-entry
+# check below now has nothing to forgive, so the next role-only write rule anyone writes is a
+# hard failure at PR time rather than a line quietly appended here.
+# `operator-year-close-attest` was here and is GONE (#3765): the ledger ext rule now carries
+# `not startswith(input.principal.id, "service-account-")`, so it is no longer role-only and
+# this list must not name it. The removal was surfaced by this script's own stale-entry
+# ratchet, not by anyone remembering — which is the argument for keeping that ratchet.
+# (end of the retired BASELINE commentary — the set above is deliberately empty)
 
 REASON_RE = re.compile(r'allowed_reasons\s+contains\s+"([^"]+)"\s+if\s*\{')
 # Role gating, in every idiom this fleet actually uses. Review of PR #2571 found the first
@@ -107,10 +127,25 @@ REASON_RE = re.compile(r'allowed_reasons\s+contains\s+"([^"]+)"\s+if\s*\{')
 # A missed idiom here is a role-only write rule that never gets discovered, which is the one
 # failure mode this script exists to prevent.
 # Only the roles the SHARED IDENTITY ACTUALLY HOLDS make a rule reachable by it.
-# openbank-realm.json gives `service-account-openbank-services` exactly
-# `realmRoles: ["ROLE_OPERATOR"]` — nothing else. So a rule gated on ROLE_COMPLIANCE,
-# ROLE_CREDIT_RISK or ROLE_LENDING_OFFICER is unreachable by it no matter how role-only it is,
-# and flagging those was the second over-broad version of this check.
+#
+# CORRECTED 2026-08-09 (#4228): an earlier revision of this comment said openbank-realm.json
+# gives `service-account-openbank-services` exactly `["ROLE_OPERATOR"]` — "nothing else". There
+# are THREE realm JSONs in this tree and they disagree, so no single-realm statement is true:
+#   openbank-infra/docker/keycloak/realm/openbank-realm.json  -> ROLE_OPERATOR, ROLE_API
+#   openbank-infra/gitops/components/keycloak/realm-template.json -> ROLE_API   (the DEPLOYED one)
+#   .github/workflows/keycloak/openbank-realm.json            -> ROLE_OPERATOR, ROLE_COMPLIANCE
+# Reason about exposure from the UNION, which is what the tuple below encodes for the purpose
+# this guard serves. ROLE_API and ROLE_COMPLIANCE are deliberately NOT added: this check is about
+# the operator-* write families, ROLE_COMPLIANCE rules are covered by compliance-read-any and the
+# ROLE_COMPLIANCE oversight reads already listed above, and widening the tuple here changes the
+# guard's SCOPE — which needs its own falsification run, not a drive-by edit. ROLE_CREDIT_RISK
+# and ROLE_LENDING_OFFICER are held by no service-account in any of the three realms, and
+# flagging those was the second over-broad version of this check.
+#
+# Note what this means for the deployed cluster specifically: the shared account holds only
+# ROLE_API there today, so the role-only rules were latent for IT and live for whichever identity
+# does hold ROLE_OPERATOR (in the deployed realm, `service-account-openbank-edge`). "Latent in one
+# realm" is not "closed" — a realm-template edit is one PR away from making it live everywhere.
 #
 # Keep this list in step with the realm. If the shared service-account is ever granted another
 # role, add it here — otherwise this guard silently stops covering the rules that role opens.

--- a/docs/threat-models/openbank-anacredit-service.md
+++ b/docs/threat-models/openbank-anacredit-service.md
@@ -31,6 +31,17 @@ service — read-only access to internal data, write-only to the regulator's end
 - All internal REST endpoints: `@RolesAllowed("ROLE_ADMIN", "ROLE_COMPLIANCE")` (verified by `AnaCreditSecurityTest`).
 - Outbound ECB/CNB calls use a service-level credential stored in **OpenBao** (never in-image).
 - OPA sidecar (ADR-0034) enforces service-to-service authz for read calls to lending/ledger.
+- **`anacredit.create` is HUMANS-ONLY (GHSA-58jq-9hq3-66jr, #4228).**
+  `anacredit_rest_ext.rego`'s `operator-anacredit-create` now carries
+  `not startswith(input.principal.id, "service-account-")`. Without it the rule was role-only, and
+  `service-account-openbank-services` — the identity nearly every backend service authenticates
+  as — carries ROLE_OPERATOR in the docker and CI realms and is classified HUMAN by
+  `AuthorizeInterceptor`, so any backend service could feed the ECB regulatory return. Measured
+  against `anacredit-opa-bundle.yaml` before the change it resolved exactly
+  `["operator-anacredit-create"]`. The exclusion strands no caller: no REST client in the fleet
+  targets this service, which the extension's own header had already asserted and #4228
+  re-confirmed. `AUTHZ_ENFORCE=false` here, so the exposure was latent — the exclusion lands
+  before the enforce flip rather than after it. Covered by `anacredit_rest_ext_test.rego`.
 
 ## 4. STRIDE
 
@@ -50,4 +61,7 @@ service — read-only access to internal data, write-only to the regulator's end
 
 ## 6. Change log
 
+- **2026-08-09** — `anacredit.create` narrowed to humans only (GHSA-58jq-9hq3-66jr, issue #4228);
+  the extension also moved out of the generator heredoc into `anacredit_rest_ext.rego` so
+  `opa-policy.yml`'s file-pair discovery can cover it — until then it had no test at all.
 - **2026-06-19** — Initial lightweight threat model (ADR-0030 D2).

--- a/docs/threat-models/openbank-standing-order-service.md
+++ b/docs/threat-models/openbank-standing-order-service.md
@@ -51,6 +51,19 @@ openbank-sdd-service.
   observation window (rules.yaml AUTHZ_ENFORCE guardrail, issue #3679 cohort).
 - Execution calls to sepa-payment are service-to-service (OIDC client credentials via
   `OidcClientRequestReactiveFilter`), not ambient authority.
+- **`standingOrder.pause` is identity-scoped, not role-only (GHSA-58jq-9hq3-66jr, #4228).**
+  `standing_order_rest_ext.rego` grants it two ways and only two: `operator-standing-order-pause`
+  for HUMANS holding ROLE_OPERATOR/ROLE_ADMIN, now carrying
+  `not startswith(input.principal.id, "service-account-")`; and `m2m-standing-order-pause`, pinned
+  to the single client id `service-account-openbank-edge`. Before this, the role branch was the
+  ONLY reason and it admitted every backend service — measured against
+  `standing-order-opa-bundle.yaml`, `service-account-openbank-services` + ROLE_OPERATOR resolved
+  exactly `["operator-standing-order-pause"]`. The identity-scoped grant had to land in the same
+  change rather than after it, because unlike vop/fx/ledger this action has a real M2M caller and
+  an exclusion alone would have broken customer self-service pause. The pin is one client id
+  rather than `startswith("service-account-")`: pausing mutates a customer's payment schedule and
+  has exactly one legitimate caller, so any-service-account would re-create the exposure.
+  Ownership is still enforced in the handler (`X-Customer-Party-Id`); OPA grants the action class.
 - The scheduler/consumer path has no human in the loop by design; there is no operator
   force-execute endpoint.
 
@@ -79,5 +92,10 @@ openbank-sdd-service.
 
 ## 6. Change log
 
+- **2026-08-09** — `standingOrder.pause` narrowed from a role-only grant to an identity-scoped
+  one (GHSA-58jq-9hq3-66jr, issue #4228): added `m2m-standing-order-pause` pinned to
+  `service-account-openbank-edge`, then the `not startswith(input.principal.id,
+  "service-account-")` exclusion on `operator-standing-order-pause`. Covered by
+  `standing_order_rest_ext_test.rego` (9 cases; stripping either half reddens a disjoint subset).
 - **2026-08-03** — Initial lightweight threat model (ADR-0030 D2), written for the
   `money_path_services` classification (issue #2188).

--- a/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: anacredit-service
     app.kubernetes.io/part-of: anacredit
   annotations:
-    openbank.tech/policy-checksum: "a0f1780e85d909b9"
+    openbank.tech/policy-checksum: "b98e0b6827706146"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -554,8 +554,21 @@ data:
 
     import rego.v1
 
+    # HUMANS ONLY (GHSA-58jq-9hq3-66jr, issue #4228). This IS a write: `@POST
+    # /api/v1/anacredit/exposures` (AnaCreditResource.registerExposure). Without the exclusion the
+    # rule was role-only, and `service-account-openbank-services` — the identity nearly every backend
+    # service authenticates as — carries ROLE_OPERATOR in the docker and CI realms and is classified
+    # HUMAN by AuthorizeInterceptor, so every backend service could feed the ECB regulatory return.
+    # anacredit-service runs AUTHZ_ENFORCE=false today, so this was latent rather than live; the
+    # exclusion lands before the enforce flip rather than after it.
+    #
+    # The exclusion strands no caller, and this is the one entry where the audit was already on
+    # record: the header above states it ("No verified M2M caller exists for anacredit-service") and
+    # re-confirming it in #4228 found no REST client in the fleet targeting the service. That claim
+    # is now load-bearing rather than advisory, which is the point of writing the exclusion down.
     allowed_reasons contains "operator-anacredit-create" if {
     	input.principal.type == "HUMAN"
+    	not startswith(input.principal.id, "service-account-")
     	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
     	role in input.principal.roles
     	input.action == "anacredit.create"

--- a/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
@@ -42,7 +42,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-anacredit-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "a0f1780e85d909b9"
+        openbank.tech/policy-checksum: "b98e0b6827706146"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/anacredit/anacredit_rest_ext.rego
+++ b/openbank-infra/gitops/components/anacredit/anacredit_rest_ext.rego
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: Apache-2.0
+# AnaCredit-service REST extension (ADR-0034 Phase 5 bootstrap, issue #938).
+# Extends openbank.rest with anacredit-domain allow reasons.
+# Mounted alongside rest.rego in the same OPA bundle — OPA merges same-package rules.
+#
+# Actions gated (AnaCreditResource):
+#   anacredit.create  — registerExposure (feed a credit exposure in)
+#   anacredit.list    — listAllExposures
+#   anacredit.read    — renderReturn (#referenceDate)
+#
+# Base rest.rego already grants operator-read-any (ROLE_OPERATOR/ROLE_ADMIN) and
+# compliance-read-any (ROLE_COMPLIANCE) for anacredit.list/.read — no extension needed for
+# those. anacredit.create has no generic base-rego grant (it is a non-resource-scoped write),
+# so this extension covers only that gap.
+#
+# No verified M2M caller exists for anacredit-service (audited: no REST client anywhere in the
+# fleet calls it, no NetworkPolicy ingress allow-list beyond the shared platform baseline) — the
+# exposure feed is fed in by an operator/compliance officer, not another service. Deliberately
+# NOT granting a "service-*" M2M rule here, unlike consent/sca's shared-client carve-outs, since
+# there is nothing to carve out for.
+
+package openbank.rest
+
+import rego.v1
+
+# HUMANS ONLY (GHSA-58jq-9hq3-66jr, issue #4228). This IS a write: `@POST
+# /api/v1/anacredit/exposures` (AnaCreditResource.registerExposure). Without the exclusion the
+# rule was role-only, and `service-account-openbank-services` — the identity nearly every backend
+# service authenticates as — carries ROLE_OPERATOR in the docker and CI realms and is classified
+# HUMAN by AuthorizeInterceptor, so every backend service could feed the ECB regulatory return.
+# anacredit-service runs AUTHZ_ENFORCE=false today, so this was latent rather than live; the
+# exclusion lands before the enforce flip rather than after it.
+#
+# The exclusion strands no caller, and this is the one entry where the audit was already on
+# record: the header above states it ("No verified M2M caller exists for anacredit-service") and
+# re-confirming it in #4228 found no REST client in the fleet targeting the service. That claim
+# is now load-bearing rather than advisory, which is the point of writing the exclusion down.
+allowed_reasons contains "operator-anacredit-create" if {
+	input.principal.type == "HUMAN"
+	not startswith(input.principal.id, "service-account-")
+	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+	role in input.principal.roles
+	input.action == "anacredit.create"
+}

--- a/openbank-infra/gitops/components/anacredit/anacredit_rest_ext_test.rego
+++ b/openbank-infra/gitops/components/anacredit/anacredit_rest_ext_test.rego
@@ -1,0 +1,96 @@
+# SPDX-License-Identifier: Apache-2.0
+# Unit tests for anacredit_rest_ext.rego (ADR-0034 Phase 5 bootstrap, issue #938).
+#
+# Follows the extract-and-test pattern of issue #1322 (see card_issuance_rest_ext_test.rego): the
+# extension lives on disk as a real .rego file so `opa test` loads and covers it, rather than as a
+# bash heredoc inside the generator. Until #4228 this extension WAS a heredoc, so the rule below
+# had never been covered by any suite — opa-policy.yml discovers suites by the
+# *_rest_ext_test.rego / *_rest_ext.rego file pair, and a heredoc has no file to pair with.
+#
+# Run from repo root (name the files explicitly — `opa test <dir>` also tries to load every
+# .yaml in the dir as data and dies with a merge error):
+#   opa test openbank-libs/governance/policies/rest.rego \
+#            openbank-infra/gitops/components/anacredit/anacredit_rest_ext.rego \
+#            openbank-infra/gitops/components/anacredit/anacredit_rest_ext_test.rego
+# (allowed_reasons here is a partial-set rule with no dependency on rules.yaml or agents.yaml.)
+
+package openbank.rest_test
+
+import data.openbank.rest
+
+# ── The shared-M2M exclusion (GHSA-58jq-9hq3-66jr, issue #4228) ───────────────────────────────
+#
+# THE point of this file. Strip `not startswith(input.principal.id, "service-account-")` from
+# operator-anacredit-create and the next two tests go red while every other test here stays
+# green — which is what makes the exclusion falsifiable rather than merely present.
+
+# The shared backend identity carries ROLE_OPERATOR (docker + CI realms) and is classified HUMAN,
+# so without the exclusion every backend service could feed the ECB regulatory return.
+test_anacredit_create_denied_for_shared_service_account if {
+	count(rest.allowed_reasons) == 0 with input as {
+		"principal": {
+			"type": "HUMAN",
+			"id": "service-account-openbank-services",
+			"roles": ["ROLE_OPERATOR", "ROLE_ADMIN"],
+		},
+		"action": "anacredit.create",
+	}
+}
+
+# ...and the exclusion is not narrowed to one client id: ANY service-account is barred, including
+# the edge client, which holds ROLE_OPERATOR in the deployed realm template.
+test_anacredit_create_denied_for_edge_service_account if {
+	count(rest.allowed_reasons) == 0 with input as {
+		"principal": {
+			"type": "HUMAN",
+			"id": "service-account-openbank-edge",
+			"roles": ["ROLE_OPERATOR"],
+		},
+		"action": "anacredit.create",
+	}
+}
+
+# ── The human path, unaffected by the above ───────────────────────────────────────────────────
+
+# A real operator keeps the grant, and gets exactly the one reason — asserting the SET rather
+# than `allow` is what distinguishes "still works" from "still works for the right reason".
+test_anacredit_create_allowed_for_human_operator if {
+	rest.allowed_reasons == {"operator-anacredit-create"} with input as {
+		"principal": {"type": "HUMAN", "id": "alice", "roles": ["ROLE_OPERATOR"]},
+		"action": "anacredit.create",
+	}
+}
+
+test_anacredit_create_allowed_for_human_admin if {
+	"operator-anacredit-create" in rest.allowed_reasons with input as {
+		"principal": {"type": "HUMAN", "id": "alice", "roles": ["ROLE_ADMIN"]},
+		"action": "anacredit.create",
+	}
+}
+
+# A principal with an unrelated role gets no allow reason.
+test_anacredit_create_denied_for_unrelated_role if {
+	count(rest.allowed_reasons) == 0 with input as {
+		"principal": {"type": "HUMAN", "id": "bob", "roles": ["ROLE_VIEWER"]},
+		"action": "anacredit.create",
+	}
+}
+
+# An AI_AGENT principal never matches this HUMAN-only extension (agent access is mediated by
+# agents.rego/charter_allowed via rest.rego's allow rule, not here).
+test_anacredit_create_denied_for_ai_agent if {
+	count(rest.allowed_reasons) == 0 with input as {
+		"principal": {"type": "AI_AGENT", "id": "agent-1", "roles": ["ROLE_OPERATOR"]},
+		"action": "anacredit.create",
+	}
+}
+
+# The extension must not widen beyond the single write it guards. anacredit.list/.read are served
+# by base rest.rego's operator-read-any, which this suite does not load data for; asserting the
+# absence of THIS reason is the scoped claim.
+test_other_anacredit_action_not_granted_by_this_extension if {
+	not "operator-anacredit-create" in rest.allowed_reasons with input as {
+		"principal": {"type": "HUMAN", "id": "alice", "roles": ["ROLE_OPERATOR"]},
+		"action": "anacredit.list",
+	}
+}

--- a/openbank-infra/gitops/components/anacredit/gen-anacredit-opa-bundle.sh
+++ b/openbank-infra/gitops/components/anacredit/gen-anacredit-opa-bundle.sh
@@ -10,44 +10,18 @@ MANIFEST=$REPO/openbank-infra/opa/bundle.manifest
 
 # AnaCredit REST extension (ADR-0034 Phase 5 bootstrap, issue #938) — no OPA enforcement
 # infrastructure existed for this service before this bootstrap.
-ANACREDIT_REST_EXT=$(cat << 'REGO'
-# SPDX-License-Identifier: Apache-2.0
 # AnaCredit-service REST extension (ADR-0034 Phase 5 bootstrap, issue #938).
-# Extends openbank.rest with anacredit-domain allow reasons.
-# Mounted alongside rest.rego in the same OPA bundle — OPA merges same-package rules.
 #
-# Actions gated (AnaCreditResource):
-#   anacredit.create  — registerExposure (feed a credit exposure in)
-#   anacredit.list    — listAllExposures
-#   anacredit.read    — renderReturn (#referenceDate)
-#
-# Base rest.rego already grants operator-read-any (ROLE_OPERATOR/ROLE_ADMIN) and
-# compliance-read-any (ROLE_COMPLIANCE) for anacredit.list/.read — no extension needed for
-# those. anacredit.create has no generic base-rego grant (it is a non-resource-scoped write),
-# so this extension covers only that gap.
-#
-# No verified M2M caller exists for anacredit-service (audited: no REST client anywhere in the
-# fleet calls it, no NetworkPolicy ingress allow-list beyond the shared platform baseline) — the
-# exposure feed is fed in by an operator/compliance officer, not another service. Deliberately
-# NOT granting a "service-*" M2M rule here, unlike consent/sca's shared-client carve-outs, since
-# there is nothing to carve out for.
-
-package openbank.rest
-
-import rego.v1
-
-allowed_reasons contains "operator-anacredit-create" if {
-	input.principal.type == "HUMAN"
-	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
-	role in input.principal.roles
-	input.action == "anacredit.create"
-}
-REGO
-)
+# Extension extracted to a standalone .rego (mirroring vop_rest_ext.rego, #4239, and the #1322
+# pattern) so `opa test` can load and cover it — see anacredit_rest_ext_test.rego in this same
+# directory. It was a heredoc until #4228, which is why its rule had no test at all:
+# opa-policy.yml discovers suites by the *_rest_ext.rego / *_rest_ext_test.rego file PAIR, and a
+# heredoc has no file to pair with.
+ANACREDIT_REST_EXT=$REPO/openbank-infra/gitops/components/anacredit/anacredit_rest_ext.rego
 
 CHECKSUM=$(printf '%s\n' \
     "$(cat "$REST_REGO")" \
-    "$(echo "$ANACREDIT_REST_EXT")" \
+    "$(cat "$ANACREDIT_REST_EXT")" \
     "$(cat "$AGENTS_REGO")" \
     "$(cat "$AGENTS_YAML")" \
     "$(cat "$RULES_YAML")" \
@@ -73,7 +47,7 @@ OUT=$REPO/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
   echo "  rest.rego: |"
   sed 's/^/    /' "$REST_REGO" | sed 's/[[:space:]]*$//'
   echo "  anacredit_rest_ext.rego: |"
-  echo "$ANACREDIT_REST_EXT" | sed 's/^/    /' | sed 's/[[:space:]]*$//'
+  sed 's/^/    /' "$ANACREDIT_REST_EXT" | sed 's/[[:space:]]*$//'
   echo "  agents.rego: |"
   sed 's/^/    /' "$AGENTS_REGO" | sed 's/[[:space:]]*$//'
   echo "  agents-data.yaml: |"

--- a/openbank-infra/gitops/components/payments/payments-services.yaml
+++ b/openbank-infra/gitops/components/payments/payments-services.yaml
@@ -1693,7 +1693,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (ADR-0034). Value is stamped by
         # gen-standing-order-opa-bundle.sh — do not hand-edit.
-        openbank.tech/policy-checksum: "7c566db83e5d2f32" # standing-order-opa-bundle
+        openbank.tech/policy-checksum: "831f0828929b4d44" # standing-order-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/payments/standing-order-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/standing-order-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: standing-order-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "7c566db83e5d2f32"
+    openbank.tech/policy-checksum: "831f0828929b4d44"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -545,23 +545,59 @@ data:
     # ROLE_SERVICE), so the effective human grantees are ROLE_OPERATOR / ROLE_ADMIN.
     #
     # Verified caller: customer-edge pauses a customer's OWN standing order (self-service,
-    # X-Customer-Party-Id actor header) via the shared `openbank-services` Keycloak client
-    # (service-account-openbank-services, whose realmRoles include ROLE_OPERATOR). Per the documented
-    # fleet-wide limitation, AuthorizeInterceptor cannot distinguish this M2M caller from a real human
-    # operator holding ROLE_OPERATOR, so granting the role necessarily covers both — same stance as
-    # card-issuance-service's card.suspend/card.resume rule.
+    # X-Customer-Party-Id actor header) — CustomerEdgeResource.kt POSTs
+    # `$standingOrderServiceUrl/api/v1/standing-orders/{id}/pause` through UpstreamClient.
+    #
+    # CORRECTION (#4228): an earlier revision of this comment said that call carries the SHARED
+    # `openbank-services` client. It does not. `UpstreamClient.clientId` is
+    # `${openbank.upstream.client-id:openbank-edge}`, so the caller is
+    # `service-account-openbank-edge` — a DIFFERENT identity, and the distinction is the whole fix.
+    # In the deployed realm (gitops/components/keycloak/realm-template.json) the edge account holds
+    # ROLE_OPERATOR while `service-account-openbank-services` holds only ROLE_API; the docker and CI
+    # realms hand the shared account ROLE_OPERATOR too. Taking the union across realms, the old
+    # role-only rule therefore admitted EVERY backend service to this write, not just the edge.
 
     package openbank.rest
 
     import rego.v1
 
     # Operators/admins may pause a standing order — mirroring StandingOrderResource.pause()'s
-    # @RolesAllowed. Covers the customer-edge self-service pause too (it carries ROLE_OPERATOR via the
-    # shared services client, indistinguishable from a human operator at this layer).
+    # @RolesAllowed.
+    #
+    # HUMANS ONLY (GHSA-58jq-9hq3-66jr, issue #4228). This is remediation path 3, not the
+    # vop/fx/ledger exclusion-only path: standingOrder.pause HAS a real M2M caller, so the
+    # identity-scoped grant below had to land first — an exclusion on its own would have broken
+    # customer self-service pause. Measured against standing-order-opa-bundle.yaml before the change,
+    # `service-account-openbank-services` + ROLE_OPERATOR resolved exactly
+    # ["operator-standing-order-pause"]: the shared identity's ONLY reason, i.e. a live over-grant
+    # with no fallback, which is why the order matters.
     allowed_reasons contains "operator-standing-order-pause" if {
     	input.principal.type == "HUMAN"
+    	not startswith(input.principal.id, "service-account-")
     	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
     	role in input.principal.roles
+    	input.action == "standingOrder.pause"
+    }
+
+    # M2M: customer-edge's self-service pause. Gated on the Keycloak client_credentials convention
+    # (`service-account-*` preferred_username), which AuthorizeInterceptor classifies as HUMAN —
+    # there is no SERVICE principal type, and a rule gated on one is unreachable dead code
+    # (rules.yaml: authz_policy.principal_type_service_unreachable).
+    #
+    # Deliberately pinned to the ONE client id, unlike m2m-vop-verify's `startswith(...)` form.
+    # vop.verify is a pre-payment lookup shared by four rails and bounded by a rate limit; pausing a
+    # standing order mutates a customer's payment schedule and has exactly one legitimate caller, so
+    # any-service-account would re-create the exposure this rule exists to close.
+    #
+    # Deliberately scoped to standingOrder.pause ONLY, never a `standingOrder.` family prefix:
+    # pause() is the sole @Authorize-annotated endpoint on the service today, and a family grant
+    # would silently pre-authorise cancel/resume the moment either gains @Authorize.
+    #
+    # Ownership is NOT checked here: the edge passes the caller's own X-Customer-Party-Id and
+    # StandingOrderResource enforces the party match. OPA grants the action class only.
+    allowed_reasons contains "m2m-standing-order-pause" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
     	input.action == "standingOrder.pause"
     }
   agents.rego: |

--- a/openbank-infra/gitops/components/payments/standing_order_rest_ext.rego
+++ b/openbank-infra/gitops/components/payments/standing_order_rest_ext.rego
@@ -14,22 +14,58 @@
 # ROLE_SERVICE), so the effective human grantees are ROLE_OPERATOR / ROLE_ADMIN.
 #
 # Verified caller: customer-edge pauses a customer's OWN standing order (self-service,
-# X-Customer-Party-Id actor header) via the shared `openbank-services` Keycloak client
-# (service-account-openbank-services, whose realmRoles include ROLE_OPERATOR). Per the documented
-# fleet-wide limitation, AuthorizeInterceptor cannot distinguish this M2M caller from a real human
-# operator holding ROLE_OPERATOR, so granting the role necessarily covers both — same stance as
-# card-issuance-service's card.suspend/card.resume rule.
+# X-Customer-Party-Id actor header) — CustomerEdgeResource.kt POSTs
+# `$standingOrderServiceUrl/api/v1/standing-orders/{id}/pause` through UpstreamClient.
+#
+# CORRECTION (#4228): an earlier revision of this comment said that call carries the SHARED
+# `openbank-services` client. It does not. `UpstreamClient.clientId` is
+# `${openbank.upstream.client-id:openbank-edge}`, so the caller is
+# `service-account-openbank-edge` — a DIFFERENT identity, and the distinction is the whole fix.
+# In the deployed realm (gitops/components/keycloak/realm-template.json) the edge account holds
+# ROLE_OPERATOR while `service-account-openbank-services` holds only ROLE_API; the docker and CI
+# realms hand the shared account ROLE_OPERATOR too. Taking the union across realms, the old
+# role-only rule therefore admitted EVERY backend service to this write, not just the edge.
 
 package openbank.rest
 
 import rego.v1
 
 # Operators/admins may pause a standing order — mirroring StandingOrderResource.pause()'s
-# @RolesAllowed. Covers the customer-edge self-service pause too (it carries ROLE_OPERATOR via the
-# shared services client, indistinguishable from a human operator at this layer).
+# @RolesAllowed.
+#
+# HUMANS ONLY (GHSA-58jq-9hq3-66jr, issue #4228). This is remediation path 3, not the
+# vop/fx/ledger exclusion-only path: standingOrder.pause HAS a real M2M caller, so the
+# identity-scoped grant below had to land first — an exclusion on its own would have broken
+# customer self-service pause. Measured against standing-order-opa-bundle.yaml before the change,
+# `service-account-openbank-services` + ROLE_OPERATOR resolved exactly
+# ["operator-standing-order-pause"]: the shared identity's ONLY reason, i.e. a live over-grant
+# with no fallback, which is why the order matters.
 allowed_reasons contains "operator-standing-order-pause" if {
 	input.principal.type == "HUMAN"
+	not startswith(input.principal.id, "service-account-")
 	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
 	role in input.principal.roles
+	input.action == "standingOrder.pause"
+}
+
+# M2M: customer-edge's self-service pause. Gated on the Keycloak client_credentials convention
+# (`service-account-*` preferred_username), which AuthorizeInterceptor classifies as HUMAN —
+# there is no SERVICE principal type, and a rule gated on one is unreachable dead code
+# (rules.yaml: authz_policy.principal_type_service_unreachable).
+#
+# Deliberately pinned to the ONE client id, unlike m2m-vop-verify's `startswith(...)` form.
+# vop.verify is a pre-payment lookup shared by four rails and bounded by a rate limit; pausing a
+# standing order mutates a customer's payment schedule and has exactly one legitimate caller, so
+# any-service-account would re-create the exposure this rule exists to close.
+#
+# Deliberately scoped to standingOrder.pause ONLY, never a `standingOrder.` family prefix:
+# pause() is the sole @Authorize-annotated endpoint on the service today, and a family grant
+# would silently pre-authorise cancel/resume the moment either gains @Authorize.
+#
+# Ownership is NOT checked here: the edge passes the caller's own X-Customer-Party-Id and
+# StandingOrderResource enforces the party match. OPA grants the action class only.
+allowed_reasons contains "m2m-standing-order-pause" if {
+	input.principal.type == "HUMAN"
+	input.principal.id == "service-account-openbank-edge"
 	input.action == "standingOrder.pause"
 }

--- a/openbank-infra/gitops/components/payments/standing_order_rest_ext_test.rego
+++ b/openbank-infra/gitops/components/payments/standing_order_rest_ext_test.rego
@@ -16,10 +16,74 @@ package openbank.rest_test
 
 import data.openbank.rest
 
+# ── The shared-M2M exclusion + its identity-scoped replacement (GHSA-58jq-9hq3-66jr, #4228) ───
+#
+# THE point of the first three tests. Strip `not startswith(input.principal.id,
+# "service-account-")` from operator-standing-order-pause and the first two go red while every
+# other test in this file stays green; delete m2m-standing-order-pause and the third goes red.
+# That pair is what makes remediation path 3 falsifiable rather than merely present.
+
+# The shared backend identity carries ROLE_OPERATOR (docker + CI realms) and is classified HUMAN,
+# so without the exclusion it reached standingOrder.pause through the OPERATOR branch. It must
+# not: it is the identity nearly every backend service authenticates as.
+test_pause_denied_for_shared_service_account if {
+	count(rest.allowed_reasons) == 0 with input as {
+		"principal": {
+			"type": "HUMAN",
+			"id": "service-account-openbank-services",
+			"roles": ["ROLE_OPERATOR", "ROLE_ADMIN"],
+		},
+		"action": "standingOrder.pause",
+	}
+}
+
+# ...and no OTHER service-account gets in through the role branch either. Asserting an unrelated
+# one (not the edge) proves the exclusion is the thing doing the work, not the id pin below.
+test_pause_denied_for_unrelated_service_account if {
+	count(rest.allowed_reasons) == 0 with input as {
+		"principal": {
+			"type": "HUMAN",
+			"id": "service-account-openbank-mcp-service",
+			"roles": ["ROLE_OPERATOR"],
+		},
+		"action": "standingOrder.pause",
+	}
+}
+
+# The one legitimate M2M caller keeps its access — via its OWN identity-pinned reason, never the
+# operator branch. Asserting the exact reason SET (not just `allow`) is what distinguishes
+# "still works" from "still works for the right reason": if this returned both reasons the
+# exclusion would not have taken effect.
+test_edge_service_account_keeps_m2m_reason_only if {
+	rest.allowed_reasons == {"m2m-standing-order-pause"} with input as {
+		"principal": {
+			"type": "HUMAN",
+			"id": "service-account-openbank-edge",
+			"roles": ["ROLE_OPERATOR"],
+		},
+		"action": "standingOrder.pause",
+	}
+}
+
+# The identity pin must not widen to other actions on the same caller: pause() is the only
+# @Authorize'd endpoint, and cancel/resume must not be pre-authorised for the edge.
+test_edge_service_account_gets_nothing_for_other_actions if {
+	count(rest.allowed_reasons) == 0 with input as {
+		"principal": {
+			"type": "HUMAN",
+			"id": "service-account-openbank-edge",
+			"roles": ["ROLE_OPERATOR"],
+		},
+		"action": "standingOrder.cancel",
+	}
+}
+
+# ── The human path, unaffected by the above ───────────────────────────────────────────────────
+
 # ROLE_OPERATOR alone must grant standingOrder.pause.
 test_standing_order_pause_allowed_for_operator if {
 	"operator-standing-order-pause" in rest.allowed_reasons with input as {
-		"principal": {"type": "HUMAN", "roles": ["ROLE_OPERATOR"]},
+		"principal": {"type": "HUMAN", "id": "alice", "roles": ["ROLE_OPERATOR"]},
 		"action": "standingOrder.pause",
 	}
 }
@@ -27,7 +91,7 @@ test_standing_order_pause_allowed_for_operator if {
 # ROLE_ADMIN alone must also grant standingOrder.pause.
 test_standing_order_pause_allowed_for_admin if {
 	"operator-standing-order-pause" in rest.allowed_reasons with input as {
-		"principal": {"type": "HUMAN", "roles": ["ROLE_ADMIN"]},
+		"principal": {"type": "HUMAN", "id": "alice", "roles": ["ROLE_ADMIN"]},
 		"action": "standingOrder.pause",
 	}
 }

--- a/openbank-infra/gitops/components/pid/gen-pid-opa-bundle.sh
+++ b/openbank-infra/gitops/components/pid/gen-pid-opa-bundle.sh
@@ -9,72 +9,18 @@ RULES_YAML=$REPO/openbank-libs/governance/rules-opa-data.yaml
 MANIFEST=$REPO/openbank-infra/opa/bundle.manifest
 
 # Pid REST extension — identity + EUDI + party actions for operators/admins
-PID_REST_EXT=$(cat << 'REGO'
-# SPDX-License-Identifier: Apache-2.0
 # Pid-service REST extension (ADR-0034, ADR-0094, ADR-0072).
-# Extends openbank.rest with identity-domain allow reasons.
-# Mounted alongside rest.rego in the same OPA bundle — OPA merges same-package rules.
 #
-# Actions gated:
-#   identity.eudi.issue   — EudiCredentialIssuerResource.issue
-#   identity.eudi.revoke  — EudiCredentialIssuerResource.revoke
-#   identity.eudi.request — EudiOpenId4VpResource.request
-#   identity.eudi.poll    — EudiOpenId4VpResource.poll
-#   identity.eudi.verify  — EudiPresentationResource.verify
-#   identity.case.list    — VerificationCaseResource.list
-#   identity.case.get     — VerificationCaseResource.get
-#   identity.case.decide  — VerificationCaseResource.decide (four-eyes in handler)
-#   identity.case.reopen  — VerificationCaseResource.reopen
-#   identity.register     — PartyResource.register
-#   identity.resolve      — PartyResource.resolve
-#   identity.link         — PartyResource.link
-#   pid.resolve           — PartyResource.resolvePid
-#   party.changeStatus    — PartyResource.changeStatus
-
-package openbank.rest
-
-import rego.v1
-
-# Operators and admins may perform any identity.* write operation on the pid-service.
-# ROLE_OPERATOR covers onboarding cockpit staff; ROLE_ADMIN covers platform administrators.
-# The specific four-eyes enforcement for identity.case.decide is inside the handler.
-allowed_reasons contains "operator-identity-write" if {
-	input.principal.type == "HUMAN"
-	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
-	role in input.principal.roles
-	startswith(input.action, "identity.")
-}
-
-# Operators and admins may resolve a PID record (pid.resolve) — used by onboarding dedup.
-allowed_reasons contains "operator-pid-resolve" if {
-	input.principal.type == "HUMAN"
-	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
-	role in input.principal.roles
-	input.action == "pid.resolve"
-}
-
-# Operators and admins may change party status (party.changeStatus) — onboarding state machine.
-allowed_reasons contains "operator-party-status" if {
-	input.principal.type == "HUMAN"
-	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
-	role in input.principal.roles
-	input.action == "party.changeStatus"
-}
-
-# Authenticated customers may request and poll their own EUDI credential presentation
-# (OpenID4VP relying-party flow, ADR-0094). The resource.id (partyId) is checked against
-# principal.id in the handler; OPA grants the action class.
-allowed_reasons contains "customer-eudi-request" if {
-	input.principal.type == "HUMAN"
-	input.principal.id != ""
-	input.action in {"identity.eudi.request", "identity.eudi.poll", "identity.eudi.verify"}
-}
-REGO
-)
+# Extension extracted to a standalone .rego (mirroring vop_rest_ext.rego, #4239, and the #1322
+# pattern) so `opa test` can load and cover it — see pid_rest_ext_test.rego in this same
+# directory. It was a heredoc until #4228, which is why its rules had no test at all:
+# opa-policy.yml discovers suites by the *_rest_ext.rego / *_rest_ext_test.rego file PAIR, and a
+# heredoc has no file to pair with.
+PID_REST_EXT=$REPO/openbank-infra/gitops/components/pid/pid_rest_ext.rego
 
 CHECKSUM=$(printf '%s\n' \
     "$(cat "$REST_REGO")" \
-    "$(echo "$PID_REST_EXT")" \
+    "$(cat "$PID_REST_EXT")" \
     "$(cat "$AGENTS_REGO")" \
     "$(cat "$AGENTS_YAML")" \
     "$(cat "$RULES_YAML")" \
@@ -100,7 +46,7 @@ OUT=$REPO/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
   echo "  rest.rego: |"
   sed 's/^/    /' "$REST_REGO" | sed 's/[[:space:]]*$//'
   echo "  pid_rest_ext.rego: |"
-  echo "$PID_REST_EXT" | sed 's/^/    /' | sed 's/[[:space:]]*$//'
+  sed 's/^/    /' "$PID_REST_EXT" | sed 's/[[:space:]]*$//'
   echo "  agents.rego: |"
   sed 's/^/    /' "$AGENTS_REGO" | sed 's/[[:space:]]*$//'
   echo "  agents-data.yaml: |"

--- a/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: pid-service
     app.kubernetes.io/part-of: pid
   annotations:
-    openbank.tech/policy-checksum: "ce65d8fac4e96c02"
+    openbank.tech/policy-checksum: "bd7381c46d9237f6"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -564,8 +564,20 @@ data:
     	startswith(input.action, "identity.")
     }
 
-    # Operators and admins may resolve a PID record (pid.resolve) — used by onboarding dedup.
-    allowed_reasons contains "operator-pid-resolve" if {
+    # Operators and admins may look up a party by a pre-computed RČ blind index (pid.resolve).
+    #
+    # RENAMED from `operator-pid-resolve` in #4228. It is a READ, and the old name hid that: it is
+    # `@GET /api/v1/parties/pid/resolve` (PartyResource.resolveByIndex), which takes an `index` query
+    # parameter and returns `{partyId}` or 404 — no state is written on any path. The
+    # check-operator-write-naming guard classifies by name, and `-read` is the one naming convention
+    # this fleet actually follows, so the honest fix here is the name, not an exclusion: the rule
+    # never was one of the role-only WRITES that guard exists to surface.
+    #
+    # Deliberately NOT given the `not startswith(input.principal.id, "service-account-")` treatment
+    # its two sibling entries got. It grants nothing a service-account could not already do — the
+    # endpoint is `@RolesAllowed(Roles.API)`, so the RBAC gate in front of OPA already requires
+    # ROLE_API, and no caller anywhere in the fleet invokes this path today (audited #4228).
+    allowed_reasons contains "operator-pid-resolve-read" if {
     	input.principal.type == "HUMAN"
     	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
     	role in input.principal.roles
@@ -573,8 +585,24 @@ data:
     }
 
     # Operators and admins may change party status (party.changeStatus) — onboarding state machine.
+    #
+    # HUMANS ONLY (GHSA-58jq-9hq3-66jr, issue #4228). This IS a write: `@PATCH
+    # /api/v1/parties/{id}/status` (PartyResource.changeStatus). Without the exclusion the rule was
+    # role-only, and `service-account-openbank-services` — the identity nearly every backend service
+    # authenticates as — carries ROLE_OPERATOR in the docker and CI realms and is classified HUMAN by
+    # AuthorizeInterceptor, so it reached a party lifecycle write. pid-service runs
+    # AUTHZ_ENFORCE=true, so this was live, not latent.
+    #
+    # The exclusion strands no caller, established two ways rather than by the shape of the rule:
+    # (1) the endpoint is `@RolesAllowed(Roles.ADMIN)`, and no service-account holds ROLE_ADMIN in
+    # ANY of the three realm JSONs in this tree (deployed template: edge=ROLE_OPERATOR,
+    # services=ROLE_API; docker: services=ROLE_OPERATOR+ROLE_API; CI: services=ROLE_OPERATOR+
+    # ROLE_COMPLIANCE) — so the RBAC gate in front of OPA already refused every M2M caller; and
+    # (2) no service in the fleet calls this path — the only cross-service traffic to pid-service is
+    # POST /parties/{id}/external-ids (identity.link) from customer-edge.
     allowed_reasons contains "operator-party-status" if {
     	input.principal.type == "HUMAN"
+    	not startswith(input.principal.id, "service-account-")
     	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
     	role in input.principal.roles
     	input.action == "party.changeStatus"

--- a/openbank-infra/gitops/components/pid/pid-service.yaml
+++ b/openbank-infra/gitops/components/pid/pid-service.yaml
@@ -32,7 +32,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-pid-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "ce65d8fac4e96c02"
+        openbank.tech/policy-checksum: "bd7381c46d9237f6"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/pid/pid_rest_ext.rego
+++ b/openbank-infra/gitops/components/pid/pid_rest_ext.rego
@@ -1,0 +1,87 @@
+# SPDX-License-Identifier: Apache-2.0
+# Pid-service REST extension (ADR-0034, ADR-0094, ADR-0072).
+# Extends openbank.rest with identity-domain allow reasons.
+# Mounted alongside rest.rego in the same OPA bundle — OPA merges same-package rules.
+#
+# Actions gated:
+#   identity.eudi.issue   — EudiCredentialIssuerResource.issue
+#   identity.eudi.revoke  — EudiCredentialIssuerResource.revoke
+#   identity.eudi.request — EudiOpenId4VpResource.request
+#   identity.eudi.poll    — EudiOpenId4VpResource.poll
+#   identity.eudi.verify  — EudiPresentationResource.verify
+#   identity.case.list    — VerificationCaseResource.list
+#   identity.case.get     — VerificationCaseResource.get
+#   identity.case.decide  — VerificationCaseResource.decide (four-eyes in handler)
+#   identity.case.reopen  — VerificationCaseResource.reopen
+#   identity.register     — PartyResource.register
+#   identity.resolve      — PartyResource.resolve
+#   identity.link         — PartyResource.link
+#   pid.resolve           — PartyResource.resolvePid
+#   party.changeStatus    — PartyResource.changeStatus
+
+package openbank.rest
+
+import rego.v1
+
+# Operators and admins may perform any identity.* write operation on the pid-service.
+# ROLE_OPERATOR covers onboarding cockpit staff; ROLE_ADMIN covers platform administrators.
+# The specific four-eyes enforcement for identity.case.decide is inside the handler.
+allowed_reasons contains "operator-identity-write" if {
+	input.principal.type == "HUMAN"
+	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+	role in input.principal.roles
+	startswith(input.action, "identity.")
+}
+
+# Operators and admins may look up a party by a pre-computed RČ blind index (pid.resolve).
+#
+# RENAMED from `operator-pid-resolve` in #4228. It is a READ, and the old name hid that: it is
+# `@GET /api/v1/parties/pid/resolve` (PartyResource.resolveByIndex), which takes an `index` query
+# parameter and returns `{partyId}` or 404 — no state is written on any path. The
+# check-operator-write-naming guard classifies by name, and `-read` is the one naming convention
+# this fleet actually follows, so the honest fix here is the name, not an exclusion: the rule
+# never was one of the role-only WRITES that guard exists to surface.
+#
+# Deliberately NOT given the `not startswith(input.principal.id, "service-account-")` treatment
+# its two sibling entries got. It grants nothing a service-account could not already do — the
+# endpoint is `@RolesAllowed(Roles.API)`, so the RBAC gate in front of OPA already requires
+# ROLE_API, and no caller anywhere in the fleet invokes this path today (audited #4228).
+allowed_reasons contains "operator-pid-resolve-read" if {
+	input.principal.type == "HUMAN"
+	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+	role in input.principal.roles
+	input.action == "pid.resolve"
+}
+
+# Operators and admins may change party status (party.changeStatus) — onboarding state machine.
+#
+# HUMANS ONLY (GHSA-58jq-9hq3-66jr, issue #4228). This IS a write: `@PATCH
+# /api/v1/parties/{id}/status` (PartyResource.changeStatus). Without the exclusion the rule was
+# role-only, and `service-account-openbank-services` — the identity nearly every backend service
+# authenticates as — carries ROLE_OPERATOR in the docker and CI realms and is classified HUMAN by
+# AuthorizeInterceptor, so it reached a party lifecycle write. pid-service runs
+# AUTHZ_ENFORCE=true, so this was live, not latent.
+#
+# The exclusion strands no caller, established two ways rather than by the shape of the rule:
+# (1) the endpoint is `@RolesAllowed(Roles.ADMIN)`, and no service-account holds ROLE_ADMIN in
+# ANY of the three realm JSONs in this tree (deployed template: edge=ROLE_OPERATOR,
+# services=ROLE_API; docker: services=ROLE_OPERATOR+ROLE_API; CI: services=ROLE_OPERATOR+
+# ROLE_COMPLIANCE) — so the RBAC gate in front of OPA already refused every M2M caller; and
+# (2) no service in the fleet calls this path — the only cross-service traffic to pid-service is
+# POST /parties/{id}/external-ids (identity.link) from customer-edge.
+allowed_reasons contains "operator-party-status" if {
+	input.principal.type == "HUMAN"
+	not startswith(input.principal.id, "service-account-")
+	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+	role in input.principal.roles
+	input.action == "party.changeStatus"
+}
+
+# Authenticated customers may request and poll their own EUDI credential presentation
+# (OpenID4VP relying-party flow, ADR-0094). The resource.id (partyId) is checked against
+# principal.id in the handler; OPA grants the action class.
+allowed_reasons contains "customer-eudi-request" if {
+	input.principal.type == "HUMAN"
+	input.principal.id != ""
+	input.action in {"identity.eudi.request", "identity.eudi.poll", "identity.eudi.verify"}
+}

--- a/openbank-infra/gitops/components/pid/pid_rest_ext_test.rego
+++ b/openbank-infra/gitops/components/pid/pid_rest_ext_test.rego
@@ -1,0 +1,140 @@
+# SPDX-License-Identifier: Apache-2.0
+# Unit tests for pid_rest_ext.rego (ADR-0034, ADR-0094, ADR-0072).
+#
+# Follows the extract-and-test pattern of issue #1322 (see card_issuance_rest_ext_test.rego): the
+# extension lives on disk as a real .rego file so `opa test` loads and covers it, rather than as a
+# bash heredoc inside the generator. Until #4228 this extension WAS a heredoc, so none of its
+# rules had ever been covered by any suite — opa-policy.yml discovers suites by the
+# *_rest_ext_test.rego / *_rest_ext.rego file pair, and a heredoc has no file to pair with.
+#
+# Run from repo root (name the files explicitly — `opa test <dir>` also tries to load every
+# .yaml in the dir as data and dies with a merge error):
+#   opa test openbank-libs/governance/policies/rest.rego \
+#            openbank-infra/gitops/components/pid/pid_rest_ext.rego \
+#            openbank-infra/gitops/components/pid/pid_rest_ext_test.rego
+# (allowed_reasons here is a partial-set rule with no dependency on rules.yaml or agents.yaml.)
+
+package openbank.rest_test
+
+import data.openbank.rest
+
+# ── The shared-M2M exclusion on party.changeStatus (GHSA-58jq-9hq3-66jr, issue #4228) ─────────
+#
+# THE point of the next two tests. Strip `not startswith(input.principal.id, "service-account-")`
+# from operator-party-status and both go red while every other test here stays green — which is
+# what makes the exclusion falsifiable rather than merely present. pid-service runs
+# AUTHZ_ENFORCE=true, so this rule is enforced in production, not advisory.
+
+# The shared backend identity carries ROLE_OPERATOR (docker + CI realms) and is classified HUMAN,
+# so without the exclusion it reached a party lifecycle write. It must not.
+test_party_status_denied_for_shared_service_account if {
+	not "operator-party-status" in rest.allowed_reasons with input as {
+		"principal": {
+			"type": "HUMAN",
+			"id": "service-account-openbank-services",
+			"roles": ["ROLE_OPERATOR", "ROLE_ADMIN"],
+		},
+		"action": "party.changeStatus",
+	}
+}
+
+# ...and the exclusion is not narrowed to one client id: ANY service-account is barred, including
+# the edge client, which holds ROLE_OPERATOR in the deployed realm template.
+test_party_status_denied_for_edge_service_account if {
+	not "operator-party-status" in rest.allowed_reasons with input as {
+		"principal": {
+			"type": "HUMAN",
+			"id": "service-account-openbank-edge",
+			"roles": ["ROLE_OPERATOR"],
+		},
+		"action": "party.changeStatus",
+	}
+}
+
+# The human path is unaffected — asserting the exact reason set rather than `allow` is what
+# distinguishes "still works" from "still works for the right reason".
+test_party_status_allowed_for_human_operator if {
+	rest.allowed_reasons == {"operator-party-status"} with input as {
+		"principal": {"type": "HUMAN", "id": "alice", "roles": ["ROLE_OPERATOR"]},
+		"action": "party.changeStatus",
+	}
+}
+
+test_party_status_allowed_for_human_admin if {
+	"operator-party-status" in rest.allowed_reasons with input as {
+		"principal": {"type": "HUMAN", "id": "alice", "roles": ["ROLE_ADMIN"]},
+		"action": "party.changeStatus",
+	}
+}
+
+test_party_status_denied_for_unrelated_role if {
+	count(rest.allowed_reasons) == 0 with input as {
+		"principal": {"type": "HUMAN", "id": "bob", "roles": ["ROLE_VIEWER"]},
+		"action": "party.changeStatus",
+	}
+}
+
+# ── pid.resolve is a READ, and keeps its role-only grant deliberately ─────────────────────────
+#
+# It is `@GET /api/v1/parties/pid/resolve` behind `@RolesAllowed(Roles.API)`. The reason was
+# renamed `operator-pid-resolve` -> `operator-pid-resolve-read` in #4228 so the name states what
+# the rule does; these tests pin the new name so a silent revert to the old one is caught.
+test_pid_resolve_read_allowed_for_human_operator if {
+	"operator-pid-resolve-read" in rest.allowed_reasons with input as {
+		"principal": {"type": "HUMAN", "id": "alice", "roles": ["ROLE_OPERATOR"]},
+		"action": "pid.resolve",
+	}
+}
+
+# The old write-shaped name must not resolve any more — this is the assertion that would fail if
+# someone reinstated it, and it is why the rename is not merely cosmetic.
+test_old_pid_resolve_reason_name_is_gone if {
+	not "operator-pid-resolve" in rest.allowed_reasons with input as {
+		"principal": {"type": "HUMAN", "id": "alice", "roles": ["ROLE_OPERATOR"]},
+		"action": "pid.resolve",
+	}
+}
+
+# ── The identity.* family and the customer EUDI path, previously untested entirely ────────────
+
+test_identity_family_allowed_for_human_operator if {
+	"operator-identity-write" in rest.allowed_reasons with input as {
+		"principal": {"type": "HUMAN", "id": "alice", "roles": ["ROLE_OPERATOR"]},
+		"action": "identity.case.decide",
+	}
+}
+
+# The family prefix must not leak past `identity.` — party.changeStatus and pid.resolve have
+# their own rules precisely because operator-identity-write does not cover them.
+test_identity_family_does_not_cover_party_status if {
+	not "operator-identity-write" in rest.allowed_reasons with input as {
+		"principal": {"type": "HUMAN", "id": "alice", "roles": ["ROLE_OPERATOR"]},
+		"action": "party.changeStatus",
+	}
+}
+
+# An authenticated customer (no role) may request their own EUDI presentation; the partyId match
+# is enforced in the handler, OPA grants the action class only.
+test_customer_eudi_request_allowed_for_authenticated_customer if {
+	"customer-eudi-request" in rest.allowed_reasons with input as {
+		"principal": {"type": "HUMAN", "id": "customer-42", "roles": []},
+		"action": "identity.eudi.request",
+	}
+}
+
+# ...but an unauthenticated principal has an empty id and gets nothing.
+test_customer_eudi_request_denied_for_empty_id if {
+	count(rest.allowed_reasons) == 0 with input as {
+		"principal": {"type": "HUMAN", "id": "", "roles": []},
+		"action": "identity.eudi.request",
+	}
+}
+
+# An AI_AGENT principal never matches this HUMAN-only extension (agent access is mediated by
+# agents.rego/charter_allowed via rest.rego's allow rule, not here).
+test_pid_ext_denied_for_ai_agent if {
+	count(rest.allowed_reasons) == 0 with input as {
+		"principal": {"type": "AI_AGENT", "id": "agent-1", "roles": ["ROLE_OPERATOR"]},
+		"action": "party.changeStatus",
+	}
+}


### PR DESCRIPTION
## What

`check-operator-write-naming.py`'s `BASELINE` is now **empty**. The four remaining role-only write
grants that escaped the shared-M2M register by name are closed, each on its own evidence.

Closes #4228

## The four, and why they needed three different fixes

The issue's premise held: "role-only write rule" was one label over three situations.

| Reason | Verdict | Fix |
|---|---|---|
| `operator-pid-resolve` | **(b) not a write** — the name was the whole defect | renamed `operator-pid-resolve-read` |
| `operator-party-status` | **(a) genuine write, LIVE** (pid `AUTHZ_ENFORCE=true`), no M2M caller | humans-only exclusion |
| `operator-anacredit-create` | **(a) genuine write, latent** (`AUTHZ_ENFORCE=false`), no M2M caller | humans-only exclusion |
| `operator-standing-order-pause` | **(a) genuine write WITH a real M2M caller** | path 3: identity-pinned rule FIRST, then the exclusion |

**`operator-pid-resolve` is a read.** `@GET /api/v1/parties/pid/resolve`
(`PartyResource.resolveByIndex`) takes an `index` query parameter and returns `{partyId}` or 404 —
no state is written on any path. The script's inline note classified it "a lookup; pending
confirmation"; this is that confirmation. `-read` is the one naming convention this fleet actually
follows, so the honest fix is the name, not an exclusion: it never was one of the writes the guard
exists to surface. Its role-only grant is kept deliberately — the endpoint sits behind
`@RolesAllowed(Roles.API)`, so RBAC in front of OPA already gates it, and nothing in the fleet
calls the path today.

**`operator-party-status` strands no caller, established two ways** rather than from the shape of
the rule: the endpoint is `@RolesAllowed(Roles.ADMIN)` and no service-account holds `ROLE_ADMIN` in
*any* of the three realm JSONs; and no service calls it (the only cross-service traffic to
pid-service is `POST /parties/{id}/external-ids` from customer-edge).

**`operator-standing-order-pause` — the rule's own comment named the wrong client.** It said the
customer-edge self-service pause arrives "via the shared `openbank-services` Keycloak client". It
does not: `UpstreamClient.clientId` is `${openbank.upstream.client-id:openbank-edge}`, so the caller
is `service-account-openbank-edge`. That distinction is the whole fix — it is what makes a
one-client-id pin possible instead of a `startswith("service-account-")` grant. Pinned narrowly on
purpose: unlike `vop.verify` (a lookup shared by four rails, bounded by a rate limit), pausing
mutates a customer's payment schedule and has exactly one legitimate caller.

## Measured, not read

`opa eval` against the bundle ConfigMaps materialised into the sidecar's own directory layout
(`rules-data.yaml` -> `rules/data.yaml`), probing `data.openbank.rest.allow` and
`allowed_reasons` per (principal, action). **Before** = the bundles as they stand on `origin/main`;
**after** = the regenerated bundles on this branch.

Before (`origin/main`), `service-account-openbank-services` + `ROLE_OPERATOR` + `HUMAN`:

```
pid.resolve          allow=true   ["operator-pid-resolve"]
party.changeStatus   allow=true   ["operator-party-status"]
anacredit.create     allow=true   ["operator-anacredit-create"]
standingOrder.pause  allow=true   ["operator-standing-order-pause"]
```

Each resolved a **single** reason — i.e. no identity-scoped fallback existed for any of them, which
is exactly why standing-order could not take the vop treatment.

After:

```
party.changeStatus   allow=false  []
anacredit.create     allow=false  []
standingOrder.pause  allow=false  []
pid.resolve          allow=true   ["operator-pid-resolve-read"]      read, kept deliberately

service-account-openbank-edge  standingOrder.pause   allow=true  ["m2m-standing-order-pause"]
service-account-openbank-edge  standingOrder.cancel  allow=false []   pin does not widen
```

Controls in every run, both directions:

```
must-ALLOW  human alice + ROLE_OPERATOR  ->  party.changeStatus / anacredit.create /
                                             standingOrder.pause / pid.resolve  all allow=true
must-DENY   ANONYMOUS                    ->  all four  allow=false
```

**Which realm.** The three realm JSONs disagree and the difference matters, so all three were read:
`gitops/components/keycloak/realm-template.json` (**deployed**) gives
`service-account-openbank-services` only `ROLE_API` and `service-account-openbank-edge`
`ROLE_OPERATOR`; `openbank-infra/docker/.../openbank-realm.json` gives the shared account
`ROLE_OPERATOR, ROLE_API`; `.github/workflows/keycloak/openbank-realm.json` gives it
`ROLE_OPERATOR, ROLE_COMPLIANCE`. Reasoning above takes the **union**. In the deployed realm
specifically, the shared account's reach was latent and the *edge* account's was live — "latent in
one realm" is not "closed", since a realm-template edit is one PR away. The script's own comment
claiming the realm gives the shared account "exactly ROLE_OPERATOR — nothing else" was stale and is
corrected in place rather than deleted.

## Falsified, not merely present

- Strip the exclusion from `anacredit_rest_ext.rego`: the checker reports **1 new** and exits 1, and
  the suite goes `PASS 5/7` with exactly the two shared-M2M cases red.
- Put a fixed name back in `BASELINE`: the stale-entry ratchet fires and exits 1. Both directions of
  the ratchet were exercised, not just the passing one.
- Each new suite asserts the exact reason **set**, not `allow` — that is what distinguishes "still
  works" from "still works for the right reason".

## The pid and anacredit extensions had never been tested at all

Both lived in generator heredocs. `opa-policy.yml` discovers suites by the
`*_rest_ext.rego` / `*_rest_ext_test.rego` file **pair**, and a heredoc has nothing to pair with —
the lesson #4239 recorded for vop. Both are now standalone `.rego` files with suites:
`pid_rest_ext_test.rego` (12 cases) and `anacredit_rest_ext_test.rego` (7). That covers the
`identity.*` family and the customer EUDI path too, which had no coverage of any kind.

Fleet-wide after this change: **25 rest_ext suites, all green** (was 23).

## Scope of the regeneration

Derived files first, then every bundle, re-run after the final edit and after merging `main`.
`rules.yaml` is **not** touched, so `rules-opa-data.yaml` and `agents-opa-data.yaml` are unchanged
and there is no fleet-wide restamp: exactly **3** bundles and **3** pod-roll annotations move
(pid, anacredit, standing-order). No bundle or annotation was hand-edited.

**Short shelf life.** The three regenerated bundle ConfigMaps conflict textually with any other
governance PR that restamps them, so this wants merging promptly rather than sitting.

## Gates run locally (with `BASE_REF` / `PR_DIFF_BASE` exported, as CI does)

`operator-write-naming` (enforced) `0 baselined, 0 new` · `opa-bundle-parses` (43 bundles) ·
`opa-sidecar-bundle-shape` (43 sidecars) · `opa-bundle-apply-size` ·
`no-dead-code-service-principal-rego-rule` (144 policy files) · `threat-model-coverage` ·
`threat-model-updated-on-trust-boundary-change` · `license-header-consistency` — all pass.
`opa fmt --list` flags no file introduced or touched here.

## Review notes

- **money-path** (`openbank-standing-order-service`): 2 approvals + threat model, ADR-0030. The
  threat model is updated with the measured before/after and why path 3 was required;
  `openbank-anacredit-service.md` likewise. pid-service is not in `money_path_services` and has no
  threat model to update.
- The issue proposed **one PR per service**. This is one PR for all four because the deliverable it
  asks for is the *empty* `BASELINE`, and that assertion is only true when all four have landed —
  splitting it would leave the ratchet green about a list it had not finished shrinking.
- `pid.resolve` deliberately still resolves for a shared-identity caller holding `ROLE_OPERATOR`.
  That is the one place a reviewer should push back if they disagree with the read/write call.
