### PR TITLE
fix(campaign): authorize event trigger groups

### DIFF
--- a/openbank-infra/gitops/components/campaign/kafka-campaign-mtls.yaml
+++ b/openbank-infra/gitops/components/campaign/kafka-campaign-mtls.yaml
@@ -75,6 +75,19 @@ spec:
           name: openbank-campaign-service-card-conversions
           patternType: literal
         operations: [Read, Describe]
+      # Event-trigger enrolment consumes the same product topics independently from conversion
+      # attribution. Keep exact per-channel groups: they must match application.yaml and must not
+      # share offsets with the conversion consumers (issue #4569).
+      - resource:
+          type: group
+          name: openbank-campaign-service-account-triggers
+          patternType: literal
+        operations: [Read, Describe]
+      - resource:
+          type: group
+          name: openbank-campaign-service-card-triggers
+          patternType: literal
+        operations: [Read, Describe]
       # A separate group from the one above on purpose: two channels sharing a group makes
       # one member set out of two disjoint subscriptions, so a rebalance on either topic
       # churns the other and the offsets can never be reset independently.


### PR DESCRIPTION
## Summary

Authorize the two exact Kafka consumer groups used by campaign event-trigger enrolment. The live service was healthy over REST but both trigger consumers were rejected by Kafka, so `On an event` journeys could not enrol customers from account/card events.

## Type of change

- [x] fix (bug fix)

## Linked issues

Closes #4569

## Changes

- Grant `Read`/`Describe` on `openbank-campaign-service-account-triggers`.
- Grant `Read`/`Describe` on `openbank-campaign-service-card-triggers`.
- Preserve all topic ACLs and existing conversion/outcome groups unchanged.

## Definition of Done

- [x] Hexagonal layering preserved (GitOps-only change).
- [x] Relevant manifest and Kafka ACL gates pass locally.
- [x] No API, DB, event schema, or dependency change.
- [x] No new lint warnings.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No suppressions added.
- [x] No new third-party dependency.
- [x] Least privilege retained: exact literal group names, `Read`/`Describe` only.

## Compliance impact

- [x] None

## Rollout / Rollback

- Deployment strategy: Argo CD reconciliation of the Strimzi KafkaUser; no application restart required.
- Rollback plan: revert this PR to remove the two literal group grants.
- Data migration reversible: N/A

## Reviewer notes

After merge, verify the KafkaUser reaches Ready and confirm the two `GroupAuthorizationException` loops stop in campaign-service logs.