### PR TITLE
feat(admin-ui): visualize agent diagnostics

### DIFF
--- a/openbank-admin-ui/src/app/api/iaops/agents/[agentId]/route.ts
+++ b/openbank-admin-ui/src/app/api/iaops/agents/[agentId]/route.ts
@@ -16,7 +16,8 @@
 
 import { NextRequest, NextResponse } from 'next/server'
 import { auth } from '@/auth'
-import { loadAgentCharter } from '@/lib/governance/agentCharters'
+import { loadAgentCharters } from '@/lib/governance/agentCharters'
+import { deriveAgentDiagnostics, deriveAgentMesh } from '@/lib/governance/agentDiagnostics'
 import { loadAgentCharterDoc } from '@/lib/governance/docs'
 
 export const dynamic = 'force-dynamic'
@@ -69,11 +70,12 @@ async function fetchProposals(agentId: string): Promise<{ available: boolean; pr
 
 export async function GET(_req: NextRequest, ctx: { params: Promise<{ agentId: string }> }) {
   const { agentId } = await ctx.params
-  const [charter, doc, proposalData] = await Promise.all([
-    loadAgentCharter(agentId),
+  const [registry, doc, proposalData] = await Promise.all([
+    loadAgentCharters(),
     loadAgentCharterDoc(agentId),
     fetchProposals(agentId),
   ])
+  const charter = registry.agents.find(agent => agent.id === agentId) ?? null
 
   if (!charter && !doc) {
     return NextResponse.json({ error: 'unknown_agent' }, { status: 404 })
@@ -82,6 +84,8 @@ export async function GET(_req: NextRequest, ctx: { params: Promise<{ agentId: s
   return NextResponse.json({
     id: agentId,
     charter,
+    diagnostics: charter ? deriveAgentDiagnostics(charter, registry.agents) : [],
+    mesh: charter ? deriveAgentMesh(charter, registry) : null,
     narrative: doc ? { title: doc.title, adr: doc.adr, plane: doc.plane, body: doc.body } : null,
     proposals: {
       available: proposalData.available,

--- a/openbank-admin-ui/src/app/iaops/agents/[agentId]/page.tsx
+++ b/openbank-admin-ui/src/app/iaops/agents/[agentId]/page.tsx
@@ -7,12 +7,14 @@
 import { useState, useEffect, useCallback } from 'react'
 import { useParams } from 'next/navigation'
 import Link from 'next/link'
-import { ArrowLeft, RefreshCw, Bot, Lock, Users, FileText, Clock, Sparkles, Hand } from 'lucide-react'
+import { ArrowLeft, RefreshCw, Lock, Users, FileText, Clock, Sparkles, Hand } from 'lucide-react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { AuthGuard } from '@/components/auth/AuthGuard'
 import { DataUnavailable } from '@/components/feedback/DataUnavailable'
 import type { UnavailableKind } from '@/components/feedback/DataUnavailable'
 import { AgentPortrait, getAgentPersona } from '@/components/agent/AgentIdentity'
+import { AgentBodyAnalysis, AgentMeshMap } from '@/components/agent/AgentDiagnostics'
+import type { AgentDiagnostic, AgentMeshSummary } from '@/lib/governance/agentDiagnostics'
 
 // ── Types (mirror /api/iaops/agents/[agentId]) ─────────────────────────────
 interface Schedule { daily: string | null; reactive: string | null }
@@ -20,6 +22,7 @@ interface Charter {
   id: string; plane: string; charter: string; owns: string[]; skills: string[]
   dataRead: string[]; pii: string; toolsAllow: string[]; toolsDeny: string[]
   requiresHuman: string[]; tokensPerRun: number | null; runsPerDay: number | null
+  caseCapabilities: string[]
   schedule: Schedule | null
 }
 interface Narrative { title: string; adr: string; plane: string; body: string }
@@ -28,6 +31,8 @@ interface AgentDetail {
   id: string
   charter: Charter | null
   narrative: Narrative | null
+  diagnostics: AgentDiagnostic[]
+  mesh: AgentMeshSummary | null
   proposals: { available: boolean; items: ProposalSummary[]; pendingCount: number }
 }
 
@@ -257,22 +262,12 @@ function AgentDetailContent() {
             </div>
           </Card>
 
-          {agentId === 'case-coordinator' && (
-            <Card>
-              <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '8px' }}>
-                <Bot size={14} style={{ color: '#6366f1' }} />
-                <span style={{ fontSize: '13px', fontWeight: 700 }}>{t('Swarm case', 'Swarm cases')}</span>
-              </div>
-              <p style={{ fontSize: '11px', color: 'var(--text-tertiary)', margin: '0 0 10px' }}>
-                {t(
-                  'Koordinační případy, ve kterých agenti přispívají do sdíleného vlákna (Temporal CaseWorkflow, ADR-0244/0246).',
-                  'Coordination cases agents contribute to in a shared thread (Temporal CaseWorkflow, ADR-0244/0246).',
-                )}
-              </p>
-              <Link href="/iaops/cases" style={{ display: 'inline-flex', alignItems: 'center', gap: '5px', fontSize: '12px', fontWeight: 700, color: 'var(--accent-text)', textDecoration: 'none' }}>
-                {t('Otevřít vlákna case', 'Open case threads')}
-              </Link>
-            </Card>
+          {data.charter && data.diagnostics.length > 0 && (
+            <AgentBodyAnalysis agentId={agentId} diagnostics={data.diagnostics} language={language} />
+          )}
+
+          {data.mesh && (
+            <AgentMeshMap agentId={agentId} mesh={data.mesh} language={language} />
           )}
 
           {/* Tools + operating profile (agents.yaml — enforced fields) */}

--- a/openbank-admin-ui/src/components/agent/AgentDiagnostics.module.css
+++ b/openbank-admin-ui/src/components/agent/AgentDiagnostics.module.css
@@ -1,0 +1,299 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0. */
+
+.analysis,
+.mesh {
+  margin-bottom: 20px;
+  padding: 22px 24px;
+  border: 1px solid var(--border);
+  border-radius: 18px;
+  background: var(--surface);
+  box-shadow: 0 10px 28px rgba(15, 23, 42, .05);
+}
+
+.sectionHeading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 20px;
+  margin-bottom: 20px;
+}
+
+.sectionHeading h2 {
+  margin: 5px 0 5px;
+  color: var(--text-primary);
+  font-size: 18px;
+  letter-spacing: -.025em;
+}
+
+.sectionHeading p {
+  max-width: 720px;
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 12px;
+  line-height: 1.6;
+}
+
+.eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: #4338ca;
+  font-size: 10px;
+  font-weight: 850;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+}
+
+.notScore,
+.meshFoundation,
+.meshLive {
+  flex-shrink: 0;
+  padding: 5px 9px;
+  border-radius: 999px;
+  color: #475569;
+  background: #f1f5f9;
+  font-size: 10px;
+  font-weight: 750;
+}
+
+.meshFoundation { color: #92400e; background: #fef3c7; }
+.meshLive { color: #166534; background: #dcfce7; }
+
+.analysisGrid {
+  display: grid;
+  grid-template-columns: minmax(220px, 280px) 1fr;
+  gap: 26px;
+  align-items: center;
+}
+
+.scanStage {
+  position: relative;
+  display: grid;
+  place-items: center;
+  min-height: 330px;
+  overflow: hidden;
+  border: 1px solid #c7d2fe;
+  border-radius: 22px;
+  background:
+    linear-gradient(rgba(99, 102, 241, .06) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(99, 102, 241, .06) 1px, transparent 1px),
+    radial-gradient(circle at 50% 45%, #eef2ff 0%, var(--surface) 63%);
+  background-size: 24px 24px, 24px 24px, auto;
+}
+
+.scanRing {
+  position: absolute;
+  width: 190px;
+  height: 190px;
+  border: 1px dashed #818cf8;
+  border-radius: 50%;
+  box-shadow: 0 0 0 18px rgba(129, 140, 248, .06), 0 0 0 38px rgba(129, 140, 248, .035);
+}
+
+.scanLine {
+  position: absolute;
+  z-index: 2;
+  top: 60px;
+  width: 76%;
+  height: 2px;
+  background: linear-gradient(90deg, transparent, #22d3ee, transparent);
+  box-shadow: 0 0 12px #22d3ee;
+  animation: scan 3.2s ease-in-out infinite;
+}
+
+@keyframes scan {
+  0%, 100% { transform: translateY(0); opacity: .45; }
+  50% { transform: translateY(160px); opacity: 1; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .scanLine { animation: none; top: 49%; }
+}
+
+.scanPortrait { position: relative; z-index: 1; transform: scale(1.28); }
+
+.scanName,
+.scanRole {
+  position: absolute;
+  z-index: 3;
+  bottom: 31px;
+  color: var(--text-primary);
+}
+
+.scanName { bottom: 44px; font-size: 16px; }
+.scanRole { color: var(--text-secondary); font-size: 10px; }
+
+.anatomyTag {
+  position: absolute;
+  z-index: 3;
+  padding: 3px 7px;
+  border: 1px solid #c7d2fe;
+  border-radius: 7px;
+  color: #4338ca;
+  background: rgba(255, 255, 255, .9);
+  font-size: 9px;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.tagEyes { top: 75px; right: 24px; }
+.tagHands { top: 157px; left: 18px; }
+.tagCore { top: 143px; right: 18px; }
+.tagShield { top: 223px; right: 24px; }
+
+.metrics { display: grid; gap: 13px; }
+.metric { min-width: 0; }
+
+.metricTopline {
+  display: grid;
+  grid-template-columns: 24px minmax(110px, 1fr) auto;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 6px;
+  color: var(--text-primary);
+  font-size: 11px;
+}
+
+.metricTopline strong { font-size: 11px; font-variant-numeric: tabular-nums; }
+.metricName { font-weight: 750; }
+
+.metricIcon {
+  display: grid;
+  place-items: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 8px;
+  color: #4338ca;
+  background: #eef2ff;
+}
+
+.metricIcon[data-tone="data"] { color: #0e7490; background: #cffafe; }
+.metricIcon[data-tone="tools"] { color: #6d28d9; background: #ede9fe; }
+.metricIcon[data-tone="guardrails"] { color: #b45309; background: #fef3c7; }
+.metricIcon[data-tone="domain"] { color: #be123c; background: #ffe4e6; }
+.metricIcon[data-tone="tokens"] { color: #1d4ed8; background: #dbeafe; }
+.metricIcon[data-tone="cadence"] { color: #047857; background: #d1fae5; }
+
+.meterTrack {
+  height: 8px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: var(--surface-3);
+}
+
+.meterFill { display: block; height: 100%; border-radius: inherit; background: #6366f1; }
+.meterFill[data-tone="data"] { background: #0891b2; }
+.meterFill[data-tone="tools"] { background: #7c3aed; }
+.meterFill[data-tone="guardrails"] { background: #d97706; }
+.meterFill[data-tone="domain"] { background: #e11d48; }
+.meterFill[data-tone="tokens"] { background: #2563eb; }
+.meterFill[data-tone="cadence"] { background: #059669; }
+
+.metricFoot {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  margin-top: 4px;
+  color: var(--text-tertiary);
+  font-size: 9px;
+  line-height: 1.4;
+}
+
+.metricFoot span:last-child { flex-shrink: 0; font-variant-numeric: tabular-nums; }
+
+.mesh {
+  background:
+    radial-gradient(circle at 20% 0%, rgba(34, 211, 238, .08), transparent 34%),
+    radial-gradient(circle at 80% 100%, rgba(99, 102, 241, .08), transparent 34%),
+    var(--surface);
+}
+
+.meshFlow {
+  display: grid;
+  grid-template-columns: minmax(125px, 1fr) 28px minmax(125px, 1fr) 28px minmax(125px, 1fr) 28px minmax(125px, 1fr) 28px minmax(125px, 1fr);
+  align-items: stretch;
+  gap: 5px;
+}
+
+.meshNode {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  min-height: 136px;
+  padding: 14px;
+  border: 1px solid #cbd5e1;
+  border-radius: 15px;
+  color: var(--text-secondary);
+  background: var(--surface);
+  font-size: 10px;
+  line-height: 1.45;
+}
+
+.meshNode[data-status="governed"] { border-color: #99f6e4; background: linear-gradient(145deg, var(--surface), #f0fdfa); }
+.meshNode[data-status="planned"] { border-style: dashed; background: linear-gradient(145deg, var(--surface), #f8fafc); }
+.meshNode[data-status="human"] { border-color: #fde68a; background: linear-gradient(145deg, var(--surface), #fffbeb); }
+
+.meshNode strong { margin: 10px 0 5px; color: var(--text-primary); font-size: 12px; }
+.meshIcon { color: #0f766e; }
+.meshNode[data-status="planned"] .meshIcon { color: #64748b; }
+.meshNode[data-status="human"] .meshIcon { color: #a16207; }
+
+.meshStatus {
+  position: absolute;
+  top: 11px;
+  right: 10px;
+  color: #0f766e;
+  font-size: 8px;
+  font-weight: 850;
+  letter-spacing: .04em;
+  text-transform: uppercase;
+}
+
+.meshNode[data-status="planned"] .meshStatus { color: #64748b; }
+.meshNode[data-status="human"] .meshStatus { color: #92400e; }
+.meshArrow { align-self: center; width: 22px; color: #94a3b8; }
+
+.meshFooter {
+  display: grid;
+  grid-template-columns: minmax(280px, 1fr) auto auto;
+  align-items: center;
+  gap: 16px;
+  margin-top: 18px;
+  padding-top: 16px;
+  border-top: 1px solid var(--border);
+}
+
+.meshTruth { display: flex; align-items: flex-start; gap: 8px; color: var(--text-secondary); font-size: 10px; line-height: 1.5; }
+.meshTruth svg { flex-shrink: 0; color: #0f766e; }
+.caseClasses { display: flex; align-items: center; flex-wrap: wrap; gap: 5px; color: var(--text-tertiary); font-size: 9px; }
+.caseClasses code { padding: 3px 6px; border-radius: 6px; color: var(--text-secondary); background: var(--surface-2); font-size: 9px; }
+
+.meshLink {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  white-space: nowrap;
+  color: var(--accent-text);
+  font-size: 10px;
+  font-weight: 800;
+  text-decoration: none;
+}
+
+@media (max-width: 980px) {
+  .meshFlow { grid-template-columns: 1fr; }
+  .meshArrow { justify-self: center; transform: rotate(90deg); }
+  .meshNode { min-height: 100px; }
+  .meshFooter { grid-template-columns: 1fr; }
+}
+
+@media (max-width: 720px) {
+  .analysis,
+  .mesh { padding: 18px; border-radius: 15px; }
+  .sectionHeading { flex-direction: column; gap: 10px; }
+  .analysisGrid { grid-template-columns: 1fr; }
+  .scanStage { min-height: 300px; }
+  .metricTopline { grid-template-columns: 24px 1fr; }
+  .metricTopline strong { grid-column: 2; }
+  .metricFoot { flex-direction: column; gap: 2px; }
+}

--- a/openbank-admin-ui/src/components/agent/AgentDiagnostics.module.css
+++ b/openbank-admin-ui/src/components/agent/AgentDiagnostics.module.css
@@ -211,9 +211,12 @@
 
 .meshFlow {
   display: grid;
-  grid-template-columns: minmax(125px, 1fr) 28px minmax(125px, 1fr) 28px minmax(125px, 1fr) 28px minmax(125px, 1fr) 28px minmax(125px, 1fr);
+  grid-template-columns: repeat(5, minmax(125px, 1fr));
   align-items: stretch;
-  gap: 5px;
+  gap: 38px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
 }
 
 .meshNode {
@@ -228,6 +231,16 @@
   background: var(--surface);
   font-size: 10px;
   line-height: 1.45;
+}
+
+.meshNode:not(:last-child)::after {
+  content: '→';
+  position: absolute;
+  top: 50%;
+  right: -29px;
+  color: #94a3b8;
+  font-size: 22px;
+  transform: translateY(-50%);
 }
 
 .meshNode[data-status="governed"] { border-color: #99f6e4; background: linear-gradient(145deg, var(--surface), #f0fdfa); }
@@ -252,8 +265,6 @@
 
 .meshNode[data-status="planned"] .meshStatus { color: #64748b; }
 .meshNode[data-status="human"] .meshStatus { color: #92400e; }
-.meshArrow { align-self: center; width: 22px; color: #94a3b8; }
-
 .meshFooter {
   display: grid;
   grid-template-columns: minmax(280px, 1fr) auto auto;
@@ -280,9 +291,9 @@
   text-decoration: none;
 }
 
-@media (max-width: 980px) {
+@media (max-width: 1200px) {
   .meshFlow { grid-template-columns: 1fr; }
-  .meshArrow { justify-self: center; transform: rotate(90deg); }
+  .meshNode:not(:last-child)::after { content: '↓'; top: auto; right: 50%; bottom: -32px; transform: translateX(50%); }
   .meshNode { min-height: 100px; }
   .meshFooter { grid-template-columns: 1fr; }
 }

--- a/openbank-admin-ui/src/components/agent/AgentDiagnostics.tsx
+++ b/openbank-admin-ui/src/components/agent/AgentDiagnostics.tsx
@@ -142,12 +142,12 @@ function MeshNode({ icon: Icon, title, detail, status, language }: {
     human: language === 'cs' ? 'lidská brána' : 'human gate',
   }[status]
   return (
-    <div className={styles.meshNode} data-status={status}>
+    <li className={styles.meshNode} data-status={status}>
       <span className={styles.meshIcon}><Icon size={18} /></span>
       <span className={styles.meshStatus}>{statusLabel}</span>
       <strong>{title}</strong>
       <span>{detail}</span>
-    </div>
+    </li>
   )
 }
 
@@ -160,7 +160,7 @@ export function AgentMeshMap({ agentId, mesh, language }: {
   const selected = getAgentPersona(agentId, language)
   const coordinator = mesh.coordinatorId ? getAgentPersona(mesh.coordinatorId, language) : null
   const canOpen = mesh.selectedCapabilities.includes('case.open')
-  const participants = mesh.enabledParticipantIds.length
+  const participants = mesh.charteredParticipantIds.length
 
   return (
     <section className={styles.mesh} aria-labelledby="agent-mesh-title">
@@ -169,43 +169,42 @@ export function AgentMeshMap({ agentId, mesh, language }: {
           <span className={styles.eyebrow}><Network size={13} /> {t('Spolupráce agentů', 'Agent collaboration')}</span>
           <h2 id="agent-mesh-title">{t('AI mesh — jak má tým spolupracovat', 'AI mesh — how the team is designed to collaborate')}</h2>
           <p>{t(
-            'Jeden dlouho běžící Temporal case drží kontext, rozpočet i stop podmínku. Agenti přidávají důkazy, koordinátor skládá jeden návrh a člověk rozhoduje.',
-            'One durable Temporal case holds context, budget and stop conditions. Agents add evidence, the coordinator produces one proposal, and a human decides.',
+            'Jeden dlouho běžící Temporal case drží kontext, rozpočet i stop podmínku. Diagram ukazuje charterovaný design, ne živou runtime topologii.',
+            'One durable Temporal case holds context, budget and stop conditions. This diagram shows chartered design, not live runtime topology.',
           )}</p>
         </div>
-        <span className={mesh.state === 'connected' ? styles.meshLive : styles.meshFoundation}>
-          {mesh.state === 'connected'
-            ? t(`${participants} připojených specialistů`, `${participants} connected specialists`)
+        <span className={mesh.state === 'chartered' ? styles.meshLive : styles.meshFoundation}>
+          {mesh.state === 'chartered'
+            ? t(
+                participants === 1 ? '1 specialista v charteru' : `${participants} specialistů v charteru`,
+                participants === 1 ? '1 chartered specialist' : `${participants} chartered specialists`,
+              )
             : t('Dnes: základ mesh', 'Today: mesh foundation')}
         </span>
       </div>
 
-      <div className={styles.meshFlow} role="img" aria-label={t(
+      <ol className={styles.meshFlow} aria-label={t(
         'Tok od podnětu přes koordinátora a specialisty k návrhu a lidskému rozhodnutí',
         'Flow from signal through coordinator and specialists to proposal and human decision',
       )}>
         <MeshNode icon={Sparkles} title={t('Podnět nebo nález', 'Signal or finding')}
           detail={canOpen ? `${selected.name} · case.open` : t(`${selected.name} zatím nemá case.open`, `${selected.name} does not yet hold case.open`)}
           status={canOpen ? 'governed' : 'planned'} language={language} />
-        <ArrowRight className={styles.meshArrow} aria-hidden="true" />
         <MeshNode icon={Network} title={coordinator?.name ?? t('Koordinátor', 'Coordinator')}
           detail={t('Hlídá rozpočet, deadline a konvergenci', 'Owns budget, deadline and convergence')}
           status={mesh.coordinatorId ? 'governed' : 'planned'} language={language} />
-        <ArrowRight className={styles.meshArrow} aria-hidden="true" />
         <MeshNode icon={Users} title={t('Pozvaní specialisté', 'Invited specialists')}
           detail={participants > 0
-            ? t(`${participants} agentů smí join/contribute`, `${participants} agents may join/contribute`)
+            ? t(`${participants} agentů deklaruje join/contribute; runtime allowlist je zvlášť`, `${participants} agents declare join/contribute; runtime allowlist is separate`)
             : t(`0 z ${mesh.totalAgents}: capability zatím nepřidělena`, `0 of ${mesh.totalAgents}: capability not granted yet`)}
           status={participants > 0 ? 'governed' : 'planned'} language={language} />
-        <ArrowRight className={styles.meshArrow} aria-hidden="true" />
         <MeshNode icon={GitMerge} title={t('Jeden společný návrh', 'One shared proposal')}
           detail={t('Citace důkazů, dissent zůstává viditelný', 'Evidence is cited and dissent stays visible')}
           status={mesh.synthesisEnabled ? 'governed' : 'planned'} language={language} />
-        <ArrowRight className={styles.meshArrow} aria-hidden="true" />
         <MeshNode icon={Hand} title={t('Člověk rozhodne', 'Human decides')}
           detail={t('Mesh nikdy nezapisuje přímo do business služby', 'The mesh never writes directly to a business service')}
           status={mesh.humanGateEnabled ? 'human' : 'planned'} language={language} />
-      </div>
+      </ol>
 
       <div className={styles.meshFooter}>
         <div className={styles.meshTruth}>
@@ -215,11 +214,14 @@ export function AgentMeshMap({ agentId, mesh, language }: {
                 'Pravdivý stav: koordinace a syntéza jsou charterované, ale multi-agentní mesh se aktivuje až po přidání case.join / case.contribute konkrétním specialistům.',
                 'Honest status: coordination and synthesis are chartered, but the multi-agent mesh activates only after specialists receive case.join / case.contribute.',
               )
-            : t('Připojení specialisté jsou odvozeni přímo z case capabilities v agents.yaml.', 'Connected specialists are derived directly from case capabilities in agents.yaml.')}</span>
+            : t(
+                'Charterovaný stav: specialisté deklarují case.join / case.contribute. Skutečné runtime přijetí řídí samostatný allowlist case-coordinatoru a tato stránka ho netvrdí.',
+                'Chartered status: specialists declare case.join / case.contribute. Actual runtime admission is controlled by the coordinator allowlist and is not claimed by this page.',
+              )}</span>
         </div>
         <div className={styles.caseClasses}>
-          <span>{t('Typy případů', 'Case classes')}</span>
-          {mesh.caseClasses.map(caseClass => <code key={caseClass}>{caseClass}</code>)}
+          <span>{t('Deklarované třídy (ne runtime stav)', 'Declared classes (not runtime state)')}</span>
+          {mesh.declaredCaseClasses.map(caseClass => <code key={caseClass}>{caseClass}</code>)}
         </div>
         <Link href="/iaops/cases" className={styles.meshLink}>
           {t('Otevřít živá case vlákna', 'Open live case threads')} <ArrowRight size={13} />

--- a/openbank-admin-ui/src/components/agent/AgentDiagnostics.tsx
+++ b/openbank-admin-ui/src/components/agent/AgentDiagnostics.tsx
@@ -1,0 +1,230 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+import Link from 'next/link'
+import {
+  Activity, ArrowRight, BriefcaseBusiness, Cpu, Database, GitMerge,
+  Hand, Network, ShieldCheck, Sparkles, Users, Wrench,
+} from 'lucide-react'
+import { AgentPortrait, getAgentPersona } from './AgentIdentity'
+import type { AgentDiagnostic, AgentDiagnosticKey, AgentMeshSummary } from '@/lib/governance/agentDiagnostics'
+import styles from './AgentDiagnostics.module.css'
+
+type Language = 'cs' | 'en'
+
+const ICONS = {
+  data: Database,
+  tools: Wrench,
+  guardrails: ShieldCheck,
+  domain: BriefcaseBusiness,
+  tokens: Cpu,
+  cadence: Activity,
+} satisfies Record<AgentDiagnosticKey, typeof Database>
+
+const COPY: Record<AgentDiagnosticKey, {
+  cs: { anatomy: string; label: string; explanation: string; unit: string }
+  en: { anatomy: string; label: string; explanation: string; unit: string }
+}> = {
+  data: {
+    cs: { anatomy: 'Oči', label: 'Datový rozhled', explanation: 'Kolik datových oblastí smí podle charteru číst.', unit: 'oblastí' },
+    en: { anatomy: 'Eyes', label: 'Data horizon', explanation: 'How many data areas the charter allows it to read.', unit: 'areas' },
+  },
+  tools: {
+    cs: { anatomy: 'Ruce', label: 'Akční dosah', explanation: 'Počet explicitně povolených nástrojů a operací.', unit: 'nástrojů' },
+    en: { anatomy: 'Hands', label: 'Action reach', explanation: 'Explicitly allowed tools and operations.', unit: 'tools' },
+  },
+  guardrails: {
+    cs: { anatomy: 'Štít', label: 'Síla brzd', explanation: 'Zakázané operace plus okamžiky povinného lidského zásahu.', unit: 'brzd' },
+    en: { anatomy: 'Shield', label: 'Guardrail strength', explanation: 'Denied operations plus mandatory human gates.', unit: 'controls' },
+  },
+  domain: {
+    cs: { anatomy: 'Výbava', label: 'Doménová výbava', explanation: 'Vlastněné služby a explicitně povolené engineering skilly.', unit: 'položek' },
+    en: { anatomy: 'Gear', label: 'Domain kit', explanation: 'Owned services and explicitly allowed engineering skills.', unit: 'items' },
+  },
+  tokens: {
+    cs: { anatomy: 'Jádro', label: 'Výpočetní výdrž', explanation: 'Maximální tokenový rozpočet jednoho běhu.', unit: 'tokenů/běh' },
+    en: { anatomy: 'Core', label: 'Compute endurance', explanation: 'Maximum token budget for one run.', unit: 'tokens/run' },
+  },
+  cadence: {
+    cs: { anatomy: 'Motor', label: 'Provozní tempo', explanation: 'Nejvyšší deklarovaný počet běhů za den.', unit: 'běhů/den' },
+    en: { anatomy: 'Engine', label: 'Operating tempo', explanation: 'Highest declared number of runs per day.', unit: 'runs/day' },
+  },
+}
+
+function compact(value: number, language: Language): string {
+  return new Intl.NumberFormat(language === 'cs' ? 'cs-CZ' : 'en-US', {
+    notation: value >= 10_000 ? 'compact' : 'standard',
+    maximumFractionDigits: 1,
+  }).format(value)
+}
+
+export function AgentBodyAnalysis({
+  agentId,
+  diagnostics,
+  language,
+}: {
+  agentId: string
+  diagnostics: AgentDiagnostic[]
+  language: Language
+}) {
+  const persona = getAgentPersona(agentId, language)
+  const t = (cs: string, en: string) => language === 'cs' ? cs : en
+
+  return (
+    <section className={styles.analysis} aria-labelledby="agent-body-analysis-title">
+      <div className={styles.sectionHeading}>
+        <div>
+          <span className={styles.eyebrow}><Sparkles size={13} /> {t('Diagnostický sken', 'Diagnostic scan')}</span>
+          <h2 id="agent-body-analysis-title">{t('Analýza těla agenta', 'Agent body analysis')}</h2>
+          <p>{t(
+            'Barvy ukazují velikost deklarovaného provozního prostoru vůči nejsilnější hodnotě v dnešní flotile.',
+            'Bars show the declared operating envelope relative to the largest value in today’s fleet.',
+          )}</p>
+        </div>
+        <span className={styles.notScore}>{t('Není to skóre inteligence ani kvality', 'Not an intelligence or quality score')}</span>
+      </div>
+
+      <div className={styles.analysisGrid}>
+        <div className={styles.scanStage} aria-hidden="true">
+          <span className={styles.scanRing} />
+          <span className={styles.scanLine} />
+          <div className={styles.scanPortrait}><AgentPortrait agentId={agentId} /></div>
+          <span className={`${styles.anatomyTag} ${styles.tagEyes}`}>{COPY.data[language].anatomy}</span>
+          <span className={`${styles.anatomyTag} ${styles.tagHands}`}>{COPY.tools[language].anatomy}</span>
+          <span className={`${styles.anatomyTag} ${styles.tagCore}`}>{COPY.tokens[language].anatomy}</span>
+          <span className={`${styles.anatomyTag} ${styles.tagShield}`}>{COPY.guardrails[language].anatomy}</span>
+          <strong className={styles.scanName}>{persona.name}</strong>
+          <span className={styles.scanRole}>{persona.role}</span>
+        </div>
+
+        <div className={styles.metrics}>
+          {diagnostics.map(diagnostic => {
+            const copy = COPY[diagnostic.key][language]
+            const Icon = ICONS[diagnostic.key]
+            return (
+              <div className={styles.metric} key={diagnostic.key}>
+                <div className={styles.metricTopline}>
+                  <span className={styles.metricIcon} data-tone={diagnostic.key}><Icon size={14} /></span>
+                  <span className={styles.metricName}>{copy.label}</span>
+                  <strong>{compact(diagnostic.value, language)} {copy.unit}</strong>
+                </div>
+                <div className={styles.meterTrack} role="progressbar"
+                  aria-label={`${copy.label}: ${diagnostic.percent}%`}
+                  aria-valuenow={diagnostic.percent} aria-valuemin={0} aria-valuemax={100}>
+                  <span className={styles.meterFill} data-tone={diagnostic.key}
+                    style={{ width: `${diagnostic.percent}%` }} />
+                </div>
+                <div className={styles.metricFoot}>
+                  <span>{copy.explanation}</span>
+                  <span>{t('Maximum flotily', 'Fleet maximum')}: {compact(diagnostic.fleetMax, language)}</span>
+                </div>
+              </div>
+            )
+          })}
+        </div>
+      </div>
+    </section>
+  )
+}
+
+type MeshStatus = 'governed' | 'planned' | 'human'
+
+function MeshNode({ icon: Icon, title, detail, status, language }: {
+  icon: typeof Network
+  title: string
+  detail: string
+  status: MeshStatus
+  language: Language
+}) {
+  const statusLabel = {
+    governed: language === 'cs' ? 'v charteru' : 'chartered',
+    planned: language === 'cs' ? 'plánováno' : 'planned',
+    human: language === 'cs' ? 'lidská brána' : 'human gate',
+  }[status]
+  return (
+    <div className={styles.meshNode} data-status={status}>
+      <span className={styles.meshIcon}><Icon size={18} /></span>
+      <span className={styles.meshStatus}>{statusLabel}</span>
+      <strong>{title}</strong>
+      <span>{detail}</span>
+    </div>
+  )
+}
+
+export function AgentMeshMap({ agentId, mesh, language }: {
+  agentId: string
+  mesh: AgentMeshSummary
+  language: Language
+}) {
+  const t = (cs: string, en: string) => language === 'cs' ? cs : en
+  const selected = getAgentPersona(agentId, language)
+  const coordinator = mesh.coordinatorId ? getAgentPersona(mesh.coordinatorId, language) : null
+  const canOpen = mesh.selectedCapabilities.includes('case.open')
+  const participants = mesh.enabledParticipantIds.length
+
+  return (
+    <section className={styles.mesh} aria-labelledby="agent-mesh-title">
+      <div className={styles.sectionHeading}>
+        <div>
+          <span className={styles.eyebrow}><Network size={13} /> {t('Spolupráce agentů', 'Agent collaboration')}</span>
+          <h2 id="agent-mesh-title">{t('AI mesh — jak má tým spolupracovat', 'AI mesh — how the team is designed to collaborate')}</h2>
+          <p>{t(
+            'Jeden dlouho běžící Temporal case drží kontext, rozpočet i stop podmínku. Agenti přidávají důkazy, koordinátor skládá jeden návrh a člověk rozhoduje.',
+            'One durable Temporal case holds context, budget and stop conditions. Agents add evidence, the coordinator produces one proposal, and a human decides.',
+          )}</p>
+        </div>
+        <span className={mesh.state === 'connected' ? styles.meshLive : styles.meshFoundation}>
+          {mesh.state === 'connected'
+            ? t(`${participants} připojených specialistů`, `${participants} connected specialists`)
+            : t('Dnes: základ mesh', 'Today: mesh foundation')}
+        </span>
+      </div>
+
+      <div className={styles.meshFlow} role="img" aria-label={t(
+        'Tok od podnětu přes koordinátora a specialisty k návrhu a lidskému rozhodnutí',
+        'Flow from signal through coordinator and specialists to proposal and human decision',
+      )}>
+        <MeshNode icon={Sparkles} title={t('Podnět nebo nález', 'Signal or finding')}
+          detail={canOpen ? `${selected.name} · case.open` : t(`${selected.name} zatím nemá case.open`, `${selected.name} does not yet hold case.open`)}
+          status={canOpen ? 'governed' : 'planned'} language={language} />
+        <ArrowRight className={styles.meshArrow} aria-hidden="true" />
+        <MeshNode icon={Network} title={coordinator?.name ?? t('Koordinátor', 'Coordinator')}
+          detail={t('Hlídá rozpočet, deadline a konvergenci', 'Owns budget, deadline and convergence')}
+          status={mesh.coordinatorId ? 'governed' : 'planned'} language={language} />
+        <ArrowRight className={styles.meshArrow} aria-hidden="true" />
+        <MeshNode icon={Users} title={t('Pozvaní specialisté', 'Invited specialists')}
+          detail={participants > 0
+            ? t(`${participants} agentů smí join/contribute`, `${participants} agents may join/contribute`)
+            : t(`0 z ${mesh.totalAgents}: capability zatím nepřidělena`, `0 of ${mesh.totalAgents}: capability not granted yet`)}
+          status={participants > 0 ? 'governed' : 'planned'} language={language} />
+        <ArrowRight className={styles.meshArrow} aria-hidden="true" />
+        <MeshNode icon={GitMerge} title={t('Jeden společný návrh', 'One shared proposal')}
+          detail={t('Citace důkazů, dissent zůstává viditelný', 'Evidence is cited and dissent stays visible')}
+          status={mesh.synthesisEnabled ? 'governed' : 'planned'} language={language} />
+        <ArrowRight className={styles.meshArrow} aria-hidden="true" />
+        <MeshNode icon={Hand} title={t('Člověk rozhodne', 'Human decides')}
+          detail={t('Mesh nikdy nezapisuje přímo do business služby', 'The mesh never writes directly to a business service')}
+          status={mesh.humanGateEnabled ? 'human' : 'planned'} language={language} />
+      </div>
+
+      <div className={styles.meshFooter}>
+        <div className={styles.meshTruth}>
+          <ShieldCheck size={16} />
+          <span>{participants === 0
+            ? t(
+                'Pravdivý stav: koordinace a syntéza jsou charterované, ale multi-agentní mesh se aktivuje až po přidání case.join / case.contribute konkrétním specialistům.',
+                'Honest status: coordination and synthesis are chartered, but the multi-agent mesh activates only after specialists receive case.join / case.contribute.',
+              )
+            : t('Připojení specialisté jsou odvozeni přímo z case capabilities v agents.yaml.', 'Connected specialists are derived directly from case capabilities in agents.yaml.')}</span>
+        </div>
+        <div className={styles.caseClasses}>
+          <span>{t('Typy případů', 'Case classes')}</span>
+          {mesh.caseClasses.map(caseClass => <code key={caseClass}>{caseClass}</code>)}
+        </div>
+        <Link href="/iaops/cases" className={styles.meshLink}>
+          {t('Otevřít živá case vlákna', 'Open live case threads')} <ArrowRight size={13} />
+        </Link>
+      </div>
+    </section>
+  )
+}

--- a/openbank-admin-ui/src/lib/governance/agentCharters.ts
+++ b/openbank-admin-ui/src/lib/governance/agentCharters.ts
@@ -37,6 +37,7 @@ interface ParsedAgents {
   runtime?: Record<string, unknown>
   model_gateway?: Record<string, unknown>
   tool_tiers?: Record<string, string[]>
+  case_classes?: { classes?: Record<string, unknown> }
   agents?: Record<string, unknown>[]
 }
 
@@ -46,6 +47,7 @@ export interface AgentCharter {
   id: string; plane: string; charter: string; owns: string[]; skills: string[]
   dataRead: string[]; pii: string; toolsAllow: string[]; toolsDeny: string[]
   requiresHuman: string[]; tokensPerRun: number | null; runsPerDay: number | null
+  caseCapabilities: string[]
   /** Only finops-agent/devops-agent declare this today — most agents run on-demand, not on a clock. */
   schedule: AgentSchedule | null
 }
@@ -57,6 +59,7 @@ export interface AgentCharterRegistry {
   toolTiers: Record<string, string[]>
   runtime: Record<string, unknown>
   modelGateway: Record<string, unknown>
+  caseClasses: string[]
 }
 
 async function readRaw(): Promise<{ available: boolean; data: ParsedAgents | null }> {
@@ -101,6 +104,7 @@ export async function loadAgentCharters(): Promise<AgentCharterRegistry> {
         typeof r === 'string' ? r : Object.entries(r as Record<string, unknown>).map(([k, v]) => `${k}: ${v}`).join(' ')) : [],
       tokensPerRun: typeof limits.tokens_per_run === 'number' ? limits.tokens_per_run : null,
       runsPerDay: typeof limits.runs_per_day === 'number' ? limits.runs_per_day : null,
+      caseCapabilities: Array.isArray(ag.case_capabilities) ? (ag.case_capabilities as unknown[]).map(String) : [],
       schedule,
     }
   })
@@ -112,6 +116,7 @@ export async function loadAgentCharters(): Promise<AgentCharterRegistry> {
     toolTiers: (d?.tool_tiers ?? {}) as Record<string, string[]>,
     runtime: (d?.runtime ?? {}) as Record<string, unknown>,
     modelGateway: (d?.model_gateway ?? {}) as Record<string, unknown>,
+    caseClasses: Object.keys(d?.case_classes?.classes ?? {}),
   }
 }
 

--- a/openbank-admin-ui/src/lib/governance/agentDiagnostics.ts
+++ b/openbank-admin-ui/src/lib/governance/agentDiagnostics.ts
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+import type { AgentCharter, AgentCharterRegistry } from './agentCharters'
+
+export type AgentDiagnosticKey = 'data' | 'tools' | 'guardrails' | 'domain' | 'tokens' | 'cadence'
+
+export interface AgentDiagnostic {
+  key: AgentDiagnosticKey
+  value: number
+  fleetMax: number
+  percent: number
+}
+
+export interface AgentMeshSummary {
+  coordinatorId: string | null
+  selectedCapabilities: string[]
+  enabledParticipantIds: string[]
+  caseClasses: string[]
+  totalAgents: number
+  synthesisEnabled: boolean
+  humanGateEnabled: boolean
+  state: 'foundation' | 'connected'
+}
+
+interface Measure {
+  key: AgentDiagnosticKey
+  value: (agent: AgentCharter) => number
+}
+
+const MEASURES: Measure[] = [
+  { key: 'data', value: agent => agent.dataRead.length },
+  { key: 'tools', value: agent => agent.toolsAllow.length },
+  { key: 'guardrails', value: agent => agent.toolsDeny.length + agent.requiresHuman.length },
+  { key: 'domain', value: agent => agent.owns.length + agent.skills.length },
+  { key: 'tokens', value: agent => agent.tokensPerRun ?? 0 },
+  { key: 'cadence', value: agent => agent.runsPerDay ?? 0 },
+]
+
+/**
+ * Builds a relative operating envelope from charter facts. Percentages compare the selected
+ * agent with the largest declaration in the current registry; they are not quality, accuracy,
+ * autonomy or model-performance scores.
+ */
+export function deriveAgentDiagnostics(agent: AgentCharter, fleet: AgentCharter[]): AgentDiagnostic[] {
+  return MEASURES.map(measure => {
+    const value = measure.value(agent)
+    const fleetMax = fleet.reduce((max, candidate) => Math.max(max, measure.value(candidate)), 0)
+    return {
+      key: measure.key,
+      value,
+      fleetMax,
+      percent: fleetMax === 0 ? 0 : Math.round((value / fleetMax) * 100),
+    }
+  })
+}
+
+/** Derives the honest current mesh posture from case capabilities declared in agents.yaml. */
+export function deriveAgentMesh(agent: AgentCharter, registry: AgentCharterRegistry): AgentMeshSummary {
+  const coordinator = registry.agents.find(candidate => candidate.caseCapabilities.includes('case.coordinate')) ?? null
+  const participants = registry.agents.filter(candidate =>
+    candidate.caseCapabilities.includes('case.join') || candidate.caseCapabilities.includes('case.contribute'))
+
+  return {
+    coordinatorId: coordinator?.id ?? null,
+    selectedCapabilities: agent.caseCapabilities,
+    enabledParticipantIds: participants.map(candidate => candidate.id),
+    caseClasses: registry.caseClasses,
+    totalAgents: registry.agents.length,
+    synthesisEnabled: coordinator?.caseCapabilities.includes('case.synthesize') ?? false,
+    humanGateEnabled: (coordinator?.requiresHuman.length ?? 0) > 0,
+    state: participants.length > 0 ? 'connected' : 'foundation',
+  }
+}

--- a/openbank-admin-ui/src/lib/governance/agentDiagnostics.ts
+++ b/openbank-admin-ui/src/lib/governance/agentDiagnostics.ts
@@ -15,12 +15,12 @@ export interface AgentDiagnostic {
 export interface AgentMeshSummary {
   coordinatorId: string | null
   selectedCapabilities: string[]
-  enabledParticipantIds: string[]
-  caseClasses: string[]
+  charteredParticipantIds: string[]
+  declaredCaseClasses: string[]
   totalAgents: number
   synthesisEnabled: boolean
   humanGateEnabled: boolean
-  state: 'foundation' | 'connected'
+  state: 'foundation' | 'chartered'
 }
 
 interface Measure {
@@ -64,11 +64,13 @@ export function deriveAgentMesh(agent: AgentCharter, registry: AgentCharterRegis
   return {
     coordinatorId: coordinator?.id ?? null,
     selectedCapabilities: agent.caseCapabilities,
-    enabledParticipantIds: participants.map(candidate => candidate.id),
-    caseClasses: registry.caseClasses,
+    charteredParticipantIds: participants.map(candidate => candidate.id),
+    declaredCaseClasses: registry.caseClasses,
     totalAgents: registry.agents.length,
     synthesisEnabled: coordinator?.caseCapabilities.includes('case.synthesize') ?? false,
     humanGateEnabled: (coordinator?.requiresHuman.length ?? 0) > 0,
-    state: participants.length > 0 ? 'connected' : 'foundation',
+    // agents.yaml proves charter intent only. Runtime admission remains separately enforced by
+    // CaseCoordinatorConfig.case().swarmAgents(), which this admin BFF cannot observe.
+    state: participants.length > 0 ? 'chartered' : 'foundation',
   }
 }

--- a/openbank-admin-ui/src/test/agent-diagnostics.test.tsx
+++ b/openbank-admin-ui/src/test/agent-diagnostics.test.tsx
@@ -77,7 +77,7 @@ describe('agent operating diagnostics', () => {
     const foundation = deriveAgentMesh(selected, registry([selected, coordinator]))
     expect(foundation).toMatchObject({
       coordinatorId: 'case-coordinator',
-      enabledParticipantIds: [],
+      charteredParticipantIds: [],
       state: 'foundation',
       synthesisEnabled: true,
       humanGateEnabled: true,
@@ -85,8 +85,8 @@ describe('agent operating diagnostics', () => {
 
     const participant = charter('rca-investigator', { caseCapabilities: ['case.join', 'case.contribute'] })
     expect(deriveAgentMesh(selected, registry([selected, coordinator, participant]))).toMatchObject({
-      enabledParticipantIds: ['rca-investigator'],
-      state: 'connected',
+      charteredParticipantIds: ['rca-investigator'],
+      state: 'chartered',
     })
   })
 
@@ -112,5 +112,24 @@ describe('agent operating diagnostics', () => {
     expect(screen.getByText(/0 of 2: capability not granted yet/)).toBeInTheDocument()
     expect(screen.getByText(/multi-agent mesh activates only after specialists receive/)).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /Open live case threads/ })).toHaveAttribute('href', '/iaops/cases')
+    expect(screen.getByRole('list', { name: /Flow from signal through coordinator/ })).toBeInTheDocument()
+    expect(screen.getAllByRole('listitem')).toHaveLength(5)
+  })
+
+  it('does not present chartered participants or case classes as runtime-enabled', () => {
+    const selected = charter('finops-agent')
+    const coordinator = charter('case-coordinator', {
+      caseCapabilities: ['case.open', 'case.coordinate', 'case.synthesize'],
+      requiresHuman: ['every: proposal'],
+    })
+    const participant = charter('rca-investigator', { caseCapabilities: ['case.join'] })
+    const mesh = deriveAgentMesh(selected, registry([selected, coordinator, participant]))
+
+    render(<AgentMeshMap agentId="finops-agent" mesh={mesh} language="en" />)
+
+    expect(screen.getByText('1 chartered specialist')).toBeInTheDocument()
+    expect(screen.getByText(/Actual runtime admission is controlled by the coordinator allowlist/)).toBeInTheDocument()
+    expect(screen.getByText('Declared classes (not runtime state)')).toBeInTheDocument()
+    expect(screen.queryByText(/connected specialists/i)).not.toBeInTheDocument()
   })
 })

--- a/openbank-admin-ui/src/test/agent-diagnostics.test.tsx
+++ b/openbank-admin-ui/src/test/agent-diagnostics.test.tsx
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { AgentBodyAnalysis, AgentMeshMap } from '@/components/agent/AgentDiagnostics'
+import {
+  deriveAgentDiagnostics,
+  deriveAgentMesh,
+} from '@/lib/governance/agentDiagnostics'
+import type { AgentCharter, AgentCharterRegistry } from '@/lib/governance/agentCharters'
+
+function charter(id: string, overrides: Partial<AgentCharter> = {}): AgentCharter {
+  return {
+    id,
+    plane: 'control',
+    charter: 'test charter',
+    owns: [],
+    skills: [],
+    dataRead: [],
+    pii: 'masked',
+    toolsAllow: [],
+    toolsDeny: [],
+    requiresHuman: [],
+    tokensPerRun: 0,
+    runsPerDay: 0,
+    caseCapabilities: [],
+    schedule: null,
+    ...overrides,
+  }
+}
+
+function registry(agents: AgentCharter[]): AgentCharterRegistry {
+  return {
+    available: true,
+    defaults: {},
+    agents,
+    toolTiers: {},
+    runtime: {},
+    modelGateway: {},
+    caseClasses: ['incident-response', 'aml-alert'],
+  }
+}
+
+describe('agent operating diagnostics', () => {
+  it('derives relative bars from governed charter facts rather than invented ratings', () => {
+    const selected = charter('finops-agent', {
+      dataRead: ['costs', 'usage'],
+      toolsAllow: ['read.costs'],
+      toolsDeny: ['money.*'],
+      requiresHuman: ['every: proposal'],
+      tokensPerRun: 50_000,
+      runsPerDay: 12,
+    })
+    const largest = charter('devops-agent', {
+      dataRead: ['a', 'b', 'c', 'd'],
+      toolsAllow: ['a', 'b'],
+      toolsDeny: ['a', 'b'],
+      requiresHuman: ['a', 'b'],
+      tokensPerRun: 100_000,
+      runsPerDay: 24,
+    })
+
+    const diagnostics = deriveAgentDiagnostics(selected, [selected, largest])
+
+    expect(diagnostics.find(item => item.key === 'data')).toMatchObject({ value: 2, fleetMax: 4, percent: 50 })
+    expect(diagnostics.find(item => item.key === 'guardrails')).toMatchObject({ value: 2, fleetMax: 4, percent: 50 })
+    expect(diagnostics.find(item => item.key === 'tokens')).toMatchObject({ value: 50_000, fleetMax: 100_000, percent: 50 })
+  })
+
+  it('reports the mesh as a foundation until a specialist has join or contribute capability', () => {
+    const selected = charter('finops-agent')
+    const coordinator = charter('case-coordinator', {
+      caseCapabilities: ['case.open', 'case.coordinate', 'case.synthesize'],
+      requiresHuman: ['every: proposal'],
+    })
+    const foundation = deriveAgentMesh(selected, registry([selected, coordinator]))
+    expect(foundation).toMatchObject({
+      coordinatorId: 'case-coordinator',
+      enabledParticipantIds: [],
+      state: 'foundation',
+      synthesisEnabled: true,
+      humanGateEnabled: true,
+    })
+
+    const participant = charter('rca-investigator', { caseCapabilities: ['case.join', 'case.contribute'] })
+    expect(deriveAgentMesh(selected, registry([selected, coordinator, participant]))).toMatchObject({
+      enabledParticipantIds: ['rca-investigator'],
+      state: 'connected',
+    })
+  })
+
+  it('renders accessible operating meters and names the current mesh limitation', () => {
+    const selected = charter('finops-agent', { dataRead: ['costs'], toolsAllow: ['read.costs'] })
+    const coordinator = charter('case-coordinator', {
+      caseCapabilities: ['case.open', 'case.coordinate', 'case.synthesize'],
+      requiresHuman: ['every: proposal'],
+    })
+    const fleet = registry([selected, coordinator])
+    const diagnostics = deriveAgentDiagnostics(selected, fleet.agents)
+    const mesh = deriveAgentMesh(selected, fleet)
+
+    render(
+      <>
+        <AgentBodyAnalysis agentId="finops-agent" diagnostics={diagnostics} language="en" />
+        <AgentMeshMap agentId="finops-agent" mesh={mesh} language="en" />
+      </>,
+    )
+
+    expect(screen.getAllByRole('progressbar')).toHaveLength(6)
+    expect(screen.getByText('Not an intelligence or quality score')).toBeInTheDocument()
+    expect(screen.getByText(/0 of 2: capability not granted yet/)).toBeInTheDocument()
+    expect(screen.getByText(/multi-agent mesh activates only after specialists receive/)).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /Open live case threads/ })).toHaveAttribute('href', '/iaops/cases')
+  })
+})

--- a/openbank-admin-ui/src/test/iaops-governance-route.test.ts
+++ b/openbank-admin-ui/src/test/iaops-governance-route.test.ts
@@ -35,10 +35,11 @@ describe('GET /api/iaops/governance', () => {
     vi.mocked(loadAgentCharters).mockResolvedValue({
       available: true,
       defaults: { enforced: 'block', policy_decision: 'deny' },
-      agents: [{ id: 'ui-assistant', plane: 'control', charter: 'chat', owns: [], skills: [], dataRead: [], pii: 'masked', toolsAllow: ['query.ledger.readonly'], toolsDeny: ['money.*'], requiresHuman: ['every: proposal'], tokensPerRun: 100000, runsPerDay: 500, schedule: null }],
+      agents: [{ id: 'ui-assistant', plane: 'control', charter: 'chat', owns: [], skills: [], dataRead: [], pii: 'masked', toolsAllow: ['query.ledger.readonly'], toolsDeny: ['money.*'], requiresHuman: ['every: proposal'], tokensPerRun: 100000, runsPerDay: 500, caseCapabilities: [], schedule: null }],
       toolTiers: { read: ['query.ledger.readonly'] },
       runtime: { orchestration: 'temporal' },
       modelGateway: { gateway: 'litellm' },
+      caseClasses: ['incident-response'],
     })
 
     const { GET } = await import('../app/api/iaops/governance/route')


### PR DESCRIPTION
## Summary

Make the IAOps agent detail understandable at a glance without replacing its technical charter. The new body analysis compares governed operating declarations across the fleet, while the AI mesh explains the intended collaboration path and clearly distinguishes chartered behavior from capabilities that are not yet assigned.

## Type of change

- [x] feat (new functionality)
- [ ] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [ ] docs
- [ ] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change

## Linked issues

Closes #4488

## Changes

- Add a responsive, bilingual body-analysis card with six accessible meters derived from `agents.yaml`: data scope, allowed tools, guardrails, domain kit, token budget, and run cadence.
- Add an AI mesh flow from signal through coordinator and specialists to one proposal and a mandatory human decision.
- Derive mesh status from governed `case_capabilities` and case classes; today the UI honestly reports the foundation state because no specialist has `case.join` / `case.contribute` yet.
- Preserve the existing detailed narrative, tools, data scope, HITL conditions, and proposal history.
- Cover relative diagnostics, foundation/connected mesh states, and accessible rendering with focused tests.

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports).
- [x] Unit tests added/updated.
- [ ] Integration tests added/updated (not applicable: existing BFF boundary, no external contract change).
- [ ] Contract tests updated (not applicable: no public API change).
- [x] Admin UI test, lint, type-check, and production build pass.
- [x] No new lint warnings.
- [ ] OpenAPI spec regenerated (not applicable: internal admin BFF response only).
- [ ] Flyway migration added + rollback note (not applicable).
- [ ] Avro schema versioned backward-compatibly (not applicable).
- [x] Detailed charter and ADR-linked narrative remain available in the UI.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings`, `as Any`, or suppression annotations.
- [x] No new third-party dependency.
- [x] Auth / crypto / payment code unchanged.
- [x] PII path unchanged.
- [x] Cardholder data path unchanged.

## Compliance impact

- [x] None

This is a read-only presentation change over existing governed metadata. It does not grant capabilities, change authorization, or write to a business service.

## Rollout / Rollback

- Deployment strategy: rolling admin UI deployment
- Rollback plan: revert the single feature commit and redeploy the previous admin UI image
- Data migration reversible: N/A

## Screenshots / demo

- Visually verified in the local Next.js app at desktop width.
- Responsive stacking and reduced-motion behavior are implemented in the component stylesheet.

## Validation

- `npm test` — 87 files, 1,155 tests passed
- `npm run lint` — 0 errors (existing repository warnings only)
- `npm run type-check`
- `npm run build`
- `.github/scripts/check-license-headers.py`
- `git diff --check`

## Reviewer notes

Independent subagent review passed after the mesh was changed to keep charter intent separate from the case-coordinator runtime allowlist, expose declared case classes as non-runtime state, use a semantic ordered list, and stack below 1,200 px. The relative bars intentionally describe operating envelope only and explicitly state that they are not intelligence or quality scores.
