### PR TITLE
test(notification): the #4512 code path is sound — pin the durable-record invariant

### DIFF
--- a/openbank-notification-service/src/test/kotlin/com/openbank/notification/integration/NotificationConsumerIT.kt
+++ b/openbank-notification-service/src/test/kotlin/com/openbank/notification/integration/NotificationConsumerIT.kt
@@ -8,6 +8,7 @@ import com.openbank.notification.application.NotificationConsumer.Companion.GENE
 import com.openbank.notification.application.port.out.PushMessage
 import com.openbank.notification.application.port.out.PushSender
 import com.openbank.notification.domain.model.NotificationChannel
+import com.openbank.notification.domain.model.NotificationOutcomeEvent
 import com.openbank.notification.domain.model.NotificationRequest
 import com.openbank.notification.domain.model.NotificationTemplate
 import com.openbank.notification.domain.model.PushResult
@@ -446,6 +447,44 @@ class NotificationConsumerIT {
         // A delivered push carries no failure reason — the column means "why this FAILED", so a
         // stale value on a SENT row would be worse than none.
         assertThat(failureReasonFor(partyId)).isNull()
+    }
+
+    /**
+     * Issue #4512 — a PUSH for a party with NO device token must still leave a durable row.
+     *
+     * Measured in the sandbox on 2026-08-13: four SCA_APPROVAL pushes were logged on 2026-08-09
+     * (`PUSH: no active devices`, four distinct parties, three hours apart) and the `notifications`
+     * table holds no row for any of them — its newest row is 2026-08-08 11:35. Not erasure (no
+     * `GDPR Art. 17` log line and no `party-events-in` erase in the window), not a restore (the
+     * CNPG cluster has run on its original `initdb` bootstrap since 2026-06-01), and not a
+     * dispatch failure (`Failed to process notification` never logged).
+     *
+     * This pins the code path the issue accuses: `dispatch` persists the row in its own
+     * transaction BEFORE the channel fan-out, and the no-device branch then marks it FAILED with
+     * `no_active_device`. If this passes, the persistence path is sound and the missing rows are
+     * an operational fact about the deployment rather than a defect here — which is worth knowing
+     * before anyone "fixes" the code.
+     */
+    @Test
+    fun `a PUSH to a party with no device still persists a FAILED row and its reason`() {
+        val partyId = UUID.randomUUID()
+        // Deliberately seed nothing: this is the no-device case.
+
+        consumeAndAwait(
+            NotificationRequest(
+                partyId = partyId,
+                channel = NotificationChannel.PUSH,
+                template = NotificationTemplate.SCA_APPROVAL,
+                recipient = "no-device@example.com",
+                variables = mapOf("detail" to "Payment of 10.00 EUR"),
+            ),
+        )
+
+        // The row is the point. A notification that was attempted and left no trace cannot be
+        // counted, alerted on, or reconstructed after the fact.
+        assertThat(countFor(partyId)).isEqualTo(1)
+        assertThat(statusFor(partyId)).isEqualTo("FAILED")
+        assertThat(failureReasonFor(partyId)).isEqualTo(NotificationOutcomeEvent.REASON_NO_DEVICE)
     }
 
     /**


### PR DESCRIPTION
Closes the investigation half of #4512. **The accused code path is sound** — the reproduction test
passes against `main` — so this ships the test rather than a fix, and re-aims the issue.

## What was measured

`dispatch` persists the notification row in its own transaction **before** the channel fan-out, and
the no-device branch marks it `FAILED` / `no_active_device`. Driven end to end through the real
consumer and a real database (`NotificationConsumerIT`, Testcontainers), that is exactly what
happens: **14 tests, 0 failures, 0 skipped**, including the new one.

So the four missing rows in the sandbox are not this defect. Shipping a speculative fix to the
persistence path would have changed working code on a wrong diagnosis.

## Why the test stays

The invariant it pins — *a notification that was attempted leaves evidence that it was attempted* —
is precisely what #4512 found violated in production, and nothing else asserted it. A mocked
repository cannot see this class of failure, which is why the existing suite never did.

## Ruled out, recorded so nobody re-walks it

| Hypothesis | Verdict |
|---|---|
| GDPR erasure removed the rows | No. Zero `GDPR Art. 17` lines and no `party-events-in` erase in the window. |
| The database was restored from a backup | No. The CNPG cluster has run on its original `initdb` bootstrap since 2026-06-01; `firstRecoverabilityPoint` 2026-07-14. |
| The dispatch failed and was swallowed | No. `Failed to process notification` is never logged in the window. |
| The id gaps prove mass deletion | **No — and this one is the trap.** 71 rows spread over ids 1..1351 with the sequence at 1551 reads exactly like 1280 deleted rows. It is not: Hibernate's pooled sequence allocation burns a block per application instance, and this service's pod is replaced on every sandbox deploy, so sparse ids are the expected shape. I nearly filed that as the finding. |

## What is still unexplained, and how a recurrence gets caught

I cannot account for the four missing rows from the evidence available, and I am not going to invent
a cause to close the issue with. What has changed is that a recurrence is now **detectable**:
`openbank_notification_push_fanouts_total` (phase 0) increments in code before the database write, so
a divergence between that counter and the row count is a measurable signal rather than something
only a manual query would ever surface.

Note also that the pod is replaced on every sandbox deploy, and the four log lines each fell within
~10 minutes of a container start. That is a correlation, not a cause — I could not establish that
in-flight work is lost on replacement, and say so rather than dressing the coincidence up.

Refs #4512, #4353, #4348.
