### PR TITLE
fix(analytics-sink): normalise aggregate_type at ingest so one aggregate cannot split in two

### DIFF
--- a/openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/application/AnalyticsConsumer.kt
+++ b/openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/application/AnalyticsConsumer.kt
@@ -198,10 +198,34 @@ class AnalyticsConsumer {
             ?: address.key
             ?: UNKNOWN_SERVICE
 
-    private fun resolveAggregateType(node: JsonNode, address: EventAddress): String = node["aggregateType"]?.asText()
-        ?: inferAggregateType(node).takeIf { it != UNKNOWN }
-        ?: TopicAttribution.aggregateType(address.topic)
-        ?: UNKNOWN
+    /**
+     * The aggregate type, UPPERCASED (issue #4553).
+     *
+     * The producer's spelling used to survive verbatim while both fallbacks below emit uppercase, so
+     * the value recorded WHICH PATH attributed the event rather than what the aggregate is. Bronze
+     * ended up holding `ACCOUNT` (294 rows) and `Account` (17) for the same domain — five account ids
+     * under both — and `silver_current_state`, which groups by `(aggregate_type, aggregate_id)`, then
+     * emitted TWO current-state rows for one account. Last-writer-wins cannot fire across a group
+     * boundary, so a reader filtering one spelling got a stale row presented as current.
+     *
+     * `Transaction` and `Consent` existed ONLY in mixed case, which is why every consumer comparing
+     * against `'TRANSACTION'` matched nothing at all, and a Grafana tile asking for `'Party'` read 0
+     * against a true 4 for its whole life (fixed in #4556).
+     *
+     * Uppercasing also repairs [idForType], whose `when (type)` matches uppercase literals only: a
+     * mixed-case type fell through to the `accountId`/`partyId` fallback — the exact pairing of a
+     * TRANSACTION type with an ACCOUNT id that [resolveAggregateId]'s KDoc exists to prevent.
+     *
+     * Rows already in bronze keep their original spelling; this stops the split growing, it does not
+     * heal it. The backfill is tracked separately on #4553 — bronze is a `ReplacingMergeTree`, so
+     * re-keying is an explicit CORRECTION ingest, not an in-place update.
+     */
+    private fun resolveAggregateType(node: JsonNode, address: EventAddress): String = (
+        node["aggregateType"]?.asText()
+            ?: inferAggregateType(node).takeIf { it != UNKNOWN }
+            ?: TopicAttribution.aggregateType(address.topic)
+            ?: UNKNOWN
+        ).uppercase()
 
     private fun resolveAggregateVersion(node: JsonNode): Long = node["aggregateVersion"]?.asLong()
         ?: node["version"]?.asLong()

--- a/openbank-analytics-sink/src/test/kotlin/com/openbank/analytics/application/AnalyticsAttributionTest.kt
+++ b/openbank-analytics-sink/src/test/kotlin/com/openbank/analytics/application/AnalyticsAttributionTest.kt
@@ -118,6 +118,59 @@ class AnalyticsAttributionTest {
         assertThat(env.sourceService).isEqualTo("openbank-party-service")
     }
 
+    // ---------------------------------------------------------------------------------------------
+    // Issue #4553 — the producer's spelling used to survive verbatim while both fallbacks emit
+    // uppercase, so aggregate_type recorded which path attributed the event. Measured on the sandbox
+    // warehouse: ACCOUNT 294 rows / Account 17, five account ids under BOTH, and therefore two
+    // current-state rows per account in silver_current_state (it groups by (type, id), so
+    // last-writer-wins cannot fire across the split). Transaction and Consent existed only in mixed
+    // case, so every consumer comparing against 'TRANSACTION' matched nothing.
+    // ---------------------------------------------------------------------------------------------
+
+    @Test
+    fun `a producer's mixed-case aggregateType is normalised, so one aggregate cannot split in two`() {
+        val mixed = consumer.toEnvelope(
+            mapper.readTree(
+                """{ "aggregateType": "Account", "aggregateId": "acc-1", "eventType": "AccountCreated" }""",
+            ),
+        )
+        val upper = consumer.toEnvelope(
+            mapper.readTree(
+                """{ "aggregateType": "ACCOUNT", "aggregateId": "acc-1", "eventType": "BALANCE_UPDATED" }""",
+            ),
+        )
+
+        assertThat(mixed.aggregateType).isEqualTo("ACCOUNT")
+        // The property that matters is not the string — it is that both events reduce to ONE silver
+        // group. Asserting the pair is what a single isEqualTo("ACCOUNT") cannot express.
+        assertThat(mixed.aggregateType to mixed.aggregateId)
+            .describedAs("both spellings of one account must land in the same silver group")
+            .isEqualTo(upper.aggregateType to upper.aggregateId)
+    }
+
+    @Test
+    fun `a mixed-case type still resolves its own id field, never the accountId fallback`() {
+        // idForType is a `when (type)` over uppercase literals, so before normalisation a
+        // "Transaction" envelope fell through to `?: node["accountId"]` — pairing a TRANSACTION type
+        // with an ACCOUNT id, which is precisely what resolveAggregateId's KDoc exists to prevent and
+        // what would collapse every transaction on an account into one aggregate in silver.
+        val env = consumer.toEnvelope(
+            mapper.readTree("""{ "aggregateType": "Transaction", "transactionId": "tx-1", "accountId": "acc-1" }"""),
+        )
+
+        assertThat(env.aggregateType).isEqualTo("TRANSACTION")
+        assertThat(env.aggregateId).isEqualTo("tx-1")
+    }
+
+    @Test
+    fun `normalisation does not manufacture attribution for an unidentifiable event`() {
+        // The UNKNOWN sentinel must survive uppercasing unchanged: #2598's whole point is that an
+        // unattributed event stays visibly unattributed rather than being quietly bucketed.
+        val env = consumer.toEnvelope(mapper.readTree("""{ "somethingElse": "x" }"""), EventAddress.NONE)
+
+        assertThat(env.aggregateType).isEqualTo("UNKNOWN")
+    }
+
     @Test
     fun `every subscribed topic resolves to a domain and a service`() {
         // Scope derived from the config, never hand-kept: a list maintained separately from the


### PR DESCRIPTION
## Summary

Normalises `aggregate_type` at ingest (#4553 item 1). `resolveAggregateType` took the producer's
spelling verbatim while both of its fallbacks emit uppercase, so the stored value recorded **which
path attributed the event**, not what the aggregate is. This is the source fix only — it stops the
split growing; it does not heal the rows already in bronze.

## Type of change

- [x] fix (bug fix)

## Linked issues

Refs #4553 — deliberately not `Closes`: the backfill and the consumer sweep are still open there.

## The defect, measured

| aggregate_type | rows | note |
|---|---|---|
| `ACCOUNT` / `Account` | 294 / 17 | **five account ids appear under both** |
| `Transaction` | 43 | no `TRANSACTION` rows exist at all |
| `Consent` | 10 | no `CONSENT` rows exist at all |

`silver_current_state` groups by `(aggregate_type, aggregate_id)`, so those five accounts have **two
current states that never reconcile** — last-writer-wins cannot fire across a group boundary, and a
reader filtering one spelling gets a stale row presented as current.

## What else this repairs

`idForType` is a `when (type)` over uppercase literals, so a mixed-case type fell through to
`?: node["accountId"] ?: node["partyId"]` — the TRANSACTION-type-with-an-ACCOUNT-id pairing that
`resolveAggregateId`'s KDoc exists to prevent, and which would collapse every transaction on an
account into one aggregate in silver. It was not firing in the sandbox (the 43 `Transaction` rows
take their id from the envelope's `aggregateId`, and none equals the payload's `accountId` — checked
before claiming it), but the guard was bypassed on the mixed-case path. A `"Transaction"` envelope
now keys on its `transactionId`.

## Verification

- `:openbank-analytics-sink:test` → **78 tests, 0 failures, 0 errors, 0 skipped** (read from the JUnit
  XML, not the console — the run prints a stack trace from a negative-path test and `| tail` would
  have masked the exit code).
- **Falsified against the unfixed consumer**: restoring `origin/main`'s `AnalyticsConsumer.kt` turns
  two of the three new tests red — `expected "ACCOUNT" but was "Account"` and `expected "TRANSACTION"
  but was "Transaction"`.
- The third new test is a **guard on this change, not a reproduction**: `UNKNOWN` must survive
  uppercasing unchanged, or an unattributed event would be quietly bucketed — which is what #2598 was
  about. It passes either way by design, and saying so here is the point: counting it as evidence
  would overstate what was falsified.
- `ktlintCheck` + `detekt` green (`ktlintFormat` rewrapped two test arguments).

## A correction to #4553

The issue claimed `VaultCryptoErasure` would "shred one of the two groups" because its key name
embeds `aggregateType`. **That is wrong** — `keyName` lowercases every part, so `ACCOUNT` and
`Account` already map to one Vault key and erasure was never split by this. Corrected on the issue.
The reconciliation path is the one still worth a look: `HttpReconciliationSource` and
`ClickHouseWarehouseStateReader` both build `AggregateKey(aggregateType, aggregateId)` and compare
them, so a case mismatch between the warehouse and the owning service reads as drift. Not touched
here.

## Definition of Done

- [x] Hexagonal layering preserved — a private function in the application layer; no new imports.
- [x] Unit tests added, and falsified against the unfixed source.
- [ ] Integration tests — N/A. `ClickHouseAnalyticsSinkIT` asserts the insert path, not attribution.
- [ ] Contract tests / OpenAPI / Flyway / Avro — N/A. No API, no schema, no event contract changed:
      this narrows the *values* written to an existing column.
- [x] `ktlintCheck`, `detekt`, module `test` pass locally.

## Security checklist

- [x] No secrets, no PII. `aggregate_type` is a domain discriminator; payload masking is untouched.
- [x] No new `@Suppress`, no new dependency.
- [x] GDPR: erasure is keyed through `VaultCryptoErasure.keyName`, which already lowercases — this
      change cannot orphan a crypto key. Verified in the source rather than assumed (see above).

## Compliance impact

- [x] GDPR — no behaviour change to erasure or retention. `RetentionPolicies.categoryForAggregateType`
      already calls `.uppercase()`, so category mapping was never affected and is not now.
- [x] None otherwise.

## Rollout / Rollback

- Deployment strategy: rolling. Takes effect for events ingested after the pod restarts.
- **Expected during rollout**: for a brief window one aggregate may receive events under both
  spellings — the same state as today, not a new one. No consumer breaks, because every consumer that
  matters already folds case (`silver_party_accounts` from #4520, the two Grafana tiles from #4556).
- Rollback: revert. New rows return to producer spelling; nothing needs undoing.
- Data migration reversible: N/A — no existing row is touched.

## Reviewer notes

The honest limit of this PR: after it ships, an account whose last event arrived pre-fix keeps a
frozen `Account` row in silver forever, and the `Events by aggregate type` Grafana panel still draws
two series. That is the backfill, and it is a separate piece of work with real risk (a CORRECTION
ingest against a 10-year log of record), which is why it is not bolted on here.
