### PR TITLE
test(document-service): replay the domestic-payment and statement contracts on every PR

### DIFF
--- a/openbank-document-service/build.gradle.kts
+++ b/openbank-document-service/build.gradle.kts
@@ -53,11 +53,12 @@ dependencies {
     testImplementation(libs.quarkus.test.security)
     testImplementation(libs.assertj)
     testImplementation(libs.mockk)
-    // ADR-0063: document-service is a pact PROVIDER. sepa-payment renders the customer's payment
-    // confirmation through this service's template list + preview endpoints (ADR-0248 #3), and
-    // until DocumentPactProviderVerificationTest nothing replayed that contract — the only cover
-    // was sepa-payment's own WireMock stub, which is written from the client and so cannot
-    // disagree with it (the #2269 shape).
+    // ADR-0063: document-service is a pact PROVIDER. Three merged services render documents
+    // through this service's template list + preview endpoints (ADR-0248 #3) — sepa-payment and
+    // domestic-payment (payment confirmations) and statement-service — and until
+    // DocumentPactProviderVerificationTest nothing replayed those contracts. The only cover was
+    // each consumer's own WireMock/mock stub, written from the client and so unable to disagree
+    // with it (the #2269 shape).
     testImplementation(libs.pact.provider)
     // AuditEventTime — the ONE copy of the rule openbank-audit-service's AuditConsumer applies to
     // a domain-event payload, so this service's producer tests assert against the real contract

--- a/openbank-document-service/src/test/kotlin/com/openbank/document/contract/DocumentPactProviderVerificationTest.kt
+++ b/openbank-document-service/src/test/kotlin/com/openbank/document/contract/DocumentPactProviderVerificationTest.kt
@@ -21,9 +21,20 @@ import org.junit.jupiter.api.extension.ExtendWith
 
 /**
  * Provider-side Pact verification for the contracts consumers publish against
- * `openbank-document-service`. The first is `openbank-sepa-payment`'s payment-confirmation render
- * (ADR-0248 #3): `GET /api/v1/documents/templates` then
- * `POST /api/v1/documents/templates/preview` — see `SepaPaymentDocumentServicePactConsumerTest`.
+ * `openbank-document-service`. `@PactFolder` replays EVERY pact in `../pacts` naming this provider,
+ * so the set below is what is committed today rather than a list this class maintains — all three
+ * merged services holding a live synchronous REST client against document-service, each making the
+ * same two calls (ADR-0248 #3): `GET /api/v1/documents/templates` then
+ * `POST /api/v1/documents/templates/preview`.
+ *
+ *  - `openbank-sepa-payment` — `SepaPaymentDocumentServicePactConsumerTest` (#4299)
+ *  - `openbank-domestic-payment` — `DomesticPaymentDocumentServicePactConsumerTest`
+ *  - `openbank-statement-service` — `StatementDocumentServicePactConsumerTest`
+ *
+ * All three declare the same two provider states, which is why adding them cost no new
+ * `@State` handler: the states are properties of the provider (seeded templates, a stateless
+ * renderer), not of any one consumer. Deliberately ONE class — a second broker-sourced `@Provider`
+ * class for the same provider collides, since each fetches every pact the broker holds.
  *
  * **Why this class is the load-bearing half.** A consumer pact ALONE cannot catch a wrong request
  * path: the Pact mock server answers whatever path the client asks for, so pointing a client at a
@@ -43,10 +54,11 @@ import org.junit.jupiter.api.extension.ExtendWith
  * `@IgnoreNoPactsToVerify(ignoreIoErrors)` makes a missing/unreadable pact folder a skip rather
  * than a failure, matching every other `@PactFolder` provider class in the fleet.
  *
- * IMPORTANT: if `SepaPaymentDocumentServicePactConsumerTest` changes the contract, regenerate
- * (`./gradlew :openbank-sepa-payment:test --tests "*SepaPaymentDocumentServicePactConsumerTest*"`)
- * and commit the updated `pacts/openbank-sepa-payment-openbank-document-service.json` in the same
- * PR, or this test replays a stale contract.
+ * IMPORTANT: if any of the three consumer tests changes the contract, regenerate that consumer's
+ * pact (`./gradlew :<consumer-module>:test --rerun --tests "*.contract.*PactConsumerTest"`) and
+ * commit the updated `pacts/*-openbank-document-service.json` in the same PR, or this test replays
+ * a stale contract. `pact-drift-check.yml` enforces it over a scope derived from the `@Pact`
+ * annotations, so a new consumer module is in scope automatically.
  */
 @QuarkusTest
 @QuarkusTestResource(com.openbank.document.it.PostgresRedisTestResource::class)

--- a/openbank-document-service/src/test/kotlin/com/openbank/document/contract/DocumentPactProviderVerificationTest.kt
+++ b/openbank-document-service/src/test/kotlin/com/openbank/document/contract/DocumentPactProviderVerificationTest.kt
@@ -56,7 +56,9 @@ import org.junit.jupiter.api.extension.ExtendWith
  *
  * IMPORTANT: if any of the three consumer tests changes the contract, regenerate that consumer's
  * pact (`./gradlew :<consumer-module>:test --rerun --tests "*.contract.*PactConsumerTest"`) and
- * commit the updated `pacts/*-openbank-document-service.json` in the same PR, or this test replays
+ * commit that consumer's updated `<consumer>-openbank-document-service.json` under `pacts` in the
+ * same PR (spelled without a leading slash-star on purpose: Kotlin block comments NEST, so a glob
+ * written as a path prefix inside a KDoc opens a comment that never closes), or this test replays
  * a stale contract. `pact-drift-check.yml` enforces it over a scope derived from the `@Pact`
  * annotations, so a new consumer module is in scope automatically.
  */

--- a/openbank-domestic-payment/src/test/kotlin/com/openbank/domestic/contract/DomesticPaymentDocumentServicePactConsumerTest.kt
+++ b/openbank-domestic-payment/src/test/kotlin/com/openbank/domestic/contract/DomesticPaymentDocumentServicePactConsumerTest.kt
@@ -1,0 +1,233 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.domestic.contract
+
+import au.com.dius.pact.consumer.MockServer
+import au.com.dius.pact.consumer.dsl.LambdaDsl.newJsonArrayMinLike
+import au.com.dius.pact.consumer.dsl.LambdaDsl.newJsonBody
+import au.com.dius.pact.consumer.dsl.PactDslWithProvider
+import au.com.dius.pact.consumer.junit5.PactConsumerTestExt
+import au.com.dius.pact.consumer.junit5.PactTestFor
+import au.com.dius.pact.core.model.PactSpecVersion
+import au.com.dius.pact.core.model.RequestResponsePact
+import au.com.dius.pact.core.model.annotations.Pact
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import com.openbank.domestic.infrastructure.client.DocumentServiceClient
+import com.openbank.domestic.infrastructure.client.DocumentTemplateSummary
+import com.openbank.domestic.infrastructure.client.PreviewTemplateRequest
+import com.openbank.domestic.infrastructure.client.PreviewTemplateResponse
+import io.restassured.RestAssured.given
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.QueryParam
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+/**
+ * Consumer-driven contract for the two `openbank-document-service` calls that render a DOMESTIC
+ * payment confirmation (ADR-0248 #3): `GET /api/v1/documents/templates` to resolve the PUBLISHED
+ * `bodyHtml` for a template code, then `POST /api/v1/documents/templates/preview` to merge the
+ * payment's data into it. Both are driven by
+ * [com.openbank.domestic.infrastructure.client.PaymentConfirmationRenderAdapter], synchronously, on
+ * the customer-facing confirmation download; the adapter is fail-CLOSED (it raises
+ * `PaymentConfirmationRenderException`), so a document-service contract break surfaces to the
+ * customer as a failed download immediately.
+ *
+ * **Why this test exists.** #4299 covered `openbank-sepa-payment`'s copy of this same two-call
+ * flow. Three merged services hold live synchronous REST clients against document-service and this
+ * is the second of them; the third is `openbank-statement-service`
+ * (`StatementDocumentServicePactConsumerTest`). Until now this module's only cover for these calls
+ * was consumer-authored mocks, which hard-code the very paths the client sends and therefore agree
+ * with the client by construction — the configuration that let finrep-service ship a call to
+ * `/api/v1/ledger/trial-balance`, a ledger route that has never existed, with green unit tests
+ * (#2269).
+ *
+ * **The two sides are deliberately sourced differently.** Each interaction declares the contract as
+ * a LITERAL ([TEMPLATES_PATH], [PREVIEW_PATH], [LIMIT_PARAM]); the REQUESTS are issued against
+ * [templatesPath] / [previewPath] / [limitQueryParam], derived by reflection from
+ * [DocumentServiceClient]'s own `@Path` and `@QueryParam` annotations. That asymmetry IS the test:
+ * the pact mock server fails when the production client is annotated with anything other than the
+ * contract path. Deriving BOTH sides from the annotation is DRY and vacuous — expectation and
+ * request move together, so the test stays green against a client pointing anywhere at all (#2290).
+ *
+ * Note the consumer half can only catch a client whose annotation disagrees with the literal here.
+ * A path this repo has agreed on but the PROVIDER does not serve is caught only by replaying the
+ * committed pact against the real service — `DocumentPactProviderVerificationTest`
+ * (openbank-document-service), `@PactFolder("../pacts")` and ungated, so it runs on every pull
+ * request. A `@PactBroker` class would not: the PR lane blanks `PACT_BROKER_URL` (ADR-0056), so its
+ * `@EnabledIfSystemProperty(pactbroker.url)` gate skips and the contract would be replayed only
+ * after the merge (#2327).
+ *
+ * IMPORTANT — regenerate on change: if this test's `@Pact` methods change, re-run
+ * (`./gradlew :openbank-domestic-payment:test --tests "*DomesticPaymentDocumentServicePactConsumerTest*"`)
+ * and commit the updated `pacts/openbank-domestic-payment-openbank-document-service.json` in the
+ * same PR — an un-regenerated pact silently verifies the OLD contract on the provider side.
+ * `pact-drift-check.yml` enforces this over a scope derived from the `@Pact` annotations.
+ */
+@ExtendWith(PactConsumerTestExt::class)
+@PactTestFor(providerName = "openbank-document-service", pactVersion = PactSpecVersion.V3)
+class DomesticPaymentDocumentServicePactConsumerTest {
+
+    private val json = jacksonObjectMapper()
+
+    @Pact(consumer = "openbank-domestic-payment", provider = "openbank-document-service")
+    fun listTemplatesPact(builder: PactDslWithProvider): RequestResponsePact = builder
+        .given("the canonical document templates are seeded and published")
+        .uponReceiving("GET the document templates to resolve a PUBLISHED domestic-confirmation body")
+        .path(TEMPLATES_PATH)
+        .query("$LIMIT_PARAM=$TEMPLATE_LIST_LIMIT")
+        .method("GET")
+        .headers(mapOf("Accept" to "application/json"))
+        .willRespondWith()
+        .status(200)
+        .headers(mapOf("Content-Type" to "application/json"))
+        .body(
+            // stringType on every element field, DELIBERATELY: the template list is HETEROGENEOUS —
+            // document-service seeds six templates across three codes and two locales, in DRAFT /
+            // PUBLISHED / RETIRED states. Pinning `code` or `status` to a value would assert "every
+            // template is POTVRZENI_O_PLATBE_EN and every one is PUBLISHED", a claim the contract
+            // does not make and the provider's own seed data falsifies on the first run. What the
+            // consumer needs from the contract is that the three fields it filters and reads on are
+            // PRESENT and are strings; the selection itself is PaymentConfirmationRenderAdapter's
+            // own business.
+            newJsonArrayMinLike(1) { a ->
+                a.`object` { t ->
+                    t.stringType("code", "POTVRZENI_O_PLATBE_EN")
+                    t.stringType("status", "PUBLISHED")
+                    t.stringType("bodyHtml", "<p>{{document.status}}</p>")
+                }
+            }.build(),
+        )
+        .toPact()
+
+    @Pact(consumer = "openbank-domestic-payment", provider = "openbank-document-service")
+    fun previewTemplatePact(builder: PactDslWithProvider): RequestResponsePact = builder
+        .given("the template preview renderer is available")
+        .uponReceiving("POST a template body plus domestic payment data to render the confirmation HTML")
+        .path(PREVIEW_PATH)
+        .method("POST")
+        .headers(mapOf("Content-Type" to "application/json"))
+        .body(json.writeValueAsString(PREVIEW_REQUEST))
+        .willRespondWith()
+        .status(200)
+        .headers(mapOf("Content-Type" to "application/json"))
+        .body(
+            // stringType, NOT stringValue: `renderedHtml` is the Handlebars OUTPUT, so pinning it
+            // would make every whitespace or letterhead change in the renderer a contract break.
+            // The claim under contract is that a non-persisting preview answers 200 with a
+            // `renderedHtml` string — the only field the adapter returns.
+            newJsonBody { o -> o.stringType("renderedHtml", "<p>COMPLETED</p>") }.build(),
+        )
+        .toPact()
+
+    @Test
+    @PactTestFor(pactMethod = "listTemplatesPact")
+    fun `the template list carries the code, status and body the confirmation adapter reads`(mockServer: MockServer) {
+        // Guards the reflection helpers themselves: were they ever to return an empty or partial
+        // path, the interaction and the request would still agree with each other and both pact
+        // tests would pass against a contract that pins nothing.
+        assertThat(templatesPath).isEqualTo(TEMPLATES_PATH)
+        assertThat(limitQueryParam).isEqualTo(LIMIT_PARAM)
+
+        val body = given()
+            .baseUri(mockServer.getUrl())
+            .accept("application/json")
+            .queryParam(limitQueryParam, TEMPLATE_LIST_LIMIT)
+            .get(templatesPath)
+            .then()
+            .statusCode(200)
+            .extract().body().asString()
+
+        val templates: List<DocumentTemplateSummary> = json.readValue(body)
+        assertThat(templates).isNotEmpty()
+        // All three fields PaymentConfirmationRenderAdapter touches must deserialize into the
+        // client DTO: it filters on `code` + `status`, then sends `bodyHtml` on to the preview call.
+        val template = templates.first()
+        assertThat(template.code).isNotBlank()
+        assertThat(template.status).isNotBlank()
+        assertThat(template.bodyHtml).isNotBlank()
+    }
+
+    @Test
+    @PactTestFor(pactMethod = "previewTemplatePact")
+    fun `preview returns the rendered confirmation HTML for the template body and payment data`(
+        mockServer: MockServer,
+    ) {
+        assertThat(previewPath).isEqualTo(PREVIEW_PATH)
+
+        val body = given()
+            .baseUri(mockServer.getUrl())
+            .contentType("application/json")
+            .body(json.writeValueAsString(PREVIEW_REQUEST))
+            .post(previewPath)
+            .then()
+            .statusCode(200)
+            .extract().body().asString()
+
+        val response: PreviewTemplateResponse = json.readValue(body)
+        assertThat(response.renderedHtml).isNotBlank()
+    }
+
+    private companion object {
+        /**
+         * The contract, written out LITERALLY on purpose: openbank-document-service serves the
+         * bounded template list here (`DocumentResource.listTemplates`, `@Path("/api/v1/documents")`
+         * + `@Path("/templates")`).
+         *
+         * It must NOT be derived from [DocumentServiceClient] like [templatesPath] is. Deriving
+         * both sides from the same annotation makes the interaction and the request move together,
+         * so the pact mock server always sees exactly what it expects and the test passes against a
+         * client pointing anywhere at all. The literal is the fixed point the annotation is
+         * measured against.
+         */
+        const val TEMPLATES_PATH = "/api/v1/documents/templates"
+
+        /** Likewise literal: `DocumentResource.previewTemplate`, the non-persisting render. */
+        const val PREVIEW_PATH = "/api/v1/documents/templates/preview"
+
+        /** document-service's query-parameter name for the list bound — likewise literal. */
+        const val LIMIT_PARAM = "limit"
+
+        /** Mirrors `PaymentConfirmationRenderAdapter.LIST_LIMIT`, the bound the adapter sends. */
+        const val TEMPLATE_LIST_LIMIT = 200
+
+        /**
+         * The exact body the adapter posts: the PUBLISHED template body it just resolved, plus the
+         * data map the confirmation mapper builds. Kept minimal — the contract is the two-field
+         * envelope, not the confirmation's field vocabulary, which is the mapper's own business.
+         */
+        val PREVIEW_REQUEST = PreviewTemplateRequest(
+            bodyHtml = "<p>{{document.status}}</p>",
+            data = mapOf("document" to mapOf("status" to "COMPLETED")),
+        )
+
+        private val listTemplatesMethod =
+            DocumentServiceClient::class.java.getDeclaredMethod("listTemplates", Int::class.javaPrimitiveType)
+
+        private val previewMethod =
+            DocumentServiceClient::class.java.getDeclaredMethod("previewTemplate", PreviewTemplateRequest::class.java)
+
+        /** The client's interface-level `@Path`; both methods here add their own segment to it. */
+        private val interfacePath: String =
+            DocumentServiceClient::class.java.getAnnotation(Path::class.java).value
+
+        /** Interface `@Path` + method `@Path`, joined the way JAX-RS resolves them. */
+        val templatesPath: String = joinJaxRs(listTemplatesMethod.getAnnotation(Path::class.java).value)
+
+        /** Likewise, for the preview POST. */
+        val previewPath: String = joinJaxRs(previewMethod.getAnnotation(Path::class.java).value)
+
+        /** The query-parameter name the production client sends the list bound under. */
+        val limitQueryParam: String = listTemplatesMethod.parameterAnnotations
+            .flatMap { it.toList() }
+            .filterIsInstance<QueryParam>()
+            .single()
+            .value
+
+        private fun joinJaxRs(methodPath: String): String =
+            "/" + listOf(interfacePath, methodPath).joinToString("/") { it.trim('/') }.trim('/')
+    }
+}

--- a/openbank-statement-service/build.gradle.kts
+++ b/openbank-statement-service/build.gradle.kts
@@ -56,6 +56,29 @@ dependencies {
     testImplementation(libs.testcontainers)
     testImplementation(libs.testcontainers.junit)
     testImplementation(libs.testcontainers.postgresql)
+    // ADR-0063 P2: consumer-driven contract tests (Pact). StatementDocumentServicePactConsumerTest
+    // publishes the document-service template/preview contract that
+    // DocumentPactProviderVerificationTest replays on every PR.
+    testImplementation(libs.pact.consumer)
+}
+
+// Pact: write generated consumer contracts to pacts/ and forward broker config for provider
+// verification (ADR-0063 P2). pactbroker.* props are injected by CI with -D. Without
+// `pact.rootDir` the generated pact lands in this module's build/pacts and the committed
+// pacts/*.json is never rewritten — the drift gate would then be green about work it never did.
+tasks.withType<Test> {
+    systemProperty("pact.rootDir", "${rootProject.projectDir}/pacts")
+    listOf(
+        "pactbroker.url",
+        "pactbroker.auth.username",
+        "pactbroker.auth.password",
+        "pactbroker.enablePending",
+        "pactbroker.providerBranch",
+        "pact.verifier.publishResults",
+        "pact.provider.version",
+        "pact.provider.branch",
+        "pact.provider.tag",
+    ).forEach { key -> System.getProperty(key)?.let { systemProperty(key, it) } }
 }
 
 kover {

--- a/openbank-statement-service/src/test/kotlin/com/openbank/statement/contract/StatementDocumentServicePactConsumerTest.kt
+++ b/openbank-statement-service/src/test/kotlin/com/openbank/statement/contract/StatementDocumentServicePactConsumerTest.kt
@@ -1,0 +1,243 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.statement.contract
+
+import au.com.dius.pact.consumer.MockServer
+import au.com.dius.pact.consumer.dsl.LambdaDsl.newJsonArrayMinLike
+import au.com.dius.pact.consumer.dsl.LambdaDsl.newJsonBody
+import au.com.dius.pact.consumer.dsl.PactDslWithProvider
+import au.com.dius.pact.consumer.junit5.PactConsumerTestExt
+import au.com.dius.pact.consumer.junit5.PactTestFor
+import au.com.dius.pact.core.model.PactSpecVersion
+import au.com.dius.pact.core.model.RequestResponsePact
+import au.com.dius.pact.core.model.annotations.Pact
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import com.openbank.statement.infrastructure.client.DocumentRestClient
+import com.openbank.statement.infrastructure.client.DocumentTemplateDto
+import com.openbank.statement.infrastructure.client.PreviewTemplateRequestDto
+import com.openbank.statement.infrastructure.client.PreviewTemplateResponseDto
+import io.restassured.RestAssured.given
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.QueryParam
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+/**
+ * Consumer-driven contract for the two `openbank-document-service` calls that render a statement
+ * document (ADR-0248): `GET /api/v1/documents/templates` to resolve the PUBLISHED `bodyHtml` for a
+ * template code, then `POST /api/v1/documents/templates/preview` to merge the statement data into
+ * it. Both are driven by
+ * [com.openbank.statement.infrastructure.client.DocumentTemplateRestAdapter], synchronously, and
+ * the adapter is fail-CLOSED (it raises `DocumentServiceException`), so a document-service contract
+ * break surfaces on the caller's endpoint immediately.
+ *
+ * **Why this test exists.** #4299 covered `openbank-sepa-payment`'s copy of this same two-call
+ * flow; this is the third and last of the merged services holding a live synchronous REST client
+ * against document-service (the second being `openbank-domestic-payment`,
+ * `DomesticPaymentDocumentServicePactConsumerTest`). Until now this module's only cover for these
+ * calls was consumer-authored mocks, which hard-code the very paths the client sends and therefore
+ * agree with the client by construction — the configuration that let finrep-service ship a call to
+ * `/api/v1/ledger/trial-balance`, a ledger route that has never existed, with green unit tests
+ * (#2269).
+ *
+ * **The two sides are deliberately sourced differently.** Each interaction declares the contract as
+ * a LITERAL ([TEMPLATES_PATH], [PREVIEW_PATH], [LIMIT_PARAM]); the REQUESTS are issued against
+ * [templatesPath] / [previewPath] / [limitQueryParam], derived by reflection from
+ * [DocumentRestClient]'s own `@Path` and `@QueryParam` annotations. That asymmetry IS the test: the
+ * pact mock server fails when the production client is annotated with anything other than the
+ * contract path. Deriving BOTH sides from the annotation is DRY and vacuous — expectation and
+ * request move together, so the test stays green against a client pointing anywhere at all (#2290).
+ *
+ * Note the consumer half can only catch a client whose annotation disagrees with the literal here.
+ * A path this repo has agreed on but the PROVIDER does not serve is caught only by replaying the
+ * committed pact against the real service — `DocumentPactProviderVerificationTest`
+ * (openbank-document-service), `@PactFolder("../pacts")` and ungated, so it runs on every pull
+ * request. A `@PactBroker` class would not: the PR lane blanks `PACT_BROKER_URL` (ADR-0056), so its
+ * `@EnabledIfSystemProperty(pactbroker.url)` gate skips and the contract would be replayed only
+ * after the merge (#2327).
+ *
+ * IMPORTANT — regenerate on change: if this test's `@Pact` methods change, re-run
+ * (`./gradlew :openbank-statement-service:test --tests "*StatementDocumentServicePactConsumerTest*"`)
+ * and commit the updated `pacts/openbank-statement-service-openbank-document-service.json` in the
+ * same PR — an un-regenerated pact silently verifies the OLD contract on the provider side.
+ * `pact-drift-check.yml` enforces this over a scope derived from the `@Pact` annotations.
+ */
+@ExtendWith(PactConsumerTestExt::class)
+@PactTestFor(providerName = "openbank-document-service", pactVersion = PactSpecVersion.V3)
+class StatementDocumentServicePactConsumerTest {
+
+    private val json = jacksonObjectMapper()
+
+    @Pact(consumer = "openbank-statement-service", provider = "openbank-document-service")
+    fun listTemplatesPact(builder: PactDslWithProvider): RequestResponsePact = builder
+        .given("the canonical document templates are seeded and published")
+        .uponReceiving("GET the document templates to resolve a PUBLISHED statement-document body")
+        .path(TEMPLATES_PATH)
+        .query("$LIMIT_PARAM=$TEMPLATE_LIST_LIMIT")
+        .method("GET")
+        .headers(mapOf("Accept" to "application/json"))
+        .willRespondWith()
+        .status(200)
+        .headers(mapOf("Content-Type" to "application/json"))
+        .body(
+            // stringType on every element field, DELIBERATELY: the template list is HETEROGENEOUS —
+            // document-service seeds six templates across three codes and two locales, in DRAFT /
+            // PUBLISHED / RETIRED states. Pinning `code` or `status` to a value would assert a claim
+            // the contract does not make and the provider's own seed data falsifies on the first
+            // run. What the consumer needs from the contract is that the three fields it filters and
+            // reads on are PRESENT and are strings; the selection itself is
+            // DocumentTemplateRestAdapter's own business.
+            newJsonArrayMinLike(1) { a ->
+                a.`object` { t ->
+                    t.stringType("code", "POTVRZENI_O_PLATBE_EN")
+                    t.stringType("status", "PUBLISHED")
+                    t.stringType("bodyHtml", "<p>{{document.status}}</p>")
+                }
+            }.build(),
+        )
+        .toPact()
+
+    @Pact(consumer = "openbank-statement-service", provider = "openbank-document-service")
+    fun previewTemplatePact(builder: PactDslWithProvider): RequestResponsePact = builder
+        .given("the template preview renderer is available")
+        .uponReceiving("POST a template body plus statement data to render the document HTML")
+        .path(PREVIEW_PATH)
+        .method("POST")
+        .headers(mapOf("Content-Type" to "application/json"))
+        .body(json.writeValueAsString(PREVIEW_REQUEST))
+        .willRespondWith()
+        .status(200)
+        .headers(mapOf("Content-Type" to "application/json"))
+        .body(
+            // stringType, NOT stringValue: `renderedHtml` is the Handlebars OUTPUT, so pinning it
+            // would make every whitespace or letterhead change in the renderer a contract break.
+            // The claim under contract is that a non-persisting preview answers 200 with a
+            // `renderedHtml` string — the only field the adapter reads.
+            newJsonBody { o -> o.stringType("renderedHtml", "<p>COMPLETED</p>") }.build(),
+        )
+        .toPact()
+
+    @Test
+    @PactTestFor(pactMethod = "listTemplatesPact")
+    fun `the template list carries the code, status and body the document adapter reads`(mockServer: MockServer) {
+        // Guards the reflection helpers themselves: were they ever to return an empty or partial
+        // path, the interaction and the request would still agree with each other and both pact
+        // tests would pass against a contract that pins nothing.
+        assertThat(templatesPath).isEqualTo(TEMPLATES_PATH)
+        assertThat(limitQueryParam).isEqualTo(LIMIT_PARAM)
+
+        val body = given()
+            .baseUri(mockServer.getUrl())
+            .accept("application/json")
+            .queryParam(limitQueryParam, TEMPLATE_LIST_LIMIT)
+            .get(templatesPath)
+            .then()
+            .statusCode(200)
+            .extract().body().asString()
+
+        val templates: List<DocumentTemplateDto> = json.readValue(body)
+        assertThat(templates).isNotEmpty()
+        // All three fields DocumentTemplateRestAdapter touches must deserialize into the client DTO:
+        // it filters on `code` + `status`, then sends `bodyHtml` on to the preview call. The DTO
+        // declares them nullable, so asserting NOT-NULL here is the real check — a renamed provider
+        // field would deserialize to null rather than failing, and the adapter would then report
+        // "no PUBLISHED template" for a template that is published.
+        val template = templates.first()
+        assertThat(template.code).isNotNull()
+        assertThat(template.status).isNotNull()
+        assertThat(template.bodyHtml).isNotNull()
+    }
+
+    @Test
+    @PactTestFor(pactMethod = "previewTemplatePact")
+    fun `preview returns the rendered document HTML for the template body and statement data`(
+        mockServer: MockServer,
+    ) {
+        assertThat(previewPath).isEqualTo(PREVIEW_PATH)
+
+        val body = given()
+            .baseUri(mockServer.getUrl())
+            .contentType("application/json")
+            .body(json.writeValueAsString(PREVIEW_REQUEST))
+            .post(previewPath)
+            .then()
+            .statusCode(200)
+            .extract().body().asString()
+
+        val response: PreviewTemplateResponseDto = json.readValue(body)
+        // Nullable in the DTO, and `renderedHtml.orEmpty()` in the adapter — so a renamed provider
+        // field would silently render an EMPTY document rather than fail. Assert it is present.
+        assertThat(response.renderedHtml).isNotNull()
+    }
+
+    private companion object {
+        /**
+         * The contract, written out LITERALLY on purpose: openbank-document-service serves the
+         * bounded template list here (`DocumentResource.listTemplates`, `@Path("/api/v1/documents")`
+         * + `@Path("/templates")`).
+         *
+         * It must NOT be derived from [DocumentRestClient] like [templatesPath] is. Deriving both
+         * sides from the same annotation makes the interaction and the request move together, so the
+         * pact mock server always sees exactly what it expects and the test passes against a client
+         * pointing anywhere at all. The literal is the fixed point the annotation is measured
+         * against.
+         */
+        const val TEMPLATES_PATH = "/api/v1/documents/templates"
+
+        /** Likewise literal: `DocumentResource.previewTemplate`, the non-persisting render. */
+        const val PREVIEW_PATH = "/api/v1/documents/templates/preview"
+
+        /** document-service's query-parameter name for the list bound — likewise literal. */
+        const val LIMIT_PARAM = "limit"
+
+        /** Mirrors `DocumentTemplateRestAdapter.TEMPLATE_LIST_LIMIT`, the bound the adapter sends. */
+        const val TEMPLATE_LIST_LIMIT = 200
+
+        /**
+         * The exact body the adapter posts: the PUBLISHED template body it just resolved, plus the
+         * statement data map. Kept minimal — the contract is the two-field envelope, not the
+         * document's field vocabulary, which is the caller's own business.
+         */
+        val PREVIEW_REQUEST = PreviewTemplateRequestDto(
+            bodyHtml = "<p>{{document.status}}</p>",
+            data = mapOf("document" to mapOf("status" to "COMPLETED")),
+        )
+
+        private val listTemplatesMethod =
+            DocumentRestClient::class.java.getDeclaredMethod("listTemplates", Int::class.javaPrimitiveType)
+
+        private val previewMethod =
+            DocumentRestClient::class.java.getDeclaredMethod("preview", PreviewTemplateRequestDto::class.java)
+
+        /**
+         * Unlike sepa-payment's and domestic-payment's clients, [DocumentRestClient] carries NO
+         * interface-level `@Path` — each method spells the full route. Read as an empty prefix so
+         * the join below is uniform, and so ADDING an interface `@Path` (which would prefix every
+         * route and break both calls) fails the equality assertions in the tests above.
+         */
+        private val interfacePath: String =
+            DocumentRestClient::class.java.getAnnotation(Path::class.java)?.value ?: ""
+
+        /** Interface `@Path` (empty here) + method `@Path`, joined the way JAX-RS resolves them. */
+        val templatesPath: String = joinJaxRs(listTemplatesMethod.getAnnotation(Path::class.java).value)
+
+        /** Likewise, for the preview POST. */
+        val previewPath: String = joinJaxRs(previewMethod.getAnnotation(Path::class.java).value)
+
+        /** The query-parameter name the production client sends the list bound under. */
+        val limitQueryParam: String = listTemplatesMethod.parameterAnnotations
+            .flatMap { it.toList() }
+            .filterIsInstance<QueryParam>()
+            .single()
+            .value
+
+        private fun joinJaxRs(methodPath: String): String = "/" +
+            listOf(interfacePath, methodPath)
+                .filter { it.trim('/').isNotEmpty() }
+                .joinToString("/") { it.trim('/') }
+    }
+}

--- a/openbank-statement-service/src/test/kotlin/com/openbank/statement/contract/StatementDocumentServicePactConsumerTest.kt
+++ b/openbank-statement-service/src/test/kotlin/com/openbank/statement/contract/StatementDocumentServicePactConsumerTest.kt
@@ -154,9 +154,7 @@ class StatementDocumentServicePactConsumerTest {
 
     @Test
     @PactTestFor(pactMethod = "previewTemplatePact")
-    fun `preview returns the rendered document HTML for the template body and statement data`(
-        mockServer: MockServer,
-    ) {
+    fun `preview returns the rendered document HTML for the template body and statement data`(mockServer: MockServer) {
         assertThat(previewPath).isEqualTo(PREVIEW_PATH)
 
         val body = given()

--- a/pacts/openbank-domestic-payment-openbank-document-service.json
+++ b/pacts/openbank-domestic-payment-openbank-document-service.json
@@ -1,0 +1,132 @@
+{
+  "consumer": {
+    "name": "openbank-domestic-payment"
+  },
+  "interactions": [
+    {
+      "description": "GET the document templates to resolve a PUBLISHED domestic-confirmation body",
+      "providerStates": [
+        {
+          "name": "the canonical document templates are seeded and published"
+        }
+      ],
+      "request": {
+        "headers": {
+          "Accept": "application/json"
+        },
+        "method": "GET",
+        "path": "/api/v1/documents/templates",
+        "query": {
+          "limit": [
+            "200"
+          ]
+        }
+      },
+      "response": {
+        "body": [
+          {
+            "bodyHtml": "<p>{{document.status}}</p>",
+            "code": "POTVRZENI_O_PLATBE_EN",
+            "status": "PUBLISHED"
+          }
+        ],
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "matchingRules": {
+          "body": {
+            "$": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type",
+                  "min": 1
+                }
+              ]
+            },
+            "$[*].bodyHtml": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$[*].code": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$[*].status": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        },
+        "status": 200
+      }
+    },
+    {
+      "description": "POST a template body plus domestic payment data to render the confirmation HTML",
+      "providerStates": [
+        {
+          "name": "the template preview renderer is available"
+        }
+      ],
+      "request": {
+        "body": {
+          "bodyHtml": "<p>{{document.status}}</p>",
+          "data": {
+            "document": {
+              "status": "COMPLETED"
+            }
+          }
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "method": "POST",
+        "path": "/api/v1/documents/templates/preview"
+      },
+      "response": {
+        "body": {
+          "renderedHtml": "<p>COMPLETED</p>"
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "matchingRules": {
+          "body": {
+            "$.renderedHtml": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        },
+        "status": 200
+      }
+    }
+  ],
+  "metadata": {
+    "pact-jvm": {
+      "version": "4.7.3"
+    },
+    "pactSpecification": {
+      "version": "3.0.0"
+    }
+  },
+  "provider": {
+    "name": "openbank-document-service"
+  }
+}

--- a/pacts/openbank-statement-service-openbank-document-service.json
+++ b/pacts/openbank-statement-service-openbank-document-service.json
@@ -1,0 +1,132 @@
+{
+  "consumer": {
+    "name": "openbank-statement-service"
+  },
+  "interactions": [
+    {
+      "description": "GET the document templates to resolve a PUBLISHED statement-document body",
+      "providerStates": [
+        {
+          "name": "the canonical document templates are seeded and published"
+        }
+      ],
+      "request": {
+        "headers": {
+          "Accept": "application/json"
+        },
+        "method": "GET",
+        "path": "/api/v1/documents/templates",
+        "query": {
+          "limit": [
+            "200"
+          ]
+        }
+      },
+      "response": {
+        "body": [
+          {
+            "bodyHtml": "<p>{{document.status}}</p>",
+            "code": "POTVRZENI_O_PLATBE_EN",
+            "status": "PUBLISHED"
+          }
+        ],
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "matchingRules": {
+          "body": {
+            "$": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type",
+                  "min": 1
+                }
+              ]
+            },
+            "$[*].bodyHtml": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$[*].code": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$[*].status": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        },
+        "status": 200
+      }
+    },
+    {
+      "description": "POST a template body plus statement data to render the document HTML",
+      "providerStates": [
+        {
+          "name": "the template preview renderer is available"
+        }
+      ],
+      "request": {
+        "body": {
+          "bodyHtml": "<p>{{document.status}}</p>",
+          "data": {
+            "document": {
+              "status": "COMPLETED"
+            }
+          }
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "method": "POST",
+        "path": "/api/v1/documents/templates/preview"
+      },
+      "response": {
+        "body": {
+          "renderedHtml": "<p>COMPLETED</p>"
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "matchingRules": {
+          "body": {
+            "$.renderedHtml": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        },
+        "status": 200
+      }
+    }
+  ],
+  "metadata": {
+    "pact-jvm": {
+      "version": "4.7.3"
+    },
+    "pactSpecification": {
+      "version": "3.0.0"
+    }
+  },
+  "provider": {
+    "name": "openbank-document-service"
+  }
+}


### PR DESCRIPTION
## What

Closes the contract-coverage item of #4109: the remaining two of the three merged services holding
a live **synchronous** REST client against `openbank-document-service` now publish a consumer pact,
and all three are replayed against the real provider on every pull request.

| consumer | client | covered by |
| --- | --- | --- |
| `openbank-sepa-payment` | `DocumentServiceClient` | `SepaPaymentDocumentServicePactConsumerTest` (#4299) |
| `openbank-domestic-payment` | `DocumentServiceClient` | `DomesticPaymentDocumentServicePactConsumerTest` (**this PR**) |
| `openbank-statement-service` | `DocumentRestClient` | `StatementDocumentServicePactConsumerTest` (**this PR**) |

All three make the same two calls (ADR-0248 #3), neither of which persists anything on the
document-service side: `GET /api/v1/documents/templates` to resolve the PUBLISHED `bodyHtml` for a
template code (there is no get-by-code route), then `POST /api/v1/documents/templates/preview` to
merge the caller's data into that body.

Both payment services are **money-path** (`rules.yaml: money_path_services`), so this PR needs
**2 approvals**.

## The asymmetry IS the test

In each consumer test the expected path is a string **LITERAL** (`TEMPLATES_PATH`, `PREVIEW_PATH`,
`LIMIT_PARAM`); only the **outgoing request** is reflected off the production client's `@Path` /
`@QueryParam`. Deriving both sides from the annotation is DRY and vacuous — expectation and request
move together, so the test stays green against a client pointing at a route that does not exist
(#2290). Each test also asserts the reflected value equals the literal, so a reflection helper that
silently returned an empty or partial path cannot leave both pact tests passing against a contract
that pins nothing.

## Provider replay

`DocumentPactProviderVerificationTest` (openbank-document-service) is **extended, not duplicated** —
a second broker-sourced `@Provider` class for the same provider collides, since each fetches every
pact the broker holds. It is `@PactFolder("../pacts")` and **ungated**, so it replays every
committed pact naming this provider on every PR; a `@PactBroker` class would not, because the PR
lane blanks `PACT_BROKER_URL` (ADR-0056) and its `@EnabledIfSystemProperty(pactbroker.url)` gate
would skip (#2327). Neither consumer needed a new `@State` handler: both declare the same two states
the sepa pact already did, which are properties of the provider (seeded templates, a stateless
renderer) rather than of any one consumer. Confirmed no `build.gradle.kts` exclusion drops the class
in CI.

## FALSIFICATION — proving the consumer pact alone cannot catch a wrong path

Not asserted — **measured**. The experiment simulates the realistic failure: the whole repo agrees
on a path the provider does not serve. `openbank-domestic-payment`'s client `@Path("/templates")`
**and** the test's `TEMPLATES_PATH` literal were repointed together to
`/api/v1/documents/templates-not-served`, the pact regenerated, then both sides run. Verdicts read
from the JUnit XML, never the console — pact-jvm prints `Not all of the N were verified` even on a
fully green run.

| step | consumer (`:openbank-domestic-payment:test`) | provider replay (`:openbank-document-service:test`) |
| --- | --- | --- |
| baseline (path correct) | 2 tests / 0 failures / 0 skipped | **6 tests / 0 failures / 0 skipped** |
| path repointed to a route the provider does not serve | **2 tests / 0 failures / 0 skipped — still GREEN** | **6 tests / 1 failure / 0 skipped — RED** |
| restored | 2 / 0 / 0 | **6 / 0 / 0 — green again** |

The single provider failure is exactly the broken interaction, and only it:

```
  pass  openbank-sepa-payment      - GET  the document templates ...
  pass  openbank-sepa-payment      - POST a template body plus payment data ...
  pass  openbank-statement-service - GET  the document templates ...
  pass  openbank-statement-service - POST a template body plus statement data ...
  FAIL  openbank-domestic-payment  - GET  the document templates ...
  pass  openbank-domestic-payment  - POST a template body plus domestic payment data ...
```

The committed pact under the broken run asked for `GET /api/v1/documents/templates-not-served`, and
the Pact mock server answered it happily — which is the whole point: **the consumer pact could not
tell.** Only the replay against the running provider went red (#2269).

The skipped counts are quoted deliberately: a module whose Quarkus boot fails reports every
`@QuarkusTest` as SKIPPED and reads as a pass. Zero skipped throughout, and the provider run is 6
interactions, so all three consumers really were replayed rather than silently absent.


## Gate output

```
$ python3 .github/scripts/check-pact-provider-replay.py
Committed pacts: 45
Replayed on a PR by an always-running @PactFolder class: 45
Declared uncovered (backlog, #2327): 0
  RUNS  openbank-document-service  .../DocumentPactProviderVerificationTest.kt  [runs]
OK — every committed pact is either replayed on a PR or a declared, still-accurate exception.

$ BASE_REF=main PR_DIFF_BASE=$(git merge-base HEAD origin/main) \
    python3 .github/scripts/run-gates.py --only pact-provider-replay-coverage
1 gates  PASS=1
```

`KNOWN_UNCOVERED` stays **empty** — both new pacts count as covered, so the total moved 43 -> 45
with the covered count moving with it.

**Drift scope** (`derive-pact-drift-scope.sh`, exit 0) now lists `openbank-domestic-payment` and
`openbank-statement-service` among its gated modules. This was falsified rather than assumed: run
against the two new tests *before* their pacts were committed, the script failed with
`a consumer test generates openbank-domestic-payment-openbank-document-service.json but
pacts/... is not committed` for both — proof the scope derivation actually reaches the new modules
rather than silently ignoring them.

**Local gate:** `ktlintCheck` + `detekt` + the consumer tests green on all three touched modules.


## Also

- `openbank-statement-service/build.gradle.kts` gains `libs.pact.consumer` and the standard
  `pact.rootDir` + broker-property forwarding block. Without `pact.rootDir` the generated pact lands
  in the module's `build/` and the committed `pacts/*.json` is never rewritten — the drift gate would
  then be green about work it never did.
- Corrected the now-stale comment on document-service's `libs.pact.provider` dependency, which named
  sepa-payment as the only consumer.

Refs #4109
