### PR TITLE
fix(ci): make the image rescan fail on an empty scope instead of going green about nothing

### DIFF
--- a/.github/workflows/image-rescan.yml
+++ b/.github/workflows/image-rescan.yml
@@ -48,18 +48,50 @@ jobs:
           REQUESTED: ${{ inputs.services }}
         run: |
           set -euo pipefail
+          # Same discovery rule as ghcr-publish.yml: a module is a released
+          # component iff it has a version.txt; only services bake an image.
+          # Always computed, even for a narrowed dispatch, so the run can state
+          # its own DENOMINATOR — see the coverage note below.
+          all="$(for d in openbank-*-service; do
+            [ -f "$d/version.txt" ] && [ -f "$d/build.gradle.kts" ] && echo "$d"
+          done)"
+          total="$(echo "$all" | grep -c . || true)"
+
           if [ -n "${REQUESTED:-}" ]; then
             list="$(printf '%s\n' $REQUESTED)"
+            # A typo in the dispatch input is otherwise invisible: the matrix
+            # entry exists, its image is not on GHCR, the scan step is skipped
+            # by `found == 'false'` and the job goes GREEN having scanned
+            # nothing. Reject a requested name that is not a released service.
+            unknown=""
+            for svc in $REQUESTED; do
+              echo "$all" | grep -qx "$svc" || unknown="$unknown $svc"
+            done
+            if [ -n "$unknown" ]; then
+              echo "::error::not released openbank-*-service module(s):${unknown}"
+              exit 1
+            fi
           else
-            # Same discovery rule as ghcr-publish.yml: a module is a released
-            # component iff it has a version.txt; only services bake an image.
-            list="$(for d in openbank-*-service; do
-              [ -f "$d/version.txt" ] && [ -f "$d/build.gradle.kts" ] && echo "$d"
-            done)"
+            list="$all"
           fi
+
           services="$(echo "$list" | jq -Rnc '[inputs | select(length > 0)]')"
+          selected="$(echo "$services" | jq 'length')"
+
+          # An empty scope must FAIL, never pass quietly. With `services=[]` the
+          # rescan job's `if:` is false, so it is SKIPPED; `escalate` then guards
+          # on `needs.rescan.result == 'failure'`, which 'skipped' is not — so the
+          # whole run concludes SUCCESS having rescanned zero images and told
+          # nobody. A control that reports green about nothing is worse than an
+          # absent one, because its green argues the images are covered (#4026).
+          if [ "$selected" -eq 0 ]; then
+            echo "::error::no services to rescan — refusing to report a green run that scanned nothing"
+            exit 1
+          fi
+
           echo "services=$services" >> "$GITHUB_OUTPUT"
-          echo "Rescanning: $services"
+          echo "Rescanning ${selected} of ${total} released services: $services"
+          echo "Rescanning **${selected} of ${total}** released services." >> "$GITHUB_STEP_SUMMARY"
 
   rescan:
     name: rescan / ${{ matrix.service }}


### PR DESCRIPTION
## What this is

`Image rescan` **was never broken** — see #4026, where I close out the original claim with the
measurement. This PR is not that fix. It closes the one *latent* hole the investigation surfaced:
the workflow's scope is derived, and an empty derivation is silently a **pass**.

## The hole

`discover` builds the matrix from the released-service set. With an empty result:

1. `services=[]`
2. the `rescan` job's `if: needs.discover.outputs.services != '[]'` is false, so it is **skipped**
3. `escalate` guards on `needs.rescan.result == 'failure'` — and `skipped` is not `failure`
4. the run concludes **success**, having rescanned zero images and escalated to nobody

A control that reports green about nothing is worse than an absent one, because its green argues the
published images are covered.

The same hole is reachable from the `workflow_dispatch` `services` input, which is the likelier
trigger: a typo'd name still produces a matrix entry, its image is not on GHCR, the scan step is
skipped by `found == 'false'`, and the job goes green. A narrowed run reads identically to a full one
— the shape that let an authenticated-fuzz run's first green cover exactly one service.

## The change

All three parts are inside the `discover` step; nothing about what a non-empty scope scans changes.

- The **full** released-service set is always computed, so the run states its own denominator:
  `Rescanning N of M released services`, in the log and in `$GITHUB_STEP_SUMMARY`. `1 of 41` no
  longer looks like `41 of 41`.
- A requested name that is not a released `openbank-*-service` module is **rejected**, instead of
  silently scanning nothing.
- An empty selection **exits 1**.

## Evidence

Behaviour of the new `discover` logic, run against the real tree — including the two cases that
**must** fail:

```
[A] default (must PASS)          Rescanning 41 of 41 released services.   exit=0
[B] valid narrow (must PASS)     Rescanning 1 of 41 released services.    exit=0
[C] typo (must FAIL)             ::error::not released module(s): openbank-nonexistent-service   exit=1
[D] whitespace-only (must FAIL)  ::error::no services to rescan           exit=1
```

Before this change, [D] produced `services=[]` and a green run.

The denominator is real: 41 modules on `origin/main` carry both `version.txt` and `build.gradle.kts`,
and the last scheduled run (`31363866507`, 2026-08-10) had 41 rescan jobs whose
`Rescan image (VEX-aware)` step concluded `success` — **41 of 41 actually scanned**, none skipped as
not-published. That run is the workflow's first green and it is a genuine one.

`actionlint` finding set is **unchanged** from `origin/main` — one `SC2086` on both sides, the
intentional word-split on the dispatch input. Compared as finding sets, not by exit code.

Refs #4026

🤖 Generated with [Claude Code](https://claude.com/claude-code)
