### PR TITLE
feat(admin-ui): add campaign outcome brief

### DIFF
--- a/openbank-admin-ui/src/app/campaigns/[id]/page.tsx
+++ b/openbank-admin-ui/src/app/campaigns/[id]/page.tsx
@@ -13,6 +13,7 @@ import { PageHeader, StatCard, StatusBadge, type Tone } from '@/components/ui'
 import { JourneyCanvas, type StepFunnel } from '@/components/campaigns/JourneyCanvas'
 import { SectionBoundary } from '@/components/feedback/SectionBoundary'
 import { PeopleSummary } from '@/components/campaigns/PeopleSummary'
+import { CampaignOutcomeBrief } from '@/components/campaigns/CampaignOutcomeBrief'
 
 interface Campaign {
   id: string
@@ -419,6 +420,35 @@ export default function CampaignDetailPage({ params }: { params: Promise<{ id: s
     Object.entries(summary).filter(([outcome, count]) => outcome.startsWith('SUPPRESSED') && count > 0),
   )
 
+  const campaignNextAction = () => {
+    if (!c) return { title: '', detail: '' }
+    if (c.state === 'DRAFT') return {
+      title: t('Dokončete zadání', 'Finish the brief'),
+      detail: t('Pak ho předejte k nezávislému schválení.', 'Then submit it for independent approval.'),
+    }
+    if (c.state === 'PENDING_APPROVAL') return {
+      title: t('Vyžádejte druhé oči', 'Ask for a second pair of eyes'),
+      detail: t('Autor ji nemůže sám aktivovat.', 'The author cannot activate it alone.'),
+    }
+    if (c.state === 'PAUSED') return {
+      title: t('Rozhodněte o pokračování', 'Decide whether to resume'),
+      detail: t('Zkontrolujte cestu a teprve pak změňte stav.', 'Review the journey before changing its state.'),
+    }
+    if ((summary.FAILED ?? 0) > 0) return {
+      title: t('Prověřte neúspěšná předání', 'Review failed handoffs'),
+      detail: t('Použijte detailní log níže; potlačení pravidlem není chyba.', 'Use the detailed log below; policy suppression is not an error.'),
+    }
+    if (!c.conversionRule) return {
+      title: t('Zvažte měřitelný cíl', 'Consider a measurable outcome'),
+      detail: t('Bez něj uvidíte průchod, ale ne skutečný obchodní výsledek.', 'Without one you see flow, but not the real business outcome.'),
+    }
+    return {
+      title: t('Sledujte průchod a výsledek', 'Follow the journey and outcome'),
+      detail: t('Doručení, potlačení a konverze jsou níže oddělené, aby se nezaměnily.', 'Delivery, suppression and conversion remain separate below so they cannot be confused.'),
+    }
+  }
+  const nextAction = campaignNextAction()
+
   return (
     <div className="space-y-6">
       <Link href="/campaigns" className="inline-flex items-center gap-1 text-sm hover:underline">
@@ -468,14 +498,16 @@ export default function CampaignDetailPage({ params }: { params: Promise<{ id: s
 
       {!loading && !unavailable && c && (
         <>
-          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
-            <StatCard label={t('Stav', 'State')} value={c.state} />
-            <StatCard label={t('Segment', 'Segment')} value={`${c.segmentRef?.name}@${c.segmentRef?.version}`} />
-            <StatCard label={t('Zařazeno', 'Enrolled')} value={String(detail?.enrolments.length ?? 0)} />
-            {/* Surfaced as a headline number on purpose: "how many were deliberately not
-                contacted" is the question the send log exists to answer (#2895). */}
-            <StatCard label={t('Potlačených odeslání', 'Suppressed sends')} value={String(suppressed)} />
-          </div>
+          <CampaignOutcomeBrief
+            state={c.state}
+            audience={detail?.enrolments.length ?? 0}
+            handedOff={summary.SENT ?? 0}
+            suppressed={suppressed}
+            conversion={c.conversionRule ? (summary.CONVERTED ?? 0) : null}
+            conversionLabel={c.conversionRule ? conversionLabel(c.conversionRule) : t('Cíl není měřen', 'Outcome is not measured')}
+            nextAction={nextAction.title}
+            nextActionDetail={nextAction.detail}
+          />
 
           <section className="rounded-lg border p-3 text-sm" data-campaign-entry>
             <h2 className="font-semibold">{t('Vstup do cesty', 'Journey entry')}</h2>

--- a/openbank-admin-ui/src/app/globals.css
+++ b/openbank-admin-ui/src/app/globals.css
@@ -379,6 +379,26 @@ main {
 .campaign-pulse-numbers span { color: var(--text-secondary); display: block; font-size: .61rem; margin-top: .1rem; }
 .campaign-pulse-footnote { color: var(--text-secondary); font-size: .64rem; line-height: 1.35; margin-top: .85rem; }
 @media (max-width: 900px) { .campaign-decision-desk { grid-template-columns: 1fr; } }
+
+/* ── Campaign outcome brief ── */
+.campaign-outcome-brief { background: linear-gradient(110deg, #111827 0%, #172554 56%, #312e81 100%); border-radius: var(--r-xl); box-shadow: var(--shadow-lg); color: #fff; display: grid; grid-template-columns: minmax(0, 1fr) minmax(13.5rem, .32fr); overflow: hidden; }
+.campaign-outcome-main { padding: 1.25rem; }
+.campaign-outcome-title-row { align-items: center; display: flex; gap: .75rem; justify-content: space-between; margin-top: .2rem; }
+.campaign-outcome-title-row h2 { font-size: 1.05rem; font-weight: 750; }
+.campaign-outcome-title-row span { background: rgba(255,255,255,.13); border: 1px solid rgba(255,255,255,.18); border-radius: 99px; font-size: .62rem; font-weight: 800; padding: .28rem .55rem; }
+.campaign-outcome-metrics { display: grid; gap: .5rem; grid-template-columns: repeat(4, minmax(0, 1fr)); margin-top: 1rem; }
+.campaign-outcome-metrics > div { background: rgba(255,255,255,.08); border: 1px solid rgba(255,255,255,.1); border-radius: .7rem; min-width: 0; padding: .58rem; }
+.campaign-outcome-metrics strong { display: block; font-size: 1.02rem; font-variant-numeric: tabular-nums; }
+.campaign-outcome-metrics span { display: block; font-size: .67rem; font-weight: 700; margin-top: .12rem; }
+.campaign-outcome-metrics small { color: rgba(255,255,255,.65); display: block; font-size: .58rem; line-height: 1.2; margin-top: .08rem; }
+.campaign-outcome-conversion[data-conversion='unmeasured'] { background: rgba(255,255,255,.035); }
+.campaign-outcome-evidence { color: rgba(255,255,255,.64); font-size: .64rem; line-height: 1.35; margin-top: .72rem; }
+.campaign-outcome-action { background: rgba(255,255,255,.1); border-left: 1px solid rgba(255,255,255,.12); display: flex; flex-direction: column; justify-content: center; padding: 1.25rem; }
+.campaign-outcome-action p { color: #c7d2fe; font-size: .65rem; font-weight: 800; letter-spacing: .08em; text-transform: uppercase; }
+.campaign-outcome-action strong { font-size: .92rem; line-height: 1.25; margin-top: .32rem; }
+.campaign-outcome-action span { color: rgba(255,255,255,.72); font-size: .7rem; line-height: 1.4; margin-top: .38rem; }
+@media (max-width: 840px) { .campaign-outcome-brief { grid-template-columns: 1fr; } .campaign-outcome-action { border-left: 0; border-top: 1px solid rgba(255,255,255,.12); } }
+@media (max-width: 560px) { .campaign-outcome-metrics { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
 /* Stat-card internals (ADR-0208 D1). `.stat-card` only ever styled the container, so every page
    hand-rolled the label/value typography inline — including colour values derived from a literal
    (`background: ${k.color}18`), which is the duplication D2 exists to remove. These three classes

--- a/openbank-admin-ui/src/components/campaigns/CampaignOutcomeBrief.tsx
+++ b/openbank-admin-ui/src/components/campaigns/CampaignOutcomeBrief.tsx
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+'use client'
+
+import { useLanguage } from '@/lib/i18n/LanguageContext'
+
+/**
+ * The campaign detail's decision layer.
+ *
+ * This uses the campaign service's whole-campaign aggregates, never the visible page of send rows.
+ * "Handed off" is intentionally not called delivered: Campaign-service knows it accepted a send
+ * request, while notification-service owns the later delivery confirmation. The distinction is
+ * critical on a marketing screen because a successful-looking number otherwise becomes a promise
+ * about a customer's device.
+ */
+export function CampaignOutcomeBrief({
+  state,
+  audience,
+  handedOff,
+  suppressed,
+  conversion,
+  conversionLabel,
+  nextAction,
+  nextActionDetail,
+}: {
+  state: string
+  audience: number
+  handedOff: number
+  suppressed: number
+  /** Null means the campaign is not configured to measure an outcome. */
+  conversion: number | null
+  conversionLabel?: string
+  nextAction: string
+  nextActionDetail: string
+}) {
+  const { t, language } = useLanguage()
+  const metrics = [
+    { label: t('Publikum', 'Audience'), value: audience, detail: t('zařazeno', 'enrolled') },
+    { label: t('Předáno', 'Handed off'), value: handedOff, detail: t('notification službě', 'to notification service') },
+    { label: t('Chráněno', 'Protected'), value: suppressed, detail: t('potlačeno pravidlem', 'suppressed by policy') },
+  ]
+
+  return (
+    <section className="campaign-outcome-brief" aria-labelledby="campaign-outcome-title" data-testid="campaign-outcome-brief">
+      <div className="campaign-outcome-main">
+        <p className="campaign-preview-kicker">{t('Pulse kampaně', 'Campaign pulse')}</p>
+        <div className="campaign-outcome-title-row">
+          <h2 id="campaign-outcome-title">{t('Další rozhodnutí opřete o data', 'Make the next decision with evidence')}</h2>
+          <span data-campaign-state={state}>{state}</span>
+        </div>
+        <div className="campaign-outcome-metrics">
+          {metrics.map(metric => (
+            <div key={metric.label}>
+              <strong>{metric.value.toLocaleString(language === 'cs' ? 'cs-CZ' : 'en-GB')}</strong>
+              <span>{metric.label}</span>
+              <small>{metric.detail}</small>
+            </div>
+          ))}
+          <div className="campaign-outcome-conversion" data-conversion={conversion === null ? 'unmeasured' : 'measured'}>
+            <strong>{conversion === null ? '—' : conversion.toLocaleString(language === 'cs' ? 'cs-CZ' : 'en-GB')}</strong>
+            <span>{conversionLabel ?? t('Výsledek', 'Outcome')}</span>
+            <small>{conversion === null ? t('neměřeno', 'not measured') : t('během zařazení', 'while enrolled')}</small>
+          </div>
+        </div>
+        <p className="campaign-outcome-evidence">{t('Jen provoz kampaně — in-app engagement se této kampani zatím nepřipisuje.', 'Campaign operations only — no in-app engagement is attributed to this campaign yet.')}</p>
+      </div>
+      <aside className="campaign-outcome-action" data-testid="campaign-outcome-next-action">
+        <p>{t('Další nejlepší akce', 'Next best action')}</p>
+        <strong>{nextAction}</strong>
+        <span>{nextActionDetail}</span>
+      </aside>
+    </section>
+  )
+}

--- a/openbank-admin-ui/src/test/campaign-outcome-brief.test.tsx
+++ b/openbank-admin-ui/src/test/campaign-outcome-brief.test.tsx
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import React from 'react'
+import { describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { CampaignOutcomeBrief } from '@/components/campaigns/CampaignOutcomeBrief'
+import { LanguageProvider } from '@/lib/i18n/LanguageContext'
+
+describe('campaign outcome brief', () => {
+  it('distinguishes handed-off sends from a measured outcome', () => {
+    render(
+      <LanguageProvider><CampaignOutcomeBrief
+          state="ACTIVE"
+          audience={1240}
+          handedOff={1110}
+          suppressed={96}
+          conversion={48}
+          conversionLabel="Account opened"
+          nextAction="Follow the journey and outcome"
+          nextActionDetail="Delivery and conversion are different facts."
+        /></LanguageProvider>,
+    )
+
+    expect(screen.getByText('Handed off')).toBeTruthy()
+    expect(screen.getByText('to notification service')).toBeTruthy()
+    expect(screen.getByText('Account opened')).toBeTruthy()
+    expect(screen.getByText(/no in-app engagement is attributed/)).toBeTruthy()
+  })
+
+  it('does not show a zero outcome when the campaign measures nothing', () => {
+    const { container } = render(
+      <LanguageProvider><CampaignOutcomeBrief
+          state="ACTIVE"
+          audience={12}
+          handedOff={10}
+          suppressed={2}
+          conversion={null}
+          conversionLabel="Outcome is not measured"
+          nextAction="Consider a measurable outcome"
+          nextActionDetail="The journey can still run."
+        /></LanguageProvider>,
+    )
+
+    expect(container.querySelector('[data-conversion="unmeasured"]')).toBeTruthy()
+    expect(screen.getByText('not measured')).toBeTruthy()
+  })
+})


### PR DESCRIPTION
## What changed

- Adds a campaign outcome brief at the top of the detail page: audience, campaign handoff, policy suppression and measured business outcome.
- Adds a next-best-action recommendation derived from the real campaign state and outcome summary.
- Keeps critical distinctions explicit: handoff is not device delivery; an absent conversion rule is not zero conversions; in-app engagement is not attributed to the campaign yet.

## Why

The existing detail contained the underlying facts, but a marketer had to assemble them from lifecycle cards, a flow diagram and event sections. The brief turns those real signals into a decision-ready overview without fabricating a cross-channel CDP funnel.

## Validation

- `npm run type-check`
- `node ./node_modules/vitest/vitest.mjs run src/test/campaign-outcome-brief.test.tsx src/test/campaign-studio.test.tsx src/test/campaigns-console-board.test.tsx src/test/campaign-experience-preview.test.tsx` (25 tests)
- Targeted ESLint for changed files
- `git diff --check`

Refs #4476
