### PR TITLE
docs(customer-edge): stop calling linkKeycloakSub an identity merge

### DIFF
--- a/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
+++ b/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
@@ -4506,8 +4506,15 @@ class CustomerEdgeResource(
     }
 
     /**
-     * Link the applicant's new Keycloak sub (KEYCLOAK_ID) to the matched existing party in pid —
-     * the ADR-0072 §5 identity merge so one human across channels maps to one golden-record party.
+     * Link the applicant's new Keycloak sub (KEYCLOAK_ID) to the matched existing party in pid, so
+     * one human arriving through another channel maps to one golden-record party (ADR-0072 §5
+     * identity unification).
+     *
+     * This is an external-id ATTACHMENT, not a party merge: it creates no `MERGED` party, moves no
+     * accounts and retires no row. The real merge is ADR-0179's `POST /api/v1/parties/{id}/merge`
+     * on party-service (four-eyes gated), whose `merged_into` pointer this service follows at
+     * request time in [PartyMergeResolver] — do not confuse the two (issue #1984).
+     *
      * Best-effort: returns true on a 2xx; failures are audited via the caller but never block
      * onboarding. The pid endpoint is idempotent and 409s a sub already linked elsewhere.
      */


### PR DESCRIPTION
## What

Corrects one misleading KDoc in `openbank-customer-edge` — the "note (minor, separable)" item on #1984.

`linkKeycloakSub` described itself as *"the ADR-0072 §5 identity merge"*. It is an external-id attachment: it POSTs `{"type":"KEYCLOAK_ID", ...}` to pid's `/api/v1/parties/{id}/external-ids` for an already-matched party. It creates no `MERGED` party, moves no accounts and retires no row.

## Why it matters more now than when #1984 was filed

There is now a real party merge for that phrase to be confused with, and it lives in the same service:

- ADR-0179 shipped `POST /api/v1/parties/{id}/merge` on party-service, four-eyes gated (`@Authorize(action = "party.merge", resource = "#id")`, `PartyResource.kt:324`), setting `merged_into`.
- customer-edge follows that pointer at the identity chokepoint in `PartyMergeResolver` — same package as the misdescribed function.

So a reader in that file has two things called "merge", one of which is not one.

## Change

Comment only. No behavior, no API, no schema. `docs(...)` type, so no release is cut.

## Verification

- `./gradlew :openbank-customer-edge:ktlintCheck :openbank-customer-edge:detekt` — BUILD SUCCESSFUL; both `ktlintMainSourceSetCheck` and `ktlintTestSourceSetCheck` and `detekt` appear in the executed task list.
- customer-edge is **not** in `rules.yaml: money_path_services` (verified against `origin/main`), so the 2-approval + threat-model rule does not apply.

Refs #1984

🤖 Generated with [Claude Code](https://claude.com/claude-code)
