### PR TITLE
fix(ci): stop the authenticated-fuzz harness pulling dev-service images it never uses

### DIFF
--- a/.github/workflows/api-fuzz-authenticated.yml
+++ b/.github/workflows/api-fuzz-authenticated.yml
@@ -94,6 +94,48 @@ jobs:
           for svc, why in skipped:
               print(f"::warning::api-fuzz-authenticated: {svc} EXCLUDED — {why}")
           print(f"fuzzing {len(keep)} service(s); {len(skipped)} excluded")
+
+          # A run's CONCLUSION is not a coverage statement, and this lane proved it: run
+          # 31688625829 (2026-08-13) is the first green this workflow ever produced, and it
+          # fuzzed ONE service — a `services:` override narrowed the matrix and nothing in the
+          # run name, conclusion or log said so. "API fuzz (authenticated): success" read
+          # identically to a full 18-service pass (#3039). So the scope is stated as a fraction
+          # of the money path, in the step summary where a reader lands, and an override is
+          # labelled as one instead of silently replacing the derived set.
+          denom = len(money)
+          summary = [
+              "## Authenticated fuzz scope",
+              "",
+              f"**{len(keep)} of {denom} money-path services actually fuzzed.**",
+              "",
+          ]
+          if override:
+              summary += [
+                  f"> ⚠️ **Scope was OVERRIDDEN by dispatch input** to {len(override)} requested "
+                  f"service(s) — this run does NOT measure the money path. "
+                  f"Requested: `{' '.join(override)}`",
+                  "",
+              ]
+              print(
+                  "::warning::api-fuzz-authenticated: scope OVERRIDDEN by dispatch input "
+                  f"({len(keep)} of {denom} money-path services) — this run is not a coverage measurement"
+              )
+          if skipped:
+              summary += ["| Excluded | Why |", "|---|---|"]
+              summary += [f"| `{svc}` | {why} |" for svc, why in skipped]
+              summary += [""]
+          summary += [f"Fuzzed: {', '.join(f'`{s}`' for s in keep) or '_none_'}"]
+          with open(os.environ.get("GITHUB_STEP_SUMMARY", os.devnull), "a") as fh:
+              fh.write("\n".join(summary) + "\n")
+
+          # An empty scope must never read as a pass. Every candidate being excluded is the one
+          # state where this lane fuzzes nothing at all, and a zero-length matrix is precisely
+          # the shape that produces a green run about no subject — the failure mode this repo
+          # keeps rediscovering. Fail here, where the reason is still in hand.
+          if not keep:
+              print("::error::api-fuzz-authenticated: derived scope is EMPTY — nothing would be fuzzed")
+              raise SystemExit(1)
+
           with open(os.environ["GITHUB_OUTPUT"], "a") as fh:
               fh.write("services=" + json.dumps(keep) + "\n")
           PY

--- a/.github/workflows/api-fuzz-authenticated.yml
+++ b/.github/workflows/api-fuzz-authenticated.yml
@@ -281,6 +281,18 @@ jobs:
           # Boot with OIDC ENABLED (override the %dev oidc.enabled=false) pointed at
           # the throwaway Keycloak. authz.enforce stays false for this target, so no
           # OPA sidecar is needed — OIDC authN is the only gate being exercised.
+          #
+          # DEV SERVICES OFF (#3039). Dev mode starts containers for anything it thinks is
+          # unconfigured, and on a cold hosted runner the PULL is what blows the readiness
+          # window: run 31746030097 left account-service mid-`Extracting 250.7MB/638.7MB` of
+          # docker.io/grafana/otel-lgtm at the exact second the loop gave up, and pulled
+          # apache/kafka-native alongside it. Neither is reachable from the fuzzed surface.
+          # The backing services this lane actually needs are provisioned explicitly above
+          # (Postgres, Redis, Keycloak, Temporal) and are already suppressing their own dev
+          # service by explicit config — the log says so per component ("Not starting Dev
+          # Services for default datasource as it has explicit configuration"). Kafka is lazy
+          # behind the outbox, so no broker is needed to serve a request. What was left was an
+          # observability stack and a Kafka image, pulled on every one of 18 jobs, for nothing.
           echo "==> [${svc}] starting quarkusDev with OIDC on"
           ./gradlew ":${svc}:quarkusDev" \
             -Dquarkus.console.basic=true --console=plain --quiet \
@@ -291,18 +303,31 @@ jobs:
             -Dquarkus.oidc.auth-server-url=http://localhost:8543/realms/openbank \
             -Dquarkus.oidc.client-id=openbank-services \
             -Dquarkus.oidc.credentials.secret="${OIDC_CLIENT_SECRET}" \
+            -Dquarkus.devservices.enabled=false \
             ${TEMPORAL_ARGS} \
             > "fuzz-reports/${svc}-boot.log" 2>&1 &
           DEV_PID=$!
           UP=0
-          for i in $(seq 1 90); do
+          # 90x2s=180s had to cover a cold Gradle build AND the boot; with dev-service pulls
+          # gone the boot is short, but the build is not, so keep real margin.
+          READY_ITERS=180; READY_TIMEOUT_S=$((READY_ITERS * 2))
+          for i in $(seq 1 "$READY_ITERS"); do
             code="$(curl -s -o /dev/null -w '%{http_code}' "http://localhost:${PORT}/q/health" || true)"
             if [ "$code" != "000" ]; then UP=1; break; fi
             kill -0 "$DEV_PID" 2>/dev/null || break
             sleep 2
           done
           if [ "$UP" != "1" ]; then
-            echo "::error::[${svc}] failed to boot"
+            # "failed to boot" is two different states and they need different fixes. A CRASH
+            # leaves a dead process and an error chain; a TIMEOUT leaves the JVM alive and
+            # still working, and its ERROR grep prints NOTHING — which is exactly how six
+            # triage passes on #3039 recorded "cause not determined" for a service that had
+            # not failed at all. Say which one happened.
+            if kill -0 "$DEV_PID" 2>/dev/null; then
+              echo "::error::[${svc}] did not become ready within ${READY_TIMEOUT_S}s — the process is STILL ALIVE (timeout, not a crash: look at what the log is doing at its end, not for an ERROR)"
+            else
+              echo "::error::[${svc}] failed to boot — the dev-mode process exited"
+            fi
             # A blind `tail` puts the root cause above the window — every ERROR and every
             # `Caused by:` is what actually identifies it (issue #3039: six of seven services
             # were "not determined" purely because of this).


### PR DESCRIPTION
## Coverage

| | money-path services **actually fuzzed** |
|---|---|
| **Before** (`main`, run [31746030097](https://github.com/JiRaska/open-bank-oss/actions/runs/31746030097)) | **12 of 18** |
| **After** (this branch) | **18 of 18** |

Measured by artifact contents, not job conclusion: a service that reached the fuzzer emits `<svc>-auth-fuzz.log`; one that did not emits the boot log alone. "The job is green" is not a coverage statement — six of the eighteen never reached the fuzzer at all.

Stacked on **#4695** (same file). Merge that first.

## What the six were actually doing

Not failing to boot. The workflow's own `ERROR`/`Caused by:` grep printed **nothing** for any of them — which is the answer, not a gap in the diagnostic. The JVM was alive and still working. `account-service`'s boot log ends here:

```
status=Extracting, progress=[=================>    ]  250.7MB/638.7MB, id=b6877d682741
```

`docker.io/grafana/otel-lgtm:0.24.0`, mid-pull at the exact second the 180 s readiness loop gave up. `apache/kafka-native:4.2.0` was pulled alongside it. **Quarkus Dev Services**, starting containers for components the fuzzed surface never touches.

Everything this lane genuinely needs is provisioned explicitly by the harness and already suppresses its own dev service — the boot log says so per component:

```
Not starting Dev Services for default datasource as it has explicit configuration
Not starting Dev Services for Keycloak as 'quarkus.oidc.auth-server-url' has been provided
```

What remained was an observability stack and a Kafka image, pulled on all 18 jobs, for nothing. Kafka is lazy behind the outbox, so no broker is needed to serve a request.

**This is one shared cause for all six, and it is a harness defect — no service code is touched by this PR.**

## The change

- `-Dquarkus.devservices.enabled=false` on the `quarkusDev` invocation.
- Readiness window 180 s → 360 s, so a cold Gradle build still has margin.
- **The readiness diagnostic now distinguishes a crash from a timeout.** A crash leaves a dead process and an error chain; a timeout leaves the JVM alive and its ERROR grep empty. That distinction is not cosmetic — it is exactly how six triage passes on #3039 recorded "cause not determined" for services that had never crashed, and how `Port already bound: 8080` got recorded as a root cause when it was a consequence.

## Verification

Every one of the six gaps was re-run on this branch and re-checked by artifact:

| Service | Before | After |
|---|---|---|
| `account-service` | not fuzzed | **fuzzed**, job green ([31746602329](https://github.com/JiRaska/open-bank-oss/actions/runs/31746602329)) |
| `sepa-payment` | not fuzzed | **fuzzed**, job green |
| `transaction-service` | not fuzzed | **fuzzed**, job green |
| `ledger-service` | not fuzzed | **fuzzed** — job red on `Server error: 2` |
| `domestic-payment` | not fuzzed | **fuzzed**, job green ([31747082471](https://github.com/JiRaska/open-bank-oss/actions/runs/31747082471)) |
| `fx-service` | not fuzzed | **fuzzed** — job red on `Server error: 1` |

`ledger` and `fx` staying red is the lane **working**: they now reach the fuzzed surface and report genuine 5xx findings instead of timing out before being tested. Those findings are service defects and belong to the separate triage, not here.

Stated precisely, since it matters: the "after" figure is 12 unchanged services from the baseline run plus these 6 verified individually on this branch — not one 18-job run on this branch.

`actionlint` finding set is unchanged from `main` (2× pre-existing `SC2034: i appears unused`, line numbers shifted only).

## Note

The failing set differed between waves of the same baseline run — a contention-dependent timeout, which is why this presented as five different "service defects" across five re-triages of #3039. Removing the pulls removes the variance, not just the mean.

Refs #3039
