### PR TITLE
docs(edge): document the merchant field the edge already forwards (D5)

### DIFF
--- a/openbank-customer-edge/src/main/resources/openapi.yaml
+++ b/openbank-customer-edge/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: Customer Edge API
-  version: 1.34.0
+  version: 1.35.0
   description: >-
     Customer-facing edge proxy (ADR-0065). Single internet-facing entry point for the
     retail customer app. Validates JWTs from the openbank-customers Keycloak realm,
@@ -2090,6 +2090,48 @@ components:
           type: string
           nullable: true
           description: MCC-derived merchant category for card spend (ADR-0103).
+        merchant:
+          type: object
+          nullable: true
+          description: >-
+            Resolved public identity of the merchant behind a card transaction (D5). This edge
+            forwards the field byte-for-byte from transaction-service's response, which already
+            documents the invariant that matters: absent — not an empty object — when the
+            acquirer descriptor has no catalogue match, which is most transactions. A client must
+            render exactly what it renders today when this is absent, never a guess.
+          properties:
+            cleanName:
+              type: string
+            logoUrl:
+              type: string
+              nullable: true
+            category:
+              type: string
+              nullable: true
+            geo:
+              type: object
+              nullable: true
+              description: >-
+                The SHOP's location for card-present spend, never the cardholder's. Absent for
+                card-not-present transactions — an e-shop has no location a purchase happened at.
+              properties:
+                lat:
+                  type: number
+                  format: double
+                lon:
+                  type: number
+                  format: double
+                city:
+                  type: string
+                  nullable: true
+                country:
+                  type: string
+                  nullable: true
+              required: [lat, lon]
+            source:
+              type: string
+              enum: [ENRICHED]
+          required: [cleanName, source]
 
     # Mirrors openbank-transaction-service TransactionPage (GET /api/v1/transactions is
     # cursor-paginated, not a bare array).


### PR DESCRIPTION
The edge has forwarded transaction-service's optional `merchant` object byte-for-byte since D5 landed — `enrichWithCounterpartyIban` re-serialises the whole upstream tree, nothing strips it. Only the edge's own OpenAPI never named it, so the customer app's daily-synced contract test sees an undocumented field on the wire.

Adds the schema (`cleanName`/`logoUrl`/`category`/`geo`/`source`) mirroring transaction-service's contract exactly. `geo` stays nullable for card-not-present spend.

Docs-only: no route, no Kotlin. `check-openapi-route-conformance`: 0 new findings.

N/A — no tracking issue. This documents a field the edge has already been forwarding since D5; there
is no defect to close and no backlog item to reference. `issue-hygiene` accepts an explicit N/A with
a reason precisely for this shape, and stating it is the point — the check exists to stop the
template placeholder surviving unread, not to force a number.

<sub>Added by a triage pass. Note the check reads the PR body from the event payload, so
`gh run rerun` re-evaluates the ORIGINAL text and can never see this; its workflow subscribes to
`edited` for exactly that reason, which this edit triggers.</sub>
