### PR TITLE
fix(observability): the journey caught two real failures and nothing alerted

### DIFF
--- a/openbank-infra/gitops/components/observability/prometheus-rules-journey.yaml
+++ b/openbank-infra/gitops/components/observability/prometheus-rules-journey.yaml
@@ -37,6 +37,36 @@ spec:
         # — no result, no alert. Same for JourneyStale below. That case belongs entirely to
         # JourneyMissing, which is why that rule is not redundant and must not be "simplified"
         # away: it is the only one of the three that can fire on a journey broken from birth.
+        # A SINGLE failed journey run. Added after measuring the rules below against reality:
+        # on 2026-08-13 the public-edge journey went red twice in 24h — customer-edge answered
+        # 5xx and p95 crossed 2s — and NOTHING fired, because every rule here compares
+        # last_schedule against last_success and one failure on a 5-minute schedule is a
+        # 5-minute gap, far short of the 900s those rules need.
+        #
+        # That was the wrong shape for this signal. The journey asserts a customer-visible
+        # property; one failed assertion IS the event, not a blip to be smoothed away. So this
+        # fires on the Job's own failure count, at ticket severity — the sustained case still
+        # pages through JourneyFailing below, and the two do not duplicate each other because
+        # they answer different questions ("something broke once" vs "it has been broken").
+        #
+        # `max_over_time` because kube-state-metrics drops the series when the Job object is
+        # garbage-collected (failedJobsHistoryLimit: 1), and an alert that vanishes with its
+        # evidence is one nobody can triage.
+        - alert: JourneyRunFailed
+          expr: |
+            max by (namespace, job_name) (
+              max_over_time(kube_job_status_failed{namespace="observability", job_name=~"journey-.*"}[30m])
+            ) > 0
+          for: 1m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Journey run {{ $labels.job_name }} failed"
+            description: >-
+              A synthetic journey run failed its thresholds against production. k6 prints which
+              check failed and the latency percentiles — read the Job logs. A single failure here
+              is a customer-visible property that did not hold, not a flake; if it repeats,
+              JourneyFailing will page. Catalog: openbank-libs/governance/journeys.yaml.
         - alert: JourneyFailing
           expr: |
             max by (namespace, cronjob) (


### PR DESCRIPTION
**The journey worked. My alerting did not.** Found by measuring the rules I wrote against what
actually happened, rather than re-reading them.

## What the platform saw, and did not say

`journey-public-edge` went red **twice in the last 24 hours**:

```
kube_job_status_failed{job_name=~"journey-.*"} == 1
  journey-public-edge-29775890
  journey-public-edge-29776905
ALERTS{alertname=~"Journey.*"}   ->  0 series. Ever.
```

The failed run's log is unambiguous:

```
✓ api edge answers
✗ customer edge answers          ↳ 0% — ✓ 0 / ✗ 1
✓ admin ui answers
http_req_duration ... p(95)=3.35s   (threshold: p95 < 2s)
level=error msg="thresholds on metrics 'checks, http_req_duration' have been crossed"
```

So customer-edge was serving errors or crawling at 09:45Z, the synthetic caught it exactly as
designed — and no alert fired, because the next run five minutes later passed.

## Why nothing fired

Every rule in this file compares `last_schedule_time` against `last_successful_time` with a 900s
margin. On a 5-minute schedule a single failure is a **5-minute gap**, far below all of them. The
rules were built for "has been broken for a while" and there was nothing for "broke once".

That is the wrong shape for this signal. A journey asserts a customer-visible property; one failed
assertion **is** the event, not noise to be smoothed away. If I had only re-read the rules they
would still look correct — they are internally consistent, they just never had the reachable case.

## The fix

`JourneyRunFailed` — any failed journey Job, `severity: warning`, `for: 1m`. The sustained case still
pages through `JourneyFailing`; the two answer different questions and do not duplicate.

`max_over_time(...[30m])` because kube-state-metrics drops the series when the Job object is
garbage-collected (`failedJobsHistoryLimit: 1`), and an alert that vanishes together with its
evidence is one nobody can triage.

## Verification

- **Falsified against live data, both directions.** The expression returns the real failed job
  (`journey-public-edge-29776905 = 1`); the same expression over a `job_name` pattern matching
  nothing returns empty. So it can fire, and it is not firing on everything.
- `promtool check rules` — 4 rules, SUCCESS.
- `journey-catalog-integrity` and `journey-money-path-accountability` still pass — the per-journey
  `absent()` requirement is untouched.

## Worth noting for the record

This is the second time in this programme that the thing being built was fine and the thing
measuring it was wrong. Rules that have never fired are not evidence of health.

Refs #4348, ADR-0252.
