### PR TITLE
fix(audit): give the unattributed producers a real actor, and a way to say nobody did it

### DIFF
--- a/openbank-balance-service/src/main/kotlin/com/openbank/balance/application/usecase/BalanceService.kt
+++ b/openbank-balance-service/src/main/kotlin/com/openbank/balance/application/usecase/BalanceService.kt
@@ -8,6 +8,7 @@ import com.openbank.balance.application.port.`in`.*
 import com.openbank.balance.application.port.out.*
 import com.openbank.balance.domain.model.*
 import com.openbank.libs.domain.calendar.AccountingClock
+import com.openbank.libs.domain.event.EventActor
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.inject.Inject
 import java.time.Clock
@@ -128,6 +129,8 @@ class BalanceService(
                 availableAmount = updated.availableAmount,
                 reservedAmount = updated.reservedAmount,
                 occurredAt = OffsetDateTime.now(clock),
+                actorId = BalanceEventActors.API,
+                actorType = EventActor.TYPE_SYSTEM,
             ),
         )
 
@@ -158,6 +161,8 @@ class BalanceService(
                 availableAmount = updated.availableAmount,
                 reservedAmount = updated.reservedAmount,
                 occurredAt = OffsetDateTime.now(clock),
+                actorId = BalanceEventActors.API,
+                actorType = EventActor.TYPE_SYSTEM,
             ),
         )
 
@@ -182,6 +187,8 @@ class BalanceService(
                     availableAmount = outcome.balance.availableAmount,
                     reservedAmount = outcome.balance.reservedAmount,
                     occurredAt = OffsetDateTime.now(clock),
+                    actorId = BalanceEventActors.API,
+                    actorType = EventActor.TYPE_SYSTEM,
                 ),
             )
         }
@@ -210,6 +217,8 @@ class BalanceService(
                     availableAmount = outcome.balance.availableAmount,
                     reservedAmount = outcome.balance.reservedAmount,
                     occurredAt = OffsetDateTime.now(clock),
+                    actorId = BalanceEventActors.API,
+                    actorType = EventActor.TYPE_SYSTEM,
                 ),
             )
         }

--- a/openbank-balance-service/src/main/kotlin/com/openbank/balance/application/usecase/LedgerProjectionService.kt
+++ b/openbank-balance-service/src/main/kotlin/com/openbank/balance/application/usecase/LedgerProjectionService.kt
@@ -12,7 +12,9 @@ import com.openbank.balance.application.port.out.BalanceEventPublisher
 import com.openbank.balance.application.port.out.HoldRepository
 import com.openbank.balance.application.port.out.LedgerProjectionPort
 import com.openbank.balance.domain.model.BalanceEvent
+import com.openbank.balance.domain.model.BalanceEventActors
 import com.openbank.balance.domain.model.BalanceEventType
+import com.openbank.libs.domain.event.EventActor
 import com.openbank.libs.observability.DomainMetrics
 import jakarta.enterprise.context.ApplicationScoped
 import org.jboss.logging.Logger
@@ -79,6 +81,8 @@ class LedgerProjectionService(
                     availableAmount = applied.availableAmount,
                     reservedAmount = applied.reservedAmount,
                     occurredAt = OffsetDateTime.now(clock),
+                    actorId = BalanceEventActors.LEDGER_PROJECTION,
+                    actorType = EventActor.TYPE_SYSTEM,
                 ),
             )
         }

--- a/openbank-balance-service/src/main/kotlin/com/openbank/balance/domain/model/Balance.kt
+++ b/openbank-balance-service/src/main/kotlin/com/openbank/balance/domain/model/Balance.kt
@@ -4,6 +4,7 @@
 
 package com.openbank.balance.domain.model
 
+import com.openbank.libs.domain.event.EventActor
 import java.math.BigDecimal
 import java.time.OffsetDateTime
 import java.util.UUID
@@ -172,6 +173,26 @@ data class BalanceHold(
     val releasedAt: OffsetDateTime?,
 )
 
+/**
+ * The three origins this service publishes from (#3994). See [BalanceEvent.actorId] for why all
+ * three are `SYSTEM` and none is a person.
+ *
+ * Named constants rather than string literals at five call sites: the audit trail groups on this
+ * value, so a typo at one site would silently create a fourth origin that looks real.
+ */
+object BalanceEventActors {
+    private const val SERVICE = "balance-service"
+
+    /** An inbound command on the balance API — hold, release, credit, debit. */
+    val API: String = EventActor.system(SERVICE, "balance-api")
+
+    /** The read model catching up to a posting the ledger already made (ADR-0039 Phase D). */
+    val LEDGER_PROJECTION: String = EventActor.system(SERVICE, "ledger-projection")
+
+    /** The daily value-date roll scheduler (ADR-0178, #1745). */
+    val VALUE_DATE_ROLL: String = EventActor.system(SERVICE, "value-date-roll")
+}
+
 enum class BalanceEventType {
     BALANCE_UPDATED,
     HOLD_PLACED,
@@ -189,4 +210,32 @@ data class BalanceEvent(
     val availableAmount: BigDecimal,
     val reservedAmount: BigDecimal,
     val occurredAt: OffsetDateTime,
+    /**
+     * Who originated this balance movement (#3994).
+     *
+     * **Always a `SYSTEM` id here, and that is the finding, not a shortcut.** Every one of this
+     * service's five publish sites is reached either by a machine-to-machine call from the payment
+     * orchestration (`placeHold`/`releaseHold`/`credit`/`debit`) or by this service's own
+     * projection and scheduler — none of them has, or could have, a human identity to record. The
+     * commands (`PlaceHoldCommand`, `CreditAccountCommand`, …) carry no principal, and the REST
+     * layer above them is service-to-service. So the honest answer is that no person did this, and
+     * `EventActor.system` says exactly that instead of leaving a NULL that reads identically to a
+     * lost human identity — 542 of the 1341 unattributed audit rows are these three event types.
+     *
+     * The mechanism segment is what makes the value worth storing: `balance-api` (an inbound
+     * command), `ledger-projection` (catching up to a posting the ledger already made) and
+     * `value-date-roll` (the daily scheduler) are three genuinely different origins that were all
+     * one NULL before.
+     *
+     * **This is a serialised data class, not a hand-built map** — the wire keys are these Kotlin
+     * property names, so `KafkaBalanceEventPublisher.mapper.writeValueAsString` emits `actorId` and
+     * `actorType` with no literal appearing anywhere in this module. A grep for `"actorId"` over
+     * balance-service therefore found nothing before this change and finds nothing after it, which
+     * is the exact blind spot that hides half of this fleet's event fields.
+     *
+     * Nullable with a null default only so the many test constructions of this class keep
+     * compiling; every production site sets it.
+     */
+    val actorId: String? = null,
+    val actorType: String? = null,
 )

--- a/openbank-balance-service/src/main/kotlin/com/openbank/balance/infrastructure/schedule/ValueDateRollScheduler.kt
+++ b/openbank-balance-service/src/main/kotlin/com/openbank/balance/infrastructure/schedule/ValueDateRollScheduler.kt
@@ -7,8 +7,10 @@ package com.openbank.balance.infrastructure.schedule
 import com.openbank.balance.application.port.out.BalanceEventPublisher
 import com.openbank.balance.application.port.out.BalanceRepository
 import com.openbank.balance.domain.model.BalanceEvent
+import com.openbank.balance.domain.model.BalanceEventActors
 import com.openbank.balance.domain.model.BalanceEventType
 import com.openbank.libs.domain.calendar.AccountingClock
+import com.openbank.libs.domain.event.EventActor
 import com.openbank.libs.domain.identifiers.Ids
 import com.openbank.libs.observability.DomainMetrics
 import com.openbank.libs.observability.WorkflowLivenessRecorder
@@ -162,6 +164,8 @@ class ValueDateRollScheduler(
                     availableAmount = effective.effectiveAvailable(),
                     reservedAmount = effective.reservedAmount,
                     occurredAt = OffsetDateTime.ofInstant(accountingClock.instant(), java.time.ZoneOffset.UTC),
+                    actorId = BalanceEventActors.VALUE_DATE_ROLL,
+                    actorType = EventActor.TYPE_SYSTEM,
                 ),
             )
             published++

--- a/openbank-balance-service/src/test/kotlin/com/openbank/balance/application/usecase/BalanceServiceTest.kt
+++ b/openbank-balance-service/src/test/kotlin/com/openbank/balance/application/usecase/BalanceServiceTest.kt
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0\n// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.\n// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.\n
 package com.openbank.balance.application.usecase
 
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.openbank.balance.application.port.`in`.CreditAccountCommand
 import com.openbank.balance.application.port.`in`.DebitAccountCommand
 import com.openbank.balance.application.port.`in`.InitializeBalanceCommand
@@ -13,8 +15,10 @@ import com.openbank.balance.application.port.out.HoldRepository
 import com.openbank.balance.application.port.out.MovementOutcome
 import com.openbank.balance.domain.model.Balance
 import com.openbank.balance.domain.model.BalanceEvent
+import com.openbank.balance.domain.model.BalanceEventActors
 import com.openbank.balance.domain.model.BalanceEventType
 import com.openbank.balance.domain.model.BalanceHold
+import com.openbank.libs.domain.event.EventActor
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -238,6 +242,89 @@ class BalanceServiceTest {
         assertThrows<BalanceNotFoundException> {
             service.setOverdraftLimit(SetOverdraftLimitCommand(UUID.randomUUID(), "EUR", BigDecimal.ZERO))
         }
+    }
+
+    /**
+     * #3994 — red against `origin/main`, where `BalanceEvent` had no `actorId` at all and the three
+     * balance event types accounted for 542 of the 1341 unattributed rows in the live audit trail.
+     *
+     * Asserts the EXACT id, not that one is present: `assertNotNull` would pass against the empty
+     * string, against `"null"` (the four-character string #4307 removed from `actor_id`) and
+     * against a mechanism copied from the wrong call site, and the mechanism segment is the only
+     * part that makes the value worth storing.
+     */
+    @Test
+    fun `an inbound hold names the balance API as its system origin - no person placed it`(): Unit = runBlocking {
+        val balance = sampleBalance()
+        val balanceRepo = FakeBalanceRepository(balance)
+        val publisher = RecordingBalanceEventPublisher()
+        val service = BalanceService(
+            balanceRepo,
+            FakeHoldRepository(),
+            publisher,
+            FakeBalanceMovementPort(balanceRepo),
+        )
+
+        service.placeHold(
+            PlaceHoldCommand(balance.accountId, BigDecimal("20.00"), "CZK", "card auth", "ref-1", ttlSeconds = 60),
+        )
+
+        val event = publisher.events.single()
+        assertEquals("system:balance-service:balance-api", event.actorId)
+        assertEquals("SYSTEM", event.actorType)
+    }
+
+    @Test
+    fun `a credit carries the same system origin`(): Unit = runBlocking {
+        val balanceRepo = FakeBalanceRepository(sampleBalance())
+        val publisher = RecordingBalanceEventPublisher()
+        val service = BalanceService(
+            balanceRepo,
+            FakeHoldRepository(),
+            publisher,
+            FakeBalanceMovementPort(balanceRepo),
+        )
+
+        service.credit(CreditAccountCommand(balanceRepo.seed.accountId, BigDecimal("5.00"), "CZK", "ref-credit"))
+
+        assertEquals("system:balance-service:balance-api", publisher.events.single().actorId)
+        assertEquals("SYSTEM", publisher.events.single().actorType)
+    }
+
+    /**
+     * The wire, not the object (#3994).
+     *
+     * `BalanceEvent` is a SERIALISED data class — `KafkaBalanceEventPublisher` hands it to
+     * `ObjectMapper.writeValueAsString`, so the JSON keys are Kotlin property names and no string
+     * literal `"actorId"` exists anywhere in this module. A `command grep '"actorId"'` over
+     * balance-service therefore reports nothing whether the field is on the wire or not, which is
+     * exactly how a survey by grep misses half this fleet's event fields. Only serialising can
+     * tell, so this test serialises.
+     */
+    @Test
+    fun `the serialised event puts the actor on the wire under the key AuditConsumer reads`() {
+        // findAndRegisterModules mirrors the Quarkus-configured mapper the real publisher uses.
+        val mapper = ObjectMapper().findAndRegisterModules()
+        val json: JsonNode = mapper.readTree(
+            mapper.writeValueAsString(
+                BalanceEvent(
+                    eventId = UUID.randomUUID(),
+                    eventType = BalanceEventType.BALANCE_UPDATED,
+                    accountId = UUID.randomUUID(),
+                    currency = "CZK",
+                    amount = BigDecimal("1.00"),
+                    bookedAmount = BigDecimal("1.00"),
+                    availableAmount = BigDecimal("1.00"),
+                    reservedAmount = BigDecimal.ZERO,
+                    occurredAt = OffsetDateTime.parse("2026-01-01T00:00:00Z"),
+                    actorId = BalanceEventActors.LEDGER_PROJECTION,
+                    actorType = EventActor.TYPE_SYSTEM,
+                ),
+            ),
+        )
+
+        assertEquals("system:balance-service:ledger-projection", json.get("actorId").asText())
+        assertEquals("SYSTEM", json.get("actorType").asText())
     }
 
     private class FakeBalanceRepository(initial: Balance? = null) : BalanceRepository {

--- a/openbank-kyc-service/src/main/kotlin/com/openbank/kyc/domain/model/KycEvent.kt
+++ b/openbank-kyc-service/src/main/kotlin/com/openbank/kyc/domain/model/KycEvent.kt
@@ -4,6 +4,7 @@
 
 package com.openbank.kyc.domain.model
 
+import com.openbank.libs.domain.event.EventActor
 import java.time.Instant
 import java.util.UUID
 
@@ -54,6 +55,42 @@ object KycEvents {
             "status" to case.status,
             "riskLevel" to case.riskLevel,
             "occurredAt" to at,
+            EventActor.FIELD_ACTOR_ID to actorId(case),
+            EventActor.FIELD_ACTOR_TYPE to actorType(case),
         ),
     )
+
+    /**
+     * Who caused this transition (#3994).
+     *
+     * This service is the one place in the survey where the aggregate ALREADY knows the human:
+     * `approveCase`/`rejectCase` take the reviewer from the authenticated security context — never
+     * from the request body, per the ČNB AML/KYC §8 four-eyes mandate (ADR-0068) — and store it on
+     * [KycCase.reviewedBy]. It was simply never put on the wire, so 117 audit rows
+     * (`KYC_CASE_OPENED` + `KYC_CASE_APPROVED`) recorded a four-eyes decision with no eyes.
+     *
+     * A case with no reviewer has genuinely had no human touch it: `KYC_CASE_OPENED` is opened by
+     * the `PARTY_CREATED` consumer, and the check-result transitions are screening callbacks. Those
+     * get the `SYSTEM` id rather than a borrowed identity.
+     *
+     * Note the sandbox path: `autoEvaluateAndApprove` writes the literal `"sandbox-auto-approval"`
+     * into `reviewedBy`, so that string flows through here as-is. That is deliberate — it is what
+     * actually approved the case, it is already the stored value, and rewriting it to a `SYSTEM` id
+     * here would make the event disagree with the row it describes. It is also self-evidently not a
+     * person, which is the property that matters.
+     */
+    private fun actorId(case: KycCase): String = case.reviewedBy?.takeIf { it.isNotBlank() }
+        ?: EventActor.system(SERVICE, "case-lifecycle")
+
+    private fun actorType(case: KycCase): String =
+        if (case.reviewedBy.isNullOrBlank()) EventActor.TYPE_SYSTEM else ACTOR_TYPE_REVIEWER
+
+    private const val SERVICE = "kyc-service"
+
+    /**
+     * A named human reviewer. Not `OPERATOR`: the audit trail's existing `actorType` vocabulary uses
+     * `CUSTOMER` for a self-service subject, and a KYC reviewer is neither the subject nor a generic
+     * operator — the four-eyes record is specifically about the reviewing analyst.
+     */
+    private const val ACTOR_TYPE_REVIEWER = "REVIEWER"
 }

--- a/openbank-kyc-service/src/test/kotlin/com/openbank/kyc/domain/model/KycEventActorTest.kt
+++ b/openbank-kyc-service/src/test/kotlin/com/openbank/kyc/domain/model/KycEventActorTest.kt
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.kyc.domain.model
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * The four-eyes reviewer reaches the audit trail (#3994).
+ *
+ * Red against `origin/main`: `KycEvents.lifecycle` emitted no `actorId` key at all, so
+ * `AuditConsumer` had nothing to read and stored NULL — 117 rows recording a ČNB AML/KYC §8
+ * four-eyes decision with no eyes, even though `KycCase.reviewedBy` had held the reviewer's
+ * identity, taken from the authenticated security context, the whole time.
+ *
+ * Every assertion is on an exact value. `assertThat(actorId).isNotNull()` would pass against the
+ * `SYSTEM` id in the reviewed case and against the reviewer in the unreviewed one — i.e. against
+ * both of the two failures this pair exists to separate.
+ */
+class KycEventActorTest {
+
+    private val at: Instant = Instant.parse("2026-06-11T08:00:00Z")
+
+    private fun case(reviewedBy: String?) = KycCase(
+        id = UUID.fromString("11111111-1111-1111-1111-111111111111"),
+        partyId = UUID.fromString("22222222-2222-2222-2222-222222222222"),
+        status = KycCaseStatus.APPROVED,
+        riskLevel = RiskLevel.MEDIUM,
+        assignedTo = null,
+        checks = emptyList(),
+        notes = null,
+        reviewedBy = reviewedBy,
+        reviewedAt = null,
+        expiresAt = null,
+        createdAt = at,
+        updatedAt = at,
+    )
+
+    @Test
+    fun `an approved case names the reviewer who approved it`() {
+        val envelope = KycEvents.caseApproved(case("analyst.novak@openbank.cz"), at).envelope
+
+        assertThat(envelope["actorId"]).isEqualTo("analyst.novak@openbank.cz")
+        assertThat(envelope["actorType"]).isEqualTo("REVIEWER")
+    }
+
+    @Test
+    fun `a case nobody has reviewed says so, rather than borrowing an identity`() {
+        // KYC_CASE_OPENED is opened by the PARTY_CREATED consumer — no human is involved, and
+        // inventing one would be worse than the NULL it replaces.
+        val envelope = KycEvents.caseOpened(case(reviewedBy = null), at).envelope
+
+        assertThat(envelope["actorId"]).isEqualTo("system:kyc-service:case-lifecycle")
+        assertThat(envelope["actorType"]).isEqualTo("SYSTEM")
+    }
+
+    @Test
+    fun `a blank reviewer is treated as no reviewer, not as an actor named empty string`() {
+        val envelope = KycEvents.caseApproved(case(reviewedBy = "  "), at).envelope
+
+        assertThat(envelope["actorId"]).isEqualTo("system:kyc-service:case-lifecycle")
+        assertThat(envelope["actorType"]).isEqualTo("SYSTEM")
+    }
+
+    @Test
+    fun `the two states stay distinguishable - a reviewer is never a system id`() {
+        val reviewed = KycEvents.caseRejected(case("analyst.novak@openbank.cz"), at).envelope
+        val unreviewed = KycEvents.caseRejected(case(null), at).envelope
+
+        assertThat(reviewed["actorId"] as String).doesNotStartWith("system:")
+        assertThat(unreviewed["actorId"] as String).startsWith("system:")
+    }
+}

--- a/openbank-libs-domain/src/main/kotlin/com/openbank/libs/domain/event/EventActor.kt
+++ b/openbank-libs-domain/src/main/kotlin/com/openbank/libs/domain/event/EventActor.kt
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.libs.domain.event
+
+/**
+ * The `actorId`/`actorType` a producer puts on the wire so the audit trail can say WHO (#3994).
+ *
+ * ## The two states this exists to separate
+ *
+ * `openbank-audit-service`'s consumer reads `requestedBy` / `actorId` / `initiatedByPartyId` off
+ * the event body and stores NULL when it finds none. Measured on the live audit database on
+ * 2026-08-09, **1341 of 1789 rows carry `actor_id IS NULL`** — and every one of them is a producer
+ * that emits no actor key at all, so there was never anything for the consumer to read. That single
+ * NULL is currently doing two completely different jobs:
+ *
+ *  - **"nobody did this — a scheduler or an event projection did"**, which is a correct and
+ *    complete record. `BALANCE_UPDATED` is balance-service catching up to a posting the ledger
+ *    already made; `account.statement.period.closed.v1` is a cron.
+ *  - **"a person did this and we failed to record which person"**, which is an evidentiary gap —
+ *    GDPR Art. 30 (records of processing) and DORA Art. 17 both want the actor.
+ *
+ * Those are the two states issue #3994 exists to tell apart, and one NULL cannot.
+ *
+ * ## The representation, and why not the obvious alternatives
+ *
+ * A system-originated event states its origin explicitly: `actorType = "SYSTEM"` and an
+ * `actorId` of `system:<service>:<mechanism>` ([system]). A human-originated event carries the
+ * real subject identity and its own type. **Absence keeps its meaning**: no key at all still means
+ * "not recorded", still stores NULL, and is still the state to go fix.
+ *
+ * Rejected: inventing a placeholder person (`"system"`, `"admin"`, the service account's subject)
+ * for the scheduler case. That is worse than the NULL it replaces, and this repo has measured
+ * exactly why twice — a confident false value in a tamper-evident record reads as attributed and
+ * so is never revisited (the `"unknown"` sourceService that reached 76%, and the four-character
+ * string `"null"` that #4307 removed from `actor_id`). The `system:` prefix is deliberately not a
+ * UUID, not a Keycloak subject and not an email, so a `system:` value can never be mistaken for a
+ * person by `findByActorId`, by the ADR-0226 cross-channel person query, or by the GDPR Art. 15
+ * access log — and a query for real people can exclude it with a prefix match.
+ *
+ * Rejected: a `SERVICE` actor *type*. `input.principal.type == "SERVICE"` is already structurally
+ * unreachable in this platform's authorization layer (`rules.yaml: authz_policy`), and reusing the
+ * word here would invite a rego rule keyed on a value the interceptor never emits. `SYSTEM` names
+ * "no principal was involved", which is the fact being recorded.
+ *
+ * ## Why a shared value and not a per-service convention
+ *
+ * The alternative was N services each spelling their own sentinel, which is how `"unknown"`,
+ * `"UNKNOWN"` and `"null"` all became separate problems. One canonical spelling means the audit
+ * side can classify a row by prefix rather than by a hand-kept list of sentinels, and the mechanism
+ * segment keeps the origin answerable ("which scheduler wrote this?") instead of collapsing every
+ * automated write into one indistinguishable bucket.
+ *
+ * Pure Kotlin by construction — this is `openbank-libs-domain` and the domain layer carries zero
+ * framework imports (ADR-0002/ADR-0122). Producers serialise these two strings with whatever
+ * mechanism they already use; there is nothing to inject and no CDI bean to consume, so adding
+ * this file cannot affect a module that does not call it.
+ */
+object EventActor {
+
+    /** `actorType` for an event no principal originated: a scheduler, a consumer, a projection. */
+    const val TYPE_SYSTEM: String = "SYSTEM"
+
+    /** Prefix reserved for [system] ids. Never a person; safe to exclude with a prefix match. */
+    const val SYSTEM_PREFIX: String = "system:"
+
+    /** Wire key for the actor identity — the spelling `AuditConsumer` reads. */
+    const val FIELD_ACTOR_ID: String = "actorId"
+
+    /** Wire key for the actor kind. */
+    const val FIELD_ACTOR_TYPE: String = "actorType"
+
+    /**
+     * The `actorId` for an event that no person originated.
+     *
+     * @param service the producing module without the `openbank-` prefix — the fleet's audit
+     *   convention, and the same spelling `sourceService` uses, so the two agree.
+     * @param mechanism what inside that service originated it: a scheduler name, the consumed
+     *   topic, the projection. Required, and required to be non-blank: "some automation in
+     *   balance-service" is not an answer anyone can act on, and making it optional is how every
+     *   call site ends up omitting it.
+     */
+    fun system(service: String, mechanism: String): String {
+        require(service.isNotBlank()) { "service must not be blank" }
+        require(mechanism.isNotBlank()) { "mechanism must not be blank" }
+        return "$SYSTEM_PREFIX$service:$mechanism"
+    }
+
+    /** True when [actorId] is a [system] id rather than a person. Null/blank is neither. */
+    fun isSystem(actorId: String?): Boolean = actorId != null && actorId.startsWith(SYSTEM_PREFIX)
+}

--- a/openbank-libs-domain/src/test/kotlin/com/openbank/libs/domain/event/EventActorTest.kt
+++ b/openbank-libs-domain/src/test/kotlin/com/openbank/libs/domain/event/EventActorTest.kt
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.libs.domain.event
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+
+/**
+ * The canonical spelling of a system-originated actor (#3994).
+ *
+ * Every assertion here is on an EXACT string. That is the point: the audit trail groups and
+ * prefix-matches on this value, so "it is non-null" or "it contains system" would pass against a
+ * value no downstream query can use — the same failure shape as asserting `isNotNull()` against
+ * `Instant.EPOCH`, or against the four-character string `"null"` #4307 removed from `actor_id`.
+ */
+class EventActorTest {
+
+    @Test
+    fun `a system actor id names the service and the mechanism, in that order`() {
+        assertThat(EventActor.system("balance-service", "ledger-projection"))
+            .isEqualTo("system:balance-service:ledger-projection")
+    }
+
+    @Test
+    fun `a system actor id can never be mistaken for a person`() {
+        val id = EventActor.system("statement-service", "period-close")
+
+        assertThat(EventActor.isSystem(id)).isTrue()
+        // Not a UUID, not a Keycloak subject, not an email — so the GDPR Art. 15 access log and the
+        // ADR-0226 cross-channel person query can exclude it with one prefix match.
+        assertThat(id).startsWith("system:")
+        assertThat(id).doesNotContain("@")
+    }
+
+    @Test
+    fun `absence is not a system actor - the two states this issue exists to separate`() {
+        // "we failed to record who did this" must stay distinguishable from "nobody did this".
+        assertThat(EventActor.isSystem(null)).isFalse()
+        assertThat(EventActor.isSystem("")).isFalse()
+        assertThat(EventActor.isSystem("7d13ecc0-443b-456e-a504-dd8999000000")).isFalse()
+    }
+
+    @Test
+    fun `a blank mechanism is rejected rather than silently producing a useless id`() {
+        // "some automation in balance-service" is not an answer anyone can act on, and an optional
+        // mechanism is how every call site ends up omitting it.
+        assertThatThrownBy { EventActor.system("balance-service", " ") }
+            .isInstanceOf(IllegalArgumentException::class.java)
+        assertThatThrownBy { EventActor.system("", "period-close") }
+            .isInstanceOf(IllegalArgumentException::class.java)
+    }
+
+    @Test
+    fun `the wire keys are the ones AuditConsumer reads`() {
+        // AuditConsumer resolves the actor from `requestedBy` / `actorId` / `initiatedByPartyId`
+        // and the type from `actorType`. A different spelling here stores NULL, silently.
+        assertThat(EventActor.FIELD_ACTOR_ID).isEqualTo("actorId")
+        assertThat(EventActor.FIELD_ACTOR_TYPE).isEqualTo("actorType")
+        assertThat(EventActor.TYPE_SYSTEM).isEqualTo("SYSTEM")
+    }
+}

--- a/openbank-party-service/src/main/kotlin/com/openbank/party/application/usecase/PartyService.kt
+++ b/openbank-party-service/src/main/kotlin/com/openbank/party/application/usecase/PartyService.kt
@@ -99,7 +99,10 @@ class PartyService : PartyUseCase {
             consentMarketing = cmd.consentMarketing,
             consentCapturedAt = consentCapturedAt,
         )
-        val saved = partyRepo.save(party, PartyEvents.created(party, Instant.now(clock)))
+        val saved = partyRepo.save(
+            party,
+            PartyEvents.created(party, Instant.now(clock), PartyActor.system("party-api")),
+        )
         metrics.partyCreated(saved.partyType.name)
         return saved
     }
@@ -184,7 +187,10 @@ class PartyService : PartyUseCase {
             tradingName = cmd.tradingName ?: party.tradingName,
             updatedAt = Instant.now(clock),
         )
-        val saved = partyRepo.update(updated, PartyEvents.updated(updated, Instant.now(clock)))
+        val saved = partyRepo.update(
+            updated,
+            PartyEvents.updated(updated, Instant.now(clock), PartyActor.system("party-api")),
+        )
         return saved
     }
 
@@ -287,7 +293,10 @@ class PartyService : PartyUseCase {
             status = deriveStatus(status, party.amlStatus, party.status),
             updatedAt = Instant.now(clock),
         )
-        val saved = partyRepo.update(updated, PartyEvents.kycStatusChanged(updated, Instant.now(clock)))
+        val saved = partyRepo.update(
+            updated,
+            PartyEvents.kycStatusChanged(updated, Instant.now(clock), PartyActor.system("kyc-status-projection")),
+        )
         countIfVerifyingTransition(party.status, saved)
         return saved
     }
@@ -301,7 +310,10 @@ class PartyService : PartyUseCase {
         )
         // Emits the party's current status (incl. ACTIVE) to downstream consumers
         // (account-service activation, onboarding cockpit) on the party events topic.
-        val saved = partyRepo.update(updated, PartyEvents.kycStatusChanged(updated, Instant.now(clock)))
+        val saved = partyRepo.update(
+            updated,
+            PartyEvents.kycStatusChanged(updated, Instant.now(clock), PartyActor.system("aml-status-projection")),
+        )
         countIfVerifyingTransition(party.status, saved)
         return saved
     }
@@ -398,7 +410,10 @@ class PartyService : PartyUseCase {
             mergedIntoPartyId = target.id,
             updatedAt = Instant.now(clock),
         )
-        val saved = partyRepo.update(merged, PartyEvents.merged(merged, target.id, Instant.now(clock)))
+        val saved = partyRepo.update(
+            merged,
+            PartyEvents.merged(merged, target.id, Instant.now(clock), PartyActor.system("party-merge")),
+        )
         return saved
     }
 
@@ -423,7 +438,10 @@ class PartyService : PartyUseCase {
             createdAt = Instant.now(clock),
             updatedAt = Instant.now(clock),
         )
-        val saved = partyRepo.save(party, PartyEvents.created(party, Instant.now(clock)))
+        val saved = partyRepo.save(
+            party,
+            PartyEvents.created(party, Instant.now(clock), PartyActor.customer(cmd.keycloakSub)),
+        )
         return Pair(saved, true)
     }
 

--- a/openbank-party-service/src/main/kotlin/com/openbank/party/domain/model/PartyEvent.kt
+++ b/openbank-party-service/src/main/kotlin/com/openbank/party/domain/model/PartyEvent.kt
@@ -4,6 +4,7 @@
 
 package com.openbank.party.domain.model
 
+import com.openbank.libs.domain.event.EventActor
 import java.time.Instant
 import java.util.UUID
 
@@ -25,6 +26,43 @@ data class PartyEvent(
 )
 
 /**
+ * Who a party event is attributed to (#3994).
+ *
+ * An explicit parameter on every builder rather than a default, because the honest answer differs
+ * per entry path and a default would let the wrong one be inherited silently — which is how the
+ * 171 unattributed `PARTY_*`/`KYC_STATUS_CHANGED` audit rows happened in the first place.
+ *
+ * There is no request-scoped holder behind this and deliberately so: `PartyService` is the domain
+ * use case, `openbank-libs-domain` carries zero framework imports (ADR-0002/ADR-0122), and a
+ * CDI-produced ambient actor in `openbank-libs-runtime` would be injected into every service that
+ * consumes the module whether or not it wants one.
+ */
+data class PartyActor(val id: String, val type: String) {
+    companion object {
+        private const val SERVICE = "party-service"
+
+        /** No person originated this — a projection, a consumer, or an unattributed API call. */
+        fun system(mechanism: String): PartyActor =
+            PartyActor(EventActor.system(SERVICE, mechanism), EventActor.TYPE_SYSTEM)
+
+        /**
+         * The customer acting on their own record, identified by their Keycloak subject.
+         *
+         * Used only where the identity is unambiguous — self-registration, where `keycloakSub` IS
+         * the authenticated caller. It is deliberately NOT used for the admin/onboarding
+         * `createParty` path: the B1 invariant makes `cmd.id` equal the subject for self-service
+         * onboarding but that path is also driven by onboarding-service, so attributing every
+         * creation to the party itself would be a plausible, confident and sometimes false claim —
+         * strictly worse than the `SYSTEM` id, which is at least true.
+         */
+        fun customer(keycloakSub: String): PartyActor = PartyActor(keycloakSub, TYPE_CUSTOMER)
+
+        /** Matches the `actorType` customer-edge already writes for a self-service subject. */
+        private const val TYPE_CUSTOMER = "CUSTOMER"
+    }
+}
+
+/**
  * Builds the party lifecycle events.
  *
  * These used to be built inside `KafkaPartyEventPublisher`, a bare `@Channel("party-events-out")`
@@ -36,12 +74,21 @@ data class PartyEvent(
  */
 object PartyEvents {
 
-    fun created(party: Party, at: Instant): PartyEvent = lifecycle("PARTY_CREATED", party, at)
+    fun created(party: Party, at: Instant, actor: PartyActor): PartyEvent = lifecycle("PARTY_CREATED", party, at, actor)
 
-    fun updated(party: Party, at: Instant): PartyEvent = lifecycle("PARTY_UPDATED", party, at)
+    fun updated(party: Party, at: Instant, actor: PartyActor): PartyEvent = lifecycle("PARTY_UPDATED", party, at, actor)
 
-    fun kycStatusChanged(party: Party, at: Instant): PartyEvent = lifecycle("KYC_STATUS_CHANGED", party, at)
+    fun kycStatusChanged(party: Party, at: Instant, actor: PartyActor): PartyEvent =
+        lifecycle("KYC_STATUS_CHANGED", party, at, actor)
 
+    /**
+     * **Deliberately carries no actor (#3994).** Every other builder here gained `actorId`/
+     * `actorType`; this one did not. GDPR Art. 17 erasure is the one event whose envelope is
+     * narrowed on purpose (see `PartyEventEnvelopeContractTest`), and the plausible actor for a
+     * self-service erasure is the data subject's own Keycloak subject — putting that on a
+     * broadcast topic would re-publish an identifier for the person the event exists to erase.
+     * Zero rows of the live unattributed set are `PARTY_ERASED`, so nothing is lost by leaving it.
+     */
     fun erased(partyId: UUID, at: Instant): PartyEvent = PartyEvent(
         eventType = "PARTY_ERASED",
         aggregateId = partyId,
@@ -57,7 +104,7 @@ object PartyEvents {
      * ADR-0179: [merged] is the retired duplicate (status MERGED); [survivingPartyId] is the party
      * consumers should follow from now on.
      */
-    fun merged(merged: Party, survivingPartyId: UUID, at: Instant): PartyEvent = PartyEvent(
+    fun merged(merged: Party, survivingPartyId: UUID, at: Instant, actor: PartyActor): PartyEvent = PartyEvent(
         eventType = "PARTY_MERGED",
         aggregateId = merged.id,
         occurredAt = at,
@@ -67,10 +114,12 @@ object PartyEvents {
             "mergedIntoPartyId" to survivingPartyId,
             "status" to merged.status,
             "occurredAt" to at,
+            EventActor.FIELD_ACTOR_ID to actor.id,
+            EventActor.FIELD_ACTOR_TYPE to actor.type,
         ),
     )
 
-    private fun lifecycle(eventType: String, party: Party, at: Instant): PartyEvent = PartyEvent(
+    private fun lifecycle(eventType: String, party: Party, at: Instant, actor: PartyActor): PartyEvent = PartyEvent(
         eventType = eventType,
         aggregateId = party.id,
         occurredAt = at,
@@ -83,6 +132,8 @@ object PartyEvents {
             "legalName" to party.legalName,
             "email" to party.email,
             "occurredAt" to at,
+            EventActor.FIELD_ACTOR_ID to actor.id,
+            EventActor.FIELD_ACTOR_TYPE to actor.type,
         ),
     )
 }

--- a/openbank-party-service/src/test/kotlin/com/openbank/party/domain/model/PartyEventEnvelopeContractTest.kt
+++ b/openbank-party-service/src/test/kotlin/com/openbank/party/domain/model/PartyEventEnvelopeContractTest.kt
@@ -59,7 +59,7 @@ class PartyEventEnvelopeContractTest {
 
     @Test
     fun `PARTY_CREATED emits the flat envelope consumers depend on`() {
-        val event = PartyEvents.created(individual(), at)
+        val event = PartyEvents.created(individual(), at, PartyActor.system("party-api"))
         val json = mapper.readTree(mapper.writeValueAsString(event.envelope))
 
         // Field-name contract — these exact names are read by account/aml/kyc/onboarding consumers.
@@ -77,7 +77,11 @@ class PartyEventEnvelopeContractTest {
 
     @Test
     fun `PARTY_UPDATED to ACTIVE carries the status field account-service reconciles on`() {
-        val event = PartyEvents.updated(individual().copy(status = PartyStatus.ACTIVE), at)
+        val event = PartyEvents.updated(
+            individual().copy(status = PartyStatus.ACTIVE),
+            at,
+            PartyActor.system("party-api"),
+        )
         val json = mapper.readTree(mapper.writeValueAsString(event.envelope))
 
         assertThat(json.get("eventType").asText()).isEqualTo("PARTY_UPDATED")
@@ -94,6 +98,7 @@ class PartyEventEnvelopeContractTest {
             individual(),
             UUID.fromString("22222222-2222-2222-2222-222222222222"),
             at,
+            PartyActor.system("party-merge"),
         )
         assertThat(event.eventType).isEqualTo("PARTY_MERGED")
         assertThat(event.aggregateId).isEqualTo(UUID.fromString("11111111-1111-1111-1111-111111111111"))
@@ -114,5 +119,55 @@ class PartyEventEnvelopeContractTest {
         listOf("legalName", "email", "partyType", "status", "kycStatus").forEach {
             assertThat(json.has(it)).describedAs("PARTY_ERASED must not carry %s", it).isFalse()
         }
+    }
+
+    /**
+     * #3994 — red against `origin/main`, where no `PartyEvents` builder emitted an actor key and
+     * 171 `PARTY_*` / `KYC_STATUS_CHANGED` audit rows therefore stored NULL.
+     *
+     * Exact values, not presence: the mechanism segment is what makes an unattributed row
+     * actionable ("which path wrote this?"), and `isNotNull` would pass against every one of the
+     * four different origins below.
+     */
+    @Test
+    fun `a self-registration is attributed to the customer who registered`() {
+        val sub = "d0b1d110-6698-46f0-8fcd-22314d000000"
+        val json = mapper.readTree(
+            mapper.writeValueAsString(PartyEvents.created(individual(), at, PartyActor.customer(sub)).envelope),
+        )
+
+        assertThat(json.get("actorId").asText()).isEqualTo(sub)
+        assertThat(json.get("actorType").asText()).isEqualTo("CUSTOMER")
+    }
+
+    @Test
+    fun `a KYC status projection says a system did it, and which one`() {
+        val json = mapper.readTree(
+            mapper.writeValueAsString(
+                PartyEvents.kycStatusChanged(individual(), at, PartyActor.system("kyc-status-projection")).envelope,
+            ),
+        )
+
+        assertThat(json.get("actorId").asText()).isEqualTo("system:party-service:kyc-status-projection")
+        assertThat(json.get("actorType").asText()).isEqualTo("SYSTEM")
+    }
+
+    @Test
+    fun `the AML projection is a DIFFERENT origin from the KYC one`() {
+        // Both land on KYC_STATUS_CHANGED, and before this change both were one indistinguishable
+        // NULL. Collapsing them back into a single "system" id would lose that again.
+        val kyc = PartyEvents.kycStatusChanged(individual(), at, PartyActor.system("kyc-status-projection"))
+        val aml = PartyEvents.kycStatusChanged(individual(), at, PartyActor.system("aml-status-projection"))
+
+        assertThat(kyc.envelope["actorId"]).isNotEqualTo(aml.envelope["actorId"])
+        assertThat(aml.envelope["actorId"]).isEqualTo("system:party-service:aml-status-projection")
+    }
+
+    @Test
+    fun `PARTY_ERASED still carries no actor - it must not re-publish the erased subject`() {
+        val json = mapper.readTree(mapper.writeValueAsString(PartyEvents.erased(UUID.randomUUID(), at).envelope))
+
+        assertThat(json.has("actorId")).isFalse()
+        assertThat(json.has("actorType")).isFalse()
     }
 }

--- a/openbank-statement-service/src/main/kotlin/com/openbank/statement/application/usecase/CloseOrchestrator.kt
+++ b/openbank-statement-service/src/main/kotlin/com/openbank/statement/application/usecase/CloseOrchestrator.kt
@@ -3,6 +3,7 @@
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 package com.openbank.statement.application.usecase
 
+import com.openbank.libs.domain.event.EventActor
 import com.openbank.statement.application.port.`in`.ClosePocketUseCase
 import com.openbank.statement.application.port.`in`.CloseRunQueryUseCase
 import com.openbank.statement.application.port.`in`.RunCloseUseCase
@@ -19,6 +20,7 @@ import com.openbank.statement.domain.model.CloseFailureReason
 import com.openbank.statement.domain.model.CloseRun
 import com.openbank.statement.domain.model.CloseRunStatus
 import com.openbank.statement.domain.model.CloseTrigger
+import com.openbank.statement.domain.model.StatementEventActors
 import io.smallrye.mutiny.Multi
 import io.smallrye.mutiny.Uni
 import jakarta.enterprise.context.ApplicationScoped
@@ -217,7 +219,9 @@ class CloseOrchestrator(
             "reason":"$reason",
             "detail":"$detail",
             "failedAt":"$failedAt",
-            "occurredAt":"$failedAt"}
+            "occurredAt":"$failedAt",
+            "actorId":"${StatementEventActors.PERIOD_CLOSE}",
+            "actorType":"${EventActor.TYPE_SYSTEM}"}
         """.trimIndent().replace("\n", "")
         return outbox.append(
             StatementOutboxMessage(

--- a/openbank-statement-service/src/main/kotlin/com/openbank/statement/application/usecase/StatementService.kt
+++ b/openbank-statement-service/src/main/kotlin/com/openbank/statement/application/usecase/StatementService.kt
@@ -3,6 +3,7 @@
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 package com.openbank.statement.application.usecase
 
+import com.openbank.libs.domain.event.EventActor
 import com.openbank.statement.application.port.`in`.AdHocExportUseCase
 import com.openbank.statement.application.port.`in`.ClosePeriodUseCase
 import com.openbank.statement.application.port.`in`.ClosePocketUseCase
@@ -19,6 +20,7 @@ import com.openbank.statement.application.port.out.StatementPeriodRepository
 import com.openbank.statement.domain.model.BalanceAnchor
 import com.openbank.statement.domain.model.PeriodCloseStatus
 import com.openbank.statement.domain.model.StatementEntry
+import com.openbank.statement.domain.model.StatementEventActors
 import com.openbank.statement.domain.model.StatementFormat
 import com.openbank.statement.domain.model.StatementModel
 import com.openbank.statement.domain.model.StatementPeriod
@@ -306,7 +308,9 @@ class StatementService(
             "closingBalance":${period.closingBalance.toPlainString()},
             "entryCount":${period.entryCount},
             "closedAt":"${period.closedAt}",
-            "occurredAt":"${period.closedAt}"}
+            "occurredAt":"${period.closedAt}",
+            "actorId":"${StatementEventActors.PERIOD_CLOSE}",
+            "actorType":"${EventActor.TYPE_SYSTEM}"}
         """.trimIndent().replace("\n", "")
         return StatementOutboxMessage(
             eventId = UUID.randomUUID(),

--- a/openbank-statement-service/src/main/kotlin/com/openbank/statement/domain/model/StatementEventActors.kt
+++ b/openbank-statement-service/src/main/kotlin/com/openbank/statement/domain/model/StatementEventActors.kt
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.statement.domain.model
+
+import com.openbank.libs.domain.event.EventActor
+
+/**
+ * The `actorId` this service stamps on its outbox events (#3994).
+ *
+ * Both `account.statement.period.closed.v1` (78 unattributed audit rows) and
+ * `account.statement.period.close_failed.v1` (8) are produced by the period-close run. Nobody
+ * presses a button: the close is driven by the scheduled orchestrator against the accounting
+ * calendar, so `SYSTEM` is not a fallback here, it is the complete and correct answer.
+ *
+ * A named constant rather than a literal inside the two hand-built JSON payload strings — those
+ * are `"""…"""` templates with no compiler check on their keys or values, so a divergent spelling
+ * between the success and the failure event would silently create two origins in the audit trail.
+ */
+object StatementEventActors {
+    /** The scheduled statement period-close run — success and failure alike. */
+    val PERIOD_CLOSE: String = EventActor.system("statement-service", "period-close")
+}

--- a/openbank-statement-service/src/test/kotlin/com/openbank/statement/application/usecase/StatementServiceTest.kt
+++ b/openbank-statement-service/src/test/kotlin/com/openbank/statement/application/usecase/StatementServiceTest.kt
@@ -3,6 +3,7 @@
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 package com.openbank.statement.application.usecase
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.openbank.libs.testing.audit.AuditEventTime
 import com.openbank.statement.Fixtures
 import com.openbank.statement.application.port.out.AccountInfoPort
@@ -108,6 +109,33 @@ class StatementServiceTest {
         val closed = service.closeMonth(Fixtures.ACCOUNT_ID, from, to).await().indefinitely().first()
 
         AuditEventTime.assertRecordedAsEventTime(msg.captured.payload, closed.closedAt)
+    }
+
+    /**
+     * #3994 — red against `origin/main`, where the period-close payload carried no actor key and
+     * the 86 statement audit rows (78 closed + 8 close_failed) stored NULL.
+     *
+     * A statutory period-close is scheduled, not pressed: nobody is the honest answer, and this
+     * asserts the payload SAYS so with the exact canonical id rather than leaving a NULL that reads
+     * identically to a human identity we lost. Parsed as JSON rather than substring-matched — the
+     * payload is a hand-built `"""` template, so a `contains("SYSTEM")` would also match a value
+     * that landed under some other key.
+     */
+    @Test
+    fun `the period-closed payload names the scheduled close as its system origin`() {
+        every { periods.findByPeriod(any(), any(), any(), any()) } returns Uni.createFrom().nullItem()
+        every { balance.closingBalance(Fixtures.ACCOUNT_ID, "CZK", to) } returns
+            Uni.createFrom().item(BalanceAnchor(BigDecimal("1075.00"), "CZK", to))
+        every { periods.nextLegalSequence(Fixtures.ACCOUNT_ID, "CZK") } returns Uni.createFrom().item(7L)
+        val msg = slot<StatementOutboxMessage>()
+        every { periods.saveWithOutbox(any(), capture(msg)) } answers
+            { Uni.createFrom().item(firstArg<StatementPeriod>()) }
+
+        service.closeMonth(Fixtures.ACCOUNT_ID, from, to).await().indefinitely()
+
+        val json = ObjectMapper().readTree(msg.captured.payload)
+        assertThat(json.get("actorId").asText()).isEqualTo("system:statement-service:period-close")
+        assertThat(json.get("actorType").asText()).isEqualTo("SYSTEM")
     }
 
     @Test


### PR DESCRIPTION
## What

The **producer half** of #3994. The consumer half already shipped: #4270 recovered the producer and
event type the transport was carrying, #4307 stopped a JSON null becoming the four-character actor
`"null"`. What was left is the larger part — rows whose producer emits **no actor key at all**, so
there has never been anything for `AuditConsumer` to read.

`Refs #3994` — it does not close it; see *Not fixed* below.

## The survey, re-derived from the stored payloads (not from the code)

Read-only against the live `audit` CNPG cluster on 2026-08-09/10 (`SELECT` only; `audit_entries`
carries `DO INSTEAD NOTHING` rules on UPDATE/DELETE, so **a backfill is not available at all** and
none is proposed — every fix here is forward-only).

```sql
SELECT count(*) FILTER (WHERE actor_id IS NULL)                                AS null_actor,
       count(*) FILTER (WHERE actor_id = 'null')                               AS str_null,
       count(*) FILTER (WHERE actor_id IS NOT NULL AND actor_id <> 'null')     AS attributed,
       count(*)                                                                AS total
FROM audit_entries;
--  1341 | 7 | 441 | 1789
```

Then the keys each unattributed payload actually carries, from the payload itself:

```sql
SELECT event_type, string_agg(DISTINCT k, ',' ORDER BY k)
FROM (SELECT event_type, jsonb_object_keys(payload::jsonb) AS k
      FROM audit_entries
      WHERE (actor_id IS NULL OR actor_id = 'null') AND payload ~ '^\s*\{') s
GROUP BY 1;
```

| event_type | rows | actor-ish key in the stored payload |
|---|---:|---|
| `BALANCE_UPDATED` | 314 | none |
| `UNKNOWN` (topics with no discriminator) | 131 | one sub-shape has `reviewedBy` |
| `HOLD_PLACED` | 114 | none |
| `HOLD_RELEASED` | 114 | none |
| `KYC_STATUS_CHANGED` | 107 | none |
| `TransactionInitiated` | 79 | `initiatedByPartyId` **present but null/absent on these rows** |
| `account.statement.period.closed.v1` | 78 | none |
| `TransactionCompleted` | 76 | none |
| `AccountCreated` | 63 | none |
| `AccountStatusChanged` | 63 | none |
| `KYC_CASE_OPENED` | 62 | none |
| `PARTY_CREATED` | 61 | none |
| `KYC_CASE_APPROVED` | 55 | none |
| `account.statement.period.close_failed.v1` | 8 | none |
| `TransactionFailed` | 7 | none |
| `ConsentGranted` / `ConsentRevoked` | 11 | none |
| `PARTY_UPDATED` / `PARTY_MERGED` | 3 | none |
| `complaint.received` | 2 | none |

Deriving this from stored payloads rather than from source sidesteps the blind spot below entirely:
the database sees the wire, and the wire is the thing that has two different sources.

## The blind spot, stated per producer

This repo builds event payloads two ways and **a grep finds only one of them**.

| producer | how the payload is built | can `command grep '"actorId"'` see it? | method I used |
|---|---|---|---|
| balance-service | `data class BalanceEvent` → `ObjectMapper.writeValueAsString` | **No** — keys are Kotlin property names, no literal exists in the module before or after this PR | read the type + the publisher; asserted the **serialised JSON** in a test |
| kyc-service | hand-built `linkedMapOf` in `KycEvents` | Yes | read `KycEvent.kt`, grep confirmed |
| party-service | hand-built `linkedMapOf` in `PartyEvents` | Yes | read `PartyEvent.kt`, grep confirmed |
| statement-service | hand-built `"""…"""` raw JSON template | Yes | read both template sites |

So a survey by grep would have reported balance-service — the single largest bucket, 542 rows — as
carrying no event fields worth checking, and been wrong for a structural reason rather than a
missed match.

## The judgement this PR makes explicitly: what a system-originated event says

Most of these events have **no human actor and cannot have one**. Inventing one is worse than
leaving the field absent, and this repo has measured that twice (`"unknown"` reaching 76% of
`source_service`; the string `"null"` in `actor_id`). So:

| state | representation | how it is distinguishable |
|---|---|---|
| nobody did this — a scheduler, a projection, a consumer | `actorType: "SYSTEM"`, `actorId: "system:<service>:<mechanism>"` | reserved `system:` prefix — never a UUID, a Keycloak subject or an email |
| a person did this | the real subject id + its own type (`CUSTOMER`, `REVIEWER`) | not `system:`-prefixed |
| **we failed to record who did this** | **key absent → NULL, exactly as today** | unchanged, still the state to go fix, still counted |

`EventActor` (new, `openbank-libs-domain`, pure Kotlin, no CDI producer) is the one spelling. The
`mechanism` segment is mandatory and non-blank: "some automation in balance-service" is not an
answer anyone can act on, and an optional field is how every call site ends up omitting it.

Rejected `SERVICE` as the type word — `input.principal.type == "SERVICE"` is already structurally
unreachable in the authz layer (`rules.yaml: authz_policy`), and reusing it invites dead rego.

## Fixed — 916 of the 1348 unattributed rows

| service | event types | rows | actor |
|---|---|---:|---|
| balance-service | `BALANCE_UPDATED`, `HOLD_PLACED`, `HOLD_RELEASED` | 542 | `SYSTEM`, three distinct mechanisms: `balance-api`, `ledger-projection`, `value-date-roll` |
| party-service | `PARTY_CREATED`, `PARTY_UPDATED`, `PARTY_MERGED`, `KYC_STATUS_CHANGED` | 171 | customer's Keycloak subject on self-registration; `SYSTEM` with separate `kyc-status-projection` / `aml-status-projection` / `party-api` / `party-merge` mechanisms elsewhere |
| kyc-service | `KYC_CASE_OPENED`, `KYC_CASE_APPROVED` (+ the other two builders) | 117 | **the real four-eyes reviewer** from `KycCase.reviewedBy`; `SYSTEM` only where no human touched the case |
| statement-service | `…period.closed.v1`, `…period.close_failed.v1` | 86 | `SYSTEM` / `period-close` |

Two deliberate non-changes inside the fixed set:

- **`PARTY_ERASED` keeps no actor.** Its envelope is narrowed on purpose for GDPR Art. 17, and the
  plausible actor for a self-service erasure is the data subject's own identifier — which must not
  be re-broadcast by the event that erases them. Zero live rows.
- **`createParty` gets the `SYSTEM` id, not the party's own id.** The B1 invariant makes `cmd.id`
  equal the Keycloak subject for self-service onboarding, but onboarding-service drives the same
  method, so attributing every creation to the party itself would be plausible, confident and
  sometimes false — strictly worse than a true `SYSTEM`.

### Shared publisher vs. call sites

Preferred the shared path where it exists and said so where it does not. There is **no single
shared publisher** to hang this on: `DomainEvent` (libs-domain) is extended by only some of these
producers, and the rest hand-build maps or raw JSON. A request-scoped CDI actor holder in
libs-runtime was rejected outright — a `@Produces` there is injected into every consuming service
whether it wants one or not. So the shared part is the **representation** (`EventActor`), and the
value is supplied per call site, which is also the only correct answer: the honest actor genuinely
differs per entry path (kyc's reviewer vs. its consumer-opened case; party's self-registration vs.
its AML projection), and a default would let the wrong one be inherited silently.

## Not fixed — 432 rows, with reasons

| service | event types | rows | why not here |
|---|---|---:|---|
| transaction-service | `TransactionInitiated` / `Completed` / `Failed` | 162 | money-path; `initiatedByPartyId` already exists on the type but is null on these rows — the fix is upstream in whoever constructs the command, a separate investigation, not an envelope change |
| — | the `UNKNOWN` bucket (payloads with no discriminator) | 131 | not one producer: the bucket is topics whose body carries no event type, several with a `reviewedBy` already present. Needs the per-topic work #4270 started, not an actor decision |
| account-service | `AccountCreated`, `AccountStatusChanged` | 126 | money-path; same shape as party but a larger `DomainEvent` subclass surface — deliberately left so this PR stays reviewable |
| consent-service | `ConsentGranted`, `ConsentRevoked` | 11 | money-path |
| complaint | `complaint.received` | 2 | tail |

**Money-path** (`rules.yaml: money_path_services`): `openbank-balance-service` is money-path, so this
PR needs **2 approvals** and its threat model consulted (`docs/threat-models/`). The three services
left largest — transaction, account, consent — are all money-path too, which is the honest reason
they are a follow-up rather than a bigger diff here.

## Verification — both runs

Read the existing tests before writing any: **no test encoded the unattributed behaviour** (the
nearest was `PartyEventEnvelopeContractTest`, which pins a field-name contract and an explicit
forbidden-field list for `PARTY_ERASED`, neither of which asserts an absent actor). The pacts assert
only a subset of each envelope, so the added keys are compatible.

Every assertion is on an **exact expected value**. `isNotNull()` would have passed against the empty
string, against `"null"`, and — in the kyc pair — against *both* of the two states the change exists
to separate.

### Against `origin/main` (RED)

Copied the two tests that compile unchanged against main into a detached `origin/main` worktree:

```
KycEventActorTest > an approved case names the reviewer who approved it()            FAILED
   expected: "analyst.novak@openbank.cz"                     but was: null
KycEventActorTest > a case nobody has reviewed says so...()                          FAILED
   expected: "system:kyc-service:case-lifecycle"             but was: null
KycEventActorTest > a blank reviewer is treated as no reviewer...()                  FAILED
   expected: "system:kyc-service:case-lifecycle"             but was: null
KycEventActorTest > the two states stay distinguishable...()                         FAILED
   NullPointerException: null cannot be cast to non-null type kotlin.String
StatementServiceTest > the period-closed payload names the scheduled close...()      FAILED
   NullPointerException: JsonNode.asText() on the return of JsonNode.get("actorId")
```

The balance, party and `EventActor` tests cannot be run against main at all — the field and the type
they assert do not exist there, so they fail at compile. Stating that rather than dressing it up as
a nicer red.

### Against this branch (GREEN), read from the JUnit XML

| module | tests | failures | **skipped** |
|---|---:|---:|---:|
| `openbank-libs-domain` | 415 | 0 | 0 |
| `openbank-balance-service` | 156 | 0 | 1 |
| `openbank-kyc-service` | 78 | 0 | 1 |
| `openbank-party-service` | 151 | 0 | 1 |
| `openbank-statement-service` | 86 | 0 | 0 |

Skipped counts read from the XML, not the console. The first combined run showed one failure each in
kyc and statement — both `Unable to start HTTP server`, the shared-machine port collision, not a
product failure; re-run serially, both green, and the skipped counts did **not** move (a Quarkus boot
failure would have shown as a jump in skips, not only in failures).

`detekt`, `ktlintCheck`, `test` and `quarkusBuild` all pass on all five modules — task list read, not
assumed. `check-domain-purity.py`: **0 new** violations (the new libs import is pure domain).
`check-license-headers.py`: OK.

### The libs-change blast radius

`openbank-libs-domain` has **50** dependent modules (`command grep -rl openbank-libs-domain
--include=build.gradle.kts`). This change adds one new file containing one new `object` — no existing
signature moves, no `@Produces`, no CDI bean — so no dependent can break by not being updated. The
four services edited here are the only ones that reference it.
