### PR TITLE
fix(ci): stop OIDC-client-secret-wiring gate from matching KDoc prose and shared libs

### DIFF
--- a/.github/scripts/check-oidc-client-secret-wiring.py
+++ b/.github/scripts/check-oidc-client-secret-wiring.py
@@ -49,6 +49,14 @@ GITOPS = REPO / "openbank-infra" / "gitops"
 FILTER_MARKERS = ("OidcClientRequestReactiveFilter", "OidcClientRequestFilter")
 ENV_NAME = "OIDC_CLIENT_SECRET"
 
+# Shared library modules — never their own Deployment/Rollout, so they can never carry an
+# OIDC_CLIENT_SECRET env ref of their own; a mention of a FILTER_MARKERS name anywhere in their
+# source (code OR a KDoc comparing themselves to a real filter, as `SyntheticTaintClientFilter`'s
+# KDoc does) is therefore an unfixable-by-design false positive, never a real gap. This is a small,
+# stable set of directory names — not a growing debt list — so a hand-kept exclusion is the
+# `rules.yaml: agpl_modules` shape, not the kind this repo distrusts.
+NON_DEPLOYABLE_MODULES = frozenset({"openbank-libs", "openbank-libs-domain", "openbank-libs-runtime"})
+
 # Workloads still carrying `optional: true` on a secret that IS provisioned by an ExternalSecret.
 # Not flipped here on purpose: `optional: false` makes the pod refuse to start if the Secret is
 # absent, and this check can only see the ExternalSecret DECLARATION, never whether ESO actually
@@ -70,11 +78,51 @@ OPTIONAL_TRUE_PENDING_LIVE_CHECK: dict[str, str] = {
 }
 
 
+def strip_kotlin_comments(src: str) -> str:
+    """Remove `//` and `/* */` comments so a KDoc mentioning a marker CLASS NAME by way of
+    comparison (`SyntheticTaintClientFilter`'s KDoc names `OidcClientRequestReactiveFilter` as a
+    sibling registration, never wiring one itself) does not read as the code wiring it. Kotlin
+    block comments NEST, so track depth rather than matching the first `*/`.
+    """
+    out: list[str] = []
+    i, n, depth = 0, len(src), 0
+    while i < n:
+        two = src[i : i + 2]
+        if depth:
+            if two == "/*":
+                depth += 1
+                i += 2
+                continue
+            if two == "*/":
+                depth -= 1
+                i += 2
+                continue
+            out.append("\n" if src[i] == "\n" else " ")
+            i += 1
+            continue
+        if two == "/*":
+            depth += 1
+            i += 2
+            continue
+        if two == "//":
+            j = src.find("\n", i)
+            if j == -1:
+                break
+            out.append("\n")
+            i = j + 1
+            continue
+        out.append(src[i])
+        i += 1
+    return "".join(out)
+
+
 def services_minting_tokens() -> set[str]:
     """Services whose main sources wire an OIDC client filter onto a rest-client."""
     found: set[str] = set()
     for service in gatelib.glob(REPO, "openbank-*/src/main"):
         name = service.parts[len(REPO.parts)]
+        if name in NON_DEPLOYABLE_MODULES:
+            continue
         for path in gatelib.rglob(service, "*"):
             if not path.is_file() or path.suffix not in (".kt", ".yaml", ".yml", ".properties"):
                 continue
@@ -82,6 +130,8 @@ def services_minting_tokens() -> set[str]:
                 text = gatelib.read_text(path)
             except (UnicodeDecodeError, OSError):
                 continue
+            if path.suffix == ".kt":
+                text = strip_kotlin_comments(text)
             if any(marker in text for marker in FILTER_MARKERS):
                 found.add(name)
                 break


### PR DESCRIPTION
## Summary
- `check-oidc-client-secret-wiring.py`'s `services_minting_tokens()` substring-matched `FILTER_MARKERS` against raw file text, so a KDoc merely *comparing itself* to `OidcClientRequestReactiveFilter` (as #4413's `SyntheticTaintClientFilter` KDoc does) read as the code wiring one.
- The same scan globs `openbank-*/src/main`, which also matches the three shared library modules (`openbank-libs`, `openbank-libs-domain`, `openbank-libs-runtime`). None of them is ever its own Deployment/Rollout, so a match there can never resolve to a real `OIDC_CLIENT_SECRET` env ref — an unfixable-by-design false positive independent of the comment bug.

Both bugs compounded on #4413: `gates (gitops)` / `Validate manifests` went red for `openbank-libs-runtime`, a module that cannot possibly carry the env ref this gate wants.

## Fix
- Added `strip_kotlin_comments` (same nesting-aware routine `check-event-contract-code-agreement.py` already uses — Kotlin block comments nest, so a naive first-`*/`-match under-strips).
- Added a small, stable `NON_DEPLOYABLE_MODULES` exclusion set for the three shared-library directories.

## Verification
- `--selftest`: unchanged (31/41/157).
- `--enforce` against clean `origin/main`: still clean (31 token-minting services, same as before).
- Falsification: injected a real (non-comment) `OidcClientRequestReactiveFilter` string into `openbank-analytics-sink` (a genuinely uncovered service) — the gate correctly flags it. Reverted, then injected the same text as a `//` comment — the gate correctly does NOT flag it.
- Confirmed the fixed script run against #4413's actual diff (`openbank-libs-runtime`'s `SyntheticTaintClientFilter.kt`) returns clean.

## Test plan
- [x] `python3 .github/scripts/check-oidc-client-secret-wiring.py --selftest`
- [x] `python3 .github/scripts/check-oidc-client-secret-wiring.py --enforce` on `origin/main`
- [x] Falsification: real occurrence in an uncovered service is caught; comment-only occurrence is not
- [x] Re-run against #4413's branch confirms the false positive is gone

Closes the `gates (gitops)` / `Validate manifests` red on #4413 caused by this gate, not by that PR's own code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
