### PR TITLE
feat(admin-ui): add campaign portfolio decision desk

### DIFF
--- a/openbank-admin-ui/src/app/campaigns/page.tsx
+++ b/openbank-admin-ui/src/app/campaigns/page.tsx
@@ -15,11 +15,10 @@
 // language on one console would be worse than either (see components/flow/StageBoard).
 //
 // WHAT THIS PAGE HONESTLY CANNOT SHOW
-// Reach, delivery and conversion — the numbers a CDP screen is really about. `GET /api/v1/campaigns`
-// returns campaign records only; enrolments and sends are per-campaign endpoints, so a performance
-// overview here would mean one request per campaign or an API that does not exist yet. Inventing
-// the numbers, or quietly implying the page covers performance, would be worse than saying so — the
-// board carries that sentence rather than hiding it in a doc.
+// The optional summary endpoint supplies only enrolment and delivery. It does not supply in-app
+// engagement or a business conversion, so this page calls the aggregate a *delivery pulse*, never
+// performance. Inventing the rest of a CDP funnel would be worse than saying exactly where evidence
+// ends; the detail still owns the event-level journey.
 //
 // Read-only by design (#2895). Authoring is ADR-0221: `submit` → `activate`-by-a-DIFFERENT-approver
 // is a two-people-at-a-screen flow, and exposing half of it as buttons would lose the point of the
@@ -67,6 +66,16 @@ const LIFECYCLE: { key: string; cs: string; en: string; terminal?: boolean }[] =
   { key: 'PAUSED', cs: 'Pozastavená', en: 'Paused' },
   { key: 'CLOSED', cs: 'Ukončená', en: 'Closed', terminal: true },
 ]
+
+/** A marketing landing page should surface the next decision, not merely count lifecycle states.
+ *  This is a display priority only — it never changes the campaign state machine. */
+const DECISION_PRIORITY: Record<string, number> = {
+  PENDING_APPROVAL: 0,
+  PAUSED: 1,
+  DRAFT: 2,
+  ACTIVE: 3,
+  CLOSED: 9,
+}
 
 export default function CampaignsPage() {
   const { t, language } = useLanguage()
@@ -122,12 +131,42 @@ export default function CampaignsPage() {
 
   const counts = (k: string) => stats.get(k)?.count ?? 0
 
+  const decisionQueue = useMemo(
+    () => [...items]
+      .filter(c => c.state !== 'CLOSED')
+      .sort((a, b) => {
+        const priority = (DECISION_PRIORITY[a.state] ?? 8) - (DECISION_PRIORITY[b.state] ?? 8)
+        return priority !== 0 ? priority : Date.parse(a.createdAt) - Date.parse(b.createdAt)
+      })
+      .slice(0, 3),
+    [items],
+  )
+
+  const deliveryPulse = useMemo(() => {
+    if (!summary) return null
+    return Object.values(summary).reduce(
+      (total, item) => ({
+        enrolled: total.enrolled + item.enrolled,
+        sent: total.sent + item.sent,
+        suppressed: total.suppressed + item.suppressed,
+      }),
+      { enrolled: 0, sent: 0, suppressed: 0 },
+    )
+  }, [summary])
+
   const needle = search.trim().toLowerCase()
   const filtered = items.filter(
     c =>
       (!stateFilter || c.state === stateFilter) &&
       (!needle || c.name.toLowerCase().includes(needle) || (c.goal ?? '').toLowerCase().includes(needle)),
   )
+
+  const nextAction = (campaign: Campaign) => {
+    if (campaign.state === 'PENDING_APPROVAL') return t('Čeká na druhé oči', 'Needs a second pair of eyes')
+    if (campaign.state === 'PAUSED') return t('Rozhodněte o pokračování', 'Decide whether to resume')
+    if (campaign.state === 'DRAFT') return t('Dokončete zadání', 'Finish the brief')
+    return t('Sledujte živou cestu', 'Follow the live journey')
+  }
 
   return (
     <div className="space-y-6">
@@ -168,6 +207,54 @@ export default function CampaignsPage() {
             <StatCard label={t('Pozastavené', 'Paused')} value={counts('PAUSED')}
                       tone={counts('PAUSED') > 0 ? 'warning' : undefined} icon={<PauseCircle size={13} />} />
           </div>
+
+          <section className="campaign-decision-desk" aria-label={t('Dnešní priority kampaní', 'Today’s campaign priorities')} data-testid="campaign-decision-desk">
+            <div className="campaign-decision-queue">
+              <div className="campaign-desk-heading">
+                <div>
+                  <p>{t('Dnešní fokus', 'Today’s focus')}</p>
+                  <h2>{t('Co posune kampaně dál', 'What moves campaigns forward')}</h2>
+                </div>
+                <span>{decisionQueue.length}</span>
+              </div>
+              {decisionQueue.length > 0 ? (
+                <div className="campaign-decision-items">
+                  {decisionQueue.map((campaign, index) => (
+                    <Link key={campaign.id} href={`/campaigns/${campaign.id}`} className="campaign-decision-item" data-decision-campaign={campaign.id}>
+                      <span className="campaign-decision-rank">0{index + 1}</span>
+                      <span className="campaign-decision-copy">
+                        <strong>{campaign.name}</strong>
+                        <small>{nextAction(campaign)}</small>
+                      </span>
+                      <StatusBadge status={campaign.state} label={label(campaign.state)} />
+                    </Link>
+                  ))}
+                </div>
+              ) : (
+                <p className="campaign-decision-empty">{t('Nic nečeká. Můžete připravit další nápad.', 'Nothing is waiting. You can prepare the next idea.')}</p>
+              )}
+            </div>
+
+            <div className="campaign-delivery-pulse" data-testid="campaign-delivery-pulse">
+              <div className="campaign-desk-heading">
+                <div>
+                  <p>{t('Doručení', 'Delivery')}</p>
+                  <h2>{t('Pulse portfolia', 'Portfolio pulse')}</h2>
+                </div>
+                <span className={deliveryPulse ? 'campaign-pulse-live' : 'campaign-pulse-muted'}>{deliveryPulse ? t('Živě', 'Live') : t('Čeká na data', 'Waiting for data')}</span>
+              </div>
+              {deliveryPulse ? (
+                <div className="campaign-pulse-numbers">
+                  <div><strong>{deliveryPulse.enrolled.toLocaleString(language === 'cs' ? 'cs-CZ' : 'en-GB')}</strong><span>{t('zařazeno', 'enrolled')}</span></div>
+                  <div><strong>{deliveryPulse.sent.toLocaleString(language === 'cs' ? 'cs-CZ' : 'en-GB')}</strong><span>{t('odesláno', 'sent')}</span></div>
+                  <div><strong>{deliveryPulse.suppressed.toLocaleString(language === 'cs' ? 'cs-CZ' : 'en-GB')}</strong><span>{t('potlačeno', 'suppressed')}</span></div>
+                </div>
+              ) : (
+                <p className="campaign-pulse-empty">{t('Nasazená služba zatím neposílá souhrn doručení. Nuly by byly zavádějící.', 'The deployed service does not yet return a delivery aggregate. Zeros would mislead.')}</p>
+              )}
+              <p className="campaign-pulse-footnote">{t('Nejde o konverzi ani engagement — tyto signály zatím v přehledu nemáme.', 'This is not conversion or engagement — those signals are not in this overview yet.')}</p>
+            </div>
+          </section>
 
           <StageBoard
             stages={stages}

--- a/openbank-admin-ui/src/app/globals.css
+++ b/openbank-admin-ui/src/app/globals.css
@@ -353,6 +353,32 @@ main {
 .campaign-readiness-list [data-state='waiting'] > span { background: var(--surface-4); color: var(--text-secondary); }
 @media (max-width: 960px) { .campaign-studio-companion-grid { grid-template-columns: 1fr; } }
 @media (max-width: 450px) { .campaign-preview-stage { gap: 0.4rem; } .campaign-phone { transform: scale(.9); transform-origin: left center; margin-right: -0.75rem; } .campaign-push-card { transform: rotate(-2deg) scale(.9); transform-origin: left center; } }
+
+/* ── Campaign portfolio decision desk ── */
+.campaign-decision-desk { display: grid; grid-template-columns: minmax(0, 1.18fr) minmax(17rem, .82fr); gap: 1rem; }
+.campaign-decision-queue, .campaign-delivery-pulse { border: 1px solid var(--border); border-radius: var(--r-xl); overflow: hidden; padding: 1.1rem; }
+.campaign-decision-queue { background: linear-gradient(135deg, #f5f3ff, var(--surface) 58%); }
+.campaign-delivery-pulse { background: var(--surface); }
+.campaign-desk-heading { align-items: flex-start; display: flex; justify-content: space-between; gap: .75rem; }
+.campaign-desk-heading p { color: var(--ob-accent-text); font-size: .66rem; font-weight: 800; letter-spacing: .09em; text-transform: uppercase; }
+.campaign-desk-heading h2 { font-size: 1rem; font-weight: 750; margin-top: .16rem; }
+.campaign-desk-heading > span { align-items: center; background: var(--ob-accent); border-radius: 99px; color: #fff; display: inline-flex; font-size: .7rem; font-weight: 800; height: 1.8rem; justify-content: center; min-width: 1.8rem; padding: 0 .52rem; }
+.campaign-decision-items { display: grid; gap: .48rem; margin-top: .9rem; }
+.campaign-decision-item { align-items: center; background: rgba(255,255,255,.78); border: 1px solid rgba(199,210,254,.65); border-radius: .75rem; color: inherit; display: flex; gap: .7rem; padding: .62rem .7rem; text-decoration: none; transition: transform .16s ease, box-shadow .16s ease; }
+.campaign-decision-item:hover { box-shadow: var(--shadow-md); transform: translateX(2px); }
+.campaign-decision-rank { color: var(--ob-accent-text); font-family: var(--font-mono); font-size: .64rem; font-weight: 700; }
+.campaign-decision-copy { display: grid; flex: 1; min-width: 0; }
+.campaign-decision-copy strong { font-size: .78rem; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.campaign-decision-copy small { color: var(--text-secondary); font-size: .67rem; margin-top: .12rem; }
+.campaign-decision-empty, .campaign-pulse-empty { color: var(--text-secondary); font-size: .74rem; line-height: 1.45; margin-top: .9rem; }
+.campaign-pulse-live { background: var(--success-bg) !important; color: var(--success-text) !important; }
+.campaign-pulse-muted { background: var(--surface-3) !important; color: var(--text-secondary) !important; }
+.campaign-pulse-numbers { display: grid; gap: .45rem; grid-template-columns: repeat(3, 1fr); margin-top: 1.02rem; }
+.campaign-pulse-numbers div { background: var(--surface-2); border-radius: .66rem; padding: .6rem; }
+.campaign-pulse-numbers strong { display: block; font-size: .95rem; font-variant-numeric: tabular-nums; }
+.campaign-pulse-numbers span { color: var(--text-secondary); display: block; font-size: .61rem; margin-top: .1rem; }
+.campaign-pulse-footnote { color: var(--text-secondary); font-size: .64rem; line-height: 1.35; margin-top: .85rem; }
+@media (max-width: 900px) { .campaign-decision-desk { grid-template-columns: 1fr; } }
 /* Stat-card internals (ADR-0208 D1). `.stat-card` only ever styled the container, so every page
    hand-rolled the label/value typography inline — including colour values derived from a literal
    (`background: ${k.color}18`), which is the duplication D2 exists to remove. These three classes

--- a/openbank-admin-ui/src/test/campaigns-console-board.test.tsx
+++ b/openbank-admin-ui/src/test/campaigns-console-board.test.tsx
@@ -81,12 +81,12 @@ describe('campaigns console', () => {
     campaign('CLOSED', 900, 4),
   ]
 
-  function mockFetch(items = ITEMS, state = 'ok') {
+  function mockFetch(items = ITEMS, state = 'ok', summary?: unknown[]) {
     return vi.fn(async (input: RequestInfo | URL) => {
       const url = String(input)
       const json = (b: unknown) => new Response(JSON.stringify(b), { status: 200, headers: { 'content-type': 'application/json' } })
       if (url.includes('/api/auth/session')) return new Response('null', { status: 200, headers: { 'content-type': 'application/json' } })
-      if (url.includes('/api/campaigns')) return json({ items, state })
+      if (url.includes('/api/campaigns')) return json({ items, state, ...(summary ? { summary } : {}) })
       return json({})
     })
   }
@@ -132,8 +132,28 @@ describe('campaigns console', () => {
     fireEvent.click(screen.getByTestId('stage-ACTIVE'))
 
     await waitFor(() => expect(screen.getByTestId('clear-state')).toBeTruthy())
-    expect(screen.queryByText('Campaign DRAFT 1')).toBeNull()
-    expect(screen.getByText('Campaign ACTIVE 3')).toBeTruthy()
+    // The decision desk deliberately keeps the most important next action visible above the
+    // filtered inventory. The assertion belongs to the table, which is the surface the stage filter
+    // controls; a global text query would now reject the useful priority card as though it were a
+    // leaked table row.
+    const table = document.querySelector('table')!
+    expect(table.textContent).not.toContain('Campaign DRAFT 1')
+    expect(table.textContent).toContain('Campaign ACTIVE 3')
+  })
+
+  it('puts the next marketing decisions first and names delivery evidence without inventing conversion', async () => {
+    vi.stubGlobal('fetch', mockFetch(ITEMS, 'ok', [{
+      campaignId: 'ACTIVE-3', enrolled: 1240, sent: 1110, suppressed: 96, failed: 34,
+    }]))
+    render(React.createElement(Providers, null, React.createElement(CampaignsPage)))
+
+    await waitFor(() => expect(screen.getByTestId('campaign-decision-desk')).toBeTruthy())
+    const decisions = Array.from(document.querySelectorAll('[data-decision-campaign]'))
+      .map(node => node.getAttribute('data-decision-campaign'))
+    // Approval is a more urgent human decision than an unfinished draft or a live campaign.
+    expect(decisions[0]).toBe('PENDING_APPROVAL-2')
+    expect(screen.getByTestId('campaign-delivery-pulse').textContent).toMatch(/1,240|1 240/)
+    expect(screen.getByTestId('campaign-delivery-pulse').textContent).toMatch(/not conversion or engagement/)
   })
 
 })


### PR DESCRIPTION
## What changed

- Adds a marketer-focused decision desk to the Campaign portfolio landing page.
- Prioritises the next three human decisions: pending approval, paused campaigns, drafts, then active journeys.
- Adds a transparent portfolio delivery pulse using only the optional aggregate the service actually returns: enrolled, sent and suppressed.
- Keeps the lifecycle board and filter semantics intact; filtering the inventory does not hide the separate decision desk.

## Why

An inventory table makes a marketer search for work. The new desk answers the immediate question: what needs my attention today? It makes priorities visible without inventing conversion or engagement data that the Campaign API does not expose.

## Validation

- `npm run type-check`
- `node ./node_modules/vitest/vitest.mjs run src/test/campaigns-console-board.test.tsx src/test/campaign-experience-preview.test.tsx src/test/campaign-builder-interaction.test.tsx src/test/journey-editor.test.tsx` (28 tests)
- Targeted ESLint for changed files
- `git diff --check`

Refs #4476
