### PR TITLE
fix(notification): count the outcome events published for a notification row that does not exist

### DIFF
--- a/openbank-infra/gitops/components/observability/prometheus-rules-push.yaml
+++ b/openbank-infra/gitops/components/observability/prometheus-rules-push.yaml
@@ -91,6 +91,39 @@ spec:
               device-registration path (POST /api/v1/devices) or a mass token invalidation, not
               the push provider.
 
+        # A terminal transition that found no row to write itself onto (issue #4512). The service
+        # then publishes a NotificationOutcome event for a notification the table cannot show:
+        # the producer's funnel is told about a message that has no durable record, which is an
+        # evidence gap under DORA Art. 17-19, not a counting quirk.
+        #
+        # Measured 2026-08-09: four SCA_APPROVAL PUSH fan-outs, four NotificationOutcome rows in
+        # notification_outbox, zero notifications rows, and zero error lines in the pod. Every
+        # conventional signal was green — the consumer acked, the offsets advanced, the outbox
+        # dispatched. There is NOTHING failing to alert on, which is why this reads a counter that
+        # only increments on a path the code treats as successful.
+        #
+        # Same `or vector(0)` self-delta as ScaApprovalPushUndeliverable below, and for the same
+        # measured reason: Micrometer registers a counter lazily on its first increment, so the
+        # series is born at 1 after every pod restart and increase() would read 0 on the very
+        # first occurrence — the one that matters most. Threshold is one: a single orphaned
+        # transition is already a lost record.
+        - alert: NotificationStatusRowMissing
+          expr: |
+            (sum(openbank_notification_status_row_missing_total) or vector(0))
+            -
+            (sum(openbank_notification_status_row_missing_total offset 15m) or vector(0)) > 0
+          for: 0m
+          labels:
+            severity: critical
+          annotations:
+            summary: "A notification outcome was published for a row that does not exist"
+            description: >-
+              notification-service completed a terminal transition against a missing notifications
+              row and published the outcome event anyway, so a delivery attempt happened with no
+              durable record of it. Check the notification.status.row_missing ERROR line for the
+              notificationId and party, then compare notification_outbox against notifications for
+              that window — an outbox row with no matching notifications row is the fingerprint.
+
         # The ratio rules above are about the channel; this one is about a single message, because
         # not every push is worth the same alert. SCA_APPROVAL is the prompt telling a customer a
         # payment waits on their approval — a PSD2 Art. 97 control — so ONE undelivered instance

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/application/NotificationConsumer.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/application/NotificationConsumer.kt
@@ -682,6 +682,7 @@ class NotificationConsumer {
             deviceTokenRepo.invalidate(invalidIds).chain { _ ->
                 notificationRepo.find("notificationId", entity.notificationId).firstResult()
                     .map { e ->
+                        if (e == null) reportMissingRow(req, entity, outcome)
                         e?.also {
                             it.status = outcome.name
                             // ADR-0252's counters answer "how is the channel doing"; this answers
@@ -714,6 +715,7 @@ class NotificationConsumer {
     ): Uni<Void> = Panache.withTransaction {
         notificationRepo.find("notificationId", entity.notificationId).firstResult()
             .map { e ->
+                if (e == null) reportMissingRow(req, entity, status)
                 e?.also {
                     it.status = status.name
                     // Persist the reason alongside the status (V13): the outcome event below
@@ -725,6 +727,36 @@ class NotificationConsumer {
             }
             .chain { _ -> outboxRepo.persistInTransaction(outcomeMessage(req, entity, status, reason)) }
     }.replaceWithVoid()
+
+    /**
+     * The row a terminal transition was supposed to land on is not there (issue #4512).
+     *
+     * Both status writers locate the row by `notificationId` and apply the transition through a
+     * null-safe `?.also { ... }`, then commit the outcome event in the same transaction whether or
+     * not a row was found. That was silent by construction: the outbox row commits, the event is
+     * published, the message is acked, and no branch anywhere logs. On 2026-08-09 four
+     * `SCA_APPROVAL` PUSH fan-outs ran that way — four `NotificationOutcome` rows in
+     * `notification_outbox`, zero `notifications` rows, and not one error line in the pod.
+     *
+     * This does not repair the row; by the time it runs the insert is already lost, and inventing
+     * one here would fabricate a `created_at` and a body the service no longer holds. What it does
+     * is stop the state from being unobservable — an ERROR with the identifiers needed to
+     * reconstruct the message, and a counter an alert can read. Deliberately loud: an outcome
+     * event announcing a notification that has no durable record is an evidence gap under DORA
+     * Art. 17-19, not a housekeeping detail.
+     */
+    private fun reportMissingRow(req: NotificationRequest, entity: NotificationEntity, outcome: NotificationOutcome) {
+        pushMetrics.recordMissingRow(req.channel, req.template)
+        log.errorf(
+            "notification.status.row_missing notificationId=%s party=%s channel=%s template=%s outcome=%s " +
+                "— the outcome event will be published for a notification that has no row",
+            entity.notificationId,
+            req.partyId,
+            req.channel,
+            req.template,
+            outcome,
+        )
+    }
 
     /**
      * The outbox row for one terminal transition.

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/application/port/out/PushMetricsPort.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/application/port/out/PushMetricsPort.kt
@@ -4,6 +4,7 @@
 
 package com.openbank.notification.application.port.out
 
+import com.openbank.notification.domain.model.NotificationChannel
 import com.openbank.notification.domain.model.NotificationOutcome
 import com.openbank.notification.domain.model.NotificationTemplate
 import com.openbank.notification.domain.model.PushPlatform
@@ -47,4 +48,21 @@ interface PushMetricsPort {
      * label is bounded by construction and cannot become a cardinality problem.
      */
     fun recordFanOut(template: NotificationTemplate, outcome: NotificationOutcome, devices: Int)
+
+    /**
+     * Record that a terminal transition found **no row** to write it onto (issue #4512).
+     *
+     * The status writers locate the row by `notificationId` and update it through a null-safe
+     * `?.also { ... }`, then commit the outcome event regardless. When the row is missing that
+     * reads as a successful transition from every angle: the outbox row commits, the event is
+     * published, the consumer acks, and nothing logs. The service announces an outcome for a
+     * notification that has no durable record — the producer's funnel is told about a message the
+     * table cannot show, which is the state measured on 2026-08-09 (four `SCA_APPROVAL` PUSH
+     * fan-outs, four `NotificationOutcome` outbox rows, zero `notifications` rows, zero errors).
+     *
+     * This counter is the alertable form of that. It is a **success**-path signal by construction:
+     * there is no failure anywhere to alert on, so absence of errors is not evidence, and only an
+     * explicit count of the orphaned transition can make a recurrence visible.
+     */
+    fun recordMissingRow(channel: NotificationChannel, template: NotificationTemplate)
 }

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/infrastructure/observability/PushMetricsAdapter.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/infrastructure/observability/PushMetricsAdapter.kt
@@ -5,6 +5,7 @@
 package com.openbank.notification.infrastructure.observability
 
 import com.openbank.notification.application.port.out.PushMetricsPort
+import com.openbank.notification.domain.model.NotificationChannel
 import com.openbank.notification.domain.model.NotificationOutcome
 import com.openbank.notification.domain.model.NotificationTemplate
 import com.openbank.notification.domain.model.PushPlatform
@@ -16,10 +17,15 @@ import jakarta.enterprise.inject.Instance
 import jakarta.inject.Inject
 
 /**
- * Micrometer adapter for [PushMetricsPort] (ADR-0252 phase 0). Emits two series:
+ * Micrometer adapter for [PushMetricsPort] (ADR-0252 phase 0). Emits three series:
  *
  * - `openbank_notification_push_sends_total{platform,outcome,error_code,service="notification"}`
  * - `openbank_notification_push_fanouts_total{outcome,devices_bucket,service="notification"}`
+ * - `openbank_notification_status_row_missing_total{channel,template,service="notification"}`
+ *
+ * The third is the issue-#4512 signal: a terminal transition that found no row to write itself
+ * onto, and published its outcome event anyway. Like `SKIPPED` above it is a **success**-path
+ * counter — nothing fails when it increments, which is exactly why nothing could see it before.
  *
  * `outcome=ACCEPTED` counts provider acceptances, not deliveries — see [PushSendOutcome.ACCEPTED].
  * The alert this is built for is the one that was missing: `ACCEPTED` sitting at zero while the
@@ -68,6 +74,17 @@ class PushMetricsAdapter(private val registry: MeterRegistry?) : PushMetricsPort
                 .tag("template", template.name)
                 .tag("outcome", outcome.name)
                 .tag("devices_bucket", deviceBucket(devices))
+                .register(r)
+                .increment()
+        }
+    }
+
+    override fun recordMissingRow(channel: NotificationChannel, template: NotificationTemplate) {
+        registry?.let { r ->
+            Counter.builder("openbank.notification.status.row.missing")
+                .tag("service", SERVICE)
+                .tag("channel", channel.name)
+                .tag("template", template.name)
                 .register(r)
                 .increment()
         }

--- a/openbank-notification-service/src/test/kotlin/com/openbank/notification/infrastructure/observability/PushMetricsAdapterTest.kt
+++ b/openbank-notification-service/src/test/kotlin/com/openbank/notification/infrastructure/observability/PushMetricsAdapterTest.kt
@@ -4,6 +4,7 @@
 
 package com.openbank.notification.infrastructure.observability
 
+import com.openbank.notification.domain.model.NotificationChannel
 import com.openbank.notification.domain.model.NotificationOutcome
 import com.openbank.notification.domain.model.NotificationTemplate
 import com.openbank.notification.domain.model.PushPlatform
@@ -43,6 +44,18 @@ class PushMetricsAdapterTest {
         // Without this tag an undeliverable SCA approval — a PSD2 Art. 97 prompt — is
         // indistinguishable from an undeliverable marketing message, and no alert can single
         // it out. Measured 2026-08-08: 11 failed SCA_APPROVAL pushes across 6 parties.
+        assertThat(counter?.id?.getTag("template")).isEqualTo("SCA_APPROVAL")
+    }
+
+    @Test
+    fun `a transition with no row to land on is counted, channel and template kept`() {
+        // Issue #4512. Nothing fails when this happens — the outcome event still commits and the
+        // message is still acked — so this counter is the only observable the state has.
+        adapter.recordMissingRow(NotificationChannel.PUSH, NotificationTemplate.SCA_APPROVAL)
+
+        val counter = registry.find("openbank.notification.status.row.missing").counter()
+        assertThat(counter?.count()).isEqualTo(1.0)
+        assertThat(counter?.id?.getTag("channel")).isEqualTo("PUSH")
         assertThat(counter?.id?.getTag("template")).isEqualTo("SCA_APPROVAL")
     }
 


### PR DESCRIPTION
## Summary

Makes the 2026-08-09 state observable. It does **not** claim a root cause — see #4512 for what was
measured and what remains unexplained.

A terminal transition in `NotificationConsumer` locates its row by `notificationId` and applies the
status through a null-safe `?.also { ... }`, then commits the outcome event in the same transaction
**whether or not a row was found**. When the row is absent the service publishes a
`NotificationOutcome` event for a notification that has no durable record, and every conventional
signal stays green: the outbox row commits, the message is acked, the offset advances, nothing logs.

That is exactly the shape measured on 2026-08-09 — four `SCA_APPROVAL` PUSH fan-outs, four
`NotificationOutcome` rows in `notification_outbox`, **zero** `notifications` rows, **zero** error
lines in any of the four pods.

## What this adds

- `PushMetricsPort.recordMissingRow(channel, template)` and its Micrometer adapter, emitting
  `openbank_notification_status_row_missing_total{channel,template,service="notification"}`.
- An ERROR line (`notification.status.row_missing`) carrying `notificationId`, party, channel,
  template and outcome — the identifiers needed to reconstruct the message from the outbox payload.
- `NotificationStatusRowMissing`, a critical alert on the counter's 15m self-delta.

Both status writers are covered: `markStatus` (EMAIL and the no-device PUSH branch) and
`persistPushFanOut` (the PUSH branch that reached a provider).

## Why the alert reads a success state

There is nothing failing to alert on. The transition the counter watches is one the code treats as
successful from end to end, so an error rate, a lag alert and a health probe are all structurally
blind to it. Same reasoning — and the same file — as `PushChannelSkippedOnly` from ADR-0252 phase 0.

The `or vector(0)` self-delta rather than `increase()` is the measured Micrometer trap already
documented next to `ScaApprovalPushUndeliverable`: the counter is registered lazily on first
increment, so the series is born at `1` after a pod restart and `increase()` reads `0` on the very
first occurrence — the one that matters most. Threshold is one: a single orphaned transition is
already a lost record.

## What this deliberately does not do

It does not recreate the row. By the time the branch runs the insert is already lost, and writing
one here would fabricate a `created_at` and a body the service no longer holds. The persistence path
itself is untouched — #4532 measured it sound against a real database, and this PR does not
contradict that.

## Scope

`openbank-notification-service` is not a money-path service (`rules.yaml: money_path_services`).
No API change, no schema change, no behaviour change on the success path.

Refs #4512
