### PR TITLE
security(sdd): enforce OPA authorization, with a viewer/compliance read grant

### DIFF
--- a/openbank-infra/gitops/components/sdd/sdd-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sdd/sdd-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sdd-service
     app.kubernetes.io/part-of: sdd
   annotations:
-    openbank.tech/policy-checksum: "0d6ffeead298ace7"
+    openbank.tech/policy-checksum: "8e0f99066014f337"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -614,6 +614,38 @@ data:
     # queue only. The same shape as interest-service's accrueAll at its own bootstrap. When the
     # clearing-side caller is built, it gets its own identity-scoped rule naming that caller — not a
     # family widening here, and not a role-only grant that the shared backend client would inherit.
+
+    # Read-only oversight personas, added as the precondition of the AUTHZ_ENFORCE flip (#3679).
+    #
+    # WHY THIS IS NOT AN OVER-GRANT, AND WHY THE FLIP NEEDED IT. Both read resources declare
+    # @RolesAllowed("ROLE_VIEWER", "ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_PAYMENTS", "ROLE_API"), so a
+    # ROLE_VIEWER holder can reach GET /api/v1/sdd/mandates, /mandates/{id} and
+    # /mandates/{id}/refund-assessment today. Base rest.rego grants that persona nothing:
+    # operator-read-any needs ROLE_OPERATOR, and compliance-read-any matches only actions ending in
+    # ".read", so a ROLE_COMPLIANCE analyst is granted sdd.read but NOT sdd.list. Measured with
+    # `opa eval` against the DEPLOYED sdd-opa-bundle ConfigMap before this rule existed:
+    #
+    #   sdd.list  ROLE_VIEWER      -> false      sdd.read  ROLE_VIEWER      -> false
+    #   sdd.list  ROLE_COMPLIANCE  -> false      sdd.read  ROLE_COMPLIANCE  -> compliance-read-any
+    #
+    # The deployed realm (gitops/components/keycloak/realm-template.json) seeds demo@openbank.local
+    # with ROLE_VIEWER and nothing else, and compliance@/compliance2@ with ROLE_COMPLIANCE+ROLE_VIEWER;
+    # admin-ui's /sdd page is not role-gated, so it is reachable by all three. Flipping AUTHZ_ENFORCE
+    # without this rule would 403 every one of them on a read they are entitled to — a regression
+    # introduced by the security change itself.
+    #
+    # READ-ONLY BY CONSTRUCTION, which is what makes a role-only grant acceptable here where the write
+    # rule above had to exclude service accounts: the action set is a closed literal of the two read
+    # actions, so no widening of sdd.* can leak through it, and neither role appears on any sdd write
+    # path. It also grants the shared backend client nothing new — service-account-openbank-services
+    # holds ROLE_API in the deployed realm (and ROLE_OPERATOR in the docker/CI realms, where base
+    # operator-read-any already covers both actions), so this rule changes no M2M exposure.
+    allowed_reasons contains "sdd-oversight-read" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_VIEWER", "ROLE_COMPLIANCE"}
+    	role in input.principal.roles
+    	input.action in {"sdd.read", "sdd.list"}
+    }
   agents.rego: |
     # SPDX-License-Identifier: Apache-2.0
     # Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.

--- a/openbank-infra/gitops/components/sdd/sdd-service.yaml
+++ b/openbank-infra/gitops/components/sdd/sdd-service.yaml
@@ -31,7 +31,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sdd-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "0d6ffeead298ace7"
+        openbank.tech/policy-checksum: "8e0f99066014f337"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -103,28 +103,41 @@ spec:
               value: "http://tempo.observability.svc:4317"
             - name: OTEL_TRACES_SAMPLER_ARG
               value: "0.1"
-            # OPA advisory mode (ADR-0034 Phase 5). STILL false — deliberately, and this is the
-            # one remaining step of #3679, not an oversight.
+            # OPA ENFORCING (ADR-0034 Phase 5) — the last step of #3679 for this service.
+            # sdd-service is in rules.yaml: money_path_services (it posts a real debtor debit
+            # through TransactionServiceClient for every authorised collection, #1478), so
+            # advisory mode here meant a valid bearer token was the whole authorization check.
             #
-            # The comment that stood here was wrong on its own terms: it justified advisory mode
-            # with "non-money-path services run authz advisory", and sdd-service IS in
-            # rules.yaml: money_path_services — it posts a real debtor debit through
-            # TransactionServiceClient for every authorised collection (#1478). It also asserted
-            # that no sidecar existed, which was true and is what this change fixes: the `opa`
-            # container below now serves data.openbank.rest.allow, so every @Authorize decision is
-            # EVALUATED and LOGGED ("advisory: would DENY") instead of failing at the PDP call with
-            # nothing to record.
+            # WHY THE PRECONDITION THE PREVIOUS COMMENT SET IS NOT THE ONE THAT WAS MET. It said
+            # to flip "once the live decision log confirms the would-DENY population is empty for
+            # real callers". That criterion is unsatisfiable on this service and would have read
+            # as satisfied anyway: the `opa` sidecar has served ZERO policy queries since the
+            # bundle was deployed (its log contains /health and nothing else), and the app log has
+            # 23 lines, all boot. So "no would-DENY lines" is a fact about there being no traffic,
+            # not about the deny set — the absent-subject trap, and it fails in the reassuring
+            # direction.
             #
-            # Flipping this to "true" is a separate, deliberate change and must not ride along with
-            # the bootstrap: enforcement is only safe once the live decision log confirms the
-            # would-DENY population is empty for real callers. Two callers exist today — admin-ui
-            # operators (their own session token) and customer-edge (service-account-openbank-edge)
-            # — and sdd_rest_ext.rego grants both; the log is what proves there is no third.
-            # Access meanwhile stays enforced by JAX-RS @RolesAllowed and, for customer traffic, by
-            # the customer-edge ownership (IDOR) check before it ever reaches this service.
-            # Refs #1730, #3679.
+            # Replaced with a strictly stronger criterion: EXHAUSTIVE enumeration. Every action
+            # the two @Authorize-bearing resources declare (sdd.create/list/read/approve/update/
+            # delete/authorise) was evaluated with `opa eval` against this namespace's DEPLOYED
+            # sdd-opa-bundle ConfigMap, materialised to the sidecar's own layout, for every
+            # principal shape a real caller can present, with a must-DENY control (zzz.frobnicate,
+            # false for all) and must-ALLOW controls in the same run. That covers actions no
+            # traffic has ever exercised, which a decision log by construction cannot.
+            #
+            # The caller set is derived from the code, not assumed: customer-edge's five sdd
+            # routes (UpstreamClient authenticates client_credentials as `openbank-edge`, so
+            # principal.id == service-account-openbank-edge) and admin-ui's /sdd page, whose BFF
+            # forwards the operator's OWN session token. Nothing else calls this service — the
+            # only other repo hits for "sdd" outside it are comments.
+            #
+            # That enumeration found a regression the flip would otherwise have caused: both read
+            # resources admit ROLE_VIEWER, and the seeded demo@ / compliance@ users hold
+            # VIEWER / COMPLIANCE+VIEWER, yet base rest.rego granted them nothing on sdd.list.
+            # sdd_rest_ext.rego's `sdd-oversight-read` (added in the same change) closes it,
+            # read-only and as a closed two-action literal. Refs #1730, #3679.
             - name: AUTHZ_ENFORCE
-              value: "false"
+              value: "true"
           startupProbe:
             tcpSocket:
               port: management

--- a/openbank-infra/gitops/components/sdd/sdd_rest_ext.rego
+++ b/openbank-infra/gitops/components/sdd/sdd_rest_ext.rego
@@ -83,3 +83,35 @@ allowed_reasons contains "edge-service-sdd" if {
 # queue only. The same shape as interest-service's accrueAll at its own bootstrap. When the
 # clearing-side caller is built, it gets its own identity-scoped rule naming that caller — not a
 # family widening here, and not a role-only grant that the shared backend client would inherit.
+
+# Read-only oversight personas, added as the precondition of the AUTHZ_ENFORCE flip (#3679).
+#
+# WHY THIS IS NOT AN OVER-GRANT, AND WHY THE FLIP NEEDED IT. Both read resources declare
+# @RolesAllowed("ROLE_VIEWER", "ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_PAYMENTS", "ROLE_API"), so a
+# ROLE_VIEWER holder can reach GET /api/v1/sdd/mandates, /mandates/{id} and
+# /mandates/{id}/refund-assessment today. Base rest.rego grants that persona nothing:
+# operator-read-any needs ROLE_OPERATOR, and compliance-read-any matches only actions ending in
+# ".read", so a ROLE_COMPLIANCE analyst is granted sdd.read but NOT sdd.list. Measured with
+# `opa eval` against the DEPLOYED sdd-opa-bundle ConfigMap before this rule existed:
+#
+#   sdd.list  ROLE_VIEWER      -> false      sdd.read  ROLE_VIEWER      -> false
+#   sdd.list  ROLE_COMPLIANCE  -> false      sdd.read  ROLE_COMPLIANCE  -> compliance-read-any
+#
+# The deployed realm (gitops/components/keycloak/realm-template.json) seeds demo@openbank.local
+# with ROLE_VIEWER and nothing else, and compliance@/compliance2@ with ROLE_COMPLIANCE+ROLE_VIEWER;
+# admin-ui's /sdd page is not role-gated, so it is reachable by all three. Flipping AUTHZ_ENFORCE
+# without this rule would 403 every one of them on a read they are entitled to — a regression
+# introduced by the security change itself.
+#
+# READ-ONLY BY CONSTRUCTION, which is what makes a role-only grant acceptable here where the write
+# rule above had to exclude service accounts: the action set is a closed literal of the two read
+# actions, so no widening of sdd.* can leak through it, and neither role appears on any sdd write
+# path. It also grants the shared backend client nothing new — service-account-openbank-services
+# holds ROLE_API in the deployed realm (and ROLE_OPERATOR in the docker/CI realms, where base
+# operator-read-any already covers both actions), so this rule changes no M2M exposure.
+allowed_reasons contains "sdd-oversight-read" if {
+	input.principal.type == "HUMAN"
+	some role in {"ROLE_VIEWER", "ROLE_COMPLIANCE"}
+	role in input.principal.roles
+	input.action in {"sdd.read", "sdd.list"}
+}

--- a/openbank-infra/gitops/components/sdd/sdd_rest_ext_test.rego
+++ b/openbank-infra/gitops/components/sdd/sdd_rest_ext_test.rego
@@ -95,3 +95,35 @@ test_edge_may_not_confirm_b2b_mandate if {
 test_edge_may_not_authorise_collection if {
 	count(allowed_reasons) == 0 with input as {"principal": edge, "action": "sdd.authorise"}
 }
+
+# --- read-only oversight personas (the AUTHZ_ENFORCE precondition, #3679) ---
+
+compliance := {"type": "HUMAN", "id": "u-comp", "roles": ["ROLE_COMPLIANCE"]}
+
+test_viewer_may_read_and_list if {
+	"sdd-oversight-read" in allowed_reasons with input as {"principal": viewer, "action": "sdd.read"}
+	"sdd-oversight-read" in allowed_reasons with input as {"principal": viewer, "action": "sdd.list"}
+}
+
+# The gap that made the flip a regression: base compliance-read-any matches ".read" only, so the
+# list endpoint an analyst actually opens was ungranted.
+test_compliance_may_list_not_only_read if {
+	"sdd-oversight-read" in allowed_reasons with input as {"principal": compliance, "action": "sdd.list"}
+}
+
+# The grant is a closed two-action literal, so it can never reach a write — asserted per action
+# rather than as a family, since a family assertion would pass against a widened rule.
+test_oversight_read_grants_no_write if {
+	not "sdd-oversight-read" in allowed_reasons with input as {"principal": viewer, "action": "sdd.create"}
+	not "sdd-oversight-read" in allowed_reasons with input as {"principal": viewer, "action": "sdd.update"}
+	not "sdd-oversight-read" in allowed_reasons with input as {"principal": compliance, "action": "sdd.delete"}
+	not "sdd-oversight-read" in allowed_reasons with input as {"principal": compliance, "action": "sdd.approve"}
+	not "sdd-oversight-read" in allowed_reasons with input as {"principal": compliance, "action": "sdd.authorise"}
+}
+
+# Must-DENY control for this file: an action outside the sdd family gets no reason from any rule
+# here, so a rule that ever starts matching on principal alone fails this test.
+test_no_reason_for_unknown_action if {
+	count(allowed_reasons) == 0 with input as {"principal": viewer, "action": "zzz.frobnicate"}
+	count(allowed_reasons) == 0 with input as {"principal": operator, "action": "zzz.frobnicate"}
+}


### PR DESCRIPTION
Closes the sdd half of #3679.

`openbank-sdd-service` is in `rules.yaml: money_path_services` — it posts a real debtor debit through `TransactionServiceClient` for every authorised collection (#1478) — and it ran `AUTHZ_ENFORCE=false`, so a valid bearer token was its entire authorization check. #3807 gave it a PDP sidecar, a bundle and `sdd_rest_ext.rego`; this is the flip.

## The precondition in the manifest could not have been met, and would have read as met

The comment this PR replaces said to flip "once the live decision log confirms the would-DENY population is empty for real callers". Measured on the running pod (`sdd-service-5c75845dd9-2jpcr`, up 8h, 0 restarts):

- `opa` sidecar log: **0** requests to `/v1/data` — only `/health`. Not one policy query has ever been evaluated.
- app log: **23 lines**, all boot (Flyway, Kafka, Quarkus started).

So "no would-DENY lines" is a fact about there being no traffic, not about the deny set. It is the absent-subject trap and it fails in the reassuring direction — and no amount of waiting fixes it, because there is no traffic to produce the evidence.

Replaced with a strictly stronger criterion: **exhaustive enumeration**. Every action the two `@Authorize`-bearing resources declare, evaluated with `opa eval` against the **deployed** `sdd-opa-bundle` ConfigMap materialised to the sidecar's own layout (`rules-data.yaml` -> `rules/data.yaml`), for every principal shape a real caller can present, with a must-DENY control in the same run. That covers actions no traffic has ever exercised, which a decision log by construction cannot.

## The caller set, derived rather than assumed

- **customer-edge** — five routes (`GET/POST /sdd/mandates`, `GET /sdd/mandates/{id}`, `cancel`, `suspend`, `resume`). `UpstreamClient` authenticates client_credentials with `openbank-edge`, so `principal.id == "service-account-openbank-edge"`.
- **admin-ui** `/sdd` — one call, `/api/v1/sdd/mandates/recent` (`sdd.list`). Its BFF forwards the operator's **own** session token, not a service account.

Nothing else calls it: the only other repo hits for sdd outside the service (sentinel, delegation) are comments.

## Evidence — post-change matrix against the regenerated bundle

Realm read: the **deployed** `gitops/components/keycloak/realm-template.json`, which seeds `demo@` = `ROLE_VIEWER`, `compliance@`/`compliance2@` = `ROLE_COMPLIANCE`+`ROLE_VIEWER`, `admin@` = `ADMIN`+`OPERATOR`+`VIEWER`, `service-account-openbank-edge` = `ROLE_OPERATOR`, `service-account-openbank-services` = `ROLE_API`. The docker and CI realms also give the shared client `ROLE_OPERATOR`, so that row is evaluated **both ways** below.

| action | operator | admin | demo VIEWER | compliance | edge SA | services SA (API) | services SA (OPERATOR) | anon |
|---|---|---|---|---|---|---|---|---|
| sdd.create | operator-sdd-write | operator-sdd-write | DENY | DENY | edge-service-sdd | DENY | DENY | DENY |
| sdd.list | operator-read-any | operator-read-any | sdd-oversight-read | sdd-oversight-read | edge-service-sdd | DENY | operator-read-any | DENY |
| sdd.read | operator-read-any | operator-read-any | sdd-oversight-read | compliance-read-any | edge-service-sdd | DENY | operator-read-any | DENY |
| sdd.approve | operator-sdd-write | operator-sdd-write | DENY | DENY | DENY | DENY | DENY | DENY |
| sdd.update | operator-sdd-write | operator-sdd-write | DENY | DENY | edge-service-sdd | DENY | DENY | DENY |
| sdd.delete | operator-sdd-write | operator-sdd-write | DENY | DENY | edge-service-sdd | DENY | DENY | DENY |
| sdd.authorise | operator-sdd-write | operator-sdd-write | DENY | DENY | DENY | DENY | DENY | DENY |
| **zzz.frobnicate (must-DENY control)** | **DENY** | **DENY** | **DENY** | **DENY** | **DENY** | **DENY** | **DENY** | **DENY** |

Every action a real caller uses resolves ALLOW for that caller. `sdd.approve` (B2B confirmation) and `sdd.authorise` (the decision that books the debit) stay closed to every M2M principal, as `sdd_rest_ext.rego` documents.

The probe was falsified before it was trusted: the first run returned `false` for **every** cell including the must-ALLOW controls — `opa eval -I` takes the input document directly, and the input had been wrapped in `{"input": …}`. A run with no passing control is not evidence.

## The regression this found, and the rule that closes it

Both read resources declare `@RolesAllowed("ROLE_VIEWER", "ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_PAYMENTS", "ROLE_API")`, and admin-ui's `/sdd` page is not role-gated. Against the bundle **as deployed today**:

```
sdd.list  ROLE_VIEWER      -> false      sdd.read  ROLE_VIEWER      -> false
sdd.list  ROLE_COMPLIANCE  -> false      sdd.read  ROLE_COMPLIANCE  -> compliance-read-any
```

`operator-read-any` needs `ROLE_OPERATOR`; `compliance-read-any` matches only actions ending in `.read`, so the **list** endpoint an analyst actually opens was ungranted. Flipping alone would have 403'd `demo@` and both compliance users on a read they are entitled to — a regression introduced by the security change itself.

`sdd-oversight-read` closes it, following the shape aml / balances / fx / ledger already use. It is read-only **by construction**: the action set is a closed two-action literal, not a `startswith(input.action, "sdd.")` family, so no widening of `sdd.*` can leak through it, and neither role appears on any sdd write path. It grants the shared backend client nothing new (`ROLE_API` in the deployed realm; where it holds `ROLE_OPERATOR`, base `operator-read-any` already covered both actions).

Four tests added, and falsified: replacing the literal action set with `startswith(input.action, "sdd.")` turns `test_oversight_read_grants_no_write` red (16/17), and restoring it returns 17/17. One of the four is this file's own must-DENY control.

## Known residual, not introduced here

`service-account-openbank-services` holding `ROLE_OPERATOR` resolves ALLOW on `sdd.list`/`sdd.read` via base `matrix-allows`/`operator-read-any` — the fleet-wide M2M read residual tracked in #3734/#3765. It is **reads only**: every sdd write denies for that principal in the table above, which is exactly what `sdd_rest_ext.rego`'s `service-account-` exclusion exists to guarantee. So this flip does not depend on #3734 landing first.

## Scope and process

- Money-path service: **2 approvals** required, and the threat model `docs/threat-models/openbank-sdd-service.md` already exists (ADR-0030).
- Bundle regenerated with `gen-sdd-opa-bundle.sh`, checked idempotent; the pod-roll `policy-checksum` annotation moved to `8e0f99066014f337` in the same run so the flip actually rolls the pod. No bundle or annotation hand-edited.
- Read-only against the cluster and AWS throughout — nothing applied, nothing patched, nothing merged.

## Deliberately NOT flipped

The other three money-path services still at `AUTHZ_ENFORCE=false` — `psd2-service`, `sanctions-service`, `standing-order-service` — are untouched here. Each needs its own per-action enumeration against its own bundle, and `psd2` in particular has a third-party caller by design. #3679 stays open for them.
