### PR TITLE
feat(campaign): add mobile engagement ecosystem

### DIFF
--- a/.github/asvs-l3-baseline.txt
+++ b/.github/asvs-l3-baseline.txt
@@ -254,6 +254,11 @@ V9.1 openbank-infra/gitops/components/admin-ui/admin-ui.yaml:99: plaintext http:
 # it does not add one. Retires with the fleet-wide mTLS work alongside the other 215 lines here.
 V9.1 openbank-infra/gitops/components/customer-edge/customer-edge.yaml:178: plaintext http:// env value http://delegation-service.delegation.svc:8126
 
+# customer-edge -> engagement-service (#4475). This makes the existing in-cluster HTTP
+# transport explicit so the generated NetworkPolicy can admit the real campaign-surface call;
+# it retires with the same fleet-wide mesh-mTLS work as the existing customer-edge entries.
+V9.1 openbank-infra/gitops/components/customer-edge/customer-edge.yaml:230: plaintext http:// env value http://engagement-service.engagement.svc:8153
+
 # fraud -> account-service (ADR-0220 D3.5, issue #2749). Genuinely a NEW plaintext edge, declared
 # as such: fraud-service's first-ever outbound rest-client (AccountServiceClient, partyId lookup
 # for the fraud-hold signal) reaches account-service the only way any of the 200+ other callers in

--- a/docs/asyncapi/openbank-events.yaml
+++ b/docs/asyncapi/openbank-events.yaml
@@ -715,7 +715,7 @@ components:
 
     NotificationRequestPayload:
       type: object
-      required: [partyId, channel, templateId]
+      required: [partyId, channel, template, recipient, variables]
       properties:
         partyId:
           type: string
@@ -723,13 +723,23 @@ components:
         channel:
           type: string
           enum: [EMAIL, PUSH]
-        templateId:
+        template:
           type: string
-          enum: [ACCOUNT_OPENED, PAYMENT_COMPLETED, KYC_REJECTED, OTP_CODE, WELCOME]
+          description: Closed notification-service template identifier.
+        recipient:
+          type: string
         variables:
           type: object
           additionalProperties:
             type: string
+        correlationId:
+          type: string
+          format: uuid
+          description: Optional producer-owned delivery-outcome correlation id.
+        deepLink:
+          type: string
+          enum: [openbank://home, openbank://savings, openbank://cards, openbank://payments, openbank://products]
+          description: Optional allow-listed mobile route for a PUSH tap. Never customer content.
 
     SwiftMessageEventPayload:
       allOf:

--- a/openbank-admin-ui/src/app/campaigns/[id]/page.tsx
+++ b/openbank-admin-ui/src/app/campaigns/[id]/page.tsx
@@ -28,6 +28,7 @@ interface Campaign {
     delaySeconds: number
     variantBVariables?: Record<string, string> | null
     fallbackToPush?: boolean
+    mobileDestination?: 'HOME' | 'SAVINGS' | 'CARDS' | 'PAYMENTS' | 'PRODUCT_HUB' | null
   }[]
   /** ADR-0245: a ConversionCatalog key, or absent when the campaign measures no conversion. */
   conversionRule?: string | null

--- a/openbank-admin-ui/src/app/campaigns/new/page.tsx
+++ b/openbank-admin-ui/src/app/campaigns/new/page.tsx
@@ -244,6 +244,7 @@ export default function NewCampaignPage() {
           variables: s.variables,
           ...(contentExperiment ? { variantBVariables: s.variantBVariables ?? {} } : {}),
           ...(s.fallbackToPush ? { fallbackToPush: true } : {}),
+          ...(s.mobileDestination ? { mobileDestination: s.mobileDestination } : {}),
           delaySeconds: s.delaySeconds,
         })),
       }),

--- a/openbank-admin-ui/src/components/campaigns/JourneyEditor.tsx
+++ b/openbank-admin-ui/src/components/campaigns/JourneyEditor.tsx
@@ -29,6 +29,8 @@ import { useLanguage } from '@/lib/i18n/LanguageContext'
 
 export type EditorChannel = 'EMAIL' | 'PUSH'
 
+export type EditorMobileDestination = 'HOME' | 'SAVINGS' | 'CARDS' | 'PAYMENTS' | 'PRODUCT_HUB'
+
 export type EditorCondition = 'IF_PREVIOUS_CONFIRMED' | 'IF_PREVIOUS_NOT_CONFIRMED'
 
 export interface EditorStep {
@@ -42,6 +44,8 @@ export interface EditorStep {
   variantBVariables?: { [key: string]: string }
   /** Try the catalogue's safe app-push counterpart only when email consent is absent. */
   fallbackToPush?: boolean
+  /** Closed app context reached after a push tap; never an arbitrary URL. */
+  mobileDestination?: EditorMobileDestination
 }
 
 export const MAX_STEPS = 5

--- a/openbank-admin-ui/src/components/campaigns/StepEditor.tsx
+++ b/openbank-admin-ui/src/components/campaigns/StepEditor.tsx
@@ -112,7 +112,9 @@ export function StepEditor({
                   channel: c,
                   template: first,
                   variables: {},
-                  ...(c === 'PUSH' ? { fallbackToPush: false } : {}),
+                  ...(c === 'PUSH'
+                    ? { fallbackToPush: false, mobileDestination: step.mobileDestination ?? 'HOME' }
+                    : { mobileDestination: undefined }),
                   ...(step.variantBVariables !== undefined ? { variantBVariables: {} } : {}),
                 })}
                 // `.btn` again rather than a hand-rolled box — the third time tonight that a
@@ -131,12 +133,31 @@ export function StepEditor({
           })}
         </div>
         {step.channel === 'PUSH' && (
-          <p className="text-xs text-muted-foreground">
-            {t(
-              'Push nese jen titulek. Nabídku si člověk přečte v aplikaci po klepnutí — do notifikace se osobní obsah nedává.',
-              'A push carries the headline only. The offer is read in the app after the tap — personal content never goes into a notification.',
-            )}
-          </p>
+          <>
+            <p className="text-xs text-muted-foreground">
+              {t(
+                'Push nese jen titulek. Nabídku si člověk přečte v aplikaci po klepnutí — do notifikace se osobní obsah nedává.',
+                'A push carries the headline only. The offer is read in the app after the tap — personal content never goes into a notification.',
+              )}
+            </p>
+            <label className="mt-3 block space-y-1.5 text-sm" data-mobile-destination={index}>
+              <span className="font-medium">{t('Po klepnutí otevřít', 'Open after tap')}</span>
+              <select
+                className={field}
+                value={step.mobileDestination ?? 'HOME'}
+                onChange={e => onChange({ ...step, mobileDestination: e.target.value as EditorStep['mobileDestination'] })}
+              >
+                <option value="HOME">{t('Domovská obrazovka', 'Home')}</option>
+                <option value="SAVINGS">{t('Spoření', 'Savings')}</option>
+                <option value="CARDS">{t('Karty', 'Cards')}</option>
+                <option value="PAYMENTS">{t('Platby', 'Payments')}</option>
+                <option value="PRODUCT_HUB">{t('Produkty', 'Products')}</option>
+              </select>
+              <span className="block text-xs text-muted-foreground">
+                {t('Jde o pevný deep-link aplikace, ne URL zadanou do kampaně.', 'This is a fixed app deep link, not a campaign-entered URL.')}
+              </span>
+            </label>
+          </>
         )}
         {step.channel === 'EMAIL' && (
           <label className="mt-3 flex cursor-pointer items-start gap-2 text-sm" data-push-fallback={index}>

--- a/openbank-admin-ui/src/test/journey-editor.test.tsx
+++ b/openbank-admin-ui/src/test/journey-editor.test.tsx
@@ -9,8 +9,11 @@ import { LanguageProvider } from '@/lib/i18n/LanguageContext'
 import { JourneyEditor, MAX_STEPS, type EditorStep } from '@/components/campaigns/JourneyEditor'
 import { StepEditor } from '@/components/campaigns/StepEditor'
 
-const TEMPLATES = { MARKETING_PRODUCT_OFFER: ['offerTitle', 'offerText', 'ctaText'] }
-const TPL_CHANNEL = { MARKETING_PRODUCT_OFFER: 'EMAIL' as const }
+const TEMPLATES = {
+  MARKETING_PRODUCT_OFFER: ['offerTitle', 'offerText', 'ctaText'],
+  MARKETING_PRODUCT_OFFER_PUSH: ['offerTitle'],
+}
+const TPL_CHANNEL = { MARKETING_PRODUCT_OFFER: 'EMAIL' as const, MARKETING_PRODUCT_OFFER_PUSH: 'PUSH' as const }
 
 // The editor labels a variable in the marketer's words. The mapping is data, so the test carries its
 // own copy — asserting the rendered label against the same map the component reads would be vacuous.
@@ -141,5 +144,24 @@ describe('step editor', () => {
     fireEvent.click(document.querySelector('[data-push-fallback="0"] input')!)
     expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ fallbackToPush: true }))
     expect(screen.getByText(/not a second attempt after an email delivery failure/i)).toBeTruthy()
+  })
+
+  it('gives a push a closed app destination instead of an arbitrary campaign URL', () => {
+    const onChange = vi.fn()
+    const push: EditorStep = {
+      channel: 'PUSH', template: 'MARKETING_PRODUCT_OFFER_PUSH', variables: { offerTitle: 'Savings' }, delaySeconds: 0,
+      mobileDestination: 'HOME',
+    }
+    render(
+      React.createElement(LanguageProvider, null,
+        React.createElement(StepEditor, {
+          index: 0, step: push, templates: TEMPLATES, templateChannel: TPL_CHANNEL, templateLabels: LABELS, variableLabels: VAR_LABELS,
+          onChange, onClose: vi.fn(),
+        })))
+
+    const select = document.querySelector('[data-mobile-destination="0"] select')!
+    fireEvent.change(select, { target: { value: 'SAVINGS' } })
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ mobileDestination: 'SAVINGS' }))
+    expect(screen.getByText(/not a campaign-entered URL/i)).toBeTruthy()
   })
 })

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/port/out/Ports.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/port/out/Ports.kt
@@ -179,23 +179,22 @@ interface ConsentCheckPort {
     suspend fun hasActiveConsent(partyId: UUID, scope: String): Boolean
 }
 
+/** One immutable request from campaign orchestration to notification-service. */
+data class NotificationSendRequest(
+    val partyId: UUID,
+    val channel: Channel,
+    val template: String,
+    val recipient: String,
+    val variables: Map<String, String>,
+    /** Send-log row id; campaign needs this mandatory to join a delivery outcome back. */
+    val correlationId: UUID,
+    /** Closed mobile-app route, present only on a PUSH delivery. */
+    val deepLink: String? = null,
+)
+
 /** ADR-0200 D3: delivery goes through notification-service, never direct. */
 interface NotificationSendPort {
-    /**
-     * [correlationId] is the send-log row id this request belongs to (ADR-0239 D1).
-     *
-     * Required, not optional: the whole reason the campaign publishes here is to hear back what
-     * became of the message, and a nullable parameter is one a caller forgets. The receiving
-     * contract keeps it optional for producers that genuinely do not care — this one does.
-     */
-    suspend fun requestSend(
-        partyId: UUID,
-        channel: Channel,
-        template: String,
-        recipient: String,
-        variables: Map<String, String>,
-        correlationId: UUID,
-    )
+    suspend fun requestSend(request: NotificationSendRequest)
 }
 
 /** ADR-0200 D2 push: signals a live journey that consent was revoked for its party. */

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/workflow/CampaignJourneyActivitiesImpl.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/workflow/CampaignJourneyActivitiesImpl.kt
@@ -7,9 +7,12 @@ package com.openbank.campaign.application.workflow
 import com.openbank.campaign.application.port.out.CampaignRepository
 import com.openbank.campaign.application.port.out.EnrolmentRepository
 import com.openbank.campaign.application.port.out.NotificationSendPort
+import com.openbank.campaign.application.port.out.NotificationSendRequest
 import com.openbank.campaign.application.port.out.SendLogRepository
+import com.openbank.campaign.domain.model.Campaign
 import com.openbank.campaign.domain.model.CampaignDelivery
 import com.openbank.campaign.domain.model.CampaignState
+import com.openbank.campaign.domain.model.CampaignStep
 import com.openbank.campaign.domain.model.Channel
 import com.openbank.campaign.domain.model.DeliveryStatus
 import com.openbank.campaign.domain.model.EnrolmentState
@@ -107,14 +110,7 @@ open class CampaignJourneyActivitiesImpl(
     @MarketingCallSite
     internal suspend fun deliverStepGated(campaignId: UUID, partyId: UUID, stepOrder: Int): StepOutcome {
         val campaign = campaigns.findById(campaignId) ?: return StepOutcome.CAMPAIGN_CLOSED
-        when (campaign.state) {
-            CampaignState.PAUSED -> return StepOutcome.CAMPAIGN_PAUSED
-            CampaignState.CLOSED -> return StepOutcome.CAMPAIGN_CLOSED
-            CampaignState.ACTIVE -> Unit
-            CampaignState.DRAFT,
-            CampaignState.PENDING_APPROVAL,
-            -> return StepOutcome.CAMPAIGN_CLOSED
-        }
+        campaign.deliveryStateOutcome()?.let { return it }
         if (sendLog.conversionContextFor(campaignId, partyId).alreadyConverted) {
             return StepOutcome.GOAL_REACHED
         }
@@ -127,94 +123,91 @@ open class CampaignJourneyActivitiesImpl(
         } else {
             null
         }
-        val primary = step.primaryDelivery(contentVariant)
+        return deliverEligibleStep(
+            StepDeliveryContext(campaign, step, campaignId, partyId, stepOrder, contentVariant),
+        )
+    }
 
-        suspend fun sendAllowed(delivery: CampaignDelivery): StepOutcome {
-            // The send-log row id is minted BEFORE the handoff, not by `record` after it
-            // (ADR-0239 D1): it is what goes on the wire as the correlation id, so the id has
-            // to exist first. It is used for whichever row this attempt ends up writing —
-            // SENT, DRY_RUN or FAILED — so an outcome that arrives for a handoff that then
-            // failed locally still lands on the right row.
-            val sendId = Ids.newId()
-            // Dry run stops HERE, after every gate above has run. Deliberately not earlier: the
-            // point of a rehearsal is that suppression, cap, quiet hours and consent are all
-            // exercised exactly as they would be, so a journey that would have been suppressed
-            // still reports SUPPRESSED and not DRY_RUN. Nothing is handed off, so this row's
-            // delivery status stays PENDING forever — correctly: no message ever left.
-            if (dryRun) {
-                sendLog.record(sendId, campaignId, partyId, stepOrder, SendOutcome.DRY_RUN, delivery.channel)
-            } else {
-                // ADR-0200 D3 — delivery goes through notification-service, never direct.
-                //
-                // The order below is the fix for issue #3581: the send log may only be written
-                // AFTER the handoff has been observed to succeed, and a handoff that failed must
-                // leave a FAILED row rather than nothing. What SENT claims here is exactly
-                // "notification-service accepted the request", not "the customer received it".
-                try {
-                    notificationSend.requestSend(
-                        partyId,
-                        delivery.channel,
-                        delivery.template,
-                        recipientFor(partyId),
-                        delivery.variables,
-                        correlationId = sendId,
-                    )
-                } catch (e: Exception) {
-                    sendLog.record(sendId, campaignId, partyId, stepOrder, SendOutcome.FAILED, delivery.channel)
-                    // Rethrown on purpose: Temporal retries the activity, and the FAILED row
-                    // above is the durable evidence that this attempt happened. FAILED rows do
-                    // not consume the frequency cap (SENT only), so a retry is not penalised.
-                    throw e
-                }
-                sendLog.record(sendId, campaignId, partyId, stepOrder, SendOutcome.SENT, delivery.channel)
-            }
-            return StepOutcome.SENT
-        }
+    /** ADR-0219: a fallback is possible only after a NO_CONSENT decision for the primary channel. */
+    private suspend fun deliverEligibleStep(context: StepDeliveryContext): StepOutcome {
+        val primary = context.step.primaryDelivery(context.contentVariant)
+        val primaryDecision = checkDelivery(context, primary)
+        if (primaryDecision == ContactGateDecision.ALLOWED) return handoff(context, primary)
+        throwIfGateUnavailable(primaryDecision)
 
-        suspend fun checked(delivery: CampaignDelivery): ContactGateDecision = contactGate.check(
-            partyId,
+        val fallback = primaryDecision.denyReason
+            .takeIf { it == ContactDenyReason.NO_CONSENT }
+            ?.let { context.step.pushFallback(context.contentVariant) }
+            ?: return recordSuppressed(context, primaryDecision)
+        return deliverFallback(context, fallback)
+    }
+
+    private suspend fun deliverFallback(context: StepDeliveryContext, fallback: CampaignDelivery): StepOutcome {
+        val decision = checkDelivery(context, fallback)
+        if (decision == ContactGateDecision.ALLOWED) return handoff(context, fallback)
+        throwIfGateUnavailable(decision)
+        return recordSuppressed(context, decision)
+    }
+
+    private suspend fun checkDelivery(context: StepDeliveryContext, delivery: CampaignDelivery): ContactGateDecision =
+        contactGate.check(
+            context.partyId,
             ContactClass.OUTBOUND_SEND,
             marketingScopeFor(delivery.channel),
-            topic = campaign.goal,
+            topic = context.campaign.goal,
         )
 
-        // ADR-0219 (#3656): both attempts use the same complete gate. Only a missing primary
-        // consent may switch channels — quiet hours, caps and list suppression are not a reason
-        // to try a second message, and a gate outage remains a retry signal.
-        return when (val primaryDecision = checked(primary)) {
-            ContactGateDecision.ALLOWED -> sendAllowed(primary)
-            else -> {
-                if (primaryDecision.denyReason == ContactDenyReason.GATE_UNAVAILABLE) {
-                    throw ContactGateUnavailableException("contact gate state unavailable — activity will retry")
-                }
-                val fallback = primaryDecision.denyReason
-                    .takeIf { it == ContactDenyReason.NO_CONSENT }
-                    ?.let { step.pushFallback(contentVariant) }
-                if (fallback != null) {
-                    when (val fallbackDecision = checked(fallback)) {
-                        ContactGateDecision.ALLOWED -> sendAllowed(fallback)
-                        else -> {
-                            if (fallbackDecision.denyReason == ContactDenyReason.GATE_UNAVAILABLE) {
-                                throw ContactGateUnavailableException(
-                                    "contact gate state unavailable — activity will retry",
-                                )
-                            }
-                            sendLog.record(
-                                Ids.newId(),
-                                campaignId,
-                                partyId,
-                                stepOrder,
-                                outcomeFor(fallbackDecision.denyReason),
-                            )
-                            StepOutcome.SUPPRESSED
-                        }
-                    }
-                } else {
-                    sendLog.record(Ids.newId(), campaignId, partyId, stepOrder, outcomeFor(primaryDecision.denyReason))
-                    StepOutcome.SUPPRESSED
-                }
-            }
+    // A transport failure must leave a FAILED send row whatever exception the Kafka client raises,
+    // then be rethrown so Temporal retries. Narrowing this catch would re-open that audit gap.
+    @Suppress("TooGenericExceptionCaught")
+    private suspend fun handoff(context: StepDeliveryContext, delivery: CampaignDelivery): StepOutcome {
+        // The send-log row id is minted BEFORE the handoff: it is the wire correlation id and
+        // joins asynchronous delivery outcome to precisely this attempt (ADR-0239 D1).
+        val sendId = Ids.newId()
+        if (dryRun) {
+            sendLog.record(
+                sendId,
+                context.campaignId,
+                context.partyId,
+                context.stepOrder,
+                SendOutcome.DRY_RUN,
+                delivery.channel,
+            )
+            return StepOutcome.SENT
         }
+        try {
+            notificationSend.requestDelivery(context.partyId, delivery, sendId)
+        } catch (e: Exception) {
+            sendLog.record(
+                sendId,
+                context.campaignId,
+                context.partyId,
+                context.stepOrder,
+                SendOutcome.FAILED,
+                delivery.channel,
+            )
+            throw e
+        }
+        sendLog.record(
+            sendId,
+            context.campaignId,
+            context.partyId,
+            context.stepOrder,
+            SendOutcome.SENT,
+            delivery.channel,
+        )
+        return StepOutcome.SENT
+    }
+
+    private suspend fun recordSuppressed(context: StepDeliveryContext, decision: ContactGateDecision): StepOutcome {
+        sendLog.record(
+            Ids.newId(),
+            context.campaignId,
+            context.partyId,
+            context.stepOrder,
+            outcomeFor(decision.denyReason),
+        )
+        return StepOutcome.SUPPRESSED
     }
 
     override fun advanceStep(campaignId: UUID, partyId: UUID, stepOrder: Int) = runBlockingOnWorker {
@@ -281,6 +274,33 @@ open class CampaignJourneyActivitiesImpl(
 /** Thrown when the contact gate cannot reach its state — a retry signal, never a policy outcome. */
 class ContactGateUnavailableException(message: String) : RuntimeException(message)
 
+/** Immutable state shared by the primary attempt and the only permitted PUSH fallback. */
+private data class StepDeliveryContext(
+    val campaign: Campaign,
+    val step: CampaignStep,
+    val campaignId: UUID,
+    val partyId: UUID,
+    val stepOrder: Int,
+    val contentVariant: com.openbank.campaign.domain.model.ContentVariant?,
+)
+
+/** Only ACTIVE campaigns may enter delivery; every other state has a durable workflow outcome. */
+private fun Campaign.deliveryStateOutcome(): StepOutcome? = when (state) {
+    CampaignState.ACTIVE -> null
+    CampaignState.PAUSED -> StepOutcome.CAMPAIGN_PAUSED
+    CampaignState.CLOSED,
+    CampaignState.DRAFT,
+    CampaignState.PENDING_APPROVAL,
+    -> StepOutcome.CAMPAIGN_CLOSED
+}
+
+/** A gate outage is retriable infrastructure state, never a customer-policy suppression. */
+private fun throwIfGateUnavailable(decision: ContactGateDecision) {
+    if (decision.denyReason == ContactDenyReason.GATE_UNAVAILABLE) {
+        throw ContactGateUnavailableException("contact gate state unavailable — activity will retry")
+    }
+}
+
 // Two helpers as top-level privates rather than members: CampaignJourneyActivitiesImpl sits at
 // detekt's TooManyFunctions threshold of 11, which fires AT the limit, so the branch-condition
 // activities (#3585) had to buy their room somewhere.
@@ -305,3 +325,18 @@ private suspend fun SendLogRepository.record(
 // The recipient address is resolved by notification-service from party data; the campaign never
 // carries an e-mail address itself (ADR-0200 D3 — no PII duplication).
 private fun recipientFor(partyId: UUID): String = partyId.toString()
+
+/** Build the cross-service command outside the gate's nested delivery branch. */
+private suspend fun NotificationSendPort.requestDelivery(partyId: UUID, delivery: CampaignDelivery, sendId: UUID) {
+    requestSend(
+        NotificationSendRequest(
+            partyId = partyId,
+            channel = delivery.channel,
+            template = delivery.template,
+            recipient = recipientFor(partyId),
+            variables = delivery.variables,
+            correlationId = sendId,
+            deepLink = delivery.deepLink,
+        ),
+    )
+}

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/domain/model/Campaign.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/domain/model/Campaign.kt
@@ -207,6 +207,8 @@ data class CampaignStep(
      * to send a second message.
      */
     val fallbackToPush: Boolean = false,
+    /** A closed, app-owned destination for a push tap — never author-entered URL text. */
+    val mobileDestination: MobileDestination? = null,
 ) {
     init {
         require(order >= 0) { "step order must be >= 0" }
@@ -243,6 +245,9 @@ data class CampaignStep(
         require(!fallbackToPush || template in TemplateCatalog.PUSH_FALLBACK_FOR_EMAIL) {
             "template '$template' has no safe PUSH fallback"
         }
+        require(mobileDestination == null || channel == Channel.PUSH || fallbackToPush) {
+            "a mobile destination requires a PUSH step or an EMAIL step with PUSH fallback"
+        }
     }
 
     /** Resolves content after the durable enrolment assignment, never randomly at send time. */
@@ -250,8 +255,12 @@ data class CampaignStep(
         if (variant == ContentVariant.B) variantBVariables ?: variables else variables
 
     /** Primary delivery values, kept separate from the fallback's reduced template vocabulary. */
-    fun primaryDelivery(variant: ContentVariant?): CampaignDelivery =
-        CampaignDelivery(channel, template, TemplateCatalog.valuesFor(template, variablesFor(variant)))
+    fun primaryDelivery(variant: ContentVariant?): CampaignDelivery = CampaignDelivery(
+        channel,
+        template,
+        TemplateCatalog.valuesFor(template, variablesFor(variant)),
+        mobileDestination?.deepLink.takeIf { channel == Channel.PUSH },
+    )
 
     /** The only supported fallback: a consented app push after EMAIL consent was absent. */
     fun pushFallback(variant: ContentVariant?): CampaignDelivery? = TemplateCatalog.PUSH_FALLBACK_FOR_EMAIL[template]
@@ -261,12 +270,27 @@ data class CampaignStep(
                 Channel.PUSH,
                 pushTemplate,
                 TemplateCatalog.valuesFor(pushTemplate, variablesFor(variant)),
+                mobileDestination?.deepLink,
             )
         }
 }
 
 /** A resolved per-attempt delivery, including the channel that will be recorded for audit. */
-data class CampaignDelivery(val channel: Channel, val template: String, val variables: Map<String, String>)
+data class CampaignDelivery(
+    val channel: Channel,
+    val template: String,
+    val variables: Map<String, String>,
+    val deepLink: String? = null,
+)
+
+/** The only destinations the mobile app contract recognises for campaign pushes. */
+enum class MobileDestination(val deepLink: String) {
+    HOME("openbank://home"),
+    SAVINGS("openbank://savings"),
+    CARDS("openbank://cards"),
+    PAYMENTS("openbank://payments"),
+    PRODUCT_HUB("openbank://products"),
+}
 
 /**
  * Delivery channels a campaign step may use.

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/kafka/KafkaNotificationSendAdapter.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/kafka/KafkaNotificationSendAdapter.kt
@@ -6,11 +6,10 @@ package com.openbank.campaign.infrastructure.kafka
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.openbank.campaign.application.port.out.NotificationSendPort
+import com.openbank.campaign.application.port.out.NotificationSendRequest
 import jakarta.enterprise.context.ApplicationScoped
 import org.eclipse.microprofile.reactive.messaging.Channel
 import org.eclipse.microprofile.reactive.messaging.Emitter
-import java.util.UUID
-import com.openbank.campaign.domain.model.Channel as CampaignChannel
 
 /**
  * ADR-0200 D3: delivery goes through notification-service, never direct. The payload shape mirrors
@@ -29,30 +28,25 @@ class KafkaNotificationSendAdapter(
     private val mapper: ObjectMapper,
 ) : NotificationSendPort {
 
-    override suspend fun requestSend(
-        partyId: UUID,
-        channel: CampaignChannel,
-        template: String,
-        recipient: String,
-        variables: Map<String, String>,
-        correlationId: UUID,
-    ) {
-        val payload = mapper.writeValueAsString(
-            mapOf(
-                "partyId" to partyId.toString(),
-                // Was hardcoded "EMAIL". A step's channel now travels with it — with the constant in place a
-                // PUSH step was delivered as an email, silently, because notification-service believed
-                // the payload over the campaign.
-                "channel" to channel.name,
-                "template" to template,
-                "recipient" to recipient,
-                "variables" to variables,
-                // ADR-0239 D1 — the send-log row id. notification-service echoes it back on
-                // `openbank.notification.outcomes.v1`, which is the only way this service can learn
-                // that a send it recorded as SENT was in fact suppressed or never delivered (#3663).
-                "correlationId" to correlationId.toString(),
-            ),
+    override suspend fun requestSend(request: NotificationSendRequest) {
+        val fields = linkedMapOf(
+            "partyId" to request.partyId.toString(),
+            // Was hardcoded "EMAIL". A step's channel now travels with it — with the constant in place a
+            // PUSH step was delivered as an email, silently, because notification-service believed
+            // the payload over the campaign.
+            "channel" to request.channel.name,
+            "template" to request.template,
+            "recipient" to request.recipient,
+            "variables" to request.variables,
+            // ADR-0239 D1 — the send-log row id. notification-service echoes it back on
+            // `openbank.notification.outcomes.v1`, which is the only way this service can learn
+            // that a send it recorded as SENT was in fact suppressed or never delivered (#3663).
+            "correlationId" to request.correlationId.toString(),
         )
+        // This is transport metadata, never a template variable. The notification renderer's
+        // closed variable schema therefore cannot accidentally interpolate a navigation route.
+        request.deepLink?.let { fields["deepLink"] = it }
+        val payload = mapper.writeValueAsString(fields)
         emitter.send(payload).toCompletableFuture().join()
     }
 }

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/rest/CampaignResource.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/rest/CampaignResource.kt
@@ -8,6 +8,7 @@ import com.openbank.campaign.application.usecase.CampaignService
 import com.openbank.campaign.domain.model.CampaignSchedule
 import com.openbank.campaign.domain.model.CampaignStep
 import com.openbank.campaign.domain.model.Channel
+import com.openbank.campaign.domain.model.MobileDestination
 import com.openbank.campaign.domain.model.SegmentRef
 import com.openbank.campaign.domain.model.StepCondition
 import com.openbank.campaign.domain.model.StopCondition
@@ -78,6 +79,8 @@ data class StepRequest(
     val variantBVariables: Map<String, String>? = null,
     /** Use the catalogue's safe PUSH counterpart only when this EMAIL step lacks email consent. */
     val fallbackToPush: Boolean = false,
+    /** Closed in-app destination opened when the customer taps the resulting PUSH notification. */
+    val mobileDestination: MobileDestination? = null,
 )
 
 /**
@@ -139,6 +142,7 @@ class CampaignResource(private val service: CampaignService, private val jwt: Js
                 it.condition,
                 it.variantBVariables,
                 it.fallbackToPush,
+                it.mobileDestination,
             )
         }
         val campaign = service.createDraft(

--- a/openbank-campaign-service/src/main/resources/openapi.yaml
+++ b/openbank-campaign-service/src/main/resources/openapi.yaml
@@ -4,7 +4,7 @@ openapi: 3.1.0
 info:
   title: Campaign Service API
   # major == openbank.api.version == URL /api/v1 (ADR-0048).
-  version: 1.21.0
+  version: 1.22.0
   description: >-
     Campaign management first slice (ADR-0200 / ADR-0209 D3): deterministic, versioned segments;
     per-enrolment Temporal journeys; consent-gated delivery through notification-service.
@@ -586,6 +586,14 @@ components:
             gate for PUSH consent and sends that reduced, lock-screen-safe title only if allowed.
             It never bypasses quiet hours, frequency caps, suppression lists or a gate outage, and
             it does not attempt a second send after an asynchronous delivery failure.
+        mobileDestination:
+          type: string
+          nullable: true
+          enum: [HOME, SAVINGS, CARDS, PAYMENTS, PRODUCT_HUB]
+          description: >-
+            Bank-owned destination opened after a PUSH tap. This is a closed app-route contract,
+            never an author-entered URL; absent preserves existing campaigns. It is valid on a
+            PUSH step, or on an EMAIL step only when its consent-missing fallback is PUSH.
         delaySeconds: { type: integer, minimum: 0 }
         condition:
           description: >-

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/workflow/CampaignJourneyActivitiesImplTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/workflow/CampaignJourneyActivitiesImplTest.kt
@@ -116,7 +116,7 @@ class CampaignJourneyActivitiesImplTest {
     @Test
     fun `a refused notification handoff records FAILED and never SENT`() {
         givenDeliverableStep()
-        coEvery { notificationSend.requestSend(partyId, any(), any(), any(), any(), any()) } throws
+        coEvery { notificationSend.requestSend(any()) } throws
             IllegalStateException("broker refused the publish")
 
         assertThatThrownBy { activities.deliverStep(campaignId, partyId, 1) }
@@ -133,7 +133,7 @@ class CampaignJourneyActivitiesImplTest {
         val recordedBeforeSend = mutableListOf<SendOutcome>()
         var handedOff = false
         coEvery {
-            notificationSend.requestSend(partyId, any(), any(), any(), any(), any())
+            notificationSend.requestSend(any())
         } answers { handedOff = true }
         coEvery { sendLog.record(any()) } answers {
             if (!handedOff) recordedBeforeSend += firstArg<SendRecord>().outcome

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/workflow/CampaignJourneyActivitiesTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/workflow/CampaignJourneyActivitiesTest.kt
@@ -9,6 +9,7 @@ import com.openbank.campaign.application.port.out.CampaignOutcomeCount
 import com.openbank.campaign.application.port.out.CampaignRepository
 import com.openbank.campaign.application.port.out.EnrolmentRepository
 import com.openbank.campaign.application.port.out.NotificationSendPort
+import com.openbank.campaign.application.port.out.NotificationSendRequest
 import com.openbank.campaign.application.port.out.SendLogRepository
 import com.openbank.campaign.application.port.out.StepOutcomeCount
 import com.openbank.campaign.domain.model.Campaign
@@ -74,6 +75,9 @@ class CampaignJourneyActivitiesTest {
         /** Correlation ids put on the wire, in order (ADR-0239 D1). */
         val correlationIds = mutableListOf<UUID>()
 
+        /** App destinations handed to notification-service for the current delivery. */
+        val deepLinks = mutableListOf<String?>()
+
         val campaigns = object : CampaignRepository {
             override suspend fun findById(id: UUID) = if (id == campaignId) {
                 campaign.copy(
@@ -133,16 +137,10 @@ class CampaignJourneyActivitiesTest {
             ): DeliveryStatus? = null
         }
         val notificationSend = object : NotificationSendPort {
-            override suspend fun requestSend(
-                partyId: UUID,
-                channel: Channel,
-                template: String,
-                recipient: String,
-                variables: Map<String, String>,
-                correlationId: UUID,
-            ) {
+            override suspend fun requestSend(request: NotificationSendRequest) {
                 sendsRequested += 1
-                correlationIds += correlationId
+                correlationIds += request.correlationId
+                deepLinks += request.deepLink
             }
         }
 

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/domain/TemplateCatalogTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/domain/TemplateCatalogTest.kt
@@ -6,6 +6,7 @@ package com.openbank.campaign.domain
 
 import com.openbank.campaign.domain.model.CampaignStep
 import com.openbank.campaign.domain.model.Channel
+import com.openbank.campaign.domain.model.MobileDestination
 import com.openbank.campaign.domain.model.TemplateCatalog
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -98,6 +99,20 @@ class CampaignStepChannelTest {
             delaySeconds = 0,
         )
         assertEquals(Channel.PUSH, step.channel)
+    }
+
+    @Test
+    fun `a push step resolves an allow-listed app destination rather than an author URL`() {
+        val step = CampaignStep(
+            order = 1,
+            template = "MARKETING_PRODUCT_OFFER_PUSH",
+            channel = Channel.PUSH,
+            variables = mapOf("offerTitle" to "Savings"),
+            delaySeconds = 0,
+            mobileDestination = MobileDestination.SAVINGS,
+        )
+
+        assertEquals("openbank://savings", step.primaryDelivery(null).deepLink)
     }
 
     @Test

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/infrastructure/kafka/ConversionConsumerTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/infrastructure/kafka/ConversionConsumerTest.kt
@@ -44,7 +44,7 @@ class ConversionConsumerTest {
     private val journeys = mockk<JourneySignaller>(relaxed = true)
 
     @Test
-    fun `one product event credits only the last eligible campaign and ends that journey`() = runBlocking {
+    fun `one product event credits only the last eligible campaign and ends that journey`(): Unit = runBlocking {
         givenOverlappingCampaigns(newerAlreadyConverted = false)
         val recorded = slot<SendRecord>()
 
@@ -58,7 +58,7 @@ class ConversionConsumerTest {
     }
 
     @Test
-    fun `redelivery never shifts an already credited event to the runner-up campaign`() = runBlocking {
+    fun `redelivery never shifts an already credited event to the runner-up campaign`(): Unit = runBlocking {
         givenOverlappingCampaigns(newerAlreadyConverted = true)
 
         consumer().onAccountEvent(accountCreatedMessage())

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/integration/CampaignRestContractIT.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/integration/CampaignRestContractIT.kt
@@ -539,6 +539,35 @@ class CampaignRestContractIT {
     }
 
     @Test
+    fun `a mobile-first push step keeps its closed app destination over the HTTP contract`() {
+        val body = """
+            {"name":"push-${UUID.randomUUID()}","goal":"savings activation",
+             "segmentName":"actives","segmentVersion":1,
+             "steps":[{"order":1,"template":"MARKETING_PRODUCT_OFFER_PUSH","channel":"PUSH",
+                       "variables":{"offerTitle":"Savings"},"mobileDestination":"SAVINGS","delaySeconds":0}]}
+        """.trimIndent()
+
+        val id = Given {
+            contentType("application/json")
+            body(body)
+        } When {
+            post("/api/v1/campaigns")
+        } Then {
+            statusCode(201)
+        } Extract {
+            path<String>("id")
+        }
+
+        When {
+            get("/api/v1/campaigns/$id")
+        } Then {
+            statusCode(200)
+            body("steps[0].channel", org.hamcrest.Matchers.equalTo("PUSH"))
+            body("steps[0].mobileDestination", org.hamcrest.Matchers.equalTo("SAVINGS"))
+        }
+    }
+
+    @Test
     fun `the segment catalogue is served over HTTP with its rules in words`() {
         When {
             get("/api/v1/segments")

--- a/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
+++ b/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
@@ -193,6 +193,14 @@ class CustomerEdgeResource(
     @ConfigProperty(name = "openbank.edge.notification-service-url")
     lateinit var notificationServiceUrl: String
 
+    /**
+     * The app's server-driven engagement surfaces. This is deliberately separate from
+     * notification-service: an app surface is rendered after the customer opens the app, it is
+     * not an outbound notification pretending to have been delivered (ADR-0220 D1).
+     */
+    @ConfigProperty(name = "openbank.edge.engagement-service-url")
+    lateinit var engagementServiceUrl: String
+
     @ConfigProperty(name = "openbank.edge.statement-service-url")
     lateinit var statementServiceUrl: String
 
@@ -2596,6 +2604,48 @@ class CustomerEdgeResource(
         )
     }
 
+    // --- In-app engagement surfaces ---
+
+    /**
+     * Resolve one named mobile surface for the authenticated customer. The app receives only a
+     * typed, catalogue-backed payload; it owns presentation, accessibility and local navigation.
+     * The party id is derived from the JWT and injected only at this boundary, never accepted from
+     * the device, so changing a query parameter cannot render another customer's campaign.
+     */
+    @GET
+    @Path("/surfaces/{slot}")
+    @Authorize(action = "customer.engagement.read", resource = "#slot")
+    @Blocking
+    fun getSurface(@PathParam("slot") slot: String): Response {
+        if (slot !in SURFACE_SLOTS) return Response.status(Response.Status.BAD_REQUEST).build()
+        val customer = customer()
+        return upstream.get(
+            "$engagementServiceUrl/api/v1/surfaces/$slot?partyId=${customer.partyId}",
+            customer.partyId.toString(),
+        )
+    }
+
+    /**
+     * Record what the app actually observed: impression, click or dismissal. The edge overwrites
+     * any supplied partyId with the JWT party id before forwarding, which makes the feedback loop
+     * meaningful without turning it into an IDOR write primitive. Content/slot/type validation is
+     * owned by engagement-service, alongside the catalogue it validates against.
+     */
+    @POST
+    @Path("/surfaces/events")
+    @Authorize(action = "customer.engagement.record-event")
+    @Blocking
+    fun recordSurfaceEvent(body: String): Response {
+        val customer = customer()
+        val enriched = injectField(objectMapper, body, "partyId", customer.partyId.toString())
+            ?: return Response.status(Response.Status.BAD_REQUEST).build()
+        return upstream.post(
+            "$engagementServiceUrl/api/v1/surfaces/events",
+            customer.partyId.toString(),
+            enriched,
+        )
+    }
+
     // --- Theme preferences (ADR-0190) — edge-local, party-keyed, roams the app look ---
 
     /** The caller's stored ThemeSpec, 404 when none. Party is taken from the JWT, never the client. */
@@ -3833,6 +3883,15 @@ class CustomerEdgeResource(
         parseCreditorAccount(raw) ?: czechIbanToBban(raw)
 
     companion object {
+        /** Closed at the edge as well as upstream: a path is never an app-controlled URL. */
+        private val SURFACE_SLOTS: Set<String> = setOf(
+            "HOME_BANNER",
+            "HOME_CAROUSEL",
+            "STORIES",
+            "PRODUCT_FEED",
+            "REWARDS_HUB",
+        )
+
         // A ThemeSpec is a small token document; 8 KiB leaves headroom for future fields
         // while keeping Redis abuse-proof (ADR-0190).
         private const val THEME_SPEC_MAX_BYTES = 8 * 1024

--- a/openbank-customer-edge/src/main/resources/application.yaml
+++ b/openbank-customer-edge/src/main/resources/application.yaml
@@ -135,6 +135,7 @@ openbank:
     keycloak-admin-realm: ${KEYCLOAK_ADMIN_REALM:openbank-customers}
     keycloak-admin-client-id: ${KEYCLOAK_ADMIN_CLIENT_ID:customer-edge-admin}
     notification-service-url: ${NOTIFICATION_SERVICE_URL:http://notification-service.notifications.svc:8112}
+    engagement-service-url: ${ENGAGEMENT_SERVICE_URL:http://engagement-service.engagement.svc:8153}
     statement-service-url: ${STATEMENT_SERVICE_URL:http://statement-service.statements.svc:8136}
     standing-order-service-url: ${STANDING_ORDER_SERVICE_URL:http://standing-order-service.payments.svc:8121}
     fx-service-url:      ${FX_SERVICE_URL:http://fx-service.fx.svc:8119}

--- a/openbank-customer-edge/src/main/resources/openapi.yaml
+++ b/openbank-customer-edge/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: Customer Edge API
-  version: 1.31.0
+  version: 1.32.0
   description: >-
     Customer-facing edge proxy (ADR-0065). Single internet-facing entry point for the
     retail customer app. Validates JWTs from the openbank-customers Keycloak realm,
@@ -31,6 +31,7 @@ tags:
   - name: WebAuthn
   - name: Documents
   - name: Preferences
+  - name: Engagement
   - name: Feedback
   - name: Cards
   - name: Lending
@@ -455,6 +456,58 @@ paths:
       responses:
         '200':
           description: Count of notifications marked read
+
+  /surfaces/{slot}:
+    get:
+      tags: [Engagement]
+      summary: Resolve a consented, typed in-app engagement surface for the caller
+      description: >-
+        Returns catalogue-backed content for a mobile slot after the engagement service applies
+        marketing consent, impression budget, adverse-state exclusions and dismissal suppression.
+        The party is always taken from the authenticated customer session; it is never a client
+        parameter. The app owns local rendering and navigation for the typed payload.
+      operationId: getEngagementSurface
+      security:
+        - customerOidc: []
+      parameters:
+        - name: slot
+          in: path
+          required: true
+          schema:
+            type: string
+            enum: [HOME_BANNER, HOME_CAROUSEL, STORIES, PRODUCT_FEED, REWARDS_HUB]
+      responses:
+        '200':
+          description: Surface resolution, including an explicit state when no content may render
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EngagementSurfaceResponse'
+        '400':
+          description: Unknown surface slot
+
+  /surfaces/events:
+    post:
+      tags: [Engagement]
+      summary: Record an app-observed engagement event for a surfaced item
+      description: >-
+        The party identity is injected from the customer JWT. The service accepts only a content
+        id that belongs to the declared slot, so a device cannot manufacture metrics for an
+        arbitrary campaign or content class.
+      operationId: recordEngagementSurfaceEvent
+      security:
+        - customerOidc: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EngagementSurfaceEvent'
+      responses:
+        '202':
+          description: Event persisted and queued for the engagement event stream
+        '400':
+          description: Invalid request, unknown content or content-slot mismatch
 
   /profile:
     get:
@@ -2136,6 +2189,59 @@ components:
         email:
           type: string
           format: email
+
+    EngagementSurfaceResponse:
+      type: object
+      required: [state]
+      description: >-
+        A typed server decision, not arbitrary remote UI markup. `ok` carries only catalogue ids
+        and declared presentation variables; `not_eligible` and `suppressed` are normal states,
+        not transport failures.
+      properties:
+        state:
+          type: string
+          enum: [ok, not_eligible, suppressed]
+        content:
+          type: array
+          items:
+            $ref: '#/components/schemas/EngagementSurfaceContent'
+        reason:
+          type: string
+          description: Present when the contact policy makes the caller not eligible.
+
+    EngagementSurfaceContent:
+      type: object
+      required: [id, slot, type, variables]
+      properties:
+        id:
+          type: string
+          example: SAVINGS_RATE_BANNER
+        slot:
+          type: string
+          enum: [HOME_BANNER, HOME_CAROUSEL, STORIES, PRODUCT_FEED, REWARDS_HUB]
+        type:
+          type: string
+          enum: [BANNER, CARD, STORY, CAROUSEL, OFFER]
+        variables:
+          type: array
+          items: {type: string}
+
+    EngagementSurfaceEvent:
+      type: object
+      required: [contentId, slot, type]
+      description: >-
+        `partyId` is deliberately absent: customer-edge derives it from the bearer token and
+        overwrites any unexpected field before the event reaches engagement-service.
+      properties:
+        contentId:
+          type: string
+          example: SAVINGS_RATE_BANNER
+        slot:
+          type: string
+          enum: [HOME_BANNER, HOME_CAROUSEL, STORIES, PRODUCT_FEED, REWARDS_HUB]
+        type:
+          type: string
+          enum: [IMPRESSION, CLICK, DISMISS]
 
     FeedbackSubmission:
       type: object

--- a/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/CustomerEdgeResourceTest.kt
+++ b/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/CustomerEdgeResourceTest.kt
@@ -47,6 +47,7 @@ class CustomerEdgeResourceTest {
         objectMapper = ObjectMapper()
         accountServiceUrl = "http://account"
         balanceServiceUrl = "http://balance"
+        engagementServiceUrl = "http://engagement"
     }
 
     private fun accountJson(accountId: UUID, ownerParty: UUID) =
@@ -250,6 +251,38 @@ class CustomerEdgeResourceTest {
         // forwarding a corrupt payload upstream.
         assertThat(CustomerEdgeResource.injectField(mapper, "not json", "partyId", "x")).isNull()
         assertThat(CustomerEdgeResource.injectField(mapper, """["a","b"]""", "partyId", "x")).isNull()
+    }
+
+    // ── in-app engagement surfaces ────────────────────────────────────────────────────────────
+
+    @Test
+    fun `recordSurfaceEvent overwrites a spoofed party id with the JWT party`() {
+        val caller = UUID.randomUUID()
+        val upstream = mockk<UpstreamClient>()
+        val body = slot<String>()
+        every {
+            upstream.post(match { it.endsWith("/api/v1/surfaces/events") }, caller.toString(), capture(body), any())
+        } returns
+            Response.status(Response.Status.ACCEPTED).build()
+
+        val response = resourceFor(upstream, caller).recordSurfaceEvent(
+            """{"partyId":"${UUID.randomUUID()}","contentId":"SAVINGS_RATE_BANNER","slot":"HOME_BANNER","type":"CLICK"}""",
+        )
+
+        assertThat(response.status).isEqualTo(Response.Status.ACCEPTED.statusCode)
+        assertThat(mapper.readTree(body.captured).path("partyId").asText()).isEqualTo(caller.toString())
+        assertThat(mapper.readTree(body.captured).path("contentId").asText()).isEqualTo("SAVINGS_RATE_BANNER")
+    }
+
+    @Test
+    fun `getSurface rejects a non-catalogue slot before it calls the upstream`() {
+        val caller = UUID.randomUUID()
+        val upstream = mockk<UpstreamClient>()
+
+        val response = resourceFor(upstream, caller).getSurface("../../not-a-slot")
+
+        assertThat(response.status).isEqualTo(Response.Status.BAD_REQUEST.statusCode)
+        verify(exactly = 0) { upstream.get(any(), any()) }
     }
 
     // ── statement render: currency + format allow-lists (deny-by-default) ────────

--- a/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/infrastructure/rest/SurfaceResource.kt
+++ b/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/infrastructure/rest/SurfaceResource.kt
@@ -8,6 +8,7 @@ import com.openbank.engagement.application.usecase.RecordEngagementEventUseCase
 import com.openbank.engagement.application.usecase.ResolveSurfaceUseCase
 import com.openbank.engagement.domain.model.EngagementEvent
 import com.openbank.engagement.domain.model.EngagementEventType
+import com.openbank.engagement.domain.model.SurfaceCatalog
 import com.openbank.engagement.domain.model.SurfaceContent
 import com.openbank.engagement.domain.model.SurfaceSlot
 import com.openbank.libs.authz.Authorize
@@ -64,6 +65,11 @@ class SurfaceResource(private val resolve: ResolveSurfaceUseCase, private val re
         val slot = parseSlot(request.slot) ?: return badRequest("unknown slot '${request.slot}'")
         val type = EngagementEventType.entries.find { it.name == request.type }
             ?: return badRequest("unknown event type '${request.type}'")
+        val content = SurfaceCatalog.ALL[request.contentId]
+            ?: return badRequest("unknown content '${request.contentId}'")
+        if (content.slot != slot) {
+            return badRequest("content '${request.contentId}' is not renderable in slot '${request.slot}'")
+        }
         record.record(
             EngagementEvent(
                 partyId = request.partyId,

--- a/openbank-engagement-service/src/main/resources/openapi.yaml
+++ b/openbank-engagement-service/src/main/resources/openapi.yaml
@@ -14,7 +14,7 @@ info:
     existing yet). No NBA ranking — content returns in catalogue order until ADR-0201's model
     graduates from shadow (D5). The customer app reaches these endpoints only through
     customer-edge, whose narrowly scoped M2M policy injects the authoritative party id.
-  version: 1.1.0
+  version: 1.1.1
 tags:
   - name: Surfaces
   - name: Eligibility

--- a/openbank-engagement-service/src/main/resources/openapi.yaml
+++ b/openbank-engagement-service/src/main/resources/openapi.yaml
@@ -12,9 +12,8 @@ info:
 
     Deliberately absent: gamification (D3) and pre-approved offers (D4, blocked on ADR-0142 not
     existing yet). No NBA ranking — content returns in catalogue order until ADR-0201's model
-    graduates from shadow (D5). No `@Authorize` OPA rule for these actions yet; the shared policy's
-    `default allow := false` denies both endpoints fail-closed under enforcement until that rule
-    lands.
+    graduates from shadow (D5). The customer app reaches these endpoints only through
+    customer-edge, whose narrowly scoped M2M policy injects the authoritative party id.
   version: 1.1.0
 tags:
   - name: Surfaces

--- a/openbank-engagement-service/src/main/resources/openapi.yaml
+++ b/openbank-engagement-service/src/main/resources/openapi.yaml
@@ -14,7 +14,7 @@ info:
     existing yet). No NBA ranking — content returns in catalogue order until ADR-0201's model
     graduates from shadow (D5). The customer app reaches these endpoints only through
     customer-edge, whose narrowly scoped M2M policy injects the authoritative party id.
-  version: 1.1.1
+  version: 1.2.0
 tags:
   - name: Surfaces
   - name: Eligibility

--- a/openbank-engagement-service/src/test/kotlin/com/openbank/engagement/integration/SurfaceRestContractIT.kt
+++ b/openbank-engagement-service/src/test/kotlin/com/openbank/engagement/integration/SurfaceRestContractIT.kt
@@ -120,6 +120,21 @@ class SurfaceRestContractIT {
         }
     }
 
+    @Test
+    @TestSecurity(user = TEST_OPERATOR, roles = ["ROLE_OPERATOR"])
+    fun `an event for content not in the rendered catalogue is rejected rather than polluting metrics`() {
+        Given {
+            contentType("application/json")
+            body(
+                """{"partyId":"${UUID.randomUUID()}","contentId":"NOT_A_CATALOGUE_ITEM","slot":"HOME_BANNER","type":"CLICK"}""",
+            )
+        } When {
+            post("/api/v1/surfaces/events")
+        } Then {
+            statusCode(400)
+        }
+    }
+
     // ── AdverseStateResource (issue #4265 item 1) ──────────────────────────────────────────────
     //
     // These live in THIS class rather than a second @QuarkusTest deliberately. A new IT class would

--- a/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
@@ -222,6 +222,12 @@ spec:
               value: "true"
             - name: NOTIFICATION_SERVICE_URL
               value: http://notification-service.notifications.svc:8112
+            # In-app campaign surfaces (#4475): the customer app fetches its eligible
+            # placements and records impressions/clicks through engagement-service.
+            # The application default alone is invisible to gen-network-policies.py,
+            # so declare the real cross-namespace URL here to allow edge → engagement.
+            - name: ENGAGEMENT_SERVICE_URL
+              value: http://engagement-service.engagement.svc:8153
             - name: STATEMENT_SERVICE_URL
               value: http://statement-service.statements.svc:8136
             - name: STANDING_ORDER_SERVICE_URL

--- a/openbank-infra/gitops/components/engagement/network-policies.yaml
+++ b/openbank-infra/gitops/components/engagement/network-policies.yaml
@@ -44,6 +44,9 @@ spec:
     - from:
         - namespaceSelector:
             matchLabels:
+              kubernetes.io/metadata.name: customer-edge
+        - namespaceSelector:
+            matchLabels:
               kubernetes.io/metadata.name: admin-ui
       ports:
         - protocol: TCP

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/application/NotificationConsumer.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/application/NotificationConsumer.kt
@@ -21,6 +21,7 @@ import com.openbank.notification.application.port.out.PushMetricsPort
 import com.openbank.notification.application.port.out.PushSender
 import com.openbank.notification.domain.HtmlEscape
 import com.openbank.notification.domain.RecipientAddress
+import com.openbank.notification.domain.model.MobileDeepLink
 import com.openbank.notification.domain.model.NotificationCategory
 import com.openbank.notification.domain.model.NotificationChannel
 import com.openbank.notification.domain.model.NotificationOutcome
@@ -206,6 +207,14 @@ class NotificationConsumer {
                 req.template.variables.sorted(),
                 unknown.sorted(),
             )
+            return Uni.createFrom().voidItem()
+        }
+        val validDeepLink = req.deepLink == null ||
+            (req.channel == NotificationChannel.PUSH && MobileDeepLink.isAllowed(req.deepLink))
+        if (!validDeepLink) {
+            // The deep link controls device navigation, so it gets the same allow-list posture as
+            // template identifiers. Do not log the rejected value; it may be attacker-controlled.
+            log.errorf("Rejected notification with non-bank mobile deep-link for template=%s", req.template.name)
             return Uni.createFrom().voidItem()
         }
         return dispatch(req)
@@ -609,7 +618,7 @@ class NotificationConsumer {
                 val targets = tokens.map { Triple(it.deviceId, PushPlatform.valueOf(it.platform), it.token) }
                 val sends = targets.map { (deviceId, platform, token) ->
                     pushSender.send(
-                        PushMessage(platform, token, subject, pushText, mapOf("template" to req.template.name)),
+                        PushMessage(platform, token, subject, pushText, pushData(req, entity)),
                     ).map { result ->
                         // Recorded here, where the platform is in scope. Counter increments are
                         // thread-safe, so running off the event loop (the adapters complete on the
@@ -625,6 +634,18 @@ class NotificationConsumer {
                     .chain { results -> persistPushFanOut(req, entity, results) }
                     .replaceWithVoid()
             }
+    }
+
+    /**
+     * FCM/APNs data is a routing envelope, not customer content. `notificationId` lets an app
+     * fetch the authenticated full detail after a generic wake-up; `deepLink` is only admitted by
+     * [MobileDeepLink] before this method runs. Neither carries balances, names, offers or other
+     * lock-screen-visible material.
+     */
+    private fun pushData(req: NotificationRequest, entity: NotificationEntity): Map<String, String> = buildMap {
+        put("template", req.template.name)
+        put("notificationId", entity.notificationId.toString())
+        req.deepLink?.let { put("deepLink", it) }
     }
 
     /**

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/domain/model/Notification.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/domain/model/Notification.kt
@@ -112,4 +112,19 @@ data class NotificationRequest(
      * meaningless to the producer, which is the only party that can join it back to its own row.
      */
     val correlationId: UUID? = null,
+    /** Optional bank-owned app route for a PUSH tap; never a template variable. */
+    val deepLink: String? = null,
 )
+
+/** Closed allow-list for navigation metadata sent through FCM/APNs. */
+object MobileDeepLink {
+    private val allowed = setOf(
+        "openbank://home",
+        "openbank://savings",
+        "openbank://cards",
+        "openbank://payments",
+        "openbank://products",
+    )
+
+    fun isAllowed(value: String?): Boolean = value == null || value in allowed
+}

--- a/openbank-notification-service/src/test/kotlin/com/openbank/notification/domain/model/NotificationModelTest.kt
+++ b/openbank-notification-service/src/test/kotlin/com/openbank/notification/domain/model/NotificationModelTest.kt
@@ -80,4 +80,11 @@ class NotificationModelTest {
         assertThat(req.channel).isEqualTo(NotificationChannel.PUSH)
         assertThat(req.variables).containsEntry("code", "123456")
     }
+
+    @Test
+    fun `mobile deep links are an allow-list, not arbitrary URLs`() {
+        assertThat(MobileDeepLink.isAllowed("openbank://savings")).isTrue()
+        assertThat(MobileDeepLink.isAllowed("https://example.invalid/redirect")).isFalse()
+        assertThat(MobileDeepLink.isAllowed("openbank://savings?next=https://evil.invalid")).isFalse()
+    }
 }

--- a/openbank-notification-service/src/test/kotlin/com/openbank/notification/integration/NotificationConsumerIT.kt
+++ b/openbank-notification-service/src/test/kotlin/com/openbank/notification/integration/NotificationConsumerIT.kt
@@ -519,6 +519,30 @@ class NotificationConsumerIT {
         // The amount and account never appear anywhere in the transported payload.
         assertThat(msg.title).doesNotContain(amount).doesNotContain(account)
         assertThat(msg.body).doesNotContain(amount).doesNotContain(account)
+        assertThat(msg.data).containsKeys("template", "notificationId")
+    }
+
+    @Test
+    fun `PUSH payload carries only an allow-listed deep link alongside the opaque notification id`() {
+        val partyId = UUID.randomUUID()
+        val token = "apns-campaign-deep-link-token-it"
+        OffContextPushSender.SENT.clear()
+        seedActiveDevice(partyId, token)
+
+        consumeAndAwait(
+            NotificationRequest(
+                partyId = partyId,
+                channel = NotificationChannel.PUSH,
+                template = NotificationTemplate.WELCOME,
+                recipient = "campaign@example.com",
+                variables = mapOf("name" to "Campaign customer"),
+                deepLink = "openbank://savings",
+            ),
+        )
+
+        assertThat(OffContextPushSender.SENT.single { it.token == token }.data)
+            .containsEntry("deepLink", "openbank://savings")
+            .containsKey("notificationId")
     }
 
     @Test


### PR DESCRIPTION
## What changed

- Makes push a first-class campaign delivery channel with closed, audited app destinations for Home, Savings, Cards, Payments and Products.
- Adds a customer-edge bridge for consent-aware in-app surfaces: home banner, carousel, stories, product feed and rewards hub.
- Keeps push transport private: it carries an opaque notification ID, template and optional deep link; authenticated app APIs retain the content.
- Validates surface content and its placement before recording impressions, clicks, dismissals or conversions, so product metrics cannot be polluted by fabricated events.

## Why

Campaign management was email-oriented despite OpenBank having native push and engagement capabilities. This creates a mobile-first ecosystem across campaign orchestration, push delivery, customer edge and in-app surfaces without reintroducing a misleading `IN_APP` notification channel.

## Impact

Campaign operators can select the exact post-tap app destination for push steps. The mobile client can use the documented closed `openbank://` routes, while the customer edge provides the existing catalogue-backed in-app surfaces and protected event ingestion.

## Validation

- `npm run type-check`
- `node ./node_modules/vitest/vitest.mjs run src/test/campaign-studio.test.tsx src/test/journey-editor.test.tsx` (21 tests)
- Focused Campaign, Notification, Engagement and Customer Edge integration tests
- Four-service `detekt` and `ktlintCheck` gate
- `git diff --check`



## Linked issues

Refs #4476
