### PR TITLE
fix(engagement): preserve legacy banner placements

### DIFF
--- a/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/infrastructure/kafka/CampaignBannerPlacementConsumer.kt
+++ b/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/infrastructure/kafka/CampaignBannerPlacementConsumer.kt
@@ -35,8 +35,13 @@ class CampaignBannerPlacementConsumer(
                 values = mapper.convertValue(node.required("variables"), MAP_TYPE),
                 deepLink = node.requiredText("deepLink"),
                 placedAt = Instant.now(),
-                slot = SurfaceSlot.entries.find { it.name == node.requiredText("inAppSurface") }
-                    ?: error("unknown inAppSurface"),
+                // `inAppSurface` was added after HOME_BANNER shipped. Older campaign producers
+                // legitimately omit it during a rolling deployment, so absence retains the
+                // original slot; a present invalid value remains a malformed command.
+                slot = node["inAppSurface"]?.let { slotNode ->
+                    SurfaceSlot.entries.find { it.name == slotNode.asText().takeIf(String::isNotBlank) }
+                        ?: error("unknown inAppSurface")
+                } ?: SurfaceSlot.HOME_BANNER,
             )
             placements.save(placement)
         } catch (e: Exception) {

--- a/openbank-engagement-service/src/test/kotlin/com/openbank/engagement/infrastructure/kafka/CampaignBannerPlacementConsumerTest.kt
+++ b/openbank-engagement-service/src/test/kotlin/com/openbank/engagement/infrastructure/kafka/CampaignBannerPlacementConsumerTest.kt
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+package com.openbank.engagement.infrastructure.kafka
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.engagement.application.port.out.CampaignBannerPlacementRepository
+import com.openbank.engagement.domain.model.CampaignBannerPlacement
+import com.openbank.engagement.domain.model.SurfaceSlot
+import io.mockk.coVerify
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+class CampaignBannerPlacementConsumerTest {
+
+    private val repository = mockk<CampaignBannerPlacementRepository>(relaxed = true)
+
+    @Test
+    fun `legacy banner command without surface remains a home banner`(): Unit = runBlocking {
+        val interactionRef = UUID.randomUUID()
+        CampaignBannerPlacementConsumer(repository, ObjectMapper()).consume(
+            """{"interactionRef":"$interactionRef","partyId":"${UUID.randomUUID()}","campaignId":"${UUID.randomUUID()}","stepOrder":1,"template":"MARKETING_PRODUCT_OFFER_BANNER","variables":{"offerTitle":"Offer","offerText":"Details","ctaText":"Open"},"deepLink":"openbank://products"}""",
+        )
+
+        val placement = slot<CampaignBannerPlacement>()
+        coVerify(exactly = 1) { repository.save(capture(placement)) }
+        assertThat(placement.captured.slot).isEqualTo(SurfaceSlot.HOME_BANNER)
+    }
+}


### PR DESCRIPTION
## Why

Keeps the campaign banner command additive during a rolling deployment: commands emitted by older campaign-service pods omit `inAppSurface` and must retain the shipped `HOME_BANNER` default.

## Verification

- `./gradlew :openbank-engagement-service:test --tests 'com.openbank.engagement.infrastructure.kafka.CampaignBannerPlacementConsumerTest' :openbank-engagement-service:detekt`

Refs #4577