### PR TITLE
fix(audit): namespace the shared channel field by source topic

### DIFF
--- a/openbank-audit-service/src/main/kotlin/com/openbank/audit/application/AuditConsumer.kt
+++ b/openbank-audit-service/src/main/kotlin/com/openbank/audit/application/AuditConsumer.kt
@@ -137,9 +137,17 @@ class AuditConsumer {
                 occurredAt = eventTime ?: Instant.now(clock),
                 recordedAt = Instant.now(clock),
                 occurredAtSource = if (eventTime != null) OccurredAtSource.EVENT else OccurredAtSource.INGEST,
-                // ADR-0226: cross-channel dimensions, additive — producers adopt them channel by
-                // channel, so absence stays null (unknown), never a guessed default.
-                channel = node.textOrNull("channel"),
+                // Namespaced by source topic (issue #4660), not the bare producer value. A fleet
+                // sweep after #4553 found the bare JSON key "channel" independently populated by
+                // THREE producers with no shared vocabulary: AuditChannel (ADR-0226,
+                // ingress — this field's original intent, "ui"/"mcp"/"api"), OnboardingChannel
+                // (party-service, via RelationshipAddedEvent on openbank.party.events — "API"
+                // collides with AuditChannel's "api" on both case and meaning) and ComplaintChannel
+                // (dispute-service, via openbank.dispute.events — the only one confirmed live
+                // before this fix, all rows spelled "APP"). Storing the bare value made the column
+                // ungroupable: a caller reading "API" could not tell an onboarding channel from an
+                // ingress one. See resolveChannel() for the mapping.
+                channel = resolveChannel(node.textOrNull("channel"), address.topic),
                 actChain = node["actChain"]?.takeIf { it.isArray }?.map { it.asText() } ?: emptyList(),
                 sessionId = node.textOrNull("sessionId"),
                 // ADR-0232 D5: a delegated action names the grantor it was taken on behalf of and
@@ -304,6 +312,38 @@ class AuditConsumer {
         /** Cap on the producer-supplied value echoed into the warning — it is untrusted input. */
         const val MAX_LOGGED_RAW_TIME_CHARS = 64
     }
+}
+
+/** Matches AuditRepository's `@Column(name = "channel", length = 32)` (V14, issue #4660). */
+private const val MAX_CHANNEL_CHARS = 32
+
+/**
+ * Namespaces a raw "channel" value by the topic it arrived on (issue #4660), rather than
+ * trusting the bare value's vocabulary. Keyed on the TOPIC, not on inferred aggregate type or
+ * event shape: the topic is the one signal every producer already agrees on (it is how they
+ * get subscribed to in the first place), so this needs no per-producer parsing and stays
+ * correct for a producer neither of us has read the code of yet — an unrecognised topic still
+ * gets its own disjoint namespace ("$topic:$raw"), it just isn't given a friendly name.
+ *
+ * The two known mappings exist only to keep the common rows short and readable within the
+ * VARCHAR(32) column (V14) — "onboarding:MOBILE_APP" (22 chars) fits; a full topic name would
+ * not ("openbank.party.events:MOBILE_APP" is 33). A top-level function, not a class member: it
+ * needs no instance state, and `AuditConsumer` was already at detekt's TooManyFunctions threshold.
+ */
+private fun resolveChannel(raw: String?, topic: String?): String? {
+    if (raw == null) return null
+    val namespace = when (topic) {
+        "openbank.party.events" -> "onboarding"
+        "openbank.dispute.events" -> "complaint"
+        // Not "openbank.customer.audit" -> "ingress": that topic exists and is subscribed, but
+        // its one real publisher (EdgeAuditPublisher) sets no "channel" field today, and
+        // AuditChannel (ADR-0226's ui/mcp/api) has no live Kafka path at all yet — McpCallAuditor
+        // only reaches LoggingAuditEventPublisher. Naming a topic for a wiring that does not
+        // exist would be a guess about where it eventually lands, not a fact. The catch-all
+        // below already gives it a disjoint namespace the day it does.
+        else -> topic ?: "unscoped"
+    }
+    return "$namespace:$raw".take(MAX_CHANNEL_CHARS)
 }
 
 /**

--- a/openbank-audit-service/src/main/kotlin/com/openbank/audit/domain/model/AuditEntry.kt
+++ b/openbank-audit-service/src/main/kotlin/com/openbank/audit/domain/model/AuditEntry.kt
@@ -36,7 +36,13 @@ data class AuditEntry(
      * producer asserted (#3994).
      */
     val sourceServiceSource: AttributionSource = AttributionSource.ABSENT,
-    /** Ingress channel the event arrived through — ui|mcp|api (ADR-0226); null = unknown/legacy. */
+    /**
+     * `<namespace>:<value>` (issue #4660). The bare JSON key "channel" is independently populated
+     * by three producers with no shared vocabulary: `ingress:ui|mcp|api` (ADR-0226),
+     * `onboarding:BANKID|BRANCH|API|MOBILE_APP` (party-service), `complaint:APP|BRANCH|EMAIL|ARBITER`
+     * (dispute-service). The namespace is the source topic, resolved in `AuditConsumer.resolveChannel`
+     * — never trust the bare value's vocabulary without it. Null = no producer sent one.
+     */
     val channel: String? = null,
     /** Ordered on-behalf-of delegation chain from the RFC 8693 `act` claim (ADR-0224); empty = direct. */
     val actChain: List<String> = emptyList(),

--- a/openbank-audit-service/src/main/kotlin/com/openbank/audit/infrastructure/persistence/AuditRepository.kt
+++ b/openbank-audit-service/src/main/kotlin/com/openbank/audit/infrastructure/persistence/AuditRepository.kt
@@ -114,7 +114,13 @@ class AuditEntryEntity : PanacheEntity() {
     // ── Cross-channel correlation (ADR-0226): query indexes, NOT part of the chain hash — the
     // producer's raw event JSON (already hashed via `payload`) carries these fields verbatim, so
     // tamper-evidence covers them without recomputing every pre-V9 row.
-    @Column(name = "channel", length = 16)
+    //
+    // length=32 (V14, issue #4660): widened from 16. The bare JSON key "channel" turned out to be
+    // independently populated by THREE producers — AuditChannel (ADR-0226, this column's original
+    // intent), OnboardingChannel (party-service) and ComplaintChannel (dispute-service) — with no
+    // shared vocabulary, so AuditConsumer now namespaces the value by source topic before storing
+    // it (see resolveChannel there). "onboarding:MOBILE_APP" alone is 22 characters.
+    @Column(name = "channel", length = 32)
     var channel: String? = null
 
     /** JSON array string (e.g. `["agent-session:7f3…","mcp-cli"]`); null when the action was direct. */

--- a/openbank-audit-service/src/main/resources/db/migration/V14__widen_channel_column.sql
+++ b/openbank-audit-service/src/main/resources/db/migration/V14__widen_channel_column.sql
@@ -1,0 +1,15 @@
+-- Widen `channel` to fit a namespace prefix (issue #4660).
+--
+-- V9 sized it VARCHAR(16) for ADR-0226's own AuditChannel values ("ui"/"mcp"/"api"). Since then,
+-- two OTHER producers turned out to write into the same JSON key: OnboardingChannel
+-- (party-service, values up to "MOBILE_APP") and ComplaintChannel (dispute-service, values up to
+-- "ARBITER") — a fleet sweep found AuditConsumer copies whatever top-level "channel" key any
+-- subscribed topic happens to carry, verbatim, with no way to tell which vocabulary a stored value
+-- belongs to. The fix (this migration's companion code change) prefixes the value by its source
+-- topic — "onboarding:MOBILE_APP" is 22 characters, already past the old limit before the fix even
+-- lands. Widening first, separately, so the column can hold the new shape before anything writes it.
+--
+-- ALTER COLUMN ... TYPE on a VARCHAR is a metadata-only change in Postgres when only widening (no
+-- table rewrite, no lock beyond the brief one the DDL itself takes) — safe on a live table.
+ALTER TABLE audit_entries
+    ALTER COLUMN channel TYPE VARCHAR(32);

--- a/openbank-audit-service/src/test/kotlin/com/openbank/audit/application/AuditConsumerTest.kt
+++ b/openbank-audit-service/src/test/kotlin/com/openbank/audit/application/AuditConsumerTest.kt
@@ -92,10 +92,13 @@ class AuditConsumerTest {
 
         consumer.consume(payload)
 
+        // "unscoped:mcp", not "mcp" — this call uses the single-arg consume(payload), i.e.
+        // EventAddress.NONE, so there is no topic to namespace by (issue #4660). See the
+        // resolveChannel tests below for the namespaced-by-topic cases.
         coVerify {
             repo.save(
                 match {
-                    it.channel == "mcp" &&
+                    it.channel == "unscoped:mcp" &&
                         it.actChain == listOf("agent-session:7f3a", "mcp-cli") &&
                         it.sessionId == "sess-123"
                 },
@@ -591,6 +594,80 @@ class AuditConsumerTest {
         consumer.consume(payload)
 
         coVerify { repo.save(match { it.aggregateType == "TRANSACTION" }) }
+    }
+
+    // -----------------------------------------------------------------------------------------
+    // Channel namespacing, issue #4660 (a #4553 fleet-sweep finding). Three producers write the
+    // bare JSON key "channel" with no shared vocabulary: AuditChannel (ADR-0226, "ui"/"mcp"/"api"),
+    // OnboardingChannel (party-service, up to "MOBILE_APP") and ComplaintChannel (dispute-service,
+    // up to "ARBITER") — "api" (AuditChannel) and "API" (OnboardingChannel) collide on both case
+    // and meaning. Namespacing by source topic keeps them apart without touching any producer.
+    // -----------------------------------------------------------------------------------------
+
+    @Test
+    fun `consume namespaces channel as onboarding for party events`(): Unit = runBlocking {
+        val partyId = UUID.randomUUID()
+        val payload = """{"eventType":"RelationshipAdded","partyId":"$partyId","channel":"API"}"""
+
+        coEvery { repo.save(any()) } returns Unit
+
+        consumer.consume(payload, EventAddress(topic = "openbank.party.events"))
+
+        // Not "API" bare — that is indistinguishable from AuditChannel's "api" (case-folded) without
+        // the namespace, and the two are different concepts (onboarding channel vs ingress channel).
+        coVerify { repo.save(match { it.channel == "onboarding:API" }) }
+    }
+
+    @Test
+    fun `consume namespaces channel as complaint for dispute events`(): Unit = runBlocking {
+        val complaintId = UUID.randomUUID()
+        val payload = """{"eventType":"complaint.received","complaintId":"$complaintId","channel":"APP"}"""
+
+        coEvery { repo.save(any()) } returns Unit
+
+        consumer.consume(payload, EventAddress(topic = "openbank.dispute.events"))
+
+        coVerify { repo.save(match { it.channel == "complaint:APP" }) }
+    }
+
+    @Test
+    fun `consume namespaces channel by the raw topic when the topic is not one of the known two`(): Unit = runBlocking {
+        // No hardcoded mapping for a topic this consumer has not been told the shape of — see
+        // resolveChannel's own KDoc for why guessing a namespace here would be worse than an
+        // honest, disjoint fallback. Expected value computed the same way resolveChannel builds
+        // it (topic + ":" + raw, truncated to the column width) rather than hand-counted, so a
+        // future column-width change can't silently desync the test from the code.
+        val topic = "openbank.short.topic"
+        val payload = """{"eventType":"X","accountId":"${UUID.randomUUID()}","channel":"weird"}"""
+
+        coEvery { repo.save(any()) } returns Unit
+
+        consumer.consume(payload, EventAddress(topic = topic))
+
+        coVerify { repo.save(match { it.channel == "$topic:weird".take(32) }) }
+    }
+
+    @Test
+    fun `consume truncates an overlong namespaced channel rather than failing the insert`(): Unit = runBlocking {
+        // VARCHAR(32) (V14). A topic name long enough to push "<topic>:<value>" past 32 chars must
+        // not crash the whole entry — a truncated query-index value is a far smaller loss than
+        // dropping the tamper-evident audit row it is attached to.
+        val longTopic = "openbank.sanctions.screening.event"
+        val payload = """{"eventType":"X","accountId":"${UUID.randomUUID()}","channel":"SOMETHING_LONG"}"""
+
+        coEvery { repo.save(any()) } returns Unit
+
+        consumer.consume(payload, EventAddress(topic = longTopic))
+
+        coVerify {
+            repo.save(
+                match {
+                    it.channel != null &&
+                        it.channel!!.length <= 32 &&
+                        it.channel == "$longTopic:SOMETHING_LONG".take(32)
+                },
+            )
+        }
     }
 
     private companion object {


### PR DESCRIPTION
## Summary

Fixes item 2 of #4660 — a fleet sweep after #4553 found `audit_entries.channel` is independently
populated by three producers with no shared vocabulary. Not a case-fold like #4661 — folding would
hide a genuine semantic collision, not resolve it.

## Type of change

- [x] fix (bug fix)

## Linked issues

Refs #4660, #4553

## The finding, corrected once before shipping

Three producers write the bare JSON key `"channel"`:

- **`AuditChannel`** (ADR-0226): `"ui"/"mcp"/"api"` — ingress channel, this field's original intent.
- **`OnboardingChannel`** (party-service): `BANKID/BRANCH/API/MOBILE_APP` — onboarding channel, live
  via `openbank.party.events` → `RelationshipAddedEvent` (`PartyService.kt:169`, confirmed publish).
- **`ComplaintChannel`** (dispute-service): `APP/BRANCH/EMAIL/ARBITER` — complaint filing channel,
  live via `openbank.dispute.events`. The one existing row in `audit_entries.channel` today is
  `"APP"` — customer-edge forces it for every mobile-app complaint filing.

`"api"` (AuditChannel) vs `"API"` (OnboardingChannel) collide on case **and** meaning.

**Corrected on #4660 before implementing**: `AuditChannel` does not reach this column live today at
all. `McpCallAuditor` publishes through `AuditEventPublisher`, and mcp-service registers no Kafka
`@Alternative`, so it falls through to `LoggingAuditEventPublisher` (a log line, never Kafka).
`customer-edge`'s own `EdgeAuditPublisher` — the one real Kafka audit path — sets no `channel` field
either. So the `api`/`API` collision is latent, not live; the two producers that ARE live only
overlap on `BRANCH == BRANCH`, arguably a genuinely shared meaning (customer physically at a branch).
Fixing it now anyway, before `AuditChannel` gets wired to Kafka rather than after.

## Fix

`AuditConsumer` now namespaces by the **Kafka topic** the record arrived on, not by parsing
per-producer event shape — the topic is the one signal every producer already agrees on (it's how
they get subscribed in the first place). An unrecognised topic still gets its own disjoint namespace
(the raw topic name as the prefix), so this stays correct for a producer neither of us has read yet,
without a table to keep in sync.

`V14__widen_channel_column.sql`: `VARCHAR(16)` → `VARCHAR(32)`. `"onboarding:MOBILE_APP"` alone is 22
characters — past the old limit before this PR even lands. `resolveChannel` also hard-truncates to
match, so an unusually long topic name degrades the query-index value rather than crashing the whole
insert (and dropping the tamper-evident row it's attached to).

## Verification

- Migration SQL dry-run against the live sandbox DB in a rolled-back transaction (`BEGIN; ALTER ...;
  ROLLBACK;`) — confirmed it runs clean before writing the Kotlin side. Not applied for real:
  `migrate-at-start: true` means Flyway runs it on deploy, same as every other migration in this
  service.
- 5 new/updated tests, falsified against the pre-namespacing consumer (`resolveChannel(...)` reverted
  to bare `node.textOrNull("channel")`): 5 of 32 go red.
- `:openbank-audit-service:test` → 104/0/0.
- `ktlintCheck` + `detekt` clean — `resolveChannel` is a top-level function, not a class member,
  because `AuditConsumer` was already at detekt's `TooManyFunctions` threshold (fires **at** 11, not
  above it — same trap this repo's own `CLAUDE.md` documents for `LongParameterList`).
- `quarkusBuild` green — CDI wiring, which lint + unit tests alone don't validate per this repo's own
  documented pitfall.

## Definition of Done

- [x] Hexagonal layering preserved.
- [x] Unit tests added, falsified against the pre-fix consumer.
- [ ] Integration tests — N/A, no service boundary changed beyond the migration itself.
- [ ] Contract tests / OpenAPI — N/A, no API shape changed (`channel` was always `String?`).
- [x] Flyway migration + this is the rollback note: `ALTER COLUMN ... TYPE VARCHAR(32)` is a
      metadata-only widen in Postgres (no rewrite, no data loss); reverting would need a second
      migration narrowing it back, safe as long as no value written in between exceeds 16 chars —
      not attempting that revert path speculatively.
- [x] `ktlintCheck`, `detekt`, `quarkusBuild`, module `test` all pass locally.

## Security checklist

- [x] No secrets, no PII. `channel` is a query-index dimension, not content.
- [x] No new `@Suppress`, no new dependency.
- [x] Tamper-evidence unaffected — `channel` was never part of `chainHash` (V9's own comment: "query
      indexes, NOT part of the chain hash").

## Compliance impact

- [x] None to erasure/retention. Existing rows keep their un-namespaced value (1 row, `"APP"`) —
      cheap enough to leave as pre-decision debt rather than backfill, unlike the `aggregate_type`
      case where volume argued against touching history at all.

## Rollout / Rollback

- Flyway migrates on deploy (`migrate-at-start: true`) — no manual step.
- Code and migration land together; a pod that has the code but not yet the migration would fail
  cleanly at the schema check Flyway does at boot (migration runs before the app serves traffic).
- Rollback: revert. The widened column accepts old-shaped (un-namespaced, ≤16 char) values fine, so
  reverting the code alone (without reverting V14) is also safe if ever needed.

## Reviewer notes

Deliberately did not add a namespace mapping for `openbank.customer.audit` (the one real audit
topic) — its current publisher sets no `channel` field, and guessing where `AuditChannel`'s eventual
Kafka wiring will land would be exactly the kind of unverified claim this repo's culture warns
against. The catch-all already covers it correctly the day that wiring exists.
