### PR TITLE
feat(campaign): add in-app campaign surfaces

### DIFF
--- a/openbank-admin-ui/src/app/campaigns/new/page.tsx
+++ b/openbank-admin-ui/src/app/campaigns/new/page.tsx
@@ -66,6 +66,9 @@ const TEMPLATES: Record<string, string[]> = {
   // title plus a fixed generic body, so there is nowhere for offer copy to go (#1182).
   MARKETING_PRODUCT_OFFER_PUSH: ['offerTitle'],
   MARKETING_PRODUCT_OFFER_BANNER: ['offerTitle', 'offerText', 'ctaText'],
+  MARKETING_PRODUCT_OFFER_CAROUSEL: ['offerTitle', 'offerText', 'ctaText'],
+  MARKETING_PRODUCT_OFFER_PRODUCT_FEED: ['offerTitle', 'offerText', 'ctaText'],
+  MARKETING_PRODUCT_OFFER_REWARDS_HUB: ['offerTitle', 'offerText', 'ctaText'],
 }
 
 /** Which channel each template renders on. The service refuses a step whose two disagree. */
@@ -73,6 +76,9 @@ const TEMPLATE_CHANNEL: Record<string, EditorChannel> = {
   MARKETING_PRODUCT_OFFER: 'EMAIL',
   MARKETING_PRODUCT_OFFER_PUSH: 'PUSH',
   MARKETING_PRODUCT_OFFER_BANNER: 'BANNER',
+  MARKETING_PRODUCT_OFFER_CAROUSEL: 'BANNER',
+  MARKETING_PRODUCT_OFFER_PRODUCT_FEED: 'BANNER',
+  MARKETING_PRODUCT_OFFER_REWARDS_HUB: 'BANNER',
 }
 
 const newStep = (): EditorStep => ({
@@ -119,6 +125,9 @@ export default function NewCampaignPage() {
     MARKETING_PRODUCT_OFFER: t('Nabídka produktu', 'Product offer'),
     MARKETING_PRODUCT_OFFER_PUSH: t('Nabídka produktu', 'Product offer'),
     MARKETING_PRODUCT_OFFER_BANNER: t('Nabídka v banneru', 'Banner offer'),
+    MARKETING_PRODUCT_OFFER_CAROUSEL: t('Nabídka v carouselu', 'Carousel offer'),
+    MARKETING_PRODUCT_OFFER_PRODUCT_FEED: t('Nabídka ve feedu produktů', 'Product feed offer'),
+    MARKETING_PRODUCT_OFFER_REWARDS_HUB: t('Nabídka v centru odměn', 'Rewards hub offer'),
   }
 
   // The template declares `offerTitle`; a marketer writes a headline. Same field, and only one of
@@ -253,6 +262,7 @@ export default function NewCampaignPage() {
           ...(contentExperiment ? { variantBVariables: s.variantBVariables ?? {} } : {}),
           ...(s.fallbackToPush ? { fallbackToPush: true } : {}),
           ...(s.mobileDestination ? { mobileDestination: s.mobileDestination } : {}),
+          ...(s.inAppSurface ? { inAppSurface: s.inAppSurface } : {}),
           delaySeconds: s.delaySeconds,
         })),
       }),

--- a/openbank-admin-ui/src/components/campaigns/CampaignExperiencePreview.tsx
+++ b/openbank-admin-ui/src/components/campaigns/CampaignExperiencePreview.tsx
@@ -5,7 +5,7 @@
 'use client'
 
 import { useLanguage } from '@/lib/i18n/LanguageContext'
-import type { EditorMobileDestination, EditorStep } from '@/components/campaigns/JourneyEditor'
+import type { EditorInAppSurface, EditorMobileDestination, EditorStep } from '@/components/campaigns/JourneyEditor'
 
 type Destination = Exclude<EditorMobileDestination, undefined>
 
@@ -15,6 +15,13 @@ const destinationCopy: Record<Destination, { cs: string; en: string; eyebrowCs: 
   CARDS: { cs: 'Karty', en: 'Cards', eyebrowCs: 'Vaše karty', eyebrowEn: 'Your cards' },
   PAYMENTS: { cs: 'Platby', en: 'Payments', eyebrowCs: 'Poslat peníze', eyebrowEn: 'Move money' },
   PRODUCT_HUB: { cs: 'Produkty', en: 'Products', eyebrowCs: 'Pro vás', eyebrowEn: 'Picked for you' },
+}
+
+const surfaceCopy: Record<EditorInAppSurface, { cs: string; en: string; metaCs: string; metaEn: string }> = {
+  HOME_BANNER: { cs: 'Banner na domovské obrazovce', en: 'Home banner', metaCs: 'DOMOVSKÁ OBRAZOVKA', metaEn: 'HOME SCREEN' },
+  HOME_CAROUSEL: { cs: 'Carousel na domovské obrazovce', en: 'Home carousel', metaCs: 'DOMOVSKÝ CAROUSEL', metaEn: 'HOME CAROUSEL' },
+  PRODUCT_FEED: { cs: 'Feed produktů', en: 'Product feed', metaCs: 'FEED PRODUKTŮ', metaEn: 'PRODUCT FEED' },
+  REWARDS_HUB: { cs: 'Centrum odměn', en: 'Rewards hub', metaCs: 'CENTRUM ODMĚN', metaEn: 'REWARDS HUB' },
 }
 
 /**
@@ -35,6 +42,8 @@ export function CampaignExperiencePreview({
   const { t, language } = useLanguage()
   const isPush = step?.channel === 'PUSH'
   const isBanner = step?.channel === 'BANNER'
+  const inAppSurface = step?.inAppSurface ?? 'HOME_BANNER'
+  const surface = surfaceCopy[inAppSurface]
   const destination = step?.mobileDestination ?? 'HOME'
   const copy = destinationCopy[destination]
   const headline = step?.variables.offerTitle?.trim() || t('Vaše další chytrá volba', 'Your next smart move')
@@ -60,8 +69,8 @@ export function CampaignExperiencePreview({
             </div>
             <p className="campaign-phone-eyebrow">{language === 'cs' ? copy.eyebrowCs : copy.eyebrowEn}</p>
             <h4>{language === 'cs' ? copy.cs : copy.en}</h4>
-            <div className={`campaign-phone-hero${isBanner ? ' campaign-phone-banner' : ''}`}>
-              <span>{isBanner ? t('Pro vás v aplikaci', 'For you in the app') : t('Doporučeno pro vás', 'Recommended for you')}</span>
+            <div className={`campaign-phone-hero${isBanner ? ` campaign-phone-banner campaign-phone-${inAppSurface.toLowerCase()}` : ''}`} data-preview-surface={isBanner ? inAppSurface : undefined}>
+              <span>{isBanner ? (language === 'cs' ? surface.cs : surface.en) : t('Doporučeno pro vás', 'Recommended for you')}</span>
               <strong>{headline}</strong>
               <button type="button" tabIndex={-1}>{t('Zjistit víc', 'Explore')}</button>
             </div>
@@ -72,12 +81,12 @@ export function CampaignExperiencePreview({
         <div className={`campaign-push-card${isBanner ? ' campaign-banner-card' : ''}`} data-preview-channel={isPush ? 'PUSH' : isBanner ? 'BANNER' : 'EMAIL'}>
           <div className="campaign-push-icon">o</div>
           <div>
-            <div className="campaign-push-meta">OPENBANK · {isBanner ? t('DOMOVSKÁ OBRAZOVKA', 'HOME SCREEN') : t('nyní', 'now')}</div>
-            <p className="campaign-push-title">{isPush ? headline : isBanner ? t('Banner v přihlášené aplikaci', 'Banner in the signed-in app') : t('Zvolte push krok', 'Choose a push step')}</p>
+            <div className="campaign-push-meta">OPENBANK · {isBanner ? (language === 'cs' ? surface.metaCs : surface.metaEn) : t('nyní', 'now')}</div>
+            <p className="campaign-push-title">{isPush ? headline : isBanner ? (language === 'cs' ? surface.cs : surface.en) : t('Zvolte push krok', 'Choose a push step')}</p>
             <p>{isPush
               ? t('Otevře zabezpečenou aplikaci — bez osobního obsahu v notifikaci.', 'Opens the secure app — with no personal content in the notification.')
               : isBanner
-                ? t('Zobrazí se při další návštěvě domova. Žádné vyrušení, žádná zamčená obrazovka.', 'Shown on the next home visit. No interruption, no lock screen.')
+                ? t('Zobrazí se při další návštěvě této plochy. Žádné vyrušení, žádná zamčená obrazovka.', 'Shown on the next visit to this surface. No interruption, no lock screen.')
               : t('Tento krok je e-mail. Vyberte push krok na cestě pro náhled notifikace.', 'This step is email. Select a push step on the journey to preview the notification.')}</p>
           </div>
         </div>

--- a/openbank-admin-ui/src/components/campaigns/JourneyEditor.tsx
+++ b/openbank-admin-ui/src/components/campaigns/JourneyEditor.tsx
@@ -31,6 +31,8 @@ export type EditorChannel = 'EMAIL' | 'PUSH' | 'BANNER'
 
 export type EditorMobileDestination = 'HOME' | 'SAVINGS' | 'CARDS' | 'PAYMENTS' | 'PRODUCT_HUB'
 
+export type EditorInAppSurface = 'HOME_BANNER' | 'HOME_CAROUSEL' | 'PRODUCT_FEED' | 'REWARDS_HUB'
+
 export type EditorCondition = 'IF_PREVIOUS_CONFIRMED' | 'IF_PREVIOUS_NOT_CONFIRMED'
 
 export interface EditorStep {
@@ -46,6 +48,8 @@ export interface EditorStep {
   fallbackToPush?: boolean
   /** Closed app context reached after a push tap; never an arbitrary URL. */
   mobileDestination?: EditorMobileDestination
+  /** Closed in-app inventory for a BANNER step; absent remains the backwards-compatible home banner. */
+  inAppSurface?: EditorInAppSurface
 }
 
 export const MAX_STEPS = 5
@@ -302,7 +306,7 @@ export function JourneyEditor({
                   {t('KROK', 'STEP')} {i + 1} · {step.channel === 'PUSH'
                     ? t('PUSH', 'PUSH')
                     : step.channel === 'BANNER'
-                      ? t('BANNER V APLIKACI', 'IN-APP BANNER')
+                      ? t('PLOCHA V APLIKACI', 'IN-APP SURFACE')
                       : t('E-MAIL', 'EMAIL')}
                 </text>
                 <text x={x + 14 + ICON + 12} y={ROW_Y + 8} fontSize="13.5" fontWeight="600"

--- a/openbank-admin-ui/src/components/campaigns/StepEditor.tsx
+++ b/openbank-admin-ui/src/components/campaigns/StepEditor.tsx
@@ -7,6 +7,13 @@
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import type { EditorChannel, EditorCondition, EditorStep } from '@/components/campaigns/JourneyEditor'
 
+const IN_APP_TEMPLATE: Record<NonNullable<EditorStep['inAppSurface']>, string> = {
+  HOME_BANNER: 'MARKETING_PRODUCT_OFFER_BANNER',
+  HOME_CAROUSEL: 'MARKETING_PRODUCT_OFFER_CAROUSEL',
+  PRODUCT_FEED: 'MARKETING_PRODUCT_OFFER_PRODUCT_FEED',
+  REWARDS_HUB: 'MARKETING_PRODUCT_OFFER_REWARDS_HUB',
+}
+
 /**
  * Edits the step selected on the canvas.
  *
@@ -110,11 +117,14 @@ export function StepEditor({
                 onClick={() => first && onChange({
                   ...step,
                   channel: c,
-                  template: first,
+                  template: c === 'BANNER'
+                    ? IN_APP_TEMPLATE[step.inAppSurface ?? 'HOME_BANNER']
+                    : first,
                   variables: {},
                   ...(c === 'PUSH' || c === 'BANNER'
                     ? { fallbackToPush: false, mobileDestination: step.mobileDestination ?? 'HOME' }
                     : { mobileDestination: undefined }),
+                  ...(c === 'BANNER' ? { inAppSurface: step.inAppSurface ?? 'HOME_BANNER' } : { inAppSurface: undefined }),
                   ...(step.variantBVariables !== undefined ? { variantBVariables: {} } : {}),
                 })}
                 // `.btn` again rather than a hand-rolled box — the third time tonight that a
@@ -167,10 +177,35 @@ export function StepEditor({
           <>
             <p className="text-xs text-muted-foreground">
               {t(
-                'Banner se zobrazí na domovské obrazovce přihlášené aplikace. Není to push a neobjeví se na zamčeném telefonu.',
-                'The banner is shown on the signed-in app home screen. It is not a push and never appears on a locked phone.',
+                'Zvolte přesnou plochu přihlášené aplikace. Není to push a nic se neobjeví na zamčeném telefonu.',
+                'Choose the exact signed-in app surface. It is not a push and never appears on a locked phone.',
               )}
             </p>
+            <label className="mt-3 block space-y-1.5 text-sm" data-in-app-surface={index}>
+              <span className="font-medium">{t('Plocha v aplikaci', 'In-app surface')}</span>
+              <select
+                className={field}
+                value={step.inAppSurface ?? 'HOME_BANNER'}
+                onChange={e => {
+                  const inAppSurface = e.target.value as NonNullable<EditorStep['inAppSurface']>
+                  onChange({
+                    ...step,
+                    inAppSurface,
+                    template: IN_APP_TEMPLATE[inAppSurface],
+                    variables: {},
+                    ...(step.variantBVariables !== undefined ? { variantBVariables: {} } : {}),
+                  })
+                }}
+              >
+                <option value="HOME_BANNER">{t('Banner na domovské obrazovce', 'Home banner')}</option>
+                <option value="HOME_CAROUSEL">{t('Carousel na domovské obrazovce', 'Home carousel')}</option>
+                <option value="PRODUCT_FEED">{t('Feed produktů', 'Product feed')}</option>
+                <option value="REWARDS_HUB">{t('Centrum odměn', 'Rewards hub')}</option>
+              </select>
+              <span className="block text-xs text-muted-foreground">
+                {t('Každá plocha má schválený tvar karty; šablona se přepne spolu s ní.', 'Each surface has an approved card shape; its template changes with the surface.')}
+              </span>
+            </label>
             <label className="mt-3 block space-y-1.5 text-sm" data-mobile-destination={index}>
               <span className="font-medium">{t('Po klepnutí otevřít', 'Open after tap')}</span>
               <select
@@ -225,7 +260,9 @@ export function StepEditor({
             ...(step.variantBVariables !== undefined ? { variantBVariables: {} } : {}),
           })}
         >
-          {Object.keys(templates).filter(tpl => templateChannel[tpl] === step.channel).map(tpl => (
+          {Object.keys(templates).filter(tpl => templateChannel[tpl] === step.channel && (
+            step.channel !== 'BANNER' || tpl === IN_APP_TEMPLATE[step.inAppSurface ?? 'HOME_BANNER']
+          )).map(tpl => (
             <option key={tpl} value={tpl}>
               {templateLabels[tpl] ?? tpl}
             </option>
@@ -240,8 +277,8 @@ export function StepEditor({
               )
             : step.channel === 'BANNER'
               ? t(
-                  'Banner používá schválenou kartu aplikace. Tady se vyplňují jen její pojmenované hodnoty.',
-                  'The banner uses an approved in-app card. Only its named values are filled in here.',
+                  'Plocha používá schválenou kartu aplikace. Tady se vyplňují jen její pojmenované hodnoty.',
+                  'The surface uses an approved in-app card. Only its named values are filled in here.',
                 )
               : t(
                 'Text e-mailu je v šabloně. Tady se vyplňují jen její pojmenované hodnoty.',

--- a/openbank-admin-ui/src/test/campaign-experience-preview.test.tsx
+++ b/openbank-admin-ui/src/test/campaign-experience-preview.test.tsx
@@ -52,8 +52,22 @@ describe('campaign customer experience preview', () => {
     )
 
     expect(container.querySelector('[data-preview-channel="BANNER"]')).toBeTruthy()
-    expect(screen.getByText(/Banner in the signed-in app/)).toBeTruthy()
+    expect(screen.getAllByText(/Home banner/)).toHaveLength(2)
     expect(screen.getByText(/No interruption, no lock screen/)).toBeTruthy()
+  })
+
+  it('renders the selected carousel surface in the live app preview', () => {
+    const { container } = render(
+      <LanguageProvider>
+        <CampaignExperiencePreview
+          step={{ ...push, channel: 'BANNER', template: 'MARKETING_PRODUCT_OFFER_CAROUSEL', inAppSurface: 'HOME_CAROUSEL' }}
+          campaignName="Summer saving"
+        />
+      </LanguageProvider>,
+    )
+
+    expect(container.querySelector('[data-preview-surface="HOME_CAROUSEL"]')).toBeTruthy()
+    expect(screen.getAllByText(/Home carousel/)).toHaveLength(2)
   })
 })
 

--- a/openbank-admin-ui/src/test/journey-editor.test.tsx
+++ b/openbank-admin-ui/src/test/journey-editor.test.tsx
@@ -13,11 +13,17 @@ const TEMPLATES = {
   MARKETING_PRODUCT_OFFER: ['offerTitle', 'offerText', 'ctaText'],
   MARKETING_PRODUCT_OFFER_PUSH: ['offerTitle'],
   MARKETING_PRODUCT_OFFER_BANNER: ['offerTitle', 'offerText', 'ctaText'],
+  MARKETING_PRODUCT_OFFER_CAROUSEL: ['offerTitle', 'offerText', 'ctaText'],
+  MARKETING_PRODUCT_OFFER_PRODUCT_FEED: ['offerTitle', 'offerText', 'ctaText'],
+  MARKETING_PRODUCT_OFFER_REWARDS_HUB: ['offerTitle', 'offerText', 'ctaText'],
 }
 const TPL_CHANNEL = {
   MARKETING_PRODUCT_OFFER: 'EMAIL' as const,
   MARKETING_PRODUCT_OFFER_PUSH: 'PUSH' as const,
   MARKETING_PRODUCT_OFFER_BANNER: 'BANNER' as const,
+  MARKETING_PRODUCT_OFFER_CAROUSEL: 'BANNER' as const,
+  MARKETING_PRODUCT_OFFER_PRODUCT_FEED: 'BANNER' as const,
+  MARKETING_PRODUCT_OFFER_REWARDS_HUB: 'BANNER' as const,
 }
 
 // The editor labels a variable in the marketer's words. The mapping is data, so the test carries its
@@ -182,6 +188,25 @@ describe('step editor', () => {
     fireEvent.click(document.querySelector('[data-channel-pick="BANNER"]')!)
     expect(onChange).toHaveBeenCalledWith(expect.objectContaining({
       channel: 'BANNER', template: 'MARKETING_PRODUCT_OFFER_BANNER', mobileDestination: 'HOME',
+    }))
+  })
+
+  it('switches a campaign placement to its matching carousel template', () => {
+    const onChange = vi.fn()
+    const banner: EditorStep = {
+      channel: 'BANNER', template: 'MARKETING_PRODUCT_OFFER_BANNER', variables: {}, delaySeconds: 0,
+      mobileDestination: 'HOME', inAppSurface: 'HOME_BANNER',
+    }
+    render(
+      React.createElement(LanguageProvider, null,
+        React.createElement(StepEditor, {
+          index: 0, step: banner, templates: TEMPLATES, templateChannel: TPL_CHANNEL, templateLabels: LABELS, variableLabels: VAR_LABELS,
+          onChange, onClose: vi.fn(),
+        })))
+
+    fireEvent.change(document.querySelector('[data-in-app-surface="0"] select')!, { target: { value: 'HOME_CAROUSEL' } })
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({
+      inAppSurface: 'HOME_CAROUSEL', template: 'MARKETING_PRODUCT_OFFER_CAROUSEL',
     }))
   })
 })

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/port/out/Ports.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/port/out/Ports.kt
@@ -5,12 +5,12 @@
 package com.openbank.campaign.application.port.out
 
 import com.openbank.campaign.domain.model.Campaign
-import com.openbank.campaign.domain.model.InAppSurface
 import com.openbank.campaign.domain.model.Channel
 import com.openbank.campaign.domain.model.ContentVariant
 import com.openbank.campaign.domain.model.DeliveryStatus
 import com.openbank.campaign.domain.model.Enrolment
 import com.openbank.campaign.domain.model.ExperimentCohort
+import com.openbank.campaign.domain.model.InAppSurface
 import com.openbank.campaign.domain.model.Segment
 import com.openbank.campaign.domain.model.SendOutcome
 import com.openbank.campaign.domain.model.SendRecord

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/port/out/Ports.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/port/out/Ports.kt
@@ -5,6 +5,7 @@
 package com.openbank.campaign.application.port.out
 
 import com.openbank.campaign.domain.model.Campaign
+import com.openbank.campaign.domain.model.InAppSurface
 import com.openbank.campaign.domain.model.Channel
 import com.openbank.campaign.domain.model.ContentVariant
 import com.openbank.campaign.domain.model.DeliveryStatus
@@ -222,7 +223,7 @@ interface NotificationSendPort {
     suspend fun requestSend(request: NotificationSendRequest)
 }
 
-/** One approved, customer-specific placement for the authenticated app home surface. */
+/** One approved, customer-specific placement for a closed authenticated-app surface. */
 data class BannerPlacementRequest(
     val interactionRef: UUID,
     val partyId: UUID,
@@ -231,6 +232,7 @@ data class BannerPlacementRequest(
     val template: String,
     val variables: Map<String, String>,
     val deepLink: String,
+    val inAppSurface: InAppSurface,
 )
 
 /** Campaign emits placement commands; engagement-service owns rendering and event recording. */

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/workflow/CampaignJourneyActivitiesImpl.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/workflow/CampaignJourneyActivitiesImpl.kt
@@ -189,6 +189,7 @@ open class CampaignJourneyActivitiesImpl(
                         template = delivery.template,
                         variables = delivery.variables,
                         deepLink = requireNotNull(delivery.deepLink),
+                        inAppSurface = requireNotNull(delivery.inAppSurface),
                     ),
                 )
             } else {

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/domain/model/Campaign.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/domain/model/Campaign.kt
@@ -274,7 +274,8 @@ data class CampaignStep(
         template,
         TemplateCatalog.valuesFor(template, variablesFor(variant)),
         mobileDestination?.deepLink.takeIf { channel == Channel.PUSH || channel == Channel.BANNER },
-        inAppSurface?.takeIf { channel == Channel.BANNER } ?: InAppSurface.HOME_BANNER.takeIf { channel == Channel.BANNER },
+        inAppSurface?.takeIf { channel == Channel.BANNER }
+            ?: InAppSurface.HOME_BANNER.takeIf { channel == Channel.BANNER },
     )
 
     /** The only supported fallback: a consented app push after EMAIL consent was absent. */

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/domain/model/Campaign.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/domain/model/Campaign.kt
@@ -209,6 +209,12 @@ data class CampaignStep(
     val fallbackToPush: Boolean = false,
     /** A closed, app-owned destination for a push tap — never author-entered URL text. */
     val mobileDestination: MobileDestination? = null,
+    /**
+     * The authenticated-app slot a BANNER step is allowed to occupy. Null keeps placements created
+     * before multi-surface support on HOME_BANNER; it is resolved before a command leaves this
+     * service, so engagement never has to guess a customer's intended surface.
+     */
+    val inAppSurface: InAppSurface? = null,
 ) {
     init {
         require(order >= 0) { "step order must be >= 0" }
@@ -248,6 +254,14 @@ data class CampaignStep(
         require(mobileDestination == null || channel == Channel.PUSH || channel == Channel.BANNER || fallbackToPush) {
             "a mobile destination requires a PUSH or BANNER step, or an EMAIL step with PUSH fallback"
         }
+        require(inAppSurface == null || channel == Channel.BANNER) {
+            "an in-app surface requires a BANNER step"
+        }
+        if (channel == Channel.BANNER) {
+            require(template == TemplateCatalog.templateForInAppSurface(inAppSurface ?: InAppSurface.HOME_BANNER)) {
+                "template '$template' does not render on ${inAppSurface ?: InAppSurface.HOME_BANNER}"
+            }
+        }
     }
 
     /** Resolves content after the durable enrolment assignment, never randomly at send time. */
@@ -260,6 +274,7 @@ data class CampaignStep(
         template,
         TemplateCatalog.valuesFor(template, variablesFor(variant)),
         mobileDestination?.deepLink.takeIf { channel == Channel.PUSH || channel == Channel.BANNER },
+        inAppSurface?.takeIf { channel == Channel.BANNER } ?: InAppSurface.HOME_BANNER.takeIf { channel == Channel.BANNER },
     )
 
     /** The only supported fallback: a consented app push after EMAIL consent was absent. */
@@ -281,6 +296,7 @@ data class CampaignDelivery(
     val template: String,
     val variables: Map<String, String>,
     val deepLink: String? = null,
+    val inAppSurface: InAppSurface? = null,
 )
 
 /** The only destinations the mobile app contract recognises for campaign push and banner taps. */
@@ -291,6 +307,9 @@ enum class MobileDestination(val deepLink: String) {
     PAYMENTS("openbank://payments"),
     PRODUCT_HUB("openbank://products"),
 }
+
+/** Closed app inventory a campaign may use; STORIES remains product-owned, not a campaign slot. */
+enum class InAppSurface { HOME_BANNER, HOME_CAROUSEL, PRODUCT_FEED, REWARDS_HUB }
 
 /**
  * Delivery channels a campaign step may use.

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/domain/model/TemplateCatalog.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/domain/model/TemplateCatalog.kt
@@ -41,6 +41,9 @@ object TemplateCatalog {
         // A banner renders only in the authenticated app, so its approved card may contain the
         // offer body and CTA. It remains a closed template, never marketer-authored markup.
         "MARKETING_PRODUCT_OFFER_BANNER" to setOf("offerTitle", "offerText", "ctaText"),
+        "MARKETING_PRODUCT_OFFER_CAROUSEL" to setOf("offerTitle", "offerText", "ctaText"),
+        "MARKETING_PRODUCT_OFFER_PRODUCT_FEED" to setOf("offerTitle", "offerText", "ctaText"),
+        "MARKETING_PRODUCT_OFFER_REWARDS_HUB" to setOf("offerTitle", "offerText", "ctaText"),
     )
 
     /**
@@ -54,6 +57,9 @@ object TemplateCatalog {
         "MARKETING_PRODUCT_OFFER" to Channel.EMAIL,
         "MARKETING_PRODUCT_OFFER_PUSH" to Channel.PUSH,
         "MARKETING_PRODUCT_OFFER_BANNER" to Channel.BANNER,
+        "MARKETING_PRODUCT_OFFER_CAROUSEL" to Channel.BANNER,
+        "MARKETING_PRODUCT_OFFER_PRODUCT_FEED" to Channel.BANNER,
+        "MARKETING_PRODUCT_OFFER_REWARDS_HUB" to Channel.BANNER,
     )
 
     /**
@@ -68,6 +74,14 @@ object TemplateCatalog {
 
     /** Templates renderable on [channel] — what an authoring screen may offer for a step. */
     fun forChannel(channel: Channel): Set<String> = CHANNEL_OF.filterValues { it == channel }.keys
+
+    /** The reviewed template is coupled to its app surface: a payload cannot masquerade as another shape. */
+    fun templateForInAppSurface(surface: InAppSurface): String = when (surface) {
+        InAppSurface.HOME_BANNER -> "MARKETING_PRODUCT_OFFER_BANNER"
+        InAppSurface.HOME_CAROUSEL -> "MARKETING_PRODUCT_OFFER_CAROUSEL"
+        InAppSurface.PRODUCT_FEED -> "MARKETING_PRODUCT_OFFER_PRODUCT_FEED"
+        InAppSurface.REWARDS_HUB -> "MARKETING_PRODUCT_OFFER_REWARDS_HUB"
+    }
 
     fun exists(template: String): Boolean = template in ALL
 

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/kafka/KafkaNotificationSendAdapter.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/kafka/KafkaNotificationSendAdapter.kt
@@ -79,6 +79,7 @@ class KafkaBannerPlacementAdapter(
                 "template" to request.template,
                 "variables" to request.variables,
                 "deepLink" to request.deepLink,
+                "inAppSurface" to request.inAppSurface.name,
             ),
         )
         // The compacted placement topic retains the current assignment for this send interaction.

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/rest/CampaignResource.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/rest/CampaignResource.kt
@@ -8,8 +8,8 @@ import com.openbank.campaign.application.usecase.CampaignService
 import com.openbank.campaign.domain.model.CampaignSchedule
 import com.openbank.campaign.domain.model.CampaignStep
 import com.openbank.campaign.domain.model.Channel
-import com.openbank.campaign.domain.model.MobileDestination
 import com.openbank.campaign.domain.model.InAppSurface
+import com.openbank.campaign.domain.model.MobileDestination
 import com.openbank.campaign.domain.model.SegmentRef
 import com.openbank.campaign.domain.model.StepCondition
 import com.openbank.campaign.domain.model.StopCondition

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/rest/CampaignResource.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/rest/CampaignResource.kt
@@ -9,6 +9,7 @@ import com.openbank.campaign.domain.model.CampaignSchedule
 import com.openbank.campaign.domain.model.CampaignStep
 import com.openbank.campaign.domain.model.Channel
 import com.openbank.campaign.domain.model.MobileDestination
+import com.openbank.campaign.domain.model.InAppSurface
 import com.openbank.campaign.domain.model.SegmentRef
 import com.openbank.campaign.domain.model.StepCondition
 import com.openbank.campaign.domain.model.StopCondition
@@ -81,6 +82,8 @@ data class StepRequest(
     val fallbackToPush: Boolean = false,
     /** Closed in-app destination opened when the customer taps the resulting PUSH notification. */
     val mobileDestination: MobileDestination? = null,
+    /** Closed authenticated-app inventory for a BANNER placement; absent preserves HOME_BANNER. */
+    val inAppSurface: InAppSurface? = null,
 )
 
 /**
@@ -143,6 +146,7 @@ class CampaignResource(private val service: CampaignService, private val jwt: Js
                 it.variantBVariables,
                 it.fallbackToPush,
                 it.mobileDestination,
+                it.inAppSurface,
             )
         }
         val campaign = service.createDraft(

--- a/openbank-campaign-service/src/main/resources/openapi.yaml
+++ b/openbank-campaign-service/src/main/resources/openapi.yaml
@@ -4,7 +4,7 @@ openapi: 3.1.0
 info:
   title: Campaign Service API
   # major == openbank.api.version == URL /api/v1 (ADR-0048).
-  version: 1.25.0
+  version: 1.26.0
   description: >-
     Campaign management first slice (ADR-0200 / ADR-0209 D3): deterministic, versioned segments;
     per-enrolment Temporal journeys; consent-gated delivery through notification-service.
@@ -629,7 +629,8 @@ components:
           description: >-
             Optional on create; absent means EMAIL. Must agree with the template's own channel —
             MARKETING_PRODUCT_OFFER renders on EMAIL, MARKETING_PRODUCT_OFFER_PUSH on PUSH and
-            MARKETING_PRODUCT_OFFER_BANNER on BANNER — and a
+            MARKETING_PRODUCT_OFFER_BANNER, MARKETING_PRODUCT_OFFER_CAROUSEL,
+            MARKETING_PRODUCT_OFFER_PRODUCT_FEED and MARKETING_PRODUCT_OFFER_REWARDS_HUB on BANNER — and a
             mismatch is rejected with 400.
         variables:
           type: object
@@ -660,6 +661,14 @@ components:
             Bank-owned destination opened after a PUSH or BANNER tap. This is a closed app-route contract,
             never an author-entered URL; absent preserves existing campaigns. It is valid on a
             PUSH or BANNER step, or on an EMAIL step only when its consent-missing fallback is PUSH.
+        inAppSurface:
+          type: string
+          nullable: true
+          enum: [HOME_BANNER, HOME_CAROUSEL, PRODUCT_FEED, REWARDS_HUB]
+          description: >-
+            Closed authenticated-app inventory for a BANNER step. Absent retains HOME_BANNER for
+            backwards-compatible placements. Each surface has its own reviewed template shape;
+            the service rejects a BANNER template that does not match this value.
         delaySeconds: { type: integer, minimum: 0 }
         condition:
           description: >-

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/domain/TemplateCatalogTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/domain/TemplateCatalogTest.kt
@@ -7,6 +7,7 @@ package com.openbank.campaign.domain
 import com.openbank.campaign.domain.model.CampaignStep
 import com.openbank.campaign.domain.model.Channel
 import com.openbank.campaign.domain.model.MobileDestination
+import com.openbank.campaign.domain.model.InAppSurface
 import com.openbank.campaign.domain.model.TemplateCatalog
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -101,7 +102,45 @@ class CampaignStepChannelTest {
         )
 
         assertEquals("openbank://savings", step.primaryDelivery(null).deepLink)
-        assertEquals(setOf("MARKETING_PRODUCT_OFFER_BANNER"), TemplateCatalog.forChannel(Channel.BANNER))
+        assertEquals(
+            setOf(
+                "MARKETING_PRODUCT_OFFER_BANNER",
+                "MARKETING_PRODUCT_OFFER_CAROUSEL",
+                "MARKETING_PRODUCT_OFFER_PRODUCT_FEED",
+                "MARKETING_PRODUCT_OFFER_REWARDS_HUB",
+            ),
+            TemplateCatalog.forChannel(Channel.BANNER),
+        )
+    }
+
+    @Test
+    fun `a carousel placement carries its selected surface through delivery`() {
+        val step = CampaignStep(
+            order = 1,
+            template = "MARKETING_PRODUCT_OFFER_CAROUSEL",
+            channel = Channel.BANNER,
+            variables = mapOf("offerTitle" to "Savings", "offerText" to "Four percent", "ctaText" to "Explore"),
+            delaySeconds = 0,
+            mobileDestination = MobileDestination.SAVINGS,
+            inAppSurface = InAppSurface.HOME_CAROUSEL,
+        )
+
+        assertEquals(InAppSurface.HOME_CAROUSEL, step.primaryDelivery(null).inAppSurface)
+    }
+
+    @Test
+    fun `a banner template cannot be posted to a different app surface`() {
+        assertThrows<IllegalArgumentException> {
+            CampaignStep(
+                order = 1,
+                template = "MARKETING_PRODUCT_OFFER_BANNER",
+                channel = Channel.BANNER,
+                variables = emptyMap(),
+                delaySeconds = 0,
+                mobileDestination = MobileDestination.HOME,
+                inAppSurface = InAppSurface.PRODUCT_FEED,
+            )
+        }
     }
 
     @Test

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/domain/TemplateCatalogTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/domain/TemplateCatalogTest.kt
@@ -6,8 +6,8 @@ package com.openbank.campaign.domain
 
 import com.openbank.campaign.domain.model.CampaignStep
 import com.openbank.campaign.domain.model.Channel
-import com.openbank.campaign.domain.model.MobileDestination
 import com.openbank.campaign.domain.model.InAppSurface
+import com.openbank.campaign.domain.model.MobileDestination
 import com.openbank.campaign.domain.model.TemplateCatalog
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue

--- a/openbank-contracts/openbank-campaign-service/asyncapi.yaml
+++ b/openbank-contracts/openbank-campaign-service/asyncapi.yaml
@@ -24,20 +24,23 @@ channels:
   campaignBannerPlacements:
     address: openbank.campaign.banner.placements
     description: |
-      First-party HOME_BANNER placement command emitted by KafkaBannerPlacementAdapter and consumed
+      First-party app-surface placement command emitted by KafkaBannerPlacementAdapter and consumed
       by engagement-service. The compacted record key is the opaque interactionRef, so retries
       remain idempotent and do not create a second customer surface.
 components:
   schemas:
     campaignBannerPlacement:
       type: object
-      required: [interactionRef, partyId, campaignId, stepOrder, template, variables, deepLink]
+      required: [interactionRef, partyId, campaignId, stepOrder, template, variables, deepLink, inAppSurface]
       properties:
         interactionRef: { type: string, format: uuid, description: Campaign send-log id and opaque app interaction reference. }
         partyId: { type: string, format: uuid }
         campaignId: { type: string, format: uuid }
         stepOrder: { type: integer, minimum: 0 }
-        template: { type: string, enum: [MARKETING_PRODUCT_OFFER_BANNER] }
+        template:
+          type: string
+          enum: [MARKETING_PRODUCT_OFFER_BANNER, MARKETING_PRODUCT_OFFER_CAROUSEL, MARKETING_PRODUCT_OFFER_PRODUCT_FEED, MARKETING_PRODUCT_OFFER_REWARDS_HUB]
+        inAppSurface: { type: string, enum: [HOME_BANNER, HOME_CAROUSEL, PRODUCT_FEED, REWARDS_HUB] }
         variables:
           type: object
           additionalProperties: { type: string }

--- a/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/application/port/out/Ports.kt
+++ b/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/application/port/out/Ports.kt
@@ -37,9 +37,9 @@ interface AdverseStateRepository {
     suspend fun activeStates(partyId: UUID): Set<AdverseState>
 }
 
-/** Latest campaign banner wins for the fixed HOME_BANNER slot; no hidden ranking system exists. */
+/** Latest placement wins within each closed app surface; there is no hidden cross-surface ranking. */
 interface CampaignBannerPlacementRepository {
     suspend fun save(placement: CampaignBannerPlacement)
-    suspend fun latestForParty(partyId: UUID): CampaignBannerPlacement?
-    suspend fun belongsToParty(interactionRef: UUID, partyId: UUID): Boolean
+    suspend fun latestForPartyAndSlot(partyId: UUID, slot: SurfaceSlot): CampaignBannerPlacement?
+    suspend fun belongsToPartyAtSlot(interactionRef: UUID, partyId: UUID, slot: SurfaceSlot): Boolean
 }

--- a/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/application/usecase/ResolveSurfaceUseCase.kt
+++ b/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/application/usecase/ResolveSurfaceUseCase.kt
@@ -80,9 +80,9 @@ class ResolveSurfaceUseCase(
             asOf = Instant.now(),
         )
         val catalogue = SurfaceResolver.resolve(slot, eligibility)
-        val campaignBanner = if (slot == SurfaceSlot.HOME_BANNER) banners.latestForParty(partyId) else null
-        // The home slot intentionally has one campaign surface, with no opaque score or rotation.
-        // A current campaign placement comes before the generic catalogue fallback.
+        val campaignBanner = banners.latestForPartyAndSlot(partyId, slot)
+        // Each slot intentionally has one current campaign placement, with no opaque score or
+        // cross-surface rotation. It comes before that slot's generic catalogue fallback.
         return Result.Rendered(listOfNotNull(campaignBanner?.toSurfaceContent()) + catalogue)
     }
 

--- a/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/domain/model/CampaignBannerPlacement.kt
+++ b/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/domain/model/CampaignBannerPlacement.kt
@@ -6,7 +6,7 @@ package com.openbank.engagement.domain.model
 import java.time.Instant
 import java.util.UUID
 
-/** A campaign-approved card for the one supported campaign slot, the signed-in app home banner. */
+/** A campaign-approved card for one closed authenticated-app surface. */
 data class CampaignBannerPlacement(
     val interactionRef: UUID,
     val partyId: UUID,
@@ -16,18 +16,19 @@ data class CampaignBannerPlacement(
     val values: Map<String, String>,
     val deepLink: String,
     val placedAt: Instant,
+    val slot: SurfaceSlot = SurfaceSlot.HOME_BANNER,
 ) {
     init {
         require(stepOrder >= 0) { "campaign step order must be non-negative" }
-        require(template == PRODUCT_OFFER_BANNER_TEMPLATE) { "unknown campaign banner template '$template'" }
+        require(template == templateFor(slot)) { "template '$template' does not render in $slot" }
         require(values.keys.all { it in PRODUCT_OFFER_BANNER_VARIABLES }) { "banner has undeclared variables" }
         require(deepLink.startsWith("openbank://")) { "banner deep link must be an app route" }
     }
 
     fun toSurfaceContent(): SurfaceContent = SurfaceContent(
-        id = CAMPAIGN_BANNER_CONTENT_ID,
-        slot = SurfaceSlot.HOME_BANNER,
-        type = SurfaceContentType.BANNER,
+        id = contentIdFor(slot),
+        slot = slot,
+        type = typeFor(slot),
         variables = PRODUCT_OFFER_BANNER_VARIABLES,
         values = values,
         deepLink = deepLink,
@@ -38,5 +39,31 @@ data class CampaignBannerPlacement(
         const val CAMPAIGN_BANNER_CONTENT_ID = "CAMPAIGN_HOME_BANNER"
         const val PRODUCT_OFFER_BANNER_TEMPLATE = "MARKETING_PRODUCT_OFFER_BANNER"
         val PRODUCT_OFFER_BANNER_VARIABLES = setOf("offerTitle", "offerText", "ctaText")
+
+        fun templateFor(slot: SurfaceSlot): String = when (slot) {
+            SurfaceSlot.HOME_BANNER -> PRODUCT_OFFER_BANNER_TEMPLATE
+            SurfaceSlot.HOME_CAROUSEL -> "MARKETING_PRODUCT_OFFER_CAROUSEL"
+            SurfaceSlot.PRODUCT_FEED -> "MARKETING_PRODUCT_OFFER_PRODUCT_FEED"
+            SurfaceSlot.REWARDS_HUB -> "MARKETING_PRODUCT_OFFER_REWARDS_HUB"
+            SurfaceSlot.STORIES -> error("campaign placements do not render in STORIES")
+        }
+
+        fun contentIdFor(slot: SurfaceSlot): String = "CAMPAIGN_${slot.name}"
+
+        fun isCampaignContentId(contentId: String): Boolean = contentId in campaignSlots.map(::contentIdFor)
+
+        private fun typeFor(slot: SurfaceSlot): SurfaceContentType = when (slot) {
+            SurfaceSlot.HOME_BANNER -> SurfaceContentType.BANNER
+            SurfaceSlot.HOME_CAROUSEL -> SurfaceContentType.CAROUSEL
+            SurfaceSlot.PRODUCT_FEED, SurfaceSlot.REWARDS_HUB -> SurfaceContentType.CARD
+            SurfaceSlot.STORIES -> error("campaign placements do not render in STORIES")
+        }
+
+        private val campaignSlots = setOf(
+            SurfaceSlot.HOME_BANNER,
+            SurfaceSlot.HOME_CAROUSEL,
+            SurfaceSlot.PRODUCT_FEED,
+            SurfaceSlot.REWARDS_HUB,
+        )
     }
 }

--- a/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/infrastructure/kafka/CampaignBannerPlacementConsumer.kt
+++ b/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/infrastructure/kafka/CampaignBannerPlacementConsumer.kt
@@ -6,6 +6,7 @@ package com.openbank.engagement.infrastructure.kafka
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.openbank.engagement.application.port.out.CampaignBannerPlacementRepository
 import com.openbank.engagement.domain.model.CampaignBannerPlacement
+import com.openbank.engagement.domain.model.SurfaceSlot
 import jakarta.enterprise.context.ApplicationScoped
 import org.eclipse.microprofile.reactive.messaging.Incoming
 import org.jboss.logging.Logger
@@ -34,6 +35,8 @@ class CampaignBannerPlacementConsumer(
                 values = mapper.convertValue(node.required("variables"), MAP_TYPE),
                 deepLink = node.requiredText("deepLink"),
                 placedAt = Instant.now(),
+                slot = SurfaceSlot.entries.find { it.name == node.requiredText("inAppSurface") }
+                    ?: error("unknown inAppSurface"),
             )
             placements.save(placement)
         } catch (e: Exception) {

--- a/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/infrastructure/persistence/entity/CampaignBannerPlacementEntity.kt
+++ b/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/infrastructure/persistence/entity/CampaignBannerPlacementEntity.kt
@@ -6,6 +6,7 @@ package com.openbank.engagement.infrastructure.persistence.entity
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.openbank.engagement.domain.model.CampaignBannerPlacement
+import com.openbank.engagement.domain.model.SurfaceSlot
 import io.quarkus.hibernate.reactive.panache.PanacheEntityBase
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
@@ -39,6 +40,9 @@ class CampaignBannerPlacementEntity : PanacheEntityBase() {
     lateinit var deepLink: String
 
     @Column(nullable = false)
+    lateinit var slot: String
+
+    @Column(nullable = false)
     lateinit var placedAt: Instant
 
     fun toDomain(mapper: ObjectMapper) = CampaignBannerPlacement(
@@ -50,6 +54,7 @@ class CampaignBannerPlacementEntity : PanacheEntityBase() {
         mapper.readValue(valuesJson),
         deepLink,
         placedAt,
+        SurfaceSlot.valueOf(slot),
     )
 
     companion object {
@@ -62,6 +67,7 @@ class CampaignBannerPlacementEntity : PanacheEntityBase() {
             valuesJson = mapper.writeValueAsString(placement.values)
             deepLink = placement.deepLink
             placedAt = placement.placedAt
+            slot = placement.slot.name
         }
     }
 }

--- a/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/infrastructure/persistence/repository/CampaignBannerPlacementRepositoryImpl.kt
+++ b/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/infrastructure/persistence/repository/CampaignBannerPlacementRepositoryImpl.kt
@@ -24,11 +24,15 @@ class CampaignBannerPlacementRepositoryImpl(private val mapper: ObjectMapper) :
         }.awaitSuspending()
     }
 
-    override suspend fun latestForParty(partyId: UUID): CampaignBannerPlacement? = Panache.withSession {
-        find("partyId = ?1 order by placedAt desc", partyId).firstResult()
+    override suspend fun latestForPartyAndSlot(partyId: UUID, slot: com.openbank.engagement.domain.model.SurfaceSlot): CampaignBannerPlacement? = Panache.withSession {
+        find("partyId = ?1 and slot = ?2 order by placedAt desc", partyId, slot.name).firstResult()
     }.awaitSuspending()?.toDomain(mapper)
 
-    override suspend fun belongsToParty(interactionRef: UUID, partyId: UUID): Boolean = Panache.withSession {
-        count("interactionRef = ?1 and partyId = ?2", interactionRef, partyId)
+    override suspend fun belongsToPartyAtSlot(
+        interactionRef: UUID,
+        partyId: UUID,
+        slot: com.openbank.engagement.domain.model.SurfaceSlot,
+    ): Boolean = Panache.withSession {
+        count("interactionRef = ?1 and partyId = ?2 and slot = ?3", interactionRef, partyId, slot.name)
     }.awaitSuspending() == 1L
 }

--- a/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/infrastructure/persistence/repository/CampaignBannerPlacementRepositoryImpl.kt
+++ b/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/infrastructure/persistence/repository/CampaignBannerPlacementRepositoryImpl.kt
@@ -6,6 +6,7 @@ package com.openbank.engagement.infrastructure.persistence.repository
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.openbank.engagement.application.port.out.CampaignBannerPlacementRepository
 import com.openbank.engagement.domain.model.CampaignBannerPlacement
+import com.openbank.engagement.domain.model.SurfaceSlot
 import com.openbank.engagement.infrastructure.persistence.entity.CampaignBannerPlacementEntity
 import io.quarkus.hibernate.reactive.panache.Panache
 import io.quarkus.hibernate.reactive.panache.kotlin.PanacheRepository
@@ -24,15 +25,13 @@ class CampaignBannerPlacementRepositoryImpl(private val mapper: ObjectMapper) :
         }.awaitSuspending()
     }
 
-    override suspend fun latestForPartyAndSlot(partyId: UUID, slot: com.openbank.engagement.domain.model.SurfaceSlot): CampaignBannerPlacement? = Panache.withSession {
-        find("partyId = ?1 and slot = ?2 order by placedAt desc", partyId, slot.name).firstResult()
-    }.awaitSuspending()?.toDomain(mapper)
+    override suspend fun latestForPartyAndSlot(partyId: UUID, slot: SurfaceSlot): CampaignBannerPlacement? =
+        Panache.withSession {
+            find("partyId = ?1 and slot = ?2 order by placedAt desc", partyId, slot.name).firstResult()
+        }.awaitSuspending()?.toDomain(mapper)
 
-    override suspend fun belongsToPartyAtSlot(
-        interactionRef: UUID,
-        partyId: UUID,
-        slot: com.openbank.engagement.domain.model.SurfaceSlot,
-    ): Boolean = Panache.withSession {
-        count("interactionRef = ?1 and partyId = ?2 and slot = ?3", interactionRef, partyId, slot.name)
-    }.awaitSuspending() == 1L
+    override suspend fun belongsToPartyAtSlot(interactionRef: UUID, partyId: UUID, slot: SurfaceSlot): Boolean =
+        Panache.withSession {
+            count("interactionRef = ?1 and partyId = ?2 and slot = ?3", interactionRef, partyId, slot.name)
+        }.awaitSuspending() == 1L
 }

--- a/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/infrastructure/rest/SurfaceResource.kt
+++ b/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/infrastructure/rest/SurfaceResource.kt
@@ -90,7 +90,7 @@ class SurfaceResource(
             null
         }
         if (campaignAttribution?.channel == "BANNER" && !content.isCampaignPlacement) {
-            return badRequest("campaign banner attribution must name its assigned banner")
+            return badRequest("campaign banner attribution must name its assigned app placement")
         }
         record.record(
             EngagementEvent(
@@ -111,11 +111,10 @@ class SurfaceResource(
         val catalogue = SurfaceCatalog.ALL[request.contentId]
         if (catalogue != null) return catalogue.takeIf { it.slot == slot }?.let { ValidatedContent(false) }
 
-        val isCampaignPlacement = request.contentId == CampaignBannerPlacement.CAMPAIGN_BANNER_CONTENT_ID &&
+        val isCampaignPlacement = CampaignBannerPlacement.isCampaignContentId(request.contentId) &&
             request.interactionRef != null &&
-            banners.belongsToParty(request.interactionRef, request.partyId)
-        val isInteractiveCampaignPlacement =
-            isCampaignPlacement && slot == SurfaceSlot.HOME_BANNER && request.type in INTERACTION_EVENT_TYPES
+            banners.belongsToPartyAtSlot(request.interactionRef, request.partyId, slot)
+        val isInteractiveCampaignPlacement = isCampaignPlacement && request.type in INTERACTION_EVENT_TYPES
         return if (isInteractiveCampaignPlacement) {
             ValidatedContent(true)
         } else {

--- a/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/infrastructure/rest/SurfaceResource.kt
+++ b/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/infrastructure/rest/SurfaceResource.kt
@@ -72,8 +72,7 @@ class SurfaceResource(
         val slot = parseSlot(request.slot) ?: return badRequest("unknown slot '${request.slot}'")
         val type = EngagementEventType.entries.find { it.name == request.type }
             ?: return badRequest("unknown event type '${request.type}'")
-        val content = validateContent(request, slot)
-            ?: return badRequest("unknown or incompatible content '${request.contentId}'")
+        val content = validateContent(request, slot) ?: return badRequest("unknown or incompatible content '${request.contentId}'")
         val campaignFields = listOf(request.campaignId, request.stepOrder, request.channel)
         val campaignAttribution = if (campaignFields.any { it != null }) {
             if (request.interactionRef == null || campaignFields.any { it == null }) {
@@ -114,13 +113,9 @@ class SurfaceResource(
         val isCampaignPlacement = request.contentId == CampaignBannerPlacement.CAMPAIGN_BANNER_CONTENT_ID &&
             request.interactionRef != null &&
             banners.belongsToParty(request.interactionRef, request.partyId)
-        val isInteractiveCampaignPlacement =
-            isCampaignPlacement && slot == SurfaceSlot.HOME_BANNER && request.type in INTERACTION_EVENT_TYPES
-        return if (isInteractiveCampaignPlacement) {
-            ValidatedContent(true)
-        } else {
-            null
-        }
+        return isCampaignPlacement
+            .takeIf { slot == SurfaceSlot.HOME_BANNER && request.type in INTERACTION_EVENT_TYPES }
+            ?.let { ValidatedContent(true) }
     }
 
     private fun parseSlot(name: String): SurfaceSlot? = SurfaceSlot.entries.find { it.name == name }

--- a/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/infrastructure/rest/SurfaceResource.kt
+++ b/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/infrastructure/rest/SurfaceResource.kt
@@ -113,9 +113,13 @@ class SurfaceResource(
         val isCampaignPlacement = request.contentId == CampaignBannerPlacement.CAMPAIGN_BANNER_CONTENT_ID &&
             request.interactionRef != null &&
             banners.belongsToParty(request.interactionRef, request.partyId)
-        return isCampaignPlacement
-            .takeIf { slot == SurfaceSlot.HOME_BANNER && request.type in INTERACTION_EVENT_TYPES }
-            ?.let { ValidatedContent(true) }
+        val isInteractiveCampaignPlacement =
+            isCampaignPlacement && slot == SurfaceSlot.HOME_BANNER && request.type in INTERACTION_EVENT_TYPES
+        return if (isInteractiveCampaignPlacement) {
+            ValidatedContent(true)
+        } else {
+            null
+        }
     }
 
     private fun parseSlot(name: String): SurfaceSlot? = SurfaceSlot.entries.find { it.name == name }

--- a/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/infrastructure/rest/SurfaceResource.kt
+++ b/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/infrastructure/rest/SurfaceResource.kt
@@ -72,7 +72,8 @@ class SurfaceResource(
         val slot = parseSlot(request.slot) ?: return badRequest("unknown slot '${request.slot}'")
         val type = EngagementEventType.entries.find { it.name == request.type }
             ?: return badRequest("unknown event type '${request.type}'")
-        val content = validateContent(request, slot) ?: return badRequest("unknown or incompatible content '${request.contentId}'")
+        val content = validateContent(request, slot)
+            ?: return badRequest("unknown or incompatible content '${request.contentId}'")
         val campaignFields = listOf(request.campaignId, request.stepOrder, request.channel)
         val campaignAttribution = if (campaignFields.any { it != null }) {
             if (request.interactionRef == null || campaignFields.any { it == null }) {

--- a/openbank-engagement-service/src/main/resources/db/migration/V7__campaign_banner_placement_slot.sql
+++ b/openbank-engagement-service/src/main/resources/db/migration/V7__campaign_banner_placement_slot.sql
@@ -1,0 +1,16 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+-- Existing banner placements retain their original home surface through the explicit default.
+ALTER TABLE campaign_banner_placement
+    ADD COLUMN slot VARCHAR(32) NOT NULL DEFAULT 'HOME_BANNER';
+
+ALTER TABLE campaign_banner_placement
+    ADD CONSTRAINT chk_campaign_banner_placement_slot CHECK (
+        slot IN ('HOME_BANNER', 'HOME_CAROUSEL', 'PRODUCT_FEED', 'REWARDS_HUB')
+    );
+
+CREATE INDEX idx_campaign_banner_placement_party_slot_placed
+    ON campaign_banner_placement (party_id, slot, placed_at DESC);
+
+-- Rollback: drop the index and constraint, then the slot column after traffic returns to HOME_BANNER only.

--- a/openbank-engagement-service/src/main/resources/openapi.yaml
+++ b/openbank-engagement-service/src/main/resources/openapi.yaml
@@ -14,7 +14,7 @@ info:
     existing yet). No NBA ranking — content returns in catalogue order until ADR-0201's model
     graduates from shadow (D5). The customer app reaches these endpoints only through
     customer-edge, whose narrowly scoped M2M policy injects the authoritative party id.
-  version: 1.5.0
+  version: 1.6.0
 tags:
   - name: Surfaces
   - name: Eligibility

--- a/openbank-engagement-service/src/test/kotlin/com/openbank/engagement/application/ResolveSurfaceUseCaseTest.kt
+++ b/openbank-engagement-service/src/test/kotlin/com/openbank/engagement/application/ResolveSurfaceUseCaseTest.kt
@@ -48,7 +48,7 @@ class ResolveSurfaceUseCaseTest {
     }
 
     private fun banners() = mockk<CampaignBannerPlacementRepository>().also {
-        coEvery { it.latestForParty(any()) } returns null
+        coEvery { it.latestForPartyAndSlot(any(), any()) } returns null
     }
 
     @Test
@@ -70,7 +70,7 @@ class ResolveSurfaceUseCaseTest {
         val placements = mockk<CampaignBannerPlacementRepository>()
         val ref = UUID.randomUUID()
         coEvery { events.recentForPartyAndSlot(party, SurfaceSlot.HOME_BANNER, any()) } returns emptyList()
-        coEvery { placements.latestForParty(party) } returns CampaignBannerPlacement(
+        coEvery { placements.latestForPartyAndSlot(party, SurfaceSlot.HOME_BANNER) } returns CampaignBannerPlacement(
             ref,
             party,
             UUID.randomUUID(),
@@ -92,6 +92,24 @@ class ResolveSurfaceUseCaseTest {
         assertThat(content.id).isEqualTo(CampaignBannerPlacement.CAMPAIGN_BANNER_CONTENT_ID)
         assertThat(content.interactionRef).isEqualTo(ref)
         assertThat(content.deepLink).isEqualTo("openbank://savings")
+    }
+
+    @Test
+    fun `a campaign carousel is returned only in its selected app surface`(): Unit = runBlocking {
+        val events = mockk<EngagementEventRepository>()
+        val placements = mockk<CampaignBannerPlacementRepository>()
+        coEvery { events.recentForPartyAndSlot(party, SurfaceSlot.HOME_CAROUSEL, any()) } returns emptyList()
+        coEvery { placements.latestForPartyAndSlot(party, SurfaceSlot.HOME_CAROUSEL) } returns CampaignBannerPlacement(
+            UUID.randomUUID(), party, UUID.randomUUID(), 0, "MARKETING_PRODUCT_OFFER_CAROUSEL",
+            mapOf("offerTitle" to "Savings", "offerText" to "Four percent", "ctaText" to "Explore"),
+            "openbank://savings", Instant.now(), SurfaceSlot.HOME_CAROUSEL,
+        )
+
+        val result = ResolveSurfaceUseCase(gate(), events, adverseStates(), placements)
+            .resolve(party, SurfaceSlot.HOME_CAROUSEL) as ResolveSurfaceUseCase.Result.Rendered
+
+        assertThat(result.content.single().id).isEqualTo("CAMPAIGN_HOME_CAROUSEL")
+        assertThat(result.content.single().slot).isEqualTo(SurfaceSlot.HOME_CAROUSEL)
     }
 
     @Test

--- a/openbank-engagement-service/src/test/kotlin/com/openbank/engagement/integration/SurfaceRestContractIT.kt
+++ b/openbank-engagement-service/src/test/kotlin/com/openbank/engagement/integration/SurfaceRestContractIT.kt
@@ -185,6 +185,36 @@ class SurfaceRestContractIT {
 
     @Test
     @TestSecurity(user = TEST_OPERATOR, roles = ["ROLE_OPERATOR"])
+    fun `a campaign carousel is attributed only in its assigned app surface`() {
+        val party = UUID.randomUUID()
+        val interactionRef = UUID.randomUUID()
+        val campaignId = UUID.randomUUID()
+        insertCampaignBanner(
+            interactionRef,
+            party,
+            campaignId,
+            slot = "HOME_CAROUSEL",
+            template = "MARKETING_PRODUCT_OFFER_CAROUSEL",
+        )
+
+        Given {
+            contentType("application/json")
+            body(
+                """{"partyId":"$party","contentId":"CAMPAIGN_HOME_CAROUSEL","slot":"HOME_CAROUSEL","type":"CLICK","interactionRef":"$interactionRef","campaignId":"$campaignId","stepOrder":0,"channel":"BANNER"}""",
+            )
+        } When {
+            post("/api/v1/surfaces/events")
+        } Then {
+            statusCode(202)
+        }
+
+        assertThat(readCampaignAttributionFor(party)).isEqualTo(
+            StoredCampaignAttribution(interactionRef, campaignId, 0, "BANNER"),
+        )
+    }
+
+    @Test
+    @TestSecurity(user = TEST_OPERATOR, roles = ["ROLE_OPERATOR"])
     fun `a banner interaction cannot be attached to a catalogue card`() {
         val party = UUID.randomUUID()
         val interactionRef = UUID.randomUUID()
@@ -316,23 +346,30 @@ class SurfaceRestContractIT {
         }
     }
 
-    private fun insertCampaignBanner(interactionRef: UUID, partyId: UUID, campaignId: UUID) {
+    private fun insertCampaignBanner(
+        interactionRef: UUID,
+        partyId: UUID,
+        campaignId: UUID,
+        slot: String = "HOME_BANNER",
+        template: String = "MARKETING_PRODUCT_OFFER_BANNER",
+    ) {
         openTestDatabase().use { conn ->
             conn.prepareStatement(
                 """
                 INSERT INTO campaign_banner_placement
-                    (interaction_ref, party_id, campaign_id, step_order, template, values_json, deep_link, placed_at)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                    (interaction_ref, party_id, campaign_id, step_order, template, values_json, deep_link, placed_at, slot)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """.trimIndent(),
             ).use { st ->
                 st.setObject(1, interactionRef)
                 st.setObject(2, partyId)
                 st.setObject(3, campaignId)
                 st.setInt(4, 0)
-                st.setString(5, "MARKETING_PRODUCT_OFFER_BANNER")
+                st.setString(5, template)
                 st.setString(6, """{"offerTitle":"Savings","offerText":"Four percent","ctaText":"Explore"}""")
                 st.setString(7, "openbank://savings")
                 st.setTimestamp(8, Timestamp.from(Instant.now()))
+                st.setString(9, slot)
                 st.executeUpdate()
             }
         }

--- a/openbank-infra/gitops/components/engagement/engagement-service-msg-override.yaml
+++ b/openbank-infra/gitops/components/engagement/engagement-service-msg-override.yaml
@@ -15,6 +15,8 @@ metadata:
 data:
   override.properties: |
     config_ordinal=500
+    mp.messaging.incoming.campaign-banner-placements-in.group.id=openbank-engagement-service
+    mp.messaging.incoming.campaign-banner-placements-in.auto.offset.reset=earliest
     mp.messaging.incoming.lending-events-in.group.id=openbank-engagement-service
     mp.messaging.incoming.lending-events-in.auto.offset.reset=earliest
     mp.messaging.incoming.party-events-in.group.id=openbank-engagement-service

--- a/openbank-infra/gitops/components/engagement/engagement-service-msg-override.yaml
+++ b/openbank-infra/gitops/components/engagement/engagement-service-msg-override.yaml
@@ -15,8 +15,6 @@ metadata:
 data:
   override.properties: |
     config_ordinal=500
-    mp.messaging.incoming.campaign-banner-placements-in.group.id=openbank-engagement-service
-    mp.messaging.incoming.campaign-banner-placements-in.auto.offset.reset=earliest
     mp.messaging.incoming.lending-events-in.group.id=openbank-engagement-service
     mp.messaging.incoming.lending-events-in.auto.offset.reset=earliest
     mp.messaging.incoming.party-events-in.group.id=openbank-engagement-service


### PR DESCRIPTION
## Summary

- adds HOME_CAROUSEL, PRODUCT_FEED and REWARDS_HUB alongside the home banner
- keeps placement ownership, slot binding and BANNER attribution enforced end to end
- adds authoring controls, in-context preview, API and event contracts, Flyway migration, and HTTP/DB coverage

## Delivery

Stacked on #4577: merge this PR after the banner-channel foundation.

Refs #4476

## Verification

- npm run type-check
- npx vitest run src/test/journey-editor.test.tsx src/test/campaign-experience-preview.test.tsx src/test/campaign-builder-interaction.test.tsx
- ./gradlew --offline --console=plain :openbank-engagement-service:test --tests com.openbank.engagement.integration.SurfaceRestContractIT