### PR TITLE
fix(ci): provision Temporal and resolve config expressions in the authenticated-fuzz harness

### DIFF
--- a/.github/workflows/api-fuzz-authenticated.yml
+++ b/.github/workflows/api-fuzz-authenticated.yml
@@ -178,6 +178,10 @@ jobs:
           # reached `docker run -e POSTGRES_USER=${QUARKUS_DATASOURCE_USERNAME:openbank_settlement}`,
           # initdb rejected it, the container exited, and the boot log then blamed Flyway
           # ("Connection to localhost:5432 refused") — never the container that was already gone.
+          # Credentials are then passed EXPLICITLY below rather than left to whichever env var
+          # the service happens to read: the fleet mostly reads ${POSTGRES_PASSWORD}, which this
+          # job sets, while settlement-service reads ${QUARKUS_DATASOURCE_PASSWORD}, which it does
+          # not — so settlement met "password authentication failed" once its container did start.
           resolve_expr() {
             printf '%s' "$1" | sed -E 's/^"//; s/"$//; s/^\$\{[A-Za-z0-9_]+:([^}]*)\}$/\1/'
           }
@@ -239,6 +243,8 @@ jobs:
           ./gradlew ":${svc}:quarkusDev" \
             -Dquarkus.console.basic=true --console=plain --quiet \
             -Dquarkus.datasource.jdbc.url="jdbc:postgresql://localhost:5432/${DB}" \
+            -Dquarkus.datasource.username="${DBUSER}" \
+            -Dquarkus.datasource.password="${POSTGRES_PASSWORD}" \
             -Dquarkus.oidc.enabled=true \
             -Dquarkus.oidc.auth-server-url=http://localhost:8543/realms/openbank \
             -Dquarkus.oidc.client-id=openbank-services \

--- a/.github/workflows/api-fuzz-authenticated.yml
+++ b/.github/workflows/api-fuzz-authenticated.yml
@@ -172,8 +172,22 @@ jobs:
           SPEC="${svc}/src/main/resources/openapi.yaml"
           PORT="$(grep -m1 -A3 '^  http:' "$APP_YAML" | grep -m1 'port:' | grep -oE '[0-9]+')"
           DB="$(grep -m1 'jdbc:postgresql://\|postgresql://' "$APP_YAML" | sed -E 's|.*/([A-Za-z0-9_]+).*|\1|')"
-          DBUSER="$(grep -m1 '^    username:' "$APP_YAML" | awk '{print $2}')"
+          # `${VAR:default}` is a MicroProfile config EXPRESSION, not a literal. The harness sets
+          # no env, so the DEFAULT is what the service will actually use, and the raw string must
+          # never be handed to docker. settlement-service writes its username that way; the literal
+          # reached `docker run -e POSTGRES_USER=${QUARKUS_DATASOURCE_USERNAME:openbank_settlement}`,
+          # initdb rejected it, the container exited, and the boot log then blamed Flyway
+          # ("Connection to localhost:5432 refused") — never the container that was already gone.
+          resolve_expr() {
+            printf '%s' "$1" | sed -E 's/^"//; s/"$//; s/^\$\{[A-Za-z0-9_]+:([^}]*)\}$/\1/'
+          }
+          DBUSER="$(resolve_expr "$(grep -m1 '^    username:' "$APP_YAML" | sed -E 's/^[^:]*:[[:space:]]*//')")"
           DBUSER="${DBUSER:-openbank}"
+          case "$DBUSER" in
+            *[!A-Za-z0-9_]*)
+              echo "::error::[${svc}] datasource username did not resolve to a plain identifier: ${DBUSER}"
+              exit 1 ;;
+          esac
           echo "==> [${svc}] port=${PORT} db=${DB} user=${DBUSER}"
 
           docker run -d --name fuzz-pg -p 5432:5432 \
@@ -186,6 +200,38 @@ jobs:
             docker exec fuzz-pg pg_isready -U "${DBUSER}" >/dev/null 2>&1 && break; sleep 2
           done
 
+          # Four money-path services register a Temporal worker AT BOOT and the harness provided no
+          # Temporal server: dev mode retried gRPC to :7233 (or to the cluster DNS name, which does
+          # not resolve on a runner) until the readiness window expired, so they never reached the
+          # fuzz step. 4 of the 5 boot failures in run 30804842325 — sepa-payment, transaction,
+          # domestic-payment, lending (#3039). The CLI image's `server start-dev` is IN-MEMORY, so
+          # this costs no extra database, and it creates the namespaces it is given — a worker
+          # registering against a namespace that does not exist fails the same way.
+          # The namespace is READ FROM THE SERVICE's own config, never a list kept here.
+          TEMPORAL_NS="$(resolve_expr "$(grep -m1 -A6 '^  temporal:' "$APP_YAML" \
+            | grep -m1 'namespace:' | sed -E 's/^[^:]*:[[:space:]]*//')")"
+          TEMPORAL_ARGS=""
+          if [ -n "${TEMPORAL_NS:-}" ]; then
+            echo "==> [${svc}] starting Temporal dev server (namespace ${TEMPORAL_NS})"
+            docker run -d --name fuzz-temporal -p 7233:7233 temporalio/temporal:1.8.2 \
+              server start-dev --ip 0.0.0.0 --port 7233 -n "${TEMPORAL_NS}" >/dev/null
+            TEMPORAL_UP=0
+            for i in $(seq 1 30); do
+              if docker exec fuzz-temporal temporal operator namespace describe \
+                   --address localhost:7233 "${TEMPORAL_NS}" >/dev/null 2>&1; then
+                TEMPORAL_UP=1; break
+              fi
+              sleep 2
+            done
+            if [ "$TEMPORAL_UP" != "1" ]; then
+              echo "::error::[${svc}] Temporal dev server never became ready"
+              docker logs fuzz-temporal 2>&1 | tail -20; exit 1
+            fi
+            # domestic-payment and lending default to the in-cluster frontend DNS name; the
+            # override points every target at the throwaway server regardless of its default.
+            TEMPORAL_ARGS="-Dopenbank.temporal.server-url=localhost:7233"
+          fi
+
           # Boot with OIDC ENABLED (override the %dev oidc.enabled=false) pointed at
           # the throwaway Keycloak. authz.enforce stays false for this target, so no
           # OPA sidecar is needed — OIDC authN is the only gate being exercised.
@@ -197,6 +243,7 @@ jobs:
             -Dquarkus.oidc.auth-server-url=http://localhost:8543/realms/openbank \
             -Dquarkus.oidc.client-id=openbank-services \
             -Dquarkus.oidc.credentials.secret="${OIDC_CLIENT_SECRET}" \
+            ${TEMPORAL_ARGS} \
             > "fuzz-reports/${svc}-boot.log" 2>&1 &
           DEV_PID=$!
           UP=0
@@ -245,7 +292,7 @@ jobs:
 
           kill "$DEV_PID" 2>/dev/null || true
           pkill -f "quarkusDev" 2>/dev/null || true
-          docker rm -f fuzz-pg fuzz-redis fuzz-keycloak >/dev/null 2>&1 || true
+          docker rm -f fuzz-pg fuzz-redis fuzz-keycloak fuzz-temporal >/dev/null 2>&1 || true
           exit "$RC"
 
       - name: Upload fuzz reports


### PR DESCRIPTION
# The five boot failures, grouped by root cause

Re-derived from run [30804842325](https://github.com/JiRaska/open-bank-oss/actions/runs/30804842325)
(the most recent run of `api-fuzz-authenticated.yml`, attempt-scoped jobs endpoint). The matrix is
now **18 services, 12 failing**. Only **5 of those 12 fail to boot** — the other 7 boot, serve the
fuzzed surface and fail on genuine findings, which is the lane working and is not this PR's subject.

Method note, because this repo has been bitten by it: the boot failures were identified by the
`::error::[<svc>] failed to boot` marker with the service name **substituted**, not the literal
`${svc}` that the job log also contains from its own `run:` script listing. Causes were read from the
executed `--- boot failure ---` section, not the echoed script.

| # | Service | Terminating cause (quoted from the run log) | Class |
|---|---|---|---|
| 1 | `openbank-sepa-payment` | `Connection refused: localhost/127.0.0.1:7233` (Temporal gRPC) | harness — **fixed here** |
| 2 | `openbank-transaction-service` | `Connection refused: localhost/127.0.0.1:7233` (Temporal gRPC) | harness — **fixed here** |
| 3 | `openbank-domestic-payment` | `UnknownHostException: temporal-frontend.temporal.svc.cluster.local` | harness — **fixed here** |
| 4 | `openbank-lending-service` | `UnknownHostException: temporal-frontend.temporal.svc.cluster.local` | harness — **fixed here** |
| 5 | `openbank-settlement-service` | `FlywaySqlUnableToConnectToDbException: … Connection to localhost:5432 refused` | harness — **fixed here** |

Both groups are harness gaps: a dependency the harness should provide and did not. No service change
is in this PR.

## Group A — no Temporal server (4 services)

These four register a Temporal worker at boot. The harness provisions Postgres, Redis and Keycloak,
and no Temporal, so dev mode retried the gRPC channel until the 180 s readiness window expired:

```
[io.te.se.ChannelManager] Resetting gRPC connection backoff on the gRPC channel
  ManagedChannelOrphanWrapper{delegate=ManagedChannelImpl{logId=1, target=localhost:7233}}
```

Two of them (`domestic-payment`, `lending`) default to the in-cluster frontend DNS name, which does
not resolve on a hosted runner, so the same gap presents as `UnknownHostException`.

Fix: start `temporalio/temporal:1.8.2 server start-dev`. That is the CLI image's **in-memory** server
— it needs no extra database, unlike `auto-setup`. The namespace is read from the service's own
`openbank.temporal.namespace` and passed as `-n`, because a worker registering against a namespace
that does not exist fails the same way as no server at all; and a namespace list kept in the workflow
would be exactly the "gate scoped by a hand-kept list" shape this repo already has a rule about.
`-Dopenbank.temporal.server-url=localhost:7233` points every target at it regardless of its own
default.

## Group B — an unresolved config expression killed the database (1 service)

`settlement-service` writes its datasource username as a MicroProfile config **expression**:

```yaml
username: "${QUARKUS_DATASOURCE_USERNAME:openbank_settlement}"
```

The harness's `awk '{print $2}'` took that string literally and handed it to
`docker run -e POSTGRES_USER=…`. initdb rejected it, the container exited, and the service then met
`Connection to localhost:5432 refused` — so the boot log named **Flyway**, and never the container
that had already gone. The step now resolves `${VAR:default}` to its default (the harness sets no
env, so the default is what the service will use), strips quotes, and fails loudly if the result is
still not a plain identifier rather than passing it to docker.

## What this does not fix

Nothing is left in the boot group — all 5 are addressed. Deliberately **not** in scope:

- **The 7 services that fail on findings** (balance 3, delegation 4, ledger 2, interest 2, fx 1,
  fraud 1, swift 1 server errors). Those are what the lane exists to produce and need per-service
  triage, mostly already in flight.
- **Two non-fatal schema-validation ERRORs** that appear in these logs *above* the terminating cause:
  `missing table [object_store_blobs]` (sepa-payment, transaction, domestic-payment) and
  `wrong column type … [description] in table [collateral]` (lending). Boot continued past both in
  the recorded run — the Temporal chain is what terminated it — so they are not what this PR fixes.
  They are real drift and belong to #2872, and the verification run below is what establishes whether
  they matter once Temporal is present.

## Verification

Local, before pushing:

- `temporalio/temporal:1.8.2 server start-dev -n <ns>` starts and creates the namespace; the exact
  readiness probe used in the step (`temporal operator namespace describe`) went green after 2 polls.
- The new derivation was run against all 18 matrix services' `application.yaml`: usernames resolve to
  plain identifiers for all 18 (settlement now `openbank_settlement` instead of the raw expression),
  and a Temporal namespace is derived for exactly the services that declare one.
- `actionlint` finding set is byte-identical to `origin/main` (2 pre-existing SC2034 on the loop
  counter). Largest `run:` step is 6235 chars, well under the 19000 gate.

A real dispatch of this branch against the five services is running; its result is posted as a
comment on this PR. **Until that lands, "these five now boot" is a claim supported by the local
evidence above, not by a green run** — and a harness that boots a service but fuzzes nothing would be
the same failure one layer along, so what the comment must show is the fuzz step doing work, not just
the absence of the boot marker.

Refs #3039
