### PR TITLE
fix(audit): normalise aggregate_type at ingest, same defect as #4553

### DIFF
--- a/openbank-audit-service/src/main/kotlin/com/openbank/audit/application/AuditConsumer.kt
+++ b/openbank-audit-service/src/main/kotlin/com/openbank/audit/application/AuditConsumer.kt
@@ -112,7 +112,19 @@ class AuditConsumer {
                     ?: node.textOrNull("type")
                     ?: address.ceType
                     ?: "UNKNOWN",
-                aggregateType = node.textOrNull("aggregateType") ?: inferAggregateType(node),
+                // Uppercased (issue #4553's pattern, confirmed live here 2026-08-13): a producer's
+                // own "aggregateType" field survives verbatim while inferAggregateType's table below
+                // is all uppercase, so the column records WHICH resolution path fired, not what the
+                // aggregate is. Measured on the live audit_entries table before this fix:
+                // ACCOUNT 656 / Account 126, Transaction 193 with ZERO uppercase TRANSACTION rows,
+                // Consent 11 with ZERO uppercase CONSENT rows. AuditConsumer's own KDoc already
+                // claims "the same fix as the analytics sink's #2598" for the attribution gap; this
+                // is the casing gap #2598's fix didn't cover, in the SAME shape #4553/#4576 found
+                // and fixed in openbank-analytics-sink. Rows already written keep their spelling —
+                // this stops the split growing, it does not backfill the 10-year tamper-evident
+                // audit trail (ADR-0023-equivalent reasoning: a mutation of the log of record needs
+                // its own decision, not a drive-by fix here).
+                aggregateType = (node.textOrNull("aggregateType") ?: inferAggregateType(node)).uppercase(),
                 aggregateId = inferAggregateId(node),
                 actorId = node.textOrNull("requestedBy")
                     ?: node.textOrNull("actorId")

--- a/openbank-audit-service/src/test/kotlin/com/openbank/audit/application/AuditConsumerTest.kt
+++ b/openbank-audit-service/src/test/kotlin/com/openbank/audit/application/AuditConsumerTest.kt
@@ -550,6 +550,49 @@ class AuditConsumerTest {
         coVerify { repo.save(match { it.occurredAtSource == OccurredAtSource.INGEST }) }
     }
 
+    // -----------------------------------------------------------------------------------------
+    // Case fold, issue #4553's pattern found again here 2026-08-13. A producer's own
+    // "aggregateType" field used to survive verbatim while inferAggregateType's table is all
+    // uppercase, so the column recorded WHICH resolution path fired, not what the aggregate is.
+    // Measured on the live audit_entries table before this fix: ACCOUNT 656 / Account 126,
+    // Transaction 193 with ZERO uppercase TRANSACTION rows, Consent 11 with ZERO uppercase
+    // CONSENT rows.
+    // -----------------------------------------------------------------------------------------
+
+    @Test
+    fun `consume uppercases a producer's mixed-case aggregateType`(): Unit = runBlocking {
+        val accountId = UUID.randomUUID()
+        val payload = """
+            {
+              "eventType": "AccountCreated",
+              "aggregateType": "Account",
+              "accountId": "$accountId",
+              "occurredAt": "2026-05-27T12:00:00Z"
+            }
+        """.trimIndent()
+
+        coEvery { repo.save(any()) } returns Unit
+
+        consumer.consume(payload)
+
+        coVerify { repo.save(match { it.aggregateType == "ACCOUNT" }) }
+    }
+
+    @Test
+    fun `consume uppercases an INFERRED aggregateType too, so both paths agree`(): Unit = runBlocking {
+        // inferAggregateType already returns uppercase ("TRANSACTION"), so this asserts the fold
+        // is a no-op on that path — both paths must converge on the SAME casing, not just each
+        // individually look fine.
+        val transactionId = UUID.randomUUID()
+        val payload = """{"eventType":"X","transactionId":"$transactionId"}"""
+
+        coEvery { repo.save(any()) } returns Unit
+
+        consumer.consume(payload)
+
+        coVerify { repo.save(match { it.aggregateType == "TRANSACTION" }) }
+    }
+
     private companion object {
         val INGEST_TIME: Instant = Instant.parse("2026-05-27T12:00:00Z")
     }


### PR DESCRIPTION
## Summary

Fleet sweep after closing #4553's chain in `openbank-analytics-sink` (#4520, #4556, #4576, #4582,
#4589, #4618, #4638) found the same defect in `openbank-audit-service`. Fixes item 1 of #4660; item 2
of that issue (a genuine `channel`-field semantic collision, not a case-fold) is deliberately not in
this PR — it needs a product decision, not a code fix.

## Type of change

- [x] fix (bug fix)

## Linked issues

Refs #4660, #4553

## The defect, confirmed live before writing the fix

`AuditConsumer.aggregateType` resolution: `node.textOrNull("aggregateType") ?: inferAggregateType(node)`
— identical shape to analytics-sink's `resolveAggregateType` before #4576. A producer's own field
survives verbatim; the fallback table is all uppercase; the column ends up recording which resolution
path fired, not what the aggregate is.

Measured on the live `audit_entries` table (`openbank_audit` DB, pod `audit-db-1`, namespace `audit`):

```
ACCOUNT      656 rows
Account      126 rows   <- same domain as ACCOUNT
Transaction  193 rows   <- zero uppercase TRANSACTION rows exist at all
Consent       11 rows   <- zero uppercase CONSENT rows exist at all
```

This is the fleet's 10-year tamper-evident regulatory audit trail. No case-sensitive reader of this
column exists in-repo yet — `AuditRepository`/`AuditResource` only echo the value — so this was a
live data-integrity defect with no active exploiting reader, same "latent until someone builds the
dashboard" shape #4553's Grafana tile eventually became.

## Fix

`.uppercase()` on the resolved value, both paths — the explicit-field case and the inferred-fallback
case, matching #4576's fix exactly. `AuditConsumer`'s own KDoc already claims "the same fix as the
analytics sink's #2598" for a prior *attribution* gap (#3994-adjacent); this is the *casing* gap that
fix never covered.

## Verification

- Two new tests. Falsified against the unfixed consumer: the explicit-field test goes red (1
  failure); the inferred-path test does **not**, correctly — `inferAggregateType` already returns
  uppercase, so the fold is idempotent on that path. Both facts are asserted and the test comments
  say so explicitly, so the second test isn't mistaken for weak coverage of the first.
- `:openbank-audit-service:test` → 89 tests, 0 failures, 0 errors.
- `ktlintCheck` + `detekt` clean.

## Definition of Done

- [x] Hexagonal layering preserved — a private-scope resolution change in the application layer.
- [x] Unit tests added, falsified against the unfixed source.
- [ ] Integration tests / contract tests / OpenAPI / Flyway / Avro — N/A, no schema or API changed.
- [x] `ktlintCheck`, `detekt`, module `test` pass locally.

## Security checklist

- [x] No secrets, no PII. `aggregate_type` is a domain discriminator.
- [x] No new `@Suppress`, no new dependency.

## Compliance impact

- [x] None to the erasure/retention mechanism. This changes what NEW rows record; it does not touch
      how existing rows are retained, erased, or exported.

## Rollout / Rollback

- Takes effect for entries ingested after the pod restarts. No coordinated step needed.
- **Not done here, deliberately**: backfilling the rows already written (782 account rows split,
  193+11 rows entirely in the pre-fix spelling). Same reasoning #4632 settled on for the
  analytics-sink case (closed via a read-side fold, not a bronze mutation) — a correction to a 10-year
  tamper-evident log needs its own decision. Tracked as open scope in #4660, not silently dropped.
- Rollback: revert. No data written or altered by this change in either direction.

## Reviewer notes

- No case-fold gate exists in `audit-service` (analytics-sink has one, #4618's
  `check-aggregate-type-case-fold.py`). Porting it here is separate, reviewable work — not bundled
  into this fix, since there's currently no live comparison site in this service for it to protect.
- #4660 item 2 (the `channel` field collision between `AuditChannel` and `OnboardingChannel`) is a
  real, live-both-producers issue but is NOT a case-fold problem — `AuditChannel.API = "api"` and
  `OnboardingChannel.API` (serializes to `"API"`) are two different *concepts* that happen to share a
  field name and a similar string. Folding case would hide the collision, not fix it. Left for a
  product decision.
