### PR TITLE
ci(governance): falsify the event-contract, release-scope and advisory-registration gates

### DIFF
--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -666,6 +666,8 @@ gates:
     verified: "2026-08-09 — heuristic by design (classifies from PR title before the squash commit exists); PR-only, still noisy-not-wrong, no graduation planned"
     when: pull_request
     needs_base: required
+    selftest: python3 openbank-infra/scripts/check-release-scope-mismatch.py --self-test
+    selftest_expect: pass
     run: |
       set -euo pipefail
       python3 openbank-infra/scripts/check-release-scope-mismatch.py \
@@ -874,6 +876,8 @@ gates:
     # once flagged itself for the same reason), which is why `mode:` is declared here
     # rather than inferred anywhere.
     mode: enforced
+    selftest: python3 .github/scripts/check-advisory-gate-registration.py --self-test
+    selftest_expect: pass
     run: |
       python3 .github/scripts/check-advisory-gate-registration.py --expect-manifest
 
@@ -2243,6 +2247,8 @@ gates:
     verified: "2026-08-09 — on track for ADR-0144's 2026-09-15 enforce target"
     when: pull_request
     needs_base: required
+    selftest: python3 .github/scripts/check-event-schema-compat.py --self-test
+    selftest_expect: pass
     run: |
       python3 .github/scripts/check-event-schema-compat.py --base "${PR_DIFF_BASE}"
 

--- a/.github/scripts/check-advisory-gate-registration.py
+++ b/.github/scripts/check-advisory-gate-registration.py
@@ -155,15 +155,123 @@ def advisory_manifest_gates(root: pathlib.Path, errors):
             yield MANIFEST, gate.get("group", "?"), gate.get("id", "?"), script
 
 
+def self_test() -> int:
+    """Falsify the rules walker and both advisory-gate discoverers.
+
+    ADR-0144: an advisory rule must carry a `target_enforce_date`, or "advisory" becomes
+    permanent by omission — a gate that warns forever is a gate nobody ever has to satisfy.
+    This script is what makes that checkable, so its own failure mode is the meta version of
+    the same thing: discover FEWER advisory gates and the registration requirement quietly
+    applies to fewer of them, with no signal that coverage shrank.
+
+    The walker is the part with real history. A line-wise scan attributed `enforced:` to
+    whichever bare `key:` it saw last, so a rule containing a nested mapping (`finops_tiers`
+    holds a `tiers:` sub-tree) had its metadata read under the wrong name — the gate reported
+    a rule as registered while reading ANOTHER rule's fields. The nested fixture below is
+    that case.
+    """
+    import tempfile
+
+    fails: list[str] = []
+
+    with tempfile.TemporaryDirectory() as td:
+        root = pathlib.Path(td)
+        (root / RULES).parent.mkdir(parents=True, exist_ok=True)
+        (root / RULES).write_text(
+            "simple_rule:\n"
+            "  enforced: advisory\n"
+            '  target_enforce_date: "2026-12-31"\n'
+            '  ci_producer: ".github/scripts/check-simple.py"\n'
+            "no_date_rule:\n"
+            "  enforced: advisory\n"
+            '  ci_producer: ".github/scripts/check-nodate.py"\n'
+            "nested_rule:\n"
+            "  tiers:\n"
+            "    T3:\n"
+            "      budget: 10\n"
+            "  enforced: advisory\n"
+            '  target_enforce_date: "2026-12-31"\n'
+            '  ci_producer: ".github/scripts/check-nested.py"\n'
+        )
+        errors: list = []
+        got = rules_by_producer(root, errors)
+        if errors:
+            fails.append(f"a well-formed rules.yaml produced errors: {errors}")
+
+        for script, want_name, want_date in (
+            (".github/scripts/check-simple.py", "simple_rule", True),
+            (".github/scripts/check-nodate.py", "no_date_rule", False),
+            # THE HISTORICAL DEFECT: metadata after a nested mapping must still attribute to
+            # the OUTER rule. Read under `T3` it looked registered while describing nothing.
+            (".github/scripts/check-nested.py", "nested_rule", True),
+        ):
+            entry = got.get(script)
+            if entry is None:
+                fails.append(f"{script} was not found in the walk: {sorted(got)}")
+                continue
+            name, _enforced, has_date = entry
+            if name != want_name:
+                fails.append(f"{script} attributed to rule {name!r}, expected {want_name!r} "
+                             f"— metadata was read under the wrong rule")
+            if has_date != want_date:
+                fails.append(f"{script} has_date={has_date}, expected {want_date}")
+
+        # A missing rules.yaml is an ERROR, not an empty map: silently returning {} makes
+        # every advisory gate look unregistered, or (worse, depending on the caller) makes the
+        # check pass having read nothing.
+        errors2: list = []
+        rules_by_producer(root / "nowhere", errors2)
+        if not errors2:
+            fails.append("a missing rules.yaml produced no error")
+
+        # --- the manifest discoverer -------------------------------------------------------
+        gates_dir = root / ".github" / "gates"
+        gates_dir.mkdir(parents=True, exist_ok=True)
+        (gates_dir / "gates.yaml").write_text(
+            "gates:\n"
+            "  - id: adv\n"
+            "    name: an advisory gate\n"
+            "    group: lint\n"
+            "    mode: advisory\n"
+            "    run: |\n"
+            "      python3 .github/scripts/check-adv.py\n"
+            "  - id: enf\n"
+            "    name: an enforced gate\n"
+            "    group: lint\n"
+            "    mode: enforced\n"
+            "    run: |\n"
+            "      python3 .github/scripts/check-enf.py\n"
+        )
+        errs3: list = []
+        found = {script for _src, _grp, _gid, script in advisory_manifest_gates(root, errs3)}
+        if ".github/scripts/check-adv.py" not in found:
+            fails.append(f"the advisory manifest gate was not discovered: {sorted(found)}")
+        if ".github/scripts/check-enf.py" in found:
+            fails.append("an ENFORCED gate was discovered as advisory — it would then be "
+                         "required to carry a target_enforce_date it has no need of")
+
+    if fails:
+        for f in fails:
+            sys.stderr.write(f"::error::self-test: {f}\n")
+        sys.stderr.write(f"self-test FAILED ({len(fails)} case(s))\n")
+        return 1
+    print("self-test ok: advisory-gate registration is falsifiable (9 cases)")
+    return 0
+
+
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--root", default=".")
+    ap.add_argument("--self-test", action="store_true")
     ap.add_argument(
         "--expect-manifest",
         action="store_true",
         help="fail if .github/gates/gates.yaml contributes no advisory gate (see header)",
     )
     args = ap.parse_args()
+
+    if args.self_test:
+        return self_test()
     root = pathlib.Path(args.root).resolve()
 
     errors = []

--- a/.github/scripts/check-event-schema-compat.py
+++ b/.github/scripts/check-event-schema-compat.py
@@ -209,7 +209,95 @@ def compare_avsc(path: str, old_text: str, new_text: str) -> list[str]:
     return findings
 
 
+def self_test() -> int:
+    """Falsify the Kotlin event parser and both compatibility comparators.
+
+    ADR-0006: an event on the wire is a contract with every consumer AND with every message
+    already in the topic. A removed property, a changed type, or a new required field breaks
+    REPLAY — historical payloads stop deserializing — and the failure surfaces at consumer
+    start-up, or worse during a replay months later, never in the PR that caused it.
+
+    Every rule below has a lenient direction that reports clean, which is the one that ships.
+    """
+    fails: list[str] = []
+
+    def case(label, findings, want_hit, want_sub=""):
+        got = bool(findings)
+        if got != want_hit:
+            fails.append(f"{label}: expected finding={want_hit}, got {findings}")
+        elif want_sub and not any(want_sub in f for f in findings):
+            fails.append(f"{label}: flagged for the wrong reason — no {want_sub!r} in {findings}")
+
+    def ev(body: str) -> dict:
+        return parse_events(body)
+
+    base = 'data class Paid(val id: String, val amount: Long) : DomainEvent()\n'
+    old = ev(base)
+    if "Paid" not in old or set(old["Paid"]["props"]) != {"id", "amount"}:
+        fails.append(f"the parser did not read the baseline event: {old}")
+
+    # Identical is compatible — without this case a comparator that flags everything looks
+    # exactly like a working one.
+    case("an unchanged event is compatible", compare_events("p", old, ev(base)), False)
+
+    # THE BREAKING SET. Each is invisible until a consumer or a replay hits it.
+    case("a removed property is breaking",
+         compare_events("p", old, ev('data class Paid(val id: String) : DomainEvent()\n')),
+         True, "removed")
+    case("a changed type is breaking",
+         compare_events("p", old, ev('data class Paid(val id: String, val amount: String) : DomainEvent()\n')),
+         True, "type changed")
+    case("a removed event class is breaking",
+         compare_events("p", old, ev('data class Other(val id: String) : DomainEvent()\n')),
+         True, "removed/renamed")
+
+    # ADDITIVE rules. A new field is only safe if old payloads can still deserialize — which
+    # means nullable, or defaulted. Getting this wrong in the lenient direction ships a
+    # required field into a topic full of messages that lack it.
+    case("a new REQUIRED non-nullable field is breaking",
+         compare_events("p", old, ev('data class Paid(val id: String, val amount: Long, val fee: Long) : DomainEvent()\n')),
+         True)
+    case("a new NULLABLE field is compatible",
+         compare_events("p", old, ev('data class Paid(val id: String, val amount: Long, val fee: Long?) : DomainEvent()\n')),
+         False)
+    case("a new DEFAULTED field is compatible",
+         compare_events("p", old, ev('data class Paid(val id: String, val amount: Long, val fee: Long = 0) : DomainEvent()\n')),
+         False)
+
+    # --- Avro, the other wire format ------------------------------------------------------
+    import json as _json
+    a_old = _json.dumps({"type": "record", "name": "Paid",
+                         "fields": [{"name": "id", "type": "string"}]})
+    case("an unchanged avsc is compatible", compare_avsc("s.avsc", a_old, a_old), False)
+    case("a removed avro field is breaking",
+         compare_avsc("s.avsc", a_old, _json.dumps({"type": "record", "name": "Paid", "fields": []})),
+         True)
+    a_new_req = _json.dumps({"type": "record", "name": "Paid", "fields": [
+        {"name": "id", "type": "string"}, {"name": "fee", "type": "long"}]})
+    case("a new avro field with no default is breaking", compare_avsc("s.avsc", a_old, a_new_req), True)
+    a_new_def = _json.dumps({"type": "record", "name": "Paid", "fields": [
+        {"name": "id", "type": "string"}, {"name": "fee", "type": "long", "default": 0}]})
+    case("a new avro field WITH a default is compatible",
+         compare_avsc("s.avsc", a_old, a_new_def), False)
+
+    # A class that is not a DomainEvent must not be parsed as one — otherwise every ordinary
+    # data class in the diff becomes an event contract and the gate is unusable.
+    if parse_events('data class NotAnEvent(val x: String)\n'):
+        fails.append("a plain data class was parsed as a DomainEvent")
+
+    if fails:
+        for f in fails:
+            sys.stderr.write(f"::error::self-test: {f}\n")
+        sys.stderr.write(f"self-test FAILED ({len(fails)} case(s))\n")
+        return 1
+    print("self-test ok: event schema compatibility is falsifiable (14 cases)")
+    return 0
+
+
 def main() -> int:
+    if "--self-test" in sys.argv:
+        return self_test()
+
     ap = argparse.ArgumentParser()
     ap.add_argument("--base", required=True)
     ap.add_argument("--enforce", action="store_true")

--- a/.github/scripts/check-gate-selftest-declaration.py
+++ b/.github/scripts/check-gate-selftest-declaration.py
@@ -329,7 +329,6 @@ def main():
 # self-corroboration trap as widening a known-good set with the layer it is checking).
 DEBT = {
     "adr-registry-integrity-check": DEBT_MARKER,
-    "advisory-gate-registration": DEBT_MARKER,
     "ai-act-high-risk-inventory-vs-code": DEBT_MARKER,
     "ai-governance-snapshot-drift": DEBT_MARKER,
     "db-backup-association-gate": DEBT_MARKER,
@@ -339,8 +338,6 @@ DEBT = {
     "gen-network-policies-drift-gate": DEBT_MARKER,
     "mcp-real-port-requires-caller-auth-first": DEBT_MARKER,
     "openapi-route-conformance": DEBT_MARKER,
-    "release-scope-mismatch-gate": DEBT_MARKER,
-    "schema-compat-gate": DEBT_MARKER,
     "service-runbook-drift": DEBT_MARKER,
 }
 

--- a/openbank-infra/scripts/check-release-scope-mismatch.py
+++ b/openbank-infra/scripts/check-release-scope-mismatch.py
@@ -114,14 +114,99 @@ def find_mismatches(changed: list[str], packages: list[str]) -> list[tuple[str, 
     return findings
 
 
+def self_test() -> int:
+    """Falsify the commit classifier and the release-scope comparison.
+
+    release-please needs BOTH axes to cut a release: a releasing TYPE and a touched path
+    inside the package's release subtree. This gate catches the combination that produces a
+    version bump for an artifact that did not change — a feat/fix PR touching only src/test,
+    docs or gitops under a package directory.
+
+    Both halves classify strings, and both have a lenient direction that reports clean: a
+    type the regex fails to parse is "not releasing", and a package prefix that matches too
+    eagerly makes every diff look release-worthy.
+    """
+    fails: list[str] = []
+
+    def case(label, got, want):
+        if got != want:
+            fails.append(f"{label}: expected {want}, got {got}")
+
+    # --- the classifier ------------------------------------------------------------------
+    for title, want in (
+        ("feat(ledger): add x", ("feat", True)),
+        ("fix(ledger): repair x", ("fix", True)),
+        ("perf(ledger): speed x", ("perf", True)),
+        ("security(ledger): patch x", ("security", True)),
+        # Hidden types do not release at any path — that is the lever when a PR changes no
+        # shipped code.
+        ("docs(ledger): explain x", ("docs", False)),
+        ("chore(ledger): tidy x", ("chore", False)),
+        ("ci(ledger): wire x", ("ci", False)),
+        ("refactor(ledger): move x", ("refactor", False)),
+        # A breaking marker releases a MAJOR even on a hidden type — the documented lever.
+        ("docs(ledger)!: drop x", ("docs", True)),
+        ("chore!: drop x", ("chore", True)),
+        # No scope at all is still a conventional commit.
+        ("feat: add x", ("feat", True)),
+    ):
+        case(f"classify({title!r})", classify(title, False), want)
+
+    # A BREAKING CHANGE footer releases a major even with no `!` in the subject — missing this
+    # would classify a real breaking change as non-releasing, the lenient direction.
+    case("a BREAKING CHANGE footer makes a hidden type releasing",
+         classify("docs(ledger): drop x", True), ("docs", True))
+
+    # A non-conventional subject is not classifiable. It must yield None rather than a guess:
+    # inventing a type here would either force or suppress a release on a subject nobody
+    # parsed.
+    for junk in ("no colon here", "Feat(ledger): capitalised", "123(ledger): numeric", ""):
+        case(f"classify({junk!r}) is unparseable", classify(junk, False), (None, False))
+
+    # --- the scope comparison -------------------------------------------------------------
+    pkgs = ["openbank-ledger-service", "openbank-admin-ui"]
+
+    # THE DEFECT: a package touched only outside its release subtree.
+    case("test-only changes under a package are a mismatch",
+         find_mismatches(["openbank-ledger-service/src/test/kotlin/T.kt"], pkgs),
+         [("openbank-ledger-service", ["openbank-ledger-service/src/test/kotlin/T.kt"])])
+    # A real source change is release-worthy — nothing to flag.
+    case("a src/main change is not a mismatch",
+         find_mismatches(["openbank-ledger-service/src/main/kotlin/A.kt"], pkgs), [])
+    # MIXED: one release-worthy file is enough to justify the bump.
+    case("a mixed diff with one src/main file is not a mismatch",
+         find_mismatches(["openbank-ledger-service/src/test/kotlin/T.kt",
+                          "openbank-ledger-service/src/main/kotlin/A.kt"], pkgs), [])
+    # A package not touched at all must not appear.
+    case("an untouched package is not reported", find_mismatches(["docs/adr/x.md"], pkgs), [])
+    # PREFIX PRECISION: a sibling directory that merely starts with the package name is a
+    # different package. Matching it would attribute someone else's diff to this one.
+    case("a same-prefix sibling directory is not this package",
+         find_mismatches(["openbank-ledger-service-extras/src/test/T.kt"], pkgs), [])
+
+    if fails:
+        for f in fails:
+            sys.stderr.write(f"::error::self-test: {f}\n")
+        sys.stderr.write(f"self-test FAILED ({len(fails)} case(s))\n")
+        return 1
+    print("self-test ok: release-scope-mismatch is falsifiable (21 cases)")
+    return 0
+
+
 def main() -> int:
     ap = argparse.ArgumentParser()
-    ap.add_argument("--title", required=True, help="PR title (the default squash-commit subject)")
+    ap.add_argument("--self-test", action="store_true")
+    ap.add_argument("--title", required=False, help="PR title (the default squash-commit subject)")
     ap.add_argument("--body", default="", help="PR body, scanned for a BREAKING CHANGE: footer")
     ap.add_argument("--base", default="origin/main", help="PR base ref/sha (3-dot diff)")
     ap.add_argument("--changed-files", help="file with a newline-separated changed-file list (skips git)")
     ap.add_argument("--enforce", action="store_true")
     args = ap.parse_args()
+
+    if args.self_test:
+        return self_test()
+    if not args.title:
+        ap.error("--title is required")
 
     ctype, triggering = classify(args.title, "BREAKING CHANGE:" in args.body)
     if not triggering:


### PR DESCRIPTION
Stacked on #4557. **Debt 14 → 11**; 113 of 142 gates declare a self-test.

| gate | cases | what it prevents |
|---|---|---|
| `schema-compat-gate` | 14 | an event is a contract with every consumer **and every message already in the topic** — a removed property or new required field breaks **replay**, surfacing at consumer start-up or months later, never in the PR that caused it |
| `release-scope-mismatch-gate` | 21 | release-please needs **both** axes; a `feat` touching only `src/test` bumps an artifact that did not change |
| `advisory-gate-registration` | 9 | an advisory rule with no `target_enforce_date` is **permanent by omission** — a gate that warns forever is one nobody has to satisfy |

### The historical defect, now pinned
`check-advisory-gate-registration.py`'s own docstring records it: a **line-wise** scan attributed `enforced:` to whichever bare `key:` it saw last, so a rule holding a sub-tree (`finops_tiers` has `tiers:`) had its metadata read under the **wrong name** — the gate reported a rule as registered while describing another rule's fields. The nested fixture reproduces exactly that.

### The lenient direction is the one that ships
For `schema-compat`, every rule has a version that reports clean: a nullable check that always says "nullable", a type comparison that never fires. Both directions of the additive rules are pinned — a new field is safe **only** if nullable or defaulted.

For `release-scope`, an unparseable subject must yield `None` rather than a guess: inventing a type would either force or suppress a release on a subject nobody parsed. And a sibling directory that merely **starts with** the package name is a different package.

**13 deliberate breaks across the three, every one caught.** Verdicts unchanged. Shards: `lint 18/18 · data 13/13 · supplychain 20/20`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
