### PR TITLE
chore(gitops): deploy campaign sandbox-30775711

### DIFF
--- a/openbank-infra/gitops/components/campaign/campaign-service.yaml
+++ b/openbank-infra/gitops/components/campaign/campaign-service.yaml
@@ -48,7 +48,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: campaign-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-campaign-service:sandbox-f7e57bd3
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-campaign-service:sandbox-30775711
           imagePullPolicy: IfNotPresent
           ports:
             - name: http


### PR DESCRIPTION
Restores the campaign-service image pin from the verified campaign rollout that was automatically superseded by an unrelated deployment PR.

- changes only `campaign-service` from `sandbox-f7e57bd3` to the signed Arm64 image `sandbox-30775711`
- source build, SBOM/cosign attestation and deployment contract gate passed in the original rollout
- no other service or environment is changed

Refs #4480