### PR TITLE
feat(admin-ui): clarify campaign customer surfaces

### DIFF
--- a/openbank-admin-ui/src/app/campaigns/new/page.tsx
+++ b/openbank-admin-ui/src/app/campaigns/new/page.tsx
@@ -7,7 +7,7 @@
 import { useEffect, useState } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import Link from 'next/link'
-import { ArrowLeft, Clock3, Megaphone, Send, Sparkles, Users } from 'lucide-react'
+import { ArrowLeft, BellRing, Clock3, Mail, Megaphone, PanelsTopLeft, Send, Sparkles, Users } from 'lucide-react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { PageHeader } from '@/components/ui'
 import {
@@ -357,6 +357,12 @@ export default function NewCampaignPage() {
     (entryMode === 'TRIGGER' && trigger !== '')
   const ready = name.trim() !== '' && goal.trim() !== '' && segment !== '' && steps.length > 0 &&
     contentCatalogueState === 'ok' && !incomplete && entryConfigured && (!contentExperiment || conversionRule !== null)
+  // A campaign is an experience across surfaces, not a list of transport rows. Keep this compact
+  // overview next to the canvas so a marketer can scan the whole customer footprint without
+  // opening every node. It is derived solely from the steps that will be sent to campaign-service.
+  const experienceSurfaces = (['PUSH', 'BANNER', 'EMAIL'] as EditorChannel[])
+    .map(channel => ({ channel, count: steps.filter(step => step.channel === channel).length }))
+    .filter(({ count }) => count > 0)
 
   const setContentExperimentEnabled = (enabled: boolean) => {
     setContentExperiment(enabled)
@@ -683,6 +689,23 @@ export default function NewCampaignPage() {
         )}
 
         </div>
+
+        <aside className="campaign-surface-map" aria-label={t('Přehled zákaznických ploch', 'Customer surface overview')}>
+          <div>
+            <p className="campaign-composer-eyebrow"><PanelsTopLeft className="h-3.5 w-3.5" /> {t('Zážitek napříč aplikací', 'Experience across the app')}</p>
+            <h3>{t('Co lidé skutečně uvidí', 'What people will actually see')}</h3>
+            <p>{t('Jen plochy z této cesty. Nic se nedoplňuje domněnkou.', 'Only surfaces in this journey. Nothing is inferred.')}</p>
+          </div>
+          <div className="campaign-surface-map-items" data-testid="campaign-surface-map">
+            {experienceSurfaces.length === 0 ? (
+              <span className="campaign-surface-map-empty">{t('Přidejte první ověřený krok.', 'Add the first reviewed step.')}</span>
+            ) : experienceSurfaces.map(({ channel, count }) => {
+              const Icon = channel === 'PUSH' ? BellRing : channel === 'BANNER' ? PanelsTopLeft : Mail
+              const label = channel === 'PUSH' ? t('Push', 'Push') : channel === 'BANNER' ? t('Banner v aplikaci', 'In-app banner') : t('E-mail', 'Email')
+              return <span key={channel} data-surface={channel}><Icon className="h-3.5 w-3.5" /> {label}<strong>{count}</strong></span>
+            })}
+          </div>
+        </aside>
 
         <div className="campaign-studio-companion-grid">
           <CampaignExperiencePreview step={selected === null ? undefined : steps[selected]} campaignName={name} />

--- a/openbank-admin-ui/src/app/globals.css
+++ b/openbank-admin-ui/src/app/globals.css
@@ -451,6 +451,14 @@ main {
 .campaign-workbench-status { display: inline-flex; align-items: center; gap: .4rem; flex: 0 0 auto; padding: .43rem .62rem; border: 1px solid #e0e4ff; border-radius: 99px; background: #f5f5ff; color: #5550be; font-size: .69rem; font-weight: 800; }
 .campaign-workbench-status span { width: .42rem; height: .42rem; border-radius: 99px; background: #7c72ff; box-shadow: 0 0 0 .22rem rgba(124,114,255,.12); }
 .campaign-journey-workbench > .space-y-0 > div:first-child { border-color: #d7dded; box-shadow: 0 12px 25px rgba(58, 65, 113, .06); }
+.campaign-surface-map { display: flex; align-items: center; justify-content: space-between; gap: 1rem; margin-top: 1rem; padding: .85rem .95rem; border: 1px solid #e1e6f5; border-radius: .95rem; background: linear-gradient(105deg, #f8f9ff 0%, #fff 48%, #f6fffd 100%); }
+.campaign-surface-map h3 { color: var(--campaign-ink); font-size: .84rem; font-weight: 780; letter-spacing: -.02em; }
+.campaign-surface-map > div > p:last-child { margin-top: .18rem; color: var(--campaign-muted); font-size: .69rem; }
+.campaign-surface-map-items { display: flex; flex-wrap: wrap; justify-content: flex-end; gap: .42rem; }
+.campaign-surface-map-items > span { display: inline-flex; align-items: center; gap: .32rem; padding: .38rem .48rem; border: 1px solid #e0e5f5; border-radius: .58rem; background: rgba(255,255,255,.86); color: #42516b; font-size: .68rem; font-weight: 750; white-space: nowrap; }
+.campaign-surface-map-items svg { color: var(--campaign-violet); }
+.campaign-surface-map-items strong { display: inline-grid; min-width: 1.15rem; height: 1.15rem; place-items: center; border-radius: 99px; background: #edeaff; color: #5e57cf; font-size: .61rem; }
+.campaign-surface-map-empty { color: var(--campaign-muted) !important; font-weight: 650 !important; }
 .campaign-measurement-grid { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: .7rem; margin-top: 1rem; }
 .campaign-measurement-card {
   display: flex;
@@ -564,7 +572,8 @@ main {
   .campaign-brief-card .campaign-section-heading { margin-bottom: .8rem; }
   .campaign-brief-card .input + .input { margin-top: .65rem !important; }
   .campaign-measurement-grid { grid-template-columns: 1fr; }
-  .campaign-workbench-heading, .campaign-composer-footer { align-items: flex-start; flex-direction: column; }
+  .campaign-workbench-heading, .campaign-composer-footer, .campaign-surface-map { align-items: flex-start; flex-direction: column; }
+  .campaign-surface-map-items { justify-content: flex-start; }
   .campaign-recipe-heading { align-items: flex-start; flex-direction: column; }
   .campaign-recipe-heading > span { text-align: left; }
   .campaign-composer-footer-actions { justify-content: flex-start; }

--- a/openbank-admin-ui/src/test/campaign-studio.test.tsx
+++ b/openbank-admin-ui/src/test/campaign-studio.test.tsx
@@ -117,6 +117,21 @@ describe('campaign studio', () => {
     expect(screen.getByText(/fixed app deep link/i)).toBeTruthy()
   }, 15000)
 
+  it('keeps the customer-surface overview in sync with the authored journey', async () => {
+    vi.stubGlobal('fetch', mockFetch({ '/api/segments': SEGMENTS }))
+    render(React.createElement(Providers, null, React.createElement(NewCampaignPage)))
+
+    await waitFor(() => expect(document.querySelector('[data-surface="PUSH"]')).toBeTruthy(), { timeout: 8000 })
+    // The initial app-first step is a push. The overview must reflect the actual authored channel,
+    // not an aspirational multi-channel plan.
+    expect(document.querySelector('[data-surface="BANNER"]')).toBeNull()
+
+    fireEvent.click(document.querySelector('[data-channel-pick="BANNER"]')!)
+
+    await waitFor(() => expect(document.querySelector('[data-surface="BANNER"]')).toBeTruthy(), { timeout: 8000 })
+    expect(document.querySelector('[data-surface="PUSH"]')).toBeNull()
+  }, 15000)
+
   /**
    * ADR-0176 D4 / ADR-0221 D1 step 3: a campaign supplies values, never body text. The fields
    * offered are exactly the template's declared variables — a free-form body field here would be a


### PR DESCRIPTION
## What\n\nAdds a compact customer-surface overview to Campaign Studio's journey workbench. It derives Push, in-app banner and e-mail counts from the authored journey, so marketers can scan the actual customer footprint without opening every step.\n\n## Safety\n\n- No reach or delivery claim is fabricated.\n- No campaign API contract or runtime behaviour changes.\n- Responsive layout preserves the existing single-column mobile composition.\n\nRefs #4712