### PR TITLE
feat(campaign): add push interaction reference

### DIFF
--- a/docs/asyncapi/openbank-events.yaml
+++ b/docs/asyncapi/openbank-events.yaml
@@ -740,6 +740,13 @@ components:
           type: string
           enum: [openbank://home, openbank://savings, openbank://cards, openbank://payments, openbank://products]
           description: Optional allow-listed mobile route for a PUSH tap. Never customer content.
+        interactionRef:
+          type: string
+          format: uuid
+          description: >-
+            Optional opaque producer-owned PUSH interaction reference. campaign-service supplies
+            its send-log id; it is neither a campaign id nor party identity and is not a delivery
+            outcome correlation.
 
     SwiftMessageEventPayload:
       allOf:

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/port/out/Ports.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/port/out/Ports.kt
@@ -190,6 +190,15 @@ data class NotificationSendRequest(
     val correlationId: UUID,
     /** Closed mobile-app route, present only on a PUSH delivery. */
     val deepLink: String? = null,
+    /**
+     * Opaque, producer-owned reference carried only in a PUSH routing envelope. It is deliberately
+     * not a campaign id, party id, content id or URL: the app may return it later as evidence of
+     * an interaction, but it cannot use it to discover or select another campaign.
+     *
+     * Today it equals this request's send-log id. The later customer-edge/engagement join must
+     * validate ownership against that row before it attributes anything (issue #4480).
+     */
+    val interactionRef: UUID? = null,
 )
 
 /** ADR-0200 D3: delivery goes through notification-service, never direct. */

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/workflow/CampaignJourneyActivitiesImpl.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/workflow/CampaignJourneyActivitiesImpl.kt
@@ -337,6 +337,9 @@ private suspend fun NotificationSendPort.requestDelivery(partyId: UUID, delivery
             variables = delivery.variables,
             correlationId = sendId,
             deepLink = delivery.deepLink,
+            // A send-log id is opaque to the device but is the one durable campaign-owned row
+            // that a future attribution boundary can validate against. EMAIL never exposes it.
+            interactionRef = sendId.takeIf { delivery.channel == Channel.PUSH },
         ),
     )
 }

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/kafka/KafkaNotificationSendAdapter.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/kafka/KafkaNotificationSendAdapter.kt
@@ -14,7 +14,7 @@ import org.eclipse.microprofile.reactive.messaging.Emitter
 /**
  * ADR-0200 D3: delivery goes through notification-service, never direct. The payload shape mirrors
  * notification-service's `NotificationRequest` (partyId, channel, template, recipient, variables,
- * correlationId); the template name resolves against the notification-service catalogue there, so an
+ * correlationId, interactionRef); the template name resolves against the notification-service catalogue there, so an
  * unknown template fails closed at the choke point, not here.
  *
  * The payload is hand-built as a map rather than shared as a type — the two services do not share a
@@ -46,6 +46,9 @@ class KafkaNotificationSendAdapter(
         // This is transport metadata, never a template variable. The notification renderer's
         // closed variable schema therefore cannot accidentally interpolate a navigation route.
         request.deepLink?.let { fields["deepLink"] = it }
+        // An opaque per-send reference for an eventual app interaction. It deliberately travels
+        // beside the deep link rather than inside the template variables or customer content.
+        request.interactionRef?.let { fields["interactionRef"] = it.toString() }
         val payload = mapper.writeValueAsString(fields)
         emitter.send(payload).toCompletableFuture().join()
     }

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/workflow/CampaignJourneyActivitiesTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/workflow/CampaignJourneyActivitiesTest.kt
@@ -78,6 +78,9 @@ class CampaignJourneyActivitiesTest {
         /** App destinations handed to notification-service for the current delivery. */
         val deepLinks = mutableListOf<String?>()
 
+        /** Opaque PUSH-only references handed to notification-service (issue #4480). */
+        val interactionRefs = mutableListOf<UUID?>()
+
         val campaigns = object : CampaignRepository {
             override suspend fun findById(id: UUID) = if (id == campaignId) {
                 campaign.copy(
@@ -141,6 +144,7 @@ class CampaignJourneyActivitiesTest {
                 sendsRequested += 1
                 correlationIds += request.correlationId
                 deepLinks += request.deepLink
+                interactionRefs += request.interactionRef
             }
         }
 
@@ -206,6 +210,19 @@ class CampaignJourneyActivitiesTest {
         assertThat(h.correlationIds).hasSize(1)
         assertThat(h.recorded).hasSize(1)
         assertThat(h.correlationIds.single()).isEqualTo(h.recorded.single().id)
+    }
+
+    @Test
+    fun `a PUSH handoff carries its opaque send reference but email does not`() {
+        val push = Harness().apply { channel = Channel.PUSH }
+        runBlocking { push.activities.deliverStepGated(campaignId, partyId, 1) }
+
+        assertThat(push.interactionRefs).containsExactly(push.recorded.single().id)
+
+        val email = Harness()
+        runBlocking { email.activities.deliverStepGated(campaignId, partyId, 1) }
+
+        assertThat(email.interactionRefs).containsExactly(null)
     }
 
     /**

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/infrastructure/kafka/KafkaNotificationSendAdapterTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/infrastructure/kafka/KafkaNotificationSendAdapterTest.kt
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+package com.openbank.campaign.infrastructure.kafka
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.campaign.application.port.out.NotificationSendRequest
+import com.openbank.campaign.domain.model.Channel
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.eclipse.microprofile.reactive.messaging.Emitter
+import org.junit.jupiter.api.Test
+import java.util.UUID
+import java.util.concurrent.CompletableFuture
+
+class KafkaNotificationSendAdapterTest {
+    private val emitter = mockk<Emitter<String>>()
+    private val mapper = ObjectMapper()
+
+    @Test
+    fun `push interaction reference is transport metadata not a template variable`(): Unit = runBlocking {
+        val payload = slot<String>()
+        every { emitter.send(capture(payload)) } returns CompletableFuture.completedFuture(null)
+        val interactionRef = UUID.randomUUID()
+
+        KafkaNotificationSendAdapter(emitter, mapper).requestSend(
+            NotificationSendRequest(
+                partyId = UUID.randomUUID(),
+                channel = Channel.PUSH,
+                template = "MARKETING_PRODUCT_OFFER_PUSH",
+                recipient = "party-id",
+                variables = mapOf("offerTitle" to "Savings"),
+                correlationId = UUID.randomUUID(),
+                deepLink = "openbank://savings",
+                interactionRef = interactionRef,
+            ),
+        )
+
+        val node = mapper.readTree(payload.captured)
+        assertThat(node.path("interactionRef").asText()).isEqualTo(interactionRef.toString())
+        assertThat(node.path("variables").has("interactionRef")).isFalse()
+    }
+
+    @Test
+    fun `email handoff does not serialize an interaction reference`(): Unit = runBlocking {
+        val payload = slot<String>()
+        every { emitter.send(capture(payload)) } returns CompletableFuture.completedFuture(null)
+
+        KafkaNotificationSendAdapter(emitter, mapper).requestSend(
+            NotificationSendRequest(
+                partyId = UUID.randomUUID(),
+                channel = Channel.EMAIL,
+                template = "MARKETING_PRODUCT_OFFER",
+                recipient = "party-id",
+                variables = mapOf("offerTitle" to "Savings"),
+                correlationId = UUID.randomUUID(),
+            ),
+        )
+
+        assertThat(mapper.readTree(payload.captured).has("interactionRef")).isFalse()
+    }
+}

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/application/NotificationConsumer.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/application/NotificationConsumer.kt
@@ -646,6 +646,7 @@ class NotificationConsumer {
         put("template", req.template.name)
         put("notificationId", entity.notificationId.toString())
         req.deepLink?.let { put("deepLink", it) }
+        req.interactionRef?.let { put("interactionRef", it.toString()) }
     }
 
     /**

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/domain/model/Notification.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/domain/model/Notification.kt
@@ -114,6 +114,12 @@ data class NotificationRequest(
     val correlationId: UUID? = null,
     /** Optional bank-owned app route for a PUSH tap; never a template variable. */
     val deepLink: String? = null,
+    /**
+     * Opaque producer-owned reference supplied only for a PUSH interaction. It is passed to the
+     * device as routing metadata and is not persisted as notification content or emitted in a
+     * delivery outcome. campaign-service currently supplies its send-log id (issue #4480).
+     */
+    val interactionRef: UUID? = null,
 )
 
 /** Closed allow-list for navigation metadata sent through FCM/APNs. */

--- a/openbank-notification-service/src/test/kotlin/com/openbank/notification/integration/NotificationConsumerIT.kt
+++ b/openbank-notification-service/src/test/kotlin/com/openbank/notification/integration/NotificationConsumerIT.kt
@@ -523,8 +523,9 @@ class NotificationConsumerIT {
     }
 
     @Test
-    fun `PUSH payload carries only an allow-listed deep link alongside the opaque notification id`() {
+    fun `PUSH payload carries an allow-listed deep link and opaque interaction reference`() {
         val partyId = UUID.randomUUID()
+        val interactionRef = UUID.randomUUID()
         val token = "apns-campaign-deep-link-token-it"
         OffContextPushSender.SENT.clear()
         seedActiveDevice(partyId, token)
@@ -537,11 +538,13 @@ class NotificationConsumerIT {
                 recipient = "campaign@example.com",
                 variables = mapOf("name" to "Campaign customer"),
                 deepLink = "openbank://savings",
+                interactionRef = interactionRef,
             ),
         )
 
         assertThat(OffContextPushSender.SENT.single { it.token == token }.data)
             .containsEntry("deepLink", "openbank://savings")
+            .containsEntry("interactionRef", interactionRef.toString())
             .containsKey("notificationId")
     }
 


### PR DESCRIPTION
## What changed

Adds an opaque per-send interaction reference to campaign PUSH notifications. The reference is the campaign send-log UUID, travels as routing metadata beside the allow-listed deep link, and is never a template variable, campaign ID, party ID, URL, notification record field, or delivery outcome field.

## Why

This is the first safe contract slice for #4480. It lets the app retain evidence of which campaign PUSH opened the app without fabricating campaign engagement or conversion metrics.

## Safety boundary

Only campaign PUSH handoff supplies the reference. Email sends serialize none. The future customer-edge and engagement join must verify that the reference belongs to the authenticated party before any attribution is recorded.

## Validation

- Static diff check passed.
- Production Kotlin sources compiled locally.
- Added workflow, Kafka transport, and notification PUSH-envelope coverage.
- Targeted Gradle tests could not complete locally because this isolated ARM worktree rejects unverified Gradle plugin artifacts; CI remains the authoritative verified test run.

Refs #4480
