### PR TITLE
fix(gitops): mount the whole msg-override ConfigMap so document-service can start

### DIFF
--- a/openbank-infra/gitops/components/document-service/document-service-service.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-service.yaml
@@ -367,12 +367,18 @@ spec:
           secret:
             secretName: document-service-signing-keystore
             optional: true
+        # No `items:` — project the whole ConfigMap, exactly as account-service and every other
+        # msg-override consumer does. An `items:` block naming `keystore.p12` stood here, evidently
+        # copy-pasted from the signing-keystore volume directly above: this ConfigMap holds ONE key,
+        # `override.properties`, and never held a keystore. Kubernetes treats a named key that does
+        # not exist as a hard mount failure, so the pod sat in ContainerCreating with
+        # `MountVolume.SetUp failed for volume "msg-override": configmap references non-existent
+        # config key: keystore.p12` — 173 times over 5h40m — and document-service was DOWN.
+        # QUARKUS_CONFIG_LOCATIONS above expects /mnt/msg-config/override.properties, which the
+        # whole-ConfigMap projection produces naturally.
         - name: msg-override
           configMap:
             name: document-service-msg-override
-            items:
-              - key: keystore.p12
-                path: keystore.p12
 ---
 apiVersion: v1
 kind: ServiceAccount


### PR DESCRIPTION
## document-service is DOWN, and has been for 5h40m

Its `msg-override` volume asks for a ConfigMap key that does not exist:

```yaml
- name: msg-override
  configMap:
    name: document-service-msg-override
    items:
      - key: keystore.p12        # this ConfigMap has no such key
        path: keystore.p12
```

`document-service-msg-override` holds exactly **one** key, `override.properties` — the SmallRye
`group.id` override from #3798/#2945. It has never held a keystore. The block was evidently
copy-pasted from the `signing-keystore` **secret** volume declared immediately above it.

Kubernetes treats a named-but-absent key as a hard mount failure, so the pod never started:

```
MountVolume.SetUp failed for volume "msg-override" :
  configmap references non-existent config key: keystore.p12
(x173 over 5h40m)     0/2  ContainerCreating     ProgressDeadlineExceeded
```

## Why a one-line manifest bug cost the whole fleet

A down document-service publishes no pacts, so `can-i-deploy` answers **UNVERIFIABLE** for every
counterpart and refuses to release them.

- **13 of the last 30 auto-deploy runs failed.**
- All 8 sampled failures name the identical cause: `openbank-document-service@ee974ea3` carrying
  **ZERO pacts**.
- `openbank-sepa-payment` — money-path — has been left behind main as a result.

The gate is explicit that nothing self-heals it:

> `this will NOT clear on its own and waiting for a reconcile tick cannot help (#3223)`

## Neither recovery path could have fixed this

Worth recording, because both are the obvious things to reach for:

- `gh workflow run auto-deploy.yml -f services=openbank-document-service` is **refused by
  auto-deploy's own guard** — the service did not change in HEAD, so the broker has no pact version
  for that SHA.
- `reconcile=true` does **not** select it either: its gitops pin is not behind main. A dry run of
  `auto-deploy-reconcile-lag.sh` returns
  `["openbank-developer-portal","openbank-billing-service","openbank-analytics-sink","openbank-sepa-payment"]`
  — no document-service.

The manifest was **wrong**, not stale, and redeploying the same manifest cannot help.

## The fix

Drop the `items:` block and project the whole ConfigMap. Measured across
`openbank-infra/gitops/components`: **18 msg-override consumers have no `items:` block, and
document-service was the only one that did.** `QUARKUS_CONFIG_LOCATIONS` already expects
`/mnt/msg-config/override.properties`, which the whole-ConfigMap projection produces naturally.

## A diagnostic note worth keeping

The Deployment reported `Available=True  MinimumReplicasAvailable: Deployment has minimum
availability` while **zero** replicas were ready — the old ReplicaSet still counted toward it. Only
`Progressing=False ProgressDeadlineExceeded` showed the truth. A health check reading `Available`
would have called this service healthy for the entire outage.

## Verification

- Root cause read from the live pod's own events, not inferred.
- The absent key confirmed directly: `kubectl get cm document-service-msg-override -o json` →
  `keys: ['override.properties']`.
- Fleet swept for the same shape: 1 of 19 affected, fixed here.
- Local `gitops` gate group: **26 PASS, 1 UNFALSIFIED** (`loki-rule-load-test`, which fails
  identically on a clean `origin/main` worktree and is unrelated).

Expected effect once synced: document-service starts, publishes pacts, and the `can-i-deploy` block
on sepa-payment clears.

Refs #3223
