### PR TITLE
fix(gitops): admit ns platform to the Temporal frontend so case-coordinator-agent can boot

### DIFF
--- a/openbank-infra/gitops/components/temporal/temporal-network-policies.yaml
+++ b/openbank-infra/gitops/components/temporal/temporal-network-policies.yaml
@@ -47,7 +47,11 @@ spec:
     - Ingress
   ingress:
     # OpenBank services calling the Temporal frontend gRPC (7233).
-    # - platform-plane: copilot, agent, etc. (openbank.io/plane: platform).
+    # - namespaces labelled openbank.io/plane: platform. NOTE this is a PLANE label, not the
+    #   namespace named `platform`: it is carried by argo-rollouts, external-dns, external-secrets,
+    #   falco, reposilite, vault and vpa, and NOT by `platform` itself. This comment used to read
+    #   "platform-plane: copilot, agent, etc.", which named workloads that live in ns `platform`
+    #   and so implied a coverage this selector has never provided (#4187).
     # - app-plane Temporal workflow clients enumerated explicitly (least-privilege).
     #   ADD a namespace here when a service flips openbank.temporal.enabled=true,
     #   otherwise its worker onStart() blocks on getSystemInfo → DEADLINE_EXCEEDED →
@@ -74,6 +78,13 @@ spec:
                   - docs-truth-agent
                   - authz-policy-auditor
                   - flaky-test-hunter
+                  # ns `platform` hosts case-coordinator-agent (ADR-0244 phase 4, TEMPORAL_ENABLED
+                  # =true, namespace openbank-casecoord). It was never added, so the pod
+                  # CrashLoopBackOff'd on exactly the failure this comment predicts:
+                  # "DEADLINE_EXCEEDED: CallOptions deadline exceeded after 4.98s ...
+                  # connecting_and_lb_delay" out of CaseWorkerRegistrar.onStart. The plane-label
+                  # branch above does not cover it — see the note there.
+                  - platform
       ports:
         - protocol: TCP
           port: 7233


### PR DESCRIPTION
## case-coordinator-agent has never booted

11 restarts, `0/1` ready, CrashLoopBackOff since deploy — on exactly the failure this policy's own
comment predicts:

```
Caused by: io.grpc.StatusRuntimeException: DEADLINE_EXCEEDED:
  CallOptions deadline exceeded after 4.980181899s.
  Name resolution delay 0.005055880 seconds.
  [closed=[], open=[[connecting_and_lb_delay=4985283315ns, was_still_waiting]]]
    at ...WorkflowServiceGrpc...getSystemInfo
    at com.openbank.casecoordinator.application.workflow.CaseWorkerRegistrar.onStart
```

The comment in `temporal-network-policies.yaml` says it outright:

> ADD a namespace here when a service flips `openbank.temporal.enabled=true`, otherwise its worker
> `onStart()` blocks on `getSystemInfo` → DEADLINE_EXCEEDED → the service fails to boot

ADR-0244 phase 4 shipped the workload (`TEMPORAL_ENABLED=true`,
`TEMPORAL_NAMESPACE=openbank-casecoord`) without doing that, and **#4187 was closed**.

Name resolution succeeds in **5 ms** and the TCP connect then hangs — the signature of a
NetworkPolicy drop, not a wrong address or a down peer. `temporal-frontend` itself has been Running
for 14d.

## The trap: a name collision

The policy is called `temporal-**platform**-ingress`, and its first branch selects
`openbank.io/plane: platform` — a **plane label**, not the namespace called `platform`.

Measured on the live cluster:

```
$ kubectl get ns -l openbank.io/plane=platform
argo-rollouts  external-dns  external-secrets  falco  reposilite  vault  vpa

$ kubectl get ns platform -o jsonpath='{.metadata.labels}'
{"app.kubernetes.io/part-of":"openbank","kubernetes.io/metadata.name":"platform"}
```

So a policy whose name contains "platform" did not admit the namespace named `platform`. And the
comment above it read *"platform-plane: copilot, agent, etc."* — naming workloads that live in ns
`platform`, and so asserting a coverage this selector has never provided. Corrected in place rather
than deleted, so the next reader learns the claim was wrong instead of never seeing it.

## The fix

Add `platform` to the explicit least-privilege list, the same way every other Temporal client
namespace is admitted. Port stays `7233/TCP`, frontend pods only. No selector widened.

## Verification

- Root cause read from the pod's own stack trace and the live namespace labels, not inferred.
- Both branches of the selector checked against the live cluster — neither matched.
- Peer health confirmed (`temporal-frontend` Running 14d), so "down peer" is excluded.
- YAML re-parsed after patching.
- Local `gitops` gate group: **26 PASS, 1 UNFALSIFIED** (`loki-rule-load-test`, fails identically on
  a clean `origin/main` worktree, unrelated).

## Related

Found while investigating why the fleet deploy pipeline was blocked. That turned out to be a
different dead workload — document-service, fixed in #4580. **Two of 127 Deployments were down and
nothing alerted**: the fleet has `RolloutProgressDeadlineExceeded` (Argo Rollouts, 21 objects) and
`StatefulSetNoReadyReplicas`, but no equivalent for plain Deployments. Filing that separately.

Refs #4187
