### PR TITLE
fix(ci): stop reporting a failed attestation probe as a fleet gap

### DIFF
--- a/.github/scripts/check-fleet-attestations.sh
+++ b/.github/scripts/check-fleet-attestations.sh
@@ -25,21 +25,44 @@
 # sidecars alike. The image regex is intentionally position-blind (it does not care which
 # YAML key an image hangs off) precisely so a sidecar or initContainer cannot slip through.
 #
-# TWO FAILURE CLASSES, kept distinct on purpose:
-#   UNATTESTED — the image IS in the registry but carries no valid attestation. This is the
-#                outage class: pods run now, die forever on the next reschedule. Always fatal.
+# THREE OUTCOME CLASSES, kept distinct on purpose:
+#   UNATTESTED — cosign REACHED the artifact and returned an attestation verdict: no valid
+#                CycloneDX attestation for this key. This is the outage class: pods run now,
+#                die forever on the next reschedule. Always fatal (exit 1).
 #   ABSENT     — the image is not in the registry at all (a first-registration placeholder
 #                tag that was never built). Also broken, but a different bug with a different
 #                fix, and it is NOT an attestation regression. Fatal unless the image is
 #                listed in the placeholder allowlist below.
-# Conflating the two would make this gate permanently red on a known placeholder — and a
+#   UNKNOWN    — the PROBE could not run: ECR throttle, 5xx, expired credentials, DNS, a
+#                cosign crash. This is NOT a verdict about the image and must never be
+#                reported as one. Exit 2, mirroring
+#                `.github/scripts/check-verification-metadata-complete.py` (0 = clean,
+#                1 = real gap, 2 = could not run).
+# Conflating the first two would make this gate permanently red on a known placeholder — and a
 # permanently-red check is one nobody reads. That is exactly how sbom-drift-scanner's
 # `sepa-payment: no-pod-found` sat unactioned on the morning of the outage.
+#
+# WHY UNKNOWN EXISTS (#1915, measured 2026-08-13): the loop used to special-case only the
+# registry-absence strings and let EVERY other non-zero cosign exit fall through to
+# UNATTESTED. Run 31729895636 therefore reported
+# `UNATTESTED openbank-release-steward:sandbox-e80f4bc7 … 61 attested / 1 unattested / 62
+# total` while 24 of the 25 most recent runs of the same gate passed on the identical,
+# unchanged image, and a hand `cosign verify-attestation` against digest sha256:31d626…
+# answered "The signatures were verified against the specified public key". A transient
+# registry failure was published as a supply-chain verdict. Classification is now POSITIVE
+# in both directions — an image is called UNATTESTED only when cosign says so in words —
+# and every candidate failure is retried before being classified at all.
 #
 # Usage:
 #   .github/scripts/check-fleet-attestations.sh              # verify the whole fleet
 #   COSIGN_BIN=/path/to/cosign-v2 ... check-fleet-attestations.sh
 #   FLEET_ATTEST_JSON=out.json ...                           # also emit a JSON report
+#   VERIFY_ATTEMPTS=3 VERIFY_RETRY_SLEEP=5 ...               # bounded retry (defaults)
+#   .github/scripts/check-fleet-attestations.sh --selftest   # prove the classifier both ways
+#
+# Exit codes: 0 = every declared image attested; 1 = a real gap (UNATTESTED and/or ABSENT);
+#             2 = the check COULD NOT RUN for at least one image (registry/credential/tool
+#             failure). 2 is not a verdict — callers must not report it as a fleet gap.
 #
 # Requires: AWS credentials with ECR read access, cosign v2.x, jq (report only).
 # Read-only: never pushes, retags, signs, or mutates any image.
@@ -47,11 +70,83 @@
 set -uo pipefail
 
 GITOPS_DIR="${GITOPS_DIR:-openbank-infra/gitops}"
+VERIFY_ATTEMPTS="${VERIFY_ATTEMPTS:-3}"
+VERIFY_RETRY_SLEEP="${VERIFY_RETRY_SLEEP:-5}"
 PLACEHOLDER_FILE="${PLACEHOLDER_FILE:-.github/scripts/fleet-attestation-placeholders.txt}"
 COSIGN_KEY="${COSIGN_KEY:-awskms:///alias/openbank-cosign-signing}"
 COSIGN_VERSION="${COSIGN_VERSION:-v2.4.3}"
 ECR_REGISTRY="${ECR_REGISTRY:-265175468565.dkr.ecr.eu-north-1.amazonaws.com}"
 FLEET_ATTEST_JSON="${FLEET_ATTEST_JSON:-}"
+
+# Classify one failed `cosign verify-attestation` by its stderr. POSITIVE in both directions:
+# ABSENT and UNATTESTED each require cosign to have SAID so; anything else is UNKNOWN, because
+# a probe that could not reach a verdict has not produced one. The old shape had a positive
+# rule for ABSENT and used UNATTESTED as the fallback, which is what turned an ECR throttle
+# into a supply-chain finding (#1915).
+classify_failure() {
+  local err="$1"
+  if printf '%s' "$err" | grep -qE 'NAME_UNKNOWN|MANIFEST_UNKNOWN|does not exist|not found|404'; then
+    printf 'ABSENT\n'
+    return 0
+  fi
+  # cosign's own attestation verdicts. `no matching attestations` covers both "none at all"
+  # and "none this key/type accepts"; the signature/certificate wordings cover a payload that
+  # exists but does not verify. All of these mean the artifact WAS fetched.
+  if printf '%s' "$err" | grep -qE 'no matching attestations|no attestations|none of the attestations matched|signature not found|invalid signature|failed to verify signature|unable to verify signature|no signatures found|error validating.*signature|crypto/rsa: verification error'; then
+    printf 'UNATTESTED\n'
+    return 0
+  fi
+  printf 'UNKNOWN\n'
+}
+
+selftest() {
+  local failures=0 got
+  check_case() {
+    local name="$1" expected="$2" input="$3"
+    got="$(classify_failure "$input")"
+    if [ "$got" = "$expected" ]; then
+      printf '  ok: %s (%s)\n' "$name" "$got"
+    else
+      printf '  FAIL: %s — expected %s, got %s\n' "$name" "$expected" "$got"
+      failures=$((failures + 1))
+    fi
+  }
+
+  # ABSENT — the registry says the reference is not there.
+  check_case "MANIFEST_UNKNOWN" ABSENT \
+    'GET https://265175468565.dkr.ecr.eu-north-1.amazonaws.com/v2/openbank-x/manifests/t: MANIFEST_UNKNOWN'
+  check_case "NAME_UNKNOWN" ABSENT 'NAME_UNKNOWN: The repository with name openbank-x does not exist'
+
+  # UNATTESTED — cosign reached the artifact and returned a verdict.
+  check_case "no matching attestations" UNATTESTED \
+    'Error: no matching attestations:
+main.go:74: error during command execution: no matching attestations:'
+  check_case "invalid signature" UNATTESTED 'Error: invalid signature when validating ASN.1 encoded signature'
+
+  # UNKNOWN — the probe could not run. Each of these used to be published as UNATTESTED.
+  check_case "ECR throttle" UNKNOWN \
+    'Error: GET https://...amazonaws.com/v2/: TOOMANYREQUESTS: Rate exceeded'
+  check_case "registry 5xx" UNKNOWN \
+    'Error: unexpected status code 503 Service Unavailable'
+  check_case "expired credentials" UNKNOWN \
+    'Error: unable to get credentials: ExpiredToken: The security token included in the request is expired'
+  check_case "DNS failure" UNKNOWN \
+    'Error: Get "https://...amazonaws.com/v2/": dial tcp: lookup ...: no such host'
+  check_case "KMS unreachable" UNKNOWN \
+    'Error: loading public key: getting signer: kms get: RequestCanceled: request context canceled'
+
+  if [ "$failures" -gt 0 ]; then
+    printf 'selftest FAILED (%s case(s))\n' "$failures"
+    return 1
+  fi
+  printf 'selftest OK — classifier proven on all three classes, both directions.\n'
+  return 0
+}
+
+if [ "${1:-}" = "--selftest" ]; then
+  selftest
+  exit $?
+fi
 
 # cosign v2 is pinned on purpose: kyverno 3.2.6 discovers attestations only via the legacy
 # `sha256-<digest>.att` tag scheme; cosign v3 writes OCI 1.1 referrers it cannot read. This
@@ -128,41 +223,69 @@ PASS=0
 UNATTESTED=0
 ABSENT=0
 ALLOWED=0
+UNKNOWN=0
 UNATTESTED_IMAGES=()
 ABSENT_IMAGES=()
+UNKNOWN_IMAGES=()
 
 for image in "${IMAGES[@]}"; do
   short="${image#"${ECR_REGISTRY}"/}"
-  if err="$(COSIGN_YES=true "$COSIGN_BIN_RESOLVED" verify-attestation \
-              --key "$COSIGN_KEY" --type cyclonedx "$image" 2>&1)"; then
-    printf '  OK          %s\n' "$short"
-    PASS=$((PASS + 1))
-    continue
-  fi
 
-  # Distinguish "not in the registry" from "in the registry, not attested". cosign surfaces
-  # the former as a registry NAME_UNKNOWN / MANIFEST_UNKNOWN / 404 from the manifest GET.
-  if printf '%s' "$err" | grep -qE 'NAME_UNKNOWN|MANIFEST_UNKNOWN|does not exist|not found|404'; then
-    if is_allowed_placeholder "$image"; then
-      printf '  PLACEHOLDER %s  (allowlisted: never built, cannot be admitted)\n' "$short"
-      ALLOWED=$((ALLOWED + 1))
-    else
-      printf '  ABSENT      %s  <-- declared in gitops but NOT in the registry\n' "$short"
-      ABSENT=$((ABSENT + 1))
-      ABSENT_IMAGES+=("$image")
+  # Bounded retry, then classify. A verdict (OK / ABSENT / UNATTESTED) is final on the first
+  # attempt that produces one; only an UNKNOWN — which is precisely the transient class — is
+  # retried, so a genuinely unattested image still fails fast and no result is retried into
+  # existence. Attempts are logged so a flaky registry is visible rather than smoothed over.
+  verdict=""
+  attempt=1
+  while :; do
+    if err="$(COSIGN_YES=true "$COSIGN_BIN_RESOLVED" verify-attestation \
+                --key "$COSIGN_KEY" --type cyclonedx "$image" 2>&1)"; then
+      verdict=OK
+      break
     fi
-    continue
-  fi
+    verdict="$(classify_failure "$err")"
+    [ "$verdict" != "UNKNOWN" ] && break
+    [ "$attempt" -ge "$VERIFY_ATTEMPTS" ] && break
+    printf '  retry %s/%s  %s  (probe failed, not a verdict)\n' \
+      "$attempt" "$VERIFY_ATTEMPTS" "$short"
+    sleep "$VERIFY_RETRY_SLEEP"
+    attempt=$((attempt + 1))
+  done
 
-  printf '  UNATTESTED  %s  <-- no valid CycloneDX SBOM attestation\n' "$short"
-  UNATTESTED=$((UNATTESTED + 1))
-  UNATTESTED_IMAGES+=("$image")
+  case "$verdict" in
+    OK)
+      printf '  OK          %s\n' "$short"
+      PASS=$((PASS + 1))
+      ;;
+    ABSENT)
+      if is_allowed_placeholder "$image"; then
+        printf '  PLACEHOLDER %s  (allowlisted: never built, cannot be admitted)\n' "$short"
+        ALLOWED=$((ALLOWED + 1))
+      else
+        printf '  ABSENT      %s  <-- declared in gitops but NOT in the registry\n' "$short"
+        ABSENT=$((ABSENT + 1))
+        ABSENT_IMAGES+=("$image")
+      fi
+      ;;
+    UNATTESTED)
+      printf '  UNATTESTED  %s  <-- no valid CycloneDX SBOM attestation\n' "$short"
+      UNATTESTED=$((UNATTESTED + 1))
+      UNATTESTED_IMAGES+=("$image")
+      ;;
+    *)
+      printf '  UNKNOWN     %s  <-- probe failed %s time(s), NO verdict about this image\n' \
+        "$short" "$VERIFY_ATTEMPTS"
+      printf '%s\n' "$err" | sed 's/^/                  | /' | tail -5
+      UNKNOWN=$((UNKNOWN + 1))
+      UNKNOWN_IMAGES+=("$image")
+      ;;
+  esac
 done
 
 FAIL=$((UNATTESTED + ABSENT))
 
 echo
-echo "==> Fleet summary: ${PASS} attested / ${UNATTESTED} unattested / ${ABSENT} absent / ${ALLOWED} allowlisted placeholder / ${#IMAGES[@]} total"
+echo "==> Fleet summary: ${PASS} attested / ${UNATTESTED} unattested / ${ABSENT} absent / ${ALLOWED} allowlisted placeholder / ${UNKNOWN} unknown (probe failed) / ${#IMAGES[@]} total"
 
 if [ -n "$FLEET_ATTEST_JSON" ] && command -v jq >/dev/null 2>&1; then
   # `${arr[@]+"${arr[@]}"}` guards bash 3.2's unbound-variable error on an empty array
@@ -180,11 +303,14 @@ if [ -n "$FLEET_ATTEST_JSON" ] && command -v jq >/dev/null 2>&1; then
     --argjson placeholders "$ALLOWED" \
     --argjson unattestedImages "$(_json_arr ${UNATTESTED_IMAGES[@]+"${UNATTESTED_IMAGES[@]}"})" \
     --argjson absentImages "$(_json_arr ${ABSENT_IMAGES[@]+"${ABSENT_IMAGES[@]}"})" \
+    --argjson unknown "$UNKNOWN" \
+    --argjson unknownImages "$(_json_arr ${UNKNOWN_IMAGES[@]+"${UNKNOWN_IMAGES[@]}"})" \
     --arg scannedAt "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-    --arg gateResult "$([ "$FAIL" -gt 0 ] && echo FAIL || echo PASS)" \
+    --arg gateResult "$([ "$FAIL" -gt 0 ] && echo FAIL || { [ "$UNKNOWN" -gt 0 ] && echo INCOMPLETE || echo PASS; })" \
     '{scannedAt: $scannedAt, gateResult: $gateResult, total: $total, attested: $attested,
       unattested: $unattested, absent: $absent, allowlistedPlaceholders: $placeholders,
-      unattestedImages: $unattestedImages, absentImages: $absentImages}' \
+      unknown: $unknown, unattestedImages: $unattestedImages, absentImages: $absentImages,
+      unknownImages: $unknownImages}' \
     > "$FLEET_ATTEST_JSON"
   echo "    JSON report: ${FLEET_ATTEST_JSON}"
 fi
@@ -214,13 +340,38 @@ if [ "$ABSENT" -gt 0 ]; then
   echo "  in ${PLACEHOLDER_FILE}."
 fi
 
+if [ "$UNKNOWN" -gt 0 ]; then
+  echo
+  echo "UNKNOWN (${UNKNOWN}) — the probe could not reach a verdict after ${VERIFY_ATTEMPTS} attempt(s):"
+  for image in "${UNKNOWN_IMAGES[@]}"; do
+    echo "  - ${image}"
+  done
+  echo
+  echo "  This says NOTHING about whether these images are attested — it is a registry,"
+  echo "  credential or tooling failure, not a supply-chain finding. Do not report it as a"
+  echo "  fleet gap and do not rebuild anything on the strength of it. Re-run; if it persists,"
+  echo "  verify one image by digest by hand and treat it as an infrastructure problem:"
+  echo "    cosign verify-attestation --key ${COSIGN_KEY} --type cyclonedx <image>@<digest>"
+fi
+
 if [ "$FAIL" -gt 0 ]; then
   echo
   echo "FLEET ATTESTATION GATE: FAIL — ${FAIL} of ${#IMAGES[@]} declared image(s) not deployable."
   echo
-  echo "No image-provenance policy may graduate Audit -> Enforce while this gate fails"
+  echo "Both image-provenance policies are already Enforce in-cluster"
+  echo "(verify-openbank-image-signatures; verify-openbank-image-sbom-attestation, graduated"
+  echo "2026-07-12), so this is a LATENT OUTAGE, not a graduation blocker: the affected pods"
+  echo "keep running until something reschedules them, and are then denied admission and can"
+  echo "never restart. Fix before a reschedule, not after"
   echo "(rules.yaml: provenance.enforce_criteria)."
   exit 1
+fi
+
+if [ "$UNKNOWN" -gt 0 ]; then
+  echo
+  echo "FLEET ATTESTATION GATE: INCOMPLETE — ${PASS} verified, ${UNKNOWN} could not be checked."
+  echo "  Exit 2 = 'could not run', NOT a verdict. Callers must not treat it as a fleet gap."
+  exit 2
 fi
 
 echo

--- a/.github/workflows/auto-deploy.yml
+++ b/.github/workflows/auto-deploy.yml
@@ -773,6 +773,11 @@ jobs:
       #
       # The daily schedule on `fleet-attestation.yml` stays, and is not made redundant: a latent
       # gap can appear with no deploy at all (a registry lifecycle rule, a hand-pushed image).
+      #
+      # Exit 2 ("the probe could not run", #1915) also fails this step, deliberately: on the
+      # deploy path an unchecked fleet must not open a gitops PR. The distinction still
+      # matters for the OPERATOR — a 2 is a registry/credential problem to re-run, never an
+      # image to rebuild — and the script says which one it is in its own last two lines.
       - name: Fleet SBOM attestation gate (issue #2947)
         timeout-minutes: 20  # measured max 198s on the same check in fleet-attestation.yml
         run: bash .github/scripts/check-fleet-attestations.sh

--- a/.github/workflows/fleet-attestation.yml
+++ b/.github/workflows/fleet-attestation.yml
@@ -50,6 +50,12 @@ jobs:
       - name: shellcheck
         run: shellcheck -S warning .github/scripts/check-fleet-attestations.sh
 
+      # The classifier decides whether a cosign failure is published as a supply-chain
+      # verdict or as "the probe could not run" (#1915). It needs no registry, so it is
+      # proven here on every PR — against inputs it must classify each of the three ways.
+      - name: Classifier selftest
+        run: .github/scripts/check-fleet-attestations.sh --selftest
+
   verify:
     name: Verify fleet attestations
     runs-on: ubuntu-latest
@@ -60,6 +66,10 @@ jobs:
     permissions:
       contents: read
       id-token: write # AWS OIDC
+    outputs:
+      # 0 = clean, 1 = a real fleet gap, 2 = the probe could not run (#1915). `raise-issue`
+      # reads this so a registry throttle never files a supply-chain gap ticket.
+      status: ${{ steps.gate.outputs.status }}
     env:
       AWS_REGION: eu-north-1
       ECR_REGISTRY: "265175468565.dkr.ecr.eu-north-1.amazonaws.com"
@@ -85,9 +95,21 @@ jobs:
         # pipeline below exits with `tee`'s status, so the gate printed
         # "FLEET ATTESTATION GATE: FAIL" and the step still went green. Verified against
         # run 29488481556, which reported FAIL on an absent image and concluded success.
+        #
+        # The exit code is captured rather than propagated straight through, because 1 and 2
+        # mean different things: 1 is a fleet gap, 2 is "the probe could not run" and is NOT a
+        # verdict about any image (#1915). Both still fail the step — an unchecked fleet is not
+        # a pass — but the code is published so `raise-issue` can refuse to file a supply-chain
+        # ticket for a registry throttle.
         run: |
-          set -euo pipefail
+          set -uo pipefail
           .github/scripts/check-fleet-attestations.sh | tee "${RUNNER_TEMP}/gate.log"
+          status="${PIPESTATUS[0]}"
+          echo "status=${status}" >> "$GITHUB_OUTPUT"
+          if [ "$status" -eq 2 ]; then
+            echo "::warning title=Fleet attestation gate could not run::The probe failed for at least one image (registry/credential/tooling). This says nothing about whether the fleet is attested — do not report it as a gap."
+          fi
+          exit "$status"
 
       - name: Job summary
         if: always()
@@ -113,10 +135,13 @@ jobs:
   # unread red schedule is how sbom-drift-scanner's `no-pod-found` sat unactioned. On the
   # scheduled run only (a PR failure is already visible to its author), file/refresh an
   # issue so the gap has an owner and a paper trail.
+  # `status != '2'` is the whole point of the exit-code split: a probe that could not run must
+  # not open (or bump) an issue asserting a latent admission failure. A 2 still leaves the
+  # scheduled run red, which is the honest signal for "unchecked".
   raise-issue:
     name: Raise issue on gap
     needs: verify
-    if: ${{ failure() && github.event_name == 'schedule' }}
+    if: ${{ failure() && github.event_name == 'schedule' && needs.verify.outputs.status != '2' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5  # API calls only
     permissions:

--- a/docs/runbooks/0011-kyverno-admission-rollback.md
+++ b/docs/runbooks/0011-kyverno-admission-rollback.md
@@ -127,6 +127,36 @@ key"*. Classification is now positive in both directions (an image is called `UN
 cosign says so in words) and each candidate failure is retried `VERIFY_ATTEMPTS` times first — but a
 red `1` still deserves the hand check: verify the named image by digest before rebuilding anything.
 
+### What to copy from this into the next probe
+
+Four rules, each of which this gate broke:
+
+1. **A checker that knows the difference must ENCODE the difference in the one thing its caller
+   reads.** Knowing "this was a throttle, not a gap" is worth nothing if both outcomes exit `1`:
+   the workflow's `if: failure()` fires either way and files the same supply-chain ticket. Give
+   "could not run" its own exit code (`2`) and branch on it in the caller —
+   `.github/scripts/check-verification-metadata-complete.py` had already paid for this once
+   (#4162, three shards dead of `Java heap space` reported as dependency drift). The reasoning
+   generalizes past exit codes: it is the same defect as a skipped/disabled adapter sharing a
+   `success` boolean with a real success — a distinct state needs a distinct value, not prose in
+   a log nobody parses.
+2. **Classify positively in both directions; never let the alarming verdict be the fallback
+   branch.** Every failure mode nobody enumerated lands in the fallback, and the set of ways a
+   registry call can fail is open-ended while the set of ways cosign says "not attested" is
+   closed. Match the closed sets — absence, and an explicit attestation verdict — and route the
+   remainder to "unknown". Written the other way round, the gate is guaranteed to manufacture a
+   false supply-chain finding eventually; that is not bad luck, it is the structure.
+3. **Retry only the class that is not a verdict.** Retrying a real `UNATTESTED` would slow a true
+   gap down and, worse, invites the next author to widen the retry until a verdict is retried
+   into existence. A verdict is final on the first attempt that produces one.
+4. **A "could not run" path is unfalsifiable by CI here — prove it another way or it is code
+   nobody has run.** No PR can summon an ECR throttle on demand, so the green run of this gate on
+   the fixing PR says nothing about the branch that matters. Prove it with a stubbed `COSIGN_BIN`
+   (a script that fails per-image the four ways) plus `check-fleet-attestations.sh --selftest`,
+   which needs no registry and runs in the lint job on every PR. Falsify the selftest itself by
+   reverting the classifier to the old fallback and confirming exactly the transient cases go
+   red — a classifier that has only ever agreed with you is unfalsified.
+
 ## 5. Related
 
 - ADR-0030 D4 (supply-chain verification), ADR-0144 (graduation criteria)

--- a/docs/runbooks/0011-kyverno-admission-rollback.md
+++ b/docs/runbooks/0011-kyverno-admission-rollback.md
@@ -107,16 +107,25 @@ exactly the worklist you need for §4.
    older envelope.
 3. Remove any §3a exception you added in the same change, or it silently outlives the incident.
 
-**Do not treat a single red `Verify fleet attestations` run as the answer.**
-`.github/scripts/check-fleet-attestations.sh` special-cases only `NAME_UNKNOWN|MANIFEST_UNKNOWN|404`
-as "absent"; **every other** non-zero `cosign verify-attestation` exit — including a transient ECR
-throttle or 5xx — is counted and printed as `UNATTESTED`, i.e. a probe failure is reported as a
-supply-chain verdict. Measured 2026-08-13: run `31729895636` reported
+**Read the gate's EXIT CODE, not just its colour.**
+`.github/scripts/check-fleet-attestations.sh` exits `0` (every declared image attested), `1` (a real
+gap: `UNATTESTED` and/or `ABSENT`) or `2` (`UNKNOWN` — the probe could not run for at least one
+image: ECR throttle, 5xx, expired credentials, a cosign crash). **A 2 is not a verdict about any
+image**: re-run it, and if it persists treat it as a registry/credential problem, never as an image
+to rebuild. `Verify fleet attestations` prints a `could not run` warning annotation in that case, and
+the scheduled run deliberately does NOT open a fleet-gap issue for it.
+
+That distinction was paid for once. Until #1915 the loop special-cased only
+`NAME_UNKNOWN|MANIFEST_UNKNOWN|404` as absent and let **every other** non-zero cosign exit fall
+through to `UNATTESTED`, so a transient failure was published as a supply-chain verdict: run
+`31729895636` (2026-08-13) reported
 `UNATTESTED openbank-release-steward:sandbox-e80f4bc7 … 61 attested / 1 unattested / 62 total`,
 while the **24 other runs of that same gate that day passed on the identical, unchanged image**, and
 `cosign verify-attestation --key awskms:///alias/openbank-cosign-signing --type cyclonedx` against
-its digest `sha256:31d626…` returns *"The signatures were verified against the specified public
-key"*. Before acting on a red gate, re-run it and verify the named image by digest by hand.
+its digest `sha256:31d626…` returned *"The signatures were verified against the specified public
+key"*. Classification is now positive in both directions (an image is called `UNATTESTED` only when
+cosign says so in words) and each candidate failure is retried `VERIFY_ATTEMPTS` times first — but a
+red `1` still deserves the hand check: verify the named image by digest before rebuilding anything.
 
 ## 5. Related
 


### PR DESCRIPTION
## What

Two defects in `.github/scripts/check-fleet-attestations.sh`, both measured 2026-08-13 (#1915).

**1. A failed probe was published as a supply-chain verdict.** The loop special-cased only
`NAME_UNKNOWN|MANIFEST_UNKNOWN|does not exist|not found|404` as `ABSENT`; every other non-zero
`cosign verify-attestation` exit (ECR throttle, 5xx, expired token, a cosign crash) fell through to
`UNATTESTED` and failed the gate. Run `31729895636` reported
`UNATTESTED openbank-release-steward:sandbox-e80f4bc7 … 61 attested / 1 unattested / 62 total`,
while 24 of the 25 most recent runs of the same gate passed on the identical, unchanged image, and a
hand `cosign verify-attestation --key awskms:///alias/openbank-cosign-signing --type cyclonedx`
against digest `sha256:31d626…` answers *"The signatures were verified against the specified public
key"*.

**2. Stale veto text.** `No image-provenance policy may graduate Audit -> Enforce while this gate
fails` — nothing is on Audit any more. Both `verify-openbank-image-signatures` and
`verify-openbank-image-sbom-attestation` are Enforce and Ready in-cluster (SBOM graduated
2026-07-12), so a failing gate is a latent outage now, not a graduation blocker.

## How

- Classification is **positive in both directions**. `ABSENT` needs the registry to say the
  reference is not there; `UNATTESTED` needs cosign to return an attestation verdict in words
  (`no matching attestations`, signature-validation failures); anything else is `UNKNOWN`. The old
  shape had a positive rule for absence and used `UNATTESTED` as the fallback — that fallback is
  the bug.
- **Bounded retry before classifying**: only an `UNKNOWN` is retried (`VERIFY_ATTEMPTS`, default 3,
  `VERIFY_RETRY_SLEEP` 5s), so a genuinely unattested image still fails on the first attempt and no
  result is retried into existence. Retries are printed, so a flaky registry stays visible.
- **Exit codes copy `check-verification-metadata-complete.py`**: `0` clean, `1` a real gap,
  `2` = could not run and explicitly NOT a verdict. JSON report gains `unknown`/`unknownImages` and
  a `gateResult: INCOMPLETE`.
- `fleet-attestation.yml` publishes the exit code as a job output; `raise-issue` no longer files (or
  bumps) the latent-admission-failure issue on a `2`, and the step prints a `could not run` warning
  annotation. The run still goes red — unchecked is not a pass. `auto-deploy.yml` still fails closed
  on `2` (no gitops PR for an unchecked fleet), with the operator distinction written down.
- `--selftest` proves the classifier on all three classes with no registry, and runs in the lint job
  on every PR.
- Veto text reworded to the latent-outage framing; runbook §4 goes from "the script does this wrong"
  to "read the exit code".

## Verification

- `--selftest`: 9 cases green; **falsified** by reverting the classifier's fallback to the old
  behaviour — exactly the 5 `UNKNOWN` cases go red (`expected UNKNOWN, got UNATTESTED`).
- End-to-end against a stubbed cosign (4 images: attested / absent / unattested / always-throttling):
  prints one of each class, retries only the throttling one, exits `1` with `gateResult: FAIL`.
  Unknown-only fleet exits `2` / `INCOMPLETE`; all-attested exits `0` / `PASS`.
- `shellcheck -S warning` clean; `actionlint` clean on `fleet-attestation.yml` (`auto-deploy.yml`'s
  only finding is the pre-existing `openbank-build` self-hosted label); selftest re-run under
  `bash:5.2` in Docker as well as the local bash 3.2; `check-workflow-run-step-size.py` clean.

`rules.yaml` is deliberately untouched — the `enforcement_rule` there is about a future successor
policy and still reads correctly, and editing the file would restamp every OPA bundle for nothing.

## Linked issues

Refs #1915
