### PR TITLE
feat(campaign): add delivery decision paths

### DIFF
--- a/openbank-admin-ui/src/app/campaigns/new/page.tsx
+++ b/openbank-admin-ui/src/app/campaigns/new/page.tsx
@@ -295,6 +295,30 @@ export default function NewCampaignPage() {
       }]
     })
 
+  /**
+   * A binary decision is an authoring shortcut over the service's two complementary, observable
+   * delivery conditions. Keeping both steps adjacent makes their shared predecessor unambiguous:
+   * when the first path is skipped, the second still evaluates that predecessor; when it sends,
+   * the second condition is false. The workflow has covered this replay-safe semantics since #3585.
+   */
+  const addDeliveryDecision = () =>
+    setSteps(prev => {
+      if (prev.length < 1 || prev.length > MAX_STEPS - 2) return prev
+      const first = defaultStep()
+      if (!first) return prev
+      const decisionStep = (condition: EditorStep['condition']): EditorStep => ({
+        ...newStep(first),
+        condition,
+        ...(contentExperiment ? { variantBVariables: {} } : {}),
+      })
+      setSelected(prev.length)
+      return [
+        ...prev,
+        decisionStep('IF_PREVIOUS_CONFIRMED'),
+        decisionStep('IF_PREVIOUS_NOT_CONFIRMED'),
+      ]
+    })
+
   const applyRecipe = (recipe: JourneyRecipe) => {
     const verified = recipe.steps.every(step =>
       templates[step.template] !== undefined && templateChannel[step.template] === step.channel,
@@ -633,6 +657,7 @@ export default function NewCampaignPage() {
           selected={selected}
           onSelect={setSelected}
           onAdd={addStep}
+          onAddDecision={addDeliveryDecision}
           contentCatalogueReady={contentCatalogueState === 'ok'}
           onRemove={removeStep}
           templateLabels={templateLabels}

--- a/openbank-admin-ui/src/components/campaigns/JourneyEditor.tsx
+++ b/openbank-admin-ui/src/components/campaigns/JourneyEditor.tsx
@@ -97,6 +97,7 @@ export function JourneyEditor({
   selected,
   onSelect,
   onAdd,
+  onAddDecision,
   contentCatalogueReady = true,
   onRemove,
   templateLabels,
@@ -110,6 +111,8 @@ export function JourneyEditor({
   selected: number | null
   onSelect: (index: number | null) => void
   onAdd: () => void
+  /** Adds the complementary delivered / not-delivered pair after the current journey path. */
+  onAddDecision?: () => void
   /** Without the served catalogue, a new node would be an unverified template choice. */
   contentCatalogueReady?: boolean
   onRemove: (index: number) => void
@@ -132,6 +135,9 @@ export function JourneyEditor({
   }
 
   const canAdd = steps.length < MAX_STEPS && contentCatalogueReady
+  // A binary decision consumes two bounded journey slots. Reusing the service's complementary
+  // conditions means the authored paths remain observable and requires no invented engagement data.
+  const canAddDecision = contentCatalogueReady && steps.length >= 1 && steps.length <= MAX_STEPS - 2 && onAddDecision
   // Entry + steps + the add affordance, which occupies a slot so the canvas does not jump when a
   // step is added.
   const cols = 1 + steps.length + (canAdd ? 1 : 0)
@@ -413,6 +419,30 @@ export function JourneyEditor({
           </text>
         )}
       </svg>
+      {canAddDecision && (
+        <div className="border-t border-dashed px-4 py-3" data-decision-creator>
+          <button
+            type="button"
+            onClick={onAddDecision}
+            className="flex w-full items-center gap-3 rounded-lg border border-dashed px-3 py-2 text-left text-sm transition-colors hover:border-[var(--accent)] hover:bg-[var(--surface)]"
+            data-add-decision="delivery"
+          >
+            <span
+              aria-hidden="true"
+              className="grid h-7 w-7 shrink-0 place-items-center rounded-md text-base font-semibold"
+              style={{ background: 'color-mix(in srgb, var(--warning) 14%, transparent)', color: 'var(--warning)' }}
+            >
+              ⑂
+            </span>
+            <span>
+              <span className="block font-medium text-foreground">{t('Rozdělit podle doručení', 'Split by delivery')}</span>
+              <span className="block text-xs text-muted-foreground">
+                {t('Vytvoří dvě výhradní cesty: doručeno a bez potvrzeného doručení.', 'Creates two exclusive paths: delivered and not confirmed delivered.')}
+              </span>
+            </span>
+          </button>
+        </div>
+      )}
     </div>
   )
 }

--- a/openbank-admin-ui/src/test/campaign-builder-interaction.test.tsx
+++ b/openbank-admin-ui/src/test/campaign-builder-interaction.test.tsx
@@ -179,6 +179,21 @@ describe('campaign builder conditions', () => {
     expect(container.querySelector('[data-edge-condition="IF_PREVIOUS_CONFIRMED"]')).toBeTruthy()
   }, 25000)
 
+  it('makes a real delivery decision as two complementary paths, not two manually guessed gates', async () => {
+    stub()
+    const { container, getByText } = render(
+      React.createElement(LanguageProvider, null, React.createElement(NewCampaignPage)))
+    await waitFor(() => getByText('active-clients'), { timeout: 8000 })
+    await waitFor(() => expect(container.querySelector('[data-step="0"]')).toBeTruthy())
+
+    fireEvent.click(container.querySelector('[data-add-decision="delivery"]')!)
+
+    expect(container.querySelectorAll('[data-step]')).toHaveLength(3)
+    expect(container.querySelector('[data-step-editor="1"]')).toBeTruthy()
+    expect(container.querySelector('[data-edge-condition="IF_PREVIOUS_CONFIRMED"]')).toBeTruthy()
+    expect(container.querySelector('[data-edge-condition="IF_PREVIOUS_NOT_CONFIRMED"]')).toBeTruthy()
+  }, 25000)
+
   it('warns that a condition on the first step has nothing to test', async () => {
     stub()
     const { container, getByText, queryByText } = render(

--- a/openbank-admin-ui/src/test/journey-editor.test.tsx
+++ b/openbank-admin-ui/src/test/journey-editor.test.tsx
@@ -46,7 +46,7 @@ const step = (delay = 0, vars: Record<string, string> = {}): EditorStep => ({
   delaySeconds: delay,
 })
 
-function canvas(steps: EditorStep[], handlers: Partial<Record<'onAdd' | 'onRemove' | 'onSelect', ReturnType<typeof vi.fn>>> = {}) {
+function canvas(steps: EditorStep[], handlers: Partial<Record<'onAdd' | 'onAddDecision' | 'onRemove' | 'onSelect', ReturnType<typeof vi.fn>>> = {}) {
   const props = {
     steps,
     audience: 'actives@1',
@@ -54,6 +54,7 @@ function canvas(steps: EditorStep[], handlers: Partial<Record<'onAdd' | 'onRemov
     selected: null,
     onSelect: handlers.onSelect ?? vi.fn(),
     onAdd: handlers.onAdd ?? vi.fn(),
+    onAddDecision: handlers.onAddDecision,
     onRemove: handlers.onRemove ?? vi.fn(),
     templateLabels: LABELS,
   }
@@ -89,6 +90,17 @@ describe('campaign builder canvas', () => {
     expect(add).toBeTruthy()
     fireEvent.click(add!)
     expect(onAdd).toHaveBeenCalled()
+  })
+
+  it('offers a delivery decision only when its two complementary paths fit', () => {
+    const onAddDecision = vi.fn()
+    const { container } = canvas([step()], { onAddDecision })
+
+    fireEvent.click(container.querySelector('[data-add-decision="delivery"]')!)
+    expect(onAddDecision).toHaveBeenCalledTimes(1)
+
+    const full = canvas(Array.from({ length: MAX_STEPS - 1 }, () => step()), { onAddDecision })
+    expect(full.container.querySelector('[data-add-decision="delivery"]')).toBeNull()
   })
 
   it('removes the step whose node was clicked, not the last one', () => {


### PR DESCRIPTION
What: Adds a Campaign Studio decision action that creates the two mutually exclusive existing delivery-status paths: confirmed delivery and no confirmed delivery. It is deliberately bounded and authoring-first: no free-form DAG, no raw condition editor, and no unobservable opens or clicks. The created steps use replay-safe workflow semantics already covered by campaign-service. Closes #4680. Proof: Journey Editor and composer interaction tests: 23 passing. UI lint: 0 errors, pre-existing warnings only. TypeScript check passed. Rollout: existing campaigns remain untouched; this changes only the Studio authoring affordance.