### PR TITLE
fix(document-service): a stub delivery must not record the statement as delivered

### DIFF
--- a/openbank-document-service/src/main/kotlin/com/openbank/document/application/port/out/StatementDeliveryPort.kt
+++ b/openbank-document-service/src/main/kotlin/com/openbank/document/application/port/out/StatementDeliveryPort.kt
@@ -16,5 +16,26 @@ package com.openbank.document.application.port.out
  * exists anywhere in this repo yet.
  */
 interface StatementDeliveryPort {
-    fun deliver(partyRef: String, documentBytes: ByteArray, contentType: String, subject: String)
+    fun deliver(partyRef: String, documentBytes: ByteArray, contentType: String, subject: String): DeliveryOutcome
+}
+
+/**
+ * What a [StatementDeliveryPort.deliver] call actually achieved.
+ *
+ * A no-op MUST NOT share a value with a real send. The port used to return `Unit`, so the only
+ * implementation — a stub that logs and sends nothing — was indistinguishable from a working
+ * channel, and [AnnualStatementDeliveryService][com.openbank.document.application.usecase.AnnualStatementDeliveryService]
+ * recorded a 400-day "delivered" idempotency key on the strength of it. That key is what a later,
+ * real channel would then consult and skip, so the stub did not merely fail to deliver — it
+ * suppressed the delivery that would eventually have succeeded.
+ *
+ * Same rule and same remedy as `PushResult.outcome` (ADR-0252 phase 0): the skipped case gets its
+ * own enum value, never a flag shared with success.
+ */
+enum class DeliveryOutcome {
+    /** The document was handed to a real channel that accepted it. Only this may be recorded. */
+    DELIVERED,
+
+    /** No channel exists or it is disabled: nothing was sent, and nothing may be recorded. */
+    SKIPPED,
 }

--- a/openbank-document-service/src/main/kotlin/com/openbank/document/application/usecase/AnnualStatementDeliveryService.kt
+++ b/openbank-document-service/src/main/kotlin/com/openbank/document/application/usecase/AnnualStatementDeliveryService.kt
@@ -9,6 +9,7 @@ import com.openbank.document.application.port.`in`.AnnualStatementDeliveryUseCas
 import com.openbank.document.application.port.`in`.DocumentTemplateUseCase
 import com.openbank.document.application.port.out.AccountInfo
 import com.openbank.document.application.port.out.AccountLookupPort
+import com.openbank.document.application.port.out.DeliveryOutcome
 import com.openbank.document.application.port.out.PartyInfo
 import com.openbank.document.application.port.out.PartyLookupPort
 import com.openbank.document.application.port.out.StatementDeliveryPort
@@ -81,12 +82,29 @@ class AnnualStatementDeliveryService(
         val account = partyId?.let { accountLookupPort.findCurrentAccount(it) }
 
         val renderedHtml = templateUseCase.previewRender(template.bodyHtml, buildRenderData(cmd, party, account))
-        deliveryPort.deliver(
+        val outcome = deliveryPort.deliver(
             partyRef = cmd.partyRef,
             documentBytes = renderedHtml.toByteArray(Charsets.UTF_8),
             contentType = "text/html",
             subject = "Annual statement of fees ${cmd.year} — account ${cmd.accountId}",
         )
+
+        // Only a REAL delivery may be recorded. The idempotency key lives for 400 days and the
+        // guard at the top of this method consults it, so recording one for a no-op does not merely
+        // overstate today — it suppresses the delivery a real channel would make for the rest of
+        // that window, silently, for a PAD Art. 5 obligation the bank must fulfil. While the only
+        // implementation is the phase-1 stub this branch is always taken, which is the point: the
+        // work stays outstanding and re-attemptable instead of being marked done.
+        if (outcome != DeliveryOutcome.DELIVERED) {
+            log.warnf(
+                "Annual statement for account %s year %d was NOT delivered (outcome=%s) — no " +
+                    "idempotency record written, so a real delivery channel will still send it.",
+                cmd.accountId,
+                cmd.year,
+                outcome,
+            )
+            return
+        }
 
         idempotencyStore.save(
             idempotencyKey,

--- a/openbank-document-service/src/main/kotlin/com/openbank/document/infrastructure/delivery/LoggingStatementDeliveryAdapter.kt
+++ b/openbank-document-service/src/main/kotlin/com/openbank/document/infrastructure/delivery/LoggingStatementDeliveryAdapter.kt
@@ -4,6 +4,7 @@
 
 package com.openbank.document.infrastructure.delivery
 
+import com.openbank.document.application.port.out.DeliveryOutcome
 import com.openbank.document.application.port.out.StatementDeliveryPort
 import jakarta.enterprise.context.ApplicationScoped
 import org.jboss.logging.Logger
@@ -26,12 +27,20 @@ import org.jboss.logging.Logger
 class LoggingStatementDeliveryAdapter : StatementDeliveryPort {
     private val log = Logger.getLogger(LoggingStatementDeliveryAdapter::class.java)
 
-    override fun deliver(partyRef: String, documentBytes: ByteArray, contentType: String, subject: String) {
+    override fun deliver(
+        partyRef: String,
+        documentBytes: ByteArray,
+        contentType: String,
+        subject: String,
+    ): DeliveryOutcome {
         log.infof(
             "STUB DELIVERY (ADR-0248 phase-1, NOT actually sent) — subject=\"%s\" contentType=%s bytes=%d",
             subject,
             contentType,
             documentBytes.size,
         )
+        // SKIPPED, never DELIVERED: the caller keys a 400-day idempotency record off this, and a
+        // record written now is what a real channel would later consult and skip.
+        return DeliveryOutcome.SKIPPED
     }
 }

--- a/openbank-document-service/src/test/kotlin/com/openbank/document/application/usecase/AnnualStatementDeliveryServiceTest.kt
+++ b/openbank-document-service/src/test/kotlin/com/openbank/document/application/usecase/AnnualStatementDeliveryServiceTest.kt
@@ -9,6 +9,7 @@ import com.openbank.document.application.port.`in`.AnnualFeeSummaryReadyCommand
 import com.openbank.document.application.port.`in`.DocumentTemplateUseCase
 import com.openbank.document.application.port.out.AccountInfo
 import com.openbank.document.application.port.out.AccountLookupPort
+import com.openbank.document.application.port.out.DeliveryOutcome
 import com.openbank.document.application.port.out.PartyInfo
 import com.openbank.document.application.port.out.PartyLookupPort
 import com.openbank.document.application.port.out.StatementDeliveryPort
@@ -98,6 +99,9 @@ class AnnualStatementDeliveryServiceTest {
         val dataSlot = slot<Map<String, Any?>>()
         every { templateUseCase.previewRender(any(), capture(dataSlot)) } returns "<p>2026</p>"
         coEvery { idempotencyStore.save(any(), any(), any(), any()) } returns Unit
+        // Explicit, not left to the relaxed mock: `deliver` returns an enum now, and a relaxed
+        // mock would invent one — the test would then pass without ever choosing a branch.
+        every { deliveryPort.deliver(any(), any(), any(), any()) } returns DeliveryOutcome.DELIVERED
 
         service.deliverAnnualStatement(command())
 
@@ -129,6 +133,47 @@ class AnnualStatementDeliveryServiceTest {
             )
         }
         coVerify(exactly = 1) { idempotencyStore.save(idempotencyKey, 200, "delivered", any()) }
+    }
+
+    @Test
+    fun `does not record delivery when the channel skipped it`(): Unit = runBlocking {
+        // The defect: the phase-1 stub sends nothing, and the service recorded a 400-day
+        // "delivered" key anyway. The guard at the top of deliverAnnualStatement reads that key,
+        // so the record does not merely overstate today — it suppresses the delivery a REAL
+        // channel would make for the rest of the window, for a PAD Art. 5 push duty.
+        coEvery { idempotencyStore.get(idempotencyKey) } returns null
+        coEvery { templateRepo.findLatestPublished("ROCNI_VYPIS_POPLATKU_CS") } returns template()
+        coEvery { partyLookupPort.findById(partyId) } returns
+            PartyInfo(legalName = "Jan Novák", formattedAddress = "Praha 1")
+        coEvery { accountLookupPort.findCurrentAccount(partyId) } returns
+            AccountInfo(iban = "CZ6508000000192000145399", productId = UUID.randomUUID())
+        every { templateUseCase.previewRender(any(), any()) } returns "<p>2026</p>"
+        every { deliveryPort.deliver(any(), any(), any(), any()) } returns DeliveryOutcome.SKIPPED
+
+        service.deliverAnnualStatement(command())
+
+        verify(exactly = 1) { deliveryPort.deliver(any(), any(), any(), any()) }
+        coVerify(exactly = 0) { idempotencyStore.save(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `a skipped delivery stays re-attemptable on the next event`(): Unit = runBlocking {
+        // The consequence of the assertion above, stated as behaviour: because nothing was
+        // recorded, a redelivery is not short-circuited and reaches the channel again.
+        coEvery { idempotencyStore.get(idempotencyKey) } returns null
+        coEvery { templateRepo.findLatestPublished("ROCNI_VYPIS_POPLATKU_CS") } returns template()
+        coEvery { partyLookupPort.findById(partyId) } returns
+            PartyInfo(legalName = "Jan Novák", formattedAddress = "Praha 1")
+        coEvery { accountLookupPort.findCurrentAccount(partyId) } returns
+            AccountInfo(iban = "CZ6508000000192000145399", productId = UUID.randomUUID())
+        every { templateUseCase.previewRender(any(), any()) } returns "<p>2026</p>"
+        every { deliveryPort.deliver(any(), any(), any(), any()) } returns DeliveryOutcome.SKIPPED
+
+        service.deliverAnnualStatement(command())
+        service.deliverAnnualStatement(command())
+
+        verify(exactly = 2) { deliveryPort.deliver(any(), any(), any(), any()) }
+        coVerify(exactly = 0) { idempotencyStore.save(any(), any(), any(), any()) }
     }
 
     @Test


### PR DESCRIPTION
## A stub that sends nothing was recording the statement as delivered — for 400 days

`AnnualStatementDeliveryService` calls `StatementDeliveryPort.deliver`, whose only implementation is
the ADR-0248 phase-1 stub that logs and sends nothing, and then **unconditionally** wrote:

```kotlin
idempotencyStore.save(idempotencyKey, statusCode = 200, responseBody = "delivered",
                      ttlSeconds = 400L * 24 * 60 * 60)
log.infof("Delivered the annual statement of fees for account %s year %d.", ...)
```

The port returned `Unit`, so a no-op and a real send were indistinguishable to the caller.

## Why this is worse than an overstated log line

The guard at the *top* of the same method reads that key:

```kotlin
if (idempotencyStore.get(idempotencyKey) != null) { log.infof("...already delivered — skipping"); return }
```

So the record does not merely misdescribe today. **For the next 400 days it suppresses the delivery
a real channel would have made** — silently, with no error anywhere and nothing to retry, for a
PAD Art. 5 push duty the bank is obliged to fulfil.

Wiring the real email/postal channel would have shipped straight into it: every `(accountId, year)`
pair the stub had already stamped would be skipped as "already delivered". The failure would surface
as customers not receiving a statement, a year later, with the system reporting success throughout.

Same shape as the APNs `PushResult` defect (ADR-0252 phase 0) — a skipped outcome sharing a value
with success — with the extra turn that here the false record is *consulted* later.

## The fix follows the precedent rather than inventing one

- `StatementDeliveryPort.deliver` returns `DeliveryOutcome` — `DELIVERED | SKIPPED`. The skipped
  case gets its own enum value and never shares a flag with success. That is `PushResult.outcome`'s
  rule applied here.
- `LoggingStatementDeliveryAdapter` returns `SKIPPED`. Its log line was already honest
  (`"NOT actually sent"`); its **return** was not, and only the return is machine-readable.
- The service records the key only on `DELIVERED`, and warns otherwise.

While the stub is the only implementation, that branch is always taken — which is the point. The
obligation stays outstanding and re-attemptable instead of being marked done.

## Tests

Two new cases, both falsified — removing the guard reddens exactly these two and nothing else:

| Test | Asserts |
|---|---|
| `does not record delivery when the channel skipped it` | `SKIPPED` ⇒ zero `idempotencyStore.save` calls |
| `a skipped delivery stays re-attemptable on the next event` | two events ⇒ two `deliver` calls, still zero saves |

I also made the happy-path test stub `deliver` **explicitly** instead of leaning on
`mockk(relaxed = true)`. A relaxed mock invents an enum value, so that test would have kept passing
without ever selecting a branch — green about a decision it never made.

## Verification

`detekt`, `ktlintCheck`, `koverVerify`, `test`, `quarkusBuild` (forced with `--rerun-tasks`, since
an up-to-date run proves nothing about CDI wiring) — all green.

**136 tests, 0 failures, 0 skipped**, read from the JUnit XML rather than the console (this module
has a test that deliberately logs a parse stack trace, which reads like a failure and is not).

Gate groups with `PR_DIFF_BASE=origin/main`: kotlin 19/19, registry 26/26, security 12/12, data 14/14.

## Note: this also carries the document-service rebuild

Chosen deliberately as the carrier for the deploy discussed in #3223. `can-i-deploy` has been
blocking document-service's consumers against a broker record of `ee974ea3`, a version carrying zero
pacts, and nothing self-heals it: the record only moves when a gitops PR changes an image pin, which
only happens when auto-deploy builds a new image, which only happens on a push touching
`openbank-document-service/src/main` or its `build.gradle.kts`.

This is such a push, and it is real work rather than a no-op commit made to trigger one.

Refs #4109, #3223
