### PR TITLE
feat(gitops): make document-service's billing channel group.id reach the connector (#4217)

### DIFF
--- a/.github/scripts/check-kafka-dotted-keys.py
+++ b/.github/scripts/check-kafka-dotted-keys.py
@@ -99,12 +99,13 @@ BASELINE = {
     ("openbank-party-service", "aml-events-in", "auto.offset.reset"): "#2945 — same",
     ("openbank-party-service", "consent-events-in", "auto.offset.reset"): "#2945 — same",
     ("openbank-statement-service", "account-events-in", "auto.offset.reset"): "#2945 — same",
-    # #4122/#4217/ADR-0248, temporary — neither override can be added yet:
-    # check-msg-channel-image-parity.py correctly refuses it while the deployed
-    # document-service image predates this channel (SRMSG00071 boot-crash risk). Remove both
-    # entries in the follow-up PR that adds the overrides, once #4122 has merged and deployed.
-    ("openbank-document-service", "billing-outbox-events-in", "group.id"): "#4122 — deferred until the deployed image has the channel; see check-msg-channel-image-parity.py",
-    ("openbank-document-service", "billing-outbox-events-in", "auto.offset.reset"): "#4122 — same, deferred",
+    # #4122/#4217/ADR-0248. The group.id entry that stood here is GONE: the deployed image now
+    # carries the channel (check-msg-channel-image-parity.py passes), so the override was added and
+    # the key is covered. Only auto.offset.reset remains, and for a different reason than the
+    # original deferral — not image parity, which is satisfied, but the #2945 replay rule: its
+    # declared `earliest` and its effective `latest` genuinely differ, so making it effective
+    # re-reads the retained log for a group already running as `latest`. Owner decision.
+    ("openbank-document-service", "billing-outbox-events-in", "auto.offset.reset"): "#2945 — declared earliest vs effective latest; setting it would replay the retained log",
 }
 
 

--- a/openbank-infra/gitops/components/document-service/document-service-msg-override.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-msg-override.yaml
@@ -10,19 +10,30 @@
 # which is what kafka-document-service-mtls.yaml grants Read on and where today's committed
 # offsets live.
 #
-# `auto.offset.reset: earliest` is declared in application.yaml and is subject to the same bug
-# (effective value: the connector default `latest`). It is deliberately NOT set here — making it
-# effective would replay the retained log on the next offset expiry. Owner decision, see #2945.
+# `auto.offset.reset: earliest` is declared in application.yaml — on BOTH incoming channels,
+# account-created-in and billing-outbox-events-in — and both are subject to the same bug (effective
+# value: the connector default `latest`). It is deliberately NOT set here for either. Unlike
+# group.id there is no saving coincidence: the declared value and the effective one genuinely
+# differ, so setting it does not make a no-op effective — it re-reads the retained log from the
+# beginning for a group already running as `latest`. Owner decision, see #2945.
 #
 # Properties file rather than env vars: the hyphenated channel name hits the unresolved
 # quarkusio/quarkus#30106 / smallrye-reactive-messaging#2028 env-var split bug (SRMSG00071).
 # config_ordinal=500 outranks the baked application.yaml (~254); loaded via QUARKUS_CONFIG_LOCATIONS.
 #
-# #4217/ADR-0248: the new billing-outbox-events-in channel needs the same override, but NOT yet —
-# `gates (gitops)` correctly refuses it here: SmallRye treats a configured channel with no
-# `connector:` in the DEPLOYED image's application.yaml as a hard boot failure (SRMSG00071), and
-# the currently deployed document-service image predates #4122 (which declares the channel).
-# Add the line once #4122 has merged AND deployed, in a follow-up PR — not before.
+# #4217/ADR-0248: the billing-outbox-events-in line below was deferred until the channel existed in
+# the DEPLOYED image — SmallRye treats a configured channel with no `connector:` there as a hard
+# boot failure (SRMSG00071), and the image then in service predated #4122, which declares it.
+# Both conditions are now met and were verified rather than assumed: #4122 (02e437367) is an
+# ancestor of the deployed image e80f4bc7, and that image's own application.yaml declares
+# `billing-outbox-events-in` with `connector: smallrye-kafka`.
+#
+# Like the account-created-in line, this changes NO effective value: the declared group.id is
+# `openbank-document-service`, which is exactly what the connector's fallback to
+# quarkus.application.name already produces. It is set so the group stops depending on that
+# coincidence — a rename or a channel-specific group would otherwise silently move the consumer to
+# a group its KafkaUser does not grant. The ACL covers both today: Read on
+# openbank.billing.fee.event and Read on group openbank-document-service.
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -35,3 +46,4 @@ data:
   override.properties: |
     config_ordinal=500
     mp.messaging.incoming.account-created-in.group.id=openbank-document-service
+    mp.messaging.incoming.billing-outbox-events-in.group.id=openbank-document-service


### PR DESCRIPTION
## The deferred override, now that its precondition actually holds

`document-service-msg-override.yaml` carried an explicit deferral:

> #4217/ADR-0248: the new `billing-outbox-events-in` channel needs the same override, **but NOT yet**
> — `gates (gitops)` correctly refuses it here: SmallRye treats a configured channel with no
> `connector:` in the DEPLOYED image's application.yaml as a hard boot failure (SRMSG00071), and the
> currently deployed document-service image predates #4122 (which declares the channel).
> **Add the line once #4122 has merged AND deployed, in a follow-up PR — not before.**

Both halves now hold, and both were verified rather than assumed — "merged" is the easy one and
"deployed" is the one that gets skipped:

- #4122 (`02e437367`) is an ancestor of the deployed image `e80f4bc7` —
  `git merge-base --is-ancestor` confirms it.
- That image's *own* `application.yaml` declares `billing-outbox-events-in` with
  `connector: smallrye-kafka`, read straight out of `git show e80f4bc7:...` rather than off `main`.

`msg-channel-image-parity` — the gate that was correctly refusing this — now **passes** on the
change. The gate agrees, not just my reading of it.

## Changes no effective value

Exactly like the `account-created-in` line above it. The declared `group.id` is
`openbank-document-service`, which is precisely what the connector's fallback to
`quarkus.application.name` already produces, so the broken dotted key was a no-op by coincidence.

Setting it removes the dependence on that coincidence: a service rename or a channel-specific group
would otherwise move the consumer to a group its KafkaUser does not grant, silently. Checked against
the live KafkaUser — `Read` on `openbank.billing.fee.event`, `Read` on group
`openbank-document-service` — so it is covered either way today.

## `auto.offset.reset` is deliberately NOT added

This is the part worth reviewing. For `group.id` there is a saving coincidence; for
`auto.offset.reset` there is none — its declared `earliest` and its effective `latest` genuinely
differ. Setting it would not make a no-op effective, it would re-read the retained log from the
beginning for a group already running as `latest`. That stays an owner decision (#2945).

The comment above the data block now says this for **both** channels; it previously spoke of one,
while two now declare it.

## The ratchet drove the rest, and its in-place instruction was wrong to follow

`kafka-dotted-key-ratchet` is bidirectional, so covering the key made its baseline entry stale:

```
STALE  baseline entry ('openbank-document-service', 'billing-outbox-events-in', 'group.id')
       no longer occurs — it is either fixed or the service is gone.
```

I removed **that one entry only**. The comment sitting next to it said *"Remove both entries in the
follow-up PR"* — following that literally would have been a mistake: the sibling
`auto.offset.reset` entry still occurs, so deleting it would have made the gate report a **new**
occurrence. Its recorded reason is rewritten instead, because the original deferral (image parity)
is now satisfied and the reason it remains is the replay rule.

## Verification

Local gate groups with `PR_DIFF_BASE=origin/main`: **gitops 26 PASS**, **registry 26 PASS**,
**security 12 PASS**. The single non-pass is `loki-rule-load-test` (UNFALSIFIED), which fails
identically on a clean `origin/main` worktree and is unrelated.

`gen-network-policies-drift-gate` failed first and passes now — it diffs the working tree, so it
only becomes meaningful after committing.

## Note on the wider deploy block

This does not clear the `can-i-deploy` block on document-service's consumers (#3223). A gitops PR
only updates the broker's deployed-version record when it changes an image pin, and this one does
not. Tracked in that issue.

Refs #4217, #4122, #2945
