### PR TITLE
fix(ci): let the verification-metadata sweep actually report its verdict

### DIFF
--- a/.github/workflows/verification-metadata-drift.yml
+++ b/.github/workflows/verification-metadata-drift.yml
@@ -17,7 +17,7 @@
 #
 # Sharded on purpose: one fleet-wide regeneration needs ~12g of heap (measured;
 # 6g died with `Java heap space` after 3h40m on the quarkusBuild variant), which is
-# more than a 16 GB runner can safely hand a single JVM. TWELVE shards of ~5 modules
+# more than a 16 GB runner can safely hand a single JVM. EIGHTEEN shards of ~3-4 modules
 # each keep every job well inside that budget and run concurrently.
 #
 # Was eight. Raised after three of eight shards died of `Java heap space` on
@@ -47,13 +47,13 @@ concurrency:
 
 jobs:
   sweep:
-    name: sweep ${{ matrix.shard }}/12
+    name: sweep ${{ matrix.shard }}/18
     runs-on: ubuntu-latest
     timeout-minutes: 45
     strategy:
       fail-fast: false # one shard's gap must not hide another's
       matrix:
-        shard: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+        shard: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18]
     steps:
       - uses: actions/checkout@v7
 
@@ -75,28 +75,39 @@ jobs:
       # the metadata. Record which it was as an ARTIFACT rather than leaving raise-issue to
       # grep a log: a job log contains the step's own `run:` script, so a grep matches
       # strings that never executed.
+      #
+      # The verdict is written INSIDE the workspace, and that is not cosmetic. It used to go
+      # to /tmp, and `hashFiles()` is resolved relative to GITHUB_WORKSPACE and cannot see a
+      # path outside it — so the guard on the upload step evaluated to '' on every shard, the
+      # upload was SKIPPED every time, and raise-issue downloaded nothing. Measured on run
+      # 31356989272: shard 10 died of Java heap space, its upload step reads `skipped`, the
+      # run produced 0 artifacts, and the issue it filed said "0 shard(s) exited 2, 0 reported
+      # a gap". Both numbers were structural zeros. A REAL metadata gap would have been
+      # reported the same way, which is the dangerous direction. `if-no-files-found: error`
+      # is there so this cannot regress quietly a second time.
       - name: Sweep shard for unpinned artifacts
         id: sweep
         run: |
           set +e
           python3 .github/scripts/check-verification-metadata-complete.py \
-            --modules all --shard "${{ matrix.shard }}/12" --enforce
+            --modules all --shard "${{ matrix.shard }}/18" --enforce
           rc=$?
           set -e
-          mkdir -p /tmp/sweep-verdict
+          mkdir -p ${{ github.workspace }}/sweep-verdict
           case "$rc" in
             0) exit 0 ;;
-            2) echo "could-not-run" > "/tmp/sweep-verdict/shard-${{ matrix.shard }}" ;;
-            *) echo "gap" > "/tmp/sweep-verdict/shard-${{ matrix.shard }}" ;;
+            2) echo "could-not-run" > "${{ github.workspace }}/sweep-verdict/shard-${{ matrix.shard }}" ;;
+            *) echo "gap" > "${{ github.workspace }}/sweep-verdict/shard-${{ matrix.shard }}" ;;
           esac
           exit "$rc"
 
       - name: Upload this shard's verdict
-        if: ${{ always() && hashFiles('/tmp/sweep-verdict/**') != '' }}
+        if: ${{ always() && hashFiles('sweep-verdict/**') != '' }}
         uses: actions/upload-artifact@v7
         with:
           name: sweep-verdict-${{ matrix.shard }}
-          path: /tmp/sweep-verdict/
+          path: ${{ github.workspace }}/sweep-verdict/
+          if-no-files-found: error
           retention-days: 7
 
   # A red schedule is addressed to nobody. Turn a real gap into an owned ticket —


### PR DESCRIPTION
## The escalation could never have reported anything

#4434 says *"0 shard(s) exited 2, 0 reported a gap"*. Both numbers are **structural zeros** — the
escalation has never seen a verdict from any shard of any run, and could not have.

Each shard writes its verdict to `/tmp/sweep-verdict/`, and the upload step is guarded by
`hashFiles('/tmp/sweep-verdict/**')`. **`hashFiles()` resolves relative to `GITHUB_WORKSPACE` and
cannot see a path outside it**, so that guard evaluates to `''` every time.

Measured on run `31356989272`, the one that filed the issue:

| | |
|---|---|
| shard 10 | `failure` — `Java heap space` |
| its *"Upload this shard's verdict"* step | **`skipped`** |
| artifacts produced by the whole run | **`0`** |

## Why this is worse than the heap failure it was reporting

A **real metadata gap** would have been summarised identically — "0 reported a gap". The escalation
was blind in the direction that matters, and its own sentence *"This says NOTHING about whether the
metadata is complete"* happened to be true for a reason nobody knew.

The trap is invisible at the call site: the path looks absolute and correct, and nothing errors.

## Three changes

1. The verdict is written **inside the workspace**, and the guard uses a workspace-relative glob.
2. `if-no-files-found: error` on the upload — a silent no-op cannot regress quietly a second time.
3. **12 shards → 18.** The fleet is 65 modules, so 12 shards is ~5 each and shard 10 ran out of
   heap. This file's own header already said to expect this and to *prefer more shards over more
   `-Xmx`*, because 6g of a 16 GB runner is the safe per-JVM ceiling and the shard count is fixed
   while the fleet grows. It went 8 → 12 on 2026-08-08 for the same reason; ~3-4 modules per shard
   now.

The cause is recorded next to the code, not only here.

`actionlint` clean; `workflow-run-step-size` passes.

Closes #4434
