### PR TITLE
fix(gitops): nest FCM secret template correctly

### DIFF
--- a/openbank-infra/gitops/components/notifications/fcm-externalsecret.yaml
+++ b/openbank-infra/gitops/components/notifications/fcm-externalsecret.yaml
@@ -36,12 +36,12 @@ spec:
     name: notification-service-fcm
     creationPolicy: Owner
     deletionPolicy: Retain
-  template:
-    engineVersion: v2
-    mergePolicy: Merge
-    metadata:
-      annotations:
-        argocd.argoproj.io/compare-options: IgnoreExtraneous
+    template:
+      engineVersion: v2
+      mergePolicy: Merge
+      metadata:
+        annotations:
+          argocd.argoproj.io/compare-options: IgnoreExtraneous
   data:
     - secretKey: FCM_SERVICE_ACCOUNT_JSON
       remoteRef:


### PR DESCRIPTION
Fixes the ExternalSecret schema error that blocks ArgoCD notification sync.\n\nThe target template is nested under spec.target, matching the v1beta1 CRD and sibling manifests. Verified with server-side dry-run; no secret value is added or changed.\n\nRefs #4650