### PR TITLE
feat(campaign): validate push engagement attribution

### DIFF
--- a/.github/scripts/check-external-feeds.py
+++ b/.github/scripts/check-external-feeds.py
@@ -155,6 +155,10 @@ NOT_PROBED = [
     ("https://s3.eu-north-1.amazonaws.com", "AWS endpoint, reached with SigV4 credentials"),
     ("https://kc.open-bank.tech/realms/openbank-customers", "our own Keycloak realm, covered by its own probes"),
     ("https://pid.open-bank.tech", "our own PID issuer, covered by its own probes"),
+    (
+        "https://campaign-service.campaign.svc:8443",
+        "private in-cluster ownership validator; protected by mTLS and the campaign network policy",
+    ),
 ]
 
 URL_IN_TEXT = re.compile(r"https?://[^\s\"'}\)>,]+")

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/port/out/Ports.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/port/out/Ports.kt
@@ -79,9 +79,21 @@ data class CampaignEnrolmentCount(val campaignId: UUID, val count: Long)
  */
 data class ConversionContext(val firstSentAt: Instant?, val alreadyConverted: Boolean)
 
+@Suppress("TooManyFunctions") // One aggregate port; see PanacheSendLogRepository's matching rationale.
 interface SendLogRepository {
     suspend fun record(send: SendRecord)
     suspend fun countRecentForParty(partyId: UUID, sinceEpochSeconds: Long): Int
+
+    /**
+     * Whether [interactionRef] names a PUSH send made to [partyId]. This is intentionally a
+     * yes/no capability: the customer edge must never learn the campaign, step or another
+     * party from a reference supplied by a device.
+     *
+     * The fail-closed default keeps lightweight fakes safe. Production overrides it with the
+     * send-log lookup; an adapter that has not implemented attribution cannot accidentally
+     * validate a client-controlled reference.
+     */
+    suspend fun hasPushInteractionForParty(interactionRef: UUID, partyId: UUID): Boolean = false
 
     /**
      * Lifetime SENT rows for one party in one campaign — the observable state the ADR-0200 D1

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/usecase/CampaignInteractionQuery.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/usecase/CampaignInteractionQuery.kt
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.campaign.application.usecase
+
+import com.openbank.campaign.application.port.out.SendLogRepository
+import jakarta.enterprise.context.ApplicationScoped
+import java.util.UUID
+
+/**
+ * Narrow customer-edge lookup for campaign-originated app interactions.
+ *
+ * It deliberately returns no campaign data. The caller needs only one fact — that this opaque
+ * reference belongs to the authenticated party and originated from a PUSH handoff — before it
+ * allows engagement-service to append an attributed event.
+ */
+@ApplicationScoped
+class CampaignInteractionQuery(private val sendLog: SendLogRepository) {
+    suspend fun isValidForParty(interactionRef: UUID, partyId: UUID): Boolean =
+        sendLog.hasPushInteractionForParty(interactionRef, partyId)
+}

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/persistence/Persistence.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/persistence/Persistence.kt
@@ -529,6 +529,25 @@ class PanacheSendLogRepository :
     }.awaitSuspending().toInt()
 
     /**
+     * A push interaction reference is the immutable send-log id. Check ownership, medium and
+     * handoff outcome in one SQL predicate so neither the caller nor the edge can turn this into
+     * a campaign/party discovery oracle. A persisted `SENT` is the point at which the request was
+     * accepted by notification-service; suppressed and email rows are not attributable. Delivery
+     * status is deliberately not a precondition: a PUSH gateway acknowledgement is a later, weaker
+     * signal and must not erase an app interaction the bank actually observed.
+     */
+    override suspend fun hasPushInteractionForParty(interactionRef: UUID, partyId: UUID): Boolean =
+        Panache.withSession {
+            count(
+                "id = ?1 and partyId = ?2 and channel = ?3 and outcome = ?4",
+                interactionRef,
+                partyId,
+                Channel.PUSH.name,
+                SendOutcome.SENT.name,
+            ).map { it > 0 }
+        }.awaitSuspending()
+
+    /**
      * The predecessor send's delivery status (#3585 branch conditions).
      *
      * Ordered by step DESC then time DESC, and limited to one row: a retried step can leave more

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/rest/CampaignInteractionResource.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/rest/CampaignInteractionResource.kt
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.campaign.infrastructure.rest
+
+import com.openbank.campaign.application.usecase.CampaignInteractionQuery
+import com.openbank.libs.authz.Authorize
+import jakarta.annotation.security.RolesAllowed
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.ws.rs.GET
+import jakarta.ws.rs.HeaderParam
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.PathParam
+import jakarta.ws.rs.core.Response
+import java.util.UUID
+
+/**
+ * Internal, data-minimising ownership check used by customer-edge before accepting an app event.
+ *
+ * A 404 covers every invalid case (unknown id, another party, email, or a request that never made
+ * the notification handoff). Returning a common result prevents the route becoming an oracle for
+ * campaign activity. The edge turns that 404 into its public generic 400 response.
+ */
+@Path("/api/v1/campaigns/interactions")
+@ApplicationScoped
+class CampaignInteractionResource(private val query: CampaignInteractionQuery) {
+
+    @GET
+    @Path("/{interactionRef}")
+    @RolesAllowed("ROLE_API")
+    @Authorize(action = "campaign.interaction.validate", resource = "#partyId")
+    suspend fun validate(
+        @PathParam("interactionRef") interactionRef: UUID,
+        @HeaderParam("X-Customer-Party-Id") partyId: String?,
+    ): Response {
+        val customerPartyId = partyId?.let { runCatching { UUID.fromString(it) }.getOrNull() }
+            ?: return Response.status(Response.Status.BAD_REQUEST).build()
+        return if (query.isValidForParty(interactionRef, customerPartyId)) {
+            Response.noContent().build()
+        } else {
+            Response.status(Response.Status.NOT_FOUND).build()
+        }
+    }
+}

--- a/openbank-campaign-service/src/main/resources/openapi.yaml
+++ b/openbank-campaign-service/src/main/resources/openapi.yaml
@@ -4,7 +4,7 @@ openapi: 3.1.0
 info:
   title: Campaign Service API
   # major == openbank.api.version == URL /api/v1 (ADR-0048).
-  version: 1.22.0
+  version: 1.23.0
   description: >-
     Campaign management first slice (ADR-0200 / ADR-0209 D3): deterministic, versioned segments;
     per-enrolment Temporal journeys; consent-gated delivery through notification-service.
@@ -20,6 +20,35 @@ tags:
   - name: Campaigns
 
 paths:
+  /api/v1/campaigns/interactions/{interactionRef}:
+    get:
+      tags: [Campaigns]
+      summary: Validate an opaque PUSH interaction reference for the caller party
+      description: >-
+        Internal customer-edge capability only. The request carries the authoritative caller party
+        in `X-Customer-Party-Id`; the response intentionally contains no campaign, step or party
+        data. A 404 has one meaning for every unsafe state: unknown reference, wrong party, a
+        non-PUSH handoff, or a send that was never accepted by notification-service.
+      parameters:
+        - name: interactionRef
+          in: path
+          required: true
+          schema: { type: string, format: uuid }
+        - name: X-Customer-Party-Id
+          in: header
+          required: true
+          schema: { type: string, format: uuid }
+      responses:
+        "204":
+          description: Reference belongs to the caller and originated from an accepted PUSH handoff
+        "400":
+          description: Missing or malformed caller party header
+        "404":
+          description: Reference is not valid for this caller; deliberately non-specific
+        "401":
+          description: Missing service token
+        "403":
+          description: Caller is not customer-edge
   /api/v1/campaigns:
     get:
       tags: [Campaigns]

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/usecase/CampaignInteractionQueryTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/usecase/CampaignInteractionQueryTest.kt
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.campaign.application.usecase
+
+import com.openbank.campaign.application.port.out.SendLogRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+class CampaignInteractionQueryTest {
+    private val sendLog = mockk<SendLogRepository>()
+    private val query = CampaignInteractionQuery(sendLog)
+
+    @Test
+    fun `delegates the opaque reference and authoritative party to the send log`() = runBlocking {
+        val interactionRef = UUID.randomUUID()
+        val partyId = UUID.randomUUID()
+        coEvery { sendLog.hasPushInteractionForParty(interactionRef, partyId) } returns true
+
+        assertThat(query.isValidForParty(interactionRef, partyId)).isTrue()
+        coVerify(exactly = 1) { sendLog.hasPushInteractionForParty(interactionRef, partyId) }
+    }
+}

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/usecase/CampaignInteractionQueryTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/usecase/CampaignInteractionQueryTest.kt
@@ -18,7 +18,7 @@ class CampaignInteractionQueryTest {
     private val query = CampaignInteractionQuery(sendLog)
 
     @Test
-    fun `delegates the opaque reference and authoritative party to the send log`() = runBlocking {
+    fun `delegates the opaque reference and authoritative party to the send log`(): Unit = runBlocking {
         val interactionRef = UUID.randomUUID()
         val partyId = UUID.randomUUID()
         coEvery { sendLog.hasPushInteractionForParty(interactionRef, partyId) } returns true

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/integration/CampaignRestContractIT.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/integration/CampaignRestContractIT.kt
@@ -127,6 +127,85 @@ class CampaignRestContractIT {
         }
     }
 
+    private fun insertPushSend(campaignId: UUID, partyId: UUID): UUID {
+        val interactionRef = UUID.randomUUID()
+        dataSource.connection.use { connection ->
+            connection.prepareStatement(
+                """
+                INSERT INTO send_log (id, campaign_id, party_id, step_order, outcome, occurred_at, delivery_status, channel)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """.trimIndent(),
+            ).use { statement ->
+                statement.setObject(1, interactionRef)
+                statement.setObject(2, campaignId)
+                statement.setObject(3, partyId)
+                statement.setInt(4, 1)
+                statement.setString(5, "SENT")
+                statement.setObject(6, OffsetDateTime.now())
+                statement.setString(7, "PENDING")
+                statement.setString(8, "PUSH")
+                statement.executeUpdate()
+            }
+            connection.commit()
+        }
+        return interactionRef
+    }
+
+    private fun insertCampaignForSendLog(campaignId: UUID) {
+        dataSource.connection.use { connection ->
+            connection.prepareStatement(
+                """
+                INSERT INTO campaigns (
+                    id, name, goal, segment_name, segment_version, steps_json, holdout_percent,
+                    state, created_by, created_at, updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """.trimIndent(),
+            ).use { statement ->
+                statement.setObject(1, campaignId)
+                statement.setString(2, "interaction validation fixture")
+                statement.setString(3, "prove private ownership validation")
+                statement.setString(4, "actives")
+                statement.setInt(5, 1)
+                statement.setString(6, "[]")
+                statement.setInt(7, 0)
+                statement.setString(8, "ACTIVE")
+                statement.setString(9, "fixture")
+                statement.setObject(10, OffsetDateTime.now())
+                statement.setObject(11, OffsetDateTime.now())
+                statement.executeUpdate()
+            }
+            connection.commit()
+        }
+    }
+
+    @Test
+    @TestSecurity(user = "service-account-openbank-edge", roles = ["ROLE_API"])
+    fun `interaction validation is served only for the owning party and reveals no campaign data`() {
+        // The validation route intentionally needs no campaign lifecycle read. Seed the minimal
+        // durable parent directly, so this test runs entirely under the edge's ROLE_API identity
+        // rather than borrowing an operator token to create a draft.
+        val campaignId = UUID.randomUUID()
+        insertCampaignForSendLog(campaignId)
+        val owner = UUID.randomUUID()
+        val interactionRef = insertPushSend(campaignId, owner)
+
+        Given {
+            header("X-Customer-Party-Id", owner.toString())
+        } When {
+            get("/api/v1/campaigns/interactions/$interactionRef")
+        } Then {
+            statusCode(204)
+        }
+
+        Given {
+            header("X-Customer-Party-Id", UUID.randomUUID().toString())
+        } When {
+            get("/api/v1/campaigns/interactions/$interactionRef")
+        } Then {
+            statusCode(404)
+        }
+    }
+
     /**
      * The regression this file exists for, and the reason a manual check was not enough.
      *

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/integration/CampaignRestContractIT.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/integration/CampaignRestContractIT.kt
@@ -146,7 +146,6 @@ class CampaignRestContractIT {
                 statement.setString(8, "PUSH")
                 statement.executeUpdate()
             }
-            connection.commit()
         }
         return interactionRef
     }
@@ -174,7 +173,6 @@ class CampaignRestContractIT {
                 statement.setObject(11, OffsetDateTime.now())
                 statement.executeUpdate()
             }
-            connection.commit()
         }
     }
 

--- a/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
+++ b/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
@@ -201,6 +201,10 @@ class CustomerEdgeResource(
     @ConfigProperty(name = "openbank.edge.engagement-service-url")
     lateinit var engagementServiceUrl: String
 
+    /** Campaign validates opaque PUSH interaction references before engagement data is appended. */
+    @ConfigProperty(name = "openbank.edge.campaign-service-url")
+    lateinit var campaignServiceUrl: String
+
     @ConfigProperty(name = "openbank.edge.statement-service-url")
     lateinit var statementServiceUrl: String
 
@@ -2630,6 +2634,11 @@ class CustomerEdgeResource(
      * any supplied partyId with the JWT party id before forwarding, which makes the feedback loop
      * meaningful without turning it into an IDOR write primitive. Content/slot/type validation is
      * owned by engagement-service, alongside the catalogue it validates against.
+     *
+     * When the app includes an interactionRef from a PUSH payload, it is validated against the
+     * campaign send log for this JWT party before it can become an attribution datum. A reference
+     * for another party, a non-PUSH send, or an unknown id all receive the same public error — the
+     * endpoint must never disclose which of those cases happened.
      */
     @POST
     @Path("/surfaces/events")
@@ -2637,8 +2646,29 @@ class CustomerEdgeResource(
     @Blocking
     fun recordSurfaceEvent(body: String): Response {
         val customer = customer()
+        val event = runCatching { objectMapper.readTree(body) as? ObjectNode }.getOrNull()
+            ?: return badRequest("Malformed engagement event")
+        val interactionRefNode = event.get("interactionRef")
+        if (interactionRefNode != null) {
+            if (!interactionRefNode.isTextual) return badRequest("Invalid interaction reference")
+            val interactionRef = runCatching { UUID.fromString(interactionRefNode.asText()) }.getOrNull()
+                ?: return badRequest("Invalid interaction reference")
+            val validation = upstream.get(
+                "$campaignServiceUrl/api/v1/campaigns/interactions/$interactionRef",
+                customer.partyId.toString(),
+            )
+            if (validation.status != Response.Status.NO_CONTENT.statusCode) {
+                // 400/403/404 are deliberately indistinguishable to the mobile client. Upstream
+                // failure stays a 502 so the client can safely retry instead of discarding an event.
+                return if (validation.status >= UPSTREAM_SERVER_ERROR_MIN) {
+                    Response.status(Response.Status.BAD_GATEWAY).build()
+                } else {
+                    badRequest("Invalid interaction reference")
+                }
+            }
+        }
         val enriched = injectField(objectMapper, body, "partyId", customer.partyId.toString())
-            ?: return Response.status(Response.Status.BAD_REQUEST).build()
+            ?: return badRequest("Malformed engagement event")
         return upstream.post(
             "$engagementServiceUrl/api/v1/surfaces/events",
             customer.partyId.toString(),
@@ -4020,6 +4050,9 @@ class CustomerEdgeResource(
 
         /** Upper bound for upstream error text carried into an audit detail field. */
         private const val AUDIT_DETAIL_MAX_CHARS = 300
+
+        /** HTTP status classes start at this value; named to keep upstream-retry policy legible. */
+        private const val UPSTREAM_SERVER_ERROR_MIN = 500
 
         /** PSD2 RTS 2018/389 Art. 15: same-person, same-PSP transfers are SCA-exempt. */
         internal const val SCA_EXEMPTION_OWN_ACCOUNT = "PSD2_RTS_ART15_OWN_ACCOUNT"

--- a/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/UpstreamClient.kt
+++ b/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/UpstreamClient.kt
@@ -13,8 +13,13 @@ import java.net.URI
 import java.net.http.HttpClient
 import java.net.http.HttpRequest
 import java.net.http.HttpResponse
+import java.nio.file.Files
+import java.nio.file.Path
+import java.security.KeyStore
 import java.time.Duration
 import java.util.UUID
+import javax.net.ssl.SSLContext
+import javax.net.ssl.TrustManagerFactory
 
 /**
  * Singleton upstream proxy client (ADR-0065).
@@ -64,6 +69,14 @@ class UpstreamClient {
     // Quarkus to this dotted property.
     @ConfigProperty(name = "openbank.upstream.client-secret", defaultValue = "")
     var clientSecret: String = ""
+
+    /**
+     * Optional PEM CA certificate for the private HTTPS campaign validator. The edge currently
+     * uses HTTP for its other in-cluster calls, so an empty value keeps development fixtures on
+     * the platform default while GitOps mounts the private CA only in the deployed edge.
+     */
+    @ConfigProperty(name = "openbank.upstream.tls-trust-certificate-file", defaultValue = "")
+    var tlsTrustCertificateFile: String = ""
 
     // SSRF hardening: every public method below takes a caller-supplied `url` and hands it to
     // URI.create() with no host check of its own — it relies entirely on callers building `url`
@@ -127,7 +140,26 @@ class UpstreamClient {
             .version(HttpClient.Version.HTTP_1_1)
             .connectTimeout(Duration.ofMillis(connectTimeoutMs))
             .followRedirects(HttpClient.Redirect.NEVER)
+            .apply {
+                tlsTrustCertificateFile.takeIf { it.isNotBlank() }
+                    ?.let { sslContext(trustContext(Path.of(it))) }
+            }
             .build()
+    }
+
+    private fun trustContext(certificatePath: Path): SSLContext {
+        val certificates = Files.newInputStream(certificatePath).use { input ->
+            java.security.cert.CertificateFactory.getInstance("X.509").generateCertificates(input)
+        }
+        require(certificates.isNotEmpty()) { "TLS trust certificate file is empty: $certificatePath" }
+        val trustStore = KeyStore.getInstance(KeyStore.getDefaultType()).apply { load(null, null) }
+        certificates.forEachIndexed { index, certificate ->
+            trustStore.setCertificateEntry("upstream-ca-$index", certificate)
+        }
+        val trustManagers = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm()).apply {
+            init(trustStore)
+        }
+        return SSLContext.getInstance("TLS").apply { init(null, trustManagers.trustManagers, null) }
     }
 
     @Volatile private var cachedToken: String? = null

--- a/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/UpstreamClient.kt
+++ b/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/UpstreamClient.kt
@@ -17,6 +17,7 @@ import java.nio.file.Files
 import java.nio.file.Path
 import java.security.KeyStore
 import java.time.Duration
+import java.util.Optional
 import java.util.UUID
 import javax.net.ssl.SSLContext
 import javax.net.ssl.TrustManagerFactory
@@ -75,8 +76,8 @@ class UpstreamClient {
      * uses HTTP for its other in-cluster calls, so an empty value keeps development fixtures on
      * the platform default while GitOps mounts the private CA only in the deployed edge.
      */
-    @ConfigProperty(name = "openbank.upstream.tls-trust-certificate-file", defaultValue = "")
-    lateinit var tlsTrustCertificateFile: String
+    @ConfigProperty(name = "openbank.upstream.tls-trust-certificate-file")
+    lateinit var tlsTrustCertificateFile: Optional<String>
 
     // SSRF hardening: every public method below takes a caller-supplied `url` and hands it to
     // URI.create() with no host check of its own — it relies entirely on callers building `url`
@@ -141,8 +142,9 @@ class UpstreamClient {
             .connectTimeout(Duration.ofMillis(connectTimeoutMs))
             .followRedirects(HttpClient.Redirect.NEVER)
             .apply {
-                tlsTrustCertificateFile.takeIf { it.isNotBlank() }
-                    ?.let { sslContext(trustContext(Path.of(it))) }
+                tlsTrustCertificateFile
+                    .filter { it.isNotBlank() }
+                    .ifPresent { sslContext(trustContext(Path.of(it))) }
             }
             .build()
     }

--- a/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/UpstreamClient.kt
+++ b/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/UpstreamClient.kt
@@ -76,7 +76,7 @@ class UpstreamClient {
      * the platform default while GitOps mounts the private CA only in the deployed edge.
      */
     @ConfigProperty(name = "openbank.upstream.tls-trust-certificate-file", defaultValue = "")
-    var tlsTrustCertificateFile: String = ""
+    lateinit var tlsTrustCertificateFile: String
 
     // SSRF hardening: every public method below takes a caller-supplied `url` and hands it to
     // URI.create() with no host check of its own — it relies entirely on callers building `url`

--- a/openbank-customer-edge/src/main/resources/application.yaml
+++ b/openbank-customer-edge/src/main/resources/application.yaml
@@ -136,6 +136,7 @@ openbank:
     keycloak-admin-client-id: ${KEYCLOAK_ADMIN_CLIENT_ID:customer-edge-admin}
     notification-service-url: ${NOTIFICATION_SERVICE_URL:http://notification-service.notifications.svc:8112}
     engagement-service-url: ${ENGAGEMENT_SERVICE_URL:http://engagement-service.engagement.svc:8153}
+    campaign-service-url: ${CAMPAIGN_SERVICE_URL:http://campaign-service.campaign.svc:8128}
     statement-service-url: ${STATEMENT_SERVICE_URL:http://statement-service.statements.svc:8136}
     standing-order-service-url: ${STANDING_ORDER_SERVICE_URL:http://standing-order-service.payments.svc:8121}
     fx-service-url:      ${FX_SERVICE_URL:http://fx-service.fx.svc:8119}

--- a/openbank-customer-edge/src/main/resources/application.yaml
+++ b/openbank-customer-edge/src/main/resources/application.yaml
@@ -136,7 +136,7 @@ openbank:
     keycloak-admin-client-id: ${KEYCLOAK_ADMIN_CLIENT_ID:customer-edge-admin}
     notification-service-url: ${NOTIFICATION_SERVICE_URL:http://notification-service.notifications.svc:8112}
     engagement-service-url: ${ENGAGEMENT_SERVICE_URL:http://engagement-service.engagement.svc:8153}
-    campaign-service-url: ${CAMPAIGN_SERVICE_URL:http://campaign-service.campaign.svc:8128}
+    campaign-service-url: ${CAMPAIGN_SERVICE_URL:https://campaign-service.campaign.svc:8443}
     statement-service-url: ${STATEMENT_SERVICE_URL:http://statement-service.statements.svc:8136}
     standing-order-service-url: ${STANDING_ORDER_SERVICE_URL:http://standing-order-service.payments.svc:8121}
     fx-service-url:      ${FX_SERVICE_URL:http://fx-service.fx.svc:8119}
@@ -148,6 +148,9 @@ openbank:
   upstream:
     connect-timeout-ms: 5000
     request-timeout-ms: 10000
+    # The campaign interaction validator uses the private platform CA. Blank keeps local HTTP
+    # fixtures on the normal JVM trust store while the remaining east-west fleet migrates.
+    tls-trust-certificate-file: ${OPENBANK_UPSTREAM_TLS_TRUST_CERTIFICATE_FILE:}
     # M2M (client_credentials) creds for the operator realm. token-url and client-id
     # have sensible defaults in UpstreamClient; the SECRET is supplied at runtime via the
     # env var OPENBANK_UPSTREAM_CLIENT_SECRET, which Quarkus maps to the dotted property

--- a/openbank-customer-edge/src/main/resources/openapi.yaml
+++ b/openbank-customer-edge/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: Customer Edge API
-  version: 1.32.0
+  version: 1.33.0
   description: >-
     Customer-facing edge proxy (ADR-0065). Single internet-facing entry point for the
     retail customer app. Validates JWTs from the openbank-customers Keycloak realm,
@@ -2231,7 +2231,9 @@ components:
       required: [contentId, slot, type]
       description: >-
         `partyId` is deliberately absent: customer-edge derives it from the bearer token and
-        overwrites any unexpected field before the event reaches engagement-service.
+        overwrites any unexpected field before the event reaches engagement-service. `interactionRef`
+        is optional and opaque: it may only be copied from a PUSH payload. customer-edge verifies
+        its ownership and PUSH origin before accepting the event, so it is never a campaign id.
       properties:
         contentId:
           type: string
@@ -2242,6 +2244,10 @@ components:
         type:
           type: string
           enum: [IMPRESSION, CLICK, DISMISS]
+        interactionRef:
+          type: string
+          format: uuid
+          description: Opaque reference from a campaign PUSH payload, accepted only for its owning caller.
 
     FeedbackSubmission:
       type: object

--- a/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/CustomerEdgeResourceTest.kt
+++ b/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/CustomerEdgeResourceTest.kt
@@ -48,6 +48,7 @@ class CustomerEdgeResourceTest {
         accountServiceUrl = "http://account"
         balanceServiceUrl = "http://balance"
         engagementServiceUrl = "http://engagement"
+        campaignServiceUrl = "http://campaign"
     }
 
     private fun accountJson(accountId: UUID, ownerParty: UUID) =
@@ -272,6 +273,48 @@ class CustomerEdgeResourceTest {
         assertThat(response.status).isEqualTo(Response.Status.ACCEPTED.statusCode)
         assertThat(mapper.readTree(body.captured).path("partyId").asText()).isEqualTo(caller.toString())
         assertThat(mapper.readTree(body.captured).path("contentId").asText()).isEqualTo("SAVINGS_RATE_BANNER")
+    }
+
+    @Test
+    fun `recordSurfaceEvent validates an opaque interaction reference for the caller before forwarding`() {
+        val caller = UUID.randomUUID()
+        val interactionRef = UUID.randomUUID()
+        val upstream = mockk<UpstreamClient>()
+        every {
+            upstream.get(
+                "http://campaign/api/v1/campaigns/interactions/$interactionRef",
+                caller.toString(),
+            )
+        } returns Response.noContent().build()
+        every { upstream.post(any(), caller.toString(), any(), any()) } returns Response.status(202).build()
+
+        val response = resourceFor(upstream, caller).recordSurfaceEvent(
+            """{"contentId":"SAVINGS_RATE_BANNER","slot":"HOME_BANNER","type":"CLICK","interactionRef":"$interactionRef"}""",
+        )
+
+        assertThat(response.status).isEqualTo(202)
+        verify(exactly = 1) {
+            upstream.get(
+                "http://campaign/api/v1/campaigns/interactions/$interactionRef",
+                caller.toString(),
+            )
+        }
+        verify(exactly = 1) { upstream.post(any(), caller.toString(), any(), any()) }
+    }
+
+    @Test
+    fun `recordSurfaceEvent rejects another party interaction reference without forwarding`() {
+        val caller = UUID.randomUUID()
+        val interactionRef = UUID.randomUUID()
+        val upstream = mockk<UpstreamClient>()
+        every { upstream.get(any(), caller.toString()) } returns Response.status(404).build()
+
+        val response = resourceFor(upstream, caller).recordSurfaceEvent(
+            """{"contentId":"SAVINGS_RATE_BANNER","slot":"HOME_BANNER","type":"CLICK","interactionRef":"$interactionRef"}""",
+        )
+
+        assertThat(response.status).isEqualTo(400)
+        verify(exactly = 0) { upstream.post(any(), any(), any(), any()) }
     }
 
     @Test

--- a/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/UpstreamClientTest.kt
+++ b/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/UpstreamClientTest.kt
@@ -261,6 +261,7 @@ class UpstreamClientTest {
                 tokenEndpointBase = "$baseUrl/realms/openbank"
                 clientId = "openbank-edge"
                 clientSecret = "test-secret"
+                tlsTrustCertificateFile = ""
                 connectTimeoutMs = 2000
                 requestTimeoutMs = 2000
             }

--- a/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/UpstreamClientTest.kt
+++ b/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/UpstreamClientTest.kt
@@ -261,7 +261,7 @@ class UpstreamClientTest {
                 tokenEndpointBase = "$baseUrl/realms/openbank"
                 clientId = "openbank-edge"
                 clientSecret = "test-secret"
-                tlsTrustCertificateFile = ""
+                tlsTrustCertificateFile = java.util.Optional.empty()
                 connectTimeoutMs = 2000
                 requestTimeoutMs = 2000
             }

--- a/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/contract/CustomerEdgeDelegatedPaymentPactConsumerTest.kt
+++ b/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/contract/CustomerEdgeDelegatedPaymentPactConsumerTest.kt
@@ -110,6 +110,7 @@ class CustomerEdgeDelegatedPaymentPactConsumerTest {
             tokenEndpointBase = "http://127.0.0.1:${tokenServer.address.port}"
             clientId = "openbank-edge"
             clientSecret = "pact"
+            tlsTrustCertificateFile = ""
             // The Pact mock server binds 127.0.0.1, which the production default already allows.
             allowedHostSuffixes = ".svc,127.0.0.1,localhost"
         }

--- a/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/contract/CustomerEdgeDelegatedPaymentPactConsumerTest.kt
+++ b/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/contract/CustomerEdgeDelegatedPaymentPactConsumerTest.kt
@@ -110,7 +110,7 @@ class CustomerEdgeDelegatedPaymentPactConsumerTest {
             tokenEndpointBase = "http://127.0.0.1:${tokenServer.address.port}"
             clientId = "openbank-edge"
             clientSecret = "pact"
-            tlsTrustCertificateFile = ""
+            tlsTrustCertificateFile = java.util.Optional.empty()
             // The Pact mock server binds 127.0.0.1, which the production default already allows.
             allowedHostSuffixes = ".svc,127.0.0.1,localhost"
         }

--- a/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/domain/model/Engagement.kt
+++ b/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/domain/model/Engagement.kt
@@ -23,6 +23,8 @@ data class EngagementEvent(
     val slot: SurfaceSlot,
     val type: EngagementEventType,
     val occurredAt: Instant,
+    /** Opaque campaign PUSH handoff reference, validated by customer-edge before this service sees it. */
+    val interactionRef: UUID? = null,
 )
 
 /**

--- a/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/infrastructure/persistence/entity/EngagementEventEntity.kt
+++ b/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/infrastructure/persistence/entity/EngagementEventEntity.kt
@@ -38,12 +38,17 @@ class EngagementEventEntity : PanacheEntityBase() {
     @Column(nullable = false)
     lateinit var occurredAt: Instant
 
+    /** Nullable so pre-attribution app events remain explicitly unattributed, never fabricated. */
+    @Column
+    var interactionRef: UUID? = null
+
     fun toDomain(): EngagementEvent = EngagementEvent(
         partyId = partyId,
         contentId = contentId,
         slot = SurfaceSlot.valueOf(slot),
         type = EngagementEventType.valueOf(type),
         occurredAt = occurredAt,
+        interactionRef = interactionRef,
     )
 
     companion object {
@@ -55,6 +60,7 @@ class EngagementEventEntity : PanacheEntityBase() {
             entity.slot = event.slot.name
             entity.type = event.type.name
             entity.occurredAt = event.occurredAt
+            entity.interactionRef = event.interactionRef
             return entity
         }
     }

--- a/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/infrastructure/persistence/repository/EngagementEventRepositoryImpl.kt
+++ b/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/infrastructure/persistence/repository/EngagementEventRepositoryImpl.kt
@@ -34,14 +34,15 @@ class EngagementEventRepositoryImpl(
         Panache.withTransaction {
             persist(EngagementEventEntity.from(event, eventId)).chain { _ ->
                 val payload = mapper.writeValueAsString(
-                    mapOf(
-                        "eventId" to eventId.toString(),
-                        "partyId" to event.partyId.toString(),
-                        "contentId" to event.contentId,
-                        "slot" to event.slot.name,
-                        "type" to event.type.name,
-                        "occurredAt" to event.occurredAt.toString(),
-                    ),
+                    buildMap {
+                        put("eventId", eventId.toString())
+                        put("partyId", event.partyId.toString())
+                        put("contentId", event.contentId)
+                        put("slot", event.slot.name)
+                        put("type", event.type.name)
+                        put("occurredAt", event.occurredAt.toString())
+                        event.interactionRef?.let { put("interactionRef", it.toString()) }
+                    },
                 )
                 outbox.persistInTransaction(
                     OutboxMessage(

--- a/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/infrastructure/rest/SurfaceResource.kt
+++ b/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/infrastructure/rest/SurfaceResource.kt
@@ -77,6 +77,7 @@ class SurfaceResource(private val resolve: ResolveSurfaceUseCase, private val re
                 slot = slot,
                 type = type,
                 occurredAt = Instant.now(),
+                interactionRef = request.interactionRef,
             ),
         )
         return Response.status(Response.Status.ACCEPTED).build()
@@ -96,4 +97,11 @@ class SurfaceResource(private val resolve: ResolveSurfaceUseCase, private val re
     )
 }
 
-data class EngagementEventRequest(val partyId: UUID, val contentId: String, val slot: String, val type: String)
+data class EngagementEventRequest(
+    val partyId: UUID,
+    val contentId: String,
+    val slot: String,
+    val type: String,
+    /** Present only after customer-edge verified an opaque PUSH reference for this party. */
+    val interactionRef: UUID? = null,
+)

--- a/openbank-engagement-service/src/main/resources/db/migration/V3__engagement_event_interaction_reference.sql
+++ b/openbank-engagement-service/src/main/resources/db/migration/V3__engagement_event_interaction_reference.sql
@@ -1,0 +1,14 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+-- See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+--
+-- Opaque, validated campaign PUSH handoff reference (issue #4480). Nullable keeps historic and
+-- non-campaign surface events explicitly unattributed. Rollback: DROP INDEX
+-- idx_engagement_event_interaction_ref; ALTER TABLE engagement_event DROP COLUMN interaction_ref;
+
+ALTER TABLE engagement_event ADD COLUMN interaction_ref UUID;
+
+-- Supports a later bounded attribution aggregate without scanning the append-only event history.
+CREATE INDEX idx_engagement_event_interaction_ref
+    ON engagement_event (interaction_ref)
+    WHERE interaction_ref IS NOT NULL;

--- a/openbank-engagement-service/src/main/resources/openapi.yaml
+++ b/openbank-engagement-service/src/main/resources/openapi.yaml
@@ -14,7 +14,7 @@ info:
     existing yet). No NBA ranking — content returns in catalogue order until ADR-0201's model
     graduates from shadow (D5). The customer app reaches these endpoints only through
     customer-edge, whose narrowly scoped M2M policy injects the authoritative party id.
-  version: 1.2.0
+  version: 1.3.0
 tags:
   - name: Surfaces
   - name: Eligibility
@@ -155,3 +155,10 @@ components:
         type:
           type: string
           enum: [IMPRESSION, CLICK, DISMISS, CONVERSION]
+        interactionRef:
+          type: string
+          format: uuid
+          description: >-
+            Opaque reference to an accepted campaign PUSH handoff. customer-edge validates that it
+            belongs to the authenticated party before forwarding; it is absent for unattributed
+            in-app content and must never be replaced with a campaign or party identifier.

--- a/openbank-engagement-service/src/test/kotlin/com/openbank/engagement/integration/SurfaceRestContractIT.kt
+++ b/openbank-engagement-service/src/test/kotlin/com/openbank/engagement/integration/SurfaceRestContractIT.kt
@@ -16,6 +16,7 @@ import io.smallrye.reactive.messaging.memory.InMemoryConnector
 import org.assertj.core.api.Assertions.assertThat
 import org.eclipse.microprofile.config.ConfigProvider
 import org.junit.jupiter.api.Test
+import java.sql.Connection
 import java.sql.DriverManager
 import java.sql.Timestamp
 import java.time.Instant
@@ -135,6 +136,25 @@ class SurfaceRestContractIT {
         }
     }
 
+    @Test
+    @TestSecurity(user = TEST_OPERATOR, roles = ["ROLE_OPERATOR"])
+    fun `a validated opaque interaction reference survives the real HTTP to database path`() {
+        val party = UUID.randomUUID()
+        val interactionRef = UUID.randomUUID()
+        Given {
+            contentType("application/json")
+            body(
+                """{"partyId":"$party","contentId":"SAVINGS_RATE_BANNER","slot":"HOME_BANNER","type":"CLICK","interactionRef":"$interactionRef"}""",
+            )
+        } When {
+            post("/api/v1/surfaces/events")
+        } Then {
+            statusCode(202)
+        }
+
+        assertThat(readInteractionRefFor(party)).isEqualTo(interactionRef)
+    }
+
     // ── AdverseStateResource (issue #4265 item 1) ──────────────────────────────────────────────
     //
     // These live in THIS class rather than a second @QuarkusTest deliberately. A new IT class would
@@ -220,12 +240,7 @@ class SurfaceRestContractIT {
 
     /** The JDBC URL is the one EngagementPostgresTestResource injected — never a second copy. */
     private fun insertAdverseState(partyId: UUID, state: String) {
-        val config = ConfigProvider.getConfig()
-        DriverManager.getConnection(
-            config.getValue("quarkus.datasource.jdbc.url", String::class.java),
-            config.getValue("quarkus.datasource.username", String::class.java),
-            config.getValue("quarkus.datasource.password", String::class.java),
-        ).use { conn ->
+        openTestDatabase().use { conn ->
             conn.prepareStatement(
                 "INSERT INTO party_adverse_state (id, party_id, state, set_at) VALUES (?, ?, ?, ?)",
             ).use { st ->
@@ -236,6 +251,26 @@ class SurfaceRestContractIT {
                 st.executeUpdate()
             }
         }
+    }
+
+    private fun readInteractionRefFor(partyId: UUID): UUID? = openTestDatabase().use { conn ->
+        readInteractionRef(conn, partyId)
+    }
+
+    private fun openTestDatabase(): Connection {
+        val config = ConfigProvider.getConfig()
+        return DriverManager.getConnection(
+            config.getValue("quarkus.datasource.jdbc.url", String::class.java),
+            config.getValue("quarkus.datasource.username", String::class.java),
+            config.getValue("quarkus.datasource.password", String::class.java),
+        )
+    }
+
+    private fun readInteractionRef(connection: Connection, partyId: UUID): UUID? = connection.prepareStatement(
+        "SELECT interaction_ref FROM engagement_event WHERE party_id = ? ORDER BY occurred_at DESC LIMIT 1",
+    ).use { statement ->
+        statement.setObject(1, partyId)
+        statement.executeQuery().use { rows -> if (rows.next()) rows.getObject(1, UUID::class.java) else null }
     }
 
     private companion object {

--- a/openbank-infra/gitops/components/campaign/campaign-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/campaign/campaign-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: campaign-service
     app.kubernetes.io/part-of: campaign
   annotations:
-    openbank.tech/policy-checksum: "e74f4c8fcd208fc2"
+    openbank.tech/policy-checksum: "1c9cf23a7c9fa0a9"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -586,6 +586,16 @@ data:
     	not startswith(input.principal.id, "service-account-")
     	"ROLE_AUDITOR" in input.principal.roles
     	input.action in {"campaign.read", "campaign.list"}
+    }
+
+    # The customer edge may validate only the opaque interaction reference that it received back from
+    # notification-service. It gets a yes/no response scoped to the JWT-derived party id; campaign
+    # details never leave this boundary. This is deliberately a different action from campaign.read:
+    # granting the edge the latter would expose the entire operator campaign plane.
+    allowed_reasons contains "edge-campaign-interaction-validation" if {
+        input.principal.type == "HUMAN"
+        input.principal.id == "service-account-openbank-edge"
+        input.action == "campaign.interaction.validate"
     }
   agents.rego: |
     # SPDX-License-Identifier: Apache-2.0

--- a/openbank-infra/gitops/components/campaign/campaign-service-internal-tls.yaml
+++ b/openbank-infra/gitops/components/campaign/campaign-service-internal-tls.yaml
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+#
+# The application keeps HTTP/8128 for the existing admin BFF and exposes the customer-edge
+# interaction validator in parallel over this private-CA TLS listener on 8443.
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: campaign-service-internal-tls
+  namespace: campaign
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  secretName: campaign-service-internal-tls
+  duration: 2160h
+  renewBefore: 360h
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  dnsNames:
+    - campaign-service.campaign.svc
+    - campaign-service.campaign.svc.cluster.local
+  issuerRef:
+    name: openbank-ca
+    kind: ClusterIssuer
+    group: cert-manager.io

--- a/openbank-infra/gitops/components/campaign/campaign-service.yaml
+++ b/openbank-infra/gitops/components/campaign/campaign-service.yaml
@@ -53,9 +53,19 @@ spec:
           ports:
             - name: http
               containerPort: 8128
+            - name: https
+              containerPort: 8443
             - name: management
               containerPort: 8085
           env:
+            # Keep the existing HTTP port for the admin BFF. The interaction validator gets a
+            # parallel TLS port, so customer-edge does not introduce another plaintext edge.
+            - name: QUARKUS_HTTP_SSL_CERTIFICATE_FILES
+              value: /mnt/campaign-tls/tls.crt
+            - name: QUARKUS_HTTP_SSL_CERTIFICATE_KEY_FILES
+              value: /mnt/campaign-tls/tls.key
+            - name: QUARKUS_HTTP_SSL_PORT
+              value: "8443"
             # Reactive + JDBC (Flyway) legs onto the same CNPG primary; username is
             # the `openbank` owner, password from the CNPG-generated app secret.
             - name: QUARKUS_DATASOURCE_JDBC_URL
@@ -283,6 +293,10 @@ spec:
           secret:
             secretName: kafka-cluster-ca-truststore
             optional: false
+        - name: campaign-tls
+          secret:
+            secretName: campaign-service-internal-tls
+            optional: false
         - name: opa-tmp
           emptyDir: {}
         - name: opa-bundle
@@ -305,6 +319,9 @@ spec:
     - name: http
       port: 8128
       targetPort: http
+    - name: https
+      port: 8443
+      targetPort: https
     - name: management
       port: 8085
       targetPort: management

--- a/openbank-infra/gitops/components/campaign/campaign-service.yaml
+++ b/openbank-infra/gitops/components/campaign/campaign-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-campaign-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "e74f4c8fcd208fc2"
+        openbank.tech/policy-checksum: "1c9cf23a7c9fa0a9"
       labels:
         app.kubernetes.io/name: campaign-service
         app.kubernetes.io/part-of: campaign

--- a/openbank-infra/gitops/components/campaign/campaign_rest_ext.rego
+++ b/openbank-infra/gitops/components/campaign/campaign_rest_ext.rego
@@ -56,3 +56,13 @@ allowed_reasons contains "campaign-auditor-read" if {
 	"ROLE_AUDITOR" in input.principal.roles
 	input.action in {"campaign.read", "campaign.list"}
 }
+
+# The customer edge may validate only the opaque interaction reference that it received back from
+# notification-service. It gets a yes/no response scoped to the JWT-derived party id; campaign
+# details never leave this boundary. This is deliberately a different action from campaign.read:
+# granting the edge the latter would expose the entire operator campaign plane.
+allowed_reasons contains "edge-campaign-interaction-validation" if {
+    input.principal.type == "HUMAN"
+    input.principal.id == "service-account-openbank-edge"
+    input.action == "campaign.interaction.validate"
+}

--- a/openbank-infra/gitops/components/campaign/network-policies.yaml
+++ b/openbank-infra/gitops/components/campaign/network-policies.yaml
@@ -44,6 +44,9 @@ spec:
     - from:
         - namespaceSelector:
             matchLabels:
+              kubernetes.io/metadata.name: customer-edge
+        - namespaceSelector:
+            matchLabels:
               kubernetes.io/metadata.name: admin-ui
       ports:
         - protocol: TCP

--- a/openbank-infra/gitops/components/campaign/network-policies.yaml
+++ b/openbank-infra/gitops/components/campaign/network-policies.yaml
@@ -51,6 +51,8 @@ spec:
       ports:
         - protocol: TCP
           port: 8128
+        - protocol: TCP
+          port: 8443
     - from:
         - namespaceSelector:
             matchLabels:

--- a/openbank-infra/gitops/components/customer-edge/customer-edge-internal-tls.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge-internal-tls.yaml
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+#
+# Materialises a namespace-local copy of the private CA chain. customer-edge mounts only ca.crt
+# and never receives the campaign server key; OIDC and OPA remain the request-authorization controls.
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: customer-edge-internal-tls
+  namespace: customer-edge
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  secretName: customer-edge-internal-tls
+  duration: 2160h
+  renewBefore: 360h
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  commonName: customer-edge.customer-edge.svc
+  issuerRef:
+    name: openbank-ca
+    kind: ClusterIssuer
+    group: cert-manager.io

--- a/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
@@ -232,7 +232,9 @@ spec:
             # reference before engagement-service appends it. Declare it here (not only in the
             # in-image default) so the generated NetworkPolicy permits customer-edge → campaign.
             - name: CAMPAIGN_SERVICE_URL
-              value: http://campaign-service.campaign.svc:8128
+              value: https://campaign-service.campaign.svc:8443
+            - name: OPENBANK_UPSTREAM_TLS_TRUST_CERTIFICATE_FILE
+              value: /mnt/campaign-tls/ca.crt
             - name: STATEMENT_SERVICE_URL
               value: http://statement-service.statements.svc:8136
             - name: STANDING_ORDER_SERVICE_URL
@@ -310,6 +312,10 @@ spec:
               readOnly: true
             - name: kafka-truststore
               mountPath: /mnt/kafka-truststore
+              readOnly: true
+            - name: campaign-tls-trust
+              mountPath: /mnt/campaign-tls/ca.crt
+              subPath: ca.crt
               readOnly: true
           readinessProbe:
             httpGet:
@@ -420,6 +426,9 @@ spec:
         - name: kafka-truststore
           secret:
             secretName: kafka-cluster-ca-truststore
+        - name: campaign-tls-trust
+          secret:
+            secretName: customer-edge-internal-tls
 ---
 apiVersion: v1
 kind: Service

--- a/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
@@ -228,6 +228,11 @@ spec:
             # so declare the real cross-namespace URL here to allow edge → engagement.
             - name: ENGAGEMENT_SERVICE_URL
               value: http://engagement-service.engagement.svc:8153
+            # Campaign's ownership-only endpoint validates an optional opaque PUSH interaction
+            # reference before engagement-service appends it. Declare it here (not only in the
+            # in-image default) so the generated NetworkPolicy permits customer-edge → campaign.
+            - name: CAMPAIGN_SERVICE_URL
+              value: http://campaign-service.campaign.svc:8128
             - name: STATEMENT_SERVICE_URL
               value: http://statement-service.statements.svc:8136
             - name: STANDING_ORDER_SERVICE_URL


### PR DESCRIPTION
## What changed

Completes the first safe in-app campaign-attribution path, stacked on #4516:

- campaign-service validates an opaque PUSH send-log reference for the authoritative caller party;
- customer-edge reads the party only from the customer JWT, validates an optional reference before forwarding an engagement event, and never exposes campaign details;
- engagement-service persists the validated optional reference append-only and carries it through its transactional outbox;
- GitOps declares the new edge → campaign dependency and regenerates the campaign OPA bundle / ingress allow-list.

## Why

Before this PR, an app impression/click/dismiss had no trustworthy campaign correlation. Adding a client-supplied campaign id would permit forged attribution and cross-customer leakage. The new reference is opaque, ownership-scoped, PUSH-only, and non-specific when invalid (404 upstream / generic 400 at the public edge).

This is deliberately a data-integrity foundation, not a claim that campaign engagement or conversion reporting is already complete. Aggregate marketer reporting remains a follow-up once events are observed at volume.

Refs #4480

## Validation

- Gradle ktlintCheck and detekt for campaign, engagement and customer-edge
- campaign HTTP + Postgres contract: 27/27
- engagement HTTP + Postgres contract: 10/10
- customer-edge unit tests: 82/82
