### PR TITLE
feat(campaign): expose journey entry sources

### DIFF
--- a/.github/asvs-l3-baseline.txt
+++ b/.github/asvs-l3-baseline.txt
@@ -254,6 +254,11 @@ V9.1 openbank-infra/gitops/components/admin-ui/admin-ui.yaml:99: plaintext http:
 # it does not add one. Retires with the fleet-wide mTLS work alongside the other 215 lines here.
 V9.1 openbank-infra/gitops/components/customer-edge/customer-edge.yaml:178: plaintext http:// env value http://delegation-service.delegation.svc:8126
 
+# customer-edge -> engagement-service (#4475). This makes the existing in-cluster HTTP
+# transport explicit so the generated NetworkPolicy can admit the real campaign-surface call;
+# it retires with the same fleet-wide mesh-mTLS work as the existing customer-edge entries.
+V9.1 openbank-infra/gitops/components/customer-edge/customer-edge.yaml:230: plaintext http:// env value http://engagement-service.engagement.svc:8153
+
 # fraud -> account-service (ADR-0220 D3.5, issue #2749). Genuinely a NEW plaintext edge, declared
 # as such: fraud-service's first-ever outbound rest-client (AccountServiceClient, partyId lookup
 # for the fraud-hold signal) reaches account-service the only way any of the 200+ other callers in

--- a/docs/asyncapi/openbank-events.yaml
+++ b/docs/asyncapi/openbank-events.yaml
@@ -715,7 +715,7 @@ components:
 
     NotificationRequestPayload:
       type: object
-      required: [partyId, channel, templateId]
+      required: [partyId, channel, template, recipient, variables]
       properties:
         partyId:
           type: string
@@ -723,13 +723,23 @@ components:
         channel:
           type: string
           enum: [EMAIL, PUSH]
-        templateId:
+        template:
           type: string
-          enum: [ACCOUNT_OPENED, PAYMENT_COMPLETED, KYC_REJECTED, OTP_CODE, WELCOME]
+          description: Closed notification-service template identifier.
+        recipient:
+          type: string
         variables:
           type: object
           additionalProperties:
             type: string
+        correlationId:
+          type: string
+          format: uuid
+          description: Optional producer-owned delivery-outcome correlation id.
+        deepLink:
+          type: string
+          enum: [openbank://home, openbank://savings, openbank://cards, openbank://payments, openbank://products]
+          description: Optional allow-listed mobile route for a PUSH tap. Never customer content.
 
     SwiftMessageEventPayload:
       allOf:

--- a/openbank-admin-ui/e2e/campaign-content-experiment.spec.ts
+++ b/openbank-admin-ui/e2e/campaign-content-experiment.spec.ts
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import { expect, test } from '@playwright/test'
+import { signInAsOperator } from './helpers/auth'
+
+const CAMPAIGN_ID = '019fb93a-0d54-7f05-aad3-9e8c7c9bc110'
+
+test.beforeEach(async ({ context, baseURL }) => {
+  await signInAsOperator(context, baseURL!)
+})
+
+test('authors a measured A/B content experiment and renders its conservative result', async ({ page }) => {
+  let createBody: Record<string, unknown> | undefined
+  await page.route(/\/api\/segments$/, route => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({ state: 'ok', items: [{ name: 'actives', version: 1, rules: ['party status is ACTIVE'] }] }),
+  }))
+  await page.route(/\/api\/campaigns\/cadences$/, route => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({ state: 'ok', items: [{ cadence: 'DAILY_MORNING', humanForm: 'every day at 09:00', zone: 'Europe/Prague' }] }),
+  }))
+  await page.route(/\/api\/campaigns\/triggers$/, route => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({ state: 'ok', items: [{ trigger: 'ACCOUNT_OPENED', humanForm: 'when an account is opened' }] }),
+  }))
+  await page.route(/\/api\/campaigns$/, route => {
+    if (route.request().method() !== 'POST') return route.fallback()
+    createBody = route.request().postDataJSON() as Record<string, unknown>
+    return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ state: 'ok', campaign: { id: CAMPAIGN_ID } }) })
+  })
+  await page.route(new RegExp(`/api/campaigns/${CAMPAIGN_ID}$`), route => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({
+      campaign: {
+        id: CAMPAIGN_ID,
+        name: 'Headline comparison',
+        goal: 'Open more accounts',
+        segmentRef: { name: 'actives', version: 1 },
+        state: 'ACTIVE',
+        createdBy: 'operator',
+        approvedBy: 'checker',
+        conversionRule: 'ACCOUNT_OPENED',
+        steps: [{ order: 1, template: 'MARKETING_PRODUCT_OFFER', delaySeconds: 0, variantBVariables: { offerTitle: 'B' } }],
+      },
+      enrolments: [],
+      sends: { items: [], total: 0, page: 0, size: 50 },
+      partyNames: {},
+      sendSummary: {},
+      journey: [],
+      contentExperiment: {
+        a: { assigned: 120, converted: 10, conversionRate: 10 / 120 },
+        b: { assigned: 120, converted: 30, conversionRate: 0.25 },
+        observedLiftPercentagePoints: 16.666667,
+        decision: {
+          state: 'B_OUTPERFORMS_A',
+          minimumAssignedPerVariant: 100,
+          aConfidenceInterval: { lower: 0.04, upper: 0.16 },
+          bConfidenceInterval: { lower: 0.18, upper: 0.34 },
+        },
+      },
+      sources: { campaign: 'ok', enrolments: 'ok', sends: 'ok', sendSummary: 'ok', journey: 'ok', contentExperiment: 'ok' },
+    }),
+  }))
+
+  await page.goto('/campaigns/new')
+  await page.locator('#c-name').fill('Headline comparison')
+  await page.locator('#c-goal').fill('Open more accounts')
+  await page.locator('[data-segment="actives@1"]').click()
+  await page.locator('#var-0-offerTitle').fill('Save more with A')
+  await page.locator('#var-0-offerText').fill('A copy')
+  await page.locator('#var-0-ctaText').fill('Open')
+  await page.locator('[data-conversion-pick="ACCOUNT_OPENED"]').click()
+  await page.locator('#c-content-experiment').check()
+  await page.locator('#var-b-0-offerTitle').fill('Save more with B')
+  await page.locator('#var-b-0-offerText').fill('B copy')
+  await page.locator('#var-b-0-ctaText').fill('Try')
+  await page.getByRole('button', { name: /Založit koncept|Create draft/ }).click()
+
+  await expect.poll(() => createBody).toMatchObject({
+    conversionRule: 'ACCOUNT_OPENED',
+    steps: [{ variables: { offerTitle: 'Save more with A' }, variantBVariables: { offerTitle: 'Save more with B' } }],
+  })
+  await expect(page).toHaveURL(`/campaigns/${CAMPAIGN_ID}`)
+  await expect(page.locator('[data-content-experiment-decision]')).toContainText(/variant B|varianty B/i)
+  await expect(page.locator('[data-content-experiment-decision]')).toContainText(/not deploy|sám nenasazuje/i)
+})

--- a/openbank-admin-ui/e2e/campaign-entry-authoring.spec.ts
+++ b/openbank-admin-ui/e2e/campaign-entry-authoring.spec.ts
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import { expect, test } from '@playwright/test'
+import { signInAsOperator } from './helpers/auth'
+
+const CAMPAIGN_ID = '019fb939-3e0a-7716-a1ed-7854754c8786'
+
+test.beforeEach(async ({ context, baseURL }) => {
+  await signInAsOperator(context, baseURL!)
+})
+
+test('authors a recurring campaign from the service cadence catalogue', async ({ page }) => {
+  let createBody: Record<string, unknown> | undefined
+  await page.route('**/api/segments', route => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({ state: 'ok', items: [{ name: 'actives', version: 1, rules: ['party status is ACTIVE'] }] }),
+  }))
+  await page.route('**/api/campaigns/cadences', route => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({
+      state: 'ok',
+      items: [{ cadence: 'DAILY_MORNING', humanForm: 'every day at 09:00', zone: 'Europe/Prague' }],
+    }),
+  }))
+  await page.route('**/api/campaigns/triggers', route => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({ state: 'ok', items: [{ trigger: 'ACCOUNT_OPENED', humanForm: 'when an account is opened' }] }),
+  }))
+  await page.route('**/api/campaigns', route => {
+    if (route.request().method() !== 'POST') return route.fallback()
+    createBody = route.request().postDataJSON() as Record<string, unknown>
+    return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ state: 'ok', campaign: { id: CAMPAIGN_ID } }) })
+  })
+  await page.route(`**/api/campaigns/${CAMPAIGN_ID}`, route => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({
+      campaign: { id: CAMPAIGN_ID, name: 'Recurring welcome', goal: 'Engage new customers', segmentRef: { name: 'actives', version: 1 }, state: 'DRAFT', createdBy: 'operator', approvedBy: null, steps: [] },
+      enrolments: [], sends: { items: [], total: 0, page: 0, size: 50 }, partyNames: {}, sendSummary: {}, journey: [], sources: { campaign: 'ok', enrolments: 'ok', sends: 'ok', sendSummary: 'ok', journey: 'ok', experiment: 'not_configured' },
+    }),
+  }))
+
+  await page.goto('/campaigns/new')
+  await page.locator('#c-name').fill('Recurring welcome')
+  await page.locator('#c-goal').fill('Engage new customers')
+  await page.locator('[data-segment="actives@1"]').click()
+  await page.locator('#var-0-offerTitle').fill('Welcome')
+  await page.locator('#var-0-offerText').fill('Thanks for joining.')
+  await page.locator('#var-0-ctaText').fill('Explore')
+  await page.locator('[data-entry-pick="SCHEDULE"]').click()
+  await expect(page.locator('[data-cadence]')).toHaveValue('DAILY_MORNING')
+  await page.getByRole('button', { name: /Založit koncept|Create draft/ }).click()
+
+  await expect.poll(() => createBody).toMatchObject({ schedule: { cadence: 'DAILY_MORNING' } })
+  expect(createBody).not.toHaveProperty('trigger')
+  await expect(page).toHaveURL(`/campaigns/${CAMPAIGN_ID}`)
+})

--- a/openbank-admin-ui/src/app/api/campaigns/[id]/route.ts
+++ b/openbank-admin-ui/src/app/api/campaigns/[id]/route.ts
@@ -96,6 +96,26 @@ async function readExperiment(headers: HeadersInit, id: string): Promise<Part> {
   }
 }
 
+/** A 409 is the honest absent A/B configuration, distinct from a degraded campaign-service. */
+async function readContentExperiment(headers: HeadersInit, id: string): Promise<Part> {
+  try {
+    const res = await fetch(
+      serverSvcUrl('campaign-service', 'campaign', 8128, `/api/v1/campaigns/${encodeURIComponent(id)}/content-experiment`),
+      { headers, signal: AbortSignal.timeout(4000), cache: 'no-store' },
+    )
+    if (res.status === 409) return { data: null, state: 'not_configured' }
+    if (!res.ok) {
+      return {
+        data: null,
+        state: res.status === 401 || res.status === 403 ? 'unauthorized' : res.status === 404 ? 'not_deployed' : 'unreachable',
+      }
+    }
+    return { data: await res.json(), state: 'ok' }
+  } catch {
+    return { data: null, state: 'unreachable' }
+  }
+}
+
 export async function GET(_req: Request, ctx: { params: Promise<{ id: string }> }) {
   const session = await auth()
   if (!session?.user?.accessToken) {
@@ -128,10 +148,16 @@ export async function GET(_req: Request, ctx: { params: Promise<{ id: string }> 
 
   // Stable catalogue keys belong on the campaign record. Resolve the human label only for a
   // configured entry source, so an ordinary detail page does not pay two calls to explain nulls.
-  const entry = campaign.data as { schedule?: unknown; trigger?: unknown } | null
-  const [cadences, triggers] = await Promise.all([
+  const entry = campaign.data as {
+    schedule?: unknown
+    trigger?: unknown
+    steps?: Array<{ variantBVariables?: unknown }>
+  } | null
+  const hasContentExperiment = entry?.steps?.some(step => step.variantBVariables != null) ?? false
+  const [cadences, triggers, contentExperiment] = await Promise.all([
     entry?.schedule ? read(headers, '/api/v1/campaigns/cadences', []) : Promise.resolve({ data: [], state: 'ok' as PartState }),
     entry?.trigger ? read(headers, '/api/v1/campaigns/triggers', []) : Promise.resolve({ data: [], state: 'ok' as PartState }),
+    hasContentExperiment ? readContentExperiment(headers, id) : Promise.resolve({ data: null, state: 'not_configured' as PartState }),
   ])
 
   // Names for every party on this screen, resolved once and deduplicated. Done here rather than in
@@ -155,6 +181,7 @@ export async function GET(_req: Request, ctx: { params: Promise<{ id: string }> 
     sendSummary: sendSummary.data,
     journey: journey.data,
     experiment: experiment.data,
+    contentExperiment: contentExperiment.data,
     entryCatalogues: { cadences: cadences.data, triggers: triggers.data },
     // Per-part state travels to the client: the send log is the part most likely to be
     // restricted, and an empty send log rendered as "nothing was suppressed" would be the
@@ -166,6 +193,7 @@ export async function GET(_req: Request, ctx: { params: Promise<{ id: string }> 
       sendSummary: sendSummary.state,
       journey: journey.state,
       experiment: experiment.state,
+      contentExperiment: contentExperiment.state,
       cadences: cadences.state,
       triggers: triggers.state,
     },

--- a/openbank-admin-ui/src/app/api/campaigns/[id]/route.ts
+++ b/openbank-admin-ui/src/app/api/campaigns/[id]/route.ts
@@ -126,6 +126,14 @@ export async function GET(_req: Request, ctx: { params: Promise<{ id: string }> 
     readExperiment(headers, id),
   ])
 
+  // Stable catalogue keys belong on the campaign record. Resolve the human label only for a
+  // configured entry source, so an ordinary detail page does not pay two calls to explain nulls.
+  const entry = campaign.data as { schedule?: unknown; trigger?: unknown } | null
+  const [cadences, triggers] = await Promise.all([
+    entry?.schedule ? read(headers, '/api/v1/campaigns/cadences', []) : Promise.resolve({ data: [], state: 'ok' as PartState }),
+    entry?.trigger ? read(headers, '/api/v1/campaigns/triggers', []) : Promise.resolve({ data: [], state: 'ok' as PartState }),
+  ])
+
   // Names for every party on this screen, resolved once and deduplicated. Done here rather than in
   // the component so the client never fans out one request per row, and so an unresolved name
   // degrades to the id instead of blanking the screen (lib/campaigns/party-names).
@@ -147,6 +155,7 @@ export async function GET(_req: Request, ctx: { params: Promise<{ id: string }> 
     sendSummary: sendSummary.data,
     journey: journey.data,
     experiment: experiment.data,
+    entryCatalogues: { cadences: cadences.data, triggers: triggers.data },
     // Per-part state travels to the client: the send log is the part most likely to be
     // restricted, and an empty send log rendered as "nothing was suppressed" would be the
     // exact misreading this screen exists to prevent.
@@ -157,6 +166,8 @@ export async function GET(_req: Request, ctx: { params: Promise<{ id: string }> 
       sendSummary: sendSummary.state,
       journey: journey.state,
       experiment: experiment.state,
+      cadences: cadences.state,
+      triggers: triggers.state,
     },
   })
 }

--- a/openbank-admin-ui/src/app/api/campaigns/cadences/route.ts
+++ b/openbank-admin-ui/src/app/api/campaigns/cadences/route.ts
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import { NextResponse } from 'next/server'
+import { auth } from '@/auth'
+import { serverSvcUrl } from '@/lib/services/bff'
+
+export const dynamic = 'force-dynamic'
+
+/** The reviewed cadence catalogue for Campaign Studio; never a locally duplicated cron list. */
+export async function GET() {
+  const session = await auth()
+  if (!session?.user?.accessToken) return NextResponse.json({ error: 'unauthenticated' }, { status: 401 })
+  try {
+    const res = await fetch(serverSvcUrl('campaign-service', 'campaign', 8128, '/api/v1/campaigns/cadences'), {
+      headers: { authorization: `Bearer ${session.user.accessToken}` },
+      signal: AbortSignal.timeout(4000),
+      cache: 'no-store',
+    })
+    if (!res.ok) {
+      return NextResponse.json({ items: [], state: res.status === 401 || res.status === 403 ? 'unauthorized' : 'unreachable' })
+    }
+    return NextResponse.json({ items: await res.json(), state: 'ok' })
+  } catch {
+    return NextResponse.json({ items: [], state: 'unreachable' })
+  }
+}

--- a/openbank-admin-ui/src/app/api/campaigns/triggers/route.ts
+++ b/openbank-admin-ui/src/app/api/campaigns/triggers/route.ts
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import { NextResponse } from 'next/server'
+import { auth } from '@/auth'
+import { serverSvcUrl } from '@/lib/services/bff'
+
+export const dynamic = 'force-dynamic'
+
+/** The trigger catalogue is an upstream contract, never a client-maintained event list. */
+export async function GET() {
+  const session = await auth()
+  if (!session?.user?.accessToken) return NextResponse.json({ error: 'unauthenticated' }, { status: 401 })
+  try {
+    const res = await fetch(serverSvcUrl('campaign-service', 'campaign', 8128, '/api/v1/campaigns/triggers'), {
+      headers: { authorization: `Bearer ${session.user.accessToken}` },
+      signal: AbortSignal.timeout(4000),
+      cache: 'no-store',
+    })
+    if (!res.ok) {
+      return NextResponse.json({ items: [], state: res.status === 401 || res.status === 403 ? 'unauthorized' : 'unreachable' })
+    }
+    return NextResponse.json({ items: await res.json(), state: 'ok' })
+  } catch {
+    return NextResponse.json({ items: [], state: 'unreachable' })
+  }
+}

--- a/openbank-admin-ui/src/app/campaigns/[id]/page.tsx
+++ b/openbank-admin-ui/src/app/campaigns/[id]/page.tsx
@@ -13,6 +13,7 @@ import { PageHeader, StatCard, StatusBadge, type Tone } from '@/components/ui'
 import { JourneyCanvas, type StepFunnel } from '@/components/campaigns/JourneyCanvas'
 import { SectionBoundary } from '@/components/feedback/SectionBoundary'
 import { PeopleSummary } from '@/components/campaigns/PeopleSummary'
+import { CampaignOutcomeBrief } from '@/components/campaigns/CampaignOutcomeBrief'
 
 interface Campaign {
   id: string
@@ -22,7 +23,14 @@ interface Campaign {
   state: string
   createdBy: string
   approvedBy: string | null
-  steps: { order: number; template: string; delaySeconds: number }[]
+  steps: {
+    order: number
+    template: string
+    delaySeconds: number
+    variantBVariables?: Record<string, string> | null
+    fallbackToPush?: boolean
+    mobileDestination?: 'HOME' | 'SAVINGS' | 'CARDS' | 'PAYMENTS' | 'PRODUCT_HUB' | null
+  }[]
   /** ADR-0245: a ConversionCatalog key, or absent when the campaign measures no conversion. */
   conversionRule?: string | null
   /** Percentage deliberately kept in the no-contact control cohort. */
@@ -51,6 +59,8 @@ interface Send {
    */
   deliveryStatus?: string
   deliveryReason?: string | null
+  /** Actual request medium, including a consent-authorized EMAIL → PUSH fallback. */
+  channel?: 'EMAIL' | 'PUSH' | null
 }
 
 interface SendPage {
@@ -74,6 +84,18 @@ interface Experiment {
   }
 }
 
+interface ContentExperiment {
+  a: { assigned: number; converted: number; conversionRate: number | null }
+  b: { assigned: number; converted: number; conversionRate: number | null }
+  observedLiftPercentagePoints: number | null
+  decision?: {
+    state: 'COLLECTING_DATA' | 'INCONCLUSIVE' | 'A_OUTPERFORMS_B' | 'B_OUTPERFORMS_A'
+    minimumAssignedPerVariant: number
+    aConfidenceInterval: { lower: number; upper: number } | null
+    bConfidenceInterval: { lower: number; upper: number } | null
+  }
+}
+
 type Detail = {
   campaign: Campaign | null
   enrolments: Enrolment[]
@@ -81,7 +103,8 @@ type Detail = {
   partyNames: Record<string, string>
   sendSummary: Record<string, number>
   journey: StepFunnel[]
-  experiment: Experiment | null;
+  experiment: Experiment | null
+  contentExperiment: ContentExperiment | null
   entryCatalogues?: {
     cadences: { cadence: string; humanForm: string; zone: string }[]
     triggers: { trigger: string; humanForm: string }[]
@@ -248,6 +271,7 @@ export default function CampaignDetailPage({ params }: { params: Promise<{ id: s
   }
   const summary = detail?.sendSummary ?? {}
   const experiment = detail?.experiment
+  const contentExperiment = detail?.contentExperiment
   const cadence = c?.schedule
     ? detail?.entryCatalogues?.cadences.find(x => x.cadence === c.schedule?.cadence)
     : undefined
@@ -298,6 +322,32 @@ export default function CampaignDetailPage({ params }: { params: Promise<{ id: s
         return t(
           '95% intervaly se oddělily ve prospěch kontroly. Zkontrolujte obsah a provedení kampaně; systém nic automaticky nevypíná.',
           'The 95% intervals separate in favour of holdout. Review campaign content and delivery; the system does not stop anything automatically.',
+        )
+    }
+  }
+
+  const contentExperimentDecisionText = (decision: ContentExperiment['decision']) => {
+    if (!decision) return t('Tato verze služby zatím neposkytuje bránu připravenosti rozhodnutí.', 'This service version does not yet provide a decision-readiness gate.')
+    switch (decision.state) {
+      case 'COLLECTING_DATA':
+        return t(
+          `Sbíráme data: pro obě varianty je potřeba alespoň ${decision.minimumAssignedPerVariant} zařazených lidí.`,
+          `Collecting data: each variant needs at least ${decision.minimumAssignedPerVariant} assigned people.`,
+        )
+      case 'INCONCLUSIVE':
+        return t(
+          'Požadovaný rozsah dat už máme, ale 95% intervaly se překrývají. Obsah teď neměňte.',
+          'The sample threshold is met, but the 95% intervals overlap. Do not change the content yet.',
+        )
+      case 'A_OUTPERFORMS_B':
+        return t(
+          '95% intervaly se oddělily ve prospěch varianty A. Je to konzervativní signál, ne automatická změna kampaně.',
+          'The 95% intervals separate in favour of variant A. It is a conservative signal, not an automatic campaign change.',
+        )
+      case 'B_OUTPERFORMS_A':
+        return t(
+          '95% intervaly se oddělily ve prospěch varianty B. Zkontrolujte výsledek; systém ji sám nenasazuje.',
+          'The 95% intervals separate in favour of variant B. Review the result; the system does not deploy it automatically.',
         )
     }
   }
@@ -370,6 +420,35 @@ export default function CampaignDetailPage({ params }: { params: Promise<{ id: s
     Object.entries(summary).filter(([outcome, count]) => outcome.startsWith('SUPPRESSED') && count > 0),
   )
 
+  const campaignNextAction = () => {
+    if (!c) return { title: '', detail: '' }
+    if (c.state === 'DRAFT') return {
+      title: t('Dokončete zadání', 'Finish the brief'),
+      detail: t('Pak ho předejte k nezávislému schválení.', 'Then submit it for independent approval.'),
+    }
+    if (c.state === 'PENDING_APPROVAL') return {
+      title: t('Vyžádejte druhé oči', 'Ask for a second pair of eyes'),
+      detail: t('Autor ji nemůže sám aktivovat.', 'The author cannot activate it alone.'),
+    }
+    if (c.state === 'PAUSED') return {
+      title: t('Rozhodněte o pokračování', 'Decide whether to resume'),
+      detail: t('Zkontrolujte cestu a teprve pak změňte stav.', 'Review the journey before changing its state.'),
+    }
+    if ((summary.FAILED ?? 0) > 0) return {
+      title: t('Prověřte neúspěšná předání', 'Review failed handoffs'),
+      detail: t('Použijte detailní log níže; potlačení pravidlem není chyba.', 'Use the detailed log below; policy suppression is not an error.'),
+    }
+    if (!c.conversionRule) return {
+      title: t('Zvažte měřitelný cíl', 'Consider a measurable outcome'),
+      detail: t('Bez něj uvidíte průchod, ale ne skutečný obchodní výsledek.', 'Without one you see flow, but not the real business outcome.'),
+    }
+    return {
+      title: t('Sledujte průchod a výsledek', 'Follow the journey and outcome'),
+      detail: t('Doručení, potlačení a konverze jsou níže oddělené, aby se nezaměnily.', 'Delivery, suppression and conversion remain separate below so they cannot be confused.'),
+    }
+  }
+  const nextAction = campaignNextAction()
+
   return (
     <div className="space-y-6">
       <Link href="/campaigns" className="inline-flex items-center gap-1 text-sm hover:underline">
@@ -419,14 +498,16 @@ export default function CampaignDetailPage({ params }: { params: Promise<{ id: s
 
       {!loading && !unavailable && c && (
         <>
-          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
-            <StatCard label={t('Stav', 'State')} value={c.state} />
-            <StatCard label={t('Segment', 'Segment')} value={`${c.segmentRef?.name}@${c.segmentRef?.version}`} />
-            <StatCard label={t('Zařazeno', 'Enrolled')} value={String(detail?.enrolments.length ?? 0)} />
-            {/* Surfaced as a headline number on purpose: "how many were deliberately not
-                contacted" is the question the send log exists to answer (#2895). */}
-            <StatCard label={t('Potlačených odeslání', 'Suppressed sends')} value={String(suppressed)} />
-          </div>
+          <CampaignOutcomeBrief
+            state={c.state}
+            audience={detail?.enrolments.length ?? 0}
+            handedOff={summary.SENT ?? 0}
+            suppressed={suppressed}
+            conversion={c.conversionRule ? (summary.CONVERTED ?? 0) : null}
+            conversionLabel={c.conversionRule ? conversionLabel(c.conversionRule) : t('Cíl není měřen', 'Outcome is not measured')}
+            nextAction={nextAction.title}
+            nextActionDetail={nextAction.detail}
+          />
 
           <section className="rounded-lg border p-3 text-sm" data-campaign-entry>
             <h2 className="font-semibold">{t('Vstup do cesty', 'Journey entry')}</h2>
@@ -539,6 +620,66 @@ export default function CampaignDetailPage({ params }: { params: Promise<{ id: s
                 {t(
                   'Rozdíl je popisný. Brána používá konzervativní 95% Wilsonovy intervaly a nemůže sama prokázat příčinu ani změnit běžící kampaň.',
                   'The difference is descriptive. The gate uses conservative 95% Wilson intervals; it cannot prove causality or change a running campaign itself.',
+                )}
+              </p>
+            </section>
+          )}
+
+          {c.steps.some(step => step.variantBVariables) && (
+            <section className="space-y-2 rounded-lg border p-3" data-content-experiment>
+              <div>
+                <h2 className="text-sm font-semibold">{t('Porovnání obsahu A/B', 'A/B content comparison')}</h2>
+                <p className="text-xs text-muted-foreground">
+                  {t(
+                    'Každý oslovený člověk zůstává ve variantě A nebo B po celou cestu. Porovnává se jen skutečná bankovní konverze.',
+                    'Each contacted person stays in A or B throughout the journey. Only real banking conversion is compared.',
+                  )}
+                </p>
+              </div>
+              {detail?.sources?.contentExperiment === 'ok' && contentExperiment ? (
+                <>
+                  <div className="grid gap-3 sm:grid-cols-3">
+                    <StatCard label={t('Varianta A', 'Variant A')} value={`${fmtRate(contentExperiment.a.conversionRate)} · ${contentExperiment.a.converted}/${contentExperiment.a.assigned}`} />
+                    <StatCard label={t('Varianta B', 'Variant B')} value={`${fmtRate(contentExperiment.b.conversionRate)} · ${contentExperiment.b.converted}/${contentExperiment.b.assigned}`} />
+                    <StatCard label={t('B − A (p. b.)', 'B − A (pp)')} value={contentExperiment.observedLiftPercentagePoints === null ? '—' : contentExperiment.observedLiftPercentagePoints.toFixed(1)} />
+                  </div>
+                  <div className="rounded-md bg-muted p-2 text-xs text-muted-foreground" data-content-experiment-decision>
+                    <span className="font-medium text-foreground">{t('Připravenost rozhodnutí: ', 'Decision readiness: ')}</span>
+                    {contentExperimentDecisionText(contentExperiment.decision)}
+                    {contentExperiment.decision?.aConfidenceInterval && contentExperiment.decision?.bConfidenceInterval && (
+                      <span>
+                        {' '}{t('95% intervaly — A ', '95% intervals — A ')}
+                        {fmtRate(contentExperiment.decision.aConfidenceInterval.lower)}–{fmtRate(contentExperiment.decision.aConfidenceInterval.upper)}
+                        {t(', B ', ', B ')}
+                        {fmtRate(contentExperiment.decision.bConfidenceInterval.lower)}–{fmtRate(contentExperiment.decision.bConfidenceInterval.upper)}.
+                      </span>
+                    )}
+                  </div>
+                </>
+              ) : (
+                <DataUnavailable
+                  kind={detail?.sources?.contentExperiment === 'unauthorized' ? 'unauthorized' : 'unreachable'}
+                  service="Campaign-service"
+                  feature={t('Vyhodnocení variant obsahu', 'Content-variant result')}
+                  dense
+                />
+              )}
+              <p className="text-xs text-muted-foreground">
+                {t(
+                  'Rozdíl je popisný. Brána používá 95% Wilsonovy intervaly, automaticky nemění aktivní cestu a sama nedokazuje příčinu.',
+                  'The difference is descriptive. The 95% Wilson gate never changes an active journey and does not establish causality itself.',
+                )}
+              </p>
+            </section>
+          )}
+
+          {c.steps.some(step => step.fallbackToPush) && (
+            <section className="space-y-1 rounded-lg border p-3" data-channel-fallback>
+              <h2 className="text-sm font-semibold">{t('Záložní kanál', 'Fallback channel')}</h2>
+              <p className="text-xs text-muted-foreground">
+                {t(
+                  'U vybraných e-mailových kroků se při chybějícím e-mailovém souhlasu zkusí push. I ten projde vlastním souhlasem, frekvenčním limitem, quiet hours a suppression listem; po nedoručení e-mailu se druhá zpráva neposílá.',
+                  'Selected email steps may try push when email consent is absent. Push still passes its own consent, frequency cap, quiet hours and suppression list; an email delivery failure never triggers a second message.',
                 )}
               </p>
             </section>
@@ -696,6 +837,10 @@ export default function CampaignDetailPage({ params }: { params: Promise<{ id: s
                         'Co se se zprávou skutečně stalo, podle notification-service.',
                         'What actually became of the message, as reported by notification-service.',
                       )}>{t('Doručení', 'Delivery')}</th>
+                      <th title={t(
+                        'Kanál, který campaign-service skutečně předal notification-service.',
+                        'The channel campaign-service actually handed to notification-service.',
+                      )}>{t('Kanál', 'Channel')}</th>
                       <th>{t('Kdy', 'When')}</th>
                     </tr>
                   </thead>
@@ -725,6 +870,13 @@ export default function CampaignDetailPage({ params }: { params: Promise<{ id: s
                           ) : (
                             <span className="text-xs text-muted-foreground">—</span>
                           )}
+                        </td>
+                        <td>
+                          {s.channel === 'EMAIL'
+                            ? t('E-mail', 'Email')
+                            : s.channel === 'PUSH'
+                              ? t('Push', 'Push')
+                              : <span className="text-xs text-muted-foreground">—</span>}
                         </td>
                         <td className="text-xs whitespace-nowrap">{fmtDateTime(s.occurredAt)}</td>
                       </tr>

--- a/openbank-admin-ui/src/app/campaigns/[id]/page.tsx
+++ b/openbank-admin-ui/src/app/campaigns/[id]/page.tsx
@@ -27,6 +27,8 @@ interface Campaign {
   conversionRule?: string | null
   /** Percentage deliberately kept in the no-contact control cohort. */
   holdoutPercent?: number
+  schedule?: { cadence: string; endAt?: string | null } | null
+  trigger?: string | null
 }
 
 interface Enrolment {
@@ -80,6 +82,10 @@ type Detail = {
   sendSummary: Record<string, number>
   journey: StepFunnel[]
   experiment: Experiment | null;
+  entryCatalogues?: {
+    cadences: { cadence: string; humanForm: string; zone: string }[]
+    triggers: { trigger: string; humanForm: string }[]
+  }
   sources: Record<string, string>
 }
 
@@ -242,6 +248,12 @@ export default function CampaignDetailPage({ params }: { params: Promise<{ id: s
   }
   const summary = detail?.sendSummary ?? {}
   const experiment = detail?.experiment
+  const cadence = c?.schedule
+    ? detail?.entryCatalogues?.cadences.find(x => x.cadence === c.schedule?.cadence)
+    : undefined
+  const trigger = c?.trigger
+    ? detail?.entryCatalogues?.triggers.find(x => x.trigger === c.trigger)
+    : undefined
 
   // From the server-side summary, never from the loaded page: a headline derived from the rows on
   // screen understates every campaign larger than one page.
@@ -415,6 +427,35 @@ export default function CampaignDetailPage({ params }: { params: Promise<{ id: s
                 contacted" is the question the send log exists to answer (#2895). */}
             <StatCard label={t('Potlačených odeslání', 'Suppressed sends')} value={String(suppressed)} />
           </div>
+
+          <section className="rounded-lg border p-3 text-sm" data-campaign-entry>
+            <h2 className="font-semibold">{t('Vstup do cesty', 'Journey entry')}</h2>
+            {c.trigger ? (
+              <p className="mt-1 text-muted-foreground">
+                {t('Při události: ', 'On an event: ')}
+                <span className="font-medium text-foreground">{trigger?.humanForm ?? c.trigger}</span>
+                {t(
+                  ' — událost určí okamžik, ale člověk musí stále patřit do schváleného segmentu.',
+                  ' — the event chooses the moment, but the person must still belong to the approved segment.',
+                )}
+              </p>
+            ) : c.schedule ? (
+              <p className="mt-1 text-muted-foreground">
+                {t('Opakovaně: ', 'Recurring: ')}
+                <span className="font-medium text-foreground">
+                  {cadence ? `${cadence.humanForm} (${cadence.zone})` : c.schedule.cadence}
+                </span>
+                {c.schedule.endAt && ` · ${t('do ', 'until ')}${fmtDateTime(c.schedule.endAt)}`}
+              </p>
+            ) : (
+              <p className="mt-1 text-muted-foreground">
+                {t(
+                  'Jednorázově — po spuštění se aktuální publikum zařadí ručně.',
+                  'One time — the current audience is enrolled manually after activation.',
+                )}
+              </p>
+            )}
+          </section>
 
           {/* Absent rule and zero conversions are different facts and must never render the same:
               a campaign measuring nothing has no number, and saying so is the honest empty state

--- a/openbank-admin-ui/src/app/campaigns/new/page.tsx
+++ b/openbank-admin-ui/src/app/campaigns/new/page.tsx
@@ -44,6 +44,19 @@ interface Segment {
   rules: string[]
 }
 
+interface Cadence {
+  cadence: string
+  humanForm: string
+  zone: string
+}
+
+interface CampaignTrigger {
+  trigger: string
+  humanForm: string
+}
+
+type EntryMode = 'MANUAL' | 'SCHEDULE' | 'TRIGGER'
+
 /** Mirrors the service's catalogue; the service rejects anything not in its own copy. */
 const TEMPLATES: Record<string, string[]> = {
   MARKETING_PRODUCT_OFFER: ['offerTitle', 'offerText', 'ctaText'],
@@ -73,6 +86,12 @@ export default function NewCampaignPage() {
   const [goal, setGoal] = useState('')
   const [segment, setSegment] = useState('')
   const [segments, setSegments] = useState<Segment[]>([])
+  const [cadences, setCadences] = useState<Cadence[]>([])
+  const [triggers, setTriggers] = useState<CampaignTrigger[]>([])
+  const [entryMode, setEntryMode] = useState<EntryMode>('MANUAL')
+  const [cadence, setCadence] = useState('')
+  const [trigger, setTrigger] = useState('')
+  const [entryUnavailable, setEntryUnavailable] = useState(false)
   const [steps, setSteps] = useState<EditorStep[]>([newStep()])
   const [selected, setSelected] = useState<number | null>(0)
   const [reach, setReach] = useState<number | null>(null)
@@ -117,6 +136,25 @@ export default function NewCampaignPage() {
       .catch(() => undefined)
   }, [])
 
+  // Entry catalogues come from campaign-service rather than a second hard-coded list: an event
+  // whose consumer was removed must disappear from Studio, and a cadence may never become a raw
+  // cron field that looks valid while doing something different in Temporal.
+  useEffect(() => {
+    Promise.all([
+      fetch('/api/campaigns/cadences').then(r => r.json()),
+      fetch('/api/campaigns/triggers').then(r => r.json()),
+    ])
+      .then(([cadenceResponse, triggerResponse]: [
+        { items?: Cadence[]; state?: string },
+        { items?: CampaignTrigger[]; state?: string },
+      ]) => {
+        if (cadenceResponse.state === 'ok') setCadences(cadenceResponse.items ?? [])
+        if (triggerResponse.state === 'ok') setTriggers(triggerResponse.items ?? [])
+        if (cadenceResponse.state !== 'ok' || triggerResponse.state !== 'ok') setEntryUnavailable(true)
+      })
+      .catch(() => setEntryUnavailable(true))
+  }, [])
+
   // The reach is the segment's own preview, run by the service — the same evaluation enrolment runs.
   // A number computed here from a different query would agree with the send only by luck.
   const previewReach = (ref: string) => {
@@ -151,7 +189,17 @@ export default function NewCampaignPage() {
   const incomplete = steps.some(s =>
     (TEMPLATES[s.template] ?? []).some(v => !(s.variables[v] ?? '').trim()),
   )
-  const ready = name.trim() !== '' && goal.trim() !== '' && segment !== '' && steps.length > 0 && !incomplete
+  const entryConfigured =
+    entryMode === 'MANUAL' ||
+    (entryMode === 'SCHEDULE' && cadence !== '') ||
+    (entryMode === 'TRIGGER' && trigger !== '')
+  const ready = name.trim() !== '' && goal.trim() !== '' && segment !== '' && steps.length > 0 && !incomplete && entryConfigured
+
+  const chooseEntryMode = (next: EntryMode) => {
+    setEntryMode(next)
+    if (next === 'SCHEDULE' && cadence === '' && cadences[0]) setCadence(cadences[0].cadence)
+    if (next === 'TRIGGER' && trigger === '' && triggers[0]) setTrigger(triggers[0].trigger)
+  }
 
   const submit = () => {
     setSaving(true)
@@ -168,6 +216,8 @@ export default function NewCampaignPage() {
         ...(stopAfter !== null ? { stopCondition: { maxSendsPerParty: stopAfter } } : {}),
         ...(conversionRule ? { conversionRule } : {}),
         ...(holdoutPercent > 0 ? { holdoutPercent } : {}),
+        ...(entryMode === 'SCHEDULE' && cadence ? { schedule: { cadence } } : {}),
+        ...(entryMode === 'TRIGGER' && trigger ? { trigger } : {}),
         steps: steps.map((s, i) => ({
           order: i + 1,
           template: s.template,
@@ -289,6 +339,95 @@ export default function NewCampaignPage() {
               'Segments are defined in code and versioned. A new segment is a pull request, not a UI action.',
             )}
           </p>
+        </div>
+
+        <div className="space-y-3" data-entry-mode={entryMode}>
+          <div>
+            <h2 className="text-sm font-semibold">{t('Kdy cesta začne', 'When the journey starts')}</h2>
+            <p className="text-xs text-muted-foreground" style={{ marginTop: '0.25rem' }}>
+              {t(
+                'Vyberte jeden přezkoumatelný zdroj vstupu. Publikum stále určuje segment výše.',
+                'Choose one reviewable entry source. The segment above still decides who may enter.',
+              )}
+            </p>
+          </div>
+          <div className="grid gap-2 sm:grid-cols-3">
+            <button
+              type="button"
+              data-entry-pick="MANUAL"
+              data-selected={entryMode === 'MANUAL' ? 'true' : 'false'}
+              onClick={() => chooseEntryMode('MANUAL')}
+              className="rounded-lg border p-3 text-left text-sm"
+              style={entryMode === 'MANUAL' ? { borderColor: 'var(--accent)', boxShadow: '0 0 0 1px var(--accent)' } : undefined}
+            >
+              <span className="font-medium">{t('Jednorázově', 'One time')}</span>
+              <span className="mt-1 block text-xs text-muted-foreground">
+                {t('Po spuštění ručně zařadíte aktuální publikum.', 'After activation, enrol the current audience manually.')}
+              </span>
+            </button>
+            <button
+              type="button"
+              data-entry-pick="SCHEDULE"
+              data-selected={entryMode === 'SCHEDULE' ? 'true' : 'false'}
+              onClick={() => chooseEntryMode('SCHEDULE')}
+              disabled={cadences.length === 0}
+              className="rounded-lg border p-3 text-left text-sm disabled:opacity-40"
+              style={entryMode === 'SCHEDULE' ? { borderColor: 'var(--accent)', boxShadow: '0 0 0 1px var(--accent)' } : undefined}
+            >
+              <span className="font-medium">{t('Opakovaně', 'Recurring')}</span>
+              <span className="mt-1 block text-xs text-muted-foreground">
+                {t('Pravidelně zkontroluje, kdo do segmentu nově patří.', 'Rechecks who newly belongs to the segment on a schedule.')}
+              </span>
+            </button>
+            <button
+              type="button"
+              data-entry-pick="TRIGGER"
+              data-selected={entryMode === 'TRIGGER' ? 'true' : 'false'}
+              onClick={() => chooseEntryMode('TRIGGER')}
+              disabled={triggers.length === 0}
+              className="rounded-lg border p-3 text-left text-sm disabled:opacity-40"
+              style={entryMode === 'TRIGGER' ? { borderColor: 'var(--accent)', boxShadow: '0 0 0 1px var(--accent)' } : undefined}
+            >
+              <span className="font-medium">{t('Při události', 'On an event')}</span>
+              <span className="mt-1 block text-xs text-muted-foreground">
+                {t('Zařadí člověka hned po sledované bankovní události.', 'Enrols a person as soon as the observed banking event happens.')}
+              </span>
+            </button>
+          </div>
+          {entryMode === 'SCHEDULE' && (
+            <label className="block max-w-xl text-sm">
+              <span className="font-medium">{t('Rytmus', 'Cadence')}</span>
+              <select
+                className="input mt-1 block w-full"
+                value={cadence}
+                onChange={e => setCadence(e.target.value)}
+                data-cadence
+              >
+                {cadences.map(c => <option key={c.cadence} value={c.cadence}>{c.humanForm} ({c.zone})</option>)}
+              </select>
+            </label>
+          )}
+          {entryMode === 'TRIGGER' && (
+            <label className="block max-w-xl text-sm">
+              <span className="font-medium">{t('Událost', 'Event')}</span>
+              <select
+                className="input mt-1 block w-full"
+                value={trigger}
+                onChange={e => setTrigger(e.target.value)}
+                data-trigger
+              >
+                {triggers.map(x => <option key={x.trigger} value={x.trigger}>{x.humanForm}</option>)}
+              </select>
+            </label>
+          )}
+          {entryUnavailable && (
+            <p className="text-xs text-muted-foreground">
+              {t(
+                'Některý katalog vstupů teď není dostupný; nenabízíme jeho neověřené volby.',
+                'One entry catalogue is unavailable; its unverified choices are not offered.',
+              )}
+            </p>
+          )}
         </div>
       </section>
 

--- a/openbank-admin-ui/src/app/campaigns/new/page.tsx
+++ b/openbank-admin-ui/src/app/campaigns/new/page.tsx
@@ -17,6 +17,8 @@ import {
   type EditorStep,
 } from '@/components/campaigns/JourneyEditor'
 import { StepEditor } from '@/components/campaigns/StepEditor'
+import { CampaignExperiencePreview } from '@/components/campaigns/CampaignExperiencePreview'
+import { CampaignLaunchReadiness } from '@/components/campaigns/CampaignLaunchReadiness'
 
 /**
  * Campaign Studio — authoring on a canvas (ADR-0221 D1).
@@ -102,6 +104,9 @@ export default function NewCampaignPage() {
   // A bounded, explicit control group is the only way to compare outcome rates with no-contact
   // peers; zero preserves the existing all-treatment behaviour.
   const [holdoutPercent, setHoldoutPercent] = useState(0)
+  // A/B compares two contacted content arms. It needs the same observed conversion fact as a
+  // holdout, but it never withholds a message and never chooses a winner automatically.
+  const [contentExperiment, setContentExperiment] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [saving, setSaving] = useState(false)
 
@@ -176,7 +181,10 @@ export default function NewCampaignPage() {
     setSteps(prev => {
       if (prev.length >= MAX_STEPS) return prev
       setSelected(prev.length)
-      return [...prev, newStep()]
+      return [...prev, {
+        ...newStep(),
+        ...(contentExperiment ? { variantBVariables: {} } : {}),
+      }]
     })
 
   const removeStep = (i: number) =>
@@ -187,13 +195,25 @@ export default function NewCampaignPage() {
     })
 
   const incomplete = steps.some(s =>
-    (TEMPLATES[s.template] ?? []).some(v => !(s.variables[v] ?? '').trim()),
+    (TEMPLATES[s.template] ?? []).some(v =>
+      !(s.variables[v] ?? '').trim() || (contentExperiment && !(s.variantBVariables?.[v] ?? '').trim()),
+    ),
   )
   const entryConfigured =
     entryMode === 'MANUAL' ||
     (entryMode === 'SCHEDULE' && cadence !== '') ||
     (entryMode === 'TRIGGER' && trigger !== '')
-  const ready = name.trim() !== '' && goal.trim() !== '' && segment !== '' && steps.length > 0 && !incomplete && entryConfigured
+  const ready = name.trim() !== '' && goal.trim() !== '' && segment !== '' && steps.length > 0 &&
+    !incomplete && entryConfigured && (!contentExperiment || conversionRule !== null)
+
+  const setContentExperimentEnabled = (enabled: boolean) => {
+    setContentExperiment(enabled)
+    if (enabled) {
+      // Copy A once when the test is enabled. Later edits intentionally diverge, otherwise both
+      // arms would change together and the test would be a convincing-looking no-op.
+      setSteps(prev => prev.map(s => ({ ...s, variantBVariables: { ...s.variables } })))
+    }
+  }
 
   const chooseEntryMode = (next: EntryMode) => {
     setEntryMode(next)
@@ -224,6 +244,9 @@ export default function NewCampaignPage() {
           channel: s.channel,
           ...(s.condition ? { condition: s.condition } : {}),
           variables: s.variables,
+          ...(contentExperiment ? { variantBVariables: s.variantBVariables ?? {} } : {}),
+          ...(s.fallbackToPush ? { fallbackToPush: true } : {}),
+          ...(s.mobileDestination ? { mobileDestination: s.mobileDestination } : {}),
           delaySeconds: s.delaySeconds,
         })),
       }),
@@ -461,11 +484,25 @@ export default function NewCampaignPage() {
             templateChannel={TEMPLATE_CHANNEL}
             templateLabels={templateLabels}
             variableLabels={variableLabels}
+            contentExperiment={contentExperiment}
             onChange={next => updateStep(selected, next)}
             onClose={() => setSelected(null)}
           />
         )}
 
+        </div>
+
+        <div className="campaign-studio-companion-grid">
+          <CampaignExperiencePreview step={selected === null ? undefined : steps[selected]} campaignName={name} />
+          <CampaignLaunchReadiness
+            audienceChosen={segment !== ''}
+            audienceSize={reach}
+            entryConfigured={entryConfigured}
+            incomplete={incomplete}
+            conversionRule={conversionRule}
+            contentExperiment={contentExperiment}
+            steps={steps}
+          />
         </div>
 
         {/* What "it worked" means, asked at authoring time because it cannot be answered later:
@@ -483,7 +520,10 @@ export default function NewCampaignPage() {
                 data-selected={conversionRule === r ? 'true' : 'false'}
                 onClick={() => {
                   setConversionRule(r)
-                  if (r === null) setHoldoutPercent(0)
+                  if (r === null) {
+                    setHoldoutPercent(0)
+                    setContentExperiment(false)
+                  }
                 }}
                 className="btn"
                 style={
@@ -505,6 +545,30 @@ export default function NewCampaignPage() {
               'Počítá se skutečná událost v bance, ne otevření e-mailu ani proklik — ty se nesledují.',
               'Counted from a real banking event, never an email open or a click — those are not tracked.',
             )}
+          </p>
+        </div>
+
+        <div className="max-w-2xl rounded-lg border p-3 space-y-2" data-content-experiment={contentExperiment ? 'true' : 'false'}>
+          <label className="flex items-center gap-2 text-sm font-medium" htmlFor="c-content-experiment">
+            <input
+              id="c-content-experiment"
+              type="checkbox"
+              checked={contentExperiment}
+              disabled={!conversionRule}
+              onChange={e => setContentExperimentEnabled(e.target.checked)}
+            />
+            {t('Porovnat variantu A a B', 'Compare variant A and B')}
+          </label>
+          <p className="text-xs text-muted-foreground">
+            {conversionRule
+              ? t(
+                  'Každý člověk dostane stabilně A nebo B; u každého kroku pak upravíte hodnoty varianty B. Výsledek vychází jen ze skutečné bankovní konverze.',
+                  'Each person consistently receives A or B; edit B values in every step. The result comes only from a real banking conversion.',
+                )
+              : t(
+                  'Nejdřív vyberte měřitelný cíl. Bez něj by dvě verze obsahu neměly důvěryhodný výsledek.',
+                  'Choose a measurable success event first. Without it, two content versions have no credible outcome.',
+                )}
           </p>
         </div>
 

--- a/openbank-admin-ui/src/app/campaigns/page.tsx
+++ b/openbank-admin-ui/src/app/campaigns/page.tsx
@@ -15,11 +15,10 @@
 // language on one console would be worse than either (see components/flow/StageBoard).
 //
 // WHAT THIS PAGE HONESTLY CANNOT SHOW
-// Reach, delivery and conversion — the numbers a CDP screen is really about. `GET /api/v1/campaigns`
-// returns campaign records only; enrolments and sends are per-campaign endpoints, so a performance
-// overview here would mean one request per campaign or an API that does not exist yet. Inventing
-// the numbers, or quietly implying the page covers performance, would be worse than saying so — the
-// board carries that sentence rather than hiding it in a doc.
+// The optional summary endpoint supplies only enrolment and delivery. It does not supply in-app
+// engagement or a business conversion, so this page calls the aggregate a *delivery pulse*, never
+// performance. Inventing the rest of a CDP funnel would be worse than saying exactly where evidence
+// ends; the detail still owns the event-level journey.
 //
 // Read-only by design (#2895). Authoring is ADR-0221: `submit` → `activate`-by-a-DIFFERENT-approver
 // is a two-people-at-a-screen flow, and exposing half of it as buttons would lose the point of the
@@ -67,6 +66,16 @@ const LIFECYCLE: { key: string; cs: string; en: string; terminal?: boolean }[] =
   { key: 'PAUSED', cs: 'Pozastavená', en: 'Paused' },
   { key: 'CLOSED', cs: 'Ukončená', en: 'Closed', terminal: true },
 ]
+
+/** A marketing landing page should surface the next decision, not merely count lifecycle states.
+ *  This is a display priority only — it never changes the campaign state machine. */
+const DECISION_PRIORITY: Record<string, number> = {
+  PENDING_APPROVAL: 0,
+  PAUSED: 1,
+  DRAFT: 2,
+  ACTIVE: 3,
+  CLOSED: 9,
+}
 
 export default function CampaignsPage() {
   const { t, language } = useLanguage()
@@ -122,12 +131,42 @@ export default function CampaignsPage() {
 
   const counts = (k: string) => stats.get(k)?.count ?? 0
 
+  const decisionQueue = useMemo(
+    () => [...items]
+      .filter(c => c.state !== 'CLOSED')
+      .sort((a, b) => {
+        const priority = (DECISION_PRIORITY[a.state] ?? 8) - (DECISION_PRIORITY[b.state] ?? 8)
+        return priority !== 0 ? priority : Date.parse(a.createdAt) - Date.parse(b.createdAt)
+      })
+      .slice(0, 3),
+    [items],
+  )
+
+  const deliveryPulse = useMemo(() => {
+    if (!summary) return null
+    return Object.values(summary).reduce(
+      (total, item) => ({
+        enrolled: total.enrolled + item.enrolled,
+        sent: total.sent + item.sent,
+        suppressed: total.suppressed + item.suppressed,
+      }),
+      { enrolled: 0, sent: 0, suppressed: 0 },
+    )
+  }, [summary])
+
   const needle = search.trim().toLowerCase()
   const filtered = items.filter(
     c =>
       (!stateFilter || c.state === stateFilter) &&
       (!needle || c.name.toLowerCase().includes(needle) || (c.goal ?? '').toLowerCase().includes(needle)),
   )
+
+  const nextAction = (campaign: Campaign) => {
+    if (campaign.state === 'PENDING_APPROVAL') return t('Čeká na druhé oči', 'Needs a second pair of eyes')
+    if (campaign.state === 'PAUSED') return t('Rozhodněte o pokračování', 'Decide whether to resume')
+    if (campaign.state === 'DRAFT') return t('Dokončete zadání', 'Finish the brief')
+    return t('Sledujte živou cestu', 'Follow the live journey')
+  }
 
   return (
     <div className="space-y-6">
@@ -168,6 +207,54 @@ export default function CampaignsPage() {
             <StatCard label={t('Pozastavené', 'Paused')} value={counts('PAUSED')}
                       tone={counts('PAUSED') > 0 ? 'warning' : undefined} icon={<PauseCircle size={13} />} />
           </div>
+
+          <section className="campaign-decision-desk" aria-label={t('Dnešní priority kampaní', 'Today’s campaign priorities')} data-testid="campaign-decision-desk">
+            <div className="campaign-decision-queue">
+              <div className="campaign-desk-heading">
+                <div>
+                  <p>{t('Dnešní fokus', 'Today’s focus')}</p>
+                  <h2>{t('Co posune kampaně dál', 'What moves campaigns forward')}</h2>
+                </div>
+                <span>{decisionQueue.length}</span>
+              </div>
+              {decisionQueue.length > 0 ? (
+                <div className="campaign-decision-items">
+                  {decisionQueue.map((campaign, index) => (
+                    <Link key={campaign.id} href={`/campaigns/${campaign.id}`} className="campaign-decision-item" data-decision-campaign={campaign.id}>
+                      <span className="campaign-decision-rank">0{index + 1}</span>
+                      <span className="campaign-decision-copy">
+                        <strong>{campaign.name}</strong>
+                        <small>{nextAction(campaign)}</small>
+                      </span>
+                      <StatusBadge status={campaign.state} label={label(campaign.state)} />
+                    </Link>
+                  ))}
+                </div>
+              ) : (
+                <p className="campaign-decision-empty">{t('Nic nečeká. Můžete připravit další nápad.', 'Nothing is waiting. You can prepare the next idea.')}</p>
+              )}
+            </div>
+
+            <div className="campaign-delivery-pulse" data-testid="campaign-delivery-pulse">
+              <div className="campaign-desk-heading">
+                <div>
+                  <p>{t('Doručení', 'Delivery')}</p>
+                  <h2>{t('Pulse portfolia', 'Portfolio pulse')}</h2>
+                </div>
+                <span className={deliveryPulse ? 'campaign-pulse-live' : 'campaign-pulse-muted'}>{deliveryPulse ? t('Živě', 'Live') : t('Čeká na data', 'Waiting for data')}</span>
+              </div>
+              {deliveryPulse ? (
+                <div className="campaign-pulse-numbers">
+                  <div><strong>{deliveryPulse.enrolled.toLocaleString(language === 'cs' ? 'cs-CZ' : 'en-GB')}</strong><span>{t('zařazeno', 'enrolled')}</span></div>
+                  <div><strong>{deliveryPulse.sent.toLocaleString(language === 'cs' ? 'cs-CZ' : 'en-GB')}</strong><span>{t('odesláno', 'sent')}</span></div>
+                  <div><strong>{deliveryPulse.suppressed.toLocaleString(language === 'cs' ? 'cs-CZ' : 'en-GB')}</strong><span>{t('potlačeno', 'suppressed')}</span></div>
+                </div>
+              ) : (
+                <p className="campaign-pulse-empty">{t('Nasazená služba zatím neposílá souhrn doručení. Nuly by byly zavádějící.', 'The deployed service does not yet return a delivery aggregate. Zeros would mislead.')}</p>
+              )}
+              <p className="campaign-pulse-footnote">{t('Nejde o konverzi ani engagement — tyto signály zatím v přehledu nemáme.', 'This is not conversion or engagement — those signals are not in this overview yet.')}</p>
+            </div>
+          </section>
 
           <StageBoard
             stages={stages}

--- a/openbank-admin-ui/src/app/globals.css
+++ b/openbank-admin-ui/src/app/globals.css
@@ -296,6 +296,109 @@ main {
 .stat-card:hover::before {
   background: var(--ob-accent);
 }
+
+/* ── Campaign Studio companion surfaces ── */
+.campaign-studio-companion-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.15fr) minmax(19rem, 0.85fr);
+  gap: 1rem;
+  margin-top: 1rem;
+}
+.campaign-experience-preview,
+.campaign-launch-readiness {
+  border: 1px solid var(--border);
+  border-radius: var(--r-xl);
+  box-shadow: var(--shadow-sm);
+  overflow: hidden;
+}
+.campaign-experience-preview { background: radial-gradient(circle at 76% 15%, #dbeafe 0, transparent 32%), linear-gradient(135deg, #111827 0%, #172554 55%, #312e81 100%); color: #fff; padding: 1.15rem; }
+.campaign-preview-heading, .campaign-readiness-heading { display: flex; align-items: flex-start; justify-content: space-between; gap: 0.75rem; }
+.campaign-preview-kicker { color: inherit; font-size: 0.67rem; font-weight: 800; letter-spacing: 0.09em; opacity: 0.65; text-transform: uppercase; }
+.campaign-preview-heading h3, .campaign-readiness-heading h3 { font-size: 1rem; font-weight: 700; margin-top: 0.2rem; }
+.campaign-preview-live { background: rgba(255,255,255,0.14); border: 1px solid rgba(255,255,255,0.16); border-radius: 99px; font-size: 0.68rem; font-weight: 700; padding: 0.3rem 0.55rem; white-space: nowrap; }
+.campaign-preview-stage { display: flex; align-items: center; gap: 0.75rem; min-height: 15rem; padding: 1rem 0.35rem 0.65rem; }
+.campaign-phone { width: 8.65rem; height: 14.8rem; background: #f8fafc; border: 4px solid #020617; border-radius: 1.55rem; box-shadow: 0 18px 32px rgba(0,0,0,.3); color: #0f172a; flex: 0 0 auto; overflow: hidden; position: relative; }
+.campaign-phone-island { background: #020617; border-radius: 0 0 0.8rem 0.8rem; height: 0.9rem; left: 50%; position: absolute; top: 0; transform: translateX(-50%); width: 3.5rem; }
+.campaign-phone-content { padding: 1.3rem 0.68rem 0.65rem; }
+.campaign-phone-topline { display: flex; justify-content: space-between; color: #6366f1; font-size: 0.55rem; font-weight: 800; }
+.campaign-phone-eyebrow { color: #64748b; font-size: 0.48rem; margin-top: 0.85rem; }
+.campaign-phone h4 { font-size: 0.82rem; font-weight: 800; line-height: 1.1; margin-top: 0.18rem; }
+.campaign-phone-hero { background: linear-gradient(145deg, #ede9fe, #dbeafe); border-radius: 0.75rem; margin-top: 0.65rem; padding: 0.58rem; }
+.campaign-phone-hero span { color: #4f46e5; display: block; font-size: 0.43rem; font-weight: 800; text-transform: uppercase; }
+.campaign-phone-hero strong { display: block; font-size: 0.62rem; line-height: 1.15; margin: 0.28rem 0; }
+.campaign-phone-hero button { background: #4f46e5; border: 0; border-radius: 0.4rem; color: #fff; font-size: 0.45rem; font-weight: 700; padding: 0.28rem 0.42rem; }
+.campaign-phone-row { display: flex; gap: 0.28rem; margin-top: 0.58rem; }
+.campaign-phone-row span { background: #e2e8f0; border-radius: 0.25rem; height: 1.45rem; flex: 1; }
+.campaign-push-card { background: rgba(255,255,255,0.95); border: 1px solid rgba(255,255,255,0.75); border-radius: 0.9rem; box-shadow: 0 12px 28px rgba(0,0,0,.18); color: #0f172a; display: flex; gap: 0.48rem; max-width: 15.5rem; padding: 0.62rem; transform: rotate(-2deg); }
+.campaign-push-icon { align-items: center; background: linear-gradient(140deg, #4f46e5, #7c3aed); border-radius: 0.45rem; color: #fff; display: flex; font-size: 0.85rem; font-weight: 800; height: 1.65rem; justify-content: center; width: 1.65rem; }
+.campaign-push-meta { color: #64748b; font-size: 0.43rem; font-weight: 800; letter-spacing: 0.04em; }
+.campaign-push-title { font-size: 0.66rem; font-weight: 800; line-height: 1.15; margin-top: 0.15rem; }
+.campaign-push-card p:last-child { color: #475569; font-size: 0.52rem; line-height: 1.25; margin-top: 0.25rem; }
+.campaign-preview-route { align-items: center; background: rgba(255,255,255,.1); border: 1px solid rgba(255,255,255,.13); border-radius: 0.65rem; display: flex; flex-wrap: wrap; font-size: 0.67rem; gap: 0.35rem 0.55rem; padding: 0.55rem 0.65rem; }
+.campaign-preview-route span { opacity: .68; }
+.campaign-preview-route strong { font-size: 0.67rem; }
+.campaign-preview-route code { font-size: 0.59rem; opacity: .74; }
+.campaign-launch-readiness { background: var(--surface); padding: 1.15rem; }
+.campaign-readiness-heading strong { align-items: center; background: var(--ob-accent-light); border-radius: 99px; color: var(--ob-accent-text); display: inline-flex; font-size: 0.75rem; min-height: 2rem; padding: 0 0.7rem; }
+.campaign-readiness-intro { color: var(--text-secondary); font-size: 0.75rem; margin: 0.75rem 0; }
+.campaign-readiness-list { display: grid; gap: 0.55rem; list-style: none; }
+.campaign-readiness-list li { align-items: flex-start; border-radius: 0.65rem; display: flex; gap: 0.55rem; padding: 0.42rem; }
+.campaign-readiness-list li > span { align-items: center; border-radius: 99px; display: inline-flex; flex: 0 0 auto; font-size: 0.68rem; font-weight: 800; height: 1.2rem; justify-content: center; margin-top: 0.1rem; width: 1.2rem; }
+.campaign-readiness-list strong { display: block; font-size: 0.74rem; line-height: 1.25; }
+.campaign-readiness-list p { color: var(--text-secondary); font-size: 0.66rem; line-height: 1.32; margin-top: 0.12rem; }
+.campaign-readiness-list [data-state='ready'] > span { background: var(--success-bg); color: var(--success-text); }
+.campaign-readiness-list [data-state='attention'] { background: var(--warning-bg); }
+.campaign-readiness-list [data-state='attention'] > span { background: #fef3c7; color: var(--warning-text); }
+.campaign-readiness-list [data-state='waiting'] { background: var(--surface-2); }
+.campaign-readiness-list [data-state='waiting'] > span { background: var(--surface-4); color: var(--text-secondary); }
+@media (max-width: 960px) { .campaign-studio-companion-grid { grid-template-columns: 1fr; } }
+@media (max-width: 450px) { .campaign-preview-stage { gap: 0.4rem; } .campaign-phone { transform: scale(.9); transform-origin: left center; margin-right: -0.75rem; } .campaign-push-card { transform: rotate(-2deg) scale(.9); transform-origin: left center; } }
+
+/* ── Campaign portfolio decision desk ── */
+.campaign-decision-desk { display: grid; grid-template-columns: minmax(0, 1.18fr) minmax(17rem, .82fr); gap: 1rem; }
+.campaign-decision-queue, .campaign-delivery-pulse { border: 1px solid var(--border); border-radius: var(--r-xl); overflow: hidden; padding: 1.1rem; }
+.campaign-decision-queue { background: linear-gradient(135deg, #f5f3ff, var(--surface) 58%); }
+.campaign-delivery-pulse { background: var(--surface); }
+.campaign-desk-heading { align-items: flex-start; display: flex; justify-content: space-between; gap: .75rem; }
+.campaign-desk-heading p { color: var(--ob-accent-text); font-size: .66rem; font-weight: 800; letter-spacing: .09em; text-transform: uppercase; }
+.campaign-desk-heading h2 { font-size: 1rem; font-weight: 750; margin-top: .16rem; }
+.campaign-desk-heading > span { align-items: center; background: var(--ob-accent); border-radius: 99px; color: #fff; display: inline-flex; font-size: .7rem; font-weight: 800; height: 1.8rem; justify-content: center; min-width: 1.8rem; padding: 0 .52rem; }
+.campaign-decision-items { display: grid; gap: .48rem; margin-top: .9rem; }
+.campaign-decision-item { align-items: center; background: rgba(255,255,255,.78); border: 1px solid rgba(199,210,254,.65); border-radius: .75rem; color: inherit; display: flex; gap: .7rem; padding: .62rem .7rem; text-decoration: none; transition: transform .16s ease, box-shadow .16s ease; }
+.campaign-decision-item:hover { box-shadow: var(--shadow-md); transform: translateX(2px); }
+.campaign-decision-rank { color: var(--ob-accent-text); font-family: var(--font-mono); font-size: .64rem; font-weight: 700; }
+.campaign-decision-copy { display: grid; flex: 1; min-width: 0; }
+.campaign-decision-copy strong { font-size: .78rem; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.campaign-decision-copy small { color: var(--text-secondary); font-size: .67rem; margin-top: .12rem; }
+.campaign-decision-empty, .campaign-pulse-empty { color: var(--text-secondary); font-size: .74rem; line-height: 1.45; margin-top: .9rem; }
+.campaign-pulse-live { background: var(--success-bg) !important; color: var(--success-text) !important; }
+.campaign-pulse-muted { background: var(--surface-3) !important; color: var(--text-secondary) !important; }
+.campaign-pulse-numbers { display: grid; gap: .45rem; grid-template-columns: repeat(3, 1fr); margin-top: 1.02rem; }
+.campaign-pulse-numbers div { background: var(--surface-2); border-radius: .66rem; padding: .6rem; }
+.campaign-pulse-numbers strong { display: block; font-size: .95rem; font-variant-numeric: tabular-nums; }
+.campaign-pulse-numbers span { color: var(--text-secondary); display: block; font-size: .61rem; margin-top: .1rem; }
+.campaign-pulse-footnote { color: var(--text-secondary); font-size: .64rem; line-height: 1.35; margin-top: .85rem; }
+@media (max-width: 900px) { .campaign-decision-desk { grid-template-columns: 1fr; } }
+
+/* ── Campaign outcome brief ── */
+.campaign-outcome-brief { background: linear-gradient(110deg, #111827 0%, #172554 56%, #312e81 100%); border-radius: var(--r-xl); box-shadow: var(--shadow-lg); color: #fff; display: grid; grid-template-columns: minmax(0, 1fr) minmax(13.5rem, .32fr); overflow: hidden; }
+.campaign-outcome-main { padding: 1.25rem; }
+.campaign-outcome-title-row { align-items: center; display: flex; gap: .75rem; justify-content: space-between; margin-top: .2rem; }
+.campaign-outcome-title-row h2 { font-size: 1.05rem; font-weight: 750; }
+.campaign-outcome-title-row span { background: rgba(255,255,255,.13); border: 1px solid rgba(255,255,255,.18); border-radius: 99px; font-size: .62rem; font-weight: 800; padding: .28rem .55rem; }
+.campaign-outcome-metrics { display: grid; gap: .5rem; grid-template-columns: repeat(4, minmax(0, 1fr)); margin-top: 1rem; }
+.campaign-outcome-metrics > div { background: rgba(255,255,255,.08); border: 1px solid rgba(255,255,255,.1); border-radius: .7rem; min-width: 0; padding: .58rem; }
+.campaign-outcome-metrics strong { display: block; font-size: 1.02rem; font-variant-numeric: tabular-nums; }
+.campaign-outcome-metrics span { display: block; font-size: .67rem; font-weight: 700; margin-top: .12rem; }
+.campaign-outcome-metrics small { color: rgba(255,255,255,.65); display: block; font-size: .58rem; line-height: 1.2; margin-top: .08rem; }
+.campaign-outcome-conversion[data-conversion='unmeasured'] { background: rgba(255,255,255,.035); }
+.campaign-outcome-evidence { color: rgba(255,255,255,.64); font-size: .64rem; line-height: 1.35; margin-top: .72rem; }
+.campaign-outcome-action { background: rgba(255,255,255,.1); border-left: 1px solid rgba(255,255,255,.12); display: flex; flex-direction: column; justify-content: center; padding: 1.25rem; }
+.campaign-outcome-action p { color: #c7d2fe; font-size: .65rem; font-weight: 800; letter-spacing: .08em; text-transform: uppercase; }
+.campaign-outcome-action strong { font-size: .92rem; line-height: 1.25; margin-top: .32rem; }
+.campaign-outcome-action span { color: rgba(255,255,255,.72); font-size: .7rem; line-height: 1.4; margin-top: .38rem; }
+@media (max-width: 840px) { .campaign-outcome-brief { grid-template-columns: 1fr; } .campaign-outcome-action { border-left: 0; border-top: 1px solid rgba(255,255,255,.12); } }
+@media (max-width: 560px) { .campaign-outcome-metrics { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
 /* Stat-card internals (ADR-0208 D1). `.stat-card` only ever styled the container, so every page
    hand-rolled the label/value typography inline — including colour values derived from a literal
    (`background: ${k.color}18`), which is the duplication D2 exists to remove. These three classes

--- a/openbank-admin-ui/src/components/campaigns/CampaignExperiencePreview.tsx
+++ b/openbank-admin-ui/src/components/campaigns/CampaignExperiencePreview.tsx
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+'use client'
+
+import { useLanguage } from '@/lib/i18n/LanguageContext'
+import type { EditorMobileDestination, EditorStep } from '@/components/campaigns/JourneyEditor'
+
+type Destination = Exclude<EditorMobileDestination, undefined>
+
+const destinationCopy: Record<Destination, { cs: string; en: string; eyebrowCs: string; eyebrowEn: string }> = {
+  HOME: { cs: 'Domovská obrazovka', en: 'Home', eyebrowCs: 'Dnešní přehled', eyebrowEn: 'Today at a glance' },
+  SAVINGS: { cs: 'Spoření', en: 'Savings', eyebrowCs: 'Vaše spoření', eyebrowEn: 'Your savings' },
+  CARDS: { cs: 'Karty', en: 'Cards', eyebrowCs: 'Vaše karty', eyebrowEn: 'Your cards' },
+  PAYMENTS: { cs: 'Platby', en: 'Payments', eyebrowCs: 'Poslat peníze', eyebrowEn: 'Move money' },
+  PRODUCT_HUB: { cs: 'Produkty', en: 'Products', eyebrowCs: 'Pro vás', eyebrowEn: 'Picked for you' },
+}
+
+/**
+ * A deliberately faithful *structure* preview, not an invented content renderer.
+ *
+ * Campaign-service authorises a closed application destination, not arbitrary native UI or copy.
+ * The preview therefore demonstrates the customer sequence (notification → authenticated app →
+ * destination) and uses the selected template headline, while never pretending that Admin UI owns
+ * the mobile app. It keeps the operator's decision tangible without becoming a second app client.
+ */
+export function CampaignExperiencePreview({
+  step,
+  campaignName,
+}: {
+  step: EditorStep | undefined
+  campaignName: string
+}) {
+  const { t, language } = useLanguage()
+  const isPush = step?.channel === 'PUSH'
+  const destination = step?.mobileDestination ?? 'HOME'
+  const copy = destinationCopy[destination]
+  const headline = step?.variables.offerTitle?.trim() || t('Vaše další chytrá volba', 'Your next smart move')
+  const campaignLabel = campaignName.trim() || t('Nová kampaň', 'New campaign')
+
+  return (
+    <section className="campaign-experience-preview" aria-labelledby="experience-preview-title" data-testid="campaign-experience-preview">
+      <div className="campaign-preview-heading">
+        <div>
+          <p className="campaign-preview-kicker">{t('Zážitek zákazníka', 'Customer experience')}</p>
+          <h3 id="experience-preview-title">{t('Na telefonu, ne v tabulce', 'On the phone, not in a table')}</h3>
+        </div>
+        <span className="campaign-preview-live">{t('Živý náhled', 'Live preview')}</span>
+      </div>
+
+      <div className="campaign-preview-stage">
+        <div className="campaign-phone" aria-label={t('Náhled mobilní aplikace', 'Mobile app preview')}>
+          <div className="campaign-phone-island" />
+          <div className="campaign-phone-content">
+            <div className="campaign-phone-topline">
+              <span>openbank</span>
+              <span>•••</span>
+            </div>
+            <p className="campaign-phone-eyebrow">{language === 'cs' ? copy.eyebrowCs : copy.eyebrowEn}</p>
+            <h4>{language === 'cs' ? copy.cs : copy.en}</h4>
+            <div className="campaign-phone-hero">
+              <span>{t('Doporučeno pro vás', 'Recommended for you')}</span>
+              <strong>{headline}</strong>
+              <button type="button" tabIndex={-1}>{t('Zjistit víc', 'Explore')}</button>
+            </div>
+            <div className="campaign-phone-row"><span /><span /><span /></div>
+          </div>
+        </div>
+
+        <div className="campaign-push-card" data-preview-channel={isPush ? 'PUSH' : 'EMAIL'}>
+          <div className="campaign-push-icon">o</div>
+          <div>
+            <div className="campaign-push-meta">OPENBANK · {t('nyní', 'now')}</div>
+            <p className="campaign-push-title">{isPush ? headline : t('Zvolte push krok', 'Choose a push step')}</p>
+            <p>{isPush
+              ? t('Otevře zabezpečenou aplikaci — bez osobního obsahu v notifikaci.', 'Opens the secure app — with no personal content in the notification.')
+              : t('Tento krok je e-mail. Vyberte push krok na cestě pro náhled notifikace.', 'This step is email. Select a push step on the journey to preview the notification.')}</p>
+          </div>
+        </div>
+      </div>
+
+      <div className="campaign-preview-route">
+        <span>{t('Po klepnutí', 'After tap')}</span>
+        <strong>{campaignLabel} → {language === 'cs' ? copy.cs : copy.en}</strong>
+        <code>{`openbank://${destination.toLowerCase().replace('product_hub', 'products')}`}</code>
+      </div>
+    </section>
+  )
+}

--- a/openbank-admin-ui/src/components/campaigns/CampaignLaunchReadiness.tsx
+++ b/openbank-admin-ui/src/components/campaigns/CampaignLaunchReadiness.tsx
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+'use client'
+
+import { useLanguage } from '@/lib/i18n/LanguageContext'
+import type { EditorStep } from '@/components/campaigns/JourneyEditor'
+
+type ReadinessState = 'ready' | 'attention' | 'waiting'
+
+interface ReadinessItem {
+  id: string
+  state: ReadinessState
+  label: string
+  detail: string
+}
+
+/**
+ * Turns platform constraints into a launch conversation at the point of authoring.
+ *
+ * A disabled Create button is technically correct but tells a marketer neither what is missing nor
+ * whether a policy will still change the reachable audience. This list has no hidden validation:
+ * every item is derived from the same state sent to campaign-service, and policy remains explicitly
+ * read-only rather than offering a fake override.
+ */
+export function CampaignLaunchReadiness({
+  audienceChosen,
+  audienceSize,
+  entryConfigured,
+  incomplete,
+  conversionRule,
+  contentExperiment,
+  steps,
+}: {
+  audienceChosen: boolean
+  audienceSize: number | null
+  entryConfigured: boolean
+  incomplete: boolean
+  conversionRule: string | null
+  contentExperiment: boolean
+  steps: EditorStep[]
+}) {
+  const { t, language } = useLanguage()
+  const n = (value: number) => value.toLocaleString(language === 'cs' ? 'cs-CZ' : 'en-GB')
+  const push = steps.find(step => step.channel === 'PUSH')
+  const readyCount = [audienceChosen, entryConfigured, !incomplete, !contentExperiment || conversionRule !== null].filter(Boolean).length
+
+  const items: ReadinessItem[] = [
+    audienceChosen
+      ? {
+          id: 'audience', state: audienceSize === null ? 'attention' : 'ready',
+          label: t('Publikum je vybrané', 'Audience is selected'),
+          detail: audienceSize === null
+            ? t('Dosah se ještě dopočítává.', 'Reach is still being calculated.')
+            : t(`Před kontrolou souhlasu: přibližně ${n(audienceSize)} lidí.`, `Before consent checks: roughly ${n(audienceSize)} people.`),
+        }
+      : { id: 'audience', state: 'waiting', label: t('Vyberte publikum', 'Choose an audience'), detail: t('Segment určí, kdo může do cesty vstoupit.', 'A segment decides who may enter the journey.') },
+    entryConfigured
+      ? { id: 'entry', state: 'ready', label: t('Vstup do cesty je jasný', 'Journey entry is clear'), detail: t('Každý vstup je dohledatelný a přezkoumatelný.', 'Every entry is traceable and reviewable.') }
+      : { id: 'entry', state: 'waiting', label: t('Vyberte, kdy cesta začne', 'Choose when the journey starts'), detail: t('Jednorázově, opakovaně nebo po události.', 'One time, recurring, or after an event.') },
+    incomplete
+      ? { id: 'content', state: 'waiting', label: t('Doplňte obsah kroku', 'Complete step content'), detail: t('Každý krok potřebuje všechny hodnoty své schválené šablony.', 'Every step needs all values from its approved template.') }
+      : { id: 'content', state: 'ready', label: t('Cesta má kompletní obsah', 'Journey content is complete'), detail: t(`${steps.length} ${steps.length === 1 ? 'krok je' : 'kroky jsou'} připravené ke kontrole.`, `${steps.length} ${steps.length === 1 ? 'step is' : 'steps are'} ready for review.`) },
+    contentExperiment && conversionRule === null
+      ? { id: 'measurement', state: 'waiting', label: t('Experiment potřebuje měřitelný cíl', 'Experiment needs a measurable goal'), detail: t('Bez skutečné bankovní konverze by A/B srovnání nemělo výsledek.', 'Without a real banking conversion, A/B comparison has no outcome.') }
+      : conversionRule
+        ? { id: 'measurement', state: 'ready', label: t('Výsledek je měřitelný', 'Outcome is measurable'), detail: t('Měříme bankovní událost, ne domnělý proklik.', 'This measures a banking event, not an assumed click.') }
+        : { id: 'measurement', state: 'attention', label: t('Kampaň neměří výsledek', 'Campaign does not measure an outcome'), detail: t('Můžete pokračovat, ale po spuštění nepůjde porovnat skutečný dopad.', 'You can continue, but the actual outcome cannot be compared after launch.') },
+    push
+      ? { id: 'destination', state: 'ready', label: t('Push má bezpečný cíl v aplikaci', 'Push has a safe in-app destination'), detail: t('Jen schválený deep link; žádná URL z kampaně.', 'An approved deep link only; no campaign-entered URL.') }
+      : { id: 'destination', state: 'attention', label: t('Cesta zatím nemá push krok', 'Journey has no push step yet'), detail: t('Přidejte ho, pokud má kampaň přivést lidi zpět do aplikace.', 'Add one if the campaign should bring people back into the app.') },
+    { id: 'policy', state: 'ready', label: t('Ochrana kontaktu zůstává zapnutá', 'Contact protection stays on'), detail: t('Souhlas, tiché hodiny a frekvenční limit se ověřují při doručení.', 'Consent, quiet hours and frequency limits are checked at delivery.') },
+  ]
+
+  return (
+    <section className="campaign-launch-readiness" aria-labelledby="launch-readiness-title" data-testid="campaign-launch-readiness">
+      <div className="campaign-readiness-heading">
+        <div>
+          <p className="campaign-preview-kicker">{t('Před spuštěním', 'Before launch')}</p>
+          <h3 id="launch-readiness-title">{t('Připraveno na kontrolu?', 'Ready for review?')}</h3>
+        </div>
+        <strong>{readyCount}/4</strong>
+      </div>
+      <p className="campaign-readiness-intro">
+        {t('Jeden pohled na to, co lidé uvidí a co může změnit skutečný dosah.', 'One view of what people see and what can change actual reach.')}
+      </p>
+      <ul className="campaign-readiness-list">
+        {items.map(item => (
+          <li key={item.id} data-readiness={item.id} data-state={item.state}>
+            <span aria-hidden="true">{item.state === 'ready' ? '✓' : item.state === 'attention' ? '!' : '·'}</span>
+            <div><strong>{item.label}</strong><p>{item.detail}</p></div>
+          </li>
+        ))}
+      </ul>
+    </section>
+  )
+}

--- a/openbank-admin-ui/src/components/campaigns/CampaignOutcomeBrief.tsx
+++ b/openbank-admin-ui/src/components/campaigns/CampaignOutcomeBrief.tsx
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+'use client'
+
+import { useLanguage } from '@/lib/i18n/LanguageContext'
+
+/**
+ * The campaign detail's decision layer.
+ *
+ * This uses the campaign service's whole-campaign aggregates, never the visible page of send rows.
+ * "Handed off" is intentionally not called delivered: Campaign-service knows it accepted a send
+ * request, while notification-service owns the later delivery confirmation. The distinction is
+ * critical on a marketing screen because a successful-looking number otherwise becomes a promise
+ * about a customer's device.
+ */
+export function CampaignOutcomeBrief({
+  state,
+  audience,
+  handedOff,
+  suppressed,
+  conversion,
+  conversionLabel,
+  nextAction,
+  nextActionDetail,
+}: {
+  state: string
+  audience: number
+  handedOff: number
+  suppressed: number
+  /** Null means the campaign is not configured to measure an outcome. */
+  conversion: number | null
+  conversionLabel?: string
+  nextAction: string
+  nextActionDetail: string
+}) {
+  const { t, language } = useLanguage()
+  const metrics = [
+    { label: t('Publikum', 'Audience'), value: audience, detail: t('zařazeno', 'enrolled') },
+    { label: t('Předáno', 'Handed off'), value: handedOff, detail: t('notification službě', 'to notification service') },
+    { label: t('Chráněno', 'Protected'), value: suppressed, detail: t('potlačeno pravidlem', 'suppressed by policy') },
+  ]
+
+  return (
+    <section className="campaign-outcome-brief" aria-labelledby="campaign-outcome-title" data-testid="campaign-outcome-brief">
+      <div className="campaign-outcome-main">
+        <p className="campaign-preview-kicker">{t('Pulse kampaně', 'Campaign pulse')}</p>
+        <div className="campaign-outcome-title-row">
+          <h2 id="campaign-outcome-title">{t('Další rozhodnutí opřete o data', 'Make the next decision with evidence')}</h2>
+          <span data-campaign-state={state}>{state}</span>
+        </div>
+        <div className="campaign-outcome-metrics">
+          {metrics.map(metric => (
+            <div key={metric.label}>
+              <strong>{metric.value.toLocaleString(language === 'cs' ? 'cs-CZ' : 'en-GB')}</strong>
+              <span>{metric.label}</span>
+              <small>{metric.detail}</small>
+            </div>
+          ))}
+          <div className="campaign-outcome-conversion" data-conversion={conversion === null ? 'unmeasured' : 'measured'}>
+            <strong>{conversion === null ? '—' : conversion.toLocaleString(language === 'cs' ? 'cs-CZ' : 'en-GB')}</strong>
+            <span>{conversionLabel ?? t('Výsledek', 'Outcome')}</span>
+            <small>{conversion === null ? t('neměřeno', 'not measured') : t('během zařazení', 'while enrolled')}</small>
+          </div>
+        </div>
+        <p className="campaign-outcome-evidence">{t('Jen provoz kampaně — in-app engagement se této kampani zatím nepřipisuje.', 'Campaign operations only — no in-app engagement is attributed to this campaign yet.')}</p>
+      </div>
+      <aside className="campaign-outcome-action" data-testid="campaign-outcome-next-action">
+        <p>{t('Další nejlepší akce', 'Next best action')}</p>
+        <strong>{nextAction}</strong>
+        <span>{nextActionDetail}</span>
+      </aside>
+    </section>
+  )
+}

--- a/openbank-admin-ui/src/components/campaigns/JourneyEditor.tsx
+++ b/openbank-admin-ui/src/components/campaigns/JourneyEditor.tsx
@@ -29,15 +29,23 @@ import { useLanguage } from '@/lib/i18n/LanguageContext'
 
 export type EditorChannel = 'EMAIL' | 'PUSH'
 
+export type EditorMobileDestination = 'HOME' | 'SAVINGS' | 'CARDS' | 'PAYMENTS' | 'PRODUCT_HUB'
+
 export type EditorCondition = 'IF_PREVIOUS_CONFIRMED' | 'IF_PREVIOUS_NOT_CONFIRMED'
 
 export interface EditorStep {
   template: string
   channel: EditorChannel
-  variables: Record<string, string>
+  variables: { [key: string]: string }
   delaySeconds: number
   /** Absent means the step always runs. Evaluated against the previous send's delivery status. */
   condition?: EditorCondition
+  /** Alternative B-arm values in a campaign-wide content experiment. */
+  variantBVariables?: { [key: string]: string }
+  /** Try the catalogue's safe app-push counterpart only when email consent is absent. */
+  fallbackToPush?: boolean
+  /** Closed app context reached after a push tap; never an arbitrary URL. */
+  mobileDestination?: EditorMobileDestination
 }
 
 export const MAX_STEPS = 5
@@ -292,6 +300,11 @@ export function JourneyEditor({
                   fill="var(--text-primary)">
                   {templateLabels[step.template] ?? step.template}
                 </text>
+                {step.fallbackToPush && (
+                  <text x={x + 14 + ICON + 12} y={ROW_Y + 26} fontSize="10.5" fill="var(--text-secondary)">
+                    {t('bez e-mail souhlasu → push', 'no email consent → push')}
+                  </text>
+                )}
               </g>
 
               {/* Remove sits on the node rather than in a toolbar: the thing it acts on is the thing

--- a/openbank-admin-ui/src/components/campaigns/StepEditor.tsx
+++ b/openbank-admin-ui/src/components/campaigns/StepEditor.tsx
@@ -26,6 +26,7 @@ export function StepEditor({
   templateChannel,
   templateLabels,
   variableLabels,
+  contentExperiment = false,
   onChange,
   onClose,
   attached = false,
@@ -45,6 +46,8 @@ export function StepEditor({
    * actual question and a bare box does not answer it.
    */
   variableLabels: Record<string, { label: string; example: string }>
+  /** When enabled, every step has a B-arm copy to compare against its original A-arm values. */
+  contentExperiment?: boolean
   onChange: (next: EditorStep) => void
   onClose: () => void
   /**
@@ -104,7 +107,16 @@ export function StepEditor({
                 data-channel-pick={c}
                 data-selected={active ? 'true' : 'false'}
                 disabled={!first}
-                onClick={() => first && onChange({ ...step, channel: c, template: first, variables: {} })}
+                onClick={() => first && onChange({
+                  ...step,
+                  channel: c,
+                  template: first,
+                  variables: {},
+                  ...(c === 'PUSH'
+                    ? { fallbackToPush: false, mobileDestination: step.mobileDestination ?? 'HOME' }
+                    : { mobileDestination: undefined }),
+                  ...(step.variantBVariables !== undefined ? { variantBVariables: {} } : {}),
+                })}
                 // `.btn` again rather than a hand-rolled box — the third time tonight that a
                 // house primitive existed and a worse copy was written next to it. `py-1.5` is not
                 // even generated in this build, so the copy rendered cramped.
@@ -121,12 +133,49 @@ export function StepEditor({
           })}
         </div>
         {step.channel === 'PUSH' && (
-          <p className="text-xs text-muted-foreground">
-            {t(
-              'Push nese jen titulek. Nabídku si člověk přečte v aplikaci po klepnutí — do notifikace se osobní obsah nedává.',
-              'A push carries the headline only. The offer is read in the app after the tap — personal content never goes into a notification.',
-            )}
-          </p>
+          <>
+            <p className="text-xs text-muted-foreground">
+              {t(
+                'Push nese jen titulek. Nabídku si člověk přečte v aplikaci po klepnutí — do notifikace se osobní obsah nedává.',
+                'A push carries the headline only. The offer is read in the app after the tap — personal content never goes into a notification.',
+              )}
+            </p>
+            <label className="mt-3 block space-y-1.5 text-sm" data-mobile-destination={index}>
+              <span className="font-medium">{t('Po klepnutí otevřít', 'Open after tap')}</span>
+              <select
+                className={field}
+                value={step.mobileDestination ?? 'HOME'}
+                onChange={e => onChange({ ...step, mobileDestination: e.target.value as EditorStep['mobileDestination'] })}
+              >
+                <option value="HOME">{t('Domovská obrazovka', 'Home')}</option>
+                <option value="SAVINGS">{t('Spoření', 'Savings')}</option>
+                <option value="CARDS">{t('Karty', 'Cards')}</option>
+                <option value="PAYMENTS">{t('Platby', 'Payments')}</option>
+                <option value="PRODUCT_HUB">{t('Produkty', 'Products')}</option>
+              </select>
+              <span className="block text-xs text-muted-foreground">
+                {t('Jde o pevný deep-link aplikace, ne URL zadanou do kampaně.', 'This is a fixed app deep link, not a campaign-entered URL.')}
+              </span>
+            </label>
+          </>
+        )}
+        {step.channel === 'EMAIL' && (
+          <label className="mt-3 flex cursor-pointer items-start gap-2 text-sm" data-push-fallback={index}>
+            <input
+              type="checkbox"
+              checked={step.fallbackToPush === true}
+              onChange={e => onChange({ ...step, fallbackToPush: e.target.checked })}
+            />
+            <span>
+              <span className="font-medium">{t('Když chybí e-mailový souhlas, zkusit push', 'When email consent is absent, try push')}</span>
+              <span className="mt-0.5 block text-xs text-muted-foreground">
+                {t(
+                  'Push projde vlastním souhlasem i stejnými limity. Není to druhý pokus po nedoručení e-mailu.',
+                  'Push goes through its own consent and the same limits. It is not a second attempt after an email delivery failure.',
+                )}
+              </span>
+            </span>
+          </label>
         )}
       </div>
 
@@ -138,7 +187,12 @@ export function StepEditor({
           id={`tpl-${index}`}
           className={field}
           value={step.template}
-          onChange={e => onChange({ ...step, template: e.target.value, variables: {} })}
+          onChange={e => onChange({
+            ...step,
+            template: e.target.value,
+            variables: {},
+            ...(step.variantBVariables !== undefined ? { variantBVariables: {} } : {}),
+          })}
         >
           {Object.keys(templates).filter(tpl => templateChannel[tpl] === step.channel).map(tpl => (
             <option key={tpl} value={tpl}>
@@ -174,6 +228,37 @@ export function StepEditor({
           />
         </div>
       ))}
+
+      {contentExperiment && (
+        <div className="rounded-md border border-dashed p-3 space-y-3" data-variant-b-editor={index}>
+          <div>
+            <p className="text-sm font-medium">{t('Varianta B', 'Variant B')}</p>
+            <p className="text-xs text-muted-foreground">
+              {t(
+                'Každý člověk zůstane po celou cestu ve stejné variantě. Změňte jen hodnoty, které chcete porovnat.',
+                'Each person stays in the same variant throughout the journey. Change only the values you want to compare.',
+              )}
+            </p>
+          </div>
+          {declared.map(v => (
+            <div key={v} className="space-y-1.5">
+              <label htmlFor={`var-b-${index}-${v}`} className="text-sm font-medium">
+                {variableLabels[v]?.label ?? v}
+              </label>
+              <input
+                id={`var-b-${index}-${v}`}
+                className={field}
+                placeholder={variableLabels[v]?.example ?? ''}
+                value={step.variantBVariables?.[v] ?? ''}
+                onChange={e => onChange({
+                  ...step,
+                  variantBVariables: { ...step.variantBVariables, [v]: e.target.value },
+                })}
+              />
+            </div>
+          ))}
+        </div>
+      )}
 
       {/* The gate, next to the delay, because the two together answer "when does this go out, and to
           whom". `CONFIRMED` is delivery as notification-service reports it (ADR-0239 D3) — never

--- a/openbank-admin-ui/src/test/campaign-detail-bff.test.ts
+++ b/openbank-admin-ui/src/test/campaign-detail-bff.test.ts
@@ -72,4 +72,34 @@ describe('campaign detail bundle', () => {
     expect(d.sources.journey).toBe('not_deployed')
     expect(Array.isArray(d.journey)).toBe(true)
   })
+
+  it('reads A/B measurement only for a campaign that configured variant B', async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      const u = String(url)
+      if (u.endsWith('/content-experiment')) {
+        return { ok: true, status: 200, json: async () => ({ from: 'content-experiment' }), headers: new Headers() }
+      }
+      if (u.endsWith('/abc')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ steps: [{ variantBVariables: { offerTitle: 'B' } }] }),
+          headers: new Headers(),
+        }
+      }
+      return { ok: true, status: 200, json: async () => [], headers: new Headers() }
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { GET } = await import('@/app/api/campaigns/[id]/route')
+    const res = await GET(new Request('http://x/api/campaigns/abc'), { params: Promise.resolve({ id: 'abc' }) })
+    const d = await res.json()
+
+    expect(d.contentExperiment).toEqual({ from: 'content-experiment' })
+    expect(d.sources.contentExperiment).toBe('ok')
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining('/api/v1/campaigns/abc/content-experiment'),
+      expect.anything(),
+    )
+  })
 })

--- a/openbank-admin-ui/src/test/campaign-entry-catalogues-bff.test.ts
+++ b/openbank-admin-ui/src/test/campaign-entry-catalogues-bff.test.ts
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/auth', () => ({ auth: async () => ({ user: { accessToken: 'token' } }) }))
+vi.mock('@/lib/services/bff', () => ({ serverSvcUrl: (_service: string, _name: string, _port: number, path: string) => `http://campaign${path}` }))
+
+describe('campaign entry catalogue BFF', () => {
+  beforeEach(() => vi.resetModules())
+
+  it('forwards cadence and trigger catalogues through the authenticated BFF', async () => {
+    const fetchMock = vi.fn(async (url: string) => ({
+      ok: true,
+      status: 200,
+      json: async () => url.endsWith('/cadences')
+        ? [{ cadence: 'DAILY_MORNING', humanForm: 'every day at 09:00', zone: 'Europe/Prague' }]
+        : [{ trigger: 'ACCOUNT_OPENED', humanForm: 'when an account is opened' }],
+    }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { GET: cadences } = await import('@/app/api/campaigns/cadences/route')
+    const { GET: triggers } = await import('@/app/api/campaigns/triggers/route')
+
+    await expect((await cadences()).json()).resolves.toEqual({
+      items: [{ cadence: 'DAILY_MORNING', humanForm: 'every day at 09:00', zone: 'Europe/Prague' }],
+      state: 'ok',
+    })
+    await expect((await triggers()).json()).resolves.toEqual({
+      items: [{ trigger: 'ACCOUNT_OPENED', humanForm: 'when an account is opened' }],
+      state: 'ok',
+    })
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://campaign/api/v1/campaigns/cadences',
+      expect.objectContaining({ headers: { authorization: 'Bearer token' } }),
+    )
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://campaign/api/v1/campaigns/triggers',
+      expect.objectContaining({ headers: { authorization: 'Bearer token' } }),
+    )
+  })
+})

--- a/openbank-admin-ui/src/test/campaign-experience-preview.test.tsx
+++ b/openbank-admin-ui/src/test/campaign-experience-preview.test.tsx
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import React from 'react'
+import { describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { LanguageProvider } from '@/lib/i18n/LanguageContext'
+import { CampaignExperiencePreview } from '@/components/campaigns/CampaignExperiencePreview'
+import { CampaignLaunchReadiness } from '@/components/campaigns/CampaignLaunchReadiness'
+import type { EditorStep } from '@/components/campaigns/JourneyEditor'
+
+const push: EditorStep = {
+  channel: 'PUSH',
+  template: 'MARKETING_PRODUCT_OFFER_PUSH',
+  variables: { offerTitle: 'Savings at 4%' },
+  delaySeconds: 0,
+  mobileDestination: 'SAVINGS',
+}
+
+describe('campaign customer experience preview', () => {
+  it('renders a push with its selected closed app destination', () => {
+    const { container } = render(
+      <LanguageProvider><CampaignExperiencePreview step={push} campaignName="Summer saving" /></LanguageProvider>,
+    )
+
+    // The headline intentionally appears in the notification and again in the authenticated app
+    // destination. One occurrence would test only half of the customer sequence.
+    expect(screen.getAllByText('Savings at 4%')).toHaveLength(2)
+    expect(screen.getByText(/Summer saving → Savings/)).toBeTruthy()
+    expect(container.querySelector('[data-preview-channel="PUSH"]')).toBeTruthy()
+    expect(screen.getByText('openbank://savings')).toBeTruthy()
+  })
+
+  it('does not pretend an email is a push notification', () => {
+    const { container } = render(
+      <LanguageProvider><CampaignExperiencePreview step={{ ...push, channel: 'EMAIL', mobileDestination: undefined }} campaignName="" /></LanguageProvider>,
+    )
+
+    expect(container.querySelector('[data-preview-channel="EMAIL"]')).toBeTruthy()
+    expect(screen.getByText(/Choose a push step/)).toBeTruthy()
+  })
+})
+
+describe('campaign launch readiness', () => {
+  it('names missing inputs and preserves policy as a non-optional guardrail', () => {
+    const { container } = render(
+      <LanguageProvider>
+        <CampaignLaunchReadiness
+          audienceChosen={false}
+          audienceSize={null}
+          entryConfigured={false}
+          incomplete
+          conversionRule={null}
+          contentExperiment={false}
+          steps={[{ ...push, channel: 'EMAIL', mobileDestination: undefined }]}
+        />
+      </LanguageProvider>,
+    )
+
+    expect(container.querySelector('[data-readiness="audience"][data-state="waiting"]')).toBeTruthy()
+    expect(container.querySelector('[data-readiness="content"][data-state="waiting"]')).toBeTruthy()
+    expect(container.querySelector('[data-readiness="policy"][data-state="ready"]')).toBeTruthy()
+    expect(screen.getByText(/Journey has no push step/)).toBeTruthy()
+  })
+})

--- a/openbank-admin-ui/src/test/campaign-outcome-brief.test.tsx
+++ b/openbank-admin-ui/src/test/campaign-outcome-brief.test.tsx
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import React from 'react'
+import { describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { CampaignOutcomeBrief } from '@/components/campaigns/CampaignOutcomeBrief'
+import { LanguageProvider } from '@/lib/i18n/LanguageContext'
+
+describe('campaign outcome brief', () => {
+  it('distinguishes handed-off sends from a measured outcome', () => {
+    render(
+      <LanguageProvider><CampaignOutcomeBrief
+          state="ACTIVE"
+          audience={1240}
+          handedOff={1110}
+          suppressed={96}
+          conversion={48}
+          conversionLabel="Account opened"
+          nextAction="Follow the journey and outcome"
+          nextActionDetail="Delivery and conversion are different facts."
+        /></LanguageProvider>,
+    )
+
+    expect(screen.getByText('Handed off')).toBeTruthy()
+    expect(screen.getByText('to notification service')).toBeTruthy()
+    expect(screen.getByText('Account opened')).toBeTruthy()
+    expect(screen.getByText(/no in-app engagement is attributed/)).toBeTruthy()
+  })
+
+  it('does not show a zero outcome when the campaign measures nothing', () => {
+    const { container } = render(
+      <LanguageProvider><CampaignOutcomeBrief
+          state="ACTIVE"
+          audience={12}
+          handedOff={10}
+          suppressed={2}
+          conversion={null}
+          conversionLabel="Outcome is not measured"
+          nextAction="Consider a measurable outcome"
+          nextActionDetail="The journey can still run."
+        /></LanguageProvider>,
+    )
+
+    expect(container.querySelector('[data-conversion="unmeasured"]')).toBeTruthy()
+    expect(screen.getByText('not measured')).toBeTruthy()
+  })
+})

--- a/openbank-admin-ui/src/test/campaign-studio.test.tsx
+++ b/openbank-admin-ui/src/test/campaign-studio.test.tsx
@@ -147,6 +147,43 @@ describe('campaign studio', () => {
     expect(createBody).not.toHaveProperty('trigger')
   }, 15000)
 
+  it('authors both content arms and submits a measurable A/B experiment', async () => {
+    let createBody: Record<string, unknown> | undefined
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (url.includes('/api/segments')) return { ok: true, status: 200, json: async () => SEGMENTS }
+      if (url.includes('/api/campaigns/cadences')) return { ok: true, status: 200, json: async () => CADENCES }
+      if (url.includes('/api/campaigns/triggers')) return { ok: true, status: 200, json: async () => TRIGGERS }
+      if (url === '/api/campaigns') {
+        createBody = JSON.parse(String(init?.body))
+        return { ok: true, status: 200, json: async () => ({ state: 'ok', campaign: { id: CAMPAIGN_ID } }) }
+      }
+      return { ok: true, status: 200, json: async () => ({}) }
+    }))
+    render(React.createElement(Providers, null, React.createElement(NewCampaignPage)))
+
+    await waitFor(() => expect(document.querySelector('[data-segment="actives@1"]')).toBeTruthy(), { timeout: 8000 })
+    fireEvent.change(document.getElementById('c-name')!, { target: { value: 'Two headlines' } })
+    fireEvent.change(document.getElementById('c-goal')!, { target: { value: 'Open more accounts' } })
+    fireEvent.click(document.querySelector('[data-segment="actives@1"]')!)
+    fireEvent.change(document.getElementById('var-0-offerTitle')!, { target: { value: 'A headline' } })
+    fireEvent.change(document.getElementById('var-0-offerText')!, { target: { value: 'A copy' } })
+    fireEvent.change(document.getElementById('var-0-ctaText')!, { target: { value: 'Open' } })
+    fireEvent.click(document.querySelector('[data-conversion-pick="ACCOUNT_OPENED"]')!)
+    fireEvent.click(document.getElementById('c-content-experiment')!)
+
+    await waitFor(() => expect(document.getElementById('var-b-0-offerTitle')).toBeTruthy())
+    fireEvent.change(document.getElementById('var-b-0-offerTitle')!, { target: { value: 'B headline' } })
+    fireEvent.change(document.getElementById('var-b-0-offerText')!, { target: { value: 'B copy' } })
+    fireEvent.change(document.getElementById('var-b-0-ctaText')!, { target: { value: 'Try' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Create draft' }))
+
+    await waitFor(() => expect(createBody).toMatchObject({
+      conversionRule: 'ACCOUNT_OPENED',
+      steps: [{ variables: { offerTitle: 'A headline' }, variantBVariables: { offerTitle: 'B headline' } }],
+    }))
+  }, 15000)
+
   it('a draft can be submitted but not activated from the same screen', async () => {
     vi.stubGlobal('fetch', mockFetch({ [`/api/campaigns/${CAMPAIGN_ID}`]: detail('DRAFT') }))
     renderDetail()
@@ -154,6 +191,33 @@ describe('campaign studio', () => {
     await waitFor(() => expect(screen.getByText('Submit for approval')).toBeTruthy(), { timeout: 8000 })
     // The whole point of four eyes: the author never sees the button that would let them skip it.
     expect(screen.queryByText('Approve and activate')).toBeNull()
+  }, 15000)
+
+  it('submits an opted-in consent fallback as part of the step definition', async () => {
+    let createBody: Record<string, unknown> | undefined
+    vi.stubGlobal('fetch', vi.fn(async (url: string, init?: RequestInit) => {
+      if (String(url) === '/api/campaigns' && init?.method === 'POST') {
+        createBody = JSON.parse(String(init.body))
+        return { ok: true, status: 201, json: async () => ({ state: 'ok', campaign: { id: CAMPAIGN_ID } }) }
+      }
+      if (String(url).includes('/api/segments')) return { ok: true, status: 200, json: async () => SEGMENTS }
+      if (String(url).includes('/cadences')) return { ok: true, status: 200, json: async () => CADENCES }
+      if (String(url).includes('/triggers')) return { ok: true, status: 200, json: async () => TRIGGERS }
+      return { ok: true, status: 200, json: async () => ({}) }
+    }))
+    render(React.createElement(Providers, null, React.createElement(NewCampaignPage)))
+
+    await waitFor(() => expect(document.querySelector('[data-segment="actives@1"]')).toBeTruthy(), { timeout: 8000 })
+    fireEvent.change(document.getElementById('c-name')!, { target: { value: 'Fallback offer' } })
+    fireEvent.change(document.getElementById('c-goal')!, { target: { value: 'Open more accounts' } })
+    fireEvent.click(document.querySelector('[data-segment="actives@1"]')!)
+    fireEvent.change(document.getElementById('var-0-offerTitle')!, { target: { value: 'Headline' } })
+    fireEvent.change(document.getElementById('var-0-offerText')!, { target: { value: 'Copy' } })
+    fireEvent.change(document.getElementById('var-0-ctaText')!, { target: { value: 'Open' } })
+    fireEvent.click(document.querySelector('[data-push-fallback="0"] input')!)
+    fireEvent.click(screen.getByRole('button', { name: 'Create draft' }))
+
+    await waitFor(() => expect(createBody).toMatchObject({ steps: [{ fallbackToPush: true }] }))
   }, 15000)
 
   /**
@@ -198,5 +262,68 @@ describe('campaign studio', () => {
 
     await waitFor(() => expect(document.querySelector('[data-campaign-entry]')).toBeTruthy(), { timeout: 8000 })
     expect(screen.getByText(/every day at 09:00 \(Europe\/Prague\)/)).toBeTruthy()
+  }, 15000)
+
+  it('states the consent-bound push fallback in campaign detail', async () => {
+    const fallbackDetail = {
+      ...detail('ACTIVE'),
+      campaign: {
+        ...detail('ACTIVE').campaign,
+        steps: [{ order: 1, template: 'MARKETING_PRODUCT_OFFER', delaySeconds: 0, fallbackToPush: true }],
+      },
+    }
+    vi.stubGlobal('fetch', mockFetch({ [`/api/campaigns/${CAMPAIGN_ID}`]: fallbackDetail }))
+    renderDetail()
+
+    await waitFor(() => expect(document.querySelector('[data-channel-fallback]')).toBeTruthy(), { timeout: 8000 })
+    expect(screen.getByText('Fallback channel')).toBeTruthy()
+    expect(screen.getByText(/never triggers a second message/i)).toBeTruthy()
+  }, 15000)
+
+  it('shows the actual push channel in the send log instead of inferring it from the step', async () => {
+    const auditDetail = {
+      ...detail('ACTIVE'),
+      sends: {
+        items: [{
+          id: 'send-1', partyId: 'party-1', stepOrder: 1, outcome: 'SENT', channel: 'PUSH',
+          deliveryStatus: 'CONFIRMED', occurredAt: '2026-08-12T10:00:00Z',
+        }], total: 1, page: 0, size: 50,
+      },
+    }
+    vi.stubGlobal('fetch', mockFetch({ [`/api/campaigns/${CAMPAIGN_ID}`]: auditDetail }))
+    renderDetail()
+
+    await waitFor(() => expect(screen.getByText('Channel')).toBeTruthy(), { timeout: 8000 })
+    expect(screen.getByText('Push')).toBeTruthy()
+  }, 15000)
+
+  it('renders a content experiment as A and B measurements, never an automatic winner', async () => {
+    const experimentDetail = {
+      ...detail('ACTIVE'),
+      campaign: {
+        ...detail('ACTIVE').campaign,
+        conversionRule: 'ACCOUNT_OPENED',
+        steps: [{ order: 1, template: 'MARKETING_PRODUCT_OFFER', delaySeconds: 0, variantBVariables: { offerTitle: 'B' } }],
+      },
+      contentExperiment: {
+        a: { assigned: 120, converted: 10, conversionRate: 10 / 120 },
+        b: { assigned: 120, converted: 30, conversionRate: 0.25 },
+        observedLiftPercentagePoints: 16.666667,
+        decision: {
+          state: 'B_OUTPERFORMS_A',
+          minimumAssignedPerVariant: 100,
+          aConfidenceInterval: { lower: 0.04, upper: 0.16 },
+          bConfidenceInterval: { lower: 0.18, upper: 0.34 },
+        },
+      },
+      sources: { campaign: 'ok', enrolments: 'ok', sends: 'ok', sendSummary: 'ok', journey: 'ok', contentExperiment: 'ok' },
+    }
+    vi.stubGlobal('fetch', mockFetch({ [`/api/campaigns/${CAMPAIGN_ID}`]: experimentDetail }))
+    renderDetail()
+
+    await waitFor(() => expect(document.querySelector('[data-content-experiment]')).toBeTruthy(), { timeout: 8000 })
+    expect(screen.getByText('A/B content comparison')).toBeTruthy()
+    expect(screen.getAllByText(/variant B/i)).not.toHaveLength(0)
+    expect(screen.getByText(/does not deploy it automatically/i)).toBeTruthy()
   }, 15000)
 })

--- a/openbank-admin-ui/src/test/campaign-studio.test.tsx
+++ b/openbank-admin-ui/src/test/campaign-studio.test.tsx
@@ -4,7 +4,7 @@
 
 import React from 'react'
 import { describe, expect, it, vi, beforeEach } from 'vitest'
-import { render, screen, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { SessionProvider } from 'next-auth/react'
 import { LanguageProvider } from '@/lib/i18n/LanguageContext'
 import CampaignDetailPage from '@/app/campaigns/[id]/page'
@@ -17,6 +17,16 @@ const CAMPAIGN_ID = '7b1f1d5e-0d2a-4a6a-8f7e-2c1b9a0d3e4f'
 const SEGMENTS = {
   state: 'ok',
   items: [{ name: 'actives', version: 1, rules: ['party status is ACTIVE'] }],
+}
+
+const CADENCES = {
+  state: 'ok',
+  items: [{ cadence: 'DAILY_MORNING', humanForm: 'every day at 09:00', zone: 'Europe/Prague' }],
+}
+
+const TRIGGERS = {
+  state: 'ok',
+  items: [{ trigger: 'ACCOUNT_OPENED', humanForm: 'when an account is opened' }],
 }
 
 function detail(state: string) {
@@ -106,6 +116,37 @@ describe('campaign studio', () => {
     expect(document.querySelectorAll('[id^="var-0-"]').length).toBe(3)
   }, 15000)
 
+  it('creates a recurring campaign from the served cadence catalogue', async () => {
+    let createBody: Record<string, unknown> | undefined
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (url.includes('/api/segments')) return { ok: true, status: 200, json: async () => SEGMENTS }
+      if (url.includes('/api/campaigns/cadences')) return { ok: true, status: 200, json: async () => CADENCES }
+      if (url.includes('/api/campaigns/triggers')) return { ok: true, status: 200, json: async () => TRIGGERS }
+      if (url === '/api/campaigns') {
+        createBody = JSON.parse(String(init?.body))
+        return { ok: true, status: 200, json: async () => ({ state: 'ok', campaign: { id: CAMPAIGN_ID } }) }
+      }
+      return { ok: true, status: 200, json: async () => ({}) }
+    }))
+    render(React.createElement(Providers, null, React.createElement(NewCampaignPage)))
+
+    await waitFor(() => expect(document.querySelector('[data-segment="actives@1"]')).toBeTruthy(), { timeout: 8000 })
+    fireEvent.change(document.getElementById('c-name')!, { target: { value: 'Recurring welcome' } })
+    fireEvent.change(document.getElementById('c-goal')!, { target: { value: 'Keep new customers engaged' } })
+    fireEvent.click(document.querySelector('[data-segment="actives@1"]')!)
+    fireEvent.change(document.getElementById('var-0-offerTitle')!, { target: { value: 'Welcome' } })
+    fireEvent.change(document.getElementById('var-0-offerText')!, { target: { value: 'Thanks for joining.' } })
+    fireEvent.change(document.getElementById('var-0-ctaText')!, { target: { value: 'Explore' } })
+    fireEvent.click(document.querySelector('[data-entry-pick="SCHEDULE"]')!)
+
+    await waitFor(() => expect(document.querySelector('[data-cadence]')).toBeTruthy())
+    fireEvent.click(screen.getByRole('button', { name: 'Create draft' }))
+
+    await waitFor(() => expect(createBody).toMatchObject({ schedule: { cadence: 'DAILY_MORNING' } }))
+    expect(createBody).not.toHaveProperty('trigger')
+  }, 15000)
+
   it('a draft can be submitted but not activated from the same screen', async () => {
     vi.stubGlobal('fetch', mockFetch({ [`/api/campaigns/${CAMPAIGN_ID}`]: detail('DRAFT') }))
     renderDetail()
@@ -138,5 +179,24 @@ describe('campaign studio', () => {
     // red messages are normal, which is how a real refusal stops being read.
     expect(screen.queryByText('Submit for approval')).toBeNull()
     expect(screen.queryByText('Resume')).toBeNull()
+  }, 15000)
+
+  it('states the configured recurring entry in the campaign detail', async () => {
+    const recurring = {
+      ...detail('ACTIVE'),
+      campaign: {
+        ...detail('ACTIVE').campaign,
+        schedule: { cadence: 'DAILY_MORNING', endAt: null },
+      },
+      entryCatalogues: {
+        cadences: [{ cadence: 'DAILY_MORNING', humanForm: 'every day at 09:00', zone: 'Europe/Prague' }],
+        triggers: [],
+      },
+    }
+    vi.stubGlobal('fetch', mockFetch({ [`/api/campaigns/${CAMPAIGN_ID}`]: recurring }))
+    renderDetail()
+
+    await waitFor(() => expect(document.querySelector('[data-campaign-entry]')).toBeTruthy(), { timeout: 8000 })
+    expect(screen.getByText(/every day at 09:00 \(Europe\/Prague\)/)).toBeTruthy()
   }, 15000)
 })

--- a/openbank-admin-ui/src/test/campaigns-console-board.test.tsx
+++ b/openbank-admin-ui/src/test/campaigns-console-board.test.tsx
@@ -81,12 +81,12 @@ describe('campaigns console', () => {
     campaign('CLOSED', 900, 4),
   ]
 
-  function mockFetch(items = ITEMS, state = 'ok') {
+  function mockFetch(items = ITEMS, state = 'ok', summary?: unknown[]) {
     return vi.fn(async (input: RequestInfo | URL) => {
       const url = String(input)
       const json = (b: unknown) => new Response(JSON.stringify(b), { status: 200, headers: { 'content-type': 'application/json' } })
       if (url.includes('/api/auth/session')) return new Response('null', { status: 200, headers: { 'content-type': 'application/json' } })
-      if (url.includes('/api/campaigns')) return json({ items, state })
+      if (url.includes('/api/campaigns')) return json({ items, state, ...(summary ? { summary } : {}) })
       return json({})
     })
   }
@@ -132,8 +132,28 @@ describe('campaigns console', () => {
     fireEvent.click(screen.getByTestId('stage-ACTIVE'))
 
     await waitFor(() => expect(screen.getByTestId('clear-state')).toBeTruthy())
-    expect(screen.queryByText('Campaign DRAFT 1')).toBeNull()
-    expect(screen.getByText('Campaign ACTIVE 3')).toBeTruthy()
+    // The decision desk deliberately keeps the most important next action visible above the
+    // filtered inventory. The assertion belongs to the table, which is the surface the stage filter
+    // controls; a global text query would now reject the useful priority card as though it were a
+    // leaked table row.
+    const table = document.querySelector('table')!
+    expect(table.textContent).not.toContain('Campaign DRAFT 1')
+    expect(table.textContent).toContain('Campaign ACTIVE 3')
+  })
+
+  it('puts the next marketing decisions first and names delivery evidence without inventing conversion', async () => {
+    vi.stubGlobal('fetch', mockFetch(ITEMS, 'ok', [{
+      campaignId: 'ACTIVE-3', enrolled: 1240, sent: 1110, suppressed: 96, failed: 34,
+    }]))
+    render(React.createElement(Providers, null, React.createElement(CampaignsPage)))
+
+    await waitFor(() => expect(screen.getByTestId('campaign-decision-desk')).toBeTruthy())
+    const decisions = Array.from(document.querySelectorAll('[data-decision-campaign]'))
+      .map(node => node.getAttribute('data-decision-campaign'))
+    // Approval is a more urgent human decision than an unfinished draft or a live campaign.
+    expect(decisions[0]).toBe('PENDING_APPROVAL-2')
+    expect(screen.getByTestId('campaign-delivery-pulse').textContent).toMatch(/1,240|1 240/)
+    expect(screen.getByTestId('campaign-delivery-pulse').textContent).toMatch(/not conversion or engagement/)
   })
 
 })

--- a/openbank-admin-ui/src/test/journey-editor.test.tsx
+++ b/openbank-admin-ui/src/test/journey-editor.test.tsx
@@ -9,8 +9,11 @@ import { LanguageProvider } from '@/lib/i18n/LanguageContext'
 import { JourneyEditor, MAX_STEPS, type EditorStep } from '@/components/campaigns/JourneyEditor'
 import { StepEditor } from '@/components/campaigns/StepEditor'
 
-const TEMPLATES = { MARKETING_PRODUCT_OFFER: ['offerTitle', 'offerText', 'ctaText'] }
-const TPL_CHANNEL = { MARKETING_PRODUCT_OFFER: 'EMAIL' as const }
+const TEMPLATES = {
+  MARKETING_PRODUCT_OFFER: ['offerTitle', 'offerText', 'ctaText'],
+  MARKETING_PRODUCT_OFFER_PUSH: ['offerTitle'],
+}
+const TPL_CHANNEL = { MARKETING_PRODUCT_OFFER: 'EMAIL' as const, MARKETING_PRODUCT_OFFER_PUSH: 'PUSH' as const }
 
 // The editor labels a variable in the marketer's words. The mapping is data, so the test carries its
 // own copy — asserting the rendered label against the same map the component reads would be vacuous.
@@ -127,5 +130,38 @@ describe('step editor', () => {
     // Named the way the fields above are named. Listing `offerText` under a field labelled
     // "Offer text" would send someone hunting for a control that is not on the screen.
     expect(screen.getByText(/Offer text, Button text/)).toBeTruthy()
+  })
+
+  it('lets an email step opt into push only for absent email consent', () => {
+    const onChange = vi.fn()
+    render(
+      React.createElement(LanguageProvider, null,
+        React.createElement(StepEditor, {
+          index: 0, step: step(), templates: TEMPLATES, templateChannel: TPL_CHANNEL, templateLabels: LABELS, variableLabels: VAR_LABELS,
+          onChange, onClose: vi.fn(),
+        })))
+
+    fireEvent.click(document.querySelector('[data-push-fallback="0"] input')!)
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ fallbackToPush: true }))
+    expect(screen.getByText(/not a second attempt after an email delivery failure/i)).toBeTruthy()
+  })
+
+  it('gives a push a closed app destination instead of an arbitrary campaign URL', () => {
+    const onChange = vi.fn()
+    const push: EditorStep = {
+      channel: 'PUSH', template: 'MARKETING_PRODUCT_OFFER_PUSH', variables: { offerTitle: 'Savings' }, delaySeconds: 0,
+      mobileDestination: 'HOME',
+    }
+    render(
+      React.createElement(LanguageProvider, null,
+        React.createElement(StepEditor, {
+          index: 0, step: push, templates: TEMPLATES, templateChannel: TPL_CHANNEL, templateLabels: LABELS, variableLabels: VAR_LABELS,
+          onChange, onClose: vi.fn(),
+        })))
+
+    const select = document.querySelector('[data-mobile-destination="0"] select')!
+    fireEvent.change(select, { target: { value: 'SAVINGS' } })
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ mobileDestination: 'SAVINGS' }))
+    expect(screen.getByText(/not a campaign-entered URL/i)).toBeTruthy()
   })
 })

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/port/out/Ports.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/port/out/Ports.kt
@@ -6,6 +6,7 @@ package com.openbank.campaign.application.port.out
 
 import com.openbank.campaign.domain.model.Campaign
 import com.openbank.campaign.domain.model.Channel
+import com.openbank.campaign.domain.model.ContentVariant
 import com.openbank.campaign.domain.model.DeliveryStatus
 import com.openbank.campaign.domain.model.Enrolment
 import com.openbank.campaign.domain.model.ExperimentCohort
@@ -50,6 +51,13 @@ data class ExperimentCohortMetrics(val cohort: ExperimentCohort, val assigned: L
  */
 interface CampaignExperimentRepository {
     suspend fun metrics(campaignId: UUID): List<ExperimentCohortMetrics>
+}
+
+/** Counts remain in SQL so an A/B read stays bounded for a campaign with millions of enrolments. */
+data class ContentVariantMetrics(val variant: ContentVariant, val assigned: Long, val converted: Long)
+
+interface CampaignContentExperimentRepository {
+    suspend fun metrics(campaignId: UUID): List<ContentVariantMetrics>
 }
 
 /** A single cell of the per-step funnel: how many sends of [outcome] step [stepOrder] produced. */
@@ -171,23 +179,22 @@ interface ConsentCheckPort {
     suspend fun hasActiveConsent(partyId: UUID, scope: String): Boolean
 }
 
+/** One immutable request from campaign orchestration to notification-service. */
+data class NotificationSendRequest(
+    val partyId: UUID,
+    val channel: Channel,
+    val template: String,
+    val recipient: String,
+    val variables: Map<String, String>,
+    /** Send-log row id; campaign needs this mandatory to join a delivery outcome back. */
+    val correlationId: UUID,
+    /** Closed mobile-app route, present only on a PUSH delivery. */
+    val deepLink: String? = null,
+)
+
 /** ADR-0200 D3: delivery goes through notification-service, never direct. */
 interface NotificationSendPort {
-    /**
-     * [correlationId] is the send-log row id this request belongs to (ADR-0239 D1).
-     *
-     * Required, not optional: the whole reason the campaign publishes here is to hear back what
-     * became of the message, and a nullable parameter is one a caller forgets. The receiving
-     * contract keeps it optional for producers that genuinely do not care — this one does.
-     */
-    suspend fun requestSend(
-        partyId: UUID,
-        channel: Channel,
-        template: String,
-        recipient: String,
-        variables: Map<String, String>,
-        correlationId: UUID,
-    )
+    suspend fun requestSend(request: NotificationSendRequest)
 }
 
 /** ADR-0200 D2 push: signals a live journey that consent was revoked for its party. */

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/usecase/CampaignContentExperimentQuery.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/usecase/CampaignContentExperimentQuery.kt
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.campaign.application.usecase
+
+import com.openbank.campaign.application.port.out.CampaignContentExperimentRepository
+import com.openbank.campaign.application.port.out.CampaignRepository
+import com.openbank.campaign.application.port.out.ContentVariantMetrics
+import com.openbank.campaign.domain.model.ContentVariant
+import jakarta.enterprise.context.ApplicationScoped
+import java.util.UUID
+import kotlin.math.sqrt
+
+/** Outcome of one stable content arm. A null rate means no party has been assigned yet. */
+data class ContentVariantOutcome(val assigned: Long, val converted: Long, val conversionRate: Double?)
+
+enum class ContentExperimentDecisionState { COLLECTING_DATA, INCONCLUSIVE, A_OUTPERFORMS_B, B_OUTPERFORMS_A }
+
+/** Readiness guidance, never an instruction to alter an active campaign automatically. */
+data class ContentExperimentDecision(
+    val state: ContentExperimentDecisionState,
+    val minimumAssignedPerVariant: Int,
+    val aConfidenceInterval: RateConfidenceInterval?,
+    val bConfidenceInterval: RateConfidenceInterval?,
+)
+
+data class CampaignContentExperimentSummary(
+    val campaignId: UUID,
+    val a: ContentVariantOutcome,
+    val b: ContentVariantOutcome,
+    val observedLiftPercentagePoints: Double?,
+    val decision: ContentExperimentDecision,
+)
+
+/**
+ * A measured two-arm content experiment. It does not infer an open or click — the only outcome is
+ * the campaign's explicitly declared product conversion rule, and assignment is the durable value
+ * on the enrolment. Holdout enrolments are intentionally absent from this comparison.
+ */
+@ApplicationScoped
+class CampaignContentExperimentQuery(
+    private val campaigns: CampaignRepository,
+    private val experiments: CampaignContentExperimentRepository,
+) {
+    suspend fun summary(campaignId: UUID): CampaignContentExperimentSummary? {
+        val campaign = campaigns.findById(campaignId) ?: return null
+        check(campaign.hasContentExperiment) { "campaign $campaignId has no content experiment" }
+        check(campaign.conversionRule != null) { "a content experiment requires a conversionRule" }
+        val metrics = experiments.metrics(campaignId).associateBy { it.variant }
+        val a = metrics.outcomeFor(ContentVariant.A)
+        val b = metrics.outcomeFor(ContentVariant.B)
+        val lift = b.conversionRate?.let { bRate -> a.conversionRate?.let { aRate -> (bRate - aRate) * PERCENT } }
+        return CampaignContentExperimentSummary(
+            campaignId = campaignId,
+            a = a,
+            b = b,
+            observedLiftPercentagePoints = lift,
+            decision = ContentExperimentStatistics.evaluate(a, b),
+        )
+    }
+
+    private fun Map<ContentVariant, ContentVariantMetrics>.outcomeFor(variant: ContentVariant): ContentVariantOutcome {
+        val metrics = get(variant) ?: ContentVariantMetrics(variant, assigned = 0, converted = 0)
+        return ContentVariantOutcome(
+            assigned = metrics.assigned,
+            converted = metrics.converted,
+            conversionRate = metrics.converted.toDouble().div(metrics.assigned).takeIf { metrics.assigned > 0 },
+        )
+    }
+
+    private companion object {
+        const val PERCENT = 100.0
+    }
+}
+
+private object ContentExperimentStatistics {
+    private const val MINIMUM_ASSIGNED_PER_VARIANT = 100
+    private const val Z_95 = 1.959_963_984_540_054
+    private const val HALF = 2.0
+    private const val QUARTER = 4.0
+
+    fun evaluate(a: ContentVariantOutcome, b: ContentVariantOutcome): ContentExperimentDecision {
+        val aInterval = a.wilsonInterval()
+        val bInterval = b.wilsonInterval()
+        val state = when {
+            a.assigned < MINIMUM_ASSIGNED_PER_VARIANT || b.assigned < MINIMUM_ASSIGNED_PER_VARIANT ->
+                ContentExperimentDecisionState.COLLECTING_DATA
+            aInterval == null || bInterval == null -> ContentExperimentDecisionState.COLLECTING_DATA
+            aInterval.lower > bInterval.upper -> ContentExperimentDecisionState.A_OUTPERFORMS_B
+            bInterval.lower > aInterval.upper -> ContentExperimentDecisionState.B_OUTPERFORMS_A
+            else -> ContentExperimentDecisionState.INCONCLUSIVE
+        }
+        return ContentExperimentDecision(state, MINIMUM_ASSIGNED_PER_VARIANT, aInterval, bInterval)
+    }
+
+    private fun ContentVariantOutcome.wilsonInterval(): RateConfidenceInterval? {
+        val rate = conversionRate ?: return null
+        val n = assigned.toDouble()
+        val zSquared = Z_95 * Z_95
+        val denominator = 1 + zSquared / n
+        val centre = (rate + zSquared / (HALF * n)) / denominator
+        val margin = Z_95 * sqrt((rate * (1 - rate) + zSquared / (QUARTER * n)) / n) / denominator
+        return RateConfidenceInterval((centre - margin).coerceAtLeast(0.0), (centre + margin).coerceAtMost(1.0))
+    }
+}

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/usecase/CampaignService.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/usecase/CampaignService.kt
@@ -14,6 +14,7 @@ import com.openbank.campaign.domain.model.Campaign
 import com.openbank.campaign.domain.model.CampaignSchedule
 import com.openbank.campaign.domain.model.CampaignState
 import com.openbank.campaign.domain.model.CampaignStep
+import com.openbank.campaign.domain.model.ContentVariant
 import com.openbank.campaign.domain.model.ConversionCatalog
 import com.openbank.campaign.domain.model.Enrolment
 import com.openbank.campaign.domain.model.EnrolmentState
@@ -209,6 +210,7 @@ class CampaignService(
                             startedAt = Instant.now(),
                             completedAt = Instant.now(),
                             experimentCohort = cohort,
+                            contentVariant = null,
                         ),
                     )
                     started++
@@ -220,6 +222,8 @@ class CampaignService(
                     // already committed, the skip below sees it, and that party is never contacted and
                     // never retried (#2953).
                     journeys.startJourney(id, partyId)
+                    val contentVariant = ContentVariant.assign(campaign.id, partyId)
+                        .takeIf { campaign.hasContentExperiment }
                     enrolments.save(
                         Enrolment(
                             id = Ids.newId(),
@@ -230,6 +234,7 @@ class CampaignService(
                             startedAt = Instant.now(),
                             completedAt = null,
                             experimentCohort = cohort,
+                            contentVariant = contentVariant,
                         ),
                     )
                     started++

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/workflow/CampaignJourneyActivitiesImpl.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/workflow/CampaignJourneyActivitiesImpl.kt
@@ -7,8 +7,12 @@ package com.openbank.campaign.application.workflow
 import com.openbank.campaign.application.port.out.CampaignRepository
 import com.openbank.campaign.application.port.out.EnrolmentRepository
 import com.openbank.campaign.application.port.out.NotificationSendPort
+import com.openbank.campaign.application.port.out.NotificationSendRequest
 import com.openbank.campaign.application.port.out.SendLogRepository
+import com.openbank.campaign.domain.model.Campaign
+import com.openbank.campaign.domain.model.CampaignDelivery
 import com.openbank.campaign.domain.model.CampaignState
+import com.openbank.campaign.domain.model.CampaignStep
 import com.openbank.campaign.domain.model.Channel
 import com.openbank.campaign.domain.model.DeliveryStatus
 import com.openbank.campaign.domain.model.EnrolmentState
@@ -106,78 +110,104 @@ open class CampaignJourneyActivitiesImpl(
     @MarketingCallSite
     internal suspend fun deliverStepGated(campaignId: UUID, partyId: UUID, stepOrder: Int): StepOutcome {
         val campaign = campaigns.findById(campaignId) ?: return StepOutcome.CAMPAIGN_CLOSED
-        when (campaign.state) {
-            CampaignState.PAUSED -> return StepOutcome.CAMPAIGN_PAUSED
-            CampaignState.CLOSED -> return StepOutcome.CAMPAIGN_CLOSED
-            CampaignState.ACTIVE -> Unit
-            CampaignState.DRAFT,
-            CampaignState.PENDING_APPROVAL,
-            -> return StepOutcome.CAMPAIGN_CLOSED
-        }
+        campaign.deliveryStateOutcome()?.let { return it }
         if (sendLog.conversionContextFor(campaignId, partyId).alreadyConverted) {
             return StepOutcome.GOAL_REACHED
         }
         val step = campaign.steps.firstOrNull { it.order == stepOrder } ?: return StepOutcome.SUPPRESSED
-
-        // ADR-0219 (#3656): one gate call wraps the suppression list, the frequency cap, quiet
-        // hours and the live consent pull, in the gate's ordering.
-        return when (
-            val decision = contactGate.check(
-                partyId,
-                ContactClass.OUTBOUND_SEND,
-                marketingScopeFor(step.channel),
-                topic = campaign.goal,
-            )
-        ) {
-            ContactGateDecision.ALLOWED -> {
-                // The send-log row id is minted BEFORE the handoff, not by `record` after it
-                // (ADR-0239 D1): it is what goes on the wire as the correlation id, so the id has
-                // to exist first. It is used for whichever row this attempt ends up writing —
-                // SENT, DRY_RUN or FAILED — so an outcome that arrives for a handoff that then
-                // failed locally still lands on the right row.
-                val sendId = Ids.newId()
-                // Dry run stops HERE, after every gate above has run. Deliberately not earlier: the
-                // point of a rehearsal is that suppression, cap, quiet hours and consent are all
-                // exercised exactly as they would be, so a journey that would have been suppressed
-                // still reports SUPPRESSED and not DRY_RUN. Nothing is handed off, so this row's
-                // delivery status stays PENDING forever — correctly: no message ever left.
-                if (dryRun) {
-                    sendLog.record(sendId, campaignId, partyId, stepOrder, SendOutcome.DRY_RUN)
-                } else {
-                    // ADR-0200 D3 — delivery goes through notification-service, never direct.
-                    //
-                    // The order below is the fix for issue #3581: the send log may only be written
-                    // AFTER the handoff has been observed to succeed, and a handoff that failed must
-                    // leave a FAILED row rather than nothing. What SENT claims here is exactly
-                    // "notification-service accepted the request", not "the customer received it".
-                    try {
-                        notificationSend.requestSend(
-                            partyId,
-                            step.channel,
-                            step.template,
-                            recipientFor(partyId),
-                            step.variables,
-                            correlationId = sendId,
-                        )
-                    } catch (e: Exception) {
-                        sendLog.record(sendId, campaignId, partyId, stepOrder, SendOutcome.FAILED)
-                        // Rethrown on purpose: Temporal retries the activity, and the FAILED row
-                        // above is the durable evidence that this attempt happened. FAILED rows do
-                        // not consume the frequency cap (SENT only), so a retry is not penalised.
-                        throw e
-                    }
-                    sendLog.record(sendId, campaignId, partyId, stepOrder, SendOutcome.SENT)
-                }
-                StepOutcome.SENT
-            }
-            else -> {
-                if (decision.denyReason == ContactDenyReason.GATE_UNAVAILABLE) {
-                    throw ContactGateUnavailableException("contact gate state unavailable — activity will retry")
-                }
-                sendLog.record(Ids.newId(), campaignId, partyId, stepOrder, outcomeFor(decision.denyReason))
-                StepOutcome.SUPPRESSED
-            }
+        // The assignment is stored on the enrolment before its workflow starts. Do not choose an
+        // arm at this point: a retry must send the same treatment, and an audit must explain which
+        // wording the person was actually offered.
+        val contentVariant = if (campaign.hasContentExperiment) {
+            enrolments.findByCampaignAndParty(campaignId, partyId)?.contentVariant
+        } else {
+            null
         }
+        return deliverEligibleStep(
+            StepDeliveryContext(campaign, step, campaignId, partyId, stepOrder, contentVariant),
+        )
+    }
+
+    /** ADR-0219: a fallback is possible only after a NO_CONSENT decision for the primary channel. */
+    private suspend fun deliverEligibleStep(context: StepDeliveryContext): StepOutcome {
+        val primary = context.step.primaryDelivery(context.contentVariant)
+        val primaryDecision = checkDelivery(context, primary)
+        if (primaryDecision == ContactGateDecision.ALLOWED) return handoff(context, primary)
+        throwIfGateUnavailable(primaryDecision)
+
+        val fallback = primaryDecision.denyReason
+            .takeIf { it == ContactDenyReason.NO_CONSENT }
+            ?.let { context.step.pushFallback(context.contentVariant) }
+            ?: return recordSuppressed(context, primaryDecision)
+        return deliverFallback(context, fallback)
+    }
+
+    private suspend fun deliverFallback(context: StepDeliveryContext, fallback: CampaignDelivery): StepOutcome {
+        val decision = checkDelivery(context, fallback)
+        if (decision == ContactGateDecision.ALLOWED) return handoff(context, fallback)
+        throwIfGateUnavailable(decision)
+        return recordSuppressed(context, decision)
+    }
+
+    private suspend fun checkDelivery(context: StepDeliveryContext, delivery: CampaignDelivery): ContactGateDecision =
+        contactGate.check(
+            context.partyId,
+            ContactClass.OUTBOUND_SEND,
+            marketingScopeFor(delivery.channel),
+            topic = context.campaign.goal,
+        )
+
+    // A transport failure must leave a FAILED send row whatever exception the Kafka client raises,
+    // then be rethrown so Temporal retries. Narrowing this catch would re-open that audit gap.
+    @Suppress("TooGenericExceptionCaught")
+    private suspend fun handoff(context: StepDeliveryContext, delivery: CampaignDelivery): StepOutcome {
+        // The send-log row id is minted BEFORE the handoff: it is the wire correlation id and
+        // joins asynchronous delivery outcome to precisely this attempt (ADR-0239 D1).
+        val sendId = Ids.newId()
+        if (dryRun) {
+            sendLog.record(
+                sendId,
+                context.campaignId,
+                context.partyId,
+                context.stepOrder,
+                SendOutcome.DRY_RUN,
+                delivery.channel,
+            )
+            return StepOutcome.SENT
+        }
+        try {
+            notificationSend.requestDelivery(context.partyId, delivery, sendId)
+        } catch (e: Exception) {
+            sendLog.record(
+                sendId,
+                context.campaignId,
+                context.partyId,
+                context.stepOrder,
+                SendOutcome.FAILED,
+                delivery.channel,
+            )
+            throw e
+        }
+        sendLog.record(
+            sendId,
+            context.campaignId,
+            context.partyId,
+            context.stepOrder,
+            SendOutcome.SENT,
+            delivery.channel,
+        )
+        return StepOutcome.SENT
+    }
+
+    private suspend fun recordSuppressed(context: StepDeliveryContext, decision: ContactGateDecision): StepOutcome {
+        sendLog.record(
+            Ids.newId(),
+            context.campaignId,
+            context.partyId,
+            context.stepOrder,
+            outcomeFor(decision.denyReason),
+        )
+        return StepOutcome.SUPPRESSED
     }
 
     override fun advanceStep(campaignId: UUID, partyId: UUID, stepOrder: Int) = runBlockingOnWorker {
@@ -244,6 +274,33 @@ open class CampaignJourneyActivitiesImpl(
 /** Thrown when the contact gate cannot reach its state — a retry signal, never a policy outcome. */
 class ContactGateUnavailableException(message: String) : RuntimeException(message)
 
+/** Immutable state shared by the primary attempt and the only permitted PUSH fallback. */
+private data class StepDeliveryContext(
+    val campaign: Campaign,
+    val step: CampaignStep,
+    val campaignId: UUID,
+    val partyId: UUID,
+    val stepOrder: Int,
+    val contentVariant: com.openbank.campaign.domain.model.ContentVariant?,
+)
+
+/** Only ACTIVE campaigns may enter delivery; every other state has a durable workflow outcome. */
+private fun Campaign.deliveryStateOutcome(): StepOutcome? = when (state) {
+    CampaignState.ACTIVE -> null
+    CampaignState.PAUSED -> StepOutcome.CAMPAIGN_PAUSED
+    CampaignState.CLOSED,
+    CampaignState.DRAFT,
+    CampaignState.PENDING_APPROVAL,
+    -> StepOutcome.CAMPAIGN_CLOSED
+}
+
+/** A gate outage is retriable infrastructure state, never a customer-policy suppression. */
+private fun throwIfGateUnavailable(decision: ContactGateDecision) {
+    if (decision.denyReason == ContactDenyReason.GATE_UNAVAILABLE) {
+        throw ContactGateUnavailableException("contact gate state unavailable — activity will retry")
+    }
+}
+
 // Two helpers as top-level privates rather than members: CampaignJourneyActivitiesImpl sits at
 // detekt's TooManyFunctions threshold of 11, which fires AT the limit, so the branch-condition
 // activities (#3585) had to buy their room somewhere.
@@ -262,8 +319,24 @@ private suspend fun SendLogRepository.record(
     partyId: UUID,
     stepOrder: Int,
     outcome: SendOutcome,
-) = record(SendRecord(id, campaignId, partyId, stepOrder, outcome, Instant.now()))
+    channel: Channel? = null,
+) = record(SendRecord(id, campaignId, partyId, stepOrder, outcome, Instant.now(), channel = channel))
 
 // The recipient address is resolved by notification-service from party data; the campaign never
 // carries an e-mail address itself (ADR-0200 D3 — no PII duplication).
 private fun recipientFor(partyId: UUID): String = partyId.toString()
+
+/** Build the cross-service command outside the gate's nested delivery branch. */
+private suspend fun NotificationSendPort.requestDelivery(partyId: UUID, delivery: CampaignDelivery, sendId: UUID) {
+    requestSend(
+        NotificationSendRequest(
+            partyId = partyId,
+            channel = delivery.channel,
+            template = delivery.template,
+            recipient = recipientFor(partyId),
+            variables = delivery.variables,
+            correlationId = sendId,
+            deepLink = delivery.deepLink,
+        ),
+    )
+}

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/domain/model/Campaign.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/domain/model/Campaign.kt
@@ -63,7 +63,21 @@ data class Campaign(
         require(holdoutPercent == 0 || conversionRule != null) {
             "a holdout requires a conversionRule to measure its outcome"
         }
+        // A/B assignment is campaign-wide, not a step-level surprise. Letting the first message
+        // have two variants while a later one silently collapses them would turn the result into
+        // an unreviewable mixture of different treatments. Existing campaigns have no B variables
+        // on any step and keep their exact pre-experiment path.
+        val contentExperiment = steps.firstOrNull()?.variantBVariables != null
+        require(steps.all { (it.variantBVariables != null) == contentExperiment }) {
+            "a content experiment must define variant B for every campaign step"
+        }
+        require(!contentExperiment || conversionRule != null) {
+            "a content experiment requires a conversionRule to measure its outcome"
+        }
     }
+
+    /** Both variants exist on every step; a null B map means this is not a content experiment. */
+    val hasContentExperiment: Boolean get() = steps.firstOrNull()?.variantBVariables != null
 
     /** DRAFT → PENDING_APPROVAL → ACTIVE ⇄ PAUSED → CLOSED. Terminal states never leave. */
     fun submit(): Campaign {
@@ -129,6 +143,29 @@ enum class ExperimentCohort {
     }
 }
 
+/**
+ * The durable arm of a content experiment. `A` is the author's original declared values and `B`
+ * is the alternative. Keeping the names neutral avoids declaring a winner before there is data.
+ */
+enum class ContentVariant {
+    A,
+    B,
+    ;
+
+    companion object {
+        /** A stable 50/50 split, independent from the campaign's no-contact holdout split. */
+        fun assign(campaignId: UUID, partyId: UUID): ContentVariant {
+            val digest = MessageDigest.getInstance("SHA-256")
+                .digest("content:$campaignId:$partyId".toByteArray(StandardCharsets.UTF_8))
+            val bucket = (ByteBuffer.wrap(digest, 0, Int.SIZE_BYTES).int.toLong() and UNSIGNED_INT_MASK) % BUCKETS
+            return if (bucket < BUCKETS / 2) A else B
+        }
+
+        private const val UNSIGNED_INT_MASK = 0xffff_ffffL
+        private const val BUCKETS = 10_000L
+    }
+}
+
 enum class CampaignState { DRAFT, PENDING_APPROVAL, ACTIVE, PAUSED, CLOSED }
 
 /**
@@ -156,6 +193,22 @@ data class CampaignStep(
      * it took before. See [StepCondition].
      */
     val condition: StepCondition? = null,
+    /**
+     * Alternative declared values for the B arm of a campaign-wide A/B content experiment.
+     * Null preserves the historical single-content step; when present every step must provide it
+     * (enforced by [Campaign]) so one party keeps the same treatment throughout the journey.
+     */
+    val variantBVariables: Map<String, String>? = null,
+    /**
+     * If the primary EMAIL step has no active e-mail marketing consent, retry the same offer as a
+     * PUSH only after its own full contact-policy check succeeds. This is intentionally not a
+     * generic failover: quiet hours, caps and suppression lists are channel-independent policy
+     * decisions and must never be bypassed; an asynchronous mail bounce is also not a safe prompt
+     * to send a second message.
+     */
+    val fallbackToPush: Boolean = false,
+    /** A closed, app-owned destination for a push tap — never author-entered URL text. */
+    val mobileDestination: MobileDestination? = null,
 ) {
     init {
         require(order >= 0) { "step order must be >= 0" }
@@ -181,7 +234,62 @@ data class CampaignStep(
         TemplateCatalog.unknownVariables(template, variables).let {
             require(it.isEmpty()) { "template '$template' does not declare ${it.sorted()}" }
         }
+        variantBVariables?.let { alternative ->
+            TemplateCatalog.unknownVariables(template, alternative).let {
+                require(it.isEmpty()) { "template '$template' does not declare ${it.sorted()}" }
+            }
+        }
+        require(!fallbackToPush || channel == Channel.EMAIL) {
+            "only an EMAIL step can fall back to PUSH"
+        }
+        require(!fallbackToPush || template in TemplateCatalog.PUSH_FALLBACK_FOR_EMAIL) {
+            "template '$template' has no safe PUSH fallback"
+        }
+        require(mobileDestination == null || channel == Channel.PUSH || fallbackToPush) {
+            "a mobile destination requires a PUSH step or an EMAIL step with PUSH fallback"
+        }
     }
+
+    /** Resolves content after the durable enrolment assignment, never randomly at send time. */
+    fun variablesFor(variant: ContentVariant?): Map<String, String> =
+        if (variant == ContentVariant.B) variantBVariables ?: variables else variables
+
+    /** Primary delivery values, kept separate from the fallback's reduced template vocabulary. */
+    fun primaryDelivery(variant: ContentVariant?): CampaignDelivery = CampaignDelivery(
+        channel,
+        template,
+        TemplateCatalog.valuesFor(template, variablesFor(variant)),
+        mobileDestination?.deepLink.takeIf { channel == Channel.PUSH },
+    )
+
+    /** The only supported fallback: a consented app push after EMAIL consent was absent. */
+    fun pushFallback(variant: ContentVariant?): CampaignDelivery? = TemplateCatalog.PUSH_FALLBACK_FOR_EMAIL[template]
+        ?.takeIf { fallbackToPush }
+        ?.let { pushTemplate ->
+            CampaignDelivery(
+                Channel.PUSH,
+                pushTemplate,
+                TemplateCatalog.valuesFor(pushTemplate, variablesFor(variant)),
+                mobileDestination?.deepLink,
+            )
+        }
+}
+
+/** A resolved per-attempt delivery, including the channel that will be recorded for audit. */
+data class CampaignDelivery(
+    val channel: Channel,
+    val template: String,
+    val variables: Map<String, String>,
+    val deepLink: String? = null,
+)
+
+/** The only destinations the mobile app contract recognises for campaign pushes. */
+enum class MobileDestination(val deepLink: String) {
+    HOME("openbank://home"),
+    SAVINGS("openbank://savings"),
+    CARDS("openbank://cards"),
+    PAYMENTS("openbank://payments"),
+    PRODUCT_HUB("openbank://products"),
 }
 
 /**

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/domain/model/Enrolment.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/domain/model/Enrolment.kt
@@ -22,6 +22,12 @@ data class Enrolment(
     val completedAt: Instant?,
     /** Stored experiment assignment; historical rows default to [ExperimentCohort.TREATMENT]. */
     val experimentCohort: ExperimentCohort = ExperimentCohort.TREATMENT,
+    /**
+     * Stable content arm, null when this campaign has no content experiment or this party is a
+     * no-contact holdout. Persisted rather than recalculated so an audit remains true if the
+     * allocation implementation ever changes.
+     */
+    val contentVariant: ContentVariant? = null,
 )
 
 enum class EnrolmentState {
@@ -78,6 +84,8 @@ data class SendRecord(
     val deliveryReason: String? = null,
     /** When [deliveryStatus] last moved. Null while it has never moved off `PENDING`. */
     val deliveryUpdatedAt: Instant? = null,
+    /** The actual medium passed to notification-service; null for historical and non-send rows. */
+    val channel: Channel? = null,
 )
 
 /**

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/domain/model/TemplateCatalog.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/domain/model/TemplateCatalog.kt
@@ -52,6 +52,16 @@ object TemplateCatalog {
         "MARKETING_PRODUCT_OFFER_PUSH" to Channel.PUSH,
     )
 
+    /**
+     * A deliberately small, explicit fallback catalogue. This is not a naming convention: a
+     * fallback can only use a push template that is safe to render with the values from its email
+     * counterpart. The push renderer deliberately accepts only the shared headline, never the
+     * e-mail body or CTA (#1182).
+     */
+    val PUSH_FALLBACK_FOR_EMAIL: Map<String, String> = mapOf(
+        "MARKETING_PRODUCT_OFFER" to "MARKETING_PRODUCT_OFFER_PUSH",
+    )
+
     /** Templates renderable on [channel] — what an authoring screen may offer for a step. */
     fun forChannel(channel: Channel): Set<String> = CHANNEL_OF.filterValues { it == channel }.keys
 
@@ -69,4 +79,8 @@ object TemplateCatalog {
     /** Variables [template] declares that this step does not supply. */
     fun missingVariables(template: String, variables: Map<String, String>): Set<String> =
         (ALL[template] ?: emptySet()) - variables.keys
+
+    /** Values safe for [template]; a push fallback receives only its declared shared values. */
+    fun valuesFor(template: String, values: Map<String, String>): Map<String, String> =
+        values.filterKeys { it in (ALL[template] ?: emptySet()) }
 }

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/domain/model/TriggerCatalog.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/domain/model/TriggerCatalog.kt
@@ -39,16 +39,23 @@ object TriggerCatalog {
      *   `openbank.cards.events` is a shared topic where matching the topic alone would enrol a
      *   party on a limit change.
      */
-    data class Trigger(val topic: String, val eventTypes: Set<String>)
+    data class Trigger(
+        val topic: String,
+        val eventTypes: Set<String>,
+        /** The sentence an operator approves; topic and event type are integration detail. */
+        val humanForm: String,
+    )
 
     val ALL: Map<String, Trigger> = mapOf(
         "ACCOUNT_OPENED" to Trigger(
             topic = "openbank.accounts.account.created",
             eventTypes = setOf("AccountCreated", "account.created.v1"),
+            humanForm = "when an account is opened",
         ),
         "CARD_ISSUED" to Trigger(
             topic = "openbank.cards.events",
             eventTypes = setOf("card.issued.v1", "CardIssued"),
+            humanForm = "when a card is issued",
         ),
     )
 

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/kafka/KafkaNotificationSendAdapter.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/kafka/KafkaNotificationSendAdapter.kt
@@ -6,11 +6,10 @@ package com.openbank.campaign.infrastructure.kafka
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.openbank.campaign.application.port.out.NotificationSendPort
+import com.openbank.campaign.application.port.out.NotificationSendRequest
 import jakarta.enterprise.context.ApplicationScoped
 import org.eclipse.microprofile.reactive.messaging.Channel
 import org.eclipse.microprofile.reactive.messaging.Emitter
-import java.util.UUID
-import com.openbank.campaign.domain.model.Channel as CampaignChannel
 
 /**
  * ADR-0200 D3: delivery goes through notification-service, never direct. The payload shape mirrors
@@ -29,30 +28,25 @@ class KafkaNotificationSendAdapter(
     private val mapper: ObjectMapper,
 ) : NotificationSendPort {
 
-    override suspend fun requestSend(
-        partyId: UUID,
-        channel: CampaignChannel,
-        template: String,
-        recipient: String,
-        variables: Map<String, String>,
-        correlationId: UUID,
-    ) {
-        val payload = mapper.writeValueAsString(
-            mapOf(
-                "partyId" to partyId.toString(),
-                // Was hardcoded "EMAIL". A step's channel now travels with it — with the constant in place a
-                // PUSH step was delivered as an email, silently, because notification-service believed
-                // the payload over the campaign.
-                "channel" to channel.name,
-                "template" to template,
-                "recipient" to recipient,
-                "variables" to variables,
-                // ADR-0239 D1 — the send-log row id. notification-service echoes it back on
-                // `openbank.notification.outcomes.v1`, which is the only way this service can learn
-                // that a send it recorded as SENT was in fact suppressed or never delivered (#3663).
-                "correlationId" to correlationId.toString(),
-            ),
+    override suspend fun requestSend(request: NotificationSendRequest) {
+        val fields = linkedMapOf(
+            "partyId" to request.partyId.toString(),
+            // Was hardcoded "EMAIL". A step's channel now travels with it — with the constant in place a
+            // PUSH step was delivered as an email, silently, because notification-service believed
+            // the payload over the campaign.
+            "channel" to request.channel.name,
+            "template" to request.template,
+            "recipient" to request.recipient,
+            "variables" to request.variables,
+            // ADR-0239 D1 — the send-log row id. notification-service echoes it back on
+            // `openbank.notification.outcomes.v1`, which is the only way this service can learn
+            // that a send it recorded as SENT was in fact suppressed or never delivered (#3663).
+            "correlationId" to request.correlationId.toString(),
         )
+        // This is transport metadata, never a template variable. The notification renderer's
+        // closed variable schema therefore cannot accidentally interpolate a navigation route.
+        request.deepLink?.let { fields["deepLink"] = it }
+        val payload = mapper.writeValueAsString(fields)
         emitter.send(payload).toCompletableFuture().join()
     }
 }

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/persistence/Persistence.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/persistence/Persistence.kt
@@ -6,10 +6,12 @@ package com.openbank.campaign.infrastructure.persistence
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
+import com.openbank.campaign.application.port.out.CampaignContentExperimentRepository
 import com.openbank.campaign.application.port.out.CampaignEnrolmentCount
 import com.openbank.campaign.application.port.out.CampaignExperimentRepository
 import com.openbank.campaign.application.port.out.CampaignOutcomeCount
 import com.openbank.campaign.application.port.out.CampaignRepository
+import com.openbank.campaign.application.port.out.ContentVariantMetrics
 import com.openbank.campaign.application.port.out.ConversionContext
 import com.openbank.campaign.application.port.out.EnrolmentRepository
 import com.openbank.campaign.application.port.out.ExperimentCohortMetrics
@@ -20,6 +22,8 @@ import com.openbank.campaign.domain.model.Campaign
 import com.openbank.campaign.domain.model.CampaignSchedule
 import com.openbank.campaign.domain.model.CampaignState
 import com.openbank.campaign.domain.model.CampaignStep
+import com.openbank.campaign.domain.model.Channel
+import com.openbank.campaign.domain.model.ContentVariant
 import com.openbank.campaign.domain.model.DeliveryStatus
 import com.openbank.campaign.domain.model.DeliveryTransition
 import com.openbank.campaign.domain.model.Enrolment
@@ -141,6 +145,10 @@ class EnrolmentEntity : PanacheEntityBase() {
     /** Stored rather than re-derived so reports keep the original experimental assignment. */
     @Column(nullable = false)
     var experimentCohort: String = ExperimentCohort.TREATMENT.name
+
+    /** Null for historic and no-contact rows; A/B enrolments keep the arm they were assigned. */
+    @Column(length = 1)
+    var contentVariant: String? = null
 }
 
 @Entity
@@ -174,6 +182,10 @@ class SendLogEntity : PanacheEntityBase() {
 
     @Column
     var deliveryUpdatedAt: Instant? = null
+
+    /** Actual request medium; nullable so migration leaves historical decision rows intact. */
+    @Column(length = 8)
+    var channel: String? = null
 }
 
 @Entity
@@ -304,6 +316,7 @@ class PanacheEnrolmentRepository :
         startedAt = this@toEntity.startedAt
         completedAt = this@toEntity.completedAt
         experimentCohort = this@toEntity.experimentCohort.name
+        contentVariant = this@toEntity.contentVariant?.name
     }
 
     private fun EnrolmentEntity.toDomain(): Enrolment = Enrolment(
@@ -315,6 +328,7 @@ class PanacheEnrolmentRepository :
         startedAt,
         completedAt,
         ExperimentCohort.valueOf(experimentCohort),
+        contentVariant?.let(ContentVariant::valueOf),
     )
 }
 
@@ -339,6 +353,33 @@ class PanacheCampaignExperimentRepository : CampaignExperimentRepository {
         .map { row ->
             ExperimentCohortMetrics(
                 cohort = ExperimentCohort.valueOf(row[0] as String),
+                assigned = row[1] as Long,
+                converted = row[2] as Long,
+            )
+        }
+}
+
+/** A/B outcomes are grouped in SQL, never reconstructed from an unbounded send-log page. */
+@ApplicationScoped
+class PanacheCampaignContentExperimentRepository : CampaignContentExperimentRepository {
+    override suspend fun metrics(campaignId: UUID): List<ContentVariantMetrics> = Panache.withSession {
+        Panache.getSession().flatMap { session ->
+            session.createQuery(
+                "select e.contentVariant, count(e), count(distinct s.partyId) " +
+                    "from EnrolmentEntity e left join SendLogEntity s on " +
+                    "s.campaignId = e.campaignId and s.partyId = e.partyId and s.outcome = :converted " +
+                    "where e.campaignId = :campaignId and e.contentVariant is not null group by e.contentVariant",
+                Array<Any>::class.java,
+            )
+                .setParameter("converted", SendOutcome.CONVERTED.name)
+                .setParameter("campaignId", campaignId)
+                .resultList
+        }
+    }
+        .awaitSuspending()
+        .map { row ->
+            ContentVariantMetrics(
+                variant = ContentVariant.valueOf(row[0] as String),
                 assigned = row[1] as Long,
                 converted = row[2] as Long,
             )
@@ -372,6 +413,7 @@ class PanacheSendLogRepository :
                     deliveryStatus = send.deliveryStatus.name
                     deliveryReason = send.deliveryReason
                     deliveryUpdatedAt = send.deliveryUpdatedAt
+                    channel = send.channel?.name
                 },
             )
         }.awaitSuspending()
@@ -589,4 +631,5 @@ private fun SendLogEntity.toDomain(): SendRecord = SendRecord(
     deliveryStatus = DeliveryStatus.valueOf(deliveryStatus),
     deliveryReason = deliveryReason,
     deliveryUpdatedAt = deliveryUpdatedAt,
+    channel = channel?.let(Channel::valueOf),
 )

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/rest/CampaignContentExperimentResource.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/rest/CampaignContentExperimentResource.kt
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.campaign.infrastructure.rest
+
+import com.openbank.campaign.application.usecase.CampaignContentExperimentQuery
+import com.openbank.libs.authz.Authorize
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.ws.rs.GET
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.PathParam
+import jakarta.ws.rs.core.Response
+import java.util.UUID
+
+/** The conversion comparison of a campaign explicitly configured with A/B message content. */
+@Path("/api/v1/campaigns")
+@ApplicationScoped
+class CampaignContentExperimentResource(private val query: CampaignContentExperimentQuery) {
+
+    @GET
+    @Path("/{id}/content-experiment")
+    @Authorize(action = "campaign.read", resource = "#id")
+    suspend fun contentExperiment(@PathParam("id") id: UUID): Response = try {
+        query.summary(id)
+            ?.let { Response.ok(it).build() }
+            ?: Response.status(Response.Status.NOT_FOUND).build()
+    } catch (e: IllegalStateException) {
+        Response.status(Response.Status.CONFLICT).entity(mapOf("error" to e.message)).build()
+    }
+}

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/rest/CampaignResource.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/rest/CampaignResource.kt
@@ -8,6 +8,7 @@ import com.openbank.campaign.application.usecase.CampaignService
 import com.openbank.campaign.domain.model.CampaignSchedule
 import com.openbank.campaign.domain.model.CampaignStep
 import com.openbank.campaign.domain.model.Channel
+import com.openbank.campaign.domain.model.MobileDestination
 import com.openbank.campaign.domain.model.SegmentRef
 import com.openbank.campaign.domain.model.StepCondition
 import com.openbank.campaign.domain.model.StopCondition
@@ -74,6 +75,12 @@ data class StepRequest(
     val delaySeconds: Long = 0,
     /** Optional branch condition (ADR-0200 D1, #3585). Absent means the step always runs. */
     val condition: StepCondition? = null,
+    /** The B-arm values for a campaign-wide content experiment; absent keeps one shared message. */
+    val variantBVariables: Map<String, String>? = null,
+    /** Use the catalogue's safe PUSH counterpart only when this EMAIL step lacks email consent. */
+    val fallbackToPush: Boolean = false,
+    /** Closed in-app destination opened when the customer taps the resulting PUSH notification. */
+    val mobileDestination: MobileDestination? = null,
 )
 
 /**
@@ -126,7 +133,17 @@ class CampaignResource(private val service: CampaignService, private val jwt: Js
     suspend fun create(request: CreateCampaignRequest): Response {
         val createdBy = jwt.principalName()
         val steps = request.steps.map {
-            CampaignStep(it.order, it.template, it.channel, it.variables, it.delaySeconds, it.condition)
+            CampaignStep(
+                it.order,
+                it.template,
+                it.channel,
+                it.variables,
+                it.delaySeconds,
+                it.condition,
+                it.variantBVariables,
+                it.fallbackToPush,
+                it.mobileDestination,
+            )
         }
         val campaign = service.createDraft(
             request.name,

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/rest/CampaignTriggerResource.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/rest/CampaignTriggerResource.kt
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.campaign.infrastructure.rest
+
+import com.openbank.campaign.domain.model.TriggerCatalog
+import com.openbank.libs.authz.Authorize
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.ws.rs.GET
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.core.Response
+
+/**
+ * Product events that may start a campaign journey.
+ *
+ * As with [CampaignCadenceResource], the authoring surface reads the catalogue instead of keeping
+ * a second list in TypeScript. A trigger is an executable integration contract: showing an event
+ * that no consumer watches would let an author publish a campaign that waits forever. The human
+ * form is intentionally served with the key — a marketer approves the event's meaning, never a
+ * Kafka topic or CloudEvents type.
+ */
+@Path("/api/v1/campaigns/triggers")
+@ApplicationScoped
+class CampaignTriggerResource {
+
+    @GET
+    @Authorize(action = "campaign.read", resource = "#id")
+    suspend fun triggers(): Response = Response.ok(
+        TriggerCatalog.ALL.map { (key, trigger) ->
+            mapOf("trigger" to key, "humanForm" to trigger.humanForm)
+        },
+    ).build()
+}

--- a/openbank-campaign-service/src/main/resources/db/migration/V10__send_log_channel.sql
+++ b/openbank-campaign-service/src/main/resources/db/migration/V10__send_log_channel.sql
@@ -1,0 +1,10 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+-- See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+-- The actual medium is audit evidence for a consent-triggered EMAIL → PUSH fallback. Nullable
+-- preserves historic rows and non-send decisions (conversion, condition skip, policy suppression).
+ALTER TABLE send_log
+    ADD COLUMN channel TEXT CHECK (channel IN ('EMAIL', 'PUSH'));
+
+-- Rollback: ALTER TABLE send_log DROP COLUMN channel;

--- a/openbank-campaign-service/src/main/resources/db/migration/V9__campaign_content_experiment.sql
+++ b/openbank-campaign-service/src/main/resources/db/migration/V9__campaign_content_experiment.sql
@@ -1,0 +1,8 @@
+-- A/B assignment is written once at enrolment so retries and audit reads never recalculate which
+-- wording a party saw. Nullable preserves all historic campaigns and deliberate no-contact holds.
+ALTER TABLE enrolments
+    ADD COLUMN content_variant TEXT
+    CHECK (content_variant IN ('A', 'B'));
+
+-- Rollback: retain this additive nullable column until every deployed reader understands it. A
+-- destructive DROP is only safe in a later migration after all content-experiment campaigns end.

--- a/openbank-campaign-service/src/main/resources/openapi.yaml
+++ b/openbank-campaign-service/src/main/resources/openapi.yaml
@@ -4,7 +4,7 @@ openapi: 3.1.0
 info:
   title: Campaign Service API
   # major == openbank.api.version == URL /api/v1 (ADR-0048).
-  version: 1.18.0
+  version: 1.19.0
   description: >-
     Campaign management first slice (ADR-0200 / ADR-0209 D3): deterministic, versioned segments;
     per-enrolment Temporal journeys; consent-gated delivery through notification-service.
@@ -98,6 +98,29 @@ paths:
                       description: >-
                         Never UTC. A cron evaluated in UTC reaches Czech customers an hour or two
                         off their morning, and the offset moves twice a year.
+  /api/v1/campaigns/triggers:
+    get:
+      tags: [Campaigns]
+      summary: Product events that may start a campaign journey
+      operationId: listCampaignTriggers
+      description: >-
+        The closed trigger catalogue, served so the authoring surface cannot offer a product event
+        nobody consumes. The event determines when a journey is considered; the campaign's
+        versioned segment still determines who may enter it.
+        NOTE the literal path segment: it must keep matching ahead of /api/v1/campaigns/{id}.
+      responses:
+        '200':
+          description: Every supported product-event trigger with an operator-facing description
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  required: [trigger, humanForm]
+                  properties:
+                    trigger: { type: string, example: ACCOUNT_OPENED }
+                    humanForm: { type: string, example: when an account is opened }
   /api/v1/campaigns/{id}:
     get:
       tags: [Campaigns]

--- a/openbank-campaign-service/src/main/resources/openapi.yaml
+++ b/openbank-campaign-service/src/main/resources/openapi.yaml
@@ -4,7 +4,7 @@ openapi: 3.1.0
 info:
   title: Campaign Service API
   # major == openbank.api.version == URL /api/v1 (ADR-0048).
-  version: 1.19.0
+  version: 1.22.0
   description: >-
     Campaign management first slice (ADR-0200 / ADR-0209 D3): deterministic, versioned segments;
     per-enrolment Temporal journeys; consent-gated delivery through notification-service.
@@ -281,6 +281,29 @@ paths:
         '409':
           description: Campaign has no holdout experiment configured
 
+  /api/v1/campaigns/{id}/content-experiment:
+    get:
+      tags: [Campaigns]
+      summary: Compare two assigned message-content variants
+      description: >-
+        A durable 50/50 A/B assignment for campaigns that declare alternate B values on every
+        step. Outcomes are conversion-rule events, not inferred opens or clicks. The response is
+        a conservative measurement aid; it never selects a winner or changes a live campaign.
+      operationId: campaignContentExperiment
+      parameters:
+        - $ref: '#/components/parameters/CampaignId'
+      responses:
+        '200':
+          description: Variant assignment and observed conversion outcomes
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CampaignContentExperimentSummary'
+        '404':
+          description: Campaign not found
+        '409':
+          description: Campaign has no measured A/B content experiment configured
+
   /api/v1/campaigns/{id}/journey:
     get:
       tags: [Campaigns]
@@ -545,6 +568,32 @@ components:
         variables:
           type: object
           additionalProperties: { type: string }
+        variantBVariables:
+          type: object
+          nullable: true
+          additionalProperties: { type: string }
+          description: >-
+            Alternative declared template values for the B arm. Its presence turns the entire
+            campaign into a two-arm experiment, so every step must provide it and conversionRule
+            is required. `variables` remains the A arm. Assignment is persisted at enrolment and
+            neither an activity retry nor a later code change can switch a person between arms.
+        fallbackToPush:
+          type: boolean
+          default: false
+          description: >-
+            Available only for an EMAIL offer with a catalogue-defined safe PUSH counterpart. When
+            EMAIL marketing consent is absent, the service re-evaluates the entire contact-policy
+            gate for PUSH consent and sends that reduced, lock-screen-safe title only if allowed.
+            It never bypasses quiet hours, frequency caps, suppression lists or a gate outage, and
+            it does not attempt a second send after an asynchronous delivery failure.
+        mobileDestination:
+          type: string
+          nullable: true
+          enum: [HOME, SAVINGS, CARDS, PAYMENTS, PRODUCT_HUB]
+          description: >-
+            Bank-owned destination opened after a PUSH tap. This is a closed app-route contract,
+            never an author-entered URL; absent preserves existing campaigns. It is valid on a
+            PUSH step, or on an EMAIL step only when its consent-missing fallback is PUSH.
         delaySeconds: { type: integer, minimum: 0 }
         condition:
           description: >-
@@ -679,6 +728,20 @@ components:
             is descriptive and is not a statistical-significance verdict.
         decision: { $ref: '#/components/schemas/ExperimentDecision' }
 
+    CampaignContentExperimentSummary:
+      type: object
+      required: [campaignId, a, b, observedLiftPercentagePoints, decision]
+      properties:
+        campaignId: { type: string, format: uuid }
+        a: { $ref: '#/components/schemas/CohortOutcome' }
+        b: { $ref: '#/components/schemas/CohortOutcome' }
+        observedLiftPercentagePoints:
+          type: number
+          format: double
+          nullable: true
+          description: B conversion rate minus A conversion rate, in percentage points.
+        decision: { $ref: '#/components/schemas/ContentExperimentDecision' }
+
     RateConfidenceInterval:
       type: object
       required: [lower, upper]
@@ -703,6 +766,25 @@ components:
           allOf: [{ $ref: '#/components/schemas/RateConfidenceInterval' }]
           nullable: true
         holdoutConfidenceInterval:
+          allOf: [{ $ref: '#/components/schemas/RateConfidenceInterval' }]
+          nullable: true
+
+    ContentExperimentDecision:
+      type: object
+      required: [state, minimumAssignedPerVariant, aConfidenceInterval, bConfidenceInterval]
+      description: >-
+        Conservative decision readiness only. Non-overlapping 95% Wilson intervals with the
+        minimum sample in each arm are necessary before a result is shown; no automatic action is
+        taken and the result is not a causal-effect claim.
+      properties:
+        state:
+          type: string
+          enum: [COLLECTING_DATA, INCONCLUSIVE, A_OUTPERFORMS_B, B_OUTPERFORMS_A]
+        minimumAssignedPerVariant: { type: integer, minimum: 1 }
+        aConfidenceInterval:
+          allOf: [{ $ref: '#/components/schemas/RateConfidenceInterval' }]
+          nullable: true
+        bConfidenceInterval:
           allOf: [{ $ref: '#/components/schemas/RateConfidenceInterval' }]
           nullable: true
 
@@ -799,6 +881,13 @@ components:
           description: When `deliveryStatus` last moved. Null while it has never moved off `PENDING`.
           type: [string, 'null']
           format: date-time
+        channel:
+          description: >-
+            Actual request medium. It is PUSH only when a configured EMAIL step lacked email
+            consent and the separate PUSH gate allowed its safe fallback; null for historical and
+            non-send decision rows.
+          type: [string, 'null']
+          enum: [EMAIL, PUSH, null]
 
     Enrolment:
       type: object
@@ -823,3 +912,10 @@ components:
         experimentCohort:
           type: string
           enum: [TREATMENT, HOLDOUT]
+        contentVariant:
+          type: string
+          nullable: true
+          enum: [A, B]
+          description: >-
+            Durable A/B content arm, null when the campaign has one message or this enrolment is
+            a no-contact holdout.

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/usecase/CampaignContentExperimentQueryTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/usecase/CampaignContentExperimentQueryTest.kt
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.campaign.application.usecase
+
+import com.openbank.campaign.application.port.out.CampaignContentExperimentRepository
+import com.openbank.campaign.application.port.out.CampaignRepository
+import com.openbank.campaign.application.port.out.ContentVariantMetrics
+import com.openbank.campaign.domain.model.Campaign
+import com.openbank.campaign.domain.model.CampaignState
+import com.openbank.campaign.domain.model.CampaignStep
+import com.openbank.campaign.domain.model.Channel
+import com.openbank.campaign.domain.model.ContentVariant
+import com.openbank.campaign.domain.model.SegmentRef
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.data.Offset.offset
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.UUID
+
+class CampaignContentExperimentQueryTest {
+    private val campaignId = UUID.randomUUID()
+
+    @Test
+    fun `summary compares durable A and B conversion denominators without choosing a live winner`(): Unit =
+        runBlocking {
+            val summary = CampaignContentExperimentQuery(campaign(), metrics(100, 8, 100, 30)).summary(campaignId)!!
+
+            assertThat(summary.a.conversionRate).isEqualTo(0.08)
+            assertThat(summary.b.conversionRate).isEqualTo(0.30)
+            assertThat(summary.observedLiftPercentagePoints).isCloseTo(22.0, offset(0.000_001))
+            assertThat(summary.decision.state).isEqualTo(ContentExperimentDecisionState.B_OUTPERFORMS_A)
+            assertThat(summary.decision.bConfidenceInterval!!.lower)
+                .isGreaterThan(summary.decision.aConfidenceInterval!!.upper)
+        }
+
+    @Test
+    fun `empty B arm reports unknown lift rather than manufactured zero`(): Unit = runBlocking {
+        val summary = CampaignContentExperimentQuery(campaign(), metrics(12, 1, 0, 0)).summary(campaignId)!!
+
+        assertThat(summary.b.conversionRate).isNull()
+        assertThat(summary.observedLiftPercentagePoints).isNull()
+        assertThat(summary.decision.state).isEqualTo(ContentExperimentDecisionState.COLLECTING_DATA)
+    }
+
+    private fun campaign() = object : CampaignRepository {
+        private val campaign = Campaign(
+            id = campaignId,
+            name = "content experiment",
+            goal = "open an account",
+            segmentRef = SegmentRef("eligible", 1),
+            steps = listOf(
+                CampaignStep(
+                    order = 0,
+                    template = "MARKETING_PRODUCT_OFFER",
+                    channel = Channel.EMAIL,
+                    variables = mapOf("offerTitle" to "A"),
+                    delaySeconds = 0,
+                    variantBVariables = mapOf("offerTitle" to "B"),
+                ),
+            ),
+            conversionRule = "ACCOUNT_OPENED",
+            state = CampaignState.ACTIVE,
+            createdBy = "maker",
+            approvedBy = "checker",
+            createdAt = Instant.EPOCH,
+            updatedAt = Instant.EPOCH,
+        )
+
+        override suspend fun findById(id: UUID): Campaign? = campaign.takeIf { it.id == id }
+        override suspend fun list(): List<Campaign> = listOf(campaign)
+        override suspend fun save(campaign: Campaign): Campaign = campaign
+        override suspend fun findActiveByTrigger(trigger: String): List<Campaign> = emptyList()
+    }
+
+    private fun metrics(aAssigned: Long, aConverted: Long, bAssigned: Long, bConverted: Long) =
+        object : CampaignContentExperimentRepository {
+            override suspend fun metrics(campaignId: UUID) = listOf(
+                ContentVariantMetrics(ContentVariant.A, aAssigned, aConverted),
+                ContentVariantMetrics(ContentVariant.B, bAssigned, bConverted),
+            )
+        }
+}

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/workflow/CampaignJourneyActivitiesImplTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/workflow/CampaignJourneyActivitiesImplTest.kt
@@ -116,7 +116,7 @@ class CampaignJourneyActivitiesImplTest {
     @Test
     fun `a refused notification handoff records FAILED and never SENT`() {
         givenDeliverableStep()
-        coEvery { notificationSend.requestSend(partyId, any(), any(), any(), any(), any()) } throws
+        coEvery { notificationSend.requestSend(any()) } throws
             IllegalStateException("broker refused the publish")
 
         assertThatThrownBy { activities.deliverStep(campaignId, partyId, 1) }
@@ -133,7 +133,7 @@ class CampaignJourneyActivitiesImplTest {
         val recordedBeforeSend = mutableListOf<SendOutcome>()
         var handedOff = false
         coEvery {
-            notificationSend.requestSend(partyId, any(), any(), any(), any(), any())
+            notificationSend.requestSend(any())
         } answers { handedOff = true }
         coEvery { sendLog.record(any()) } answers {
             if (!handedOff) recordedBeforeSend += firstArg<SendRecord>().outcome

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/workflow/CampaignJourneyActivitiesTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/workflow/CampaignJourneyActivitiesTest.kt
@@ -9,6 +9,7 @@ import com.openbank.campaign.application.port.out.CampaignOutcomeCount
 import com.openbank.campaign.application.port.out.CampaignRepository
 import com.openbank.campaign.application.port.out.EnrolmentRepository
 import com.openbank.campaign.application.port.out.NotificationSendPort
+import com.openbank.campaign.application.port.out.NotificationSendRequest
 import com.openbank.campaign.application.port.out.SendLogRepository
 import com.openbank.campaign.application.port.out.StepOutcomeCount
 import com.openbank.campaign.domain.model.Campaign
@@ -60,9 +61,11 @@ class CampaignJourneyActivitiesTest {
     )
 
     private inner class Harness {
-        var consent = true
+        var emailConsent = true
+        var pushConsent = true
         var consentScope: String? = null
         var channel = Channel.EMAIL
+        var fallbackToPush = false
         var sends = 0
         var entries = listOf<SuppressionEntry>()
         var failWith: RuntimeException? = null
@@ -71,6 +74,9 @@ class CampaignJourneyActivitiesTest {
 
         /** Correlation ids put on the wire, in order (ADR-0239 D1). */
         val correlationIds = mutableListOf<UUID>()
+
+        /** App destinations handed to notification-service for the current delivery. */
+        val deepLinks = mutableListOf<String?>()
 
         val campaigns = object : CampaignRepository {
             override suspend fun findById(id: UUID) = if (id == campaignId) {
@@ -83,6 +89,7 @@ class CampaignJourneyActivitiesTest {
                             } else {
                                 "MARKETING_PRODUCT_OFFER"
                             },
+                            fallbackToPush = fallbackToPush,
                         ),
                     ),
                 )
@@ -130,16 +137,10 @@ class CampaignJourneyActivitiesTest {
             ): DeliveryStatus? = null
         }
         val notificationSend = object : NotificationSendPort {
-            override suspend fun requestSend(
-                partyId: UUID,
-                channel: Channel,
-                template: String,
-                recipient: String,
-                variables: Map<String, String>,
-                correlationId: UUID,
-            ) {
+            override suspend fun requestSend(request: NotificationSendRequest) {
                 sendsRequested += 1
-                correlationIds += correlationId
+                correlationIds += request.correlationId
+                deepLinks += request.deepLink
             }
         }
 
@@ -147,7 +148,11 @@ class CampaignJourneyActivitiesTest {
             consent = ContactConsentPort { _, scope ->
                 consentScope = scope
                 failWith?.let { throw it }
-                consent
+                when (scope) {
+                    "MARKETING_COMMS_EMAIL" -> emailConsent
+                    "MARKETING_COMMS_PUSH" -> pushConsent
+                    else -> false
+                }
             },
             counters = object : ContactCounterPort {
                 override suspend fun sendsInWindow(partyId: UUID, windowStart: Instant): Int {
@@ -244,7 +249,7 @@ class CampaignJourneyActivitiesTest {
 
     @Test
     fun `no consent maps to SUPPRESSED_CONSENT`() {
-        val h = Harness().apply { consent = false }
+        val h = Harness().apply { emailConsent = false }
         assertThat(
             runBlocking {
                 h.activities.deliverStepGated(campaignId, partyId, 1)
@@ -269,6 +274,36 @@ class CampaignJourneyActivitiesTest {
         runBlocking { h.activities.deliverStepGated(campaignId, partyId, 1) }
 
         assertThat(h.consentScope).isEqualTo("MARKETING_COMMS_PUSH")
+    }
+
+    @Test
+    fun `missing email consent falls back to a separately consented push and records the actual channel`() {
+        val h = Harness().apply {
+            emailConsent = false
+            pushConsent = true
+            fallbackToPush = true
+        }
+
+        assertThat(runBlocking { h.activities.deliverStepGated(campaignId, partyId, 1) }).isEqualTo(StepOutcome.SENT)
+        assertThat(h.sendsRequested).isEqualTo(1)
+        assertThat(h.consentScope).isEqualTo("MARKETING_COMMS_PUSH")
+        assertThat(h.recorded.single().channel).isEqualTo(Channel.PUSH)
+    }
+
+    @Test
+    fun `a cap denial never switches to push`() {
+        val h = Harness().apply {
+            sends = 2
+            fallbackToPush = true
+        }
+
+        assertThat(
+            runBlocking {
+                h.activities.deliverStepGated(campaignId, partyId, 1)
+            },
+        ).isEqualTo(StepOutcome.SUPPRESSED)
+        assertThat(h.sendsRequested).isZero()
+        assertThat(h.recorded.single().outcome).isEqualTo(SendOutcome.SUPPRESSED_CAP)
     }
 
     @Test

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/domain/TemplateCatalogTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/domain/TemplateCatalogTest.kt
@@ -6,6 +6,7 @@ package com.openbank.campaign.domain
 
 import com.openbank.campaign.domain.model.CampaignStep
 import com.openbank.campaign.domain.model.Channel
+import com.openbank.campaign.domain.model.MobileDestination
 import com.openbank.campaign.domain.model.TemplateCatalog
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -101,6 +102,20 @@ class CampaignStepChannelTest {
     }
 
     @Test
+    fun `a push step resolves an allow-listed app destination rather than an author URL`() {
+        val step = CampaignStep(
+            order = 1,
+            template = "MARKETING_PRODUCT_OFFER_PUSH",
+            channel = Channel.PUSH,
+            variables = mapOf("offerTitle" to "Savings"),
+            delaySeconds = 0,
+            mobileDestination = MobileDestination.SAVINGS,
+        )
+
+        assertEquals("openbank://savings", step.primaryDelivery(null).deepLink)
+    }
+
+    @Test
     fun `an email template on a push step is refused`() {
         val e = assertThrows<IllegalArgumentException> {
             CampaignStep(
@@ -147,5 +162,34 @@ class CampaignStepChannelTest {
     fun `the catalogue offers exactly the templates a channel can render`() {
         assertEquals(setOf("MARKETING_PRODUCT_OFFER"), TemplateCatalog.forChannel(Channel.EMAIL))
         assertEquals(setOf("MARKETING_PRODUCT_OFFER_PUSH"), TemplateCatalog.forChannel(Channel.PUSH))
+    }
+
+    @Test
+    fun `an email step can safely reduce to its push fallback without carrying email body copy`() {
+        val step = CampaignStep(
+            order = 1,
+            template = "MARKETING_PRODUCT_OFFER",
+            channel = Channel.EMAIL,
+            variables = mapOf("offerTitle" to "Savings", "offerText" to "Email body", "ctaText" to "Open"),
+            delaySeconds = 0,
+            fallbackToPush = true,
+        )
+
+        assertEquals(Channel.PUSH, step.pushFallback(null)?.channel)
+        assertEquals(mapOf("offerTitle" to "Savings"), step.pushFallback(null)?.variables)
+    }
+
+    @Test
+    fun `a push step cannot declare another push fallback`() {
+        assertThrows<IllegalArgumentException> {
+            CampaignStep(
+                order = 1,
+                template = "MARKETING_PRODUCT_OFFER_PUSH",
+                channel = Channel.PUSH,
+                variables = mapOf("offerTitle" to "Savings"),
+                delaySeconds = 0,
+                fallbackToPush = true,
+            )
+        }
     }
 }

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/infrastructure/kafka/ConversionConsumerTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/infrastructure/kafka/ConversionConsumerTest.kt
@@ -44,7 +44,7 @@ class ConversionConsumerTest {
     private val journeys = mockk<JourneySignaller>(relaxed = true)
 
     @Test
-    fun `one product event credits only the last eligible campaign and ends that journey`() = runBlocking {
+    fun `one product event credits only the last eligible campaign and ends that journey`(): Unit = runBlocking {
         givenOverlappingCampaigns(newerAlreadyConverted = false)
         val recorded = slot<SendRecord>()
 
@@ -58,7 +58,7 @@ class ConversionConsumerTest {
     }
 
     @Test
-    fun `redelivery never shifts an already credited event to the runner-up campaign`() = runBlocking {
+    fun `redelivery never shifts an already credited event to the runner-up campaign`(): Unit = runBlocking {
         givenOverlappingCampaigns(newerAlreadyConverted = true)
 
         consumer().onAccountEvent(accountCreatedMessage())

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/integration/CampaignRestContractIT.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/integration/CampaignRestContractIT.kt
@@ -482,6 +482,21 @@ class CampaignRestContractIT {
         }
     }
 
+    /** Studio reads these labels from the service instead of duplicating an executable event list. */
+    @Test
+    fun `the trigger catalogue is served with its operator-facing meaning`() {
+        When {
+            get("/api/v1/campaigns/triggers")
+        } Then {
+            statusCode(200)
+            body("trigger", org.hamcrest.Matchers.hasItem("ACCOUNT_OPENED"))
+            body(
+                "find { it.trigger == 'ACCOUNT_OPENED' }.humanForm",
+                org.hamcrest.Matchers.equalTo("when an account is opened"),
+            )
+        }
+    }
+
     @Test
     fun `the segment catalogue is served over HTTP with its rules in words`() {
         When {

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/integration/CampaignRestContractIT.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/integration/CampaignRestContractIT.kt
@@ -497,6 +497,76 @@ class CampaignRestContractIT {
         }
     }
 
+    /** A/B content survives HTTP and has a measured endpoint even before either arm has enrolled. */
+    @Test
+    fun `a content experiment keeps both declared arms and exposes its empty measurement`() {
+        val body = """
+            {"name":"ab-${UUID.randomUUID()}","goal":"prove A/B content round trip",
+             "segmentName":"actives","segmentVersion":1,"conversionRule":"ACCOUNT_OPENED",
+             "steps":[{"order":1,"template":"MARKETING_PRODUCT_OFFER",
+                       "variables":{"offerTitle":"A","offerText":"A copy","ctaText":"Go"},
+                       "variantBVariables":{"offerTitle":"B","offerText":"B copy","ctaText":"Try"},
+                       "fallbackToPush":true,
+                       "delaySeconds":0}]}
+        """.trimIndent()
+
+        val id = Given {
+            contentType("application/json")
+            body(body)
+        } When {
+            post("/api/v1/campaigns")
+        } Then {
+            statusCode(201)
+        } Extract {
+            path<String>("id")
+        }
+
+        When {
+            get("/api/v1/campaigns/$id")
+        } Then {
+            statusCode(200)
+            body("steps[0].variantBVariables.offerTitle", org.hamcrest.Matchers.equalTo("B"))
+            body("steps[0].fallbackToPush", org.hamcrest.Matchers.equalTo(true))
+        }
+        When {
+            get("/api/v1/campaigns/$id/content-experiment")
+        } Then {
+            statusCode(200)
+            body("a.assigned", org.hamcrest.Matchers.equalTo(0))
+            body("b.assigned", org.hamcrest.Matchers.equalTo(0))
+            body("decision.state", org.hamcrest.Matchers.equalTo("COLLECTING_DATA"))
+        }
+    }
+
+    @Test
+    fun `a mobile-first push step keeps its closed app destination over the HTTP contract`() {
+        val body = """
+            {"name":"push-${UUID.randomUUID()}","goal":"savings activation",
+             "segmentName":"actives","segmentVersion":1,
+             "steps":[{"order":1,"template":"MARKETING_PRODUCT_OFFER_PUSH","channel":"PUSH",
+                       "variables":{"offerTitle":"Savings"},"mobileDestination":"SAVINGS","delaySeconds":0}]}
+        """.trimIndent()
+
+        val id = Given {
+            contentType("application/json")
+            body(body)
+        } When {
+            post("/api/v1/campaigns")
+        } Then {
+            statusCode(201)
+        } Extract {
+            path<String>("id")
+        }
+
+        When {
+            get("/api/v1/campaigns/$id")
+        } Then {
+            statusCode(200)
+            body("steps[0].channel", org.hamcrest.Matchers.equalTo("PUSH"))
+            body("steps[0].mobileDestination", org.hamcrest.Matchers.equalTo("SAVINGS"))
+        }
+    }
+
     @Test
     fun `the segment catalogue is served over HTTP with its rules in words`() {
         When {

--- a/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
+++ b/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
@@ -193,6 +193,14 @@ class CustomerEdgeResource(
     @ConfigProperty(name = "openbank.edge.notification-service-url")
     lateinit var notificationServiceUrl: String
 
+    /**
+     * The app's server-driven engagement surfaces. This is deliberately separate from
+     * notification-service: an app surface is rendered after the customer opens the app, it is
+     * not an outbound notification pretending to have been delivered (ADR-0220 D1).
+     */
+    @ConfigProperty(name = "openbank.edge.engagement-service-url")
+    lateinit var engagementServiceUrl: String
+
     @ConfigProperty(name = "openbank.edge.statement-service-url")
     lateinit var statementServiceUrl: String
 
@@ -2596,6 +2604,48 @@ class CustomerEdgeResource(
         )
     }
 
+    // --- In-app engagement surfaces ---
+
+    /**
+     * Resolve one named mobile surface for the authenticated customer. The app receives only a
+     * typed, catalogue-backed payload; it owns presentation, accessibility and local navigation.
+     * The party id is derived from the JWT and injected only at this boundary, never accepted from
+     * the device, so changing a query parameter cannot render another customer's campaign.
+     */
+    @GET
+    @Path("/surfaces/{slot}")
+    @Authorize(action = "customer.engagement.read", resource = "#slot")
+    @Blocking
+    fun getSurface(@PathParam("slot") slot: String): Response {
+        if (slot !in SURFACE_SLOTS) return Response.status(Response.Status.BAD_REQUEST).build()
+        val customer = customer()
+        return upstream.get(
+            "$engagementServiceUrl/api/v1/surfaces/$slot?partyId=${customer.partyId}",
+            customer.partyId.toString(),
+        )
+    }
+
+    /**
+     * Record what the app actually observed: impression, click or dismissal. The edge overwrites
+     * any supplied partyId with the JWT party id before forwarding, which makes the feedback loop
+     * meaningful without turning it into an IDOR write primitive. Content/slot/type validation is
+     * owned by engagement-service, alongside the catalogue it validates against.
+     */
+    @POST
+    @Path("/surfaces/events")
+    @Authorize(action = "customer.engagement.record-event")
+    @Blocking
+    fun recordSurfaceEvent(body: String): Response {
+        val customer = customer()
+        val enriched = injectField(objectMapper, body, "partyId", customer.partyId.toString())
+            ?: return Response.status(Response.Status.BAD_REQUEST).build()
+        return upstream.post(
+            "$engagementServiceUrl/api/v1/surfaces/events",
+            customer.partyId.toString(),
+            enriched,
+        )
+    }
+
     // --- Theme preferences (ADR-0190) — edge-local, party-keyed, roams the app look ---
 
     /** The caller's stored ThemeSpec, 404 when none. Party is taken from the JWT, never the client. */
@@ -3833,6 +3883,15 @@ class CustomerEdgeResource(
         parseCreditorAccount(raw) ?: czechIbanToBban(raw)
 
     companion object {
+        /** Closed at the edge as well as upstream: a path is never an app-controlled URL. */
+        private val SURFACE_SLOTS: Set<String> = setOf(
+            "HOME_BANNER",
+            "HOME_CAROUSEL",
+            "STORIES",
+            "PRODUCT_FEED",
+            "REWARDS_HUB",
+        )
+
         // A ThemeSpec is a small token document; 8 KiB leaves headroom for future fields
         // while keeping Redis abuse-proof (ADR-0190).
         private const val THEME_SPEC_MAX_BYTES = 8 * 1024

--- a/openbank-customer-edge/src/main/resources/application.yaml
+++ b/openbank-customer-edge/src/main/resources/application.yaml
@@ -135,6 +135,7 @@ openbank:
     keycloak-admin-realm: ${KEYCLOAK_ADMIN_REALM:openbank-customers}
     keycloak-admin-client-id: ${KEYCLOAK_ADMIN_CLIENT_ID:customer-edge-admin}
     notification-service-url: ${NOTIFICATION_SERVICE_URL:http://notification-service.notifications.svc:8112}
+    engagement-service-url: ${ENGAGEMENT_SERVICE_URL:http://engagement-service.engagement.svc:8153}
     statement-service-url: ${STATEMENT_SERVICE_URL:http://statement-service.statements.svc:8136}
     standing-order-service-url: ${STANDING_ORDER_SERVICE_URL:http://standing-order-service.payments.svc:8121}
     fx-service-url:      ${FX_SERVICE_URL:http://fx-service.fx.svc:8119}

--- a/openbank-customer-edge/src/main/resources/openapi.yaml
+++ b/openbank-customer-edge/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: Customer Edge API
-  version: 1.31.0
+  version: 1.32.0
   description: >-
     Customer-facing edge proxy (ADR-0065). Single internet-facing entry point for the
     retail customer app. Validates JWTs from the openbank-customers Keycloak realm,
@@ -31,6 +31,7 @@ tags:
   - name: WebAuthn
   - name: Documents
   - name: Preferences
+  - name: Engagement
   - name: Feedback
   - name: Cards
   - name: Lending
@@ -455,6 +456,58 @@ paths:
       responses:
         '200':
           description: Count of notifications marked read
+
+  /surfaces/{slot}:
+    get:
+      tags: [Engagement]
+      summary: Resolve a consented, typed in-app engagement surface for the caller
+      description: >-
+        Returns catalogue-backed content for a mobile slot after the engagement service applies
+        marketing consent, impression budget, adverse-state exclusions and dismissal suppression.
+        The party is always taken from the authenticated customer session; it is never a client
+        parameter. The app owns local rendering and navigation for the typed payload.
+      operationId: getEngagementSurface
+      security:
+        - customerOidc: []
+      parameters:
+        - name: slot
+          in: path
+          required: true
+          schema:
+            type: string
+            enum: [HOME_BANNER, HOME_CAROUSEL, STORIES, PRODUCT_FEED, REWARDS_HUB]
+      responses:
+        '200':
+          description: Surface resolution, including an explicit state when no content may render
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EngagementSurfaceResponse'
+        '400':
+          description: Unknown surface slot
+
+  /surfaces/events:
+    post:
+      tags: [Engagement]
+      summary: Record an app-observed engagement event for a surfaced item
+      description: >-
+        The party identity is injected from the customer JWT. The service accepts only a content
+        id that belongs to the declared slot, so a device cannot manufacture metrics for an
+        arbitrary campaign or content class.
+      operationId: recordEngagementSurfaceEvent
+      security:
+        - customerOidc: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EngagementSurfaceEvent'
+      responses:
+        '202':
+          description: Event persisted and queued for the engagement event stream
+        '400':
+          description: Invalid request, unknown content or content-slot mismatch
 
   /profile:
     get:
@@ -2136,6 +2189,59 @@ components:
         email:
           type: string
           format: email
+
+    EngagementSurfaceResponse:
+      type: object
+      required: [state]
+      description: >-
+        A typed server decision, not arbitrary remote UI markup. `ok` carries only catalogue ids
+        and declared presentation variables; `not_eligible` and `suppressed` are normal states,
+        not transport failures.
+      properties:
+        state:
+          type: string
+          enum: [ok, not_eligible, suppressed]
+        content:
+          type: array
+          items:
+            $ref: '#/components/schemas/EngagementSurfaceContent'
+        reason:
+          type: string
+          description: Present when the contact policy makes the caller not eligible.
+
+    EngagementSurfaceContent:
+      type: object
+      required: [id, slot, type, variables]
+      properties:
+        id:
+          type: string
+          example: SAVINGS_RATE_BANNER
+        slot:
+          type: string
+          enum: [HOME_BANNER, HOME_CAROUSEL, STORIES, PRODUCT_FEED, REWARDS_HUB]
+        type:
+          type: string
+          enum: [BANNER, CARD, STORY, CAROUSEL, OFFER]
+        variables:
+          type: array
+          items: {type: string}
+
+    EngagementSurfaceEvent:
+      type: object
+      required: [contentId, slot, type]
+      description: >-
+        `partyId` is deliberately absent: customer-edge derives it from the bearer token and
+        overwrites any unexpected field before the event reaches engagement-service.
+      properties:
+        contentId:
+          type: string
+          example: SAVINGS_RATE_BANNER
+        slot:
+          type: string
+          enum: [HOME_BANNER, HOME_CAROUSEL, STORIES, PRODUCT_FEED, REWARDS_HUB]
+        type:
+          type: string
+          enum: [IMPRESSION, CLICK, DISMISS]
 
     FeedbackSubmission:
       type: object

--- a/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/CustomerEdgeResourceTest.kt
+++ b/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/CustomerEdgeResourceTest.kt
@@ -47,6 +47,7 @@ class CustomerEdgeResourceTest {
         objectMapper = ObjectMapper()
         accountServiceUrl = "http://account"
         balanceServiceUrl = "http://balance"
+        engagementServiceUrl = "http://engagement"
     }
 
     private fun accountJson(accountId: UUID, ownerParty: UUID) =
@@ -250,6 +251,38 @@ class CustomerEdgeResourceTest {
         // forwarding a corrupt payload upstream.
         assertThat(CustomerEdgeResource.injectField(mapper, "not json", "partyId", "x")).isNull()
         assertThat(CustomerEdgeResource.injectField(mapper, """["a","b"]""", "partyId", "x")).isNull()
+    }
+
+    // ── in-app engagement surfaces ────────────────────────────────────────────────────────────
+
+    @Test
+    fun `recordSurfaceEvent overwrites a spoofed party id with the JWT party`() {
+        val caller = UUID.randomUUID()
+        val upstream = mockk<UpstreamClient>()
+        val body = slot<String>()
+        every {
+            upstream.post(match { it.endsWith("/api/v1/surfaces/events") }, caller.toString(), capture(body), any())
+        } returns
+            Response.status(Response.Status.ACCEPTED).build()
+
+        val response = resourceFor(upstream, caller).recordSurfaceEvent(
+            """{"partyId":"${UUID.randomUUID()}","contentId":"SAVINGS_RATE_BANNER","slot":"HOME_BANNER","type":"CLICK"}""",
+        )
+
+        assertThat(response.status).isEqualTo(Response.Status.ACCEPTED.statusCode)
+        assertThat(mapper.readTree(body.captured).path("partyId").asText()).isEqualTo(caller.toString())
+        assertThat(mapper.readTree(body.captured).path("contentId").asText()).isEqualTo("SAVINGS_RATE_BANNER")
+    }
+
+    @Test
+    fun `getSurface rejects a non-catalogue slot before it calls the upstream`() {
+        val caller = UUID.randomUUID()
+        val upstream = mockk<UpstreamClient>()
+
+        val response = resourceFor(upstream, caller).getSurface("../../not-a-slot")
+
+        assertThat(response.status).isEqualTo(Response.Status.BAD_REQUEST.statusCode)
+        verify(exactly = 0) { upstream.get(any(), any()) }
     }
 
     // ── statement render: currency + format allow-lists (deny-by-default) ────────

--- a/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/infrastructure/rest/SurfaceResource.kt
+++ b/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/infrastructure/rest/SurfaceResource.kt
@@ -8,6 +8,7 @@ import com.openbank.engagement.application.usecase.RecordEngagementEventUseCase
 import com.openbank.engagement.application.usecase.ResolveSurfaceUseCase
 import com.openbank.engagement.domain.model.EngagementEvent
 import com.openbank.engagement.domain.model.EngagementEventType
+import com.openbank.engagement.domain.model.SurfaceCatalog
 import com.openbank.engagement.domain.model.SurfaceContent
 import com.openbank.engagement.domain.model.SurfaceSlot
 import com.openbank.libs.authz.Authorize
@@ -64,6 +65,11 @@ class SurfaceResource(private val resolve: ResolveSurfaceUseCase, private val re
         val slot = parseSlot(request.slot) ?: return badRequest("unknown slot '${request.slot}'")
         val type = EngagementEventType.entries.find { it.name == request.type }
             ?: return badRequest("unknown event type '${request.type}'")
+        val content = SurfaceCatalog.ALL[request.contentId]
+            ?: return badRequest("unknown content '${request.contentId}'")
+        if (content.slot != slot) {
+            return badRequest("content '${request.contentId}' is not renderable in slot '${request.slot}'")
+        }
         record.record(
             EngagementEvent(
                 partyId = request.partyId,

--- a/openbank-engagement-service/src/main/resources/openapi.yaml
+++ b/openbank-engagement-service/src/main/resources/openapi.yaml
@@ -12,10 +12,9 @@ info:
 
     Deliberately absent: gamification (D3) and pre-approved offers (D4, blocked on ADR-0142 not
     existing yet). No NBA ranking — content returns in catalogue order until ADR-0201's model
-    graduates from shadow (D5). No `@Authorize` OPA rule for these actions yet; the shared policy's
-    `default allow := false` denies both endpoints fail-closed under enforcement until that rule
-    lands.
-  version: 1.1.0
+    graduates from shadow (D5). The customer app reaches these endpoints only through
+    customer-edge, whose narrowly scoped M2M policy injects the authoritative party id.
+  version: 1.2.0
 tags:
   - name: Surfaces
   - name: Eligibility

--- a/openbank-engagement-service/src/test/kotlin/com/openbank/engagement/integration/SurfaceRestContractIT.kt
+++ b/openbank-engagement-service/src/test/kotlin/com/openbank/engagement/integration/SurfaceRestContractIT.kt
@@ -120,6 +120,21 @@ class SurfaceRestContractIT {
         }
     }
 
+    @Test
+    @TestSecurity(user = TEST_OPERATOR, roles = ["ROLE_OPERATOR"])
+    fun `an event for content not in the rendered catalogue is rejected rather than polluting metrics`() {
+        Given {
+            contentType("application/json")
+            body(
+                """{"partyId":"${UUID.randomUUID()}","contentId":"NOT_A_CATALOGUE_ITEM","slot":"HOME_BANNER","type":"CLICK"}""",
+            )
+        } When {
+            post("/api/v1/surfaces/events")
+        } Then {
+            statusCode(400)
+        }
+    }
+
     // ── AdverseStateResource (issue #4265 item 1) ──────────────────────────────────────────────
     //
     // These live in THIS class rather than a second @QuarkusTest deliberately. A new IT class would

--- a/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
@@ -222,6 +222,12 @@ spec:
               value: "true"
             - name: NOTIFICATION_SERVICE_URL
               value: http://notification-service.notifications.svc:8112
+            # In-app campaign surfaces (#4475): the customer app fetches its eligible
+            # placements and records impressions/clicks through engagement-service.
+            # The application default alone is invisible to gen-network-policies.py,
+            # so declare the real cross-namespace URL here to allow edge → engagement.
+            - name: ENGAGEMENT_SERVICE_URL
+              value: http://engagement-service.engagement.svc:8153
             - name: STATEMENT_SERVICE_URL
               value: http://statement-service.statements.svc:8136
             - name: STANDING_ORDER_SERVICE_URL

--- a/openbank-infra/gitops/components/engagement/network-policies.yaml
+++ b/openbank-infra/gitops/components/engagement/network-policies.yaml
@@ -44,6 +44,9 @@ spec:
     - from:
         - namespaceSelector:
             matchLabels:
+              kubernetes.io/metadata.name: customer-edge
+        - namespaceSelector:
+            matchLabels:
               kubernetes.io/metadata.name: admin-ui
       ports:
         - protocol: TCP

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/application/NotificationConsumer.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/application/NotificationConsumer.kt
@@ -21,6 +21,7 @@ import com.openbank.notification.application.port.out.PushMetricsPort
 import com.openbank.notification.application.port.out.PushSender
 import com.openbank.notification.domain.HtmlEscape
 import com.openbank.notification.domain.RecipientAddress
+import com.openbank.notification.domain.model.MobileDeepLink
 import com.openbank.notification.domain.model.NotificationCategory
 import com.openbank.notification.domain.model.NotificationChannel
 import com.openbank.notification.domain.model.NotificationOutcome
@@ -206,6 +207,14 @@ class NotificationConsumer {
                 req.template.variables.sorted(),
                 unknown.sorted(),
             )
+            return Uni.createFrom().voidItem()
+        }
+        val validDeepLink = req.deepLink == null ||
+            (req.channel == NotificationChannel.PUSH && MobileDeepLink.isAllowed(req.deepLink))
+        if (!validDeepLink) {
+            // The deep link controls device navigation, so it gets the same allow-list posture as
+            // template identifiers. Do not log the rejected value; it may be attacker-controlled.
+            log.errorf("Rejected notification with non-bank mobile deep-link for template=%s", req.template.name)
             return Uni.createFrom().voidItem()
         }
         return dispatch(req)
@@ -609,7 +618,7 @@ class NotificationConsumer {
                 val targets = tokens.map { Triple(it.deviceId, PushPlatform.valueOf(it.platform), it.token) }
                 val sends = targets.map { (deviceId, platform, token) ->
                     pushSender.send(
-                        PushMessage(platform, token, subject, pushText, mapOf("template" to req.template.name)),
+                        PushMessage(platform, token, subject, pushText, pushData(req, entity)),
                     ).map { result ->
                         // Recorded here, where the platform is in scope. Counter increments are
                         // thread-safe, so running off the event loop (the adapters complete on the
@@ -625,6 +634,18 @@ class NotificationConsumer {
                     .chain { results -> persistPushFanOut(req, entity, results) }
                     .replaceWithVoid()
             }
+    }
+
+    /**
+     * FCM/APNs data is a routing envelope, not customer content. `notificationId` lets an app
+     * fetch the authenticated full detail after a generic wake-up; `deepLink` is only admitted by
+     * [MobileDeepLink] before this method runs. Neither carries balances, names, offers or other
+     * lock-screen-visible material.
+     */
+    private fun pushData(req: NotificationRequest, entity: NotificationEntity): Map<String, String> = buildMap {
+        put("template", req.template.name)
+        put("notificationId", entity.notificationId.toString())
+        req.deepLink?.let { put("deepLink", it) }
     }
 
     /**

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/domain/model/Notification.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/domain/model/Notification.kt
@@ -112,4 +112,19 @@ data class NotificationRequest(
      * meaningless to the producer, which is the only party that can join it back to its own row.
      */
     val correlationId: UUID? = null,
+    /** Optional bank-owned app route for a PUSH tap; never a template variable. */
+    val deepLink: String? = null,
 )
+
+/** Closed allow-list for navigation metadata sent through FCM/APNs. */
+object MobileDeepLink {
+    private val allowed = setOf(
+        "openbank://home",
+        "openbank://savings",
+        "openbank://cards",
+        "openbank://payments",
+        "openbank://products",
+    )
+
+    fun isAllowed(value: String?): Boolean = value == null || value in allowed
+}

--- a/openbank-notification-service/src/test/kotlin/com/openbank/notification/domain/model/NotificationModelTest.kt
+++ b/openbank-notification-service/src/test/kotlin/com/openbank/notification/domain/model/NotificationModelTest.kt
@@ -80,4 +80,11 @@ class NotificationModelTest {
         assertThat(req.channel).isEqualTo(NotificationChannel.PUSH)
         assertThat(req.variables).containsEntry("code", "123456")
     }
+
+    @Test
+    fun `mobile deep links are an allow-list, not arbitrary URLs`() {
+        assertThat(MobileDeepLink.isAllowed("openbank://savings")).isTrue()
+        assertThat(MobileDeepLink.isAllowed("https://example.invalid/redirect")).isFalse()
+        assertThat(MobileDeepLink.isAllowed("openbank://savings?next=https://evil.invalid")).isFalse()
+    }
 }

--- a/openbank-notification-service/src/test/kotlin/com/openbank/notification/integration/NotificationConsumerIT.kt
+++ b/openbank-notification-service/src/test/kotlin/com/openbank/notification/integration/NotificationConsumerIT.kt
@@ -519,6 +519,30 @@ class NotificationConsumerIT {
         // The amount and account never appear anywhere in the transported payload.
         assertThat(msg.title).doesNotContain(amount).doesNotContain(account)
         assertThat(msg.body).doesNotContain(amount).doesNotContain(account)
+        assertThat(msg.data).containsKeys("template", "notificationId")
+    }
+
+    @Test
+    fun `PUSH payload carries only an allow-listed deep link alongside the opaque notification id`() {
+        val partyId = UUID.randomUUID()
+        val token = "apns-campaign-deep-link-token-it"
+        OffContextPushSender.SENT.clear()
+        seedActiveDevice(partyId, token)
+
+        consumeAndAwait(
+            NotificationRequest(
+                partyId = partyId,
+                channel = NotificationChannel.PUSH,
+                template = NotificationTemplate.WELCOME,
+                recipient = "campaign@example.com",
+                variables = mapOf("name" to "Campaign customer"),
+                deepLink = "openbank://savings",
+            ),
+        )
+
+        assertThat(OffContextPushSender.SENT.single { it.token == token }.data)
+            .containsEntry("deepLink", "openbank://savings")
+            .containsKey("notificationId")
     }
 
     @Test


### PR DESCRIPTION
## What changed

- expose the supported campaign trigger catalogue from campaign-service
- let Campaign Studio author one reviewed entry source: manual, scheduled, or product-event triggered
- render the persisted entry source in campaign detail, resolving readable labels through the service catalogue
- cover the API contract, authenticated BFF routes, studio submission, and browser journey

## Why

Campaign-service already enforced cadences and consumed product events, but the authoring surface only exposed a manual start. Showing the service-owned catalogues closes that gap without duplicating cron or event definitions in the UI.

## Validation

- `./gradlew :openbank-campaign-service:build :openbank-campaign-service:quarkusBuild`
- `npm test` (ARM64 Node)
- `npm run test:e2e` (ARM64 Node)