### PR TITLE
feat(admin-ui): add campaign experience workspace

### DIFF
--- a/openbank-admin-ui/src/app/campaigns/new/page.tsx
+++ b/openbank-admin-ui/src/app/campaigns/new/page.tsx
@@ -17,6 +17,8 @@ import {
   type EditorStep,
 } from '@/components/campaigns/JourneyEditor'
 import { StepEditor } from '@/components/campaigns/StepEditor'
+import { CampaignExperiencePreview } from '@/components/campaigns/CampaignExperiencePreview'
+import { CampaignLaunchReadiness } from '@/components/campaigns/CampaignLaunchReadiness'
 
 /**
  * Campaign Studio — authoring on a canvas (ADR-0221 D1).
@@ -488,6 +490,19 @@ export default function NewCampaignPage() {
           />
         )}
 
+        </div>
+
+        <div className="campaign-studio-companion-grid">
+          <CampaignExperiencePreview step={selected === null ? undefined : steps[selected]} campaignName={name} />
+          <CampaignLaunchReadiness
+            audienceChosen={segment !== ''}
+            audienceSize={reach}
+            entryConfigured={entryConfigured}
+            incomplete={incomplete}
+            conversionRule={conversionRule}
+            contentExperiment={contentExperiment}
+            steps={steps}
+          />
         </div>
 
         {/* What "it worked" means, asked at authoring time because it cannot be answered later:

--- a/openbank-admin-ui/src/app/globals.css
+++ b/openbank-admin-ui/src/app/globals.css
@@ -296,6 +296,63 @@ main {
 .stat-card:hover::before {
   background: var(--ob-accent);
 }
+
+/* ── Campaign Studio companion surfaces ── */
+.campaign-studio-companion-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.15fr) minmax(19rem, 0.85fr);
+  gap: 1rem;
+  margin-top: 1rem;
+}
+.campaign-experience-preview,
+.campaign-launch-readiness {
+  border: 1px solid var(--border);
+  border-radius: var(--r-xl);
+  box-shadow: var(--shadow-sm);
+  overflow: hidden;
+}
+.campaign-experience-preview { background: radial-gradient(circle at 76% 15%, #dbeafe 0, transparent 32%), linear-gradient(135deg, #111827 0%, #172554 55%, #312e81 100%); color: #fff; padding: 1.15rem; }
+.campaign-preview-heading, .campaign-readiness-heading { display: flex; align-items: flex-start; justify-content: space-between; gap: 0.75rem; }
+.campaign-preview-kicker { color: inherit; font-size: 0.67rem; font-weight: 800; letter-spacing: 0.09em; opacity: 0.65; text-transform: uppercase; }
+.campaign-preview-heading h3, .campaign-readiness-heading h3 { font-size: 1rem; font-weight: 700; margin-top: 0.2rem; }
+.campaign-preview-live { background: rgba(255,255,255,0.14); border: 1px solid rgba(255,255,255,0.16); border-radius: 99px; font-size: 0.68rem; font-weight: 700; padding: 0.3rem 0.55rem; white-space: nowrap; }
+.campaign-preview-stage { display: flex; align-items: center; gap: 0.75rem; min-height: 15rem; padding: 1rem 0.35rem 0.65rem; }
+.campaign-phone { width: 8.65rem; height: 14.8rem; background: #f8fafc; border: 4px solid #020617; border-radius: 1.55rem; box-shadow: 0 18px 32px rgba(0,0,0,.3); color: #0f172a; flex: 0 0 auto; overflow: hidden; position: relative; }
+.campaign-phone-island { background: #020617; border-radius: 0 0 0.8rem 0.8rem; height: 0.9rem; left: 50%; position: absolute; top: 0; transform: translateX(-50%); width: 3.5rem; }
+.campaign-phone-content { padding: 1.3rem 0.68rem 0.65rem; }
+.campaign-phone-topline { display: flex; justify-content: space-between; color: #6366f1; font-size: 0.55rem; font-weight: 800; }
+.campaign-phone-eyebrow { color: #64748b; font-size: 0.48rem; margin-top: 0.85rem; }
+.campaign-phone h4 { font-size: 0.82rem; font-weight: 800; line-height: 1.1; margin-top: 0.18rem; }
+.campaign-phone-hero { background: linear-gradient(145deg, #ede9fe, #dbeafe); border-radius: 0.75rem; margin-top: 0.65rem; padding: 0.58rem; }
+.campaign-phone-hero span { color: #4f46e5; display: block; font-size: 0.43rem; font-weight: 800; text-transform: uppercase; }
+.campaign-phone-hero strong { display: block; font-size: 0.62rem; line-height: 1.15; margin: 0.28rem 0; }
+.campaign-phone-hero button { background: #4f46e5; border: 0; border-radius: 0.4rem; color: #fff; font-size: 0.45rem; font-weight: 700; padding: 0.28rem 0.42rem; }
+.campaign-phone-row { display: flex; gap: 0.28rem; margin-top: 0.58rem; }
+.campaign-phone-row span { background: #e2e8f0; border-radius: 0.25rem; height: 1.45rem; flex: 1; }
+.campaign-push-card { background: rgba(255,255,255,0.95); border: 1px solid rgba(255,255,255,0.75); border-radius: 0.9rem; box-shadow: 0 12px 28px rgba(0,0,0,.18); color: #0f172a; display: flex; gap: 0.48rem; max-width: 15.5rem; padding: 0.62rem; transform: rotate(-2deg); }
+.campaign-push-icon { align-items: center; background: linear-gradient(140deg, #4f46e5, #7c3aed); border-radius: 0.45rem; color: #fff; display: flex; font-size: 0.85rem; font-weight: 800; height: 1.65rem; justify-content: center; width: 1.65rem; }
+.campaign-push-meta { color: #64748b; font-size: 0.43rem; font-weight: 800; letter-spacing: 0.04em; }
+.campaign-push-title { font-size: 0.66rem; font-weight: 800; line-height: 1.15; margin-top: 0.15rem; }
+.campaign-push-card p:last-child { color: #475569; font-size: 0.52rem; line-height: 1.25; margin-top: 0.25rem; }
+.campaign-preview-route { align-items: center; background: rgba(255,255,255,.1); border: 1px solid rgba(255,255,255,.13); border-radius: 0.65rem; display: flex; flex-wrap: wrap; font-size: 0.67rem; gap: 0.35rem 0.55rem; padding: 0.55rem 0.65rem; }
+.campaign-preview-route span { opacity: .68; }
+.campaign-preview-route strong { font-size: 0.67rem; }
+.campaign-preview-route code { font-size: 0.59rem; opacity: .74; }
+.campaign-launch-readiness { background: var(--surface); padding: 1.15rem; }
+.campaign-readiness-heading strong { align-items: center; background: var(--ob-accent-light); border-radius: 99px; color: var(--ob-accent-text); display: inline-flex; font-size: 0.75rem; min-height: 2rem; padding: 0 0.7rem; }
+.campaign-readiness-intro { color: var(--text-secondary); font-size: 0.75rem; margin: 0.75rem 0; }
+.campaign-readiness-list { display: grid; gap: 0.55rem; list-style: none; }
+.campaign-readiness-list li { align-items: flex-start; border-radius: 0.65rem; display: flex; gap: 0.55rem; padding: 0.42rem; }
+.campaign-readiness-list li > span { align-items: center; border-radius: 99px; display: inline-flex; flex: 0 0 auto; font-size: 0.68rem; font-weight: 800; height: 1.2rem; justify-content: center; margin-top: 0.1rem; width: 1.2rem; }
+.campaign-readiness-list strong { display: block; font-size: 0.74rem; line-height: 1.25; }
+.campaign-readiness-list p { color: var(--text-secondary); font-size: 0.66rem; line-height: 1.32; margin-top: 0.12rem; }
+.campaign-readiness-list [data-state='ready'] > span { background: var(--success-bg); color: var(--success-text); }
+.campaign-readiness-list [data-state='attention'] { background: var(--warning-bg); }
+.campaign-readiness-list [data-state='attention'] > span { background: #fef3c7; color: var(--warning-text); }
+.campaign-readiness-list [data-state='waiting'] { background: var(--surface-2); }
+.campaign-readiness-list [data-state='waiting'] > span { background: var(--surface-4); color: var(--text-secondary); }
+@media (max-width: 960px) { .campaign-studio-companion-grid { grid-template-columns: 1fr; } }
+@media (max-width: 450px) { .campaign-preview-stage { gap: 0.4rem; } .campaign-phone { transform: scale(.9); transform-origin: left center; margin-right: -0.75rem; } .campaign-push-card { transform: rotate(-2deg) scale(.9); transform-origin: left center; } }
 /* Stat-card internals (ADR-0208 D1). `.stat-card` only ever styled the container, so every page
    hand-rolled the label/value typography inline — including colour values derived from a literal
    (`background: ${k.color}18`), which is the duplication D2 exists to remove. These three classes

--- a/openbank-admin-ui/src/components/campaigns/CampaignExperiencePreview.tsx
+++ b/openbank-admin-ui/src/components/campaigns/CampaignExperiencePreview.tsx
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+'use client'
+
+import { useLanguage } from '@/lib/i18n/LanguageContext'
+import type { EditorMobileDestination, EditorStep } from '@/components/campaigns/JourneyEditor'
+
+type Destination = Exclude<EditorMobileDestination, undefined>
+
+const destinationCopy: Record<Destination, { cs: string; en: string; eyebrowCs: string; eyebrowEn: string }> = {
+  HOME: { cs: 'Domovská obrazovka', en: 'Home', eyebrowCs: 'Dnešní přehled', eyebrowEn: 'Today at a glance' },
+  SAVINGS: { cs: 'Spoření', en: 'Savings', eyebrowCs: 'Vaše spoření', eyebrowEn: 'Your savings' },
+  CARDS: { cs: 'Karty', en: 'Cards', eyebrowCs: 'Vaše karty', eyebrowEn: 'Your cards' },
+  PAYMENTS: { cs: 'Platby', en: 'Payments', eyebrowCs: 'Poslat peníze', eyebrowEn: 'Move money' },
+  PRODUCT_HUB: { cs: 'Produkty', en: 'Products', eyebrowCs: 'Pro vás', eyebrowEn: 'Picked for you' },
+}
+
+/**
+ * A deliberately faithful *structure* preview, not an invented content renderer.
+ *
+ * Campaign-service authorises a closed application destination, not arbitrary native UI or copy.
+ * The preview therefore demonstrates the customer sequence (notification → authenticated app →
+ * destination) and uses the selected template headline, while never pretending that Admin UI owns
+ * the mobile app. It keeps the operator's decision tangible without becoming a second app client.
+ */
+export function CampaignExperiencePreview({
+  step,
+  campaignName,
+}: {
+  step: EditorStep | undefined
+  campaignName: string
+}) {
+  const { t, language } = useLanguage()
+  const isPush = step?.channel === 'PUSH'
+  const destination = step?.mobileDestination ?? 'HOME'
+  const copy = destinationCopy[destination]
+  const headline = step?.variables.offerTitle?.trim() || t('Vaše další chytrá volba', 'Your next smart move')
+  const campaignLabel = campaignName.trim() || t('Nová kampaň', 'New campaign')
+
+  return (
+    <section className="campaign-experience-preview" aria-labelledby="experience-preview-title" data-testid="campaign-experience-preview">
+      <div className="campaign-preview-heading">
+        <div>
+          <p className="campaign-preview-kicker">{t('Zážitek zákazníka', 'Customer experience')}</p>
+          <h3 id="experience-preview-title">{t('Na telefonu, ne v tabulce', 'On the phone, not in a table')}</h3>
+        </div>
+        <span className="campaign-preview-live">{t('Živý náhled', 'Live preview')}</span>
+      </div>
+
+      <div className="campaign-preview-stage">
+        <div className="campaign-phone" aria-label={t('Náhled mobilní aplikace', 'Mobile app preview')}>
+          <div className="campaign-phone-island" />
+          <div className="campaign-phone-content">
+            <div className="campaign-phone-topline">
+              <span>openbank</span>
+              <span>•••</span>
+            </div>
+            <p className="campaign-phone-eyebrow">{language === 'cs' ? copy.eyebrowCs : copy.eyebrowEn}</p>
+            <h4>{language === 'cs' ? copy.cs : copy.en}</h4>
+            <div className="campaign-phone-hero">
+              <span>{t('Doporučeno pro vás', 'Recommended for you')}</span>
+              <strong>{headline}</strong>
+              <button type="button" tabIndex={-1}>{t('Zjistit víc', 'Explore')}</button>
+            </div>
+            <div className="campaign-phone-row"><span /><span /><span /></div>
+          </div>
+        </div>
+
+        <div className="campaign-push-card" data-preview-channel={isPush ? 'PUSH' : 'EMAIL'}>
+          <div className="campaign-push-icon">o</div>
+          <div>
+            <div className="campaign-push-meta">OPENBANK · {t('nyní', 'now')}</div>
+            <p className="campaign-push-title">{isPush ? headline : t('Zvolte push krok', 'Choose a push step')}</p>
+            <p>{isPush
+              ? t('Otevře zabezpečenou aplikaci — bez osobního obsahu v notifikaci.', 'Opens the secure app — with no personal content in the notification.')
+              : t('Tento krok je e-mail. Vyberte push krok na cestě pro náhled notifikace.', 'This step is email. Select a push step on the journey to preview the notification.')}</p>
+          </div>
+        </div>
+      </div>
+
+      <div className="campaign-preview-route">
+        <span>{t('Po klepnutí', 'After tap')}</span>
+        <strong>{campaignLabel} → {language === 'cs' ? copy.cs : copy.en}</strong>
+        <code>{`openbank://${destination.toLowerCase().replace('product_hub', 'products')}`}</code>
+      </div>
+    </section>
+  )
+}

--- a/openbank-admin-ui/src/components/campaigns/CampaignLaunchReadiness.tsx
+++ b/openbank-admin-ui/src/components/campaigns/CampaignLaunchReadiness.tsx
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+'use client'
+
+import { useLanguage } from '@/lib/i18n/LanguageContext'
+import type { EditorStep } from '@/components/campaigns/JourneyEditor'
+
+type ReadinessState = 'ready' | 'attention' | 'waiting'
+
+interface ReadinessItem {
+  id: string
+  state: ReadinessState
+  label: string
+  detail: string
+}
+
+/**
+ * Turns platform constraints into a launch conversation at the point of authoring.
+ *
+ * A disabled Create button is technically correct but tells a marketer neither what is missing nor
+ * whether a policy will still change the reachable audience. This list has no hidden validation:
+ * every item is derived from the same state sent to campaign-service, and policy remains explicitly
+ * read-only rather than offering a fake override.
+ */
+export function CampaignLaunchReadiness({
+  audienceChosen,
+  audienceSize,
+  entryConfigured,
+  incomplete,
+  conversionRule,
+  contentExperiment,
+  steps,
+}: {
+  audienceChosen: boolean
+  audienceSize: number | null
+  entryConfigured: boolean
+  incomplete: boolean
+  conversionRule: string | null
+  contentExperiment: boolean
+  steps: EditorStep[]
+}) {
+  const { t, language } = useLanguage()
+  const n = (value: number) => value.toLocaleString(language === 'cs' ? 'cs-CZ' : 'en-GB')
+  const push = steps.find(step => step.channel === 'PUSH')
+  const readyCount = [audienceChosen, entryConfigured, !incomplete, !contentExperiment || conversionRule !== null].filter(Boolean).length
+
+  const items: ReadinessItem[] = [
+    audienceChosen
+      ? {
+          id: 'audience', state: audienceSize === null ? 'attention' : 'ready',
+          label: t('Publikum je vybrané', 'Audience is selected'),
+          detail: audienceSize === null
+            ? t('Dosah se ještě dopočítává.', 'Reach is still being calculated.')
+            : t(`Před kontrolou souhlasu: přibližně ${n(audienceSize)} lidí.`, `Before consent checks: roughly ${n(audienceSize)} people.`),
+        }
+      : { id: 'audience', state: 'waiting', label: t('Vyberte publikum', 'Choose an audience'), detail: t('Segment určí, kdo může do cesty vstoupit.', 'A segment decides who may enter the journey.') },
+    entryConfigured
+      ? { id: 'entry', state: 'ready', label: t('Vstup do cesty je jasný', 'Journey entry is clear'), detail: t('Každý vstup je dohledatelný a přezkoumatelný.', 'Every entry is traceable and reviewable.') }
+      : { id: 'entry', state: 'waiting', label: t('Vyberte, kdy cesta začne', 'Choose when the journey starts'), detail: t('Jednorázově, opakovaně nebo po události.', 'One time, recurring, or after an event.') },
+    incomplete
+      ? { id: 'content', state: 'waiting', label: t('Doplňte obsah kroku', 'Complete step content'), detail: t('Každý krok potřebuje všechny hodnoty své schválené šablony.', 'Every step needs all values from its approved template.') }
+      : { id: 'content', state: 'ready', label: t('Cesta má kompletní obsah', 'Journey content is complete'), detail: t(`${steps.length} ${steps.length === 1 ? 'krok je' : 'kroky jsou'} připravené ke kontrole.`, `${steps.length} ${steps.length === 1 ? 'step is' : 'steps are'} ready for review.`) },
+    contentExperiment && conversionRule === null
+      ? { id: 'measurement', state: 'waiting', label: t('Experiment potřebuje měřitelný cíl', 'Experiment needs a measurable goal'), detail: t('Bez skutečné bankovní konverze by A/B srovnání nemělo výsledek.', 'Without a real banking conversion, A/B comparison has no outcome.') }
+      : conversionRule
+        ? { id: 'measurement', state: 'ready', label: t('Výsledek je měřitelný', 'Outcome is measurable'), detail: t('Měříme bankovní událost, ne domnělý proklik.', 'This measures a banking event, not an assumed click.') }
+        : { id: 'measurement', state: 'attention', label: t('Kampaň neměří výsledek', 'Campaign does not measure an outcome'), detail: t('Můžete pokračovat, ale po spuštění nepůjde porovnat skutečný dopad.', 'You can continue, but the actual outcome cannot be compared after launch.') },
+    push
+      ? { id: 'destination', state: 'ready', label: t('Push má bezpečný cíl v aplikaci', 'Push has a safe in-app destination'), detail: t('Jen schválený deep link; žádná URL z kampaně.', 'An approved deep link only; no campaign-entered URL.') }
+      : { id: 'destination', state: 'attention', label: t('Cesta zatím nemá push krok', 'Journey has no push step yet'), detail: t('Přidejte ho, pokud má kampaň přivést lidi zpět do aplikace.', 'Add one if the campaign should bring people back into the app.') },
+    { id: 'policy', state: 'ready', label: t('Ochrana kontaktu zůstává zapnutá', 'Contact protection stays on'), detail: t('Souhlas, tiché hodiny a frekvenční limit se ověřují při doručení.', 'Consent, quiet hours and frequency limits are checked at delivery.') },
+  ]
+
+  return (
+    <section className="campaign-launch-readiness" aria-labelledby="launch-readiness-title" data-testid="campaign-launch-readiness">
+      <div className="campaign-readiness-heading">
+        <div>
+          <p className="campaign-preview-kicker">{t('Před spuštěním', 'Before launch')}</p>
+          <h3 id="launch-readiness-title">{t('Připraveno na kontrolu?', 'Ready for review?')}</h3>
+        </div>
+        <strong>{readyCount}/4</strong>
+      </div>
+      <p className="campaign-readiness-intro">
+        {t('Jeden pohled na to, co lidé uvidí a co může změnit skutečný dosah.', 'One view of what people see and what can change actual reach.')}
+      </p>
+      <ul className="campaign-readiness-list">
+        {items.map(item => (
+          <li key={item.id} data-readiness={item.id} data-state={item.state}>
+            <span aria-hidden="true">{item.state === 'ready' ? '✓' : item.state === 'attention' ? '!' : '·'}</span>
+            <div><strong>{item.label}</strong><p>{item.detail}</p></div>
+          </li>
+        ))}
+      </ul>
+    </section>
+  )
+}

--- a/openbank-admin-ui/src/test/campaign-experience-preview.test.tsx
+++ b/openbank-admin-ui/src/test/campaign-experience-preview.test.tsx
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import React from 'react'
+import { describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { LanguageProvider } from '@/lib/i18n/LanguageContext'
+import { CampaignExperiencePreview } from '@/components/campaigns/CampaignExperiencePreview'
+import { CampaignLaunchReadiness } from '@/components/campaigns/CampaignLaunchReadiness'
+import type { EditorStep } from '@/components/campaigns/JourneyEditor'
+
+const push: EditorStep = {
+  channel: 'PUSH',
+  template: 'MARKETING_PRODUCT_OFFER_PUSH',
+  variables: { offerTitle: 'Savings at 4%' },
+  delaySeconds: 0,
+  mobileDestination: 'SAVINGS',
+}
+
+describe('campaign customer experience preview', () => {
+  it('renders a push with its selected closed app destination', () => {
+    const { container } = render(
+      <LanguageProvider><CampaignExperiencePreview step={push} campaignName="Summer saving" /></LanguageProvider>,
+    )
+
+    // The headline intentionally appears in the notification and again in the authenticated app
+    // destination. One occurrence would test only half of the customer sequence.
+    expect(screen.getAllByText('Savings at 4%')).toHaveLength(2)
+    expect(screen.getByText(/Summer saving → Savings/)).toBeTruthy()
+    expect(container.querySelector('[data-preview-channel="PUSH"]')).toBeTruthy()
+    expect(screen.getByText('openbank://savings')).toBeTruthy()
+  })
+
+  it('does not pretend an email is a push notification', () => {
+    const { container } = render(
+      <LanguageProvider><CampaignExperiencePreview step={{ ...push, channel: 'EMAIL', mobileDestination: undefined }} campaignName="" /></LanguageProvider>,
+    )
+
+    expect(container.querySelector('[data-preview-channel="EMAIL"]')).toBeTruthy()
+    expect(screen.getByText(/Choose a push step/)).toBeTruthy()
+  })
+})
+
+describe('campaign launch readiness', () => {
+  it('names missing inputs and preserves policy as a non-optional guardrail', () => {
+    const { container } = render(
+      <LanguageProvider>
+        <CampaignLaunchReadiness
+          audienceChosen={false}
+          audienceSize={null}
+          entryConfigured={false}
+          incomplete
+          conversionRule={null}
+          contentExperiment={false}
+          steps={[{ ...push, channel: 'EMAIL', mobileDestination: undefined }]}
+        />
+      </LanguageProvider>,
+    )
+
+    expect(container.querySelector('[data-readiness="audience"][data-state="waiting"]')).toBeTruthy()
+    expect(container.querySelector('[data-readiness="content"][data-state="waiting"]')).toBeTruthy()
+    expect(container.querySelector('[data-readiness="policy"][data-state="ready"]')).toBeTruthy()
+    expect(screen.getByText(/Journey has no push step/)).toBeTruthy()
+  })
+})


### PR DESCRIPTION
## What changed

- Adds a phone-first customer-experience preview beside the campaign journey canvas.
- Shows the actual sequence marketers need to reason about: push notification, authenticated app, and the chosen closed deep-link destination.
- Adds a launch-readiness panel that turns audience reach, content completeness, entry mode, measurement, push destination and contact policy into clear next actions.
- Adds focused UX contract tests for the preview and readiness states.

## Why

Campaign Studio already had a constrained journey canvas, but it still made marketers mentally translate engine fields into the experience a customer receives. The new companion surfaces make the campaign's customer journey and launch constraints understandable at a glance without inventing unsupported app capabilities or bypassing consent policy.

## Impact

Marketing users can design with a mobile outcome in view and see what must be completed before a campaign is ready for review. The preview is deliberately tied to the closed `openbank://` contract: it never accepts arbitrary external destinations or claims that Admin UI owns the native app.

## Validation

- `npm run type-check`
- `node ./node_modules/vitest/vitest.mjs run src/test/campaign-experience-preview.test.tsx src/test/campaign-builder-interaction.test.tsx src/test/journey-editor.test.tsx` (20 tests)
- Targeted ESLint check for changed Campaign Studio files
- `npm run lint` (passes; pre-existing repository warnings only)
- `git diff --check`

Refs #4476
