### PR TITLE
feat(admin-ui): add app-first journey recipes

### DIFF
--- a/openbank-admin-ui/src/app/campaigns/new/page.tsx
+++ b/openbank-admin-ui/src/app/campaigns/new/page.tsx
@@ -19,6 +19,11 @@ import {
 import { StepEditor } from '@/components/campaigns/StepEditor'
 import { CampaignExperiencePreview } from '@/components/campaigns/CampaignExperiencePreview'
 import { CampaignLaunchReadiness } from '@/components/campaigns/CampaignLaunchReadiness'
+import {
+  JourneyRecipePicker,
+  type JourneyRecipe,
+  type JourneyRecipeId,
+} from '@/components/campaigns/JourneyRecipePicker'
 
 /**
  * Campaign Studio — authoring on a canvas (ADR-0221 D1).
@@ -106,6 +111,7 @@ export default function NewCampaignPage() {
   const [trigger, setTrigger] = useState('')
   const [entryUnavailable, setEntryUnavailable] = useState(false)
   const [steps, setSteps] = useState<EditorStep[]>([newStep()])
+  const [journeyRecipe, setJourneyRecipe] = useState<JourneyRecipeId | null>('RETURN_TO_APP')
   const [selected, setSelected] = useState<number | null>(0)
   const [reach, setReach] = useState<number | null>(null)
   // Null = no cap, which is the service's own default (absent stopCondition runs every step).
@@ -201,6 +207,18 @@ export default function NewCampaignPage() {
         ...(contentExperiment ? { variantBVariables: {} } : {}),
       }]
     })
+
+  const applyRecipe = (recipe: JourneyRecipe) => {
+    // A recipe is only an authoring shortcut. Clone every map so opening one step can never alter
+    // another step's values through a shared object reference.
+    setSteps(recipe.steps.map(step => ({
+      ...step,
+      variables: { ...step.variables },
+      ...(step.variantBVariables ? { variantBVariables: { ...step.variantBVariables } } : {}),
+    })))
+    setJourneyRecipe(recipe.id)
+    setSelected(0)
+  }
 
   const removeStep = (i: number) =>
     setSteps(prev => {
@@ -489,6 +507,8 @@ export default function NewCampaignPage() {
           )}
         </div>
       </section>
+
+      <JourneyRecipePicker selected={journeyRecipe} onApply={applyRecipe} />
 
       <section className="campaign-journey-workbench">
         <div className="campaign-workbench-heading">

--- a/openbank-admin-ui/src/app/globals.css
+++ b/openbank-admin-ui/src/app/globals.css
@@ -473,6 +473,27 @@ main {
 .campaign-composer-footer > div:first-child span { display: block; margin-top: .15rem; color: var(--campaign-muted); font-size: .68rem; }
 .campaign-composer-footer-actions { display: flex; align-items: center; justify-content: flex-end; flex-wrap: wrap; gap: .6rem; }
 .campaign-composer-footer-actions .btn-primary { box-shadow: 0 8px 17px rgba(99,91,255,.24); }
+.campaign-recipe-picker {
+  margin-top: 1rem; padding: 1.1rem; border: 1px solid #e4e7f3; border-radius: 1.15rem;
+  background: radial-gradient(circle at 3% 0%, rgba(119, 110, 255, .11), transparent 31%), #fff;
+  box-shadow: 0 10px 28px rgba(25, 35, 65, .045);
+}
+.campaign-recipe-heading { display: flex; justify-content: space-between; align-items: end; gap: 1rem; margin-bottom: .9rem; }
+.campaign-recipe-heading p { display: flex; align-items: center; gap: .35rem; color: var(--campaign-violet); font-size: .68rem; font-weight: 800; letter-spacing: .08em; text-transform: uppercase; }
+.campaign-recipe-heading h2 { margin-top: .22rem; color: #16213a; font-size: 1.05rem; font-weight: 760; letter-spacing: -.025em; }
+.campaign-recipe-heading > span { max-width: 18rem; color: var(--campaign-muted); font-size: .72rem; line-height: 1.45; text-align: right; }
+.campaign-recipe-grid { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: .65rem; }
+.campaign-recipe-card { position: relative; display: flex; min-width: 0; flex-direction: column; align-items: flex-start; gap: .7rem; padding: .9rem; overflow: hidden; border: 1px solid #e1e5f0; border-radius: .95rem; background: rgba(255, 255, 255, .84); text-align: left; transition: border-color .16s ease, box-shadow .16s ease, transform .16s ease, background .16s ease; }
+.campaign-recipe-card:hover { transform: translateY(-2px); border-color: rgba(99,91,255,.46); box-shadow: 0 10px 20px rgba(63, 54, 150, .1); }
+.campaign-recipe-card[data-selected='true'] { border-color: var(--campaign-violet); background: linear-gradient(145deg, #f5f3ff, #fff); box-shadow: 0 0 0 2px rgba(99,91,255,.15), 0 10px 22px rgba(63,54,150,.1); }
+.campaign-recipe-icon { display: grid; width: 2.25rem; height: 2.25rem; place-items: center; border-radius: .7rem; color: var(--campaign-violet); background: #eeecff; }
+.campaign-recipe-card[data-tone='amber'] .campaign-recipe-icon { color: #a75c00; background: #fff2d9; }
+.campaign-recipe-card[data-tone='blue'] .campaign-recipe-icon { color: #2463d4; background: #e9f0ff; }
+.campaign-recipe-card[data-tone='emerald'] .campaign-recipe-icon { color: #087d65; background: #e4f8f1; }
+.campaign-recipe-copy { display: grid; gap: .28rem; }
+.campaign-recipe-copy strong { color: #1d2942; font-size: .79rem; font-weight: 760; line-height: 1.25; }
+.campaign-recipe-copy small { color: var(--campaign-muted); font-size: .68rem; line-height: 1.42; }
+.campaign-recipe-channel { color: #68758c; font-size: .62rem; font-weight: 750; letter-spacing: .025em; }
 .campaign-studio-companion-grid {
   display: grid;
   grid-template-columns: minmax(0, 1.15fr) minmax(19rem, 0.85fr);
@@ -534,7 +555,7 @@ main {
   .campaign-composer-principles { justify-content: flex-start; max-width: none; }
 }
 @media (max-width: 960px) {
-  .campaign-studio-companion-grid, .campaign-setup-grid { grid-template-columns: 1fr; }
+  .campaign-studio-companion-grid, .campaign-setup-grid, .campaign-recipe-grid { grid-template-columns: 1fr; }
   .campaign-brief-card { grid-column: auto; }
 }
 @media (max-width: 640px) {
@@ -544,6 +565,8 @@ main {
   .campaign-brief-card .input + .input { margin-top: .65rem !important; }
   .campaign-measurement-grid { grid-template-columns: 1fr; }
   .campaign-workbench-heading, .campaign-composer-footer { align-items: flex-start; flex-direction: column; }
+  .campaign-recipe-heading { align-items: flex-start; flex-direction: column; }
+  .campaign-recipe-heading > span { text-align: left; }
   .campaign-composer-footer-actions { justify-content: flex-start; }
   .campaign-workbench-status { margin-top: -.15rem; }
 }

--- a/openbank-admin-ui/src/components/campaigns/JourneyRecipePicker.tsx
+++ b/openbank-admin-ui/src/components/campaigns/JourneyRecipePicker.tsx
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+'use client'
+
+import { BellRing, LayoutPanelTop, MailCheck, PanelsTopLeft, Sparkles } from 'lucide-react'
+import { useLanguage } from '@/lib/i18n/LanguageContext'
+import type { EditorStep } from '@/components/campaigns/JourneyEditor'
+
+/**
+ * A recipe is a starting shape for a bounded, linear journey — never a hidden automation or a
+ * second campaign type. Marketers get the common app experiences in one click while every step
+ * remains visible and editable on the canvas immediately below.
+ *
+ * The recipes intentionally carry no copy. The template contract remains the source of truth for
+ * what an author must fill in, and choosing a recipe can therefore never create a sendable draft
+ * by accident.
+ */
+export type JourneyRecipeId = 'RETURN_TO_APP' | 'IN_APP_DISCOVERY' | 'RESPONSIBLE_FALLBACK' | 'PRODUCT_DISCOVERY'
+
+export interface JourneyRecipe {
+  id: JourneyRecipeId
+  steps: EditorStep[]
+}
+
+const empty = (): Record<string, string> => ({})
+
+export const JOURNEY_RECIPES: JourneyRecipe[] = [
+  {
+    id: 'RETURN_TO_APP',
+    steps: [{
+      template: 'MARKETING_PRODUCT_OFFER_PUSH', channel: 'PUSH', variables: empty(),
+      delaySeconds: 0, mobileDestination: 'HOME',
+    }],
+  },
+  {
+    id: 'IN_APP_DISCOVERY',
+    steps: [
+      {
+        template: 'MARKETING_PRODUCT_OFFER_BANNER', channel: 'BANNER', variables: empty(),
+        delaySeconds: 0, mobileDestination: 'HOME', inAppSurface: 'HOME_BANNER',
+      },
+      {
+        template: 'MARKETING_PRODUCT_OFFER_CAROUSEL', channel: 'BANNER', variables: empty(),
+        delaySeconds: 172800, mobileDestination: 'PRODUCT_HUB', inAppSurface: 'HOME_CAROUSEL',
+      },
+    ],
+  },
+  {
+    id: 'RESPONSIBLE_FALLBACK',
+    steps: [{
+      template: 'MARKETING_PRODUCT_OFFER', channel: 'EMAIL', variables: empty(), delaySeconds: 0,
+      fallbackToPush: true, mobileDestination: 'HOME',
+    }],
+  },
+  {
+    id: 'PRODUCT_DISCOVERY',
+    steps: [
+      {
+        template: 'MARKETING_PRODUCT_OFFER_PRODUCT_FEED', channel: 'BANNER', variables: empty(),
+        delaySeconds: 0, mobileDestination: 'PRODUCT_HUB', inAppSurface: 'PRODUCT_FEED',
+      },
+      {
+        template: 'MARKETING_PRODUCT_OFFER_REWARDS_HUB', channel: 'BANNER', variables: empty(),
+        delaySeconds: 259200, mobileDestination: 'HOME', inAppSurface: 'REWARDS_HUB',
+      },
+    ],
+  },
+]
+
+const visual: Record<JourneyRecipeId, { Icon: typeof BellRing; tone: string }> = {
+  RETURN_TO_APP: { Icon: BellRing, tone: 'violet' },
+  IN_APP_DISCOVERY: { Icon: PanelsTopLeft, tone: 'amber' },
+  RESPONSIBLE_FALLBACK: { Icon: MailCheck, tone: 'blue' },
+  PRODUCT_DISCOVERY: { Icon: LayoutPanelTop, tone: 'emerald' },
+}
+
+export function JourneyRecipePicker({
+  selected,
+  onApply,
+}: {
+  selected: JourneyRecipeId | null
+  onApply: (recipe: JourneyRecipe) => void
+}) {
+  const { t } = useLanguage()
+  const copy: Record<JourneyRecipeId, { title: string; detail: string; channels: string }> = {
+    RETURN_TO_APP: {
+      title: t('Přivést zpět do aplikace', 'Bring people back to the app'),
+      detail: t('Jedna push notifikace s bezpečným cílem v aplikaci.', 'One app push with a safe in-app destination.'),
+      channels: t('Push', 'Push'),
+    },
+    IN_APP_DISCOVERY: {
+      title: t('Objevit v aplikaci', 'Discover in the app'),
+      detail: t('Domovský banner a za dva dny navazující carousel.', 'A home banner followed by a carousel two days later.'),
+      channels: t('Banner · Carousel', 'Banner · Carousel'),
+    },
+    RESPONSIBLE_FALLBACK: {
+      title: t('E-mail s bezpečným fallbackem', 'Email with safe fallback'),
+      detail: t('E-mail; pouze při chybějícím souhlasu se ověří samostatný push.', 'Email; only absent email consent may try a separately checked push.'),
+      channels: t('E-mail · Push fallback', 'Email · Push fallback'),
+    },
+    PRODUCT_DISCOVERY: {
+      title: t('Objevování produktů', 'Product discovery'),
+      detail: t('Produktový feed a pozdější připomenutí v centru odměn.', 'Product feed followed by a later rewards-hub reminder.'),
+      channels: t('Produktový feed · Odměny', 'Product feed · Rewards'),
+    },
+  }
+
+  return (
+    <section className="campaign-recipe-picker" aria-labelledby="journey-recipe-title">
+      <div className="campaign-recipe-heading">
+        <div>
+          <p><Sparkles className="h-3.5 w-3.5" /> {t('Začněte osvědčeným vzorem', 'Start with a proven pattern')}</p>
+          <h2 id="journey-recipe-title">{t('Jaký zážitek chceme vytvořit?', 'What experience do we want to create?')}</h2>
+        </div>
+        <span>{t('Každý krok pak upravíte na plátně.', 'Every step stays editable on the canvas.')}</span>
+      </div>
+      <div className="campaign-recipe-grid">
+        {JOURNEY_RECIPES.map(recipe => {
+          const item = copy[recipe.id]
+          const { Icon, tone } = visual[recipe.id]
+          const active = recipe.id === selected
+          return (
+            <button
+              key={recipe.id}
+              type="button"
+              className="campaign-recipe-card"
+              data-journey-recipe={recipe.id}
+              data-selected={active ? 'true' : 'false'}
+              data-tone={tone}
+              onClick={() => onApply(recipe)}
+            >
+              <span className="campaign-recipe-icon"><Icon className="h-5 w-5" /></span>
+              <span className="campaign-recipe-copy">
+                <strong>{item.title}</strong>
+                <small>{item.detail}</small>
+              </span>
+              <span className="campaign-recipe-channel">{item.channels}</span>
+            </button>
+          )
+        })}
+      </div>
+    </section>
+  )
+}

--- a/openbank-admin-ui/src/test/campaign-builder-interaction.test.tsx
+++ b/openbank-admin-ui/src/test/campaign-builder-interaction.test.tsx
@@ -26,6 +26,23 @@ const stub = () => vi.stubGlobal('fetch', vi.fn(async (u: string) =>
         { name: 'savers', version: 2, rules: ['has a savings account', 'balance over 50 000 CZK'] }] }) }))
 
 describe('campaign builder interaction', () => {
+  it('turns an app-first recipe into an explicit, editable multi-surface journey', async () => {
+    stub()
+    const { container, getByText } = render(
+      React.createElement(LanguageProvider, null, React.createElement(NewCampaignPage)))
+    await waitFor(() => getByText('savers'), { timeout: 8000 })
+
+    fireEvent.click(container.querySelector('[data-journey-recipe="IN_APP_DISCOVERY"]')!)
+
+    expect(container.querySelectorAll('[data-step]').length).toBe(2)
+    expect(container.querySelector('[data-step="0"]')!.getAttribute('data-channel')).toBe('BANNER')
+    expect(container.querySelector('[data-step="1"]')!.getAttribute('data-channel')).toBe('BANNER')
+    expect(container.querySelector('[data-journey-recipe="IN_APP_DISCOVERY"]')!.getAttribute('data-selected')).toBe('true')
+    // A recipe must reveal its first node for immediate editing, rather than act as a hidden
+    // black-box automation.
+    expect(container.querySelector('[data-step-editor="0"]')).toBeTruthy()
+  }, 25000)
+
   it('adds steps up to the domain cap, and the add affordance then disappears', async () => {
     stub()
     const { container, getByText } = render(


### PR DESCRIPTION
Closes #4642\n\nAdds curated app-first campaign starting patterns: push return, in-app discovery, product discovery, and consent-safe email fallback. A pattern expands into the same bounded, visible and editable journey steps that campaign-service executes; it does not create hidden automation or bypass four-eyes approval.\n\nVerification:\n- `npm test -- --run src/test/campaign-builder-interaction.test.tsx`\n- `npm run type-check`\n- `npm run lint`