### PR TITLE
feat(campaign): let makers revise drafts

### DIFF
--- a/openbank-admin-ui/e2e/campaign-content-experiment.spec.ts
+++ b/openbank-admin-ui/e2e/campaign-content-experiment.spec.ts
@@ -6,6 +6,14 @@ import { expect, test } from '@playwright/test'
 import { signInAsOperator } from './helpers/auth'
 
 const CAMPAIGN_ID = '019fb93a-0d54-7f05-aad3-9e8c7c9bc110'
+const CONTENT_CATALOGUE = [
+  { template: 'MARKETING_PRODUCT_OFFER', channel: 'EMAIL', variables: ['offerTitle', 'offerText', 'ctaText'] },
+  { template: 'MARKETING_PRODUCT_OFFER_PUSH', channel: 'PUSH', variables: ['offerTitle'] },
+  { template: 'MARKETING_PRODUCT_OFFER_BANNER', channel: 'BANNER', variables: ['offerTitle', 'offerText', 'ctaText'], inAppSurface: 'HOME_BANNER' },
+  { template: 'MARKETING_PRODUCT_OFFER_CAROUSEL', channel: 'BANNER', variables: ['offerTitle', 'offerText', 'ctaText'], inAppSurface: 'HOME_CAROUSEL' },
+  { template: 'MARKETING_PRODUCT_OFFER_PRODUCT_FEED', channel: 'BANNER', variables: ['offerTitle', 'offerText', 'ctaText'], inAppSurface: 'PRODUCT_FEED' },
+  { template: 'MARKETING_PRODUCT_OFFER_REWARDS_HUB', channel: 'BANNER', variables: ['offerTitle', 'offerText', 'ctaText'], inAppSurface: 'REWARDS_HUB' },
+]
 
 test.beforeEach(async ({ context, baseURL }) => {
   await signInAsOperator(context, baseURL!)
@@ -27,6 +35,11 @@ test('authors a measured A/B content experiment and renders its conservative res
     status: 200,
     contentType: 'application/json',
     body: JSON.stringify({ state: 'ok', items: [{ trigger: 'ACCOUNT_OPENED', humanForm: 'when an account is opened' }] }),
+  }))
+  await page.route(/\/api\/campaigns\/templates$/, route => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({ state: 'ok', items: CONTENT_CATALOGUE }),
   }))
   await page.route(/\/api\/campaigns$/, route => {
     if (route.request().method() !== 'POST') return route.fallback()

--- a/openbank-admin-ui/e2e/campaign-entry-authoring.spec.ts
+++ b/openbank-admin-ui/e2e/campaign-entry-authoring.spec.ts
@@ -6,6 +6,14 @@ import { expect, test } from '@playwright/test'
 import { signInAsOperator } from './helpers/auth'
 
 const CAMPAIGN_ID = '019fb939-3e0a-7716-a1ed-7854754c8786'
+const CONTENT_CATALOGUE = [
+  { template: 'MARKETING_PRODUCT_OFFER', channel: 'EMAIL', variables: ['offerTitle', 'offerText', 'ctaText'] },
+  { template: 'MARKETING_PRODUCT_OFFER_PUSH', channel: 'PUSH', variables: ['offerTitle'] },
+  { template: 'MARKETING_PRODUCT_OFFER_BANNER', channel: 'BANNER', variables: ['offerTitle', 'offerText', 'ctaText'], inAppSurface: 'HOME_BANNER' },
+  { template: 'MARKETING_PRODUCT_OFFER_CAROUSEL', channel: 'BANNER', variables: ['offerTitle', 'offerText', 'ctaText'], inAppSurface: 'HOME_CAROUSEL' },
+  { template: 'MARKETING_PRODUCT_OFFER_PRODUCT_FEED', channel: 'BANNER', variables: ['offerTitle', 'offerText', 'ctaText'], inAppSurface: 'PRODUCT_FEED' },
+  { template: 'MARKETING_PRODUCT_OFFER_REWARDS_HUB', channel: 'BANNER', variables: ['offerTitle', 'offerText', 'ctaText'], inAppSurface: 'REWARDS_HUB' },
+]
 
 test.beforeEach(async ({ context, baseURL }) => {
   await signInAsOperator(context, baseURL!)
@@ -30,6 +38,11 @@ test('authors a recurring campaign from the service cadence catalogue', async ({
     status: 200,
     contentType: 'application/json',
     body: JSON.stringify({ state: 'ok', items: [{ trigger: 'ACCOUNT_OPENED', humanForm: 'when an account is opened' }] }),
+  }))
+  await page.route('**/api/campaigns/templates', route => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({ state: 'ok', items: CONTENT_CATALOGUE }),
   }))
   await page.route('**/api/campaigns', route => {
     if (route.request().method() !== 'POST') return route.fallback()

--- a/openbank-admin-ui/package-lock.json
+++ b/openbank-admin-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openbank-admin-ui",
-  "version": "0.107.0",
+  "version": "0.116.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openbank-admin-ui",
-      "version": "0.107.0",
+      "version": "0.116.0",
       "dependencies": {
         "@hookform/resolvers": "5.7.1",
         "@radix-ui/react-dialog": "1.1.23",
@@ -1194,9 +1194,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1212,9 +1209,6 @@
       "integrity": "sha512-C0SqjoFKnszqa44EQ7xoaT48nnO0lOyXEULfXMWi8krrjOPGYkeK30Okzla6ATbBYsyZ0ySinK0FVkpv3DwzfQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1232,9 +1226,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1250,9 +1241,6 @@
       "integrity": "sha512-DRWw0mOHusrCCuw2rqP87oLg6PGlkomVDFqw2hIwsSfwWpu4k3XLcBPaKKl6ct/GtL/cwNkgwjV/tc0Mqht3VA==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1270,9 +1258,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1288,9 +1273,6 @@
       "integrity": "sha512-y9RNUYDe2A1UAdhLyfeOodGRszQdaEoe4nfOpp/sNVPl2CWIcUyFaDoCh4vPLPxu19803j2naLqZup2WxDXCLA==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1308,9 +1290,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1327,9 +1306,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1345,9 +1321,6 @@
       "integrity": "sha512-VVlpEWwizEFIOom0zdoeKuO5nuTswzVE5uHcBNvHzmeHUpNFajY3HFfbQ+zIH4E2kVaZ/yVxmsShW56TtEy4uA==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1371,9 +1344,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1395,9 +1365,6 @@
       "integrity": "sha512-N3hzbEpUTJC8pWpPVJvgzGxM+so/MAXc8O2s/53B0LL9ZGpfXpME7Wizkc5d/8fRBlBtkDjzoZGDCqqNDHqLEw==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1421,9 +1388,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1445,9 +1409,6 @@
       "integrity": "sha512-MYlMiPFiv/EKPAHnp3yNZ9AAWFsxga9c5Bkc6wkar6bqzHLlkGVJHRm0u1ei+VXnZxp3Mz9MG9ZIsI8vSOf3sQ==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1471,9 +1432,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1496,9 +1454,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1520,9 +1475,6 @@
       "integrity": "sha512-K7ykQ+26Rt6+4BTU80AuGgTPIYX86UxiAKT4rcXX/WNTo7k1ZxpKz+TguHnwVpCqQK3B5PK0vZ0ZBe6nz/ib1w==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1781,9 +1733,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1799,9 +1748,6 @@
       "integrity": "sha512-tXXGKJw0m37O0eKJARVTX/TheKPhz0QFVtVVZXmOig+9YKLQOSP6hvf2pxv5DO7CLEJyTHx3Pg043CDQkv1G4Q==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1819,9 +1765,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1837,9 +1780,6 @@
       "integrity": "sha512-sjo++Xx+lomlPs3HRsHWhVDyGG6ms1kGW5EtHLERdII8AyG1i+f6aq68xHREO6AEMlhjTNEWBSmfJfqm9orf7g==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2964,9 +2904,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2984,9 +2921,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3004,9 +2938,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3024,9 +2955,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3044,9 +2972,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3064,9 +2989,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4221,9 +4143,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4241,9 +4160,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4261,9 +4177,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4281,9 +4194,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11502,9 +11412,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",
@@ -12173,6 +12083,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/openbank-admin-ui/package.json
+++ b/openbank-admin-ui/package.json
@@ -57,7 +57,7 @@
   "overrides": {
     "postcss": "8.5.26",
     "sharp": "0.35.0",
-    "nanoid": "3.3.17"
+    "nanoid": "3.3.18"
   },
   "devDependencies": {
     "@playwright/test": "^1.62.1",

--- a/openbank-admin-ui/src/app/api/campaigns/[id]/route.ts
+++ b/openbank-admin-ui/src/app/api/campaigns/[id]/route.ts
@@ -204,3 +204,38 @@ export async function GET(_req: Request, ctx: { params: Promise<{ id: string }> 
     },
   })
 }
+
+/**
+ * Revise a definition before it enters four-eyes review.  The BFF deliberately forwards no maker
+ * identity: campaign-service derives that from the access token and rejects anyone other than the
+ * original maker, so a browser cannot turn an edit into an impersonation claim.
+ */
+export async function PUT(req: Request, ctx: { params: Promise<{ id: string }> }) {
+  const session = await auth()
+  if (!session?.user?.accessToken) {
+    return NextResponse.json({ error: 'unauthenticated' }, { status: 401 })
+  }
+  const { id } = await ctx.params
+  try {
+    const raw = await req.json() as Record<string, unknown>
+    // These fields are server-owned.  Dropping them at the BFF keeps an accidental stale detail
+    // payload from looking like an editable audit record; campaign-service independently derives
+    // and verifies the maker from the token.
+    const { id: _id, state: _state, createdBy: _createdBy, approvedBy: _approvedBy, createdAt: _createdAt, updatedAt: _updatedAt, ...draft } = raw
+    const res = await fetch(serverSvcUrl('campaign-service', 'campaign', 8128, `/api/v1/campaigns/${encodeURIComponent(id)}`), {
+      method: 'PUT',
+      headers: { authorization: `Bearer ${session.user.accessToken}`, 'content-type': 'application/json' },
+      body: JSON.stringify(draft),
+      signal: AbortSignal.timeout(8000),
+      cache: 'no-store',
+    })
+    const text = await res.text()
+    const payload = text ? JSON.parse(text) : {}
+    return NextResponse.json(
+      res.ok ? { state: 'ok', campaign: payload } : { state: res.status === 401 || res.status === 403 ? 'forbidden' : 'rejected', ...payload },
+      { status: 200 },
+    )
+  } catch {
+    return NextResponse.json({ state: 'unreachable' }, { status: 200 })
+  }
+}

--- a/openbank-admin-ui/src/app/api/campaigns/templates/route.ts
+++ b/openbank-admin-ui/src/app/api/campaigns/templates/route.ts
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+import { NextResponse } from 'next/server'
+import { auth } from '@/auth'
+import { serverSvcUrl } from '@/lib/services/bff'
+
+export const dynamic = 'force-dynamic'
+
+/** The reviewed cross-channel catalogue is an upstream contract, never a second client-side list. */
+export async function GET() {
+  const session = await auth()
+  if (!session?.user?.accessToken) return NextResponse.json({ error: 'unauthenticated' }, { status: 401 })
+  try {
+    const res = await fetch(serverSvcUrl('campaign-service', 'campaign', 8128, '/api/v1/campaigns/templates'), {
+      headers: { authorization: `Bearer ${session.user.accessToken}` },
+      signal: AbortSignal.timeout(4000),
+      cache: 'no-store',
+    })
+    if (!res.ok) {
+      return NextResponse.json({ items: [], state: res.status === 401 || res.status === 403 ? 'unauthorized' : 'unreachable' })
+    }
+    return NextResponse.json({ items: await res.json(), state: 'ok' })
+  } catch {
+    return NextResponse.json({ items: [], state: 'unreachable' })
+  }
+}

--- a/openbank-admin-ui/src/app/campaigns/[id]/page.tsx
+++ b/openbank-admin-ui/src/app/campaigns/[id]/page.tsx
@@ -482,6 +482,11 @@ export default function CampaignDetailPage({ params }: { params: Promise<{ id: s
           which is how a real refusal stops being read. */}
       {!loading && !unavailable && c && actionsFor(c.state).length > 0 && (
         <div className="flex flex-wrap items-center gap-2">
+          {c.state === 'DRAFT' && (
+            <Link href={`/campaigns/new?draft=${encodeURIComponent(c.id)}`} className="rounded-md border px-3 py-1.5 text-sm">
+              {t('Upravit koncept', 'Edit draft')}
+            </Link>
+          )}
           {actionsFor(c.state).map(a => (
             <button
               key={a}

--- a/openbank-admin-ui/src/app/campaigns/new/page.tsx
+++ b/openbank-admin-ui/src/app/campaigns/new/page.tsx
@@ -101,6 +101,7 @@ export default function NewCampaignPage() {
   const router = useRouter()
   const searchParams = useSearchParams()
   const requestedAudience = searchParams.get('audience')
+  const draftId = searchParams.get('draft')
 
   const [name, setName] = useState('')
   const [goal, setGoal] = useState('')
@@ -164,6 +165,67 @@ export default function NewCampaignPage() {
       .catch(() => undefined)
   }, [])
 
+  // The reach is the segment's own preview, run by the service — the same evaluation enrolment runs.
+  // A number computed here from a different query would agree with the send only by luck.
+  function previewReach(ref: string) {
+    setReach(null)
+    const [segName, segVersion] = ref.split('@')
+    if (!segName) return
+    fetch(`/api/segments/${encodeURIComponent(segName)}/${encodeURIComponent(segVersion)}/preview`)
+      .then(r => r.json())
+      .then((d: { size?: number; state: string }) => {
+        if (d.state === 'ok') setReach(d.size ?? 0)
+      })
+      .catch(() => undefined)
+  }
+
+  // A campaign is editable only before submit.  Load the real stored definition rather than
+  // reconstructing it from the canvas, otherwise an omitted later field could silently disappear
+  // when a maker saves an unrelated change.
+  useEffect(() => {
+    if (!draftId) return
+    fetch(`/api/campaigns/${encodeURIComponent(draftId)}`)
+      .then(r => r.json())
+      .then((d: { campaign?: {
+        state?: string; name?: string; goal?: string; segmentRef?: { name: string; version: number }
+        steps?: EditorStep[]; stopCondition?: { maxSendsPerParty: number } | null; conversionRule?: string | null
+        holdoutPercent?: number; schedule?: { cadence: string } | null; trigger?: string | null
+      }; sources?: { campaign?: string } }) => {
+        const campaign = d.campaign
+        if (d.sources?.campaign !== 'ok' || !campaign || campaign.state !== 'DRAFT') {
+          setError(t('Tento koncept už nelze upravit.', 'This campaign draft can no longer be edited.'))
+          return
+        }
+        setName(campaign.name ?? '')
+        setGoal(campaign.goal ?? '')
+        if (campaign.segmentRef) {
+          const ref = `${campaign.segmentRef.name}@${campaign.segmentRef.version}`
+          setSegment(ref)
+          previewReach(ref)
+        }
+        if (campaign.steps?.length) {
+          setSteps(campaign.steps)
+          setSelected(0)
+        }
+        setStopAfter(campaign.stopCondition?.maxSendsPerParty ?? null)
+        setConversionRule(campaign.conversionRule ?? null)
+        setHoldoutPercent(campaign.holdoutPercent ?? 0)
+        setContentExperiment(campaign.steps?.some(step => step.variantBVariables !== undefined) ?? false)
+        if (campaign.schedule) {
+          setEntryMode('SCHEDULE')
+          setCadence(campaign.schedule.cadence)
+        } else if (campaign.trigger) {
+          setEntryMode('TRIGGER')
+          setTrigger(campaign.trigger)
+        }
+        setJourneyRecipe(null)
+      })
+      .catch(() => setError(t('Koncept se nepodařilo načíst.', 'The campaign draft could not be loaded.')))
+  // previewReach is deliberately called from this initial hydration only; it has no unstable
+  // dependencies and is declared in the component closure.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [draftId])
+
   // The Audience Library hands the exact, versioned identifier to Studio. The service still
   // evaluates this audience on create; the query parameter only saves the marketer from selecting
   // the same reviewed item twice and never carries an audience definition itself.
@@ -197,20 +259,6 @@ export default function NewCampaignPage() {
       })
       .catch(() => setEntryUnavailable(true))
   }, [])
-
-  // The reach is the segment's own preview, run by the service — the same evaluation enrolment runs.
-  // A number computed here from a different query would agree with the send only by luck.
-  const previewReach = (ref: string) => {
-    setReach(null)
-    const [segName, segVersion] = ref.split('@')
-    if (!segName) return
-    fetch(`/api/segments/${encodeURIComponent(segName)}/${encodeURIComponent(segVersion)}/preview`)
-      .then(r => r.json())
-      .then((d: { size?: number; state: string }) => {
-        if (d.state === 'ok') setReach(d.size ?? 0)
-      })
-      .catch(() => undefined)
-  }
 
   const updateStep = (i: number, next: EditorStep) =>
     setSteps(prev => prev.map((s, k) => (k === i ? next : s)))
@@ -275,8 +323,8 @@ export default function NewCampaignPage() {
     setSaving(true)
     setError(null)
     const [segName, segVersion] = segment.split('@')
-    fetch('/api/campaigns', {
-      method: 'POST',
+    fetch(draftId ? `/api/campaigns/${encodeURIComponent(draftId)}` : '/api/campaigns', {
+      method: draftId ? 'PUT' : 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({
         name: name.trim(),
@@ -317,7 +365,7 @@ export default function NewCampaignPage() {
           d.message ??
             d.error ??
             (d.state === 'forbidden'
-              ? t('Nemáte oprávnění zakládat kampaně.', 'You are not permitted to create campaigns.')
+              ? t('Nemáte oprávnění tento koncept upravit.', 'You are not permitted to revise this draft.')
               : t('Campaign-service neodpovídá.', 'Campaign-service is not responding.')),
         )
       })
@@ -335,7 +383,7 @@ export default function NewCampaignPage() {
           <div>
             <p className="campaign-composer-eyebrow"><Sparkles className="h-3.5 w-3.5" /> {t('Campaign studio', 'Campaign studio')}</p>
             <PageHeader
-              title={t('Nová kampaň', 'New campaign')}
+              title={draftId ? t('Upravit koncept', 'Edit draft') : t('Nová kampaň', 'New campaign')}
               subtitle={t(
                 'Navrhněte zážitek v aplikaci, zprávu a okamžik, kdy má přijít. Aktivaci pak vždy potvrdí druhý člověk.',
                 'Design the in-app moment, the message and when it appears. A second person always confirms activation.',
@@ -740,7 +788,7 @@ export default function NewCampaignPage() {
 
       <footer className="campaign-composer-footer">
         <div>
-          <p>{t('Koncept se zatím nikomu neposílá.', 'A draft does not send anything yet.')}</p>
+          <p>{draftId ? t('Upravujete koncept; zatím nikomu nic neposílá.', 'You are revising a draft; it still sends nothing.') : t('Koncept se zatím nikomu neposílá.', 'A draft does not send anything yet.')}</p>
           <span>{t('Po kontrole jej aktivuje jiný oprávněný člověk.', 'A different authorised person activates it after review.')}</span>
         </div>
         <div className="campaign-composer-footer-actions">
@@ -749,7 +797,9 @@ export default function NewCampaignPage() {
           disabled={!ready || saving}
           className="btn btn-primary disabled:opacity-40"
         >
-          {saving ? t('Zakládám…', 'Creating…') : t('Založit koncept', 'Create draft')}
+          {saving
+            ? (draftId ? t('Ukládám…', 'Saving…') : t('Zakládám…', 'Creating…'))
+            : (draftId ? t('Uložit koncept', 'Save draft') : t('Založit koncept', 'Create draft'))}
         </button>
         {!ready && (
           <span className="text-xs text-muted-foreground">

--- a/openbank-admin-ui/src/app/campaigns/new/page.tsx
+++ b/openbank-admin-ui/src/app/campaigns/new/page.tsx
@@ -14,6 +14,7 @@ import {
   JourneyEditor,
   MAX_STEPS,
   type EditorChannel,
+  type EditorInAppSurface,
   type EditorStep,
 } from '@/components/campaigns/JourneyEditor'
 import { StepEditor } from '@/components/campaigns/StepEditor'
@@ -62,38 +63,25 @@ interface CampaignTrigger {
   humanForm: string
 }
 
+/** The reviewed content choice served by campaign-service, rather than a second client-side copy. */
+interface CampaignTemplate {
+  template: string
+  channel: EditorChannel
+  variables: string[]
+  inAppSurface?: EditorInAppSurface | null
+}
+
 type EntryMode = 'MANUAL' | 'SCHEDULE' | 'TRIGGER'
 
-/** Mirrors the service's catalogue; the service rejects anything not in its own copy. */
-const TEMPLATES: Record<string, string[]> = {
-  MARKETING_PRODUCT_OFFER: ['offerTitle', 'offerText', 'ctaText'],
-  // One variable, and that is the channel's rule rather than a simplification: a push renders its
-  // title plus a fixed generic body, so there is nowhere for offer copy to go (#1182).
-  MARKETING_PRODUCT_OFFER_PUSH: ['offerTitle'],
-  MARKETING_PRODUCT_OFFER_BANNER: ['offerTitle', 'offerText', 'ctaText'],
-  MARKETING_PRODUCT_OFFER_CAROUSEL: ['offerTitle', 'offerText', 'ctaText'],
-  MARKETING_PRODUCT_OFFER_PRODUCT_FEED: ['offerTitle', 'offerText', 'ctaText'],
-  MARKETING_PRODUCT_OFFER_REWARDS_HUB: ['offerTitle', 'offerText', 'ctaText'],
-}
-
-/** Which channel each template renders on. The service refuses a step whose two disagree. */
-const TEMPLATE_CHANNEL: Record<string, EditorChannel> = {
-  MARKETING_PRODUCT_OFFER: 'EMAIL',
-  MARKETING_PRODUCT_OFFER_PUSH: 'PUSH',
-  MARKETING_PRODUCT_OFFER_BANNER: 'BANNER',
-  MARKETING_PRODUCT_OFFER_CAROUSEL: 'BANNER',
-  MARKETING_PRODUCT_OFFER_PRODUCT_FEED: 'BANNER',
-  MARKETING_PRODUCT_OFFER_REWARDS_HUB: 'BANNER',
-}
-
-const newStep = (): EditorStep => ({
+const newStep = (choice: CampaignTemplate): EditorStep => ({
   // The studio starts with the primary owned surface: the bank app. E-mail remains a supported
   // channel, but leading an app-first campaign with it made the canvas teach the wrong product.
-  template: 'MARKETING_PRODUCT_OFFER_PUSH',
-  channel: 'PUSH',
+  template: choice.template,
+  channel: choice.channel,
   variables: {},
   delaySeconds: 0,
-  mobileDestination: 'HOME',
+  ...(choice.channel === 'PUSH' || choice.channel === 'BANNER' ? { mobileDestination: 'HOME' as const } : {}),
+  ...(choice.inAppSurface ? { inAppSurface: choice.inAppSurface } : {}),
 })
 
 export default function NewCampaignPage() {
@@ -109,11 +97,13 @@ export default function NewCampaignPage() {
   const [segments, setSegments] = useState<Segment[]>([])
   const [cadences, setCadences] = useState<Cadence[]>([])
   const [triggers, setTriggers] = useState<CampaignTrigger[]>([])
+  const [contentCatalogue, setContentCatalogue] = useState<CampaignTemplate[]>([])
+  const [contentCatalogueState, setContentCatalogueState] = useState<'loading' | 'ok' | 'unavailable'>('loading')
   const [entryMode, setEntryMode] = useState<EntryMode>('MANUAL')
   const [cadence, setCadence] = useState('')
   const [trigger, setTrigger] = useState('')
   const [entryUnavailable, setEntryUnavailable] = useState(false)
-  const [steps, setSteps] = useState<EditorStep[]>([newStep()])
+  const [steps, setSteps] = useState<EditorStep[]>([])
   const [journeyRecipe, setJourneyRecipe] = useState<JourneyRecipeId | null>('RETURN_TO_APP')
   const [selected, setSelected] = useState<number | null>(0)
   const [reach, setReach] = useState<number | null>(null)
@@ -129,6 +119,13 @@ export default function NewCampaignPage() {
   const [contentExperiment, setContentExperiment] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [saving, setSaving] = useState(false)
+
+  const templates = Object.fromEntries(contentCatalogue.map(entry => [entry.template, entry.variables])) as Record<string, string[]>
+  const templateChannel = Object.fromEntries(contentCatalogue.map(entry => [entry.template, entry.channel])) as Record<string, EditorChannel>
+  const templateSurface = Object.fromEntries(
+    contentCatalogue.flatMap(entry => entry.inAppSurface ? [[entry.inAppSurface, entry.template] as const] : []),
+  ) as Partial<Record<EditorInAppSurface, string>>
+  const defaultStep = () => contentCatalogue.find(entry => entry.channel === 'PUSH') ?? contentCatalogue[0]
 
   const templateLabels: Record<string, string> = {
     MARKETING_PRODUCT_OFFER: t('Nabídka produktu', 'Product offer'),
@@ -248,17 +245,40 @@ export default function NewCampaignPage() {
     Promise.all([
       fetch('/api/campaigns/cadences').then(r => r.json()),
       fetch('/api/campaigns/triggers').then(r => r.json()),
+      fetch('/api/campaigns/templates').then(r => r.json()),
     ])
-      .then(([cadenceResponse, triggerResponse]: [
+      .then(([cadenceResponse, triggerResponse, templateResponse]: [
         { items?: Cadence[]; state?: string },
         { items?: CampaignTrigger[]; state?: string },
+        { items?: CampaignTemplate[]; state?: string },
       ]) => {
         if (cadenceResponse.state === 'ok') setCadences(cadenceResponse.items ?? [])
         if (triggerResponse.state === 'ok') setTriggers(triggerResponse.items ?? [])
         if (cadenceResponse.state !== 'ok' || triggerResponse.state !== 'ok') setEntryUnavailable(true)
+        if (templateResponse.state === 'ok' && (templateResponse.items?.length ?? 0) > 0) {
+          setContentCatalogue(templateResponse.items ?? [])
+          setContentCatalogueState('ok')
+        } else {
+          setContentCatalogueState('unavailable')
+        }
       })
-      .catch(() => setEntryUnavailable(true))
+      .catch(() => {
+        setEntryUnavailable(true)
+        setContentCatalogueState('unavailable')
+      })
   }, [])
+
+  // A new journey gets a server-approved app-first step only after the catalogue arrives. There is
+  // intentionally no browser fallback: a stale template fails after a marketer has authored it.
+  useEffect(() => {
+    if (draftId || contentCatalogueState !== 'ok') return
+    const first = defaultStep()
+    if (!first) return
+    setSteps(previous => previous.length === 0 ? [newStep(first)] : previous)
+    setSelected(previous => previous ?? 0)
+  // The catalogue state changes only when its authoritative response arrives.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [contentCatalogueState, draftId])
 
   const updateStep = (i: number, next: EditorStep) =>
     setSteps(prev => prev.map((s, k) => (k === i ? next : s)))
@@ -266,14 +286,23 @@ export default function NewCampaignPage() {
   const addStep = () =>
     setSteps(prev => {
       if (prev.length >= MAX_STEPS) return prev
+      const first = defaultStep()
+      if (!first) return prev
       setSelected(prev.length)
       return [...prev, {
-        ...newStep(),
+        ...newStep(first),
         ...(contentExperiment ? { variantBVariables: {} } : {}),
       }]
     })
 
   const applyRecipe = (recipe: JourneyRecipe) => {
+    const verified = recipe.steps.every(step =>
+      templates[step.template] !== undefined && templateChannel[step.template] === step.channel,
+    )
+    if (!verified) {
+      setError(t('Tento recept používá obsah, který už není v ověřeném katalogu.', 'This recipe uses content no longer in the verified catalogue.'))
+      return
+    }
     // A recipe is only an authoring shortcut. Clone every map so opening one step can never alter
     // another step's values through a shared object reference.
     setSteps(recipe.steps.map(step => ({
@@ -293,8 +322,9 @@ export default function NewCampaignPage() {
     })
 
   const incomplete = steps.some(s =>
-    (TEMPLATES[s.template] ?? []).some(v => !(s.variables[v] ?? '').trim()) ||
-    (contentExperiment && (TEMPLATES[s.variantBTemplate ?? s.template] ?? [])
+    templates[s.template] === undefined ||
+    templates[s.template].some(v => !(s.variables[v] ?? '').trim()) ||
+    (contentExperiment && (templates[s.variantBTemplate ?? s.template] ?? [])
       .some(v => !(s.variantBVariables?.[v] ?? '').trim())),
   )
   const entryConfigured =
@@ -302,7 +332,7 @@ export default function NewCampaignPage() {
     (entryMode === 'SCHEDULE' && cadence !== '') ||
     (entryMode === 'TRIGGER' && trigger !== '')
   const ready = name.trim() !== '' && goal.trim() !== '' && segment !== '' && steps.length > 0 &&
-    !incomplete && entryConfigured && (!contentExperiment || conversionRule !== null)
+    contentCatalogueState === 'ok' && !incomplete && entryConfigured && (!contentExperiment || conversionRule !== null)
 
   const setContentExperimentEnabled = (enabled: boolean) => {
     setContentExperiment(enabled)
@@ -573,7 +603,7 @@ export default function NewCampaignPage() {
         </div>
       </section>
 
-      <JourneyRecipePicker selected={journeyRecipe} onApply={applyRecipe} />
+      {contentCatalogueState === 'ok' && <JourneyRecipePicker selected={journeyRecipe} onApply={applyRecipe} />}
 
       <section className="campaign-journey-workbench">
         <div className="campaign-workbench-heading">
@@ -584,6 +614,13 @@ export default function NewCampaignPage() {
           </div>
           <span className="campaign-workbench-status"><span /> {steps.length}/{MAX_STEPS} {t('kroků', 'steps')}</span>
         </div>
+        {contentCatalogueState !== 'ok' && (
+          <p className="text-xs text-muted-foreground" data-content-catalogue-state={contentCatalogueState}>
+            {contentCatalogueState === 'loading'
+              ? t('Načítáme ověřený katalog obsahu…', 'Loading the reviewed content catalogue…')
+              : t('Katalog obsahu teď není dostupný; nové kroky ani recepty nenabízíme.', 'The content catalogue is unavailable; new steps and recipes are not offered.')}
+          </p>
+        )}
         {/* space-y-0 around the canvas+panel pair: any gap between them undoes the join. */}
         <div className="space-y-0">
         <JourneyEditor
@@ -596,6 +633,7 @@ export default function NewCampaignPage() {
           selected={selected}
           onSelect={setSelected}
           onAdd={addStep}
+          contentCatalogueReady={contentCatalogueState === 'ok'}
           onRemove={removeStep}
           templateLabels={templateLabels}
           stopAfter={stopAfter}
@@ -608,8 +646,9 @@ export default function NewCampaignPage() {
             attached
             index={selected}
             step={steps[selected]}
-            templates={TEMPLATES}
-            templateChannel={TEMPLATE_CHANNEL}
+            templates={templates}
+            templateChannel={templateChannel}
+            templateSurface={templateSurface}
             templateLabels={templateLabels}
             variableLabels={variableLabels}
             contentExperiment={contentExperiment}

--- a/openbank-admin-ui/src/components/campaigns/JourneyEditor.tsx
+++ b/openbank-admin-ui/src/components/campaigns/JourneyEditor.tsx
@@ -97,6 +97,7 @@ export function JourneyEditor({
   selected,
   onSelect,
   onAdd,
+  contentCatalogueReady = true,
   onRemove,
   templateLabels,
   stopAfter,
@@ -109,6 +110,8 @@ export function JourneyEditor({
   selected: number | null
   onSelect: (index: number | null) => void
   onAdd: () => void
+  /** Without the served catalogue, a new node would be an unverified template choice. */
+  contentCatalogueReady?: boolean
   onRemove: (index: number) => void
   templateLabels: Record<string, string>
   /** Campaign-level cap: the journey ends once a party has had this many sends. Null = no cap. */
@@ -128,7 +131,7 @@ export function JourneyEditor({
     return t(`za ${Math.floor(s / 60)} min`, `after ${Math.floor(s / 60)} min`)
   }
 
-  const canAdd = steps.length < MAX_STEPS
+  const canAdd = steps.length < MAX_STEPS && contentCatalogueReady
   // Entry + steps + the add affordance, which occupies a slot so the canvas does not jump when a
   // step is added.
   const cols = 1 + steps.length + (canAdd ? 1 : 0)
@@ -396,7 +399,7 @@ export function JourneyEditor({
           </g>
         )}
 
-        {!canAdd && (
+        {steps.length >= MAX_STEPS && (
           // Stated, not enforced silently: the cap is a domain rule (Campaign.MAX_STEPS), and a
           // marketer who cannot find the add button deserves to know why rather than assume a bug.
           <text

--- a/openbank-admin-ui/src/components/campaigns/StepEditor.tsx
+++ b/openbank-admin-ui/src/components/campaigns/StepEditor.tsx
@@ -5,14 +5,7 @@
 'use client'
 
 import { useLanguage } from '@/lib/i18n/LanguageContext'
-import type { EditorChannel, EditorCondition, EditorStep } from '@/components/campaigns/JourneyEditor'
-
-const IN_APP_TEMPLATE: Record<NonNullable<EditorStep['inAppSurface']>, string> = {
-  HOME_BANNER: 'MARKETING_PRODUCT_OFFER_BANNER',
-  HOME_CAROUSEL: 'MARKETING_PRODUCT_OFFER_CAROUSEL',
-  PRODUCT_FEED: 'MARKETING_PRODUCT_OFFER_PRODUCT_FEED',
-  REWARDS_HUB: 'MARKETING_PRODUCT_OFFER_REWARDS_HUB',
-}
+import type { EditorChannel, EditorCondition, EditorInAppSurface, EditorStep } from '@/components/campaigns/JourneyEditor'
 
 /**
  * Edits the step selected on the canvas.
@@ -31,6 +24,7 @@ export function StepEditor({
   step,
   templates,
   templateChannel,
+  templateSurface,
   templateLabels,
   variableLabels,
   contentExperiment = false,
@@ -44,6 +38,8 @@ export function StepEditor({
   templates: Record<string, string[]>
   /** template id → the channel it renders on. The service refuses a mismatch. */
   templateChannel: Record<string, EditorChannel>
+  /** Authenticated app surface → its reviewed banner template, served by campaign-service. */
+  templateSurface: Partial<Record<EditorInAppSurface, string>>
   templateLabels: Record<string, string>
   /**
    * variable id → what to call it, and what a filled-in one looks like.
@@ -72,6 +68,17 @@ export function StepEditor({
   const variantBTemplate = step.variantBTemplate ?? step.template
   const variantBChannel = step.variantBChannel ?? step.channel
   const variantBDeclared = templates[variantBTemplate] ?? []
+  const firstSurface = Object.keys(templateSurface)[0] as EditorInAppSurface | undefined
+  const selectedSurface = step.inAppSurface ?? firstSurface
+  const templateForSurface = (surface: EditorInAppSurface | undefined) => surface ? templateSurface[surface] : undefined
+  const surfaceLabel = (surface: EditorInAppSurface) => {
+    switch (surface) {
+      case 'HOME_BANNER': return t('Banner na domovské obrazovce', 'Home banner')
+      case 'HOME_CAROUSEL': return t('Carousel na domovské obrazovce', 'Home carousel')
+      case 'PRODUCT_FEED': return t('Feed produktů', 'Product feed')
+      case 'REWARDS_HUB': return t('Centrum odměn', 'Rewards hub')
+    }
+  }
   const missing = declared.filter(v => !(step.variables[v] ?? '').trim())
   // `.input` is the console's own field style — hover, focus ring, sizing — and I had hand-rolled a
   // worse copy of it. Reinventing a house primitive is the same failure ADR-0208 D2 names for colour.
@@ -108,7 +115,9 @@ export function StepEditor({
         <span className="text-sm font-medium">{t('Kanál', 'Channel')}</span>
         <div className="flex gap-2">
           {(['EMAIL', 'PUSH', 'BANNER'] as EditorChannel[]).map(c => {
-            const first = Object.keys(templates).find(tpl => templateChannel[tpl] === c)
+            const first = c === 'BANNER'
+              ? templateForSurface(selectedSurface)
+              : Object.keys(templates).find(tpl => templateChannel[tpl] === c)
             const active = step.channel === c
             return (
               <button
@@ -120,14 +129,12 @@ export function StepEditor({
                 onClick={() => first && onChange({
                   ...step,
                   channel: c,
-                  template: c === 'BANNER'
-                    ? IN_APP_TEMPLATE[step.inAppSurface ?? 'HOME_BANNER']
-                    : first,
+                  template: first,
                   variables: {},
                   ...(c === 'PUSH' || c === 'BANNER'
                     ? { fallbackToPush: false, mobileDestination: step.mobileDestination ?? 'HOME' }
                     : { mobileDestination: undefined }),
-                  ...(c === 'BANNER' ? { inAppSurface: step.inAppSurface ?? 'HOME_BANNER' } : { inAppSurface: undefined }),
+                  ...(c === 'BANNER' && selectedSurface ? { inAppSurface: selectedSurface } : { inAppSurface: undefined }),
                   ...(step.variantBVariables !== undefined ? { variantBVariables: {} } : {}),
                 })}
                 // `.btn` again rather than a hand-rolled box — the third time tonight that a
@@ -188,22 +195,23 @@ export function StepEditor({
               <span className="font-medium">{t('Plocha v aplikaci', 'In-app surface')}</span>
               <select
                 className={field}
-                value={step.inAppSurface ?? 'HOME_BANNER'}
+                value={selectedSurface ?? ''}
                 onChange={e => {
-                  const inAppSurface = e.target.value as NonNullable<EditorStep['inAppSurface']>
+                  const inAppSurface = e.target.value as EditorInAppSurface
+                  const template = templateForSurface(inAppSurface)
+                  if (!template) return
                   onChange({
                     ...step,
                     inAppSurface,
-                    template: IN_APP_TEMPLATE[inAppSurface],
+                    template,
                     variables: {},
                     ...(step.variantBVariables !== undefined ? { variantBVariables: {} } : {}),
                   })
                 }}
               >
-                <option value="HOME_BANNER">{t('Banner na domovské obrazovce', 'Home banner')}</option>
-                <option value="HOME_CAROUSEL">{t('Carousel na domovské obrazovce', 'Home carousel')}</option>
-                <option value="PRODUCT_FEED">{t('Feed produktů', 'Product feed')}</option>
-                <option value="REWARDS_HUB">{t('Centrum odměn', 'Rewards hub')}</option>
+                {Object.keys(templateSurface).map(surface => (
+                  <option key={surface} value={surface}>{surfaceLabel(surface as EditorInAppSurface)}</option>
+                ))}
               </select>
               <span className="block text-xs text-muted-foreground">
                 {t('Každá plocha má schválený tvar karty; šablona se přepne spolu s ní.', 'Each surface has an approved card shape; its template changes with the surface.')}
@@ -264,7 +272,7 @@ export function StepEditor({
           })}
         >
           {Object.keys(templates).filter(tpl => templateChannel[tpl] === step.channel && (
-            step.channel !== 'BANNER' || tpl === IN_APP_TEMPLATE[step.inAppSurface ?? 'HOME_BANNER']
+            step.channel !== 'BANNER' || tpl === templateForSurface(selectedSurface)
           )).map(tpl => (
             <option key={tpl} value={tpl}>
               {templateLabels[tpl] ?? tpl}
@@ -325,7 +333,7 @@ export function StepEditor({
                 onChange={e => {
                   const channel = e.target.value as EditorChannel
                   const first = Object.keys(templates).find(tpl => templateChannel[tpl] === channel && (
-                    channel !== 'BANNER' || tpl === IN_APP_TEMPLATE.HOME_BANNER
+                    channel !== 'BANNER' || tpl === templateForSurface('HOME_BANNER')
                   ))
                   if (!first) return
                   onChange({ ...step, variantBChannel: channel, variantBTemplate: first, variantBVariables: {} })
@@ -346,7 +354,7 @@ export function StepEditor({
                 onChange={e => onChange({ ...step, variantBTemplate: e.target.value, variantBVariables: {} })}
               >
                 {Object.keys(templates).filter(tpl => templateChannel[tpl] === variantBChannel && (
-                  variantBChannel !== 'BANNER' || tpl === IN_APP_TEMPLATE.HOME_BANNER
+                  variantBChannel !== 'BANNER' || tpl === templateForSurface('HOME_BANNER')
                 )).map(tpl => <option key={tpl} value={tpl}>{templateLabels[tpl] ?? tpl}</option>)}
               </select>
             </label>

--- a/openbank-admin-ui/src/test/campaign-builder-interaction.test.tsx
+++ b/openbank-admin-ui/src/test/campaign-builder-interaction.test.tsx
@@ -18,8 +18,22 @@ import { LanguageProvider } from '@/lib/i18n/LanguageContext'
 import NewCampaignPage from '@/app/campaigns/new/page'
 vi.mock('next/navigation', () => ({ useRouter: () => ({ push: vi.fn() }), useSearchParams: () => new URLSearchParams() }))
 
+const TEMPLATES = {
+  state: 'ok',
+  items: [
+    { template: 'MARKETING_PRODUCT_OFFER', channel: 'EMAIL', variables: ['offerTitle', 'offerText', 'ctaText'] },
+    { template: 'MARKETING_PRODUCT_OFFER_PUSH', channel: 'PUSH', variables: ['offerTitle'] },
+    { template: 'MARKETING_PRODUCT_OFFER_BANNER', channel: 'BANNER', variables: ['offerTitle', 'offerText', 'ctaText'], inAppSurface: 'HOME_BANNER' },
+    { template: 'MARKETING_PRODUCT_OFFER_CAROUSEL', channel: 'BANNER', variables: ['offerTitle', 'offerText', 'ctaText'], inAppSurface: 'HOME_CAROUSEL' },
+    { template: 'MARKETING_PRODUCT_OFFER_PRODUCT_FEED', channel: 'BANNER', variables: ['offerTitle', 'offerText', 'ctaText'], inAppSurface: 'PRODUCT_FEED' },
+    { template: 'MARKETING_PRODUCT_OFFER_REWARDS_HUB', channel: 'BANNER', variables: ['offerTitle', 'offerText', 'ctaText'], inAppSurface: 'REWARDS_HUB' },
+  ],
+}
+
 const stub = () => vi.stubGlobal('fetch', vi.fn(async (u: string) =>
-  String(u).includes('/preview')
+  String(u).includes('/templates')
+    ? { ok: true, json: async () => TEMPLATES }
+    : String(u).includes('/preview')
     ? { ok: true, json: async () => ({ size: 1240, state: 'ok' }) }
     : { ok: true, json: async () => ({ state: 'ok', items: [
         { name: 'active-clients', version: 1, rules: ['party status is ACTIVE'] },
@@ -31,6 +45,7 @@ describe('campaign builder interaction', () => {
     const { container, getByText } = render(
       React.createElement(LanguageProvider, null, React.createElement(NewCampaignPage)))
     await waitFor(() => getByText('savers'), { timeout: 8000 })
+    await waitFor(() => expect(container.querySelector('[data-step="0"]')).toBeTruthy())
 
     fireEvent.click(container.querySelector('[data-journey-recipe="IN_APP_DISCOVERY"]')!)
 
@@ -48,6 +63,7 @@ describe('campaign builder interaction', () => {
     const { container, getByText } = render(
       React.createElement(LanguageProvider, null, React.createElement(NewCampaignPage)))
     await waitFor(() => getByText('savers'), { timeout: 8000 })
+    await waitFor(() => expect(container.querySelector('[data-step="0"]')).toBeTruthy())
     expect(container.querySelectorAll('[data-step]').length).toBe(1)
     for (let i = 0; i < 4; i++) fireEvent.click(container.querySelector('[data-add-step]')!)
     expect(container.querySelectorAll('[data-step]').length).toBe(5)
@@ -61,6 +77,7 @@ describe('campaign builder interaction', () => {
     const { container, getByText } = render(
       React.createElement(LanguageProvider, null, React.createElement(NewCampaignPage)))
     await waitFor(() => getByText('savers'), { timeout: 8000 })
+    await waitFor(() => expect(container.querySelector('[data-step="0"]')).toBeTruthy())
     fireEvent.click(container.querySelector('[data-add-step]')!)
     // A newly added step opens itself — you added it to fill it in.
     expect(container.querySelector('[data-step-editor="1"]')).toBeTruthy()
@@ -74,6 +91,7 @@ describe('campaign builder interaction', () => {
     const { container, getByText } = render(
       React.createElement(LanguageProvider, null, React.createElement(NewCampaignPage)))
     await waitFor(() => getByText('savers'), { timeout: 8000 })
+    await waitFor(() => expect(container.querySelector('[data-step="0"]')).toBeTruthy())
     fireEvent.click(container.querySelector('[data-segment="savers@2"]')!)
     await waitFor(() => getByText(/1240 people/), { timeout: 8000 })
     fireEvent.click(container.querySelector('[data-add-step]')!)
@@ -99,13 +117,16 @@ describe('campaign builder interaction', () => {
 describe('campaign builder channels', () => {
   it('starts app-first and switching channels exposes only fields that channel can carry', async () => {
     vi.stubGlobal('fetch', vi.fn(async (u: string) =>
-      String(u).includes('/preview')
+      String(u).includes('/templates')
+        ? { ok: true, json: async () => TEMPLATES }
+        : String(u).includes('/preview')
         ? { ok: true, json: async () => ({ size: 10, state: 'ok' }) }
         : { ok: true, json: async () => ({ state: 'ok', items: [
             { name: 'active-clients', version: 1, rules: ['party status is ACTIVE'] }] }) }))
     const { container, getByText } = render(
       React.createElement(LanguageProvider, null, React.createElement(NewCampaignPage)))
     await waitFor(() => getByText('active-clients'), { timeout: 8000 })
+    await waitFor(() => expect(container.querySelector('[data-step="0"]')).toBeTruthy())
 
     // App-first: a new campaign opens on push with only its headline field.
     expect(container.querySelector('[data-step="0"]')!.getAttribute('data-channel')).toBe('PUSH')
@@ -137,7 +158,9 @@ describe('campaign builder channels', () => {
  */
 describe('campaign builder conditions', () => {
   const stub = () => vi.stubGlobal('fetch', vi.fn(async (u: string) =>
-    String(u).includes('/preview')
+    String(u).includes('/templates')
+      ? { ok: true, json: async () => TEMPLATES }
+      : String(u).includes('/preview')
       ? { ok: true, json: async () => ({ size: 10, state: 'ok' }) }
       : { ok: true, json: async () => ({ state: 'ok', items: [
           { name: 'active-clients', version: 1, rules: ['party status is ACTIVE'] }] }) }))
@@ -147,6 +170,7 @@ describe('campaign builder conditions', () => {
     const { container, getByText } = render(
       React.createElement(LanguageProvider, null, React.createElement(NewCampaignPage)))
     await waitFor(() => getByText('active-clients'), { timeout: 8000 })
+    await waitFor(() => expect(container.querySelector('[data-step="0"]')).toBeTruthy())
     fireEvent.click(container.querySelector('[data-add-step]')!)
 
     expect(container.querySelector('[data-edge-condition]')).toBeNull()
@@ -160,6 +184,7 @@ describe('campaign builder conditions', () => {
     const { container, getByText, queryByText } = render(
       React.createElement(LanguageProvider, null, React.createElement(NewCampaignPage)))
     await waitFor(() => getByText('active-clients'), { timeout: 8000 })
+    await waitFor(() => expect(container.querySelector('[data-step="0"]')).toBeTruthy())
 
     expect(queryByText(/has no predecessor/)).toBeNull()
     fireEvent.click(container.querySelector('[data-condition-pick="IF_PREVIOUS_CONFIRMED"]')!)
@@ -172,6 +197,7 @@ describe('campaign builder conditions', () => {
     const { container, getByText } = render(
       React.createElement(LanguageProvider, null, React.createElement(NewCampaignPage)))
     await waitFor(() => getByText('active-clients'), { timeout: 8000 })
+    await waitFor(() => expect(container.querySelector('[data-step="0"]')).toBeTruthy())
 
     expect(container.querySelector('[data-stop-after]')).toBeNull()
     fireEvent.click(container.querySelector('[data-stop-enabled]')!)
@@ -190,13 +216,16 @@ describe('campaign builder conditions', () => {
 describe('campaign builder conversion', () => {
   it('offers only catalogue rules, and says engagement is not tracked', async () => {
     vi.stubGlobal('fetch', vi.fn(async (u: string) =>
-      String(u).includes('/preview')
+      String(u).includes('/templates')
+        ? { ok: true, json: async () => TEMPLATES }
+        : String(u).includes('/preview')
         ? { ok: true, json: async () => ({ size: 10, state: 'ok' }) }
         : { ok: true, json: async () => ({ state: 'ok', items: [
             { name: 'active-clients', version: 1, rules: ['party status is ACTIVE'] }] }) }))
     const { container, getByText } = render(
       React.createElement(LanguageProvider, null, React.createElement(NewCampaignPage)))
     await waitFor(() => getByText('active-clients'), { timeout: 8000 })
+    await waitFor(() => expect(container.querySelector('[data-step="0"]')).toBeTruthy())
 
     const picks = Array.from(container.querySelectorAll('[data-conversion-pick]'))
       .map(e => e.getAttribute('data-conversion-pick'))

--- a/openbank-admin-ui/src/test/campaign-detail-bff.test.ts
+++ b/openbank-admin-ui/src/test/campaign-detail-bff.test.ts
@@ -102,4 +102,34 @@ describe('campaign detail bundle', () => {
       expect.anything(),
     )
   })
+
+  it('relays a draft revision with the caller token but never a maker identity from the browser', async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({ id: 'abc', state: 'DRAFT', name: 'Updated draft' }),
+    }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { PUT } = await import('@/app/api/campaigns/[id]/route')
+    const res = await PUT(
+      new Request('http://x/api/campaigns/abc', {
+        method: 'PUT',
+        body: JSON.stringify({ name: 'Updated draft', createdBy: 'forged@openbank.test' }),
+      }),
+      { params: Promise.resolve({ id: 'abc' }) },
+    )
+
+    expect(await res.json()).toMatchObject({ state: 'ok', campaign: { name: 'Updated draft' } })
+    expect(fetchMock).toHaveBeenCalledWith(
+      // The BFF resolves its service host from the deployment environment.  The contract we own
+      // here is the protected campaign resource and the payload it receives, not a test-only host.
+      expect.stringContaining('/api/v1/campaigns/abc'),
+      expect.objectContaining({
+        method: 'PUT',
+        headers: expect.objectContaining({ authorization: 'Bearer tok' }),
+        body: expect.not.stringContaining('createdBy'),
+      }),
+    )
+  })
 })

--- a/openbank-admin-ui/src/test/campaign-entry-catalogues-bff.test.ts
+++ b/openbank-admin-ui/src/test/campaign-entry-catalogues-bff.test.ts
@@ -10,18 +10,21 @@ vi.mock('@/lib/services/bff', () => ({ serverSvcUrl: (_service: string, _name: s
 describe('campaign entry catalogue BFF', () => {
   beforeEach(() => vi.resetModules())
 
-  it('forwards cadence and trigger catalogues through the authenticated BFF', async () => {
+  it('forwards entry and cross-channel content catalogues through the authenticated BFF', async () => {
     const fetchMock = vi.fn(async (url: string) => ({
       ok: true,
       status: 200,
       json: async () => url.endsWith('/cadences')
         ? [{ cadence: 'DAILY_MORNING', humanForm: 'every day at 09:00', zone: 'Europe/Prague' }]
-        : [{ trigger: 'ACCOUNT_OPENED', humanForm: 'when an account is opened' }],
+        : url.endsWith('/templates')
+          ? [{ template: 'MARKETING_PRODUCT_OFFER_BANNER', channel: 'BANNER', variables: ['offerTitle'], inAppSurface: 'HOME_BANNER' }]
+          : [{ trigger: 'ACCOUNT_OPENED', humanForm: 'when an account is opened' }],
     }))
     vi.stubGlobal('fetch', fetchMock)
 
     const { GET: cadences } = await import('@/app/api/campaigns/cadences/route')
     const { GET: triggers } = await import('@/app/api/campaigns/triggers/route')
+    const { GET: templates } = await import('@/app/api/campaigns/templates/route')
 
     await expect((await cadences()).json()).resolves.toEqual({
       items: [{ cadence: 'DAILY_MORNING', humanForm: 'every day at 09:00', zone: 'Europe/Prague' }],
@@ -31,12 +34,20 @@ describe('campaign entry catalogue BFF', () => {
       items: [{ trigger: 'ACCOUNT_OPENED', humanForm: 'when an account is opened' }],
       state: 'ok',
     })
+    await expect((await templates()).json()).resolves.toEqual({
+      items: [{ template: 'MARKETING_PRODUCT_OFFER_BANNER', channel: 'BANNER', variables: ['offerTitle'], inAppSurface: 'HOME_BANNER' }],
+      state: 'ok',
+    })
     expect(fetchMock).toHaveBeenCalledWith(
       'http://campaign/api/v1/campaigns/cadences',
       expect.objectContaining({ headers: { authorization: 'Bearer token' } }),
     )
     expect(fetchMock).toHaveBeenCalledWith(
       'http://campaign/api/v1/campaigns/triggers',
+      expect.objectContaining({ headers: { authorization: 'Bearer token' } }),
+    )
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://campaign/api/v1/campaigns/templates',
       expect.objectContaining({ headers: { authorization: 'Bearer token' } }),
     )
   })

--- a/openbank-admin-ui/src/test/campaign-studio.test.tsx
+++ b/openbank-admin-ui/src/test/campaign-studio.test.tsx
@@ -29,6 +29,18 @@ const TRIGGERS = {
   items: [{ trigger: 'ACCOUNT_OPENED', humanForm: 'when an account is opened' }],
 }
 
+const TEMPLATES = {
+  state: 'ok',
+  items: [
+    { template: 'MARKETING_PRODUCT_OFFER', channel: 'EMAIL', variables: ['offerTitle', 'offerText', 'ctaText'] },
+    { template: 'MARKETING_PRODUCT_OFFER_PUSH', channel: 'PUSH', variables: ['offerTitle'] },
+    { template: 'MARKETING_PRODUCT_OFFER_BANNER', channel: 'BANNER', variables: ['offerTitle', 'offerText', 'ctaText'], inAppSurface: 'HOME_BANNER' },
+    { template: 'MARKETING_PRODUCT_OFFER_CAROUSEL', channel: 'BANNER', variables: ['offerTitle', 'offerText', 'ctaText'], inAppSurface: 'HOME_CAROUSEL' },
+    { template: 'MARKETING_PRODUCT_OFFER_PRODUCT_FEED', channel: 'BANNER', variables: ['offerTitle', 'offerText', 'ctaText'], inAppSurface: 'PRODUCT_FEED' },
+    { template: 'MARKETING_PRODUCT_OFFER_REWARDS_HUB', channel: 'BANNER', variables: ['offerTitle', 'offerText', 'ctaText'], inAppSurface: 'REWARDS_HUB' },
+  ],
+}
+
 function detail(state: string) {
   return {
     campaign: {
@@ -51,8 +63,9 @@ function detail(state: string) {
 
 function mockFetch(routes: Record<string, unknown>) {
   return vi.fn(async (url: string) => {
-    const match = Object.keys(routes).find(k => String(url).includes(k))
-    return { ok: true, status: 200, json: async () => (match ? routes[match] : {}) }
+    const key = String(url)
+    const match = Object.keys(routes).find(k => key.includes(k))
+    return { ok: true, status: 200, json: async () => (match ? routes[match] : key.includes('/api/campaigns/templates') ? TEMPLATES : {}) }
   })
 }
 
@@ -113,6 +126,7 @@ describe('campaign studio', () => {
     vi.stubGlobal('fetch', mockFetch({ '/api/segments': SEGMENTS }))
     render(React.createElement(Providers, null, React.createElement(NewCampaignPage)))
 
+    await waitFor(() => expect(document.querySelector('[data-channel-pick="EMAIL"]')).toBeTruthy(), { timeout: 8000 })
     // Mobile is the studio's starting surface. E-mail remains available when a campaign genuinely
     // needs its richer template, and that switch—not the initial screen—owns these three fields.
     fireEvent.click(document.querySelector('[data-channel-pick="EMAIL"]')!)
@@ -136,6 +150,7 @@ describe('campaign studio', () => {
       if (url.includes('/api/segments')) return { ok: true, status: 200, json: async () => SEGMENTS }
       if (url.includes('/api/campaigns/cadences')) return { ok: true, status: 200, json: async () => CADENCES }
       if (url.includes('/api/campaigns/triggers')) return { ok: true, status: 200, json: async () => TRIGGERS }
+      if (url.includes('/api/campaigns/templates')) return { ok: true, status: 200, json: async () => TEMPLATES }
       if (url === '/api/campaigns') {
         createBody = JSON.parse(String(init?.body))
         return { ok: true, status: 200, json: async () => ({ state: 'ok', campaign: { id: CAMPAIGN_ID } }) }
@@ -145,6 +160,7 @@ describe('campaign studio', () => {
     render(React.createElement(Providers, null, React.createElement(NewCampaignPage)))
 
     await waitFor(() => expect(document.querySelector('[data-segment="actives@1"]')).toBeTruthy(), { timeout: 8000 })
+    await waitFor(() => expect(document.querySelector('[data-channel-pick="EMAIL"]')).toBeTruthy(), { timeout: 8000 })
     fireEvent.change(document.getElementById('c-name')!, { target: { value: 'Recurring welcome' } })
     fireEvent.change(document.getElementById('c-goal')!, { target: { value: 'Keep new customers engaged' } })
     fireEvent.click(document.querySelector('[data-segment="actives@1"]')!)
@@ -168,6 +184,7 @@ describe('campaign studio', () => {
       if (url.includes('/api/segments')) return { ok: true, status: 200, json: async () => SEGMENTS }
       if (url.includes('/api/campaigns/cadences')) return { ok: true, status: 200, json: async () => CADENCES }
       if (url.includes('/api/campaigns/triggers')) return { ok: true, status: 200, json: async () => TRIGGERS }
+      if (url.includes('/api/campaigns/templates')) return { ok: true, status: 200, json: async () => TEMPLATES }
       if (url === '/api/campaigns') {
         createBody = JSON.parse(String(init?.body))
         return { ok: true, status: 200, json: async () => ({ state: 'ok', campaign: { id: CAMPAIGN_ID } }) }
@@ -177,6 +194,7 @@ describe('campaign studio', () => {
     render(React.createElement(Providers, null, React.createElement(NewCampaignPage)))
 
     await waitFor(() => expect(document.querySelector('[data-segment="actives@1"]')).toBeTruthy(), { timeout: 8000 })
+    await waitFor(() => expect(document.querySelector('[data-channel-pick="EMAIL"]')).toBeTruthy(), { timeout: 8000 })
     fireEvent.change(document.getElementById('c-name')!, { target: { value: 'Two headlines' } })
     fireEvent.change(document.getElementById('c-goal')!, { target: { value: 'Open more accounts' } })
     fireEvent.click(document.querySelector('[data-segment="actives@1"]')!)
@@ -218,11 +236,13 @@ describe('campaign studio', () => {
       if (String(url).includes('/api/segments')) return { ok: true, status: 200, json: async () => SEGMENTS }
       if (String(url).includes('/cadences')) return { ok: true, status: 200, json: async () => CADENCES }
       if (String(url).includes('/triggers')) return { ok: true, status: 200, json: async () => TRIGGERS }
+      if (String(url).includes('/templates')) return { ok: true, status: 200, json: async () => TEMPLATES }
       return { ok: true, status: 200, json: async () => ({}) }
     }))
     render(React.createElement(Providers, null, React.createElement(NewCampaignPage)))
 
     await waitFor(() => expect(document.querySelector('[data-segment="actives@1"]')).toBeTruthy(), { timeout: 8000 })
+    await waitFor(() => expect(document.querySelector('[data-channel-pick="EMAIL"]')).toBeTruthy(), { timeout: 8000 })
     fireEvent.change(document.getElementById('c-name')!, { target: { value: 'Fallback offer' } })
     fireEvent.change(document.getElementById('c-goal')!, { target: { value: 'Open more accounts' } })
     fireEvent.click(document.querySelector('[data-segment="actives@1"]')!)

--- a/openbank-admin-ui/src/test/journey-editor.test.tsx
+++ b/openbank-admin-ui/src/test/journey-editor.test.tsx
@@ -25,6 +25,12 @@ const TPL_CHANNEL = {
   MARKETING_PRODUCT_OFFER_PRODUCT_FEED: 'BANNER' as const,
   MARKETING_PRODUCT_OFFER_REWARDS_HUB: 'BANNER' as const,
 }
+const TPL_SURFACE = {
+  HOME_BANNER: 'MARKETING_PRODUCT_OFFER_BANNER',
+  HOME_CAROUSEL: 'MARKETING_PRODUCT_OFFER_CAROUSEL',
+  PRODUCT_FEED: 'MARKETING_PRODUCT_OFFER_PRODUCT_FEED',
+  REWARDS_HUB: 'MARKETING_PRODUCT_OFFER_REWARDS_HUB',
+}
 
 // The editor labels a variable in the marketer's words. The mapping is data, so the test carries its
 // own copy — asserting the rendered label against the same map the component reads would be vacuous.
@@ -104,7 +110,7 @@ describe('step editor', () => {
     const { container } = render(
       React.createElement(LanguageProvider, null,
         React.createElement(StepEditor, {
-          index: 0, step: step(), templates: TEMPLATES, templateChannel: TPL_CHANNEL, templateLabels: LABELS, variableLabels: VAR_LABELS,
+          index: 0, step: step(), templates: TEMPLATES, templateChannel: TPL_CHANNEL, templateSurface: TPL_SURFACE, templateLabels: LABELS, variableLabels: VAR_LABELS,
           onChange: vi.fn(), onClose: vi.fn(),
         })))
 
@@ -122,7 +128,7 @@ describe('step editor', () => {
     render(
       React.createElement(LanguageProvider, null,
         React.createElement(StepEditor, {
-          index: 0, step: step(), templates: TEMPLATES, templateChannel: TPL_CHANNEL, templateLabels: LABELS, variableLabels: VAR_LABELS,
+          index: 0, step: step(), templates: TEMPLATES, templateChannel: TPL_CHANNEL, templateSurface: TPL_SURFACE, templateLabels: LABELS, variableLabels: VAR_LABELS,
           onChange, onClose: vi.fn(),
         })))
 
@@ -134,7 +140,7 @@ describe('step editor', () => {
     render(
       React.createElement(LanguageProvider, null,
         React.createElement(StepEditor, {
-          index: 0, step: step(0, { offerTitle: 'T' }), templates: TEMPLATES, templateChannel: TPL_CHANNEL, templateLabels: LABELS, variableLabels: VAR_LABELS,
+          index: 0, step: step(0, { offerTitle: 'T' }), templates: TEMPLATES, templateChannel: TPL_CHANNEL, templateSurface: TPL_SURFACE, templateLabels: LABELS, variableLabels: VAR_LABELS,
           onChange: vi.fn(), onClose: vi.fn(),
         })))
 
@@ -148,7 +154,7 @@ describe('step editor', () => {
     render(
       React.createElement(LanguageProvider, null,
         React.createElement(StepEditor, {
-          index: 0, step: step(), templates: TEMPLATES, templateChannel: TPL_CHANNEL, templateLabels: LABELS, variableLabels: VAR_LABELS,
+          index: 0, step: step(), templates: TEMPLATES, templateChannel: TPL_CHANNEL, templateSurface: TPL_SURFACE, templateLabels: LABELS, variableLabels: VAR_LABELS,
           onChange, onClose: vi.fn(),
         })))
 
@@ -166,7 +172,7 @@ describe('step editor', () => {
     render(
       React.createElement(LanguageProvider, null,
         React.createElement(StepEditor, {
-          index: 0, step: push, templates: TEMPLATES, templateChannel: TPL_CHANNEL, templateLabels: LABELS, variableLabels: VAR_LABELS,
+          index: 0, step: push, templates: TEMPLATES, templateChannel: TPL_CHANNEL, templateSurface: TPL_SURFACE, templateLabels: LABELS, variableLabels: VAR_LABELS,
           onChange, onClose: vi.fn(),
         })))
 
@@ -181,7 +187,7 @@ describe('step editor', () => {
     render(
       React.createElement(LanguageProvider, null,
         React.createElement(StepEditor, {
-          index: 0, step: step(), templates: TEMPLATES, templateChannel: TPL_CHANNEL, templateLabels: LABELS, variableLabels: VAR_LABELS,
+          index: 0, step: step(), templates: TEMPLATES, templateChannel: TPL_CHANNEL, templateSurface: TPL_SURFACE, templateLabels: LABELS, variableLabels: VAR_LABELS,
           onChange, onClose: vi.fn(),
         })))
 
@@ -200,7 +206,7 @@ describe('step editor', () => {
     render(
       React.createElement(LanguageProvider, null,
         React.createElement(StepEditor, {
-          index: 0, step: banner, templates: TEMPLATES, templateChannel: TPL_CHANNEL, templateLabels: LABELS, variableLabels: VAR_LABELS,
+          index: 0, step: banner, templates: TEMPLATES, templateChannel: TPL_CHANNEL, templateSurface: TPL_SURFACE, templateLabels: LABELS, variableLabels: VAR_LABELS,
           onChange, onClose: vi.fn(),
         })))
 
@@ -216,7 +222,7 @@ describe('step editor', () => {
     const { container } = render(
       React.createElement(LanguageProvider, null,
         React.createElement(StepEditor, {
-          index: 0, step: experimentStep, templates: TEMPLATES, templateChannel: TPL_CHANNEL, templateLabels: LABELS, variableLabels: VAR_LABELS,
+          index: 0, step: experimentStep, templates: TEMPLATES, templateChannel: TPL_CHANNEL, templateSurface: TPL_SURFACE, templateLabels: LABELS, variableLabels: VAR_LABELS,
           contentExperiment: true, onChange, onClose: vi.fn(),
         })))
 

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/usecase/CampaignService.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/usecase/CampaignService.kt
@@ -67,24 +67,12 @@ class CampaignService(
         schedule: CampaignSchedule? = null,
         trigger: String? = null,
     ): Campaign {
-        val segment = segments.load(segmentRef.name, segmentRef.version)
-            ?: throw NoSuchElementException("segment ${segmentRef.name}@${segmentRef.version} not found")
-        // Rejected here rather than at the consumer: a campaign carrying a key nobody watches would
-        // be approved, run, and report nothing, and the first person to notice would be whoever
-        // asked why it converted zero people (ADR-0245 D1).
-        require(conversionRule == null || ConversionCatalog.exists(conversionRule)) {
-            "unknown conversion rule '$conversionRule' — must be one of ${ConversionCatalog.ALL.keys.sorted()}"
-        }
-        // Same reasoning as the conversion rule: a key nobody watches would be approved, run, and
-        // never enrol anyone, and the first person to notice would ask why the campaign was empty.
-        require(trigger == null || TriggerCatalog.exists(trigger)) {
-            "unknown trigger '$trigger' — must be one of ${TriggerCatalog.ALL.keys.sorted()}"
-        }
+        val resolvedSegment = validateDraftReferences(segmentRef, conversionRule, trigger)
         val campaign = Campaign(
             id = Ids.newId(),
             name = name,
             goal = goal,
-            segmentRef = SegmentRef(segment.name, segment.version),
+            segmentRef = resolvedSegment,
             steps = steps.sortedBy { it.order },
             stopCondition = stopCondition,
             conversionRule = conversionRule,
@@ -101,6 +89,60 @@ class CampaignService(
             updatedAt = Instant.now(),
         )
         return campaigns.save(campaign)
+    }
+
+    /** A draft belongs to its maker until submitted; the request never supplies that identity. */
+    suspend fun reviseDraft(
+        id: UUID,
+        name: String,
+        goal: String,
+        segmentRef: SegmentRef,
+        steps: List<CampaignStep>,
+        revisedBy: String,
+        stopCondition: StopCondition? = null,
+        conversionRule: String? = null,
+        holdoutPercent: Int = 0,
+        schedule: CampaignSchedule? = null,
+        trigger: String? = null,
+    ): Campaign {
+        val existing = campaigns.findById(id) ?: throw NoSuchElementException("campaign $id not found")
+        require(existing.createdBy == revisedBy) { "only the campaign maker can revise this draft" }
+        val resolvedSegment = validateDraftReferences(segmentRef, conversionRule, trigger)
+        return campaigns.save(
+            existing.revise(
+                name = name,
+                goal = goal,
+                segmentRef = resolvedSegment,
+                steps = steps,
+                stopCondition = stopCondition,
+                conversionRule = conversionRule,
+                holdoutPercent = holdoutPercent,
+                schedule = schedule,
+                trigger = trigger,
+            ),
+        )
+    }
+
+    /** Keeps create and draft revision tied to the same reviewed catalogue boundary. */
+    private suspend fun validateDraftReferences(
+        segmentRef: SegmentRef,
+        conversionRule: String?,
+        trigger: String?,
+    ): SegmentRef {
+        val segment = segments.load(segmentRef.name, segmentRef.version)
+            ?: throw NoSuchElementException("segment ${segmentRef.name}@${segmentRef.version} not found")
+        // Rejected here rather than at the consumer: a campaign carrying a key nobody watches would
+        // be approved, run, and report nothing, and the first person to notice would be whoever
+        // asked why it converted zero people (ADR-0245 D1).
+        require(conversionRule == null || ConversionCatalog.exists(conversionRule)) {
+            "unknown conversion rule '$conversionRule' — must be one of ${ConversionCatalog.ALL.keys.sorted()}"
+        }
+        // Same reasoning as the conversion rule: a key nobody watches would be approved, run, and
+        // never enrol anyone, and the first person to notice would ask why the campaign was empty.
+        require(trigger == null || TriggerCatalog.exists(trigger)) {
+            "unknown trigger '$trigger' — must be one of ${TriggerCatalog.ALL.keys.sorted()}"
+        }
+        return SegmentRef(segment.name, segment.version)
     }
 
     suspend fun get(id: UUID): Campaign? = campaigns.findById(id)

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/usecase/CampaignService.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/usecase/CampaignService.kt
@@ -11,6 +11,7 @@ import com.openbank.campaign.application.port.out.JourneySignaller
 import com.openbank.campaign.application.port.out.SegmentEvaluationPort
 import com.openbank.campaign.application.port.out.SegmentRegistry
 import com.openbank.campaign.domain.model.Campaign
+import com.openbank.campaign.domain.model.CampaignDefinition
 import com.openbank.campaign.domain.model.CampaignSchedule
 import com.openbank.campaign.domain.model.CampaignState
 import com.openbank.campaign.domain.model.CampaignStep
@@ -44,6 +45,7 @@ data class EnrolmentOutcome(val enrolled: Int, val failed: Int)
  * [Campaign.activate] — a domain rule, not a UI convention.
  */
 @ApplicationScoped
+@Suppress("TooManyFunctions") // Lifecycle actions are separate authenticated use cases, not helpers.
 class CampaignService(
     private val campaigns: CampaignRepository,
     private val enrolments: EnrolmentRepository,
@@ -92,34 +94,16 @@ class CampaignService(
     }
 
     /** A draft belongs to its maker until submitted; the request never supplies that identity. */
-    suspend fun reviseDraft(
-        id: UUID,
-        name: String,
-        goal: String,
-        segmentRef: SegmentRef,
-        steps: List<CampaignStep>,
-        revisedBy: String,
-        stopCondition: StopCondition? = null,
-        conversionRule: String? = null,
-        holdoutPercent: Int = 0,
-        schedule: CampaignSchedule? = null,
-        trigger: String? = null,
-    ): Campaign {
+    suspend fun reviseDraft(id: UUID, definition: CampaignDefinition, revisedBy: String): Campaign {
         val existing = campaigns.findById(id) ?: throw NoSuchElementException("campaign $id not found")
         require(existing.createdBy == revisedBy) { "only the campaign maker can revise this draft" }
-        val resolvedSegment = validateDraftReferences(segmentRef, conversionRule, trigger)
+        val resolvedSegment = validateDraftReferences(
+            definition.segmentRef,
+            definition.conversionRule,
+            definition.trigger,
+        )
         return campaigns.save(
-            existing.revise(
-                name = name,
-                goal = goal,
-                segmentRef = resolvedSegment,
-                steps = steps,
-                stopCondition = stopCondition,
-                conversionRule = conversionRule,
-                holdoutPercent = holdoutPercent,
-                schedule = schedule,
-                trigger = trigger,
-            ),
+            existing.revise(definition.copy(segmentRef = resolvedSegment)),
         )
     }
 

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/domain/model/Campaign.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/domain/model/Campaign.kt
@@ -11,6 +11,23 @@ import java.time.Instant
 import java.util.UUID
 
 /**
+ * The editable definition of a draft, deliberately separate from [Campaign]'s server-owned
+ * identity, lifecycle and audit fields. A maker supplies this whole value; revision can therefore
+ * never accidentally preserve an old field merely because another endpoint forgot to pass it.
+ */
+data class CampaignDefinition(
+    val name: String,
+    val goal: String,
+    val segmentRef: SegmentRef,
+    val steps: List<CampaignStep>,
+    val stopCondition: StopCondition? = null,
+    val conversionRule: String? = null,
+    val holdoutPercent: Int = 0,
+    val schedule: CampaignSchedule? = null,
+    val trigger: String? = null,
+)
+
+/**
  * Campaign aggregate (ADR-0200). A definition — steps, delays, stop conditions — that is executed
  * as one Temporal workflow per enrolled party. Content is composed from the notification-service
  * template catalogue with declared variables; free-form bodies are rejected by construction
@@ -90,28 +107,18 @@ data class Campaign(
      * exact reviewed definition is immutable: changing it afterwards would make the checker
      * approve one journey while a different one is actually run.
      */
-    fun revise(
-        name: String,
-        goal: String,
-        segmentRef: SegmentRef,
-        steps: List<CampaignStep>,
-        stopCondition: StopCondition?,
-        conversionRule: String?,
-        holdoutPercent: Int,
-        schedule: CampaignSchedule?,
-        trigger: String?,
-    ): Campaign {
+    fun revise(definition: CampaignDefinition): Campaign {
         require(state == CampaignState.DRAFT) { "only a DRAFT campaign can be revised" }
         return copy(
-            name = name,
-            goal = goal,
-            segmentRef = segmentRef,
-            steps = steps.sortedBy { it.order },
-            stopCondition = stopCondition,
-            conversionRule = conversionRule,
-            holdoutPercent = holdoutPercent,
-            schedule = schedule,
-            trigger = trigger,
+            name = definition.name,
+            goal = definition.goal,
+            segmentRef = definition.segmentRef,
+            steps = definition.steps.sortedBy { it.order },
+            stopCondition = definition.stopCondition,
+            conversionRule = definition.conversionRule,
+            holdoutPercent = definition.holdoutPercent,
+            schedule = definition.schedule,
+            trigger = definition.trigger,
             updatedAt = Instant.now(),
         )
     }

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/domain/model/Campaign.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/domain/model/Campaign.kt
@@ -85,6 +85,37 @@ data class Campaign(
         return copy(state = CampaignState.PENDING_APPROVAL, updatedAt = Instant.now())
     }
 
+    /**
+     * A maker may revise the definition while it is still a draft.  Once it enters approval, the
+     * exact reviewed definition is immutable: changing it afterwards would make the checker
+     * approve one journey while a different one is actually run.
+     */
+    fun revise(
+        name: String,
+        goal: String,
+        segmentRef: SegmentRef,
+        steps: List<CampaignStep>,
+        stopCondition: StopCondition?,
+        conversionRule: String?,
+        holdoutPercent: Int,
+        schedule: CampaignSchedule?,
+        trigger: String?,
+    ): Campaign {
+        require(state == CampaignState.DRAFT) { "only a DRAFT campaign can be revised" }
+        return copy(
+            name = name,
+            goal = goal,
+            segmentRef = segmentRef,
+            steps = steps.sortedBy { it.order },
+            stopCondition = stopCondition,
+            conversionRule = conversionRule,
+            holdoutPercent = holdoutPercent,
+            schedule = schedule,
+            trigger = trigger,
+            updatedAt = Instant.now(),
+        )
+    }
+
     fun activate(approver: String): Campaign {
         require(state == CampaignState.PENDING_APPROVAL) { "only a PENDING_APPROVAL campaign can activate" }
         require(approver != createdBy) { "maker/checker: the approver must differ from the creator (ADR-0200 D5)" }

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/domain/model/TemplateCatalog.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/domain/model/TemplateCatalog.kt
@@ -83,6 +83,10 @@ object TemplateCatalog {
         InAppSurface.REWARDS_HUB -> "MARKETING_PRODUCT_OFFER_REWARDS_HUB"
     }
 
+    /** The app placement a banner template is approved to render on, or null for dispatched channels. */
+    fun inAppSurfaceFor(template: String): InAppSurface? =
+        InAppSurface.entries.firstOrNull { templateForInAppSurface(it) == template }
+
     fun exists(template: String): Boolean = template in ALL
 
     /**

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/rest/CampaignResource.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/rest/CampaignResource.kt
@@ -5,6 +5,7 @@
 package com.openbank.campaign.infrastructure.rest
 
 import com.openbank.campaign.application.usecase.CampaignService
+import com.openbank.campaign.domain.model.CampaignDefinition
 import com.openbank.campaign.domain.model.CampaignSchedule
 import com.openbank.campaign.domain.model.CampaignStep
 import com.openbank.campaign.domain.model.Channel
@@ -112,8 +113,8 @@ data class ApprovalRequest(val approver: String? = null)
 /**
  * The authenticated caller — recorded as the maker on create and as the checker on activate.
  *
- * A top-level extension rather than a method: `CampaignResource` sits exactly at detekt's
- * `TooManyFunctions` threshold of 11, which fires AT the limit, so a private helper costs the gate.
+ * A top-level extension rather than a method: lifecycle endpoints remain separately authorized,
+ * while this keeps identity extraction outside the HTTP adapter's public surface.
  */
 private fun JsonWebToken.principalName(): String = name ?: subject ?: "unknown"
 
@@ -135,6 +136,18 @@ private fun CreateCampaignRequest.toSteps(): List<CampaignStep> = steps.map {
     )
 }
 
+private fun CreateCampaignRequest.toDefinition(): CampaignDefinition = CampaignDefinition(
+    name = name,
+    goal = goal,
+    segmentRef = SegmentRef(segmentName, segmentVersion),
+    steps = toSteps(),
+    stopCondition = stopCondition?.let { StopCondition(it.maxSendsPerParty) },
+    conversionRule = conversionRule,
+    holdoutPercent = holdoutPercent,
+    schedule = schedule?.let { CampaignSchedule(it.cadence, it.endAt) },
+    trigger = trigger,
+)
+
 /**
  * Operator API for the campaign first slice (ADR-0200). Activation is four-eyes gated by the
  * `campaign.activate` action (rules.yaml four_eyes.actions) and re-asserted by the domain
@@ -142,6 +155,7 @@ private fun CreateCampaignRequest.toSteps(): List<CampaignStep> = steps.map {
  */
 @Path("/api/v1/campaigns")
 @ApplicationScoped
+@Suppress("TooManyFunctions") // Each method is a separately authorised lifecycle endpoint.
 class CampaignResource(private val service: CampaignService, private val jwt: JsonWebToken) {
 
     @GET
@@ -181,16 +195,8 @@ class CampaignResource(private val service: CampaignService, private val jwt: Js
         Response.ok(
             service.reviseDraft(
                 id = id,
-                name = request.name,
-                goal = request.goal,
-                segmentRef = SegmentRef(request.segmentName, request.segmentVersion),
-                steps = request.toSteps(),
+                definition = request.toDefinition(),
                 revisedBy = jwt.principalName(),
-                stopCondition = request.stopCondition?.let { StopCondition(it.maxSendsPerParty) },
-                conversionRule = request.conversionRule,
-                holdoutPercent = request.holdoutPercent,
-                schedule = request.schedule?.let { CampaignSchedule(it.cadence, it.endAt) },
-                trigger = request.trigger,
             ),
         ).build()
     }.getOrElse { Response.status(Response.Status.CONFLICT).entity(mapOf("error" to it.message)).build() }

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/rest/CampaignResource.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/rest/CampaignResource.kt
@@ -17,6 +17,7 @@ import com.openbank.libs.authz.Authorize
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.ws.rs.GET
 import jakarta.ws.rs.POST
+import jakarta.ws.rs.PUT
 import jakarta.ws.rs.Path
 import jakarta.ws.rs.PathParam
 import jakarta.ws.rs.core.Response
@@ -116,6 +117,24 @@ data class ApprovalRequest(val approver: String? = null)
  */
 private fun JsonWebToken.principalName(): String = name ?: subject ?: "unknown"
 
+private fun CreateCampaignRequest.toSteps(): List<CampaignStep> = steps.map {
+    CampaignStep(
+        it.order,
+        it.template,
+        it.channel,
+        it.variables,
+        it.delaySeconds,
+        it.condition,
+        it.variantBVariables,
+        it.fallbackToPush,
+        it.mobileDestination,
+        it.inAppSurface,
+        it.variantBTemplate,
+        it.variantBChannel,
+        it.variantBDelaySeconds,
+    )
+}
+
 /**
  * Operator API for the campaign first slice (ADR-0200). Activation is four-eyes gated by the
  * `campaign.activate` action (rules.yaml four_eyes.actions) and re-asserted by the domain
@@ -139,28 +158,11 @@ class CampaignResource(private val service: CampaignService, private val jwt: Js
     @Authorize(action = "campaign.create", resource = "#request.name")
     suspend fun create(request: CreateCampaignRequest): Response {
         val createdBy = jwt.principalName()
-        val steps = request.steps.map {
-            CampaignStep(
-                it.order,
-                it.template,
-                it.channel,
-                it.variables,
-                it.delaySeconds,
-                it.condition,
-                it.variantBVariables,
-                it.fallbackToPush,
-                it.mobileDestination,
-                it.inAppSurface,
-                it.variantBTemplate,
-                it.variantBChannel,
-                it.variantBDelaySeconds,
-            )
-        }
         val campaign = service.createDraft(
             request.name,
             request.goal,
             SegmentRef(request.segmentName, request.segmentVersion),
-            steps,
+            request.toSteps(),
             createdBy,
             request.stopCondition?.let { StopCondition(it.maxSendsPerParty) },
             request.conversionRule,
@@ -170,6 +172,28 @@ class CampaignResource(private val service: CampaignService, private val jwt: Js
         )
         return Response.status(Response.Status.CREATED).entity(campaign).build()
     }
+
+    /** The authenticated maker may revise only the unsubmitted definition. */
+    @PUT
+    @Path("/{id}")
+    @Authorize(action = "campaign.create", resource = "#id")
+    suspend fun revise(@PathParam("id") id: UUID, request: CreateCampaignRequest): Response = runCatching {
+        Response.ok(
+            service.reviseDraft(
+                id = id,
+                name = request.name,
+                goal = request.goal,
+                segmentRef = SegmentRef(request.segmentName, request.segmentVersion),
+                steps = request.toSteps(),
+                revisedBy = jwt.principalName(),
+                stopCondition = request.stopCondition?.let { StopCondition(it.maxSendsPerParty) },
+                conversionRule = request.conversionRule,
+                holdoutPercent = request.holdoutPercent,
+                schedule = request.schedule?.let { CampaignSchedule(it.cadence, it.endAt) },
+                trigger = request.trigger,
+            ),
+        ).build()
+    }.getOrElse { Response.status(Response.Status.CONFLICT).entity(mapOf("error" to it.message)).build() }
 
     @POST
     @Path("/{id}/submit")

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/rest/CampaignTemplateCatalogResource.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/rest/CampaignTemplateCatalogResource.kt
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+package com.openbank.campaign.infrastructure.rest
+
+import com.openbank.campaign.domain.model.Channel
+import com.openbank.campaign.domain.model.InAppSurface
+import com.openbank.campaign.domain.model.TemplateCatalog
+import com.openbank.libs.authz.Authorize
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.ws.rs.GET
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.core.Response
+
+/** A reviewed content choice the Campaign Studio may offer for one journey step. */
+data class CampaignTemplateSummary(
+    val template: String,
+    val channel: Channel,
+    val variables: List<String>,
+    val inAppSurface: InAppSurface? = null,
+)
+
+/**
+ * The content catalogue for Campaign Studio.
+ *
+ * Templates are deliberately served from the same closed catalogue the aggregate validates.  A
+ * front-end copy inevitably drifts: a newly approved app surface either remains invisible to a
+ * marketer or appears as a stale choice the server no longer accepts.  This endpoint is read-only;
+ * adding a template remains reviewed code, never a browser-authored message or markup.
+ */
+@Path("/api/v1/campaigns/templates")
+@ApplicationScoped
+class CampaignTemplateCatalogResource {
+
+    @GET
+    @Authorize(action = "campaign.read", resource = "#id")
+    suspend fun templates(): Response = Response.ok(
+        TemplateCatalog.ALL.keys.sorted().map { template ->
+            CampaignTemplateSummary(
+                template = template,
+                channel = checkNotNull(TemplateCatalog.CHANNEL_OF[template]),
+                variables = TemplateCatalog.ALL.getValue(template).sorted(),
+                inAppSurface = TemplateCatalog.inAppSurfaceFor(template),
+            )
+        },
+    ).build()
+}

--- a/openbank-campaign-service/src/main/resources/openapi.yaml
+++ b/openbank-campaign-service/src/main/resources/openapi.yaml
@@ -4,7 +4,7 @@ openapi: 3.1.0
 info:
   title: Campaign Service API
   # major == openbank.api.version == URL /api/v1 (ADR-0048).
-  version: 1.28.0
+  version: 1.29.0
   description: >-
     Campaign management first slice (ADR-0200 / ADR-0209 D3): deterministic, versioned segments;
     per-enrolment Temporal journeys; consent-gated delivery through notification-service.
@@ -202,6 +202,30 @@ paths:
                 $ref: '#/components/schemas/Campaign'
         '404':
           description: Not found
+    put:
+      tags: [Campaigns]
+      summary: Revise the authenticated maker's unsubmitted campaign draft
+      description: >-
+        A DRAFT may be revised only by its recorded maker. Once submitted, the approved definition
+        is immutable through this endpoint so the checker always approves the journey that runs.
+      operationId: reviseCampaignDraft
+      parameters:
+        - $ref: '#/components/parameters/CampaignId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateCampaignRequest'
+      responses:
+        '200':
+          description: Draft revised
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Campaign'
+        '409':
+          description: Campaign is not a draft, caller is not its maker, or the definition is invalid
   /api/v1/campaigns/{id}/submit:
     post:
       tags: [Campaigns]

--- a/openbank-campaign-service/src/main/resources/openapi.yaml
+++ b/openbank-campaign-service/src/main/resources/openapi.yaml
@@ -4,7 +4,7 @@ openapi: 3.1.0
 info:
   title: Campaign Service API
   # major == openbank.api.version == URL /api/v1 (ADR-0048).
-  version: 1.29.0
+  version: 1.30.0
   description: >-
     Campaign management first slice (ADR-0200 / ADR-0209 D3): deterministic, versioned segments;
     per-enrolment Temporal journeys; consent-gated delivery through notification-service.
@@ -186,6 +186,37 @@ paths:
                   properties:
                     trigger: { type: string, example: ACCOUNT_OPENED }
                     humanForm: { type: string, example: when an account is opened }
+  /api/v1/campaigns/templates:
+    get:
+      tags: [Campaigns]
+      summary: Reviewed cross-channel templates available to Campaign Studio
+      operationId: listCampaignTemplates
+      description: >-
+        The exact closed content catalogue the aggregate accepts. It is served so Studio never
+        duplicates a stale e-mail, push, banner, carousel, product-feed, or rewards-hub option.
+        Templates remain reviewed code; this endpoint does not accept marketer-authored markup.
+        NOTE the literal path segment: it must keep matching ahead of /api/v1/campaigns/{id}.
+      responses:
+        '200':
+          description: Every marketing template with its channel, named variables, and app surface where applicable
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  required: [template, channel, variables]
+                  properties:
+                    template: { type: string, example: MARKETING_PRODUCT_OFFER_BANNER }
+                    channel: { type: string, enum: [EMAIL, PUSH, BANNER] }
+                    variables:
+                      type: array
+                      items: { type: string }
+                      example: [offerTitle, offerText, ctaText]
+                    inAppSurface:
+                      type: string
+                      nullable: true
+                      enum: [HOME_BANNER, HOME_CAROUSEL, PRODUCT_FEED, REWARDS_HUB]
   /api/v1/campaigns/{id}:
     get:
       tags: [Campaigns]

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/CampaignDraftRevisionTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/CampaignDraftRevisionTest.kt
@@ -11,6 +11,7 @@ import com.openbank.campaign.application.port.out.SegmentEvaluationPort
 import com.openbank.campaign.application.port.out.SegmentRegistry
 import com.openbank.campaign.application.usecase.CampaignService
 import com.openbank.campaign.domain.model.Campaign
+import com.openbank.campaign.domain.model.CampaignDefinition
 import com.openbank.campaign.domain.model.CampaignState
 import com.openbank.campaign.domain.model.CampaignStep
 import com.openbank.campaign.domain.model.Channel
@@ -52,10 +53,12 @@ class CampaignDraftRevisionTest {
 
         val revised = service.reviseDraft(
             id = campaignId,
-            name = "Savings nudge v2",
-            goal = draft.goal,
-            segmentRef = draft.segmentRef,
-            steps = draft.steps,
+            definition = CampaignDefinition(
+                name = "Savings nudge v2",
+                goal = draft.goal,
+                segmentRef = draft.segmentRef,
+                steps = draft.steps,
+            ),
             revisedBy = "maker@openbank.test",
         )
 
@@ -66,10 +69,7 @@ class CampaignDraftRevisionTest {
         assertThrows<IllegalArgumentException> {
             service.reviseDraft(
                 id = campaignId,
-                name = draft.name,
-                goal = draft.goal,
-                segmentRef = draft.segmentRef,
-                steps = draft.steps,
+                definition = CampaignDefinition(draft.name, draft.goal, draft.segmentRef, draft.steps),
                 revisedBy = "other@openbank.test",
             )
         }

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/CampaignDraftRevisionTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/CampaignDraftRevisionTest.kt
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+package com.openbank.campaign.application
+
+import com.openbank.campaign.application.port.out.CampaignRepository
+import com.openbank.campaign.application.port.out.CampaignScheduler
+import com.openbank.campaign.application.port.out.EnrolmentRepository
+import com.openbank.campaign.application.port.out.JourneySignaller
+import com.openbank.campaign.application.port.out.SegmentEvaluationPort
+import com.openbank.campaign.application.port.out.SegmentRegistry
+import com.openbank.campaign.application.usecase.CampaignService
+import com.openbank.campaign.domain.model.Campaign
+import com.openbank.campaign.domain.model.CampaignState
+import com.openbank.campaign.domain.model.CampaignStep
+import com.openbank.campaign.domain.model.Channel
+import com.openbank.campaign.domain.model.Segment
+import com.openbank.campaign.domain.model.SegmentRef
+import com.openbank.campaign.domain.model.SegmentRule
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.Instant
+import java.util.UUID
+
+class CampaignDraftRevisionTest {
+
+    private val campaignId = UUID.randomUUID()
+    private val draft = Campaign(
+        id = campaignId,
+        name = "Savings nudge",
+        goal = "Open a savings account",
+        segmentRef = SegmentRef("actives", 1),
+        steps = listOf(CampaignStep(1, "MARKETING_PRODUCT_OFFER", Channel.EMAIL, emptyMap(), 0)),
+        state = CampaignState.DRAFT,
+        createdBy = "maker@openbank.test",
+        approvedBy = null,
+        createdAt = Instant.parse("2026-08-13T08:00:00Z"),
+        updatedAt = Instant.parse("2026-08-13T08:00:00Z"),
+    )
+
+    @Test
+    fun `only the recorded maker can revise an unsubmitted draft`(): Unit = runBlocking {
+        val campaigns = mockk<CampaignRepository>()
+        coEvery { campaigns.findById(campaignId) } returns draft
+        coEvery { campaigns.save(any()) } answers { firstArg<Campaign>() }
+        val service = service(campaigns)
+
+        val revised = service.reviseDraft(
+            id = campaignId,
+            name = "Savings nudge v2",
+            goal = draft.goal,
+            segmentRef = draft.segmentRef,
+            steps = draft.steps,
+            revisedBy = "maker@openbank.test",
+        )
+
+        assertThat(revised.name).isEqualTo("Savings nudge v2")
+        assertThat(revised.createdBy).isEqualTo("maker@openbank.test")
+        coVerify(exactly = 1) { campaigns.save(any()) }
+
+        assertThrows<IllegalArgumentException> {
+            service.reviseDraft(
+                id = campaignId,
+                name = draft.name,
+                goal = draft.goal,
+                segmentRef = draft.segmentRef,
+                steps = draft.steps,
+                revisedBy = "other@openbank.test",
+            )
+        }
+        coVerify(exactly = 1) { campaigns.save(any()) }
+    }
+
+    private fun service(campaigns: CampaignRepository): CampaignService {
+        val segment = Segment("actives", 1, listOf(SegmentRule.PartyStatusIs("ACTIVE")))
+        return CampaignService(
+            campaigns = campaigns,
+            enrolments = mockk<EnrolmentRepository>(),
+            segments = object : SegmentRegistry {
+                override suspend fun load(name: String, version: Int): Segment? = segment
+                override suspend fun save(segment: Segment): Segment = segment
+                override suspend fun list(): List<Segment> = listOf(segment)
+            },
+            segmentEvaluation = mockk<SegmentEvaluationPort>(),
+            journeys = mockk<JourneySignaller>(),
+            scheduler = mockk<CampaignScheduler>(),
+        )
+    }
+}

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/domain/CampaignStateMachineTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/domain/CampaignStateMachineTest.kt
@@ -36,6 +36,29 @@ class CampaignStateMachineTest {
     }
 
     @Test
+    fun `only a draft can be revised`() {
+        val revised = draft().revise(
+            name = "Jarní vklady",
+            goal = "Zvýšit spoření",
+            segmentRef = SegmentRef("saver-high-balance", 1),
+            steps = listOf(CampaignStep(0, "MARKETING_PRODUCT_OFFER", Channel.EMAIL, mapOf("offerTitle" to "4 %"), 0)),
+            stopCondition = null,
+            conversionRule = null,
+            holdoutPercent = 0,
+            schedule = null,
+            trigger = null,
+        )
+
+        assertEquals("Jarní vklady", revised.name)
+        assertEquals("maker", revised.createdBy)
+        assertThrows<IllegalArgumentException> {
+            draft().submit().revise(
+                "Nesmí projít", "", SegmentRef("saver-high-balance", 1), emptyList(), null, null, 0, null, null,
+            )
+        }
+    }
+
+    @Test
     fun `only pending approval can activate`() {
         assertThrows<IllegalArgumentException> { draft().activate("checker") }
     }

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/domain/CampaignStateMachineTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/domain/CampaignStateMachineTest.kt
@@ -5,6 +5,7 @@
 package com.openbank.campaign.domain
 
 import com.openbank.campaign.domain.model.Campaign
+import com.openbank.campaign.domain.model.CampaignDefinition
 import com.openbank.campaign.domain.model.CampaignState
 import com.openbank.campaign.domain.model.CampaignStep
 import com.openbank.campaign.domain.model.Channel
@@ -38,22 +39,32 @@ class CampaignStateMachineTest {
     @Test
     fun `only a draft can be revised`() {
         val revised = draft().revise(
-            name = "Jarní vklady",
-            goal = "Zvýšit spoření",
-            segmentRef = SegmentRef("saver-high-balance", 1),
-            steps = listOf(CampaignStep(0, "MARKETING_PRODUCT_OFFER", Channel.EMAIL, mapOf("offerTitle" to "4 %"), 0)),
-            stopCondition = null,
-            conversionRule = null,
-            holdoutPercent = 0,
-            schedule = null,
-            trigger = null,
+            CampaignDefinition(
+                name = "Jarní vklady",
+                goal = "Zvýšit spoření",
+                segmentRef = SegmentRef("saver-high-balance", 1),
+                steps = listOf(
+                    CampaignStep(
+                        order = 0,
+                        template = "MARKETING_PRODUCT_OFFER",
+                        channel = Channel.EMAIL,
+                        variables = mapOf("offerTitle" to "4 %"),
+                        delaySeconds = 0,
+                    ),
+                ),
+            ),
         )
 
         assertEquals("Jarní vklady", revised.name)
         assertEquals("maker", revised.createdBy)
         assertThrows<IllegalArgumentException> {
             draft().submit().revise(
-                "Nesmí projít", "", SegmentRef("saver-high-balance", 1), emptyList(), null, null, 0, null, null,
+                CampaignDefinition(
+                    name = "Nesmí projít",
+                    goal = "",
+                    segmentRef = SegmentRef("saver-high-balance", 1),
+                    steps = emptyList(),
+                ),
             )
         }
     }

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/integration/CampaignRestContractIT.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/integration/CampaignRestContractIT.kt
@@ -544,6 +544,32 @@ class CampaignRestContractIT {
         }
     }
 
+    /** Studio reads the exact catalogue the aggregate validates, including authenticated app placement. */
+    @Test
+    fun `the template catalogue serves channels declared variables and in-app surfaces`() {
+        When {
+            get("/api/v1/campaigns/templates")
+        } Then {
+            statusCode(200)
+            body(
+                "template",
+                org.hamcrest.Matchers.hasItems("MARKETING_PRODUCT_OFFER", "MARKETING_PRODUCT_OFFER_BANNER"),
+            )
+            body(
+                "find { it.template == 'MARKETING_PRODUCT_OFFER_PUSH' }.channel",
+                org.hamcrest.Matchers.equalTo("PUSH"),
+            )
+            body(
+                "find { it.template == 'MARKETING_PRODUCT_OFFER_PUSH' }.variables",
+                org.hamcrest.Matchers.contains("offerTitle"),
+            )
+            body(
+                "find { it.template == 'MARKETING_PRODUCT_OFFER_BANNER' }.inAppSurface",
+                org.hamcrest.Matchers.equalTo("HOME_BANNER"),
+            )
+        }
+    }
+
     /** A trigger key survives the round trip, so a campaign can declare what wakes it. */
     @Test
     fun `a campaign can declare a trigger and reads it back`() {

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/integration/CampaignRestContractIT.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/integration/CampaignRestContractIT.kt
@@ -85,6 +85,30 @@ class CampaignRestContractIT {
 
     private fun submit(id: String) = When { post("/api/v1/campaigns/$id/submit") } Then { statusCode(200) }
 
+    @Test
+    fun `maker can revise an unsubmitted draft through the HTTP contract`() {
+        val id = createDraft()
+        val revisedName = "revised-${UUID.randomUUID()}"
+
+        Given {
+            contentType("application/json")
+            body(draftBody(revisedName))
+        } When {
+            put("/api/v1/campaigns/$id")
+        } Then {
+            statusCode(200)
+            body("name", equalTo(revisedName))
+            body("state", equalTo("DRAFT"))
+        }
+
+        When {
+            get("/api/v1/campaigns/$id")
+        } Then {
+            statusCode(200)
+            body("name", equalTo(revisedName))
+        }
+    }
+
     private fun insertEnrolment(
         campaignId: UUID,
         state: String,


### PR DESCRIPTION
Closes #4656

## Outcome

A maker can open and revise only their own DRAFT in Campaign Studio before submitting it to the existing independent approval flow.

## Safety

- campaign-service derives the maker from the authenticated token; the browser cannot choose it.
- Revision is refused after submit, so the checker approves the exact definition that can run.
- The BFF removes server-owned audit/lifecycle fields before forwarding a revision request.
- The same versioned segment, content, schedule, trigger and conversion catalogues validate create and revision.

## Verification

- Focused domain tests: CampaignDraftRevisionTest and CampaignStateMachineTest passed.
- Admin UI TypeScript check passed.
- Added a real HTTP contract test for PUT revision and BFF relay coverage; full CI remains the release gate.