### PR TITLE
fix(ci): retry the spot-kill re-run API call on a transient 5xx

### DIFF
--- a/.github/workflows/auto-retry-cancelled.yml
+++ b/.github/workflows/auto-retry-cancelled.yml
@@ -108,11 +108,75 @@ jobs:
       - name: Re-run only if the runner was reclaimed
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Belt AND braces with the `-R` on every call (see the header note): this job has no
+          # actions/checkout, so without one of the two `gh` exits 1 with "failed to determine
+          # base repo" — the defect behind 208 silent failures (#2898). `-R` stays because it
+          # is the explicit one; GH_REPO covers any `gh` call added later that forgets it, and
+          # is what check-gh-repo-context.py reads at PR time.
+          GH_REPO: ${{ github.repository }}
           RUN_ID: ${{ github.event.workflow_run.id }}
           RUN_URL: ${{ github.event.workflow_run.html_url }}
           CONCLUSION: ${{ github.event.workflow_run.conclusion }}
         run: |
           set -euo pipefail
+
+          # ── EVIDENCE (issue #4595) ──────────────────────────────────────────────────
+          # Every exit path records ONE line saying what was examined and what was decided,
+          # into the job summary as well as the log. Before this, a no-op and a success were
+          # both "green with a notice buried in a log nobody opens", so the only observable
+          # difference between "the control ran and correctly declined" and "the control ran
+          # and did nothing because it could not tell" was a log download. `decision=` is the
+          # field to read; it is one of skipped-queue-cancel / rerun-cancelled /
+          # no-spot-kill-signature / jobs-unreadable / rerun-partial.
+          decide() { # decide <decision> <human sentence>
+            echo "spot-kill-auto-retry run=${RUN_ID} conclusion=${CONCLUSION} decision=$1"
+            echo "| \`${CONCLUSION}\` | [${RUN_ID}](${RUN_URL}) | \`$1\` | $2 |" \
+              >> "${GITHUB_STEP_SUMMARY:-/dev/null}"
+          }
+          printf '%s\n' \
+            '| triggering conclusion | run | decision | detail |' \
+            '|---|---|---|---|' >> "${GITHUB_STEP_SUMMARY:-/dev/null}"
+
+          # ── TRANSIENT-FAILURE RETRY (issue #4595) ───────────────────────────────────
+          # The re-run API call itself can fail transiently, and when it does the whole point
+          # of this workflow is lost: the reclaimed run stays red and waits for the human
+          # round-trip #2330 removed. Measured on run 31710803432 — detection was correct
+          # ("1 job(s) interrupted mid-flight"), and `gh run rerun` answered
+          #   failed to rerun: HTTP 502: Server Error
+          # with no retry, so the step exited 1, raise-issue filed #4595, and the target run
+          # (31710216158) only reached attempt 2 seventeen minutes later by a human hand.
+          # Note what that failure was NOT: not "never triggered" and not "never detected" —
+          # 3 of 10 sampled runs the same day issued a real re-run that landed as attempt 2.
+          # Only 5xx / 429 / a transport error are retried. A 403/404/422 is a real answer
+          # (run too old, already re-running, no permission); retrying those just burns the
+          # budget and delays the alarm, so they fail immediately.
+          rerun_with_retry() {
+            # Written with `if ... fi`, never `[ x ] && cmd`, because a trailing AND-list that
+            # evaluates false is a FAILING last command and `set -e` would exit the whole step
+            # from inside the success path — the shape that turns a retry helper into a new
+            # silent failure.
+            local out
+            for attempt in 1 2 3; do
+              if out="$(gh run rerun -R "${GITHUB_REPOSITORY}" "$@" 2>&1)"; then
+                echo "${out}"
+                if [ "${attempt}" -gt 1 ]; then
+                  echo "gh run rerun succeeded on attempt ${attempt}/3 after a transient error"
+                fi
+                return 0
+              fi
+              echo "gh run rerun attempt ${attempt}/3 failed: ${out}"
+              case "${out}" in
+                *"HTTP 5"*|*"HTTP 429"*|*"Server Error"*|*"connection reset"*|*"EOF"*|*"timeout"*) ;;
+                *) echo "::error title=spot-kill auto-retry::Non-transient error from gh run rerun; not retrying: ${out}"
+                   return 1 ;;
+              esac
+              if [ "${attempt}" -lt 3 ]; then
+                sleep $((attempt * 15))
+              fi
+            done
+            echo "::error title=spot-kill auto-retry::gh run rerun failed 3/3 times on ${RUN_URL} (last: ${out}). Needs a manual re-run."
+            return 1
+          }
 
           if [ "${CONCLUSION}" = "cancelled" ]; then
             # A reclaim kills a RUNNING job. So if not one cancelled job ever started a step,
@@ -135,14 +199,16 @@ jobs:
                         --jq '[.jobs[] | select(.conclusion == "cancelled") | select((.steps | length) > 0)] | length')"
             if [ "${RUNNING:-0}" -eq 0 ]; then
               echo "::notice title=spot-kill auto-retry::NOT re-running ${RUN_URL} — no cancelled job had started a step, so no runner was reclaimed. Treating it as a deliberate cancel (#3208)."
+              decide skipped-queue-cancel "0 cancelled jobs had started a step — deliberate cancel, not a reclaim (#3208)"
               exit 0
             fi
 
             # At least one job was interrupted mid-flight: a reclaim is possible, so retry once.
             # `--failed` is a no-op against `cancelled`, so this is always the full re-run.
             echo "Re-running cancelled run ${RUN_URL} (${RUNNING} job(s) interrupted mid-flight; issue #2330)"
-            gh run rerun -R "${GITHUB_REPOSITORY}" "${RUN_ID}"
+            rerun_with_retry "${RUN_ID}"
             echo "::notice title=spot-kill auto-retry::Re-ran cancelled run ${RUN_URL} (attempt 2 of max 2; a second kill stays for a human)"
+            decide rerun-cancelled "${RUNNING} job(s) interrupted mid-flight — full re-run issued (attempt 2 of max 2)"
             exit 0
           fi
 
@@ -162,17 +228,20 @@ jobs:
 
           if [ -z "${killed}" ]; then
             echo "::warning title=spot-kill auto-retry::Could not read jobs for ${RUN_URL}; not re-running. A genuine reclaim will need a manual re-run."
+            decide jobs-unreadable "the jobs API could not be read — a genuine reclaim here needs a MANUAL re-run"
             exit 0
           fi
 
           if [ "${killed}" -eq 0 ]; then
             echo "::notice title=spot-kill auto-retry::${RUN_URL} failed with no spot-kill signature (no job has a cancelled step and no failed step) — treating it as a real failure and NOT re-running."
+            decide no-spot-kill-signature "no failed job has a cancelled step and no failed step — a real build failure"
             exit 0
           fi
 
           echo "Re-running ${RUN_URL}: ${killed} job(s) killed mid-step by a runner reclaim (issue #2841)"
-          gh run rerun -R "${GITHUB_REPOSITORY}" "${RUN_ID}" --failed
+          rerun_with_retry "${RUN_ID}" --failed
           echo "::notice title=spot-kill auto-retry::Re-ran ${killed} spot-killed job(s) in ${RUN_URL} (attempt 2 of max 2; a second kill stays for a human)"
+          decide rerun-partial "${killed} job(s) carry the spot-kill signature — failed jobs re-run (attempt 2 of max 2)"
 
   # ── The alarm (issue #2901) ───────────────────────────────────────────────────
   # Why this exists: this workflow failed 208 times without anyone noticing. It is
@@ -248,6 +317,13 @@ jobs:
           repo\`, fixed in #2898). If the log says that, something dropped the \`-R\` or the
           \`GH_REPO\` env — \`.github/scripts/check-gh-repo-context.py\` should have caught it
           at PR time, so check that gate too.
+
+          **If instead the log says \`HTTP 5xx\` / \`Server Error\`, detection worked and only
+          the API call lost.** Since #4595 that call is retried 3x with backoff, so reaching
+          this issue on a 5xx means all three attempts lost — re-run the triggering run by
+          hand and check GitHub's status page. The \`decision=\` line in the retry job's log
+          and step summary says what was examined and what was decided on every path,
+          including the no-op ones.
 
           Read the step output from **after the last** \`##[endgroup]\`: GitHub prints the
           step's own script into the log header, so grepping the whole log matches strings


### PR DESCRIPTION
## What was measured, before anything was changed

The prior finding in this repo is that spot-kill auto-retry had **never actually run**. That is
no longer the state, and the fix depends on which state it is in, so it was measured first
rather than inferred from the YAML.

`auto-retry-cancelled.yml` has **10,099 runs**. Sampling the 10 most recent successes and
reading each log **after the last `##[endgroup]`** (so the step's own echoed script cannot
match):

| decision in the log | count |
|---|---|
| issued a real `gh run rerun` | 3 |
| declined — `no spot-kill signature` / queue cancel | 7 |

The three re-runs landed: targets `31734133882`, `31728606315`, `31723055599` are all at
`run_attempt=2`. So the mechanism **triggers, detects, and re-runs**.

**This is case (iii): it triggered and detected correctly, and the API call failed.**
Run [31710803432](https://github.com/JiRaska/open-bank-oss/actions/runs/31710803432), the one
that filed #4595, after the last `##[endgroup]`:

```
Re-running cancelled run .../runs/31710216158 (1 job(s) interrupted mid-flight; issue #2330)
failed to rerun: HTTP 502: Server Error (https://api.github.com/.../runs/31710216158/rerun)
##[error]Process completed with exit code 1.
```

Detection was right. `gh run rerun` hit a transient GitHub 502 and there was no retry, so the
step exited 1. The cost is exactly what #2330 removed: the triggering run reached attempt 2 at
`14:50:37Z`, **17 minutes** after the 502 at `14:33:33Z` — by a human hand, not by this job.

Not case (i) or (ii): no repo-context regression (`check-gh-repo-context.py` passes), and the
detection branch printed the correct mid-flight count.

## The fix

1. **`rerun_with_retry`** wraps both `gh run rerun` call sites — 3 attempts, 15s/30s backoff.
   Only `HTTP 5xx` / `429` / transport errors are retried. A `403`/`404`/`422` is a real answer
   (run too old, already re-running, no permission) and fails immediately, so the alarm is not
   delayed by three pointless attempts.
2. **`GH_REPO` on the step** alongside the existing `-R` on every call. `-R` stays — it is the
   explicit one — but `GH_REPO` covers any `gh` call added later that forgets it. This is the
   defect behind the 208 silent failures (#2898).
3. **Evidence, because the standing complaint is controls with no sign of firing.** Every exit
   path now emits `decision=<one of five>` to the log **and** to the job step summary:
   `skipped-queue-cancel`, `rerun-cancelled`, `no-spot-kill-signature`, `jobs-unreadable`,
   `rerun-partial`. Before this, a no-op and a success were both "green, with a notice buried
   in a log nobody opens". Now the step summary alone distinguishes them.
4. The alarm's issue body gains the `HTTP 5xx` branch, so the next occurrence points at the
   right cause instead of only at the (already fixed) repo-context one.

## Verification

`actionlint`, `shellcheck`, `check-gh-repo-context.py` (58 workflows) and
`check-workflow-run-step-size.py` all pass.

The retry helper was extracted from the workflow and driven against four cases:

| case | expected | result |
|---|---|---|
| first attempt succeeds | return 0 | return 0 |
| 502, 502, then success | return 0 on attempt 3 | return 0 on attempt 3 |
| 502 x3 | nonzero, alarm fires | nonzero, alarm fires |
| HTTP 403 | nonzero **without** retrying | nonzero, 1 attempt |

The first version of that harness had a broken regex and loaded **no function at all**, and it
still printed "correct" for two of the four cases — the repo's documented shape where a probe
reports success because it never reached its subject. The table above is from the fixed harness,
which is why the happy path is in it: `set -e` plus a trailing `[ x ] && cmd` that evaluates
false would have exited the step from inside the *success* path, turning a retry helper into a
new silent failure. Written as `if ... fi` for that reason, with a comment saying so.

## How you will know it worked

The next spot reclaim: the retry job's **step summary** names the run it examined and its
`decision=`. A transient 5xx now shows as `gh run rerun attempt 1/3 failed ... succeeded on
attempt 2/3` and a green job, instead of a red job and this issue.

**Not closing #4595 on this PR** — that needs a run that demonstrably survives a transient
failure, which cannot be manufactured. Close it once a `decision=rerun-*` run is green with a
retried attempt in its log.

Refs #4595
