### PR TITLE
fix(notification): record device sweep liveness

### DIFF
--- a/.github/scripts/check-scheduler-liveness.py
+++ b/.github/scripts/check-scheduler-liveness.py
@@ -77,7 +77,6 @@ BASELINE = [
     "openbank-consent-service/src/main/kotlin/com/openbank/consent/infrastructure/ConsentExpirationJob.kt",
     "openbank-delegation-service/src/main/kotlin/com/openbank/delegation/infrastructure/DelegationExpirationJob.kt",
     "openbank-dispute-service/src/main/kotlin/com/openbank/dispute/infrastructure/observability/ComplaintDeadlineGauge.kt",
-    "openbank-notification-service/src/main/kotlin/com/openbank/notification/infrastructure/DeviceTokenSweepJob.kt",
     "openbank-notification-service/src/main/kotlin/com/openbank/notification/infrastructure/NotificationOutboxDeadLetterJanitorJob.kt",
     "openbank-onboarding-service/src/main/kotlin/com/openbank/onboarding/infrastructure/observability/OnboardingFunnelGauge.kt",
     "openbank-onboarding-service/src/main/kotlin/com/openbank/onboarding/infrastructure/scheduler/AbandonedRegistrationCleaner.kt",

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/infrastructure/DeviceTokenSweepJob.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/infrastructure/DeviceTokenSweepJob.kt
@@ -4,14 +4,19 @@
 
 package com.openbank.notification.infrastructure
 
+import com.openbank.libs.observability.DomainMetrics
+import com.openbank.libs.observability.WorkflowLivenessRecorder
 import com.openbank.notification.infrastructure.persistence.repository.DeviceTokenRepository
 import io.quarkus.logging.Log
+import io.quarkus.runtime.StartupEvent
 import io.quarkus.scheduler.Scheduled
 import io.quarkus.scheduler.Scheduled.ConcurrentExecution.SKIP
 import io.smallrye.mutiny.coroutines.awaitSuspending
 import jakarta.enterprise.context.ApplicationScoped
+import jakarta.enterprise.event.Observes
 import jakarta.inject.Inject
 import java.time.Clock
+import java.time.Duration
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 
@@ -40,6 +45,19 @@ class DeviceTokenSweepJob {
     @Inject
     lateinit var clock: Clock
 
+    @Inject
+    lateinit var domainMetrics: DomainMetrics
+
+    private var liveness: WorkflowLivenessRecorder? = null
+
+    /**
+     * Registers the boot-seeded ADR-0237 heartbeat before the first nightly sweep. The sweep
+     * intentionally catches its failures, so only a completed repository call may record success.
+     */
+    fun registerLiveness(@Observes @Suppress("UNUSED_PARAMETER") event: StartupEvent) {
+        liveness = domainMetrics.registerWorkflowLiveness(WORKFLOW_NAME, EXPECTED_INTERVAL)
+    }
+
     // TooGenericExceptionCaught: a non-critical nightly sweep must not surface as a Quarkus
     // Scheduler failure — ANY fault is logged and tomorrow's tick sweeps the same rows again.
     @Suppress("TooGenericExceptionCaught")
@@ -48,6 +66,7 @@ class DeviceTokenSweepJob {
         val threshold = Instant.now(clock).minus(STALE_DAYS, ChronoUnit.DAYS)
         try {
             val count = repo.sweepStale(threshold).awaitSuspending()
+            liveness?.recordSuccess()
             if (count > 0) Log.infof("Swept %d stale device tokens (threshold %s)", count, threshold)
         } catch (err: Exception) {
             Log.errorf(err, "Failed to sweep stale device tokens")
@@ -56,5 +75,7 @@ class DeviceTokenSweepJob {
 
     companion object {
         private const val STALE_DAYS = 90L
+        private const val WORKFLOW_NAME = "device-token-stale-sweep"
+        private val EXPECTED_INTERVAL: Duration = Duration.ofDays(1)
     }
 }

--- a/openbank-notification-service/src/test/kotlin/com/openbank/notification/infrastructure/DeviceTokenSweepJobLivenessTest.kt
+++ b/openbank-notification-service/src/test/kotlin/com/openbank/notification/infrastructure/DeviceTokenSweepJobLivenessTest.kt
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.notification.infrastructure
+
+import com.openbank.libs.observability.DomainMetrics
+import com.openbank.libs.observability.WorkflowLivenessRecorder
+import com.openbank.notification.infrastructure.persistence.repository.DeviceTokenRepository
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import io.quarkus.runtime.StartupEvent
+import io.smallrye.mutiny.Uni
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+
+class DeviceTokenSweepJobLivenessTest {
+
+    private val repo = mockk<DeviceTokenRepository>()
+    private val metrics = mockk<DomainMetrics>()
+    private val liveness = mockk<WorkflowLivenessRecorder>(relaxed = true)
+    private val job = DeviceTokenSweepJob().also {
+        it.repo = repo
+        it.clock = Clock.fixed(Instant.parse("2026-08-13T03:00:00Z"), ZoneOffset.UTC)
+        it.domainMetrics = metrics
+    }
+
+    @Test
+    fun `registers heartbeat at startup and records success after completed sweep`(): Unit = runBlocking {
+        every { metrics.registerWorkflowLiveness(any(), any()) } returns liveness
+        every { repo.sweepStale(any()) } returns Uni.createFrom().item(0)
+
+        job.registerLiveness(StartupEvent())
+        job.sweepStaleTokens()
+
+        verify(exactly = 1) { metrics.registerWorkflowLiveness("device-token-stale-sweep", any()) }
+        verify(exactly = 1) { liveness.recordSuccess() }
+    }
+
+    @Test
+    fun `swallowed repository failure records no success`(): Unit = runBlocking {
+        every { metrics.registerWorkflowLiveness(any(), any()) } returns liveness
+        every { repo.sweepStale(any()) } returns Uni.createFrom().failure(IllegalStateException("db down"))
+
+        job.registerLiveness(StartupEvent())
+        job.sweepStaleTokens()
+
+        verify(exactly = 0) { liveness.recordSuccess() }
+    }
+}


### PR DESCRIPTION
## Summary
- register ADR-0237 liveness for the nightly device-token stale sweep at startup
- record success only after the repository sweep completes; swallowed failures remain unreported as success
- remove the now-compliant scheduler from the ratchet baseline and add focused coverage

## Validation
- `:openbank-notification-service:ktlintCheck`
- `python3 .github/scripts/check-scheduler-liveness.py --self-test`
- `python3 .github/scripts/check-scheduler-liveness.py --root .`
- focused Gradle test is still progressing locally; PR CI is required before merge

Refs #3345