### PR TITLE
feat(campaign): add explicit decision sources

### DIFF
--- a/openbank-admin-ui/src/app/campaigns/[id]/page.tsx
+++ b/openbank-admin-ui/src/app/campaigns/[id]/page.tsx
@@ -27,6 +27,9 @@ interface Campaign {
     order: number
     template: string
     delaySeconds: number
+    channel?: 'EMAIL' | 'PUSH' | 'BANNER'
+    condition?: 'IF_PREVIOUS_CONFIRMED' | 'IF_PREVIOUS_NOT_CONFIRMED'
+    conditionSourceOrder?: number
     variantBVariables?: Record<string, string> | null
     fallbackToPush?: boolean
     mobileDestination?: 'HOME' | 'SAVINGS' | 'CARDS' | 'PAYMENTS' | 'PRODUCT_HUB' | null

--- a/openbank-admin-ui/src/app/campaigns/new/page.tsx
+++ b/openbank-admin-ui/src/app/campaigns/new/page.tsx
@@ -297,9 +297,8 @@ export default function NewCampaignPage() {
 
   /**
    * A binary decision is an authoring shortcut over the service's two complementary, observable
-   * delivery conditions. Keeping both steps adjacent makes their shared predecessor unambiguous:
-   * when the first path is skipped, the second still evaluates that predecessor; when it sends,
-   * the second condition is false. The workflow has covered this replay-safe semantics since #3585.
+   * delivery conditions. Both generated paths explicitly point at the same source step: a skipped
+   * first path can therefore never become the second path's input.
    */
   const addDeliveryDecision = () =>
     setSteps(prev => {
@@ -309,6 +308,7 @@ export default function NewCampaignPage() {
       const decisionStep = (condition: EditorStep['condition']): EditorStep => ({
         ...newStep(first),
         condition,
+        conditionSourceOrder: prev.length - 1,
         ...(contentExperiment ? { variantBVariables: {} } : {}),
       })
       setSelected(prev.length)
@@ -395,6 +395,7 @@ export default function NewCampaignPage() {
           template: s.template,
           channel: s.channel,
           ...(s.condition ? { condition: s.condition } : {}),
+          ...(s.conditionSourceOrder !== undefined ? { conditionSourceOrder: s.conditionSourceOrder + 1 } : {}),
           variables: s.variables,
           ...(contentExperiment ? { variantBVariables: s.variantBVariables ?? {} } : {}),
           ...(contentExperiment && s.variantBTemplate ? { variantBTemplate: s.variantBTemplate } : {}),

--- a/openbank-admin-ui/src/components/campaigns/JourneyCanvas.tsx
+++ b/openbank-admin-ui/src/components/campaigns/JourneyCanvas.tsx
@@ -36,6 +36,8 @@ export interface StepFunnel {
   reached: number
   delivered: number
   failed: number
+  /** Present from campaign-service 1.32.0; absence during rollout must not invent a branch count. */
+  skipped?: number
   suppressed: SuppressionCount[]
 }
 
@@ -43,6 +45,9 @@ export interface JourneyStep {
   order: number
   template: string
   delaySeconds: number
+  channel?: 'EMAIL' | 'PUSH' | 'BANNER'
+  condition?: 'IF_PREVIOUS_CONFIRMED' | 'IF_PREVIOUS_NOT_CONFIRMED'
+  conditionSourceOrder?: number
 }
 
 const NODE_W = 190
@@ -98,6 +103,19 @@ export function JourneyCanvas({
     return t(`čekat ${Math.floor(s / 60)} min`, `wait ${Math.floor(s / 60)} min`)
   }
 
+  const channelLabel = (channel?: JourneyStep['channel']): string =>
+    channel === 'PUSH' ? t('push', 'push') : channel === 'BANNER' ? t('banner', 'banner') : t('e-mail', 'email')
+
+  const conditionLabel = (step: JourneyStep): string | null => {
+    if (!step.condition) return null
+    const source = step.conditionSourceOrder === undefined
+      ? t('výsledek předchozího kroku', 'previous-step delivery')
+      : t(`krok ${step.conditionSourceOrder + 1}`, `step ${step.conditionSourceOrder + 1}`)
+    return step.condition === 'IF_PREVIOUS_CONFIRMED'
+      ? t(`${source} doručen`, `${source} delivered`)
+      : t(`${source} nedoručen`, `${source} not delivered`)
+  }
+
   const rows = Array.isArray(funnel) ? funnel : []
   const byStep = new Map(rows.map(f => [f.stepOrder, f]))
   const ordered = Array.isArray(steps) ? [...steps].sort((a, b) => a.order - b.order) : []
@@ -149,6 +167,11 @@ export function JourneyCanvas({
           const f = byStep.get(step.order)
           const reached = f?.reached ?? 0
           const delivered = f?.delivered ?? 0
+          const skipped = f?.skipped
+          // A skipped conditional record proves the *other* reviewed branch was chosen. It is not
+          // a delivery attempt, failure or policy suppression, and must not inflate this path.
+          const pathTaken = step.condition && skipped !== undefined ? Math.max(0, reached - skipped) : reached
+          const branch = conditionLabel(step)
           const drops: SuppressionCount[] = [
             ...(f?.suppressed ?? []),
             ...(f && f.failed > 0 ? [{ reason: 'FAILED', count: f.failed }] : []),
@@ -168,9 +191,14 @@ export function JourneyCanvas({
               <text x={midX} y={ROW_Y - 12} fontSize="11" textAnchor="middle" fill="var(--text-secondary)">
                 {delayLabel(step.delaySeconds)}
               </text>
-              {reached > 0 && (
+              {pathTaken > 0 && (
                 <text x={midX} y={ROW_Y + 20} fontSize="12" textAnchor="middle" fontWeight="600" fill="var(--text-primary)">
-                  {n(reached)}
+                  {n(pathTaken)}
+                </text>
+              )}
+              {branch && (
+                <text x={midX} y={ROW_Y + 34} fontSize="10" textAnchor="middle" fill="var(--text-secondary)" data-branch={step.condition}>
+                  {branch}
                 </text>
               )}
 
@@ -180,7 +208,7 @@ export function JourneyCanvas({
                   fill="var(--surface-2)" stroke="var(--border-strong)" strokeWidth="1.2"
                 />
                 <text x={x + 16} y={ROW_Y - 16} fontSize="11" fill="var(--text-secondary)">
-                  {t('KROK', 'STEP')} {step.order} · {t('e-mail', 'email')}
+                  {t('KROK', 'STEP')} {step.order} · {channelLabel(step.channel)}
                 </text>
                 <text x={x + 16} y={ROW_Y + 6} fontSize="14" fontWeight="600" fill="var(--text-primary)">
                   {templateLabel(step.template)}
@@ -191,6 +219,11 @@ export function JourneyCanvas({
                   </tspan>
                   {' '}{t('doručeno', 'delivered')}
                 </text>
+                {branch && skipped !== undefined && (
+                  <text x={x + 16} y={ROW_Y + 40} fontSize="10" fill="var(--text-secondary)">
+                    {n(skipped)} {t('jinou cestou', 'took another path')}
+                  </text>
+                )}
               </g>
 
               {/* Drop branches: one line per reason, labelled in words. A marketer reads "12 nemá

--- a/openbank-admin-ui/src/components/campaigns/JourneyEditor.tsx
+++ b/openbank-admin-ui/src/components/campaigns/JourneyEditor.tsx
@@ -40,8 +40,10 @@ export interface EditorStep {
   channel: EditorChannel
   variables: { [key: string]: string }
   delaySeconds: number
-  /** Absent means the step always runs. Evaluated against the previous send's delivery status. */
+  /** Absent means the step always runs. */
   condition?: EditorCondition
+  /** Optional explicit source step (zero-based canvas index) for a multi-path decision. */
+  conditionSourceOrder?: number
   /** Alternative B-arm values in a campaign-wide content experiment. */
   variantBVariables?: { [key: string]: string }
   /** Optional journey-path treatment for B; absent retains the historical copy-only experiment. */
@@ -154,9 +156,12 @@ export function JourneyEditor({
    * would be ornament suggesting a freedom of layout this canvas does not have. The label sits in a
    * chip that masks the line, which is what keeps it readable when the theme is dark.
    */
-  const conditionLabel = (c?: EditorCondition): string => {
-    if (c === 'IF_PREVIOUS_CONFIRMED') return t('jen po doručení', 'if delivered')
-    if (c === 'IF_PREVIOUS_NOT_CONFIRMED') return t('jen bez doručení', 'if not delivered')
+  const conditionLabel = (c?: EditorCondition, sourceOrder?: number): string => {
+    const source = sourceOrder !== undefined
+      ? t(`po kroku ${sourceOrder + 1}`, `step ${sourceOrder + 1}`)
+      : ''
+    if (c === 'IF_PREVIOUS_CONFIRMED') return source ? t(`${source} doručen`, `${source} delivered`) : t('jen po doručení', 'if delivered')
+    if (c === 'IF_PREVIOUS_NOT_CONFIRMED') return source ? t(`${source} nedoručen`, `${source} not delivered`) : t('jen bez doručení', 'if not delivered')
     return ''
   }
 
@@ -166,12 +171,18 @@ export function JourneyEditor({
    * the message rather than of the hop, and a marketer scanning the row would have to open each step
    * to find out why someone might not get it.
    */
-  const edge = (fromIdx: number, toIdx: number, label: string, condition?: EditorCondition) => {
+  const edge = (
+    fromIdx: number,
+    toIdx: number,
+    label: string,
+    condition?: EditorCondition,
+    conditionSourceOrder?: number,
+  ) => {
     const x0 = colX(fromIdx) + NODE_W
     const x1 = colX(toIdx)
     const mid = (x0 + x1) / 2
     const chipW = Math.max(46, label.length * 6.4 + 16)
-    const cLabel = conditionLabel(condition)
+    const cLabel = conditionLabel(condition, conditionSourceOrder)
     const cW = Math.max(60, cLabel.length * 6.2 + 22)
     return (
       <g key={`e${fromIdx}`}>
@@ -284,7 +295,7 @@ export function JourneyEditor({
           const ch = CHANNEL[step.channel] ?? CHANNEL.EMAIL
           return (
             <g key={i}>
-              {edge(i, i + 1, delayLabel(step.delaySeconds), step.condition)}
+              {edge(i, i + 1, delayLabel(step.delaySeconds), step.condition, step.conditionSourceOrder)}
               <g
                 filter="url(#je-shadow)"
                 style={{ cursor: 'pointer' }}

--- a/openbank-admin-ui/src/components/campaigns/StepEditor.tsx
+++ b/openbank-admin-ui/src/components/campaigns/StepEditor.tsx
@@ -427,6 +427,14 @@ export function StepEditor({
             )}
           </p>
         )}
+        {step.conditionSourceOrder !== undefined && step.condition && (
+          <p className="text-xs text-muted-foreground">
+            {t(
+              `Tato větev vždy čte výsledek kroku ${step.conditionSourceOrder + 1}.`,
+              `This path always reads the result of step ${step.conditionSourceOrder + 1}.`,
+            )}
+          </p>
+        )}
         {step.condition === 'IF_PREVIOUS_NOT_CONFIRMED' && (
           <p className="text-xs text-muted-foreground">
             {t(

--- a/openbank-admin-ui/src/test/campaign-builder-interaction.test.tsx
+++ b/openbank-admin-ui/src/test/campaign-builder-interaction.test.tsx
@@ -192,6 +192,7 @@ describe('campaign builder conditions', () => {
     expect(container.querySelector('[data-step-editor="1"]')).toBeTruthy()
     expect(container.querySelector('[data-edge-condition="IF_PREVIOUS_CONFIRMED"]')).toBeTruthy()
     expect(container.querySelector('[data-edge-condition="IF_PREVIOUS_NOT_CONFIRMED"]')).toBeTruthy()
+    expect(container.textContent).toMatch(/step 1 delivered|kroku 1 doručen/)
   }, 25000)
 
   it('warns that a condition on the first step has nothing to test', async () => {

--- a/openbank-admin-ui/src/test/journey-flow.test.tsx
+++ b/openbank-admin-ui/src/test/journey-flow.test.tsx
@@ -15,8 +15,11 @@ import { JourneyCanvas } from '@/components/campaigns/JourneyCanvas'
  */
 
 const STEPS = [
-  { order: 1, template: 'MARKETING_PRODUCT_OFFER', delaySeconds: 0 },
-  { order: 2, template: 'MARKETING_PRODUCT_OFFER', delaySeconds: 172800 },
+  { order: 1, template: 'MARKETING_PRODUCT_OFFER', delaySeconds: 0, channel: 'PUSH' as const },
+  {
+    order: 2, template: 'MARKETING_PRODUCT_OFFER', delaySeconds: 172800, channel: 'BANNER' as const,
+    condition: 'IF_PREVIOUS_CONFIRMED' as const, conditionSourceOrder: 0,
+  },
 ]
 
 const FUNNEL = [
@@ -30,6 +33,7 @@ const FUNNEL = [
       { reason: 'SUPPRESSED_QUIET_HOURS', count: 90 },
     ],
   },
+  { stepOrder: 2, reached: 600, delivered: 420, failed: 0, skipped: 180, suppressed: [] },
 ]
 
 function renderFlow(funnel = FUNNEL, audience: number | null = 1000) {
@@ -105,5 +109,15 @@ describe('journey canvas', () => {
     renderFlow()
 
     expect(screen.getByText(/people in segment/)).toBeTruthy()
+  })
+
+  it('shows the reviewed decision and separates its other path from delivery loss', () => {
+    const { container } = renderFlow()
+
+    expect(screen.getByText(/step 1 delivered/)).toBeTruthy()
+    expect(screen.getByText(/180 took another path/)).toBeTruthy()
+    expect(container.querySelector('[data-branch="IF_PREVIOUS_CONFIRMED"]')).toBeTruthy()
+    expect(screen.getByText(/STEP 1 · push/)).toBeTruthy()
+    expect(screen.getByText(/STEP 2 · banner/)).toBeTruthy()
   })
 })

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/port/out/Ports.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/port/out/Ports.kt
@@ -177,6 +177,13 @@ interface SendLogRepository {
     suspend fun latestDeliveryStatusBeforeStep(campaignId: UUID, partyId: UUID, stepOrder: Int): DeliveryStatus?
 
     /**
+     * The newest observable delivery state for one explicitly named source step.  This is separate
+     * from [latestDeliveryStatusBeforeStep]: a multi-path decision must not let a skipped sibling
+     * change the condition's source.
+     */
+    suspend fun deliveryStatusForStep(campaignId: UUID, partyId: UUID, stepOrder: Int): DeliveryStatus? = null
+
+    /**
      * One page of send attempts for a campaign, newest first — the operator view of what happened.
      *
      * Paged at the repository, not in the caller: a campaign's send log has one row per party per

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/usecase/CampaignSendLogQuery.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/usecase/CampaignSendLogQuery.kt
@@ -65,6 +65,7 @@ class CampaignSendLogQuery(private val sendLog: SendLogRepository) {
                 reached = rows.sumOf { it.count },
                 delivered = byOutcome[SendOutcome.SENT] ?: 0,
                 failed = byOutcome[SendOutcome.FAILED] ?: 0,
+                skipped = byOutcome[SendOutcome.SKIPPED_CONDITION] ?: 0,
                 suppressed = SUPPRESSION_REASONS.mapNotNull { r ->
                     byOutcome[r]?.takeIf { it > 0 }?.let { SuppressionCount(r.name, it) }
                 },
@@ -106,6 +107,8 @@ data class StepFunnel(
     val reached: Long,
     val delivered: Long,
     val failed: Long,
+    /** The condition did not hold, so this party continued through another reviewed path. */
+    val skipped: Long,
     val suppressed: List<SuppressionCount>,
 )
 

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/workflow/CampaignJourneyActivities.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/workflow/CampaignJourneyActivities.kt
@@ -26,6 +26,9 @@ interface CampaignJourneyActivities {
      */
     fun previousDeliveryStatus(campaignId: UUID, partyId: UUID, stepOrder: Int): DeliveryStatus?
 
+    /** Delivery state for an explicit source step in a multi-path decision. */
+    fun deliveryStatusForStep(campaignId: UUID, partyId: UUID, stepOrder: Int): DeliveryStatus?
+
     /**
      * Record that [stepOrder] was skipped because its branch condition did not hold, and move the
      * enrolment past it. One activity, not a record + an advance: a skip that logged and then

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/workflow/CampaignJourneyActivities.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/workflow/CampaignJourneyActivities.kt
@@ -12,6 +12,8 @@ import io.temporal.activity.ActivityInterface
 import java.util.UUID
 
 @ActivityInterface
+// Temporal requires one stable activity contract; splitting it would distribute replay compatibility.
+@Suppress("TooManyFunctions")
 interface CampaignJourneyActivities {
     fun loadDefinition(campaignId: UUID): JourneyDefinition
     fun controlState(campaignId: UUID, partyId: UUID): JourneyControlState

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/workflow/CampaignJourneyActivitiesImpl.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/workflow/CampaignJourneyActivitiesImpl.kt
@@ -96,6 +96,11 @@ open class CampaignJourneyActivitiesImpl(
             sendLog.latestDeliveryStatusBeforeStep(campaignId, partyId, stepOrder)
         }
 
+    override fun deliveryStatusForStep(campaignId: UUID, partyId: UUID, stepOrder: Int): DeliveryStatus? =
+        runBlockingOnWorker {
+            sendLog.deliveryStatusForStep(campaignId, partyId, stepOrder)
+        }
+
     override fun skipStep(campaignId: UUID, partyId: UUID, stepOrder: Int) = runBlockingOnWorker {
         sendLog.record(
             SendRecord(Ids.newId(), campaignId, partyId, stepOrder, SendOutcome.SKIPPED_CONDITION, Instant.now()),

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/workflow/CampaignJourneyWorkflowImpl.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/workflow/CampaignJourneyWorkflowImpl.kt
@@ -51,9 +51,14 @@ class CampaignJourneyWorkflowImpl : CampaignJourneyWorkflow {
         // Existing workflow histories did not call controlState. Temporal versioning keeps their
         // replay command-for-command identical; new signals still protect them immediately.
         val controlVersion = Workflow.getVersion(CONTROL_STATE_CHANGE_ID, Workflow.DEFAULT_VERSION, CONTROL_STATE_V1)
+        val decisionSourceVersion = Workflow.getVersion(
+            DECISION_SOURCE_CHANGE_ID,
+            Workflow.DEFAULT_VERSION,
+            DECISION_SOURCE_V1,
+        )
         val definition = activities.loadDefinition(campaignId)
         for (step in definition.steps.sortedBy { it.order }) {
-            executeStep(campaignId, partyId, definition, step, controlVersion)?.let {
+            executeStep(campaignId, partyId, definition, step, controlVersion, decisionSourceVersion)?.let {
                 activities.markTerminated(campaignId, partyId, it)
                 return
             }
@@ -68,6 +73,7 @@ class CampaignJourneyWorkflowImpl : CampaignJourneyWorkflow {
         definition: JourneyDefinition,
         step: CampaignStep,
         controlVersion: Int,
+        decisionSourceVersion: Int,
     ): TerminationReason? {
         readyOrTermination(campaignId, partyId, controlVersion)?.let { return it }
         // ADR-0200 D1: evaluate durable SENT rows before every step, including the first.
@@ -95,12 +101,23 @@ class CampaignJourneyWorkflowImpl : CampaignJourneyWorkflow {
         }
         // Conditions are evaluated after the delay, when the predecessor's outcome can exist.
         if (step.condition != null &&
-            !step.condition.holdsFor(activities.previousDeliveryStatus(campaignId, partyId, step.order))
+            !step.condition.holdsFor(deliveryStatusForCondition(campaignId, partyId, step, decisionSourceVersion))
         ) {
             activities.skipStep(campaignId, partyId, step.order)
             return null
         }
         return deliverWhenReady(campaignId, partyId, step.order, controlVersion)
+    }
+
+    private fun deliveryStatusForCondition(
+        campaignId: UUID,
+        partyId: UUID,
+        step: CampaignStep,
+        decisionSourceVersion: Int,
+    ) = if (decisionSourceVersion >= DECISION_SOURCE_V1 && step.conditionSourceOrder != null) {
+        activities.deliveryStatusForStep(campaignId, partyId, step.conditionSourceOrder)
+    } else {
+        activities.previousDeliveryStatus(campaignId, partyId, step.order)
     }
 
     private fun deliverWhenReady(
@@ -197,6 +214,8 @@ class CampaignJourneyWorkflowImpl : CampaignJourneyWorkflow {
         private const val SCHEDULE_TO_CLOSE_MINUTES = 5L
         private const val CONTROL_STATE_CHANGE_ID = "campaign-control-state-v1"
         private const val CONTROL_STATE_V1 = 1
+        private const val DECISION_SOURCE_CHANGE_ID = "campaign-decision-source-v1"
+        private const val DECISION_SOURCE_V1 = 1
         private const val PATH_EXPERIMENT_DELAY_CHANGE_ID = "campaign-path-experiment-delay-v1"
         private const val PATH_EXPERIMENT_DELAY_V1 = 1
         private val CONTROL_RECHECK_INTERVAL: Duration = Duration.ofMinutes(1)

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/domain/model/Campaign.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/domain/model/Campaign.kt
@@ -74,6 +74,14 @@ data class Campaign(
         require(name.isNotBlank()) { "campaign name must not be blank" }
         require(steps.isNotEmpty()) { "campaign must have at least one step" }
         require(steps.size <= MAX_STEPS) { "journeys are capped at $MAX_STEPS steps in the first slice" }
+        require(steps.map { it.order }.distinct().size == steps.size) { "campaign step orders must be unique" }
+        steps.forEach { step ->
+            step.conditionSourceOrder?.let { sourceOrder ->
+                require(step.condition != null) { "a condition source requires a branch condition" }
+                require(sourceOrder < step.order) { "a condition source must be an earlier step" }
+                require(steps.any { it.order == sourceOrder }) { "a condition source must name a campaign step" }
+            }
+        }
         require(holdoutPercent in 0..MAX_HOLDOUT_PERCENT) {
             "holdoutPercent must be between 0 and $MAX_HOLDOUT_PERCENT"
         }
@@ -231,6 +239,12 @@ data class CampaignStep(
      * it took before. See [StepCondition].
      */
     val condition: StepCondition? = null,
+    /**
+     * Optional explicit source for [condition].  Absent preserves the original "latest earlier
+     * delivery" semantics.  When present, both arms of a decision can name the same source step,
+     * so a skipped arm can never accidentally become the other's predecessor.
+     */
+    val conditionSourceOrder: Int? = null,
     /**
      * Alternative declared values for the B arm of a campaign-wide A/B content experiment.
      * Null preserves the historical single-content step; when present every step must provide it

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/persistence/Persistence.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/persistence/Persistence.kt
@@ -660,6 +660,20 @@ class PanacheSendLogRepository :
         ).firstResult<SendLogEntity>()
     }.awaitSuspending()?.let { DeliveryStatus.valueOf(it.deliveryStatus) }
 
+    override suspend fun deliveryStatusForStep(
+        campaignId: UUID,
+        partyId: UUID,
+        stepOrder: Int,
+    ): DeliveryStatus? = Panache.withSession {
+        find(
+            "campaignId = ?1 and partyId = ?2 and stepOrder = ?3 and outcome <> ?4 order by occurredAt desc",
+            campaignId,
+            partyId,
+            stepOrder,
+            SendOutcome.SKIPPED_CONDITION.name,
+        ).firstResult<SendLogEntity>()
+    }.awaitSuspending()?.let { DeliveryStatus.valueOf(it.deliveryStatus) }
+
     override suspend fun conversionContextFor(campaignId: UUID, partyId: UUID): ConversionContext =
         Panache.withSession {
             find(

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/persistence/Persistence.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/persistence/Persistence.kt
@@ -660,19 +660,16 @@ class PanacheSendLogRepository :
         ).firstResult<SendLogEntity>()
     }.awaitSuspending()?.let { DeliveryStatus.valueOf(it.deliveryStatus) }
 
-    override suspend fun deliveryStatusForStep(
-        campaignId: UUID,
-        partyId: UUID,
-        stepOrder: Int,
-    ): DeliveryStatus? = Panache.withSession {
-        find(
-            "campaignId = ?1 and partyId = ?2 and stepOrder = ?3 and outcome <> ?4 order by occurredAt desc",
-            campaignId,
-            partyId,
-            stepOrder,
-            SendOutcome.SKIPPED_CONDITION.name,
-        ).firstResult<SendLogEntity>()
-    }.awaitSuspending()?.let { DeliveryStatus.valueOf(it.deliveryStatus) }
+    override suspend fun deliveryStatusForStep(campaignId: UUID, partyId: UUID, stepOrder: Int): DeliveryStatus? =
+        Panache.withSession {
+            find(
+                "campaignId = ?1 and partyId = ?2 and stepOrder = ?3 and outcome <> ?4 order by occurredAt desc",
+                campaignId,
+                partyId,
+                stepOrder,
+                SendOutcome.SKIPPED_CONDITION.name,
+            ).firstResult<SendLogEntity>()
+        }.awaitSuspending()?.let { DeliveryStatus.valueOf(it.deliveryStatus) }
 
     override suspend fun conversionContextFor(campaignId: UUID, partyId: UUID): ConversionContext =
         Panache.withSession {

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/rest/CampaignResource.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/rest/CampaignResource.kt
@@ -78,6 +78,8 @@ data class StepRequest(
     val delaySeconds: Long = 0,
     /** Optional branch condition (ADR-0200 D1, #3585). Absent means the step always runs. */
     val condition: StepCondition? = null,
+    /** Optional explicit earlier source step for a multi-path decision. */
+    val conditionSourceOrder: Int? = null,
     /** The B-arm values for a campaign-wide content experiment; absent keeps one shared message. */
     val variantBVariables: Map<String, String>? = null,
     /** Use the catalogue's safe PUSH counterpart only when this EMAIL step lacks email consent. */
@@ -126,6 +128,7 @@ private fun CreateCampaignRequest.toSteps(): List<CampaignStep> = steps.map {
         it.variables,
         it.delaySeconds,
         it.condition,
+        it.conditionSourceOrder,
         it.variantBVariables,
         it.fallbackToPush,
         it.mobileDestination,

--- a/openbank-campaign-service/src/main/resources/openapi.yaml
+++ b/openbank-campaign-service/src/main/resources/openapi.yaml
@@ -4,7 +4,7 @@ openapi: 3.1.0
 info:
   title: Campaign Service API
   # major == openbank.api.version == URL /api/v1 (ADR-0048).
-  version: 1.30.0
+  version: 1.31.0
   description: >-
     Campaign management first slice (ADR-0200 / ADR-0209 D3): deterministic, versioned segments;
     per-enrolment Temporal journeys; consent-gated delivery through notification-service.
@@ -780,6 +780,14 @@ components:
             so IF_PREVIOUS_CONFIRMED does not hold and IF_PREVIOUS_NOT_CONFIRMED does.
           type: string
           enum: [IF_PREVIOUS_CONFIRMED, IF_PREVIOUS_NOT_CONFIRMED]
+        conditionSourceOrder:
+          type: integer
+          nullable: true
+          minimum: 0
+          description: >-
+            Optional explicit earlier step whose delivery status the condition reads. Both arms of
+            a decision use the same source, so a skipped arm cannot become the other arm's input.
+            Absent preserves the historical most-recent-earlier-step behaviour.
     CreateCampaignRequest:
       type: object
       required: [name, goal, segmentName, segmentVersion, steps]

--- a/openbank-campaign-service/src/main/resources/openapi.yaml
+++ b/openbank-campaign-service/src/main/resources/openapi.yaml
@@ -4,7 +4,7 @@ openapi: 3.1.0
 info:
   title: Campaign Service API
   # major == openbank.api.version == URL /api/v1 (ADR-0048).
-  version: 1.31.0
+  version: 1.32.0
   description: >-
     Campaign management first slice (ADR-0200 / ADR-0209 D3): deterministic, versioned segments;
     per-enrolment Temporal journeys; consent-gated delivery through notification-service.
@@ -979,6 +979,13 @@ components:
           description: Sends this step recorded at all — delivered plus every suppression.
         delivered: { type: integer, format: int64 }
         failed: { type: integer, format: int64 }
+        skipped:
+          type: integer
+          format: int64
+          description: >-
+            Parties for whom this conditional step did not run because its reviewed delivery
+            predicate did not hold. They are not failures or suppressions; they continued through
+            the complementary path.
         suppressed:
           type: array
           description: >-

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/CampaignSendLogTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/CampaignSendLogTest.kt
@@ -33,6 +33,7 @@ class CampaignSendLogTest {
         record(SendOutcome.SUPPRESSED_CAP, 2),
         record(SendOutcome.SUPPRESSED_QUIET_HOURS, 2),
         record(SendOutcome.FAILED, 3),
+        record(SendOutcome.SKIPPED_CONDITION, 3),
     )
 
     private fun record(outcome: SendOutcome, step: Int) = SendRecord(
@@ -93,6 +94,7 @@ class CampaignSendLogTest {
                 SendOutcome.SUPPRESSED_CAP,
                 SendOutcome.SUPPRESSED_QUIET_HOURS,
                 SendOutcome.FAILED,
+                SendOutcome.SKIPPED_CONDITION,
             ),
             sends.map { it.outcome }.toSet(),
         )
@@ -164,5 +166,14 @@ class CampaignSendLogTest {
         assertEquals(0, page.page)
         assertEquals(1, page.size)
         assertEquals(1, page.items.size)
+    }
+
+    @Test
+    fun `a skipped conditional branch is reported separately from failure and suppression`(): Unit = runBlocking {
+        val step = query.funnel(campaignId).single { it.stepOrder == 3 }
+
+        assertEquals(1, step.skipped)
+        assertEquals(1, step.failed)
+        assertEquals(0, step.suppressed.size)
     }
 }

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/workflow/CampaignJourneyWorkflowTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/workflow/CampaignJourneyWorkflowTest.kt
@@ -62,14 +62,14 @@ class CampaignJourneyWorkflowTest {
             delaySeconds: Long = 0,
             conditionSourceOrder: Int? = null,
         ): CampaignStep = CampaignStep(
-                order = order,
-                template = "MARKETING_PRODUCT_OFFER",
-                channel = Channel.EMAIL,
-                variables = emptyMap(),
-                delaySeconds = delaySeconds,
-                condition = condition,
-                conditionSourceOrder = conditionSourceOrder,
-            )
+            order = order,
+            template = "MARKETING_PRODUCT_OFFER",
+            channel = Channel.EMAIL,
+            variables = emptyMap(),
+            delaySeconds = delaySeconds,
+            condition = condition,
+            conditionSourceOrder = conditionSourceOrder,
+        )
     }
 
     @BeforeEach

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/workflow/CampaignJourneyWorkflowTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/workflow/CampaignJourneyWorkflowTest.kt
@@ -56,7 +56,12 @@ class CampaignJourneyWorkflowTest {
                 ),
             )
 
-        private fun step(order: Int, condition: StepCondition? = null, delaySeconds: Long = 0): CampaignStep =
+        private fun step(
+            order: Int,
+            condition: StepCondition? = null,
+            delaySeconds: Long = 0,
+            conditionSourceOrder: Int? = null,
+        ): CampaignStep =
             CampaignStep(
                 order = order,
                 template = "MARKETING_PRODUCT_OFFER",
@@ -64,6 +69,7 @@ class CampaignJourneyWorkflowTest {
                 variables = emptyMap(),
                 delaySeconds = delaySeconds,
                 condition = condition,
+                conditionSourceOrder = conditionSourceOrder,
             )
     }
 
@@ -88,6 +94,7 @@ class CampaignJourneyWorkflowTest {
             JourneyControlState(CampaignState.ACTIVE, goalReached = false)
         every { activities.deliverStep(any(), any(), any()) } returns StepOutcome.SENT
         every { activities.previousDeliveryStatus(any(), any(), any()) } returns null
+        every { activities.deliveryStatusForStep(any(), any(), any()) } returns null
         worker.registerActivitiesImplementations(activities)
         env.start()
     }
@@ -184,6 +191,29 @@ class CampaignJourneyWorkflowTest {
     }
 
     @Test
+    fun `complementary paths read their one explicit source, not a skipped sibling`() {
+        every { activities.loadDefinition(campaignId) } returns JourneyDefinition(
+            listOf(
+                step(0),
+                step(1, StepCondition.IF_PREVIOUS_CONFIRMED, conditionSourceOrder = 0),
+                step(2, StepCondition.IF_PREVIOUS_NOT_CONFIRMED, conditionSourceOrder = 0),
+            ),
+            null,
+        )
+        every { activities.deliveryStatusForStep(campaignId, partyId, 0) } returns DeliveryStatus.CONFIRMED
+
+        run()
+
+        verify { activities.deliverStep(campaignId, partyId, 0) }
+        verify { activities.deliverStep(campaignId, partyId, 1) }
+        verify(exactly = 0) { activities.deliverStep(campaignId, partyId, 2) }
+        verify { activities.skipStep(campaignId, partyId, 2) }
+        verify(exactly = 2) { activities.deliveryStatusForStep(campaignId, partyId, 0) }
+        verify(exactly = 0) { activities.previousDeliveryStatus(campaignId, partyId, 1) }
+        verify(exactly = 0) { activities.previousDeliveryStatus(campaignId, partyId, 2) }
+    }
+
+    @Test
     fun `IF_PREVIOUS_CONFIRMED does not hold for a first step, which has no predecessor`() {
         every { activities.loadDefinition(campaignId) } returns
             JourneyDefinition(listOf(step(0, StepCondition.IF_PREVIOUS_CONFIRMED)), null)
@@ -206,6 +236,7 @@ class CampaignJourneyWorkflowTest {
         // the new activity is never invoked, so a journey started before this change emits no
         // command its recorded history lacks.
         verify(exactly = 0) { activities.previousDeliveryStatus(any(), any(), any()) }
+        verify(exactly = 0) { activities.deliveryStatusForStep(any(), any(), any()) }
     }
 
     // --- live campaign controls and goal exit ---------------------------------------------------

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/workflow/CampaignJourneyWorkflowTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/workflow/CampaignJourneyWorkflowTest.kt
@@ -61,8 +61,7 @@ class CampaignJourneyWorkflowTest {
             condition: StepCondition? = null,
             delaySeconds: Long = 0,
             conditionSourceOrder: Int? = null,
-        ): CampaignStep =
-            CampaignStep(
+        ): CampaignStep = CampaignStep(
                 order = order,
                 template = "MARKETING_PRODUCT_OFFER",
                 channel = Channel.EMAIL,

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/domain/CampaignStateMachineTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/domain/CampaignStateMachineTest.kt
@@ -10,6 +10,7 @@ import com.openbank.campaign.domain.model.CampaignState
 import com.openbank.campaign.domain.model.CampaignStep
 import com.openbank.campaign.domain.model.Channel
 import com.openbank.campaign.domain.model.SegmentRef
+import com.openbank.campaign.domain.model.StepCondition
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -94,6 +95,28 @@ class CampaignStateMachineTest {
         val sixSteps = (0..5).map { CampaignStep(it, "MARKETING_PRODUCT_OFFER", Channel.EMAIL, emptyMap(), 0) }
         assertThrows<IllegalArgumentException> {
             draft().copy(steps = sixSteps)
+        }
+    }
+
+    @Test
+    fun `a decision source must be an earlier existing step with a condition`() {
+        val source = CampaignStep(0, "MARKETING_PRODUCT_OFFER", Channel.EMAIL, emptyMap(), 0)
+        val target = CampaignStep(
+            order = 1,
+            template = "MARKETING_PRODUCT_OFFER",
+            channel = Channel.EMAIL,
+            variables = emptyMap(),
+            delaySeconds = 0,
+            condition = StepCondition.IF_PREVIOUS_CONFIRMED,
+            conditionSourceOrder = 0,
+        )
+        assertEquals(listOf(source, target), draft().copy(steps = listOf(source, target)).steps)
+
+        assertThrows<IllegalArgumentException> {
+            draft().copy(steps = listOf(source, target.copy(conditionSourceOrder = 1)))
+        }
+        assertThrows<IllegalArgumentException> {
+            draft().copy(steps = listOf(source, target.copy(condition = null)))
         }
     }
 

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/integration/CampaignRestContractIT.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/integration/CampaignRestContractIT.kt
@@ -389,6 +389,45 @@ class CampaignRestContractIT {
         }
     }
 
+    @Test
+    fun `two decision paths can name the same explicit source step`() {
+        val body = """
+            {"name":"decision-${UUID.randomUUID()}","goal":"prove an explicit decision source survives HTTP",
+             "segmentName":"actives","segmentVersion":1,
+             "steps":[
+               {"order":1,"template":"MARKETING_PRODUCT_OFFER",
+                "variables":{"offerTitle":"T","offerText":"X","ctaText":"Go"},"delaySeconds":0},
+               {"order":2,"template":"MARKETING_PRODUCT_OFFER",
+                "variables":{"offerTitle":"T","offerText":"X","ctaText":"Go"},"delaySeconds":0,
+                "condition":"IF_PREVIOUS_CONFIRMED","conditionSourceOrder":1},
+               {"order":3,"template":"MARKETING_PRODUCT_OFFER",
+                "variables":{"offerTitle":"T","offerText":"X","ctaText":"Go"},"delaySeconds":0,
+                "condition":"IF_PREVIOUS_NOT_CONFIRMED","conditionSourceOrder":1}
+             ]}
+        """.trimIndent()
+
+        val id = Given {
+            contentType("application/json")
+            body(body)
+        } When {
+            post("/api/v1/campaigns")
+        } Then {
+            statusCode(201)
+            body("steps[1].conditionSourceOrder", org.hamcrest.Matchers.equalTo(1))
+            body("steps[2].conditionSourceOrder", org.hamcrest.Matchers.equalTo(1))
+        } Extract {
+            path<String>("id")
+        }
+
+        When {
+            get("/api/v1/campaigns/$id")
+        } Then {
+            statusCode(200)
+            body("steps[1].conditionSourceOrder", org.hamcrest.Matchers.equalTo(1))
+            body("steps[2].conditionSourceOrder", org.hamcrest.Matchers.equalTo(1))
+        }
+    }
+
     /**
      * These terminal reasons are operator-visible contract values, not internal workflow detail.
      * Drive the real endpoint over rows that can only be produced by live journey control: a test


### PR DESCRIPTION
Refs #4680. Adds an explicit persisted source step for each delivery decision path, a version-gated Temporal execution path, API/OpenAPI support, and Campaign Studio source visibility. Focused workflow, domain, typecheck, lint and UI interaction tests pass locally. The real HTTP contract test is included but local Docker did not respond, so CI must execute it.