### PR TITLE
feat(campaign): add consent-aware channel fallback

### DIFF
--- a/.github/asvs-l3-baseline.txt
+++ b/.github/asvs-l3-baseline.txt
@@ -254,6 +254,11 @@ V9.1 openbank-infra/gitops/components/admin-ui/admin-ui.yaml:99: plaintext http:
 # it does not add one. Retires with the fleet-wide mTLS work alongside the other 215 lines here.
 V9.1 openbank-infra/gitops/components/customer-edge/customer-edge.yaml:178: plaintext http:// env value http://delegation-service.delegation.svc:8126
 
+# customer-edge -> engagement-service (#4475). This makes the existing in-cluster HTTP
+# transport explicit so the generated NetworkPolicy can admit the real campaign-surface call;
+# it retires with the same fleet-wide mesh-mTLS work as the existing customer-edge entries.
+V9.1 openbank-infra/gitops/components/customer-edge/customer-edge.yaml:230: plaintext http:// env value http://engagement-service.engagement.svc:8153
+
 # fraud -> account-service (ADR-0220 D3.5, issue #2749). Genuinely a NEW plaintext edge, declared
 # as such: fraud-service's first-ever outbound rest-client (AccountServiceClient, partyId lookup
 # for the fraud-hold signal) reaches account-service the only way any of the 200+ other callers in

--- a/docs/asyncapi/openbank-events.yaml
+++ b/docs/asyncapi/openbank-events.yaml
@@ -715,7 +715,7 @@ components:
 
     NotificationRequestPayload:
       type: object
-      required: [partyId, channel, templateId]
+      required: [partyId, channel, template, recipient, variables]
       properties:
         partyId:
           type: string
@@ -723,13 +723,23 @@ components:
         channel:
           type: string
           enum: [EMAIL, PUSH]
-        templateId:
+        template:
           type: string
-          enum: [ACCOUNT_OPENED, PAYMENT_COMPLETED, KYC_REJECTED, OTP_CODE, WELCOME]
+          description: Closed notification-service template identifier.
+        recipient:
+          type: string
         variables:
           type: object
           additionalProperties:
             type: string
+        correlationId:
+          type: string
+          format: uuid
+          description: Optional producer-owned delivery-outcome correlation id.
+        deepLink:
+          type: string
+          enum: [openbank://home, openbank://savings, openbank://cards, openbank://payments, openbank://products]
+          description: Optional allow-listed mobile route for a PUSH tap. Never customer content.
 
     SwiftMessageEventPayload:
       allOf:

--- a/openbank-admin-ui/src/app/campaigns/[id]/page.tsx
+++ b/openbank-admin-ui/src/app/campaigns/[id]/page.tsx
@@ -57,6 +57,8 @@ interface Send {
    */
   deliveryStatus?: string
   deliveryReason?: string | null
+  /** Actual request medium, including a consent-authorized EMAIL → PUSH fallback. */
+  channel?: 'EMAIL' | 'PUSH' | null
 }
 
 interface SendPage {
@@ -802,6 +804,10 @@ export default function CampaignDetailPage({ params }: { params: Promise<{ id: s
                         'Co se se zprávou skutečně stalo, podle notification-service.',
                         'What actually became of the message, as reported by notification-service.',
                       )}>{t('Doručení', 'Delivery')}</th>
+                      <th title={t(
+                        'Kanál, který campaign-service skutečně předal notification-service.',
+                        'The channel campaign-service actually handed to notification-service.',
+                      )}>{t('Kanál', 'Channel')}</th>
                       <th>{t('Kdy', 'When')}</th>
                     </tr>
                   </thead>
@@ -831,6 +837,13 @@ export default function CampaignDetailPage({ params }: { params: Promise<{ id: s
                           ) : (
                             <span className="text-xs text-muted-foreground">—</span>
                           )}
+                        </td>
+                        <td>
+                          {s.channel === 'EMAIL'
+                            ? t('E-mail', 'Email')
+                            : s.channel === 'PUSH'
+                              ? t('Push', 'Push')
+                              : <span className="text-xs text-muted-foreground">—</span>}
                         </td>
                         <td className="text-xs whitespace-nowrap">{fmtDateTime(s.occurredAt)}</td>
                       </tr>

--- a/openbank-admin-ui/src/app/campaigns/[id]/page.tsx
+++ b/openbank-admin-ui/src/app/campaigns/[id]/page.tsx
@@ -13,6 +13,7 @@ import { PageHeader, StatCard, StatusBadge, type Tone } from '@/components/ui'
 import { JourneyCanvas, type StepFunnel } from '@/components/campaigns/JourneyCanvas'
 import { SectionBoundary } from '@/components/feedback/SectionBoundary'
 import { PeopleSummary } from '@/components/campaigns/PeopleSummary'
+import { CampaignOutcomeBrief } from '@/components/campaigns/CampaignOutcomeBrief'
 
 interface Campaign {
   id: string
@@ -419,6 +420,35 @@ export default function CampaignDetailPage({ params }: { params: Promise<{ id: s
     Object.entries(summary).filter(([outcome, count]) => outcome.startsWith('SUPPRESSED') && count > 0),
   )
 
+  const campaignNextAction = () => {
+    if (!c) return { title: '', detail: '' }
+    if (c.state === 'DRAFT') return {
+      title: t('Dokončete zadání', 'Finish the brief'),
+      detail: t('Pak ho předejte k nezávislému schválení.', 'Then submit it for independent approval.'),
+    }
+    if (c.state === 'PENDING_APPROVAL') return {
+      title: t('Vyžádejte druhé oči', 'Ask for a second pair of eyes'),
+      detail: t('Autor ji nemůže sám aktivovat.', 'The author cannot activate it alone.'),
+    }
+    if (c.state === 'PAUSED') return {
+      title: t('Rozhodněte o pokračování', 'Decide whether to resume'),
+      detail: t('Zkontrolujte cestu a teprve pak změňte stav.', 'Review the journey before changing its state.'),
+    }
+    if ((summary.FAILED ?? 0) > 0) return {
+      title: t('Prověřte neúspěšná předání', 'Review failed handoffs'),
+      detail: t('Použijte detailní log níže; potlačení pravidlem není chyba.', 'Use the detailed log below; policy suppression is not an error.'),
+    }
+    if (!c.conversionRule) return {
+      title: t('Zvažte měřitelný cíl', 'Consider a measurable outcome'),
+      detail: t('Bez něj uvidíte průchod, ale ne skutečný obchodní výsledek.', 'Without one you see flow, but not the real business outcome.'),
+    }
+    return {
+      title: t('Sledujte průchod a výsledek', 'Follow the journey and outcome'),
+      detail: t('Doručení, potlačení a konverze jsou níže oddělené, aby se nezaměnily.', 'Delivery, suppression and conversion remain separate below so they cannot be confused.'),
+    }
+  }
+  const nextAction = campaignNextAction()
+
   return (
     <div className="space-y-6">
       <Link href="/campaigns" className="inline-flex items-center gap-1 text-sm hover:underline">
@@ -468,14 +498,16 @@ export default function CampaignDetailPage({ params }: { params: Promise<{ id: s
 
       {!loading && !unavailable && c && (
         <>
-          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
-            <StatCard label={t('Stav', 'State')} value={c.state} />
-            <StatCard label={t('Segment', 'Segment')} value={`${c.segmentRef?.name}@${c.segmentRef?.version}`} />
-            <StatCard label={t('Zařazeno', 'Enrolled')} value={String(detail?.enrolments.length ?? 0)} />
-            {/* Surfaced as a headline number on purpose: "how many were deliberately not
-                contacted" is the question the send log exists to answer (#2895). */}
-            <StatCard label={t('Potlačených odeslání', 'Suppressed sends')} value={String(suppressed)} />
-          </div>
+          <CampaignOutcomeBrief
+            state={c.state}
+            audience={detail?.enrolments.length ?? 0}
+            handedOff={summary.SENT ?? 0}
+            suppressed={suppressed}
+            conversion={c.conversionRule ? (summary.CONVERTED ?? 0) : null}
+            conversionLabel={c.conversionRule ? conversionLabel(c.conversionRule) : t('Cíl není měřen', 'Outcome is not measured')}
+            nextAction={nextAction.title}
+            nextActionDetail={nextAction.detail}
+          />
 
           <section className="rounded-lg border p-3 text-sm" data-campaign-entry>
             <h2 className="font-semibold">{t('Vstup do cesty', 'Journey entry')}</h2>

--- a/openbank-admin-ui/src/app/campaigns/[id]/page.tsx
+++ b/openbank-admin-ui/src/app/campaigns/[id]/page.tsx
@@ -28,6 +28,7 @@ interface Campaign {
     delaySeconds: number
     variantBVariables?: Record<string, string> | null
     fallbackToPush?: boolean
+    mobileDestination?: 'HOME' | 'SAVINGS' | 'CARDS' | 'PAYMENTS' | 'PRODUCT_HUB' | null
   }[]
   /** ADR-0245: a ConversionCatalog key, or absent when the campaign measures no conversion. */
   conversionRule?: string | null

--- a/openbank-admin-ui/src/app/campaigns/[id]/page.tsx
+++ b/openbank-admin-ui/src/app/campaigns/[id]/page.tsx
@@ -22,7 +22,13 @@ interface Campaign {
   state: string
   createdBy: string
   approvedBy: string | null
-  steps: { order: number; template: string; delaySeconds: number; variantBVariables?: Record<string, string> | null }[]
+  steps: {
+    order: number
+    template: string
+    delaySeconds: number
+    variantBVariables?: Record<string, string> | null
+    fallbackToPush?: boolean
+  }[]
   /** ADR-0245: a ConversionCatalog key, or absent when the campaign measures no conversion. */
   conversionRule?: string | null
   /** Percentage deliberately kept in the no-contact control cohort. */
@@ -627,6 +633,18 @@ export default function CampaignDetailPage({ params }: { params: Promise<{ id: s
                 {t(
                   'Rozdíl je popisný. Brána používá 95% Wilsonovy intervaly, automaticky nemění aktivní cestu a sama nedokazuje příčinu.',
                   'The difference is descriptive. The 95% Wilson gate never changes an active journey and does not establish causality itself.',
+                )}
+              </p>
+            </section>
+          )}
+
+          {c.steps.some(step => step.fallbackToPush) && (
+            <section className="space-y-1 rounded-lg border p-3" data-channel-fallback>
+              <h2 className="text-sm font-semibold">{t('Záložní kanál', 'Fallback channel')}</h2>
+              <p className="text-xs text-muted-foreground">
+                {t(
+                  'U vybraných e-mailových kroků se při chybějícím e-mailovém souhlasu zkusí push. I ten projde vlastním souhlasem, frekvenčním limitem, quiet hours a suppression listem; po nedoručení e-mailu se druhá zpráva neposílá.',
+                  'Selected email steps may try push when email consent is absent. Push still passes its own consent, frequency cap, quiet hours and suppression list; an email delivery failure never triggers a second message.',
                 )}
               </p>
             </section>

--- a/openbank-admin-ui/src/app/campaigns/new/page.tsx
+++ b/openbank-admin-ui/src/app/campaigns/new/page.tsx
@@ -243,6 +243,7 @@ export default function NewCampaignPage() {
           ...(s.condition ? { condition: s.condition } : {}),
           variables: s.variables,
           ...(contentExperiment ? { variantBVariables: s.variantBVariables ?? {} } : {}),
+          ...(s.fallbackToPush ? { fallbackToPush: true } : {}),
           delaySeconds: s.delaySeconds,
         })),
       }),

--- a/openbank-admin-ui/src/app/campaigns/new/page.tsx
+++ b/openbank-admin-ui/src/app/campaigns/new/page.tsx
@@ -244,6 +244,7 @@ export default function NewCampaignPage() {
           variables: s.variables,
           ...(contentExperiment ? { variantBVariables: s.variantBVariables ?? {} } : {}),
           ...(s.fallbackToPush ? { fallbackToPush: true } : {}),
+          ...(s.mobileDestination ? { mobileDestination: s.mobileDestination } : {}),
           delaySeconds: s.delaySeconds,
         })),
       }),

--- a/openbank-admin-ui/src/app/campaigns/new/page.tsx
+++ b/openbank-admin-ui/src/app/campaigns/new/page.tsx
@@ -17,6 +17,8 @@ import {
   type EditorStep,
 } from '@/components/campaigns/JourneyEditor'
 import { StepEditor } from '@/components/campaigns/StepEditor'
+import { CampaignExperiencePreview } from '@/components/campaigns/CampaignExperiencePreview'
+import { CampaignLaunchReadiness } from '@/components/campaigns/CampaignLaunchReadiness'
 
 /**
  * Campaign Studio — authoring on a canvas (ADR-0221 D1).
@@ -488,6 +490,19 @@ export default function NewCampaignPage() {
           />
         )}
 
+        </div>
+
+        <div className="campaign-studio-companion-grid">
+          <CampaignExperiencePreview step={selected === null ? undefined : steps[selected]} campaignName={name} />
+          <CampaignLaunchReadiness
+            audienceChosen={segment !== ''}
+            audienceSize={reach}
+            entryConfigured={entryConfigured}
+            incomplete={incomplete}
+            conversionRule={conversionRule}
+            contentExperiment={contentExperiment}
+            steps={steps}
+          />
         </div>
 
         {/* What "it worked" means, asked at authoring time because it cannot be answered later:

--- a/openbank-admin-ui/src/app/campaigns/page.tsx
+++ b/openbank-admin-ui/src/app/campaigns/page.tsx
@@ -15,11 +15,10 @@
 // language on one console would be worse than either (see components/flow/StageBoard).
 //
 // WHAT THIS PAGE HONESTLY CANNOT SHOW
-// Reach, delivery and conversion — the numbers a CDP screen is really about. `GET /api/v1/campaigns`
-// returns campaign records only; enrolments and sends are per-campaign endpoints, so a performance
-// overview here would mean one request per campaign or an API that does not exist yet. Inventing
-// the numbers, or quietly implying the page covers performance, would be worse than saying so — the
-// board carries that sentence rather than hiding it in a doc.
+// The optional summary endpoint supplies only enrolment and delivery. It does not supply in-app
+// engagement or a business conversion, so this page calls the aggregate a *delivery pulse*, never
+// performance. Inventing the rest of a CDP funnel would be worse than saying exactly where evidence
+// ends; the detail still owns the event-level journey.
 //
 // Read-only by design (#2895). Authoring is ADR-0221: `submit` → `activate`-by-a-DIFFERENT-approver
 // is a two-people-at-a-screen flow, and exposing half of it as buttons would lose the point of the
@@ -67,6 +66,16 @@ const LIFECYCLE: { key: string; cs: string; en: string; terminal?: boolean }[] =
   { key: 'PAUSED', cs: 'Pozastavená', en: 'Paused' },
   { key: 'CLOSED', cs: 'Ukončená', en: 'Closed', terminal: true },
 ]
+
+/** A marketing landing page should surface the next decision, not merely count lifecycle states.
+ *  This is a display priority only — it never changes the campaign state machine. */
+const DECISION_PRIORITY: Record<string, number> = {
+  PENDING_APPROVAL: 0,
+  PAUSED: 1,
+  DRAFT: 2,
+  ACTIVE: 3,
+  CLOSED: 9,
+}
 
 export default function CampaignsPage() {
   const { t, language } = useLanguage()
@@ -122,12 +131,42 @@ export default function CampaignsPage() {
 
   const counts = (k: string) => stats.get(k)?.count ?? 0
 
+  const decisionQueue = useMemo(
+    () => [...items]
+      .filter(c => c.state !== 'CLOSED')
+      .sort((a, b) => {
+        const priority = (DECISION_PRIORITY[a.state] ?? 8) - (DECISION_PRIORITY[b.state] ?? 8)
+        return priority !== 0 ? priority : Date.parse(a.createdAt) - Date.parse(b.createdAt)
+      })
+      .slice(0, 3),
+    [items],
+  )
+
+  const deliveryPulse = useMemo(() => {
+    if (!summary) return null
+    return Object.values(summary).reduce(
+      (total, item) => ({
+        enrolled: total.enrolled + item.enrolled,
+        sent: total.sent + item.sent,
+        suppressed: total.suppressed + item.suppressed,
+      }),
+      { enrolled: 0, sent: 0, suppressed: 0 },
+    )
+  }, [summary])
+
   const needle = search.trim().toLowerCase()
   const filtered = items.filter(
     c =>
       (!stateFilter || c.state === stateFilter) &&
       (!needle || c.name.toLowerCase().includes(needle) || (c.goal ?? '').toLowerCase().includes(needle)),
   )
+
+  const nextAction = (campaign: Campaign) => {
+    if (campaign.state === 'PENDING_APPROVAL') return t('Čeká na druhé oči', 'Needs a second pair of eyes')
+    if (campaign.state === 'PAUSED') return t('Rozhodněte o pokračování', 'Decide whether to resume')
+    if (campaign.state === 'DRAFT') return t('Dokončete zadání', 'Finish the brief')
+    return t('Sledujte živou cestu', 'Follow the live journey')
+  }
 
   return (
     <div className="space-y-6">
@@ -168,6 +207,54 @@ export default function CampaignsPage() {
             <StatCard label={t('Pozastavené', 'Paused')} value={counts('PAUSED')}
                       tone={counts('PAUSED') > 0 ? 'warning' : undefined} icon={<PauseCircle size={13} />} />
           </div>
+
+          <section className="campaign-decision-desk" aria-label={t('Dnešní priority kampaní', 'Today’s campaign priorities')} data-testid="campaign-decision-desk">
+            <div className="campaign-decision-queue">
+              <div className="campaign-desk-heading">
+                <div>
+                  <p>{t('Dnešní fokus', 'Today’s focus')}</p>
+                  <h2>{t('Co posune kampaně dál', 'What moves campaigns forward')}</h2>
+                </div>
+                <span>{decisionQueue.length}</span>
+              </div>
+              {decisionQueue.length > 0 ? (
+                <div className="campaign-decision-items">
+                  {decisionQueue.map((campaign, index) => (
+                    <Link key={campaign.id} href={`/campaigns/${campaign.id}`} className="campaign-decision-item" data-decision-campaign={campaign.id}>
+                      <span className="campaign-decision-rank">0{index + 1}</span>
+                      <span className="campaign-decision-copy">
+                        <strong>{campaign.name}</strong>
+                        <small>{nextAction(campaign)}</small>
+                      </span>
+                      <StatusBadge status={campaign.state} label={label(campaign.state)} />
+                    </Link>
+                  ))}
+                </div>
+              ) : (
+                <p className="campaign-decision-empty">{t('Nic nečeká. Můžete připravit další nápad.', 'Nothing is waiting. You can prepare the next idea.')}</p>
+              )}
+            </div>
+
+            <div className="campaign-delivery-pulse" data-testid="campaign-delivery-pulse">
+              <div className="campaign-desk-heading">
+                <div>
+                  <p>{t('Doručení', 'Delivery')}</p>
+                  <h2>{t('Pulse portfolia', 'Portfolio pulse')}</h2>
+                </div>
+                <span className={deliveryPulse ? 'campaign-pulse-live' : 'campaign-pulse-muted'}>{deliveryPulse ? t('Živě', 'Live') : t('Čeká na data', 'Waiting for data')}</span>
+              </div>
+              {deliveryPulse ? (
+                <div className="campaign-pulse-numbers">
+                  <div><strong>{deliveryPulse.enrolled.toLocaleString(language === 'cs' ? 'cs-CZ' : 'en-GB')}</strong><span>{t('zařazeno', 'enrolled')}</span></div>
+                  <div><strong>{deliveryPulse.sent.toLocaleString(language === 'cs' ? 'cs-CZ' : 'en-GB')}</strong><span>{t('odesláno', 'sent')}</span></div>
+                  <div><strong>{deliveryPulse.suppressed.toLocaleString(language === 'cs' ? 'cs-CZ' : 'en-GB')}</strong><span>{t('potlačeno', 'suppressed')}</span></div>
+                </div>
+              ) : (
+                <p className="campaign-pulse-empty">{t('Nasazená služba zatím neposílá souhrn doručení. Nuly by byly zavádějící.', 'The deployed service does not yet return a delivery aggregate. Zeros would mislead.')}</p>
+              )}
+              <p className="campaign-pulse-footnote">{t('Nejde o konverzi ani engagement — tyto signály zatím v přehledu nemáme.', 'This is not conversion or engagement — those signals are not in this overview yet.')}</p>
+            </div>
+          </section>
 
           <StageBoard
             stages={stages}

--- a/openbank-admin-ui/src/app/globals.css
+++ b/openbank-admin-ui/src/app/globals.css
@@ -296,6 +296,63 @@ main {
 .stat-card:hover::before {
   background: var(--ob-accent);
 }
+
+/* ── Campaign Studio companion surfaces ── */
+.campaign-studio-companion-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.15fr) minmax(19rem, 0.85fr);
+  gap: 1rem;
+  margin-top: 1rem;
+}
+.campaign-experience-preview,
+.campaign-launch-readiness {
+  border: 1px solid var(--border);
+  border-radius: var(--r-xl);
+  box-shadow: var(--shadow-sm);
+  overflow: hidden;
+}
+.campaign-experience-preview { background: radial-gradient(circle at 76% 15%, #dbeafe 0, transparent 32%), linear-gradient(135deg, #111827 0%, #172554 55%, #312e81 100%); color: #fff; padding: 1.15rem; }
+.campaign-preview-heading, .campaign-readiness-heading { display: flex; align-items: flex-start; justify-content: space-between; gap: 0.75rem; }
+.campaign-preview-kicker { color: inherit; font-size: 0.67rem; font-weight: 800; letter-spacing: 0.09em; opacity: 0.65; text-transform: uppercase; }
+.campaign-preview-heading h3, .campaign-readiness-heading h3 { font-size: 1rem; font-weight: 700; margin-top: 0.2rem; }
+.campaign-preview-live { background: rgba(255,255,255,0.14); border: 1px solid rgba(255,255,255,0.16); border-radius: 99px; font-size: 0.68rem; font-weight: 700; padding: 0.3rem 0.55rem; white-space: nowrap; }
+.campaign-preview-stage { display: flex; align-items: center; gap: 0.75rem; min-height: 15rem; padding: 1rem 0.35rem 0.65rem; }
+.campaign-phone { width: 8.65rem; height: 14.8rem; background: #f8fafc; border: 4px solid #020617; border-radius: 1.55rem; box-shadow: 0 18px 32px rgba(0,0,0,.3); color: #0f172a; flex: 0 0 auto; overflow: hidden; position: relative; }
+.campaign-phone-island { background: #020617; border-radius: 0 0 0.8rem 0.8rem; height: 0.9rem; left: 50%; position: absolute; top: 0; transform: translateX(-50%); width: 3.5rem; }
+.campaign-phone-content { padding: 1.3rem 0.68rem 0.65rem; }
+.campaign-phone-topline { display: flex; justify-content: space-between; color: #6366f1; font-size: 0.55rem; font-weight: 800; }
+.campaign-phone-eyebrow { color: #64748b; font-size: 0.48rem; margin-top: 0.85rem; }
+.campaign-phone h4 { font-size: 0.82rem; font-weight: 800; line-height: 1.1; margin-top: 0.18rem; }
+.campaign-phone-hero { background: linear-gradient(145deg, #ede9fe, #dbeafe); border-radius: 0.75rem; margin-top: 0.65rem; padding: 0.58rem; }
+.campaign-phone-hero span { color: #4f46e5; display: block; font-size: 0.43rem; font-weight: 800; text-transform: uppercase; }
+.campaign-phone-hero strong { display: block; font-size: 0.62rem; line-height: 1.15; margin: 0.28rem 0; }
+.campaign-phone-hero button { background: #4f46e5; border: 0; border-radius: 0.4rem; color: #fff; font-size: 0.45rem; font-weight: 700; padding: 0.28rem 0.42rem; }
+.campaign-phone-row { display: flex; gap: 0.28rem; margin-top: 0.58rem; }
+.campaign-phone-row span { background: #e2e8f0; border-radius: 0.25rem; height: 1.45rem; flex: 1; }
+.campaign-push-card { background: rgba(255,255,255,0.95); border: 1px solid rgba(255,255,255,0.75); border-radius: 0.9rem; box-shadow: 0 12px 28px rgba(0,0,0,.18); color: #0f172a; display: flex; gap: 0.48rem; max-width: 15.5rem; padding: 0.62rem; transform: rotate(-2deg); }
+.campaign-push-icon { align-items: center; background: linear-gradient(140deg, #4f46e5, #7c3aed); border-radius: 0.45rem; color: #fff; display: flex; font-size: 0.85rem; font-weight: 800; height: 1.65rem; justify-content: center; width: 1.65rem; }
+.campaign-push-meta { color: #64748b; font-size: 0.43rem; font-weight: 800; letter-spacing: 0.04em; }
+.campaign-push-title { font-size: 0.66rem; font-weight: 800; line-height: 1.15; margin-top: 0.15rem; }
+.campaign-push-card p:last-child { color: #475569; font-size: 0.52rem; line-height: 1.25; margin-top: 0.25rem; }
+.campaign-preview-route { align-items: center; background: rgba(255,255,255,.1); border: 1px solid rgba(255,255,255,.13); border-radius: 0.65rem; display: flex; flex-wrap: wrap; font-size: 0.67rem; gap: 0.35rem 0.55rem; padding: 0.55rem 0.65rem; }
+.campaign-preview-route span { opacity: .68; }
+.campaign-preview-route strong { font-size: 0.67rem; }
+.campaign-preview-route code { font-size: 0.59rem; opacity: .74; }
+.campaign-launch-readiness { background: var(--surface); padding: 1.15rem; }
+.campaign-readiness-heading strong { align-items: center; background: var(--ob-accent-light); border-radius: 99px; color: var(--ob-accent-text); display: inline-flex; font-size: 0.75rem; min-height: 2rem; padding: 0 0.7rem; }
+.campaign-readiness-intro { color: var(--text-secondary); font-size: 0.75rem; margin: 0.75rem 0; }
+.campaign-readiness-list { display: grid; gap: 0.55rem; list-style: none; }
+.campaign-readiness-list li { align-items: flex-start; border-radius: 0.65rem; display: flex; gap: 0.55rem; padding: 0.42rem; }
+.campaign-readiness-list li > span { align-items: center; border-radius: 99px; display: inline-flex; flex: 0 0 auto; font-size: 0.68rem; font-weight: 800; height: 1.2rem; justify-content: center; margin-top: 0.1rem; width: 1.2rem; }
+.campaign-readiness-list strong { display: block; font-size: 0.74rem; line-height: 1.25; }
+.campaign-readiness-list p { color: var(--text-secondary); font-size: 0.66rem; line-height: 1.32; margin-top: 0.12rem; }
+.campaign-readiness-list [data-state='ready'] > span { background: var(--success-bg); color: var(--success-text); }
+.campaign-readiness-list [data-state='attention'] { background: var(--warning-bg); }
+.campaign-readiness-list [data-state='attention'] > span { background: #fef3c7; color: var(--warning-text); }
+.campaign-readiness-list [data-state='waiting'] { background: var(--surface-2); }
+.campaign-readiness-list [data-state='waiting'] > span { background: var(--surface-4); color: var(--text-secondary); }
+@media (max-width: 960px) { .campaign-studio-companion-grid { grid-template-columns: 1fr; } }
+@media (max-width: 450px) { .campaign-preview-stage { gap: 0.4rem; } .campaign-phone { transform: scale(.9); transform-origin: left center; margin-right: -0.75rem; } .campaign-push-card { transform: rotate(-2deg) scale(.9); transform-origin: left center; } }
 /* Stat-card internals (ADR-0208 D1). `.stat-card` only ever styled the container, so every page
    hand-rolled the label/value typography inline — including colour values derived from a literal
    (`background: ${k.color}18`), which is the duplication D2 exists to remove. These three classes

--- a/openbank-admin-ui/src/app/globals.css
+++ b/openbank-admin-ui/src/app/globals.css
@@ -353,6 +353,32 @@ main {
 .campaign-readiness-list [data-state='waiting'] > span { background: var(--surface-4); color: var(--text-secondary); }
 @media (max-width: 960px) { .campaign-studio-companion-grid { grid-template-columns: 1fr; } }
 @media (max-width: 450px) { .campaign-preview-stage { gap: 0.4rem; } .campaign-phone { transform: scale(.9); transform-origin: left center; margin-right: -0.75rem; } .campaign-push-card { transform: rotate(-2deg) scale(.9); transform-origin: left center; } }
+
+/* ── Campaign portfolio decision desk ── */
+.campaign-decision-desk { display: grid; grid-template-columns: minmax(0, 1.18fr) minmax(17rem, .82fr); gap: 1rem; }
+.campaign-decision-queue, .campaign-delivery-pulse { border: 1px solid var(--border); border-radius: var(--r-xl); overflow: hidden; padding: 1.1rem; }
+.campaign-decision-queue { background: linear-gradient(135deg, #f5f3ff, var(--surface) 58%); }
+.campaign-delivery-pulse { background: var(--surface); }
+.campaign-desk-heading { align-items: flex-start; display: flex; justify-content: space-between; gap: .75rem; }
+.campaign-desk-heading p { color: var(--ob-accent-text); font-size: .66rem; font-weight: 800; letter-spacing: .09em; text-transform: uppercase; }
+.campaign-desk-heading h2 { font-size: 1rem; font-weight: 750; margin-top: .16rem; }
+.campaign-desk-heading > span { align-items: center; background: var(--ob-accent); border-radius: 99px; color: #fff; display: inline-flex; font-size: .7rem; font-weight: 800; height: 1.8rem; justify-content: center; min-width: 1.8rem; padding: 0 .52rem; }
+.campaign-decision-items { display: grid; gap: .48rem; margin-top: .9rem; }
+.campaign-decision-item { align-items: center; background: rgba(255,255,255,.78); border: 1px solid rgba(199,210,254,.65); border-radius: .75rem; color: inherit; display: flex; gap: .7rem; padding: .62rem .7rem; text-decoration: none; transition: transform .16s ease, box-shadow .16s ease; }
+.campaign-decision-item:hover { box-shadow: var(--shadow-md); transform: translateX(2px); }
+.campaign-decision-rank { color: var(--ob-accent-text); font-family: var(--font-mono); font-size: .64rem; font-weight: 700; }
+.campaign-decision-copy { display: grid; flex: 1; min-width: 0; }
+.campaign-decision-copy strong { font-size: .78rem; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.campaign-decision-copy small { color: var(--text-secondary); font-size: .67rem; margin-top: .12rem; }
+.campaign-decision-empty, .campaign-pulse-empty { color: var(--text-secondary); font-size: .74rem; line-height: 1.45; margin-top: .9rem; }
+.campaign-pulse-live { background: var(--success-bg) !important; color: var(--success-text) !important; }
+.campaign-pulse-muted { background: var(--surface-3) !important; color: var(--text-secondary) !important; }
+.campaign-pulse-numbers { display: grid; gap: .45rem; grid-template-columns: repeat(3, 1fr); margin-top: 1.02rem; }
+.campaign-pulse-numbers div { background: var(--surface-2); border-radius: .66rem; padding: .6rem; }
+.campaign-pulse-numbers strong { display: block; font-size: .95rem; font-variant-numeric: tabular-nums; }
+.campaign-pulse-numbers span { color: var(--text-secondary); display: block; font-size: .61rem; margin-top: .1rem; }
+.campaign-pulse-footnote { color: var(--text-secondary); font-size: .64rem; line-height: 1.35; margin-top: .85rem; }
+@media (max-width: 900px) { .campaign-decision-desk { grid-template-columns: 1fr; } }
 /* Stat-card internals (ADR-0208 D1). `.stat-card` only ever styled the container, so every page
    hand-rolled the label/value typography inline — including colour values derived from a literal
    (`background: ${k.color}18`), which is the duplication D2 exists to remove. These three classes

--- a/openbank-admin-ui/src/app/globals.css
+++ b/openbank-admin-ui/src/app/globals.css
@@ -379,6 +379,26 @@ main {
 .campaign-pulse-numbers span { color: var(--text-secondary); display: block; font-size: .61rem; margin-top: .1rem; }
 .campaign-pulse-footnote { color: var(--text-secondary); font-size: .64rem; line-height: 1.35; margin-top: .85rem; }
 @media (max-width: 900px) { .campaign-decision-desk { grid-template-columns: 1fr; } }
+
+/* ── Campaign outcome brief ── */
+.campaign-outcome-brief { background: linear-gradient(110deg, #111827 0%, #172554 56%, #312e81 100%); border-radius: var(--r-xl); box-shadow: var(--shadow-lg); color: #fff; display: grid; grid-template-columns: minmax(0, 1fr) minmax(13.5rem, .32fr); overflow: hidden; }
+.campaign-outcome-main { padding: 1.25rem; }
+.campaign-outcome-title-row { align-items: center; display: flex; gap: .75rem; justify-content: space-between; margin-top: .2rem; }
+.campaign-outcome-title-row h2 { font-size: 1.05rem; font-weight: 750; }
+.campaign-outcome-title-row span { background: rgba(255,255,255,.13); border: 1px solid rgba(255,255,255,.18); border-radius: 99px; font-size: .62rem; font-weight: 800; padding: .28rem .55rem; }
+.campaign-outcome-metrics { display: grid; gap: .5rem; grid-template-columns: repeat(4, minmax(0, 1fr)); margin-top: 1rem; }
+.campaign-outcome-metrics > div { background: rgba(255,255,255,.08); border: 1px solid rgba(255,255,255,.1); border-radius: .7rem; min-width: 0; padding: .58rem; }
+.campaign-outcome-metrics strong { display: block; font-size: 1.02rem; font-variant-numeric: tabular-nums; }
+.campaign-outcome-metrics span { display: block; font-size: .67rem; font-weight: 700; margin-top: .12rem; }
+.campaign-outcome-metrics small { color: rgba(255,255,255,.65); display: block; font-size: .58rem; line-height: 1.2; margin-top: .08rem; }
+.campaign-outcome-conversion[data-conversion='unmeasured'] { background: rgba(255,255,255,.035); }
+.campaign-outcome-evidence { color: rgba(255,255,255,.64); font-size: .64rem; line-height: 1.35; margin-top: .72rem; }
+.campaign-outcome-action { background: rgba(255,255,255,.1); border-left: 1px solid rgba(255,255,255,.12); display: flex; flex-direction: column; justify-content: center; padding: 1.25rem; }
+.campaign-outcome-action p { color: #c7d2fe; font-size: .65rem; font-weight: 800; letter-spacing: .08em; text-transform: uppercase; }
+.campaign-outcome-action strong { font-size: .92rem; line-height: 1.25; margin-top: .32rem; }
+.campaign-outcome-action span { color: rgba(255,255,255,.72); font-size: .7rem; line-height: 1.4; margin-top: .38rem; }
+@media (max-width: 840px) { .campaign-outcome-brief { grid-template-columns: 1fr; } .campaign-outcome-action { border-left: 0; border-top: 1px solid rgba(255,255,255,.12); } }
+@media (max-width: 560px) { .campaign-outcome-metrics { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
 /* Stat-card internals (ADR-0208 D1). `.stat-card` only ever styled the container, so every page
    hand-rolled the label/value typography inline — including colour values derived from a literal
    (`background: ${k.color}18`), which is the duplication D2 exists to remove. These three classes

--- a/openbank-admin-ui/src/components/campaigns/CampaignExperiencePreview.tsx
+++ b/openbank-admin-ui/src/components/campaigns/CampaignExperiencePreview.tsx
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+'use client'
+
+import { useLanguage } from '@/lib/i18n/LanguageContext'
+import type { EditorMobileDestination, EditorStep } from '@/components/campaigns/JourneyEditor'
+
+type Destination = Exclude<EditorMobileDestination, undefined>
+
+const destinationCopy: Record<Destination, { cs: string; en: string; eyebrowCs: string; eyebrowEn: string }> = {
+  HOME: { cs: 'Domovská obrazovka', en: 'Home', eyebrowCs: 'Dnešní přehled', eyebrowEn: 'Today at a glance' },
+  SAVINGS: { cs: 'Spoření', en: 'Savings', eyebrowCs: 'Vaše spoření', eyebrowEn: 'Your savings' },
+  CARDS: { cs: 'Karty', en: 'Cards', eyebrowCs: 'Vaše karty', eyebrowEn: 'Your cards' },
+  PAYMENTS: { cs: 'Platby', en: 'Payments', eyebrowCs: 'Poslat peníze', eyebrowEn: 'Move money' },
+  PRODUCT_HUB: { cs: 'Produkty', en: 'Products', eyebrowCs: 'Pro vás', eyebrowEn: 'Picked for you' },
+}
+
+/**
+ * A deliberately faithful *structure* preview, not an invented content renderer.
+ *
+ * Campaign-service authorises a closed application destination, not arbitrary native UI or copy.
+ * The preview therefore demonstrates the customer sequence (notification → authenticated app →
+ * destination) and uses the selected template headline, while never pretending that Admin UI owns
+ * the mobile app. It keeps the operator's decision tangible without becoming a second app client.
+ */
+export function CampaignExperiencePreview({
+  step,
+  campaignName,
+}: {
+  step: EditorStep | undefined
+  campaignName: string
+}) {
+  const { t, language } = useLanguage()
+  const isPush = step?.channel === 'PUSH'
+  const destination = step?.mobileDestination ?? 'HOME'
+  const copy = destinationCopy[destination]
+  const headline = step?.variables.offerTitle?.trim() || t('Vaše další chytrá volba', 'Your next smart move')
+  const campaignLabel = campaignName.trim() || t('Nová kampaň', 'New campaign')
+
+  return (
+    <section className="campaign-experience-preview" aria-labelledby="experience-preview-title" data-testid="campaign-experience-preview">
+      <div className="campaign-preview-heading">
+        <div>
+          <p className="campaign-preview-kicker">{t('Zážitek zákazníka', 'Customer experience')}</p>
+          <h3 id="experience-preview-title">{t('Na telefonu, ne v tabulce', 'On the phone, not in a table')}</h3>
+        </div>
+        <span className="campaign-preview-live">{t('Živý náhled', 'Live preview')}</span>
+      </div>
+
+      <div className="campaign-preview-stage">
+        <div className="campaign-phone" aria-label={t('Náhled mobilní aplikace', 'Mobile app preview')}>
+          <div className="campaign-phone-island" />
+          <div className="campaign-phone-content">
+            <div className="campaign-phone-topline">
+              <span>openbank</span>
+              <span>•••</span>
+            </div>
+            <p className="campaign-phone-eyebrow">{language === 'cs' ? copy.eyebrowCs : copy.eyebrowEn}</p>
+            <h4>{language === 'cs' ? copy.cs : copy.en}</h4>
+            <div className="campaign-phone-hero">
+              <span>{t('Doporučeno pro vás', 'Recommended for you')}</span>
+              <strong>{headline}</strong>
+              <button type="button" tabIndex={-1}>{t('Zjistit víc', 'Explore')}</button>
+            </div>
+            <div className="campaign-phone-row"><span /><span /><span /></div>
+          </div>
+        </div>
+
+        <div className="campaign-push-card" data-preview-channel={isPush ? 'PUSH' : 'EMAIL'}>
+          <div className="campaign-push-icon">o</div>
+          <div>
+            <div className="campaign-push-meta">OPENBANK · {t('nyní', 'now')}</div>
+            <p className="campaign-push-title">{isPush ? headline : t('Zvolte push krok', 'Choose a push step')}</p>
+            <p>{isPush
+              ? t('Otevře zabezpečenou aplikaci — bez osobního obsahu v notifikaci.', 'Opens the secure app — with no personal content in the notification.')
+              : t('Tento krok je e-mail. Vyberte push krok na cestě pro náhled notifikace.', 'This step is email. Select a push step on the journey to preview the notification.')}</p>
+          </div>
+        </div>
+      </div>
+
+      <div className="campaign-preview-route">
+        <span>{t('Po klepnutí', 'After tap')}</span>
+        <strong>{campaignLabel} → {language === 'cs' ? copy.cs : copy.en}</strong>
+        <code>{`openbank://${destination.toLowerCase().replace('product_hub', 'products')}`}</code>
+      </div>
+    </section>
+  )
+}

--- a/openbank-admin-ui/src/components/campaigns/CampaignLaunchReadiness.tsx
+++ b/openbank-admin-ui/src/components/campaigns/CampaignLaunchReadiness.tsx
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+'use client'
+
+import { useLanguage } from '@/lib/i18n/LanguageContext'
+import type { EditorStep } from '@/components/campaigns/JourneyEditor'
+
+type ReadinessState = 'ready' | 'attention' | 'waiting'
+
+interface ReadinessItem {
+  id: string
+  state: ReadinessState
+  label: string
+  detail: string
+}
+
+/**
+ * Turns platform constraints into a launch conversation at the point of authoring.
+ *
+ * A disabled Create button is technically correct but tells a marketer neither what is missing nor
+ * whether a policy will still change the reachable audience. This list has no hidden validation:
+ * every item is derived from the same state sent to campaign-service, and policy remains explicitly
+ * read-only rather than offering a fake override.
+ */
+export function CampaignLaunchReadiness({
+  audienceChosen,
+  audienceSize,
+  entryConfigured,
+  incomplete,
+  conversionRule,
+  contentExperiment,
+  steps,
+}: {
+  audienceChosen: boolean
+  audienceSize: number | null
+  entryConfigured: boolean
+  incomplete: boolean
+  conversionRule: string | null
+  contentExperiment: boolean
+  steps: EditorStep[]
+}) {
+  const { t, language } = useLanguage()
+  const n = (value: number) => value.toLocaleString(language === 'cs' ? 'cs-CZ' : 'en-GB')
+  const push = steps.find(step => step.channel === 'PUSH')
+  const readyCount = [audienceChosen, entryConfigured, !incomplete, !contentExperiment || conversionRule !== null].filter(Boolean).length
+
+  const items: ReadinessItem[] = [
+    audienceChosen
+      ? {
+          id: 'audience', state: audienceSize === null ? 'attention' : 'ready',
+          label: t('Publikum je vybrané', 'Audience is selected'),
+          detail: audienceSize === null
+            ? t('Dosah se ještě dopočítává.', 'Reach is still being calculated.')
+            : t(`Před kontrolou souhlasu: přibližně ${n(audienceSize)} lidí.`, `Before consent checks: roughly ${n(audienceSize)} people.`),
+        }
+      : { id: 'audience', state: 'waiting', label: t('Vyberte publikum', 'Choose an audience'), detail: t('Segment určí, kdo může do cesty vstoupit.', 'A segment decides who may enter the journey.') },
+    entryConfigured
+      ? { id: 'entry', state: 'ready', label: t('Vstup do cesty je jasný', 'Journey entry is clear'), detail: t('Každý vstup je dohledatelný a přezkoumatelný.', 'Every entry is traceable and reviewable.') }
+      : { id: 'entry', state: 'waiting', label: t('Vyberte, kdy cesta začne', 'Choose when the journey starts'), detail: t('Jednorázově, opakovaně nebo po události.', 'One time, recurring, or after an event.') },
+    incomplete
+      ? { id: 'content', state: 'waiting', label: t('Doplňte obsah kroku', 'Complete step content'), detail: t('Každý krok potřebuje všechny hodnoty své schválené šablony.', 'Every step needs all values from its approved template.') }
+      : { id: 'content', state: 'ready', label: t('Cesta má kompletní obsah', 'Journey content is complete'), detail: t(`${steps.length} ${steps.length === 1 ? 'krok je' : 'kroky jsou'} připravené ke kontrole.`, `${steps.length} ${steps.length === 1 ? 'step is' : 'steps are'} ready for review.`) },
+    contentExperiment && conversionRule === null
+      ? { id: 'measurement', state: 'waiting', label: t('Experiment potřebuje měřitelný cíl', 'Experiment needs a measurable goal'), detail: t('Bez skutečné bankovní konverze by A/B srovnání nemělo výsledek.', 'Without a real banking conversion, A/B comparison has no outcome.') }
+      : conversionRule
+        ? { id: 'measurement', state: 'ready', label: t('Výsledek je měřitelný', 'Outcome is measurable'), detail: t('Měříme bankovní událost, ne domnělý proklik.', 'This measures a banking event, not an assumed click.') }
+        : { id: 'measurement', state: 'attention', label: t('Kampaň neměří výsledek', 'Campaign does not measure an outcome'), detail: t('Můžete pokračovat, ale po spuštění nepůjde porovnat skutečný dopad.', 'You can continue, but the actual outcome cannot be compared after launch.') },
+    push
+      ? { id: 'destination', state: 'ready', label: t('Push má bezpečný cíl v aplikaci', 'Push has a safe in-app destination'), detail: t('Jen schválený deep link; žádná URL z kampaně.', 'An approved deep link only; no campaign-entered URL.') }
+      : { id: 'destination', state: 'attention', label: t('Cesta zatím nemá push krok', 'Journey has no push step yet'), detail: t('Přidejte ho, pokud má kampaň přivést lidi zpět do aplikace.', 'Add one if the campaign should bring people back into the app.') },
+    { id: 'policy', state: 'ready', label: t('Ochrana kontaktu zůstává zapnutá', 'Contact protection stays on'), detail: t('Souhlas, tiché hodiny a frekvenční limit se ověřují při doručení.', 'Consent, quiet hours and frequency limits are checked at delivery.') },
+  ]
+
+  return (
+    <section className="campaign-launch-readiness" aria-labelledby="launch-readiness-title" data-testid="campaign-launch-readiness">
+      <div className="campaign-readiness-heading">
+        <div>
+          <p className="campaign-preview-kicker">{t('Před spuštěním', 'Before launch')}</p>
+          <h3 id="launch-readiness-title">{t('Připraveno na kontrolu?', 'Ready for review?')}</h3>
+        </div>
+        <strong>{readyCount}/4</strong>
+      </div>
+      <p className="campaign-readiness-intro">
+        {t('Jeden pohled na to, co lidé uvidí a co může změnit skutečný dosah.', 'One view of what people see and what can change actual reach.')}
+      </p>
+      <ul className="campaign-readiness-list">
+        {items.map(item => (
+          <li key={item.id} data-readiness={item.id} data-state={item.state}>
+            <span aria-hidden="true">{item.state === 'ready' ? '✓' : item.state === 'attention' ? '!' : '·'}</span>
+            <div><strong>{item.label}</strong><p>{item.detail}</p></div>
+          </li>
+        ))}
+      </ul>
+    </section>
+  )
+}

--- a/openbank-admin-ui/src/components/campaigns/CampaignOutcomeBrief.tsx
+++ b/openbank-admin-ui/src/components/campaigns/CampaignOutcomeBrief.tsx
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+'use client'
+
+import { useLanguage } from '@/lib/i18n/LanguageContext'
+
+/**
+ * The campaign detail's decision layer.
+ *
+ * This uses the campaign service's whole-campaign aggregates, never the visible page of send rows.
+ * "Handed off" is intentionally not called delivered: Campaign-service knows it accepted a send
+ * request, while notification-service owns the later delivery confirmation. The distinction is
+ * critical on a marketing screen because a successful-looking number otherwise becomes a promise
+ * about a customer's device.
+ */
+export function CampaignOutcomeBrief({
+  state,
+  audience,
+  handedOff,
+  suppressed,
+  conversion,
+  conversionLabel,
+  nextAction,
+  nextActionDetail,
+}: {
+  state: string
+  audience: number
+  handedOff: number
+  suppressed: number
+  /** Null means the campaign is not configured to measure an outcome. */
+  conversion: number | null
+  conversionLabel?: string
+  nextAction: string
+  nextActionDetail: string
+}) {
+  const { t, language } = useLanguage()
+  const metrics = [
+    { label: t('Publikum', 'Audience'), value: audience, detail: t('zařazeno', 'enrolled') },
+    { label: t('Předáno', 'Handed off'), value: handedOff, detail: t('notification službě', 'to notification service') },
+    { label: t('Chráněno', 'Protected'), value: suppressed, detail: t('potlačeno pravidlem', 'suppressed by policy') },
+  ]
+
+  return (
+    <section className="campaign-outcome-brief" aria-labelledby="campaign-outcome-title" data-testid="campaign-outcome-brief">
+      <div className="campaign-outcome-main">
+        <p className="campaign-preview-kicker">{t('Pulse kampaně', 'Campaign pulse')}</p>
+        <div className="campaign-outcome-title-row">
+          <h2 id="campaign-outcome-title">{t('Další rozhodnutí opřete o data', 'Make the next decision with evidence')}</h2>
+          <span data-campaign-state={state}>{state}</span>
+        </div>
+        <div className="campaign-outcome-metrics">
+          {metrics.map(metric => (
+            <div key={metric.label}>
+              <strong>{metric.value.toLocaleString(language === 'cs' ? 'cs-CZ' : 'en-GB')}</strong>
+              <span>{metric.label}</span>
+              <small>{metric.detail}</small>
+            </div>
+          ))}
+          <div className="campaign-outcome-conversion" data-conversion={conversion === null ? 'unmeasured' : 'measured'}>
+            <strong>{conversion === null ? '—' : conversion.toLocaleString(language === 'cs' ? 'cs-CZ' : 'en-GB')}</strong>
+            <span>{conversionLabel ?? t('Výsledek', 'Outcome')}</span>
+            <small>{conversion === null ? t('neměřeno', 'not measured') : t('během zařazení', 'while enrolled')}</small>
+          </div>
+        </div>
+        <p className="campaign-outcome-evidence">{t('Jen provoz kampaně — in-app engagement se této kampani zatím nepřipisuje.', 'Campaign operations only — no in-app engagement is attributed to this campaign yet.')}</p>
+      </div>
+      <aside className="campaign-outcome-action" data-testid="campaign-outcome-next-action">
+        <p>{t('Další nejlepší akce', 'Next best action')}</p>
+        <strong>{nextAction}</strong>
+        <span>{nextActionDetail}</span>
+      </aside>
+    </section>
+  )
+}

--- a/openbank-admin-ui/src/components/campaigns/JourneyEditor.tsx
+++ b/openbank-admin-ui/src/components/campaigns/JourneyEditor.tsx
@@ -29,6 +29,8 @@ import { useLanguage } from '@/lib/i18n/LanguageContext'
 
 export type EditorChannel = 'EMAIL' | 'PUSH'
 
+export type EditorMobileDestination = 'HOME' | 'SAVINGS' | 'CARDS' | 'PAYMENTS' | 'PRODUCT_HUB'
+
 export type EditorCondition = 'IF_PREVIOUS_CONFIRMED' | 'IF_PREVIOUS_NOT_CONFIRMED'
 
 export interface EditorStep {
@@ -42,6 +44,8 @@ export interface EditorStep {
   variantBVariables?: { [key: string]: string }
   /** Try the catalogue's safe app-push counterpart only when email consent is absent. */
   fallbackToPush?: boolean
+  /** Closed app context reached after a push tap; never an arbitrary URL. */
+  mobileDestination?: EditorMobileDestination
 }
 
 export const MAX_STEPS = 5

--- a/openbank-admin-ui/src/components/campaigns/JourneyEditor.tsx
+++ b/openbank-admin-ui/src/components/campaigns/JourneyEditor.tsx
@@ -40,6 +40,8 @@ export interface EditorStep {
   condition?: EditorCondition
   /** Alternative B-arm values in a campaign-wide content experiment. */
   variantBVariables?: { [key: string]: string }
+  /** Try the catalogue's safe app-push counterpart only when email consent is absent. */
+  fallbackToPush?: boolean
 }
 
 export const MAX_STEPS = 5
@@ -294,6 +296,11 @@ export function JourneyEditor({
                   fill="var(--text-primary)">
                   {templateLabels[step.template] ?? step.template}
                 </text>
+                {step.fallbackToPush && (
+                  <text x={x + 14 + ICON + 12} y={ROW_Y + 26} fontSize="10.5" fill="var(--text-secondary)">
+                    {t('bez e-mail souhlasu → push', 'no email consent → push')}
+                  </text>
+                )}
               </g>
 
               {/* Remove sits on the node rather than in a toolbar: the thing it acts on is the thing

--- a/openbank-admin-ui/src/components/campaigns/StepEditor.tsx
+++ b/openbank-admin-ui/src/components/campaigns/StepEditor.tsx
@@ -112,7 +112,9 @@ export function StepEditor({
                   channel: c,
                   template: first,
                   variables: {},
-                  ...(c === 'PUSH' ? { fallbackToPush: false } : {}),
+                  ...(c === 'PUSH'
+                    ? { fallbackToPush: false, mobileDestination: step.mobileDestination ?? 'HOME' }
+                    : { mobileDestination: undefined }),
                   ...(step.variantBVariables !== undefined ? { variantBVariables: {} } : {}),
                 })}
                 // `.btn` again rather than a hand-rolled box — the third time tonight that a
@@ -131,12 +133,31 @@ export function StepEditor({
           })}
         </div>
         {step.channel === 'PUSH' && (
-          <p className="text-xs text-muted-foreground">
-            {t(
-              'Push nese jen titulek. Nabídku si člověk přečte v aplikaci po klepnutí — do notifikace se osobní obsah nedává.',
-              'A push carries the headline only. The offer is read in the app after the tap — personal content never goes into a notification.',
-            )}
-          </p>
+          <>
+            <p className="text-xs text-muted-foreground">
+              {t(
+                'Push nese jen titulek. Nabídku si člověk přečte v aplikaci po klepnutí — do notifikace se osobní obsah nedává.',
+                'A push carries the headline only. The offer is read in the app after the tap — personal content never goes into a notification.',
+              )}
+            </p>
+            <label className="mt-3 block space-y-1.5 text-sm" data-mobile-destination={index}>
+              <span className="font-medium">{t('Po klepnutí otevřít', 'Open after tap')}</span>
+              <select
+                className={field}
+                value={step.mobileDestination ?? 'HOME'}
+                onChange={e => onChange({ ...step, mobileDestination: e.target.value as EditorStep['mobileDestination'] })}
+              >
+                <option value="HOME">{t('Domovská obrazovka', 'Home')}</option>
+                <option value="SAVINGS">{t('Spoření', 'Savings')}</option>
+                <option value="CARDS">{t('Karty', 'Cards')}</option>
+                <option value="PAYMENTS">{t('Platby', 'Payments')}</option>
+                <option value="PRODUCT_HUB">{t('Produkty', 'Products')}</option>
+              </select>
+              <span className="block text-xs text-muted-foreground">
+                {t('Jde o pevný deep-link aplikace, ne URL zadanou do kampaně.', 'This is a fixed app deep link, not a campaign-entered URL.')}
+              </span>
+            </label>
+          </>
         )}
         {step.channel === 'EMAIL' && (
           <label className="mt-3 flex cursor-pointer items-start gap-2 text-sm" data-push-fallback={index}>

--- a/openbank-admin-ui/src/components/campaigns/StepEditor.tsx
+++ b/openbank-admin-ui/src/components/campaigns/StepEditor.tsx
@@ -112,6 +112,7 @@ export function StepEditor({
                   channel: c,
                   template: first,
                   variables: {},
+                  ...(c === 'PUSH' ? { fallbackToPush: false } : {}),
                   ...(step.variantBVariables !== undefined ? { variantBVariables: {} } : {}),
                 })}
                 // `.btn` again rather than a hand-rolled box — the third time tonight that a
@@ -136,6 +137,24 @@ export function StepEditor({
               'A push carries the headline only. The offer is read in the app after the tap — personal content never goes into a notification.',
             )}
           </p>
+        )}
+        {step.channel === 'EMAIL' && (
+          <label className="mt-3 flex cursor-pointer items-start gap-2 text-sm" data-push-fallback={index}>
+            <input
+              type="checkbox"
+              checked={step.fallbackToPush === true}
+              onChange={e => onChange({ ...step, fallbackToPush: e.target.checked })}
+            />
+            <span>
+              <span className="font-medium">{t('Když chybí e-mailový souhlas, zkusit push', 'When email consent is absent, try push')}</span>
+              <span className="mt-0.5 block text-xs text-muted-foreground">
+                {t(
+                  'Push projde vlastním souhlasem i stejnými limity. Není to druhý pokus po nedoručení e-mailu.',
+                  'Push goes through its own consent and the same limits. It is not a second attempt after an email delivery failure.',
+                )}
+              </span>
+            </span>
+          </label>
         )}
       </div>
 

--- a/openbank-admin-ui/src/test/campaign-experience-preview.test.tsx
+++ b/openbank-admin-ui/src/test/campaign-experience-preview.test.tsx
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import React from 'react'
+import { describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { LanguageProvider } from '@/lib/i18n/LanguageContext'
+import { CampaignExperiencePreview } from '@/components/campaigns/CampaignExperiencePreview'
+import { CampaignLaunchReadiness } from '@/components/campaigns/CampaignLaunchReadiness'
+import type { EditorStep } from '@/components/campaigns/JourneyEditor'
+
+const push: EditorStep = {
+  channel: 'PUSH',
+  template: 'MARKETING_PRODUCT_OFFER_PUSH',
+  variables: { offerTitle: 'Savings at 4%' },
+  delaySeconds: 0,
+  mobileDestination: 'SAVINGS',
+}
+
+describe('campaign customer experience preview', () => {
+  it('renders a push with its selected closed app destination', () => {
+    const { container } = render(
+      <LanguageProvider><CampaignExperiencePreview step={push} campaignName="Summer saving" /></LanguageProvider>,
+    )
+
+    // The headline intentionally appears in the notification and again in the authenticated app
+    // destination. One occurrence would test only half of the customer sequence.
+    expect(screen.getAllByText('Savings at 4%')).toHaveLength(2)
+    expect(screen.getByText(/Summer saving → Savings/)).toBeTruthy()
+    expect(container.querySelector('[data-preview-channel="PUSH"]')).toBeTruthy()
+    expect(screen.getByText('openbank://savings')).toBeTruthy()
+  })
+
+  it('does not pretend an email is a push notification', () => {
+    const { container } = render(
+      <LanguageProvider><CampaignExperiencePreview step={{ ...push, channel: 'EMAIL', mobileDestination: undefined }} campaignName="" /></LanguageProvider>,
+    )
+
+    expect(container.querySelector('[data-preview-channel="EMAIL"]')).toBeTruthy()
+    expect(screen.getByText(/Choose a push step/)).toBeTruthy()
+  })
+})
+
+describe('campaign launch readiness', () => {
+  it('names missing inputs and preserves policy as a non-optional guardrail', () => {
+    const { container } = render(
+      <LanguageProvider>
+        <CampaignLaunchReadiness
+          audienceChosen={false}
+          audienceSize={null}
+          entryConfigured={false}
+          incomplete
+          conversionRule={null}
+          contentExperiment={false}
+          steps={[{ ...push, channel: 'EMAIL', mobileDestination: undefined }]}
+        />
+      </LanguageProvider>,
+    )
+
+    expect(container.querySelector('[data-readiness="audience"][data-state="waiting"]')).toBeTruthy()
+    expect(container.querySelector('[data-readiness="content"][data-state="waiting"]')).toBeTruthy()
+    expect(container.querySelector('[data-readiness="policy"][data-state="ready"]')).toBeTruthy()
+    expect(screen.getByText(/Journey has no push step/)).toBeTruthy()
+  })
+})

--- a/openbank-admin-ui/src/test/campaign-outcome-brief.test.tsx
+++ b/openbank-admin-ui/src/test/campaign-outcome-brief.test.tsx
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import React from 'react'
+import { describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { CampaignOutcomeBrief } from '@/components/campaigns/CampaignOutcomeBrief'
+import { LanguageProvider } from '@/lib/i18n/LanguageContext'
+
+describe('campaign outcome brief', () => {
+  it('distinguishes handed-off sends from a measured outcome', () => {
+    render(
+      <LanguageProvider><CampaignOutcomeBrief
+          state="ACTIVE"
+          audience={1240}
+          handedOff={1110}
+          suppressed={96}
+          conversion={48}
+          conversionLabel="Account opened"
+          nextAction="Follow the journey and outcome"
+          nextActionDetail="Delivery and conversion are different facts."
+        /></LanguageProvider>,
+    )
+
+    expect(screen.getByText('Handed off')).toBeTruthy()
+    expect(screen.getByText('to notification service')).toBeTruthy()
+    expect(screen.getByText('Account opened')).toBeTruthy()
+    expect(screen.getByText(/no in-app engagement is attributed/)).toBeTruthy()
+  })
+
+  it('does not show a zero outcome when the campaign measures nothing', () => {
+    const { container } = render(
+      <LanguageProvider><CampaignOutcomeBrief
+          state="ACTIVE"
+          audience={12}
+          handedOff={10}
+          suppressed={2}
+          conversion={null}
+          conversionLabel="Outcome is not measured"
+          nextAction="Consider a measurable outcome"
+          nextActionDetail="The journey can still run."
+        /></LanguageProvider>,
+    )
+
+    expect(container.querySelector('[data-conversion="unmeasured"]')).toBeTruthy()
+    expect(screen.getByText('not measured')).toBeTruthy()
+  })
+})

--- a/openbank-admin-ui/src/test/campaign-studio.test.tsx
+++ b/openbank-admin-ui/src/test/campaign-studio.test.tsx
@@ -280,6 +280,23 @@ describe('campaign studio', () => {
     expect(screen.getByText(/never triggers a second message/i)).toBeTruthy()
   }, 15000)
 
+  it('shows the actual push channel in the send log instead of inferring it from the step', async () => {
+    const auditDetail = {
+      ...detail('ACTIVE'),
+      sends: {
+        items: [{
+          id: 'send-1', partyId: 'party-1', stepOrder: 1, outcome: 'SENT', channel: 'PUSH',
+          deliveryStatus: 'CONFIRMED', occurredAt: '2026-08-12T10:00:00Z',
+        }], total: 1, page: 0, size: 50,
+      },
+    }
+    vi.stubGlobal('fetch', mockFetch({ [`/api/campaigns/${CAMPAIGN_ID}`]: auditDetail }))
+    renderDetail()
+
+    await waitFor(() => expect(screen.getByText('Channel')).toBeTruthy(), { timeout: 8000 })
+    expect(screen.getByText('Push')).toBeTruthy()
+  }, 15000)
+
   it('renders a content experiment as A and B measurements, never an automatic winner', async () => {
     const experimentDetail = {
       ...detail('ACTIVE'),

--- a/openbank-admin-ui/src/test/campaign-studio.test.tsx
+++ b/openbank-admin-ui/src/test/campaign-studio.test.tsx
@@ -193,6 +193,33 @@ describe('campaign studio', () => {
     expect(screen.queryByText('Approve and activate')).toBeNull()
   }, 15000)
 
+  it('submits an opted-in consent fallback as part of the step definition', async () => {
+    let createBody: Record<string, unknown> | undefined
+    vi.stubGlobal('fetch', vi.fn(async (url: string, init?: RequestInit) => {
+      if (String(url) === '/api/campaigns' && init?.method === 'POST') {
+        createBody = JSON.parse(String(init.body))
+        return { ok: true, status: 201, json: async () => ({ state: 'ok', campaign: { id: CAMPAIGN_ID } }) }
+      }
+      if (String(url).includes('/api/segments')) return { ok: true, status: 200, json: async () => SEGMENTS }
+      if (String(url).includes('/cadences')) return { ok: true, status: 200, json: async () => CADENCES }
+      if (String(url).includes('/triggers')) return { ok: true, status: 200, json: async () => TRIGGERS }
+      return { ok: true, status: 200, json: async () => ({}) }
+    }))
+    render(React.createElement(Providers, null, React.createElement(NewCampaignPage)))
+
+    await waitFor(() => expect(document.querySelector('[data-segment="actives@1"]')).toBeTruthy(), { timeout: 8000 })
+    fireEvent.change(document.getElementById('c-name')!, { target: { value: 'Fallback offer' } })
+    fireEvent.change(document.getElementById('c-goal')!, { target: { value: 'Open more accounts' } })
+    fireEvent.click(document.querySelector('[data-segment="actives@1"]')!)
+    fireEvent.change(document.getElementById('var-0-offerTitle')!, { target: { value: 'Headline' } })
+    fireEvent.change(document.getElementById('var-0-offerText')!, { target: { value: 'Copy' } })
+    fireEvent.change(document.getElementById('var-0-ctaText')!, { target: { value: 'Open' } })
+    fireEvent.click(document.querySelector('[data-push-fallback="0"] input')!)
+    fireEvent.click(screen.getByRole('button', { name: 'Create draft' }))
+
+    await waitFor(() => expect(createBody).toMatchObject({ steps: [{ fallbackToPush: true }] }))
+  }, 15000)
+
   /**
    * ADR-0200 D5: maker != checker. The approver is taken from the token, so the creator's own
    * attempt is refused — and a refusal that reads as a generic failure is indistinguishable from an
@@ -235,6 +262,22 @@ describe('campaign studio', () => {
 
     await waitFor(() => expect(document.querySelector('[data-campaign-entry]')).toBeTruthy(), { timeout: 8000 })
     expect(screen.getByText(/every day at 09:00 \(Europe\/Prague\)/)).toBeTruthy()
+  }, 15000)
+
+  it('states the consent-bound push fallback in campaign detail', async () => {
+    const fallbackDetail = {
+      ...detail('ACTIVE'),
+      campaign: {
+        ...detail('ACTIVE').campaign,
+        steps: [{ order: 1, template: 'MARKETING_PRODUCT_OFFER', delaySeconds: 0, fallbackToPush: true }],
+      },
+    }
+    vi.stubGlobal('fetch', mockFetch({ [`/api/campaigns/${CAMPAIGN_ID}`]: fallbackDetail }))
+    renderDetail()
+
+    await waitFor(() => expect(document.querySelector('[data-channel-fallback]')).toBeTruthy(), { timeout: 8000 })
+    expect(screen.getByText('Fallback channel')).toBeTruthy()
+    expect(screen.getByText(/never triggers a second message/i)).toBeTruthy()
   }, 15000)
 
   it('renders a content experiment as A and B measurements, never an automatic winner', async () => {

--- a/openbank-admin-ui/src/test/campaigns-console-board.test.tsx
+++ b/openbank-admin-ui/src/test/campaigns-console-board.test.tsx
@@ -81,12 +81,12 @@ describe('campaigns console', () => {
     campaign('CLOSED', 900, 4),
   ]
 
-  function mockFetch(items = ITEMS, state = 'ok') {
+  function mockFetch(items = ITEMS, state = 'ok', summary?: unknown[]) {
     return vi.fn(async (input: RequestInfo | URL) => {
       const url = String(input)
       const json = (b: unknown) => new Response(JSON.stringify(b), { status: 200, headers: { 'content-type': 'application/json' } })
       if (url.includes('/api/auth/session')) return new Response('null', { status: 200, headers: { 'content-type': 'application/json' } })
-      if (url.includes('/api/campaigns')) return json({ items, state })
+      if (url.includes('/api/campaigns')) return json({ items, state, ...(summary ? { summary } : {}) })
       return json({})
     })
   }
@@ -132,8 +132,28 @@ describe('campaigns console', () => {
     fireEvent.click(screen.getByTestId('stage-ACTIVE'))
 
     await waitFor(() => expect(screen.getByTestId('clear-state')).toBeTruthy())
-    expect(screen.queryByText('Campaign DRAFT 1')).toBeNull()
-    expect(screen.getByText('Campaign ACTIVE 3')).toBeTruthy()
+    // The decision desk deliberately keeps the most important next action visible above the
+    // filtered inventory. The assertion belongs to the table, which is the surface the stage filter
+    // controls; a global text query would now reject the useful priority card as though it were a
+    // leaked table row.
+    const table = document.querySelector('table')!
+    expect(table.textContent).not.toContain('Campaign DRAFT 1')
+    expect(table.textContent).toContain('Campaign ACTIVE 3')
+  })
+
+  it('puts the next marketing decisions first and names delivery evidence without inventing conversion', async () => {
+    vi.stubGlobal('fetch', mockFetch(ITEMS, 'ok', [{
+      campaignId: 'ACTIVE-3', enrolled: 1240, sent: 1110, suppressed: 96, failed: 34,
+    }]))
+    render(React.createElement(Providers, null, React.createElement(CampaignsPage)))
+
+    await waitFor(() => expect(screen.getByTestId('campaign-decision-desk')).toBeTruthy())
+    const decisions = Array.from(document.querySelectorAll('[data-decision-campaign]'))
+      .map(node => node.getAttribute('data-decision-campaign'))
+    // Approval is a more urgent human decision than an unfinished draft or a live campaign.
+    expect(decisions[0]).toBe('PENDING_APPROVAL-2')
+    expect(screen.getByTestId('campaign-delivery-pulse').textContent).toMatch(/1,240|1 240/)
+    expect(screen.getByTestId('campaign-delivery-pulse').textContent).toMatch(/not conversion or engagement/)
   })
 
 })

--- a/openbank-admin-ui/src/test/journey-editor.test.tsx
+++ b/openbank-admin-ui/src/test/journey-editor.test.tsx
@@ -9,8 +9,11 @@ import { LanguageProvider } from '@/lib/i18n/LanguageContext'
 import { JourneyEditor, MAX_STEPS, type EditorStep } from '@/components/campaigns/JourneyEditor'
 import { StepEditor } from '@/components/campaigns/StepEditor'
 
-const TEMPLATES = { MARKETING_PRODUCT_OFFER: ['offerTitle', 'offerText', 'ctaText'] }
-const TPL_CHANNEL = { MARKETING_PRODUCT_OFFER: 'EMAIL' as const }
+const TEMPLATES = {
+  MARKETING_PRODUCT_OFFER: ['offerTitle', 'offerText', 'ctaText'],
+  MARKETING_PRODUCT_OFFER_PUSH: ['offerTitle'],
+}
+const TPL_CHANNEL = { MARKETING_PRODUCT_OFFER: 'EMAIL' as const, MARKETING_PRODUCT_OFFER_PUSH: 'PUSH' as const }
 
 // The editor labels a variable in the marketer's words. The mapping is data, so the test carries its
 // own copy — asserting the rendered label against the same map the component reads would be vacuous.
@@ -141,5 +144,24 @@ describe('step editor', () => {
     fireEvent.click(document.querySelector('[data-push-fallback="0"] input')!)
     expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ fallbackToPush: true }))
     expect(screen.getByText(/not a second attempt after an email delivery failure/i)).toBeTruthy()
+  })
+
+  it('gives a push a closed app destination instead of an arbitrary campaign URL', () => {
+    const onChange = vi.fn()
+    const push: EditorStep = {
+      channel: 'PUSH', template: 'MARKETING_PRODUCT_OFFER_PUSH', variables: { offerTitle: 'Savings' }, delaySeconds: 0,
+      mobileDestination: 'HOME',
+    }
+    render(
+      React.createElement(LanguageProvider, null,
+        React.createElement(StepEditor, {
+          index: 0, step: push, templates: TEMPLATES, templateChannel: TPL_CHANNEL, templateLabels: LABELS, variableLabels: VAR_LABELS,
+          onChange, onClose: vi.fn(),
+        })))
+
+    const select = document.querySelector('[data-mobile-destination="0"] select')!
+    fireEvent.change(select, { target: { value: 'SAVINGS' } })
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ mobileDestination: 'SAVINGS' }))
+    expect(screen.getByText(/not a campaign-entered URL/i)).toBeTruthy()
   })
 })

--- a/openbank-admin-ui/src/test/journey-editor.test.tsx
+++ b/openbank-admin-ui/src/test/journey-editor.test.tsx
@@ -128,4 +128,18 @@ describe('step editor', () => {
     // "Offer text" would send someone hunting for a control that is not on the screen.
     expect(screen.getByText(/Offer text, Button text/)).toBeTruthy()
   })
+
+  it('lets an email step opt into push only for absent email consent', () => {
+    const onChange = vi.fn()
+    render(
+      React.createElement(LanguageProvider, null,
+        React.createElement(StepEditor, {
+          index: 0, step: step(), templates: TEMPLATES, templateChannel: TPL_CHANNEL, templateLabels: LABELS, variableLabels: VAR_LABELS,
+          onChange, onClose: vi.fn(),
+        })))
+
+    fireEvent.click(document.querySelector('[data-push-fallback="0"] input')!)
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ fallbackToPush: true }))
+    expect(screen.getByText(/not a second attempt after an email delivery failure/i)).toBeTruthy()
+  })
 })

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/port/out/Ports.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/port/out/Ports.kt
@@ -179,23 +179,22 @@ interface ConsentCheckPort {
     suspend fun hasActiveConsent(partyId: UUID, scope: String): Boolean
 }
 
+/** One immutable request from campaign orchestration to notification-service. */
+data class NotificationSendRequest(
+    val partyId: UUID,
+    val channel: Channel,
+    val template: String,
+    val recipient: String,
+    val variables: Map<String, String>,
+    /** Send-log row id; campaign needs this mandatory to join a delivery outcome back. */
+    val correlationId: UUID,
+    /** Closed mobile-app route, present only on a PUSH delivery. */
+    val deepLink: String? = null,
+)
+
 /** ADR-0200 D3: delivery goes through notification-service, never direct. */
 interface NotificationSendPort {
-    /**
-     * [correlationId] is the send-log row id this request belongs to (ADR-0239 D1).
-     *
-     * Required, not optional: the whole reason the campaign publishes here is to hear back what
-     * became of the message, and a nullable parameter is one a caller forgets. The receiving
-     * contract keeps it optional for producers that genuinely do not care — this one does.
-     */
-    suspend fun requestSend(
-        partyId: UUID,
-        channel: Channel,
-        template: String,
-        recipient: String,
-        variables: Map<String, String>,
-        correlationId: UUID,
-    )
+    suspend fun requestSend(request: NotificationSendRequest)
 }
 
 /** ADR-0200 D2 push: signals a live journey that consent was revoked for its party. */

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/workflow/CampaignJourneyActivitiesImpl.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/workflow/CampaignJourneyActivitiesImpl.kt
@@ -7,9 +7,12 @@ package com.openbank.campaign.application.workflow
 import com.openbank.campaign.application.port.out.CampaignRepository
 import com.openbank.campaign.application.port.out.EnrolmentRepository
 import com.openbank.campaign.application.port.out.NotificationSendPort
+import com.openbank.campaign.application.port.out.NotificationSendRequest
 import com.openbank.campaign.application.port.out.SendLogRepository
+import com.openbank.campaign.domain.model.Campaign
 import com.openbank.campaign.domain.model.CampaignDelivery
 import com.openbank.campaign.domain.model.CampaignState
+import com.openbank.campaign.domain.model.CampaignStep
 import com.openbank.campaign.domain.model.Channel
 import com.openbank.campaign.domain.model.DeliveryStatus
 import com.openbank.campaign.domain.model.EnrolmentState
@@ -107,14 +110,7 @@ open class CampaignJourneyActivitiesImpl(
     @MarketingCallSite
     internal suspend fun deliverStepGated(campaignId: UUID, partyId: UUID, stepOrder: Int): StepOutcome {
         val campaign = campaigns.findById(campaignId) ?: return StepOutcome.CAMPAIGN_CLOSED
-        when (campaign.state) {
-            CampaignState.PAUSED -> return StepOutcome.CAMPAIGN_PAUSED
-            CampaignState.CLOSED -> return StepOutcome.CAMPAIGN_CLOSED
-            CampaignState.ACTIVE -> Unit
-            CampaignState.DRAFT,
-            CampaignState.PENDING_APPROVAL,
-            -> return StepOutcome.CAMPAIGN_CLOSED
-        }
+        campaign.deliveryStateOutcome()?.let { return it }
         if (sendLog.conversionContextFor(campaignId, partyId).alreadyConverted) {
             return StepOutcome.GOAL_REACHED
         }
@@ -127,94 +123,91 @@ open class CampaignJourneyActivitiesImpl(
         } else {
             null
         }
-        val primary = step.primaryDelivery(contentVariant)
+        return deliverEligibleStep(
+            StepDeliveryContext(campaign, step, campaignId, partyId, stepOrder, contentVariant),
+        )
+    }
 
-        suspend fun sendAllowed(delivery: CampaignDelivery): StepOutcome {
-            // The send-log row id is minted BEFORE the handoff, not by `record` after it
-            // (ADR-0239 D1): it is what goes on the wire as the correlation id, so the id has
-            // to exist first. It is used for whichever row this attempt ends up writing —
-            // SENT, DRY_RUN or FAILED — so an outcome that arrives for a handoff that then
-            // failed locally still lands on the right row.
-            val sendId = Ids.newId()
-            // Dry run stops HERE, after every gate above has run. Deliberately not earlier: the
-            // point of a rehearsal is that suppression, cap, quiet hours and consent are all
-            // exercised exactly as they would be, so a journey that would have been suppressed
-            // still reports SUPPRESSED and not DRY_RUN. Nothing is handed off, so this row's
-            // delivery status stays PENDING forever — correctly: no message ever left.
-            if (dryRun) {
-                sendLog.record(sendId, campaignId, partyId, stepOrder, SendOutcome.DRY_RUN, delivery.channel)
-            } else {
-                // ADR-0200 D3 — delivery goes through notification-service, never direct.
-                //
-                // The order below is the fix for issue #3581: the send log may only be written
-                // AFTER the handoff has been observed to succeed, and a handoff that failed must
-                // leave a FAILED row rather than nothing. What SENT claims here is exactly
-                // "notification-service accepted the request", not "the customer received it".
-                try {
-                    notificationSend.requestSend(
-                        partyId,
-                        delivery.channel,
-                        delivery.template,
-                        recipientFor(partyId),
-                        delivery.variables,
-                        correlationId = sendId,
-                    )
-                } catch (e: Exception) {
-                    sendLog.record(sendId, campaignId, partyId, stepOrder, SendOutcome.FAILED, delivery.channel)
-                    // Rethrown on purpose: Temporal retries the activity, and the FAILED row
-                    // above is the durable evidence that this attempt happened. FAILED rows do
-                    // not consume the frequency cap (SENT only), so a retry is not penalised.
-                    throw e
-                }
-                sendLog.record(sendId, campaignId, partyId, stepOrder, SendOutcome.SENT, delivery.channel)
-            }
-            return StepOutcome.SENT
-        }
+    /** ADR-0219: a fallback is possible only after a NO_CONSENT decision for the primary channel. */
+    private suspend fun deliverEligibleStep(context: StepDeliveryContext): StepOutcome {
+        val primary = context.step.primaryDelivery(context.contentVariant)
+        val primaryDecision = checkDelivery(context, primary)
+        if (primaryDecision == ContactGateDecision.ALLOWED) return handoff(context, primary)
+        throwIfGateUnavailable(primaryDecision)
 
-        suspend fun checked(delivery: CampaignDelivery): ContactGateDecision = contactGate.check(
-            partyId,
+        val fallback = primaryDecision.denyReason
+            .takeIf { it == ContactDenyReason.NO_CONSENT }
+            ?.let { context.step.pushFallback(context.contentVariant) }
+            ?: return recordSuppressed(context, primaryDecision)
+        return deliverFallback(context, fallback)
+    }
+
+    private suspend fun deliverFallback(context: StepDeliveryContext, fallback: CampaignDelivery): StepOutcome {
+        val decision = checkDelivery(context, fallback)
+        if (decision == ContactGateDecision.ALLOWED) return handoff(context, fallback)
+        throwIfGateUnavailable(decision)
+        return recordSuppressed(context, decision)
+    }
+
+    private suspend fun checkDelivery(context: StepDeliveryContext, delivery: CampaignDelivery): ContactGateDecision =
+        contactGate.check(
+            context.partyId,
             ContactClass.OUTBOUND_SEND,
             marketingScopeFor(delivery.channel),
-            topic = campaign.goal,
+            topic = context.campaign.goal,
         )
 
-        // ADR-0219 (#3656): both attempts use the same complete gate. Only a missing primary
-        // consent may switch channels — quiet hours, caps and list suppression are not a reason
-        // to try a second message, and a gate outage remains a retry signal.
-        return when (val primaryDecision = checked(primary)) {
-            ContactGateDecision.ALLOWED -> sendAllowed(primary)
-            else -> {
-                if (primaryDecision.denyReason == ContactDenyReason.GATE_UNAVAILABLE) {
-                    throw ContactGateUnavailableException("contact gate state unavailable — activity will retry")
-                }
-                val fallback = primaryDecision.denyReason
-                    .takeIf { it == ContactDenyReason.NO_CONSENT }
-                    ?.let { step.pushFallback(contentVariant) }
-                if (fallback != null) {
-                    when (val fallbackDecision = checked(fallback)) {
-                        ContactGateDecision.ALLOWED -> sendAllowed(fallback)
-                        else -> {
-                            if (fallbackDecision.denyReason == ContactDenyReason.GATE_UNAVAILABLE) {
-                                throw ContactGateUnavailableException(
-                                    "contact gate state unavailable — activity will retry",
-                                )
-                            }
-                            sendLog.record(
-                                Ids.newId(),
-                                campaignId,
-                                partyId,
-                                stepOrder,
-                                outcomeFor(fallbackDecision.denyReason),
-                            )
-                            StepOutcome.SUPPRESSED
-                        }
-                    }
-                } else {
-                    sendLog.record(Ids.newId(), campaignId, partyId, stepOrder, outcomeFor(primaryDecision.denyReason))
-                    StepOutcome.SUPPRESSED
-                }
-            }
+    // A transport failure must leave a FAILED send row whatever exception the Kafka client raises,
+    // then be rethrown so Temporal retries. Narrowing this catch would re-open that audit gap.
+    @Suppress("TooGenericExceptionCaught")
+    private suspend fun handoff(context: StepDeliveryContext, delivery: CampaignDelivery): StepOutcome {
+        // The send-log row id is minted BEFORE the handoff: it is the wire correlation id and
+        // joins asynchronous delivery outcome to precisely this attempt (ADR-0239 D1).
+        val sendId = Ids.newId()
+        if (dryRun) {
+            sendLog.record(
+                sendId,
+                context.campaignId,
+                context.partyId,
+                context.stepOrder,
+                SendOutcome.DRY_RUN,
+                delivery.channel,
+            )
+            return StepOutcome.SENT
         }
+        try {
+            notificationSend.requestDelivery(context.partyId, delivery, sendId)
+        } catch (e: Exception) {
+            sendLog.record(
+                sendId,
+                context.campaignId,
+                context.partyId,
+                context.stepOrder,
+                SendOutcome.FAILED,
+                delivery.channel,
+            )
+            throw e
+        }
+        sendLog.record(
+            sendId,
+            context.campaignId,
+            context.partyId,
+            context.stepOrder,
+            SendOutcome.SENT,
+            delivery.channel,
+        )
+        return StepOutcome.SENT
+    }
+
+    private suspend fun recordSuppressed(context: StepDeliveryContext, decision: ContactGateDecision): StepOutcome {
+        sendLog.record(
+            Ids.newId(),
+            context.campaignId,
+            context.partyId,
+            context.stepOrder,
+            outcomeFor(decision.denyReason),
+        )
+        return StepOutcome.SUPPRESSED
     }
 
     override fun advanceStep(campaignId: UUID, partyId: UUID, stepOrder: Int) = runBlockingOnWorker {
@@ -281,6 +274,33 @@ open class CampaignJourneyActivitiesImpl(
 /** Thrown when the contact gate cannot reach its state — a retry signal, never a policy outcome. */
 class ContactGateUnavailableException(message: String) : RuntimeException(message)
 
+/** Immutable state shared by the primary attempt and the only permitted PUSH fallback. */
+private data class StepDeliveryContext(
+    val campaign: Campaign,
+    val step: CampaignStep,
+    val campaignId: UUID,
+    val partyId: UUID,
+    val stepOrder: Int,
+    val contentVariant: com.openbank.campaign.domain.model.ContentVariant?,
+)
+
+/** Only ACTIVE campaigns may enter delivery; every other state has a durable workflow outcome. */
+private fun Campaign.deliveryStateOutcome(): StepOutcome? = when (state) {
+    CampaignState.ACTIVE -> null
+    CampaignState.PAUSED -> StepOutcome.CAMPAIGN_PAUSED
+    CampaignState.CLOSED,
+    CampaignState.DRAFT,
+    CampaignState.PENDING_APPROVAL,
+    -> StepOutcome.CAMPAIGN_CLOSED
+}
+
+/** A gate outage is retriable infrastructure state, never a customer-policy suppression. */
+private fun throwIfGateUnavailable(decision: ContactGateDecision) {
+    if (decision.denyReason == ContactDenyReason.GATE_UNAVAILABLE) {
+        throw ContactGateUnavailableException("contact gate state unavailable — activity will retry")
+    }
+}
+
 // Two helpers as top-level privates rather than members: CampaignJourneyActivitiesImpl sits at
 // detekt's TooManyFunctions threshold of 11, which fires AT the limit, so the branch-condition
 // activities (#3585) had to buy their room somewhere.
@@ -305,3 +325,18 @@ private suspend fun SendLogRepository.record(
 // The recipient address is resolved by notification-service from party data; the campaign never
 // carries an e-mail address itself (ADR-0200 D3 — no PII duplication).
 private fun recipientFor(partyId: UUID): String = partyId.toString()
+
+/** Build the cross-service command outside the gate's nested delivery branch. */
+private suspend fun NotificationSendPort.requestDelivery(partyId: UUID, delivery: CampaignDelivery, sendId: UUID) {
+    requestSend(
+        NotificationSendRequest(
+            partyId = partyId,
+            channel = delivery.channel,
+            template = delivery.template,
+            recipient = recipientFor(partyId),
+            variables = delivery.variables,
+            correlationId = sendId,
+            deepLink = delivery.deepLink,
+        ),
+    )
+}

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/workflow/CampaignJourneyActivitiesImpl.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/workflow/CampaignJourneyActivitiesImpl.kt
@@ -8,6 +8,7 @@ import com.openbank.campaign.application.port.out.CampaignRepository
 import com.openbank.campaign.application.port.out.EnrolmentRepository
 import com.openbank.campaign.application.port.out.NotificationSendPort
 import com.openbank.campaign.application.port.out.SendLogRepository
+import com.openbank.campaign.domain.model.CampaignDelivery
 import com.openbank.campaign.domain.model.CampaignState
 import com.openbank.campaign.domain.model.Channel
 import com.openbank.campaign.domain.model.DeliveryStatus
@@ -126,65 +127,92 @@ open class CampaignJourneyActivitiesImpl(
         } else {
             null
         }
-        val variables = step.variablesFor(contentVariant)
+        val primary = step.primaryDelivery(contentVariant)
 
-        // ADR-0219 (#3656): one gate call wraps the suppression list, the frequency cap, quiet
-        // hours and the live consent pull, in the gate's ordering.
-        return when (
-            val decision = contactGate.check(
-                partyId,
-                ContactClass.OUTBOUND_SEND,
-                marketingScopeFor(step.channel),
-                topic = campaign.goal,
-            )
-        ) {
-            ContactGateDecision.ALLOWED -> {
-                // The send-log row id is minted BEFORE the handoff, not by `record` after it
-                // (ADR-0239 D1): it is what goes on the wire as the correlation id, so the id has
-                // to exist first. It is used for whichever row this attempt ends up writing —
-                // SENT, DRY_RUN or FAILED — so an outcome that arrives for a handoff that then
-                // failed locally still lands on the right row.
-                val sendId = Ids.newId()
-                // Dry run stops HERE, after every gate above has run. Deliberately not earlier: the
-                // point of a rehearsal is that suppression, cap, quiet hours and consent are all
-                // exercised exactly as they would be, so a journey that would have been suppressed
-                // still reports SUPPRESSED and not DRY_RUN. Nothing is handed off, so this row's
-                // delivery status stays PENDING forever — correctly: no message ever left.
-                if (dryRun) {
-                    sendLog.record(sendId, campaignId, partyId, stepOrder, SendOutcome.DRY_RUN)
-                } else {
-                    // ADR-0200 D3 — delivery goes through notification-service, never direct.
-                    //
-                    // The order below is the fix for issue #3581: the send log may only be written
-                    // AFTER the handoff has been observed to succeed, and a handoff that failed must
-                    // leave a FAILED row rather than nothing. What SENT claims here is exactly
-                    // "notification-service accepted the request", not "the customer received it".
-                    try {
-                        notificationSend.requestSend(
-                            partyId,
-                            step.channel,
-                            step.template,
-                            recipientFor(partyId),
-                            variables,
-                            correlationId = sendId,
-                        )
-                    } catch (e: Exception) {
-                        sendLog.record(sendId, campaignId, partyId, stepOrder, SendOutcome.FAILED)
-                        // Rethrown on purpose: Temporal retries the activity, and the FAILED row
-                        // above is the durable evidence that this attempt happened. FAILED rows do
-                        // not consume the frequency cap (SENT only), so a retry is not penalised.
-                        throw e
-                    }
-                    sendLog.record(sendId, campaignId, partyId, stepOrder, SendOutcome.SENT)
+        suspend fun sendAllowed(delivery: CampaignDelivery): StepOutcome {
+            // The send-log row id is minted BEFORE the handoff, not by `record` after it
+            // (ADR-0239 D1): it is what goes on the wire as the correlation id, so the id has
+            // to exist first. It is used for whichever row this attempt ends up writing —
+            // SENT, DRY_RUN or FAILED — so an outcome that arrives for a handoff that then
+            // failed locally still lands on the right row.
+            val sendId = Ids.newId()
+            // Dry run stops HERE, after every gate above has run. Deliberately not earlier: the
+            // point of a rehearsal is that suppression, cap, quiet hours and consent are all
+            // exercised exactly as they would be, so a journey that would have been suppressed
+            // still reports SUPPRESSED and not DRY_RUN. Nothing is handed off, so this row's
+            // delivery status stays PENDING forever — correctly: no message ever left.
+            if (dryRun) {
+                sendLog.record(sendId, campaignId, partyId, stepOrder, SendOutcome.DRY_RUN, delivery.channel)
+            } else {
+                // ADR-0200 D3 — delivery goes through notification-service, never direct.
+                //
+                // The order below is the fix for issue #3581: the send log may only be written
+                // AFTER the handoff has been observed to succeed, and a handoff that failed must
+                // leave a FAILED row rather than nothing. What SENT claims here is exactly
+                // "notification-service accepted the request", not "the customer received it".
+                try {
+                    notificationSend.requestSend(
+                        partyId,
+                        delivery.channel,
+                        delivery.template,
+                        recipientFor(partyId),
+                        delivery.variables,
+                        correlationId = sendId,
+                    )
+                } catch (e: Exception) {
+                    sendLog.record(sendId, campaignId, partyId, stepOrder, SendOutcome.FAILED, delivery.channel)
+                    // Rethrown on purpose: Temporal retries the activity, and the FAILED row
+                    // above is the durable evidence that this attempt happened. FAILED rows do
+                    // not consume the frequency cap (SENT only), so a retry is not penalised.
+                    throw e
                 }
-                StepOutcome.SENT
+                sendLog.record(sendId, campaignId, partyId, stepOrder, SendOutcome.SENT, delivery.channel)
             }
+            return StepOutcome.SENT
+        }
+
+        suspend fun checked(delivery: CampaignDelivery): ContactGateDecision = contactGate.check(
+            partyId,
+            ContactClass.OUTBOUND_SEND,
+            marketingScopeFor(delivery.channel),
+            topic = campaign.goal,
+        )
+
+        // ADR-0219 (#3656): both attempts use the same complete gate. Only a missing primary
+        // consent may switch channels — quiet hours, caps and list suppression are not a reason
+        // to try a second message, and a gate outage remains a retry signal.
+        return when (val primaryDecision = checked(primary)) {
+            ContactGateDecision.ALLOWED -> sendAllowed(primary)
             else -> {
-                if (decision.denyReason == ContactDenyReason.GATE_UNAVAILABLE) {
+                if (primaryDecision.denyReason == ContactDenyReason.GATE_UNAVAILABLE) {
                     throw ContactGateUnavailableException("contact gate state unavailable — activity will retry")
                 }
-                sendLog.record(Ids.newId(), campaignId, partyId, stepOrder, outcomeFor(decision.denyReason))
-                StepOutcome.SUPPRESSED
+                val fallback = primaryDecision.denyReason
+                    .takeIf { it == ContactDenyReason.NO_CONSENT }
+                    ?.let { step.pushFallback(contentVariant) }
+                if (fallback != null) {
+                    when (val fallbackDecision = checked(fallback)) {
+                        ContactGateDecision.ALLOWED -> sendAllowed(fallback)
+                        else -> {
+                            if (fallbackDecision.denyReason == ContactDenyReason.GATE_UNAVAILABLE) {
+                                throw ContactGateUnavailableException(
+                                    "contact gate state unavailable — activity will retry",
+                                )
+                            }
+                            sendLog.record(
+                                Ids.newId(),
+                                campaignId,
+                                partyId,
+                                stepOrder,
+                                outcomeFor(fallbackDecision.denyReason),
+                            )
+                            StepOutcome.SUPPRESSED
+                        }
+                    }
+                } else {
+                    sendLog.record(Ids.newId(), campaignId, partyId, stepOrder, outcomeFor(primaryDecision.denyReason))
+                    StepOutcome.SUPPRESSED
+                }
             }
         }
     }
@@ -271,7 +299,8 @@ private suspend fun SendLogRepository.record(
     partyId: UUID,
     stepOrder: Int,
     outcome: SendOutcome,
-) = record(SendRecord(id, campaignId, partyId, stepOrder, outcome, Instant.now()))
+    channel: Channel? = null,
+) = record(SendRecord(id, campaignId, partyId, stepOrder, outcome, Instant.now(), channel = channel))
 
 // The recipient address is resolved by notification-service from party data; the campaign never
 // carries an e-mail address itself (ADR-0200 D3 — no PII duplication).

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/domain/model/Campaign.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/domain/model/Campaign.kt
@@ -199,6 +199,14 @@ data class CampaignStep(
      * (enforced by [Campaign]) so one party keeps the same treatment throughout the journey.
      */
     val variantBVariables: Map<String, String>? = null,
+    /**
+     * If the primary EMAIL step has no active e-mail marketing consent, retry the same offer as a
+     * PUSH only after its own full contact-policy check succeeds. This is intentionally not a
+     * generic failover: quiet hours, caps and suppression lists are channel-independent policy
+     * decisions and must never be bypassed; an asynchronous mail bounce is also not a safe prompt
+     * to send a second message.
+     */
+    val fallbackToPush: Boolean = false,
 ) {
     init {
         require(order >= 0) { "step order must be >= 0" }
@@ -229,12 +237,36 @@ data class CampaignStep(
                 require(it.isEmpty()) { "template '$template' does not declare ${it.sorted()}" }
             }
         }
+        require(!fallbackToPush || channel == Channel.EMAIL) {
+            "only an EMAIL step can fall back to PUSH"
+        }
+        require(!fallbackToPush || template in TemplateCatalog.PUSH_FALLBACK_FOR_EMAIL) {
+            "template '$template' has no safe PUSH fallback"
+        }
     }
 
     /** Resolves content after the durable enrolment assignment, never randomly at send time. */
     fun variablesFor(variant: ContentVariant?): Map<String, String> =
         if (variant == ContentVariant.B) variantBVariables ?: variables else variables
+
+    /** Primary delivery values, kept separate from the fallback's reduced template vocabulary. */
+    fun primaryDelivery(variant: ContentVariant?): CampaignDelivery =
+        CampaignDelivery(channel, template, TemplateCatalog.valuesFor(template, variablesFor(variant)))
+
+    /** The only supported fallback: a consented app push after EMAIL consent was absent. */
+    fun pushFallback(variant: ContentVariant?): CampaignDelivery? = TemplateCatalog.PUSH_FALLBACK_FOR_EMAIL[template]
+        ?.takeIf { fallbackToPush }
+        ?.let { pushTemplate ->
+            CampaignDelivery(
+                Channel.PUSH,
+                pushTemplate,
+                TemplateCatalog.valuesFor(pushTemplate, variablesFor(variant)),
+            )
+        }
 }
+
+/** A resolved per-attempt delivery, including the channel that will be recorded for audit. */
+data class CampaignDelivery(val channel: Channel, val template: String, val variables: Map<String, String>)
 
 /**
  * Delivery channels a campaign step may use.

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/domain/model/Campaign.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/domain/model/Campaign.kt
@@ -207,6 +207,8 @@ data class CampaignStep(
      * to send a second message.
      */
     val fallbackToPush: Boolean = false,
+    /** A closed, app-owned destination for a push tap — never author-entered URL text. */
+    val mobileDestination: MobileDestination? = null,
 ) {
     init {
         require(order >= 0) { "step order must be >= 0" }
@@ -243,6 +245,9 @@ data class CampaignStep(
         require(!fallbackToPush || template in TemplateCatalog.PUSH_FALLBACK_FOR_EMAIL) {
             "template '$template' has no safe PUSH fallback"
         }
+        require(mobileDestination == null || channel == Channel.PUSH || fallbackToPush) {
+            "a mobile destination requires a PUSH step or an EMAIL step with PUSH fallback"
+        }
     }
 
     /** Resolves content after the durable enrolment assignment, never randomly at send time. */
@@ -250,8 +255,12 @@ data class CampaignStep(
         if (variant == ContentVariant.B) variantBVariables ?: variables else variables
 
     /** Primary delivery values, kept separate from the fallback's reduced template vocabulary. */
-    fun primaryDelivery(variant: ContentVariant?): CampaignDelivery =
-        CampaignDelivery(channel, template, TemplateCatalog.valuesFor(template, variablesFor(variant)))
+    fun primaryDelivery(variant: ContentVariant?): CampaignDelivery = CampaignDelivery(
+        channel,
+        template,
+        TemplateCatalog.valuesFor(template, variablesFor(variant)),
+        mobileDestination?.deepLink.takeIf { channel == Channel.PUSH },
+    )
 
     /** The only supported fallback: a consented app push after EMAIL consent was absent. */
     fun pushFallback(variant: ContentVariant?): CampaignDelivery? = TemplateCatalog.PUSH_FALLBACK_FOR_EMAIL[template]
@@ -261,12 +270,27 @@ data class CampaignStep(
                 Channel.PUSH,
                 pushTemplate,
                 TemplateCatalog.valuesFor(pushTemplate, variablesFor(variant)),
+                mobileDestination?.deepLink,
             )
         }
 }
 
 /** A resolved per-attempt delivery, including the channel that will be recorded for audit. */
-data class CampaignDelivery(val channel: Channel, val template: String, val variables: Map<String, String>)
+data class CampaignDelivery(
+    val channel: Channel,
+    val template: String,
+    val variables: Map<String, String>,
+    val deepLink: String? = null,
+)
+
+/** The only destinations the mobile app contract recognises for campaign pushes. */
+enum class MobileDestination(val deepLink: String) {
+    HOME("openbank://home"),
+    SAVINGS("openbank://savings"),
+    CARDS("openbank://cards"),
+    PAYMENTS("openbank://payments"),
+    PRODUCT_HUB("openbank://products"),
+}
 
 /**
  * Delivery channels a campaign step may use.

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/domain/model/Enrolment.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/domain/model/Enrolment.kt
@@ -84,6 +84,8 @@ data class SendRecord(
     val deliveryReason: String? = null,
     /** When [deliveryStatus] last moved. Null while it has never moved off `PENDING`. */
     val deliveryUpdatedAt: Instant? = null,
+    /** The actual medium passed to notification-service; null for historical and non-send rows. */
+    val channel: Channel? = null,
 )
 
 /**

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/domain/model/TemplateCatalog.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/domain/model/TemplateCatalog.kt
@@ -52,6 +52,16 @@ object TemplateCatalog {
         "MARKETING_PRODUCT_OFFER_PUSH" to Channel.PUSH,
     )
 
+    /**
+     * A deliberately small, explicit fallback catalogue. This is not a naming convention: a
+     * fallback can only use a push template that is safe to render with the values from its email
+     * counterpart. The push renderer deliberately accepts only the shared headline, never the
+     * e-mail body or CTA (#1182).
+     */
+    val PUSH_FALLBACK_FOR_EMAIL: Map<String, String> = mapOf(
+        "MARKETING_PRODUCT_OFFER" to "MARKETING_PRODUCT_OFFER_PUSH",
+    )
+
     /** Templates renderable on [channel] — what an authoring screen may offer for a step. */
     fun forChannel(channel: Channel): Set<String> = CHANNEL_OF.filterValues { it == channel }.keys
 
@@ -69,4 +79,8 @@ object TemplateCatalog {
     /** Variables [template] declares that this step does not supply. */
     fun missingVariables(template: String, variables: Map<String, String>): Set<String> =
         (ALL[template] ?: emptySet()) - variables.keys
+
+    /** Values safe for [template]; a push fallback receives only its declared shared values. */
+    fun valuesFor(template: String, values: Map<String, String>): Map<String, String> =
+        values.filterKeys { it in (ALL[template] ?: emptySet()) }
 }

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/kafka/KafkaNotificationSendAdapter.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/kafka/KafkaNotificationSendAdapter.kt
@@ -6,11 +6,10 @@ package com.openbank.campaign.infrastructure.kafka
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.openbank.campaign.application.port.out.NotificationSendPort
+import com.openbank.campaign.application.port.out.NotificationSendRequest
 import jakarta.enterprise.context.ApplicationScoped
 import org.eclipse.microprofile.reactive.messaging.Channel
 import org.eclipse.microprofile.reactive.messaging.Emitter
-import java.util.UUID
-import com.openbank.campaign.domain.model.Channel as CampaignChannel
 
 /**
  * ADR-0200 D3: delivery goes through notification-service, never direct. The payload shape mirrors
@@ -29,30 +28,25 @@ class KafkaNotificationSendAdapter(
     private val mapper: ObjectMapper,
 ) : NotificationSendPort {
 
-    override suspend fun requestSend(
-        partyId: UUID,
-        channel: CampaignChannel,
-        template: String,
-        recipient: String,
-        variables: Map<String, String>,
-        correlationId: UUID,
-    ) {
-        val payload = mapper.writeValueAsString(
-            mapOf(
-                "partyId" to partyId.toString(),
-                // Was hardcoded "EMAIL". A step's channel now travels with it — with the constant in place a
-                // PUSH step was delivered as an email, silently, because notification-service believed
-                // the payload over the campaign.
-                "channel" to channel.name,
-                "template" to template,
-                "recipient" to recipient,
-                "variables" to variables,
-                // ADR-0239 D1 — the send-log row id. notification-service echoes it back on
-                // `openbank.notification.outcomes.v1`, which is the only way this service can learn
-                // that a send it recorded as SENT was in fact suppressed or never delivered (#3663).
-                "correlationId" to correlationId.toString(),
-            ),
+    override suspend fun requestSend(request: NotificationSendRequest) {
+        val fields = linkedMapOf(
+            "partyId" to request.partyId.toString(),
+            // Was hardcoded "EMAIL". A step's channel now travels with it — with the constant in place a
+            // PUSH step was delivered as an email, silently, because notification-service believed
+            // the payload over the campaign.
+            "channel" to request.channel.name,
+            "template" to request.template,
+            "recipient" to request.recipient,
+            "variables" to request.variables,
+            // ADR-0239 D1 — the send-log row id. notification-service echoes it back on
+            // `openbank.notification.outcomes.v1`, which is the only way this service can learn
+            // that a send it recorded as SENT was in fact suppressed or never delivered (#3663).
+            "correlationId" to request.correlationId.toString(),
         )
+        // This is transport metadata, never a template variable. The notification renderer's
+        // closed variable schema therefore cannot accidentally interpolate a navigation route.
+        request.deepLink?.let { fields["deepLink"] = it }
+        val payload = mapper.writeValueAsString(fields)
         emitter.send(payload).toCompletableFuture().join()
     }
 }

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/persistence/Persistence.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/persistence/Persistence.kt
@@ -22,6 +22,7 @@ import com.openbank.campaign.domain.model.Campaign
 import com.openbank.campaign.domain.model.CampaignSchedule
 import com.openbank.campaign.domain.model.CampaignState
 import com.openbank.campaign.domain.model.CampaignStep
+import com.openbank.campaign.domain.model.Channel
 import com.openbank.campaign.domain.model.ContentVariant
 import com.openbank.campaign.domain.model.DeliveryStatus
 import com.openbank.campaign.domain.model.DeliveryTransition
@@ -181,6 +182,10 @@ class SendLogEntity : PanacheEntityBase() {
 
     @Column
     var deliveryUpdatedAt: Instant? = null
+
+    /** Actual request medium; nullable so migration leaves historical decision rows intact. */
+    @Column(length = 8)
+    var channel: String? = null
 }
 
 @Entity
@@ -408,6 +413,7 @@ class PanacheSendLogRepository :
                     deliveryStatus = send.deliveryStatus.name
                     deliveryReason = send.deliveryReason
                     deliveryUpdatedAt = send.deliveryUpdatedAt
+                    channel = send.channel?.name
                 },
             )
         }.awaitSuspending()
@@ -625,4 +631,5 @@ private fun SendLogEntity.toDomain(): SendRecord = SendRecord(
     deliveryStatus = DeliveryStatus.valueOf(deliveryStatus),
     deliveryReason = deliveryReason,
     deliveryUpdatedAt = deliveryUpdatedAt,
+    channel = channel?.let(Channel::valueOf),
 )

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/rest/CampaignResource.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/rest/CampaignResource.kt
@@ -76,6 +76,8 @@ data class StepRequest(
     val condition: StepCondition? = null,
     /** The B-arm values for a campaign-wide content experiment; absent keeps one shared message. */
     val variantBVariables: Map<String, String>? = null,
+    /** Use the catalogue's safe PUSH counterpart only when this EMAIL step lacks email consent. */
+    val fallbackToPush: Boolean = false,
 )
 
 /**
@@ -136,6 +138,7 @@ class CampaignResource(private val service: CampaignService, private val jwt: Js
                 it.delaySeconds,
                 it.condition,
                 it.variantBVariables,
+                it.fallbackToPush,
             )
         }
         val campaign = service.createDraft(

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/rest/CampaignResource.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/rest/CampaignResource.kt
@@ -8,6 +8,7 @@ import com.openbank.campaign.application.usecase.CampaignService
 import com.openbank.campaign.domain.model.CampaignSchedule
 import com.openbank.campaign.domain.model.CampaignStep
 import com.openbank.campaign.domain.model.Channel
+import com.openbank.campaign.domain.model.MobileDestination
 import com.openbank.campaign.domain.model.SegmentRef
 import com.openbank.campaign.domain.model.StepCondition
 import com.openbank.campaign.domain.model.StopCondition
@@ -78,6 +79,8 @@ data class StepRequest(
     val variantBVariables: Map<String, String>? = null,
     /** Use the catalogue's safe PUSH counterpart only when this EMAIL step lacks email consent. */
     val fallbackToPush: Boolean = false,
+    /** Closed in-app destination opened when the customer taps the resulting PUSH notification. */
+    val mobileDestination: MobileDestination? = null,
 )
 
 /**
@@ -139,6 +142,7 @@ class CampaignResource(private val service: CampaignService, private val jwt: Js
                 it.condition,
                 it.variantBVariables,
                 it.fallbackToPush,
+                it.mobileDestination,
             )
         }
         val campaign = service.createDraft(

--- a/openbank-campaign-service/src/main/resources/db/migration/V10__send_log_channel.sql
+++ b/openbank-campaign-service/src/main/resources/db/migration/V10__send_log_channel.sql
@@ -1,0 +1,10 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+-- See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+-- The actual medium is audit evidence for a consent-triggered EMAIL → PUSH fallback. Nullable
+-- preserves historic rows and non-send decisions (conversion, condition skip, policy suppression).
+ALTER TABLE send_log
+    ADD COLUMN channel TEXT CHECK (channel IN ('EMAIL', 'PUSH'));
+
+-- Rollback: ALTER TABLE send_log DROP COLUMN channel;

--- a/openbank-campaign-service/src/main/resources/openapi.yaml
+++ b/openbank-campaign-service/src/main/resources/openapi.yaml
@@ -4,7 +4,7 @@ openapi: 3.1.0
 info:
   title: Campaign Service API
   # major == openbank.api.version == URL /api/v1 (ADR-0048).
-  version: 1.20.0
+  version: 1.21.0
   description: >-
     Campaign management first slice (ADR-0200 / ADR-0209 D3): deterministic, versioned segments;
     per-enrolment Temporal journeys; consent-gated delivery through notification-service.
@@ -577,6 +577,15 @@ components:
             campaign into a two-arm experiment, so every step must provide it and conversionRule
             is required. `variables` remains the A arm. Assignment is persisted at enrolment and
             neither an activity retry nor a later code change can switch a person between arms.
+        fallbackToPush:
+          type: boolean
+          default: false
+          description: >-
+            Available only for an EMAIL offer with a catalogue-defined safe PUSH counterpart. When
+            EMAIL marketing consent is absent, the service re-evaluates the entire contact-policy
+            gate for PUSH consent and sends that reduced, lock-screen-safe title only if allowed.
+            It never bypasses quiet hours, frequency caps, suppression lists or a gate outage, and
+            it does not attempt a second send after an asynchronous delivery failure.
         delaySeconds: { type: integer, minimum: 0 }
         condition:
           description: >-
@@ -864,6 +873,13 @@ components:
           description: When `deliveryStatus` last moved. Null while it has never moved off `PENDING`.
           type: [string, 'null']
           format: date-time
+        channel:
+          description: >-
+            Actual request medium. It is PUSH only when a configured EMAIL step lacked email
+            consent and the separate PUSH gate allowed its safe fallback; null for historical and
+            non-send decision rows.
+          type: [string, 'null']
+          enum: [EMAIL, PUSH, null]
 
     Enrolment:
       type: object

--- a/openbank-campaign-service/src/main/resources/openapi.yaml
+++ b/openbank-campaign-service/src/main/resources/openapi.yaml
@@ -4,7 +4,7 @@ openapi: 3.1.0
 info:
   title: Campaign Service API
   # major == openbank.api.version == URL /api/v1 (ADR-0048).
-  version: 1.21.0
+  version: 1.22.0
   description: >-
     Campaign management first slice (ADR-0200 / ADR-0209 D3): deterministic, versioned segments;
     per-enrolment Temporal journeys; consent-gated delivery through notification-service.
@@ -586,6 +586,14 @@ components:
             gate for PUSH consent and sends that reduced, lock-screen-safe title only if allowed.
             It never bypasses quiet hours, frequency caps, suppression lists or a gate outage, and
             it does not attempt a second send after an asynchronous delivery failure.
+        mobileDestination:
+          type: string
+          nullable: true
+          enum: [HOME, SAVINGS, CARDS, PAYMENTS, PRODUCT_HUB]
+          description: >-
+            Bank-owned destination opened after a PUSH tap. This is a closed app-route contract,
+            never an author-entered URL; absent preserves existing campaigns. It is valid on a
+            PUSH step, or on an EMAIL step only when its consent-missing fallback is PUSH.
         delaySeconds: { type: integer, minimum: 0 }
         condition:
           description: >-

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/workflow/CampaignJourneyActivitiesImplTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/workflow/CampaignJourneyActivitiesImplTest.kt
@@ -116,7 +116,7 @@ class CampaignJourneyActivitiesImplTest {
     @Test
     fun `a refused notification handoff records FAILED and never SENT`() {
         givenDeliverableStep()
-        coEvery { notificationSend.requestSend(partyId, any(), any(), any(), any(), any()) } throws
+        coEvery { notificationSend.requestSend(any()) } throws
             IllegalStateException("broker refused the publish")
 
         assertThatThrownBy { activities.deliverStep(campaignId, partyId, 1) }
@@ -133,7 +133,7 @@ class CampaignJourneyActivitiesImplTest {
         val recordedBeforeSend = mutableListOf<SendOutcome>()
         var handedOff = false
         coEvery {
-            notificationSend.requestSend(partyId, any(), any(), any(), any(), any())
+            notificationSend.requestSend(any())
         } answers { handedOff = true }
         coEvery { sendLog.record(any()) } answers {
             if (!handedOff) recordedBeforeSend += firstArg<SendRecord>().outcome

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/workflow/CampaignJourneyActivitiesTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/workflow/CampaignJourneyActivitiesTest.kt
@@ -60,9 +60,11 @@ class CampaignJourneyActivitiesTest {
     )
 
     private inner class Harness {
-        var consent = true
+        var emailConsent = true
+        var pushConsent = true
         var consentScope: String? = null
         var channel = Channel.EMAIL
+        var fallbackToPush = false
         var sends = 0
         var entries = listOf<SuppressionEntry>()
         var failWith: RuntimeException? = null
@@ -83,6 +85,7 @@ class CampaignJourneyActivitiesTest {
                             } else {
                                 "MARKETING_PRODUCT_OFFER"
                             },
+                            fallbackToPush = fallbackToPush,
                         ),
                     ),
                 )
@@ -147,7 +150,11 @@ class CampaignJourneyActivitiesTest {
             consent = ContactConsentPort { _, scope ->
                 consentScope = scope
                 failWith?.let { throw it }
-                consent
+                when (scope) {
+                    "MARKETING_COMMS_EMAIL" -> emailConsent
+                    "MARKETING_COMMS_PUSH" -> pushConsent
+                    else -> false
+                }
             },
             counters = object : ContactCounterPort {
                 override suspend fun sendsInWindow(partyId: UUID, windowStart: Instant): Int {
@@ -244,7 +251,7 @@ class CampaignJourneyActivitiesTest {
 
     @Test
     fun `no consent maps to SUPPRESSED_CONSENT`() {
-        val h = Harness().apply { consent = false }
+        val h = Harness().apply { emailConsent = false }
         assertThat(
             runBlocking {
                 h.activities.deliverStepGated(campaignId, partyId, 1)
@@ -269,6 +276,36 @@ class CampaignJourneyActivitiesTest {
         runBlocking { h.activities.deliverStepGated(campaignId, partyId, 1) }
 
         assertThat(h.consentScope).isEqualTo("MARKETING_COMMS_PUSH")
+    }
+
+    @Test
+    fun `missing email consent falls back to a separately consented push and records the actual channel`() {
+        val h = Harness().apply {
+            emailConsent = false
+            pushConsent = true
+            fallbackToPush = true
+        }
+
+        assertThat(runBlocking { h.activities.deliverStepGated(campaignId, partyId, 1) }).isEqualTo(StepOutcome.SENT)
+        assertThat(h.sendsRequested).isEqualTo(1)
+        assertThat(h.consentScope).isEqualTo("MARKETING_COMMS_PUSH")
+        assertThat(h.recorded.single().channel).isEqualTo(Channel.PUSH)
+    }
+
+    @Test
+    fun `a cap denial never switches to push`() {
+        val h = Harness().apply {
+            sends = 2
+            fallbackToPush = true
+        }
+
+        assertThat(
+            runBlocking {
+                h.activities.deliverStepGated(campaignId, partyId, 1)
+            },
+        ).isEqualTo(StepOutcome.SUPPRESSED)
+        assertThat(h.sendsRequested).isZero()
+        assertThat(h.recorded.single().outcome).isEqualTo(SendOutcome.SUPPRESSED_CAP)
     }
 
     @Test

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/workflow/CampaignJourneyActivitiesTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/workflow/CampaignJourneyActivitiesTest.kt
@@ -9,6 +9,7 @@ import com.openbank.campaign.application.port.out.CampaignOutcomeCount
 import com.openbank.campaign.application.port.out.CampaignRepository
 import com.openbank.campaign.application.port.out.EnrolmentRepository
 import com.openbank.campaign.application.port.out.NotificationSendPort
+import com.openbank.campaign.application.port.out.NotificationSendRequest
 import com.openbank.campaign.application.port.out.SendLogRepository
 import com.openbank.campaign.application.port.out.StepOutcomeCount
 import com.openbank.campaign.domain.model.Campaign
@@ -74,6 +75,9 @@ class CampaignJourneyActivitiesTest {
         /** Correlation ids put on the wire, in order (ADR-0239 D1). */
         val correlationIds = mutableListOf<UUID>()
 
+        /** App destinations handed to notification-service for the current delivery. */
+        val deepLinks = mutableListOf<String?>()
+
         val campaigns = object : CampaignRepository {
             override suspend fun findById(id: UUID) = if (id == campaignId) {
                 campaign.copy(
@@ -133,16 +137,10 @@ class CampaignJourneyActivitiesTest {
             ): DeliveryStatus? = null
         }
         val notificationSend = object : NotificationSendPort {
-            override suspend fun requestSend(
-                partyId: UUID,
-                channel: Channel,
-                template: String,
-                recipient: String,
-                variables: Map<String, String>,
-                correlationId: UUID,
-            ) {
+            override suspend fun requestSend(request: NotificationSendRequest) {
                 sendsRequested += 1
-                correlationIds += correlationId
+                correlationIds += request.correlationId
+                deepLinks += request.deepLink
             }
         }
 

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/domain/TemplateCatalogTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/domain/TemplateCatalogTest.kt
@@ -6,6 +6,7 @@ package com.openbank.campaign.domain
 
 import com.openbank.campaign.domain.model.CampaignStep
 import com.openbank.campaign.domain.model.Channel
+import com.openbank.campaign.domain.model.MobileDestination
 import com.openbank.campaign.domain.model.TemplateCatalog
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -98,6 +99,20 @@ class CampaignStepChannelTest {
             delaySeconds = 0,
         )
         assertEquals(Channel.PUSH, step.channel)
+    }
+
+    @Test
+    fun `a push step resolves an allow-listed app destination rather than an author URL`() {
+        val step = CampaignStep(
+            order = 1,
+            template = "MARKETING_PRODUCT_OFFER_PUSH",
+            channel = Channel.PUSH,
+            variables = mapOf("offerTitle" to "Savings"),
+            delaySeconds = 0,
+            mobileDestination = MobileDestination.SAVINGS,
+        )
+
+        assertEquals("openbank://savings", step.primaryDelivery(null).deepLink)
     }
 
     @Test

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/domain/TemplateCatalogTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/domain/TemplateCatalogTest.kt
@@ -148,4 +148,33 @@ class CampaignStepChannelTest {
         assertEquals(setOf("MARKETING_PRODUCT_OFFER"), TemplateCatalog.forChannel(Channel.EMAIL))
         assertEquals(setOf("MARKETING_PRODUCT_OFFER_PUSH"), TemplateCatalog.forChannel(Channel.PUSH))
     }
+
+    @Test
+    fun `an email step can safely reduce to its push fallback without carrying email body copy`() {
+        val step = CampaignStep(
+            order = 1,
+            template = "MARKETING_PRODUCT_OFFER",
+            channel = Channel.EMAIL,
+            variables = mapOf("offerTitle" to "Savings", "offerText" to "Email body", "ctaText" to "Open"),
+            delaySeconds = 0,
+            fallbackToPush = true,
+        )
+
+        assertEquals(Channel.PUSH, step.pushFallback(null)?.channel)
+        assertEquals(mapOf("offerTitle" to "Savings"), step.pushFallback(null)?.variables)
+    }
+
+    @Test
+    fun `a push step cannot declare another push fallback`() {
+        assertThrows<IllegalArgumentException> {
+            CampaignStep(
+                order = 1,
+                template = "MARKETING_PRODUCT_OFFER_PUSH",
+                channel = Channel.PUSH,
+                variables = mapOf("offerTitle" to "Savings"),
+                delaySeconds = 0,
+                fallbackToPush = true,
+            )
+        }
+    }
 }

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/infrastructure/kafka/ConversionConsumerTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/infrastructure/kafka/ConversionConsumerTest.kt
@@ -44,7 +44,7 @@ class ConversionConsumerTest {
     private val journeys = mockk<JourneySignaller>(relaxed = true)
 
     @Test
-    fun `one product event credits only the last eligible campaign and ends that journey`() = runBlocking {
+    fun `one product event credits only the last eligible campaign and ends that journey`(): Unit = runBlocking {
         givenOverlappingCampaigns(newerAlreadyConverted = false)
         val recorded = slot<SendRecord>()
 
@@ -58,7 +58,7 @@ class ConversionConsumerTest {
     }
 
     @Test
-    fun `redelivery never shifts an already credited event to the runner-up campaign`() = runBlocking {
+    fun `redelivery never shifts an already credited event to the runner-up campaign`(): Unit = runBlocking {
         givenOverlappingCampaigns(newerAlreadyConverted = true)
 
         consumer().onAccountEvent(accountCreatedMessage())

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/integration/CampaignRestContractIT.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/integration/CampaignRestContractIT.kt
@@ -506,6 +506,7 @@ class CampaignRestContractIT {
              "steps":[{"order":1,"template":"MARKETING_PRODUCT_OFFER",
                        "variables":{"offerTitle":"A","offerText":"A copy","ctaText":"Go"},
                        "variantBVariables":{"offerTitle":"B","offerText":"B copy","ctaText":"Try"},
+                       "fallbackToPush":true,
                        "delaySeconds":0}]}
         """.trimIndent()
 
@@ -525,6 +526,7 @@ class CampaignRestContractIT {
         } Then {
             statusCode(200)
             body("steps[0].variantBVariables.offerTitle", org.hamcrest.Matchers.equalTo("B"))
+            body("steps[0].fallbackToPush", org.hamcrest.Matchers.equalTo(true))
         }
         When {
             get("/api/v1/campaigns/$id/content-experiment")

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/integration/CampaignRestContractIT.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/integration/CampaignRestContractIT.kt
@@ -539,6 +539,35 @@ class CampaignRestContractIT {
     }
 
     @Test
+    fun `a mobile-first push step keeps its closed app destination over the HTTP contract`() {
+        val body = """
+            {"name":"push-${UUID.randomUUID()}","goal":"savings activation",
+             "segmentName":"actives","segmentVersion":1,
+             "steps":[{"order":1,"template":"MARKETING_PRODUCT_OFFER_PUSH","channel":"PUSH",
+                       "variables":{"offerTitle":"Savings"},"mobileDestination":"SAVINGS","delaySeconds":0}]}
+        """.trimIndent()
+
+        val id = Given {
+            contentType("application/json")
+            body(body)
+        } When {
+            post("/api/v1/campaigns")
+        } Then {
+            statusCode(201)
+        } Extract {
+            path<String>("id")
+        }
+
+        When {
+            get("/api/v1/campaigns/$id")
+        } Then {
+            statusCode(200)
+            body("steps[0].channel", org.hamcrest.Matchers.equalTo("PUSH"))
+            body("steps[0].mobileDestination", org.hamcrest.Matchers.equalTo("SAVINGS"))
+        }
+    }
+
+    @Test
     fun `the segment catalogue is served over HTTP with its rules in words`() {
         When {
             get("/api/v1/segments")

--- a/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
+++ b/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
@@ -193,6 +193,14 @@ class CustomerEdgeResource(
     @ConfigProperty(name = "openbank.edge.notification-service-url")
     lateinit var notificationServiceUrl: String
 
+    /**
+     * The app's server-driven engagement surfaces. This is deliberately separate from
+     * notification-service: an app surface is rendered after the customer opens the app, it is
+     * not an outbound notification pretending to have been delivered (ADR-0220 D1).
+     */
+    @ConfigProperty(name = "openbank.edge.engagement-service-url")
+    lateinit var engagementServiceUrl: String
+
     @ConfigProperty(name = "openbank.edge.statement-service-url")
     lateinit var statementServiceUrl: String
 
@@ -2596,6 +2604,48 @@ class CustomerEdgeResource(
         )
     }
 
+    // --- In-app engagement surfaces ---
+
+    /**
+     * Resolve one named mobile surface for the authenticated customer. The app receives only a
+     * typed, catalogue-backed payload; it owns presentation, accessibility and local navigation.
+     * The party id is derived from the JWT and injected only at this boundary, never accepted from
+     * the device, so changing a query parameter cannot render another customer's campaign.
+     */
+    @GET
+    @Path("/surfaces/{slot}")
+    @Authorize(action = "customer.engagement.read", resource = "#slot")
+    @Blocking
+    fun getSurface(@PathParam("slot") slot: String): Response {
+        if (slot !in SURFACE_SLOTS) return Response.status(Response.Status.BAD_REQUEST).build()
+        val customer = customer()
+        return upstream.get(
+            "$engagementServiceUrl/api/v1/surfaces/$slot?partyId=${customer.partyId}",
+            customer.partyId.toString(),
+        )
+    }
+
+    /**
+     * Record what the app actually observed: impression, click or dismissal. The edge overwrites
+     * any supplied partyId with the JWT party id before forwarding, which makes the feedback loop
+     * meaningful without turning it into an IDOR write primitive. Content/slot/type validation is
+     * owned by engagement-service, alongside the catalogue it validates against.
+     */
+    @POST
+    @Path("/surfaces/events")
+    @Authorize(action = "customer.engagement.record-event")
+    @Blocking
+    fun recordSurfaceEvent(body: String): Response {
+        val customer = customer()
+        val enriched = injectField(objectMapper, body, "partyId", customer.partyId.toString())
+            ?: return Response.status(Response.Status.BAD_REQUEST).build()
+        return upstream.post(
+            "$engagementServiceUrl/api/v1/surfaces/events",
+            customer.partyId.toString(),
+            enriched,
+        )
+    }
+
     // --- Theme preferences (ADR-0190) — edge-local, party-keyed, roams the app look ---
 
     /** The caller's stored ThemeSpec, 404 when none. Party is taken from the JWT, never the client. */
@@ -3833,6 +3883,15 @@ class CustomerEdgeResource(
         parseCreditorAccount(raw) ?: czechIbanToBban(raw)
 
     companion object {
+        /** Closed at the edge as well as upstream: a path is never an app-controlled URL. */
+        private val SURFACE_SLOTS: Set<String> = setOf(
+            "HOME_BANNER",
+            "HOME_CAROUSEL",
+            "STORIES",
+            "PRODUCT_FEED",
+            "REWARDS_HUB",
+        )
+
         // A ThemeSpec is a small token document; 8 KiB leaves headroom for future fields
         // while keeping Redis abuse-proof (ADR-0190).
         private const val THEME_SPEC_MAX_BYTES = 8 * 1024

--- a/openbank-customer-edge/src/main/resources/application.yaml
+++ b/openbank-customer-edge/src/main/resources/application.yaml
@@ -135,6 +135,7 @@ openbank:
     keycloak-admin-realm: ${KEYCLOAK_ADMIN_REALM:openbank-customers}
     keycloak-admin-client-id: ${KEYCLOAK_ADMIN_CLIENT_ID:customer-edge-admin}
     notification-service-url: ${NOTIFICATION_SERVICE_URL:http://notification-service.notifications.svc:8112}
+    engagement-service-url: ${ENGAGEMENT_SERVICE_URL:http://engagement-service.engagement.svc:8153}
     statement-service-url: ${STATEMENT_SERVICE_URL:http://statement-service.statements.svc:8136}
     standing-order-service-url: ${STANDING_ORDER_SERVICE_URL:http://standing-order-service.payments.svc:8121}
     fx-service-url:      ${FX_SERVICE_URL:http://fx-service.fx.svc:8119}

--- a/openbank-customer-edge/src/main/resources/openapi.yaml
+++ b/openbank-customer-edge/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: Customer Edge API
-  version: 1.31.0
+  version: 1.32.0
   description: >-
     Customer-facing edge proxy (ADR-0065). Single internet-facing entry point for the
     retail customer app. Validates JWTs from the openbank-customers Keycloak realm,
@@ -31,6 +31,7 @@ tags:
   - name: WebAuthn
   - name: Documents
   - name: Preferences
+  - name: Engagement
   - name: Feedback
   - name: Cards
   - name: Lending
@@ -455,6 +456,58 @@ paths:
       responses:
         '200':
           description: Count of notifications marked read
+
+  /surfaces/{slot}:
+    get:
+      tags: [Engagement]
+      summary: Resolve a consented, typed in-app engagement surface for the caller
+      description: >-
+        Returns catalogue-backed content for a mobile slot after the engagement service applies
+        marketing consent, impression budget, adverse-state exclusions and dismissal suppression.
+        The party is always taken from the authenticated customer session; it is never a client
+        parameter. The app owns local rendering and navigation for the typed payload.
+      operationId: getEngagementSurface
+      security:
+        - customerOidc: []
+      parameters:
+        - name: slot
+          in: path
+          required: true
+          schema:
+            type: string
+            enum: [HOME_BANNER, HOME_CAROUSEL, STORIES, PRODUCT_FEED, REWARDS_HUB]
+      responses:
+        '200':
+          description: Surface resolution, including an explicit state when no content may render
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EngagementSurfaceResponse'
+        '400':
+          description: Unknown surface slot
+
+  /surfaces/events:
+    post:
+      tags: [Engagement]
+      summary: Record an app-observed engagement event for a surfaced item
+      description: >-
+        The party identity is injected from the customer JWT. The service accepts only a content
+        id that belongs to the declared slot, so a device cannot manufacture metrics for an
+        arbitrary campaign or content class.
+      operationId: recordEngagementSurfaceEvent
+      security:
+        - customerOidc: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EngagementSurfaceEvent'
+      responses:
+        '202':
+          description: Event persisted and queued for the engagement event stream
+        '400':
+          description: Invalid request, unknown content or content-slot mismatch
 
   /profile:
     get:
@@ -2136,6 +2189,59 @@ components:
         email:
           type: string
           format: email
+
+    EngagementSurfaceResponse:
+      type: object
+      required: [state]
+      description: >-
+        A typed server decision, not arbitrary remote UI markup. `ok` carries only catalogue ids
+        and declared presentation variables; `not_eligible` and `suppressed` are normal states,
+        not transport failures.
+      properties:
+        state:
+          type: string
+          enum: [ok, not_eligible, suppressed]
+        content:
+          type: array
+          items:
+            $ref: '#/components/schemas/EngagementSurfaceContent'
+        reason:
+          type: string
+          description: Present when the contact policy makes the caller not eligible.
+
+    EngagementSurfaceContent:
+      type: object
+      required: [id, slot, type, variables]
+      properties:
+        id:
+          type: string
+          example: SAVINGS_RATE_BANNER
+        slot:
+          type: string
+          enum: [HOME_BANNER, HOME_CAROUSEL, STORIES, PRODUCT_FEED, REWARDS_HUB]
+        type:
+          type: string
+          enum: [BANNER, CARD, STORY, CAROUSEL, OFFER]
+        variables:
+          type: array
+          items: {type: string}
+
+    EngagementSurfaceEvent:
+      type: object
+      required: [contentId, slot, type]
+      description: >-
+        `partyId` is deliberately absent: customer-edge derives it from the bearer token and
+        overwrites any unexpected field before the event reaches engagement-service.
+      properties:
+        contentId:
+          type: string
+          example: SAVINGS_RATE_BANNER
+        slot:
+          type: string
+          enum: [HOME_BANNER, HOME_CAROUSEL, STORIES, PRODUCT_FEED, REWARDS_HUB]
+        type:
+          type: string
+          enum: [IMPRESSION, CLICK, DISMISS]
 
     FeedbackSubmission:
       type: object

--- a/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/CustomerEdgeResourceTest.kt
+++ b/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/CustomerEdgeResourceTest.kt
@@ -47,6 +47,7 @@ class CustomerEdgeResourceTest {
         objectMapper = ObjectMapper()
         accountServiceUrl = "http://account"
         balanceServiceUrl = "http://balance"
+        engagementServiceUrl = "http://engagement"
     }
 
     private fun accountJson(accountId: UUID, ownerParty: UUID) =
@@ -250,6 +251,38 @@ class CustomerEdgeResourceTest {
         // forwarding a corrupt payload upstream.
         assertThat(CustomerEdgeResource.injectField(mapper, "not json", "partyId", "x")).isNull()
         assertThat(CustomerEdgeResource.injectField(mapper, """["a","b"]""", "partyId", "x")).isNull()
+    }
+
+    // ── in-app engagement surfaces ────────────────────────────────────────────────────────────
+
+    @Test
+    fun `recordSurfaceEvent overwrites a spoofed party id with the JWT party`() {
+        val caller = UUID.randomUUID()
+        val upstream = mockk<UpstreamClient>()
+        val body = slot<String>()
+        every {
+            upstream.post(match { it.endsWith("/api/v1/surfaces/events") }, caller.toString(), capture(body), any())
+        } returns
+            Response.status(Response.Status.ACCEPTED).build()
+
+        val response = resourceFor(upstream, caller).recordSurfaceEvent(
+            """{"partyId":"${UUID.randomUUID()}","contentId":"SAVINGS_RATE_BANNER","slot":"HOME_BANNER","type":"CLICK"}""",
+        )
+
+        assertThat(response.status).isEqualTo(Response.Status.ACCEPTED.statusCode)
+        assertThat(mapper.readTree(body.captured).path("partyId").asText()).isEqualTo(caller.toString())
+        assertThat(mapper.readTree(body.captured).path("contentId").asText()).isEqualTo("SAVINGS_RATE_BANNER")
+    }
+
+    @Test
+    fun `getSurface rejects a non-catalogue slot before it calls the upstream`() {
+        val caller = UUID.randomUUID()
+        val upstream = mockk<UpstreamClient>()
+
+        val response = resourceFor(upstream, caller).getSurface("../../not-a-slot")
+
+        assertThat(response.status).isEqualTo(Response.Status.BAD_REQUEST.statusCode)
+        verify(exactly = 0) { upstream.get(any(), any()) }
     }
 
     // ── statement render: currency + format allow-lists (deny-by-default) ────────

--- a/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/infrastructure/rest/SurfaceResource.kt
+++ b/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/infrastructure/rest/SurfaceResource.kt
@@ -8,6 +8,7 @@ import com.openbank.engagement.application.usecase.RecordEngagementEventUseCase
 import com.openbank.engagement.application.usecase.ResolveSurfaceUseCase
 import com.openbank.engagement.domain.model.EngagementEvent
 import com.openbank.engagement.domain.model.EngagementEventType
+import com.openbank.engagement.domain.model.SurfaceCatalog
 import com.openbank.engagement.domain.model.SurfaceContent
 import com.openbank.engagement.domain.model.SurfaceSlot
 import com.openbank.libs.authz.Authorize
@@ -64,6 +65,11 @@ class SurfaceResource(private val resolve: ResolveSurfaceUseCase, private val re
         val slot = parseSlot(request.slot) ?: return badRequest("unknown slot '${request.slot}'")
         val type = EngagementEventType.entries.find { it.name == request.type }
             ?: return badRequest("unknown event type '${request.type}'")
+        val content = SurfaceCatalog.ALL[request.contentId]
+            ?: return badRequest("unknown content '${request.contentId}'")
+        if (content.slot != slot) {
+            return badRequest("content '${request.contentId}' is not renderable in slot '${request.slot}'")
+        }
         record.record(
             EngagementEvent(
                 partyId = request.partyId,

--- a/openbank-engagement-service/src/main/resources/openapi.yaml
+++ b/openbank-engagement-service/src/main/resources/openapi.yaml
@@ -12,10 +12,9 @@ info:
 
     Deliberately absent: gamification (D3) and pre-approved offers (D4, blocked on ADR-0142 not
     existing yet). No NBA ranking — content returns in catalogue order until ADR-0201's model
-    graduates from shadow (D5). No `@Authorize` OPA rule for these actions yet; the shared policy's
-    `default allow := false` denies both endpoints fail-closed under enforcement until that rule
-    lands.
-  version: 1.1.0
+    graduates from shadow (D5). The customer app reaches these endpoints only through
+    customer-edge, whose narrowly scoped M2M policy injects the authoritative party id.
+  version: 1.2.0
 tags:
   - name: Surfaces
   - name: Eligibility

--- a/openbank-engagement-service/src/test/kotlin/com/openbank/engagement/integration/SurfaceRestContractIT.kt
+++ b/openbank-engagement-service/src/test/kotlin/com/openbank/engagement/integration/SurfaceRestContractIT.kt
@@ -120,6 +120,21 @@ class SurfaceRestContractIT {
         }
     }
 
+    @Test
+    @TestSecurity(user = TEST_OPERATOR, roles = ["ROLE_OPERATOR"])
+    fun `an event for content not in the rendered catalogue is rejected rather than polluting metrics`() {
+        Given {
+            contentType("application/json")
+            body(
+                """{"partyId":"${UUID.randomUUID()}","contentId":"NOT_A_CATALOGUE_ITEM","slot":"HOME_BANNER","type":"CLICK"}""",
+            )
+        } When {
+            post("/api/v1/surfaces/events")
+        } Then {
+            statusCode(400)
+        }
+    }
+
     // ── AdverseStateResource (issue #4265 item 1) ──────────────────────────────────────────────
     //
     // These live in THIS class rather than a second @QuarkusTest deliberately. A new IT class would

--- a/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
@@ -222,6 +222,12 @@ spec:
               value: "true"
             - name: NOTIFICATION_SERVICE_URL
               value: http://notification-service.notifications.svc:8112
+            # In-app campaign surfaces (#4475): the customer app fetches its eligible
+            # placements and records impressions/clicks through engagement-service.
+            # The application default alone is invisible to gen-network-policies.py,
+            # so declare the real cross-namespace URL here to allow edge → engagement.
+            - name: ENGAGEMENT_SERVICE_URL
+              value: http://engagement-service.engagement.svc:8153
             - name: STATEMENT_SERVICE_URL
               value: http://statement-service.statements.svc:8136
             - name: STANDING_ORDER_SERVICE_URL

--- a/openbank-infra/gitops/components/engagement/network-policies.yaml
+++ b/openbank-infra/gitops/components/engagement/network-policies.yaml
@@ -44,6 +44,9 @@ spec:
     - from:
         - namespaceSelector:
             matchLabels:
+              kubernetes.io/metadata.name: customer-edge
+        - namespaceSelector:
+            matchLabels:
               kubernetes.io/metadata.name: admin-ui
       ports:
         - protocol: TCP

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/application/NotificationConsumer.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/application/NotificationConsumer.kt
@@ -21,6 +21,7 @@ import com.openbank.notification.application.port.out.PushMetricsPort
 import com.openbank.notification.application.port.out.PushSender
 import com.openbank.notification.domain.HtmlEscape
 import com.openbank.notification.domain.RecipientAddress
+import com.openbank.notification.domain.model.MobileDeepLink
 import com.openbank.notification.domain.model.NotificationCategory
 import com.openbank.notification.domain.model.NotificationChannel
 import com.openbank.notification.domain.model.NotificationOutcome
@@ -206,6 +207,14 @@ class NotificationConsumer {
                 req.template.variables.sorted(),
                 unknown.sorted(),
             )
+            return Uni.createFrom().voidItem()
+        }
+        val validDeepLink = req.deepLink == null ||
+            (req.channel == NotificationChannel.PUSH && MobileDeepLink.isAllowed(req.deepLink))
+        if (!validDeepLink) {
+            // The deep link controls device navigation, so it gets the same allow-list posture as
+            // template identifiers. Do not log the rejected value; it may be attacker-controlled.
+            log.errorf("Rejected notification with non-bank mobile deep-link for template=%s", req.template.name)
             return Uni.createFrom().voidItem()
         }
         return dispatch(req)
@@ -609,7 +618,7 @@ class NotificationConsumer {
                 val targets = tokens.map { Triple(it.deviceId, PushPlatform.valueOf(it.platform), it.token) }
                 val sends = targets.map { (deviceId, platform, token) ->
                     pushSender.send(
-                        PushMessage(platform, token, subject, pushText, mapOf("template" to req.template.name)),
+                        PushMessage(platform, token, subject, pushText, pushData(req, entity)),
                     ).map { result ->
                         // Recorded here, where the platform is in scope. Counter increments are
                         // thread-safe, so running off the event loop (the adapters complete on the
@@ -625,6 +634,18 @@ class NotificationConsumer {
                     .chain { results -> persistPushFanOut(req, entity, results) }
                     .replaceWithVoid()
             }
+    }
+
+    /**
+     * FCM/APNs data is a routing envelope, not customer content. `notificationId` lets an app
+     * fetch the authenticated full detail after a generic wake-up; `deepLink` is only admitted by
+     * [MobileDeepLink] before this method runs. Neither carries balances, names, offers or other
+     * lock-screen-visible material.
+     */
+    private fun pushData(req: NotificationRequest, entity: NotificationEntity): Map<String, String> = buildMap {
+        put("template", req.template.name)
+        put("notificationId", entity.notificationId.toString())
+        req.deepLink?.let { put("deepLink", it) }
     }
 
     /**

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/domain/model/Notification.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/domain/model/Notification.kt
@@ -112,4 +112,19 @@ data class NotificationRequest(
      * meaningless to the producer, which is the only party that can join it back to its own row.
      */
     val correlationId: UUID? = null,
+    /** Optional bank-owned app route for a PUSH tap; never a template variable. */
+    val deepLink: String? = null,
 )
+
+/** Closed allow-list for navigation metadata sent through FCM/APNs. */
+object MobileDeepLink {
+    private val allowed = setOf(
+        "openbank://home",
+        "openbank://savings",
+        "openbank://cards",
+        "openbank://payments",
+        "openbank://products",
+    )
+
+    fun isAllowed(value: String?): Boolean = value == null || value in allowed
+}

--- a/openbank-notification-service/src/test/kotlin/com/openbank/notification/domain/model/NotificationModelTest.kt
+++ b/openbank-notification-service/src/test/kotlin/com/openbank/notification/domain/model/NotificationModelTest.kt
@@ -80,4 +80,11 @@ class NotificationModelTest {
         assertThat(req.channel).isEqualTo(NotificationChannel.PUSH)
         assertThat(req.variables).containsEntry("code", "123456")
     }
+
+    @Test
+    fun `mobile deep links are an allow-list, not arbitrary URLs`() {
+        assertThat(MobileDeepLink.isAllowed("openbank://savings")).isTrue()
+        assertThat(MobileDeepLink.isAllowed("https://example.invalid/redirect")).isFalse()
+        assertThat(MobileDeepLink.isAllowed("openbank://savings?next=https://evil.invalid")).isFalse()
+    }
 }

--- a/openbank-notification-service/src/test/kotlin/com/openbank/notification/integration/NotificationConsumerIT.kt
+++ b/openbank-notification-service/src/test/kotlin/com/openbank/notification/integration/NotificationConsumerIT.kt
@@ -519,6 +519,30 @@ class NotificationConsumerIT {
         // The amount and account never appear anywhere in the transported payload.
         assertThat(msg.title).doesNotContain(amount).doesNotContain(account)
         assertThat(msg.body).doesNotContain(amount).doesNotContain(account)
+        assertThat(msg.data).containsKeys("template", "notificationId")
+    }
+
+    @Test
+    fun `PUSH payload carries only an allow-listed deep link alongside the opaque notification id`() {
+        val partyId = UUID.randomUUID()
+        val token = "apns-campaign-deep-link-token-it"
+        OffContextPushSender.SENT.clear()
+        seedActiveDevice(partyId, token)
+
+        consumeAndAwait(
+            NotificationRequest(
+                partyId = partyId,
+                channel = NotificationChannel.PUSH,
+                template = NotificationTemplate.WELCOME,
+                recipient = "campaign@example.com",
+                variables = mapOf("name" to "Campaign customer"),
+                deepLink = "openbank://savings",
+            ),
+        )
+
+        assertThat(OffContextPushSender.SENT.single { it.token == token }.data)
+            .containsEntry("deepLink", "openbank://savings")
+            .containsKey("notificationId")
     }
 
     @Test


### PR DESCRIPTION
## What changes\n\n- lets an EMAIL offer use the explicitly safe PUSH counterpart only when email consent is absent\n- re-runs the complete contact-policy gate for PUSH; suppression lists, caps, quiet hours and outages never fall through\n- records the actual medium in send_log for auditability\n- exposes and explains the bounded fallback in Campaign Studio and detail\n- includes Flyway, OpenAPI, domain, workflow, REST and UI coverage\n\n## Verification\n\n- `./gradlew :openbank-campaign-service:test :openbank-campaign-service:quarkusBuild --no-daemon --console=plain --warning-mode=none`\n- ARM64: `npm run type-check`, `npm run lint`, and 1,152 Vitest tests\n\nStacked on #4473; merge after the preceding campaign PRs.