### PR TITLE
fix(sca): DEVICE_ENROLLED carries no eventType in the payload body, so onboarding has never projected one

### DIFF
--- a/openbank-onboarding-service/src/main/kotlin/com/openbank/onboarding/infrastructure/kafka/OnboardingEventConsumer.kt
+++ b/openbank-onboarding-service/src/main/kotlin/com/openbank/onboarding/infrastructure/kafka/OnboardingEventConsumer.kt
@@ -10,6 +10,7 @@ import com.openbank.onboarding.application.usecase.OnboardingProjectionService
 import com.openbank.onboarding.domain.model.KycStage
 import com.openbank.onboarding.domain.model.OnboardingEvent
 import com.openbank.onboarding.domain.model.PartyStage
+import com.openbank.onboarding.infrastructure.observability.ProjectionOutcomeMetrics
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.inject.Inject
 import org.eclipse.microprofile.reactive.messaging.Incoming
@@ -37,6 +38,11 @@ class OnboardingEventConsumer(private val clock: Clock) {
 
     @Inject
     lateinit var objectMapper: ObjectMapper
+
+    // Field injection: the constructor already carries Clock, and detekt's LongParameterList
+    // fires AT the threshold rather than above it.
+    @Inject
+    lateinit var metrics: ProjectionOutcomeMetrics
 
     private val log = Logger.getLogger(OnboardingEventConsumer::class.java)
 
@@ -75,8 +81,12 @@ class OnboardingEventConsumer(private val clock: Clock) {
             parsePartyEvent(node)
         } catch (e: Exception) {
             log.errorf(e, "[party-events-in] Failed to map event: %.200s", payload)
+            metrics.record("party-events-in", ProjectionOutcomeMetrics.Outcome.FAILED)
             return
-        } ?: return
+        } ?: run {
+            metrics.record("party-events-in", ProjectionOutcomeMetrics.Outcome.UNRECOGNISED)
+            return
+        }
         project(event, "party-events-in")
     }
 
@@ -171,20 +181,30 @@ class OnboardingEventConsumer(private val clock: Clock) {
             objectMapper.readTree(payload)
         } catch (e: Exception) {
             log.errorf(e, "[%s] Failed to parse JSON payload: %.200s", topic, payload)
+            metrics.record(topic, ProjectionOutcomeMetrics.Outcome.FAILED)
             return null
         }
-        return try {
+        val event = try {
             parse(node)
         } catch (e: Exception) {
             log.errorf(e, "[%s] Failed to map event: %.200s", topic, payload)
-            null
+            metrics.record(topic, ProjectionOutcomeMetrics.Outcome.FAILED)
+            return null
         }
+        // A null here is the QUIET drop this counter exists for: valid JSON the parser
+        // recognised nothing in. No log — it is the normal outcome for the many event types
+        // on a shared topic that onboarding legitimately ignores — so the only way to tell
+        // "ignoring what we should ignore" from "ignoring everything" is the ratio.
+        if (event == null) metrics.record(topic, ProjectionOutcomeMetrics.Outcome.UNRECOGNISED)
+        return event
     }
 
     private suspend fun project(event: OnboardingEvent, topic: String) {
         try {
             projection.applyEvent(event)
+            metrics.record(topic, ProjectionOutcomeMetrics.Outcome.PROJECTED)
         } catch (e: Exception) {
+            metrics.record(topic, ProjectionOutcomeMetrics.Outcome.FAILED)
             log.errorf(e, "[%s] Projection failed for event type %s", topic, event::class.simpleName)
             // Ack the message (don't rethrow) — the read-model can be re-seeded from events if needed.
         }

--- a/openbank-onboarding-service/src/main/kotlin/com/openbank/onboarding/infrastructure/observability/ProjectionOutcomeMetrics.kt
+++ b/openbank-onboarding-service/src/main/kotlin/com/openbank/onboarding/infrastructure/observability/ProjectionOutcomeMetrics.kt
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+package com.openbank.onboarding.infrastructure.observability
+
+import io.micrometer.core.instrument.Counter
+import io.micrometer.core.instrument.MeterRegistry
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.enterprise.inject.Instance
+import jakarta.inject.Inject
+
+/**
+ * The outcome of every message the onboarding projection consumes, per topic (#4353).
+ *
+ * `openbank_onboarding_projection_events_total{service="onboarding",topic,outcome}`
+ *
+ * The signal that was missing. `OnboardingEventConsumer` drops an unrecognised event on the
+ * quiet path — `parse(...) ?: return` — with no log and no error, which is correct for a
+ * read-model (a poison pill must not wedge the consumer group) and is also why a whole event
+ * type could be discarded indefinitely without a trace. sca-service published 15
+ * `DEVICE_ENROLLED` events that every consumer accepted and none projected, because the
+ * discriminator was absent from the payload body; the topic had no lag, the pod was healthy,
+ * the handler and its unit tests were correct, and nothing anywhere disagreed.
+ *
+ * An error rate could not have caught that — there were no errors. The alertable state is the
+ * SUCCESS state: a topic delivering messages of which none are [Outcome.PROJECTED]. Hence
+ * [Outcome.UNRECOGNISED] is its own value rather than being folded into a generic "handled",
+ * the same reason `PushSendOutcome.SKIPPED` is not a flag shared with success.
+ *
+ * Suggested rule (per topic, over a window in which the topic delivered anything at all):
+ *   sum by (topic) (rate(...{outcome="UNRECOGNISED"}[1h])) > 0
+ *     and sum by (topic) (rate(...{outcome="PROJECTED"}[1h])) == 0
+ *
+ * Cardinality is bounded: three topics, three outcomes.
+ *
+ * Service-local [MeterRegistry], null-safe via [Instance] — same shape as
+ * [OnboardingFunnelGauge] and notification-service's `PushMetricsAdapter` (ADR-0085 §2).
+ */
+@ApplicationScoped
+class ProjectionOutcomeMetrics(private val registry: MeterRegistry?) {
+
+    // Explicit @Inject constructor: without it ArC sees two constructors, registers no bean,
+    // and OnboardingEventConsumer is left with an unsatisfied dependency at build time.
+    @Inject
+    constructor(registryInstance: Instance<MeterRegistry>) : this(
+        if (registryInstance.isResolvable) registryInstance.get() else null,
+    )
+
+    enum class Outcome {
+        /** Parsed, recognised, and applied to the read model. */
+        PROJECTED,
+
+        /**
+         * Well-formed JSON the parser returned no event for — an unknown or absent `eventType`,
+         * or a required field that would not coerce. NOT an error, and NOT a success: this is
+         * the state in which a producer and a consumer disagree about the wire format while
+         * both report healthy.
+         */
+        UNRECOGNISED,
+
+        /** Malformed payload, or the projection itself threw. Already logged at ERROR. */
+        FAILED,
+    }
+
+    fun record(topic: String, outcome: Outcome) {
+        registry?.let { r ->
+            Counter.builder(METRIC)
+                .tag("service", SERVICE)
+                .tag("topic", topic)
+                .tag("outcome", outcome.name)
+                .description("Onboarding projection outcomes per consumed message")
+                .register(r)
+                .increment()
+        }
+    }
+
+    companion object {
+        private const val SERVICE = "onboarding"
+        private const val METRIC = "openbank.onboarding.projection.events"
+    }
+}

--- a/openbank-onboarding-service/src/test/kotlin/com/openbank/onboarding/infrastructure/kafka/OnboardingEventConsumerTest.kt
+++ b/openbank-onboarding-service/src/test/kotlin/com/openbank/onboarding/infrastructure/kafka/OnboardingEventConsumerTest.kt
@@ -9,11 +9,13 @@ import com.openbank.onboarding.application.usecase.OnboardingProjectionService
 import com.openbank.onboarding.domain.model.KycStage
 import com.openbank.onboarding.domain.model.OnboardingEvent
 import com.openbank.onboarding.domain.model.PartyStage
+import com.openbank.onboarding.infrastructure.observability.ProjectionOutcomeMetrics
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
+import io.mockk.verify
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -30,6 +32,7 @@ class OnboardingEventConsumerTest {
 
     private val projection = mockk<OnboardingProjectionService>()
     private val objectMapper = ObjectMapper()
+    private val metrics = mockk<ProjectionOutcomeMetrics>(relaxed = true)
     private lateinit var consumer: OnboardingEventConsumer
 
     @BeforeEach
@@ -37,7 +40,54 @@ class OnboardingEventConsumerTest {
         consumer = OnboardingEventConsumer(Clock.systemUTC()).also {
             it.projection = projection
             it.objectMapper = objectMapper
+            it.metrics = metrics
         }
+    }
+
+    // ── DEVICE_ENROLLED (#4353) ───────────────────────────────────────────────
+
+    /**
+     * The payload is copied verbatim from a real `openbank.sca.events` message on the sandbox
+     * (2026-08-13), with the `eventType` this PR adds to the producer. Writing the JSON by hand
+     * from the parser's expectations is what let this diverge for the whole life of the topic:
+     * every unit test on both sides was green while the two artifacts disagreed on the wire.
+     */
+    @Test
+    fun `consumeScaEvent projects DEVICE_ENROLLED from the real sca-service payload`(): Unit = runBlocking {
+        val partyId = UUID.fromString("d03712b8-8814-40a7-a683-ac0c6a307204")
+        val payload = """{"eventType":"DEVICE_ENROLLED",""" +
+            """"deviceId":"78823928-36a6-44c3-bf4d-2ceb657cd623",""" +
+            """"partyId":"$partyId",""" +
+            """"credentialId":"e2e-1c0a4767-aed7-4e9a-9f91-ea8ba3e0493e",""" +
+            """"algorithm":"ES256","occurredAt":"2026-08-08T03:20:23.835301445Z"}"""
+        coEvery { projection.applyEvent(any()) } just runs
+
+        consumer.consumeScaEvent(payload)
+
+        coVerify(exactly = 1) {
+            projection.applyEvent(
+                match { it is OnboardingEvent.DeviceEnrolled && it.partyId == partyId },
+            )
+        }
+        verify(exactly = 1) { metrics.record("sca-events-in", ProjectionOutcomeMetrics.Outcome.PROJECTED) }
+    }
+
+    /**
+     * The shape as it actually shipped: no `eventType` in the body. The consumer must not throw
+     * and must not project — but it must now SAY so, because this drop was previously
+     * indistinguishable from an idle topic.
+     */
+    @Test
+    fun `consumeScaEvent counts a payload with no eventType as UNRECOGNISED`(): Unit = runBlocking {
+        val payload = """{"deviceId":"78823928-36a6-44c3-bf4d-2ceb657cd623",""" +
+            """"partyId":"d03712b8-8814-40a7-a683-ac0c6a307204",""" +
+            """"credentialId":"e2e-1","algorithm":"ES256",""" +
+            """"occurredAt":"2026-08-08T03:20:23.835301445Z"}"""
+
+        consumer.consumeScaEvent(payload)
+
+        coVerify(exactly = 0) { projection.applyEvent(any()) }
+        verify(exactly = 1) { metrics.record("sca-events-in", ProjectionOutcomeMetrics.Outcome.UNRECOGNISED) }
     }
 
     // ── PARTY_ERASED ──────────────────────────────────────────────────────────

--- a/openbank-sca-service/src/main/kotlin/com/openbank/sca/application/usecase/ScaService.kt
+++ b/openbank-sca-service/src/main/kotlin/com/openbank/sca/application/usecase/ScaService.kt
@@ -263,9 +263,20 @@ class ScaService(
         outboxRepository.save(
             OutboxMessage(
                 aggregateId = device.partyId,
-                eventType = "DEVICE_ENROLLED",
+                eventType = DEVICE_ENROLLED_EVENT_TYPE,
                 payload = objectMapper.writeValueAsString(
                     mapOf(
+                        // The discriminator MUST be in the payload body, not only in the outbox
+                        // column: every consumer of these topics receives the serialized payload
+                        // alone and switches on `eventType`. party-service and kyc-service both
+                        // embed it (PartyEvent.kt, KycEvent.kt); this publisher did not, so
+                        // onboarding-service's `parseScaEvent` read "" and fell to `else -> null`,
+                        // discarding the message on the quiet path (`?: return`, no log, no error).
+                        // Result: DEVICE_ENROLLED had never once been projected — 15 events
+                        // published and SENT, and every onboarding_records row still read
+                        // sca_enrolled=false / device_count=0, with 11 parties genuinely enrolled
+                        // (measured on the sandbox 2026-08-13, issue #4353).
+                        "eventType" to DEVICE_ENROLLED_EVENT_TYPE,
                         "deviceId" to device.id.toString(),
                         "partyId" to device.partyId.toString(),
                         "credentialId" to device.credentialId,
@@ -428,6 +439,13 @@ class ScaService(
  */
 private fun ScaChallenge.isReplayable(now: OffsetDateTime): Boolean =
     status == ScaStatus.PENDING && consumedAt == null && !isExpired(now)
+
+/**
+ * The `openbank.sca.events` discriminator. Declared once so the outbox column and the payload
+ * body cannot drift apart again — they are read by different consumers and only the body
+ * reaches onboarding-service.
+ */
+private const val DEVICE_ENROLLED_EVENT_TYPE = "DEVICE_ENROLLED"
 
 private fun Throwable.causedByUniqueViolation(): Boolean {
     var t: Throwable? = this

--- a/openbank-sca-service/src/test/kotlin/com/openbank/sca/application/usecase/ScaServiceTest.kt
+++ b/openbank-sca-service/src/test/kotlin/com/openbank/sca/application/usecase/ScaServiceTest.kt
@@ -6,6 +6,7 @@ package com.openbank.sca.application.usecase
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.openbank.libs.observability.DomainMetrics
+import com.openbank.libs.persistence.outbox.OutboxMessage
 import com.openbank.sca.application.port.`in`.ConsumeScaCommand
 import com.openbank.sca.application.port.`in`.EnrollDeviceCommand
 import com.openbank.sca.application.port.`in`.InitiateScaCommand
@@ -32,7 +33,10 @@ import com.openbank.sca.domain.model.SignatureAlgorithm
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.slot
 import io.mockk.verify
 import jakarta.persistence.PersistenceException
 import kotlinx.coroutines.runBlocking
@@ -603,6 +607,31 @@ class ScaServiceTest {
                 },
             )
         }
+    }
+
+    /**
+     * Regression for #4353. The assertion above checks `OutboxMessage.eventType` — the outbox
+     * COLUMN — and stayed green for the whole life of this publisher while the serialized
+     * payload carried no `eventType` at all. Only the body reaches a consumer: the dispatcher
+     * publishes `payload` and onboarding-service's `parseScaEvent` switches on the body's
+     * `eventType`, so a missing key sent every DEVICE_ENROLLED down `else -> null`.
+     *
+     * Asserting the column cannot catch that; this asserts what actually goes on the wire.
+     */
+    @Test
+    fun `enroll publishes eventType in the payload body, not only the outbox column`(): Unit = runBlocking {
+        val partyId = UUID.randomUUID()
+        coEvery { enrolledDeviceRepository.findByCredentialId("cred-wire") } returns null
+        coEvery { enrolledDeviceRepository.save(any()) } answers { firstArg() }
+        val captured = slot<OutboxMessage>()
+        coEvery { outboxRepository.save(capture(captured)) } just runs
+
+        service.enroll(EnrollDeviceCommand(partyId, "cred-wire", "pk", SignatureAlgorithm.ES256))
+
+        val body = objectMapper.readTree(captured.captured.payload)
+        assertThat(body.path("eventType").asText()).isEqualTo("DEVICE_ENROLLED")
+        assertThat(body.path("partyId").asText()).isEqualTo(partyId.toString())
+        assertThat(body.path("credentialId").asText()).isEqualTo("cred-wire")
     }
 
     @Test


### PR DESCRIPTION
## What this fixes

`openbank-sca-service` publishes `DEVICE_ENROLLED` to `openbank.sca.events` with **no `eventType` in the payload body** — it exists only as the `sca_outbox.event_type` column. Consumers receive the serialized body alone, so `onboarding-service`'s `parseScaEvent` read `""` and fell to `else -> null`, discarding every message on the quiet path (`?: return` — no log, no error, no lag).

**The `DeviceEnrolled` projection branch has never once executed in production.**

## Measured on the sandbox, 2026-08-13

| | |
|---|---|
| `DEVICE_ENROLLED` rows in `sca_outbox`, status `SENT` | **15** |
| SCA credentials in `sca_enrolled_devices` | 14, across **11 parties** |
| `onboarding_records` rows with `sca_enrolled = true` | **0 of 60** |
| `onboarding_records` rows with `device_count > 0` | **0 of 60** |
| Parties `ACTIVE` + KYC `APPROVED` stuck at `funnel_stage = SCA_PENDING` | **14** |

Verbatim payload off the topic — note the absent discriminator:

```json
{"deviceId":"78823928-…","partyId":"d03712b8-…","credentialId":"e2e-1c0a…","algorithm":"ES256","occurredAt":"2026-08-08T03:20:23.835301445Z"}
```

`party-service` and `kyc-service` both embed `eventType` in the body (`PartyEvent.kt`, `KycEvent.kt`) and both project correctly. sca was the only producer that did not, and the only consumer branch that never fired.

## Why nothing disagreed

Every angle you would normally check was green:

- The **topic** wiring was already correct — the earlier mis-routing was fixed in #1005 (2026-07-13), and 11 of the 15 enrolments happened *after* it.
- Both services are **deployed with that fix** (ancestry-verified: `41d83b457` is an ancestor of the running `sandbox-ca95102b` on both).
- The consumer group `onboarding-service-sca` is **connected**, subscribed to `openbank.sca.events`, `auto.offset.reset=earliest`, no ACL errors, no lag.
- The `msg-override` ConfigMap is present and correct (the dotted-key trap was already handled).
- The projection handler and its unit tests are **correct on both sides**.
- The existing producer test asserts `OutboxMessage.eventType` — the outbox **column** — and so stayed green for the entire life of this publisher while the wire format lacked the key.

`openbank.sca.events` has **no asyncapi contract** (grandfathered — 35 of 42 producer topics are), so `check-event-contract-code-agreement.py` structurally could not catch this either. That is what the second commit compensates for.

## Changes

**`fix(sca)`** — add `"eventType" to "DEVICE_ENROLLED"` to the payload map, hoisted to a single constant so the column and the body cannot drift apart again. Additive and backward-compatible: no existing consumer reads a field that moves. The new test asserts the **serialized body**, not the column.

**`feat(onboarding)`** — `openbank_onboarding_projection_events_total{service,topic,outcome}`, outcome one of `PROJECTED | UNRECOGNISED | FAILED`.

`UNRECOGNISED` is its own enum value rather than being folded into a generic "handled", for the same reason `PushSendOutcome.SKIPPED` is not a flag shared with success (ADR-0252 phase 0): a no-op that reports as a success is indistinguishable from work.

## The signal that would have caught it

An error rate could not have — there were no errors. The alertable state is the **success** state: a topic delivering messages of which none are projected.

```promql
sum by (topic) (rate(openbank_onboarding_projection_events_total{outcome="UNRECOGNISED"}[1h])) > 0
  and
sum by (topic) (rate(openbank_onboarding_projection_events_total{outcome="PROJECTED"}[1h])) == 0
```

Cardinality is bounded: three topics, three outcomes.

The consumer test now drives the **real sandbox payload verbatim** rather than JSON hand-written from the parser's own expectations — writing the fixture from the consumer's assumptions is what let the two artifacts diverge unnoticed.

## ⚠️ Money-path — please hold

`openbank-sca-service` is in `rules.yaml: money_path_services`. This needs **2 approvals**; the threat model `docs/threat-models/openbank-sca-service.md` already exists and this change does not alter the trust boundary (an additive field on an event already published on this topic). Not merging.

## Verification

- `:openbank-sca-service:test` — 146 tests, **0 failures, 1 skipped** (`ScaPactProviderVerificationTest`, broker-gated, pre-existing).
- `:openbank-onboarding-service:test` — 33 tests, **0 failures, 0 skipped**.
- `ktlintCheck` + `detekt` clean on both.
- `:openbank-onboarding-service:quarkusBuild` — CDI wiring for the new bean validated.
- `check-event-contract-code-agreement.py` and `check-event-contract-coverage.py` both pass.

Counts read from the JUnit XML, not the console.

## Scope boundary

This is **not** #4363 (a push to a party with no device is dropped, not re-routed) — that is the routing decision for a party who legitimately has no device, and it stays open and untouched.

It is also not the remaining open question of #4353 itself, which is about **push device tokens** (`notifications.device_tokens`) and stays blocked on a TestFlight build. `DEVICE_ENROLLED` is the **SCA credential** lifecycle — a different registry. They meet only in `onboarding_records`, the cockpit projection this PR repairs, which is where the "N of M onboarded customers" denominators are read from and has been reporting zeros for both.

Refs #4353
