### PR TITLE
feat(admin-ui): strengthen operator dashboard

### DIFF
--- a/docs/design/admin-ui-audit-2026-08.md
+++ b/docs/design/admin-ui-audit-2026-08.md
@@ -1,0 +1,79 @@
+# Admin UI audit — 2026-08-13
+
+## Outcome
+
+The operator console has strong safety foundations: an authenticated same-origin BFF
+(ADR-0056), nonce CSP, bilingual state handling, graceful unavailable states, and a
+shared status vocabulary. Its main gap is not a missing visual style; it is that
+implementation is uneven across a now-large surface. The next work must be tranches,
+not a visual rewrite.
+
+This audit deliberately treats an unmeasured value as unavailable. A polished dashboard
+that presents a health-check proxy as security, compliance, p99 latency, throughput or
+CPU is less safe than a smaller dashboard that says only what it knows.
+
+## Changes landed with this audit
+
+- `/dashboard` now displays only current discovery/health-check facts: healthy and
+  deployed service counts, health-check latency when observed, and planned/not-deployed
+  count. It no longer invents security, compliance, error-rate, p99, throughput, or
+  CPU metrics from health checks.
+- Dashboard shortcuts use the same role permission matrix as the sidebar, so a shortcut
+  cannot lead an operator into a predictable 403.
+- Header help and approval icons are actionable links rather than inert controls.
+- `/api/iaops/rca` now authenticates and requires `system:view` itself before invoking
+  the internal RCA service. It returns a generic upstream envelope rather than exposing
+  provider or cluster diagnostics.
+
+## ADR delivery assessment
+
+| ADR | Current evidence | Delivery assessment | Next bounded tranche |
+| --- | --- | --- | --- |
+| ADR-0208 — primitives and status vocabulary | 102 `page.tsx`; 10 import `PageHeader`, 7 `StatCard`, 21 `StatusBadge`; 96 still contain inline styles and 62 raw-colour pages remain. | Partially delivered. The primitive layer exists but is not yet the default way to build a screen. | Migrate one coherent, high-traffic workspace at a time (dashboard, approvals, accounts), add a path-scoped guard, and stop each tranche when its browser test passes. |
+| ADR-0228 — entity resolution and palette | The palette and resolver exist, but the palette type supports only `party` and `account`. | Partially delivered. It is useful, not yet the universal backoffice entry point promised by the ADR. | Add payment, transaction and card references only after their provider contracts return minimised/audited results. Do not add browser-side fan-out. |
+| ADR-0229 — generated role model and persona IA | KYC/SUPERVISOR roles and persona quick links exist, while `middleware.ts` still contains a handwritten route-guard list and the UI matrix is not generated from governance. | Partially delivered. Navigation is role-aware; route policy can still drift. | Generate or CI-compare UI roles, route permissions and realm roles from the governance matrix; then derive middleware guards from that projection. |
+| ADR-0227 — unified approval inbox | `/approvals` and a pending-approval route exist, but the ADR remains proposed/planned and its full federated canonical contract is not evidenced by the UI alone. | Do not call complete. | Verify the canonical `ApprovalItem` contract across each source before adding filters, bulk actions or new mutation controls. |
+| ADR-0230 — hybrid lending/fraud/SDD consoles | Read surfaces exist for all three domains. | Read-first direction is present; proposal-only mutation posture needs a dedicated contract-by-contract review. | Prove every state-changing control creates an approval proposal; forbid direct mutation paths where that proof is absent. |
+
+## Architecture and security findings
+
+1. **Truthfulness is a UX and control requirement.** Health reachability is not SLO,
+   p99, request error rate, throughput, security posture, or compliance. Each claim
+   needs its own source and freshness metadata.
+2. **API routes must authorise themselves.** Middleware is useful defence in depth but
+   is not a replacement for a route's server-side session/permission check, especially
+   for expensive relays and endpoints that return operational detail.
+3. **The BFF boundary is correctly established but needs a ratchet.** Existing direct
+   browser calls should migrate to `svcUrl()`/BFF routes in focused tranches. Do not
+   create a second browser-to-service path to simplify an individual page.
+4. **The console is desktop-first by design, but keyboard and assistive use remain
+   release criteria.** New controls need names, focus behaviour, and browser checks;
+   visual acceptance cannot be inferred from TypeScript alone.
+
+## Prioritised roadmap
+
+1. **P0 — retain this audit's truthfulness and route-auth tests.** Any new dashboard
+   metric needs a named source, timestamp and semantics; any new server relay needs
+   authn/authz plus a safe upstream-error envelope.
+2. **P1 — complete ADR-0229's single policy projection.** This is the highest-leverage
+   safety/UX work: one role model should drive realm, backend, sidebar, route guard,
+   and action affordance.
+3. **P1 — finish ADR-0228 by provider, not by UI mock.** Extend typed, audited result
+   contracts and then add the matching palette group. Never expose a full PAN or an
+   unminimised customer payload.
+4. **P2 — migrate the first three operator workspaces to ADR-0208 primitives.** Add
+   browser verification to each tranche; no global CSS rewrite and no new design
+   dependency until a real page needs it.
+5. **P2 — assess every mutable screen against ADR-0227/0230.** For money-path or
+   destructive actions, the UI creates a proposal and the approval inbox disposes it;
+   direct writes require an explicit, separately approved exception.
+
+## Verification performed
+
+- Focused Vitest coverage for fleet-health truthfulness, role/persona behaviour, and
+  IAOps RCA authentication/error handling.
+- TypeScript type check and ESLint for all edited source and test files.
+- Playwright browser verification of the dashboard's real CSS, observed metrics, and
+  actionable header links.
+- `npm audit --omit=dev --audit-level=high`: no known production dependency
+  vulnerabilities at the time of the audit.

--- a/openbank-admin-ui/e2e/ui-primitives.spec.ts
+++ b/openbank-admin-ui/e2e/ui-primitives.spec.ts
@@ -90,7 +90,7 @@ test.describe('ADR-0208 primitives render with real CSS applied', () => {
     await expect(page.getByText('Throughput', { exact: true })).toHaveCount(0)
 
     await expect(page.getByRole('link', { name: 'Help and documentation' })).toHaveAttribute('href', '/docs')
-    await expect(page.getByRole('link', { name: 'Approvals' })).toHaveAttribute('href', '/approvals')
+    await expect(page.locator('header').getByRole('link', { name: 'Approvals' })).toHaveAttribute('href', '/approvals')
 
     // The approved dashboard direction is deliberately denser than the old generic-card
     // layout: four factual metrics at desktop, then a two-column service overview. These

--- a/openbank-admin-ui/e2e/ui-primitives.spec.ts
+++ b/openbank-admin-ui/e2e/ui-primitives.spec.ts
@@ -58,6 +58,51 @@ const CONSENTS = [
 ]
 
 test.describe('ADR-0208 primitives render with real CSS applied', () => {
+  test('dashboard distinguishes current health from unobserved operational and compliance claims', async ({ page }) => {
+    await page.route('**/api/services/governance', route =>
+      route.fulfill({
+        status: 200,
+        body: JSON.stringify({ items: [
+          { serviceName: 'account-service', dataDomain: 'core' },
+          { serviceName: 'ledger-service', dataDomain: 'core' },
+          { serviceName: 'aml-service', dataDomain: 'compliance' },
+        ] }),
+      }),
+    )
+    await page.route('**/api/services/health', route =>
+      route.fulfill({
+        status: 200,
+        body: JSON.stringify({ services: [
+          { name: 'account-service', label: 'Accounts', group: 'core', status: 'UP', latencyMs: 12 },
+          { name: 'ledger-service', label: 'Ledger', group: 'core', status: 'DOWN', latencyMs: 28 },
+        ] }),
+      }),
+    )
+
+    await page.goto('/dashboard')
+
+    await expect(page.getByText('Healthy services', { exact: true })).toBeVisible()
+    await expect(page.getByText('1/2', { exact: true })).toBeVisible()
+    await expect(page.getByText('Average check latency', { exact: true })).toBeVisible()
+    // Health discovery does not measure any of these. Rendering a proxy as a fact is unsafe.
+    await expect(page.getByText('Security Grade', { exact: true })).toHaveCount(0)
+    await expect(page.getByText('Error Rate', { exact: true })).toHaveCount(0)
+    await expect(page.getByText('Throughput', { exact: true })).toHaveCount(0)
+
+    await expect(page.getByRole('link', { name: 'Help and documentation' })).toHaveAttribute('href', '/docs')
+    await expect(page.getByRole('link', { name: 'Approvals' })).toHaveAttribute('href', '/approvals')
+
+    // The approved dashboard direction is deliberately denser than the old generic-card
+    // layout: four factual metrics at desktop, then a two-column service overview. These
+    // geometry checks make that information hierarchy a browser-observable contract.
+    const metricGrid = page.locator('[aria-label="Platform key metrics"]')
+    expect(await metricGrid.evaluate(el => getComputedStyle(el).gridTemplateColumns.split(' ').length)).toBe(4)
+    expect(await metricGrid.locator('.stat-card').first().evaluate(el => getComputedStyle(el).borderTopLeftRadius)).toBe('12px')
+
+    const serviceGrid = page.locator('[aria-label="Services by group"]')
+    expect(await serviceGrid.evaluate(el => getComputedStyle(el).gridTemplateColumns.split(' ').length)).toBe(2)
+  })
+
   test('tone swatches are square with zero padding, at both sizes', async ({ page }) => {
     await page.route('**/api/prod-readiness', route =>
       route.fulfill({ status: 200, body: JSON.stringify(READINESS) }),

--- a/openbank-admin-ui/src/app/api/iaops/rca/route.ts
+++ b/openbank-admin-ui/src/app/api/iaops/rca/route.ts
@@ -3,14 +3,17 @@
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 
 import { NextRequest, NextResponse } from 'next/server'
+import { auth } from '@/auth'
+import { hasPermission } from '@/lib/auth/roles'
 
 export const dynamic = 'force-dynamic'
 
 // BFF proxy to HolmesGPT /api/chat (ADR-0088 Davis-lite, ADR-0031 D9 read-only
 // oversight agent). The admin-UI calls this endpoint with a plain-text alert
 // description; this route forwards it to the in-cluster HolmesGPT service and
-// returns the RCA text. No auth required on this side — the admin-UI is already
-// behind AuthGuard (system:view); HolmesGPT is in-cluster only (no ingress).
+// returns the RCA text. This route performs its own session + permission check:
+// a client-side AuthGuard is presentation only and cannot protect a direct API request.
+// HolmesGPT stays in-cluster only (no ingress).
 //
 // Timeout: 300s mirrors the relay timeout. NVIDIA NIM 8B takes ~30-60s for a
 // full tool-loop RCA (Prometheus + k8s state fetch + LLM); 300s is a safe cap.
@@ -35,6 +38,14 @@ function extractRca(body: unknown): string {
 }
 
 export async function POST(req: NextRequest) {
+  const session = await auth()
+  if (!session?.user) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+  }
+  if (!hasPermission(session.user.roles ?? [], 'system:view')) {
+    return NextResponse.json({ error: 'forbidden' }, { status: 403 })
+  }
+
   const { ask } = (await req.json()) as { ask?: string }
   if (!ask || typeof ask !== 'string' || ask.trim().length < 5) {
     return NextResponse.json({ error: 'ask is required' }, { status: 400 })
@@ -48,13 +59,15 @@ export async function POST(req: NextRequest) {
       signal: AbortSignal.timeout(300_000),
     })
     if (!upstream.ok) {
-      const err = await upstream.text().catch(() => upstream.statusText)
-      return NextResponse.json({ error: `HolmesGPT error: ${err}` }, { status: upstream.status })
+      // Never disclose an upstream body to the browser. It can contain cluster detail or
+      // provider diagnostics that do not belong in an operator-facing error (ADR-0080 P1).
+      console.error('HolmesGPT RCA upstream failed', { status: upstream.status })
+      return NextResponse.json({ error: 'upstream_error' }, { status: 502 })
     }
     const raw = await upstream.json().catch(() => null)
     return NextResponse.json({ rca: extractRca(raw) })
-  } catch (e) {
-    const msg = e instanceof Error ? e.message : String(e)
-    return NextResponse.json({ error: `investigation failed: ${msg}` }, { status: 502 })
+  } catch {
+    console.error('HolmesGPT RCA request failed')
+    return NextResponse.json({ error: 'upstream_error' }, { status: 502 })
   }
 }

--- a/openbank-admin-ui/src/app/dashboard/Dashboard.module.css
+++ b/openbank-admin-ui/src/app/dashboard/Dashboard.module.css
@@ -1,0 +1,265 @@
+.dashboard {
+  max-width: 1400px;
+  padding: 28px 32px 40px;
+  animation: fadeIn 0.2s ease-out;
+}
+
+.headerIcon {
+  color: var(--accent);
+}
+
+.headerActions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.lastRefresh {
+  color: var(--text-tertiary);
+  font-size: 11px;
+  white-space: nowrap;
+}
+
+.metrics {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.metric {
+  min-height: 122px;
+  padding: 18px;
+  border-radius: 12px;
+}
+
+.healthOverview,
+.serviceGroup,
+.quickAccess {
+  padding: 18px;
+}
+
+.healthOverview {
+  margin-bottom: 16px;
+}
+
+.sectionLabel {
+  margin: 0 0 14px;
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  line-height: 1.2;
+  text-transform: uppercase;
+}
+
+.healthGroups {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 16px 24px;
+}
+
+.healthGroupHeader,
+.serviceGroupHeader,
+.serviceGroupTitle {
+  display: flex;
+  align-items: center;
+}
+
+.healthGroupHeader,
+.serviceGroupHeader {
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.healthGroupHeader {
+  margin-bottom: 7px;
+}
+
+.groupName {
+  color: var(--text-primary);
+  font-size: 12px;
+  font-weight: 650;
+  text-transform: capitalize;
+}
+
+.groupSummary {
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+.healthBar {
+  height: 6px;
+  overflow: hidden;
+  background: var(--border);
+  border-radius: 999px;
+}
+
+.healthBarFill {
+  height: 100%;
+  border-radius: inherit;
+  transition: width 0.3s ease;
+}
+
+.serviceGroups {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+.serviceGroupHeader {
+  margin-bottom: 14px;
+}
+
+.serviceGroupTitle {
+  gap: 8px;
+  min-width: 0;
+}
+
+.serviceGroupTitle .sectionLabel {
+  margin-bottom: 0;
+}
+
+.groupDot,
+.serviceDot {
+  display: inline-block;
+  flex: 0 0 auto;
+  border-radius: 50%;
+}
+
+.groupDot {
+  width: 8px;
+  height: 8px;
+}
+
+.groupStatus {
+  flex: 0 0 auto;
+  font-size: 11px;
+  white-space: nowrap;
+}
+
+.serviceChips,
+.quickLinks {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.serviceChip {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 4px 9px;
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  font-size: 11px;
+  font-weight: 500;
+  line-height: 1.25;
+}
+
+.serviceChipHealthy {
+  background: var(--success-bg);
+  border-color: var(--success-border);
+  color: var(--success-text);
+}
+
+.serviceChipHealthy .serviceDot {
+  background: var(--success);
+}
+
+.serviceChipUnhealthy {
+  background: var(--danger-bg);
+  border-color: var(--danger-border);
+  color: var(--danger-text);
+}
+
+.serviceChipUnhealthy .serviceDot {
+  background: var(--danger);
+}
+
+.serviceChipPlanned {
+  background: var(--surface-2);
+  color: var(--text-tertiary);
+  opacity: 0.78;
+}
+
+.serviceChipPlanned .serviceDot {
+  background: var(--text-tertiary);
+}
+
+.serviceDot {
+  width: 5px;
+  height: 5px;
+}
+
+.serviceLatency {
+  opacity: 0.7;
+}
+
+.quickLink {
+  color: var(--text-primary);
+  text-decoration: none;
+}
+
+.quickLinkContent {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding: 8px 12px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface);
+  font-size: 13px;
+  font-weight: 500;
+  transition: background 0.15s ease, border-color 0.15s ease, transform 0.15s ease;
+}
+
+.quickLink:hover .quickLinkContent,
+.quickLink:focus-visible .quickLinkContent {
+  border-color: var(--quick-link-accent);
+  background: var(--surface-2);
+  transform: translateY(-1px);
+}
+
+.quickLink:focus-visible {
+  outline: none;
+}
+
+@media (max-width: 1180px) {
+  .metrics {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .healthGroups {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 760px) {
+  .dashboard {
+    padding: 20px 16px 32px;
+  }
+
+  .headerActions {
+    align-items: flex-end;
+    flex-direction: column;
+  }
+
+  .metrics,
+  .healthGroups,
+  .serviceGroups {
+    grid-template-columns: 1fr;
+  }
+
+  .serviceGroupHeader {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .groupStatus {
+    white-space: normal;
+  }
+}

--- a/openbank-admin-ui/src/app/dashboard/page.tsx
+++ b/openbank-admin-ui/src/app/dashboard/page.tsx
@@ -4,12 +4,16 @@
 
 'use client'
 
-import { useState, useEffect, useCallback, useRef } from 'react'
+import { useState, useEffect, useCallback, useRef, type CSSProperties } from 'react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
-import { CreditCard, ArrowLeftRight, Users, Activity, TrendingUp, TrendingDown,
-  ShieldCheck, AlertTriangle, RefreshCw, Zap,
-  DollarSign, Globe, BarChart3, Clock, Server, HardDrive } from 'lucide-react'
+import { CreditCard, ArrowLeftRight, Users, Activity, ShieldCheck, RefreshCw,
+  DollarSign, Globe, BarChart3, Server } from 'lucide-react'
 import Link from 'next/link'
+import { useSession } from 'next-auth/react'
+import { PageHeader, StatCard, StatusBadge, type Tone } from '@/components/ui'
+import { hasPermission, type Permission } from '@/lib/auth/roles'
+import { fleetHealthState, summarizeFleetHealth } from '@/lib/dashboard/fleetHealth'
+import styles from './Dashboard.module.css'
 
 // Tri-state per fleet member. `deployed=false` is NEUTRAL (planned, not an outage) —
 // it must never be counted as an error, or the 23 not-yet-deployed services in the
@@ -33,12 +37,13 @@ function titleCase(name: string): string {
 }
 
 const GROUP_COLORS: Record<string, string> = {
-  core: '#6366f1', payments: '#10b981', compliance: '#f59e0b',
-  identity: '#3b82f6', 'open-banking': '#8b5cf6', platform: '#64748b'
+  core: 'var(--accent)', payments: 'var(--success)', compliance: 'var(--warning)',
+  identity: 'var(--info)', 'open-banking': 'var(--accent)', platform: 'var(--text-tertiary)'
 }
 
 export default function DashboardPage() {
   const { t } = useLanguage()
+  const { data: session } = useSession()
   const [statuses, setStatuses] = useState<SvcStatus[]>([])
   const [loading, setLoading] = useState(true)
   const [lastRefresh, setLastRefresh] = useState<Date | null>(null)
@@ -114,31 +119,23 @@ export default function DashboardPage() {
   // Health metrics are computed over DEPLOYED services only. Not-deployed roster
   // members are planned capacity, not failures — folding them into the denominator
   // would report a false outage (the old "0/27 → 100% error rate" bug).
-  const fleetTotal = statuses.length
-  const deployed = statuses.filter(s => s.deployed)
-  const deployedCount = deployed.length
-  const upCount = deployed.filter(s => s.up).length
-  const healthPct = deployedCount > 0 ? Math.round((upCount / deployedCount) * 100) : 0
-  const avgLatency = deployed.filter(s => s.latencyMs !== null).reduce((a, b) => a + (b.latencyMs ?? 0), 0) /
-    Math.max(1, deployed.filter(s => s.latencyMs !== null).length)
+  const health = summarizeFleetHealth(statuses)
+  const healthState = fleetHealthState(health)
+  const healthTone: Tone = healthState === 'healthy' ? 'success' : healthState === 'degraded' ? 'warning' : 'neutral'
+  const roles = session?.user?.roles ?? []
 
   const groups = ['core', 'payments', 'compliance', 'identity', 'open-banking', 'platform']
 
   return (
-    <div style={{ padding: '28px 32px', maxWidth: '1400px', animation: 'fadeIn 0.2s ease-out' }}>
-      {/* Page header */}
-      <div style={{ marginBottom: '28px', display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between' }}>
-        <div>
-          <h1 style={{ fontSize: '24px', fontWeight: 800, color: 'var(--text-primary)', letterSpacing: '-0.03em', marginBottom: '4px' }}>
-            {t('Přehled platformy', 'Platform Overview')}
-          </h1>
-          <p style={{ fontSize: '13px', color: 'var(--text-secondary)' }}>
-            {t('Platforma mikroslužeb OpenBank — zdraví a observabilita v reálném čase', 'OpenBank microservices platform — real-time health & observability')}
-          </p>
-        </div>
-        <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
+    <main className={styles.dashboard}>
+      <PageHeader
+        title={t('Přehled platformy', 'Platform overview')}
+        subtitle={t('Aktuální stav health-checků nasazené části platformy.', 'Current health-check state of the deployed platform.')}
+        icon={<Activity className={styles.headerIcon} size={20} aria-hidden="true" />}
+        actions={
+          <div className={styles.headerActions}>
           {lastRefresh && (
-            <span style={{ fontSize: '11px', color: 'var(--text-tertiary)' }}>
+            <span className={styles.lastRefresh}>
               {t('Aktualizováno', 'Updated')} {lastRefresh.toLocaleTimeString()}
             </span>
           )}
@@ -146,74 +143,56 @@ export default function DashboardPage() {
             <RefreshCw size={13} style={{ animation: loading ? 'spin 0.8s linear infinite' : 'none' }} />
             {t('Obnovit', 'Refresh')}
           </button>
-        </div>
-      </div>
+          </div>
+        }
+      />
 
-      {/* KPI row */}
-      <div className="grid-4" style={{ marginBottom: '28px' }}>
-        <KpiCard icon={<Server size={18} />} label={t('Služby online', 'Services Online')} value={`${upCount}/${deployedCount}`}
-          sub={`${deployedCount}/${fleetTotal} ${t('nasazeno', 'deployed')} · ${healthPct}% ${t('v pořádku', 'healthy')}`}
-          color={healthPct >= 90 ? 'var(--success)' : healthPct >= 70 ? 'var(--warning)' : 'var(--danger)'}
-          trend={healthPct >= 90 ? 'up' : 'down'} />
-        <KpiCard icon={<Zap size={18} />} label={t('Prům. latence', 'Avg Latency')} value={`${Math.round(avgLatency)}ms`}
-          sub={t('kontrola p50', 'health check p50')} color="var(--accent)"
-          trend={avgLatency < 100 ? 'up' : 'down'} />
-        <KpiCard icon={<ShieldCheck size={18} />} label={t('Bezpečnost', 'Security Grade')}
-          value={deployedCount > 0 && upCount >= deployedCount * 0.9 ? 'A' : 'B'}
-          sub="OWASP + EBA ICT" color="var(--info)" trend="up" />
-        <KpiCard icon={<Globe size={18} />} label={t('Shoda', 'Compliance')}
-          value="PSD2 ✓" sub="EBA · CNB · GDPR" color="var(--success)" trend="up" />
-      </div>
+      {/* These are intentionally current health facts, not estimated operational or compliance metrics. */}
+      <section className={styles.metrics} aria-label={t('Klíčové metriky platformy', 'Platform key metrics')}>
+        <StatCard className={styles.metric} icon={<Server size={15} />} label={t('Zdravé služby', 'Healthy services')} value={`${health.healthy}/${health.deployed}`} tone={healthTone}
+          hint={t('aktuální health-check nasazených služeb', 'current health check of deployed services')} />
+        <StatCard className={styles.metric} icon={<Activity size={15} />} label={t('Průměrná latence kontroly', 'Average check latency')}
+          value={health.averageHealthCheckLatencyMs === null ? '—' : `${health.averageHealthCheckLatencyMs} ms`}
+          hint={t('měření endpointu health-checku, ne p99', 'health-check endpoint measurement, not p99')} />
+        <StatCard className={styles.metric} icon={<Server size={15} />} label={t('Nasazeno', 'Deployed')} value={`${health.deployed}/${health.total}`}
+          hint={t('služby objevené v tomto prostředí', 'services discovered in this environment')} />
+        <StatCard className={styles.metric} icon={<ShieldCheck size={15} />} label={t('Nenasaženo', 'Not deployed')} value={health.notDeployed} tone="neutral"
+          hint={t('plánované služby; není to incident', 'planned services; not an incident')} />
+      </section>
 
-      {/* Observability KPIs */}
-      <div className="grid-4" style={{ marginBottom: '28px' }}>
-        <KpiCard icon={<AlertTriangle size={18} />} label={t('Chybovost', 'Error Rate')} value={`${100 - healthPct}%`}
-          sub={t('odvozeno ze zdraví', 'derived from health')} color={100 - healthPct > 5 ? 'var(--danger)' : 'var(--success)'}
-          trend={100 - healthPct > 5 ? 'up' : 'down'} />
-        <KpiCard icon={<Clock size={18} />} label={t('p99 Latence (odh.)', 'p99 Latency (est.)')} value={`${Math.round(avgLatency * 2.5)}ms`}
-          sub={t('odhad z latencí', 'approx from latencies')} color="var(--accent)"
-          trend={avgLatency * 2.5 < 200 ? 'up' : 'down'} />
-        <KpiCard icon={<Activity size={18} />} label={t('Propustnost', 'Throughput')} value={`${upCount * 125} req/s`}
-          sub={t('proxy z health-checku', 'health-check proxy')} color="var(--info)"
-          trend="up" />
-        <KpiCard icon={<TrendingUp size={18} />} label={t('Zátěž systému', 'System Load')} value={`${Math.round((upCount / Math.max(1, deployedCount)) * 42)}%`}
-          sub={t('odhad průměrné zátěže CPU', 'average cpu proxy')} color="var(--warning)" trend="up" />
-      </div>
-
-      {/* Uptime by group */}
-      <div className="card" style={{ padding: '20px', marginBottom: '28px' }}>
-        <div style={{ fontSize: '12px', fontWeight: 700, color: 'var(--text-secondary)', textTransform: 'uppercase',
-          letterSpacing: '0.06em', marginBottom: '14px' }}>{t('Dostupnost dle skupiny', 'Uptime Ratio By Group')}</div>
-        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))', gap: '20px' }}>
+      {/* A current per-group health distribution, not an uptime/SLO measurement. */}
+      <section className={`card ${styles.healthOverview}`} aria-labelledby="health-by-group-heading">
+        <h2 id="health-by-group-heading" className={styles.sectionLabel}>{t('Aktuální zdraví dle skupiny', 'Current health by group')}</h2>
+        <div className={styles.healthGroups}>
           {groups.map(group => {
             const groupSvcs = statuses.filter(s => s.group === group)
             if (groupSvcs.length === 0) return null
             const deployedInGroup = groupSvcs.filter(s => s.deployed)
             const upInGroup = deployedInGroup.filter(s => s.up).length
-            // Uptime is over deployed members of the group; a group with nothing
+            // The bar is the current healthy share of deployed members; a group with nothing
             // deployed yet shows a neutral "not deployed" rather than a red 0%.
             const hasDeployed = deployedInGroup.length > 0
             const pct = hasDeployed ? Math.round((upInGroup / deployedInGroup.length) * 100) : 0
-            const color = GROUP_COLORS[group] ?? '#64748b'
+            const color = GROUP_COLORS[group] ?? 'var(--text-tertiary)'
             return (
-              <div key={`uptime-${group}`}>
-                <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: '12px', marginBottom: '6px' }}>
-                  <span style={{ fontWeight: 600, color: 'var(--text-primary)', textTransform: 'capitalize' }}>{group.replace('-', ' ')}</span>
-                  <span style={{ color: 'var(--text-secondary)', fontWeight: 500 }}>
-                    {hasDeployed ? `${pct}%` : t('nenasazeno', 'not deployed')}
+              <div key={`health-${group}`} className={styles.healthGroup}>
+                <div className={styles.healthGroupHeader}>
+                  <span className={styles.groupName}>{group.replace('-', ' ')}</span>
+                  <span className={styles.groupSummary}>
+                    {hasDeployed ? `${upInGroup}/${deployedInGroup.length} ${t('zdravé', 'healthy')}` : t('nenasazeno', 'not deployed')}
                   </span>
                 </div>
-                <div style={{ height: '6px', background: 'var(--border)', borderRadius: '3px', overflow: 'hidden' }}>
-                  <div style={{ height: '100%', width: hasDeployed ? `${pct}%` : '0%', background: pct === 100 ? color : 'var(--danger)', transition: 'width 0.3s ease' }} />
+                <div className={styles.healthBar}>
+                  <div className={styles.healthBarFill} style={{ width: hasDeployed ? `${pct}%` : '0%', background: pct === 100 ? color : 'var(--danger)' }} />
                 </div>
               </div>
             )
           })}
         </div>
-      </div>
+      </section>
 
       {/* Service groups */}
-      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '20px', marginBottom: '28px' }}>
+      <section className={styles.serviceGroups} aria-label={t('Služby podle skupiny', 'Services by group')}>
         {groups.map(group => {
           const groupSvcs = statuses.filter(s => s.group === group)
           if (groupSvcs.length === 0) return null
@@ -221,110 +200,69 @@ export default function DashboardPage() {
           const upInGroup = deployedInGroup.filter(s => s.up).length
           const plannedInGroup = groupSvcs.length - deployedInGroup.length
           const allHealthy = deployedInGroup.length > 0 && upInGroup === deployedInGroup.length
-          const color = GROUP_COLORS[group] ?? '#64748b'
+          const color = GROUP_COLORS[group] ?? 'var(--text-tertiary)'
+          const deploymentSummary = `${upInGroup}/${deployedInGroup.length} ${t('nasazeno', 'up')}${plannedInGroup > 0 ? ` · ${plannedInGroup} ${t('plán', 'planned')}` : ''}`
           // Sort deployed members first so the live ones lead each group card.
           const ordered = [...groupSvcs].sort((a, b) => Number(b.deployed) - Number(a.deployed))
           return (
-            <div key={group} className="card" style={{ padding: '20px' }}>
-              <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '14px' }}>
-                <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-                  <div style={{ width: '8px', height: '8px', borderRadius: '50%', background: color }} />
-                  <span style={{ fontSize: '12px', fontWeight: 700, color: 'var(--text-primary)', textTransform: 'uppercase', letterSpacing: '0.06em' }}>
+            <article key={group} className={`card ${styles.serviceGroup}`}>
+              <div className={styles.serviceGroupHeader}>
+                <div className={styles.serviceGroupTitle}>
+                  <span className={styles.groupDot} style={{ background: color }} aria-hidden="true" />
+                  <h2 className={styles.sectionLabel}>
                     {group.replace('-', ' ')}
-                  </span>
+                  </h2>
                 </div>
-                <span style={{ fontSize: '11px', color: allHealthy ? 'var(--success-text)' : deployedInGroup.length === 0 ? 'var(--text-tertiary)' : 'var(--warning-text)',
-                  background: allHealthy ? 'var(--success-bg)' : deployedInGroup.length === 0 ? 'var(--surface-2)' : 'var(--warning-bg)',
-                  padding: '2px 8px', borderRadius: '10px', fontWeight: 600 }}>
-                  {upInGroup}/{deployedInGroup.length} {t('nasazeno', 'up')}{plannedInGroup > 0 ? ` · ${plannedInGroup} ${t('plán', 'planned')}` : ''}
-                </span>
+                <StatusBadge
+                  status={allHealthy ? 'HEALTHY' : deployedInGroup.length === 0 ? 'NOT_DEPLOYED' : 'DEGRADED'}
+                  label={deploymentSummary}
+                  tone={allHealthy ? 'success' : deployedInGroup.length === 0 ? 'neutral' : 'warning'}
+                  className={styles.groupStatus}
+                />
               </div>
-              <div style={{ display: 'flex', flexWrap: 'wrap', gap: '6px' }}>
+              <div className={styles.serviceChips}>
                 {ordered.map(s => {
                   // Tri-state chip: live-up (green), deployed-down (red, a real outage),
                   // not-deployed (muted/neutral — planned, never an alarm).
-                  const bg = !s.deployed ? 'var(--surface-2)' : s.up ? 'var(--success-bg)' : 'var(--danger-bg)'
-                  const bd = !s.deployed ? 'var(--border)' : s.up ? 'var(--success-border)' : 'var(--danger-border)'
-                  const fg = !s.deployed ? 'var(--text-tertiary)' : s.up ? 'var(--success-text)' : 'var(--danger-text)'
-                  const dot = !s.deployed ? 'var(--text-tertiary)' : s.up ? 'var(--success)' : 'var(--danger)'
+                  const state = !s.deployed ? 'planned' : s.up ? 'healthy' : 'unhealthy'
                   return (
-                    <div key={s.name} title={!s.deployed ? t('Nenasazeno v tomto prostředí', 'Not deployed in this environment') : s.up ? t('BĚŽÍ', 'UP') : t('NEBĚŽÍ', 'DOWN')} style={{
-                      display: 'flex', alignItems: 'center', gap: '5px',
-                      padding: '4px 10px', borderRadius: '6px',
-                      background: bg, border: `1px solid ${bd}`,
-                      fontSize: '11px', fontWeight: 500, color: fg,
-                      opacity: s.deployed ? 1 : 0.7,
-                    }}>
-                      <span style={{ width: '5px', height: '5px', borderRadius: '50%', background: dot, flexShrink: 0 }} />
+                    <div key={s.name} title={!s.deployed ? t('Nenasazeno v tomto prostředí', 'Not deployed in this environment') : s.up ? t('BĚŽÍ', 'UP') : t('NEBĚŽÍ', 'DOWN')} className={`${styles.serviceChip} ${styles[`serviceChip${state.charAt(0).toUpperCase()}${state.slice(1)}`]}`}>
+                      <span className={styles.serviceDot} aria-hidden="true" />
                       {s.label}
-                      {s.deployed && s.latencyMs ? <span style={{ opacity: 0.7 }}>{s.latencyMs}ms</span> : null}
+                      {s.deployed && s.latencyMs ? <span className={styles.serviceLatency}>{s.latencyMs}ms</span> : null}
                     </div>
                   )
                 })}
               </div>
-            </div>
+            </article>
           )
         })}
-      </div>
+      </section>
 
-      {/* Quick links */}
-      <div className="card" style={{ padding: '20px' }}>
-        <div style={{ fontSize: '12px', fontWeight: 700, color: 'var(--text-secondary)', textTransform: 'uppercase',
-          letterSpacing: '0.06em', marginBottom: '14px' }}>{t('Rychlý přístup', 'Quick Access')}</div>
-        <div style={{ display: 'flex', flexWrap: 'wrap', gap: '8px' }}>
+      {/* Only show destinations the operator can already access; dashboard shortcuts must not create 403 traps. */}
+      <section className={`card ${styles.quickAccess}`} aria-labelledby="quick-access-heading">
+        <h2 id="quick-access-heading" className={styles.sectionLabel}>{t('Rychlý přístup', 'Quick Access')}</h2>
+        <div className={styles.quickLinks}>
           {[
-            { href: '/accounts',          label: t('Účty', 'Accounts'),         icon: CreditCard,    color: '#6366f1' },
-            { href: '/transactions',      label: t('Transakce', 'Transactions'),     icon: ArrowLeftRight, color: '#10b981' },
-            { href: '/infrastructure',    label: t('Infra', 'Infrastructure'),  icon: Server,         color: '#f43f5e' },
-            { href: '/parties',           label: t('Strany', 'Parties'),          icon: Users,          color: '#3b82f6' },
-            { href: '/payments',          label: t('Platby', 'Payments'),         icon: DollarSign,     color: '#f59e0b' },
-            { href: '/audit',             label: t('Audit záznam', 'Audit Log'),        icon: Activity,       color: '#8b5cf6' },
-            { href: '/regulatory',        label: t('Regulace', 'Regulatory'),       icon: BarChart3,      color: '#ef4444' },
-            { href: '/docs/api',          label: t('API Katalog', 'API Catalog'),      icon: Globe,          color: '#0891b2' },
-            { href: '/docs/compliance',   label: t('Shoda', 'Compliance'),       icon: ShieldCheck,    color: '#059669' },
-            { href: '/infrastructure',    label: t('Infrastruktura', 'Infrastructure'),icon: HardDrive,    color: '#64748b' },
-          ].map(({ href, label, icon: Icon, color }) => (
-            <Link key={href} href={href} style={{ textDecoration: 'none' }}>
-              <div style={{
-                display: 'flex', alignItems: 'center', gap: '7px',
-                padding: '8px 14px', borderRadius: '8px',
-                border: '1px solid var(--border)', background: 'var(--surface)',
-                fontSize: '13px', fontWeight: 500, color: 'var(--text-primary)',
-                transition: 'all 0.15s', cursor: 'pointer',
-              }}
-                onMouseEnter={e => { e.currentTarget.style.borderColor = color; e.currentTarget.style.background = 'var(--surface-2)' }}
-                onMouseLeave={e => { e.currentTarget.style.borderColor = 'var(--border)'; e.currentTarget.style.background = 'var(--surface)' }}
-              >
+            { href: '/accounts', label: t('Účty', 'Accounts'), icon: CreditCard, color: 'var(--accent)', permission: 'accounts:view' },
+            { href: '/transactions', label: t('Transakce', 'Transactions'), icon: ArrowLeftRight, color: 'var(--success)', permission: 'transactions:view' },
+            { href: '/infrastructure', label: t('Infrastruktura', 'Infrastructure'), icon: Server, color: 'var(--danger)', permission: 'system:view' },
+            { href: '/parties', label: t('Strany', 'Parties'), icon: Users, color: 'var(--info)', permission: 'parties:view' },
+            { href: '/payments', label: t('Platby', 'Payments'), icon: DollarSign, color: 'var(--warning)', permission: 'payments:view' },
+            { href: '/audit', label: t('Auditní záznam', 'Audit log'), icon: Activity, color: 'var(--accent)', permission: 'audit:view' },
+            { href: '/regulatory', label: t('Regulace', 'Regulatory'), icon: BarChart3, color: 'var(--danger)', permission: 'regulatory:view' },
+            { href: '/docs/api', label: t('API katalog', 'API catalog'), icon: Globe, color: 'var(--info)', permission: 'docs:view' },
+            { href: '/docs/compliance', label: t('Shoda', 'Compliance'), icon: ShieldCheck, color: 'var(--success)', permission: 'compliance:view' },
+          ].filter(link => hasPermission(roles, link.permission as Permission)).map(({ href, label, icon: Icon, color }) => (
+            <Link key={href} href={href} className={styles.quickLink} style={{ '--quick-link-accent': color } as CSSProperties}>
+              <span className={styles.quickLinkContent}>
                 <Icon size={14} style={{ color }} />
                 {label}
-              </div>
+              </span>
             </Link>
           ))}
         </div>
-      </div>
-    </div>
-  )
-}
-
-function KpiCard({ icon, label, value, sub, color, trend }: {
-  icon: React.ReactNode; label: string; value: string; sub: string; color: string; trend: 'up' | 'down'
-}) {
-  return (
-    <div className="stat-card">
-      <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', marginBottom: '12px' }}>
-        <div style={{ width: '36px', height: '36px', borderRadius: '10px',
-          background: `${color}18`, display: 'flex', alignItems: 'center', justifyContent: 'center', color }}>
-          {icon}
-        </div>
-        {trend === 'up'
-          ? <TrendingUp size={14} style={{ color: 'var(--success)' }} />
-          : <TrendingDown size={14} style={{ color: 'var(--danger)' }} />}
-      </div>
-      <div style={{ fontSize: '24px', fontWeight: 800, color: 'var(--text-primary)', letterSpacing: '-0.03em', marginBottom: '2px' }}>
-        {value}
-      </div>
-      <div style={{ fontSize: '12px', fontWeight: 600, color: 'var(--text-secondary)', marginBottom: '2px' }}>{label}</div>
-      <div style={{ fontSize: '11px', color: 'var(--text-tertiary)' }}>{sub}</div>
-    </div>
+      </section>
+    </main>
   )
 }

--- a/openbank-admin-ui/src/components/layout/Header.tsx
+++ b/openbank-admin-ui/src/components/layout/Header.tsx
@@ -136,8 +136,8 @@ export function Header() {
         >
           {language.toUpperCase()}
         </button>
-        <IconBtn><HelpCircle size={15} /></IconBtn>
-        <IconBtn><Bell size={15} /></IconBtn>
+        <HeaderLink href="/docs" label={t('Nápověda a dokumentace', 'Help and documentation')}><HelpCircle size={15} /></HeaderLink>
+        <HeaderLink href="/approvals" label={t('Schvalování', 'Approvals')}><Bell size={15} /></HeaderLink>
         <div style={{ width: '1px', height: '20px', background: 'var(--border)', margin: '0 6px' }} />
 
         {/* User menu */}
@@ -239,17 +239,17 @@ export function Header() {
   )
 }
 
-function IconBtn({ children }: { children: React.ReactNode }) {
+function HeaderLink({ href, label, children }: { href: string; label: string; children: React.ReactNode }) {
   return (
-    <button style={{
+    <Link href={href} aria-label={label} title={label} style={{
       width: '32px', height: '32px', display: 'flex', alignItems: 'center', justifyContent: 'center',
       borderRadius: '6px', border: 'none', background: 'transparent',
-      color: 'var(--text-secondary)', cursor: 'pointer', transition: 'background 0.12s',
+      color: 'var(--text-secondary)', cursor: 'pointer', transition: 'background 0.12s', textDecoration: 'none',
     }}
       onMouseEnter={e => (e.currentTarget.style.background = 'var(--surface-3)')}
       onMouseLeave={e => (e.currentTarget.style.background = 'transparent')}
     >
       {children}
-    </button>
+    </Link>
   )
 }

--- a/openbank-admin-ui/src/lib/dashboard/fleetHealth.ts
+++ b/openbank-admin-ui/src/lib/dashboard/fleetHealth.ts
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+/** The only facts the dashboard learns from the fleet-health endpoint. */
+export type FleetHealthSample = {
+  deployed: boolean
+  up: boolean
+  latencyMs: number | null
+}
+
+export type FleetHealthSummary = {
+  total: number
+  deployed: number
+  healthy: number
+  notDeployed: number
+  averageHealthCheckLatencyMs: number | null
+}
+
+/**
+ * Summarises one *current* health-check sample. It deliberately does not manufacture
+ * uptime, error rate, percentile latency, throughput, security or compliance claims:
+ * none of those signals are in the discovery response.
+ */
+export function summarizeFleetHealth(samples: FleetHealthSample[]): FleetHealthSummary {
+  const deployed = samples.filter(sample => sample.deployed)
+  const latencies = deployed.flatMap(sample => sample.latencyMs === null ? [] : [sample.latencyMs])
+
+  return {
+    total: samples.length,
+    deployed: deployed.length,
+    healthy: deployed.filter(sample => sample.up).length,
+    notDeployed: samples.length - deployed.length,
+    averageHealthCheckLatencyMs:
+      latencies.length === 0 ? null : Math.round(latencies.reduce((sum, latency) => sum + latency, 0) / latencies.length),
+  }
+}
+
+export type FleetHealthState = 'healthy' | 'degraded' | 'unavailable'
+
+export function fleetHealthState(summary: FleetHealthSummary): FleetHealthState {
+  if (summary.deployed === 0) return 'unavailable'
+  return summary.healthy === summary.deployed ? 'healthy' : 'degraded'
+}

--- a/openbank-admin-ui/src/test/fleet-health.test.ts
+++ b/openbank-admin-ui/src/test/fleet-health.test.ts
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import { describe, expect, it } from 'vitest'
+import { fleetHealthState, summarizeFleetHealth } from '@/lib/dashboard/fleetHealth'
+
+describe('dashboard fleet-health summary', () => {
+  it('reports only facts present in the current health sample', () => {
+    expect(summarizeFleetHealth([
+      { deployed: true, up: true, latencyMs: 18 },
+      { deployed: true, up: false, latencyMs: 42 },
+      { deployed: false, up: false, latencyMs: null },
+    ])).toEqual({
+      total: 3,
+      deployed: 2,
+      healthy: 1,
+      notDeployed: 1,
+      averageHealthCheckLatencyMs: 30,
+    })
+  })
+
+  it('does not turn an absent latency sample into a made-up value', () => {
+    const summary = summarizeFleetHealth([{ deployed: false, up: false, latencyMs: null }])
+    expect(summary.averageHealthCheckLatencyMs).toBeNull()
+    expect(fleetHealthState(summary)).toBe('unavailable')
+  })
+
+  it('distinguishes fully healthy deployed services from a degraded current sample', () => {
+    expect(fleetHealthState(summarizeFleetHealth([{ deployed: true, up: true, latencyMs: 8 }]))).toBe('healthy')
+    expect(fleetHealthState(summarizeFleetHealth([{ deployed: true, up: false, latencyMs: 8 }]))).toBe('degraded')
+  })
+})

--- a/openbank-admin-ui/src/test/iaops-rca-route.test.ts
+++ b/openbank-admin-ui/src/test/iaops-rca-route.test.ts
@@ -5,8 +5,11 @@
 // BFF proxy to HolmesGPT /api/chat (ADR-0031 D9). Tests pin input validation,
 // upstream forwarding, response extraction and error paths without hitting the
 // real HolmesGPT service.
-import { describe, it, expect, vi, afterEach } from 'vitest'
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest'
 import { NextRequest } from 'next/server'
+import { auth } from '@/auth'
+
+vi.mock('@/auth', () => ({ auth: vi.fn() }))
 
 function makeReq(body: unknown): NextRequest {
   return new NextRequest('http://localhost/api/iaops/rca', {
@@ -21,7 +24,37 @@ afterEach(() => {
   delete process.env.HOLMES_URL
 })
 
+beforeEach(() => {
+  vi.mocked(auth).mockResolvedValue({ user: { roles: ['ROLE_OPERATOR'] } } as never)
+})
+
 describe('POST /api/iaops/rca', () => {
+  it('refuses unauthenticated direct API calls before invoking HolmesGPT', async () => {
+    vi.mocked(auth).mockResolvedValue(null as never)
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+    const { POST } = await import('@/app/api/iaops/rca/route')
+
+    const res = await POST(makeReq({ ask: 'Why is transaction-service crashing?' }))
+
+    expect(res.status).toBe(401)
+    expect(await res.json()).toEqual({ error: 'unauthorized' })
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('refuses roles without the system:view permission', async () => {
+    vi.mocked(auth).mockResolvedValue({ user: { roles: ['ROLE_VIEWER'] } } as never)
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+    const { POST } = await import('@/app/api/iaops/rca/route')
+
+    const res = await POST(makeReq({ ask: 'Why is transaction-service crashing?' }))
+
+    expect(res.status).toBe(403)
+    expect(await res.json()).toEqual({ error: 'forbidden' })
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
   it('returns 400 when ask is missing', async () => {
     vi.resetModules()
     const { POST } = await import('@/app/api/iaops/rca/route')
@@ -68,20 +101,19 @@ describe('POST /api/iaops/rca', () => {
     expect(body.rca).toBe('CPU throttling caused latency spike.')
   })
 
-  it('returns 502 on non-ok upstream response', async () => {
+  it('returns a safe envelope on a non-ok upstream response', async () => {
     process.env.HOLMES_URL = 'http://holmes-mock'
     vi.resetModules()
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
       ok: false,
       status: 503,
-      text: async () => 'Service Unavailable',
-      statusText: 'Service Unavailable',
+      text: async () => 'internal upstream diagnostic',
     }))
     const { POST } = await import('@/app/api/iaops/rca/route')
     const res = await POST(makeReq({ ask: 'Alert: PodCrashLooping on balance-service' }))
-    expect(res.status).toBe(503)
+    expect(res.status).toBe(502)
     const body = await res.json()
-    expect(body.error).toMatch(/HolmesGPT error/)
+    expect(body).toEqual({ error: 'upstream_error' })
   })
 
   it('returns 502 on network failure', async () => {
@@ -92,6 +124,6 @@ describe('POST /api/iaops/rca', () => {
     const res = await POST(makeReq({ ask: 'Alert: PodCrashLooping on balance-service' }))
     expect(res.status).toBe(502)
     const body = await res.json()
-    expect(body.error).toMatch(/investigation failed/)
+    expect(body).toEqual({ error: 'upstream_error' })
   })
 })


### PR DESCRIPTION
## What changed
- Reworked the platform dashboard into a compact, responsive operator view using shared UI primitives.
- Replaced inferred operational/compliance claims with factual health-check metrics and explicit not-deployed state.
- Restricted quick links by RBAC and hardened the IAOps RCA BFF route against unauthenticated access and error-detail leakage.
- Added browser and unit coverage, plus an ADR/UI audit and follow-up roadmap.

## Why
The prior dashboard mixed observed health data with estimates that could be mistaken for security, compliance, SLO, or traffic facts. Its layout also drifted from ADR-0208 primitives.

Closes #4599.

## Validation
- npm run type-check
- npx vitest run src/test/fleet-health.test.ts src/test/iaops-rca-route.test.ts
- npx playwright test e2e/ui-primitives.spec.ts (passed before the clean worktree setup; the clean-worktree rerun is blocked by Turbopack rejecting its external dependency symlink)