### PR TITLE
feat(campaign): add marketer control room

### DIFF
--- a/openbank-admin-ui/src/app/campaigns/page.tsx
+++ b/openbank-admin-ui/src/app/campaigns/page.tsx
@@ -28,7 +28,20 @@
 
 import { useEffect, useMemo, useState } from 'react'
 import Link from 'next/link'
-import { Megaphone, Play, PauseCircle, PenLine, ShieldCheck } from 'lucide-react'
+import {
+  Activity,
+  ArrowRight,
+  Clock3,
+  Eye,
+  Gauge,
+  GitBranch,
+  Megaphone,
+  PauseCircle,
+  PenLine,
+  Play,
+  ShieldCheck,
+  Sparkles,
+} from 'lucide-react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
 import { PageHeader, StatCard, StatusBadge } from '@/components/ui'
@@ -154,6 +167,15 @@ export default function CampaignsPage() {
     )
   }, [summary])
 
+  /** This is a campaign-operation rate, not customer delivery or conversion. Campaign-service
+   * can establish that it handed work to notification-service or protected someone with a
+   * suppression rule; only the channel and a campaign-attributed outcome could establish more. */
+  const handoffRate = useMemo(() => {
+    if (!deliveryPulse) return null
+    const decided = deliveryPulse.sent + deliveryPulse.suppressed
+    return decided > 0 ? Math.round((deliveryPulse.sent / decided) * 100) : null
+  }, [deliveryPulse])
+
   const needle = search.trim().toLowerCase()
   const filtered = items.filter(
     c =>
@@ -207,6 +229,75 @@ export default function CampaignsPage() {
             <StatCard label={t('Pozastavené', 'Paused')} value={counts('PAUSED')}
                       tone={counts('PAUSED') > 0 ? 'warning' : undefined} icon={<PauseCircle size={13} />} />
           </div>
+
+          <section className="campaign-control-room" aria-label={t('Řídicí místnost kampaní', 'Campaign control room')} data-testid="campaign-control-room">
+            <div className="campaign-control-hero">
+              <div className="campaign-control-orbit campaign-control-orbit-one" aria-hidden="true" />
+              <div className="campaign-control-orbit campaign-control-orbit-two" aria-hidden="true" />
+              <div className="campaign-control-kicker"><Sparkles size={13} /> {t('Campaign OS', 'Campaign OS')}</div>
+              <div className="campaign-control-hero-copy">
+                <div>
+                  <h2>{t('Od nápadu k další akci. V jednom tahu.', 'From idea to next action. In one flow.')}</h2>
+                  <p>{t('Pracovní plocha pro rozhodnutí, ne inventář kampaní.', 'A decision workspace, not a campaign inventory.')}</p>
+                </div>
+                <Link href="/campaigns/new" className="campaign-control-create">
+                  <Sparkles size={14} /> {t('Vytvořit cestu', 'Create journey')}
+                </Link>
+              </div>
+              <div className="campaign-control-flow" aria-label={t('Tok práce kampaně', 'Campaign work flow')}>
+                <div className="campaign-flow-node" data-state="brief">
+                  <PenLine size={15} /><span>{t('Zadání', 'Brief')}</span><strong>{counts('DRAFT')}</strong>
+                </div>
+                <ArrowRight className="campaign-flow-arrow" size={15} aria-hidden="true" />
+                <div className="campaign-flow-node" data-state="review">
+                  <ShieldCheck size={15} /><span>{t('Druhé oči', 'Review')}</span><strong>{counts('PENDING_APPROVAL')}</strong>
+                </div>
+                <ArrowRight className="campaign-flow-arrow" size={15} aria-hidden="true" />
+                <div className="campaign-flow-node" data-state="live">
+                  <Activity size={15} /><span>{t('Živá cesta', 'Live journey')}</span><strong>{counts('ACTIVE')}</strong>
+                </div>
+                <ArrowRight className="campaign-flow-arrow" size={15} aria-hidden="true" />
+                <div className="campaign-flow-node" data-state="learn">
+                  <Eye size={15} /><span>{t('Důkaz', 'Evidence')}</span><strong>{deliveryPulse ? t('živě', 'live') : '—'}</strong>
+                </div>
+              </div>
+            </div>
+
+            <div className="campaign-control-radar">
+              <div className="campaign-radar-heading">
+                <div>
+                  <p>{t('Signály operátora', 'Operator signals')}</p>
+                  <h3>{t('Co vyžaduje pozornost', 'What needs attention')}</h3>
+                </div>
+                <Gauge size={17} aria-hidden="true" />
+              </div>
+              <div className="campaign-radar-cards">
+                <div className="campaign-radar-card" data-tone={counts('PENDING_APPROVAL') > 0 ? 'attention' : 'clear'}>
+                  <div><Clock3 size={15} /><span>{t('Rozhodnutí čekají', 'Decisions waiting')}</span></div>
+                  <strong>{counts('PENDING_APPROVAL')}</strong>
+                  <p>{counts('PENDING_APPROVAL') > 0
+                    ? t('Kampaň potřebuje nezávislé schválení.', 'A campaign needs independent approval.')
+                    : t('Nic nečeká na schválení.', 'Nothing is waiting for approval.')}
+                  </p>
+                </div>
+                <div className="campaign-radar-card" data-tone={counts('PAUSED') > 0 ? 'attention' : 'clear'}>
+                  <div><PauseCircle size={15} /><span>{t('Zastavené cesty', 'Paused journeys')}</span></div>
+                  <strong>{counts('PAUSED')}</strong>
+                  <p>{counts('PAUSED') > 0
+                    ? t('Rozhodněte, zda pokračovat nebo uzavřít.', 'Decide whether to resume or close.')
+                    : t('Žádná cesta není pozastavená.', 'No journey is paused.')}
+                  </p>
+                </div>
+              </div>
+              <div className="campaign-evidence-strip" data-testid="campaign-evidence-strip">
+                <GitBranch size={15} aria-hidden="true" />
+                <div>
+                  <strong>{handoffRate === null ? t('Čeká na provozní data', 'Waiting for operating data') : `${handoffRate} % ${t('předáno do kanálu', 'handed to channel')}`}</strong>
+                  <span>{t('Je to provozní signál, ne potvrzené doručení, engagement ani konverze.', 'This is an operating signal, not confirmed delivery, engagement or conversion.')}</span>
+                </div>
+              </div>
+            </div>
+          </section>
 
           <section className="campaign-decision-desk" aria-label={t('Dnešní priority kampaní', 'Today’s campaign priorities')} data-testid="campaign-decision-desk">
             <div className="campaign-decision-queue">

--- a/openbank-admin-ui/src/app/globals.css
+++ b/openbank-admin-ui/src/app/globals.css
@@ -355,6 +355,44 @@ main {
 @media (max-width: 450px) { .campaign-preview-stage { gap: 0.4rem; } .campaign-phone { transform: scale(.9); transform-origin: left center; margin-right: -0.75rem; } .campaign-push-card { transform: rotate(-2deg) scale(.9); transform-origin: left center; } }
 
 /* ── Campaign portfolio decision desk ── */
+.campaign-control-room { display: grid; gap: 1rem; grid-template-columns: minmax(0, 1.4fr) minmax(18rem, .75fr); }
+.campaign-control-hero { background: radial-gradient(circle at 90% 15%, rgba(129,140,248,.54), transparent 24%), radial-gradient(circle at 40% 130%, rgba(45,212,191,.21), transparent 34%), linear-gradient(132deg, #0b1020 0%, #172554 48%, #312e81 100%); border: 1px solid rgba(165,180,252,.32); border-radius: var(--r-2xl); box-shadow: 0 20px 42px -22px rgba(30,41,59,.55); color: #fff; min-height: 17.1rem; overflow: hidden; padding: 1.35rem; position: relative; }
+.campaign-control-orbit { border: 1px solid rgba(255,255,255,.09); border-radius: 999px; pointer-events: none; position: absolute; }
+.campaign-control-orbit-one { height: 17rem; right: -5rem; top: -7rem; width: 17rem; }
+.campaign-control-orbit-two { height: 24rem; right: -8rem; top: -10.5rem; width: 24rem; }
+.campaign-control-kicker { align-items: center; color: #c7d2fe; display: inline-flex; font-size: .63rem; font-weight: 800; gap: .38rem; letter-spacing: .11em; text-transform: uppercase; }
+.campaign-control-hero-copy { align-items: flex-start; display: flex; gap: 1rem; justify-content: space-between; margin-top: .62rem; position: relative; }
+.campaign-control-hero-copy h2 { font-size: clamp(1.2rem, 2.3vw, 1.6rem); font-weight: 800; letter-spacing: -.035em; line-height: 1.13; max-width: 29rem; }
+.campaign-control-hero-copy p { color: #cbd5e1; font-size: .74rem; line-height: 1.45; margin-top: .42rem; max-width: 27rem; }
+.campaign-control-create { align-items: center; background: #fff; border-radius: .62rem; box-shadow: 0 8px 20px rgba(2,6,23,.2); color: #312e81; display: inline-flex; flex: 0 0 auto; font-size: .69rem; font-weight: 800; gap: .38rem; padding: .54rem .7rem; text-decoration: none; transition: transform .16s ease, box-shadow .16s ease; }
+.campaign-control-create:hover { box-shadow: 0 12px 26px rgba(2,6,23,.3); transform: translateY(-1px); }
+.campaign-control-flow { align-items: stretch; display: flex; gap: .3rem; margin-top: 1.5rem; position: relative; }
+.campaign-flow-node { background: rgba(15,23,42,.46); border: 1px solid rgba(255,255,255,.15); border-radius: .82rem; display: grid; flex: 1; gap: .3rem; min-width: 0; padding: .7rem; position: relative; }
+.campaign-flow-node svg { color: #c4b5fd; }
+.campaign-flow-node span { color: #cbd5e1; font-size: .59rem; font-weight: 700; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.campaign-flow-node strong { color: #fff; font-size: 1.1rem; font-variant-numeric: tabular-nums; line-height: 1; }
+.campaign-flow-node[data-state='live'] { background: rgba(16,185,129,.13); border-color: rgba(110,231,183,.34); }
+.campaign-flow-node[data-state='live'] svg { color: #6ee7b7; }
+.campaign-flow-node[data-state='review'] { background: rgba(245,158,11,.12); border-color: rgba(252,211,77,.3); }
+.campaign-flow-node[data-state='review'] svg { color: #fcd34d; }
+.campaign-flow-arrow { align-self: center; color: rgba(224,231,255,.55); flex: 0 0 auto; }
+.campaign-control-radar { background: var(--surface); border: 1px solid var(--border); border-radius: var(--r-2xl); box-shadow: var(--shadow-sm); padding: 1.15rem; }
+.campaign-radar-heading { align-items: flex-start; display: flex; justify-content: space-between; }
+.campaign-radar-heading p { color: var(--ob-accent-text); font-size: .61rem; font-weight: 800; letter-spacing: .09em; text-transform: uppercase; }
+.campaign-radar-heading h3 { font-size: .95rem; font-weight: 800; letter-spacing: -.02em; margin-top: .15rem; }
+.campaign-radar-heading > svg { color: var(--ob-accent); }
+.campaign-radar-cards { display: grid; gap: .52rem; grid-template-columns: repeat(2, minmax(0, 1fr)); margin-top: .88rem; }
+.campaign-radar-card { background: var(--surface-2); border: 1px solid var(--border); border-radius: .75rem; padding: .62rem; }
+.campaign-radar-card > div { align-items: center; color: var(--text-secondary); display: flex; font-size: .58rem; font-weight: 750; gap: .3rem; line-height: 1.2; }
+.campaign-radar-card > div svg { color: var(--ob-accent); flex: 0 0 auto; }
+.campaign-radar-card strong { display: block; font-size: 1.22rem; font-variant-numeric: tabular-nums; line-height: 1; margin-top: .52rem; }
+.campaign-radar-card p { color: var(--text-secondary); font-size: .57rem; line-height: 1.35; margin-top: .32rem; }
+.campaign-radar-card[data-tone='attention'] { background: linear-gradient(145deg, #fffbeb, #fff); border-color: #fde68a; }
+.campaign-radar-card[data-tone='attention'] strong { color: var(--warning-text); }
+.campaign-evidence-strip { align-items: flex-start; background: linear-gradient(135deg, var(--ob-accent-light), #f5f3ff); border: 1px solid var(--ob-accent-border); border-radius: .75rem; display: flex; gap: .55rem; margin-top: .65rem; padding: .62rem; }
+.campaign-evidence-strip > svg { color: var(--ob-accent); flex: 0 0 auto; margin-top: .1rem; }
+.campaign-evidence-strip strong { display: block; color: #312e81; font-size: .66rem; font-weight: 800; }
+.campaign-evidence-strip span { color: #5b5b86; display: block; font-size: .57rem; line-height: 1.35; margin-top: .15rem; }
 .campaign-decision-desk { display: grid; grid-template-columns: minmax(0, 1.18fr) minmax(17rem, .82fr); gap: 1rem; }
 .campaign-decision-queue, .campaign-delivery-pulse { border: 1px solid var(--border); border-radius: var(--r-xl); overflow: hidden; padding: 1.1rem; }
 .campaign-decision-queue { background: linear-gradient(135deg, #f5f3ff, var(--surface) 58%); }
@@ -378,7 +416,8 @@ main {
 .campaign-pulse-numbers strong { display: block; font-size: .95rem; font-variant-numeric: tabular-nums; }
 .campaign-pulse-numbers span { color: var(--text-secondary); display: block; font-size: .61rem; margin-top: .1rem; }
 .campaign-pulse-footnote { color: var(--text-secondary); font-size: .64rem; line-height: 1.35; margin-top: .85rem; }
-@media (max-width: 900px) { .campaign-decision-desk { grid-template-columns: 1fr; } }
+@media (max-width: 900px) { .campaign-control-room, .campaign-decision-desk { grid-template-columns: 1fr; } }
+@media (max-width: 560px) { .campaign-control-hero { min-height: auto; padding: 1.05rem; } .campaign-control-hero-copy { display: grid; } .campaign-control-create { justify-self: start; } .campaign-control-flow { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); margin-top: 1rem; } .campaign-flow-arrow { display: none; } }
 
 /* ── Campaign outcome brief ── */
 .campaign-outcome-brief { background: linear-gradient(110deg, #111827 0%, #172554 56%, #312e81 100%); border-radius: var(--r-xl); box-shadow: var(--shadow-lg); color: #fff; display: grid; grid-template-columns: minmax(0, 1fr) minmax(13.5rem, .32fr); overflow: hidden; }

--- a/openbank-admin-ui/src/test/campaigns-console-board.test.tsx
+++ b/openbank-admin-ui/src/test/campaigns-console-board.test.tsx
@@ -148,6 +148,10 @@ describe('campaigns console', () => {
     render(React.createElement(Providers, null, React.createElement(CampaignsPage)))
 
     await waitFor(() => expect(screen.getByTestId('campaign-decision-desk')).toBeTruthy())
+    // The control room gives the operator the complete lifecycle before they drill into the
+    // decision queue. It names operating evidence, but explicitly refuses to call it engagement.
+    expect(screen.getByTestId('campaign-control-room').textContent).toMatch(/Brief.*Review.*Live journey.*Evidence/)
+    expect(screen.getByTestId('campaign-evidence-strip').textContent).toMatch(/operating signal, not confirmed delivery, engagement or conversion/)
     const decisions = Array.from(document.querySelectorAll('[data-decision-campaign]'))
       .map(node => node.getAttribute('data-decision-campaign'))
     // Approval is a more urgent human decision than an unfinished draft or a live campaign.


### PR DESCRIPTION
## What changed

Introduces a visual Campaign Control Room for marketers: lifecycle flow, priority signals, operating evidence and a clear route into journey creation.

## Why

The campaign portfolio was readable, but not yet a focused orchestration workspace. This turns it into a decision-first surface without inventing engagement, conversion, or delivery facts that campaign-service does not establish.

## Validation

- Focused lint passed
- 17 focused Campaign Console tests passed
- Type-check passed

Refs #4476