### PR TITLE
fix(lending): stamp business event time on the money-path audit producers

### DIFF
--- a/openbank-clearing-service/src/main/kotlin/com/openbank/clearing/infrastructure/kafka/ClearingEventPublisherImpl.kt
+++ b/openbank-clearing-service/src/main/kotlin/com/openbank/clearing/infrastructure/kafka/ClearingEventPublisherImpl.kt
@@ -30,43 +30,65 @@ class ClearingEventPublisherImpl @Inject constructor(
         val message = OutboxMessage(
             aggregateId = batch.id,
             eventType = BATCH_SETTLED_EVENT,
-            payload = objectMapper.writeValueAsString(
-                mapOf(
-                    // eventType is also on OutboxMessage.eventType (-> Kafka header, ce-type), but
-                    // AuditConsumer (PR #1007) reads only the JSON body, so it is duplicated here.
-                    "eventType" to BATCH_SETTLED_EVENT,
-                    "batchId" to batch.id,
-                    "batchReference" to batch.batchReference,
-                    "rail" to batch.rail.name,
-                    "cycleId" to batch.cycleId,
-                    "totalDebit" to batch.totalDebit,
-                    "totalCredit" to batch.totalCredit,
-                    "netPosition" to batch.netPosition,
-                    "itemCount" to batch.itemCount,
-                    "settledAt" to batch.settledAt?.toString(),
-                ),
-            ),
+            payload = batchSettledPayload(batch),
         )
         return Panache.withTransaction { outboxRepo.persistInTransaction(message) }
     }
+
+    /**
+     * The `batch.settled` JSON body, split out from [publishBatchSettled] so it can be asserted
+     * without a Vert.x context (`Panache.withTransaction` needs one; a payload does not). #3914.
+     */
+    internal fun batchSettledPayload(batch: ClearingBatch): String = objectMapper.writeValueAsString(
+        mapOf(
+            // eventType is also on OutboxMessage.eventType (-> Kafka header, ce-type), but
+            // AuditConsumer (PR #1007) reads only the JSON body, so it is duplicated here.
+            "eventType" to BATCH_SETTLED_EVENT,
+            "batchId" to batch.id,
+            "batchReference" to batch.batchReference,
+            "rail" to batch.rail.name,
+            "cycleId" to batch.cycleId,
+            "totalDebit" to batch.totalDebit,
+            "totalCredit" to batch.totalCredit,
+            "netPosition" to batch.netPosition,
+            "itemCount" to batch.itemCount,
+            "settledAt" to batch.settledAt?.toString(),
+            // #3914: the business event time, not the serialisation time. `settledAt` IS
+            // the settlement instant (ClearingService.settleBatch sets it on the aggregate
+            // before this publisher ever runs); `updatedAt` is the fallback for a batch
+            // whose settledAt was never stamped. Emitted as an Instant, NOT via
+            // OffsetDateTime.toString() — AuditConsumer.eventTime() parses with
+            // Instant.parse, which rejects a non-Z offset ("...+01:00") and would fall
+            // back to ingest time, i.e. exactly the defect this line exists to fix.
+            "occurredAt" to (batch.settledAt ?: batch.updatedAt).toInstant().toString(),
+        ),
+    )
 
     override fun publishItemCleared(item: ClearingItem): Uni<Void> {
         val message = OutboxMessage(
             aggregateId = item.id,
             eventType = ITEM_CLEARED_EVENT,
-            payload = objectMapper.writeValueAsString(
-                mapOf(
-                    "eventType" to ITEM_CLEARED_EVENT,
-                    "itemId" to item.id,
-                    "batchId" to item.batchId,
-                    "paymentId" to item.paymentId,
-                    "paymentReference" to item.paymentReference,
-                    "amount" to item.amount,
-                    "currency" to item.currency,
-                    "status" to item.status.name,
-                ),
-            ),
+            payload = itemClearedPayload(item),
         )
         return Panache.withTransaction { outboxRepo.persistInTransaction(message) }
     }
+
+    /** The `item.cleared` JSON body. See [batchSettledPayload] for why this is split out. */
+    internal fun itemClearedPayload(item: ClearingItem): String = objectMapper.writeValueAsString(
+        mapOf(
+            "eventType" to ITEM_CLEARED_EVENT,
+            "itemId" to item.id,
+            "batchId" to item.batchId,
+            "paymentId" to item.paymentId,
+            "paymentReference" to item.paymentReference,
+            "amount" to item.amount,
+            "currency" to item.currency,
+            "status" to item.status.name,
+            // #3914: ClearingItem has no per-transition instant, so `updatedAt` — the
+            // instant the row last changed state, which for a cleared item IS the clearing
+            // — is the truest available business time. Same Instant-vs-offset note as
+            // publishBatchSettled above.
+            "occurredAt" to item.updatedAt.toInstant().toString(),
+        ),
+    )
 }

--- a/openbank-clearing-service/src/test/kotlin/com/openbank/clearing/infrastructure/kafka/ClearingEventPublisherOccurredAtTest.kt
+++ b/openbank-clearing-service/src/test/kotlin/com/openbank/clearing/infrastructure/kafka/ClearingEventPublisherOccurredAtTest.kt
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.clearing.infrastructure.kafka
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.clearing.domain.model.ClearingBatch
+import com.openbank.clearing.domain.model.ClearingItem
+import com.openbank.clearing.domain.model.ClearingStatus
+import com.openbank.clearing.domain.model.PaymentRail
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.Instant
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import java.util.UUID
+
+/**
+ * #3914 — the two clearing payloads must carry the BUSINESS event time.
+ *
+ * Without `occurredAt`, `AuditConsumer.eventTime()` returns null and `audit_entries.occurred_at`
+ * records the consumer's INGEST time as the business time (GDPR Art. 30 "when", DORA Art. 17
+ * evidence). Under consumer lag or a replay that value is arbitrarily wrong.
+ *
+ * Every assertion below is against an EXACT expected instant, never `isNotNull()` — a non-null
+ * check passes against `Instant.EPOCH`, and a string emptiness check passes against the
+ * four-character text `"null"` that Jackson's `asText()` yields for a JSON null. The
+ * `Instant.parse` round-trip is load-bearing on its own: `OffsetDateTime.toString()` renders a
+ * non-UTC offset as `...+01:00`, which `Instant.parse` REJECTS, and the consumer would then fall
+ * back to ingest time — i.e. the payload would look fixed and behave exactly as broken.
+ */
+class ClearingEventPublisherOccurredAtTest {
+
+    private val mapper = ObjectMapper()
+    private val publisher = ClearingEventPublisherImpl(mapper, mockk())
+
+    private val settledAt = OffsetDateTime.of(2026, 3, 1, 13, 34, 56, 0, ZoneOffset.ofHours(1))
+    private val updatedAt = OffsetDateTime.of(2026, 3, 2, 9, 0, 0, 0, ZoneOffset.ofHours(2))
+
+    private fun batch(settled: OffsetDateTime?) = ClearingBatch(
+        id = UUID.randomUUID(),
+        batchReference = "BATCH-1",
+        rail = PaymentRail.SEPA_SCT,
+        status = ClearingStatus.SETTLED,
+        totalDebit = BigDecimal("10.00"),
+        totalCredit = BigDecimal("10.00"),
+        netPosition = BigDecimal.ZERO,
+        itemCount = 1,
+        cycleId = "C1",
+        settledAt = settled,
+        createdAt = updatedAt,
+        updatedAt = updatedAt,
+    )
+
+    private fun occurredAt(payload: String): Instant =
+        Instant.parse(mapper.readTree(payload).get("occurredAt").asText())
+
+    @Test
+    fun `batch settled carries the settlement instant, normalised to UTC`() {
+        val payload = publisher.batchSettledPayload(batch(settledAt))
+
+        // 13:34:56+01:00 is 12:34:56Z — asserting the exact instant proves both that the right
+        // domain fact was chosen AND that the offset was normalised rather than emitted verbatim.
+        assertThat(occurredAt(payload)).isEqualTo(Instant.parse("2026-03-01T12:34:56Z"))
+        assertThat(occurredAt(payload)).isNotEqualTo(Instant.EPOCH)
+    }
+
+    @Test
+    fun `batch settled falls back to updatedAt when settledAt was never stamped`() {
+        val payload = publisher.batchSettledPayload(batch(null))
+
+        assertThat(occurredAt(payload)).isEqualTo(Instant.parse("2026-03-02T07:00:00Z"))
+    }
+
+    @Test
+    fun `item cleared carries the row's last transition instant`() {
+        val item = ClearingItem(
+            id = UUID.randomUUID(),
+            batchId = UUID.randomUUID(),
+            paymentId = UUID.randomUUID(),
+            paymentReference = "PMT-1",
+            debtorIban = "DE89370400440532013000",
+            creditorIban = "GB29NWBK60161331926819",
+            amount = BigDecimal("10.00"),
+            status = ClearingStatus.SETTLED,
+            createdAt = updatedAt,
+            updatedAt = updatedAt,
+        )
+
+        val payload = publisher.itemClearedPayload(item)
+
+        assertThat(occurredAt(payload)).isEqualTo(Instant.parse("2026-03-02T07:00:00Z"))
+    }
+}

--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/application/usecase/LendingService.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/application/usecase/LendingService.kt
@@ -545,8 +545,11 @@ class LendingService(
                             LendingOutboxMessage(
                                 aggregateId = saved.id.value,
                                 eventType = "loan.disbursed",
+                                // #3914: occurredAt is the loan's own `disbursedAt` — the instant the disbursement
+                                // happened on the aggregate — not the serialisation instant.
                                 payload = """{"loanId":"${saved.id.value}","partyId":"${saved.partyId}",""" +
-                                    """"principal":"${saved.principal}"}""",
+                                    """"principal":"${saved.principal}",""" +
+                                    """"occurredAt":"${saved.disbursedAt.toInstant()}"}""",
                             ),
                         )
                     }
@@ -670,8 +673,11 @@ class LendingService(
                     LendingOutboxMessage(
                         aggregateId = installment.loanId.value,
                         eventType = "loan.interest_accrued",
+                        // #3914: occurredAt is `accruedAt`, the very instant stamped on the installment by
+                        // markAccrued above — the recognition event itself, not the emit.
                         payload = """{"loanId":"${installment.loanId.value}","installment":${installment.number},""" +
-                            """"interest":"${installment.interest}","dueDate":"${installment.dueDate}"}""",
+                            """"interest":"${installment.interest}","dueDate":"${installment.dueDate}",""" +
+                            """"occurredAt":"${accruedAt.toInstant()}"}""",
                     ),
                 )
             }
@@ -711,10 +717,16 @@ class LendingService(
                             .flatMap { derecognizeAccruedInterest(loan, schedule) }
                             .flatMap { loans.update(loan.copy(status = LoanStatus.WRITTEN_OFF)) }
                             .flatMap { written ->
+                                // #3914: Loan carries no writtenOffAt column, so the derecognition instant is read
+                                // from the clock at the point the write-off completes — the house convention
+                                // already used by TerminationService and OriginationDecisionService. Emitted
+                                // once into a local so payload and any future reuse cannot disagree.
+                                val writtenOffAt = clock.instant()
                                 val wPayload = """{"loanId":"${written.id.value}",""" +
                                     """"partyId":"${written.partyId}",""" +
                                     """"writtenOff":"$outstanding",""" +
-                                    """"writtenOffBy":"${request.writtenOffBy}"}"""
+                                    """"writtenOffBy":"${request.writtenOffBy}",""" +
+                                    """"occurredAt":"$writtenOffAt"}"""
                                 events.emit(
                                     LendingOutboxMessage(
                                         aggregateId = written.id.value,
@@ -961,11 +973,14 @@ class LendingService(
                     LendingOutboxMessage(
                         aggregateId = updated.id.value,
                         eventType = "loan.rescheduled",
+                        // #3914: no rescheduledAt column on Loan; clock at the completed reschedule, same
+                        // house convention as write-off above.
                         payload = """{"loanId":"${updated.id.value}","partyId":"${updated.partyId}",""" +
                             """"newPrincipal":"$newPrincipal",""" +
                             """"newNominalAnnualRate":"${request.newNominalAnnualRate}",""" +
                             """"newTermPeriods":${request.newTermPeriods},""" +
-                            """"principalForgiveness":"${request.principalForgiveness}"}""",
+                            """"principalForgiveness":"${request.principalForgiveness}",""" +
+                            """"occurredAt":"${clock.instant()}"}""",
                     ),
                 ).map { updated }
             }
@@ -1133,6 +1148,12 @@ class LendingService(
             }
         }
 
+    /**
+     * #3914: both events emitted here carry `occurredAt` = `record.createdAt`, the instant THIS
+     * provisioning cycle ran, which is when the stage transition and the ECL delta were determined.
+     * The `asOf` field next to it is the accounting DATE and is a different fact. Without
+     * `occurredAt`, AuditConsumer records its own ingest time as the business time.
+     */
     private fun postProvisioningDelta(loan: Loan, period: String, snapshot: ProvisioningSnapshot): Uni<Boolean> =
         provisioning.findLatestBefore(loan.id, period).flatMap { prior ->
             val priorEcl = prior?.expectedCreditLoss ?: Money.zero(snapshot.expectedCreditLoss.currency.code)
@@ -1166,7 +1187,7 @@ class LendingService(
                         payload = """{"loanId":"${loan.id.value}","partyId":"${loan.partyId}",""" +
                             """"previousStage":"${prior!!.stage}","newStage":"${snapshot.stage}",""" +
                             """"daysPastDue":${snapshot.daysPastDue},"period":"$period",""" +
-                            """"asOf":"${snapshot.asOf}"}""",
+                            """"asOf":"${snapshot.asOf}","occurredAt":"${record.createdAt.toInstant()}"}""",
                     ),
                 )
             } else {
@@ -1195,7 +1216,7 @@ class LendingService(
                                     payload = """{"loanId":"${loan.id.value}","period":"$period",""" +
                                         """"stage":"${snapshot.stage}",""" +
                                         """"expectedCreditLoss":"${snapshot.expectedCreditLoss}",""" +
-                                        """"delta":"$delta"}""",
+                                        """"delta":"$delta","occurredAt":"${record.createdAt.toInstant()}"}""",
                                 ),
                             )
                         }

--- a/openbank-lending-service/src/test/kotlin/com/openbank/lending/application/usecase/LendingServiceTest.kt
+++ b/openbank-lending-service/src/test/kotlin/com/openbank/lending/application/usecase/LendingServiceTest.kt
@@ -1659,4 +1659,161 @@ class LendingServiceTest {
         verify(exactly = 0) { ledger.post(any()) }
         verify(exactly = 0) { provisioning.save(any()) }
     }
+
+    // --- #3914: business event time on the six payloads that carried none -------------------------
+    //
+    // Without `occurredAt`, `AuditConsumer.eventTime()` returns null and `audit_entries.occurred_at`
+    // stores the CONSUMER's ingest time as the business time (GDPR Art. 30 "when", DORA Art. 17
+    // evidence) — arbitrarily wrong under consumer lag or a replay.
+    //
+    // Every assertion is an EXACT expected instant, parsed back out of the JSON. Never
+    // `isNotNull()`: that passes against `Instant.EPOCH`. Never a substring/emptiness check on the
+    // raw text: Jackson's `asText()` yields the four-character string "null" for a JSON null, which
+    // passes every existence check. The `Instant.parse` round-trip also proves the value is in the
+    // Z-normalised form the consumer can actually parse.
+
+    private val expectedEventTime: Instant = Instant.parse("2024-01-01T00:00:00Z")
+
+    private fun occurredAtOf(message: LendingOutboxMessage): Instant = Instant.parse(
+        com.fasterxml.jackson.databind.ObjectMapper().readTree(message.payload).get("occurredAt").asText(),
+    )
+
+    @Test
+    fun `loan disbursed carries the disbursement instant as occurredAt`() {
+        val app = proposedApplication().copy(status = OriginationState.READY_TO_DISBURSE, decidedBy = "bob")
+        val emitted = mutableListOf<LendingOutboxMessage>()
+        every { applications.findById(app.id) } returns Uni.createFrom().item(app)
+        every { loans.save(any()) } answers { Uni.createFrom().item(firstArg<Loan>()) }
+        every { installments.saveAll(any()) } answers { Uni.createFrom().item(firstArg<List<LoanInstallment>>()) }
+        stubClaim()
+        every { ledger.post(any()) } returns Uni.createFrom().item(Unit)
+        every { events.emit(capture(emitted)) } returns Uni.createFrom().item(Unit)
+
+        val loan = service.disburse(app.id, "dave").await().indefinitely()
+
+        val disbursed = emitted.single { it.eventType == "loan.disbursed" }
+        assertThat(occurredAtOf(disbursed)).isEqualTo(loan.disbursedAt.toInstant())
+        assertThat(occurredAtOf(disbursed)).isEqualTo(expectedEventTime)
+    }
+
+    @Test
+    fun `loan interest_accrued carries the accrual instant as occurredAt`() {
+        val loanId = LoanId.random()
+        val due = listOf(
+            LoanInstallment(
+                loanId = loanId,
+                number = 1,
+                dueDate = firstDue,
+                openingBalance = eur("12000.00"),
+                principal = eur("946.19"),
+                interest = eur("120.00"),
+                payment = eur("1066.19"),
+                closingBalance = eur("11053.81"),
+            ),
+        )
+        val emitted = mutableListOf<LendingOutboxMessage>()
+        every { installments.findAccruable(any(), any()) } returns Uni.createFrom().item(due)
+        every { installments.markAccrued(any(), any()) } returns Uni.createFrom().item(1)
+        every { ledger.post(any()) } returns Uni.createFrom().item(Unit)
+        every { events.emit(capture(emitted)) } returns Uni.createFrom().item(Unit)
+
+        service.accrueDueInterest(LocalDate.parse("2026-08-01"), 500).await().indefinitely()
+
+        assertThat(occurredAtOf(emitted.single { it.eventType == "loan.interest_accrued" }))
+            .isEqualTo(expectedEventTime)
+    }
+
+    @Test
+    fun `loan written_off carries the derecognition instant as occurredAt`() {
+        val loanId = LoanId.random()
+        val loan = activeLoan(loanId)
+        val schedule = listOf(
+            LoanInstallment(
+                loanId = loanId,
+                number = 1,
+                dueDate = firstDue,
+                openingBalance = eur("12000.00"),
+                principal = eur("946.19"),
+                interest = eur("120.00"),
+                payment = eur("1066.19"),
+                closingBalance = eur("11053.81"),
+            ),
+        )
+        val emitted = mutableListOf<LendingOutboxMessage>()
+        every { loans.findById(loanId) } returns Uni.createFrom().item(loan)
+        every { installments.findByLoan(loanId) } returns Uni.createFrom().item(schedule)
+        every { ledger.post(any()) } returns Uni.createFrom().item(Unit)
+        every { loans.update(any()) } answers { Uni.createFrom().item(firstArg<Loan>()) }
+        every { events.emit(capture(emitted)) } returns Uni.createFrom().item(Unit)
+
+        service.writeOff(loanId, WriteOffRequest(writtenOffBy = "carol", reason = "insolvency"))
+            .await().indefinitely()
+
+        assertThat(occurredAtOf(emitted.single { it.eventType == "loan.written_off" }))
+            .isEqualTo(expectedEventTime)
+    }
+
+    @Test
+    fun `loan rescheduled carries the reschedule instant as occurredAt`() {
+        val loanId = LoanId.random()
+        val loan = activeLoan(loanId)
+        val schedule = twoInstallmentSchedule(loanId)
+        mockRescheduleHappyPath(loanId, loan, schedule)
+        val emitted = mutableListOf<LendingOutboxMessage>()
+        every { installments.saveAll(any()) } answers { Uni.createFrom().item(firstArg<List<LoanInstallment>>()) }
+        every { events.emit(capture(emitted)) } returns Uni.createFrom().item(Unit)
+
+        service.reschedule(loanId, rescheduleRequest(), "carol").await().indefinitely()
+
+        assertThat(occurredAtOf(emitted.single { it.eventType == "loan.rescheduled" }))
+            .isEqualTo(expectedEventTime)
+    }
+
+    @Test
+    fun `loan stage_changed and loan provisioned carry the provisioning-cycle instant as occurredAt`() {
+        val loanId = LoanId.random()
+        val loan = activeLoan(loanId)
+        val schedule = listOf(
+            LoanInstallment(
+                loanId = loanId,
+                number = 1,
+                dueDate = firstDue,
+                openingBalance = eur("12000.00"),
+                principal = eur("946.19"),
+                interest = eur("120.00"),
+                payment = eur("1066.19"),
+                closingBalance = eur("11053.81"),
+            ),
+        )
+        val asOf = firstDue.plusDays(40)
+        val prior = LoanProvisioningRecord(
+            loanId = loanId,
+            period = "2026-06",
+            asOf = firstDue,
+            outstandingBalance = eur("12000.00"),
+            daysPastDue = 0,
+            bucket = com.openbank.libs.lending.DelinquencyBucket.CURRENT,
+            stage = Ifrs9Stage.STAGE_1,
+            expectedCreditLoss = eur("108.00"),
+            createdAt = fixedNow,
+        )
+        val emitted = mutableListOf<LendingOutboxMessage>()
+        every { loans.findActive(any()) } returns Uni.createFrom().item(listOf(loan))
+        every { installments.findByLoan(loanId) } returns Uni.createFrom().item(schedule)
+        mockRiskParameters(loan, "0.02")
+        every { provisioning.findByLoanAndPeriod(loanId, "2026-07") } returns Uni.createFrom().nullItem()
+        every { provisioning.findLatestBefore(loanId, "2026-07") } returns Uni.createFrom().item(prior)
+        every { ledger.post(any()) } returns Uni.createFrom().item(Unit)
+        every { provisioning.save(any()) } answers { Uni.createFrom().item(firstArg<LoanProvisioningRecord>()) }
+        every { events.emit(capture(emitted)) } returns Uni.createFrom().item(Unit)
+
+        service.runProvisioningCycle("2026-07", asOf, 500).await().indefinitely()
+
+        // Both events describe the same provisioning cycle, so both carry that cycle's instant —
+        // NOT `asOf`, which is the accounting DATE and a different fact.
+        assertThat(occurredAtOf(emitted.single { it.eventType == "loan.stage_changed" }))
+            .isEqualTo(expectedEventTime)
+        assertThat(occurredAtOf(emitted.single { it.eventType == "loan.provisioned" }))
+            .isEqualTo(expectedEventTime)
+    }
 }

--- a/openbank-sepa-payment/src/main/kotlin/com/openbank/sepa/application/workflow/SepaPaymentActivitiesImpl.kt
+++ b/openbank-sepa-payment/src/main/kotlin/com/openbank/sepa/application/workflow/SepaPaymentActivitiesImpl.kt
@@ -104,6 +104,13 @@ open class SepaPaymentActivitiesImpl(
         decision
     }
 
+    // #3914: every payload below carries `occurredAt` = the transitioned aggregate's `updatedAt`,
+    // which `SepaPayment.transitionTo` stamps with `Instant.now(clock)` AT the state change. That
+    // is the business event time; `SepaPaymentOutboxMessage.createdAt` next to it is the outbox
+    // ROW's time and is not the same fact. Without the key, AuditConsumer.eventTime() returns null
+    // and audit_entries.occurred_at records the consumer's INGEST time as business time — under
+    // consumer lag or a replay, arbitrarily wrong. `Instant.toString()` is ISO-8601 with `Z`, which
+    // `Instant.parse` accepts. The non-Temporal path (SepaPaymentEvents.kt) was already correct.
     override fun validatePayment(paymentId: UUID): Unit = runOnVertxContext {
         val payment = paymentRepository.findById(paymentId)
             ?: error("Payment $paymentId not found during validate activity")
@@ -113,7 +120,7 @@ open class SepaPaymentActivitiesImpl(
             outboxMessage = SepaPaymentOutboxMessage(
                 aggregateId = updated.id,
                 eventType = PAYMENT_STATUS_CHANGED_EVENT,
-                payload = """{"paymentId":"$paymentId","status":"VALIDATED"}""",
+                payload = """{"paymentId":"$paymentId","status":"VALIDATED","occurredAt":"${updated.updatedAt}"}""",
                 createdAt = Instant.now(clock),
             ),
         )
@@ -129,7 +136,8 @@ open class SepaPaymentActivitiesImpl(
             outboxMessage = SepaPaymentOutboxMessage(
                 aggregateId = updated.id,
                 eventType = PAYMENT_STATUS_CHANGED_EVENT,
-                payload = """{"paymentId":"$paymentId","status":"REJECTED","reason":"SANCTIONS_HIT"}""",
+                payload = """{"paymentId":"$paymentId","status":"REJECTED","reason":"SANCTIONS_HIT",""" +
+                    """"occurredAt":"${updated.updatedAt}"}""",
                 createdAt = Instant.now(clock),
             ),
         )
@@ -188,7 +196,7 @@ open class SepaPaymentActivitiesImpl(
                 outboxMessage = SepaPaymentOutboxMessage(
                     aggregateId = rejected.id,
                     eventType = PAYMENT_STATUS_CHANGED_EVENT,
-                    payload = """{"paymentId":"$paymentId","status":"REJECTED"}""",
+                    payload = """{"paymentId":"$paymentId","status":"REJECTED","occurredAt":"${rejected.updatedAt}"}""",
                     createdAt = Instant.now(clock),
                 ),
             )
@@ -207,7 +215,7 @@ open class SepaPaymentActivitiesImpl(
             outboxMessage = SepaPaymentOutboxMessage(
                 aggregateId = processing.id,
                 eventType = PAYMENT_STATUS_CHANGED_EVENT,
-                payload = """{"paymentId":"$paymentId","status":"PROCESSING"}""",
+                payload = """{"paymentId":"$paymentId","status":"PROCESSING","occurredAt":"${processing.updatedAt}"}""",
                 createdAt = Instant.now(clock),
             ),
         )
@@ -224,7 +232,8 @@ open class SepaPaymentActivitiesImpl(
                 outboxMessage = SepaPaymentOutboxMessage(
                     aggregateId = completed.id,
                     eventType = PAYMENT_STATUS_CHANGED_EVENT,
-                    payload = """{"paymentId":"$paymentId","status":"COMPLETED"}""",
+                    payload = """{"paymentId":"$paymentId","status":"COMPLETED",""" +
+                        """"occurredAt":"${completed.updatedAt}"}""",
                     createdAt = Instant.now(clock),
                 ),
             )

--- a/openbank-sepa-payment/src/test/kotlin/com/openbank/sepa/application/workflow/SepaPaymentActivitiesImplTest.kt
+++ b/openbank-sepa-payment/src/test/kotlin/com/openbank/sepa/application/workflow/SepaPaymentActivitiesImplTest.kt
@@ -4,6 +4,7 @@
 
 package com.openbank.sepa.application.workflow
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.openbank.sepa.application.port.out.AmlCasePort
 import com.openbank.sepa.application.port.out.FraudScoreOutcome
 import com.openbank.sepa.application.port.out.FraudScoringPort
@@ -13,6 +14,7 @@ import com.openbank.sepa.application.port.out.SchemeGatewayPort
 import com.openbank.sepa.application.port.out.SchemeGatewayUnavailableException
 import com.openbank.sepa.application.port.out.SchemeSubmissionOutcome
 import com.openbank.sepa.application.port.out.ScreeningUnavailableException
+import com.openbank.sepa.application.port.out.SepaPaymentOutboxMessage
 import com.openbank.sepa.application.port.out.SepaPaymentRepository
 import com.openbank.sepa.application.port.out.SettlementOutcome
 import com.openbank.sepa.application.port.out.SettlementPort
@@ -24,10 +26,12 @@ import com.openbank.sepa.domain.screening.ScreeningDecision
 import com.openbank.sepa.domain.screening.ScreeningMatchStatus
 import com.openbank.sepa.domain.screening.ScreeningResult
 import com.openbank.sepa.domain.screening.ScreeningRole
+import io.mockk.CapturingSlot
 import io.mockk.coEvery
 import io.mockk.coJustRun
 import io.mockk.coVerify
 import io.mockk.mockk
+import io.mockk.slot
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
@@ -35,6 +39,7 @@ import org.junit.jupiter.api.Test
 import java.math.BigDecimal
 import java.time.Clock
 import java.time.Instant
+import java.time.ZoneOffset
 import java.util.UUID
 
 class SepaPaymentActivitiesImplTest {
@@ -258,6 +263,76 @@ class SepaPaymentActivitiesImplTest {
         coVerify(exactly = 0) { schemeGatewayPort.submit(any()) }
         coVerify(exactly = 0) { paymentRepository.update(any(), any()) }
     }
+
+    // --- #3914: business event time on the Temporal-path payloads -----------------------------
+    //
+    // These five payloads carried no time field at all, so AuditConsumer.eventTime() returned null
+    // and audit_entries recorded the CONSUMER's ingest time as the business time. The assertion is
+    // an EXACT expected instant against a fixed clock, never `isNotNull()` — a non-null check would
+    // pass against Instant.EPOCH, and an `isNotEmpty()` on the string would pass against the
+    // four-character text "null" that Jackson's asText() yields for a JSON null.
+
+    private val fixedInstant: Instant = Instant.parse("2026-03-01T12:34:56Z")
+
+    private fun fixedClockActivities(): SepaPaymentActivitiesImpl = TestableActivities(
+        paymentRepository,
+        screeningPort,
+        amlCasePort,
+        fraudScoringPort,
+        schemeGatewayPort,
+        settlementPort,
+        clock = Clock.fixed(fixedInstant, ZoneOffset.UTC),
+        schemeSubmissionEnabled = true,
+    )
+
+    @Test
+    fun `validatePayment stamps occurredAt with the transition instant`() {
+        val outbox: CapturingSlot<SepaPaymentOutboxMessage> = slot()
+        coEvery { paymentRepository.findById(paymentId) } returns payment
+        coEvery { paymentRepository.update(any(), capture(outbox)) } answers { firstArg() }
+
+        fixedClockActivities().validatePayment(paymentId)
+
+        assertThat(outbox.captured.payload).contains(""""occurredAt":"$fixedInstant"""")
+        val parsed = Instant.parse(
+            objectMapper.readTree(outbox.captured.payload).get("occurredAt").asText(),
+        )
+        assertThat(parsed).isEqualTo(fixedInstant)
+    }
+
+    @Test
+    fun `rejectPayment stamps occurredAt with the transition instant`() {
+        val outbox: CapturingSlot<SepaPaymentOutboxMessage> = slot()
+        coEvery { paymentRepository.findById(paymentId) } returns payment
+        coEvery { paymentRepository.update(any(), capture(outbox)) } answers { firstArg() }
+
+        fixedClockActivities().rejectPayment(paymentId)
+
+        assertThat(Instant.parse(objectMapper.readTree(outbox.captured.payload).get("occurredAt").asText()))
+            .isEqualTo(fixedInstant)
+    }
+
+    @Test
+    fun `submitToScheme stamps occurredAt on PROCESSING and COMPLETED`() {
+        val validated = payment.copy(status = SepaPaymentStatus.VALIDATED)
+        val outboxes = mutableListOf<SepaPaymentOutboxMessage>()
+        coEvery { paymentRepository.findById(paymentId) } returns validated
+        coEvery { schemeGatewayPort.submit(any()) } returns SchemeSubmissionOutcome(accepted = true, reasonCode = null)
+        coEvery { paymentRepository.update(any(), capture(outboxes)) } answers { firstArg() }
+
+        val result = fixedClockActivities().submitToScheme(paymentId)
+
+        assertThat(result).isEqualTo(SepaPaymentStatus.COMPLETED)
+        assertThat(outboxes).hasSize(2)
+        assertThat(outboxes.map { objectMapper.readTree(it.payload).get("status").asText() })
+            .containsExactly("PROCESSING", "COMPLETED")
+        outboxes.forEach {
+            assertThat(Instant.parse(objectMapper.readTree(it.payload).get("occurredAt").asText()))
+                .isEqualTo(fixedInstant)
+        }
+    }
+
+    private val objectMapper = ObjectMapper()
 }
 
 /**


### PR DESCRIPTION
## What this does

Gives the **three remaining** #3914 producers a real business event time. #3926 fixed the four
non-money-path services (dispute, statement, sanctions, document); the body of #3914 explicitly
reserved these three because all three are in `rules.yaml: money_path_services` and each therefore
needs **2 human approvals**. 13 payload sites, all 13 fixed.

Without `occurredAt`, `AuditConsumer.eventTime()` (`AuditConsumer.kt:230-236`) returns null and
`audit_entries.occurred_at` records the CONSUMER's ingest time as the business time — the GDPR
Art. 30 "when" dimension and DORA Art. 17 evidence. Under consumer lag or a replay, arbitrarily
wrong.

Refs #3914.

## Per-producer enumeration, WITH the method used for each

The repo builds event payloads two ways and a string grep sees only one of them: a hand-built map
spells the JSON key literally, while a serialised data class has no literal anywhere — the key
exists only at runtime as a Kotlin property name. So the method is stated per producer.

| producer | file | sites | payload construction | method used to enumerate |
|---|---|---|---|---|
| clearing-service | `ClearingEventPublisherImpl` | 2 | `objectMapper.writeValueAsString(mapOf(...))` — hand-built map, keys ARE literals | read the two `mapOf` blocks in full; `command grep -c occurredAt` over `src/main` = **0** (corroboration only, not the enumeration) |
| sepa-payment | `SepaPaymentActivitiesImpl` | 5 | raw Kotlin string templates — literals | read every `SepaPaymentOutboxMessage(` construction site in the file (`:116 :132 :191 :210 :227` on main) |
| lending-service | `LendingService` | 6 of 10 | raw Kotlin string templates — literals | read all 10 `LendingOutboxMessage(` sites; 4 already carried `occurredAt` (`LendingService:226`, `OriginationDecisionService:175`, `TerminationService:353` and `:364`) |

All three build payloads **literally**, so a grep and a read agree here — but the grep is not what
established it. Two near-misses that a `payload =` grep does hit and that are NOT payload sites,
re-confirmed on this branch: `CompliancePackActivationService.kt:59` (an entity column) and
`LendingResource.kt:204` (a debug projection of `entry.createdAt`).

`grep` on this machine is ugrep; every command above used `command grep`.

## Does a consumer actually STORE the missing time? Yes — all three.

A field nothing reads is a latent trap, not corruption. Checked the consumer side rather than
assuming:

- `AuditConsumer`'s `audit-events-in` `topics:` list (audit-service `application.yaml`) contains
  **all three** topics: `openbank.clearing.batch.event`, `openbank.sepa.payment.events`,
  `openbank.lending.events`.
- All three publishers emit the outbox row **verbatim** — the identical
  `emitter.sendMessage(Message.of(entry.payload).addMetadata(meta))` shape
  (`KafkaClearingOutboxEventPublisher.kt:28`, `KafkaSepaPaymentEventPublisher.kt:43`,
  `KafkaLendingOutboxEventPublisher.kt:27`) — so the bytes the writer produces are the bytes the
  consumer parses. Producer and consumer do meet.
- `AuditConsumer.eventTime()` accepts exactly one key, `occurredAt`, and `AuditEntry` is persisted
  with `occurred_at_source = INGEST` when it is absent.

So these are **live defects that land in stored rows**, not latent traps. (`DomainEvent` declares
`occurredAt`, so the consumer is reading the right name — only the missing-time case was real.)

## What each payload now carries — the domain fact, not `Instant.now()` at serialisation

| event | instant chosen | why it is the business fact |
|---|---|---|
| `clearing batch.settled` | `batch.settledAt ?: batch.updatedAt` | `ClearingService.settleBatch` stamps `settledAt` on the aggregate before the publisher runs |
| `clearing item.cleared` | `item.updatedAt` | `ClearingItem` has no per-transition column; `updatedAt` is the state-change instant |
| sepa × 5 (VALIDATED, REJECTED×2, PROCESSING, COMPLETED) | the transitioned aggregate's `updatedAt` | `SepaPayment.transitionTo` stamps it with `Instant.now(clock)` AT the state change. Note the `SepaPaymentOutboxMessage.createdAt` sitting right next to it is the outbox ROW's time — a different fact |
| `loan.disbursed` | `saved.disbursedAt` | the loan's own disbursement instant |
| `loan.interest_accrued` | `accruedAt` | the very instant `markAccrued` stamped on the installment |
| `loan.stage_changed` / `loan.provisioned` | `record.createdAt` | the instant this provisioning cycle ran. `asOf` next to it is the accounting DATE — a different fact, deliberately not reused |
| `loan.written_off` / `loan.rescheduled` | `clock.instant()` | `Loan` carries no `writtenOffAt`/`rescheduledAt` column. This is the house convention already used by the 4 sites that were already correct (`TerminationService`, `OriginationDecisionService`) — the honest answer where no truer fact exists |

**One trap worth naming: `OffsetDateTime.toString()` renders a non-UTC offset as `...+01:00`, which
`Instant.parse` REJECTS.** The clearing aggregates hold `OffsetDateTime`, so emitting them verbatim
would produce a payload that *looks* fixed and behaves exactly as broken — the consumer would log
"unparseable occurredAt" and fall back to ingest time. Both clearing values go through
`.toInstant()`, and the test asserts the normalised instant (`13:34:56+01:00` → `12:34:56Z`), so a
regression to the verbatim form is red.

## Did an existing test assert the current (broken) behaviour?

Checked before writing anything. **No.** There was no test for `ClearingEventPublisherImpl` at all,
and `LendingServiceTest` / `SepaPaymentActivitiesImplTest` assert payload substrings for other
fields only — none pinned the absence of a time field. One adjacent anti-pattern spotted and left
alone as out of scope: `ClearingServiceTest` asserts `updatedSlot.captured.settledAt).isNotNull()`,
which passes against `Instant.EPOCH`.

## Both test runs

11 new tests (3 clearing, 3 sepa, 5 lending). Counts read from the **JUnit XML**, including the
SKIPPED column.

**Against `origin/main` (production files reverted, tests kept) — RED:**

```
openbank-clearing-service   3 new tests   3 failed    (NullPointerException: readTree(...).get("occurredAt") is null)
openbank-sepa-payment       tests 101  fail 4  skipped 14   <- 3 are the new tests
openbank-lending-service    tests 223  fail 5  skipped 0    <- all 5 are the new tests
```

The clearing falsification was run the *honest* way. A plain revert of
`ClearingEventPublisherImpl.kt` makes the test file fail to COMPILE (this PR extracts
`batchSettledPayload`/`itemClearedPayload` so a payload can be asserted without a Vert.x context —
`Panache.withTransaction` needs one, a payload does not), and a compile error is not evidence the
assertion works. So the extraction was kept and only the two `occurredAt` map entries were deleted:
**3 tests, 3 failures.**

The 4th sepa failure and the `skipped 14` are environmental, not mine:
`SepaPaymentResourceAuthzTest` fails with `Failed to start quarkus` when a second Gradle build holds
the port, and its skips are the cascade. Re-run alone on this branch it is `tests 101 fail 0
skipped 0`.

**Against this branch — GREEN:**

```
openbank-clearing-service   tests 41   fail 0  skipped 0
openbank-sepa-payment       tests 101  fail 0  skipped 0
openbank-lending-service    tests 223  fail 0  skipped 0
```

A later re-run of lending on a busier machine reported `223 / 2 fail / 24 skipped`, and the two
were **not** graded from their shape — the stack was read to the root cause:
`QuarkusBindException: Port already bound: 8081: Address already in use`, from
`LendingResourceAuthzTest` and `CustomerIntakeConfigInjectionTest`, both `@QuarkusTest`. `lsof`
confirms an unrelated `java` process (pid 71180) holding 127.0.0.1:8081 — a concurrent build on
this shared machine, the failure mode CONTRIBUTING already documents. Re-run alone,
`CustomerIntakeConfigInjectionTest` is `2 / 0 / 0`. The `24 skipped` is the cascade from those boot
failures, not a suite that stopped running; on the clean run the skipped count is 0, which is why
it is quoted here rather than only the failure count.

`:quarkusBuild` (the CDI/ArC wiring check that `test` cannot make) is **green for all three
modules** — that is the run that would catch a bean-graph regression.

All 11 new tests confirmed present by name in the XML (not inferred from a passing total) — the
Kotlin/JUnit5 `= runBlocking { }` silent-drop trap means a green total proves nothing about whether
a method ran.

Assertions are **exact expected instants**, parsed back out of the JSON with `Instant.parse` —
never `isNotNull()` (which passes against `Instant.EPOCH`) and never a string emptiness check
(Jackson's `asText()` yields the four-character text `"null"` for a JSON null).

## Local gate

`:detekt :ktlintCheck :test :quarkusBuild` for all three modules; the task list was read rather
than assumed. One real detekt finding fixed on the way: the added lines pushed
`postProvisioningDelta` to exactly 60 lines and `LongMethod` fires **at** the threshold, not above
it — the rationale moved into the function's KDoc.

## Governance

- **All three services are money-path** (`rules.yaml: money_path_services`): 2 approvals required.
- `check-threat-model-diff.py --base origin/main --enforce` passes: no trust boundary, identity or
  privilege changes here — these are additive payload fields.
- **Additive fields only.** Every consumer of these topics parses via `readTree` and ignores
  unknown fields; no existing key is renamed or removed. `openapi.yaml` is untouched (no REST
  contract changes) and no libs module is touched, so the N-1-dependents hazard does not apply.
- **What this does NOT claim.** The success measure in #3914 is rows moving to
  `audit_entries.occurred_at_source = 'EVENT'` and
  `openbank.audit.event.time.missing{source_service}` going to zero — not "the field appears in the
  payload". That is only observable after these producers have live traffic, so I am claiming the
  payloads now carry the key and that the consumer accepts the exact format, nothing more. #3914
  should stay open until the counter is read.

## What is left

**Nothing in this issue's producer scope** — 13 of 13 remaining sites fixed, so all 7 producers now
emit an event time. Deliberately out of scope and still open:

1. The AsyncAPI discrepancy noted in #3914's body: `docs/asyncapi/openbank-events.yaml` gives the
   dispute channel as `openbank.disputes.dispute.event` while producer and consumer both use
   `openbank.dispute.events`. Untouched.
2. `ClearingEventPublisherImpl.publishItemCleared` has **no production caller** — `command grep -rn
   publishItemCleared openbank-clearing-service/src` finds only the port declaration, the
   implementation and no use site. Its payload is fixed anyway (cheap, and it is a live defect the
   day something calls it), but it is worth recording that one of clearing's two sites is currently
   dead code rather than letting a future audit count it as traffic.
3. `ClearingServiceTest`'s `isNotNull()` assertion on `settledAt`, noted above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
