### PR TITLE
fix(analytics-sink): materialise the ADR-0210 D2 party key as a ClickHouse view

### DIFF
--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -2044,6 +2044,22 @@ gates:
     run: |
       bash .github/scripts/libs-change-dependents.sh --selftest
 
+  # analytics-sink owns no OLTP DB and runs no migration runner (ADR-0022): its ClickHouse DDL lives
+  # once as `clickhouse/V*.sql` resources an operator applies, and once in the `clickhouse-init`
+  # ConfigMap a FRESH cluster boots from. Nothing reconciles the two, and a migration that reaches
+  # only the resources is invisible — file in git, object present in the sandbox because someone
+  # applied it, CI green — until a warehouse is rebuilt without it. V4__screen_feedback_context.sql
+  # sat that way from 2026-07 until #4511. Compares created OBJECTS, not text, in both directions.
+  - id: clickhouse-ddl-configmap-parity
+    name: "ClickHouse DDL reaches a fresh cluster (issue #4511, enforced)"
+    group: data
+    mode: enforced
+    selftest: |
+      python3 .github/scripts/check-clickhouse-ddl-in-configmap.py --self-test
+    selftest_expect: pass
+    run: |
+      python3 .github/scripts/check-clickhouse-ddl-in-configmap.py --root .
+
   - id: kafka-acl-coverage
     name: "Kafka ACL coverage (issue #2598, enforced)"
     group: data

--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -2051,6 +2051,7 @@ gates:
   # applied it, CI green — until a warehouse is rebuilt without it. V4__screen_feedback_context.sql
   # sat that way from 2026-07 until #4511. Compares created OBJECTS, not text, in both directions.
   - id: clickhouse-ddl-configmap-parity
+    min_subjects: 15   # 22 objects today (V1-V5 + the ConfigMap's copies, 2026-08-13)
     name: "ClickHouse DDL reaches a fresh cluster (issue #4511, enforced)"
     group: data
     mode: enforced

--- a/.github/scripts/check-clickhouse-ddl-in-configmap.py
+++ b/.github/scripts/check-clickhouse-ddl-in-configmap.py
@@ -36,6 +36,9 @@ import sys
 import tempfile
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import gatelib  # import after the path insert — checkers run as scripts from the repo root
+
 SQL_GLOB = "openbank-analytics-sink/src/main/resources/clickhouse/V*.sql"
 CONFIGMAP = "openbank-infra/gitops/components/analytics/clickhouse-init-configmap.yaml"
 
@@ -54,7 +57,9 @@ def objects(text: str) -> set[str]:
     return {m.lower() for m in CREATE_RE.findall(live)}
 
 
-def check(root: Path) -> list[str]:
+def check(root: Path) -> tuple[list[str], int]:
+    """Returns (errors, objects examined). The count is the gate's subject floor: a broken glob or a
+    regex that stops matching leaves the verdict clean, and only the count can say so."""
     errors: list[str] = []
     sql_files = sorted(root.glob(SQL_GLOB))
     cm_path = root / CONFIGMAP
@@ -62,13 +67,13 @@ def check(root: Path) -> list[str]:
     # A probe that finds no subject must say so, not pass. Both inputs are required to exist: this
     # gate reporting OK because a path moved is the failure mode it is meant to prevent elsewhere.
     if not sql_files:
-        return [f"no ClickHouse DDL found at {SQL_GLOB} — the gate cannot have checked anything"]
+        return ([f"no ClickHouse DDL found at {SQL_GLOB} — the gate cannot have checked anything"], 0)
     if not cm_path.is_file():
-        return [f"{CONFIGMAP} not found — the gate cannot have checked anything"]
+        return ([f"{CONFIGMAP} not found — the gate cannot have checked anything"], 0)
 
     cm_objects = objects(cm_path.read_text())
     if not cm_objects:
-        return [f"{CONFIGMAP} declares no openbank_analytics objects — parse or path drift"]
+        return ([f"{CONFIGMAP} declares no openbank_analytics objects — parse or path drift"], 0)
 
     seen: dict[str, str] = {}
     for f in sql_files:
@@ -86,7 +91,7 @@ def check(root: Path) -> list[str]:
             f"resource creates — DDL with no source of record"
         )
 
-    return errors
+    return (errors, len(set(seen) | cm_objects))
 
 
 SELF_TEST_CM = """apiVersion: v1
@@ -112,7 +117,7 @@ def self_test() -> int:
         )
 
         # known-negative: the sets agree.
-        errs = check(root)
+        errs, _ = check(root)
         if errs:
             print(f"SELF-TEST FAIL: clean tree flagged: {errs}")
             ok = False
@@ -122,7 +127,7 @@ def self_test() -> int:
             "-- CREATE VIEW openbank_analytics.commented_out AS SELECT 1;\n"
             "CREATE OR REPLACE VIEW openbank_analytics.silver_party_accounts AS SELECT 1;\n"
         )
-        errs = check(root)
+        errs, _ = check(root)
         if not any("silver_party_accounts" in e for e in errs):
             print("SELF-TEST FAIL: a resource object missing from the ConfigMap was not flagged")
             ok = False
@@ -141,7 +146,7 @@ def self_test() -> int:
                 "kind: ConfigMap",
             )
         )
-        errs = check(root)
+        errs, _ = check(root)
         if not any("orphan_view" in e for e in errs):
             print("SELF-TEST FAIL: a ConfigMap object with no resource was not flagged")
             ok = False
@@ -149,7 +154,7 @@ def self_test() -> int:
         # known-positive C: an absent subject must fail, never read as clean.
         (sqldir / "V1__a.sql").unlink()
         (sqldir / "V2__b.sql").unlink()
-        if not check(root):
+        if not check(root)[0]:
             print("SELF-TEST FAIL: an empty subject set reported clean")
             ok = False
 
@@ -166,7 +171,10 @@ def main() -> int:
     if args.self_test:
         return self_test()
 
-    errors = check(Path(args.root))
+    errors, examined = check(Path(args.root))
+    # Printed on BOTH paths: a gate that found its corpus and then failed on it must not also read
+    # as having lost it.
+    gatelib.subjects(examined, "openbank_analytics objects across the DDL resources + ConfigMap")
     for e in errors:
         print(f"::error::{e}")
     if errors:

--- a/.github/scripts/check-clickhouse-ddl-in-configmap.py
+++ b/.github/scripts/check-clickhouse-ddl-in-configmap.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+#
+# The ClickHouse warehouse has TWO copies of its DDL and no runner joining them.
+#
+# openbank-analytics-sink owns no OLTP database and uses no Flyway (ADR-0022), so its schema lives as
+# source-controlled `.sql` resources applied by an operator, and — for a cluster built from scratch —
+# as the `clickhouse-init` ConfigMap the container runs from /docker-entrypoint-initdb.d on FIRST
+# BOOT ONLY. Nothing reconciles the two. A migration added to the resources and not to the ConfigMap
+# is invisible in every direction a person normally checks: the file is in git, the sandbox has the
+# object (an operator applied it), CI is green, and the gap only surfaces the day a warehouse is
+# rebuilt and a view its readers depend on is simply not there.
+#
+# That is not hypothetical. V4__screen_feedback_context.sql shipped 2026-07 and never reached the
+# ConfigMap, so a fresh warehouse would have had `gold_screen_feedback` without os_version / locale /
+# theme / session_id and no `gold_screen_feedback_context` at all — found while landing #4511 and
+# fixed in the same PR.
+#
+# WHAT THIS CHECKS. Objects, not bytes: every `openbank_analytics.<object>` created by a
+# `clickhouse/V*.sql` resource must also be created somewhere in the ConfigMap, and vice versa.
+# Comparing text would fail on indentation and force the two to be byte-identical, which they are not
+# and need not be; comparing the created object set is the property that actually matters ("would a
+# fresh cluster have this?"). Both directions are errors — a ConfigMap object with no resource behind
+# it is DDL with no source of record.
+#
+# WHAT IT DOES NOT CHECK: that the two definitions of an object AGREE. A caller depending on a
+# column added by a redefinition still needs its own assertion (see customer-360.test.ts).
+#
+#   python3 .github/scripts/check-clickhouse-ddl-in-configmap.py --root .
+#   python3 .github/scripts/check-clickhouse-ddl-in-configmap.py --self-test
+
+import argparse
+import re
+import sys
+import tempfile
+from pathlib import Path
+
+SQL_GLOB = "openbank-analytics-sink/src/main/resources/clickhouse/V*.sql"
+CONFIGMAP = "openbank-infra/gitops/components/analytics/clickhouse-init-configmap.yaml"
+
+# CREATE [OR REPLACE] {VIEW|MATERIALIZED VIEW|TABLE|DICTIONARY} [IF NOT EXISTS] openbank_analytics.x
+CREATE_RE = re.compile(
+    r"CREATE\s+(?:OR\s+REPLACE\s+)?(?:MATERIALIZED\s+)?(?:VIEW|TABLE|DICTIONARY)\s+"
+    r"(?:IF\s+NOT\s+EXISTS\s+)?openbank_analytics\.([A-Za-z_][A-Za-z0-9_]*)",
+    re.IGNORECASE,
+)
+
+
+def objects(text: str) -> set[str]:
+    """Objects a chunk of DDL creates. Comment lines are stripped first: every one of these files
+    quotes its own statements in prose, and a commented example would otherwise count as created."""
+    live = "\n".join(l for l in text.splitlines() if not l.lstrip().startswith("--"))
+    return {m.lower() for m in CREATE_RE.findall(live)}
+
+
+def check(root: Path) -> list[str]:
+    errors: list[str] = []
+    sql_files = sorted(root.glob(SQL_GLOB))
+    cm_path = root / CONFIGMAP
+
+    # A probe that finds no subject must say so, not pass. Both inputs are required to exist: this
+    # gate reporting OK because a path moved is the failure mode it is meant to prevent elsewhere.
+    if not sql_files:
+        return [f"no ClickHouse DDL found at {SQL_GLOB} — the gate cannot have checked anything"]
+    if not cm_path.is_file():
+        return [f"{CONFIGMAP} not found — the gate cannot have checked anything"]
+
+    cm_objects = objects(cm_path.read_text())
+    if not cm_objects:
+        return [f"{CONFIGMAP} declares no openbank_analytics objects — parse or path drift"]
+
+    seen: dict[str, str] = {}
+    for f in sql_files:
+        for obj in objects(f.read_text()):
+            seen.setdefault(obj, f.name)
+            if obj not in cm_objects:
+                errors.append(
+                    f"{f.name} creates openbank_analytics.{obj}, which the init ConfigMap never "
+                    f"creates — a warehouse built from scratch would not have it"
+                )
+
+    for obj in sorted(cm_objects - set(seen)):
+        errors.append(
+            f"the init ConfigMap creates openbank_analytics.{obj}, which no clickhouse/V*.sql "
+            f"resource creates — DDL with no source of record"
+        )
+
+    return errors
+
+
+SELF_TEST_CM = """apiVersion: v1
+data:
+  01-a.sql: |
+    CREATE TABLE IF NOT EXISTS openbank_analytics.bronze_events (x String) ENGINE = Log;
+kind: ConfigMap
+"""
+
+
+def self_test() -> int:
+    """Falsify the gate: it must FLAG a resource object missing from the ConfigMap, and must PASS
+    when the two agree. A gate that has only ever passed is unfalsified."""
+    ok = True
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        sqldir = root / "openbank-analytics-sink/src/main/resources/clickhouse"
+        sqldir.mkdir(parents=True)
+        (root / CONFIGMAP).parent.mkdir(parents=True)
+        (root / CONFIGMAP).write_text(SELF_TEST_CM)
+        (sqldir / "V1__a.sql").write_text(
+            "CREATE TABLE IF NOT EXISTS openbank_analytics.bronze_events (x String) ENGINE = Log;\n"
+        )
+
+        # known-negative: the sets agree.
+        errs = check(root)
+        if errs:
+            print(f"SELF-TEST FAIL: clean tree flagged: {errs}")
+            ok = False
+
+        # known-positive A: a resource object the ConfigMap does not create (the V4 case).
+        (sqldir / "V2__b.sql").write_text(
+            "-- CREATE VIEW openbank_analytics.commented_out AS SELECT 1;\n"
+            "CREATE OR REPLACE VIEW openbank_analytics.silver_party_accounts AS SELECT 1;\n"
+        )
+        errs = check(root)
+        if not any("silver_party_accounts" in e for e in errs):
+            print("SELF-TEST FAIL: a resource object missing from the ConfigMap was not flagged")
+            ok = False
+        if any("commented_out" in e for e in errs):
+            print("SELF-TEST FAIL: a commented-out CREATE was counted as created")
+            ok = False
+
+        # known-positive B: a ConfigMap object with no resource behind it.
+        (root / CONFIGMAP).write_text(
+            SELF_TEST_CM.replace(
+                "kind: ConfigMap",
+                "  02-b.sql: |\n"
+                "    CREATE OR REPLACE VIEW openbank_analytics.silver_party_accounts AS SELECT 1;\n"
+                "  03-c.sql: |\n"
+                "    CREATE VIEW IF NOT EXISTS openbank_analytics.orphan_view AS SELECT 1;\n"
+                "kind: ConfigMap",
+            )
+        )
+        errs = check(root)
+        if not any("orphan_view" in e for e in errs):
+            print("SELF-TEST FAIL: a ConfigMap object with no resource was not flagged")
+            ok = False
+
+        # known-positive C: an absent subject must fail, never read as clean.
+        (sqldir / "V1__a.sql").unlink()
+        (sqldir / "V2__b.sql").unlink()
+        if not check(root):
+            print("SELF-TEST FAIL: an empty subject set reported clean")
+            ok = False
+
+    print("SELF-TEST PASS" if ok else "SELF-TEST FAILED")
+    return 0 if ok else 1
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--root", default=".")
+    ap.add_argument("--self-test", action="store_true")
+    args = ap.parse_args()
+
+    if args.self_test:
+        return self_test()
+
+    errors = check(Path(args.root))
+    for e in errors:
+        print(f"::error::{e}")
+    if errors:
+        print(
+            f"\n{len(errors)} ClickHouse DDL parity problem(s). Add the migration's statements to "
+            f"{CONFIGMAP} (one `NN-<name>.sql` key per resource, applied in key order on first boot)."
+        )
+        return 1
+    print("OK: every clickhouse/V*.sql object is created by the init ConfigMap, and vice versa.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/openbank-admin-ui/src/app/api/customer-360/[partyId]/route.ts
+++ b/openbank-admin-ui/src/app/api/customer-360/[partyId]/route.ts
@@ -75,7 +75,8 @@ async function chQuery(sql: string): Promise<Record<string, unknown>[]> {
  * bronze_events is keyed by (aggregate_type, aggregate_id), and only SOME events carry partyId in
  * their payload — party, account, consent and kyc events do; transaction events do NOT (they are
  * keyed by accountId). So the party's transactions are reached through the accounts the party owns,
- * which is ADR-0210 D2's account→party resolution, done here in SQL.
+ * which is ADR-0210 D2's account→party resolution — owned by the `silver_party_accounts` view, not
+ * by this route.
  *
  * ISOLATION IS THE LOAD-BEARING PROPERTY. Both arms filter on this party: the direct arm on
  * JSONExtractString(payload,'partyId'), the indirect arm on aggregate_id IN (that party's account
@@ -83,30 +84,26 @@ async function chQuery(sql: string): Promise<Record<string, unknown>[]> {
  * transactions — which is why `customer-360.test.ts` asserts isolation, not just assembly.
  */
 function scopedRowsSql(partyId: string): string {
-  // `aggregate_type` is UPPERCASE in bronze (PARTY, ACCOUNT, ONBOARDING_FUNNEL — confirmed against
-  // the sandbox), so every comparison is folded with upper(). The first version compared against
-  // lowercase literals and silently matched nothing on the account arm: a filter that finds no rows
-  // is indistinguishable from a party that has no accounts, so nothing failed — it just showed
-  // less. Casing is normalised here and again when the rows are grouped.
+  // Ownership resolution is NOT restated here. `silver_party_accounts` (V5__party_accounts.sql) is
+  // the ADR-0210 D2 view — "materialises as a ClickHouse view alongside the existing silver views"
+  // — and this route reads it rather than re-deriving it, for the same reason the ADR rejects
+  // querying bronze directly: a resolution with two definitions has two answers, and this one IS
+  // the isolation boundary. It carries the `upper()` fold and the empty-partyId guard, and it reads
+  // bronze rather than silver because an account's latest event is typically BALANCE_UPDATED, which
+  // carries no partyId. The CTE that used to live here shipped the whole of that reasoning inside
+  // one caller (issue #4511).
   //
-  // party_accounts reads bronze_events, NOT silver_current_state, and that is deliberate: silver
-  // keeps only the LATEST event per aggregate, and an account's latest event is typically
-  // BALANCE_UPDATED, whose payload has accountId but no partyId. Resolving ownership needs the
-  // event that carried it (account opened), which only the full history has.
+  // What stays here is only the party scoping: every reference to the view is filtered to THIS
+  // party, which is what `customer-360.test.ts` asserts. A reference without that WHERE is the leak.
   return `
-    WITH party_accounts AS (
-      SELECT DISTINCT aggregate_id
-      FROM ${DB}.bronze_events
-      WHERE upper(aggregate_type) = 'ACCOUNT'
-        AND JSONExtractString(payload, 'partyId') = '${partyId}'
-    )
     SELECT aggregate_type, aggregate_id, event_type, occurred_at, payload
     FROM ${DB}.silver_current_state
     WHERE JSONExtractString(payload, 'partyId') = '${partyId}'
-       OR (upper(aggregate_type) = 'TRANSACTION'
-           AND aggregate_id IN (SELECT aggregate_id FROM party_accounts))
-       OR (upper(aggregate_type) = 'ACCOUNT'
-           AND aggregate_id IN (SELECT aggregate_id FROM party_accounts))
+       OR (upper(aggregate_type) IN ('TRANSACTION', 'ACCOUNT')
+           AND aggregate_id IN (
+             SELECT account_id FROM ${DB}.silver_party_accounts
+             WHERE party_id = '${partyId}'
+           ))
     ORDER BY occurred_at DESC
     LIMIT 5000
   `

--- a/openbank-admin-ui/src/test/customer-360.test.ts
+++ b/openbank-admin-ui/src/test/customer-360.test.ts
@@ -48,20 +48,67 @@ describe('Customer 360 isolation (ADR-0210 D2)', () => {
     // Direct arm: events that carry partyId.
     expect(sql).toContain(`JSONExtractString(payload, 'partyId') = '${PARTY}'`)
     // Indirect arm: transactions and accounts, reached ONLY through this party's accounts.
-    expect(sql).toContain('party_accounts')
-    expect(sql).toMatch(/upper\(aggregate_type\) = 'TRANSACTION'\s+AND aggregate_id IN \(SELECT aggregate_id FROM party_accounts\)/)
-    // The party_accounts CTE must itself be party-scoped — an unscoped CTE is the leak.
-    const cte = sql.slice(sql.indexOf('party_accounts AS'), sql.indexOf(')\n', sql.indexOf('party_accounts AS')))
-    expect(cte).toContain(`JSONExtractString(payload, 'partyId') = '${PARTY}'`)
-    // Ownership must be resolved from bronze (full history), not silver: an account's LATEST event
-    // is typically BALANCE_UPDATED, which carries accountId but no partyId. Verified against the
-    // sandbox — silver holds no ACCOUNT row with a partyId at all.
-    expect(cte).toContain('bronze_events')
+    expect(sql).toContain('silver_party_accounts')
+    expect(sql).toMatch(/upper\(aggregate_type\) IN \('TRANSACTION', 'ACCOUNT'\)/)
+    // EVERY reference to the view must be party-scoped — an unscoped one is the leak. Asserted over
+    // all occurrences rather than the first, so adding a second (unscoped) join goes red.
+    const refs = sql.split('silver_party_accounts').slice(1)
+    expect(refs.length).toBeGreaterThan(0)
+    for (const after of refs) {
+      expect(after.slice(0, 80)).toMatch(new RegExp(`WHERE party_id = '${PARTY}'`))
+    }
     // Type comparisons must be case-folded: bronze stores PARTY/ACCOUNT uppercase, and comparing
     // against lowercase literals matched nothing while looking like "this party has no accounts".
     expect(sql).not.toMatch(/aggregate_type = '[a-z]+'/)
     // And no other party may appear anywhere in the statement.
     expect(sql).not.toContain(OTHER)
+  })
+
+  // ADR-0210 D2 says the account→party mapping "materialises as a ClickHouse view alongside the
+  // existing silver views" and is "the one thing this ADR adds to the schema". It shipped as an
+  // inline CTE in this route instead (#4511) — a definition living in one caller, which is what the
+  // ADR rejects for the silver reduction and matters more here, because this resolution IS the
+  // isolation boundary. Nothing could see that drift: the route was correct, tested and green.
+  it('resolves ownership through the shared view, never by re-deriving it (D2)', async () => {
+    const seen = stubClickHouse([])
+    const { GET } = await import('@/app/api/customer-360/[partyId]/route')
+    await GET({} as never, { params: Promise.resolve({ partyId: PARTY }) })
+    const sql = seen[0]
+
+    // The route reads the view and does NOT restate the ownership filter — no second definition.
+    expect(sql).not.toContain('bronze_events')
+    expect(sql).not.toMatch(/aggregate_type\) = 'ACCOUNT'/)
+    expect(sql).not.toContain('WITH ')
+  })
+
+  it('the D2 view exists in the DDL of record and carries the guards the route relies on', () => {
+    // Read across the tree on purpose: the route's correctness now depends on an object defined in
+    // another module, and that dependency is exactly what has no compiler behind it.
+    const file = readFileSync(
+      path.join(process.cwd(), '../openbank-analytics-sink/src/main/resources/clickhouse/V5__party_accounts.sql'),
+      'utf-8',
+    )
+    // Comments are stripped: the file explains itself at length, and asserting over the prose would
+    // pass on a statement that says something else — the file quotes `silver_current_state` to say
+    // why it does NOT read it.
+    const ddl = file.split('\n').filter((l) => !l.trimStart().startsWith('--')).join('\n')
+    expect(ddl).toContain('openbank_analytics.silver_party_accounts')
+    // Ownership must be resolved from bronze (full history), not silver: an account's LATEST event
+    // is typically BALANCE_UPDATED, which carries accountId but no partyId. Verified against the
+    // sandbox — silver holds no ACCOUNT row with a partyId at all.
+    expect(ddl).toContain('openbank_analytics.bronze_events')
+    expect(ddl).not.toContain('silver_current_state')
+    // The case fold the route used to carry itself.
+    expect(ddl).toMatch(/upper\(aggregate_type\) = 'ACCOUNT'/)
+    // A missing key extracts to '', so without this guard every partyId-less ACCOUNT event becomes a
+    // row owned by the empty party — and a caller that skips validation joins to all of them.
+    expect(ddl).toMatch(/JSONExtractString\(payload, 'partyId'\) != ''/)
+    // CREATE OR REPLACE, not IF NOT EXISTS: the latter is a no-op on a warehouse that already has
+    // the object, which is how an edit looks applied in git and does nothing in ClickHouse.
+    expect(ddl).toContain('CREATE OR REPLACE VIEW')
+    // The columns the route selects on.
+    expect(ddl).toMatch(/AS party_id/)
+    expect(ddl).toMatch(/AS account_id/)
   })
 
   it('rejects a non-UUID partyId before it reaches ClickHouse (injection boundary)', async () => {

--- a/openbank-analytics-sink/src/main/resources/clickhouse/V5__party_accounts.sql
+++ b/openbank-analytics-sink/src/main/resources/clickhouse/V5__party_accounts.sql
@@ -1,0 +1,46 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+-- See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+--
+-- The party key (ADR-0210 D2).
+--
+-- D2 calls account→party resolution "the real work" of the Customer 360 and "the only new
+-- persistence" the ADR adds, materialising "as a ClickHouse view alongside the existing silver
+-- views". It never landed: the resolution shipped as an inline CTE inside one caller
+-- (openbank-admin-ui's /api/customer-360/[partyId] route). This migration puts it where D2 says it
+-- belongs, and that route now selects from it (issue #4511).
+--
+-- WHY IT MUST HAVE ONE DEFINITION. The ADR rejects "query bronze_events directly instead of the
+-- silver views" because "every caller would re-derive the reduction, and the first one to write it
+-- slightly differently produces a different current state". That applies to the party key with a
+-- sharper failure mode: this resolution IS the isolation boundary of the Customer 360, so a caller
+-- that widens its own copy shows another customer's accounts and transactions.
+--
+-- WHY IT READS bronze_events, NOT silver_current_state. Silver keeps only the LATEST event per
+-- aggregate, and an account's latest event is typically BALANCE_UPDATED, whose payload carries
+-- accountId but no partyId. Ownership is carried by the event that established it (account opened),
+-- which only the full history has. Verified against the sandbox: silver holds no ACCOUNT row with a
+-- partyId at all.
+--
+-- WHY upper(). aggregate_type is stored uppercase in bronze (PARTY, ACCOUNT, ONBOARDING_FUNNEL).
+-- The route's first version compared against lowercase literals and matched nothing — and a filter
+-- that finds no rows is indistinguishable from a party that owns no accounts, so nothing failed, the
+-- page just showed less. The fold is load-bearing, not defensive style.
+--
+-- WHY party_id != ''. JSONExtractString returns '' for a missing key, so every ACCOUNT event whose
+-- payload has no partyId would otherwise become a row owned by the empty party — and a caller that
+-- forgets to validate its input would join to all of them at once. The Customer 360 route cannot
+-- reach that case (its UUID regex is the injection boundary), which makes this latent rather than
+-- live; a shared view must not hand the footgun to the next caller.
+--
+-- CREATE OR REPLACE, not an edit to V1: V1's statements are all `CREATE … IF NOT EXISTS`, so editing
+-- that file changes nothing on a database where the objects already exist — it would look applied in
+-- git and silently do nothing in ClickHouse. Same reasoning V4 documents.
+
+CREATE OR REPLACE VIEW openbank_analytics.silver_party_accounts AS
+SELECT DISTINCT
+    JSONExtractString(payload, 'partyId') AS party_id,
+    aggregate_id                          AS account_id
+FROM openbank_analytics.bronze_events
+WHERE upper(aggregate_type) = 'ACCOUNT'
+  AND JSONExtractString(payload, 'partyId') != '';

--- a/openbank-infra/gitops/components/analytics/clickhouse-init-configmap.yaml
+++ b/openbank-infra/gitops/components/analytics/clickhouse-init-configmap.yaml
@@ -453,6 +453,111 @@ data:
         sum(screenshot_bytes)       AS total_bytes
     FROM openbank_analytics.gold_screen_feedback
     GROUP BY day, screenshot_status;
+  04-screen-feedback-context.sql: |
+    -- SPDX-License-Identifier: Apache-2.0
+    -- Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+    -- See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+    --
+    -- Screen-feedback rendering context (ADR-0192 completion).
+    --
+    -- V3 shipped the feedback marts with platform + app_version only. The ADR's payload also names
+    -- the OS version, locale, theme and the pseudonymous session id, and the app and edge now send
+    -- them. This migration projects those four onto the gold layer.
+    --
+    -- CREATE OR REPLACE, not a V3 edit: V3's statements are all `CREATE VIEW IF NOT EXISTS`, so
+    -- editing that file changes nothing on a database where the views already exist — it would look
+    -- applied in git and silently do nothing in ClickHouse.
+    --
+    -- Backfill note: rows written before this ships have no such keys in `payload`, and
+    -- JSONExtractString returns '' for a missing key. Historic rows therefore read as empty strings,
+    -- not NULL — the same convention V3 already uses for an absent screenshot_key.
+    --
+    -- GDPR unchanged: session_id is client-generated and pseudonymous (never an account or device
+    -- identifier), and party_id remains the key an erasure request uses to find rows and objects.
+
+    CREATE OR REPLACE VIEW openbank_analytics.gold_screen_feedback AS
+    SELECT
+        aggregate_id                                        AS reference,
+        occurred_at,
+        toDate(occurred_at)                                 AS day,
+        JSONExtractString(payload, 'partyId')               AS party_id,
+        JSONExtractString(payload, 'screenId')              AS screen_id,
+        JSONExtractString(payload, 'category')              AS category,
+        JSONExtractString(payload, 'comment')               AS comment,
+        JSONExtractString(payload, 'platform')              AS platform,
+        JSONExtractString(payload, 'appVersion')            AS app_version,
+        JSONExtractString(payload, 'osVersion')             AS os_version,
+        JSONExtractString(payload, 'locale')                AS locale,
+        JSONExtractString(payload, 'theme')                 AS theme,
+        JSONExtractString(payload, 'sessionId')             AS session_id,
+        JSONExtractString(payload, 'screenshotKey')         AS screenshot_key,
+        JSONExtractString(payload, 'screenshotStatus')      AS screenshot_status,
+        JSONExtractUInt(payload, 'screenshotBytes')         AS screenshot_bytes
+    FROM openbank_analytics.bronze_events
+    WHERE aggregate_type = 'SCREEN_FEEDBACK';
+
+    -- WHERE IT BREAKS: the same screen can be fine on one OS/theme and broken on another, which is
+    -- exactly what platform+app_version alone could not show. Ranks the combinations that generate
+    -- bug reports, so a rendering fault gets attributed instead of being averaged away.
+    CREATE OR REPLACE VIEW openbank_analytics.gold_screen_feedback_context AS
+    SELECT
+        screen_id,
+        platform,
+        os_version,
+        theme,
+        locale,
+        countIf(category = 'BUG')   AS bugs,
+        count()                     AS submissions,
+        max(occurred_at)            AS last_seen
+    FROM openbank_analytics.gold_screen_feedback
+    GROUP BY screen_id, platform, os_version, theme, locale;
+  05-party-accounts.sql: |
+    -- SPDX-License-Identifier: Apache-2.0
+    -- Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+    -- See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+    --
+    -- The party key (ADR-0210 D2).
+    --
+    -- D2 calls account→party resolution "the real work" of the Customer 360 and "the only new
+    -- persistence" the ADR adds, materialising "as a ClickHouse view alongside the existing silver
+    -- views". It never landed: the resolution shipped as an inline CTE inside one caller
+    -- (openbank-admin-ui's /api/customer-360/[partyId] route). This migration puts it where D2 says it
+    -- belongs, and that route now selects from it (issue #4511).
+    --
+    -- WHY IT MUST HAVE ONE DEFINITION. The ADR rejects "query bronze_events directly instead of the
+    -- silver views" because "every caller would re-derive the reduction, and the first one to write it
+    -- slightly differently produces a different current state". That applies to the party key with a
+    -- sharper failure mode: this resolution IS the isolation boundary of the Customer 360, so a caller
+    -- that widens its own copy shows another customer's accounts and transactions.
+    --
+    -- WHY IT READS bronze_events, NOT silver_current_state. Silver keeps only the LATEST event per
+    -- aggregate, and an account's latest event is typically BALANCE_UPDATED, whose payload carries
+    -- accountId but no partyId. Ownership is carried by the event that established it (account opened),
+    -- which only the full history has. Verified against the sandbox: silver holds no ACCOUNT row with a
+    -- partyId at all.
+    --
+    -- WHY upper(). aggregate_type is stored uppercase in bronze (PARTY, ACCOUNT, ONBOARDING_FUNNEL).
+    -- The route's first version compared against lowercase literals and matched nothing — and a filter
+    -- that finds no rows is indistinguishable from a party that owns no accounts, so nothing failed, the
+    -- page just showed less. The fold is load-bearing, not defensive style.
+    --
+    -- WHY party_id != ''. JSONExtractString returns '' for a missing key, so every ACCOUNT event whose
+    -- payload has no partyId would otherwise become a row owned by the empty party — and a caller that
+    -- forgets to validate its input would join to all of them at once. The Customer 360 route cannot
+    -- reach that case (its UUID regex is the injection boundary), which makes this latent rather than
+    -- live; a shared view must not hand the footgun to the next caller.
+    --
+    -- CREATE OR REPLACE, not an edit to V1: V1's statements are all `CREATE … IF NOT EXISTS`, so editing
+    -- that file changes nothing on a database where the objects already exist — it would look applied in
+    -- git and silently do nothing in ClickHouse. Same reasoning V4 documents.
+
+    CREATE OR REPLACE VIEW openbank_analytics.silver_party_accounts AS
+    SELECT DISTINCT
+        JSONExtractString(payload, 'partyId') AS party_id,
+        aggregate_id                          AS account_id
+    FROM openbank_analytics.bronze_events
+    WHERE upper(aggregate_type) = 'ACCOUNT'
+      AND JSONExtractString(payload, 'partyId') != '';
 kind: ConfigMap
 metadata:
   name: clickhouse-init


### PR DESCRIPTION
## Summary

ADR-0210 D2's account→party view never landed — the resolution shipped as an inline CTE inside one
caller, admin-ui's Customer 360 route. This adds `silver_party_accounts` where D2 says it belongs and
points the route at it. Found on the way: `V4__screen_feedback_context.sql` never reached the
`clickhouse-init` ConfigMap, so a warehouse built from scratch would silently lack it — fixed here
too, with a gate that makes the class of drift impossible to repeat quietly.

## Type of change

- [x] fix (bug fix)

## Linked issues

Closes #4511

## Changes

- **`V5__party_accounts.sql`** — `CREATE OR REPLACE VIEW openbank_analytics.silver_party_accounts`
  as `(party_id, account_id)` over `bronze_events`. `CREATE OR REPLACE`, not an edit to V1: V1's
  statements are all `CREATE … IF NOT EXISTS`, which is a no-op on a warehouse that already has the
  objects — it would look applied in git and do nothing in ClickHouse (the trap V4 documents).
  It carries the two guards the CTE had learned:
  - `upper(aggregate_type) = 'ACCOUNT'` — bronze stores the type uppercase, and the route's first
    version compared against lowercase literals, matching nothing. A filter that finds no rows is
    indistinguishable from a party that owns no accounts, so nothing failed; the page showed less.
  - `JSONExtractString(payload, 'partyId') != ''` — a missing key extracts to `''`, so without this
    every partyId-less ACCOUNT event becomes a row owned by the empty party. The route can't reach
    that case (its UUID regex is the injection boundary), so this is latent, not live — but a shared
    view must not hand the footgun to the next caller.
- **`route.ts`** — `scopedRowsSql()` selects `account_id FROM silver_party_accounts WHERE party_id =
  '<uuid>'` instead of restating the CTE. Same two arms, same rows, no re-derived ownership rule.
- **`clickhouse-init-configmap.yaml`** — adds `05-party-accounts.sql` **and** the missing
  `04-screen-feedback-context.sql`.
- **`check-clickhouse-ddl-in-configmap.py`** + gate `clickhouse-ddl-configmap-parity` (enforced,
  group `data`).
- **`customer-360.test.ts`** — isolation assertions rewritten for the view; two new tests.

## Why the view rather than leaving a working CTE

The route was correct, tested and green — nothing was broken today. What was wrong is *where* the
definition lived. This resolution is the isolation boundary of the Customer 360 (the route's own
comment: a widened indirect arm shows another customer's transactions), and a definition inside one
caller is a definition the second caller re-derives. ADR-0210 rejects querying `bronze_events`
directly instead of the silver views for exactly that reason — "the first one to write it slightly
differently produces a different current state" — and the casing bug above is that failure mode
already having happened once, per caller.

## Verification — each check run against a case it MUST flag

- **Gate falsified against the pre-fix tree.** Restoring `origin/main`'s ConfigMap makes it exit 1
  flagging `gold_screen_feedback_context` (the real 2026-07 defect) and `silver_party_accounts`.
  Green on the fixed tree; `--self-test` covers both directions plus an absent-subject case, so it
  cannot report clean because a path moved.
- **New tests falsified against the old route:** 2 failed / 7 passed on `origin/main`'s `route.ts`.
- **Isolation assertion falsified by a simulated leak:** deleting the `WHERE party_id` from the
  subquery goes red. It asserts over *every* reference to the view, not the first, so adding a second
  unscoped join is also red.
- `npm test` → **1183 passed / 90 files**, `npm run type-check` clean, eslint clean on both changed
  files, `ruff` clean on the new script, `run-gates.py --only clickhouse-ddl-configmap-parity` PASS,
  and the two gate meta-checks (`gate-selftest-declaration`, `gate-invocation-reachability`) PASS.

## Definition of Done

- [x] Hexagonal layering preserved (no service code touched; DDL resource + BFF SQL only).
- [x] Unit tests added/updated.
- [ ] Integration tests — N/A, no service boundary changed. `ClickHouseAnalyticsSinkIT` mounts V1
      only and asserts the bronze insert path; it does not read this view.
- [ ] Contract tests — N/A, no public API changed.
- [ ] `./gradlew …` — N/A, no Kotlin changed (a `.sql` resource only).
- [x] No new lint warnings.
- [ ] OpenAPI — N/A. Flyway — N/A (ADR-0022: this service runs no migration runner).
- [x] Docs: the DDL file states its own reasoning; ADR-0210 needs no amendment — this implements what
      D2 already decided.

## Security checklist

- [x] No secrets, tokens, passwords or PII. The view exposes `party_id` + `account_id` only; both
      already live in bronze, and payloads are PII-masked at the sink.
- [x] No new `@Suppress`/`as Any`. No new dependency.
- [ ] Auth / crypto / payment code — unchanged.
- [x] **PII path touched** → the view selects `partyId` out of bronze payloads. No new store, no new
      copy: it is a view, so GDPR Art. 17 erasure stays analytics-sink's crypto-shredding
      (ADR-0210 D5), unchanged and uninherited-from-anywhere-else.

## Compliance impact

- [x] GDPR — Art. 17 erasure inherited, not reimplemented (D5); a view holds no data of its own.
      Art. 5(1)(c) unaffected: the view narrows to two identifiers rather than widening exposure.
- [x] None otherwise. Not a money path; the Customer 360 is operator-facing and read-only (D4).

## Rollout / Rollback

**This is the one ordering-sensitive part.** The init ConfigMap applies on FIRST BOOT ONLY, so the
existing sandbox warehouse does not get the view from this merge. The admin-ui image deploys on merge
and immediately queries it, so:

1. Apply the DDL to the running warehouse **before** the admin-ui deploy lands:
   `clickhouse-client --query "$(cat openbank-analytics-sink/src/main/resources/clickhouse/V5__party_accounts.sql)"`
   (or POST it to the HTTP interface). Additive and idempotent — it creates one view and touches no
   table.
2. Fresh clusters need no step: the ConfigMap now carries it.

- Deployment strategy: rolling (admin-ui), operator-applied DDL for existing warehouses.
- Rollback: `DROP VIEW openbank_analytics.silver_party_accounts` + revert the route. The view owns no
  data, so nothing is lost either way.
- Data migration reversible: yes (view only, no table, no backfill).

If the view is missing when the route runs, the failure is loud in the right place: the route catches
it and the page renders `available: false` — a calm unavailable state, not a 5xx and not an empty
Customer 360 that reads as "this customer has nothing".

## Reviewer notes

- The V4 gap is a separate defect from the D2 drift; it is fixed here rather than split off because
  the gate that prevents both cannot be added while one of them is still red.
- `card→party` and `case→party` are named by D2 and remain unimplemented — deliberately out of scope,
  called out in #4511.
- `SilverSegmentEvaluator` (campaign-service) reads the same silver layer and is the most likely next
  caller to need this view; it does not resolve accounts today, so it is untouched.
