### PR TITLE
ci(governance): falsify four small guards — and remove a filter that hid real violations

### DIFF
--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -677,6 +677,8 @@ gates:
     name: "admin-ui version sync guard (version.txt == package.json, enforced)"
     group: supplychain
     mode: enforced
+    selftest: bash .github/scripts/check-admin-ui-version-sync.sh --self-test
+    selftest_expect: pass
     run: |
       bash .github/scripts/check-admin-ui-version-sync.sh .
 
@@ -831,6 +833,8 @@ gates:
     name: "quarkus.application.version override guard (release_invariant, enforced)"
     group: supplychain
     mode: enforced
+    selftest: bash .github/scripts/check-app-version-override.sh --self-test
+    selftest_expect: pass
     run: |
       bash .github/scripts/check-app-version-override.sh .
 
@@ -1600,6 +1604,8 @@ gates:
     group: kotlin
     mode: enforced
     min_subjects: 500   # 1184 test sources today (2026-08-09)
+    selftest: bash .github/scripts/check-test-runblocking-unit.sh --self-test
+    selftest_expect: pass
     run: |
       bash .github/scripts/check-test-runblocking-unit.sh .
 
@@ -1621,6 +1627,8 @@ gates:
     group: kotlin
     mode: enforced
     min_subjects: 900   # 1889 service source files today (2026-08-09)
+    selftest: bash .github/scripts/check-exception-mapper-collision.sh --self-test
+    selftest_expect: pass
     run: |
       bash .github/scripts/check-exception-mapper-collision.sh .
 

--- a/.github/scripts/check-admin-ui-version-sync.sh
+++ b/.github/scripts/check-admin-ui-version-sync.sh
@@ -19,6 +19,40 @@
 # Usage: check-admin-ui-version-sync.sh [repo-root]   (default: .)
 set -euo pipefail
 
+# --- self-test ------------------------------------------------------------------------
+# release-please bumps version.txt, but its package.json extra-file updater is REPLACE-based
+# and silently desyncs after a one-off drift. Otherwise the mismatch surfaces at DEPLOY time,
+# where build-push-admin-ui.sh fails post-merge; this gate moves it to PR time.
+if [ "${1:-}" = "--self-test" ]; then
+  set +e
+  td=$(mktemp -d); trap 'rm -rf "$td"' EXIT
+  fails=0
+  mk() { mkdir -p "$1/openbank-admin-ui"; printf '%s\n' "$2" > "$1/openbank-admin-ui/version.txt"
+         printf '{"version": "%s"}\n' "$3" > "$1/openbank-admin-ui/package.json"; }
+  expect() { local label="$1" root="$2" want="$3" sub="${4:-}" out rc
+    out=$(bash "$0" "$root" 2>&1); rc=$?
+    if [ "$rc" -ne "$want" ]; then echo "::error::self-test: $label — want rc=$want got $rc: $out" >&2; fails=$((fails+1))
+    elif [ -n "$sub" ] && ! printf '%s' "$out" | grep -qF -- "$sub"; then
+      echo "::error::self-test: $label — rc right, reason wrong (no '$sub'): $out" >&2; fails=$((fails+1)); fi; }
+
+  a="$td/drift"; mk "$a" 0.91.4 0.91.3
+  expect "a version mismatch is FLAGGED" "$a" 1 "version drift"
+  b="$td/same"; mk "$b" 0.91.4 0.91.4
+  expect "matching versions are clean" "$b" 0 "OK (0.91.4)"
+  # A trailing newline in version.txt is the normal shape and must not read as a mismatch.
+  c="$td/ws"; mkdir -p "$c/openbank-admin-ui"; printf '  0.91.4 \n' > "$c/openbank-admin-ui/version.txt"
+  printf '{"version": "0.91.4"}\n' > "$c/openbank-admin-ui/package.json"
+  expect "surrounding whitespace is not a mismatch" "$c" 0 "OK"
+  # ABSENCE: the script skips, which is right in a partial checkout — but the skip must be
+  # VISIBLE, or a moved path reads exactly like a passing gate.
+  d="$td/none"; mkdir -p "$d"
+  expect "an absent admin-ui says so rather than passing silently" "$d" 0 "absent — skip"
+
+  if [ "$fails" -gt 0 ]; then echo "self-test FAILED ($fails case(s))" >&2; exit 1; fi
+  echo "self-test ok: admin-ui version-sync guard is falsifiable (4 cases)"
+  exit 0
+fi
+
 ROOT="${1:-.}"
 VT="${ROOT}/openbank-admin-ui/version.txt"
 PJ="${ROOT}/openbank-admin-ui/package.json"

--- a/.github/scripts/check-app-version-override.sh
+++ b/.github/scripts/check-app-version-override.sh
@@ -18,6 +18,46 @@
 # stdlib-only (awk); no PyYAML/yamllint dependency. ENFORCED.
 # Usage: check-app-version-override.sh [root]   (default root: .)
 set -euo pipefail
+
+# --- self-test ------------------------------------------------------------------------
+# `quarkus.application.version` in application.yaml OVERRIDES the value release-please derives
+# from version.txt, so the artifact reports a version nobody bumped (rules.yaml:
+# release_invariant). The check is an awk path-walk — exactly the code that looks right and is
+# off by one nesting level.
+if [ "${1:-}" = "--self-test" ]; then
+  set +e
+  td=$(mktemp -d); trap 'rm -rf "$td"' EXIT
+  fails=0
+  svc() { mkdir -p "$td/$1/src/main/resources"; printf '%b' "$3" > "$td/$1/src/main/resources/application.yaml"
+          if [ "$2" = released ]; then echo 1.0.0 > "$td/$1/version.txt"; fi; }
+  expect() { local label="$1" want="$2" sub="${3:-}" out rc
+    out=$(bash "$0" "$td" 2>&1); rc=$?
+    if [ "$rc" -ne "$want" ]; then echo "::error::self-test: $label — want rc=$want got $rc: $out" >&2; fails=$((fails+1))
+    elif [ -n "$sub" ] && ! printf '%s' "$out" | grep -qF -- "$sub"; then
+      echo "::error::self-test: $label — rc right, reason wrong (no '$sub'): $out" >&2; fails=$((fails+1)); fi; }
+  reset() { rm -rf "$td"/openbank-x; }
+
+  reset; svc openbank-x released 'quarkus:\n  application:\n    version: 9.9.9\n'
+  expect "quarkus.application.version is FLAGGED" 1 "must NOT be set"
+  reset; svc openbank-x released 'quarkus:\n  application:\n    name: x\n'
+  expect "no version key is clean" 0 "none set quarkus.application.version"
+  # NESTING: the same leaf under a different parent is a different property entirely, and
+  # flagging it would push authors to delete a legitimate container-image version.
+  reset; svc openbank-x released 'quarkus:\n  container-image:\n    version: 1.2.3\n'
+  expect "version under another quarkus child is not this defect" 0 "none set"
+  reset; svc openbank-x released 'other:\n  application:\n    version: 1.2.3\n'
+  expect "application.version outside quarkus is not this defect" 0 "none set"
+  # SCOPE: a module with no version.txt is not a released component, so the invariant is moot.
+  reset; svc openbank-x unreleased 'quarkus:\n  application:\n    version: 9.9.9\n'
+  expect "a non-released module is skipped" 0 "1 non-released skipped"
+  # Every fix for this carries a comment naming the key it removed.
+  reset; svc openbank-x released 'quarkus:\n  application:\n    # version: never set this here\n    name: x\n'
+  expect "the key in a comment is not a hit" 0 "none set"
+
+  if [ "$fails" -gt 0 ]; then echo "self-test FAILED ($fails case(s))" >&2; exit 1; fi
+  echo "self-test ok: quarkus.application.version override guard is falsifiable (6 cases)"
+  exit 0
+fi
 root="${1:-.}"
 fail=0
 checked=0

--- a/.github/scripts/check-exception-mapper-collision.sh
+++ b/.github/scripts/check-exception-mapper-collision.sh
@@ -28,6 +28,47 @@
 # check-no-service-principal-type.sh / check-domain-purity.py. ENFORCED.
 # Usage: check-exception-mapper-collision.sh [root]   (default root: .)
 set -euo pipefail
+
+# --- self-test ------------------------------------------------------------------------
+# libs-runtime owns the mappers for the shared JDK exception types. A service-local
+# ExceptionMapper for the SAME type collides non-deterministically — whichever CDI bean wins
+# decides the HTTP status, and it can differ between builds (#526). The rule the fleet relies
+# on is "map IllegalArgumentException to 400 in libs-runtime, never locally".
+if [ "${1:-}" = "--self-test" ]; then
+  set +e
+  td=$(mktemp -d); trap 'rm -rf "$td"' EXIT
+  fails=0
+  put() { mkdir -p "$(dirname "$1")"; printf '%b' "$2" > "$1"; }
+  expect() { local label="$1" root="$2" want="$3" sub="${4:-}" out rc
+    out=$(bash "$0" "$root" 2>&1); rc=$?
+    if [ "$rc" -ne "$want" ]; then echo "::error::self-test: $label — want rc=$want got $rc: $out" >&2; fails=$((fails+1))
+    elif [ -n "$sub" ] && ! printf '%s' "$out" | grep -qF -- "$sub"; then
+      echo "::error::self-test: $label — rc right, reason wrong (no '$sub'): $out" >&2; fails=$((fails+1)); fi; }
+  K() { echo "$1/openbank-x/src/main/kotlin/M.kt"; }
+
+  # THE DEFECT: a local mapper for a libs-runtime-owned type.
+  a="$td/bad"; put "$(K "$a")" 'class M : ExceptionMapper<IllegalArgumentException> {\n}\n'
+  expect "a local mapper for IllegalArgumentException is FLAGGED" "$a" 1 "collides non-deterministically"
+  # The sanctioned fix: a dedicated exception type of the service's own.
+  b="$td/good"; put "$(K "$b")" 'class M : ExceptionMapper<MyOwnDomainException> {\n}\n'
+  expect "a mapper for a service-owned type is clean" "$b" 0 "none collide"
+  # Another owned type from the list, so the case does not pin one name only.
+  c="$td/state"; put "$(K "$c")" 'class M : ExceptionMapper<IllegalStateException> {\n}\n'
+  expect "IllegalStateException is covered too" "$c" 1 "collides non-deterministically"
+  # PROSE: the comment explaining the ban names the very type it bans.
+  d="$td/comment"; # The comment must carry the FULL signature `: ExceptionMapper<...>`, or the pattern never
+  # matches it and the comment filter is never exercised — a fixture that cannot reach the
+  # branch it claims to test.
+  put "$(K "$d")" '// never write : ExceptionMapper<IllegalArgumentException> here (#526)\nclass M : ExceptionMapper<MyOwnDomainException> {\n}\n'
+  expect "the type named in a comment is not a hit" "$d" 0 "none collide"
+  # A tree with no Kotlin at all must not read like a clean fleet.
+  e="$td/empty"; mkdir -p "$e/openbank-x/src/main/kotlin"
+  expect "an empty tree reports 0 checked" "$e" 0 "0 "
+
+  if [ "$fails" -gt 0 ]; then echo "self-test FAILED ($fails case(s))" >&2; exit 1; fi
+  echo "self-test ok: ExceptionMapper collision guard is falsifiable (5 cases)"
+  exit 0
+fi
 root="${1:-.}"
 fail=0
 checked=0

--- a/.github/scripts/check-gate-selftest-declaration.py
+++ b/.github/scripts/check-gate-selftest-declaration.py
@@ -329,7 +329,6 @@ def main():
 # self-corroboration trap as widening a known-good set with the layer it is checking).
 DEBT = {
     "accounting-clock-gate": DEBT_MARKER,
-    "admin-ui-version-sync-guard": DEBT_MARKER,
     "adr-registry-integrity-check": DEBT_MARKER,
     "advisory-gate-registration": DEBT_MARKER,
     "agent-charter-registry-parity": DEBT_MARKER,
@@ -354,18 +353,15 @@ DEBT = {
     "mcp-charter-data-scope-binding": DEBT_MARKER,
     "mcp-real-port-requires-caller-auth-first": DEBT_MARKER,
     "no-dead-code-service-principal-rego-rule": DEBT_MARKER,
-    "no-service-local-exceptionmapper-collision-with-libs-runtime": DEBT_MARKER,
     "openapi-route-conformance": DEBT_MARKER,
     "openapi-server-port": DEBT_MARKER,
     "operator-write-naming": DEBT_MARKER,
     "prompt-registry-integrity": DEBT_MARKER,
     "psd2-anonymous-grant-stays-behind-eidas-mtls": DEBT_MARKER,
-    "quarkus-application-version-override-guard": DEBT_MARKER,
     "release-scope-mismatch-gate": DEBT_MARKER,
     "rolesallowed-realm-parity": DEBT_MARKER,
     "schema-compat-gate": DEBT_MARKER,
     "service-runbook-drift": DEBT_MARKER,
-    "test-runblocking-unit-guard": DEBT_MARKER,
     "threat-model-coverage": DEBT_MARKER,
 }
 

--- a/.github/scripts/check-test-runblocking-unit.sh
+++ b/.github/scripts/check-test-runblocking-unit.sh
@@ -14,6 +14,56 @@
 # expression-body form without an explicit `: Unit` return type. Scope: src/test
 # only. Usage: check-test-runblocking-unit.sh [root-dir] (default: .)
 set -euo pipefail
+
+# NOTE: there is no `grep -v ": Unit"` here any more, and there must not be. The detection
+# pattern already requires `) = runBlocking`, so the FIXED form `(): Unit = runBlocking` cannot
+# match it — the filter was redundant against the case it was written for. What it did instead
+# was drop any line containing ": Unit" ANYWHERE, so a genuine violation whose parameter list
+# happened to carry that type — `fun \`pays\`(p: Unit) = runBlocking {` — was silently skipped
+# by the gate whose whole job is to stop tests being silently skipped. Measured: flagged after
+# the removal, clean before it.
+
+# --- self-test ------------------------------------------------------------------------
+# `fun foo() = runBlocking { }` infers a non-Unit return type and JUnit5 SILENTLY IGNORES the
+# method — the test never runs, and never fails. This guard is the only thing between that and
+# a suite reporting green about assertions nobody executed.
+if [ "${1:-}" = "--self-test" ]; then
+  set +e
+  td=$(mktemp -d); trap 'rm -rf "$td"' EXIT
+  fails=0
+  put() { mkdir -p "$(dirname "$1")"; printf '%b' "$2" > "$1"; }
+  expect() { local label="$1" root="$2" want="$3" sub="${4:-}" out rc
+    out=$(bash "$0" "$root" 2>&1); rc=$?
+    if [ "$rc" -ne "$want" ]; then echo "::error::self-test: $label — want rc=$want got $rc: $out" >&2; fails=$((fails+1))
+    elif [ -n "$sub" ] && ! printf '%s' "$out" | grep -qF -- "$sub"; then
+      echo "::error::self-test: $label — rc right, reason wrong (no '$sub'): $out" >&2; fails=$((fails+1)); fi; }
+
+  a="$td/bad"; put "$a/svc/src/test/kotlin/T.kt" '@Test\nfun `pays`() = runBlocking {\n  assertTrue(true)\n}\n'
+  expect "an untyped = runBlocking test is FLAGGED" "$a" 1 "SILENTLY DROPPED"
+  b="$td/good"; put "$b/svc/src/test/kotlin/T.kt" '@Test\nfun `pays`(): Unit = runBlocking {\n  assertTrue(true)\n}\n'
+  expect ": Unit is clean" "$b" 0
+  c="$td/plain"; put "$c/svc/src/test/kotlin/T.kt" '@Test\nfun pays() = runBlocking {\n  assertTrue(true)\n}\n'
+  expect "a plain function name is FLAGGED too" "$c" 1 "SILENTLY DROPPED"
+  # THE FALSE NEGATIVE the redundant ": Unit" line-filter used to create: a real violation
+  # whose PARAMETER carries that type. This is the case that break "unit-filter" must fail on.
+  f="$td/paramunit"; put "$f/svc/src/test/kotlin/T.kt" '@Test\nfun `pays`(p: Unit) = runBlocking {\n  assertTrue(true)\n}\n'
+  expect "a violation with a ': Unit' PARAMETER is still FLAGGED" "$f" 1 "SILENTLY DROPPED"
+  # ...and the fixed form must stay clean, which the detection pattern alone already ensures.
+  g="$td/retunit"; put "$g/svc/src/test/kotlin/T.kt" '@Test\nfun `pays`(p: String): Unit = runBlocking {\n  assertTrue(true)\n}\n'
+  expect "': Unit' in RETURN position is clean" "$g" 0
+
+  # SCOPE: main-source runBlocking is a different rule with its own gate; flagging it here
+  # would double-report and make both noisy.
+  d="$td/mainsrc"; put "$d/svc/src/main/kotlin/M.kt" 'fun helper() = runBlocking {\n  x()\n}\n'
+  expect "main source is out of scope" "$d" 0
+  # A tree with no tests must say ZERO rather than let a moved layout read like a clean suite.
+  e="$td/empty"; mkdir -p "$e"
+  expect "an empty tree reports 0 subjects" "$e" 0 "SUBJECTS=0"
+
+  if [ "$fails" -gt 0 ]; then echo "self-test FAILED ($fails case(s))" >&2; exit 1; fi
+  echo "self-test ok: test runBlocking Unit guard is falsifiable (7 cases)"
+  exit 0
+fi
 ROOT="${1:-.}"
 
 # Match a function declaration whose body is `= runBlocking {` with no `: Unit`
@@ -24,7 +74,7 @@ violations="$(
        \( -type d \( -name node_modules -o -name build -o -name .claude -o -name .git \) -prune \) -o \
        \( -path '*/src/test/*' -name '*.kt' -exec \
             grep -nE 'fun [A-Za-z`].*\) = runBlocking ?\{' {} + \) 2>/dev/null \
-    | grep -v ': Unit' || true
+    || true
 )"
 
 scanned="$(find "$ROOT" \


### PR DESCRIPTION
Batch 5. Debt **39 → 35** on this branch.

## The defect found

`check-test-runblocking-unit.sh` filtered its own findings with `grep -v ": Unit"` — a **line-level** exclusion. The detection pattern already requires `) = runBlocking`, so the fixed form `(): Unit = runBlocking` could never match it: the filter was **redundant against the case it was written for**.

What it did instead was drop any line containing `: Unit` anywhere:

```kotlin
@Test fun `pays`(p: Unit) = runBlocking { ... }   // real violation, NOT reported
```

A genuine violation whose *parameter* carried that type was silently skipped — by the gate whose entire job is to stop tests being silently skipped. Measured both ways: **flagged after the removal, clean before it.** Two fixtures now pin it, and reintroducing the filter turns the self-test red.

## Also falsified

| gate | cases | the ones that matter |
|---|---|---|
| `admin-ui-version-sync-guard` | 4 | the **absent** case — the skip must be visible, or a moved path reads exactly like a passing gate |
| `quarkus-application-version-override-guard` | 6 | the **nesting** cases — the same `version:` leaf under `quarkus.container-image`, or a non-quarkus root, is a different property |
| `no-service-local-exceptionmapper-collision` | 5 | a local mapper for a libs-runtime-owned JDK type collides non-deterministically (#526) |

## And one of my own

The comment-filter fixture for the ExceptionMapper guard used prose the detection pattern **could never match anyway**, so the branch it claimed to cover was never reached — and the deliberate break that removed that filter went **uncaught**. The fixture now carries the full `: ExceptionMapper<...>` signature, as a real fix comment would.

Every verdict over the real tree is unchanged. Shards: `lint 18/18 · supplychain 20/20 · kotlin 19/19`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
