### PR TITLE
feat(campaign): add in-app banner channel

### DIFF
--- a/.github/event-contract-baseline.txt
+++ b/.github/event-contract-baseline.txt
@@ -13,7 +13,6 @@ openbank-account-service:openbank.accounts.account.created
 openbank-account-service:openbank.notification.requests
 openbank-aml-service:openbank.aml.events
 openbank-balance-service:openbank.balance.events
-openbank-campaign-service:openbank.notification.requests
 openbank-card-issuance-service:openbank.cards.events
 openbank-clearing-service:openbank.clearing.batch.event
 openbank-consent-service:openbank.consent.events

--- a/openbank-admin-ui/src/app/campaigns/new/page.tsx
+++ b/openbank-admin-ui/src/app/campaigns/new/page.tsx
@@ -65,12 +65,14 @@ const TEMPLATES: Record<string, string[]> = {
   // One variable, and that is the channel's rule rather than a simplification: a push renders its
   // title plus a fixed generic body, so there is nowhere for offer copy to go (#1182).
   MARKETING_PRODUCT_OFFER_PUSH: ['offerTitle'],
+  MARKETING_PRODUCT_OFFER_BANNER: ['offerTitle', 'offerText', 'ctaText'],
 }
 
 /** Which channel each template renders on. The service refuses a step whose two disagree. */
 const TEMPLATE_CHANNEL: Record<string, EditorChannel> = {
   MARKETING_PRODUCT_OFFER: 'EMAIL',
   MARKETING_PRODUCT_OFFER_PUSH: 'PUSH',
+  MARKETING_PRODUCT_OFFER_BANNER: 'BANNER',
 }
 
 const newStep = (): EditorStep => ({
@@ -116,6 +118,7 @@ export default function NewCampaignPage() {
   const templateLabels: Record<string, string> = {
     MARKETING_PRODUCT_OFFER: t('Nabídka produktu', 'Product offer'),
     MARKETING_PRODUCT_OFFER_PUSH: t('Nabídka produktu', 'Product offer'),
+    MARKETING_PRODUCT_OFFER_BANNER: t('Nabídka v banneru', 'Banner offer'),
   }
 
   // The template declares `offerTitle`; a marketer writes a headline. Same field, and only one of

--- a/openbank-admin-ui/src/app/globals.css
+++ b/openbank-admin-ui/src/app/globals.css
@@ -499,12 +499,14 @@ main {
 .campaign-phone-eyebrow { color: #64748b; font-size: 0.48rem; margin-top: 0.85rem; }
 .campaign-phone h4 { font-size: 0.82rem; font-weight: 800; line-height: 1.1; margin-top: 0.18rem; }
 .campaign-phone-hero { background: linear-gradient(145deg, #ede9fe, #dbeafe); border-radius: 0.75rem; margin-top: 0.65rem; padding: 0.58rem; }
+.campaign-phone-banner { background: linear-gradient(135deg, #fef3c7 0%, #ffedd5 46%, #fae8ff 100%); box-shadow: inset 0 1px 0 rgba(255,255,255,.75), 0 8px 18px rgba(217,119,6,.12); }
 .campaign-phone-hero span { color: #4f46e5; display: block; font-size: 0.43rem; font-weight: 800; text-transform: uppercase; }
 .campaign-phone-hero strong { display: block; font-size: 0.62rem; line-height: 1.15; margin: 0.28rem 0; }
 .campaign-phone-hero button { background: #4f46e5; border: 0; border-radius: 0.4rem; color: #fff; font-size: 0.45rem; font-weight: 700; padding: 0.28rem 0.42rem; }
 .campaign-phone-row { display: flex; gap: 0.28rem; margin-top: 0.58rem; }
 .campaign-phone-row span { background: #e2e8f0; border-radius: 0.25rem; height: 1.45rem; flex: 1; }
 .campaign-push-card { background: rgba(255,255,255,0.95); border: 1px solid rgba(255,255,255,0.75); border-radius: 0.9rem; box-shadow: 0 12px 28px rgba(0,0,0,.18); color: #0f172a; display: flex; gap: 0.48rem; max-width: 15.5rem; padding: 0.62rem; transform: rotate(-2deg); }
+.campaign-banner-card { border-color: rgba(251,191,36,.42); transform: rotate(2deg); }
 .campaign-push-icon { align-items: center; background: linear-gradient(140deg, #4f46e5, #7c3aed); border-radius: 0.45rem; color: #fff; display: flex; font-size: 0.85rem; font-weight: 800; height: 1.65rem; justify-content: center; width: 1.65rem; }
 .campaign-push-meta { color: #64748b; font-size: 0.43rem; font-weight: 800; letter-spacing: 0.04em; }
 .campaign-push-title { font-size: 0.66rem; font-weight: 800; line-height: 1.15; margin-top: 0.15rem; }

--- a/openbank-admin-ui/src/components/campaigns/CampaignExperiencePreview.tsx
+++ b/openbank-admin-ui/src/components/campaigns/CampaignExperiencePreview.tsx
@@ -34,6 +34,7 @@ export function CampaignExperiencePreview({
 }) {
   const { t, language } = useLanguage()
   const isPush = step?.channel === 'PUSH'
+  const isBanner = step?.channel === 'BANNER'
   const destination = step?.mobileDestination ?? 'HOME'
   const copy = destinationCopy[destination]
   const headline = step?.variables.offerTitle?.trim() || t('Vaše další chytrá volba', 'Your next smart move')
@@ -59,8 +60,8 @@ export function CampaignExperiencePreview({
             </div>
             <p className="campaign-phone-eyebrow">{language === 'cs' ? copy.eyebrowCs : copy.eyebrowEn}</p>
             <h4>{language === 'cs' ? copy.cs : copy.en}</h4>
-            <div className="campaign-phone-hero">
-              <span>{t('Doporučeno pro vás', 'Recommended for you')}</span>
+            <div className={`campaign-phone-hero${isBanner ? ' campaign-phone-banner' : ''}`}>
+              <span>{isBanner ? t('Pro vás v aplikaci', 'For you in the app') : t('Doporučeno pro vás', 'Recommended for you')}</span>
               <strong>{headline}</strong>
               <button type="button" tabIndex={-1}>{t('Zjistit víc', 'Explore')}</button>
             </div>
@@ -68,20 +69,22 @@ export function CampaignExperiencePreview({
           </div>
         </div>
 
-        <div className="campaign-push-card" data-preview-channel={isPush ? 'PUSH' : 'EMAIL'}>
+        <div className={`campaign-push-card${isBanner ? ' campaign-banner-card' : ''}`} data-preview-channel={isPush ? 'PUSH' : isBanner ? 'BANNER' : 'EMAIL'}>
           <div className="campaign-push-icon">o</div>
           <div>
-            <div className="campaign-push-meta">OPENBANK · {t('nyní', 'now')}</div>
-            <p className="campaign-push-title">{isPush ? headline : t('Zvolte push krok', 'Choose a push step')}</p>
+            <div className="campaign-push-meta">OPENBANK · {isBanner ? t('DOMOVSKÁ OBRAZOVKA', 'HOME SCREEN') : t('nyní', 'now')}</div>
+            <p className="campaign-push-title">{isPush ? headline : isBanner ? t('Banner v přihlášené aplikaci', 'Banner in the signed-in app') : t('Zvolte push krok', 'Choose a push step')}</p>
             <p>{isPush
               ? t('Otevře zabezpečenou aplikaci — bez osobního obsahu v notifikaci.', 'Opens the secure app — with no personal content in the notification.')
+              : isBanner
+                ? t('Zobrazí se při další návštěvě domova. Žádné vyrušení, žádná zamčená obrazovka.', 'Shown on the next home visit. No interruption, no lock screen.')
               : t('Tento krok je e-mail. Vyberte push krok na cestě pro náhled notifikace.', 'This step is email. Select a push step on the journey to preview the notification.')}</p>
           </div>
         </div>
       </div>
 
       <div className="campaign-preview-route">
-        <span>{t('Po klepnutí', 'After tap')}</span>
+        <span>{isBanner ? t('Po klepnutí na banner', 'After banner tap') : t('Po klepnutí', 'After tap')}</span>
         <strong>{campaignLabel} → {language === 'cs' ? copy.cs : copy.en}</strong>
         <code>{`openbank://${destination.toLowerCase().replace('product_hub', 'products')}`}</code>
       </div>

--- a/openbank-admin-ui/src/components/campaigns/CampaignLaunchReadiness.tsx
+++ b/openbank-admin-ui/src/components/campaigns/CampaignLaunchReadiness.tsx
@@ -43,7 +43,7 @@ export function CampaignLaunchReadiness({
 }) {
   const { t, language } = useLanguage()
   const n = (value: number) => value.toLocaleString(language === 'cs' ? 'cs-CZ' : 'en-GB')
-  const push = steps.find(step => step.channel === 'PUSH')
+  const appPlacement = steps.find(step => step.channel === 'PUSH' || step.channel === 'BANNER')
   const readyCount = [audienceChosen, entryConfigured, !incomplete, !contentExperiment || conversionRule !== null].filter(Boolean).length
 
   const items: ReadinessItem[] = [
@@ -67,9 +67,9 @@ export function CampaignLaunchReadiness({
       : conversionRule
         ? { id: 'measurement', state: 'ready', label: t('Výsledek je měřitelný', 'Outcome is measurable'), detail: t('Měříme bankovní událost, ne domnělý proklik.', 'This measures a banking event, not an assumed click.') }
         : { id: 'measurement', state: 'attention', label: t('Kampaň neměří výsledek', 'Campaign does not measure an outcome'), detail: t('Můžete pokračovat, ale po spuštění nepůjde porovnat skutečný dopad.', 'You can continue, but the actual outcome cannot be compared after launch.') },
-    push
-      ? { id: 'destination', state: 'ready', label: t('Push má bezpečný cíl v aplikaci', 'Push has a safe in-app destination'), detail: t('Jen schválený deep link; žádná URL z kampaně.', 'An approved deep link only; no campaign-entered URL.') }
-      : { id: 'destination', state: 'attention', label: t('Cesta zatím nemá push krok', 'Journey has no push step yet'), detail: t('Přidejte ho, pokud má kampaň přivést lidi zpět do aplikace.', 'Add one if the campaign should bring people back into the app.') },
+    appPlacement
+      ? { id: 'destination', state: 'ready', label: t('Krok v aplikaci má bezpečný cíl', 'In-app step has a safe destination'), detail: t('Jen schválený deep link; žádná URL z kampaně.', 'An approved deep link only; no campaign-entered URL.') }
+      : { id: 'destination', state: 'attention', label: t('Cesta zatím nemá krok v aplikaci', 'Journey has no in-app step yet'), detail: t('Přidejte push nebo banner, pokud má kampaň přivést lidi zpět do aplikace.', 'Add a push or banner if the campaign should bring people back into the app.') },
     { id: 'policy', state: 'ready', label: t('Ochrana kontaktu zůstává zapnutá', 'Contact protection stays on'), detail: t('Souhlas, tiché hodiny a frekvenční limit se ověřují při doručení.', 'Consent, quiet hours and frequency limits are checked at delivery.') },
   ]
 

--- a/openbank-admin-ui/src/components/campaigns/JourneyEditor.tsx
+++ b/openbank-admin-ui/src/components/campaigns/JourneyEditor.tsx
@@ -27,7 +27,7 @@ import { useLanguage } from '@/lib/i18n/LanguageContext'
  * that is a pull request against the catalogue.
  */
 
-export type EditorChannel = 'EMAIL' | 'PUSH'
+export type EditorChannel = 'EMAIL' | 'PUSH' | 'BANNER'
 
 export type EditorMobileDestination = 'HOME' | 'SAVINGS' | 'CARDS' | 'PAYMENTS' | 'PRODUCT_HUB'
 
@@ -74,6 +74,11 @@ const CHANNEL: Record<EditorChannel, { tint: string; glyph: string }> = {
   PUSH: {
     tint: 'var(--success)',
     glyph: 'M7 3h10v18H7V3zm4 15h2',
+  },
+  // A home-surface card: a banner is rendered in the signed-in app, not dispatched as a message.
+  BANNER: {
+    tint: 'var(--warning)',
+    glyph: 'M3 5h18v14H3V5zm3 4h12M6 13h7',
   },
 }
 
@@ -294,7 +299,11 @@ export function JourneyEditor({
                 />
                 <text x={x + 14 + ICON + 12} y={ROW_Y - 12} fontSize="10" fill="var(--text-secondary)"
                   letterSpacing="0.06em">
-                  {t('KROK', 'STEP')} {i + 1} · {step.channel === 'PUSH' ? t('PUSH', 'PUSH') : t('E-MAIL', 'EMAIL')}
+                  {t('KROK', 'STEP')} {i + 1} · {step.channel === 'PUSH'
+                    ? t('PUSH', 'PUSH')
+                    : step.channel === 'BANNER'
+                      ? t('BANNER V APLIKACI', 'IN-APP BANNER')
+                      : t('E-MAIL', 'EMAIL')}
                 </text>
                 <text x={x + 14 + ICON + 12} y={ROW_Y + 8} fontSize="13.5" fontWeight="600"
                   fill="var(--text-primary)">

--- a/openbank-admin-ui/src/components/campaigns/StepEditor.tsx
+++ b/openbank-admin-ui/src/components/campaigns/StepEditor.tsx
@@ -97,7 +97,7 @@ export function StepEditor({
       <div className="space-y-1.5">
         <span className="text-sm font-medium">{t('Kanál', 'Channel')}</span>
         <div className="flex gap-2">
-          {(['EMAIL', 'PUSH'] as EditorChannel[]).map(c => {
+          {(['EMAIL', 'PUSH', 'BANNER'] as EditorChannel[]).map(c => {
             const first = Object.keys(templates).find(tpl => templateChannel[tpl] === c)
             const active = step.channel === c
             return (
@@ -112,7 +112,7 @@ export function StepEditor({
                   channel: c,
                   template: first,
                   variables: {},
-                  ...(c === 'PUSH'
+                  ...(c === 'PUSH' || c === 'BANNER'
                     ? { fallbackToPush: false, mobileDestination: step.mobileDestination ?? 'HOME' }
                     : { mobileDestination: undefined }),
                   ...(step.variantBVariables !== undefined ? { variantBVariables: {} } : {}),
@@ -127,7 +127,11 @@ export function StepEditor({
                     : undefined
                 }
               >
-                {c === 'EMAIL' ? t('E-mail', 'Email') : t('Push do aplikace', 'App push')}
+                {c === 'EMAIL'
+                  ? t('E-mail', 'Email')
+                  : c === 'PUSH'
+                    ? t('Push do aplikace', 'App push')
+                    : t('Banner v aplikaci', 'In-app banner')}
               </button>
             )
           })}
@@ -155,6 +159,33 @@ export function StepEditor({
               </select>
               <span className="block text-xs text-muted-foreground">
                 {t('Jde o pevný deep-link aplikace, ne URL zadanou do kampaně.', 'This is a fixed app deep link, not a campaign-entered URL.')}
+              </span>
+            </label>
+          </>
+        )}
+        {step.channel === 'BANNER' && (
+          <>
+            <p className="text-xs text-muted-foreground">
+              {t(
+                'Banner se zobrazí na domovské obrazovce přihlášené aplikace. Není to push a neobjeví se na zamčeném telefonu.',
+                'The banner is shown on the signed-in app home screen. It is not a push and never appears on a locked phone.',
+              )}
+            </p>
+            <label className="mt-3 block space-y-1.5 text-sm" data-mobile-destination={index}>
+              <span className="font-medium">{t('Po klepnutí otevřít', 'Open after tap')}</span>
+              <select
+                className={field}
+                value={step.mobileDestination ?? 'HOME'}
+                onChange={e => onChange({ ...step, mobileDestination: e.target.value as EditorStep['mobileDestination'] })}
+              >
+                <option value="HOME">{t('Domovská obrazovka', 'Home')}</option>
+                <option value="SAVINGS">{t('Spoření', 'Savings')}</option>
+                <option value="CARDS">{t('Karty', 'Cards')}</option>
+                <option value="PAYMENTS">{t('Platby', 'Payments')}</option>
+                <option value="PRODUCT_HUB">{t('Produkty', 'Products')}</option>
+              </select>
+              <span className="block text-xs text-muted-foreground">
+                {t('Banner vede jen na pevný deep-link aplikace, nikdy na URL vložené do kampaně.', 'A banner can use only a fixed app deep link, never a campaign-entered URL.')}
               </span>
             </label>
           </>
@@ -207,7 +238,12 @@ export function StepEditor({
                 'Šablona notifikace je pevná. Tady se vyplňuje jen její titulek.',
                 'The notification template is fixed. Only its headline is filled in here.',
               )
-            : t(
+            : step.channel === 'BANNER'
+              ? t(
+                  'Banner používá schválenou kartu aplikace. Tady se vyplňují jen její pojmenované hodnoty.',
+                  'The banner uses an approved in-app card. Only its named values are filled in here.',
+                )
+              : t(
                 'Text e-mailu je v šabloně. Tady se vyplňují jen její pojmenované hodnoty.',
                 'The email copy lives in the template. Only its named values are filled in here.',
               )}

--- a/openbank-admin-ui/src/test/campaign-experience-preview.test.tsx
+++ b/openbank-admin-ui/src/test/campaign-experience-preview.test.tsx
@@ -40,6 +40,21 @@ describe('campaign customer experience preview', () => {
     expect(container.querySelector('[data-preview-channel="EMAIL"]')).toBeTruthy()
     expect(screen.getByText(/Choose a push step/)).toBeTruthy()
   })
+
+  it('shows a banner as an authenticated app surface, not as a notification', () => {
+    const { container } = render(
+      <LanguageProvider>
+        <CampaignExperiencePreview
+          step={{ ...push, channel: 'BANNER', template: 'MARKETING_PRODUCT_OFFER_BANNER' }}
+          campaignName="Summer saving"
+        />
+      </LanguageProvider>,
+    )
+
+    expect(container.querySelector('[data-preview-channel="BANNER"]')).toBeTruthy()
+    expect(screen.getByText(/Banner in the signed-in app/)).toBeTruthy()
+    expect(screen.getByText(/No interruption, no lock screen/)).toBeTruthy()
+  })
 })
 
 describe('campaign launch readiness', () => {
@@ -61,6 +76,6 @@ describe('campaign launch readiness', () => {
     expect(container.querySelector('[data-readiness="audience"][data-state="waiting"]')).toBeTruthy()
     expect(container.querySelector('[data-readiness="content"][data-state="waiting"]')).toBeTruthy()
     expect(container.querySelector('[data-readiness="policy"][data-state="ready"]')).toBeTruthy()
-    expect(screen.getByText(/Journey has no push step/)).toBeTruthy()
+    expect(screen.getByText(/Journey has no in-app step/)).toBeTruthy()
   })
 })

--- a/openbank-admin-ui/src/test/journey-editor.test.tsx
+++ b/openbank-admin-ui/src/test/journey-editor.test.tsx
@@ -12,8 +12,13 @@ import { StepEditor } from '@/components/campaigns/StepEditor'
 const TEMPLATES = {
   MARKETING_PRODUCT_OFFER: ['offerTitle', 'offerText', 'ctaText'],
   MARKETING_PRODUCT_OFFER_PUSH: ['offerTitle'],
+  MARKETING_PRODUCT_OFFER_BANNER: ['offerTitle', 'offerText', 'ctaText'],
 }
-const TPL_CHANNEL = { MARKETING_PRODUCT_OFFER: 'EMAIL' as const, MARKETING_PRODUCT_OFFER_PUSH: 'PUSH' as const }
+const TPL_CHANNEL = {
+  MARKETING_PRODUCT_OFFER: 'EMAIL' as const,
+  MARKETING_PRODUCT_OFFER_PUSH: 'PUSH' as const,
+  MARKETING_PRODUCT_OFFER_BANNER: 'BANNER' as const,
+}
 
 // The editor labels a variable in the marketer's words. The mapping is data, so the test carries its
 // own copy — asserting the rendered label against the same map the component reads would be vacuous.
@@ -163,5 +168,20 @@ describe('step editor', () => {
     fireEvent.change(select, { target: { value: 'SAVINGS' } })
     expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ mobileDestination: 'SAVINGS' }))
     expect(screen.getByText(/not a campaign-entered URL/i)).toBeTruthy()
+  })
+
+  it('offers a banner as an in-app placement with the same closed destination contract', () => {
+    const onChange = vi.fn()
+    render(
+      React.createElement(LanguageProvider, null,
+        React.createElement(StepEditor, {
+          index: 0, step: step(), templates: TEMPLATES, templateChannel: TPL_CHANNEL, templateLabels: LABELS, variableLabels: VAR_LABELS,
+          onChange, onClose: vi.fn(),
+        })))
+
+    fireEvent.click(document.querySelector('[data-channel-pick="BANNER"]')!)
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({
+      channel: 'BANNER', template: 'MARKETING_PRODUCT_OFFER_BANNER', mobileDestination: 'HOME',
+    }))
   })
 })

--- a/openbank-analytics-sink/src/main/resources/clickhouse/V6__campaign_engagement.sql
+++ b/openbank-analytics-sink/src/main/resources/clickhouse/V6__campaign_engagement.sql
@@ -27,5 +27,5 @@ FROM openbank_analytics.bronze_events
 WHERE aggregate_type = 'ENGAGEMENT'
   AND JSONExtractString(payload, 'campaignId') != ''
   AND JSONHas(payload, 'stepOrder')
-  AND JSONExtractString(payload, 'channel') = 'PUSH'
+  AND JSONExtractString(payload, 'channel') IN ('PUSH', 'BANNER')
 GROUP BY campaign_id, step_order, channel;

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/port/out/Ports.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/port/out/Ports.kt
@@ -88,7 +88,7 @@ interface SendLogRepository {
     suspend fun countRecentForParty(partyId: UUID, sinceEpochSeconds: Long): Int
 
     /**
-     * Whether [interactionRef] names a PUSH send made to [partyId]. This is intentionally a
+     * Whether [interactionRef] names an attributable app placement made to [partyId]. This is intentionally a
      * yes/no capability: the customer edge must never learn the campaign, step or another
      * party from a reference supplied by a device.
      *
@@ -96,7 +96,7 @@ interface SendLogRepository {
      * send-log lookup; an adapter that has not implemented attribution cannot accidentally
      * validate a client-controlled reference.
      */
-    suspend fun attributionForPushInteraction(interactionRef: UUID, partyId: UUID): CampaignInteractionAttribution? =
+    suspend fun attributionForAppInteraction(interactionRef: UUID, partyId: UUID): CampaignInteractionAttribution? =
         null
 
     /**
@@ -220,6 +220,22 @@ data class NotificationSendRequest(
 /** ADR-0200 D3: delivery goes through notification-service, never direct. */
 interface NotificationSendPort {
     suspend fun requestSend(request: NotificationSendRequest)
+}
+
+/** One approved, customer-specific placement for the authenticated app home surface. */
+data class BannerPlacementRequest(
+    val interactionRef: UUID,
+    val partyId: UUID,
+    val campaignId: UUID,
+    val stepOrder: Int,
+    val template: String,
+    val variables: Map<String, String>,
+    val deepLink: String,
+)
+
+/** Campaign emits placement commands; engagement-service owns rendering and event recording. */
+interface BannerPlacementPort {
+    suspend fun place(request: BannerPlacementRequest)
 }
 
 /** ADR-0200 D2 push: signals a live journey that consent was revoked for its party. */

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/usecase/CampaignInteractionQuery.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/usecase/CampaignInteractionQuery.kt
@@ -19,5 +19,5 @@ import java.util.UUID
 @ApplicationScoped
 class CampaignInteractionQuery(private val sendLog: SendLogRepository) {
     suspend fun resolve(interactionRef: UUID, partyId: UUID): CampaignInteractionAttribution? =
-        sendLog.attributionForPushInteraction(interactionRef, partyId)
+        sendLog.attributionForAppInteraction(interactionRef, partyId)
 }

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/workflow/CampaignJourneyActivitiesImpl.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/workflow/CampaignJourneyActivitiesImpl.kt
@@ -4,6 +4,8 @@
 
 package com.openbank.campaign.application.workflow
 
+import com.openbank.campaign.application.port.out.BannerPlacementPort
+import com.openbank.campaign.application.port.out.BannerPlacementRequest
 import com.openbank.campaign.application.port.out.CampaignRepository
 import com.openbank.campaign.application.port.out.EnrolmentRepository
 import com.openbank.campaign.application.port.out.NotificationSendPort
@@ -50,6 +52,7 @@ open class CampaignJourneyActivitiesImpl(
     private val sendLog: SendLogRepository,
     private val contactGate: ContactPolicyGate,
     private val notificationSend: NotificationSendPort,
+    private val bannerPlacement: BannerPlacementPort,
     /**
      * When true, a step runs every gate and then stops short of the transport: nothing is emitted to
      * notification-service on any channel, and the send log records DRY_RUN.
@@ -152,7 +155,7 @@ open class CampaignJourneyActivitiesImpl(
     private suspend fun checkDelivery(context: StepDeliveryContext, delivery: CampaignDelivery): ContactGateDecision =
         contactGate.check(
             context.partyId,
-            ContactClass.OUTBOUND_SEND,
+            contactClassFor(delivery.channel),
             marketingScopeFor(delivery.channel),
             topic = context.campaign.goal,
         )
@@ -176,7 +179,21 @@ open class CampaignJourneyActivitiesImpl(
             return StepOutcome.SENT
         }
         try {
-            notificationSend.requestDelivery(context.partyId, delivery, sendId)
+            if (delivery.channel == Channel.BANNER) {
+                bannerPlacement.place(
+                    BannerPlacementRequest(
+                        interactionRef = sendId,
+                        partyId = context.partyId,
+                        campaignId = context.campaignId,
+                        stepOrder = context.stepOrder,
+                        template = delivery.template,
+                        variables = delivery.variables,
+                        deepLink = requireNotNull(delivery.deepLink),
+                    ),
+                )
+            } else {
+                notificationSend.requestDelivery(context.partyId, delivery, sendId)
+            }
         } catch (e: Exception) {
             sendLog.record(
                 sendId,
@@ -255,6 +272,13 @@ open class CampaignJourneyActivitiesImpl(
         private fun marketingScopeFor(channel: Channel): String = when (channel) {
             Channel.EMAIL -> "MARKETING_COMMS_EMAIL"
             Channel.PUSH -> "MARKETING_COMMS_PUSH"
+            Channel.BANNER -> "MARKETING_COMMS_INAPP"
+        }
+
+        /** Banner placement is a first-party in-app impression, never an outbound send. */
+        private fun contactClassFor(channel: Channel): ContactClass = when (channel) {
+            Channel.BANNER -> ContactClass.PROMOTIONAL_IMPRESSION
+            Channel.EMAIL, Channel.PUSH -> ContactClass.OUTBOUND_SEND
         }
 
         /** Gate deny reasons that are POLICY outcomes, recorded per step (ADR-0219). */

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/domain/model/Campaign.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/domain/model/Campaign.kt
@@ -174,8 +174,8 @@ enum class CampaignState { DRAFT, PENDING_APPROVAL, ACTIVE, PAUSED, CLOSED }
  *
  * ADR-0200 D7 shipped this EMAIL-only behind three named blockers. Two have since cleared: the
  * per-channel marketing consent scope exists (`MARKETING_COMMS_PUSH`, ADR-0198 D4) and #1182 is
- * closed — push bodies are generic by construction. IN_APP and SMS remain out for the reasons on
- * [Channel].
+ * closed — push bodies are generic by construction. BANNER is a first-party home-surface
+ * placement, consented as an in-app impression rather than as a notification.
  */
 data class CampaignStep(
     val order: Int,
@@ -245,8 +245,8 @@ data class CampaignStep(
         require(!fallbackToPush || template in TemplateCatalog.PUSH_FALLBACK_FOR_EMAIL) {
             "template '$template' has no safe PUSH fallback"
         }
-        require(mobileDestination == null || channel == Channel.PUSH || fallbackToPush) {
-            "a mobile destination requires a PUSH step or an EMAIL step with PUSH fallback"
+        require(mobileDestination == null || channel == Channel.PUSH || channel == Channel.BANNER || fallbackToPush) {
+            "a mobile destination requires a PUSH or BANNER step, or an EMAIL step with PUSH fallback"
         }
     }
 
@@ -259,7 +259,7 @@ data class CampaignStep(
         channel,
         template,
         TemplateCatalog.valuesFor(template, variablesFor(variant)),
-        mobileDestination?.deepLink.takeIf { channel == Channel.PUSH },
+        mobileDestination?.deepLink.takeIf { channel == Channel.PUSH || channel == Channel.BANNER },
     )
 
     /** The only supported fallback: a consented app push after EMAIL consent was absent. */
@@ -283,7 +283,7 @@ data class CampaignDelivery(
     val deepLink: String? = null,
 )
 
-/** The only destinations the mobile app contract recognises for campaign pushes. */
+/** The only destinations the mobile app contract recognises for campaign push and banner taps. */
 enum class MobileDestination(val deepLink: String) {
     HOME("openbank://home"),
     SAVINGS("openbank://savings"),
@@ -295,14 +295,14 @@ enum class MobileDestination(val deepLink: String) {
 /**
  * Delivery channels a campaign step may use.
  *
- * EMAIL and PUSH only, and the omissions are decisions rather than gaps. SMS has no outbound port
+ * EMAIL, PUSH and BANNER only, and the omissions are decisions rather than gaps. SMS has no outbound port
  * anywhere in the platform (ADR-0200 D7). IN_APP was *removed* from `NotificationChannel` by #2372
  * because its dispatch branch silently dropped every message; re-adding it needs a terminal-status
  * transition and a wake-signal design, not an enum entry. Listing either here would let a campaign
  * be approved against a channel that delivers nothing — the "appearance of four channels" ADR-0200
  * D7 explicitly refuses.
  */
-enum class Channel { EMAIL, PUSH }
+enum class Channel { EMAIL, PUSH, BANNER }
 
 /**
  * The campaign's own stop condition (ADR-0200 D1, issue #3585 slice 1), evaluated by the journey

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/domain/model/TemplateCatalog.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/domain/model/TemplateCatalog.kt
@@ -38,6 +38,9 @@ object TemplateCatalog {
         // exactly one variable, and a campaign cannot smuggle body copy into a push by filling in
         // more.
         "MARKETING_PRODUCT_OFFER_PUSH" to setOf("offerTitle"),
+        // A banner renders only in the authenticated app, so its approved card may contain the
+        // offer body and CTA. It remains a closed template, never marketer-authored markup.
+        "MARKETING_PRODUCT_OFFER_BANNER" to setOf("offerTitle", "offerText", "ctaText"),
     )
 
     /**
@@ -50,6 +53,7 @@ object TemplateCatalog {
     val CHANNEL_OF: Map<String, Channel> = mapOf(
         "MARKETING_PRODUCT_OFFER" to Channel.EMAIL,
         "MARKETING_PRODUCT_OFFER_PUSH" to Channel.PUSH,
+        "MARKETING_PRODUCT_OFFER_BANNER" to Channel.BANNER,
     )
 
     /**

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/kafka/KafkaNotificationSendAdapter.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/kafka/KafkaNotificationSendAdapter.kt
@@ -5,11 +5,17 @@
 package com.openbank.campaign.infrastructure.kafka
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.campaign.application.port.out.BannerPlacementPort
+import com.openbank.campaign.application.port.out.BannerPlacementRequest
 import com.openbank.campaign.application.port.out.NotificationSendPort
 import com.openbank.campaign.application.port.out.NotificationSendRequest
+import io.smallrye.mutiny.coroutines.awaitSuspending
+import io.smallrye.reactive.messaging.MutinyEmitter
+import io.smallrye.reactive.messaging.kafka.api.OutgoingKafkaRecordMetadata
 import jakarta.enterprise.context.ApplicationScoped
 import org.eclipse.microprofile.reactive.messaging.Channel
 import org.eclipse.microprofile.reactive.messaging.Emitter
+import org.eclipse.microprofile.reactive.messaging.Message
 
 /**
  * ADR-0200 D3: delivery goes through notification-service, never direct. The payload shape mirrors
@@ -51,5 +57,34 @@ class KafkaNotificationSendAdapter(
         request.interactionRef?.let { fields["interactionRef"] = it.toString() }
         val payload = mapper.writeValueAsString(fields)
         emitter.send(payload).toCompletableFuture().join()
+    }
+}
+
+/**
+ * A banner is a first-party placement command, not a notification request. Its own topic prevents
+ * notification-service receiving a channel it cannot render.
+ */
+@ApplicationScoped
+class KafkaBannerPlacementAdapter(
+    @Channel("campaign-banner-placements-out") private val emitter: MutinyEmitter<String>,
+    private val mapper: ObjectMapper,
+) : BannerPlacementPort {
+    override suspend fun place(request: BannerPlacementRequest) {
+        val payload = mapper.writeValueAsString(
+            linkedMapOf(
+                "interactionRef" to request.interactionRef.toString(),
+                "partyId" to request.partyId.toString(),
+                "campaignId" to request.campaignId.toString(),
+                "stepOrder" to request.stepOrder,
+                "template" to request.template,
+                "variables" to request.variables,
+                "deepLink" to request.deepLink,
+            ),
+        )
+        // The compacted placement topic retains the current assignment for this send interaction.
+        val metadata = OutgoingKafkaRecordMetadata.builder<String>()
+            .withKey(request.interactionRef.toString())
+            .build()
+        emitter.sendMessage(Message.of(payload).addMetadata(metadata)).awaitSuspending()
     }
 }

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/persistence/Persistence.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/persistence/Persistence.kt
@@ -537,15 +537,16 @@ class PanacheSendLogRepository :
      * status is deliberately not a precondition: a PUSH gateway acknowledgement is a later, weaker
      * signal and must not erase an app interaction the bank actually observed.
      */
-    override suspend fun attributionForPushInteraction(
+    override suspend fun attributionForAppInteraction(
         interactionRef: UUID,
         partyId: UUID,
     ): CampaignInteractionAttribution? = Panache.withSession {
         find(
-            "id = ?1 and partyId = ?2 and channel = ?3 and outcome = ?4",
+            "id = ?1 and partyId = ?2 and channel in (?3, ?4) and outcome = ?5",
             interactionRef,
             partyId,
             Channel.PUSH.name,
+            Channel.BANNER.name,
             SendOutcome.SENT.name,
         ).firstResult<SendLogEntity>()
     }.awaitSuspending()?.let {

--- a/openbank-campaign-service/src/main/resources/application.yaml
+++ b/openbank-campaign-service/src/main/resources/application.yaml
@@ -99,6 +99,11 @@ mp:
         bootstrap:
           servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
     outgoing:
+      campaign-banner-placements-out:
+        connector: smallrye-kafka
+        topic: openbank.campaign.banner.placements
+        value:
+          serializer: org.apache.kafka.common.serialization.StringSerializer
       notification-requests-out:
         connector: smallrye-kafka
         topic: openbank.notification.requests

--- a/openbank-campaign-service/src/main/resources/db/migration/V11__send_log_banner_channel.sql
+++ b/openbank-campaign-service/src/main/resources/db/migration/V11__send_log_banner_channel.sql
@@ -1,0 +1,8 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+ALTER TABLE send_log DROP CONSTRAINT IF EXISTS send_log_channel_check;
+ALTER TABLE send_log
+    ADD CONSTRAINT send_log_channel_check CHECK (channel IN ('EMAIL', 'PUSH', 'BANNER'));
+
+-- Rollback: replace the constraint with `channel IN ('EMAIL', 'PUSH')` after removing BANNER rows.

--- a/openbank-campaign-service/src/main/resources/openapi.yaml
+++ b/openbank-campaign-service/src/main/resources/openapi.yaml
@@ -4,7 +4,7 @@ openapi: 3.1.0
 info:
   title: Campaign Service API
   # major == openbank.api.version == URL /api/v1 (ADR-0048).
-  version: 1.24.0
+  version: 1.25.0
   description: >-
     Campaign management first slice (ADR-0200 / ADR-0209 D3): deterministic, versioned segments;
     per-enrolment Temporal journeys; consent-gated delivery through notification-service.

--- a/openbank-campaign-service/src/main/resources/openapi.yaml
+++ b/openbank-campaign-service/src/main/resources/openapi.yaml
@@ -23,11 +23,11 @@ paths:
   /api/v1/campaigns/interactions/{interactionRef}:
     get:
       tags: [Campaigns]
-      summary: Validate an opaque PUSH interaction reference
+      summary: Validate an opaque PUSH or BANNER interaction reference
       description: >-
         Internal customer-edge capability only. The request carries the authoritative caller party
         in `X-Customer-Party-Id`. A 404 has one meaning for every unsafe state: unknown reference,
-        wrong party, non-PUSH, or no accepted handoff.
+        wrong party, non-app placement, or no accepted handoff.
       parameters:
         - name: interactionRef
           in: path
@@ -39,7 +39,7 @@ paths:
           schema: { type: string, format: uuid }
       responses:
         "204":
-          description: The reference belongs to this party and a handed-off PUSH
+          description: The reference belongs to this party and a handed-off app placement
         "400":
           description: Missing or malformed caller party header
         "404":
@@ -51,9 +51,9 @@ paths:
   /api/v1/campaigns/interactions/{interactionRef}/attribution:
     get:
       tags: [Campaigns]
-      summary: Resolve server-owned attribution for an opaque PUSH interaction reference
+      summary: Resolve server-owned attribution for an opaque app interaction reference
       description: >-
-        Additive internal customer-edge capability. Only after ownership, PUSH channel and handoff
+        Additive internal customer-edge capability. Only after ownership, app channel and handoff
         are established does the trusted response return campaign/step/channel context for the edge
         to attach to the downstream event. The app never receives or supplies these fields.
       parameters:
@@ -76,7 +76,7 @@ paths:
                 properties:
                   campaignId: { type: string, format: uuid }
                   stepOrder: { type: integer, minimum: 0 }
-                  channel: { type: string, enum: [PUSH] }
+                  channel: { type: string, enum: [PUSH, BANNER] }
         "400":
           description: Missing or malformed caller party header
         "404":
@@ -624,11 +624,12 @@ components:
           #
           # Selectable on create since 1.11.0. Until then the create body had no channel field at
           # all and the resource hardcoded EMAIL, so PUSH was documented here and unreachable.
-          enum: [EMAIL, PUSH]
+          enum: [EMAIL, PUSH, BANNER]
           default: EMAIL
           description: >-
             Optional on create; absent means EMAIL. Must agree with the template's own channel —
-            MARKETING_PRODUCT_OFFER renders on EMAIL, MARKETING_PRODUCT_OFFER_PUSH on PUSH — and a
+            MARKETING_PRODUCT_OFFER renders on EMAIL, MARKETING_PRODUCT_OFFER_PUSH on PUSH and
+            MARKETING_PRODUCT_OFFER_BANNER on BANNER — and a
             mismatch is rejected with 400.
         variables:
           type: object
@@ -656,9 +657,9 @@ components:
           nullable: true
           enum: [HOME, SAVINGS, CARDS, PAYMENTS, PRODUCT_HUB]
           description: >-
-            Bank-owned destination opened after a PUSH tap. This is a closed app-route contract,
+            Bank-owned destination opened after a PUSH or BANNER tap. This is a closed app-route contract,
             never an author-entered URL; absent preserves existing campaigns. It is valid on a
-            PUSH step, or on an EMAIL step only when its consent-missing fallback is PUSH.
+            PUSH or BANNER step, or on an EMAIL step only when its consent-missing fallback is PUSH.
         delaySeconds: { type: integer, minimum: 0 }
         condition:
           description: >-
@@ -952,7 +953,7 @@ components:
             consent and the separate PUSH gate allowed its safe fallback; null for historical and
             non-send decision rows.
           type: [string, 'null']
-          enum: [EMAIL, PUSH, null]
+          enum: [EMAIL, PUSH, BANNER, null]
 
     Enrolment:
       type: object

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/usecase/CampaignInteractionQueryTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/usecase/CampaignInteractionQueryTest.kt
@@ -24,9 +24,9 @@ class CampaignInteractionQueryTest {
         val interactionRef = UUID.randomUUID()
         val partyId = UUID.randomUUID()
         val attribution = CampaignInteractionAttribution(UUID.randomUUID(), 0, Channel.PUSH)
-        coEvery { sendLog.attributionForPushInteraction(interactionRef, partyId) } returns attribution
+        coEvery { sendLog.attributionForAppInteraction(interactionRef, partyId) } returns attribution
 
         assertThat(query.resolve(interactionRef, partyId)).isEqualTo(attribution)
-        coVerify(exactly = 1) { sendLog.attributionForPushInteraction(interactionRef, partyId) }
+        coVerify(exactly = 1) { sendLog.attributionForAppInteraction(interactionRef, partyId) }
     }
 }

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/workflow/CampaignJourneyActivitiesImplTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/workflow/CampaignJourneyActivitiesImplTest.kt
@@ -4,6 +4,7 @@
 
 package com.openbank.campaign.application.workflow
 
+import com.openbank.campaign.application.port.out.BannerPlacementPort
 import com.openbank.campaign.application.port.out.CampaignRepository
 import com.openbank.campaign.application.port.out.ConsentCheckPort
 import com.openbank.campaign.application.port.out.ConversionContext
@@ -55,6 +56,7 @@ class CampaignJourneyActivitiesImplTest {
     private val sendLog: SendLogRepository = mockk()
     private val consentCheck: ConsentCheckPort = mockk()
     private val notificationSend: NotificationSendPort = mockk()
+    private val bannerPlacement: BannerPlacementPort = mockk()
 
     private val campaignId = UUID.randomUUID()
     private val partyId = UUID.randomUUID()
@@ -80,6 +82,7 @@ class CampaignJourneyActivitiesImplTest {
             sendLog,
             gate,
             notificationSend,
+            bannerPlacement,
             dryRun = false,
         ) {
             override fun <T> runBlockingOnWorker(block: suspend () -> T): T = runBlocking { block() }

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/workflow/CampaignJourneyActivitiesTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/workflow/CampaignJourneyActivitiesTest.kt
@@ -4,6 +4,8 @@
 
 package com.openbank.campaign.application.workflow
 
+import com.openbank.campaign.application.port.out.BannerPlacementPort
+import com.openbank.campaign.application.port.out.BannerPlacementRequest
 import com.openbank.campaign.application.port.out.CampaignEnrolmentCount
 import com.openbank.campaign.application.port.out.CampaignOutcomeCount
 import com.openbank.campaign.application.port.out.CampaignRepository
@@ -18,6 +20,7 @@ import com.openbank.campaign.domain.model.CampaignStep
 import com.openbank.campaign.domain.model.Channel
 import com.openbank.campaign.domain.model.DeliveryStatus
 import com.openbank.campaign.domain.model.Enrolment
+import com.openbank.campaign.domain.model.MobileDestination
 import com.openbank.campaign.domain.model.SegmentRef
 import com.openbank.campaign.domain.model.SendOutcome
 import com.openbank.campaign.domain.model.SendRecord
@@ -71,6 +74,7 @@ class CampaignJourneyActivitiesTest {
         var failWith: RuntimeException? = null
         val recorded = mutableListOf<SendRecord>()
         var sendsRequested = 0
+        val bannerPlacements = mutableListOf<BannerPlacementRequest>()
 
         /** Correlation ids put on the wire, in order (ADR-0239 D1). */
         val correlationIds = mutableListOf<UUID>()
@@ -87,12 +91,17 @@ class CampaignJourneyActivitiesTest {
                     steps = listOf(
                         campaign.steps.single().copy(
                             channel = channel,
-                            template = if (channel == Channel.PUSH) {
-                                "MARKETING_PRODUCT_OFFER_PUSH"
-                            } else {
-                                "MARKETING_PRODUCT_OFFER"
+                            template = when (channel) {
+                                Channel.PUSH -> "MARKETING_PRODUCT_OFFER_PUSH"
+                                Channel.BANNER -> "MARKETING_PRODUCT_OFFER_BANNER"
+                                Channel.EMAIL -> "MARKETING_PRODUCT_OFFER"
                             },
                             fallbackToPush = fallbackToPush,
+                            mobileDestination = if (channel == Channel.BANNER) {
+                                MobileDestination.HOME
+                            } else {
+                                campaign.steps.single().mobileDestination
+                            },
                         ),
                     ),
                 )
@@ -147,6 +156,11 @@ class CampaignJourneyActivitiesTest {
                 interactionRefs += request.interactionRef
             }
         }
+        val bannerPlacement = object : BannerPlacementPort {
+            override suspend fun place(request: BannerPlacementRequest) {
+                bannerPlacements += request
+            }
+        }
 
         val gate = ContactPolicyGate(
             consent = ContactConsentPort { _, scope ->
@@ -155,6 +169,7 @@ class CampaignJourneyActivitiesTest {
                 when (scope) {
                     "MARKETING_COMMS_EMAIL" -> emailConsent
                     "MARKETING_COMMS_PUSH" -> pushConsent
+                    "MARKETING_COMMS_INAPP" -> pushConsent
                     else -> false
                 }
             },
@@ -180,6 +195,7 @@ class CampaignJourneyActivitiesTest {
                 sendLog,
                 gate,
                 notificationSend,
+                bannerPlacement,
                 dryRun = false,
             )
     }
@@ -191,6 +207,21 @@ class CampaignJourneyActivitiesTest {
         assertThat(outcome).isEqualTo(StepOutcome.SENT)
         assertThat(h.sendsRequested).isEqualTo(1)
         assertThat(h.recorded.map { it.outcome }).containsExactly(SendOutcome.SENT)
+    }
+
+    @Test
+    fun `banner uses in-app consent and publishes a placement instead of a notification`() {
+        val h = Harness().apply { channel = Channel.BANNER }
+
+        val outcome = runBlocking { h.activities.deliverStepGated(campaignId, partyId, 1) }
+
+        assertThat(outcome).isEqualTo(StepOutcome.SENT)
+        assertThat(h.consentScope).isEqualTo("MARKETING_COMMS_INAPP")
+        assertThat(h.sendsRequested).isZero()
+        val placement = h.bannerPlacements.single()
+        assertThat(placement.partyId).isEqualTo(partyId)
+        assertThat(placement.deepLink).isEqualTo("openbank://home")
+        assertThat(placement.template).isEqualTo("MARKETING_PRODUCT_OFFER_BANNER")
     }
 
     /**

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/domain/CampaignStateMachineTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/domain/CampaignStateMachineTest.kt
@@ -76,7 +76,7 @@ class CampaignStateMachineTest {
      */
     @Test
     fun `only channels that actually deliver are representable`() {
-        assertEquals(setOf(Channel.EMAIL, Channel.PUSH), Channel.entries.toSet())
+        assertEquals(setOf(Channel.EMAIL, Channel.PUSH, Channel.BANNER), Channel.entries.toSet())
         assertThrows<IllegalArgumentException> { Channel.valueOf("SMS") }
         assertThrows<IllegalArgumentException> { Channel.valueOf("IN_APP") }
     }

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/domain/TemplateCatalogTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/domain/TemplateCatalogTest.kt
@@ -81,13 +81,28 @@ class TemplateCatalogTest {
 }
 
 /**
- * The channel/template agreement (ADR-0200 D7 as it now stands: EMAIL + PUSH).
+ * The channel/template agreement: EMAIL, PUSH and the authenticated-app BANNER.
  *
  * Both directions matter and both fail silently in production. An EMAIL step naming a push template
  * renders a one-line title as an entire email; a PUSH step naming an email template puts offer body
  * copy into an APNs payload, which is the leak #1182 closed by making push bodies generic.
  */
 class CampaignStepChannelTest {
+
+    @Test
+    fun `a banner step carries its approved values to an app destination`() {
+        val step = CampaignStep(
+            order = 1,
+            template = "MARKETING_PRODUCT_OFFER_BANNER",
+            channel = Channel.BANNER,
+            variables = mapOf("offerTitle" to "Savings", "offerText" to "Four percent", "ctaText" to "Explore"),
+            delaySeconds = 0,
+            mobileDestination = MobileDestination.SAVINGS,
+        )
+
+        assertEquals("openbank://savings", step.primaryDelivery(null).deepLink)
+        assertEquals(setOf("MARKETING_PRODUCT_OFFER_BANNER"), TemplateCatalog.forChannel(Channel.BANNER))
+    }
 
     @Test
     fun `a push step may use a push template`() {

--- a/openbank-contracts/openbank-campaign-service/asyncapi.yaml
+++ b/openbank-contracts/openbank-campaign-service/asyncapi.yaml
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+asyncapi: 3.0.0
+info:
+  title: OpenBank Campaign Service — commands
+  version: 1.0.0
+  description: |
+    Commands emitted while executing an approved campaign journey. Campaign service owns the
+    decision, consent gate and opaque interaction id; destination services own delivery/rendering.
+  license:
+    name: Apache-2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0
+defaultContentType: application/json
+servers:
+  sandbox:
+    host: openbank-cluster-kafka-bootstrap.messaging.svc:9093
+    protocol: kafka-secure
+    description: mTLS Kafka; campaign-service publishes with its dedicated KafkaUser.
+channels:
+  notificationRequests:
+    address: openbank.notification.requests
+    description: Existing notification-service delivery command emitted by KafkaNotificationSendAdapter.
+  campaignBannerPlacements:
+    address: openbank.campaign.banner.placements
+    description: |
+      First-party HOME_BANNER placement command emitted by KafkaBannerPlacementAdapter and consumed
+      by engagement-service. The compacted record key is the opaque interactionRef, so retries
+      remain idempotent and do not create a second customer surface.
+components:
+  schemas:
+    campaignBannerPlacement:
+      type: object
+      required: [interactionRef, partyId, campaignId, stepOrder, template, variables, deepLink]
+      properties:
+        interactionRef: { type: string, format: uuid, description: Campaign send-log id and opaque app interaction reference. }
+        partyId: { type: string, format: uuid }
+        campaignId: { type: string, format: uuid }
+        stepOrder: { type: integer, minimum: 0 }
+        template: { type: string, enum: [MARKETING_PRODUCT_OFFER_BANNER] }
+        variables:
+          type: object
+          additionalProperties: { type: string }
+        deepLink:
+          type: string
+          description: Closed openbank app route; never an author-entered URL.

--- a/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
+++ b/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
@@ -2684,12 +2684,13 @@ class CustomerEdgeResource(
             val stepOrder = attribution.path("stepOrder").asInt(0)
                 .takeIf { it >= 0 && attribution.has("stepOrder") }
                 ?: return Response.status(Response.Status.BAD_GATEWAY).build()
-            if (attribution.path("channel").asText() != "PUSH") {
+            val channel = attribution.path("channel").asText()
+            if (channel !in setOf("PUSH", "BANNER")) {
                 return Response.status(Response.Status.BAD_GATEWAY).build()
             }
             event.put("campaignId", campaignId)
             event.put("stepOrder", stepOrder)
-            event.put("channel", "PUSH")
+            event.put("channel", channel)
         }
         event.put("partyId", customer.partyId.toString())
         val enriched = objectMapper.writeValueAsString(event)

--- a/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/application/port/out/Ports.kt
+++ b/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/application/port/out/Ports.kt
@@ -5,6 +5,7 @@
 package com.openbank.engagement.application.port.out
 
 import com.openbank.engagement.domain.model.AdverseState
+import com.openbank.engagement.domain.model.CampaignBannerPlacement
 import com.openbank.engagement.domain.model.EngagementEvent
 import com.openbank.engagement.domain.model.SurfaceSlot
 import java.time.Instant
@@ -34,4 +35,11 @@ interface AdverseStateRepository {
     suspend fun setActive(partyId: UUID, state: AdverseState, at: Instant)
     suspend fun clearActive(partyId: UUID, state: AdverseState)
     suspend fun activeStates(partyId: UUID): Set<AdverseState>
+}
+
+/** Latest campaign banner wins for the fixed HOME_BANNER slot; no hidden ranking system exists. */
+interface CampaignBannerPlacementRepository {
+    suspend fun save(placement: CampaignBannerPlacement)
+    suspend fun latestForParty(partyId: UUID): CampaignBannerPlacement?
+    suspend fun belongsToParty(interactionRef: UUID, partyId: UUID): Boolean
 }

--- a/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/application/usecase/ResolveSurfaceUseCase.kt
+++ b/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/application/usecase/ResolveSurfaceUseCase.kt
@@ -5,6 +5,7 @@
 package com.openbank.engagement.application.usecase
 
 import com.openbank.engagement.application.port.out.AdverseStateRepository
+import com.openbank.engagement.application.port.out.CampaignBannerPlacementRepository
 import com.openbank.engagement.application.port.out.EngagementEventRepository
 import com.openbank.engagement.domain.model.DismissalRule
 import com.openbank.engagement.domain.model.EligibilitySnapshot
@@ -31,6 +32,7 @@ class ResolveSurfaceUseCase(
     private val contactGate: ContactPolicyGate,
     private val events: EngagementEventRepository,
     private val adverseState: AdverseStateRepository,
+    private val banners: CampaignBannerPlacementRepository,
 ) {
 
     sealed interface Result {
@@ -77,7 +79,11 @@ class ResolveSurfaceUseCase(
             adverseState = adverseState.activeStates(partyId),
             asOf = Instant.now(),
         )
-        return Result.Rendered(SurfaceResolver.resolve(slot, eligibility))
+        val catalogue = SurfaceResolver.resolve(slot, eligibility)
+        val campaignBanner = if (slot == SurfaceSlot.HOME_BANNER) banners.latestForParty(partyId) else null
+        // The home slot intentionally has one campaign surface, with no opaque score or rotation.
+        // A current campaign placement comes before the generic catalogue fallback.
+        return Result.Rendered(listOfNotNull(campaignBanner?.toSurfaceContent()) + catalogue)
     }
 
     companion object {

--- a/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/domain/model/CampaignBannerPlacement.kt
+++ b/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/domain/model/CampaignBannerPlacement.kt
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+package com.openbank.engagement.domain.model
+
+import java.time.Instant
+import java.util.UUID
+
+/** A campaign-approved card for the one supported campaign slot, the signed-in app home banner. */
+data class CampaignBannerPlacement(
+    val interactionRef: UUID,
+    val partyId: UUID,
+    val campaignId: UUID,
+    val stepOrder: Int,
+    val template: String,
+    val values: Map<String, String>,
+    val deepLink: String,
+    val placedAt: Instant,
+) {
+    init {
+        require(stepOrder >= 0) { "campaign step order must be non-negative" }
+        require(template == PRODUCT_OFFER_BANNER_TEMPLATE) { "unknown campaign banner template '$template'" }
+        require(values.keys.all { it in PRODUCT_OFFER_BANNER_VARIABLES }) { "banner has undeclared variables" }
+        require(deepLink.startsWith("openbank://")) { "banner deep link must be an app route" }
+    }
+
+    fun toSurfaceContent(): SurfaceContent = SurfaceContent(
+        id = CAMPAIGN_BANNER_CONTENT_ID,
+        slot = SurfaceSlot.HOME_BANNER,
+        type = SurfaceContentType.BANNER,
+        variables = PRODUCT_OFFER_BANNER_VARIABLES,
+        values = values,
+        deepLink = deepLink,
+        interactionRef = interactionRef,
+    )
+
+    companion object {
+        const val CAMPAIGN_BANNER_CONTENT_ID = "CAMPAIGN_HOME_BANNER"
+        const val PRODUCT_OFFER_BANNER_TEMPLATE = "MARKETING_PRODUCT_OFFER_BANNER"
+        val PRODUCT_OFFER_BANNER_VARIABLES = setOf("offerTitle", "offerText", "ctaText")
+    }
+}

--- a/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/domain/model/Engagement.kt
+++ b/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/domain/model/Engagement.kt
@@ -10,15 +10,17 @@ import java.util.UUID
 /** ADR-0220 D2: the four events the app posts back. */
 enum class EngagementEventType { IMPRESSION, CLICK, DISMISS, CONVERSION }
 
-/** Server-owned campaign context resolved from an opaque PUSH interaction reference. */
+/** Server-owned campaign context resolved from an opaque app interaction reference. */
 data class CampaignAttribution(val campaignId: UUID, val stepOrder: Int, val channel: String) {
     init {
         require(stepOrder >= 0) { "campaign step order must be non-negative" }
-        require(channel == PUSH_CHANNEL) { "only PUSH interaction references are attributable" }
+        require(channel in ATTRIBUTABLE_CHANNELS) { "only PUSH and BANNER interactions are attributable" }
     }
 
     companion object {
         const val PUSH_CHANNEL = "PUSH"
+        const val BANNER_CHANNEL = "BANNER"
+        val ATTRIBUTABLE_CHANNELS = setOf(PUSH_CHANNEL, BANNER_CHANNEL)
     }
 }
 
@@ -35,7 +37,7 @@ data class EngagementEvent(
     val slot: SurfaceSlot,
     val type: EngagementEventType,
     val occurredAt: Instant,
-    /** Opaque campaign PUSH handoff reference, validated by customer-edge before this service sees it. */
+    /** Opaque campaign app interaction reference, validated by customer-edge before this service sees it. */
     val interactionRef: UUID? = null,
     /** Absent for organic in-app content; never accepted from the public mobile API on its own. */
     val campaignAttribution: CampaignAttribution? = null,

--- a/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/domain/model/Surface.kt
+++ b/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/domain/model/Surface.kt
@@ -4,6 +4,8 @@
 
 package com.openbank.engagement.domain.model
 
+import java.util.UUID
+
 /**
  * Named slots the app registers to render content into (ADR-0220 D1). A slot has no content of
  * its own — it is a place, not a message, exactly the distinction that keeps this from being the
@@ -35,6 +37,12 @@ data class SurfaceContent(
     val slot: SurfaceSlot,
     val type: SurfaceContentType,
     val variables: Set<String>,
+    /** Values exist only on a trusted, campaign-assigned placement; catalogue items declare keys. */
+    val values: Map<String, String> = emptyMap(),
+    /** Bank-owned app route, never a marketer-entered URL. */
+    val deepLink: String? = null,
+    /** Opaque campaign send-log id used only when the app reports an interaction back. */
+    val interactionRef: UUID? = null,
 ) {
     init {
         require(id.isNotBlank()) { "content id must not be blank" }

--- a/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/infrastructure/kafka/CampaignBannerPlacementConsumer.kt
+++ b/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/infrastructure/kafka/CampaignBannerPlacementConsumer.kt
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+package com.openbank.engagement.infrastructure.kafka
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.engagement.application.port.out.CampaignBannerPlacementRepository
+import com.openbank.engagement.domain.model.CampaignBannerPlacement
+import jakarta.enterprise.context.ApplicationScoped
+import org.eclipse.microprofile.reactive.messaging.Incoming
+import org.jboss.logging.Logger
+import java.time.Instant
+import java.util.UUID
+
+/** Consumes the campaign-owned command and stores the renderable first-party app placement. */
+@ApplicationScoped
+class CampaignBannerPlacementConsumer(
+    private val placements: CampaignBannerPlacementRepository,
+    private val mapper: ObjectMapper,
+) {
+    private val log = Logger.getLogger(CampaignBannerPlacementConsumer::class.java)
+
+    @Incoming("campaign-banner-placements-in")
+    @Suppress("TooGenericExceptionCaught")
+    suspend fun consume(payload: String) {
+        try {
+            val node = mapper.readTree(payload)
+            val placement = CampaignBannerPlacement(
+                interactionRef = UUID.fromString(node.requiredText("interactionRef")),
+                partyId = UUID.fromString(node.requiredText("partyId")),
+                campaignId = UUID.fromString(node.requiredText("campaignId")),
+                stepOrder = node.required("stepOrder").asInt(),
+                template = node.requiredText("template"),
+                values = mapper.convertValue(node.required("variables"), MAP_TYPE),
+                deepLink = node.requiredText("deepLink"),
+                placedAt = Instant.now(),
+            )
+            placements.save(placement)
+        } catch (e: Exception) {
+            // A malformed command cannot wedge the consumer group; campaign's send log remains
+            // the durable audit trail and the error is visible for reconciliation.
+            log.errorf(e, "Failed to place campaign banner: %.300s", payload)
+        }
+    }
+
+    private fun com.fasterxml.jackson.databind.JsonNode.requiredText(name: String): String =
+        required(name).asText().takeIf { it.isNotBlank() } ?: error("$name is required")
+
+    companion object {
+        private val MAP_TYPE = object : com.fasterxml.jackson.core.type.TypeReference<Map<String, String>>() {}
+    }
+}

--- a/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/infrastructure/persistence/entity/CampaignBannerPlacementEntity.kt
+++ b/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/infrastructure/persistence/entity/CampaignBannerPlacementEntity.kt
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+package com.openbank.engagement.infrastructure.persistence.entity
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import com.openbank.engagement.domain.model.CampaignBannerPlacement
+import io.quarkus.hibernate.reactive.panache.PanacheEntityBase
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.time.Instant
+import java.util.UUID
+
+@Entity
+@Table(name = "campaign_banner_placement")
+class CampaignBannerPlacementEntity : PanacheEntityBase() {
+    @Id
+    lateinit var interactionRef: UUID
+
+    @Column(nullable = false)
+    lateinit var partyId: UUID
+
+    @Column(nullable = false)
+    lateinit var campaignId: UUID
+
+    @Column(nullable = false)
+    var stepOrder: Int = 0
+
+    @Column(nullable = false)
+    lateinit var template: String
+
+    @Column(nullable = false, columnDefinition = "text")
+    lateinit var valuesJson: String
+
+    @Column(nullable = false)
+    lateinit var deepLink: String
+
+    @Column(nullable = false)
+    lateinit var placedAt: Instant
+
+    fun toDomain(mapper: ObjectMapper) = CampaignBannerPlacement(
+        interactionRef,
+        partyId,
+        campaignId,
+        stepOrder,
+        template,
+        mapper.readValue(valuesJson),
+        deepLink,
+        placedAt,
+    )
+
+    companion object {
+        fun from(placement: CampaignBannerPlacement, mapper: ObjectMapper) = CampaignBannerPlacementEntity().apply {
+            interactionRef = placement.interactionRef
+            partyId = placement.partyId
+            campaignId = placement.campaignId
+            stepOrder = placement.stepOrder
+            template = placement.template
+            valuesJson = mapper.writeValueAsString(placement.values)
+            deepLink = placement.deepLink
+            placedAt = placement.placedAt
+        }
+    }
+}

--- a/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/infrastructure/persistence/repository/CampaignBannerPlacementRepositoryImpl.kt
+++ b/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/infrastructure/persistence/repository/CampaignBannerPlacementRepositoryImpl.kt
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+package com.openbank.engagement.infrastructure.persistence.repository
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.engagement.application.port.out.CampaignBannerPlacementRepository
+import com.openbank.engagement.domain.model.CampaignBannerPlacement
+import com.openbank.engagement.infrastructure.persistence.entity.CampaignBannerPlacementEntity
+import io.quarkus.hibernate.reactive.panache.Panache
+import io.quarkus.hibernate.reactive.panache.kotlin.PanacheRepository
+import io.smallrye.mutiny.coroutines.awaitSuspending
+import jakarta.enterprise.context.ApplicationScoped
+import java.util.UUID
+
+@ApplicationScoped
+class CampaignBannerPlacementRepositoryImpl(private val mapper: ObjectMapper) :
+    CampaignBannerPlacementRepository,
+    PanacheRepository<CampaignBannerPlacementEntity> {
+
+    override suspend fun save(placement: CampaignBannerPlacement) {
+        Panache.withTransaction {
+            Panache.getSession().flatMap { it.merge(CampaignBannerPlacementEntity.from(placement, mapper)) }
+        }.awaitSuspending()
+    }
+
+    override suspend fun latestForParty(partyId: UUID): CampaignBannerPlacement? = Panache.withSession {
+        find("partyId = ?1 order by placedAt desc", partyId).firstResult()
+    }.awaitSuspending()?.toDomain(mapper)
+
+    override suspend fun belongsToParty(interactionRef: UUID, partyId: UUID): Boolean = Panache.withSession {
+        count("interactionRef = ?1 and partyId = ?2", interactionRef, partyId)
+    }.awaitSuspending() == 1L
+}

--- a/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/infrastructure/rest/SurfaceResource.kt
+++ b/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/infrastructure/rest/SurfaceResource.kt
@@ -72,19 +72,7 @@ class SurfaceResource(
         val slot = parseSlot(request.slot) ?: return badRequest("unknown slot '${request.slot}'")
         val type = EngagementEventType.entries.find { it.name == request.type }
             ?: return badRequest("unknown event type '${request.type}'")
-        val catalogueContent = SurfaceCatalog.ALL[request.contentId]
-        val campaignBanner = request.contentId == CampaignBannerPlacement.CAMPAIGN_BANNER_CONTENT_ID &&
-            request.interactionRef != null &&
-            banners.belongsToParty(request.interactionRef, request.partyId)
-        if (catalogueContent == null && !campaignBanner) return badRequest("unknown content '${request.contentId}'")
-        if (catalogueContent?.slot != null && catalogueContent.slot != slot) {
-            return badRequest("content '${request.contentId}' is not renderable in slot '${request.slot}'")
-        }
-        if (campaignBanner &&
-            (slot != SurfaceSlot.HOME_BANNER || request.type !in setOf("IMPRESSION", "CLICK", "DISMISS"))
-        ) {
-            return badRequest("campaign banner is not renderable in this event")
-        }
+        val content = validateContent(request, slot) ?: return badRequest("unknown or incompatible content '${request.contentId}'")
         val campaignFields = listOf(request.campaignId, request.stepOrder, request.channel)
         val campaignAttribution = if (campaignFields.any { it != null }) {
             if (request.interactionRef == null || campaignFields.any { it == null }) {
@@ -100,7 +88,7 @@ class SurfaceResource(
         } else {
             null
         }
-        if (campaignAttribution?.channel == "BANNER" && !campaignBanner) {
+        if (campaignAttribution?.channel == "BANNER" && !content.isCampaignPlacement) {
             return badRequest("campaign banner attribution must name its assigned banner")
         }
         record.record(
@@ -115,6 +103,19 @@ class SurfaceResource(
             ),
         )
         return Response.status(Response.Status.ACCEPTED).build()
+    }
+
+    /** Keeps ownership and slot validation together: an interaction reference cannot be replayed elsewhere. */
+    private suspend fun validateContent(request: EngagementEventRequest, slot: SurfaceSlot): ValidatedContent? {
+        val catalogue = SurfaceCatalog.ALL[request.contentId]
+        if (catalogue != null) return catalogue.takeIf { it.slot == slot }?.let { ValidatedContent(false) }
+
+        val isCampaignPlacement = request.contentId == CampaignBannerPlacement.CAMPAIGN_BANNER_CONTENT_ID &&
+            request.interactionRef != null &&
+            banners.belongsToParty(request.interactionRef, request.partyId)
+        return isCampaignPlacement
+            .takeIf { slot == SurfaceSlot.HOME_BANNER && request.type in INTERACTION_EVENT_TYPES }
+            ?.let { ValidatedContent(true) }
     }
 
     private fun parseSlot(name: String): SurfaceSlot? = SurfaceSlot.entries.find { it.name == name }
@@ -132,6 +133,12 @@ class SurfaceResource(
         "deepLink" to deepLink,
         "interactionRef" to interactionRef,
     )
+
+    private data class ValidatedContent(val isCampaignPlacement: Boolean)
+
+    private companion object {
+        val INTERACTION_EVENT_TYPES = setOf("IMPRESSION", "CLICK", "DISMISS")
+    }
 }
 
 data class EngagementEventRequest(

--- a/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/infrastructure/rest/SurfaceResource.kt
+++ b/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/infrastructure/rest/SurfaceResource.kt
@@ -4,9 +4,11 @@
 
 package com.openbank.engagement.infrastructure.rest
 
+import com.openbank.engagement.application.port.out.CampaignBannerPlacementRepository
 import com.openbank.engagement.application.usecase.RecordEngagementEventUseCase
 import com.openbank.engagement.application.usecase.ResolveSurfaceUseCase
 import com.openbank.engagement.domain.model.CampaignAttribution
+import com.openbank.engagement.domain.model.CampaignBannerPlacement
 import com.openbank.engagement.domain.model.EngagementEvent
 import com.openbank.engagement.domain.model.EngagementEventType
 import com.openbank.engagement.domain.model.SurfaceCatalog
@@ -32,7 +34,11 @@ import java.util.UUID
  */
 @Path("/api/v1/surfaces")
 @ApplicationScoped
-class SurfaceResource(private val resolve: ResolveSurfaceUseCase, private val record: RecordEngagementEventUseCase) {
+class SurfaceResource(
+    private val resolve: ResolveSurfaceUseCase,
+    private val record: RecordEngagementEventUseCase,
+    private val banners: CampaignBannerPlacementRepository,
+) {
 
     @GET
     @Path("/{slot}")
@@ -66,10 +72,18 @@ class SurfaceResource(private val resolve: ResolveSurfaceUseCase, private val re
         val slot = parseSlot(request.slot) ?: return badRequest("unknown slot '${request.slot}'")
         val type = EngagementEventType.entries.find { it.name == request.type }
             ?: return badRequest("unknown event type '${request.type}'")
-        val content = SurfaceCatalog.ALL[request.contentId]
-            ?: return badRequest("unknown content '${request.contentId}'")
-        if (content.slot != slot) {
+        val catalogueContent = SurfaceCatalog.ALL[request.contentId]
+        val campaignBanner = request.contentId == CampaignBannerPlacement.CAMPAIGN_BANNER_CONTENT_ID &&
+            request.interactionRef != null &&
+            banners.belongsToParty(request.interactionRef, request.partyId)
+        if (catalogueContent == null && !campaignBanner) return badRequest("unknown content '${request.contentId}'")
+        if (catalogueContent?.slot != null && catalogueContent.slot != slot) {
             return badRequest("content '${request.contentId}' is not renderable in slot '${request.slot}'")
+        }
+        if (campaignBanner &&
+            (slot != SurfaceSlot.HOME_BANNER || request.type !in setOf("IMPRESSION", "CLICK", "DISMISS"))
+        ) {
+            return badRequest("campaign banner is not renderable in this event")
         }
         val campaignFields = listOf(request.campaignId, request.stepOrder, request.channel)
         val campaignAttribution = if (campaignFields.any { it != null }) {
@@ -85,6 +99,9 @@ class SurfaceResource(private val resolve: ResolveSurfaceUseCase, private val re
             }.getOrElse { return badRequest(it.message ?: "invalid campaign attribution") }
         } else {
             null
+        }
+        if (campaignAttribution?.channel == "BANNER" && !campaignBanner) {
+            return badRequest("campaign banner attribution must name its assigned banner")
         }
         record.record(
             EngagementEvent(
@@ -111,6 +128,9 @@ class SurfaceResource(private val resolve: ResolveSurfaceUseCase, private val re
         "slot" to slot.name,
         "type" to type.name,
         "variables" to variables,
+        "values" to values,
+        "deepLink" to deepLink,
+        "interactionRef" to interactionRef,
     )
 }
 
@@ -119,7 +139,7 @@ data class EngagementEventRequest(
     val contentId: String,
     val slot: String,
     val type: String,
-    /** Present only after customer-edge verified an opaque PUSH reference for this party. */
+    /** Present only after customer-edge verified an opaque app interaction reference for this party. */
     val interactionRef: UUID? = null,
     /** Server-owned fields: customer-edge strips client values and resolves these from campaign-service. */
     val campaignId: UUID? = null,

--- a/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/infrastructure/rest/SurfaceResource.kt
+++ b/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/infrastructure/rest/SurfaceResource.kt
@@ -113,9 +113,13 @@ class SurfaceResource(
         val isCampaignPlacement = request.contentId == CampaignBannerPlacement.CAMPAIGN_BANNER_CONTENT_ID &&
             request.interactionRef != null &&
             banners.belongsToParty(request.interactionRef, request.partyId)
-        return isCampaignPlacement
-            .takeIf { slot == SurfaceSlot.HOME_BANNER && request.type in INTERACTION_EVENT_TYPES }
-            ?.let { ValidatedContent(true) }
+        val isInteractiveCampaignPlacement =
+            isCampaignPlacement && slot == SurfaceSlot.HOME_BANNER && request.type in INTERACTION_EVENT_TYPES
+        return if (isInteractiveCampaignPlacement) {
+            ValidatedContent(true)
+        } else {
+            null
+        }
     }
 
     private fun parseSlot(name: String): SurfaceSlot? = SurfaceSlot.entries.find { it.name == name }

--- a/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/infrastructure/rest/SurfaceResource.kt
+++ b/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/infrastructure/rest/SurfaceResource.kt
@@ -72,7 +72,8 @@ class SurfaceResource(
         val slot = parseSlot(request.slot) ?: return badRequest("unknown slot '${request.slot}'")
         val type = EngagementEventType.entries.find { it.name == request.type }
             ?: return badRequest("unknown event type '${request.type}'")
-        val content = validateContent(request, slot) ?: return badRequest("unknown or incompatible content '${request.contentId}'")
+        val content = validateContent(request, slot)
+            ?: return badRequest("unknown or incompatible content '${request.contentId}'")
         val campaignFields = listOf(request.campaignId, request.stepOrder, request.channel)
         val campaignAttribution = if (campaignFields.any { it != null }) {
             if (request.interactionRef == null || campaignFields.any { it == null }) {

--- a/openbank-engagement-service/src/main/resources/application.yaml
+++ b/openbank-engagement-service/src/main/resources/application.yaml
@@ -61,6 +61,11 @@ mp:
         key:
           serializer: org.apache.kafka.common.serialization.StringSerializer
     incoming:
+      campaign-banner-placements-in:
+        connector: smallrye-kafka
+        topic: openbank.campaign.banner.placements
+        value.deserializer: org.apache.kafka.common.serialization.StringDeserializer
+        key.deserializer: org.apache.kafka.common.serialization.StringDeserializer
       # group.id / auto.offset.reset for the channels below are set via the
       # engagement-service-msg-override ConfigMap (override.properties), NOT here — a dotted leaf
       # map key under mp.messaging.incoming.<channel> in YAML never resolves to the plain

--- a/openbank-engagement-service/src/main/resources/db/migration/V5__campaign_banner_placement.sql
+++ b/openbank-engagement-service/src/main/resources/db/migration/V5__campaign_banner_placement.sql
@@ -1,0 +1,16 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+CREATE TABLE campaign_banner_placement (
+    interaction_ref UUID PRIMARY KEY,
+    party_id UUID NOT NULL,
+    campaign_id UUID NOT NULL,
+    step_order INTEGER NOT NULL,
+    template VARCHAR(128) NOT NULL,
+    values_json TEXT NOT NULL,
+    deep_link VARCHAR(256) NOT NULL,
+    placed_at TIMESTAMPTZ NOT NULL
+);
+
+CREATE INDEX idx_campaign_banner_placement_party_placed
+    ON campaign_banner_placement (party_id, placed_at DESC);

--- a/openbank-engagement-service/src/main/resources/db/migration/V6__campaign_banner_attribution.sql
+++ b/openbank-engagement-service/src/main/resources/db/migration/V6__campaign_banner_attribution.sql
@@ -1,0 +1,12 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+ALTER TABLE engagement_event DROP CONSTRAINT chk_engagement_campaign_attribution;
+ALTER TABLE engagement_event
+    ADD CONSTRAINT chk_engagement_campaign_attribution CHECK (
+        (campaign_id IS NULL AND campaign_step_order IS NULL AND campaign_channel IS NULL)
+        OR
+        (campaign_id IS NOT NULL AND campaign_step_order >= 0 AND campaign_channel IN ('PUSH', 'BANNER'))
+    );
+
+-- Rollback: restore V4's PUSH-only constraint after removing BANNER-attributed event rows.

--- a/openbank-engagement-service/src/main/resources/openapi.yaml
+++ b/openbank-engagement-service/src/main/resources/openapi.yaml
@@ -14,7 +14,7 @@ info:
     existing yet). No NBA ranking — content returns in catalogue order until ADR-0201's model
     graduates from shadow (D5). The customer app reaches these endpoints only through
     customer-edge, whose narrowly scoped M2M policy injects the authoritative party id.
-  version: 1.4.0
+  version: 1.5.0
 tags:
   - name: Surfaces
   - name: Eligibility

--- a/openbank-engagement-service/src/main/resources/openapi.yaml
+++ b/openbank-engagement-service/src/main/resources/openapi.yaml
@@ -129,6 +129,19 @@ components:
         variables:
           type: array
           items: { type: string }
+        values:
+          type: object
+          additionalProperties: { type: string }
+          description: Present only for a trusted campaign assignment; catalogue items declare keys only.
+        deepLink:
+          type: string
+          nullable: true
+          description: Closed openbank app route for a campaign banner tap.
+        interactionRef:
+          type: string
+          format: uuid
+          nullable: true
+          description: Opaque interaction reference present only on a campaign banner.
     SurfaceResponse:
       type: object
       required: [state]
@@ -159,7 +172,7 @@ components:
           type: string
           format: uuid
           description: >-
-            Opaque reference to an accepted campaign PUSH handoff. customer-edge validates that it
+            Opaque reference to an accepted campaign PUSH or BANNER placement. customer-edge validates that it
             belongs to the authenticated party before forwarding; it is absent for unattributed
             in-app content and must never be replaced with a campaign or party identifier.
         campaignId:
@@ -171,8 +184,8 @@ components:
         stepOrder:
           type: integer
           minimum: 0
-          description: Server-owned journey step that created the PUSH interaction.
+          description: Server-owned journey step that created the app interaction.
         channel:
           type: string
-          enum: [PUSH]
+          enum: [PUSH, BANNER]
           description: Server-owned originating channel. Present only with complete campaign attribution.

--- a/openbank-engagement-service/src/test/kotlin/com/openbank/engagement/application/ResolveSurfaceUseCaseTest.kt
+++ b/openbank-engagement-service/src/test/kotlin/com/openbank/engagement/application/ResolveSurfaceUseCaseTest.kt
@@ -5,9 +5,11 @@
 package com.openbank.engagement.application
 
 import com.openbank.engagement.application.port.out.AdverseStateRepository
+import com.openbank.engagement.application.port.out.CampaignBannerPlacementRepository
 import com.openbank.engagement.application.port.out.EngagementEventRepository
 import com.openbank.engagement.application.usecase.ResolveSurfaceUseCase
 import com.openbank.engagement.domain.model.AdverseState
+import com.openbank.engagement.domain.model.CampaignBannerPlacement
 import com.openbank.engagement.domain.model.EngagementEvent
 import com.openbank.engagement.domain.model.EngagementEventType
 import com.openbank.engagement.domain.model.SurfaceSlot
@@ -45,12 +47,16 @@ class ResolveSurfaceUseCaseTest {
         return repo
     }
 
+    private fun banners() = mockk<CampaignBannerPlacementRepository>().also {
+        coEvery { it.latestForParty(any()) } returns null
+    }
+
     @Test
     fun `a consented party with no dismissal history sees the slot's catalogue`(): Unit = runBlocking {
         val events = mockk<EngagementEventRepository>()
         coEvery { events.recentForPartyAndSlot(party, SurfaceSlot.HOME_BANNER, any()) } returns emptyList()
 
-        val result = ResolveSurfaceUseCase(gate(consented = true), events, adverseStates())
+        val result = ResolveSurfaceUseCase(gate(consented = true), events, adverseStates(), banners())
             .resolve(party, SurfaceSlot.HOME_BANNER)
 
         assertThat(result).isInstanceOf(ResolveSurfaceUseCase.Result.Rendered::class.java)
@@ -59,11 +65,41 @@ class ResolveSurfaceUseCaseTest {
     }
 
     @Test
+    fun `a consented party sees their latest campaign banner before the catalogue fallback`(): Unit = runBlocking {
+        val events = mockk<EngagementEventRepository>()
+        val placements = mockk<CampaignBannerPlacementRepository>()
+        val ref = UUID.randomUUID()
+        coEvery { events.recentForPartyAndSlot(party, SurfaceSlot.HOME_BANNER, any()) } returns emptyList()
+        coEvery { placements.latestForParty(party) } returns CampaignBannerPlacement(
+            ref,
+            party,
+            UUID.randomUUID(),
+            0,
+            "MARKETING_PRODUCT_OFFER_BANNER",
+            mapOf("offerTitle" to "Savings", "offerText" to "Four percent", "ctaText" to "Explore"),
+            "openbank://savings",
+            Instant.now(),
+        )
+
+        val result = ResolveSurfaceUseCase(
+            gate(),
+            events,
+            adverseStates(),
+            placements,
+        ).resolve(party, SurfaceSlot.HOME_BANNER)
+
+        val content = (result as ResolveSurfaceUseCase.Result.Rendered).content.first()
+        assertThat(content.id).isEqualTo(CampaignBannerPlacement.CAMPAIGN_BANNER_CONTENT_ID)
+        assertThat(content.interactionRef).isEqualTo(ref)
+        assertThat(content.deepLink).isEqualTo("openbank://savings")
+    }
+
+    @Test
     fun `a party with no marketing consent is not eligible, not silently empty`(): Unit = runBlocking {
         val events = mockk<EngagementEventRepository>()
         coEvery { events.recentForPartyAndSlot(any(), any(), any()) } returns emptyList()
 
-        val result = ResolveSurfaceUseCase(gate(consented = false), events, adverseStates())
+        val result = ResolveSurfaceUseCase(gate(consented = false), events, adverseStates(), banners())
             .resolve(party, SurfaceSlot.HOME_BANNER)
 
         assertThat(result).isInstanceOf(ResolveSurfaceUseCase.Result.NotEligible::class.java)
@@ -83,7 +119,7 @@ class ResolveSurfaceUseCaseTest {
         }
         coEvery { events.recentForPartyAndSlot(party, SurfaceSlot.HOME_BANNER, any()) } returns dismissals
 
-        val result = ResolveSurfaceUseCase(gate(consented = true), events, adverseStates())
+        val result = ResolveSurfaceUseCase(gate(consented = true), events, adverseStates(), banners())
             .resolve(party, SurfaceSlot.HOME_BANNER)
 
         assertThat(result).isEqualTo(ResolveSurfaceUseCase.Result.Suppressed)
@@ -94,7 +130,12 @@ class ResolveSurfaceUseCaseTest {
         val events = mockk<EngagementEventRepository>()
         coEvery { events.recentForPartyAndSlot(party, SurfaceSlot.HOME_BANNER, any()) } returns emptyList()
 
-        val result = ResolveSurfaceUseCase(gate(consented = true), events, adverseStates(setOf(AdverseState.ARREARS)))
+        val result = ResolveSurfaceUseCase(
+            gate(consented = true),
+            events,
+            adverseStates(setOf(AdverseState.ARREARS)),
+            banners(),
+        )
             .resolve(party, SurfaceSlot.HOME_BANNER)
 
         // Still a Rendered result (SurfaceResolver's own D3.5 exclusion, not a gate/consent

--- a/openbank-engagement-service/src/test/kotlin/com/openbank/engagement/integration/SurfaceRestContractIT.kt
+++ b/openbank-engagement-service/src/test/kotlin/com/openbank/engagement/integration/SurfaceRestContractIT.kt
@@ -53,6 +53,7 @@ class SurfaceRestContractIT {
                     "lending-events-in",
                     "party-events-in",
                     "fraud-hold-events-in",
+                    "campaign-banner-placements-in",
                 )
 
         override fun stop() = InMemoryConnector.clear()
@@ -156,6 +157,50 @@ class SurfaceRestContractIT {
         assertThat(readCampaignAttributionFor(party)).isEqualTo(
             StoredCampaignAttribution(interactionRef, campaignId, 0, "PUSH"),
         )
+    }
+
+    @Test
+    @TestSecurity(user = TEST_OPERATOR, roles = ["ROLE_OPERATOR"])
+    fun `a placed campaign banner carries BANNER attribution through the real HTTP path`() {
+        val party = UUID.randomUUID()
+        val interactionRef = UUID.randomUUID()
+        val campaignId = UUID.randomUUID()
+        insertCampaignBanner(interactionRef, party, campaignId)
+
+        Given {
+            contentType("application/json")
+            body(
+                """{"partyId":"$party","contentId":"CAMPAIGN_HOME_BANNER","slot":"HOME_BANNER","type":"CLICK","interactionRef":"$interactionRef","campaignId":"$campaignId","stepOrder":0,"channel":"BANNER"}""",
+            )
+        } When {
+            post("/api/v1/surfaces/events")
+        } Then {
+            statusCode(202)
+        }
+
+        assertThat(readCampaignAttributionFor(party)).isEqualTo(
+            StoredCampaignAttribution(interactionRef, campaignId, 0, "BANNER"),
+        )
+    }
+
+    @Test
+    @TestSecurity(user = TEST_OPERATOR, roles = ["ROLE_OPERATOR"])
+    fun `a banner interaction cannot be attached to a catalogue card`() {
+        val party = UUID.randomUUID()
+        val interactionRef = UUID.randomUUID()
+        val campaignId = UUID.randomUUID()
+        insertCampaignBanner(interactionRef, party, campaignId)
+
+        Given {
+            contentType("application/json")
+            body(
+                """{"partyId":"$party","contentId":"SAVINGS_RATE_BANNER","slot":"HOME_BANNER","type":"CLICK","interactionRef":"$interactionRef","campaignId":"$campaignId","stepOrder":0,"channel":"BANNER"}""",
+            )
+        } When {
+            post("/api/v1/surfaces/events")
+        } Then {
+            statusCode(400)
+        }
     }
 
     @Test
@@ -266,6 +311,28 @@ class SurfaceRestContractIT {
                 st.setObject(2, partyId)
                 st.setString(3, state)
                 st.setTimestamp(4, Timestamp.from(Instant.now()))
+                st.executeUpdate()
+            }
+        }
+    }
+
+    private fun insertCampaignBanner(interactionRef: UUID, partyId: UUID, campaignId: UUID) {
+        openTestDatabase().use { conn ->
+            conn.prepareStatement(
+                """
+                INSERT INTO campaign_banner_placement
+                    (interaction_ref, party_id, campaign_id, step_order, template, values_json, deep_link, placed_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """.trimIndent(),
+            ).use { st ->
+                st.setObject(1, interactionRef)
+                st.setObject(2, partyId)
+                st.setObject(3, campaignId)
+                st.setInt(4, 0)
+                st.setString(5, "MARKETING_PRODUCT_OFFER_BANNER")
+                st.setString(6, """{"offerTitle":"Savings","offerText":"Four percent","ctaText":"Explore"}""")
+                st.setString(7, "openbank://savings")
+                st.setTimestamp(8, Timestamp.from(Instant.now()))
                 st.executeUpdate()
             }
         }

--- a/openbank-infra/gitops/components/analytics/campaign-engagement-schema-configmap.yaml
+++ b/openbank-infra/gitops/components/analytics/campaign-engagement-schema-configmap.yaml
@@ -28,5 +28,5 @@ data:
     WHERE aggregate_type = 'ENGAGEMENT'
       AND JSONExtractString(payload, 'campaignId') != ''
       AND JSONHas(payload, 'stepOrder')
-      AND JSONExtractString(payload, 'channel') = 'PUSH'
+      AND JSONExtractString(payload, 'channel') IN ('PUSH', 'BANNER')
     GROUP BY campaign_id, step_order, channel;

--- a/openbank-infra/gitops/components/analytics/clickhouse-init-configmap.yaml
+++ b/openbank-infra/gitops/components/analytics/clickhouse-init-configmap.yaml
@@ -575,7 +575,7 @@ data:
     WHERE aggregate_type = 'ENGAGEMENT'
       AND JSONExtractString(payload, 'campaignId') != ''
       AND JSONHas(payload, 'stepOrder')
-      AND JSONExtractString(payload, 'channel') = 'PUSH'
+      AND JSONExtractString(payload, 'channel') IN ('PUSH', 'BANNER')
     GROUP BY campaign_id, step_order, channel;
 kind: ConfigMap
 metadata:

--- a/openbank-infra/gitops/components/campaign/kafka-campaign-mtls.yaml
+++ b/openbank-infra/gitops/components/campaign/kafka-campaign-mtls.yaml
@@ -33,6 +33,11 @@ spec:
           name: openbank.notification.requests
           patternType: literal
         operations: [Write, Describe]
+      - resource:
+          type: topic
+          name: openbank.campaign.banner.placements
+          patternType: literal
+        operations: [Write, Describe]
       # Consume consent lifecycle events → journey revocation signals (ADR-0200 D2).
       - resource:
           type: topic

--- a/openbank-infra/gitops/components/engagement/engagement-service-msg-override.yaml
+++ b/openbank-infra/gitops/components/engagement/engagement-service-msg-override.yaml
@@ -15,6 +15,8 @@ metadata:
 data:
   override.properties: |
     config_ordinal=500
+    mp.messaging.incoming.campaign-banner-placements-in.group.id=openbank-engagement-service
+    mp.messaging.incoming.campaign-banner-placements-in.auto.offset.reset=earliest
     mp.messaging.incoming.lending-events-in.group.id=openbank-engagement-service
     mp.messaging.incoming.lending-events-in.auto.offset.reset=earliest
     mp.messaging.incoming.party-events-in.group.id=openbank-engagement-service

--- a/openbank-infra/gitops/components/engagement/engagement-service-msg-override.yaml
+++ b/openbank-infra/gitops/components/engagement/engagement-service-msg-override.yaml
@@ -15,8 +15,6 @@ metadata:
 data:
   override.properties: |
     config_ordinal=500
-    mp.messaging.incoming.campaign-banner-placements-in.group.id=openbank-engagement-service
-    mp.messaging.incoming.campaign-banner-placements-in.auto.offset.reset=earliest
     mp.messaging.incoming.lending-events-in.group.id=openbank-engagement-service
     mp.messaging.incoming.lending-events-in.auto.offset.reset=earliest
     mp.messaging.incoming.party-events-in.group.id=openbank-engagement-service

--- a/openbank-infra/gitops/components/engagement/kafka-engagement-mtls.yaml
+++ b/openbank-infra/gitops/components/engagement/kafka-engagement-mtls.yaml
@@ -57,6 +57,12 @@ spec:
         host: "*"
       - resource:
           type: topic
+          name: openbank.campaign.banner.placements
+          patternType: literal
+        operations: [Read, Describe]
+        host: "*"
+      - resource:
+          type: topic
           name: openbank.lending.events
           patternType: literal
         operations: [Read, Describe]

--- a/openbank-infra/gitops/components/kafka/kafka.yaml
+++ b/openbank-infra/gitops/components/kafka/kafka.yaml
@@ -250,3 +250,19 @@ spec:
   config:
     retention.ms: 604800000
     cleanup.policy: delete
+---
+# Campaign-owned commands consumed by engagement-service. A compacted key (the campaign send-log
+# id) makes the placement idempotent across Temporal/Kafka retries while keeping the current slot
+# materialisation recoverable.
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaTopic
+metadata:
+  name: openbank.campaign.banner.placements
+  namespace: messaging
+  labels:
+    strimzi.io/cluster: openbank-cluster
+spec:
+  partitions: 1
+  replicas: 1
+  config:
+    cleanup.policy: compact


### PR DESCRIPTION
## What changed

- Adds `BANNER` as a first-class Campaign Studio channel with a dedicated in-app phone preview, closed deep-link destination and approved banner template.
- Delivers an idempotent, consent-gated HOME_BANNER placement through a compacted Kafka command to engagement-service; it never routes via notification-service.
- Persists and serves the current per-party campaign banner, forwards authenticated banner interactions through customer-edge, and attributes only the assigned banner to the campaign.
- Adds Kafka ACLs/topic, analytics channel coverage, OpenAPI/AsyncAPI and reversible Flyway migrations.

## Safety

- Banner uses `MARKETING_COMMS_INAPP` / promotional-impression consent, a closed `openbank://` route, an opaque interaction reference and no PII in analytics.
- The event endpoint rejects attaching a `BANNER` interaction to a generic catalogue card.

## Validation

- `npm run type-check`
- `npx vitest run src/test/journey-editor.test.tsx src/test/campaign-experience-preview.test.tsx src/test/campaign-builder-interaction.test.tsx` — 22 passed
- `./gradlew :openbank-campaign-service:test --tests "*CampaignJourneyActivitiesTest" :openbank-engagement-service:test --tests "*ResolveSurfaceUseCaseTest" --tests "*SurfaceRestContractIT"`
- `./gradlew :openbank-campaign-service:ktlintCheck :openbank-engagement-service:ktlintCheck :openbank-customer-edge:ktlintCheck`
- `git diff --check`

## Linked issues

Refs #4476