### PR TITLE
feat(campaign): serve the cross-channel content catalogue

### DIFF
--- a/openbank-admin-ui/src/app/api/campaigns/templates/route.ts
+++ b/openbank-admin-ui/src/app/api/campaigns/templates/route.ts
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+import { NextResponse } from 'next/server'
+import { auth } from '@/auth'
+import { serverSvcUrl } from '@/lib/services/bff'
+
+export const dynamic = 'force-dynamic'
+
+/** The reviewed cross-channel catalogue is an upstream contract, never a second client-side list. */
+export async function GET() {
+  const session = await auth()
+  if (!session?.user?.accessToken) return NextResponse.json({ error: 'unauthenticated' }, { status: 401 })
+  try {
+    const res = await fetch(serverSvcUrl('campaign-service', 'campaign', 8128, '/api/v1/campaigns/templates'), {
+      headers: { authorization: `Bearer ${session.user.accessToken}` },
+      signal: AbortSignal.timeout(4000),
+      cache: 'no-store',
+    })
+    if (!res.ok) {
+      return NextResponse.json({ items: [], state: res.status === 401 || res.status === 403 ? 'unauthorized' : 'unreachable' })
+    }
+    return NextResponse.json({ items: await res.json(), state: 'ok' })
+  } catch {
+    return NextResponse.json({ items: [], state: 'unreachable' })
+  }
+}

--- a/openbank-admin-ui/src/app/campaigns/new/page.tsx
+++ b/openbank-admin-ui/src/app/campaigns/new/page.tsx
@@ -14,6 +14,7 @@ import {
   JourneyEditor,
   MAX_STEPS,
   type EditorChannel,
+  type EditorInAppSurface,
   type EditorStep,
 } from '@/components/campaigns/JourneyEditor'
 import { StepEditor } from '@/components/campaigns/StepEditor'
@@ -62,38 +63,25 @@ interface CampaignTrigger {
   humanForm: string
 }
 
+/** The reviewed content choice served by campaign-service, rather than a second client-side copy. */
+interface CampaignTemplate {
+  template: string
+  channel: EditorChannel
+  variables: string[]
+  inAppSurface?: EditorInAppSurface | null
+}
+
 type EntryMode = 'MANUAL' | 'SCHEDULE' | 'TRIGGER'
 
-/** Mirrors the service's catalogue; the service rejects anything not in its own copy. */
-const TEMPLATES: Record<string, string[]> = {
-  MARKETING_PRODUCT_OFFER: ['offerTitle', 'offerText', 'ctaText'],
-  // One variable, and that is the channel's rule rather than a simplification: a push renders its
-  // title plus a fixed generic body, so there is nowhere for offer copy to go (#1182).
-  MARKETING_PRODUCT_OFFER_PUSH: ['offerTitle'],
-  MARKETING_PRODUCT_OFFER_BANNER: ['offerTitle', 'offerText', 'ctaText'],
-  MARKETING_PRODUCT_OFFER_CAROUSEL: ['offerTitle', 'offerText', 'ctaText'],
-  MARKETING_PRODUCT_OFFER_PRODUCT_FEED: ['offerTitle', 'offerText', 'ctaText'],
-  MARKETING_PRODUCT_OFFER_REWARDS_HUB: ['offerTitle', 'offerText', 'ctaText'],
-}
-
-/** Which channel each template renders on. The service refuses a step whose two disagree. */
-const TEMPLATE_CHANNEL: Record<string, EditorChannel> = {
-  MARKETING_PRODUCT_OFFER: 'EMAIL',
-  MARKETING_PRODUCT_OFFER_PUSH: 'PUSH',
-  MARKETING_PRODUCT_OFFER_BANNER: 'BANNER',
-  MARKETING_PRODUCT_OFFER_CAROUSEL: 'BANNER',
-  MARKETING_PRODUCT_OFFER_PRODUCT_FEED: 'BANNER',
-  MARKETING_PRODUCT_OFFER_REWARDS_HUB: 'BANNER',
-}
-
-const newStep = (): EditorStep => ({
+const newStep = (choice: CampaignTemplate): EditorStep => ({
   // The studio starts with the primary owned surface: the bank app. E-mail remains a supported
   // channel, but leading an app-first campaign with it made the canvas teach the wrong product.
-  template: 'MARKETING_PRODUCT_OFFER_PUSH',
-  channel: 'PUSH',
+  template: choice.template,
+  channel: choice.channel,
   variables: {},
   delaySeconds: 0,
-  mobileDestination: 'HOME',
+  ...(choice.channel === 'PUSH' || choice.channel === 'BANNER' ? { mobileDestination: 'HOME' as const } : {}),
+  ...(choice.inAppSurface ? { inAppSurface: choice.inAppSurface } : {}),
 })
 
 export default function NewCampaignPage() {
@@ -109,11 +97,13 @@ export default function NewCampaignPage() {
   const [segments, setSegments] = useState<Segment[]>([])
   const [cadences, setCadences] = useState<Cadence[]>([])
   const [triggers, setTriggers] = useState<CampaignTrigger[]>([])
+  const [contentCatalogue, setContentCatalogue] = useState<CampaignTemplate[]>([])
+  const [contentCatalogueState, setContentCatalogueState] = useState<'loading' | 'ok' | 'unavailable'>('loading')
   const [entryMode, setEntryMode] = useState<EntryMode>('MANUAL')
   const [cadence, setCadence] = useState('')
   const [trigger, setTrigger] = useState('')
   const [entryUnavailable, setEntryUnavailable] = useState(false)
-  const [steps, setSteps] = useState<EditorStep[]>([newStep()])
+  const [steps, setSteps] = useState<EditorStep[]>([])
   const [journeyRecipe, setJourneyRecipe] = useState<JourneyRecipeId | null>('RETURN_TO_APP')
   const [selected, setSelected] = useState<number | null>(0)
   const [reach, setReach] = useState<number | null>(null)
@@ -129,6 +119,13 @@ export default function NewCampaignPage() {
   const [contentExperiment, setContentExperiment] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [saving, setSaving] = useState(false)
+
+  const templates = Object.fromEntries(contentCatalogue.map(entry => [entry.template, entry.variables])) as Record<string, string[]>
+  const templateChannel = Object.fromEntries(contentCatalogue.map(entry => [entry.template, entry.channel])) as Record<string, EditorChannel>
+  const templateSurface = Object.fromEntries(
+    contentCatalogue.flatMap(entry => entry.inAppSurface ? [[entry.inAppSurface, entry.template] as const] : []),
+  ) as Partial<Record<EditorInAppSurface, string>>
+  const defaultStep = () => contentCatalogue.find(entry => entry.channel === 'PUSH') ?? contentCatalogue[0]
 
   const templateLabels: Record<string, string> = {
     MARKETING_PRODUCT_OFFER: t('Nabídka produktu', 'Product offer'),
@@ -248,17 +245,40 @@ export default function NewCampaignPage() {
     Promise.all([
       fetch('/api/campaigns/cadences').then(r => r.json()),
       fetch('/api/campaigns/triggers').then(r => r.json()),
+      fetch('/api/campaigns/templates').then(r => r.json()),
     ])
-      .then(([cadenceResponse, triggerResponse]: [
+      .then(([cadenceResponse, triggerResponse, templateResponse]: [
         { items?: Cadence[]; state?: string },
         { items?: CampaignTrigger[]; state?: string },
+        { items?: CampaignTemplate[]; state?: string },
       ]) => {
         if (cadenceResponse.state === 'ok') setCadences(cadenceResponse.items ?? [])
         if (triggerResponse.state === 'ok') setTriggers(triggerResponse.items ?? [])
         if (cadenceResponse.state !== 'ok' || triggerResponse.state !== 'ok') setEntryUnavailable(true)
+        if (templateResponse.state === 'ok' && (templateResponse.items?.length ?? 0) > 0) {
+          setContentCatalogue(templateResponse.items ?? [])
+          setContentCatalogueState('ok')
+        } else {
+          setContentCatalogueState('unavailable')
+        }
       })
-      .catch(() => setEntryUnavailable(true))
+      .catch(() => {
+        setEntryUnavailable(true)
+        setContentCatalogueState('unavailable')
+      })
   }, [])
+
+  // A new journey gets a server-approved app-first step only after the catalogue arrives. There is
+  // intentionally no browser fallback: a stale template fails after a marketer has authored it.
+  useEffect(() => {
+    if (draftId || contentCatalogueState !== 'ok') return
+    const first = defaultStep()
+    if (!first) return
+    setSteps(previous => previous.length === 0 ? [newStep(first)] : previous)
+    setSelected(previous => previous ?? 0)
+  // The catalogue state changes only when its authoritative response arrives.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [contentCatalogueState, draftId])
 
   const updateStep = (i: number, next: EditorStep) =>
     setSteps(prev => prev.map((s, k) => (k === i ? next : s)))
@@ -266,14 +286,23 @@ export default function NewCampaignPage() {
   const addStep = () =>
     setSteps(prev => {
       if (prev.length >= MAX_STEPS) return prev
+      const first = defaultStep()
+      if (!first) return prev
       setSelected(prev.length)
       return [...prev, {
-        ...newStep(),
+        ...newStep(first),
         ...(contentExperiment ? { variantBVariables: {} } : {}),
       }]
     })
 
   const applyRecipe = (recipe: JourneyRecipe) => {
+    const verified = recipe.steps.every(step =>
+      templates[step.template] !== undefined && templateChannel[step.template] === step.channel,
+    )
+    if (!verified) {
+      setError(t('Tento recept používá obsah, který už není v ověřeném katalogu.', 'This recipe uses content no longer in the verified catalogue.'))
+      return
+    }
     // A recipe is only an authoring shortcut. Clone every map so opening one step can never alter
     // another step's values through a shared object reference.
     setSteps(recipe.steps.map(step => ({
@@ -293,8 +322,9 @@ export default function NewCampaignPage() {
     })
 
   const incomplete = steps.some(s =>
-    (TEMPLATES[s.template] ?? []).some(v => !(s.variables[v] ?? '').trim()) ||
-    (contentExperiment && (TEMPLATES[s.variantBTemplate ?? s.template] ?? [])
+    templates[s.template] === undefined ||
+    templates[s.template].some(v => !(s.variables[v] ?? '').trim()) ||
+    (contentExperiment && (templates[s.variantBTemplate ?? s.template] ?? [])
       .some(v => !(s.variantBVariables?.[v] ?? '').trim())),
   )
   const entryConfigured =
@@ -302,7 +332,7 @@ export default function NewCampaignPage() {
     (entryMode === 'SCHEDULE' && cadence !== '') ||
     (entryMode === 'TRIGGER' && trigger !== '')
   const ready = name.trim() !== '' && goal.trim() !== '' && segment !== '' && steps.length > 0 &&
-    !incomplete && entryConfigured && (!contentExperiment || conversionRule !== null)
+    contentCatalogueState === 'ok' && !incomplete && entryConfigured && (!contentExperiment || conversionRule !== null)
 
   const setContentExperimentEnabled = (enabled: boolean) => {
     setContentExperiment(enabled)
@@ -573,7 +603,7 @@ export default function NewCampaignPage() {
         </div>
       </section>
 
-      <JourneyRecipePicker selected={journeyRecipe} onApply={applyRecipe} />
+      {contentCatalogueState === 'ok' && <JourneyRecipePicker selected={journeyRecipe} onApply={applyRecipe} />}
 
       <section className="campaign-journey-workbench">
         <div className="campaign-workbench-heading">
@@ -584,6 +614,13 @@ export default function NewCampaignPage() {
           </div>
           <span className="campaign-workbench-status"><span /> {steps.length}/{MAX_STEPS} {t('kroků', 'steps')}</span>
         </div>
+        {contentCatalogueState !== 'ok' && (
+          <p className="text-xs text-muted-foreground" data-content-catalogue-state={contentCatalogueState}>
+            {contentCatalogueState === 'loading'
+              ? t('Načítáme ověřený katalog obsahu…', 'Loading the reviewed content catalogue…')
+              : t('Katalog obsahu teď není dostupný; nové kroky ani recepty nenabízíme.', 'The content catalogue is unavailable; new steps and recipes are not offered.')}
+          </p>
+        )}
         {/* space-y-0 around the canvas+panel pair: any gap between them undoes the join. */}
         <div className="space-y-0">
         <JourneyEditor
@@ -596,6 +633,7 @@ export default function NewCampaignPage() {
           selected={selected}
           onSelect={setSelected}
           onAdd={addStep}
+          contentCatalogueReady={contentCatalogueState === 'ok'}
           onRemove={removeStep}
           templateLabels={templateLabels}
           stopAfter={stopAfter}
@@ -608,8 +646,9 @@ export default function NewCampaignPage() {
             attached
             index={selected}
             step={steps[selected]}
-            templates={TEMPLATES}
-            templateChannel={TEMPLATE_CHANNEL}
+            templates={templates}
+            templateChannel={templateChannel}
+            templateSurface={templateSurface}
             templateLabels={templateLabels}
             variableLabels={variableLabels}
             contentExperiment={contentExperiment}

--- a/openbank-admin-ui/src/components/campaigns/JourneyEditor.tsx
+++ b/openbank-admin-ui/src/components/campaigns/JourneyEditor.tsx
@@ -97,6 +97,7 @@ export function JourneyEditor({
   selected,
   onSelect,
   onAdd,
+  contentCatalogueReady = true,
   onRemove,
   templateLabels,
   stopAfter,
@@ -109,6 +110,8 @@ export function JourneyEditor({
   selected: number | null
   onSelect: (index: number | null) => void
   onAdd: () => void
+  /** Without the served catalogue, a new node would be an unverified template choice. */
+  contentCatalogueReady?: boolean
   onRemove: (index: number) => void
   templateLabels: Record<string, string>
   /** Campaign-level cap: the journey ends once a party has had this many sends. Null = no cap. */
@@ -128,7 +131,7 @@ export function JourneyEditor({
     return t(`za ${Math.floor(s / 60)} min`, `after ${Math.floor(s / 60)} min`)
   }
 
-  const canAdd = steps.length < MAX_STEPS
+  const canAdd = steps.length < MAX_STEPS && contentCatalogueReady
   // Entry + steps + the add affordance, which occupies a slot so the canvas does not jump when a
   // step is added.
   const cols = 1 + steps.length + (canAdd ? 1 : 0)
@@ -396,7 +399,7 @@ export function JourneyEditor({
           </g>
         )}
 
-        {!canAdd && (
+        {steps.length >= MAX_STEPS && (
           // Stated, not enforced silently: the cap is a domain rule (Campaign.MAX_STEPS), and a
           // marketer who cannot find the add button deserves to know why rather than assume a bug.
           <text

--- a/openbank-admin-ui/src/components/campaigns/StepEditor.tsx
+++ b/openbank-admin-ui/src/components/campaigns/StepEditor.tsx
@@ -5,14 +5,7 @@
 'use client'
 
 import { useLanguage } from '@/lib/i18n/LanguageContext'
-import type { EditorChannel, EditorCondition, EditorStep } from '@/components/campaigns/JourneyEditor'
-
-const IN_APP_TEMPLATE: Record<NonNullable<EditorStep['inAppSurface']>, string> = {
-  HOME_BANNER: 'MARKETING_PRODUCT_OFFER_BANNER',
-  HOME_CAROUSEL: 'MARKETING_PRODUCT_OFFER_CAROUSEL',
-  PRODUCT_FEED: 'MARKETING_PRODUCT_OFFER_PRODUCT_FEED',
-  REWARDS_HUB: 'MARKETING_PRODUCT_OFFER_REWARDS_HUB',
-}
+import type { EditorChannel, EditorCondition, EditorInAppSurface, EditorStep } from '@/components/campaigns/JourneyEditor'
 
 /**
  * Edits the step selected on the canvas.
@@ -31,6 +24,7 @@ export function StepEditor({
   step,
   templates,
   templateChannel,
+  templateSurface,
   templateLabels,
   variableLabels,
   contentExperiment = false,
@@ -44,6 +38,8 @@ export function StepEditor({
   templates: Record<string, string[]>
   /** template id → the channel it renders on. The service refuses a mismatch. */
   templateChannel: Record<string, EditorChannel>
+  /** Authenticated app surface → its reviewed banner template, served by campaign-service. */
+  templateSurface: Partial<Record<EditorInAppSurface, string>>
   templateLabels: Record<string, string>
   /**
    * variable id → what to call it, and what a filled-in one looks like.
@@ -72,6 +68,17 @@ export function StepEditor({
   const variantBTemplate = step.variantBTemplate ?? step.template
   const variantBChannel = step.variantBChannel ?? step.channel
   const variantBDeclared = templates[variantBTemplate] ?? []
+  const firstSurface = Object.keys(templateSurface)[0] as EditorInAppSurface | undefined
+  const selectedSurface = step.inAppSurface ?? firstSurface
+  const templateForSurface = (surface: EditorInAppSurface | undefined) => surface ? templateSurface[surface] : undefined
+  const surfaceLabel = (surface: EditorInAppSurface) => {
+    switch (surface) {
+      case 'HOME_BANNER': return t('Banner na domovské obrazovce', 'Home banner')
+      case 'HOME_CAROUSEL': return t('Carousel na domovské obrazovce', 'Home carousel')
+      case 'PRODUCT_FEED': return t('Feed produktů', 'Product feed')
+      case 'REWARDS_HUB': return t('Centrum odměn', 'Rewards hub')
+    }
+  }
   const missing = declared.filter(v => !(step.variables[v] ?? '').trim())
   // `.input` is the console's own field style — hover, focus ring, sizing — and I had hand-rolled a
   // worse copy of it. Reinventing a house primitive is the same failure ADR-0208 D2 names for colour.
@@ -108,7 +115,9 @@ export function StepEditor({
         <span className="text-sm font-medium">{t('Kanál', 'Channel')}</span>
         <div className="flex gap-2">
           {(['EMAIL', 'PUSH', 'BANNER'] as EditorChannel[]).map(c => {
-            const first = Object.keys(templates).find(tpl => templateChannel[tpl] === c)
+            const first = c === 'BANNER'
+              ? templateForSurface(selectedSurface)
+              : Object.keys(templates).find(tpl => templateChannel[tpl] === c)
             const active = step.channel === c
             return (
               <button
@@ -120,14 +129,12 @@ export function StepEditor({
                 onClick={() => first && onChange({
                   ...step,
                   channel: c,
-                  template: c === 'BANNER'
-                    ? IN_APP_TEMPLATE[step.inAppSurface ?? 'HOME_BANNER']
-                    : first,
+                  template: first,
                   variables: {},
                   ...(c === 'PUSH' || c === 'BANNER'
                     ? { fallbackToPush: false, mobileDestination: step.mobileDestination ?? 'HOME' }
                     : { mobileDestination: undefined }),
-                  ...(c === 'BANNER' ? { inAppSurface: step.inAppSurface ?? 'HOME_BANNER' } : { inAppSurface: undefined }),
+                  ...(c === 'BANNER' && selectedSurface ? { inAppSurface: selectedSurface } : { inAppSurface: undefined }),
                   ...(step.variantBVariables !== undefined ? { variantBVariables: {} } : {}),
                 })}
                 // `.btn` again rather than a hand-rolled box — the third time tonight that a
@@ -188,22 +195,23 @@ export function StepEditor({
               <span className="font-medium">{t('Plocha v aplikaci', 'In-app surface')}</span>
               <select
                 className={field}
-                value={step.inAppSurface ?? 'HOME_BANNER'}
+                value={selectedSurface ?? ''}
                 onChange={e => {
-                  const inAppSurface = e.target.value as NonNullable<EditorStep['inAppSurface']>
+                  const inAppSurface = e.target.value as EditorInAppSurface
+                  const template = templateForSurface(inAppSurface)
+                  if (!template) return
                   onChange({
                     ...step,
                     inAppSurface,
-                    template: IN_APP_TEMPLATE[inAppSurface],
+                    template,
                     variables: {},
                     ...(step.variantBVariables !== undefined ? { variantBVariables: {} } : {}),
                   })
                 }}
               >
-                <option value="HOME_BANNER">{t('Banner na domovské obrazovce', 'Home banner')}</option>
-                <option value="HOME_CAROUSEL">{t('Carousel na domovské obrazovce', 'Home carousel')}</option>
-                <option value="PRODUCT_FEED">{t('Feed produktů', 'Product feed')}</option>
-                <option value="REWARDS_HUB">{t('Centrum odměn', 'Rewards hub')}</option>
+                {Object.keys(templateSurface).map(surface => (
+                  <option key={surface} value={surface}>{surfaceLabel(surface as EditorInAppSurface)}</option>
+                ))}
               </select>
               <span className="block text-xs text-muted-foreground">
                 {t('Každá plocha má schválený tvar karty; šablona se přepne spolu s ní.', 'Each surface has an approved card shape; its template changes with the surface.')}
@@ -264,7 +272,7 @@ export function StepEditor({
           })}
         >
           {Object.keys(templates).filter(tpl => templateChannel[tpl] === step.channel && (
-            step.channel !== 'BANNER' || tpl === IN_APP_TEMPLATE[step.inAppSurface ?? 'HOME_BANNER']
+            step.channel !== 'BANNER' || tpl === templateForSurface(selectedSurface)
           )).map(tpl => (
             <option key={tpl} value={tpl}>
               {templateLabels[tpl] ?? tpl}
@@ -325,7 +333,7 @@ export function StepEditor({
                 onChange={e => {
                   const channel = e.target.value as EditorChannel
                   const first = Object.keys(templates).find(tpl => templateChannel[tpl] === channel && (
-                    channel !== 'BANNER' || tpl === IN_APP_TEMPLATE.HOME_BANNER
+                    channel !== 'BANNER' || tpl === templateForSurface('HOME_BANNER')
                   ))
                   if (!first) return
                   onChange({ ...step, variantBChannel: channel, variantBTemplate: first, variantBVariables: {} })
@@ -346,7 +354,7 @@ export function StepEditor({
                 onChange={e => onChange({ ...step, variantBTemplate: e.target.value, variantBVariables: {} })}
               >
                 {Object.keys(templates).filter(tpl => templateChannel[tpl] === variantBChannel && (
-                  variantBChannel !== 'BANNER' || tpl === IN_APP_TEMPLATE.HOME_BANNER
+                  variantBChannel !== 'BANNER' || tpl === templateForSurface('HOME_BANNER')
                 )).map(tpl => <option key={tpl} value={tpl}>{templateLabels[tpl] ?? tpl}</option>)}
               </select>
             </label>

--- a/openbank-admin-ui/src/test/campaign-builder-interaction.test.tsx
+++ b/openbank-admin-ui/src/test/campaign-builder-interaction.test.tsx
@@ -18,8 +18,22 @@ import { LanguageProvider } from '@/lib/i18n/LanguageContext'
 import NewCampaignPage from '@/app/campaigns/new/page'
 vi.mock('next/navigation', () => ({ useRouter: () => ({ push: vi.fn() }), useSearchParams: () => new URLSearchParams() }))
 
+const TEMPLATES = {
+  state: 'ok',
+  items: [
+    { template: 'MARKETING_PRODUCT_OFFER', channel: 'EMAIL', variables: ['offerTitle', 'offerText', 'ctaText'] },
+    { template: 'MARKETING_PRODUCT_OFFER_PUSH', channel: 'PUSH', variables: ['offerTitle'] },
+    { template: 'MARKETING_PRODUCT_OFFER_BANNER', channel: 'BANNER', variables: ['offerTitle', 'offerText', 'ctaText'], inAppSurface: 'HOME_BANNER' },
+    { template: 'MARKETING_PRODUCT_OFFER_CAROUSEL', channel: 'BANNER', variables: ['offerTitle', 'offerText', 'ctaText'], inAppSurface: 'HOME_CAROUSEL' },
+    { template: 'MARKETING_PRODUCT_OFFER_PRODUCT_FEED', channel: 'BANNER', variables: ['offerTitle', 'offerText', 'ctaText'], inAppSurface: 'PRODUCT_FEED' },
+    { template: 'MARKETING_PRODUCT_OFFER_REWARDS_HUB', channel: 'BANNER', variables: ['offerTitle', 'offerText', 'ctaText'], inAppSurface: 'REWARDS_HUB' },
+  ],
+}
+
 const stub = () => vi.stubGlobal('fetch', vi.fn(async (u: string) =>
-  String(u).includes('/preview')
+  String(u).includes('/templates')
+    ? { ok: true, json: async () => TEMPLATES }
+    : String(u).includes('/preview')
     ? { ok: true, json: async () => ({ size: 1240, state: 'ok' }) }
     : { ok: true, json: async () => ({ state: 'ok', items: [
         { name: 'active-clients', version: 1, rules: ['party status is ACTIVE'] },
@@ -31,6 +45,7 @@ describe('campaign builder interaction', () => {
     const { container, getByText } = render(
       React.createElement(LanguageProvider, null, React.createElement(NewCampaignPage)))
     await waitFor(() => getByText('savers'), { timeout: 8000 })
+    await waitFor(() => expect(container.querySelector('[data-step="0"]')).toBeTruthy())
 
     fireEvent.click(container.querySelector('[data-journey-recipe="IN_APP_DISCOVERY"]')!)
 
@@ -48,6 +63,7 @@ describe('campaign builder interaction', () => {
     const { container, getByText } = render(
       React.createElement(LanguageProvider, null, React.createElement(NewCampaignPage)))
     await waitFor(() => getByText('savers'), { timeout: 8000 })
+    await waitFor(() => expect(container.querySelector('[data-step="0"]')).toBeTruthy())
     expect(container.querySelectorAll('[data-step]').length).toBe(1)
     for (let i = 0; i < 4; i++) fireEvent.click(container.querySelector('[data-add-step]')!)
     expect(container.querySelectorAll('[data-step]').length).toBe(5)
@@ -61,6 +77,7 @@ describe('campaign builder interaction', () => {
     const { container, getByText } = render(
       React.createElement(LanguageProvider, null, React.createElement(NewCampaignPage)))
     await waitFor(() => getByText('savers'), { timeout: 8000 })
+    await waitFor(() => expect(container.querySelector('[data-step="0"]')).toBeTruthy())
     fireEvent.click(container.querySelector('[data-add-step]')!)
     // A newly added step opens itself — you added it to fill it in.
     expect(container.querySelector('[data-step-editor="1"]')).toBeTruthy()
@@ -74,6 +91,7 @@ describe('campaign builder interaction', () => {
     const { container, getByText } = render(
       React.createElement(LanguageProvider, null, React.createElement(NewCampaignPage)))
     await waitFor(() => getByText('savers'), { timeout: 8000 })
+    await waitFor(() => expect(container.querySelector('[data-step="0"]')).toBeTruthy())
     fireEvent.click(container.querySelector('[data-segment="savers@2"]')!)
     await waitFor(() => getByText(/1240 people/), { timeout: 8000 })
     fireEvent.click(container.querySelector('[data-add-step]')!)
@@ -99,13 +117,16 @@ describe('campaign builder interaction', () => {
 describe('campaign builder channels', () => {
   it('starts app-first and switching channels exposes only fields that channel can carry', async () => {
     vi.stubGlobal('fetch', vi.fn(async (u: string) =>
-      String(u).includes('/preview')
+      String(u).includes('/templates')
+        ? { ok: true, json: async () => TEMPLATES }
+        : String(u).includes('/preview')
         ? { ok: true, json: async () => ({ size: 10, state: 'ok' }) }
         : { ok: true, json: async () => ({ state: 'ok', items: [
             { name: 'active-clients', version: 1, rules: ['party status is ACTIVE'] }] }) }))
     const { container, getByText } = render(
       React.createElement(LanguageProvider, null, React.createElement(NewCampaignPage)))
     await waitFor(() => getByText('active-clients'), { timeout: 8000 })
+    await waitFor(() => expect(container.querySelector('[data-step="0"]')).toBeTruthy())
 
     // App-first: a new campaign opens on push with only its headline field.
     expect(container.querySelector('[data-step="0"]')!.getAttribute('data-channel')).toBe('PUSH')
@@ -137,7 +158,9 @@ describe('campaign builder channels', () => {
  */
 describe('campaign builder conditions', () => {
   const stub = () => vi.stubGlobal('fetch', vi.fn(async (u: string) =>
-    String(u).includes('/preview')
+    String(u).includes('/templates')
+      ? { ok: true, json: async () => TEMPLATES }
+      : String(u).includes('/preview')
       ? { ok: true, json: async () => ({ size: 10, state: 'ok' }) }
       : { ok: true, json: async () => ({ state: 'ok', items: [
           { name: 'active-clients', version: 1, rules: ['party status is ACTIVE'] }] }) }))
@@ -147,6 +170,7 @@ describe('campaign builder conditions', () => {
     const { container, getByText } = render(
       React.createElement(LanguageProvider, null, React.createElement(NewCampaignPage)))
     await waitFor(() => getByText('active-clients'), { timeout: 8000 })
+    await waitFor(() => expect(container.querySelector('[data-step="0"]')).toBeTruthy())
     fireEvent.click(container.querySelector('[data-add-step]')!)
 
     expect(container.querySelector('[data-edge-condition]')).toBeNull()
@@ -160,6 +184,7 @@ describe('campaign builder conditions', () => {
     const { container, getByText, queryByText } = render(
       React.createElement(LanguageProvider, null, React.createElement(NewCampaignPage)))
     await waitFor(() => getByText('active-clients'), { timeout: 8000 })
+    await waitFor(() => expect(container.querySelector('[data-step="0"]')).toBeTruthy())
 
     expect(queryByText(/has no predecessor/)).toBeNull()
     fireEvent.click(container.querySelector('[data-condition-pick="IF_PREVIOUS_CONFIRMED"]')!)
@@ -172,6 +197,7 @@ describe('campaign builder conditions', () => {
     const { container, getByText } = render(
       React.createElement(LanguageProvider, null, React.createElement(NewCampaignPage)))
     await waitFor(() => getByText('active-clients'), { timeout: 8000 })
+    await waitFor(() => expect(container.querySelector('[data-step="0"]')).toBeTruthy())
 
     expect(container.querySelector('[data-stop-after]')).toBeNull()
     fireEvent.click(container.querySelector('[data-stop-enabled]')!)
@@ -190,13 +216,16 @@ describe('campaign builder conditions', () => {
 describe('campaign builder conversion', () => {
   it('offers only catalogue rules, and says engagement is not tracked', async () => {
     vi.stubGlobal('fetch', vi.fn(async (u: string) =>
-      String(u).includes('/preview')
+      String(u).includes('/templates')
+        ? { ok: true, json: async () => TEMPLATES }
+        : String(u).includes('/preview')
         ? { ok: true, json: async () => ({ size: 10, state: 'ok' }) }
         : { ok: true, json: async () => ({ state: 'ok', items: [
             { name: 'active-clients', version: 1, rules: ['party status is ACTIVE'] }] }) }))
     const { container, getByText } = render(
       React.createElement(LanguageProvider, null, React.createElement(NewCampaignPage)))
     await waitFor(() => getByText('active-clients'), { timeout: 8000 })
+    await waitFor(() => expect(container.querySelector('[data-step="0"]')).toBeTruthy())
 
     const picks = Array.from(container.querySelectorAll('[data-conversion-pick]'))
       .map(e => e.getAttribute('data-conversion-pick'))

--- a/openbank-admin-ui/src/test/campaign-entry-catalogues-bff.test.ts
+++ b/openbank-admin-ui/src/test/campaign-entry-catalogues-bff.test.ts
@@ -10,18 +10,21 @@ vi.mock('@/lib/services/bff', () => ({ serverSvcUrl: (_service: string, _name: s
 describe('campaign entry catalogue BFF', () => {
   beforeEach(() => vi.resetModules())
 
-  it('forwards cadence and trigger catalogues through the authenticated BFF', async () => {
+  it('forwards entry and cross-channel content catalogues through the authenticated BFF', async () => {
     const fetchMock = vi.fn(async (url: string) => ({
       ok: true,
       status: 200,
       json: async () => url.endsWith('/cadences')
         ? [{ cadence: 'DAILY_MORNING', humanForm: 'every day at 09:00', zone: 'Europe/Prague' }]
-        : [{ trigger: 'ACCOUNT_OPENED', humanForm: 'when an account is opened' }],
+        : url.endsWith('/templates')
+          ? [{ template: 'MARKETING_PRODUCT_OFFER_BANNER', channel: 'BANNER', variables: ['offerTitle'], inAppSurface: 'HOME_BANNER' }]
+          : [{ trigger: 'ACCOUNT_OPENED', humanForm: 'when an account is opened' }],
     }))
     vi.stubGlobal('fetch', fetchMock)
 
     const { GET: cadences } = await import('@/app/api/campaigns/cadences/route')
     const { GET: triggers } = await import('@/app/api/campaigns/triggers/route')
+    const { GET: templates } = await import('@/app/api/campaigns/templates/route')
 
     await expect((await cadences()).json()).resolves.toEqual({
       items: [{ cadence: 'DAILY_MORNING', humanForm: 'every day at 09:00', zone: 'Europe/Prague' }],
@@ -31,12 +34,20 @@ describe('campaign entry catalogue BFF', () => {
       items: [{ trigger: 'ACCOUNT_OPENED', humanForm: 'when an account is opened' }],
       state: 'ok',
     })
+    await expect((await templates()).json()).resolves.toEqual({
+      items: [{ template: 'MARKETING_PRODUCT_OFFER_BANNER', channel: 'BANNER', variables: ['offerTitle'], inAppSurface: 'HOME_BANNER' }],
+      state: 'ok',
+    })
     expect(fetchMock).toHaveBeenCalledWith(
       'http://campaign/api/v1/campaigns/cadences',
       expect.objectContaining({ headers: { authorization: 'Bearer token' } }),
     )
     expect(fetchMock).toHaveBeenCalledWith(
       'http://campaign/api/v1/campaigns/triggers',
+      expect.objectContaining({ headers: { authorization: 'Bearer token' } }),
+    )
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://campaign/api/v1/campaigns/templates',
       expect.objectContaining({ headers: { authorization: 'Bearer token' } }),
     )
   })

--- a/openbank-admin-ui/src/test/campaign-studio.test.tsx
+++ b/openbank-admin-ui/src/test/campaign-studio.test.tsx
@@ -29,6 +29,18 @@ const TRIGGERS = {
   items: [{ trigger: 'ACCOUNT_OPENED', humanForm: 'when an account is opened' }],
 }
 
+const TEMPLATES = {
+  state: 'ok',
+  items: [
+    { template: 'MARKETING_PRODUCT_OFFER', channel: 'EMAIL', variables: ['offerTitle', 'offerText', 'ctaText'] },
+    { template: 'MARKETING_PRODUCT_OFFER_PUSH', channel: 'PUSH', variables: ['offerTitle'] },
+    { template: 'MARKETING_PRODUCT_OFFER_BANNER', channel: 'BANNER', variables: ['offerTitle', 'offerText', 'ctaText'], inAppSurface: 'HOME_BANNER' },
+    { template: 'MARKETING_PRODUCT_OFFER_CAROUSEL', channel: 'BANNER', variables: ['offerTitle', 'offerText', 'ctaText'], inAppSurface: 'HOME_CAROUSEL' },
+    { template: 'MARKETING_PRODUCT_OFFER_PRODUCT_FEED', channel: 'BANNER', variables: ['offerTitle', 'offerText', 'ctaText'], inAppSurface: 'PRODUCT_FEED' },
+    { template: 'MARKETING_PRODUCT_OFFER_REWARDS_HUB', channel: 'BANNER', variables: ['offerTitle', 'offerText', 'ctaText'], inAppSurface: 'REWARDS_HUB' },
+  ],
+}
+
 function detail(state: string) {
   return {
     campaign: {
@@ -51,8 +63,9 @@ function detail(state: string) {
 
 function mockFetch(routes: Record<string, unknown>) {
   return vi.fn(async (url: string) => {
-    const match = Object.keys(routes).find(k => String(url).includes(k))
-    return { ok: true, status: 200, json: async () => (match ? routes[match] : {}) }
+    const key = String(url)
+    const match = Object.keys(routes).find(k => key.includes(k))
+    return { ok: true, status: 200, json: async () => (match ? routes[match] : key.includes('/api/campaigns/templates') ? TEMPLATES : {}) }
   })
 }
 
@@ -113,6 +126,7 @@ describe('campaign studio', () => {
     vi.stubGlobal('fetch', mockFetch({ '/api/segments': SEGMENTS }))
     render(React.createElement(Providers, null, React.createElement(NewCampaignPage)))
 
+    await waitFor(() => expect(document.querySelector('[data-channel-pick="EMAIL"]')).toBeTruthy(), { timeout: 8000 })
     // Mobile is the studio's starting surface. E-mail remains available when a campaign genuinely
     // needs its richer template, and that switch—not the initial screen—owns these three fields.
     fireEvent.click(document.querySelector('[data-channel-pick="EMAIL"]')!)
@@ -136,6 +150,7 @@ describe('campaign studio', () => {
       if (url.includes('/api/segments')) return { ok: true, status: 200, json: async () => SEGMENTS }
       if (url.includes('/api/campaigns/cadences')) return { ok: true, status: 200, json: async () => CADENCES }
       if (url.includes('/api/campaigns/triggers')) return { ok: true, status: 200, json: async () => TRIGGERS }
+      if (url.includes('/api/campaigns/templates')) return { ok: true, status: 200, json: async () => TEMPLATES }
       if (url === '/api/campaigns') {
         createBody = JSON.parse(String(init?.body))
         return { ok: true, status: 200, json: async () => ({ state: 'ok', campaign: { id: CAMPAIGN_ID } }) }
@@ -145,6 +160,7 @@ describe('campaign studio', () => {
     render(React.createElement(Providers, null, React.createElement(NewCampaignPage)))
 
     await waitFor(() => expect(document.querySelector('[data-segment="actives@1"]')).toBeTruthy(), { timeout: 8000 })
+    await waitFor(() => expect(document.querySelector('[data-channel-pick="EMAIL"]')).toBeTruthy(), { timeout: 8000 })
     fireEvent.change(document.getElementById('c-name')!, { target: { value: 'Recurring welcome' } })
     fireEvent.change(document.getElementById('c-goal')!, { target: { value: 'Keep new customers engaged' } })
     fireEvent.click(document.querySelector('[data-segment="actives@1"]')!)
@@ -168,6 +184,7 @@ describe('campaign studio', () => {
       if (url.includes('/api/segments')) return { ok: true, status: 200, json: async () => SEGMENTS }
       if (url.includes('/api/campaigns/cadences')) return { ok: true, status: 200, json: async () => CADENCES }
       if (url.includes('/api/campaigns/triggers')) return { ok: true, status: 200, json: async () => TRIGGERS }
+      if (url.includes('/api/campaigns/templates')) return { ok: true, status: 200, json: async () => TEMPLATES }
       if (url === '/api/campaigns') {
         createBody = JSON.parse(String(init?.body))
         return { ok: true, status: 200, json: async () => ({ state: 'ok', campaign: { id: CAMPAIGN_ID } }) }
@@ -177,6 +194,7 @@ describe('campaign studio', () => {
     render(React.createElement(Providers, null, React.createElement(NewCampaignPage)))
 
     await waitFor(() => expect(document.querySelector('[data-segment="actives@1"]')).toBeTruthy(), { timeout: 8000 })
+    await waitFor(() => expect(document.querySelector('[data-channel-pick="EMAIL"]')).toBeTruthy(), { timeout: 8000 })
     fireEvent.change(document.getElementById('c-name')!, { target: { value: 'Two headlines' } })
     fireEvent.change(document.getElementById('c-goal')!, { target: { value: 'Open more accounts' } })
     fireEvent.click(document.querySelector('[data-segment="actives@1"]')!)
@@ -218,11 +236,13 @@ describe('campaign studio', () => {
       if (String(url).includes('/api/segments')) return { ok: true, status: 200, json: async () => SEGMENTS }
       if (String(url).includes('/cadences')) return { ok: true, status: 200, json: async () => CADENCES }
       if (String(url).includes('/triggers')) return { ok: true, status: 200, json: async () => TRIGGERS }
+      if (String(url).includes('/templates')) return { ok: true, status: 200, json: async () => TEMPLATES }
       return { ok: true, status: 200, json: async () => ({}) }
     }))
     render(React.createElement(Providers, null, React.createElement(NewCampaignPage)))
 
     await waitFor(() => expect(document.querySelector('[data-segment="actives@1"]')).toBeTruthy(), { timeout: 8000 })
+    await waitFor(() => expect(document.querySelector('[data-channel-pick="EMAIL"]')).toBeTruthy(), { timeout: 8000 })
     fireEvent.change(document.getElementById('c-name')!, { target: { value: 'Fallback offer' } })
     fireEvent.change(document.getElementById('c-goal')!, { target: { value: 'Open more accounts' } })
     fireEvent.click(document.querySelector('[data-segment="actives@1"]')!)

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/domain/model/TemplateCatalog.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/domain/model/TemplateCatalog.kt
@@ -83,6 +83,10 @@ object TemplateCatalog {
         InAppSurface.REWARDS_HUB -> "MARKETING_PRODUCT_OFFER_REWARDS_HUB"
     }
 
+    /** The app placement a banner template is approved to render on, or null for dispatched channels. */
+    fun inAppSurfaceFor(template: String): InAppSurface? =
+        InAppSurface.entries.firstOrNull { templateForInAppSurface(it) == template }
+
     fun exists(template: String): Boolean = template in ALL
 
     /**

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/rest/CampaignTemplateCatalogResource.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/rest/CampaignTemplateCatalogResource.kt
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+package com.openbank.campaign.infrastructure.rest
+
+import com.openbank.campaign.domain.model.Channel
+import com.openbank.campaign.domain.model.InAppSurface
+import com.openbank.campaign.domain.model.TemplateCatalog
+import com.openbank.libs.authz.Authorize
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.ws.rs.GET
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.core.Response
+
+/** A reviewed content choice the Campaign Studio may offer for one journey step. */
+data class CampaignTemplateSummary(
+    val template: String,
+    val channel: Channel,
+    val variables: List<String>,
+    val inAppSurface: InAppSurface? = null,
+)
+
+/**
+ * The content catalogue for Campaign Studio.
+ *
+ * Templates are deliberately served from the same closed catalogue the aggregate validates.  A
+ * front-end copy inevitably drifts: a newly approved app surface either remains invisible to a
+ * marketer or appears as a stale choice the server no longer accepts.  This endpoint is read-only;
+ * adding a template remains reviewed code, never a browser-authored message or markup.
+ */
+@Path("/api/v1/campaigns/templates")
+@ApplicationScoped
+class CampaignTemplateCatalogResource {
+
+    @GET
+    @Authorize(action = "campaign.read", resource = "#id")
+    suspend fun templates(): Response = Response.ok(
+        TemplateCatalog.ALL.keys.sorted().map { template ->
+            CampaignTemplateSummary(
+                template = template,
+                channel = checkNotNull(TemplateCatalog.CHANNEL_OF[template]),
+                variables = TemplateCatalog.ALL.getValue(template).sorted(),
+                inAppSurface = TemplateCatalog.inAppSurfaceFor(template),
+            )
+        },
+    ).build()
+}

--- a/openbank-campaign-service/src/main/resources/openapi.yaml
+++ b/openbank-campaign-service/src/main/resources/openapi.yaml
@@ -4,7 +4,7 @@ openapi: 3.1.0
 info:
   title: Campaign Service API
   # major == openbank.api.version == URL /api/v1 (ADR-0048).
-  version: 1.29.0
+  version: 1.30.0
   description: >-
     Campaign management first slice (ADR-0200 / ADR-0209 D3): deterministic, versioned segments;
     per-enrolment Temporal journeys; consent-gated delivery through notification-service.
@@ -186,6 +186,37 @@ paths:
                   properties:
                     trigger: { type: string, example: ACCOUNT_OPENED }
                     humanForm: { type: string, example: when an account is opened }
+  /api/v1/campaigns/templates:
+    get:
+      tags: [Campaigns]
+      summary: Reviewed cross-channel templates available to Campaign Studio
+      operationId: listCampaignTemplates
+      description: >-
+        The exact closed content catalogue the aggregate accepts. It is served so Studio never
+        duplicates a stale e-mail, push, banner, carousel, product-feed, or rewards-hub option.
+        Templates remain reviewed code; this endpoint does not accept marketer-authored markup.
+        NOTE the literal path segment: it must keep matching ahead of /api/v1/campaigns/{id}.
+      responses:
+        '200':
+          description: Every marketing template with its channel, named variables, and app surface where applicable
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  required: [template, channel, variables]
+                  properties:
+                    template: { type: string, example: MARKETING_PRODUCT_OFFER_BANNER }
+                    channel: { type: string, enum: [EMAIL, PUSH, BANNER] }
+                    variables:
+                      type: array
+                      items: { type: string }
+                      example: [offerTitle, offerText, ctaText]
+                    inAppSurface:
+                      type: string
+                      nullable: true
+                      enum: [HOME_BANNER, HOME_CAROUSEL, PRODUCT_FEED, REWARDS_HUB]
   /api/v1/campaigns/{id}:
     get:
       tags: [Campaigns]

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/integration/CampaignRestContractIT.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/integration/CampaignRestContractIT.kt
@@ -544,6 +544,32 @@ class CampaignRestContractIT {
         }
     }
 
+    /** Studio reads the exact catalogue the aggregate validates, including authenticated app placement. */
+    @Test
+    fun `the template catalogue serves channels declared variables and in-app surfaces`() {
+        When {
+            get("/api/v1/campaigns/templates")
+        } Then {
+            statusCode(200)
+            body(
+                "template",
+                org.hamcrest.Matchers.hasItems("MARKETING_PRODUCT_OFFER", "MARKETING_PRODUCT_OFFER_BANNER"),
+            )
+            body(
+                "find { it.template == 'MARKETING_PRODUCT_OFFER_PUSH' }.channel",
+                org.hamcrest.Matchers.equalTo("PUSH"),
+            )
+            body(
+                "find { it.template == 'MARKETING_PRODUCT_OFFER_PUSH' }.variables",
+                org.hamcrest.Matchers.contains("offerTitle"),
+            )
+            body(
+                "find { it.template == 'MARKETING_PRODUCT_OFFER_BANNER' }.inAppSurface",
+                org.hamcrest.Matchers.equalTo("HOME_BANNER"),
+            )
+        }
+    }
+
     /** A trigger key survives the round trip, so a campaign can declare what wakes it. */
     @Test
     fun `a campaign can declare a trigger and reads it back`() {


### PR DESCRIPTION
Refs #4671\n\nServes the reviewed campaign template catalogue from campaign-service, including channel, declared variables, and authenticated-app surface. Campaign Studio reads it through the BFF rather than holding a duplicate list; when the catalogue is unavailable it does not offer new unverified steps or recipes.\n\nTests: focused Admin UI tests (23/23), type-check, lint; campaign-service ktlint and CampaignRestContractIT (29/29).