### PR TITLE
fix(kyc): record retention workflow liveness

### DIFF
--- a/.github/scripts/check-scheduler-liveness.py
+++ b/.github/scripts/check-scheduler-liveness.py
@@ -77,7 +77,6 @@ BASELINE = [
     "openbank-consent-service/src/main/kotlin/com/openbank/consent/infrastructure/ConsentExpirationJob.kt",
     "openbank-delegation-service/src/main/kotlin/com/openbank/delegation/infrastructure/DelegationExpirationJob.kt",
     "openbank-dispute-service/src/main/kotlin/com/openbank/dispute/infrastructure/observability/ComplaintDeadlineGauge.kt",
-    "openbank-kyc-service/src/main/kotlin/com/openbank/kyc/infrastructure/retention/KycRetentionScheduler.kt",
     "openbank-notification-service/src/main/kotlin/com/openbank/notification/infrastructure/DeviceTokenSweepJob.kt",
     "openbank-notification-service/src/main/kotlin/com/openbank/notification/infrastructure/NotificationOutboxDeadLetterJanitorJob.kt",
     "openbank-onboarding-service/src/main/kotlin/com/openbank/onboarding/infrastructure/observability/OnboardingFunnelGauge.kt",

--- a/openbank-kyc-service/src/main/kotlin/com/openbank/kyc/infrastructure/retention/KycRetentionScheduler.kt
+++ b/openbank-kyc-service/src/main/kotlin/com/openbank/kyc/infrastructure/retention/KycRetentionScheduler.kt
@@ -5,12 +5,17 @@
 package com.openbank.kyc.infrastructure.retention
 
 import com.openbank.kyc.application.port.out.KycCaseRepository
+import com.openbank.libs.observability.DomainMetrics
+import com.openbank.libs.observability.WorkflowLivenessRecorder
+import io.quarkus.runtime.StartupEvent
 import io.quarkus.scheduler.Scheduled
 import io.quarkus.scheduler.Scheduled.ConcurrentExecution.SKIP
 import jakarta.enterprise.context.ApplicationScoped
+import jakarta.enterprise.event.Observes
 import org.eclipse.microprofile.config.inject.ConfigProperty
 import org.jboss.logging.Logger
 import java.time.Clock
+import java.time.Duration
 import java.time.Instant
 import java.time.ZoneOffset
 
@@ -33,9 +38,19 @@ class KycRetentionScheduler(
     private val dryRun: Boolean,
     @ConfigProperty(name = "openbank.retention.kyc.enabled", defaultValue = "true")
     private val enabled: Boolean,
+    private val domainMetrics: DomainMetrics,
 ) {
 
     private val log = Logger.getLogger(KycRetentionScheduler::class.java)
+    private var liveness: WorkflowLivenessRecorder? = null
+
+    /**
+     * Registers a boot-seeded heartbeat (ADR-0237) before the first daily tick. A disabled or
+     * dry-run sweep deliberately does not record success: neither proves the retention delete ran.
+     */
+    fun registerLiveness(@Observes @Suppress("UNUSED_PARAMETER") event: StartupEvent) {
+        liveness = domainMetrics.registerWorkflowLiveness(WORKFLOW_NAME, EXPECTED_INTERVAL)
+    }
 
     @Scheduled(
         cron = "{openbank.retention.kyc.cron:0 30 3 * * ?}",
@@ -63,6 +78,7 @@ class KycRetentionScheduler(
         }
 
         val count = kycCaseRepository.deleteErasedCasesOlderThan(cutoff)
+        liveness?.recordSuccess()
         if (count > 0) {
             log.infof(
                 "[retention] Deleted %d KYC case(s) with erased_at < %s (ADR-0118 §5, AML Act §16)",
@@ -70,5 +86,10 @@ class KycRetentionScheduler(
                 cutoff,
             )
         }
+    }
+
+    private companion object {
+        const val WORKFLOW_NAME = "kyc-retention"
+        val EXPECTED_INTERVAL: Duration = Duration.ofDays(1)
     }
 }

--- a/openbank-kyc-service/src/test/kotlin/com/openbank/kyc/infrastructure/retention/KycRetentionSchedulerTest.kt
+++ b/openbank-kyc-service/src/test/kotlin/com/openbank/kyc/infrastructure/retention/KycRetentionSchedulerTest.kt
@@ -5,10 +5,18 @@
 package com.openbank.kyc.infrastructure.retention
 
 import com.openbank.kyc.application.port.out.KycCaseRepository
+import com.openbank.libs.observability.DomainMetrics
+import com.openbank.libs.observability.WorkflowLivenessMetrics
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.every
 import io.mockk.mockk
+import io.quarkus.runtime.StartupEvent
+import jakarta.enterprise.inject.Instance
 import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.time.Clock
 import java.time.Instant
@@ -56,12 +64,64 @@ class KycRetentionSchedulerTest {
         coVerify(exactly = 1) { kycCaseRepository.deleteErasedCasesOlderThan(any()) }
     }
 
-    private fun scheduler(retentionYears: Long = 5, dryRun: Boolean = false, enabled: Boolean = true) =
-        KycRetentionScheduler(
-            kycCaseRepository = kycCaseRepository,
-            clock = fixedClock,
-            retentionYears = retentionYears,
-            dryRun = dryRun,
-            enabled = enabled,
+    @Test
+    fun `records liveness only after the retention delete completes`(): Unit = runBlocking {
+        val registry = SimpleMeterRegistry()
+        coEvery { kycCaseRepository.deleteErasedCasesOlderThan(any()) } returns 0L
+        val scheduler = scheduler(domainMetrics = metricsOver(registry))
+
+        scheduler.registerLiveness(StartupEvent())
+        assertThat(successRecordedOf(registry)).isEqualTo(0.0)
+
+        scheduler.enforceRetention()
+
+        assertThat(successRecordedOf(registry)).isEqualTo(1.0)
+    }
+
+    @Test
+    fun `dry-run and disabled schedules do not record liveness success`(): Unit = runBlocking {
+        val registry = SimpleMeterRegistry()
+        val metrics = metricsOver(registry)
+
+        val dryRunScheduler = scheduler(dryRun = true, domainMetrics = metrics)
+        dryRunScheduler.registerLiveness(StartupEvent())
+        dryRunScheduler.enforceRetention()
+        assertThat(successRecordedOf(registry)).isEqualTo(0.0)
+
+        val disabledRegistry = SimpleMeterRegistry()
+        val disabledScheduler = scheduler(
+            enabled = false,
+            domainMetrics = metricsOver(disabledRegistry),
         )
+        disabledScheduler.registerLiveness(StartupEvent())
+        disabledScheduler.enforceRetention()
+        assertThat(successRecordedOf(disabledRegistry)).isEqualTo(0.0)
+    }
+
+    private fun metricsOver(registry: MeterRegistry): DomainMetrics {
+        val instance = mockk<Instance<MeterRegistry>>()
+        every { instance.isResolvable } returns true
+        every { instance.get() } returns registry
+        return DomainMetrics().apply { registryInstance = instance }
+    }
+
+    private fun successRecordedOf(registry: MeterRegistry): Double? = registry
+        .find(WorkflowLivenessMetrics.SUCCESS_RECORDED)
+        .tag(WorkflowLivenessMetrics.WORKFLOW_TAG, "kyc-retention")
+        .gauge()
+        ?.value()
+
+    private fun scheduler(
+        retentionYears: Long = 5,
+        dryRun: Boolean = false,
+        enabled: Boolean = true,
+        domainMetrics: DomainMetrics = mockk(relaxed = true),
+    ): KycRetentionScheduler = KycRetentionScheduler(
+        kycCaseRepository = kycCaseRepository,
+        clock = fixedClock,
+        retentionYears = retentionYears,
+        dryRun = dryRun,
+        enabled = enabled,
+        domainMetrics = domainMetrics,
+    )
 }


### PR DESCRIPTION
## Summary

Registers the KYC retention scheduler with the workflow-liveness metric and records success only after an actual retention deletion completes. Removes this now-covered scheduler from the ADR-0237 adoption baseline.

## Validation

- ./gradlew :openbank-kyc-service:ktlintCheck :openbank-kyc-service:test --tests com.openbank.kyc.infrastructure.retention.KycRetentionSchedulerTest
- python3 .github/scripts/check-scheduler-liveness.py --self-test
- python3 .github/scripts/check-scheduler-liveness.py

## Linked issues

Refs #3345