### PR TITLE
feat(campaign): show decision path outcomes

### DIFF
--- a/openbank-admin-ui/src/app/campaigns/[id]/page.tsx
+++ b/openbank-admin-ui/src/app/campaigns/[id]/page.tsx
@@ -27,6 +27,9 @@ interface Campaign {
     order: number
     template: string
     delaySeconds: number
+    channel?: 'EMAIL' | 'PUSH' | 'BANNER'
+    condition?: 'IF_PREVIOUS_CONFIRMED' | 'IF_PREVIOUS_NOT_CONFIRMED'
+    conditionSourceOrder?: number
     variantBVariables?: Record<string, string> | null
     fallbackToPush?: boolean
     mobileDestination?: 'HOME' | 'SAVINGS' | 'CARDS' | 'PAYMENTS' | 'PRODUCT_HUB' | null

--- a/openbank-admin-ui/src/components/campaigns/JourneyCanvas.tsx
+++ b/openbank-admin-ui/src/components/campaigns/JourneyCanvas.tsx
@@ -36,6 +36,8 @@ export interface StepFunnel {
   reached: number
   delivered: number
   failed: number
+  /** Present from campaign-service 1.32.0; absence during rollout must not invent a branch count. */
+  skipped?: number
   suppressed: SuppressionCount[]
 }
 
@@ -43,6 +45,9 @@ export interface JourneyStep {
   order: number
   template: string
   delaySeconds: number
+  channel?: 'EMAIL' | 'PUSH' | 'BANNER'
+  condition?: 'IF_PREVIOUS_CONFIRMED' | 'IF_PREVIOUS_NOT_CONFIRMED'
+  conditionSourceOrder?: number
 }
 
 const NODE_W = 190
@@ -98,6 +103,19 @@ export function JourneyCanvas({
     return t(`čekat ${Math.floor(s / 60)} min`, `wait ${Math.floor(s / 60)} min`)
   }
 
+  const channelLabel = (channel?: JourneyStep['channel']): string =>
+    channel === 'PUSH' ? t('push', 'push') : channel === 'BANNER' ? t('banner', 'banner') : t('e-mail', 'email')
+
+  const conditionLabel = (step: JourneyStep): string | null => {
+    if (!step.condition) return null
+    const source = step.conditionSourceOrder === undefined
+      ? t('výsledek předchozího kroku', 'previous-step delivery')
+      : t(`krok ${step.conditionSourceOrder + 1}`, `step ${step.conditionSourceOrder + 1}`)
+    return step.condition === 'IF_PREVIOUS_CONFIRMED'
+      ? t(`${source} doručen`, `${source} delivered`)
+      : t(`${source} nedoručen`, `${source} not delivered`)
+  }
+
   const rows = Array.isArray(funnel) ? funnel : []
   const byStep = new Map(rows.map(f => [f.stepOrder, f]))
   const ordered = Array.isArray(steps) ? [...steps].sort((a, b) => a.order - b.order) : []
@@ -149,6 +167,11 @@ export function JourneyCanvas({
           const f = byStep.get(step.order)
           const reached = f?.reached ?? 0
           const delivered = f?.delivered ?? 0
+          const skipped = f?.skipped
+          // A skipped conditional record proves the *other* reviewed branch was chosen. It is not
+          // a delivery attempt, failure or policy suppression, and must not inflate this path.
+          const pathTaken = step.condition && skipped !== undefined ? Math.max(0, reached - skipped) : reached
+          const branch = conditionLabel(step)
           const drops: SuppressionCount[] = [
             ...(f?.suppressed ?? []),
             ...(f && f.failed > 0 ? [{ reason: 'FAILED', count: f.failed }] : []),
@@ -168,9 +191,14 @@ export function JourneyCanvas({
               <text x={midX} y={ROW_Y - 12} fontSize="11" textAnchor="middle" fill="var(--text-secondary)">
                 {delayLabel(step.delaySeconds)}
               </text>
-              {reached > 0 && (
+              {pathTaken > 0 && (
                 <text x={midX} y={ROW_Y + 20} fontSize="12" textAnchor="middle" fontWeight="600" fill="var(--text-primary)">
-                  {n(reached)}
+                  {n(pathTaken)}
+                </text>
+              )}
+              {branch && (
+                <text x={midX} y={ROW_Y + 34} fontSize="10" textAnchor="middle" fill="var(--text-secondary)" data-branch={step.condition}>
+                  {branch}
                 </text>
               )}
 
@@ -180,7 +208,7 @@ export function JourneyCanvas({
                   fill="var(--surface-2)" stroke="var(--border-strong)" strokeWidth="1.2"
                 />
                 <text x={x + 16} y={ROW_Y - 16} fontSize="11" fill="var(--text-secondary)">
-                  {t('KROK', 'STEP')} {step.order} · {t('e-mail', 'email')}
+                  {t('KROK', 'STEP')} {step.order} · {channelLabel(step.channel)}
                 </text>
                 <text x={x + 16} y={ROW_Y + 6} fontSize="14" fontWeight="600" fill="var(--text-primary)">
                   {templateLabel(step.template)}
@@ -191,6 +219,11 @@ export function JourneyCanvas({
                   </tspan>
                   {' '}{t('doručeno', 'delivered')}
                 </text>
+                {branch && skipped !== undefined && (
+                  <text x={x + 16} y={ROW_Y + 40} fontSize="10" fill="var(--text-secondary)">
+                    {n(skipped)} {t('jinou cestou', 'took another path')}
+                  </text>
+                )}
               </g>
 
               {/* Drop branches: one line per reason, labelled in words. A marketer reads "12 nemá

--- a/openbank-admin-ui/src/test/journey-flow.test.tsx
+++ b/openbank-admin-ui/src/test/journey-flow.test.tsx
@@ -15,8 +15,11 @@ import { JourneyCanvas } from '@/components/campaigns/JourneyCanvas'
  */
 
 const STEPS = [
-  { order: 1, template: 'MARKETING_PRODUCT_OFFER', delaySeconds: 0 },
-  { order: 2, template: 'MARKETING_PRODUCT_OFFER', delaySeconds: 172800 },
+  { order: 1, template: 'MARKETING_PRODUCT_OFFER', delaySeconds: 0, channel: 'PUSH' as const },
+  {
+    order: 2, template: 'MARKETING_PRODUCT_OFFER', delaySeconds: 172800, channel: 'BANNER' as const,
+    condition: 'IF_PREVIOUS_CONFIRMED' as const, conditionSourceOrder: 0,
+  },
 ]
 
 const FUNNEL = [
@@ -30,6 +33,7 @@ const FUNNEL = [
       { reason: 'SUPPRESSED_QUIET_HOURS', count: 90 },
     ],
   },
+  { stepOrder: 2, reached: 600, delivered: 420, failed: 0, skipped: 180, suppressed: [] },
 ]
 
 function renderFlow(funnel = FUNNEL, audience: number | null = 1000) {
@@ -105,5 +109,15 @@ describe('journey canvas', () => {
     renderFlow()
 
     expect(screen.getByText(/people in segment/)).toBeTruthy()
+  })
+
+  it('shows the reviewed decision and separates its other path from delivery loss', () => {
+    const { container } = renderFlow()
+
+    expect(screen.getByText(/step 1 delivered/)).toBeTruthy()
+    expect(screen.getByText(/180 took another path/)).toBeTruthy()
+    expect(container.querySelector('[data-branch="IF_PREVIOUS_CONFIRMED"]')).toBeTruthy()
+    expect(screen.getByText(/STEP 1 · push/)).toBeTruthy()
+    expect(screen.getByText(/STEP 2 · banner/)).toBeTruthy()
   })
 })

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/usecase/CampaignSendLogQuery.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/usecase/CampaignSendLogQuery.kt
@@ -65,6 +65,7 @@ class CampaignSendLogQuery(private val sendLog: SendLogRepository) {
                 reached = rows.sumOf { it.count },
                 delivered = byOutcome[SendOutcome.SENT] ?: 0,
                 failed = byOutcome[SendOutcome.FAILED] ?: 0,
+                skipped = byOutcome[SendOutcome.SKIPPED_CONDITION] ?: 0,
                 suppressed = SUPPRESSION_REASONS.mapNotNull { r ->
                     byOutcome[r]?.takeIf { it > 0 }?.let { SuppressionCount(r.name, it) }
                 },
@@ -106,6 +107,8 @@ data class StepFunnel(
     val reached: Long,
     val delivered: Long,
     val failed: Long,
+    /** The condition did not hold, so this party continued through another reviewed path. */
+    val skipped: Long,
     val suppressed: List<SuppressionCount>,
 )
 

--- a/openbank-campaign-service/src/main/resources/openapi.yaml
+++ b/openbank-campaign-service/src/main/resources/openapi.yaml
@@ -4,7 +4,7 @@ openapi: 3.1.0
 info:
   title: Campaign Service API
   # major == openbank.api.version == URL /api/v1 (ADR-0048).
-  version: 1.31.0
+  version: 1.32.0
   description: >-
     Campaign management first slice (ADR-0200 / ADR-0209 D3): deterministic, versioned segments;
     per-enrolment Temporal journeys; consent-gated delivery through notification-service.
@@ -979,6 +979,13 @@ components:
           description: Sends this step recorded at all — delivered plus every suppression.
         delivered: { type: integer, format: int64 }
         failed: { type: integer, format: int64 }
+        skipped:
+          type: integer
+          format: int64
+          description: >-
+            Parties for whom this conditional step did not run because its reviewed delivery
+            predicate did not hold. They are not failures or suppressions; they continued through
+            the complementary path.
         suppressed:
           type: array
           description: >-

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/CampaignSendLogTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/CampaignSendLogTest.kt
@@ -33,6 +33,7 @@ class CampaignSendLogTest {
         record(SendOutcome.SUPPRESSED_CAP, 2),
         record(SendOutcome.SUPPRESSED_QUIET_HOURS, 2),
         record(SendOutcome.FAILED, 3),
+        record(SendOutcome.SKIPPED_CONDITION, 3),
     )
 
     private fun record(outcome: SendOutcome, step: Int) = SendRecord(
@@ -93,6 +94,7 @@ class CampaignSendLogTest {
                 SendOutcome.SUPPRESSED_CAP,
                 SendOutcome.SUPPRESSED_QUIET_HOURS,
                 SendOutcome.FAILED,
+                SendOutcome.SKIPPED_CONDITION,
             ),
             sends.map { it.outcome }.toSet(),
         )
@@ -164,5 +166,14 @@ class CampaignSendLogTest {
         assertEquals(0, page.page)
         assertEquals(1, page.size)
         assertEquals(1, page.items.size)
+    }
+
+    @Test
+    fun `a skipped conditional branch is reported separately from failure and suppression`(): Unit = runBlocking {
+        val step = query.funnel(campaignId).single { it.stepOrder == 3 }
+
+        assertEquals(1, step.skipped)
+        assertEquals(1, step.failed)
+        assertEquals(0, step.suppressed.size)
     }
 }


### PR DESCRIPTION
## What

Show an explicit decision path honestly in Campaign Studio: conditional steps now expose their server-recorded SKIPPED_CONDITION count separately from delivery failures and consent/frequency suppression. The journey canvas labels PUSH and BANNER channels and names the reviewed source condition.

## Why

A skipped branch means a person continued through the complementary reviewed path. Treating it as a drop, failed delivery, or zero makes decision performance unreadable and misleads campaign operators.

## Safety

- additive API field (`skipped`) only; older UI deployments preserve prior `reached` rendering
- no customer identities or interaction records added
- all counts remain campaign-level SQL aggregates

## Verification

- `./gradlew :openbank-campaign-service:ktlintCheck :openbank-campaign-service:test --tests "*CampaignSendLogTest"`
- `npm test -- --run src/test/journey-flow.test.tsx`
- `npm run type-check`

Refs #4680