### PR TITLE
fix(admin-ui): raise the nanoid override past CVE-2026-67213

### DIFF
--- a/openbank-admin-ui/package-lock.json
+++ b/openbank-admin-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openbank-admin-ui",
-  "version": "0.107.0",
+  "version": "0.117.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openbank-admin-ui",
-      "version": "0.107.0",
+      "version": "0.117.0",
       "dependencies": {
         "@hookform/resolvers": "5.7.1",
         "@radix-ui/react-dialog": "1.1.23",
@@ -11502,9 +11502,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/openbank-admin-ui/package.json
+++ b/openbank-admin-ui/package.json
@@ -57,7 +57,7 @@
   "overrides": {
     "postcss": "8.5.26",
     "sharp": "0.35.0",
-    "nanoid": "3.3.17"
+    "nanoid": "3.3.18"
   },
   "devDependencies": {
     "@playwright/test": "^1.62.1",


### PR DESCRIPTION
## The pin that was the fix is now the defect

`Trivy` is failing on PRs with:

```
Total: 1 (HIGH: 1, CRITICAL: 0)
nanoid  CVE-2026-67213  HIGH  fixed  3.3.17  ->  3.3.18, 5.1.6
```

This is not caused by any of those PRs. `nanoid@3.3.17` is on `main`, and it is held there **deliberately**: `openbank-admin-ui/package.json` already carries `overrides.nanoid: "3.3.17"`. The only package that wants it is `postcss`, which asks for `^3.3.17` — so without the override npm would already resolve the patched version on its own. The pin, presumably added to force a floor at some earlier point, is now the single thing keeping the vulnerable version in the tree.

Bumped the override to `3.3.18` and regenerated the lockfile with `--package-lock-only`.

### Scope

Two files, five lockfile lines:

```
 openbank-admin-ui/package-lock.json | 10 +++++-----
 openbank-admin-ui/package.json      |  2 +-
```

`package.json`'s `version` field is untouched, so the `version.txt == package.json` sync gate is unaffected. No `--write-verification-metadata`, no unrelated dependency churn.

### Why this is worth landing ahead of the queue

Every PR that runs Trivy fails on it, regardless of what that PR changes — it reads as "your change introduced a HIGH", which is the most expensive kind of false signal to leave in a queue that several agents are working. Confirmed the version on live `main` rather than on a branch base.

### On verification — local Trivy cannot settle this, and it took a control to find that out

`trivy` is installed here and reports **0 vulnerabilities** on the fixed tree. That result is worth nothing on its own, and I nearly published it as if it were evidence.

Run against the **known-positive** — `main`'s own `package.json` + `package-lock.json`, the exact pair CI fails on — local Trivy also reports **0**. So its vulnerability DB does not carry CVE-2026-67213 (published too recently), and `--download-db-only` did not change that. A scanner whose DB lacks the advisory returns "clean" for the vulnerable and the patched tree alike; the two are indistinguishable locally.

What actually supports this change, then:
- the resolved version in the regenerated lockfile (`node_modules/nanoid` -> `3.3.18`), which is the version the advisory names as fixed;
- the CI run on this PR, which is the only oracle that currently knows the CVE exists.
