### PR TITLE
chore(ledger): enforce the accounting-day lock (ADR-0207 D3)

### DIFF
--- a/openbank-infra/gitops/components/ledger/ledger-service.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-service.yaml
@@ -129,6 +129,19 @@ spec:
             # aborts the rollout if enforce regresses the error rate.
             - name: AUTHZ_ENFORCE
               value: "true"
+            # Accounting-day lock (ADR-0207 D3, #1302) moves shadow -> enforce. The
+            # evidence gate the ADR set was "would_refuse zero-or-explained after at
+            # least one full day cycle"; six cycles have now run (2026-08-07..12 all
+            # TIED_OUT) and the readout is zero from two independent sources. It was
+            # NOT taken from the shadow counter alone -- that counter is pod-local and
+            # Prometheus retains 12h, and posting volume here is far too low for a
+            # soak to mean anything. It was taken by enumerating the whole population
+            # in ledger-db: of all 168 journal entries ever written, 122 are
+            # future-dated and 46 are same-day (Prague); ZERO are backdated, so there
+            # is no posting shape in this environment that enforce would refuse.
+            # Rollback is this value alone: set back to "shadow".
+            - name: LEDGER_DAY_LOCK_MODE
+              value: "enforce"
           startupProbe:
             tcpSocket:
               port: management


### PR DESCRIPTION
## What

Flips `openbank.ledger.day-lock.mode` from its `shadow` default to `enforce`, by setting
`LEDGER_DAY_LOCK_MODE=enforce` in the ledger-service gitops manifest. One env var, no code change.

This is the **last remaining item on #1302**. Items 1, 2 (code), 3 are done; item 4 is #3921;
item 5 is closed (#3920 merged, #3986 closed completed); items 6/7 are #1201/#1208. A search of
all issues for `day-lock` returns only #1302, #3986 and #1745, so this flip has no other tracker.

## ⚠️ This is a money-path behaviour change — 2 approvals + threat model (ADR-0030)

`openbank-ledger-service` is a money-path service. After this merges, a posting whose `entryDate`
falls on an accounting day that is `CUTOFF` / `TIED_OUT` / `LOCKED` is **refused** with
`ClosedAccountingDayException` (409) instead of being silently recorded. A reversal of an entry in
a sealed day is **not** refused — it is routed forward into the current open day
(`forwardCorrectionDate()`), which changes that reversal's booking date.

Please do not merge on the summary alone; the evidence is below and the counterfactual query is
reproducible.

## Why now — the evidence gate is met, and this time it is not vacuous

ADR-0207 set the gate as "`would_refuse` zero-or-explained after at least one full day cycle with
the calendar live". Two earlier readouts on #1302 correctly declined to flip:

- **2026-08-07 (first readout)** — `ledger_accounting_day` held a single row that had been `OPEN`
  for its whole life. `would_refuse` can only fire when a day row exists *and* is not accepting
  postings, so zero was what an unexercised control returns.
- **2026-08-07 21:45 (second readout)** — same, plus the finding that the gate as written cannot be
  read from Prometheus at all: `storageRetention: 12h`, no Thanos/Mimir/Cortex, and the counter is
  per-pod Micrometer state that resets on every restart.

Both preconditions have now changed.

### 1. The calendar is real and has completed six full cycles

```
 business_date | status   | opened_at                     | cutoff_at                     | tied_out_at
---------------+----------+-------------------------------+-------------------------------+-------------------------------
 2026-08-07    | TIED_OUT | 2026-08-07 09:45:01.043097+00 | 2026-08-07 22:00:01.268467+00 | 2026-08-08 04:15:01.020473+00
 2026-08-08    | TIED_OUT | 2026-08-07 22:00:01.019295+00 | 2026-08-08 22:00:01.191474+00 | 2026-08-09 04:15:00.022044+00
 2026-08-09    | TIED_OUT | 2026-08-08 22:00:01.012850+00 | 2026-08-09 22:00:00.445267+00 | 2026-08-10 04:15:00.029149+00
 2026-08-10    | TIED_OUT | 2026-08-09 22:00:00.025278+00 | 2026-08-10 22:00:01.074950+00 | 2026-08-11 04:15:00.017481+00
 2026-08-11    | TIED_OUT | 2026-08-10 22:00:01.009108+00 | 2026-08-11 22:00:00.397317+00 | 2026-08-12 04:15:01.020406+00
 2026-08-12    | TIED_OUT | 2026-08-11 22:00:00.016506+00 | 2026-08-12 22:00:01.314562+00 | 2026-08-13 04:15:00.021215+00
 2026-08-13    | OPEN     | 2026-08-12 22:00:01.019324+00 |                               |
```

All transitions `opened_by = system:accounting-day-scheduler` (#3984). The `OPEN → CUTOFF →
TIED_OUT` progression the gate waited for has run six times, so days that refuse postings have
genuinely existed for six consecutive days.

### 2. The readout is zero — and it was **enumerated, not soaked**

The shadow counter on its own would still be worthless here, for the reason the 2026-08-07 comment
gave (12 h retention, pod-local) **and** for a reason that matters just as much: posting volume is
16 entries across the whole six-day live-calendar window, the most recent on 2026-08-10 11:59Z.
A soak over traffic that thin cannot distinguish "the lock found nothing" from "nothing posted".

So the evidence was taken by enumerating the entire population in `ledger-db` instead, replaying
`AccountingDayLock.evaluate`'s exact decision (`day == null → no_day_record`;
`day.acceptsPostings → allowed`; else `would_refuse`, where `acceptsPostings == (status == OPEN)`)
against each posting's real `created_at`:

**Every posting since the calendar went live (2026-08-07 09:45:01Z):**

| outcome | n | first | last |
|---|---|---|---|
| `allowed` | 7 | 2026-08-10 10:58:27Z | 2026-08-10 11:59:12Z |
| `no_day_record` | 9 | 2026-08-08 15:35:25Z | 2026-08-09 07:02:35Z |
| **`would_refuse`** | **0** | — | — |

**Every posting ever written (168 rows, since 2026-06-07), by shape against the Prague business date:**

| shape | count |
|---|---|
| `FUTURE-dated` | 122 |
| `same-day (Prague)` | 46 |
| **`BACKDATED`** | **0** |

That second table is the load-bearing one. Backdating is the operation the day lock removes, and it
has **never once happened in this environment** across the ledger's entire history. Future-dated
postings land on a day with no row yet (`no_day_record`, never refused in any mode) and same-day
postings land on an `OPEN` day (`allowed`). There is no posting shape present here that `enforce`
would refuse — so the blast radius is measured zero over the whole population, not zero over a
window that happened to be quiet.

### 3. Independent confirmation from Loki, probe validated against a known positive

`AccountingDayLock` WARN-logs *only* on `would_refuse`, and Loki retains 1 w (unlike Prometheus):

```
{namespace="ledger"} |= `Day lock`        # 7d → 0 streams, 1 646 765 lines scanned
```

Not trusted on its silence. The same pipeline over the same window as a known positive:

```
{namespace="ledger"} |= `Accounting day`  # 7d → 13 streams, AccountingDayScheduler lines
                                          #   spanning 2026-08-07 09:45 .. 2026-08-13 04:15
```

The filter works and covers the full window; there is simply nothing to match.

### 4. The one failure mode worth naming — measured, and it does not reproduce

`entryDate` is caller-supplied (`LedgerResource.kt:137`, required field, no default). Days go
`CUTOFF` at 22:00Z = midnight Prague. So a client computing "today" in **UTC** and posting between
22:00Z and 24:00Z would send the date that just went `CUTOFF`, and would start getting 409s.

Checked against the data rather than assumed. Three of 168 entries fall in that window:

| created_at | entry_date | UTC date | Prague date | verdict |
|---|---|---|---|---|
| 2026-06-13 22:01:48Z | 2026-06-15 | 2026-06-13 | 2026-06-14 | future-dated (not refused) |
| 2026-06-17 22:50:34Z | 2026-06-18 | 2026-06-17 | 2026-06-18 | Prague-aligned |
| 2026-07-20 23:20:57Z | 2026-07-21 | 2026-07-20 | 2026-07-21 | Prague-aligned |

None is UTC-aligned. Every caller that has ever posted in the cutover window already uses the
Prague business date, which is the date the lock agrees with.

### 5. Reversals — the forward-routing change has no live population either

2 reversals exist in all of history, **0** since the calendar went live. The
`correctionDate = forwardCorrectionDate()` re-routing this flip activates would not have moved a
single booking date in the measured window.

## Residual this flip does NOT close — please read before approving

`enforce` refuses only when a day **row exists** and is sealed. A day with no row is not refused in
any mode (deliberate, per `AccountingDayLock`'s KDoc — failing closed on absence would brick every
posting). **122 of 168 postings here are future-dated**, i.e. the majority of this ledger's traffic
hits `no_day_record` and passes untouched. That is correct — a future-dated entry is written before
its day is opened, so the day's eventual tie-out includes it — but it means this flip should not be
read as closing the whole backdating hole. It closes the sealed-day path, which is the one #1302
named.

Also note the 2026-08-07 finding stands and is not fixed here: the ADR-0207 gate text still points
readers at a Prometheus counter that cannot answer it (12 h retention, pod-local, resets on
restart). Worth a follow-up to amend the ADR to point at the Loki WARN stream or a persisted
decisions table. Not in scope for a config flip.

## Rollback

Env-only, single value, no migration and no code path to unwind:

```yaml
- name: LEDGER_DAY_LOCK_MODE
  value: "shadow"
```

The `openbank-money-path-canary` analysis on the rollout aborts automatically if enforce regresses
the error rate.

## Verification

- No `version.txt` / `openapi.yaml` change: gitops-only, `chore` type, path outside any released
  component — correctly produces no release (ADR-0029 two-axis rule).
- Running pod `ledger-service-7df5889c77-x2jrb` (image `sandbox-e80f4bc7`) carries **no**
  `LEDGER_DAY_LOCK_MODE` among its 19 env vars, confirming `application.yaml`'s
  `${LEDGER_DAY_LOCK_MODE:shadow}` default is what is in effect today.

Refs #1302, ADR-0207, ADR-0096, #3984.
