### PR TITLE
feat(admin-ui): refresh operator workspace

### DIFF
--- a/openbank-admin-ui/e2e/ui-primitives.spec.ts
+++ b/openbank-admin-ui/e2e/ui-primitives.spec.ts
@@ -101,6 +101,12 @@ test.describe('ADR-0208 primitives render with real CSS applied', () => {
 
     const serviceGrid = page.locator('[aria-label="Services by group"]')
     expect(await serviceGrid.evaluate(el => getComputedStyle(el).gridTemplateColumns.split(' ').length)).toBe(2)
+
+    // The shell is part of the operator experience, not decorative page chrome: the
+    // navigation rail and command bar must retain their deliberate working geometry.
+    expect(Math.round((await page.locator('aside').boundingBox())!.width)).toBe(264)
+    expect(Math.round((await page.locator('header').boundingBox())!.height)).toBe(60)
+    expect(await page.locator('.page-header').evaluate(el => getComputedStyle(el).backgroundImage)).toContain('linear-gradient')
   })
 
   test('tone swatches are square with zero padding, at both sizes', async ({ page }) => {

--- a/openbank-admin-ui/e2e/ui-primitives.spec.ts
+++ b/openbank-admin-ui/e2e/ui-primitives.spec.ts
@@ -97,7 +97,7 @@ test.describe('ADR-0208 primitives render with real CSS applied', () => {
     // geometry checks make that information hierarchy a browser-observable contract.
     const metricGrid = page.locator('[aria-label="Platform key metrics"]')
     expect(await metricGrid.evaluate(el => getComputedStyle(el).gridTemplateColumns.split(' ').length)).toBe(4)
-    expect(await metricGrid.locator('.stat-card').first().evaluate(el => getComputedStyle(el).borderTopLeftRadius)).toBe('12px')
+    expect(await metricGrid.locator('.stat-card').first().evaluate(el => getComputedStyle(el).borderTopLeftRadius)).toBe('14px')
 
     const serviceGrid = page.locator('[aria-label="Services by group"]')
     expect(await serviceGrid.evaluate(el => getComputedStyle(el).gridTemplateColumns.split(' ').length)).toBe(2)

--- a/openbank-admin-ui/src/app/dashboard/Dashboard.module.css
+++ b/openbank-admin-ui/src/app/dashboard/Dashboard.module.css
@@ -1,11 +1,28 @@
 .dashboard {
-  max-width: 1400px;
-  padding: 28px 32px 40px;
+  max-width: 1560px;
+  min-height: 100%;
+  padding: 24px 36px 48px;
   animation: fadeIn 0.2s ease-out;
 }
 
+.dashboard :global(.page-header) {
+  position: relative;
+  align-items: center;
+  min-height: 136px;
+  margin-bottom: 18px;
+  padding: 28px;
+  overflow: hidden;
+  background: linear-gradient(118deg, #111a35 0%, #172657 54%, #30338f 100%);
+  border: 1px solid rgba(129, 140, 248, 0.42);
+  border-radius: 18px;
+  box-shadow: 0 18px 42px rgba(31, 41, 105, 0.17);
+}
+.dashboard :global(.page-header)::after { position: absolute; top: -96px; right: 15%; width: 260px; height: 260px; content: ''; pointer-events: none; background: radial-gradient(circle, rgba(165, 180, 252, 0.28), transparent 67%); }
+.dashboard :global(.page-title) { color: #fff; font-size: 29px; letter-spacing: -0.045em; }
+.dashboard :global(.page-subtitle) { max-width: 680px; color: #cbd5e1; font-size: 14px; }
+
 .headerIcon {
-  color: var(--accent);
+  color: #a5b4fc;
 }
 
 .headerActions {
@@ -15,7 +32,7 @@
 }
 
 .lastRefresh {
-  color: var(--text-tertiary);
+  color: #cbd5e1;
   font-size: 11px;
   white-space: nowrap;
 }
@@ -23,15 +40,20 @@
 .metrics {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 12px;
+  gap: 14px;
   margin-bottom: 16px;
 }
 
 .metric {
   min-height: 122px;
-  padding: 18px;
-  border-radius: 12px;
+  padding: 20px;
+  border-radius: 14px;
+  box-shadow: 0 10px 22px rgba(15, 23, 42, 0.045);
 }
+.metrics > :nth-child(1) { border-top: 3px solid var(--accent); }
+.metrics > :nth-child(2) { border-top: 3px solid var(--info); }
+.metrics > :nth-child(3) { border-top: 3px solid var(--success); }
+.metrics > :nth-child(4) { border-top: 3px solid var(--warning); }
 
 .healthOverview,
 .serviceGroup,
@@ -41,7 +63,13 @@
 
 .healthOverview {
   margin-bottom: 16px;
+  color: #dbeafe;
+  background: linear-gradient(120deg, #121c36, #1c2b55);
+  border-color: #273966;
+  box-shadow: 0 14px 30px rgba(15, 23, 42, 0.13);
 }
+.healthOverview:hover { border-color: #3f568d; }
+.healthOverview .sectionLabel { color: #c7d2fe; }
 
 .sectionLabel {
   margin: 0 0 14px;
@@ -77,23 +105,23 @@
 }
 
 .groupName {
-  color: var(--text-primary);
+  color: #f8fafc;
   font-size: 12px;
   font-weight: 650;
   text-transform: capitalize;
 }
 
 .groupSummary {
-  color: var(--text-secondary);
+  color: #cbd5e1;
   font-size: 12px;
   font-weight: 500;
   white-space: nowrap;
 }
 
 .healthBar {
-  height: 6px;
+  height: 7px;
   overflow: hidden;
-  background: var(--border);
+  background: rgba(148, 163, 184, 0.2);
   border-radius: 999px;
 }
 
@@ -106,13 +134,14 @@
 .serviceGroups {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 16px;
+  gap: 14px;
   margin-bottom: 16px;
 }
 
 .serviceGroupHeader {
   margin-bottom: 14px;
 }
+.serviceGroup { min-height: 142px; border-radius: 14px; }
 
 .serviceGroupTitle {
   gap: 8px;
@@ -208,7 +237,7 @@
   display: flex;
   align-items: center;
   gap: 7px;
-  padding: 8px 12px;
+  padding: 9px 12px;
   border: 1px solid var(--border);
   border-radius: 8px;
   background: var(--surface);
@@ -240,8 +269,9 @@
 
 @media (max-width: 760px) {
   .dashboard {
-    padding: 20px 16px 32px;
+    padding: 16px 14px 32px;
   }
+  .dashboard :global(.page-header) { min-height: auto; padding: 22px 18px; border-radius: 14px; }
 
   .headerActions {
     align-items: flex-end;

--- a/openbank-admin-ui/src/components/layout/Header.module.css
+++ b/openbank-admin-ui/src/components/layout/Header.module.css
@@ -1,0 +1,43 @@
+.header {
+  position: relative;
+  z-index: 10;
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: space-between;
+  height: 60px;
+  padding: 0 28px;
+  background: rgba(255, 255, 255, 0.9);
+  border-bottom: 1px solid rgba(203, 213, 225, 0.78);
+  box-shadow: 0 2px 14px rgba(15, 23, 42, 0.025);
+  backdrop-filter: blur(14px);
+}
+
+.searchTrigger {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  min-width: 230px;
+  padding: 8px 11px;
+  color: var(--text-tertiary);
+  cursor: pointer;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: 9px;
+  font: inherit;
+  transition: background 0.15s ease, border-color 0.15s ease, box-shadow 0.15s ease;
+}
+.searchTrigger:hover,
+.searchTrigger:focus-visible { background: var(--surface); border-color: var(--accent-border); box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.1); outline: none; }
+
+.actions { display: flex; align-items: center; gap: 5px; }
+.headerLink { display: grid; width: 34px; height: 34px; place-items: center; color: var(--text-secondary); text-decoration: none; background: transparent; border-radius: 9px; transition: background 0.12s ease, color 0.12s ease; }
+.headerLink:hover,
+.headerLink:focus-visible { color: var(--accent-text); background: var(--accent-light); outline: none; }
+
+@media (max-width: 760px) {
+  .header { height: 54px; padding: 0 14px; }
+  .searchTrigger { min-width: auto; }
+  .searchTrigger span,
+  .searchTrigger kbd { display: none; }
+}

--- a/openbank-admin-ui/src/components/layout/Header.tsx
+++ b/openbank-admin-ui/src/components/layout/Header.tsx
@@ -11,6 +11,7 @@ import { useEffect, useState } from 'react'
 import { ROLE_LABELS } from '@/lib/auth/roles'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { CommandPalette } from '@/components/search/CommandPalette'
+import styles from './Header.module.css'
 
 interface BuildInfo { version: string; gitSha: string; buildDate: string }
 
@@ -53,30 +54,12 @@ export function Header() {
     : user?.email?.[0]?.toUpperCase() ?? 'U'
 
   return (
-    <header style={{
-      height: '52px',
-      background: 'var(--surface)',
-      borderBottom: '1px solid var(--border)',
-      display: 'flex',
-      alignItems: 'center',
-      justifyContent: 'space-between',
-      padding: '0 20px',
-      flexShrink: 0,
-      boxShadow: 'var(--shadow-xs)',
-      position: 'relative',
-      zIndex: 10,
-    }}>
+    <header className={styles.header}>
       {/* Search — ADR-0228 D3: the painted placeholder is now a real palette. */}
       <button
         onClick={() => setPaletteOpen(true)}
         aria-label={t('Rychlé hledání (⌘K)', 'Quick search (⌘K)')}
-        style={{
-          display: 'flex', alignItems: 'center', gap: '8px', color: 'var(--text-tertiary)',
-          background: 'none', border: 'none', cursor: 'pointer', padding: '6px 10px',
-          borderRadius: '8px', font: 'inherit',
-        }}
-        onMouseEnter={e => { e.currentTarget.style.background = 'var(--surface-3)' }}
-        onMouseLeave={e => { e.currentTarget.style.background = 'none' }}
+        className={styles.searchTrigger}
       >
         <Search size={14} />
         <span style={{ fontSize: '13px' }}>{t('Rychlé hledání…', 'Quick search…')}</span>
@@ -89,7 +72,7 @@ export function Header() {
       <CommandPalette open={paletteOpen} onClose={() => setPaletteOpen(false)} />
 
       {/* Actions */}
-      <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+      <div className={styles.actions}>
         {build && (
           <Link
             href="/docs/release-notes/admin-ui"
@@ -241,14 +224,7 @@ export function Header() {
 
 function HeaderLink({ href, label, children }: { href: string; label: string; children: React.ReactNode }) {
   return (
-    <Link href={href} aria-label={label} title={label} style={{
-      width: '32px', height: '32px', display: 'flex', alignItems: 'center', justifyContent: 'center',
-      borderRadius: '6px', border: 'none', background: 'transparent',
-      color: 'var(--text-secondary)', cursor: 'pointer', transition: 'background 0.12s', textDecoration: 'none',
-    }}
-      onMouseEnter={e => (e.currentTarget.style.background = 'var(--surface-3)')}
-      onMouseLeave={e => (e.currentTarget.style.background = 'transparent')}
-    >
+    <Link href={href} aria-label={label} title={label} className={styles.headerLink}>
       {children}
     </Link>
   )

--- a/openbank-admin-ui/src/components/layout/Sidebar.module.css
+++ b/openbank-admin-ui/src/components/layout/Sidebar.module.css
@@ -1,0 +1,82 @@
+.sidebar {
+  display: flex;
+  flex: 0 0 264px;
+  flex-direction: column;
+  width: 264px;
+  height: 100vh;
+  overflow: hidden;
+  color: var(--sidebar-text);
+  background: radial-gradient(circle at 14% -8%, #293a70 0, transparent 31%), linear-gradient(180deg, #0c1220 0%, #090d17 55%, #070b13 100%);
+  border-right: 1px solid rgba(148, 163, 184, 0.13);
+  box-shadow: 16px 0 38px rgba(15, 23, 42, 0.09);
+}
+
+.brand {
+  flex-shrink: 0;
+  padding: 24px 20px 18px;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.12);
+}
+
+.brandLockup { display: flex; align-items: center; gap: 12px; }
+.brandMark {
+  display: grid;
+  width: 36px;
+  height: 36px;
+  place-items: center;
+  color: #fff;
+  background: linear-gradient(135deg, #8489ff, #5658e6 58%, #4344b8);
+  border: 1px solid rgba(255, 255, 255, 0.22);
+  border-radius: 12px;
+  box-shadow: 0 8px 20px rgba(91, 92, 226, 0.36), inset 0 1px 0 rgba(255, 255, 255, 0.3);
+}
+.brandText { min-width: 0; }
+.brandName { color: #f8fafc; font-size: 16px; font-weight: 800; letter-spacing: -0.03em; }
+.brandSubtitle { margin-top: 2px; color: #8fa1bf; font-size: 11px; font-weight: 600; }
+
+.nav {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  min-height: 0;
+  gap: 3px;
+  padding: 14px 12px 18px;
+  overflow-y: auto;
+}
+
+.sectionLabel {
+  padding: 18px 9px 7px;
+  color: #64748b;
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.11em;
+  text-transform: uppercase;
+}
+
+.navItem {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-height: 38px;
+  padding: 8px 10px;
+  color: #9aacc5;
+  border: 1px solid transparent;
+  border-radius: 9px;
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 550;
+  transition: background 0.16s ease, border-color 0.16s ease, color 0.16s ease, transform 0.16s ease;
+}
+
+.navItem:hover { color: #f1f5f9; background: rgba(148, 163, 184, 0.1); transform: translateX(2px); }
+.active { color: #f7f7ff; background: linear-gradient(90deg, rgba(99, 102, 241, 0.34), rgba(99, 102, 241, 0.14)); border-color: rgba(165, 180, 252, 0.2); box-shadow: inset 3px 0 0 #8b8dff; }
+.active:hover { color: #fff; background: linear-gradient(90deg, rgba(99, 102, 241, 0.38), rgba(99, 102, 241, 0.18)); transform: none; }
+.locked { color: #506078; opacity: 0.64; cursor: not-allowed; user-select: none; }
+.locked:hover { color: #506078; background: transparent; transform: none; }
+.navIcon { flex: 0 0 auto; }
+.navLabel { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.lockIcon { flex: 0 0 auto; opacity: 0.7; }
+.navBadge { padding: 2px 6px; color: #fff; background: var(--sidebar-accent); border-radius: 999px; font-size: 10px; font-weight: 800; }
+
+.footer { flex-shrink: 0; padding: 15px 20px 17px; background: rgba(2, 6, 23, 0.34); border-top: 1px solid rgba(148, 163, 184, 0.12); }
+.footerVersion { color: #a8b7cc; font-size: 11px; font-weight: 700; }
+.footerScope { margin-top: 4px; color: #5a6b83; font-size: 10px; letter-spacing: 0.035em; }

--- a/openbank-admin-ui/src/components/layout/Sidebar.tsx
+++ b/openbank-admin-ui/src/components/layout/Sidebar.tsx
@@ -23,6 +23,7 @@ import {
 import { hasPermission, Permission } from '@/lib/auth/roles'
 import { personaForRoles, personaLabel, workspaceFor } from '@/lib/auth/persona'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
+import styles from './Sidebar.module.css'
 
 // `external: true` marks a destination that is NOT a Next.js route — today the
 // internal tool UIs served as sub-paths of this same host by their own Ingress
@@ -200,34 +201,24 @@ export function Sidebar() {
   }, [])
 
   return (
-    <aside style={{
-      width: '240px', flexShrink: 0,
-      background: 'var(--sidebar-bg)',
-      borderRight: '1px solid var(--sidebar-border)',
-      display: 'flex', flexDirection: 'column', height: '100vh', overflow: 'hidden',
-      boxShadow: '1px 0 10px rgba(0,0,0,0.1)'
-    }}>
+    <aside className={styles.sidebar}>
       {/* Brand */}
-      <div style={{ padding: '24px 20px 20px', borderBottom: '1px solid var(--sidebar-border)', flexShrink: 0 }}>
-        <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
-          <div style={{
-            width: '32px', height: '32px', background: 'linear-gradient(135deg, #6366f1 0%, #4f46e5 100%)',
-            borderRadius: '10px', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0,
-            boxShadow: '0 2px 4px rgba(99,102,241,0.3)'
-          }}>
+      <div className={styles.brand}>
+        <div className={styles.brandLockup}>
+          <div className={styles.brandMark}>
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="white" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
               <rect x="3" y="3" width="18" height="18" rx="3"/><path d="M3 9h18M9 21V9"/>
             </svg>
           </div>
-          <div>
-            <div style={{ fontSize: '15px', fontWeight: 800, color: '#ffffff', letterSpacing: '-0.02em' }}>OpenBank</div>
-            <div style={{ fontSize: '11px', color: 'var(--sidebar-text)', marginTop: '2px', fontWeight: 500 }}>{t('Administrace', 'Admin Portal')}</div>
+          <div className={styles.brandText}>
+            <div className={styles.brandName}>OpenBank</div>
+            <div className={styles.brandSubtitle}>{t('Administrace', 'Admin Portal')}</div>
           </div>
         </div>
       </div>
 
       {/* Nav — the only scrollable region; brand + footer stay pinned. */}
-      <nav ref={navRef} className="ob-sidebar-nav" style={{ flex: 1, minHeight: 0, overflowY: 'auto', padding: '16px 12px', display: 'flex', flexDirection: 'column', gap: '4px' }}>
+      <nav ref={navRef} className={`ob-sidebar-nav ${styles.nav}`}>
         <SectionLabel>{t('Můj přehled', 'My workspace')} · {personaLabel(persona, language === 'cs' ? 'cs' : 'en')}</SectionLabel>
         <NavSection items={filter(workspace)} pathname={pathname} />
         <NavSection items={filter(coreNav)} pathname={pathname} />
@@ -252,9 +243,9 @@ export function Sidebar() {
       </nav>
 
       {/* Footer */}
-      <div style={{ padding: '16px 20px', borderTop: '1px solid var(--sidebar-border)', flexShrink: 0, background: 'rgba(0,0,0,0.1)' }}>
-        <div style={{ fontSize: '11px', color: 'var(--sidebar-text)', fontWeight: 600 }}>OpenBank v2.0</div>
-        <div style={{ fontSize: '10px', color: 'var(--sidebar-text-muted)', marginTop: '4px', letterSpacing: '0.02em' }}>EBA · PSD2 · CNB · GDPR</div>
+      <div className={styles.footer}>
+        <div className={styles.footerVersion}>OpenBank v2.0</div>
+        <div className={styles.footerScope}>EBA · PSD2 · CNB · GDPR</div>
       </div>
     </aside>
   )
@@ -262,8 +253,7 @@ export function Sidebar() {
 
 function SectionLabel({ children }: { children: React.ReactNode }) {
   return (
-    <div style={{ fontSize: '10px', fontWeight: 700, letterSpacing: '0.1em', color: 'var(--sidebar-text-muted)',
-      padding: '16px 8px 6px', textTransform: 'uppercase' }}>
+    <div className={styles.sectionLabel}>
       {children}
     </div>
   )
@@ -283,47 +273,20 @@ function NavSection({ items, pathname, isLocked }: { items: NavItem[]; pathname:
 
         if (locked) {
           return (
-            <div key={item.href} title={language === 'cs' ? 'Přístup není povolen pro demo účet' : 'Not available for demo account'} style={{
-              display: 'flex', alignItems: 'center', gap: '10px',
-              padding: '8px 12px', borderRadius: '8px',
-              color: 'var(--sidebar-text-muted)',
-              fontSize: '13px', fontWeight: 500,
-              opacity: 0.45,
-              cursor: 'not-allowed',
-              userSelect: 'none',
-            }}>
-              <Icon size={16} style={{ flexShrink: 0 }} />
-              <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', flex: 1 }}>{displayName}</span>
-              <Lock size={11} style={{ flexShrink: 0, opacity: 0.7 }} />
+            <div key={item.href} title={language === 'cs' ? 'Přístup není povolen pro demo účet' : 'Not available for demo account'} className={`${styles.navItem} ${styles.locked}`}>
+              <Icon size={16} className={styles.navIcon} />
+              <span className={styles.navLabel}>{displayName}</span>
+              <Lock size={11} className={styles.lockIcon} />
             </div>
           )
         }
 
         const row = (
-            <div style={{
-              display: 'flex', alignItems: 'center', gap: '10px',
-              padding: '8px 12px', borderRadius: '8px', cursor: 'pointer',
-              background: active ? 'var(--sidebar-active-bg)' : 'transparent',
-              color: active ? 'var(--sidebar-active-text)' : 'var(--sidebar-text)',
-              fontSize: '13px', fontWeight: active ? 600 : 500,
-              transition: 'all 0.15s ease',
-              position: 'relative'
-            }}
-              onMouseEnter={e => { if (!active) { e.currentTarget.style.background = 'var(--sidebar-hover-bg)'; e.currentTarget.style.color = '#fff'; } }}
-              onMouseLeave={e => { if (!active) { e.currentTarget.style.background = 'transparent'; e.currentTarget.style.color = 'var(--sidebar-text)'; } }}
-            >
-              {active && (
-                <div style={{
-                  position: 'absolute', left: 0, top: '50%', transform: 'translateY(-50%)',
-                  width: '3px', height: '16px', background: 'var(--sidebar-accent)',
-                  borderRadius: '0 4px 4px 0'
-                }} />
-              )}
-              <Icon size={16} style={{ flexShrink: 0, opacity: active ? 1 : 0.7 }} />
-              <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', flex: 1 }}>{displayName}</span>
+            <div className={`${styles.navItem} ${active ? styles.active : ''}`}>
+              <Icon size={16} className={styles.navIcon} />
+              <span className={styles.navLabel}>{displayName}</span>
               {item.badge && (
-                <span style={{ fontSize: '10px', fontWeight: 800, padding: '2px 6px', borderRadius: '10px',
-                  background: 'var(--sidebar-accent)', color: '#fff' }}>{item.badge}</span>
+                <span className={styles.navBadge}>{item.badge}</span>
               )}
             </div>
         )


### PR DESCRIPTION
## What changed
- Refresh the shared navigation rail and header across the admin UI.
- Give the dashboard a distinct live-operations hierarchy with a high-signal hero and denser metrics.
- Preserve the existing RBAC, routes and factual fleet-health semantics.
- Add browser assertions for shell and dashboard geometry.

Closes #4647.

## Validation
- npm run type-check
- git diff --check

## Scope
This is the shared shell and dashboard layer. Domain-page workflows are intentionally unchanged.