### PR TITLE
feat(campaign): report attributable in-app engagement

### DIFF
--- a/openbank-admin-ui/src/app/api/campaigns/[id]/route.ts
+++ b/openbank-admin-ui/src/app/api/campaigns/[id]/route.ts
@@ -124,7 +124,7 @@ export async function GET(_req: Request, ctx: { params: Promise<{ id: string }> 
   const { id } = await ctx.params
   const headers = { authorization: `Bearer ${session.user.accessToken}` }
 
-  const [campaign, enrolments, sends, sendSummary, journey, experiment] = await Promise.all([
+  const [campaign, enrolments, sends, sendSummary, journey, engagement, experiment] = await Promise.all([
     read(headers, `/api/v1/campaigns/${encodeURIComponent(id)}`, null),
     read(headers, `/api/v1/campaigns/${encodeURIComponent(id)}/enrolments`, []),
     // First page only. Paging and filtering go through /api/campaigns/[id]/sends so turning a
@@ -143,6 +143,9 @@ export async function GET(_req: Request, ctx: { params: Promise<{ id: string }> 
     // and the screen died on `.map` with the 404 on /journey never surfacing, because its state had
     // landed under `sendSummary`.
     read(headers, `/api/v1/campaigns/${encodeURIComponent(id)}/journey`, []),
+    // App attention is a separate, privacy-minimised projection.  It is never inferred from a
+    // banner handoff, so a missing/lagging source remains visible as unavailable in Campaign Studio.
+    read(headers, `/api/v1/campaigns/${encodeURIComponent(id)}/engagement`, []),
     readExperiment(headers, id),
   ])
 
@@ -180,6 +183,7 @@ export async function GET(_req: Request, ctx: { params: Promise<{ id: string }> 
     sends: sends.data,
     sendSummary: sendSummary.data,
     journey: journey.data,
+    engagement: engagement.data,
     experiment: experiment.data,
     contentExperiment: contentExperiment.data,
     entryCatalogues: { cadences: cadences.data, triggers: triggers.data },
@@ -192,6 +196,7 @@ export async function GET(_req: Request, ctx: { params: Promise<{ id: string }> 
       sends: sends.state,
       sendSummary: sendSummary.state,
       journey: journey.state,
+      engagement: engagement.state,
       experiment: experiment.state,
       contentExperiment: contentExperiment.state,
       cadences: cadences.state,

--- a/openbank-admin-ui/src/app/campaigns/[id]/page.tsx
+++ b/openbank-admin-ui/src/app/campaigns/[id]/page.tsx
@@ -96,6 +96,14 @@ interface ContentExperiment {
   }
 }
 
+interface CampaignEngagementMetric {
+  stepOrder: number
+  channel: 'PUSH' | 'BANNER'
+  surface: 'HOME_BANNER' | 'HOME_CAROUSEL' | 'PRODUCT_FEED' | 'REWARDS_HUB'
+  type: 'IMPRESSION' | 'CLICK' | 'DISMISS'
+  count: number
+}
+
 type Detail = {
   campaign: Campaign | null
   enrolments: Enrolment[]
@@ -103,6 +111,7 @@ type Detail = {
   partyNames: Record<string, string>
   sendSummary: Record<string, number>
   journey: StepFunnel[]
+  engagement: CampaignEngagementMetric[]
   experiment: Experiment | null
   contentExperiment: ContentExperiment | null
   entryCatalogues?: {
@@ -270,6 +279,7 @@ export default function CampaignDetailPage({ params }: { params: Promise<{ id: s
     loadSends(0, outcome)
   }
   const summary = detail?.sendSummary ?? {}
+  const engagement = Array.isArray(detail?.engagement) ? detail.engagement : []
   const experiment = detail?.experiment
   const contentExperiment = detail?.contentExperiment
   const cadence = c?.schedule
@@ -284,6 +294,12 @@ export default function CampaignDetailPage({ params }: { params: Promise<{ id: s
   const suppressed = Object.entries(summary)
     .filter(([outcome]) => outcome.startsWith('SUPPRESSED'))
     .reduce((n, [, count]) => n + count, 0)
+  const impressions = engagement
+    .filter(metric => metric.type === 'IMPRESSION')
+    .reduce((n, metric) => n + metric.count, 0)
+  const interactions = engagement
+    .filter(metric => metric.type === 'CLICK' || metric.type === 'DISMISS')
+    .reduce((n, metric) => n + metric.count, 0)
 
   const fmtDateTime = (iso: string | null | undefined) =>
     iso
@@ -505,6 +521,8 @@ export default function CampaignDetailPage({ params }: { params: Promise<{ id: s
             suppressed={suppressed}
             conversion={c.conversionRule ? (summary.CONVERTED ?? 0) : null}
             conversionLabel={c.conversionRule ? conversionLabel(c.conversionRule) : t('Cíl není měřen', 'Outcome is not measured')}
+            inAppImpressions={detail?.sources?.engagement === 'ok' ? impressions : null}
+            inAppInteractions={detail?.sources?.engagement === 'ok' ? interactions : null}
             nextAction={nextAction.title}
             nextActionDetail={nextAction.detail}
           />

--- a/openbank-admin-ui/src/components/campaigns/CampaignOutcomeBrief.tsx
+++ b/openbank-admin-ui/src/components/campaigns/CampaignOutcomeBrief.tsx
@@ -22,6 +22,8 @@ export function CampaignOutcomeBrief({
   suppressed,
   conversion,
   conversionLabel,
+  inAppImpressions = null,
+  inAppInteractions = null,
   nextAction,
   nextActionDetail,
 }: {
@@ -32,6 +34,9 @@ export function CampaignOutcomeBrief({
   /** Null means the campaign is not configured to measure an outcome. */
   conversion: number | null
   conversionLabel?: string
+  /** Null means the attribution projection is unavailable; zero is a real aggregate count. */
+  inAppImpressions?: number | null
+  inAppInteractions?: number | null
   nextAction: string
   nextActionDetail: string
 }) {
@@ -63,8 +68,15 @@ export function CampaignOutcomeBrief({
             <span>{conversionLabel ?? t('Výsledek', 'Outcome')}</span>
             <small>{conversion === null ? t('neměřeno', 'not measured') : t('během zařazení', 'while enrolled')}</small>
           </div>
+          <div className="campaign-outcome-conversion" data-engagement={inAppImpressions === null ? 'unavailable' : 'measured'}>
+            <strong>{inAppImpressions === null ? '—' : inAppImpressions.toLocaleString(language === 'cs' ? 'cs-CZ' : 'en-GB')}</strong>
+            <span>{t('V aplikaci viděno', 'Seen in app')}</span>
+            <small>{inAppInteractions === null
+              ? t('data se načítají', 'data unavailable')
+              : t(`${inAppInteractions.toLocaleString(language === 'cs' ? 'cs-CZ' : 'en-GB')} interakcí`, `${inAppInteractions.toLocaleString(language === 'cs' ? 'cs-CZ' : 'en-GB')} interactions`)}</small>
+          </div>
         </div>
-        <p className="campaign-outcome-evidence">{t('Jen provoz kampaně — in-app engagement se této kampani zatím nepřipisuje.', 'Campaign operations only — no in-app engagement is attributed to this campaign yet.')}</p>
+        <p className="campaign-outcome-evidence">{t('In-app metriky jsou agregované události, ne lidé ani bankovní konverze. Kliknutí se nikdy nevydává za výsledek produktu.', 'In-app metrics are aggregate events, not people or banking conversion. A click is never presented as a product outcome.')}</p>
       </div>
       <aside className="campaign-outcome-action" data-testid="campaign-outcome-next-action">
         <p>{t('Další nejlepší akce', 'Next best action')}</p>

--- a/openbank-admin-ui/src/test/campaign-outcome-brief.test.tsx
+++ b/openbank-admin-ui/src/test/campaign-outcome-brief.test.tsx
@@ -26,7 +26,8 @@ describe('campaign outcome brief', () => {
     expect(screen.getByText('Handed off')).toBeTruthy()
     expect(screen.getByText('to notification service')).toBeTruthy()
     expect(screen.getByText('Account opened')).toBeTruthy()
-    expect(screen.getByText(/no in-app engagement is attributed/)).toBeTruthy()
+    expect(screen.getByText('Seen in app')).toBeTruthy()
+    expect(screen.getByText(/aggregate events, not people or banking conversion/)).toBeTruthy()
   })
 
   it('does not show a zero outcome when the campaign measures nothing', () => {

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/port/out/Ports.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/port/out/Ports.kt
@@ -61,6 +61,54 @@ interface CampaignContentExperimentRepository {
     suspend fun metrics(campaignId: UUID): List<ContentVariantMetrics>
 }
 
+/**
+ * One in-app observation that customer-edge has already bound to an opaque campaign interaction.
+ *
+ * This deliberately contains no party identifier.  The reporting read model is an operator-facing
+ * aggregate, and retaining a party merely to answer an aggregate count would turn a marketer view
+ * into a second customer-tracking store.  [eventId] is the producer's immutable idempotency key:
+ * engagement delivery is at-least-once, so a redelivery must not inflate a funnel.
+ */
+data class CampaignEngagementEvent(
+    val eventId: UUID,
+    val campaignId: UUID,
+    val stepOrder: Int,
+    val channel: Channel,
+    val surface: InAppSurface,
+    val type: CampaignEngagementEventType,
+    val occurredAt: Instant,
+) {
+    init {
+        require(stepOrder >= 0) { "campaign step order must be non-negative" }
+        require(channel == Channel.PUSH || channel == Channel.BANNER) {
+            "only mobile campaign interactions are attributable"
+        }
+    }
+}
+
+/** App attention signals.  Product conversion stays in [SendOutcome.CONVERTED], never here. */
+enum class CampaignEngagementEventType { IMPRESSION, CLICK, DISMISS }
+
+/** Aggregate event counts, not people: one person may legitimately create several observations. */
+data class CampaignEngagementMetric(
+    val stepOrder: Int,
+    val channel: Channel,
+    val surface: InAppSurface,
+    val type: CampaignEngagementEventType,
+    val count: Long,
+)
+
+/**
+ * Privacy-minimising, append-only read model for Campaign Studio's in-app engagement funnel.
+ * Its table has one row per source event but never a party id; SQL aggregation therefore remains
+ * bounded and does not expose a customer drill-down endpoint by accident.
+ */
+interface CampaignEngagementRepository {
+    /** Returns false for an already recorded event id (Kafka redelivery). */
+    suspend fun record(event: CampaignEngagementEvent): Boolean
+    suspend fun metrics(campaignId: UUID): List<CampaignEngagementMetric>
+}
+
 /** A single cell of the per-step funnel: how many sends of [outcome] step [stepOrder] produced. */
 data class StepOutcomeCount(val stepOrder: Int, val outcome: SendOutcome, val count: Long)
 

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/usecase/CampaignEngagementQuery.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/usecase/CampaignEngagementQuery.kt
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.campaign.application.usecase
+
+import com.openbank.campaign.application.port.out.CampaignEngagementMetric
+import com.openbank.campaign.application.port.out.CampaignEngagementRepository
+import jakarta.enterprise.context.ApplicationScoped
+import java.util.UUID
+
+/** Read-only Campaign Studio view of app attention, distinct from observed business conversion. */
+@ApplicationScoped
+class CampaignEngagementQuery(private val engagement: CampaignEngagementRepository) {
+    /**
+     * Counts observations, not unique people.  The source contains no party id by design, so this
+     * endpoint cannot accidentally become a customer drill-down surface.
+     */
+    suspend fun metrics(campaignId: UUID): List<CampaignEngagementMetric> = engagement.metrics(campaignId)
+}

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/kafka/CampaignEngagementConsumer.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/kafka/CampaignEngagementConsumer.kt
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.campaign.infrastructure.kafka
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.campaign.application.port.out.CampaignEngagementEvent
+import com.openbank.campaign.application.port.out.CampaignEngagementEventType
+import com.openbank.campaign.application.port.out.CampaignEngagementRepository
+import com.openbank.campaign.domain.model.Channel
+import com.openbank.campaign.domain.model.InAppSurface
+import jakarta.enterprise.context.ApplicationScoped
+import org.eclipse.microprofile.reactive.messaging.Incoming
+import org.jboss.logging.Logger
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * Builds the campaign-local, no-PII projection of attributable engagement events (#4480).
+ *
+ * The source topic also contains organic content events.  They are intentionally ignored: an
+ * absent campaign tuple means "unattributed", not zero engagement and not a best-effort join to
+ * a recent campaign.  Product conversion is likewise excluded; [ConversionConsumer] owns that
+ * independently from authoritative banking events.
+ */
+@ApplicationScoped
+class CampaignEngagementConsumer(
+    private val mapper: ObjectMapper,
+    private val engagement: CampaignEngagementRepository,
+) {
+    private val log = Logger.getLogger(CampaignEngagementConsumer::class.java)
+
+    /** Reporting must never block a Kafka partition on an unrelated malformed app event. */
+    @Suppress("TooGenericExceptionCaught")
+    @Incoming("engagement-events-in")
+    suspend fun onEvent(payload: String) {
+        val event = runCatching { mapper.readTree(payload) }.getOrElse {
+            log.errorf(it, "Unparseable engagement event — dropped from campaign projection")
+            return
+        }
+        val attributable = event.toCampaignEngagementEvent() ?: return
+        try {
+            engagement.record(attributable)
+        } catch (e: Exception) {
+            // This is a read model, never a delivery decision.  Dropping a poisoned record keeps
+            // campaign orchestration independent; monitoring sees the error and the UI must treat
+            // an absent metric as unavailable, not as a zero.
+            log.errorf(e, "Could not project engagement event %s", attributable.eventId)
+        }
+    }
+
+    private fun JsonNode.toCampaignEngagementEvent(): CampaignEngagementEvent? {
+        val campaignId = uuid("campaignId") ?: return null
+        val eventId = uuid("eventId") ?: return null
+        val stepOrder = path("stepOrder").takeIf { it.isInt }?.intValue()?.takeIf { it >= 0 } ?: return null
+        val channel = named("channel", Channel.entries) ?: return null
+        val surface = named("slot", InAppSurface.entries) ?: return null
+        val type = named("type", CampaignEngagementEventType.entries) ?: return null
+        val occurredAt = runCatching { Instant.parse(path("occurredAt").asText()) }.getOrNull() ?: return null
+        return runCatching {
+            CampaignEngagementEvent(eventId, campaignId, stepOrder, channel, surface, type, occurredAt)
+        }.getOrNull()
+    }
+
+    private fun JsonNode.uuid(field: String): UUID? = path(field).asText()
+        .takeIf { it.isNotBlank() }
+        ?.let { runCatching { UUID.fromString(it) }.getOrNull() }
+
+    private fun <T : Enum<T>> JsonNode.named(field: String, values: Iterable<T>): T? = path(field).asText()
+        .takeIf { it.isNotBlank() }
+        ?.let { raw -> values.find { it.name == raw } }
+}

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/persistence/Persistence.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/persistence/Persistence.kt
@@ -460,9 +460,13 @@ class PanacheCampaignEngagementRepository : CampaignEngagementRepository {
             stepOrder = row[0] as Int,
             channel = Channel.valueOf(row[1] as String),
             surface = InAppSurface.valueOf(row[2] as String),
-            type = CampaignEngagementEventType.valueOf(row[3] as String),
+            type = CampaignEngagementEventType.valueOf(row[EVENT_TYPE_INDEX] as String),
             count = row[4] as Long,
         )
+    }
+
+    private companion object {
+        const val EVENT_TYPE_INDEX = 3
     }
 }
 

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/persistence/Persistence.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/persistence/Persistence.kt
@@ -7,6 +7,10 @@ package com.openbank.campaign.infrastructure.persistence
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.openbank.campaign.application.port.out.CampaignContentExperimentRepository
+import com.openbank.campaign.application.port.out.CampaignEngagementEvent
+import com.openbank.campaign.application.port.out.CampaignEngagementEventType
+import com.openbank.campaign.application.port.out.CampaignEngagementMetric
+import com.openbank.campaign.application.port.out.CampaignEngagementRepository
 import com.openbank.campaign.application.port.out.CampaignEnrolmentCount
 import com.openbank.campaign.application.port.out.CampaignExperimentRepository
 import com.openbank.campaign.application.port.out.CampaignInteractionAttribution
@@ -30,6 +34,7 @@ import com.openbank.campaign.domain.model.DeliveryTransition
 import com.openbank.campaign.domain.model.Enrolment
 import com.openbank.campaign.domain.model.EnrolmentState
 import com.openbank.campaign.domain.model.ExperimentCohort
+import com.openbank.campaign.domain.model.InAppSurface
 import com.openbank.campaign.domain.model.Segment
 import com.openbank.campaign.domain.model.SegmentCatalog
 import com.openbank.campaign.domain.model.SegmentRef
@@ -187,6 +192,37 @@ class SendLogEntity : PanacheEntityBase() {
     /** Actual request medium; nullable so migration leaves historical decision rows intact. */
     @Column(length = 8)
     var channel: String? = null
+}
+
+/**
+ * GDPR-minimised local projection of an attributable app event.  The source event's party id is
+ * intentionally not copied: Campaign Studio needs aggregate attention signals, not a customer
+ * behavioural-history table.  The event id is the idempotency boundary for Kafka redelivery.
+ */
+@Entity
+@Table(name = "campaign_engagement_event")
+class CampaignEngagementEventEntity : PanacheEntityBase() {
+    @Id
+    @Column(nullable = false, updatable = false)
+    lateinit var eventId: UUID
+
+    @Column(nullable = false)
+    lateinit var campaignId: UUID
+
+    @Column(nullable = false)
+    var stepOrder: Int = 0
+
+    @Column(nullable = false, length = 8)
+    lateinit var channel: String
+
+    @Column(nullable = false, length = 32)
+    lateinit var surface: String
+
+    @Column(nullable = false, length = 16)
+    lateinit var type: String
+
+    @Column(nullable = false)
+    lateinit var occurredAt: Instant
 }
 
 @Entity
@@ -385,6 +421,49 @@ class PanacheCampaignContentExperimentRepository : CampaignContentExperimentRepo
                 converted = row[2] as Long,
             )
         }
+}
+
+/** Event-id idempotency is enforced by Postgres, not a racy read-then-write check in a consumer. */
+@ApplicationScoped
+class PanacheCampaignEngagementRepository : CampaignEngagementRepository {
+    override suspend fun record(event: CampaignEngagementEvent): Boolean = Panache.withTransaction {
+        Panache.getSession().flatMap { session ->
+            session.createNativeQuery<Any>(
+                "INSERT INTO campaign_engagement_event " +
+                    "(event_id, campaign_id, step_order, channel, surface, type, occurred_at) " +
+                    "VALUES (:eventId, :campaignId, :stepOrder, :channel, :surface, :type, :occurredAt) " +
+                    "ON CONFLICT (event_id) DO NOTHING",
+            )
+                .setParameter("eventId", event.eventId)
+                .setParameter("campaignId", event.campaignId)
+                .setParameter("stepOrder", event.stepOrder)
+                .setParameter("channel", event.channel.name)
+                .setParameter("surface", event.surface.name)
+                .setParameter("type", event.type.name)
+                .setParameter("occurredAt", event.occurredAt)
+                .executeUpdate()
+        }
+    }.awaitSuspending() == 1
+
+    override suspend fun metrics(campaignId: UUID): List<CampaignEngagementMetric> = Panache.withSession {
+        Panache.getSession().flatMap { session ->
+            session.createQuery(
+                "select e.stepOrder, e.channel, e.surface, e.type, count(e) " +
+                    "from CampaignEngagementEventEntity e where e.campaignId = :campaignId " +
+                    "group by e.stepOrder, e.channel, e.surface, e.type " +
+                    "order by e.stepOrder, e.channel, e.surface, e.type",
+                Array<Any>::class.java,
+            ).setParameter("campaignId", campaignId).resultList
+        }
+    }.awaitSuspending().map { row ->
+        CampaignEngagementMetric(
+            stepOrder = row[0] as Int,
+            channel = Channel.valueOf(row[1] as String),
+            surface = InAppSurface.valueOf(row[2] as String),
+            type = CampaignEngagementEventType.valueOf(row[3] as String),
+            count = row[4] as Long,
+        )
+    }
 }
 
 @ApplicationScoped

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/rest/CampaignSendLogResource.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/rest/CampaignSendLogResource.kt
@@ -4,6 +4,7 @@
 
 package com.openbank.campaign.infrastructure.rest
 
+import com.openbank.campaign.application.usecase.CampaignEngagementQuery
 import com.openbank.campaign.application.usecase.CampaignSendLogQuery
 import com.openbank.campaign.application.usecase.CampaignSummaryQuery
 import com.openbank.campaign.domain.model.SendOutcome
@@ -23,7 +24,11 @@ import java.util.UUID
  */
 @Path("/api/v1/campaigns")
 @ApplicationScoped
-class CampaignSendLogResource(private val query: CampaignSendLogQuery, private val summaries: CampaignSummaryQuery) {
+class CampaignSendLogResource(
+    private val query: CampaignSendLogQuery,
+    private val summaries: CampaignSummaryQuery,
+    private val engagement: CampaignEngagementQuery,
+) {
 
     /**
      * Reach and delivery for every campaign in one call (issue #3296).
@@ -91,6 +96,16 @@ class CampaignSendLogResource(private val query: CampaignSendLogQuery, private v
     @Path("/{id}/journey")
     @Authorize(action = "campaign.read", resource = "#id")
     suspend fun journey(@PathParam("id") id: UUID): Response = Response.ok(query.funnel(id)).build()
+
+    /**
+     * App attention after a validated campaign handoff.  These are event counts (not people and
+     * not product conversions); an empty list means no attributable event has arrived, not proof
+     * that an audience saw zero content.
+     */
+    @GET
+    @Path("/{id}/engagement")
+    @Authorize(action = "campaign.read", resource = "#id")
+    suspend fun engagement(@PathParam("id") id: UUID): Response = Response.ok(engagement.metrics(id)).build()
 
     private fun badOutcome(cause: Throwable): Response = Response.status(Response.Status.BAD_REQUEST)
         .entity(

--- a/openbank-campaign-service/src/main/resources/application.yaml
+++ b/openbank-campaign-service/src/main/resources/application.yaml
@@ -110,6 +110,20 @@ mp:
         value:
           serializer: org.apache.kafka.common.serialization.StringSerializer
     incoming:
+      # Attributable in-app attention events emitted by engagement-service.  This is aggregate-only
+      # reporting: lag can make a metric temporarily unavailable, but can never affect delivery or
+      # enrolment.  Start at latest so enabling the projection cannot reprocess historic, pre-
+      # attribution app behaviour into a campaign funnel.
+      engagement-events-in:
+        connector: smallrye-kafka
+        topic: openbank.engagement.events
+        value:
+          deserializer: org.apache.kafka.common.serialization.StringDeserializer
+        group:
+          id: openbank-campaign-service-engagement-events
+        auto:
+          offset:
+            reset: latest
       # ADR-0239 D3: delivery outcomes for this service's own send requests, correlated by the
       # send-log row id. Its own consumer group, not the service-wide default one shared with
       # consent-events-in: two channels in one group makes both subscriptions one member set, so a

--- a/openbank-campaign-service/src/main/resources/db/migration/V12__campaign_engagement_projection.sql
+++ b/openbank-campaign-service/src/main/resources/db/migration/V12__campaign_engagement_projection.sql
@@ -1,0 +1,18 @@
+-- Aggregate-only campaign in-app reporting (#4480).  This projection deliberately excludes
+-- party_id: the consumer validates ownership upstream, while Campaign Studio only needs event
+-- counts.  event_id makes at-least-once Kafka delivery idempotent.
+--
+-- Rollback: DROP TABLE campaign_engagement_event; this is a derived read model and can be rebuilt
+-- from retained engagement events if a deployment is rolled back.
+CREATE TABLE campaign_engagement_event (
+    event_id UUID PRIMARY KEY,
+    campaign_id UUID NOT NULL,
+    step_order INTEGER NOT NULL CHECK (step_order >= 0),
+    channel VARCHAR(8) NOT NULL CHECK (channel IN ('PUSH', 'BANNER')),
+    surface VARCHAR(32) NOT NULL CHECK (surface IN ('HOME_BANNER', 'HOME_CAROUSEL', 'PRODUCT_FEED', 'REWARDS_HUB')),
+    type VARCHAR(16) NOT NULL CHECK (type IN ('IMPRESSION', 'CLICK', 'DISMISS')),
+    occurred_at TIMESTAMPTZ NOT NULL
+);
+
+CREATE INDEX campaign_engagement_event_campaign_step_idx
+    ON campaign_engagement_event (campaign_id, step_order, channel, surface, type);

--- a/openbank-campaign-service/src/main/resources/openapi.yaml
+++ b/openbank-campaign-service/src/main/resources/openapi.yaml
@@ -4,7 +4,7 @@ openapi: 3.1.0
 info:
   title: Campaign Service API
   # major == openbank.api.version == URL /api/v1 (ADR-0048).
-  version: 1.27.0
+  version: 1.28.0
   description: >-
     Campaign management first slice (ADR-0200 / ADR-0209 D3): deterministic, versioned segments;
     per-enrolment Temporal journeys; consent-gated delivery through notification-service.
@@ -389,6 +389,29 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/StepFunnel'
+
+  /api/v1/campaigns/{id}/engagement:
+    get:
+      tags: [Campaigns]
+      summary: Attributable in-app attention by campaign step and surface
+      description: >-
+        Aggregate event observations from an opaque, server-validated campaign interaction
+        reference. These are not people and are never product conversion: one person can create
+        several impressions, clicks or dismissals. Organic and unknown app content is excluded
+        rather than guessed into this funnel; an empty response therefore means no attributable
+        event has arrived, not that exposure was proven to be zero.
+      operationId: campaignEngagement
+      parameters:
+        - $ref: '#/components/parameters/CampaignId'
+      responses:
+        '200':
+          description: Aggregate attributable app engagement, ordered by step and surface
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/CampaignEngagementMetric'
 
   /api/v1/campaigns/{id}/sends/summary:
     get:
@@ -901,6 +924,25 @@ components:
             rather than sent as zero, so a client cannot render an empty bar segment.
           items:
             $ref: '#/components/schemas/SuppressionCount'
+
+    CampaignEngagementMetric:
+      type: object
+      required: [stepOrder, channel, surface, type, count]
+      description: >-
+        An aggregate count of app observations, never customer identities, unique people or
+        product conversions. It is deduplicated by the source event id against Kafka redelivery.
+      properties:
+        stepOrder: { type: integer, minimum: 0 }
+        channel:
+          type: string
+          enum: [PUSH, BANNER]
+        surface:
+          type: string
+          enum: [HOME_BANNER, HOME_CAROUSEL, PRODUCT_FEED, REWARDS_HUB]
+        type:
+          type: string
+          enum: [IMPRESSION, CLICK, DISMISS]
+        count: { type: integer, format: int64, minimum: 0 }
 
     SuppressionCount:
       type: object

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/infrastructure/kafka/CampaignEngagementConsumerTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/infrastructure/kafka/CampaignEngagementConsumerTest.kt
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0.
+
+package com.openbank.campaign.infrastructure.kafka
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.campaign.application.port.out.CampaignEngagementEvent
+import com.openbank.campaign.application.port.out.CampaignEngagementEventType
+import com.openbank.campaign.application.port.out.CampaignEngagementRepository
+import com.openbank.campaign.domain.model.Channel
+import com.openbank.campaign.domain.model.InAppSurface
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.UUID
+
+class CampaignEngagementConsumerTest {
+
+    private val repository = mockk<CampaignEngagementRepository>(relaxed = true)
+    private val campaignId = UUID.randomUUID()
+    private val eventId = UUID.randomUUID()
+
+    @Test
+    fun `projects one server-attributed banner impression without party data`(): Unit = runBlocking {
+        coEvery { repository.record(any()) } returns true
+
+        consumer().onEvent(attributedEvent())
+
+        val event = slot<CampaignEngagementEvent>()
+        coVerify(exactly = 1) { repository.record(capture(event)) }
+        assertThat(event.captured).isEqualTo(
+            CampaignEngagementEvent(
+                eventId = eventId,
+                campaignId = campaignId,
+                stepOrder = 2,
+                channel = Channel.BANNER,
+                surface = InAppSurface.HOME_CAROUSEL,
+                type = CampaignEngagementEventType.IMPRESSION,
+                occurredAt = Instant.parse("2026-08-13T09:00:00Z"),
+            ),
+        )
+    }
+
+    @Test
+    fun `organic and client-forbidden conversion events never enter campaign reporting`(): Unit = runBlocking {
+        consumer().onEvent("""{"eventId":"$eventId","type":"IMPRESSION","slot":"HOME_BANNER"}""")
+        consumer().onEvent(attributedEvent().replace("IMPRESSION", "CONVERSION"))
+        consumer().onEvent("not json")
+
+        coVerify(exactly = 0) { repository.record(any()) }
+    }
+
+    private fun consumer() = CampaignEngagementConsumer(ObjectMapper(), repository)
+
+    private fun attributedEvent(): String = """
+        {
+          "eventId":"$eventId",
+          "campaignId":"$campaignId",
+          "stepOrder":2,
+          "channel":"BANNER",
+          "slot":"HOME_CAROUSEL",
+          "type":"IMPRESSION",
+          "occurredAt":"2026-08-13T09:00:00Z",
+          "partyId":"${UUID.randomUUID()}"
+        }
+    """.trimIndent()
+}

--- a/openbank-infra/gitops/components/campaign/kafka-campaign-mtls.yaml
+++ b/openbank-infra/gitops/components/campaign/kafka-campaign-mtls.yaml
@@ -50,6 +50,14 @@ spec:
           name: openbank.notification.outcomes.v1
           patternType: literal
         operations: [Read, Describe]
+      # Aggregate-only campaign attention reporting.  The source payload carries an opaque
+      # interaction reference and campaign tuple; campaign-service persists neither party id nor
+      # contact data in its derived projection (#4480).
+      - resource:
+          type: topic
+          name: openbank.engagement.events
+          patternType: literal
+        operations: [Read, Describe]
       # Consume the product events that count as a conversion (ADR-0245 D2). Read-only, and the
       # service only ever appends an outcome row from them — it cannot cause, suppress or alter a
       # send, so the blast radius of this grant is a reporting number.
@@ -99,5 +107,10 @@ spec:
       - resource:
           type: group
           name: openbank-campaign-service-notification-outcomes
+          patternType: literal
+        operations: [Read, Describe]
+      - resource:
+          type: group
+          name: openbank-campaign-service-engagement-events
           patternType: literal
         operations: [Read, Describe]


### PR DESCRIPTION
Closes #4480\n\nAdds a privacy-minimised, idempotent campaign projection for server-attributed in-app events, a campaign aggregate API, Campaign Studio evidence card, Kafka ACL/configuration and tests.\n\nVerified locally:\n- CampaignEngagementConsumerTest\n- CampaignRestContractIT (27/27)\n- Campaign UI type-check, lint and focused UI tests (5/5)\n- :openbank-campaign-service:quarkusBuild\n\nThis PR is intentionally stacked on #4588, which is stacked on #4586 and #4577.