### PR TITLE
feat(admin-ui): explain AI mesh

### DIFF
--- a/openbank-admin-ui/src/app/iaops/page.tsx
+++ b/openbank-admin-ui/src/app/iaops/page.tsx
@@ -253,6 +253,8 @@ function IAOpsContent() {
         </div>
       </div>
 
+      <AgentMeshExplainer language={language} />
+
       {loading && !data ? (
         <div style={{ display: 'flex', alignItems: 'center', gap: '10px', padding: '40px', color: 'var(--text-tertiary)' }}>
           <RefreshCw size={16} style={{ animation: 'spin 0.8s linear infinite' }} />
@@ -303,8 +305,6 @@ function IAOpsContent() {
               </span>
             </div>
           </div>
-
-          <AgentMeshExplainer language={language} />
 
           {/* ── A. Governance posture (hero) ── */}
           <div style={{ background: 'linear-gradient(135deg, rgba(99,102,241,0.06), rgba(8,145,178,0.04))',

--- a/openbank-admin-ui/src/app/iaops/page.tsx
+++ b/openbank-admin-ui/src/app/iaops/page.tsx
@@ -19,6 +19,7 @@ import type { UnavailableKind } from '@/components/feedback/DataUnavailable'
 import { AgentInsightsPanel } from '@/components/agent/AgentInsightsPanel'
 import type { AgentFinding } from '@/components/agent/AgentInsightsPanel'
 import { AgentPortrait, getAgentPersona } from '@/components/agent/AgentIdentity'
+import { AgentMeshExplainer } from '@/components/agent/AgentMeshExplainer'
 import styles from './IAOps.module.css'
 
 // ── Types (mirror /api/iaops/governance) ───────────────────────────────────
@@ -302,6 +303,8 @@ function IAOpsContent() {
               </span>
             </div>
           </div>
+
+          <AgentMeshExplainer language={language} />
 
           {/* ── A. Governance posture (hero) ── */}
           <div style={{ background: 'linear-gradient(135deg, rgba(99,102,241,0.06), rgba(8,145,178,0.04))',

--- a/openbank-admin-ui/src/components/agent/AgentDiagnostics.module.css
+++ b/openbank-admin-ui/src/components/agent/AgentDiagnostics.module.css
@@ -267,7 +267,7 @@
 .meshNode[data-status="human"] .meshStatus { color: #92400e; }
 .meshFooter {
   display: grid;
-  grid-template-columns: minmax(280px, 1fr) auto auto;
+  grid-template-columns: minmax(280px, 1fr) auto auto auto;
   align-items: center;
   gap: 16px;
   margin-top: 18px;

--- a/openbank-admin-ui/src/components/agent/AgentDiagnostics.tsx
+++ b/openbank-admin-ui/src/components/agent/AgentDiagnostics.tsx
@@ -223,6 +223,9 @@ export function AgentMeshMap({ agentId, mesh, language }: {
           <span>{t('Deklarované třídy (ne runtime stav)', 'Declared classes (not runtime state)')}</span>
           {mesh.declaredCaseClasses.map(caseClass => <code key={caseClass}>{caseClass}</code>)}
         </div>
+        <Link href="/iaops#ai-mesh" className={styles.meshLink}>
+          {t('Jak mesh funguje', 'How the mesh works')} <ArrowRight size={13} />
+        </Link>
         <Link href="/iaops/cases" className={styles.meshLink}>
           {t('Otevřít živá case vlákna', 'Open live case threads')} <ArrowRight size={13} />
         </Link>

--- a/openbank-admin-ui/src/components/agent/AgentMeshExplainer.module.css
+++ b/openbank-admin-ui/src/components/agent/AgentMeshExplainer.module.css
@@ -1,0 +1,132 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0. */
+
+.mesh {
+  margin-bottom: 20px;
+  padding: 22px 24px;
+  border: 1px solid var(--border);
+  border-radius: 18px;
+  background:
+    radial-gradient(circle at 18% 0%, rgba(34, 211, 238, .09), transparent 34%),
+    radial-gradient(circle at 82% 100%, rgba(99, 102, 241, .08), transparent 34%),
+    var(--surface);
+  box-shadow: 0 10px 28px rgba(15, 23, 42, .05);
+}
+
+.heading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 20px;
+  margin-bottom: 20px;
+}
+
+.eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: #0f766e;
+  font-size: 10px;
+  font-weight: 850;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+}
+
+.heading h2 {
+  margin: 5px 0;
+  color: var(--text-primary);
+  font-size: 18px;
+  letter-spacing: -.025em;
+}
+
+.heading p {
+  max-width: 720px;
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 12px;
+  line-height: 1.6;
+}
+
+.humanFirst {
+  display: inline-flex;
+  flex-shrink: 0;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 9px;
+  border-radius: 999px;
+  color: #92400e;
+  background: #fef3c7;
+  font-size: 10px;
+  font-weight: 750;
+}
+
+.flow {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(150px, 1fr));
+  gap: 38px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.step {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  min-height: 142px;
+  padding: 14px;
+  border: 1px solid #cbd5e1;
+  border-radius: 15px;
+  color: var(--text-secondary);
+  background: var(--surface);
+  font-size: 10px;
+  line-height: 1.45;
+}
+
+.step:not(:last-child)::after {
+  content: '→';
+  position: absolute;
+  top: 50%;
+  right: -29px;
+  color: #94a3b8;
+  font-size: 22px;
+  transform: translateY(-50%);
+}
+
+.stepNumber {
+  position: absolute;
+  top: 11px;
+  right: 10px;
+  color: #0f766e;
+  font-size: 9px;
+  font-weight: 850;
+}
+
+.icon { color: #0f766e; }
+.step:last-child .icon { color: #a16207; }
+.step strong { margin: 10px 0 5px; color: var(--text-primary); font-size: 12px; }
+
+.footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin-top: 18px;
+  padding-top: 16px;
+  border-top: 1px solid var(--border);
+}
+
+.truth { display: flex; align-items: flex-start; gap: 8px; color: var(--text-secondary); font-size: 10px; line-height: 1.5; }
+.truth svg { flex-shrink: 0; color: #0f766e; }
+.link { display: inline-flex; flex-shrink: 0; align-items: center; gap: 5px; color: var(--accent-text); font-size: 10px; font-weight: 800; text-decoration: none; }
+
+@media (max-width: 1200px) {
+  .flow { grid-template-columns: 1fr; }
+  .step { min-height: 96px; }
+  .step:not(:last-child)::after { content: '↓'; top: auto; right: 50%; bottom: -32px; transform: translateX(50%); }
+}
+
+@media (max-width: 720px) {
+  .mesh { padding: 18px; border-radius: 15px; }
+  .heading, .footer { flex-direction: column; gap: 10px; }
+}

--- a/openbank-admin-ui/src/components/agent/AgentMeshExplainer.tsx
+++ b/openbank-admin-ui/src/components/agent/AgentMeshExplainer.tsx
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+import Link from 'next/link'
+import { ArrowRight, FileSearch, Hand, Network, ShieldCheck, UsersRound } from 'lucide-react'
+import styles from './AgentMeshExplainer.module.css'
+
+type Language = 'cs' | 'en'
+
+function MeshStep({ icon: Icon, number, title, detail }: {
+  icon: typeof Network
+  number: string
+  title: string
+  detail: string
+}) {
+  return (
+    <li className={styles.step}>
+      <span className={styles.stepNumber}>{number}</span>
+      <span className={styles.icon}><Icon size={18} /></span>
+      <strong>{title}</strong>
+      <span>{detail}</span>
+    </li>
+  )
+}
+
+export function AgentMeshExplainer({ language }: { language: Language }) {
+  const t = (cs: string, en: string) => language === 'cs' ? cs : en
+
+  return (
+    <section id="ai-mesh" className={styles.mesh} aria-labelledby="ai-mesh-title">
+      <div className={styles.heading}>
+        <div>
+          <span className={styles.eyebrow}><Network size={13} /> {t('Spolupráce agentů', 'Agent collaboration')}</span>
+          <h2 id="ai-mesh-title">{t('Co je AI mesh?', 'What is the AI mesh?')}</h2>
+          <p>{t(
+            'Není to jeden „superagent“ ani automat, který rozhoduje sám. Je to řízený způsob, jak si specializovaní agenti předají jeden případ a připraví společný podklad pro člověka.',
+            'It is neither a single “super-agent” nor an automation that decides by itself. It is a governed way for specialist agents to work on one case and prepare a shared brief for a person.',
+          )}</p>
+        </div>
+        <span className={styles.humanFirst}><Hand size={13} /> {t('Člověk má poslední slovo', 'A human has the final say')}</span>
+      </div>
+
+      <ol className={styles.flow} aria-label={t('Jak AI mesh spolupracuje', 'How the AI mesh collaborates')}>
+        <MeshStep number="1" icon={FileSearch}
+          title={t('Přijde podnět', 'A signal arrives')}
+          detail={t('Například alert, nález nebo požadavek na prověření.', 'For example, an alert, finding, or request for review.')} />
+        <MeshStep number="2" icon={Network}
+          title={t('Koordinátor drží případ', 'A coordinator holds the case')}
+          detail={t('Hlídá společný kontext, rozpočet, termín a okamžik zastavení.', 'It holds shared context, budget, deadline, and the stop condition.')} />
+        <MeshStep number="3" icon={UsersRound}
+          title={t('Specialisté přispějí', 'Specialists contribute')}
+          detail={t('Každý přidá jen svůj pohled a důkazy v mezích svého charteru.', 'Each adds only its own view and evidence within its charter.')} />
+        <MeshStep number="4" icon={Hand}
+          title={t('Člověk rozhodne', 'A human decides')}
+          detail={t('Dostane jeden návrh, zdroje i případné nesouhlasy. Agenti do business služby přímo nezapisují.', 'They receive one proposal, sources, and any dissent. Agents never write directly to a business service.')} />
+      </ol>
+
+      <div className={styles.footer}>
+        <div className={styles.truth}>
+          <ShieldCheck size={16} />
+          <span>{t(
+            'Bezpečnostní pravidlo: diagram popisuje navržený způsob spolupráce. Skutečné zapojení specialisty se vždy ověřuje samostatným runtime allowlistem — nejde o živý přehled připojených agentů.',
+            'Safety rule: this diagram describes the designed collaboration model. A specialist’s actual admission is always checked by a separate runtime allowlist — this is not a live view of connected agents.',
+          )}</span>
+        </div>
+        <Link href="/iaops/cases" className={styles.link}>
+          {t('Prohlédnout case vlákna', 'Browse case threads')} <ArrowRight size={13} />
+        </Link>
+      </div>
+    </section>
+  )
+}

--- a/openbank-admin-ui/src/test/agent-diagnostics.test.tsx
+++ b/openbank-admin-ui/src/test/agent-diagnostics.test.tsx
@@ -4,6 +4,7 @@
 import { render, screen } from '@testing-library/react'
 import { describe, expect, it } from 'vitest'
 import { AgentBodyAnalysis, AgentMeshMap } from '@/components/agent/AgentDiagnostics'
+import { AgentMeshExplainer } from '@/components/agent/AgentMeshExplainer'
 import {
   deriveAgentDiagnostics,
   deriveAgentMesh,
@@ -131,5 +132,15 @@ describe('agent operating diagnostics', () => {
     expect(screen.getByText(/Actual runtime admission is controlled by the coordinator allowlist/)).toBeInTheDocument()
     expect(screen.getByText('Declared classes (not runtime state)')).toBeInTheDocument()
     expect(screen.queryByText(/connected specialists/i)).not.toBeInTheDocument()
+  })
+
+  it('explains the mesh on the AIOps overview without presenting it as live topology', () => {
+    render(<AgentMeshExplainer language="en" />)
+
+    expect(screen.getByRole('heading', { name: 'What is the AI mesh?' })).toBeInTheDocument()
+    expect(screen.getByRole('list', { name: 'How the AI mesh collaborates' })).toBeInTheDocument()
+    expect(screen.getAllByRole('listitem')).toHaveLength(4)
+    expect(screen.getByText(/not a live view of connected agents/i)).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /Browse case threads/ })).toHaveAttribute('href', '/iaops/cases')
   })
 })

--- a/openbank-admin-ui/src/test/iaops-agent-card.test.tsx
+++ b/openbank-admin-ui/src/test/iaops-agent-card.test.tsx
@@ -55,6 +55,9 @@ describe('AIOps agent card interactions', () => {
 
     render(<IAOpsPage />)
 
+    expect(screen.getByRole('heading', { name: 'What is the AI mesh?' })).toBeInTheDocument()
+    expect(document.getElementById('ai-mesh')).toBeInTheDocument()
+
     const profileLink = await screen.findByRole('link', { name: /Open Fina's agent profile/i })
     expect(profileLink).toHaveAttribute('href', '/iaops/agents/finops-agent')
     expect(profileLink.closest('[role="link"]')).toBeNull()


### PR DESCRIPTION
## What changed

- Adds a business-friendly four-step explanation of the governed AI mesh to the AIOps overview.
- Links the agent-detail mesh visualisation back to the overview explanation.
- States explicitly that this is a designed collaboration model, not a live runtime topology.

## Why

The visual mesh in an agent profile did not explain how the coordinator, specialists and human decision maker work together.

## Validation

- npm test -- --run src/test/agent-diagnostics.test.tsx
- npm run type-check
- npm run lint
- git diff --check

npm run build was started, but the shared local node_modules directory disappeared while it was running; the failure was environmental and unrelated to the diff.

Closes #4494