### PR TITLE
fix(ci): stop the perf gate timing 401s, and refuse to time an error path

### DIFF
--- a/.github/scripts/k6-smoke-path.py
+++ b/.github/scripts/k6-smoke-path.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Print the request path a k6 smoke script exercises, for perf-gate.yml's pre-flight probe.
+
+WHY THIS EXISTS. perf-gate.yml waits for /q/health/ready and then hands k6 the clock. Readiness
+says the process is up; it says nothing about the route the script calls. Measured on run
+31570530574: product-catalog reported `http_req_failed 100.00%, 108685 out of 108685` while
+`http_req_duration` PASSED at avg 1.14ms — the latency of an authentication rejection. Every
+number that gate has ever published for that service was a measurement of the error path.
+
+Extracting the path here rather than inline keeps the quoting out of a `run:` block, where a
+regex full of ${} and quotes trips shellcheck and, worse, is easy to get subtly wrong.
+
+Self-test:  k6-smoke-path.py --self-test
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+# `http.get(`${BASE_URL}/api/v1/products`, {` -> /api/v1/products
+PATTERN = re.compile(r"\$\{BASE_URL\}(?P<path>[^`'\"]*)")
+
+
+def smoke_path(source: str) -> str:
+    m = PATTERN.search(source)
+    if not m:
+        raise SystemExit("no ${BASE_URL}<path> request found — cannot pre-flight this script")
+    return m.group("path") or "/"
+
+
+def _self_test() -> int:
+    cases = [
+        ("const r = http.get(`${BASE_URL}/api/v1/products`, {});", "/api/v1/products"),
+        ('http.get(`${BASE_URL}/api/v1/fees?type=X`)', "/api/v1/fees?type=X"),
+        ("http.get(`${BASE_URL}/`)", "/"),
+        ("http.get(`${BASE_URL}`)", "/"),
+    ]
+    bad = 0
+    for src, want in cases:
+        got = smoke_path(src)
+        ok = got == want
+        bad += not ok
+        print(f"  {'PASS' if ok else 'FAIL'}  {src!r} -> {got!r} (want {want!r})")
+    try:
+        smoke_path("http.get('http://hardcoded/api')")
+        print("  FAIL  a script with no ${BASE_URL} must be rejected, not guessed")
+        bad += 1
+    except SystemExit:
+        print("  PASS  a script with no ${BASE_URL} is rejected rather than guessed")
+    print(f"self-test: {'all cases passed' if not bad else f'{bad} failed'}")
+    return 1 if bad else 0
+
+
+if __name__ == "__main__":
+    if "--self-test" in sys.argv:
+        raise SystemExit(_self_test())
+    print(smoke_path(Path(sys.argv[1]).read_text()))

--- a/.github/workflows/perf-gate.yml
+++ b/.github/workflows/perf-gate.yml
@@ -139,7 +139,7 @@ jobs:
             -Dquarkus.datasource.username=openbank \
             -Dquarkus.datasource.password="${POSTGRES_PASSWORD}" \
             -Dquarkus.oidc.enabled=false \
-            -Dquarkus.http.auth.enabled=false \
+            -Dquarkus.security.auth.enabled-in-dev-mode=false \
             -Dquarkus.management.enabled=false \
             -Dquarkus.console.basic=true \
             --console=plain --quiet \
@@ -160,6 +160,20 @@ jobs:
           fi
 
           SCRIPT="${SERVICE}/src/test/k6/$(echo "${SERVICE}" | sed 's/^openbank-//;s/-service$//')-smoke.js"
+
+          # A readiness probe is not proof the PROBED route answers. This gate spent its whole
+          # life measuring 401s: /q/health/ready returned 200, @Authenticated rejected every
+          # request to the route the script actually calls, and k6 reported a p95 for the
+          # rejection. Assert one real 200 on that route before handing k6 the clock.
+          SMOKE_PATH="$(python3 .github/scripts/k6-smoke-path.py "$SCRIPT")"
+          probe="$(curl -s -o /dev/null -w '%{http_code}' "http://localhost:${PORT}${SMOKE_PATH}" || true)"
+          if [ "$probe" != "200" ]; then
+            echo "::error::[${SERVICE}] ${SMOKE_PATH} answered ${probe}, not 200 — k6 would time the error path. Refusing to report a latency for a request that never reached the handler."
+            tail -50 "perf-reports/${SERVICE}-boot.log" || true
+            exit 1
+          fi
+          echo "==> [${SERVICE}] ${SMOKE_PATH} answered 200 — the probe reaches its subject"
+
           echo "==> [${SERVICE}] running k6 ${SCRIPT}"
           BASE_URL="http://localhost:${PORT}" \
             k6 run \


### PR DESCRIPTION
## It was never a latency breach

#4470 reports the weekly perf gate failing on `openbank-product-catalog`. From the run's own k6
summary:

```
✗ http_req_failed .......: 100.00%  108685 out of 108685
✗ checks ................:   0.00%       0 out of 326055
✓ http_req_duration .....: avg=1.14ms  min=298µs  p(95)=2.27ms
```

**Every request failed**, and the latency that *passed* is the latency of an authentication
rejection. This gate has never measured product-catalog's performance — it has been publishing a
p95 for the error path.

## Cause, proven from the jars

The harness boots with:

```
-Dquarkus.oidc.enabled=false -Dquarkus.http.auth.enabled=false
```

**`quarkus.http.auth.enabled` does not exist.** `quarkus-vertx-http-3.38.0` declares exactly one key
in that namespace — `quarkus.http.auth.proactive`. Quarkus ignores an unknown property silently, so
the flag disabled nothing, `@Authenticated` on `ProductCatalogResource.list` rejected every request,
and the result read as a performance finding.

The real switch is **`quarkus.security.auth.enabled-in-dev-mode`**, declared by
`quarkus-security-deployment-3.38.0`; `quarkusDev` is dev mode, so it applies exactly.

`ProductCatalogResourceTest` passes because `@TestSecurity` mocks an identity. Nothing in the perf
path does.

## So this cannot come back quietly

Readiness is not proof the **probed route** answers — `/q/health/ready` returned 200 throughout. The
harness now asserts one real `200` on the path the k6 script actually calls, before handing k6 the
clock, and reports the status it got otherwise:

```
::error::[openbank-product-catalog] /api/v1/products answered 401, not 200 — k6 would time the
error path. Refusing to report a latency for a request that never reached the handler.
```

The path is extracted by `.github/scripts/k6-smoke-path.py` rather than a regex inside a `run:`
block. 5 self-test cases, including that a script with **no** `${BASE_URL}` is *rejected* rather
than guessed — a helper that invents a path would reintroduce the same class of blindness.

## What this does not claim

It does **not** claim the gate is now green. With authentication genuinely off the endpoint will
answer 200 and k6 will time the handler for the first time. Those numbers have never existed, so the
first real run may breach a threshold that was set while nothing was being measured. That is a
finding to read, not a regression.

`actionlint` clean; lint shard 18/18.

Closes #4470
