### PR TITLE
feat(gitops): per-gate pass-rate and duration tables in the CI gate dashboard

### DIFF
--- a/openbank-infra/gitops/components/observability/dashboard-openbank-ci-gates.yaml
+++ b/openbank-infra/gitops/components/observability/dashboard-openbank-ci-gates.yaml
@@ -213,6 +213,72 @@ data:
             },
             "overrides": []
           }
+        },
+        {
+          "id": 8,
+          "type": "table",
+          "title": "Per-gate pass rate, worst first (30d, executed runs only)",
+          "description": "Pass rate over EXECUTED runs — status != 'skipped' — not over every run. A pull_request-only gate (`when: pull_request`) correctly skips on every push event, and counting that as a failure would put every PR-only gate at the top of a 'worst' list for running exactly as designed. Verified against real data before shipping: the naive all-runs version put six perfectly healthy PR-only/advisory gates at ~52% pass rate purely from push-event skips, with the one REAL outlier (pr-file-overlap, an advisory gate that legitimately fires when another open PR touches the same files) buried among them. HAVING executed >= 5 keeps a brand-new gate with two data points from reading as 0% or 100% on noise.",
+          "gridPos": { "x": 0, "y": 38, "w": 24, "h": 10 },
+          "datasource": { "type": "grafana-clickhouse-datasource", "uid": "clickhouse" },
+          "targets": [
+            {
+              "datasource": { "type": "grafana-clickhouse-datasource", "uid": "clickhouse" },
+              "refId": "A",
+              "editorType": "sql",
+              "format": 2,
+              "rawSql": "SELECT gate_id, shard, mode, countIf(status NOT IN ('skipped')) AS executed, round(countIf(status='ok') / greatest(countIf(status NOT IN ('skipped')), 1), 3) AS pass_rate, argMax(status, run_created_at) AS latest_status FROM openbank_analytics.ci_gate_runs WHERE run_created_at >= now() - INTERVAL 30 DAY GROUP BY gate_id, shard, mode HAVING executed >= 5 ORDER BY pass_rate ASC, executed DESC LIMIT 30"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": [
+              {
+                "matcher": { "id": "byName", "options": "pass_rate" },
+                "properties": [
+                  { "id": "unit", "value": "percentunit" },
+                  {
+                    "id": "thresholds",
+                    "value": {
+                      "mode": "absolute",
+                      "steps": [
+                        { "color": "red", "value": null },
+                        { "color": "yellow", "value": 0.9 },
+                        { "color": "green", "value": 0.99 }
+                      ]
+                    }
+                  },
+                  { "id": "custom.cellOptions", "value": { "type": "color-background" } }
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "id": 9,
+          "type": "table",
+          "title": "Per-gate wall time, slowest first (30d, p50/p95)",
+          "description": "One row per gate, not per shard — this is the breakdown the shard-level 'wall time per shard' panel above cannot give you: WHICH gate inside a slow shard is actually the slow one.",
+          "gridPos": { "x": 0, "y": 48, "w": 24, "h": 10 },
+          "datasource": { "type": "grafana-clickhouse-datasource", "uid": "clickhouse" },
+          "targets": [
+            {
+              "datasource": { "type": "grafana-clickhouse-datasource", "uid": "clickhouse" },
+              "refId": "A",
+              "editorType": "sql",
+              "format": 2,
+              "rawSql": "SELECT gate_id, shard, mode, count() AS runs, round(quantile(0.5)(seconds), 3) AS p50_seconds, round(quantile(0.95)(seconds), 3) AS p95_seconds, max(budget_seconds) AS budget_seconds FROM openbank_analytics.ci_gate_runs WHERE run_created_at >= now() - INTERVAL 30 DAY AND status != 'skipped' GROUP BY gate_id, shard, mode ORDER BY p95_seconds DESC LIMIT 30"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": [
+              {
+                "matcher": { "id": "byRegexp", "options": "p(50|95)_seconds|budget_seconds" },
+                "properties": [{ "id": "unit", "value": "s" }]
+              }
+            ]
+          }
         }
       ]
     }


### PR DESCRIPTION
## Linked issues

Refs ADR-0255

Stranded by `--auto` merging #4447 the instant its first commit's checks passed — before this
second commit (pushed to the same branch) landed. `--auto` merges immediately at whatever head
SHA satisfies checks; it does not wait for or absorb a later push. Rebasing onto the now-updated
`main` and re-opening rather than trying to reopen the closed PR.

The dashboard's existing panels are all shard-level aggregates — wall time per shard, pass rate
per shard. That answers 'is gitops slow', not 'which gate inside gitops is slow' — the user
asked for exactly that: measure and evaluate individual gates, not just shards.

Two new tables, both verified against real live data through Grafana's own `/api/ds/query`
before shipping (161+ real gate-runs from live `ci.yml` runs, not a fixture):

- **Per-gate pass rate, worst first.** First draft counted `skipped` as a failure, which put six
  perfectly healthy `pull_request`-only/advisory gates at ~52% pass rate purely from push-event
  skips, burying the one real outlier (`pr-file-overlap`, 74.2% — an advisory gate that
  legitimately fires when another open PR touches the same files) among false positives. Fixed:
  pass rate computed over EXECUTED runs (`status != 'skipped'`) only. Caught by testing against
  real data, not by reading the query.
- **Per-gate wall time, p50/p95, slowest first** — the breakdown the shard-level panel
  structurally cannot give: which gate inside a slow shard is actually the slow one.

## Verification

Both queries run through Grafana's live `/api/ds/query` endpoint against the real
`ci_gate_runs` table — status 200, values matching a direct `clickhouse-client` query.