### PR TITLE
fix(analytics-sink): fold aggregate_type case in the silver layer, close out #4632

### DIFF
--- a/openbank-analytics-sink/src/main/resources/clickhouse/V8__fold_silver_layer_case.sql
+++ b/openbank-analytics-sink/src/main/resources/clickhouse/V8__fold_silver_layer_case.sql
@@ -1,0 +1,85 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+-- See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+--
+-- Fold the silver layer's own reduction, issue #4632 (the #4553 backfill follow-up).
+--
+-- #4553 measured bronze holding both `ACCOUNT`/`Account` and `Transaction`/`Consent`-only spellings
+-- for the same domains, and #4576 stopped it growing by normalising at ingest — but rows written
+-- before that fix keep their producer's original spelling forever. #4632 was opened to plan a bronze
+-- backfill for those historical rows and closes with a different answer: the actual symptom #4553
+-- named — "one account has two current-state rows" — is a property of the SILVER reduction's own
+-- GROUP BY, not of the bronze rows themselves. Folding it here resolves the symptom for every past
+-- and future row without ever touching bronze (ADR-0022: a 10-year, append-only log of record).
+--
+-- WHY NOT A BRONZE BACKFILL INSTEAD. Two paths were considered and rejected:
+--   1. An ALTER TABLE ... UPDATE mutation on bronze_events.aggregate_type. Rejected: it edits the
+--      log of record in place — exactly what the retention floor and the WORM tamper-evidence
+--      mechanism (ADR-0023 F1/F2) exist to make visible if it ever happens, not to enable it.
+--   2. A CORRECTION re-ingest through the existing BackfillService/BackfillRequest pipeline.
+--      Rejected on two independent grounds: that pipeline's only wired BackfillSource is
+--      NoOpBackfillSource today (no real OLTP replay source exists for any domain), and even with
+--      one, its own contract — "re-ingestion is safe... dedupe on eventId + last-writer-wins on
+--      aggregateVersion, so a backfill... converges to the same state" — assumes aggregate_type is
+--      UNCHANGED between the old and replayed row. Bronze's ORDER BY is
+--      (aggregate_type, aggregate_id, event_id): a replayed row under the corrected spelling is a
+--      DIFFERENT sort key, so ReplacingMergeTree would insert it ALONGSIDE the original rather than
+--      collapsing onto it — the split would not close, it would grow by one more row per event.
+--
+-- Verified read-only against the sandbox before writing this: folding the GROUP BY (not editing
+-- bronze) drops distinct (type, id) groups from 237 to 232 — exactly the 5 previously-split accounts
+-- collapsing to one row each, each keeping the true latest state (the highest aggregate_version
+-- across BOTH of its old spellings, via argMax — same resolution silver already does per group, now
+-- computed over one group instead of two).
+--
+-- All three: CREATE OR REPLACE, not edits to V1's `CREATE VIEW IF NOT EXISTS` bodies — those have
+-- never been superseded before now, and IF NOT EXISTS is a no-op on a warehouse that already has the
+-- view (the trap V4's own header documents). Downstream is unaffected: every reader added since
+-- #4553 already folds on its own read (silver_party_accounts #4520, the reconciliation reader
+-- #4604/#4618, the Customer 360 route's `.toLowerCase()`) — this view now simply agrees with them at
+-- the source instead of relying on every reader to repeat the fold.
+
+CREATE OR REPLACE VIEW openbank_analytics.silver_current_state AS
+SELECT
+    upper(b.aggregate_type)                                                       AS aggregate_type,
+    b.aggregate_id,
+    argMax(b.event_id, (b.aggregate_version, b.occurred_at, b.ingested_at))       AS event_id,
+    max(b.aggregate_version)                                                      AS aggregate_version,
+    argMax(b.event_type, (b.aggregate_version, b.occurred_at, b.ingested_at))     AS event_type,
+    argMax(b.occurred_at, (b.aggregate_version, b.occurred_at, b.ingested_at))    AS occurred_at,
+    argMax(b.source_service, (b.aggregate_version, b.occurred_at, b.ingested_at)) AS source_service,
+    argMax(b.schema_version, (b.aggregate_version, b.occurred_at, b.ingested_at)) AS schema_version,
+    argMax(b.payload, (b.aggregate_version, b.occurred_at, b.ingested_at))        AS payload
+FROM openbank_analytics.bronze_events AS b
+GROUP BY upper(b.aggregate_type), b.aggregate_id;
+
+-- SCD2 history: PARTITION BY (not GROUP BY), so folding needs the SAME upper() in both the output
+-- column and the window's PARTITION BY — folding only the output would leave a mixed-case account's
+-- version sequence split across two windows, each computing its own (wrong) valid_from/valid_to.
+CREATE OR REPLACE VIEW openbank_analytics.silver_history AS
+SELECT
+    upper(aggregate_type)                                                 AS aggregate_type,
+    aggregate_id,
+    aggregate_version,
+    event_type,
+    occurred_at                                                           AS valid_from,
+    leadInFrame(occurred_at) OVER (
+        PARTITION BY upper(aggregate_type), aggregate_id
+        ORDER BY aggregate_version, occurred_at, ingested_at
+        ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING
+    )                                                                     AS valid_to,
+    payload
+FROM openbank_analytics.bronze_events;
+
+CREATE OR REPLACE VIEW openbank_analytics.silver_as_of AS
+SELECT
+    upper(b.aggregate_type)                                                    AS aggregate_type,
+    b.aggregate_id,
+    argMax(b.event_id, (b.aggregate_version, b.occurred_at, b.ingested_at))    AS event_id,
+    max(b.aggregate_version)                                                   AS aggregate_version,
+    argMax(b.event_type, (b.aggregate_version, b.occurred_at, b.ingested_at))  AS event_type,
+    argMax(b.occurred_at, (b.aggregate_version, b.occurred_at, b.ingested_at)) AS occurred_at,
+    argMax(b.payload, (b.aggregate_version, b.occurred_at, b.ingested_at))     AS payload
+FROM openbank_analytics.bronze_events AS b
+WHERE b.occurred_at <= {t:DateTime64(3, 'UTC')}
+GROUP BY upper(b.aggregate_type), b.aggregate_id;

--- a/openbank-infra/gitops/components/analytics/clickhouse-init-configmap.yaml
+++ b/openbank-infra/gitops/components/analytics/clickhouse-init-configmap.yaml
@@ -650,6 +650,92 @@ data:
       AND JSONHas(payload, 'stepOrder')
       AND JSONExtractString(payload, 'channel') IN ('PUSH', 'BANNER')
     GROUP BY campaign_id, step_order, channel;
+  08-fold-silver-layer-case.sql: |
+    -- SPDX-License-Identifier: Apache-2.0
+    -- Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+    -- See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+    --
+    -- Fold the silver layer's own reduction, issue #4632 (the #4553 backfill follow-up).
+    --
+    -- #4553 measured bronze holding both `ACCOUNT`/`Account` and `Transaction`/`Consent`-only spellings
+    -- for the same domains, and #4576 stopped it growing by normalising at ingest — but rows written
+    -- before that fix keep their producer's original spelling forever. #4632 was opened to plan a bronze
+    -- backfill for those historical rows and closes with a different answer: the actual symptom #4553
+    -- named — "one account has two current-state rows" — is a property of the SILVER reduction's own
+    -- GROUP BY, not of the bronze rows themselves. Folding it here resolves the symptom for every past
+    -- and future row without ever touching bronze (ADR-0022: a 10-year, append-only log of record).
+    --
+    -- WHY NOT A BRONZE BACKFILL INSTEAD. Two paths were considered and rejected:
+    --   1. An ALTER TABLE ... UPDATE mutation on bronze_events.aggregate_type. Rejected: it edits the
+    --      log of record in place — exactly what the retention floor and the WORM tamper-evidence
+    --      mechanism (ADR-0023 F1/F2) exist to make visible if it ever happens, not to enable it.
+    --   2. A CORRECTION re-ingest through the existing BackfillService/BackfillRequest pipeline.
+    --      Rejected on two independent grounds: that pipeline's only wired BackfillSource is
+    --      NoOpBackfillSource today (no real OLTP replay source exists for any domain), and even with
+    --      one, its own contract — "re-ingestion is safe... dedupe on eventId + last-writer-wins on
+    --      aggregateVersion, so a backfill... converges to the same state" — assumes aggregate_type is
+    --      UNCHANGED between the old and replayed row. Bronze's ORDER BY is
+    --      (aggregate_type, aggregate_id, event_id): a replayed row under the corrected spelling is a
+    --      DIFFERENT sort key, so ReplacingMergeTree would insert it ALONGSIDE the original rather than
+    --      collapsing onto it — the split would not close, it would grow by one more row per event.
+    --
+    -- Verified read-only against the sandbox before writing this: folding the GROUP BY (not editing
+    -- bronze) drops distinct (type, id) groups from 237 to 232 — exactly the 5 previously-split accounts
+    -- collapsing to one row each, each keeping the true latest state (the highest aggregate_version
+    -- across BOTH of its old spellings, via argMax — same resolution silver already does per group, now
+    -- computed over one group instead of two).
+    --
+    -- All three: CREATE OR REPLACE, not edits to V1's `CREATE VIEW IF NOT EXISTS` bodies — those have
+    -- never been superseded before now, and IF NOT EXISTS is a no-op on a warehouse that already has the
+    -- view (the trap V4's own header documents). Downstream is unaffected: every reader added since
+    -- #4553 already folds on its own read (silver_party_accounts #4520, the reconciliation reader
+    -- #4604/#4618, the Customer 360 route's `.toLowerCase()`) — this view now simply agrees with them at
+    -- the source instead of relying on every reader to repeat the fold.
+
+    CREATE OR REPLACE VIEW openbank_analytics.silver_current_state AS
+    SELECT
+        upper(b.aggregate_type)                                                       AS aggregate_type,
+        b.aggregate_id,
+        argMax(b.event_id, (b.aggregate_version, b.occurred_at, b.ingested_at))       AS event_id,
+        max(b.aggregate_version)                                                      AS aggregate_version,
+        argMax(b.event_type, (b.aggregate_version, b.occurred_at, b.ingested_at))     AS event_type,
+        argMax(b.occurred_at, (b.aggregate_version, b.occurred_at, b.ingested_at))    AS occurred_at,
+        argMax(b.source_service, (b.aggregate_version, b.occurred_at, b.ingested_at)) AS source_service,
+        argMax(b.schema_version, (b.aggregate_version, b.occurred_at, b.ingested_at)) AS schema_version,
+        argMax(b.payload, (b.aggregate_version, b.occurred_at, b.ingested_at))        AS payload
+    FROM openbank_analytics.bronze_events AS b
+    GROUP BY upper(b.aggregate_type), b.aggregate_id;
+
+    -- SCD2 history: PARTITION BY (not GROUP BY), so folding needs the SAME upper() in both the output
+    -- column and the window's PARTITION BY — folding only the output would leave a mixed-case account's
+    -- version sequence split across two windows, each computing its own (wrong) valid_from/valid_to.
+    CREATE OR REPLACE VIEW openbank_analytics.silver_history AS
+    SELECT
+        upper(aggregate_type)                                                 AS aggregate_type,
+        aggregate_id,
+        aggregate_version,
+        event_type,
+        occurred_at                                                           AS valid_from,
+        leadInFrame(occurred_at) OVER (
+            PARTITION BY upper(aggregate_type), aggregate_id
+            ORDER BY aggregate_version, occurred_at, ingested_at
+            ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING
+        )                                                                     AS valid_to,
+        payload
+    FROM openbank_analytics.bronze_events;
+
+    CREATE OR REPLACE VIEW openbank_analytics.silver_as_of AS
+    SELECT
+        upper(b.aggregate_type)                                                    AS aggregate_type,
+        b.aggregate_id,
+        argMax(b.event_id, (b.aggregate_version, b.occurred_at, b.ingested_at))    AS event_id,
+        max(b.aggregate_version)                                                   AS aggregate_version,
+        argMax(b.event_type, (b.aggregate_version, b.occurred_at, b.ingested_at))  AS event_type,
+        argMax(b.occurred_at, (b.aggregate_version, b.occurred_at, b.ingested_at)) AS occurred_at,
+        argMax(b.payload, (b.aggregate_version, b.occurred_at, b.ingested_at))     AS payload
+    FROM openbank_analytics.bronze_events AS b
+    WHERE b.occurred_at <= {t:DateTime64(3, 'UTC')}
+    GROUP BY upper(b.aggregate_type), b.aggregate_id;
 kind: ConfigMap
 metadata:
   name: clickhouse-init


### PR DESCRIPTION
## Summary

Closes #4632 with a different answer than "plan a bronze backfill": the actual symptom #4553 named
— one account holding two current-state rows that never reconcile — is a property of
`silver_current_state`'s own `GROUP BY`, not of the bronze rows. Folding the reduction resolves it
for every row, past and future, without touching bronze at all.

## Type of change

- [x] fix (bug fix)

## Linked issues

Closes #4632. Refs #4553.

## Why not a bronze backfill (the two paths #4632 was opened to plan, both rejected)

1. **`ALTER TABLE ... UPDATE`** on `bronze_events.aggregate_type` — edits the log of record in place.
   The 10-year retention floor and the WORM tamper-evidence mechanism (ADR-0023 F1/F2) exist to make
   that visible if it ever happens, not to enable it.
2. **A `CORRECTION` re-ingest** through the existing `BackfillService`/`BackfillRequest` pipeline —
   rejected on two independent grounds:
   - The only wired `BackfillSource` is `NoOpBackfillSource`, today, for every domain. The pipeline
     isn't operationally available to do this even if it were the right tool.
   - Its own documented contract — *"re-ingestion is safe... dedupe on eventId + last-writer-wins on
     aggregateVersion, so a backfill... converges to the same state"* — assumes `aggregate_type` is
     **unchanged** between the old and replayed row. `bronze_events`'s `ORDER BY` is
     `(aggregate_type, aggregate_id, event_id)`: a replayed row under the corrected spelling is a
     *different* sort key, so `ReplacingMergeTree` would insert it **alongside** the original instead
     of collapsing onto it. The split wouldn't close — it would grow by one row per event.

## What this does instead

`CREATE OR REPLACE VIEW` for `silver_current_state`, `silver_history`, `silver_as_of` — all fold
`upper(aggregate_type)` now. `silver_history` needed the fold in **both** the output column and the
window's `PARTITION BY`: folding only the output would leave a mixed-case account's version sequence
split across two windows, each computing its own `valid_from`/`valid_to` over a fragment of the true
sequence.

`gold_daily_event_volume` is deliberately **not** touched — it groups by raw `aggregate_type` as a
display dimension, same as the "Events by aggregate type" Grafana panel #4556 left unfolded on
purpose so the case split stays visible. That panel is the one piece of residual scope #4632 flagged
as "worth revisiting" — not resolved here, left as a follow-up decision.

## Verification — live sandbox, before AND after, not simulated

Read-only, before any apply:

```
unfolded_rows=237  folded_rows=232   (dry-run GROUP BY upper(aggregate_type), no CREATE OR REPLACE yet)
```

Applied, then reconfirmed:

```
                        before -> after
silver_current_state:     237 ->  232   (-5, exactly the previously-split accounts)
silver_history:            919 ->  919  (unchanged — per-row SCD2, folding the partition key
                                          changes which window a row belongs to, not row count)
silver_party_accounts:       9 ->    9  (unaffected — different view, already folded since #4520)
gold_onboarding_funnel_events: 513 -> 513
gold_screen_feedback:          8 ->   8
```

The split account (`28ed9683-…`) in `silver_current_state`:

```
before: ACCOUNT  maxVersion=0   |   Account  maxVersion=1     (two rows, true state hidden)
after:  ACCOUNT  maxVersion=1                                 (one row, true state)
```

Column type unchanged — `DESCRIBE TABLE` post-fold still reports `aggregate_type
LowCardinality(String)`.

Both existing DDL gates green against the tree with V8 added:
- `check-clickhouse-ddl-in-configmap.py` (#4520) — `SUBJECTS=23`, PASS (V8 redefines existing object
  names, doesn't add new ones, so the object count is unchanged; the ConfigMap addition is what the
  gate actually checks).
- `check-aggregate-type-case-fold.py` (#4618) — `SUBJECTS=2374`, PASS.

## Side-finding, not fixed here

Folding `silver_history` surfaced a genuine `occurred_at`/`aggregate_version` ordering irregularity
on the sandbox's own test account `28ed9683-…`: a `version=1` row's `occurred_at` is *earlier* than a
`version=0` row's. Previously invisible, because the case split partitioned it into two single-row
"sequences" that couldn't disagree with themselves — folding didn't create this, it stopped hiding
it. Flagging it here rather than either fixing it (out of scope, likely sandbox seed-data clock skew)
or staying silent about a side-effect this PR's own diff surfaced.

## Definition of Done

- [x] No code changed — a ClickHouse DDL resource + gitops ConfigMap only.
- [x] No test changes needed: every Kotlin/TS consumer of these views reads output columns through
      mocked responses (`ClickHouseWarehouseStateReader`, the Customer 360 route), none asserts the
      views' own SQL text.

## Security checklist

- [x] No secrets, no PII. `aggregate_type` is a domain discriminator; no payload columns touched.
- [x] `gitleaks` run locally before push: 1 pre-existing finding in `openbank-libs/governance/agents.yaml`,
      unrelated to this diff.

## Compliance impact

- [x] GDPR / ADR-0022 — bronze (the log of record) is untouched; this is a read-side reduction only.
      Erasure/retention semantics are unaffected.
- [x] None otherwise.

## Rollout / Rollback

- Applied to the sandbox warehouse out of band, verified before/after as above. Fresh clusters get it
  from the updated init ConfigMap.
- Rollback: a follow-up `CREATE OR REPLACE VIEW` reverting to the unfolded `GROUP BY`/`PARTITION BY`.
  No data written or altered by this change in any direction — views carry no state of their own.

## Reviewer notes

`#4632`'s original three risk factors (merge policy for the split account, erasure/Vault-key
interaction, WORM audit-trail implications) are all moot under this approach — none of them apply to
a view redefinition, only to an actual bronze mutation or re-ingest, neither of which this PR does.
