### PR TITLE
feat(admin-ui): elevate campaign composer

### DIFF
--- a/openbank-admin-ui/e2e/campaign-content-experiment.spec.ts
+++ b/openbank-admin-ui/e2e/campaign-content-experiment.spec.ts
@@ -72,6 +72,9 @@ test('authors a measured A/B content experiment and renders its conservative res
   await page.locator('#c-name').fill('Headline comparison')
   await page.locator('#c-goal').fill('Open more accounts')
   await page.locator('[data-segment="actives@1"]').click()
+  // The studio is app-first by default. This scenario deliberately authors the richer e-mail
+  // template because both experiment arms exercise its complete variable contract.
+  await page.locator('[data-channel-pick="EMAIL"]').click()
   await page.locator('#var-0-offerTitle').fill('Save more with A')
   await page.locator('#var-0-offerText').fill('A copy')
   await page.locator('#var-0-ctaText').fill('Open')

--- a/openbank-admin-ui/e2e/campaign-entry-authoring.spec.ts
+++ b/openbank-admin-ui/e2e/campaign-entry-authoring.spec.ts
@@ -49,6 +49,9 @@ test('authors a recurring campaign from the service cadence catalogue', async ({
   await page.locator('#c-name').fill('Recurring welcome')
   await page.locator('#c-goal').fill('Engage new customers')
   await page.locator('[data-segment="actives@1"]').click()
+  // Scheduling is channel-agnostic; keep this regression on e-mail so it still proves the full
+  // template payload while the product's default remains app-first PUSH.
+  await page.locator('[data-channel-pick="EMAIL"]').click()
   await page.locator('#var-0-offerTitle').fill('Welcome')
   await page.locator('#var-0-offerText').fill('Thanks for joining.')
   await page.locator('#var-0-ctaText').fill('Explore')

--- a/openbank-admin-ui/src/app/campaigns/new/page.tsx
+++ b/openbank-admin-ui/src/app/campaigns/new/page.tsx
@@ -7,7 +7,7 @@
 import { useEffect, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import Link from 'next/link'
-import { ArrowLeft, Megaphone } from 'lucide-react'
+import { ArrowLeft, Clock3, Megaphone, Send, Sparkles, Users } from 'lucide-react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { PageHeader } from '@/components/ui'
 import {
@@ -74,10 +74,13 @@ const TEMPLATE_CHANNEL: Record<string, EditorChannel> = {
 }
 
 const newStep = (): EditorStep => ({
-  template: 'MARKETING_PRODUCT_OFFER',
-  channel: 'EMAIL',
+  // The studio starts with the primary owned surface: the bank app. E-mail remains a supported
+  // channel, but leading an app-first campaign with it made the canvas teach the wrong product.
+  template: 'MARKETING_PRODUCT_OFFER_PUSH',
+  channel: 'PUSH',
   variables: {},
   delaySeconds: 0,
+  mobileDestination: 'HOME',
 })
 
 export default function NewCampaignPage() {
@@ -272,26 +275,41 @@ export default function NewCampaignPage() {
   }
 
   return (
-    <div className="space-y-6">
-      <Link href="/campaigns" className="inline-flex items-center gap-1 text-sm hover:underline">
-        <ArrowLeft className="h-4 w-4" /> {t('Kampaně', 'Campaigns')}
-      </Link>
-
-      <PageHeader
-        title={t('Nová kampaň', 'New campaign')}
-        subtitle={t(
-          'Sestavte cestu, kterou lidé projdou. Spustit ji musí někdo jiný — to je smysl schvalování ve dvou.',
-          'Assemble the journey people will take. Someone else activates it — that is the point of the four-eyes gate.',
-        )}
-        icon={<Megaphone className="h-6 w-6" />}
-      />
+    <div className="campaign-composer">
+      <header className="campaign-composer-hero">
+        <Link href="/campaigns" className="campaign-composer-back">
+          <ArrowLeft className="h-4 w-4" /> {t('Kampaně', 'Campaigns')}
+        </Link>
+        <div className="campaign-composer-hero-main">
+          <div>
+            <p className="campaign-composer-eyebrow"><Sparkles className="h-3.5 w-3.5" /> {t('Campaign studio', 'Campaign studio')}</p>
+            <PageHeader
+              title={t('Nová kampaň', 'New campaign')}
+              subtitle={t(
+                'Navrhněte zážitek v aplikaci, zprávu a okamžik, kdy má přijít. Aktivaci pak vždy potvrdí druhý člověk.',
+                'Design the in-app moment, the message and when it appears. A second person always confirms activation.',
+              )}
+              icon={<Megaphone className="h-6 w-6" />}
+            />
+          </div>
+          <div className="campaign-composer-principles" aria-label={t('Principy kampaně', 'Campaign principles')}>
+            <span><Users className="h-4 w-4" /> {t('Správné publikum', 'Right audience')}</span>
+            <span><Send className="h-4 w-4" /> {t('Aplikace napřed', 'App first')}</span>
+            <span><Clock3 className="h-4 w-4" /> {t('Schválení ve dvou', 'Four eyes')}</span>
+          </div>
+        </div>
+      </header>
 
       {/* A marketer names a campaign and picks who gets it. Both were `<label>` + bare box, which is
           how a database table looks, not how a campaign brief does. The name behaves like a document
           title; the audience is a set of tiles carrying its plain-language rule and its reach, which
           is the choice being made — a dropdown hides exactly the number the choice turns on. */}
-      <section className="max-w-3xl space-y-8">
-        <div>
+      <section className="campaign-setup-grid">
+        <div className="campaign-brief-card">
+          <div className="campaign-section-heading">
+            <span className="campaign-section-number">01</span>
+            <div><p>{t('Kreativní brief', 'Creative brief')}</p><h2>{t('Začněte záměrem', 'Start with intent')}</h2></div>
+          </div>
           <input
             id="c-name"
             className="input w-full"
@@ -313,10 +331,11 @@ export default function NewCampaignPage() {
           />
         </div>
 
-        <div>
-          <h2 className="text-sm font-semibold" style={{ marginBottom: '0.75rem' }}>
-            {t('Komu to půjde', 'Who gets it')}
-          </h2>
+        <div className="campaign-audience-card">
+          <div className="campaign-section-heading">
+            <span className="campaign-section-number">02</span>
+            <div><p>{t('Publikum', 'Audience')}</p><h2>{t('Komu to půjde', 'Who gets it')}</h2></div>
+          </div>
           <div className="grid gap-3 sm:grid-cols-2">
             {segments.map(s => {
               const ref = `${s.name}@${s.version}`
@@ -364,9 +383,10 @@ export default function NewCampaignPage() {
           </p>
         </div>
 
-        <div className="space-y-3" data-entry-mode={entryMode}>
-          <div>
-            <h2 className="text-sm font-semibold">{t('Kdy cesta začne', 'When the journey starts')}</h2>
+        <div className="campaign-entry-card" data-entry-mode={entryMode}>
+          <div className="campaign-section-heading">
+            <span className="campaign-section-number">03</span>
+            <div><p>{t('Vstup do cesty', 'Journey entry')}</p><h2>{t('Kdy cesta začne', 'When the journey starts')}</h2></div>
             <p className="text-xs text-muted-foreground" style={{ marginTop: '0.25rem' }}>
               {t(
                 'Vyberte jeden přezkoumatelný zdroj vstupu. Publikum stále určuje segment výše.',
@@ -454,8 +474,15 @@ export default function NewCampaignPage() {
         </div>
       </section>
 
-      <section className="space-y-3">
-        <h2 className="text-sm font-semibold">{t('Cesta', 'The journey')}</h2>
+      <section className="campaign-journey-workbench">
+        <div className="campaign-workbench-heading">
+          <div>
+            <p className="campaign-composer-eyebrow"><Sparkles className="h-3.5 w-3.5" /> {t('Journey composer', 'Journey composer')}</p>
+            <h2>{t('Cesta, kterou lidé skutečně zažijí', 'The journey people will actually experience')}</h2>
+            <p>{t('Začněte mobilním momentem. Push otevře bezpečný deep link a obsah pokračuje uvnitř aplikace.', 'Start with a mobile moment. Push opens a secure deep link and the experience continues inside the app.')}</p>
+          </div>
+          <span className="campaign-workbench-status"><span /> {steps.length}/{MAX_STEPS} {t('kroků', 'steps')}</span>
+        </div>
         {/* space-y-0 around the canvas+panel pair: any gap between them undoes the join. */}
         <div className="space-y-0">
         <JourneyEditor
@@ -509,7 +536,8 @@ export default function NewCampaignPage() {
             attribution runs from the first send, so a rule added after the fact measures nothing
             retroactively (ADR-0245 D2). The options are a closed catalogue — a marketer picks what
             the bank already observes and cannot invent a metric (D1). */}
-        <div className="max-w-2xl rounded-lg border p-3 space-y-2">
+        <div className="campaign-measurement-grid">
+        <div className="campaign-measurement-card">
           <span className="text-sm font-medium">{t('Co znamená úspěch', 'What counts as success')}</span>
           <div className="flex flex-wrap gap-2">
             {[null, 'ACCOUNT_OPENED', 'CARD_ISSUED'].map(r => (
@@ -548,7 +576,7 @@ export default function NewCampaignPage() {
           </p>
         </div>
 
-        <div className="max-w-2xl rounded-lg border p-3 space-y-2" data-content-experiment={contentExperiment ? 'true' : 'false'}>
+        <div className="campaign-measurement-card" data-content-experiment={contentExperiment ? 'true' : 'false'}>
           <label className="flex items-center gap-2 text-sm font-medium" htmlFor="c-content-experiment">
             <input
               id="c-content-experiment"
@@ -572,7 +600,7 @@ export default function NewCampaignPage() {
           </p>
         </div>
 
-        <div className="max-w-2xl rounded-lg border p-3 space-y-2">
+        <div className="campaign-measurement-card">
           <label className="flex items-center gap-2 text-sm font-medium" htmlFor="c-holdout">
             {t('Kontrolní skupina', 'Control group')}
           </label>
@@ -607,7 +635,7 @@ export default function NewCampaignPage() {
 
         {/* The one contact rule a campaign DOES own. The platform-wide ones below are read-only; this
             cap is per-campaign by design (ADR-0200 D1), so it is offered here rather than described. */}
-        <div className="max-w-2xl rounded-lg border p-3 space-y-2">
+        <div className="campaign-measurement-card">
           <label className="flex items-center gap-2 text-sm font-medium">
             <input
               type="checkbox"
@@ -640,10 +668,11 @@ export default function NewCampaignPage() {
             )}
           </p>
         </div>
+        </div>
 
         {/* Read-only on purpose: the contact policy is a single enforcement point, and a per-campaign
             override here would make that point decorative (ADR-0219 D4, ADR-0221 D1 step 4). */}
-        <div className="max-w-2xl rounded-lg border p-3 text-xs text-muted-foreground">
+        <div className="campaign-contact-rules">
           <p className="font-medium text-foreground">{t('Pravidla kontaktu', 'Contact rules')}</p>
           <p>
             {t(
@@ -656,7 +685,12 @@ export default function NewCampaignPage() {
 
       {error && <p className="text-sm text-red-600">{error}</p>}
 
-      <div className="flex items-center gap-3">
+      <footer className="campaign-composer-footer">
+        <div>
+          <p>{t('Koncept se zatím nikomu neposílá.', 'A draft does not send anything yet.')}</p>
+          <span>{t('Po kontrole jej aktivuje jiný oprávněný člověk.', 'A different authorised person activates it after review.')}</span>
+        </div>
+        <div className="campaign-composer-footer-actions">
         <button
           onClick={submit}
           disabled={!ready || saving}
@@ -681,7 +715,8 @@ export default function NewCampaignPage() {
             )}
           </span>
         )}
-      </div>
+        </div>
+      </footer>
     </div>
   )
 }

--- a/openbank-admin-ui/src/app/globals.css
+++ b/openbank-admin-ui/src/app/globals.css
@@ -298,6 +298,181 @@ main {
 }
 
 /* ── Campaign Studio companion surfaces ── */
+.campaign-composer {
+  --campaign-violet: #635bff;
+  --campaign-ink: #11192e;
+  --campaign-muted: #64748b;
+  max-width: 1520px;
+  margin: 0 auto;
+  padding: 0.25rem 0 2.5rem;
+}
+.campaign-composer-hero {
+  position: relative;
+  overflow: hidden;
+  margin-bottom: 1.25rem;
+  padding: 1.25rem 1.35rem 1.35rem;
+  border: 1px solid #dfe4ff;
+  border-radius: 1.25rem;
+  background:
+    radial-gradient(circle at 86% 0%, rgba(129, 140, 248, .22), transparent 24rem),
+    radial-gradient(circle at 67% 108%, rgba(45, 212, 191, .12), transparent 20rem),
+    linear-gradient(128deg, #ffffff 0%, #f8faff 54%, #f4f3ff 100%);
+  box-shadow: 0 18px 44px rgba(50, 58, 122, .08);
+}
+.campaign-composer-hero::after {
+  content: '';
+  position: absolute;
+  right: -4rem;
+  bottom: -6rem;
+  width: 17rem;
+  height: 17rem;
+  border: 1px solid rgba(99, 91, 255, .12);
+  border-radius: 50%;
+  box-shadow: 0 0 0 2.5rem rgba(99, 91, 255, .035), 0 0 0 5rem rgba(99, 91, 255, .025);
+  pointer-events: none;
+}
+.campaign-composer-back {
+  position: relative;
+  z-index: 1;
+  display: inline-flex;
+  align-items: center;
+  gap: .35rem;
+  color: var(--text-secondary);
+  font-size: .77rem;
+  font-weight: 700;
+  text-decoration: none;
+  transition: color .16s ease, transform .16s ease;
+}
+.campaign-composer-back:hover { color: var(--campaign-violet); transform: translateX(-2px); }
+.campaign-composer-hero-main {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 1.5rem;
+  margin-top: 1.15rem;
+}
+.campaign-composer-eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: .35rem;
+  margin-bottom: .35rem;
+  color: var(--campaign-violet);
+  font-size: .66rem;
+  font-weight: 800;
+  letter-spacing: .1em;
+  text-transform: uppercase;
+}
+.campaign-composer-hero .page-header { margin: 0; }
+.campaign-composer-hero .page-header h1 { font-size: clamp(1.8rem, 3vw, 2.45rem); letter-spacing: -.055em; }
+.campaign-composer-hero .page-header p { max-width: 45rem; color: #52617a; font-size: .92rem; line-height: 1.55; }
+.campaign-composer-principles {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: .45rem;
+  max-width: 28rem;
+}
+.campaign-composer-principles span {
+  display: inline-flex;
+  align-items: center;
+  gap: .38rem;
+  padding: .45rem .65rem;
+  border: 1px solid rgba(99, 91, 255, .13);
+  border-radius: .7rem;
+  background: rgba(255,255,255,.65);
+  color: #4d5b73;
+  font-size: .69rem;
+  font-weight: 700;
+  backdrop-filter: blur(8px);
+}
+.campaign-composer-principles svg { color: var(--campaign-violet); }
+.campaign-setup-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.14fr) minmax(22rem, .86fr);
+  gap: 1rem;
+  align-items: stretch;
+}
+.campaign-brief-card,
+.campaign-audience-card,
+.campaign-entry-card {
+  border: 1px solid #e1e7f2;
+  border-radius: 1.05rem;
+  background: var(--surface);
+  box-shadow: 0 7px 22px rgba(15, 23, 42, .035);
+}
+.campaign-brief-card {
+  display: grid;
+  grid-template-columns: minmax(9.5rem, .47fr) minmax(0, 1fr);
+  gap: .7rem .9rem;
+  grid-column: 1 / -1;
+  padding: 1.05rem;
+  background: linear-gradient(120deg, #fff 0%, #fbfcff 100%);
+}
+.campaign-brief-card .campaign-section-heading { grid-row: span 2; align-self: center; }
+.campaign-brief-card .input:first-of-type { font-size: 1.25rem !important; }
+.campaign-audience-card,
+.campaign-entry-card { padding: 1.05rem; }
+.campaign-entry-card { background: linear-gradient(145deg, #fff 0%, #fbfbff 100%); }
+.campaign-section-heading { display: flex; align-items: flex-start; gap: .65rem; margin-bottom: .9rem; }
+.campaign-section-number {
+  display: inline-grid;
+  width: 1.72rem;
+  height: 1.72rem;
+  place-items: center;
+  border-radius: .58rem;
+  background: linear-gradient(145deg, #e4e9ff, #f2f0ff);
+  color: var(--campaign-violet);
+  font-size: .66rem;
+  font-weight: 850;
+  letter-spacing: .04em;
+}
+.campaign-section-heading p { margin: .03rem 0 .18rem; color: #8190a6; font-size: .64rem; font-weight: 800; letter-spacing: .09em; text-transform: uppercase; }
+.campaign-section-heading h2 { color: var(--campaign-ink); font-size: .95rem; font-weight: 780; letter-spacing: -.025em; }
+.campaign-section-heading > p { margin: .08rem 0 0 auto; max-width: 19rem; color: var(--campaign-muted); line-height: 1.4; }
+.campaign-audience-card [data-segment],
+.campaign-entry-card [data-entry-pick] { transition: border-color .16s ease, box-shadow .16s ease, transform .16s ease, background .16s ease; }
+.campaign-audience-card [data-segment]:hover,
+.campaign-entry-card [data-entry-pick]:hover:not(:disabled) { border-color: rgba(99,91,255,.45) !important; transform: translateY(-1px); background: #fafaff !important; }
+.campaign-audience-card [data-segment][data-selected='true'],
+.campaign-entry-card [data-entry-pick][data-selected='true'] { background: linear-gradient(145deg, #f6f5ff, #fff) !important; }
+.campaign-journey-workbench {
+  margin-top: 1rem;
+  padding: 1.15rem;
+  border: 1px solid #dfe5f2;
+  border-radius: 1.25rem;
+  background: linear-gradient(180deg, #fafcff 0%, #fff 29%);
+  box-shadow: 0 14px 36px rgba(31, 41, 55, .055);
+}
+.campaign-workbench-heading { display: flex; align-items: flex-start; justify-content: space-between; gap: 1rem; margin-bottom: 1rem; }
+.campaign-workbench-heading h2 { color: var(--campaign-ink); font-size: 1.18rem; font-weight: 790; letter-spacing: -.035em; }
+.campaign-workbench-heading > div > p:last-child { max-width: 45rem; margin-top: .3rem; color: var(--campaign-muted); font-size: .78rem; line-height: 1.5; }
+.campaign-workbench-status { display: inline-flex; align-items: center; gap: .4rem; flex: 0 0 auto; padding: .43rem .62rem; border: 1px solid #e0e4ff; border-radius: 99px; background: #f5f5ff; color: #5550be; font-size: .69rem; font-weight: 800; }
+.campaign-workbench-status span { width: .42rem; height: .42rem; border-radius: 99px; background: #7c72ff; box-shadow: 0 0 0 .22rem rgba(124,114,255,.12); }
+.campaign-journey-workbench > .space-y-0 > div:first-child { border-color: #d7dded; box-shadow: 0 12px 25px rgba(58, 65, 113, .06); }
+.campaign-measurement-grid { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: .7rem; margin-top: 1rem; }
+.campaign-measurement-card {
+  display: flex;
+  flex-direction: column;
+  gap: .55rem;
+  min-width: 0;
+  padding: .85rem;
+  border: 1px solid #e2e8f3;
+  border-radius: .9rem;
+  background: #fff;
+}
+.campaign-measurement-card > span,
+.campaign-measurement-card label { color: #27344b; font-size: .76rem; font-weight: 780; }
+.campaign-measurement-card .btn { padding: .38rem .55rem; font-size: .68rem; }
+.campaign-measurement-card .text-xs { line-height: 1.4; }
+.campaign-contact-rules { margin-top: 1rem; padding: .72rem .85rem; border: 1px dashed #d9e0ee; border-radius: .78rem; background: #f8fafc; color: var(--campaign-muted); font-size: .7rem; line-height: 1.45; }
+.campaign-contact-rules p + p { margin-top: .2rem; }
+.campaign-composer-footer { display: flex; align-items: center; justify-content: space-between; gap: 1rem; margin-top: 1rem; padding: .9rem 1rem; border: 1px solid #dfe5f2; border-radius: 1rem; background: rgba(255,255,255,.86); box-shadow: 0 8px 22px rgba(15,23,42,.04); }
+.campaign-composer-footer > div:first-child p { color: #27344b; font-size: .76rem; font-weight: 780; }
+.campaign-composer-footer > div:first-child span { display: block; margin-top: .15rem; color: var(--campaign-muted); font-size: .68rem; }
+.campaign-composer-footer-actions { display: flex; align-items: center; justify-content: flex-end; flex-wrap: wrap; gap: .6rem; }
+.campaign-composer-footer-actions .btn-primary { box-shadow: 0 8px 17px rgba(99,91,255,.24); }
 .campaign-studio-companion-grid {
   display: grid;
   grid-template-columns: minmax(0, 1.15fr) minmax(19rem, 0.85fr);
@@ -351,7 +526,25 @@ main {
 .campaign-readiness-list [data-state='attention'] > span { background: #fef3c7; color: var(--warning-text); }
 .campaign-readiness-list [data-state='waiting'] { background: var(--surface-2); }
 .campaign-readiness-list [data-state='waiting'] > span { background: var(--surface-4); color: var(--text-secondary); }
-@media (max-width: 960px) { .campaign-studio-companion-grid { grid-template-columns: 1fr; } }
+@media (max-width: 1100px) {
+  .campaign-measurement-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .campaign-composer-hero-main { align-items: flex-start; flex-direction: column; }
+  .campaign-composer-principles { justify-content: flex-start; max-width: none; }
+}
+@media (max-width: 960px) {
+  .campaign-studio-companion-grid, .campaign-setup-grid { grid-template-columns: 1fr; }
+  .campaign-brief-card { grid-column: auto; }
+}
+@media (max-width: 640px) {
+  .campaign-composer-hero, .campaign-journey-workbench { padding: .9rem; border-radius: 1rem; }
+  .campaign-brief-card { display: block; }
+  .campaign-brief-card .campaign-section-heading { margin-bottom: .8rem; }
+  .campaign-brief-card .input + .input { margin-top: .65rem !important; }
+  .campaign-measurement-grid { grid-template-columns: 1fr; }
+  .campaign-workbench-heading, .campaign-composer-footer { align-items: flex-start; flex-direction: column; }
+  .campaign-composer-footer-actions { justify-content: flex-start; }
+  .campaign-workbench-status { margin-top: -.15rem; }
+}
 @media (max-width: 450px) { .campaign-preview-stage { gap: 0.4rem; } .campaign-phone { transform: scale(.9); transform-origin: left center; margin-right: -0.75rem; } .campaign-push-card { transform: rotate(-2deg) scale(.9); transform-origin: left center; } }
 
 /* ── Campaign portfolio decision desk ── */

--- a/openbank-admin-ui/src/test/campaign-builder-interaction.test.tsx
+++ b/openbank-admin-ui/src/test/campaign-builder-interaction.test.tsx
@@ -80,7 +80,7 @@ describe('campaign builder interaction', () => {
  * fields on a push step would promise a delivery the platform refuses to make (#1182).
  */
 describe('campaign builder channels', () => {
-  it('switching a step to push narrows the fields to the ones that channel can carry', async () => {
+  it('starts app-first and switching channels exposes only fields that channel can carry', async () => {
     vi.stubGlobal('fetch', vi.fn(async (u: string) =>
       String(u).includes('/preview')
         ? { ok: true, json: async () => ({ size: 10, state: 'ok' }) }
@@ -90,7 +90,14 @@ describe('campaign builder channels', () => {
       React.createElement(LanguageProvider, null, React.createElement(NewCampaignPage)))
     await waitFor(() => getByText('active-clients'), { timeout: 8000 })
 
-    // Email: the template's three declared variables.
+    // App-first: a new campaign opens on push with only its headline field.
+    expect(container.querySelector('[data-step="0"]')!.getAttribute('data-channel')).toBe('PUSH')
+    expect(container.querySelectorAll('[id^="var-0-"]').length).toBe(1)
+    expect(document.getElementById('var-0-offerTitle')).toBeTruthy()
+    expect(document.getElementById('var-0-offerText')).toBeNull()
+
+    // Email remains available and exposes the template's three declared variables.
+    fireEvent.click(container.querySelector('[data-channel-pick="EMAIL"]')!)
     expect(container.querySelectorAll('[id^="var-0-"]').length).toBe(3)
 
     fireEvent.click(container.querySelector('[data-channel-pick="PUSH"]')!)

--- a/openbank-admin-ui/src/test/campaign-studio.test.tsx
+++ b/openbank-admin-ui/src/test/campaign-studio.test.tsx
@@ -94,6 +94,16 @@ describe('campaign studio', () => {
     expect(screen.getByText(/a pull request, not a UI action/)).toBeTruthy()
   }, 15000)
 
+  it('starts a new journey in the app, with a closed deep link, not as an email sequence', async () => {
+    vi.stubGlobal('fetch', mockFetch({ '/api/segments': SEGMENTS }))
+    render(React.createElement(Providers, null, React.createElement(NewCampaignPage)))
+
+    await waitFor(() => expect(document.querySelector('[data-channel-pick="PUSH"]')).toBeTruthy(), { timeout: 8000 })
+    expect(document.querySelector('[data-channel-pick="PUSH"]')?.getAttribute('data-selected')).toBe('true')
+    expect(document.querySelector('[data-mobile-destination="0"]')).toBeTruthy()
+    expect(screen.getByText(/fixed app deep link/i)).toBeTruthy()
+  }, 15000)
+
   /**
    * ADR-0176 D4 / ADR-0221 D1 step 3: a campaign supplies values, never body text. The fields
    * offered are exactly the template's declared variables — a free-form body field here would be a
@@ -103,6 +113,9 @@ describe('campaign studio', () => {
     vi.stubGlobal('fetch', mockFetch({ '/api/segments': SEGMENTS }))
     render(React.createElement(Providers, null, React.createElement(NewCampaignPage)))
 
+    // Mobile is the studio's starting surface. E-mail remains available when a campaign genuinely
+    // needs its richer template, and that switch—not the initial screen—owns these three fields.
+    fireEvent.click(document.querySelector('[data-channel-pick="EMAIL"]')!)
     // The labels are the marketer's words, but the FIELD SET is still exactly the template's
     // declared variables — asserted by id, which carries the variable name the service knows.
     await waitFor(() => expect(document.getElementById('var-0-offerTitle')).toBeTruthy(), {
@@ -135,6 +148,7 @@ describe('campaign studio', () => {
     fireEvent.change(document.getElementById('c-name')!, { target: { value: 'Recurring welcome' } })
     fireEvent.change(document.getElementById('c-goal')!, { target: { value: 'Keep new customers engaged' } })
     fireEvent.click(document.querySelector('[data-segment="actives@1"]')!)
+    fireEvent.click(document.querySelector('[data-channel-pick="EMAIL"]')!)
     fireEvent.change(document.getElementById('var-0-offerTitle')!, { target: { value: 'Welcome' } })
     fireEvent.change(document.getElementById('var-0-offerText')!, { target: { value: 'Thanks for joining.' } })
     fireEvent.change(document.getElementById('var-0-ctaText')!, { target: { value: 'Explore' } })
@@ -166,6 +180,7 @@ describe('campaign studio', () => {
     fireEvent.change(document.getElementById('c-name')!, { target: { value: 'Two headlines' } })
     fireEvent.change(document.getElementById('c-goal')!, { target: { value: 'Open more accounts' } })
     fireEvent.click(document.querySelector('[data-segment="actives@1"]')!)
+    fireEvent.click(document.querySelector('[data-channel-pick="EMAIL"]')!)
     fireEvent.change(document.getElementById('var-0-offerTitle')!, { target: { value: 'A headline' } })
     fireEvent.change(document.getElementById('var-0-offerText')!, { target: { value: 'A copy' } })
     fireEvent.change(document.getElementById('var-0-ctaText')!, { target: { value: 'Open' } })
@@ -211,6 +226,7 @@ describe('campaign studio', () => {
     fireEvent.change(document.getElementById('c-name')!, { target: { value: 'Fallback offer' } })
     fireEvent.change(document.getElementById('c-goal')!, { target: { value: 'Open more accounts' } })
     fireEvent.click(document.querySelector('[data-segment="actives@1"]')!)
+    fireEvent.click(document.querySelector('[data-channel-pick="EMAIL"]')!)
     fireEvent.change(document.getElementById('var-0-offerTitle')!, { target: { value: 'Headline' } })
     fireEvent.change(document.getElementById('var-0-offerText')!, { target: { value: 'Copy' } })
     fireEvent.change(document.getElementById('var-0-ctaText')!, { target: { value: 'Open' } })


### PR DESCRIPTION
## What changed

- Reframed campaign creation as a compact creative brief and journey workbench.
- Made the default first step an app push with a closed, safe deep link; email remains an explicit choice.
- Added responsive visual hierarchy for audience, entry point, journey, mobile preview, readiness, and measurement.

## Why

The existing screen still read like a long administrative form and defaulted to email, despite the product being an app-centric engagement ecosystem.

## Validation

- `npm run type-check`
- `npx vitest run src/test/campaign-studio.test.tsx` (13 passed)
- `npm run lint -- --quiet`

Local browser verification reached the expected authenticated boundary; no authentication was bypassed.

Refs #4480
