### PR TITLE
fix(ci): teach the outbox-writer gate the JPA-entity write idiom

### DIFF
--- a/.github/scripts/check-outbox-has-writer.py
+++ b/.github/scripts/check-outbox-has-writer.py
@@ -7,7 +7,7 @@
 # A service that ships an outbox must write to it (issue #4007).
 #
 # THE DEFECT THIS CATCHES
-# Eight services ship the whole transactional-outbox apparatus — a `*OutboxDispatcher`, a backlog
+# Five services ship the whole transactional-outbox apparatus — a `*OutboxDispatcher`, a backlog
 # gauge, a Flyway migration for the table, `openbank.outbox.dispatch-enabled: true` — and construct
 # no `OutboxMessage` anywhere in `src/main`. The dispatcher polls a table nothing writes to, forever.
 #
@@ -40,10 +40,15 @@
 # comment.
 #
 # RATCHET, NOT A BIG BANG
-# The eight below are real and each needs a per-service decision (wire it, or delete the apparatus)
+# The five below are real and each needs a per-service decision (wire it, or delete the apparatus)
 # that is not this gate's to make. They are baselined against #4007 so the gate can be ENFORCED
-# today: a ninth service cannot be added quietly. A baseline entry that becomes covered is reported
+# today: a sixth service cannot be added quietly. A baseline entry that becomes covered is reported
 # too, so the list keeps meaning something rather than silently becoming permanent.
+#
+# The list started at eight. Three have left it, and only two of those were fixes: `party` (#4158)
+# and `kyc` (#4378) were wired onto their outbox and their direct emitters retired, while
+# `billing` was never a violation at all — see its note in BASELINE. Worth separating, because a
+# shrinking baseline reads as progress and one third of this one was a measurement error.
 
 from __future__ import annotations
 
@@ -57,7 +62,13 @@ import sys
 BASELINE = {
     "openbank-audit-service": "#4007 — dispatcher + gauge, no OutboxMessage construction",
     "openbank-balance-service": "#4007 — publishes via the direct KafkaBalanceEventPublisher instead",
-    "openbank-billing-service": "#4007 — 2 DEAD rows exist from a writer no longer present; see the issue",
+    # openbank-billing-service was never a violation (#4007): it writes billing.fee.post-intent.v1
+    # from BillingAssessmentRepositoryImpl by constructing BillingOutboxEntity() inside the same
+    # sf.withTransaction as the assessment, which is a correct atomic outbox write this gate could
+    # not see until it learned the entity idiom. Its baseline reason — "2 DEAD rows from a writer
+    # no longer present" — was wrong in both halves: the writer is present, and the 2 DEAD rows
+    # (attempt_count 10, billing_outbox, sandbox) are a DISPATCH failure, which is a different
+    # defect and is not this gate's subject.
     # openbank-kyc-service was wired instead of deleted (#4007): the case lifecycle events now go
     # through kyc_outbox in the state-change transaction and the direct KycEventPublisher is gone.
     # Removing an entry from this list is the definition of done for that service.
@@ -71,6 +82,44 @@ BASELINE = {
 
 DISPATCHER_RE = re.compile(r"class\s+\w*OutboxDispatcher\b")
 DECLARATION_RE = re.compile(r"(data\s+)?class\s+OutboxMessage\s*\(")
+# A row built as a JPA ENTITY is the third write idiom in this tree, and matching only the domain
+# type and raw SQL was blind to it. openbank-billing-service writes `billing.fee.post-intent.v1`
+# from BillingAssessmentRepositoryImpl by constructing `BillingOutboxEntity().apply { … }` inside
+# the same `sf.withTransaction` as the assessment — a correct, atomic outbox write — and this gate
+# reported it as writerless and baselined it as "2 DEAD rows from a writer no longer present".
+# The writer was never removed; the rows are DEAD because dispatch failed ten times, which is a
+# different defect entirely. A false negative here reads as a clean finding, which is exactly how
+# a wrong entry survived four re-measurements of #4007.
+ENTITY_CONSTRUCTION_RE = re.compile(r"\b\w*OutboxEntity\s*\(\s*\)")
+# ...but NOT in the outbox repository's own adapter. Every service that ships the apparatus has an
+# `*OutboxRepositoryImpl` whose `OutboxMessage.toEntity()` maps an ALREADY-constructed message on
+# the DRAIN side. That mapper is plumbing, in the same category as the data-class declaration
+# above: counting it would mark all 34 dispatcher-shipping services as writers and silently retire
+# the gate — the same failure the SQL predicate's `\w*outbox\w*` narrowness exists to avoid.
+# Verified against the tree: for audit, balance, pid, psd2 and tpp-registry the ONLY
+# `*OutboxEntity()` construction is that mapper, so all five stay violations.
+OUTBOX_ADAPTER_RE = re.compile(r"Outbox\w*RepositoryImpl\.kt$")
+
+
+def constructs_outbox_entity(body: str) -> bool:
+    """True if `body` CONSTRUCTS an outbox entity, as opposed to declaring one.
+
+    A Kotlin supertype call is spelled exactly like a constructor call, and every one of these
+    entities is declared `class XOutboxEntity : PanacheOutboxEntity()`. Matching the bare pattern
+    therefore found a "writer" in all five genuinely writerless services — in the entity's own
+    declaration file — and would have retired the gate while reporting six fixes. Measured, not
+    reasoned: the first version of this predicate did exactly that.
+
+    So a match counts only when the character before it is not `:` or `,`, the two positions a
+    supertype can occupy. That is narrower than skipping the declaration FILE, which would blind
+    the gate to a service that declares its entity and writes it in the same file.
+    """
+    for hit in ENTITY_CONSTRUCTION_RE.finditer(body):
+        before = body[: hit.start()].rstrip()
+        if before and before[-1] in ":,":
+            continue
+        return True
+    return False
 # A row written by direct SQL is just as much a write as one built through the domain type, and
 # some services cannot use the domain type at all: a Temporal activity thread carries no Vert.x
 # context, so reactive Panache throws HR000068 there and the service inserts through plain JDBC
@@ -86,7 +135,7 @@ DECLARATION_RE = re.compile(r"(data\s+)?class\s+OutboxMessage\s*\(")
 # reads as a clean finding rather than as a gap in the pattern (#4240).
 #
 # The `\w*outbox\w*` on the table NAME is what keeps this narrow. Widening to any INSERT would
-# mark all eight baselined services as fixed and silently retire the gate, so the negatives in the
+# mark all the baselined services as fixed and silently retire the gate, so the negatives in the
 # self-test are the cases that matter here, not the positives.
 #
 # The trailing `(?!\w*\s*\.)` is not decoration and was measured, not reasoned: because the schema
@@ -199,7 +248,7 @@ def classify_service(files: dict[str, str]) -> tuple[bool, bool]:
     prevent.
     """
     dispatcher = writes = False
-    for raw in files.values():
+    for path, raw in files.items():
         body = strip_comments_and_strings(raw)
         # SQL lives INSIDE a string literal, which the stripper blanks — so the SQL predicate reads
         # a comment-only strip. Prose about an insert still must not count, hence not the raw text.
@@ -209,6 +258,8 @@ def classify_service(files: dict[str, str]) -> tuple[bool, bool]:
         if "OutboxMessage(" in body and not DECLARATION_RE.search(body):
             writes = True
         if SQL_INSERT_RE.search(sql_body):
+            writes = True
+        if not OUTBOX_ADAPTER_RE.search(path) and constructs_outbox_entity(body):
             writes = True
     return dispatcher, writes
 
@@ -285,6 +336,48 @@ def self_test() -> int:
 '''
     expect("a direct SQL INSERT into the outbox table IS a writer",
            classify_service({"a.kt": sql}), (True, True))
+
+    # ── The JPA-entity write idiom (#4007) ────────────────────────────────────────────────────
+    # billing writes its outbox by constructing the ENTITY, not the domain type and not raw SQL.
+    # The negatives below are the ones that matter: they are what stops this predicate from
+    # marking every dispatcher-shipping service as a writer and retiring the gate.
+    entity = disp + "\nval e = BillingOutboxEntity().apply { eventType = t }\n"
+    expect("constructing the outbox ENTITY outside the adapter IS a writer",
+           classify_service({"a.kt": disp, "BillingAssessmentRepositoryImpl.kt": entity}),
+           (True, True))
+    # The drain-side mapper every service has. If this counted, all 34 would be "writers".
+    mapper = "private fun OutboxMessage.toEntity() = PidOutboxEntity().also { }"
+    expect("the adapter's own toEntity() mapper is NOT a writer",
+           classify_service({"a.kt": disp, "PidOutboxRepositoryImpl.kt": mapper}), (True, False))
+    # ...and the exclusion is by FILE, so the same mapper text elsewhere still counts — otherwise
+    # a service could dodge the gate by naming a file conveniently.
+    expect("the same construction in a non-adapter file still counts",
+           classify_service({"a.kt": disp, "PartyService.kt": mapper}), (True, True))
+    # Code-about-code applies here too, via the same stripper.
+    entity_kdoc = disp + "\n/** Builds a PidOutboxEntity() per transition. */\n"
+    expect("a KDoc mentioning the entity constructor is NOT a writer",
+           classify_service({"a.kt": entity_kdoc}), (True, False))
+    entity_string = disp + '\nval s = "PidOutboxEntity()"\n'
+    expect("the entity constructor inside a string literal is NOT a writer",
+           classify_service({"a.kt": entity_string}), (True, False))
+    # A non-outbox entity must not match — the `\w*Outbox` stem is what keeps this narrow.
+    other_entity = disp + "\nval e = AssessedFeeEntity().apply { }\n"
+    expect("constructing a NON-outbox entity is NOT a writer",
+           classify_service({"a.kt": other_entity}), (True, False))
+    # THE case that caught the first version of this predicate. A Kotlin supertype call is spelled
+    # identically to a constructor call, and every outbox entity in the tree is declared this way,
+    # so without the `:`-position guard all five writerless services reported as fixed.
+    supertype = disp + "\nclass PidOutboxEntity : PanacheOutboxEntity() { var id: UUID? = null }\n"
+    expect("the entity DECLARATION's supertype call is NOT a writer",
+           classify_service({"a.kt": disp, "PidOutboxEntity.kt": supertype}), (True, False))
+    multi = disp + "\nclass PidOutboxEntity : Base, PanacheOutboxEntity() { }\n"
+    expect("a supertype call after a comma is NOT a writer",
+           classify_service({"a.kt": disp, "PidOutboxEntity.kt": multi}), (True, False))
+    # ...and a declaration file that ALSO constructs one really is a writer — which is why the
+    # guard is by position and not by filename.
+    decl_and_write = supertype + "\nval e = PidOutboxEntity().apply { }\n"
+    expect("a declaration file that also constructs one IS a writer",
+           classify_service({"a.kt": disp, "PidOutboxEntity.kt": decl_and_write}), (True, True))
 
     # ── Qualified and quoted table references (#4240 follow-up) ────────────────────────────────
     # Latent: neither form appears in the tree today, and schema-qualified INSERT is not an idiom


### PR DESCRIPTION
## What this fixes

`check-outbox-has-writer.py` matched two write idioms — constructing the domain `OutboxMessage(`, and a raw `INSERT INTO …outbox`. This tree has a third, and the gate was blind to it: **building the JPA entity directly**.

`openbank-billing-service` writes `billing.fee.post-intent.v1` from `BillingAssessmentRepositoryImpl.kt:91`:

```kotlin
BillingOutboxEntity().apply {
    eventType = "billing.fee.post-intent.v1"
    payload = AssessedFeeOutboxPayloads.postIntent(fee)
    status = OutboxStatus.PENDING.name
}
…
sf.withTransaction { s, _ -> allEntities.fold(…) { acc, e -> acc.chain { s.persist(e) } } }
```

The outbox rows are persisted in the **same transaction** as the assessment and its fees. That is a correct, atomic transactional-outbox write — exactly what the gate exists to require.

## The baseline entry it corrects

#4007 baselined billing as:

> `"#4007 — 2 DEAD rows exist from a writer no longer present; see the issue"`

Wrong in both halves. The writer is present on today's `main` and always was — `git log -S 'OutboxMessage(' -- openbank-billing-service/src/main` returns nothing because billing has never used that idiom, not because a writer was removed. And the 2 `DEAD` rows are a **dispatch** failure, not a missing writer:

```
$ kubectl exec -n billing billing-db-2 -c postgres -- \
    psql -U postgres -d openbank_billing -c 'select … from billing_outbox'
1|billing.fee.post-intent.v1|2026-07-13 12:29:09+00|attempt_count=10|BillingOutboxDispatcher#publishWithRe…
2|billing.fee.post-intent.v1|2026-07-13 12:29:09+00|attempt_count=10|BillingOutboxDispatcher#publishWithRe…
```

Rows written, dispatched ten times, latched `DEAD`. #4007 flags this as the one anomaly nobody has explained (*"either a writer existed and was removed, or they arrived by a path I have not found"*). Neither: **the writer is right there, and the gate could not see it.** The residual dispatch failure is a real and separate defect, left for its own issue — it is not this gate's subject.

A false negative is the dangerous direction here: a service that *does* write its outbox reported as writerless reads as a clean finding rather than as a broken probe. That is how the wrong entry survived four re-measurements of #4007.

## Two guards keep the widening from retiring the gate

Both were **measured, not reasoned** — the first version of this predicate failed on the second one.

1. **The adapter's own `toEntity()` mapper does not count.** Every one of the 34 dispatcher-shipping services has an `*OutboxRepositoryImpl` whose `OutboxMessage.toEntity()` maps an already-constructed message on the *drain* side. Counting it would mark all 34 as writers and silently retire the gate.

2. **A Kotlin supertype call is spelled exactly like a constructor call.** Every outbox entity is declared `class XOutboxEntity : PanacheOutboxEntity()`. The first version matched those and reported **all five** remaining violations as fixed:

   ```
   ::error::openbank-audit-service: … but it now has one.
   ::error::openbank-balance-service: … but it now has one.
   …6 stale baseline entries, rc=1
   ```

   The guard is by **position** (the match is not preceded by `:` or `,`), not by filename — so a file that declares the entity *and* constructs one still counts.

## Verification

Self-test grows by 9 cases, including the supertype case that caught the first version and the negatives that keep the predicate narrow:

```
ok   constructing the outbox ENTITY outside the adapter IS a writer
ok   the adapter's own toEntity() mapper is NOT a writer
ok   the same construction in a non-adapter file still counts
ok   a KDoc mentioning the entity constructor is NOT a writer
ok   the entity constructor inside a string literal is NOT a writer
ok   constructing a NON-outbox entity is NOT a writer
ok   the entity DECLARATION's supertype call is NOT a writer
ok   a supertype call after a comma is NOT a writer
ok   a declaration file that also constructs one IS a writer
check-outbox-has-writer: self-test PASS
```

**Validated against a known-positive**, because a gate that goes quiet is the failure mode this file's own header warns about. Planting a dispatcher-only service:

```
::error::openbank-zztest-service: ships an *OutboxDispatcher but constructs no OutboxMessage…
35 service(s) ship a dispatcher; 6 without a writer (5 baselined, 1 new, 0 stale). rc=1
```

Still catches a fresh violation. Fleet verdict on this branch, in the exact form CI invokes:

```
$ python3 .github/scripts/check-outbox-has-writer.py .
check-outbox-has-writer: 34 service(s) ship a dispatcher; 5 without a writer
                         (5 baselined, 0 new, 0 stale baseline entries).
rc=0
```

## Scope — what this deliberately does not do

`6 → 5` comes **entirely** from billing leaving the baseline. Nothing is wired by this PR. The five that remain each still need the per-service decision #4007 asks for, which is not a gate's to make:

| service | state | evidence |
|---|---|---|
| `balance` | **(a)** no writer, twin direct publisher | `KafkaBalanceEventPublisher` (`@Channel("balance-events-out")`) used by `BalanceService`, `LedgerProjectionService`, `ValueDateRollScheduler`; live: 74 balances / 271 projection events / 122 holds and **`balance_outbox` = 0 rows** |
| `pid` | **(a)** no writer, twin direct publisher | `KafkaPartyEventPublisher` (`@Channel("party-events-out")`), 14 `eventPublisher.publish` sites; live: **every table empty**, so zero rows proves nothing here — the finding is from code |
| `audit` | (a)/(c) undecided | no writer, **no** direct twin; live: 24 `audit_entries` / 42 `audit_anchor`, `audit_outbox` = 0 |
| `psd2` | (a)/(c) undecided | no writer, no direct twin; live: no table has any rows |
| `tpp-registry` | (a)/(c) undecided | no writer, no direct twin; live: no table has any rows |

None is state **(b)** — all five set `openbank.outbox.dispatch-enabled: true`, so the usual "the switch was never flipped" explanation is ruled out for every one of them.

`balance` is the substantive one and is **money-path** (`rules.yaml: money_path_services`), so it needs 2 approvals + a threat model and is deliberately not bundled here. `pid` is the same twin-publisher shape as the already-landed `party` (#4158) and `kyc` (#4378) fixes, but moving 14 publish sites inside the repository transaction plus a real-DB IT is its own PR. Per-service verdicts posted to #4007.

Refs #4007
