### PR TITLE
fix(infra): correct two business-warehouse tiles that could only ever read zero

### DIFF
--- a/openbank-infra/gitops/components/observability/dashboard-openbank-business-warehouse.yaml
+++ b/openbank-infra/gitops/components/observability/dashboard-openbank-business-warehouse.yaml
@@ -204,7 +204,7 @@ data:
           "id": 4,
           "type": "stat",
           "title": "Accounts opened (30d)",
-          "description": "Distinct account aggregates with an opened-type event. uniqExact, not count(): bronze is at-least-once, so duplicates are expected and a raw count overstates.",
+          "description": "Distinct account aggregates with an opening-type event (AccountCreated today; matched case-insensitively so a producer switching to ACCOUNT_OPENED does not silently zero this tile). aggregate_type is folded with upper() because bronze holds both ACCOUNT and Account for the same account (#4553). uniqExact, not count(): bronze is at-least-once, so duplicates are expected and a raw count overstates.",
           "gridPos": {
             "x": 10,
             "y": 7,
@@ -224,7 +224,7 @@ data:
               "refId": "A",
               "editorType": "sql",
               "format": 2,
-              "rawSql": "SELECT uniqExact(aggregate_id) AS value FROM openbank_analytics.bronze_events WHERE aggregate_type = 'Account' AND event_type LIKE '%Opened%' AND occurred_at >= now() - INTERVAL 30 DAY"
+              "rawSql": "SELECT uniqExact(aggregate_id) AS value FROM openbank_analytics.bronze_events WHERE upper(aggregate_type) = 'ACCOUNT' AND (positionCaseInsensitive(event_type, 'opened') > 0 OR positionCaseInsensitive(event_type, 'created') > 0) AND occurred_at >= now() - INTERVAL 30 DAY"
             }
           ],
           "fieldConfig": {
@@ -263,7 +263,7 @@ data:
           "id": 5,
           "type": "stat",
           "title": "Parties onboarded (30d)",
-          "description": null,
+          "description": "Distinct party aggregates with a creation event (PARTY_CREATED). Previously counted ANY party event, so a party whose KYC status merely changed read as onboarded. aggregate_type is folded with upper() — bronze holds PARTY, never Party, so the old literal matched nothing (#4553).",
           "gridPos": {
             "x": 15,
             "y": 7,
@@ -283,7 +283,7 @@ data:
               "refId": "A",
               "editorType": "sql",
               "format": 2,
-              "rawSql": "SELECT uniqExact(aggregate_id) AS value FROM openbank_analytics.bronze_events WHERE aggregate_type = 'Party' AND occurred_at >= now() - INTERVAL 30 DAY"
+              "rawSql": "SELECT uniqExact(aggregate_id) AS value FROM openbank_analytics.bronze_events WHERE upper(aggregate_type) = 'PARTY' AND positionCaseInsensitive(event_type, 'created') > 0 AND occurred_at >= now() - INTERVAL 30 DAY"
             }
           ],
           "fieldConfig": {


### PR DESCRIPTION
## Summary

Two tiles on the business-warehouse dashboard filtered `aggregate_type` against a mixed-case literal
that bronze does not store. "Parties onboarded (30d)" read **0 against a true 4** for its whole life.
Surfaced while verifying #4520 on the sandbox; the underlying non-normalised `aggregate_type` is
#4553, which this does not fix — it fixes the two readers that are wrong *today*.

## Type of change

- [x] fix (bug fix)

## Linked issues

Refs #4553

## Changes

| tile | was | reads now |
|---|---|---|
| Parties onboarded (30d) | `aggregate_type = 'Party'` → **0** | `upper(...) = 'PARTY'` + creation event → **4** |
| Accounts opened (30d) | `aggregate_type = 'Account' AND event_type LIKE '%Opened%'` → **0** | `upper(...) = 'ACCOUNT'` + case-insensitive opened/created → **9** |

Three defects, not one — and this is the part worth reviewing:

1. **The case fold.** Bronze holds `PARTY` and has never held `Party`, so that filter matched nothing
   ever. For accounts both spellings exist (`ACCOUNT` 294 / `Account` 17), so the old filter saw 17 of
   311 rows.
2. **The accounts tile had a second, independent reason to be zero.** No account event type contains
   "Opened" — creation is `AccountCreated`. Folding only the case would have left the tile reading 0
   and looking fixed, which is worse than leaving it obviously broken. Both spellings are now matched
   case-insensitively, so a producer renaming to `ACCOUNT_OPENED` does not silently zero it again.
3. **The party tile did not measure what its title says.** It counted *any* party event, so a party
   whose KYC status merely changed counted as onboarded. It now requires a creation event. On today's
   data this happens not to move the number (4 either way) — flagging it because a correctness fix
   that coincidentally agrees with the old value is exactly the kind that gets reverted later as
   "no-op".

## Verification

The numbers above are not from SQL I typed into a terminal — they are the `rawSql` strings parsed
back **out of the committed file** and run verbatim against the live sandbox warehouse
(`clickhouse-0`, namespace `analytics`):

```
tile-Accounts.sql => 9
tile-Parties.sql  => 4
```

Before the change the same extraction returned 0 and 0. The embedded dashboard JSON is re-parsed
after the edit (`yaml.safe_load` → `json.loads` → panel lookup), so a broken escape would have failed
here rather than in Grafana.

## Definition of Done

- [x] No code changed — a Grafana dashboard ConfigMap only. No tests, no OpenAPI, no migration.
- [x] Panel descriptions updated to state the fold and why, so the next person does not "simplify"
      `upper()` away.

## Security checklist

- [x] No secrets, no PII. The queries return counts of distinct aggregate ids.

## Compliance impact

- [x] None. Read-only operator dashboard; no regulatory report derives from these tiles.

## Rollout / Rollback

- Deployment strategy: ArgoCD syncs the ConfigMap; the Grafana sidecar reloads the dashboard. No pod
  restart, no data change.
- Rollback: revert the commit.
- Data migration reversible: N/A — no data is written or altered.

## Reviewer notes

The third panel, "Events by aggregate type (90d)", groups by raw `aggregate_type` and therefore draws
`ACCOUNT` and `Account` as two separate series. Deliberately **not** changed here: that split is a
true rendering of what is in bronze, and it is the most visible symptom of #4553. Folding it would
hide the defect while #4553 is still open.
