### PR TITLE
fix(admin-ui): call the agent collaboration a swarm, not a mesh

### DIFF
--- a/openbank-admin-ui/src/components/agent/AgentDiagnostics.tsx
+++ b/openbank-admin-ui/src/components/agent/AgentDiagnostics.tsx
@@ -167,7 +167,7 @@ export function AgentMeshMap({ agentId, mesh, language }: {
       <div className={styles.sectionHeading}>
         <div>
           <span className={styles.eyebrow}><Network size={13} /> {t('Spolupráce agentů', 'Agent collaboration')}</span>
-          <h2 id="agent-mesh-title">{t('AI mesh — jak má tým spolupracovat', 'AI mesh — how the team is designed to collaborate')}</h2>
+          <h2 id="agent-mesh-title">{t('AI swarm — jak má tým spolupracovat', 'AI swarm — how the team is designed to collaborate')}</h2>
           <p>{t(
             'Jeden dlouho běžící Temporal case drží kontext, rozpočet i stop podmínku. Diagram ukazuje charterovaný design, ne živou runtime topologii.',
             'One durable Temporal case holds context, budget and stop conditions. This diagram shows chartered design, not live runtime topology.',
@@ -179,7 +179,7 @@ export function AgentMeshMap({ agentId, mesh, language }: {
                 participants === 1 ? '1 specialista v charteru' : `${participants} specialistů v charteru`,
                 participants === 1 ? '1 chartered specialist' : `${participants} chartered specialists`,
               )
-            : t('Dnes: základ mesh', 'Today: mesh foundation')}
+            : t('Dnes: základ swarmu', 'Today: swarm foundation')}
         </span>
       </div>
 
@@ -202,7 +202,7 @@ export function AgentMeshMap({ agentId, mesh, language }: {
           detail={t('Citace důkazů, dissent zůstává viditelný', 'Evidence is cited and dissent stays visible')}
           status={mesh.synthesisEnabled ? 'governed' : 'planned'} language={language} />
         <MeshNode icon={Hand} title={t('Člověk rozhodne', 'Human decides')}
-          detail={t('Mesh nikdy nezapisuje přímo do business služby', 'The mesh never writes directly to a business service')}
+          detail={t('Swarm nikdy nezapisuje přímo do business služby', 'The swarm never writes directly to a business service')}
           status={mesh.humanGateEnabled ? 'human' : 'planned'} language={language} />
       </ol>
 
@@ -211,8 +211,8 @@ export function AgentMeshMap({ agentId, mesh, language }: {
           <ShieldCheck size={16} />
           <span>{participants === 0
             ? t(
-                'Pravdivý stav: koordinace a syntéza jsou charterované, ale multi-agentní mesh se aktivuje až po přidání case.join / case.contribute konkrétním specialistům.',
-                'Honest status: coordination and synthesis are chartered, but the multi-agent mesh activates only after specialists receive case.join / case.contribute.',
+                'Pravdivý stav: koordinace a syntéza jsou charterované, ale multi-agentní swarm se aktivuje až po přidání case.join / case.contribute konkrétním specialistům.',
+                'Honest status: coordination and synthesis are chartered, but the multi-agent swarm activates only after specialists receive case.join / case.contribute.',
               )
             : t(
                 'Charterovaný stav: specialisté deklarují case.join / case.contribute. Skutečné runtime přijetí řídí samostatný allowlist case-coordinatoru a tato stránka ho netvrdí.',

--- a/openbank-admin-ui/src/test/agent-diagnostics.test.tsx
+++ b/openbank-admin-ui/src/test/agent-diagnostics.test.tsx
@@ -90,7 +90,7 @@ describe('agent operating diagnostics', () => {
     })
   })
 
-  it('renders accessible operating meters and names the current mesh limitation', () => {
+  it('renders accessible operating meters and names the current swarm limitation', () => {
     const selected = charter('finops-agent', { dataRead: ['costs'], toolsAllow: ['read.costs'] })
     const coordinator = charter('case-coordinator', {
       caseCapabilities: ['case.open', 'case.coordinate', 'case.synthesize'],
@@ -110,7 +110,7 @@ describe('agent operating diagnostics', () => {
     expect(screen.getAllByRole('progressbar')).toHaveLength(6)
     expect(screen.getByText('Not an intelligence or quality score')).toBeInTheDocument()
     expect(screen.getByText(/0 of 2: capability not granted yet/)).toBeInTheDocument()
-    expect(screen.getByText(/multi-agent mesh activates only after specialists receive/)).toBeInTheDocument()
+    expect(screen.getByText(/multi-agent swarm activates only after specialists receive/)).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /Open live case threads/ })).toHaveAttribute('href', '/iaops/cases')
     expect(screen.getByRole('list', { name: /Flow from signal through coordinator/ })).toBeInTheDocument()
     expect(screen.getAllByRole('listitem')).toHaveLength(5)


### PR DESCRIPTION
## What

The IAOps agent page called the agent collaboration an **AI mesh**. Everywhere else in the estate it is a **swarm**:

- ADR-0244 — *Agent swarm coordination via Temporal case workflows*
- ADR-0246 — *Admin-ui swarm thread view over Temporal case history*
- `openbank-case-coordinator-agent`, `docs/agents/case-coordinator.md`
- the whole `/iaops/cases` surface

`AgentDiagnostics.tsx` was the only place using the other word, on the one screen a reader opens to understand how the agents work together. "Mesh" also already means service-mesh mTLS in this repo (`asvs-l3-baseline.txt`, `check-openssf-gold-evidence.py`), so the two senses collided.

## Scope

User-visible copy only, CZ + EN:

- section heading
- the "today: mesh foundation" badge
- the human-gate node detail
- the honest-status footer

Identifiers (`AgentMeshSummary`, `deriveAgentMesh`, `AgentMeshMap`), CSS class names and the API shape are **unchanged**. That rename spans six files and would collide with in-flight work on `agents/[agentId]/page.tsx`.

## Verification

- `npm test -- src/test/agent-diagnostics.test.tsx` — 4 passed
- `npx tsc --noEmit` — clean
- `npx eslint` on both changed files — clean
- no other test, e2e spec or fixture asserts the changed strings

Refs #4339

🤖 Generated with [Claude Code](https://claude.com/claude-code)
