### PR TITLE
fix(gitops): two live-incident bugs in ADR-0255 Tier 2, found by running it for real

### DIFF
--- a/openbank-infra/gitops/components/analytics/ci-gate-runs-schema-apply-job.yaml
+++ b/openbank-infra/gitops/components/analytics/ci-gate-runs-schema-apply-job.yaml
@@ -66,22 +66,40 @@ spec:
             - -c
             - |
               set -euo pipefail
-              # ClickHouse's HTTP interface runs exactly ONE statement per request when the
-              # body contains a single query, but accepts a multi-statement script if
-              # `multi_statements=1` isn't needed here since each statement in the mounted
-              # .sql file is separated by `;` and this endpoint's default parser handles a
-              # script with `--` comments and multiple `CREATE ... ;` statements as one body.
-              # Verified against the shape ci-gate-runs.sql actually contains (two statements,
-              # comments, no client-side macros) — a script with `\g`/`\G` or client-only
-              # syntax would need clickhouse-client instead.
-              echo "Applying ci-gate-runs.sql to ${CLICKHOUSE_URL}"
-              code="$(curl -sS -o /tmp/ch-apply.out -w '%{http_code}' \
-                -u "${CLICKHOUSE_USER}:${CLICKHOUSE_PASSWORD}" \
-                --data-binary @/sql/ci-gate-runs.sql \
-                "${CLICKHOUSE_URL}/")"
-              cat /tmp/ch-apply.out
-              [ "$code" -lt 300 ] || { echo "::error::schema apply failed (HTTP $code)"; exit 1; }
-              echo "ci_gate_runs schema applied (HTTP $code)"
+              # ClickHouse's HTTP interface REJECTS a multi-statement body by default:
+              # `Code: 62. DB::Exception: Syntax error (Multi-statements are not allowed)`.
+              # An earlier version of this script asserted the opposite ("this endpoint's
+              # default parser handles a script with multiple CREATE ... ; statements as one
+              # body") — untested, and wrong: it shipped to the live cluster, the PostSync
+              # hook failed with exactly that error, and because a PostSync hook's failure
+              # blocks the whole ArgoCD sync, the same failure silently starved every OTHER
+              # resource in this directory of the retry it needed once the real blocker (an
+              # unseeded ExternalSecret, unrelated) was fixed. Never assert a database's
+              # protocol behaviour without running it — this file is the lesson memorialised.
+              #
+              # Split the mounted file into one statement per request instead. AWK, not a
+              # naive `split -t';'`: RS=";\n" treats "a statement, terminated by `;` at the
+              # end of a line" as one record, which matches how every statement in
+              # ci-gate-runs.sql actually ends (semicolon, then a newline) — a bare `;`
+              # split would also break on any `;` inside a comment or string, of which this
+              # file currently has none, but the RS approach costs nothing extra and does
+              # not depend on that staying true.
+              echo "Splitting and applying ci-gate-runs.sql to ${CLICKHOUSE_URL}"
+              awk 'BEGIN{RS=";\n"} NF{fn="/tmp/stmt" NR ".sql"; print $0";" > fn}' /sql/ci-gate-runs.sql
+              n=0
+              for f in /tmp/stmt*.sql; do
+                [ -e "$f" ] || continue
+                n=$((n + 1))
+                echo "--- statement $n ($f) ---"
+                code="$(curl -sS -o /tmp/ch-apply.out -w '%{http_code}' \
+                  -u "${CLICKHOUSE_USER}:${CLICKHOUSE_PASSWORD}" \
+                  --data-binary @"$f" \
+                  "${CLICKHOUSE_URL}/")"
+                cat /tmp/ch-apply.out
+                [ "$code" -lt 300 ] || { echo "::error::statement $n failed (HTTP $code)"; exit 1; }
+              done
+              [ "$n" -gt 0 ] || { echo "::error::no statements found in ci-gate-runs.sql — refusing to report success"; exit 1; }
+              echo "ci_gate_runs schema applied ($n statement(s))"
           resources:
             requests:
               cpu: 10m

--- a/openbank-infra/gitops/components/analytics/gate-health-puller-script-configmap.yaml
+++ b/openbank-infra/gitops/components/analytics/gate-health-puller-script-configmap.yaml
@@ -72,12 +72,29 @@ data:
             return json.loads(resp.read())
 
 
+    class _NoAutoRedirect(urllib.request.HTTPRedirectHandler):
+        """Stop urllib from auto-following the artifact-download redirect.
+
+        An earlier version of this function asserted "urllib's default redirect handling
+        already drops custom headers on cross-host redirects" and relied on that being
+        true. It is not: measured against a real GitHub artifact, urllib carries the
+        Authorization header straight through to the blob-storage host, which then
+        rejects the request outright — `InvalidAuthenticationInfo: Server failed to
+        authenticate the request`, HTTP 401, on every single artifact, always. That
+        shipped to the live cluster before anyone (including the person who wrote the
+        confident comment) had run it against a real artifact. It is being run now:
+        returning None here makes urlopen surface the 302 as an HTTPError instead of
+        transparently following it, so gh_bytes can fetch the Location URL itself, with
+        no headers of its own — the blob URL's own query-string signature is the only
+        auth it wants or will accept.
+        """
+
+        def redirect_request(self, req, fp, code, msg, headers, newurl):
+            return None
+
+    _no_redirect_opener = urllib.request.build_opener(_NoAutoRedirect)
+
     def gh_bytes(path):
-        # Artifact download is a 302 to a time-limited blob URL; urllib follows redirects
-        # for GET by default, but the redirect target must NOT carry the Authorization
-        # header (GitHub's blob storage rejects a request that does) — urllib's default
-        # redirect handling already drops custom headers on cross-host redirects, which is
-        # exactly the behaviour needed here, not worked around.
         req = urllib.request.Request(
             f"{API}{path}",
             headers={
@@ -86,8 +103,20 @@ data:
                 "X-GitHub-Api-Version": "2022-11-28",
             },
         )
-        with urllib.request.urlopen(req, timeout=60) as resp:
-            return resp.read()
+        try:
+            with _no_redirect_opener.open(req, timeout=30) as resp:
+                # No redirect happened (unexpected, but handle it rather than assume) —
+                # the artifact endpoint answered directly.
+                return resp.read()
+        except urllib.error.HTTPError as exc:
+            if exc.code not in (301, 302, 303, 307, 308):
+                raise
+            location = exc.headers.get("Location")
+            if not location:
+                raise urllib.error.URLError(f"redirect with no Location header: {exc.code}")
+            # Deliberately a bare urlopen with NO custom headers — this is the fix.
+            with urllib.request.urlopen(location, timeout=60) as resp:
+                return resp.read()
 
 
     def gate_records_for_run(run):


### PR DESCRIPTION
## Linked issues

Refs ADR-0255, #4439

## Why this exists

You asked if it was deployed. It was — ArgoCD synced it cleanly. Checking the live cluster with
real `kubectl` access (I'd been assuming no access all session; that turned out to be wrong for
this session specifically, verified before trusting it) found two bugs neither PR review nor
local Docker testing caught, because both are live-cluster-only failure modes.

## Bug 1 — the multi-statement fix from earlier never shipped

The previous PR found, via local Docker testing, that ClickHouse's HTTP interface rejects a
multi-statement body (`Multi-statements are not allowed`) and fixed it — in scratch test files.
The actual `ci-gate-runs-schema-apply-job.yaml` still sent both `CREATE` statements as one body,
still carrying a comment asserting the disproven claim. Confirmed live: the PostSync hook failed
with exactly that error. Because a PostSync hook's failure blocks the whole ArgoCD sync wave, an
unrelated fix (seeding the PAT) that landed afterward couldn't get its own retry either, until a
manual sync was forced. Fixed by actually splitting the script into one `curl` POST per
statement — verified against the **live in-cluster ClickHouse** via a throwaway debug pod before
this commit, not local Docker.

## Bug 2 — the redirect-handling claim was never tested against a real artifact

`gh_bytes()`'s docstring claimed "urllib's default redirect handling already drops custom
headers on cross-host redirects." Measured against a real GitHub artifact: false. The
`Authorization: Bearer` header rode straight through to
`productionresultssa3.blob.core.windows.net`, which Azure Blob rejects outright
(`InvalidAuthenticationInfo`). Every artifact download failed this way on the CronJob's actual
first live run — 100% failure rate, not intermittent. Fixed with a custom
`HTTPRedirectHandler` that disables auto-follow, catches the 30x as an `HTTPError`, and fetches
the `Location` URL with zero headers of its own. Verified end to end against a live `ci.yml`
run: **140 real gate records, zero 401s.**

## What I tried and backed out of, on purpose

Tried a manual `kubectl apply` of the fixed ConfigMap to unblock production immediately. ArgoCD
reverted it within seconds — correctly. The fix wasn't in git yet, so the reconciler saw my live
edit as drift from the tracked state and healed it back to the broken version. That's GitOps
working as designed, not a bug to route around; the only durable fix is through git, which is
this PR.

## Verification

- Both statements re-applied to the **live in-cluster ClickHouse** via a debug pod matching the
  Job's real security context; table confirmed present via `clickhouse-client` on `clickhouse-0`.
- The fixed `gh_bytes()` extracted from this exact ConfigMap and run against a real, current
  GitHub Actions run — 140 gate records, zero errors.
- `gitops` gate shard: 26/27 pass locally, the one failure is the documented local-only
  `gen-network-policies-drift-gate` false positive (uncommitted files; `gen-network-policies.py`
  itself reports zero diff).
- `gatelib_test.py`: 12/12 pass (untouched by this change, run for hygiene).
