### PR TITLE
ci(security): state authenticated-fuzz coverage as a fraction, and fail an empty scope

### DIFF
--- a/.github/workflows/api-fuzz-authenticated.yml
+++ b/.github/workflows/api-fuzz-authenticated.yml
@@ -94,6 +94,48 @@ jobs:
           for svc, why in skipped:
               print(f"::warning::api-fuzz-authenticated: {svc} EXCLUDED — {why}")
           print(f"fuzzing {len(keep)} service(s); {len(skipped)} excluded")
+
+          # A run's CONCLUSION is not a coverage statement, and this lane proved it: run
+          # 31688625829 (2026-08-13) is the first green this workflow ever produced, and it
+          # fuzzed ONE service — a `services:` override narrowed the matrix and nothing in the
+          # run name, conclusion or log said so. "API fuzz (authenticated): success" read
+          # identically to a full 18-service pass (#3039). So the scope is stated as a fraction
+          # of the money path, in the step summary where a reader lands, and an override is
+          # labelled as one instead of silently replacing the derived set.
+          denom = len(money)
+          summary = [
+              "## Authenticated fuzz scope",
+              "",
+              f"**{len(keep)} of {denom} money-path services actually fuzzed.**",
+              "",
+          ]
+          if override:
+              summary += [
+                  f"> ⚠️ **Scope was OVERRIDDEN by dispatch input** to {len(override)} requested "
+                  f"service(s) — this run does NOT measure the money path. "
+                  f"Requested: `{' '.join(override)}`",
+                  "",
+              ]
+              print(
+                  "::warning::api-fuzz-authenticated: scope OVERRIDDEN by dispatch input "
+                  f"({len(keep)} of {denom} money-path services) — this run is not a coverage measurement"
+              )
+          if skipped:
+              summary += ["| Excluded | Why |", "|---|---|"]
+              summary += [f"| `{svc}` | {why} |" for svc, why in skipped]
+              summary += [""]
+          summary += [f"Fuzzed: {', '.join(f'`{s}`' for s in keep) or '_none_'}"]
+          with open(os.environ.get("GITHUB_STEP_SUMMARY", os.devnull), "a") as fh:
+              fh.write("\n".join(summary) + "\n")
+
+          # An empty scope must never read as a pass. Every candidate being excluded is the one
+          # state where this lane fuzzes nothing at all, and a zero-length matrix is precisely
+          # the shape that produces a green run about no subject — the failure mode this repo
+          # keeps rediscovering. Fail here, where the reason is still in hand.
+          if not keep:
+              print("::error::api-fuzz-authenticated: derived scope is EMPTY — nothing would be fuzzed")
+              raise SystemExit(1)
+
           with open(os.environ["GITHUB_OUTPUT"], "a") as fh:
               fh.write("services=" + json.dumps(keep) + "\n")
           PY


### PR DESCRIPTION
## Coverage

**Before: 18 of 23 money-path services in scope — and the run conclusion said nothing about which number applied.**
**After: 18 of 23, stated as a fraction in the job summary, with an empty scope failing outright.**

This PR does **not** increase how many services get fuzzed. It makes the number *visible* and removes the one path where the lane can be green about no subject at all. Saying otherwise would overstate it.

## What was measured

`api-fuzz-authenticated.yml` **fails** on a boot failure — `::error::[svc] failed to boot` then `exit 1`. It does not skip. At job level the lane is honest, and that was the first thing worth establishing.

The dishonesty is one level up. Run [31688625829](https://github.com/JiRaska/open-bank-oss/actions/runs/31688625829) (2026-08-13 09:53Z) is **the first green this workflow has ever produced** — all six prior runs failed. It fuzzed **one** service, `settlement`, because the dispatch carried a `services:` override to verify #4530. The run reads `API fuzz (authenticated): success`, indistinguishable from a full 18-service pass.

Second path, never yet hit: the derive step drops ineligible services with `::warning::` only. If every candidate were excluded, `keep` is `[]`, the matrix is zero-length, and the run is green having fuzzed nothing. That is the shape this repo keeps rediscovering — a control reporting success about a subject it never reached.

## The change

In the `derive` step only:

- Writes **`N of M money-path services actually fuzzed`** to `$GITHUB_STEP_SUMMARY`, with the exclusion table and reasons.
- An overridden scope is **labelled as an override** — summary banner plus a `::warning::` saying the run is not a coverage measurement.
- **An empty derived scope fails the job**, where the reason is still in hand, rather than becoming a zero-length matrix.

No service code, no fuzzing behaviour, no trigger change.

## Verification

The derive script was extracted from the workflow and run against three cases, two of them known-positives it must flag:

| Case | Expected | Got |
|---|---|---|
| derived scope | rc=0, `18 of 23` | rc=0, `18 of 23`, 5 excluded (all `authz.enforce: true`, #266) |
| `services: openbank-ledger-service` | rc=0 + override warning | rc=0, `1 of 23`, `scope OVERRIDDEN … not a coverage measurement` |
| all candidates excluded | **rc=1** | rc=1, `derived scope is EMPTY` |

The derived list was also validated against the real thing: a full dispatch on `main` ([31746030097](https://github.com/JiRaska/open-bank-oss/actions/runs/31746030097)) produced exactly the 18 matrix jobs the local reproduction predicted.

## What this does not fix, and why

- **The 5 excluded services** (`sdd`, `sanctions`, `vop`, `standing-order`, `psd2`) need the OPA sidecar — #266, out of scope here.
- **The `workflow_dispatch:`-only deadlock** (it goes on a schedule once green; it is not green; nothing prompts anyone) is an owner decision, laid out as options (a)/(b)/(c) in #3039. Not decided unilaterally in a PR.
- **`perf-gate.yml` has the identical silent-shrink shape** — same derive-and-warn pattern, same zero-length matrix risk. Left alone deliberately rather than widened into an unrelated lane; worth its own issue.
- **The issue title is stale in both numbers** — the scope is 18, not 16, and the boot causes it names were fixed by #4530 earlier today.

Refs #3039
