### PR TITLE
docs(analytics-sink): cross-reference silver_party_accounts' own upper() fold

### DIFF
--- a/openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/application/AnalyticsConsumer.kt
+++ b/openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/application/AnalyticsConsumer.kt
@@ -219,6 +219,11 @@ class AnalyticsConsumer {
      * Rows already in bronze keep their original spelling; this stops the split growing, it does not
      * heal it. The backfill is tracked separately on #4553 — bronze is a `ReplacingMergeTree`, so
      * re-keying is an explicit CORRECTION ingest, not an in-place update.
+     *
+     * A downstream consumer of this invariant: `V5__party_accounts.sql`'s `silver_party_accounts`
+     * view (ADR-0210 D2, #4520) still folds `upper(aggregate_type)` itself rather than assuming every
+     * future row already arrives uppercase — the view has no way to tell a pre-fix bronze row from a
+     * post-fix one, so it keeps the defence rather than deleting it now that the source produces one.
      */
     private fun resolveAggregateType(node: JsonNode, address: EventAddress): String = (
         node["aggregateType"]?.asText()


### PR DESCRIPTION
## Summary

A doc cross-reference, and the mechanism that unblocks #4553's normalisation from actually
reaching the running pod.

## Type of change

- [x] docs

## Linked issues

Refs #4553

## Changes

Cross-references `resolveAggregateType`'s new uppercasing (#4576) with `silver_party_accounts`'
own `upper(aggregate_type)` fold (#4520) — the view keeps its defence deliberately, since it can't
tell a pre-fix bronze row from a post-fix one, and this notes that at the point someone reading one
side is most likely to wonder why the other didn't get simplified away.

## Why this PR exists at all

#4582 widened `deploy-coverage-guard` and added `analytics-sink` to `ALL_SERVICES`, but the commit
that landed it (`c0057d8`) touched only `.github/`, not `analytics-sink/src`. Reconcile builds every
selected service at the workflow's trigger commit, not each service's own last-changed commit, so
the resulting image (`sandbox-c0057d81`) had no published pact for `analytics-sink` — `can-i-deploy`
correctly refused it (`NOT_ASKED`, #3318), and the gitops manifest still points at `sandbox-d8fc121b`
(2026-07-26), pre-dating #4576's fix. The gate's own message: *"this will NOT self-clear... deploy
the sha services-ci built for openbank-analytics-sink."* This push is that sha.

## Verification

- `ktlintCheck` + `detekt` on the module: green.
- Confirmed on the sandbox ClickHouse warehouse (out of band, not part of this diff) that
  `V5__party_accounts.sql`'s view and #4576's ingest fold agree in shape — not re-verified here since
  neither's logic changed, only the comment.

## Definition of Done

- [x] No behaviour change — a KDoc addition only.
- [ ] Tests — none needed; nothing executable changed.

## Rollout / Rollback

- This push itself deploys nothing directly. It exists to give `services-ci` a fresh commit under
  `analytics-sink/src` so it publishes a pact version, which the next `auto-deploy` run (push-triggered
  by this merge) can then pass `can-i-deploy` for and actually update the gitops manifest.
- Rollback: revert. Comment-only, zero risk either direction.
