### PR TITLE
feat(admin-ui): show campaign attention funnel

### DIFF
--- a/openbank-admin-ui/e2e/campaign-attention-funnel.spec.ts
+++ b/openbank-admin-ui/e2e/campaign-attention-funnel.spec.ts
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+// The attention funnel is a decision surface. This browser contract prevents a CSS-only regression
+// from collapsing its three observed facts back into an opaque total card.
+
+import { expect, test } from '@playwright/test'
+import { signInAsOperator } from './helpers/auth'
+
+const CAMPAIGN_ID = '019fb944-6c3a-7bd2-814d-7c946371f1ae'
+
+const DETAIL = {
+  campaign: {
+    id: CAMPAIGN_ID,
+    name: 'summer-savings-surface-test',
+    goal: 'Learn which app surface earns attention.',
+    segmentRef: { name: 'active-savers', version: 2 },
+    state: 'ACTIVE',
+    createdBy: 'campaign-maker@openbank.test',
+    approvedBy: 'campaign-checker@openbank.test',
+    steps: [{ order: 1, template: 'MARKETING_PRODUCT_OFFER_BANNER', delaySeconds: 0 }],
+  },
+  enrolments: [],
+  sends: { items: [], total: 0, page: 0, size: 50 },
+  partyNames: {},
+  sendSummary: {},
+  journey: [],
+  engagement: [
+    { stepOrder: 1, channel: 'BANNER', surface: 'HOME_BANNER', type: 'IMPRESSION', count: 1200 },
+    { stepOrder: 1, channel: 'BANNER', surface: 'HOME_BANNER', type: 'CLICK', count: 186 },
+    { stepOrder: 1, channel: 'BANNER', surface: 'HOME_BANNER', type: 'DISMISS', count: 31 },
+  ],
+  sources: {
+    campaign: 'ok', enrolments: 'ok', sends: 'ok', sendSummary: 'ok', journey: 'ok', engagement: 'ok',
+  },
+}
+
+test.beforeEach(async ({ context, baseURL }) => {
+  await signInAsOperator(context, baseURL!)
+})
+
+test('renders per-surface attention as a readable, measured funnel', async ({ page }) => {
+  await page.route(`**/api/campaigns/${CAMPAIGN_ID}`, route => route.fulfill({
+    status: 200, contentType: 'application/json', body: JSON.stringify(DETAIL),
+  }))
+  await page.goto(`/campaigns/${CAMPAIGN_ID}`)
+
+  const funnel = page.getByTestId('campaign-attention-funnel')
+  await expect(funnel).toBeVisible()
+  await expect(funnel.getByRole('heading', { name: /Co lidé skutečně udělali|What people actually did/ })).toBeVisible()
+  await expect(funnel).toContainText(/Home banner/)
+  await expect(funnel).toContainText(/1,200/)
+  await expect(funnel).toContainText(/15.5 %/)
+  await expect(funnel).toContainText(/neither people nor business conversions|Nejsou to lidé ani obchodní konverze/)
+
+  // A visual hierarchy matters here: three observations remain three independent, legible metric
+  // tiles instead of wrapping into an unreadable line on a normal laptop viewport.
+  const metrics = funnel.locator('.campaign-attention-metrics')
+  expect(await metrics.evaluate(el => getComputedStyle(el).gridTemplateColumns.split(' ').length)).toBe(3)
+  const card = funnel.locator('.campaign-attention-card')
+  expect(await card.evaluate(el => getComputedStyle(el).backgroundColor)).not.toBe('rgba(0, 0, 0, 0)')
+  expect(await funnel.evaluate(el => getComputedStyle(el).backgroundImage)).toContain('gradient')
+})

--- a/openbank-admin-ui/src/app/campaigns/[id]/page.tsx
+++ b/openbank-admin-ui/src/app/campaigns/[id]/page.tsx
@@ -14,6 +14,7 @@ import { JourneyCanvas, type StepFunnel } from '@/components/campaigns/JourneyCa
 import { SectionBoundary } from '@/components/feedback/SectionBoundary'
 import { PeopleSummary } from '@/components/campaigns/PeopleSummary'
 import { CampaignOutcomeBrief } from '@/components/campaigns/CampaignOutcomeBrief'
+import { CampaignAttentionFunnel, type CampaignAttentionMetric } from '@/components/campaigns/CampaignAttentionFunnel'
 
 interface Campaign {
   id: string
@@ -99,14 +100,6 @@ interface ContentExperiment {
   }
 }
 
-interface CampaignEngagementMetric {
-  stepOrder: number
-  channel: 'PUSH' | 'BANNER'
-  surface: 'HOME_BANNER' | 'HOME_CAROUSEL' | 'PRODUCT_FEED' | 'REWARDS_HUB'
-  type: 'IMPRESSION' | 'CLICK' | 'DISMISS'
-  count: number
-}
-
 type Detail = {
   campaign: Campaign | null
   enrolments: Enrolment[]
@@ -114,7 +107,7 @@ type Detail = {
   partyNames: Record<string, string>
   sendSummary: Record<string, number>
   journey: StepFunnel[]
-  engagement: CampaignEngagementMetric[]
+  engagement: CampaignAttentionMetric[]
   experiment: Experiment | null
   contentExperiment: ContentExperiment | null
   entryCatalogues?: {
@@ -743,6 +736,8 @@ export default function CampaignDetailPage({ params }: { params: Promise<{ id: s
               </SectionBoundary>
             )}
           </section>
+
+          {detail?.sources?.engagement === 'ok' && <CampaignAttentionFunnel metrics={engagement} />}
 
           <section className="space-y-2">
             <h2 className="text-sm font-semibold">{t('Čtyři oči', 'Four-eyes')}</h2>

--- a/openbank-admin-ui/src/app/globals.css
+++ b/openbank-admin-ui/src/app/globals.css
@@ -557,6 +557,26 @@ main {
 .campaign-readiness-list [data-state='attention'] > span { background: #fef3c7; color: var(--warning-text); }
 .campaign-readiness-list [data-state='waiting'] { background: var(--surface-2); }
 .campaign-readiness-list [data-state='waiting'] > span { background: var(--surface-4); color: var(--text-secondary); }
+.campaign-attention-funnel { border: 1px solid #dce5f2; border-radius: 1.1rem; background: radial-gradient(circle at 96% 0%, rgba(14, 165, 233, .13), transparent 28%), linear-gradient(145deg, #fbfdff, #fff 62%, #f6f5ff); box-shadow: 0 10px 25px rgba(15, 23, 42, .045); padding: 1.05rem; }
+.campaign-attention-heading { align-items: flex-start; display: flex; gap: .75rem; justify-content: space-between; }
+.campaign-attention-heading p { color: #5d5ab6; font-size: .64rem; font-weight: 800; letter-spacing: .09em; text-transform: uppercase; }
+.campaign-attention-heading h2 { color: #17223a; font-size: 1.05rem; font-weight: 800; letter-spacing: -.025em; margin-top: .18rem; }
+.campaign-attention-heading > span { background: #e9f7f6; border: 1px solid #bee9e4; border-radius: 99px; color: #14746f; font-size: .63rem; font-weight: 800; padding: .32rem .55rem; white-space: nowrap; }
+.campaign-attention-intro { color: var(--text-secondary); font-size: .72rem; line-height: 1.45; margin-top: .55rem; max-width: 46rem; }
+.campaign-attention-empty { background: rgba(255,255,255,.75); border: 1px dashed #cdd8e8; border-radius: .75rem; color: var(--text-secondary); font-size: .73rem; margin-top: .85rem; padding: .72rem .8rem; }
+.campaign-attention-grid { display: grid; gap: .65rem; grid-template-columns: repeat(auto-fit, minmax(14rem, 1fr)); margin-top: .9rem; }
+.campaign-attention-card { background: rgba(255,255,255,.88); border: 1px solid #e1e8f3; border-radius: .85rem; min-width: 0; padding: .8rem; }
+.campaign-attention-card-heading { display: grid; gap: .16rem; }
+.campaign-attention-card-heading span { color: #65738a; font-size: .61rem; font-weight: 800; letter-spacing: .07em; text-transform: uppercase; }
+.campaign-attention-card-heading strong { color: #1f2b42; font-size: .8rem; font-weight: 800; }
+.campaign-attention-card-heading small { color: var(--text-secondary); font-size: .65rem; }
+.campaign-attention-metrics { display: grid; gap: .35rem; grid-template-columns: repeat(3, minmax(0, 1fr)); margin-top: .72rem; }
+.campaign-attention-metrics > div { background: #f8faff; border-radius: .58rem; min-width: 0; padding: .42rem; }
+.campaign-attention-metrics svg { color: #5c63d6; height: .78rem; width: .78rem; }
+.campaign-attention-metrics strong { color: #1f2b42; display: block; font-size: .88rem; font-variant-numeric: tabular-nums; line-height: 1.1; margin-top: .18rem; overflow: hidden; text-overflow: ellipsis; }
+.campaign-attention-metrics span { color: #758299; display: block; font-size: .57rem; margin-top: .14rem; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.campaign-attention-card > p { color: #67758b; font-size: .65rem; margin-top: .68rem; }
+.campaign-attention-card > p strong { color: #4452b8; font-variant-numeric: tabular-nums; }
 @media (max-width: 1100px) {
   .campaign-measurement-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
   .campaign-composer-hero-main { align-items: flex-start; flex-direction: column; }
@@ -578,6 +598,7 @@ main {
   .campaign-recipe-heading > span { text-align: left; }
   .campaign-composer-footer-actions { justify-content: flex-start; }
   .campaign-workbench-status { margin-top: -.15rem; }
+  .campaign-attention-heading { align-items: flex-start; flex-direction: column; }
 }
 @media (max-width: 450px) { .campaign-preview-stage { gap: 0.4rem; } .campaign-phone { transform: scale(.9); transform-origin: left center; margin-right: -0.75rem; } .campaign-push-card { transform: rotate(-2deg) scale(.9); transform-origin: left center; } }
 

--- a/openbank-admin-ui/src/components/campaigns/CampaignAttentionFunnel.tsx
+++ b/openbank-admin-ui/src/components/campaigns/CampaignAttentionFunnel.tsx
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+import { Eye, MousePointer2, X } from 'lucide-react'
+import { useLanguage } from '@/lib/i18n/LanguageContext'
+
+export type CampaignAttentionMetric = {
+  stepOrder: number
+  channel: 'PUSH' | 'BANNER'
+  surface: 'HOME_BANNER' | 'HOME_CAROUSEL' | 'PRODUCT_FEED' | 'REWARDS_HUB'
+  type: 'IMPRESSION' | 'CLICK' | 'DISMISS'
+  count: number
+}
+
+type AttentionRow = {
+  stepOrder: number
+  channel: CampaignAttentionMetric['channel']
+  surface: CampaignAttentionMetric['surface']
+  impressions: number
+  clicks: number
+  dismissals: number
+}
+
+function labels(t: (cs: string, en: string) => string) {
+  return {
+    channel: { PUSH: t('Push do aplikace', 'App push'), BANNER: t('Obsah v aplikaci', 'In-app content') },
+    surface: {
+      HOME_BANNER: t('Domovský banner', 'Home banner'),
+      HOME_CAROUSEL: t('Domovský carousel', 'Home carousel'),
+      PRODUCT_FEED: t('Feed produktů', 'Product feed'),
+      REWARDS_HUB: t('Centrum odměn', 'Rewards hub'),
+    },
+  }
+}
+
+/** Shows only verified app events; a delivery handoff is never treated as a made-up impression. */
+export function CampaignAttentionFunnel({ metrics }: { metrics: CampaignAttentionMetric[] }) {
+  const { t, language } = useLanguage()
+  const copy = labels(t)
+  const rows = new Map<string, AttentionRow>()
+  for (const metric of metrics) {
+    const key = `${metric.stepOrder}-${metric.channel}-${metric.surface}`
+    const row = rows.get(key) ?? { stepOrder: metric.stepOrder, channel: metric.channel, surface: metric.surface, impressions: 0, clicks: 0, dismissals: 0 }
+    if (metric.type === 'IMPRESSION') row.impressions += metric.count
+    if (metric.type === 'CLICK') row.clicks += metric.count
+    if (metric.type === 'DISMISS') row.dismissals += metric.count
+    rows.set(key, row)
+  }
+  const ordered = [...rows.values()].sort((a, b) => a.stepOrder - b.stepOrder || a.channel.localeCompare(b.channel) || a.surface.localeCompare(b.surface))
+  const formatNumber = (value: number) => value.toLocaleString(language === 'cs' ? 'cs-CZ' : 'en-GB')
+  const formatRate = (clicks: number, impressions: number) => impressions > 0 ? `${((clicks / impressions) * 100).toFixed(1)} %` : '—'
+
+  return (
+    <section className="campaign-attention-funnel" data-testid="campaign-attention-funnel">
+      <div className="campaign-attention-heading">
+        <div><p>{t('Pozorovaná odezva v aplikaci', 'Observed app attention')}</p><h2>{t('Co lidé skutečně udělali', 'What people actually did')}</h2></div>
+        <span>{t('bez domněnek', 'no inference')}</span>
+      </div>
+      <p className="campaign-attention-intro">{t('Imprese, otevření a zavření jsou připsané jen přes ověřený odkaz kampaně. Nejsou to lidé ani obchodní konverze.', 'Impressions, taps and dismissals are shown only for a verified campaign reference. They are neither people nor business conversions.')}</p>
+      {ordered.length === 0 ? (
+        <p className="campaign-attention-empty">{t('Zatím nepřišla žádná přiřaditelná odezva z aplikace.', 'No attributable app response has arrived yet.')}</p>
+      ) : (
+        <div className="campaign-attention-grid">
+          {ordered.map(row => (
+            <article key={`${row.stepOrder}-${row.channel}-${row.surface}`} className="campaign-attention-card">
+              <div className="campaign-attention-card-heading"><span>{t(`Krok ${row.stepOrder}`, `Step ${row.stepOrder}`)}</span><strong>{copy.surface[row.surface]}</strong><small>{copy.channel[row.channel]}</small></div>
+              <div className="campaign-attention-metrics">
+                <div><Eye aria-hidden="true" /><strong>{formatNumber(row.impressions)}</strong><span>{t('viděno', 'seen')}</span></div>
+                <div><MousePointer2 aria-hidden="true" /><strong>{formatNumber(row.clicks)}</strong><span>{t('otevřeno', 'tapped')}</span></div>
+                <div><X aria-hidden="true" /><strong>{formatNumber(row.dismissals)}</strong><span>{t('zavřeno', 'dismissed')}</span></div>
+              </div>
+              <p>{t('Míra otevření', 'Tap rate')} <strong>{formatRate(row.clicks, row.impressions)}</strong></p>
+            </article>
+          ))}
+        </div>
+      )}
+    </section>
+  )
+}

--- a/openbank-admin-ui/src/test/campaign-studio.test.tsx
+++ b/openbank-admin-ui/src/test/campaign-studio.test.tsx
@@ -4,7 +4,7 @@
 
 import React from 'react'
 import { describe, expect, it, vi, beforeEach } from 'vitest'
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { SessionProvider } from 'next-auth/react'
 import { LanguageProvider } from '@/lib/i18n/LanguageContext'
 import CampaignDetailPage from '@/app/campaigns/[id]/page'
@@ -239,6 +239,28 @@ describe('campaign studio', () => {
     await waitFor(() => expect(screen.getByText('Submit for approval')).toBeTruthy(), { timeout: 8000 })
     // The whole point of four eyes: the author never sees the button that would let them skip it.
     expect(screen.queryByText('Approve and activate')).toBeNull()
+  }, 15000)
+
+  it('turns server-attributed app attention into a per-surface campaign funnel', async () => {
+    const active = detail('ACTIVE')
+    vi.stubGlobal('fetch', mockFetch({
+      [`/api/campaigns/${CAMPAIGN_ID}`]: {
+        ...active,
+        engagement: [
+          { stepOrder: 1, channel: 'BANNER', surface: 'HOME_BANNER', type: 'IMPRESSION', count: 120 },
+          { stepOrder: 1, channel: 'BANNER', surface: 'HOME_BANNER', type: 'CLICK', count: 18 },
+          { stepOrder: 1, channel: 'BANNER', surface: 'HOME_BANNER', type: 'DISMISS', count: 7 },
+        ],
+        sources: { ...active.sources, engagement: 'ok' },
+      },
+    }))
+    renderDetail()
+
+    await waitFor(() => expect(screen.getByTestId('campaign-attention-funnel')).toBeTruthy(), { timeout: 8000 })
+    const funnel = within(screen.getByTestId('campaign-attention-funnel'))
+    expect(funnel.getByText('Home banner')).toBeTruthy()
+    expect(funnel.getByText('120')).toBeTruthy()
+    expect(funnel.getByText('15.0 %')).toBeTruthy()
   }, 15000)
 
   it('submits an opted-in consent fallback as part of the step definition', async () => {


### PR DESCRIPTION
## What changed

- turns existing server-attributed engagement observations into a per-step, per-surface attention funnel in Campaign Detail
- distinguishes observed impressions, taps and dismissals from delivery and conversion
- adds responsive visual treatment and regression coverage

## Why

Campaign Studio already receives trustworthy app engagement data, but previously reduced it to two totals. Marketers could not see which customer surface was working.

## Validation

- `npm test -- --run src/test/campaign-studio.test.tsx` (15 passed)
- `npm run type-check`
- `npm run lint -- --quiet`

Refs #4712