### PR TITLE
feat(observability): make zero-ready-endpoint windows measurable (#3806) — 12 Services, daily

### DIFF
--- a/openbank-infra/gitops/apps/loki.yaml
+++ b/openbank-infra/gitops/apps/loki.yaml
@@ -130,6 +130,25 @@ spec:
             # The missing half. Without this a rule evaluates, fires, and is delivered nowhere.
             alertmanager_url: http://kube-prometheus-stack-alertmanager.observability.svc:9093
             enable_alertmanager_v2: true
+            # The SAME half again, for recording rules — and it is a separate switch. An alerting
+            # rule needs alertmanager_url; a RECORDING rule needs remote_write, and without it the
+            # rule evaluates on schedule and the result is dropped on the floor with no error
+            # anywhere. That is the "configured-looking and inert" shape this block's own comment
+            # above was written about, one rule type over.
+            #
+            # The receiver is the same Prometheus the k6 journeys already remote-write into
+            # (enableRemoteWriteReceiver, proven working by openbank-infra/gitops/components/
+            # observability/cronjob-journey-public-edge.yaml), so this adds a client to a path
+            # that is already carrying traffic rather than a new one to prove.
+            remote_write:
+              enabled: true
+              client:
+                url: http://kube-prometheus-stack-prometheus.observability.svc:9090/api/v1/write
+                queue_config:
+                  # Small: the only producer is the endpoint-availability rule, one sample per
+                  # affected Service per minute. Sized to be unmistakably not a bulk pipe.
+                  capacity: 2500
+                  max_shards: 10
           # Single-binary needs the embedded query scheduler off.
           querier:
             max_concurrent: 2

--- a/openbank-infra/gitops/components/observability/loki-rules-endpoint-availability.yaml
+++ b/openbank-infra/gitops/components/observability/loki-rules-endpoint-availability.yaml
@@ -1,0 +1,62 @@
+# Zero-ready-endpoint windows, as a METRIC rather than an alert (#3806).
+#
+# WHAT THIS MEASURES
+#   ingress-nginx logs `Service "<ns>/<name>" does not have any active Endpoint.` every ~3s for as
+#   long as a Service it routes to has no ready backend. While that is true, every request to that
+#   Service returns 503. This recording rule turns those log lines into a per-Service time series so
+#   the condition has a trend, a before, and an after.
+#
+# WHY A RECORDING RULE AND NOT AN ALERT
+#   Because the condition is currently TRUE most of the day, across most of the estate. Measured on
+#   2026-08-13 over 24h of ingress-nginx logs (1126 lines sampled):
+#
+#     balances/balance-service 201   platform/copilot-service 181   customer-edge 173
+#     admin-ui/admin-ui 151          sanctions/sanctions-service 151  accounts/account-service 117
+#     iam/keycloak 56                payments/transaction-service 43  payments/sepa-payment 39
+#     payments/domestic-payment 7    payments/sepa-instant 6          developer-portal 1
+#
+#   Twelve Services, several money-path, plus Keycloak — so logins too. An alert on a condition that
+#   is already the resting state is not a signal, it is a permanently-red light nobody will look at
+#   twice; this estate's documented root cause is alert fatigue, so adding one would be a regression
+#   even though the condition is real. The alert belongs AFTER #3806's replica work, when a firing
+#   rule would mean something changed. This rule is what makes that change visible.
+#
+# WHY LOGS AND NOT kube-state-metrics
+#   There is no `kube_endpoint_address_available` in this kube-state-metrics version. What exists is
+#   `kube_endpointslice_endpoints{ready="true"}`, one series PER ENDPOINT ADDRESS — so a Service with
+#   zero ready endpoints has no series at all rather than a series reading zero, and the obvious
+#   `sum by (...) == 0` matches nothing precisely when it matters. Verified against live Prometheus
+#   during the 09:43 outage: that query returned zero results while the ingress log described the
+#   outage line by line. The ingress controller names every affected Service automatically, which is
+#   also what stops this from becoming a hand-kept list of services to watch.
+#
+# The rule extracts the Service from the message so the series is per Service, not per namespace —
+# `ingress-nginx` as a label would say only "something is down somewhere".
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: loki-rules-endpoint-availability
+  namespace: observability
+  labels:
+    loki_rule: "1"
+    app.kubernetes.io/part-of: observability
+data:
+  endpoint-availability.yaml: |
+    groups:
+      - name: openbank.logs.endpoint-availability
+        interval: 1m
+        rules:
+          # Log lines per minute, per Service, while it has no ready endpoint. The VALUE is a
+          # nginx-internal repeat rate and means nothing on its own; `> 0` is the whole signal,
+          # and the useful queries are `count_over_time(... > 0)` for how often, and
+          # `sum_over_time` for roughly how long.
+          - record: openbank:service_no_ready_endpoints:rate1m
+            expr: |
+              sum by (target_namespace, target_service) (
+                rate(
+                  {namespace="ingress-nginx"}
+                    |= "does not have any active Endpoint"
+                    | regexp `Service "(?P<target_namespace>[^/]+)/(?P<target_service>[^"]+)"`
+                  [1m]
+                )
+              )


### PR DESCRIPTION
Takes #3806's third acceptance item — *"something that makes a stuck roll observable"*, which the
issue calls the cheapest item on its list — and aims it at what the estate turns out to be doing.

## What the measurement changed

#3806 frames the one-replica Rollouts as *"cannot roll on a full cluster"*. Measured on 2026-08-13
against 24h of ingress-nginx logs, the live symptom is broader and routine. Twelve Services logged
`does not have any active Endpoint` — the window in which every request to them returns 503:

| Service | lines | | Service | lines |
|---|---|---|---|---|
| `balances/balance-service` | 201 | | `accounts/account-service` | 117 |
| `platform/copilot-service` | 181 | | `iam/keycloak` | 56 |
| `customer-edge/customer-edge` | 173 | | `payments/transaction-service` | 43 |
| `admin-ui/admin-ui` | 151 | | `payments/sepa-payment` | 39 |
| `sanctions/sanctions-service` | 151 | | `payments/domestic-payment`, `sepa-instant`, `developer-portal` | 7, 6, 1 |

Several money-path, plus **Keycloak — so logins**. And at 09:43–09:50 four of them were down *at the
same time* (customer-edge, admin-ui, keycloak, copilot-service) with **no ReplicaSet created at that
moment**, so the cause there is node lifecycle, not deploys: ten nodes were created on 2026-08-13
alone. My first hypothesis was a canary rollout and the ReplicaSet timestamps refused it.

## What this PR ships

A **recording rule**, not an alert:

```
openbank:service_no_ready_endpoints:rate1m{target_namespace, target_service}
```

The condition is already the resting state across most of the estate. An alert on it would be a
permanently-red light, and this estate's documented root cause is alert fatigue — so adding one now
would be a regression even though the condition is real. **The alert belongs after the replica work,
when firing would mean something changed.** This is what makes that change visible, and what gives
any fix a before and an after instead of an opinion.

Plus the half that would otherwise make it inert: **`ruler.remote_write`**. `alertmanager_url` serves
*alerting* rules; a *recording* rule needs remote_write, and without it the rule evaluates on
schedule and the result is dropped with no error anywhere — precisely the "configured-looking and
inert" shape that block's own comment was written about, one rule type over. The receiver is the
Prometheus the k6 journeys already remote-write into, so this adds a client to a proven path.

## Why logs and not kube-state-metrics

There is no `kube_endpoint_address_available` in this version. What exists is
`kube_endpointslice_endpoints{ready="true"}` — **one series per endpoint address** — so a Service
with zero ready endpoints has *no series at all* rather than a series reading zero. Verified against
live Prometheus during the 09:43 outage: the obvious `sum by (...) == 0` returned nothing while the
ingress log described the outage line by line. An `absent()` rule works but needs one instance per
Service, i.e. a hand-kept list of exactly what it is meant to cover.

## Verification

- **Falsified against live Loki**: the expression returns per-Service series over the real outage
  window — `customer-edge`, `admin-ui`, `iam/keycloak`, `copilot-service` — and the `| regexp`
  extraction yields the target Service rather than just `ingress-nginx`.
- `gitops` gate shard 27/27, `lint` 19/19.

## What this deliberately does not do

Change any replica count or add a PDB. #3806 gates that on per-service state evidence (#3467's
lending counter-example, #3644 for customer-edge's session store) and on a capacity decision worth
+9.6% of the live pool cap. Those are decisions, not commits, and they are still open.

Refs #3806, #3545, #4348.
