### PR TITLE
feat(campaign): add journey path experiments

### DIFF
--- a/openbank-admin-ui/src/app/api/campaigns/[id]/route.ts
+++ b/openbank-admin-ui/src/app/api/campaigns/[id]/route.ts
@@ -124,7 +124,7 @@ export async function GET(_req: Request, ctx: { params: Promise<{ id: string }> 
   const { id } = await ctx.params
   const headers = { authorization: `Bearer ${session.user.accessToken}` }
 
-  const [campaign, enrolments, sends, sendSummary, journey, experiment] = await Promise.all([
+  const [campaign, enrolments, sends, sendSummary, journey, engagement, experiment] = await Promise.all([
     read(headers, `/api/v1/campaigns/${encodeURIComponent(id)}`, null),
     read(headers, `/api/v1/campaigns/${encodeURIComponent(id)}/enrolments`, []),
     // First page only. Paging and filtering go through /api/campaigns/[id]/sends so turning a
@@ -143,6 +143,9 @@ export async function GET(_req: Request, ctx: { params: Promise<{ id: string }> 
     // and the screen died on `.map` with the 404 on /journey never surfacing, because its state had
     // landed under `sendSummary`.
     read(headers, `/api/v1/campaigns/${encodeURIComponent(id)}/journey`, []),
+    // App attention is a separate, privacy-minimised projection.  It is never inferred from a
+    // banner handoff, so a missing/lagging source remains visible as unavailable in Campaign Studio.
+    read(headers, `/api/v1/campaigns/${encodeURIComponent(id)}/engagement`, []),
     readExperiment(headers, id),
   ])
 
@@ -180,6 +183,7 @@ export async function GET(_req: Request, ctx: { params: Promise<{ id: string }> 
     sends: sends.data,
     sendSummary: sendSummary.data,
     journey: journey.data,
+    engagement: engagement.data,
     experiment: experiment.data,
     contentExperiment: contentExperiment.data,
     entryCatalogues: { cadences: cadences.data, triggers: triggers.data },
@@ -192,6 +196,7 @@ export async function GET(_req: Request, ctx: { params: Promise<{ id: string }> 
       sends: sends.state,
       sendSummary: sendSummary.state,
       journey: journey.state,
+      engagement: engagement.state,
       experiment: experiment.state,
       contentExperiment: contentExperiment.state,
       cadences: cadences.state,

--- a/openbank-admin-ui/src/app/campaigns/[id]/page.tsx
+++ b/openbank-admin-ui/src/app/campaigns/[id]/page.tsx
@@ -96,6 +96,14 @@ interface ContentExperiment {
   }
 }
 
+interface CampaignEngagementMetric {
+  stepOrder: number
+  channel: 'PUSH' | 'BANNER'
+  surface: 'HOME_BANNER' | 'HOME_CAROUSEL' | 'PRODUCT_FEED' | 'REWARDS_HUB'
+  type: 'IMPRESSION' | 'CLICK' | 'DISMISS'
+  count: number
+}
+
 type Detail = {
   campaign: Campaign | null
   enrolments: Enrolment[]
@@ -103,6 +111,7 @@ type Detail = {
   partyNames: Record<string, string>
   sendSummary: Record<string, number>
   journey: StepFunnel[]
+  engagement: CampaignEngagementMetric[]
   experiment: Experiment | null
   contentExperiment: ContentExperiment | null
   entryCatalogues?: {
@@ -270,6 +279,7 @@ export default function CampaignDetailPage({ params }: { params: Promise<{ id: s
     loadSends(0, outcome)
   }
   const summary = detail?.sendSummary ?? {}
+  const engagement = Array.isArray(detail?.engagement) ? detail.engagement : []
   const experiment = detail?.experiment
   const contentExperiment = detail?.contentExperiment
   const cadence = c?.schedule
@@ -284,6 +294,12 @@ export default function CampaignDetailPage({ params }: { params: Promise<{ id: s
   const suppressed = Object.entries(summary)
     .filter(([outcome]) => outcome.startsWith('SUPPRESSED'))
     .reduce((n, [, count]) => n + count, 0)
+  const impressions = engagement
+    .filter(metric => metric.type === 'IMPRESSION')
+    .reduce((n, metric) => n + metric.count, 0)
+  const interactions = engagement
+    .filter(metric => metric.type === 'CLICK' || metric.type === 'DISMISS')
+    .reduce((n, metric) => n + metric.count, 0)
 
   const fmtDateTime = (iso: string | null | undefined) =>
     iso
@@ -505,6 +521,8 @@ export default function CampaignDetailPage({ params }: { params: Promise<{ id: s
             suppressed={suppressed}
             conversion={c.conversionRule ? (summary.CONVERTED ?? 0) : null}
             conversionLabel={c.conversionRule ? conversionLabel(c.conversionRule) : t('Cíl není měřen', 'Outcome is not measured')}
+            inAppImpressions={detail?.sources?.engagement === 'ok' ? impressions : null}
+            inAppInteractions={detail?.sources?.engagement === 'ok' ? interactions : null}
             nextAction={nextAction.title}
             nextActionDetail={nextAction.detail}
           />

--- a/openbank-admin-ui/src/app/campaigns/new/page.tsx
+++ b/openbank-admin-ui/src/app/campaigns/new/page.tsx
@@ -210,9 +210,9 @@ export default function NewCampaignPage() {
     })
 
   const incomplete = steps.some(s =>
-    (TEMPLATES[s.template] ?? []).some(v =>
-      !(s.variables[v] ?? '').trim() || (contentExperiment && !(s.variantBVariables?.[v] ?? '').trim()),
-    ),
+    (TEMPLATES[s.template] ?? []).some(v => !(s.variables[v] ?? '').trim()) ||
+    (contentExperiment && (TEMPLATES[s.variantBTemplate ?? s.template] ?? [])
+      .some(v => !(s.variantBVariables?.[v] ?? '').trim())),
   )
   const entryConfigured =
     entryMode === 'MANUAL' ||
@@ -260,6 +260,9 @@ export default function NewCampaignPage() {
           ...(s.condition ? { condition: s.condition } : {}),
           variables: s.variables,
           ...(contentExperiment ? { variantBVariables: s.variantBVariables ?? {} } : {}),
+          ...(contentExperiment && s.variantBTemplate ? { variantBTemplate: s.variantBTemplate } : {}),
+          ...(contentExperiment && s.variantBChannel ? { variantBChannel: s.variantBChannel } : {}),
+          ...(contentExperiment && s.variantBDelaySeconds !== undefined ? { variantBDelaySeconds: s.variantBDelaySeconds } : {}),
           ...(s.fallbackToPush ? { fallbackToPush: true } : {}),
           ...(s.mobileDestination ? { mobileDestination: s.mobileDestination } : {}),
           ...(s.inAppSurface ? { inAppSurface: s.inAppSurface } : {}),

--- a/openbank-admin-ui/src/components/campaigns/CampaignOutcomeBrief.tsx
+++ b/openbank-admin-ui/src/components/campaigns/CampaignOutcomeBrief.tsx
@@ -22,6 +22,8 @@ export function CampaignOutcomeBrief({
   suppressed,
   conversion,
   conversionLabel,
+  inAppImpressions = null,
+  inAppInteractions = null,
   nextAction,
   nextActionDetail,
 }: {
@@ -32,6 +34,9 @@ export function CampaignOutcomeBrief({
   /** Null means the campaign is not configured to measure an outcome. */
   conversion: number | null
   conversionLabel?: string
+  /** Null means the attribution projection is unavailable; zero is a real aggregate count. */
+  inAppImpressions?: number | null
+  inAppInteractions?: number | null
   nextAction: string
   nextActionDetail: string
 }) {
@@ -63,8 +68,15 @@ export function CampaignOutcomeBrief({
             <span>{conversionLabel ?? t('Výsledek', 'Outcome')}</span>
             <small>{conversion === null ? t('neměřeno', 'not measured') : t('během zařazení', 'while enrolled')}</small>
           </div>
+          <div className="campaign-outcome-conversion" data-engagement={inAppImpressions === null ? 'unavailable' : 'measured'}>
+            <strong>{inAppImpressions === null ? '—' : inAppImpressions.toLocaleString(language === 'cs' ? 'cs-CZ' : 'en-GB')}</strong>
+            <span>{t('V aplikaci viděno', 'Seen in app')}</span>
+            <small>{inAppInteractions === null
+              ? t('data se načítají', 'data unavailable')
+              : t(`${inAppInteractions.toLocaleString(language === 'cs' ? 'cs-CZ' : 'en-GB')} interakcí`, `${inAppInteractions.toLocaleString(language === 'cs' ? 'cs-CZ' : 'en-GB')} interactions`)}</small>
+          </div>
         </div>
-        <p className="campaign-outcome-evidence">{t('Jen provoz kampaně — in-app engagement se této kampani zatím nepřipisuje.', 'Campaign operations only — no in-app engagement is attributed to this campaign yet.')}</p>
+        <p className="campaign-outcome-evidence">{t('In-app metriky jsou agregované události, ne lidé ani bankovní konverze. Kliknutí se nikdy nevydává za výsledek produktu.', 'In-app metrics are aggregate events, not people or banking conversion. A click is never presented as a product outcome.')}</p>
       </div>
       <aside className="campaign-outcome-action" data-testid="campaign-outcome-next-action">
         <p>{t('Další nejlepší akce', 'Next best action')}</p>

--- a/openbank-admin-ui/src/components/campaigns/JourneyEditor.tsx
+++ b/openbank-admin-ui/src/components/campaigns/JourneyEditor.tsx
@@ -44,6 +44,10 @@ export interface EditorStep {
   condition?: EditorCondition
   /** Alternative B-arm values in a campaign-wide content experiment. */
   variantBVariables?: { [key: string]: string }
+  /** Optional journey-path treatment for B; absent retains the historical copy-only experiment. */
+  variantBTemplate?: string
+  variantBChannel?: EditorChannel
+  variantBDelaySeconds?: number
   /** Try the catalogue's safe app-push counterpart only when email consent is absent. */
   fallbackToPush?: boolean
   /** Closed app context reached after a push tap; never an arbitrary URL. */

--- a/openbank-admin-ui/src/components/campaigns/StepEditor.tsx
+++ b/openbank-admin-ui/src/components/campaigns/StepEditor.tsx
@@ -69,6 +69,9 @@ export function StepEditor({
 }) {
   const { t } = useLanguage()
   const declared = templates[step.template] ?? []
+  const variantBTemplate = step.variantBTemplate ?? step.template
+  const variantBChannel = step.variantBChannel ?? step.channel
+  const variantBDeclared = templates[variantBTemplate] ?? []
   const missing = declared.filter(v => !(step.variables[v] ?? '').trim())
   // `.input` is the console's own field style — hover, focus ring, sizing — and I had hand-rolled a
   // worse copy of it. Reinventing a house primitive is the same failure ADR-0208 D2 names for colour.
@@ -308,12 +311,57 @@ export function StepEditor({
             <p className="text-sm font-medium">{t('Varianta B', 'Variant B')}</p>
             <p className="text-xs text-muted-foreground">
               {t(
-                'Každý člověk zůstane po celou cestu ve stejné variantě. Změňte jen hodnoty, které chcete porovnat.',
-                'Each person stays in the same variant throughout the journey. Change only the values you want to compare.',
+                'Každý člověk zůstane po celou cestu ve stejné variantě. B může porovnávat copy, kanál i časování; stejný člověk se mezi nimi nikdy nepřepíná.',
+                'Each person stays in the same variant throughout the journey. B can compare copy, channel and timing; one person is never switched between them.',
               )}
             </p>
           </div>
-          {declared.map(v => (
+          <div className="grid gap-3 sm:grid-cols-3" data-variant-b-path={index}>
+            <label className="space-y-1.5 text-sm">
+              <span className="font-medium">{t('Kanál B', 'B channel')}</span>
+              <select
+                className={field}
+                value={variantBChannel}
+                onChange={e => {
+                  const channel = e.target.value as EditorChannel
+                  const first = Object.keys(templates).find(tpl => templateChannel[tpl] === channel && (
+                    channel !== 'BANNER' || tpl === IN_APP_TEMPLATE.HOME_BANNER
+                  ))
+                  if (!first) return
+                  onChange({ ...step, variantBChannel: channel, variantBTemplate: first, variantBVariables: {} })
+                }}
+              >
+                {(['EMAIL', 'PUSH', 'BANNER'] as EditorChannel[]).map(channel => (
+                  <option key={channel} value={channel} disabled={step.fallbackToPush && channel !== 'EMAIL'}>
+                    {channel === 'EMAIL' ? t('E-mail', 'Email') : channel === 'PUSH' ? t('Push do aplikace', 'App push') : t('Banner v aplikaci', 'In-app banner')}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="space-y-1.5 text-sm">
+              <span className="font-medium">{t('Šablona B', 'B template')}</span>
+              <select
+                className={field}
+                value={variantBTemplate}
+                onChange={e => onChange({ ...step, variantBTemplate: e.target.value, variantBVariables: {} })}
+              >
+                {Object.keys(templates).filter(tpl => templateChannel[tpl] === variantBChannel && (
+                  variantBChannel !== 'BANNER' || tpl === IN_APP_TEMPLATE.HOME_BANNER
+                )).map(tpl => <option key={tpl} value={tpl}>{templateLabels[tpl] ?? tpl}</option>)}
+              </select>
+            </label>
+            <label className="space-y-1.5 text-sm">
+              <span className="font-medium">{t('Čekání B (dny)', 'B wait (days)')}</span>
+              <input
+                type="number"
+                min="0"
+                className={field}
+                value={(step.variantBDelaySeconds ?? step.delaySeconds) / 86400}
+                onChange={e => onChange({ ...step, variantBDelaySeconds: Math.max(0, Number(e.target.value) || 0) * 86400 })}
+              />
+            </label>
+          </div>
+          {variantBDeclared.map(v => (
             <div key={v} className="space-y-1.5">
               <label htmlFor={`var-b-${index}-${v}`} className="text-sm font-medium">
                 {variableLabels[v]?.label ?? v}

--- a/openbank-admin-ui/src/test/campaign-outcome-brief.test.tsx
+++ b/openbank-admin-ui/src/test/campaign-outcome-brief.test.tsx
@@ -26,7 +26,8 @@ describe('campaign outcome brief', () => {
     expect(screen.getByText('Handed off')).toBeTruthy()
     expect(screen.getByText('to notification service')).toBeTruthy()
     expect(screen.getByText('Account opened')).toBeTruthy()
-    expect(screen.getByText(/no in-app engagement is attributed/)).toBeTruthy()
+    expect(screen.getByText('Seen in app')).toBeTruthy()
+    expect(screen.getByText(/aggregate events, not people or banking conversion/)).toBeTruthy()
   })
 
   it('does not show a zero outcome when the campaign measures nothing', () => {

--- a/openbank-admin-ui/src/test/journey-editor.test.tsx
+++ b/openbank-admin-ui/src/test/journey-editor.test.tsx
@@ -209,4 +209,20 @@ describe('step editor', () => {
       inAppSurface: 'HOME_CAROUSEL', template: 'MARKETING_PRODUCT_OFFER_CAROUSEL',
     }))
   })
+
+  it('lets a journey experiment compare a B path, not just alternative copy', () => {
+    const onChange = vi.fn()
+    const experimentStep: EditorStep = { ...step(), variantBVariables: {} }
+    const { container } = render(
+      React.createElement(LanguageProvider, null,
+        React.createElement(StepEditor, {
+          index: 0, step: experimentStep, templates: TEMPLATES, templateChannel: TPL_CHANNEL, templateLabels: LABELS, variableLabels: VAR_LABELS,
+          contentExperiment: true, onChange, onClose: vi.fn(),
+        })))
+
+    fireEvent.change(container.querySelector('[data-variant-b-path="0"] select')!, { target: { value: 'PUSH' } })
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({
+      variantBChannel: 'PUSH', variantBTemplate: 'MARKETING_PRODUCT_OFFER_PUSH', variantBVariables: {},
+    }))
+  })
 })

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/port/out/Ports.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/port/out/Ports.kt
@@ -61,6 +61,54 @@ interface CampaignContentExperimentRepository {
     suspend fun metrics(campaignId: UUID): List<ContentVariantMetrics>
 }
 
+/**
+ * One in-app observation that customer-edge has already bound to an opaque campaign interaction.
+ *
+ * This deliberately contains no party identifier.  The reporting read model is an operator-facing
+ * aggregate, and retaining a party merely to answer an aggregate count would turn a marketer view
+ * into a second customer-tracking store.  [eventId] is the producer's immutable idempotency key:
+ * engagement delivery is at-least-once, so a redelivery must not inflate a funnel.
+ */
+data class CampaignEngagementEvent(
+    val eventId: UUID,
+    val campaignId: UUID,
+    val stepOrder: Int,
+    val channel: Channel,
+    val surface: InAppSurface,
+    val type: CampaignEngagementEventType,
+    val occurredAt: Instant,
+) {
+    init {
+        require(stepOrder >= 0) { "campaign step order must be non-negative" }
+        require(channel == Channel.PUSH || channel == Channel.BANNER) {
+            "only mobile campaign interactions are attributable"
+        }
+    }
+}
+
+/** App attention signals.  Product conversion stays in [SendOutcome.CONVERTED], never here. */
+enum class CampaignEngagementEventType { IMPRESSION, CLICK, DISMISS }
+
+/** Aggregate event counts, not people: one person may legitimately create several observations. */
+data class CampaignEngagementMetric(
+    val stepOrder: Int,
+    val channel: Channel,
+    val surface: InAppSurface,
+    val type: CampaignEngagementEventType,
+    val count: Long,
+)
+
+/**
+ * Privacy-minimising, append-only read model for Campaign Studio's in-app engagement funnel.
+ * Its table has one row per source event but never a party id; SQL aggregation therefore remains
+ * bounded and does not expose a customer drill-down endpoint by accident.
+ */
+interface CampaignEngagementRepository {
+    /** Returns false for an already recorded event id (Kafka redelivery). */
+    suspend fun record(event: CampaignEngagementEvent): Boolean
+    suspend fun metrics(campaignId: UUID): List<CampaignEngagementMetric>
+}
+
 /** A single cell of the per-step funnel: how many sends of [outcome] step [stepOrder] produced. */
 data class StepOutcomeCount(val stepOrder: Int, val outcome: SendOutcome, val count: Long)
 

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/usecase/CampaignEngagementQuery.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/usecase/CampaignEngagementQuery.kt
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.campaign.application.usecase
+
+import com.openbank.campaign.application.port.out.CampaignEngagementMetric
+import com.openbank.campaign.application.port.out.CampaignEngagementRepository
+import jakarta.enterprise.context.ApplicationScoped
+import java.util.UUID
+
+/** Read-only Campaign Studio view of app attention, distinct from observed business conversion. */
+@ApplicationScoped
+class CampaignEngagementQuery(private val engagement: CampaignEngagementRepository) {
+    /**
+     * Counts observations, not unique people.  The source contains no party id by design, so this
+     * endpoint cannot accidentally become a customer drill-down surface.
+     */
+    suspend fun metrics(campaignId: UUID): List<CampaignEngagementMetric> = engagement.metrics(campaignId)
+}

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/workflow/CampaignJourneyActivities.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/workflow/CampaignJourneyActivities.kt
@@ -17,6 +17,9 @@ interface CampaignJourneyActivities {
     fun controlState(campaignId: UUID, partyId: UUID): JourneyControlState
     fun sendsSoFar(campaignId: UUID, partyId: UUID): Int
 
+    /** The cohort-specific delay for a step; assignment is durable before this workflow starts. */
+    fun delayForStep(campaignId: UUID, partyId: UUID, step: CampaignStep): Long
+
     /**
      * The delivery status of the newest send before [stepOrder], for an ADR-0200 D1 branch
      * condition (#3585). Null when this party has no earlier send in this campaign.

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/workflow/CampaignJourneyActivitiesImpl.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/workflow/CampaignJourneyActivitiesImpl.kt
@@ -81,6 +81,16 @@ open class CampaignJourneyActivitiesImpl(
         sendLog.countSendsForPartyInCampaign(campaignId, partyId)
     }
 
+    override fun delayForStep(campaignId: UUID, partyId: UUID, step: CampaignStep): Long = runBlockingOnWorker {
+        val campaign = campaigns.findById(campaignId)
+        val variant = if (campaign?.hasContentExperiment == true) {
+            enrolments.findByCampaignAndParty(campaignId, partyId)?.contentVariant
+        } else {
+            null
+        }
+        campaign?.steps?.firstOrNull { it.order == step.order }?.delayFor(variant) ?: step.delayFor(variant)
+    }
+
     override fun previousDeliveryStatus(campaignId: UUID, partyId: UUID, stepOrder: Int): DeliveryStatus? =
         runBlockingOnWorker {
             sendLog.latestDeliveryStatusBeforeStep(campaignId, partyId, stepOrder)

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/workflow/CampaignJourneyWorkflowImpl.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/workflow/CampaignJourneyWorkflowImpl.kt
@@ -76,9 +76,10 @@ class CampaignJourneyWorkflowImpl : CampaignJourneyWorkflow {
         ) {
             return TerminationReason.STOPPED_MAX_SENDS
         }
-        if (step.delaySeconds > 0) {
+        val delaySeconds = activities.delayForStep(campaignId, partyId, step)
+        if (delaySeconds > 0) {
             // Pause prevents delivery but does not shift the business deadline.
-            waitThroughDelay(campaignId, partyId, controlVersion, step.delaySeconds)?.let { return it }
+            waitThroughDelay(campaignId, partyId, controlVersion, delaySeconds)?.let { return it }
         }
         // Conditions are evaluated after the delay, when the predecessor's outcome can exist.
         if (step.condition != null &&

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/workflow/CampaignJourneyWorkflowImpl.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/workflow/CampaignJourneyWorkflowImpl.kt
@@ -76,7 +76,19 @@ class CampaignJourneyWorkflowImpl : CampaignJourneyWorkflow {
         ) {
             return TerminationReason.STOPPED_MAX_SENDS
         }
-        val delaySeconds = activities.delayForStep(campaignId, partyId, step)
+        // Existing histories scheduled their delay from the definition directly. Adding an activity
+        // command to those histories would make Temporal replay nondeterministic, so only workflows
+        // started after this release resolve the selected path's delay through the activity.
+        val delayVersion = Workflow.getVersion(
+            PATH_EXPERIMENT_DELAY_CHANGE_ID,
+            Workflow.DEFAULT_VERSION,
+            PATH_EXPERIMENT_DELAY_V1,
+        )
+        val delaySeconds = if (delayVersion < PATH_EXPERIMENT_DELAY_V1) {
+            step.delaySeconds
+        } else {
+            activities.delayForStep(campaignId, partyId, step)
+        }
         if (delaySeconds > 0) {
             // Pause prevents delivery but does not shift the business deadline.
             waitThroughDelay(campaignId, partyId, controlVersion, delaySeconds)?.let { return it }
@@ -185,6 +197,8 @@ class CampaignJourneyWorkflowImpl : CampaignJourneyWorkflow {
         private const val SCHEDULE_TO_CLOSE_MINUTES = 5L
         private const val CONTROL_STATE_CHANGE_ID = "campaign-control-state-v1"
         private const val CONTROL_STATE_V1 = 1
+        private const val PATH_EXPERIMENT_DELAY_CHANGE_ID = "campaign-path-experiment-delay-v1"
+        private const val PATH_EXPERIMENT_DELAY_V1 = 1
         private val CONTROL_RECHECK_INTERVAL: Duration = Duration.ofMinutes(1)
     }
 }

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/domain/model/Campaign.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/domain/model/Campaign.kt
@@ -215,6 +215,14 @@ data class CampaignStep(
      * service, so engagement never has to guess a customer's intended surface.
      */
     val inAppSurface: InAppSurface? = null,
+    /**
+     * The optional delivery shape for the B arm of a journey experiment. Leaving all three values
+     * absent keeps the existing copy-only experiment; providing a template and channel lets a
+     * marketer compare a real path, such as e-mail today against an app push tomorrow.
+     */
+    val variantBTemplate: String? = null,
+    val variantBChannel: Channel? = null,
+    val variantBDelaySeconds: Long? = null,
 ) {
     init {
         require(order >= 0) { "step order must be >= 0" }
@@ -240,7 +248,7 @@ data class CampaignStep(
         TemplateCatalog.unknownVariables(template, variables).let {
             require(it.isEmpty()) { "template '$template' does not declare ${it.sorted()}" }
         }
-        variantBVariables?.let { alternative ->
+        variantBVariables?.takeIf { variantBTemplate == null }?.let { alternative ->
             TemplateCatalog.unknownVariables(template, alternative).let {
                 require(it.isEmpty()) { "template '$template' does not declare ${it.sorted()}" }
             }
@@ -251,8 +259,15 @@ data class CampaignStep(
         require(!fallbackToPush || template in TemplateCatalog.PUSH_FALLBACK_FOR_EMAIL) {
             "template '$template' has no safe PUSH fallback"
         }
-        require(mobileDestination == null || channel == Channel.PUSH || channel == Channel.BANNER || fallbackToPush) {
-            "a mobile destination requires a PUSH or BANNER step, or an EMAIL step with PUSH fallback"
+        require(
+            mobileDestination == null ||
+                channel == Channel.PUSH ||
+                channel == Channel.BANNER ||
+                variantBChannel == Channel.PUSH ||
+                variantBChannel == Channel.BANNER ||
+                fallbackToPush,
+        ) {
+            "a mobile destination requires a PUSH or BANNER path, or an EMAIL step with PUSH fallback"
         }
         require(inAppSurface == null || channel == Channel.BANNER) {
             "an in-app surface requires a BANNER step"
@@ -262,33 +277,87 @@ data class CampaignStep(
                 "template '$template' does not render on ${inAppSurface ?: InAppSurface.HOME_BANNER}"
             }
         }
+        require((variantBTemplate == null) == (variantBChannel == null)) {
+            "a variant B path needs both its template and channel"
+        }
+        require(variantBTemplate == null || variantBVariables != null) {
+            "a variant B path needs variant B values so the campaign records an experiment"
+        }
+        require(variantBDelaySeconds == null || variantBDelaySeconds >= 0) {
+            "variant B step delay must be >= 0"
+        }
+        variantBTemplate?.let { alternativeTemplate ->
+            val alternativeChannel = requireNotNull(variantBChannel)
+            require(TemplateCatalog.exists(alternativeTemplate)) {
+                "unknown variant B template '$alternativeTemplate' — ${TemplateCatalog.MARKETING_ONLY_REASON}"
+            }
+            require(TemplateCatalog.CHANNEL_OF[alternativeTemplate] == alternativeChannel) {
+                "variant B template '$alternativeTemplate' renders on ${TemplateCatalog.CHANNEL_OF[alternativeTemplate]}, not $alternativeChannel"
+            }
+            variantBVariables?.let { alternativeVariables ->
+                TemplateCatalog.unknownVariables(alternativeTemplate, alternativeVariables).let {
+                    require(it.isEmpty()) {
+                        "variant B template '$alternativeTemplate' does not declare ${it.sorted()}"
+                    }
+                }
+            }
+            require(!fallbackToPush || alternativeChannel == Channel.EMAIL) {
+                "an EMAIL fallback cannot be shared with a non-EMAIL variant B path"
+            }
+            if (alternativeChannel == Channel.BANNER) {
+                require(alternativeTemplate == TemplateCatalog.templateForInAppSurface(InAppSurface.HOME_BANNER)) {
+                    "a variant B BANNER path uses the reviewed HOME_BANNER card"
+                }
+            }
+        }
     }
 
     /** Resolves content after the durable enrolment assignment, never randomly at send time. */
     fun variablesFor(variant: ContentVariant?): Map<String, String> =
         if (variant == ContentVariant.B) variantBVariables ?: variables else variables
 
+    /** The persisted cohort chooses delivery structure as well as copy; retries cannot reshuffle it. */
+    fun delayFor(variant: ContentVariant?): Long =
+        variantBDelaySeconds.takeIf { variant == ContentVariant.B } ?: delaySeconds
+
+    private fun templateFor(variant: ContentVariant?): String =
+        variantBTemplate.takeIf { variant == ContentVariant.B } ?: template
+
+    private fun channelFor(variant: ContentVariant?): Channel =
+        variantBChannel.takeIf { variant == ContentVariant.B } ?: channel
+
     /** Primary delivery values, kept separate from the fallback's reduced template vocabulary. */
-    fun primaryDelivery(variant: ContentVariant?): CampaignDelivery = CampaignDelivery(
-        channel,
-        template,
-        TemplateCatalog.valuesFor(template, variablesFor(variant)),
-        mobileDestination?.deepLink.takeIf { channel == Channel.PUSH || channel == Channel.BANNER },
-        inAppSurface?.takeIf { channel == Channel.BANNER }
-            ?: InAppSurface.HOME_BANNER.takeIf { channel == Channel.BANNER },
-    )
+    fun primaryDelivery(variant: ContentVariant?): CampaignDelivery {
+        val selectedChannel = channelFor(variant)
+        val selectedTemplate = templateFor(variant)
+        val selectedInAppSurface = when {
+            selectedChannel != Channel.BANNER -> null
+            variant == ContentVariant.B && variantBTemplate != null -> InAppSurface.HOME_BANNER
+            else -> inAppSurface ?: InAppSurface.HOME_BANNER
+        }
+        return CampaignDelivery(
+            selectedChannel,
+            selectedTemplate,
+            TemplateCatalog.valuesFor(selectedTemplate, variablesFor(variant)),
+            mobileDestination?.deepLink.takeIf {
+                selectedChannel == Channel.PUSH || selectedChannel == Channel.BANNER
+            },
+            selectedInAppSurface,
+        )
+    }
 
     /** The only supported fallback: a consented app push after EMAIL consent was absent. */
-    fun pushFallback(variant: ContentVariant?): CampaignDelivery? = TemplateCatalog.PUSH_FALLBACK_FOR_EMAIL[template]
-        ?.takeIf { fallbackToPush }
-        ?.let { pushTemplate ->
-            CampaignDelivery(
-                Channel.PUSH,
-                pushTemplate,
-                TemplateCatalog.valuesFor(pushTemplate, variablesFor(variant)),
-                mobileDestination?.deepLink,
-            )
-        }
+    fun pushFallback(variant: ContentVariant?): CampaignDelivery? =
+        TemplateCatalog.PUSH_FALLBACK_FOR_EMAIL[templateFor(variant)]
+            ?.takeIf { fallbackToPush && channelFor(variant) == Channel.EMAIL }
+            ?.let { pushTemplate ->
+                CampaignDelivery(
+                    Channel.PUSH,
+                    pushTemplate,
+                    TemplateCatalog.valuesFor(pushTemplate, variablesFor(variant)),
+                    mobileDestination?.deepLink,
+                )
+            }
 }
 
 /** A resolved per-attempt delivery, including the channel that will be recorded for audit. */

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/domain/model/Campaign.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/domain/model/Campaign.kt
@@ -272,6 +272,9 @@ data class CampaignStep(
         require(inAppSurface == null || channel == Channel.BANNER) {
             "an in-app surface requires a BANNER step"
         }
+        require(channel != Channel.BANNER || mobileDestination != null) {
+            "a BANNER step requires a mobile destination"
+        }
         if (channel == Channel.BANNER) {
             require(template == TemplateCatalog.templateForInAppSurface(inAppSurface ?: InAppSurface.HOME_BANNER)) {
                 "template '$template' does not render on ${inAppSurface ?: InAppSurface.HOME_BANNER}"
@@ -282,6 +285,9 @@ data class CampaignStep(
         }
         require(variantBTemplate == null || variantBVariables != null) {
             "a variant B path needs variant B values so the campaign records an experiment"
+        }
+        require(variantBChannel != Channel.BANNER || mobileDestination != null) {
+            "a BANNER variant B path requires a mobile destination"
         }
         require(variantBDelaySeconds == null || variantBDelaySeconds >= 0) {
             "variant B step delay must be >= 0"

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/kafka/CampaignEngagementConsumer.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/kafka/CampaignEngagementConsumer.kt
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.campaign.infrastructure.kafka
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.campaign.application.port.out.CampaignEngagementEvent
+import com.openbank.campaign.application.port.out.CampaignEngagementEventType
+import com.openbank.campaign.application.port.out.CampaignEngagementRepository
+import com.openbank.campaign.domain.model.Channel
+import com.openbank.campaign.domain.model.InAppSurface
+import jakarta.enterprise.context.ApplicationScoped
+import org.eclipse.microprofile.reactive.messaging.Incoming
+import org.jboss.logging.Logger
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * Builds the campaign-local, no-PII projection of attributable engagement events (#4480).
+ *
+ * The source topic also contains organic content events.  They are intentionally ignored: an
+ * absent campaign tuple means "unattributed", not zero engagement and not a best-effort join to
+ * a recent campaign.  Product conversion is likewise excluded; [ConversionConsumer] owns that
+ * independently from authoritative banking events.
+ */
+@ApplicationScoped
+class CampaignEngagementConsumer(
+    private val mapper: ObjectMapper,
+    private val engagement: CampaignEngagementRepository,
+) {
+    private val log = Logger.getLogger(CampaignEngagementConsumer::class.java)
+
+    /** Reporting must never block a Kafka partition on an unrelated malformed app event. */
+    @Suppress("TooGenericExceptionCaught")
+    @Incoming("engagement-events-in")
+    suspend fun onEvent(payload: String) {
+        val event = runCatching { mapper.readTree(payload) }.getOrElse {
+            log.errorf(it, "Unparseable engagement event — dropped from campaign projection")
+            return
+        }
+        val attributable = event.toCampaignEngagementEvent() ?: return
+        try {
+            engagement.record(attributable)
+        } catch (e: Exception) {
+            // This is a read model, never a delivery decision.  Dropping a poisoned record keeps
+            // campaign orchestration independent; monitoring sees the error and the UI must treat
+            // an absent metric as unavailable, not as a zero.
+            log.errorf(e, "Could not project engagement event %s", attributable.eventId)
+        }
+    }
+
+    private fun JsonNode.toCampaignEngagementEvent(): CampaignEngagementEvent? {
+        val campaignId = uuid("campaignId") ?: return null
+        val eventId = uuid("eventId") ?: return null
+        val stepOrder = path("stepOrder").takeIf { it.isInt }?.intValue()?.takeIf { it >= 0 } ?: return null
+        val channel = named("channel", Channel.entries) ?: return null
+        val surface = named("slot", InAppSurface.entries) ?: return null
+        val type = named("type", CampaignEngagementEventType.entries) ?: return null
+        val occurredAt = runCatching { Instant.parse(path("occurredAt").asText()) }.getOrNull() ?: return null
+        return runCatching {
+            CampaignEngagementEvent(eventId, campaignId, stepOrder, channel, surface, type, occurredAt)
+        }.getOrNull()
+    }
+
+    private fun JsonNode.uuid(field: String): UUID? = path(field).asText()
+        .takeIf { it.isNotBlank() }
+        ?.let { runCatching { UUID.fromString(it) }.getOrNull() }
+
+    private fun <T : Enum<T>> JsonNode.named(field: String, values: Iterable<T>): T? = path(field).asText()
+        .takeIf { it.isNotBlank() }
+        ?.let { raw -> values.find { it.name == raw } }
+}

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/kafka/CampaignEngagementConsumer.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/kafka/CampaignEngagementConsumer.kt
@@ -32,8 +32,7 @@ class CampaignEngagementConsumer(
 ) {
     private val log = Logger.getLogger(CampaignEngagementConsumer::class.java)
 
-    /** Reporting must never block a Kafka partition on an unrelated malformed app event. */
-    @Suppress("TooGenericExceptionCaught")
+    /** Malformed or unattributed app events are terminal; projection storage failures must retry. */
     @Incoming("engagement-events-in")
     suspend fun onEvent(payload: String) {
         val event = runCatching { mapper.readTree(payload) }.getOrElse {
@@ -41,14 +40,7 @@ class CampaignEngagementConsumer(
             return
         }
         val attributable = event.toCampaignEngagementEvent() ?: return
-        try {
-            engagement.record(attributable)
-        } catch (e: Exception) {
-            // This is a read model, never a delivery decision.  Dropping a poisoned record keeps
-            // campaign orchestration independent; monitoring sees the error and the UI must treat
-            // an absent metric as unavailable, not as a zero.
-            log.errorf(e, "Could not project engagement event %s", attributable.eventId)
-        }
+        engagement.record(attributable)
     }
 
     private fun JsonNode.toCampaignEngagementEvent(): CampaignEngagementEvent? {

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/persistence/Persistence.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/persistence/Persistence.kt
@@ -7,6 +7,10 @@ package com.openbank.campaign.infrastructure.persistence
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.openbank.campaign.application.port.out.CampaignContentExperimentRepository
+import com.openbank.campaign.application.port.out.CampaignEngagementEvent
+import com.openbank.campaign.application.port.out.CampaignEngagementEventType
+import com.openbank.campaign.application.port.out.CampaignEngagementMetric
+import com.openbank.campaign.application.port.out.CampaignEngagementRepository
 import com.openbank.campaign.application.port.out.CampaignEnrolmentCount
 import com.openbank.campaign.application.port.out.CampaignExperimentRepository
 import com.openbank.campaign.application.port.out.CampaignInteractionAttribution
@@ -30,6 +34,7 @@ import com.openbank.campaign.domain.model.DeliveryTransition
 import com.openbank.campaign.domain.model.Enrolment
 import com.openbank.campaign.domain.model.EnrolmentState
 import com.openbank.campaign.domain.model.ExperimentCohort
+import com.openbank.campaign.domain.model.InAppSurface
 import com.openbank.campaign.domain.model.Segment
 import com.openbank.campaign.domain.model.SegmentCatalog
 import com.openbank.campaign.domain.model.SegmentRef
@@ -187,6 +192,37 @@ class SendLogEntity : PanacheEntityBase() {
     /** Actual request medium; nullable so migration leaves historical decision rows intact. */
     @Column(length = 8)
     var channel: String? = null
+}
+
+/**
+ * GDPR-minimised local projection of an attributable app event.  The source event's party id is
+ * intentionally not copied: Campaign Studio needs aggregate attention signals, not a customer
+ * behavioural-history table.  The event id is the idempotency boundary for Kafka redelivery.
+ */
+@Entity
+@Table(name = "campaign_engagement_event")
+class CampaignEngagementEventEntity : PanacheEntityBase() {
+    @Id
+    @Column(nullable = false, updatable = false)
+    lateinit var eventId: UUID
+
+    @Column(nullable = false)
+    lateinit var campaignId: UUID
+
+    @Column(nullable = false)
+    var stepOrder: Int = 0
+
+    @Column(nullable = false, length = 8)
+    lateinit var channel: String
+
+    @Column(nullable = false, length = 32)
+    lateinit var surface: String
+
+    @Column(nullable = false, length = 16)
+    lateinit var type: String
+
+    @Column(nullable = false)
+    lateinit var occurredAt: Instant
 }
 
 @Entity
@@ -385,6 +421,53 @@ class PanacheCampaignContentExperimentRepository : CampaignContentExperimentRepo
                 converted = row[2] as Long,
             )
         }
+}
+
+/** Event-id idempotency is enforced by Postgres, not a racy read-then-write check in a consumer. */
+@ApplicationScoped
+class PanacheCampaignEngagementRepository : CampaignEngagementRepository {
+    override suspend fun record(event: CampaignEngagementEvent): Boolean = Panache.withTransaction {
+        Panache.getSession().flatMap { session ->
+            session.createNativeQuery<Any>(
+                "INSERT INTO campaign_engagement_event " +
+                    "(event_id, campaign_id, step_order, channel, surface, type, occurred_at) " +
+                    "VALUES (:eventId, :campaignId, :stepOrder, :channel, :surface, :type, :occurredAt) " +
+                    "ON CONFLICT (event_id) DO NOTHING",
+            )
+                .setParameter("eventId", event.eventId)
+                .setParameter("campaignId", event.campaignId)
+                .setParameter("stepOrder", event.stepOrder)
+                .setParameter("channel", event.channel.name)
+                .setParameter("surface", event.surface.name)
+                .setParameter("type", event.type.name)
+                .setParameter("occurredAt", event.occurredAt)
+                .executeUpdate()
+        }
+    }.awaitSuspending() == 1
+
+    override suspend fun metrics(campaignId: UUID): List<CampaignEngagementMetric> = Panache.withSession {
+        Panache.getSession().flatMap { session ->
+            session.createQuery(
+                "select e.stepOrder, e.channel, e.surface, e.type, count(e) " +
+                    "from CampaignEngagementEventEntity e where e.campaignId = :campaignId " +
+                    "group by e.stepOrder, e.channel, e.surface, e.type " +
+                    "order by e.stepOrder, e.channel, e.surface, e.type",
+                Array<Any>::class.java,
+            ).setParameter("campaignId", campaignId).resultList
+        }
+    }.awaitSuspending().map { row ->
+        CampaignEngagementMetric(
+            stepOrder = row[0] as Int,
+            channel = Channel.valueOf(row[1] as String),
+            surface = InAppSurface.valueOf(row[2] as String),
+            type = CampaignEngagementEventType.valueOf(row[EVENT_TYPE_INDEX] as String),
+            count = row[4] as Long,
+        )
+    }
+
+    private companion object {
+        const val EVENT_TYPE_INDEX = 3
+    }
 }
 
 @ApplicationScoped

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/rest/CampaignResource.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/rest/CampaignResource.kt
@@ -84,6 +84,10 @@ data class StepRequest(
     val mobileDestination: MobileDestination? = null,
     /** Closed authenticated-app inventory for a BANNER placement; absent preserves HOME_BANNER. */
     val inAppSurface: InAppSurface? = null,
+    /** Optional path-experiment treatment for arm B; all three fields preserve the copy-only default. */
+    val variantBTemplate: String? = null,
+    val variantBChannel: Channel? = null,
+    val variantBDelaySeconds: Long? = null,
 )
 
 /**
@@ -147,6 +151,9 @@ class CampaignResource(private val service: CampaignService, private val jwt: Js
                 it.fallbackToPush,
                 it.mobileDestination,
                 it.inAppSurface,
+                it.variantBTemplate,
+                it.variantBChannel,
+                it.variantBDelaySeconds,
             )
         }
         val campaign = service.createDraft(

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/rest/CampaignSendLogResource.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/rest/CampaignSendLogResource.kt
@@ -4,6 +4,7 @@
 
 package com.openbank.campaign.infrastructure.rest
 
+import com.openbank.campaign.application.usecase.CampaignEngagementQuery
 import com.openbank.campaign.application.usecase.CampaignSendLogQuery
 import com.openbank.campaign.application.usecase.CampaignSummaryQuery
 import com.openbank.campaign.domain.model.SendOutcome
@@ -23,7 +24,11 @@ import java.util.UUID
  */
 @Path("/api/v1/campaigns")
 @ApplicationScoped
-class CampaignSendLogResource(private val query: CampaignSendLogQuery, private val summaries: CampaignSummaryQuery) {
+class CampaignSendLogResource(
+    private val query: CampaignSendLogQuery,
+    private val summaries: CampaignSummaryQuery,
+    private val engagement: CampaignEngagementQuery,
+) {
 
     /**
      * Reach and delivery for every campaign in one call (issue #3296).
@@ -91,6 +96,16 @@ class CampaignSendLogResource(private val query: CampaignSendLogQuery, private v
     @Path("/{id}/journey")
     @Authorize(action = "campaign.read", resource = "#id")
     suspend fun journey(@PathParam("id") id: UUID): Response = Response.ok(query.funnel(id)).build()
+
+    /**
+     * App attention after a validated campaign handoff.  These are event counts (not people and
+     * not product conversions); an empty list means no attributable event has arrived, not proof
+     * that an audience saw zero content.
+     */
+    @GET
+    @Path("/{id}/engagement")
+    @Authorize(action = "campaign.read", resource = "#id")
+    suspend fun engagement(@PathParam("id") id: UUID): Response = Response.ok(engagement.metrics(id)).build()
 
     private fun badOutcome(cause: Throwable): Response = Response.status(Response.Status.BAD_REQUEST)
         .entity(

--- a/openbank-campaign-service/src/main/resources/application.yaml
+++ b/openbank-campaign-service/src/main/resources/application.yaml
@@ -110,6 +110,20 @@ mp:
         value:
           serializer: org.apache.kafka.common.serialization.StringSerializer
     incoming:
+      # Attributable in-app attention events emitted by engagement-service.  This is aggregate-only
+      # reporting: lag can make a metric temporarily unavailable, but can never affect delivery or
+      # enrolment.  Start at latest so enabling the projection cannot reprocess historic, pre-
+      # attribution app behaviour into a campaign funnel.
+      engagement-events-in:
+        connector: smallrye-kafka
+        topic: openbank.engagement.events
+        value:
+          deserializer: org.apache.kafka.common.serialization.StringDeserializer
+        group:
+          id: openbank-campaign-service-engagement-events
+        auto:
+          offset:
+            reset: latest
       # ADR-0239 D3: delivery outcomes for this service's own send requests, correlated by the
       # send-log row id. Its own consumer group, not the service-wide default one shared with
       # consent-events-in: two channels in one group makes both subscriptions one member set, so a

--- a/openbank-campaign-service/src/main/resources/db/migration/V12__campaign_engagement_projection.sql
+++ b/openbank-campaign-service/src/main/resources/db/migration/V12__campaign_engagement_projection.sql
@@ -1,0 +1,18 @@
+-- Aggregate-only campaign in-app reporting (#4480).  This projection deliberately excludes
+-- party_id: the consumer validates ownership upstream, while Campaign Studio only needs event
+-- counts.  event_id makes at-least-once Kafka delivery idempotent.
+--
+-- Rollback: DROP TABLE campaign_engagement_event; this is a derived read model and can be rebuilt
+-- from retained engagement events if a deployment is rolled back.
+CREATE TABLE campaign_engagement_event (
+    event_id UUID PRIMARY KEY,
+    campaign_id UUID NOT NULL,
+    step_order INTEGER NOT NULL CHECK (step_order >= 0),
+    channel VARCHAR(8) NOT NULL CHECK (channel IN ('PUSH', 'BANNER')),
+    surface VARCHAR(32) NOT NULL CHECK (surface IN ('HOME_BANNER', 'HOME_CAROUSEL', 'PRODUCT_FEED', 'REWARDS_HUB')),
+    type VARCHAR(16) NOT NULL CHECK (type IN ('IMPRESSION', 'CLICK', 'DISMISS')),
+    occurred_at TIMESTAMPTZ NOT NULL
+);
+
+CREATE INDEX campaign_engagement_event_campaign_step_idx
+    ON campaign_engagement_event (campaign_id, step_order, channel, surface, type);

--- a/openbank-campaign-service/src/main/resources/openapi.yaml
+++ b/openbank-campaign-service/src/main/resources/openapi.yaml
@@ -4,7 +4,7 @@ openapi: 3.1.0
 info:
   title: Campaign Service API
   # major == openbank.api.version == URL /api/v1 (ADR-0048).
-  version: 1.26.0
+  version: 1.27.0
   description: >-
     Campaign management first slice (ADR-0200 / ADR-0209 D3): deterministic, versioned segments;
     per-enrolment Temporal journeys; consent-gated delivery through notification-service.
@@ -644,6 +644,26 @@ components:
             campaign into a two-arm experiment, so every step must provide it and conversionRule
             is required. `variables` remains the A arm. Assignment is persisted at enrolment and
             neither an activity retry nor a later code change can switch a person between arms.
+        variantBTemplate:
+          type: string
+          nullable: true
+          description: >-
+            Optional B-arm template for a path experiment. When supplied, variantBChannel is also
+            required and its catalogue channel must match. Absent preserves a copy-only experiment.
+        variantBChannel:
+          type: string
+          nullable: true
+          enum: [EMAIL, PUSH, BANNER]
+          description: >-
+            Optional B-arm delivery channel. A customer remains durably assigned to A or B before
+            the journey starts; retries reuse that treatment rather than running a new random split.
+        variantBDelaySeconds:
+          type: integer
+          nullable: true
+          minimum: 0
+          description: >-
+            Optional B-arm wait before this step. Absent uses delaySeconds, making an existing
+            content experiment backwards compatible while allowing timing-path experiments.
         fallbackToPush:
           type: boolean
           default: false

--- a/openbank-campaign-service/src/main/resources/openapi.yaml
+++ b/openbank-campaign-service/src/main/resources/openapi.yaml
@@ -4,7 +4,7 @@ openapi: 3.1.0
 info:
   title: Campaign Service API
   # major == openbank.api.version == URL /api/v1 (ADR-0048).
-  version: 1.27.0
+  version: 1.28.0
   description: >-
     Campaign management first slice (ADR-0200 / ADR-0209 D3): deterministic, versioned segments;
     per-enrolment Temporal journeys; consent-gated delivery through notification-service.
@@ -389,6 +389,29 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/StepFunnel'
+
+  /api/v1/campaigns/{id}/engagement:
+    get:
+      tags: [Campaigns]
+      summary: Attributable in-app attention by campaign step and surface
+      description: >-
+        Aggregate event observations from an opaque, server-validated campaign interaction
+        reference. These are not people and are never product conversion: one person can create
+        several impressions, clicks or dismissals. Organic and unknown app content is excluded
+        rather than guessed into this funnel; an empty response therefore means no attributable
+        event has arrived, not that exposure was proven to be zero.
+      operationId: campaignEngagement
+      parameters:
+        - $ref: '#/components/parameters/CampaignId'
+      responses:
+        '200':
+          description: Aggregate attributable app engagement, ordered by step and surface
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/CampaignEngagementMetric'
 
   /api/v1/campaigns/{id}/sends/summary:
     get:
@@ -901,6 +924,25 @@ components:
             rather than sent as zero, so a client cannot render an empty bar segment.
           items:
             $ref: '#/components/schemas/SuppressionCount'
+
+    CampaignEngagementMetric:
+      type: object
+      required: [stepOrder, channel, surface, type, count]
+      description: >-
+        An aggregate count of app observations, never customer identities, unique people or
+        product conversions. It is deduplicated by the source event id against Kafka redelivery.
+      properties:
+        stepOrder: { type: integer, minimum: 0 }
+        channel:
+          type: string
+          enum: [PUSH, BANNER]
+        surface:
+          type: string
+          enum: [HOME_BANNER, HOME_CAROUSEL, PRODUCT_FEED, REWARDS_HUB]
+        type:
+          type: string
+          enum: [IMPRESSION, CLICK, DISMISS]
+        count: { type: integer, format: int64, minimum: 0 }
 
     SuppressionCount:
       type: object

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/domain/TemplateCatalogTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/domain/TemplateCatalogTest.kt
@@ -138,9 +138,26 @@ class CampaignStepChannelTest {
             variantBVariables = emptyMap(),
             variantBTemplate = "MARKETING_PRODUCT_OFFER_BANNER",
             variantBChannel = Channel.BANNER,
+            mobileDestination = MobileDestination.HOME,
         )
 
         assertEquals(InAppSurface.HOME_BANNER, step.primaryDelivery(ContentVariant.B).inAppSurface)
+    }
+
+    @Test
+    fun `a B banner path requires its app destination before workflow handoff`() {
+        assertThrows<IllegalArgumentException> {
+            CampaignStep(
+                order = 1,
+                template = "MARKETING_PRODUCT_OFFER",
+                channel = Channel.EMAIL,
+                variables = emptyMap(),
+                delaySeconds = 0,
+                variantBVariables = emptyMap(),
+                variantBTemplate = "MARKETING_PRODUCT_OFFER_BANNER",
+                variantBChannel = Channel.BANNER,
+            )
+        }
     }
 
     @Test

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/domain/TemplateCatalogTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/domain/TemplateCatalogTest.kt
@@ -6,6 +6,7 @@ package com.openbank.campaign.domain
 
 import com.openbank.campaign.domain.model.CampaignStep
 import com.openbank.campaign.domain.model.Channel
+import com.openbank.campaign.domain.model.ContentVariant
 import com.openbank.campaign.domain.model.InAppSurface
 import com.openbank.campaign.domain.model.MobileDestination
 import com.openbank.campaign.domain.model.TemplateCatalog
@@ -89,6 +90,58 @@ class TemplateCatalogTest {
  * copy into an APNs payload, which is the leak #1182 closed by making push bodies generic.
  */
 class CampaignStepChannelTest {
+
+    @Test
+    fun `a B cohort can take a different delivery path without changing its assigned treatment`() {
+        val step = CampaignStep(
+            order = 1,
+            template = "MARKETING_PRODUCT_OFFER",
+            channel = Channel.EMAIL,
+            variables = mapOf("offerTitle" to "Savings", "offerText" to "Four percent", "ctaText" to "Explore"),
+            delaySeconds = 0,
+            variantBVariables = mapOf("offerTitle" to "Save today"),
+            variantBTemplate = "MARKETING_PRODUCT_OFFER_PUSH",
+            variantBChannel = Channel.PUSH,
+            variantBDelaySeconds = 86_400,
+            mobileDestination = MobileDestination.SAVINGS,
+        )
+
+        assertEquals(Channel.EMAIL, step.primaryDelivery(ContentVariant.A).channel)
+        assertEquals(Channel.PUSH, step.primaryDelivery(ContentVariant.B).channel)
+        assertEquals("Save today", step.primaryDelivery(ContentVariant.B).variables["offerTitle"])
+        assertEquals(86_400, step.delayFor(ContentVariant.B))
+    }
+
+    @Test
+    fun `a path experiment rejects an incomplete B treatment`() {
+        assertThrows<IllegalArgumentException> {
+            CampaignStep(
+                order = 1,
+                template = "MARKETING_PRODUCT_OFFER",
+                channel = Channel.EMAIL,
+                variables = emptyMap(),
+                delaySeconds = 0,
+                variantBTemplate = "MARKETING_PRODUCT_OFFER_PUSH",
+            )
+        }
+    }
+
+    @Test
+    fun `a B home-banner path never inherits A's different app surface`() {
+        val step = CampaignStep(
+            order = 1,
+            template = "MARKETING_PRODUCT_OFFER_CAROUSEL",
+            channel = Channel.BANNER,
+            variables = emptyMap(),
+            delaySeconds = 0,
+            inAppSurface = InAppSurface.HOME_CAROUSEL,
+            variantBVariables = emptyMap(),
+            variantBTemplate = "MARKETING_PRODUCT_OFFER_BANNER",
+            variantBChannel = Channel.BANNER,
+        )
+
+        assertEquals(InAppSurface.HOME_BANNER, step.primaryDelivery(ContentVariant.B).inAppSurface)
+    }
 
     @Test
     fun `a banner step carries its approved values to an app destination`() {

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/infrastructure/kafka/CampaignEngagementConsumerTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/infrastructure/kafka/CampaignEngagementConsumerTest.kt
@@ -16,6 +16,7 @@ import io.mockk.mockk
 import io.mockk.slot
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.Test
 import java.time.Instant
 import java.util.UUID
@@ -54,6 +55,13 @@ class CampaignEngagementConsumerTest {
         consumer().onEvent("not json")
 
         coVerify(exactly = 0) { repository.record(any()) }
+    }
+
+    @Test
+    fun `projection storage failure is retried by the Kafka connector`(): Unit = runBlocking {
+        coEvery { repository.record(any()) } throws IllegalStateException("database unavailable")
+
+        assertThrows<IllegalStateException> { consumer().onEvent(attributedEvent()) }
     }
 
     private fun consumer() = CampaignEngagementConsumer(ObjectMapper(), repository)

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/infrastructure/kafka/CampaignEngagementConsumerTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/infrastructure/kafka/CampaignEngagementConsumerTest.kt
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0.
+
+package com.openbank.campaign.infrastructure.kafka
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.campaign.application.port.out.CampaignEngagementEvent
+import com.openbank.campaign.application.port.out.CampaignEngagementEventType
+import com.openbank.campaign.application.port.out.CampaignEngagementRepository
+import com.openbank.campaign.domain.model.Channel
+import com.openbank.campaign.domain.model.InAppSurface
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.UUID
+
+class CampaignEngagementConsumerTest {
+
+    private val repository = mockk<CampaignEngagementRepository>(relaxed = true)
+    private val campaignId = UUID.randomUUID()
+    private val eventId = UUID.randomUUID()
+
+    @Test
+    fun `projects one server-attributed banner impression without party data`(): Unit = runBlocking {
+        coEvery { repository.record(any()) } returns true
+
+        consumer().onEvent(attributedEvent())
+
+        val event = slot<CampaignEngagementEvent>()
+        coVerify(exactly = 1) { repository.record(capture(event)) }
+        assertThat(event.captured).isEqualTo(
+            CampaignEngagementEvent(
+                eventId = eventId,
+                campaignId = campaignId,
+                stepOrder = 2,
+                channel = Channel.BANNER,
+                surface = InAppSurface.HOME_CAROUSEL,
+                type = CampaignEngagementEventType.IMPRESSION,
+                occurredAt = Instant.parse("2026-08-13T09:00:00Z"),
+            ),
+        )
+    }
+
+    @Test
+    fun `organic and client-forbidden conversion events never enter campaign reporting`(): Unit = runBlocking {
+        consumer().onEvent("""{"eventId":"$eventId","type":"IMPRESSION","slot":"HOME_BANNER"}""")
+        consumer().onEvent(attributedEvent().replace("IMPRESSION", "CONVERSION"))
+        consumer().onEvent("not json")
+
+        coVerify(exactly = 0) { repository.record(any()) }
+    }
+
+    private fun consumer() = CampaignEngagementConsumer(ObjectMapper(), repository)
+
+    private fun attributedEvent(): String = """
+        {
+          "eventId":"$eventId",
+          "campaignId":"$campaignId",
+          "stepOrder":2,
+          "channel":"BANNER",
+          "slot":"HOME_CAROUSEL",
+          "type":"IMPRESSION",
+          "occurredAt":"2026-08-13T09:00:00Z",
+          "partyId":"${UUID.randomUUID()}"
+        }
+    """.trimIndent()
+}

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/infrastructure/kafka/CampaignEngagementConsumerTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/infrastructure/kafka/CampaignEngagementConsumerTest.kt
@@ -16,8 +16,8 @@ import io.mockk.mockk
 import io.mockk.slot
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import java.time.Instant
 import java.util.UUID
 

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/integration/CampaignRestContractIT.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/integration/CampaignRestContractIT.kt
@@ -43,6 +43,7 @@ import java.util.UUID
 @QuarkusTestResource(CampaignRestContractIT.NoBrokerNoWorkerResource::class)
 @QuarkusTestResource(CampaignPostgresRedisTestResource::class)
 @TestSecurity(user = "maker@openbank.test", roles = ["ROLE_OPERATOR"])
+@Suppress("LargeClass") // one HTTP contract class intentionally exercises the served campaign resource
 class CampaignRestContractIT {
 
     @Inject

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/integration/CampaignRestContractIT.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/integration/CampaignRestContractIT.kt
@@ -588,16 +588,17 @@ class CampaignRestContractIT {
         }
     }
 
-    /** A/B content survives HTTP and has a measured endpoint even before either arm has enrolled. */
+    /** A/B paths survive HTTP and have a measured endpoint even before either arm has enrolled. */
     @Test
-    fun `a content experiment keeps both declared arms and exposes its empty measurement`() {
+    fun `a path experiment keeps both declared arms and exposes its empty measurement`() {
         val body = """
             {"name":"ab-${UUID.randomUUID()}","goal":"prove A/B content round trip",
              "segmentName":"actives","segmentVersion":1,"conversionRule":"ACCOUNT_OPENED",
              "steps":[{"order":1,"template":"MARKETING_PRODUCT_OFFER",
                        "variables":{"offerTitle":"A","offerText":"A copy","ctaText":"Go"},
-                       "variantBVariables":{"offerTitle":"B","offerText":"B copy","ctaText":"Try"},
-                       "fallbackToPush":true,
+                       "variantBVariables":{"offerTitle":"B"},
+                       "variantBTemplate":"MARKETING_PRODUCT_OFFER_PUSH","variantBChannel":"PUSH",
+                       "variantBDelaySeconds":86400,
                        "delaySeconds":0}]}
         """.trimIndent()
 
@@ -617,7 +618,9 @@ class CampaignRestContractIT {
         } Then {
             statusCode(200)
             body("steps[0].variantBVariables.offerTitle", org.hamcrest.Matchers.equalTo("B"))
-            body("steps[0].fallbackToPush", org.hamcrest.Matchers.equalTo(true))
+            body("steps[0].variantBTemplate", org.hamcrest.Matchers.equalTo("MARKETING_PRODUCT_OFFER_PUSH"))
+            body("steps[0].variantBChannel", org.hamcrest.Matchers.equalTo("PUSH"))
+            body("steps[0].variantBDelaySeconds", org.hamcrest.Matchers.equalTo(86400))
         }
         When {
             get("/api/v1/campaigns/$id/content-experiment")

--- a/openbank-infra/gitops/components/campaign/kafka-campaign-mtls.yaml
+++ b/openbank-infra/gitops/components/campaign/kafka-campaign-mtls.yaml
@@ -50,6 +50,14 @@ spec:
           name: openbank.notification.outcomes.v1
           patternType: literal
         operations: [Read, Describe]
+      # Aggregate-only campaign attention reporting.  The source payload carries an opaque
+      # interaction reference and campaign tuple; campaign-service persists neither party id nor
+      # contact data in its derived projection (#4480).
+      - resource:
+          type: topic
+          name: openbank.engagement.events
+          patternType: literal
+        operations: [Read, Describe]
       # Consume the product events that count as a conversion (ADR-0245 D2). Read-only, and the
       # service only ever appends an outcome row from them — it cannot cause, suppress or alter a
       # send, so the blast radius of this grant is a reporting number.
@@ -99,5 +107,10 @@ spec:
       - resource:
           type: group
           name: openbank-campaign-service-notification-outcomes
+          patternType: literal
+        operations: [Read, Describe]
+      - resource:
+          type: group
+          name: openbank-campaign-service-engagement-events
           patternType: literal
         operations: [Read, Describe]


### PR DESCRIPTION
## Summary

- lets the durable B cohort compare a different template, delivery channel and wait time, not only alternate copy
- keeps retries deterministic: assignment is persisted before the Temporal journey starts
- adds the authoring controls, OpenAPI contract, domain validation and REST/DB coverage

## Delivery

Stacked on #4586, which is stacked on #4577. Merge in that order.

Refs #4476

## Verification

- ./gradlew --offline --console=plain :openbank-campaign-service:test --tests com.openbank.campaign.domain.CampaignStepChannelTest --tests com.openbank.campaign.application.workflow.CampaignJourneyWorkflowTest
- ./gradlew --offline --console=plain :openbank-campaign-service:test --tests com.openbank.campaign.integration.CampaignRestContractIT
- ./gradlew --offline --console=plain :openbank-campaign-service:ktlintCheck
- npm run type-check
- npx vitest run src/test/journey-editor.test.tsx src/test/campaign-studio.test.tsx