### PR TITLE
fix(account): make the ADR-0232 dual-run's store disagreement observable

### DIFF
--- a/openbank-account-service/src/main/kotlin/com/openbank/account/application/usecase/AuthorizationService.kt
+++ b/openbank-account-service/src/main/kotlin/com/openbank/account/application/usecase/AuthorizationService.kt
@@ -15,7 +15,9 @@ import com.openbank.account.application.port.out.AccountRepository
 import com.openbank.account.application.port.out.DelegationProjectionRepository
 import com.openbank.account.domain.model.AccountAuthorization
 import com.openbank.account.domain.model.AuthorizationRole
+import com.openbank.libs.observability.DomainMetrics
 import jakarta.enterprise.context.ApplicationScoped
+import org.jboss.logging.Logger
 import java.time.Clock
 import java.time.Instant
 import java.time.OffsetDateTime
@@ -30,8 +32,11 @@ class AuthorizationService(
     private val accountRepository: AccountRepository,
     private val authorizationRepository: AccountAuthorizationRepository,
     private val delegationProjectionRepository: DelegationProjectionRepository,
+    private val metrics: DomainMetrics,
     private val clock: Clock,
 ) : AuthorizationUseCase {
+
+    private val log = Logger.getLogger(AuthorizationService::class.java)
 
     override suspend fun grantAuthorization(command: GrantAuthorizationCommand): AccountAuthorization {
         accountRepository.findById(command.accountId)
@@ -125,9 +130,7 @@ class AuthorizationService(
         val role = AuthorizationRole.PAYMENT_ONLY
         val legacy = authorizationRepository.findActiveByAccountAndParty(accountId, partyId)
             .filter { it.role == role || it.role == AuthorizationRole.FULL_ACCESS }
-        if (legacy.any { withinLegacyTransactionLimit(it, amount) }) {
-            return DelegatedPaymentDecision(DelegatedPaymentOutcome.LEGACY_AUTHORIZATION)
-        }
+        val legacyPermits = legacy.any { withinLegacyTransactionLimit(it, amount) }
 
         val now = OffsetDateTime.now(clock)
         val candidates = delegationProjectionRepository.findActiveByAccountAndParty(accountId, partyId)
@@ -135,6 +138,18 @@ class AuthorizationService(
         val permitting = candidates.firstOrNull { grant ->
             amount == null || grant.withinPerTransactionLimit(amount.amount, amount.currency.code)
         }
+
+        recordStoreDisagreement(legacyPermits, permitting != null)
+
+        // Order preserved deliberately: the legacy store still answers first, exactly as before.
+        // The projection is now evaluated BEFORE this return rather than after it — that is the
+        // whole change, and it is why a disagreement can be seen at all. The verdict is not
+        // affected: an observation that altered the decision would be a behaviour change smuggled
+        // in as telemetry.
+        if (legacyPermits) {
+            return DelegatedPaymentDecision(DelegatedPaymentOutcome.LEGACY_AUTHORIZATION)
+        }
+
         return when {
             permitting != null -> DelegatedPaymentDecision(
                 outcome = DelegatedPaymentOutcome.DELEGATED,
@@ -147,6 +162,42 @@ class AuthorizationService(
                 DelegatedPaymentDecision(DelegatedPaymentOutcome.LIMIT_EXCEEDED)
             else -> DelegatedPaymentDecision(DelegatedPaymentOutcome.NO_GRANT)
         }
+    }
+
+    /**
+     * The dual-run's actual risk, made visible (ADR-0232 D1, issue #2993).
+     *
+     * `account_authorizations` and the delegation projection are two stores answering one
+     * question, and nothing writes both: `AuthorizationResource.grant`/`.revoke` touch only the
+     * former, `DelegationEventConsumer` only the latter. So a revocation in either store leaves
+     * the other one granting — and because this method ORs them, the surviving arm carries the
+     * debit and no signal anywhere disagrees. That asymmetry is *deliberate* today (the KDoc on
+     * [hasDelegatedAccess] chose additive semantics), which is exactly why it needs measuring
+     * rather than fixing on a hunch: an "accepted" divergence with no instrument is
+     * indistinguishable from an unnoticed one.
+     *
+     * Recorded only when the two stores genuinely differ, and only for a non-owner — an owner
+     * never reaches here, so the counter counts delegation decisions and not traffic. It is
+     * emitted at the decision, not by a nightly diff, so it reports the state the guard acted on
+     * rather than the state some later snapshot found.
+     *
+     * A zero on this counter means one of two very different things, and the alert must not
+     * confuse them: no divergence, or no delegated payments at all. Both `account_authorizations`
+     * and `account_delegation_projection` are empty in the sandbox today, so a zero currently
+     * measures traffic. Pair it with the decision count before reading it as an invariant.
+     */
+    private fun recordStoreDisagreement(legacyPermits: Boolean, delegationPermits: Boolean) {
+        if (legacyPermits == delegationPermits) return
+        val direction = if (legacyPermits) "legacy_only" else "delegation_only"
+        metrics.authorizationStoreDisagreement("account_delegated_payment", direction)
+        log.warnf(
+            "delegation store disagreement on a payment decision (%s): " +
+                "account_authorizations permits=%s, delegation projection permits=%s — " +
+                "one store has a grant the other does not (ADR-0232 D1 dual-run, #2993)",
+            direction,
+            legacyPermits,
+            delegationPermits,
+        )
     }
 
     /**

--- a/openbank-account-service/src/test/kotlin/com/openbank/account/application/usecase/AuthorizationServiceDelegationTest.kt
+++ b/openbank-account-service/src/test/kotlin/com/openbank/account/application/usecase/AuthorizationServiceDelegationTest.kt
@@ -38,7 +38,14 @@ class AuthorizationServiceDelegationTest {
 
     @BeforeEach
     fun setUp() {
-        service = AuthorizationService(accountRepository, authorizationRepository, projectionRepository, clock)
+        service =
+            AuthorizationService(
+                accountRepository,
+                authorizationRepository,
+                projectionRepository,
+                mockk(relaxed = true),
+                clock,
+            )
         coEvery { accountRepository.findById(accountId) } returns account()
         coEvery { authorizationRepository.findActiveByAccountAndParty(any(), any()) } returns emptyList()
     }

--- a/openbank-account-service/src/test/kotlin/com/openbank/account/application/usecase/AuthorizationServiceTest.kt
+++ b/openbank-account-service/src/test/kotlin/com/openbank/account/application/usecase/AuthorizationServiceTest.kt
@@ -54,6 +54,7 @@ class AuthorizationServiceTest {
             accountRepository,
             authorizationRepository,
             delegationProjectionRepository,
+            mockk(relaxed = true),
             Clock.fixed(fixedInstant, ZoneOffset.UTC),
         )
     }

--- a/openbank-account-service/src/test/kotlin/com/openbank/account/application/usecase/AuthorizationStoreDisagreementTest.kt
+++ b/openbank-account-service/src/test/kotlin/com/openbank/account/application/usecase/AuthorizationStoreDisagreementTest.kt
@@ -1,0 +1,213 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.account.application.usecase
+
+import com.openbank.account.application.port.`in`.DelegatedPaymentOutcome
+import com.openbank.account.application.port.out.AccountAuthorizationRepository
+import com.openbank.account.application.port.out.AccountRepository
+import com.openbank.account.application.port.out.DelegationProjectionRepository
+import com.openbank.account.domain.model.Account
+import com.openbank.account.domain.model.AccountAuthorization
+import com.openbank.account.domain.model.AuthorizationRole
+import com.openbank.account.domain.model.DelegatedAccessGrant
+import com.openbank.libs.domain.money.Money
+import com.openbank.libs.observability.DomainMetrics
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import jakarta.enterprise.inject.Instance
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.time.Instant
+import java.time.LocalDate
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import java.util.UUID
+
+/**
+ * The dual-run's real question: **can the two stores disagree, and does anyone find out?**
+ * (ADR-0232 D1, issue #2993.)
+ *
+ * `account_authorizations` and the delegation projection are two stores answering one access
+ * question, and nothing writes both — `AuthorizationResource` writes only the legacy table,
+ * `DelegationEventConsumer` only the projection. `authorizeDelegatedPayment` ORs them, so a
+ * revocation in either store leaves the other one authorising a debit. That is a deliberate
+ * choice (delegation "only ever ADDS access"), and it was chosen with no instrument attached:
+ * before this test the divergence was invisible in both directions, at a decision that moves
+ * money.
+ *
+ * These tests assert against a REAL [SimpleMeterRegistry], not a verified mock. A mock would
+ * pass against a metric name nothing scrapes; the registry is asked for the series an operator
+ * would actually query, tag by tag.
+ *
+ * The verdict assertions in every case are the other half. A telemetry change that quietly moved
+ * an authorization decision would be far worse than the blindness it replaced, so each test pins
+ * the outcome as well as the counter.
+ */
+class AuthorizationStoreDisagreementTest {
+
+    private val accountRepository: AccountRepository = mockk()
+    private val authorizationRepository: AccountAuthorizationRepository = mockk()
+    private val projectionRepository: DelegationProjectionRepository = mockk()
+    private val clock: Clock = Clock.fixed(Instant.parse("2026-08-13T12:00:00Z"), ZoneOffset.UTC)
+    private val registry: MeterRegistry = SimpleMeterRegistry()
+    private lateinit var service: AuthorizationService
+
+    private val accountId: UUID = UUID.randomUUID()
+    private val owner: UUID = UUID.randomUUID()
+    private val delegate: UUID = UUID.randomUUID()
+    private val now: OffsetDateTime = OffsetDateTime.now(clock)
+
+    @BeforeEach
+    fun setUp() {
+        val instance = mockk<Instance<MeterRegistry>>()
+        every { instance.isResolvable } returns true
+        every { instance.get() } returns registry
+        val metrics = DomainMetrics().apply { registryInstance = instance }
+
+        service = AuthorizationService(
+            accountRepository,
+            authorizationRepository,
+            projectionRepository,
+            metrics,
+            clock,
+        )
+        coEvery { accountRepository.findById(accountId) } returns
+            mockk<Account>().also { every { it.partyId } returns owner }
+        coEvery { authorizationRepository.findActiveByAccountAndParty(any(), any()) } returns emptyList()
+        coEvery { projectionRepository.findActiveByAccountAndParty(any(), any()) } returns emptyList()
+    }
+
+    /** The series an operator would query, or null when it was never registered. */
+    private fun disagreements(direction: String): Double? = registry
+        .find("openbank.authz.store_disagreement")
+        .tag("question", "account_delegated_payment")
+        .tag("direction", direction)
+        .counter()
+        ?.count()
+
+    private fun legacyRow(transactionLimit: Money? = null) = listOf(
+        AccountAuthorization(
+            accountId = accountId,
+            partyId = delegate,
+            role = AuthorizationRole.PAYMENT_ONLY,
+            dailyLimit = null,
+            transactionLimit = transactionLimit,
+            validFrom = LocalDate.of(2026, 1, 1),
+            validTo = null,
+            grantedBy = owner,
+            grantedAt = Instant.now(clock),
+        ),
+    )
+
+    private fun projectionGrant(perTxAmount: String? = null) = listOf(
+        DelegatedAccessGrant(
+            id = UUID.randomUUID(),
+            accountId = accountId,
+            grantorPartyId = owner,
+            granteePartyId = delegate,
+            capabilities = setOf(DelegatedAccessGrant.CAP_INITIATE_PAYMENT),
+            perTransactionLimitAmount = perTxAmount?.toBigDecimal(),
+            perTransactionLimitCurrency = perTxAmount?.let { "CZK" },
+            validFrom = now.minusDays(1),
+            validTo = now.plusDays(30),
+            active = true,
+        ),
+    )
+
+    private fun czk(v: String) = Money.of(v, "CZK")
+
+    // ── the two directions a revocation can strand ────────────────────────────────────────
+
+    /**
+     * `DELETE /authorizations/{id}` closed the legacy row; the delegation grant is still ACTIVE.
+     * Money moves under the projection, and the operator who revoked believes it stopped.
+     */
+    @Test
+    fun `a grant live only in the delegation projection is recorded as delegation_only`(): Unit = runBlocking {
+        coEvery { projectionRepository.findActiveByAccountAndParty(accountId, delegate) } returns projectionGrant()
+
+        val d = service.authorizeDelegatedPayment(accountId, delegate, czk("1000.00"))
+
+        assertThat(d.outcome).isEqualTo(DelegatedPaymentOutcome.DELEGATED)
+        assertThat(disagreements("delegation_only")).isEqualTo(1.0)
+        assertThat(disagreements("legacy_only")).isNull()
+    }
+
+    /**
+     * The mirror: `DelegationRevoked` closed the projection row, the legacy `AccountAuthorization`
+     * still grants. This is the direction the migration is supposed to retire, and the one the
+     * money path answers `authorized: true` on.
+     */
+    @Test
+    fun `a grant live only in the legacy table is recorded as legacy_only`(): Unit = runBlocking {
+        coEvery { authorizationRepository.findActiveByAccountAndParty(accountId, delegate) } returns legacyRow()
+
+        val d = service.authorizeDelegatedPayment(accountId, delegate, czk("1000.00"))
+
+        assertThat(d.outcome).isEqualTo(DelegatedPaymentOutcome.LEGACY_AUTHORIZATION)
+        assertThat(disagreements("legacy_only")).isEqualTo(1.0)
+        assertThat(disagreements("delegation_only")).isNull()
+    }
+
+    /**
+     * A disagreement is about the ANSWER, not about row presence. Both stores hold a grant, but
+     * only the legacy ceiling admits this amount — so the two genuinely differ on this decision
+     * and that is what gets counted. Counting rows instead would have missed it.
+     */
+    @Test
+    fun `differing ceilings on the same amount are a disagreement`(): Unit = runBlocking {
+        coEvery { authorizationRepository.findActiveByAccountAndParty(accountId, delegate) } returns legacyRow()
+        coEvery { projectionRepository.findActiveByAccountAndParty(accountId, delegate) } returns
+            projectionGrant(perTxAmount = "100.00")
+
+        val d = service.authorizeDelegatedPayment(accountId, delegate, czk("1000.00"))
+
+        assertThat(d.outcome).isEqualTo(DelegatedPaymentOutcome.LEGACY_AUTHORIZATION)
+        assertThat(disagreements("legacy_only")).isEqualTo(1.0)
+    }
+
+    // ── the controls: a counter that fires on agreement measures nothing ───────────────────
+
+    @Test
+    fun `both stores permitting is not a disagreement`(): Unit = runBlocking {
+        coEvery { authorizationRepository.findActiveByAccountAndParty(accountId, delegate) } returns legacyRow()
+        coEvery { projectionRepository.findActiveByAccountAndParty(accountId, delegate) } returns projectionGrant()
+
+        assertThat(service.authorizeDelegatedPayment(accountId, delegate, czk("1000.00")).authorized).isTrue()
+
+        assertThat(disagreements("legacy_only")).isNull()
+        assertThat(disagreements("delegation_only")).isNull()
+    }
+
+    @Test
+    fun `both stores refusing is not a disagreement`(): Unit = runBlocking {
+        val d = service.authorizeDelegatedPayment(accountId, delegate, czk("1000.00"))
+
+        assertThat(d.outcome).isEqualTo(DelegatedPaymentOutcome.NO_GRANT)
+        assertThat(disagreements("legacy_only")).isNull()
+        assertThat(disagreements("delegation_only")).isNull()
+    }
+
+    /**
+     * The owner short-circuits before either store is consulted, so their payment must not
+     * register as a divergence. Without this the counter would track account traffic — the
+     * "zero from an empty population" trap in reverse, a non-zero that means nothing.
+     */
+    @Test
+    fun `an owner's own payment is never a disagreement`(): Unit = runBlocking {
+        coEvery { authorizationRepository.findActiveByAccountAndParty(accountId, owner) } returns legacyRow()
+
+        assertThat(service.authorizeDelegatedPayment(accountId, owner, czk("1000.00")).outcome)
+            .isEqualTo(DelegatedPaymentOutcome.OWNER)
+        assertThat(disagreements("legacy_only")).isNull()
+        assertThat(disagreements("delegation_only")).isNull()
+    }
+}

--- a/openbank-account-service/src/test/kotlin/com/openbank/account/application/usecase/AuthorizeDelegatedPaymentTest.kt
+++ b/openbank-account-service/src/test/kotlin/com/openbank/account/application/usecase/AuthorizeDelegatedPaymentTest.kt
@@ -50,7 +50,14 @@ class AuthorizeDelegatedPaymentTest {
 
     @BeforeEach
     fun setUp() {
-        service = AuthorizationService(accountRepository, authorizationRepository, projectionRepository, clock)
+        service =
+            AuthorizationService(
+                accountRepository,
+                authorizationRepository,
+                projectionRepository,
+                mockk(relaxed = true),
+                clock,
+            )
         coEvery { accountRepository.findById(accountId) } returns account()
         coEvery { authorizationRepository.findActiveByAccountAndParty(any(), any()) } returns emptyList()
         coEvery { projectionRepository.findActiveByAccountAndParty(any(), any()) } returns emptyList()

--- a/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/DelegatedDomesticPaymentTest.kt
+++ b/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/DelegatedDomesticPaymentTest.kt
@@ -286,6 +286,37 @@ class DelegatedDomesticPaymentTest {
         ).isEqualTo(403)
     }
 
+    /**
+     * The legacy `account_authorizations` arm of the ADR-0232 D1 dual-run cannot move money
+     * (issue #2993), and this is the only place that says so.
+     *
+     * The test above covers a grantor-less `DELEGATED`, which is an upstream *bug*. This is the
+     * different and more dangerous case: `LEGACY_AUTHORIZATION` is the response account-service is
+     * SPECIFIED to send — `authorized: true`, and `grantorPartyId` deliberately omitted, because
+     * the endpoint emits grant evidence only for `DELEGATED`. So a legacy row authorises at
+     * account-service and is refused here, and that fail-closed outcome is incidental: it falls
+     * out of the edge needing a grantor to re-fetch the account, not out of any decision that the
+     * legacy store should not carry a debit.
+     *
+     * Which makes it exactly one field away from becoming a live over-grant — a second consumer
+     * reading `authorized` alone, or `grantorPartyId` being added to that branch for tidiness,
+     * would silently put the un-reconciled legacy store on the money path. Pinning it means such a
+     * change has to argue with a red test instead of shipping as a cleanup.
+     */
+    @Test
+    fun `a legacy-only authorization cannot move money`() {
+        val upstream = upstreamWith(
+            Response.ok("""{"authorized":true,"outcome":"LEGACY_AUTHORIZATION"}""").build(),
+        )
+
+        val resp = resource(upstream, mockk(relaxed = true))
+            .createDomesticPayment(body(), "idem-legacy", SCA_ID)
+
+        assertThat(resp.status).isEqualTo(403)
+        // The refusal must be a refusal all the way down: no payment may reach the rail.
+        verify(exactly = 0) { upstream.post(match { it.contains("/domestic-payments") }, any(), any(), any()) }
+    }
+
     /** The delegate still authenticates as themselves: no grant substitutes for SCA. */
     @Test
     fun `a delegated payment without SCA is refused`() {

--- a/openbank-libs-runtime/src/main/kotlin/com/openbank/libs/observability/DomainMetrics.kt
+++ b/openbank-libs-runtime/src/main/kotlin/com/openbank/libs/observability/DomainMetrics.kt
@@ -298,6 +298,30 @@ class DomainMetrics {
         counter("openbank.authz.four_eyes", "action", action, "outcome", outcome)
     }
 
+    /**
+     * Increment when two authorization stores that are meant to hold the same grant give
+     * DIFFERENT answers to one access question (ADR-0232 D1 dual-run, issue #2993).
+     *
+     * A dual-run's risk is not "is each store written" but "can they disagree, and does anyone
+     * find out". Nothing in this fleet answers the second half: a grant revoked in one store and
+     * still live in the other is invisible, because the guards OR the two together and an OR
+     * cannot report which arm carried it. This counter is that report, sampled at the decision
+     * itself rather than by a nightly diff — so it observes the state the guard actually acted on.
+     *
+     * Emitting it is never a decision: the caller records the disagreement and then returns the
+     * same verdict it would have returned anyway. A metric that changed the answer would make the
+     * observation the thing being observed.
+     *
+     * @param question  the access question being answered, low-cardinality, e.g.
+     *                  `account_delegated_payment`
+     * @param direction which store was the permissive one — `legacy_only` (the store being
+     *                  migrated FROM permits, the new one does not) or `delegation_only` (the
+     *                  reverse). Never a store pair, an id, or a party: two values per question.
+     */
+    fun authorizationStoreDisagreement(question: String, direction: String) {
+        counter("openbank.authz.store_disagreement", "question", question, "direction", direction)
+    }
+
     // ── Outbox ────────────────────────────────────────────────────────────────
 
     /**


### PR DESCRIPTION
## What this is

Triage of #2993 (ADR-0232 D1 dual-run), re-measured on `origin/main` @ `d0c01b7cb`. Two of the
issue's standing findings changed, one of them in the safe direction. The code change is the
smallest thing that makes the dual-run's actual risk measurable, and it changes no verdict.

`Refs #2993`.

## The measurement that mattered: can the two stores disagree, and what happens when they do?

**Which paths write each store — nothing writes both, atomically or otherwise.**

| store | written by | read by |
|---|---|---|
| `account_authorizations` | `AuthorizationResource.grant` / `.revoke` (local table only; no delegation-service client exists in account-service main sources) | `isAuthorized`, `isAuthorizedForAmount`, `authorizeDelegatedPayment` |
| `account_delegation_projection` | `DelegationEventConsumer` from `openbank.delegation.events` | the same three |
| delegation-service's own `delegation_grants` | delegation-service API | **customer-edge directly**, via `POST /api/v1/delegations/check` |

There is no write-through and no reconciliation job, so the two stores can be made to disagree by
any single revocation.

**What `authorizeDelegatedPayment` does on disagreement, in each direction:**

- **legacy permits, delegation does not** (`DELETE /authorizations/{id}` never happened, but the
  grant was revoked in delegation-service): returns `LEGACY_AUTHORIZATION`, `authorized: true`.
- **delegation permits, legacy does not** (the legacy row was closed, the grant is still ACTIVE):
  returns `DELEGATED`, `authorized: true`, and the debit proceeds.

Both directions authorise. The OR can only ever *add* access — that is deliberate and documented
in the KDoc on `hasDelegatedAccess`.

## Premise change 1 — the legacy arm does **not** currently move money, and nothing said so

The issue's latest comment records that `authorizeDelegatedPayment` put the legacy `OR` on a live
money path. Half of that is now measurably false, and it is worth writing down before someone
"tidies" it away.

`DelegatedPaymentAuthorizationResource` emits `delegationId`/`grantorPartyId` **only** when the
outcome is `DELEGATED`:

```kotlin
if (decision.outcome == DelegatedPaymentOutcome.DELEGATED) {
    put("delegationId", decision.delegationId?.toString())
    put("grantorPartyId", decision.grantorPartyId?.toString())
}
```

and the only caller, `CustomerEdgeResource.resolveDebitAuthority`, requires a grantor:

```kotlin
if (decision?.authorized != true || grantor == null) { ...refuse... }
```

So a `LEGACY_AUTHORIZATION` answer — `authorized: true`, no grantor — is **refused at the edge**.
A legacy-only delegate cannot initiate a domestic payment today.

That fail-closed outcome is **incidental**: it falls out of the edge needing a grantor to re-fetch
the account and to record on-behalf-of, not out of any decision that the legacy store should not
carry a debit. It was also completely untested — `LEGACY_AUTHORIZATION` appears nowhere in the
repo outside account-service's own sources and one unit test. Adding `grantorPartyId` to that
branch for tidiness, or a second consumer reading `authorized` alone, would silently put the
un-reconciled legacy store on the money path. This PR pins it with a test so such a change has to
argue with a red build.

## Premise change 2 — the account path **does** have the ADR-0249 D2 / ADR-0232 D3 fork, and worse

Yes, and it is sharper than the card one on #2990. There are two live answers to "may this party
act on this account", and they consult **different stores**:

| route | adjudicator | consults legacy table? | freshness |
|---|---|---|---|
| balances (`:303`), transactions (`:1558`) via `mayReadAccount` | **customer-edge itself** → delegation-service `/delegations/check` | **no** | live, no cache, by design |
| domestic payment via `resolveDebitAuthority` | **account-service** `authorizeDelegatedPayment` | **yes** | event-fed local projection replica |

Two consequences that follow only from the fork, not from the legacy table at all:

1. **The money path reads a stale replica while the read path reads the source.** Revoke a grant in
   delegation-service and reads stop on the next call; payments keep succeeding until
   `DelegationEventConsumer` has consumed the revocation. The freshness ordering is backwards from
   what you would choose — the strictest surface is on the laggiest data. The consumer does handle
   `DelegationRevoked` correctly (`closeById`), so this is bounded by Kafka lag, not unbounded.
2. **A legacy-only grantee has incoherent rights**: `/authorizations/check` says yes,
   balance and transaction reads say no (the legacy table is invisible to `hasGrant`), and payments
   say no (the grantor-less refusal above). Three surfaces, three answers, one question.

Note the irony worth preserving: `DelegatedPaymentAuthorizationResource`'s own KDoc argues the
decision must live in account-service so there is never "a second copy of the projection kept in
step with this one — the failure mode this repo has been burned by repeatedly, where two copies of
a rule drift and the money-path copy is the stale one." That second copy exists; it is
delegation-service's own store, read live by the edge, and the money-path copy is indeed the stale
one.

## Live-row evidence: it cannot exist yet, and I am not reporting a comfortable zero

Read-only `SELECT`s against the sandbox (`arn:aws:eks:eu-north-1:…:cluster/openbank-sandbox`),
CNPG `status.currentPrimary` in each case:

```
accounts-db-2 / openbank_accounts
  account_authorizations         : total 0, not_revoked 0
  account_delegation_projection  : total 0, active 0

delegation-db-1 / openbank_delegations
  delegation_grants GROUP BY resource_type, status : (0 rows)
```

**Every store is empty across the estate.** Zero disagreements here is a fact about traffic, not
about the invariant — there has never been a grant to disagree about. No live-row claim about
drift is available today, in either direction, and none will be until the delegated flows are
actually exercised.

**What would produce the evidence** is the counter this PR adds: it samples at the decision, so the
first delegated payment made against a diverged pair reports it. A nightly reconciliation diff
(step 3 of the issue) is the complementary control and is still unbuilt — it would catch pairs that
diverge without anyone paying, which the counter structurally cannot see.

## The change

**`openbank-libs-runtime`** — one additive `DomainMetrics.authorizationStoreDisagreement(question,
direction)` method. Two tags, both low-cardinality; libs-runtime has no `version.txt`, so nothing
releases from it.

**`openbank-account-service`** — `authorizeDelegatedPayment` now evaluates the projection *before*
the legacy return rather than after it, compares the two verdicts, and counts the difference as
`openbank.authz.store_disagreement{question="account_delegated_payment",direction="legacy_only"|"delegation_only"}`
plus a WARN log. **The verdict is byte-identical in every case** — the outcome ladder is unchanged
and all 19 pre-existing `AuthorizeDelegatedPaymentTest` cases pass untouched. Cost is one extra
indexed local lookup on the legacy-permitting path.

**`openbank-customer-edge`** — test only (an excluded path; does not release) pinning that a
`LEGACY_AUTHORIZATION` answer produces a 403 and never reaches the payment rail.

### What I deliberately did **not** do

- **Not** emitting `grantorPartyId` for `LEGACY_AUTHORIZATION`. It would make the two stores agree
  by trusting the wider one and turn a currently-refused legacy payment into an authorised one.
  That is over-granting, the failure that matters here.
- **Not** removing the legacy disjunct. It is live, deliberate, and reverting it un-ships part of
  ADR-0232 D3; #2993 records that as decision option (c), for the owner.
- **Not** starting the migration. Steps 1-2 and 4-5 are a schema change plus a cutover — see below.

## Was the existing test suite encoding the current semantics as intended?

Checked first, as required. **Yes, and legitimately.** `AuthorizeDelegatedPaymentTest` has
`a legacy PAYMENT_ONLY row still authorises` asserting `LEGACY_AUTHORIZATION`, and
`a legacy row's own transactionLimit is enforced` asserting that `isAuthorizedForAmount` still
answers `true` where `authorizeDelegatedPayment` answers `false`. These encode the dual-run
contract ADR-0232 chose, not a defect — so **nothing was replaced**. The gap was that no test
anywhere asserted what happens when the two stores *disagree*, which is the question a dual-run
exists to answer.

The one strict-mock configuration worth noting: the three `AuthorizationService` unit tests default
`projectionRepository.findActiveByAccountAndParty` to `emptyList()` in `setUp`, so the projection
arm is silent unless a test opts in. That is why the legacy-only direction was never exercised as a
*divergence* — the mock made "no projection row" the invisible background rather than a fact under
test.

## Both test runs

New file `AuthorizationStoreDisagreementTest` asserts against a real `SimpleMeterRegistry` (not a
verified mock — a mock passes against a metric name nothing scrapes).

**Against `origin/main`** (`d0c01b7cb`, in a detached baseline worktree; the test adapted only to
main's 4-arg constructor so it *compiles* and fails on the assertion rather than the signature):

```
AuthorizationStoreDisagreementTest > a grant live only in the legacy table is recorded as legacy_only() FAILED
AuthorizationStoreDisagreementTest > a grant live only in the delegation projection is recorded as delegation_only() FAILED
AuthorizationStoreDisagreementTest > differing ceilings on the same amount are a disagreement() FAILED
6 tests completed, 3 failed
BUILD FAILED
```

The 3 that pass on main are the controls (both-permit, both-refuse, owner) — they must pass either
way, which is what makes them controls rather than the assertion.

**Against this branch:**

```
BUILD SUCCESSFUL
```

JUnit XML, read for `skipped` and not only `failures`:

```
AuthorizationStoreDisagreementTest    tests=6  failures=0 errors=0 skipped=0
AuthorizeDelegatedPaymentTest         tests=19 failures=0 errors=0 skipped=0
AuthorizationServiceTest              tests=11 failures=0 errors=0 skipped=0
AuthorizationServiceDelegationTest    tests=13 failures=0 errors=0 skipped=0
DelegatedDomesticPaymentTest          tests=14 failures=0 errors=0 skipped=0
```

The last one matters beyond the count: `a legacy-only authorization cannot move money` **passes**,
which is the empirical confirmation of premise change 1 above. The fail-closed behaviour of the
legacy arm was established by executing the edge against a real `LEGACY_AUTHORIZATION` response,
not only by reading `resolveDebitAuthority`.

Every test method is written `fun x(): Unit = runBlocking { }` — the 0-skipped counts confirm none
was silently ignored.

Gate also run: `ktlintCheck` + `detekt` on both modules, and `:openbank-account-service:quarkusBuild`
for the CDI wiring of the new constructor parameter (ArC failures surface only there).

## The remaining work is a migration with a schema change and a cutover — not started

Per acceptable-outcome (2), the sequence and the risk of each ordering, for the owner to decide:

1. **Reconciliation/observability first** (this PR is the decision-time half). Risk: none — it
   changes no verdict. Leaves the divergence live but visible. This is #2993's option (a), which
   the issue notes the repo is currently in *without* the instrument.
2. **Model mapping + backfill** (`AuthorizationRole` → capabilities, `SigningRule` →
   `approvalPolicy`). Risk: the mapping is lossy in the direction that over-grants —
   `FULL_ACCESS` → "all account capabilities" hands a migrated row every capability the new
   vocabulary has, including ones the legacy role never implied. Backfill **before** write-through
   means a window where new grants land only in the legacy store and are missed by the backfill.
3. **Write-through in `AuthorizationResource`**. Risk: it is a distributed write with no atomic
   option — a failed forward-write must fail the whole grant, or it manufactures exactly the drift
   being retired. Doing this **before** the backfill leaves historical rows unmigrated forever.
4. **Cut over enforcement to the projection.** Risk: this is the only step that can *remove*
   access, so it needs the counter from step 1 to have read zero over a real traffic window — and
   today it cannot, because the population is zero. **Cutting over on a zero from an empty table is
   the trap this repo has been burned by twice.**
5. **Sunset headers, then drop the table** (Flyway + rollback note). Irreversible; last.

The ordering risk that dominates: any sequence that cuts over (4) before the counter (1) has
observed real traffic is trading a visible additive drift for an invisible subtractive one, and
subtractive drift on an authorization path fails as a customer-visible outage rather than as a
finding.

## Governance

- `openbank-account-service` is in `rules.yaml: money_path_services` → **2 approvals**.
- Threat model: `docs/threat-models/account-service.md` — this change adds telemetry and a test and
  introduces no new trust boundary, data flow, or actor. Flagging it for the reviewer rather than
  asserting the exemption.
- No API change: the `payment-authorization` response shape is untouched, so no `openapi.yaml`
  `info.version` bump (ADR-0048).
- No DB migration, no event-schema change, no `rules.yaml` / `.rego` / `agents.yaml` edit, so no
  OPA bundle restamp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
