### PR TITLE
fix(audit): recover three unread actor spellings and count the actor gap

### DIFF
--- a/openbank-audit-service/CLAUDE.md
+++ b/openbank-audit-service/CLAUDE.md
@@ -43,6 +43,22 @@
   replaces. `TopicAttribution` is a verified table whose COVERAGE (not values) is derived from
   `application.yaml`, so a newly subscribed topic fails `TopicAttributionCoverageTest` instead of
   silently defaulting again.
+- **Asking the audit DATABASE which fields producers send measures traffic, not the wire contract —
+  and it answers "nothing to recover" with total confidence.** Chasing the actor half of #3994, the
+  obvious probe was to enumerate the payload keys of every actor-less row
+  (`jsonb_object_keys(payload::jsonb)` filtered for `%by%`/`%actor%`/`%initiat%`). It returned two
+  keys, one of them already read and the other (`reviewedBy`) JSON-null on all 53 rows — i.e. every
+  gap is a producer omission and the consumer is fine. **Wrong.** Enumerating the producers'
+  serialised TYPES instead found three actor spellings genuinely on the wire and unread —
+  `reviewedBy` (sanctions' four-eyes review identity), `changedBy` (3 of 4 card event types) and
+  `actorKind` (lending, beside an `actorId` that WAS read, so the row named the actor but not
+  whether it was a human or the policy engine). The probe missed them because cards, lending and
+  account-service's savings path have **zero rows in the sandbox**, and no manual sanctions review
+  has ever run there. Same shape as the zero-denials-from-an-idle-service trap: a topic with no
+  traffic is not evidence about that topic. Note both halves of the trap fire here — a `grep` for
+  the quoted key finds nothing either, because all three live in serialised data classes where the
+  JSON key exists only as a Kotlin property name at runtime. **Enumerate the producing types; use
+  the database only to size what you found.**
 - **Switching an `@Incoming` from `String` to `Message<String>` switches SmallRye from auto-ack to
   MANUAL ack.** A missed ack stalls the partition and the audit trail stops dead — worse than the
   under-attribution being fixed. Ack explicitly, in a `finally`, and test it on the path most

--- a/openbank-audit-service/src/main/kotlin/com/openbank/audit/application/AuditConsumer.kt
+++ b/openbank-audit-service/src/main/kotlin/com/openbank/audit/application/AuditConsumer.kt
@@ -6,6 +6,7 @@ package com.openbank.audit.application
 
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.audit.domain.model.ActorProvenance
 import com.openbank.audit.domain.model.AttributionSource
 import com.openbank.audit.domain.model.AuditEntry
 import com.openbank.audit.domain.model.OccurredAtSource
@@ -101,6 +102,7 @@ class AuditConsumer {
             val node: JsonNode = objectMapper.readTree(payload)
             val eventTime = eventTime(node)
             val resolvedSource = resolveSourceService(node, address)
+            val actor = resolveActor(node)
             val entry = AuditEntry(
                 id = UUID.randomUUID(),
                 // sepa.instant.events (KafkaSctInstEventPublisher) names its discriminator "type",
@@ -126,11 +128,8 @@ class AuditConsumer {
                 // its own decision, not a drive-by fix here).
                 aggregateType = (node.textOrNull("aggregateType") ?: inferAggregateType(node)).uppercase(),
                 aggregateId = inferAggregateId(node),
-                actorId = node.textOrNull("requestedBy")
-                    ?: node.textOrNull("actorId")
-                    // transaction.initiated events carry the customer identity here (ADR-0021).
-                    ?: node.textOrNull("initiatedByPartyId"),
-                actorType = node.textOrNull("actorType"),
+                actorId = actor.first,
+                actorType = actor.second,
                 payload = payload,
                 sourceService = resolvedSource.first,
                 sourceServiceSource = resolvedSource.second,
@@ -150,6 +149,12 @@ class AuditConsumer {
                 delegationId = node.textOrNull("delegationId"),
             )
             if (eventTime == null) countMissingEventTime(entry.sourceService)
+            if (::meterRegistry.isInitialized) {
+                meterRegistry.countActorProvenance(
+                    entry.sourceService,
+                    actorProvenance(entry.actorId, entry.actorType),
+                )
+            }
             if (entry.sourceServiceSource != AttributionSource.EVENT) {
                 countMissingAttribution(entry.sourceService, entry.sourceServiceSource)
             }
@@ -299,6 +304,113 @@ class AuditConsumer {
         /** Cap on the producer-supplied value echoed into the warning — it is untrusted input. */
         const val MAX_LOGGED_RAW_TIME_CHARS = 64
     }
+}
+
+/**
+ * `openbank.audit.actor.missing{source_service,provenance}` — the third leg of #3994, and the
+ * only one of the three that had no signal at all.
+ *
+ * The issue asked for three things in increasing cost: make the gap loud, fix the producers,
+ * and decide whether an actor can be REQUIRED. This is the first, for the actor dimension:
+ * `openbank.audit.event.time.missing` and `openbank.audit.attribution.missing` already exist,
+ * and the actor gap — 75% of the live trail, the larger of the two halves in this issue's
+ * title — was observable only by hand-running a `GROUP BY` against the audit database.
+ *
+ * **What the counter can and cannot fix, and how that was established.** Asking the live
+ * database which actor-ish keys appear in actor-less payloads is the obvious probe and it
+ * gives the WRONG answer:
+ *
+ * ```
+ * SELECT DISTINCT k FROM audit_entries, jsonb_object_keys(payload::jsonb) k
+ *  WHERE actor_id IS NULL AND (k ILIKE '%by%' OR k ILIKE '%actor%' OR ...);
+ *   -> initiatedByPartyId, reviewedBy      (and reviewedBy is JSON-null on all 53 rows)
+ * ```
+ *
+ * That reads as "no actor is recoverable, every gap is a producer omission" — and it is a
+ * measurement of sandbox TRAFFIC, not of the wire contract. `openbank.cards.events`,
+ * `openbank.lending.events` and account-service's savings path have no rows here at all, and
+ * sanctions' `reviewedBy` is null only because no manual review has run. Enumerating the
+ * producers' serialised TYPES instead found three actor spellings genuinely on the wire and
+ * unread — `reviewedBy`, `changedBy`, `actorKind` — all three in data classes where the JSON
+ * key exists only as a Kotlin property name, so no grep for a quoted field name would have
+ * found them either. Those are recovered above.
+ *
+ * What remains after that is a genuine producer-side omission — the actor is known to the
+ * service and never reaches the wire (consent's `createdBy`/`revokedBy`, dispute's
+ * `resolvedBy`, domestic-payment's command `actorId` from the JWT, statement's
+ * `period.restated.v1`). This consumer must not paper over those: `actor_id` is chain-hashed
+ * into `record_hash`, so a fabricated actor is not a lesser evil than an honest NULL. This
+ * counter is what makes each producer's fix — or regression — visible without another manual
+ * query.
+ *
+ * Counted for DECLARED too, not only the two absences: a ratio needs its denominator, and a
+ * counter that only ever increments on failure cannot distinguish "no gaps" from "no traffic"
+ * — the exact shape of the zero-denials-from-an-idle-service trap. Tag cardinality is bounded
+ * by the fixed 21-topic service list times three enum values.
+ */
+internal fun MeterRegistry.countActorProvenance(sourceService: String, provenance: ActorProvenance) {
+    counter(
+        "openbank.audit.actor.missing",
+        "source_service",
+        sourceService,
+        "provenance",
+        provenance.name,
+    ).increment()
+}
+
+/**
+ * The actor identity and kind a producer put on the wire: `(actorId, actorType)` (#3994).
+ *
+ * **The first three id spellings are unchanged and stay FIRST**, so no row that is attributed
+ * today changes actor — a fix that improves 1359 unattributed rows by silently moving the 425
+ * already-correct ones is a regression, not a fix.
+ *
+ * The last two are additive recoveries: real actor identities that were already on the wire and
+ * that this consumer simply was not reading, so they landed as NULL in a column chain-hashed into
+ * `record_hash` and served to data subjects by the GDPR Art. 15 access log.
+ *
+ *  - `reviewedBy` — sanctions.screening.event serialises the `SanctionsCheck` aggregate whole, so
+ *    the four-eyes manual-review identity (the highest-value actor in the fleet) rides as a Kotlin
+ *    property name with no string literal anywhere in the producer to grep for.
+ *  - `changedBy` — cards.events: `CardStatusChanged`, `CardLimitsChanged` and `CardControlsChanged`
+ *    all carry it; only `CardIssued` omits it.
+ *  - `actorKind` — lending's transition events emit `actorId` AND `actorKind`, so the id was
+ *    already caught while the TYPE beside it was dropped. The row named the actor but could not
+ *    say whether it was a human or the automated policy engine, which is exactly what a four-eyes
+ *    or DORA Art. 17 reconstruction asks of a credit decision.
+ *
+ * Deliberately NOT recovered, though both are actor-ish and tempting: `partyId` (a data SUBJECT on
+ * most topics, an actor only on dispute/fx — a per-topic rule, not a spelling) and
+ * `delegatePartyId` (a delegate belongs in ADR-0232's `onBehalfOf`/`delegationId` pair, which this
+ * consumer already reads separately). Guessing either would write a confident wrong actor into a
+ * tamper-evident record — the same failure mode `TopicAttribution` exists to avoid.
+ *
+ * Free-standing to keep [AuditConsumer] under detekt's function-count threshold, which fires AT
+ * the threshold and not above it.
+ */
+private fun resolveActor(node: JsonNode): Pair<String?, String?> = Pair(
+    node.textOrNull("requestedBy")
+        ?: node.textOrNull("actorId")
+        // transaction.initiated events carry the customer identity here (ADR-0021).
+        ?: node.textOrNull("initiatedByPartyId")
+        ?: node.textOrNull("reviewedBy")
+        ?: node.textOrNull("changedBy"),
+    node.textOrNull("actorType") ?: node.textOrNull("actorKind"),
+)
+
+/**
+ * Classifies one row's actor claim for the [AuditConsumer.countActorProvenance] counter (#3994).
+ *
+ * Reads the RESOLVED entry fields rather than the payload, so it classifies exactly what was
+ * stored — a second pass over the JSON could disagree with the row it is supposed to describe,
+ * which is the drift that made `inferAggregateId`/`inferAggregateType` contradict each other.
+ *
+ * Free-standing to keep [AuditConsumer] under detekt's function-count threshold.
+ */
+internal fun actorProvenance(actorId: String?, actorType: String?): ActorProvenance = when {
+    actorId != null -> ActorProvenance.DECLARED
+    actorType != null -> ActorProvenance.SYSTEM
+    else -> ActorProvenance.ABSENT
 }
 
 /**

--- a/openbank-audit-service/src/main/kotlin/com/openbank/audit/domain/model/AuditEntry.kt
+++ b/openbank-audit-service/src/main/kotlin/com/openbank/audit/domain/model/AuditEntry.kt
@@ -99,6 +99,48 @@ enum class AttributionSource {
     ABSENT,
 }
 
+/**
+ * Whether an audit row names the actor that caused the operation, and — where it does not —
+ * whether the producer SAID SO or simply stayed silent (#3994).
+ *
+ * **Not persisted, deliberately.** The sibling provenance markers ([AttributionSource],
+ * [OccurredAtSource]) each needed a column of their own because the field they describe carries a
+ * SENTINEL: `source_service = "unknown"` and an ingest-substituted `occurred_at` are both
+ * indistinguishable, in the stored row, from a real value. `actor_id` has no sentinel — it is
+ * plain SQL `NULL` — so this classification is already fully derivable from the two columns the
+ * table has:
+ *
+ * ```
+ * DECLARED  <=>  actor_id IS NOT NULL
+ * SYSTEM    <=>  actor_id IS NULL AND actor_type IS NOT NULL
+ * ABSENT    <=>  actor_id IS NULL AND actor_type IS NULL
+ * ```
+ *
+ * Adding a fourth `*_source` column for it would restate what the row already says, and grow the
+ * chain-hashed evidentiary record to hold a value that asserts nothing new. The gap this enum
+ * closes is not in the TABLE — a `GROUP BY` has always been able to answer it — it is that no
+ * TIME SERIES existed, so nothing could alert or degrade on the actor gap, and 75% of the trail
+ * reached that state unremarked. See `openbank.audit.actor.missing`.
+ */
+enum class ActorProvenance {
+    /** The producer named an actor: `requestedBy`, `actorId` or `initiatedByPartyId`. */
+    DECLARED,
+
+    /**
+     * No actor id, but the producer classified the actor anyway (`actorType`, e.g. `SYSTEM` for a
+     * scheduled balance update). An ASSERTED absence — the producer is on record that no human
+     * identity applies, which is a materially different claim from having forgotten one.
+     */
+    SYSTEM,
+
+    /**
+     * Neither an id nor a type: the producer said nothing about who acted. A SILENT absence, and
+     * the state 75% of the live trail is in — including `PARTY_CREATED`, `KYC_CASE_APPROVED`,
+     * `AccountStatusChanged` and `ConsentRevoked`, which are decisions with a decider.
+     */
+    ABSENT,
+}
+
 enum class OccurredAtSource {
     /** The producer sent a parseable `occurredAt`; [AuditEntry.occurredAt] is the real event time. */
     EVENT,

--- a/openbank-audit-service/src/test/kotlin/com/openbank/audit/application/AuditActorProvenanceTest.kt
+++ b/openbank-audit-service/src/test/kotlin/com/openbank/audit/application/AuditActorProvenanceTest.kt
@@ -1,0 +1,240 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.audit.application
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.openbank.audit.domain.model.ActorProvenance
+import com.openbank.audit.domain.model.AuditEntry
+import com.openbank.audit.infrastructure.persistence.AuditRepository
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import io.mockk.coEvery
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+import java.util.UUID
+
+/**
+ * The actor half of #3994: `openbank.audit.actor.missing` (#3994).
+ *
+ * 75% of the live audit trail names no actor, and until this counter existed that was answerable
+ * only by hand-running a `GROUP BY` against the audit database — there was no series to alert on,
+ * degrade a dashboard, or notice a producer regressing.
+ *
+ * **Every assertion here checks a VALUE — the exact actor id, the exact provenance, the exact tag
+ * set — never `isNotNull()`.** That is the discipline the sibling [AuditAttributionTest] states
+ * and the reason this whole class of defect survived: `actor_id` was NULL, not a sentinel, so
+ * nothing was ever wrong enough to fail a non-null assertion. A test that asserts presence passes
+ * against a wrong-but-present value; a test that asserts `"unknown"`-vs-a-real-name does not.
+ */
+class AuditActorProvenanceTest {
+
+    private val repo = mockk<AuditRepository>()
+
+    private val registry = SimpleMeterRegistry()
+
+    private lateinit var consumer: AuditConsumer
+
+    @BeforeEach
+    fun setUp() {
+        consumer = AuditConsumer().also {
+            it.repo = repo
+            it.objectMapper = jacksonObjectMapper().findAndRegisterModules()
+            it.clock = Clock.fixed(Instant.parse("2026-08-13T12:00:00Z"), ZoneOffset.UTC)
+            it.meterRegistry = registry
+        }
+    }
+
+    @Test
+    fun `each of the three actor spellings is read, and the id is the one the producer sent`(): Unit = runBlocking {
+        // The VALUE, not merely a non-null column: the whole point is that the row names the RIGHT
+        // person. `findByActorId` (ADR-0226) and the GDPR Art. 15 access log both key on this, so
+        // an id that is present but wrong returns another data subject's operations.
+        val spellings = mapOf(
+            "requestedBy" to "op-1",
+            "actorId" to "op-2",
+            // transaction.initiated carries the customer identity here (ADR-0021).
+            "initiatedByPartyId" to "op-3",
+        )
+
+        for ((field, id) in spellings) {
+            val entry = capturingSave()
+            consumer.consume("""{"accountId":"${UUID.randomUUID()}","$field":"$id"}""")
+            assertThat(entry.captured.actorId).isEqualTo(id)
+        }
+    }
+
+    @Test
+    fun `sanctions reviewedBy is the actor of a manual four-eyes review`(): Unit = runBlocking {
+        // RED before this change: the payload is the serialised SanctionsCheck aggregate, so
+        // `reviewedBy` is a Kotlin property name with no string literal in the producer — invisible
+        // to a grep, and unread by the consumer's three spellings. This is the four-eyes review
+        // identity, the highest-value actor in the fleet, and it was landing as NULL.
+        val entry = capturingSave()
+
+        consumer.consume(
+            """{"id":"${UUID.randomUUID()}","status":"CLEARED","reviewedBy":"analyst-14"}""",
+            EventAddress(topic = "openbank.sanctions.screening.event"),
+        )
+
+        assertThat(entry.captured.actorId).isEqualTo("analyst-14")
+        assertThat(counter("sanctions-service", ActorProvenance.DECLARED)).isEqualTo(1.0)
+    }
+
+    @Test
+    fun `card changedBy is the actor of a status, limit or control change`(): Unit = runBlocking {
+        // Three of the four card event types carry `changedBy` (only CardIssued omits it) — again
+        // a serialised data class, so no literal to grep. RED before this change.
+        val entry = capturingSave()
+
+        consumer.consume(
+            """{"cardId":"${UUID.randomUUID()}","newStatus":"BLOCKED","changedBy":"op-9"}""",
+            EventAddress(topic = "openbank.cards.events"),
+        )
+
+        assertThat(entry.captured.actorId).isEqualTo("op-9")
+    }
+
+    @Test
+    fun `lending actorKind classifies an actor whose id was already read`(): Unit = runBlocking {
+        // The asymmetric case: lending's transition events emit `actorId` AND `actorKind`, so the
+        // id was already caught while the type beside it was dropped. The row named the actor but
+        // could not say whether it was a human or the automated policy engine — which is the whole
+        // question a four-eyes or DORA reconstruction asks of a credit decision.
+        val entry = capturingSave()
+
+        consumer.consume(
+            """{"loanId":"${UUID.randomUUID()}","actorId":"officer-3","actorKind":"HUMAN"}""",
+            EventAddress(topic = "openbank.lending.events"),
+        )
+
+        assertThat(entry.captured.actorId).isEqualTo("officer-3")
+        assertThat(entry.captured.actorType).isEqualTo("HUMAN")
+    }
+
+    @Test
+    fun `the three original spellings still win, so no attributed row is re-attributed`(): Unit = runBlocking {
+        // The recoveries are appended, never inserted ahead of the existing chain. A change that
+        // improves 1359 rows by silently moving the 425 that were already right is a regression.
+        val entry = capturingSave()
+
+        consumer.consume(
+            """{"cardId":"${UUID.randomUUID()}","requestedBy":"op-1","reviewedBy":"x","changedBy":"y"}""",
+            EventAddress(topic = "openbank.cards.events"),
+        )
+
+        assertThat(entry.captured.actorId).isEqualTo("op-1")
+    }
+
+    @Test
+    fun `a declared actor is counted as DECLARED, tagged with its producing service`(): Unit = runBlocking {
+        // DECLARED is counted too, not only the absences. A counter that increments only on
+        // failure cannot tell "no gaps" from "no traffic" — a ratio needs its denominator.
+        coEvery { repo.save(any()) } returns Unit
+
+        consumer.consume(
+            """{"transactionId":"${UUID.randomUUID()}","initiatedByPartyId":"party-77"}""",
+            EventAddress(topic = "openbank.transactions.transaction.initiated"),
+        )
+
+        assertThat(counter("transaction-service", ActorProvenance.DECLARED)).isEqualTo(1.0)
+        assertThat(counter("transaction-service", ActorProvenance.ABSENT)).isEqualTo(0.0)
+    }
+
+    @Test
+    fun `an asserted non-human actor is SYSTEM, not folded in with a silent omission`(): Unit = runBlocking {
+        // The distinction the metric exists to draw. A scheduled balance update genuinely has no
+        // human actor and its producer says so; kyc-service simply sends nothing. Both leave
+        // `actor_id` NULL, so a naive "count the nulls" gauge would report them as one number and
+        // the producer sweep would have no idea which rows it still has to fix.
+        coEvery { repo.save(any()) } returns Unit
+
+        consumer.consume(
+            """{"accountId":"${UUID.randomUUID()}","actorType":"SYSTEM"}""",
+            EventAddress(topic = "openbank.balance.events"),
+        )
+
+        assertThat(counter("balance-service", ActorProvenance.SYSTEM)).isEqualTo(1.0)
+        assertThat(counter("balance-service", ActorProvenance.ABSENT)).isEqualTo(0.0)
+    }
+
+    @Test
+    fun `a producer that says nothing about the actor is ABSENT, and the row still stores`(): Unit = runBlocking {
+        // 1359 live rows are exactly this: PARTY_CREATED, KYC_CASE_APPROVED, AccountStatusChanged,
+        // ConsentRevoked — decisions with a decider, recorded naming nobody. Measured across every
+        // one of those payloads' keys, no actor field is present under ANY spelling, so there is
+        // nothing for this consumer to recover and nothing it may invent: `actor_id` is
+        // chain-hashed into `record_hash`, and a fabricated actor is worse than an honest gap.
+        val entry = capturingSave()
+
+        consumer.consume(
+            """{"partyId":"${UUID.randomUUID()}","eventType":"PARTY_CREATED"}""",
+            EventAddress(topic = "openbank.party.events"),
+        )
+
+        assertThat(entry.captured.actorId).isNull()
+        assertThat(entry.captured.actorType).isNull()
+        assertThat(counter("party-service", ActorProvenance.ABSENT)).isEqualTo(1.0)
+    }
+
+    @Test
+    fun `an explicit JSON null actor is ABSENT, never the four-character string null`(): Unit = runBlocking {
+        // Jackson's asText() on a NullNode returns the STRING "null". Seven live rows carry
+        // `actor_id = 'null'` from before that was fixed — all money-path TransactionInitiated —
+        // and that is strictly worse than the NULL it replaced: a NULL actor reads as a known gap
+        // and gets counted here, whereas "null" reads as an attributed row and is invisible to
+        // this counter. This asserts BOTH halves — the stored value and the classification — so a
+        // regression in `textOrNull` cannot pass by leaving the counter alone.
+        val entry = capturingSave()
+
+        consumer.consume(
+            """{"transactionId":"${UUID.randomUUID()}","actorId":null,"actorType":null}""",
+            EventAddress(topic = "openbank.transactions.transaction.initiated"),
+        )
+
+        assertThat(entry.captured.actorId).isNull()
+        assertThat(counter("transaction-service", ActorProvenance.ABSENT)).isEqualTo(1.0)
+        assertThat(counter("transaction-service", ActorProvenance.DECLARED)).isEqualTo(0.0)
+    }
+
+    @Test
+    fun `an unattributed producer still yields a usable series, tagged unknown`(): Unit = runBlocking {
+        // Belt and braces with TopicAttribution: if a topic ever falls out of the map, the actor
+        // gap must still be countable rather than silently disappearing from the dashboard.
+        coEvery { repo.save(any()) } returns Unit
+
+        consumer.consume("""{"accountId":"${UUID.randomUUID()}"}""")
+
+        assertThat(counter("unknown", ActorProvenance.ABSENT)).isEqualTo(1.0)
+    }
+
+    @Test
+    fun `the classifier answers about the stored row, for every combination`() {
+        // Reads the resolved entry fields rather than re-parsing the payload: a second pass over
+        // the JSON can disagree with the row it is meant to describe, which is precisely how
+        // inferAggregateId and inferAggregateType came to contradict each other on a JSON null.
+        assertThat(actorProvenance("op-1", "CUSTOMER")).isEqualTo(ActorProvenance.DECLARED)
+        assertThat(actorProvenance("op-1", null)).isEqualTo(ActorProvenance.DECLARED)
+        assertThat(actorProvenance(null, "SYSTEM")).isEqualTo(ActorProvenance.SYSTEM)
+        assertThat(actorProvenance(null, null)).isEqualTo(ActorProvenance.ABSENT)
+    }
+
+    private fun counter(sourceService: String, provenance: ActorProvenance): Double = registry.counter(
+        "openbank.audit.actor.missing",
+        "source_service",
+        sourceService,
+        "provenance",
+        provenance.name,
+    ).count()
+
+    private fun capturingSave() = slot<AuditEntry>().also {
+        coEvery { repo.save(capture(it)) } returns Unit
+    }
+}


### PR DESCRIPTION
## What this is

The **actor half** of #3994. The source-service half landed earlier and is now confirmed working on real traffic; this closes the second clause of the issue title — *"76% of rows name no actor"* — as far as the consumer honestly can, and says precisely what it leaves to the producers.

## Measured first

Live `openbank_audit`, read-only, today:

```
SELECT source_service_source, count(*) FROM audit_entries GROUP BY 1;
  NULL   | 1784      <- pre-V13, never backfilled by design
  EVENT  |   35
  TOPIC  |   60
  ABSENT |    0
```

The owner's outstanding question on the issue — *"worth one look at `source_service_source` after the next event on any subscribed topic before treating it as proven"* — is answered: 95 post-V13 rows, attributed across five producers (customer-edge EVENT; balance-service, transaction-service, domestic-payment, sanctions-service via TOPIC), **zero ABSENT**.

The actor half is unchanged and is what this PR addresses:

```
SELECT count(*), count(*) FILTER (WHERE actor_id IS NULL) FROM audit_entries;
  1879 | 1341        -> 71% name no actor
```

## The probe that gave the wrong answer

The obvious way to ask "is the consumer dropping an actor, or do producers not send one" is to enumerate the payload keys of every actor-less row:

```sql
SELECT DISTINCT k FROM audit_entries, jsonb_object_keys(payload::jsonb) k
 WHERE actor_id IS NULL AND (k ILIKE '%by%' OR k ILIKE '%actor%' OR k ILIKE '%initiat%');
  -> initiatedByPartyId   (already read)
  -> reviewedBy           (present on 53 sanctions rows, JSON-null on every one)
```

That reads as *"nothing is recoverable, every gap is a producer omission"*. **It is wrong**, and it is wrong in a specific way worth recording: it measures sandbox **traffic**, not the wire contract. `openbank.cards.events`, `openbank.lending.events` and account-service's savings path have **zero rows** in that database, and no manual sanctions review has ever run there.

Enumerating the producers' serialised **types** instead — all 21 topics, publisher by publisher — found three actor identities genuinely on the wire and unread. A `grep` for the quoted key would have missed them too: all three live in serialised data classes, where the JSON key exists only as a Kotlin property name at runtime.

## What changed

| spelling | topic / producer | why it is an actor |
|---|---|---|
| `reviewedBy` | `sanctions.screening.event` (serialised `SanctionsCheck`) | the four-eyes manual-review identity — the highest-value actor in the fleet, landing as NULL |
| `changedBy` | `cards.events` — `CardStatusChanged`, `CardLimitsChanged`, `CardControlsChanged` (3 of 4 types) | whoever blocked the card |
| `actorKind` | `lending.events` transitions | the asymmetric case: `actorId` beside it **was** already read, so the row named the actor but could not say whether it was a human or the automated policy engine |

The three original spellings stay **first**, so no row attributed today changes actor — a fix that improves 1359 rows by silently moving the 425 already-correct ones is a regression, and there is a test for exactly that.

Plus `openbank.audit.actor.missing{source_service,provenance}` — the third leg beside `openbank.audit.event.time.missing` and `openbank.audit.attribution.missing`, and the only one of the three with **no signal at all**. The actor gap was answerable only by hand-running a `GROUP BY`. `DECLARED` is counted alongside `SYSTEM` and `ABSENT` so the series has a denominator: a counter that only increments on failure cannot tell *"no gaps"* from *"no traffic"* — the trap this PR's own first probe fell into.

## Deliberately not done

**No fourth `*_source` column.** V11 and V13 each needed one because the field they describe carries a **sentinel** — `source_service = "unknown"` and an ingest-substituted `occurred_at` are indistinguishable in the stored row from real values. `actor_id` has no sentinel; it is plain SQL `NULL`, so the classification is already fully derivable from two existing columns:

```
DECLARED <=> actor_id IS NOT NULL
SYSTEM   <=> actor_id IS NULL AND actor_type IS NOT NULL
ABSENT   <=> both NULL
```

A column here would restate what the row already says and grow a chain-hashed evidentiary record to hold a value that asserts nothing new. `ActorProvenance` therefore exists only to tag the metric. **No migration in this PR.**

**`partyId` and `delegatePartyId` are not recovered.** `partyId` is the data *subject* on most topics and an actor only on dispute/fx — that is a per-topic rule, not a spelling. A delegate belongs in ADR-0232's `onBehalfOf`/`delegationId` pair, which the consumer already reads separately. Guessing either writes a confident **wrong** actor into a tamper-evident record — the failure mode `TopicAttribution` exists to avoid, and strictly worse than the NULL it replaces.

**No producer sweep.** Four producers know the actor and never put it on the wire. Per-item verdicts are posted on #3994; each is a separate service, several money-path, and none is fixable from here. The consumer must not paper over them: `actor_id` is chain-hashed into `record_hash`, so a fabricated actor is not a lesser evil than an honest gap.

## Falsification

Reverting the three recoveries in `resolveActor` and re-running turns **exactly the three new recovery tests red and nothing else**:

```
tests="11" skipped="0" failures="3"
  RED: sanctions reviewedBy is the actor of a manual four-eyes review
  RED: card changedBy is the actor of a status, limit or control change
  RED: lending actorKind classifies an actor whose id was already read
```

Restored: `:openbank-audit-service:test` = **100 tests, 0 skipped, 0 failures** (skipped count read from the JUnit XML, not the console), `ktlintCheck` + `detekt` green.

Every assertion checks a **VALUE** — the exact actor id, the exact provenance, the exact tag set — never `isNotNull()`. Non-nullity passing against a wrong-but-present value is how this whole class of defect survived to 76%.

## Note for reviewers

`AuditConsumer.kt` is also being edited on `fix/audit-normalise-aggregate-type` (aggregate-type casing, #4553's pattern). Different lines, different concern — but whichever lands second should re-read the merged result rather than trusting a clean merge.

Refs #3994
