### PR TITLE
fix(infra): baseline the frozen import artifact, not the drift

### DIFF
--- a/.github/scripts/check-realm-import-parity.py
+++ b/.github/scripts/check-realm-import-parity.py
@@ -47,13 +47,33 @@
 #   already paid for. Only a Vault write clears it, and a Vault write is not something a PR can
 #   do.
 #
-#   So today's measured gap is declared in KNOWN_STALE, the same shape check-kafka-dotted-keys
-#   and check-pact-provider-replay use. That buys the property that matters: a NEW divergence —
-#   an eleventh role added to the template, a client removed from the import artifact — is red
-#   on the next run instead of disappearing into a gap that was already red. And the baseline
-#   is checked in BOTH directions, so the day the owner runs the reconcile the entry becomes
-#   stale and this script says so, which is what turns "someone should do the Vault write" into
-#   a signal rather than a note in an issue.
+#   So the gap is baselined, the same shape check-kafka-dotted-keys and check-pact-provider-replay
+#   use. WHAT is baselined changed on 2026-08-13, and the reason is the whole point of this block.
+#
+#   The first version (#3655) baselined the DIFFERENCE — the set of names the template declared
+#   and the artifact lacked. A difference is a function of BOTH sides, and only one of them is
+#   frozen. So every legitimate addition to the template landed as `missing`, was absent from the
+#   baseline, and was reported as "NEW since #3246" — new drift, on a run where nothing about the
+#   drift had changed. #4028 (2026-08-07) did exactly that: a correct, additive, template-only PR
+#   declaring `service-account-openbank-mcp-service`, which this thread had asked for. The CronJob
+#   has been red every night since, on a finding whose only remedy was to hand-append the name
+#   here — i.e. the detector fired on the wrong event, and the response it trained was "append a
+#   name to silence a red", which is how a baseline rots.
+#
+#   So the baseline is now IMPORT_BASELINE: the names the import artifact ACTUALLY CARRIES, the
+#   side that is frozen. The gap itself (`declaredNotImported`) is reported, always, and is not a
+#   finding while the artifact matches its baseline — it is #3246's one known defect, and it grows
+#   with every template merge by construction. What IS a finding is the artifact moving:
+#
+#     * names GAINED  -> a Vault write happened. Either the #3246 reconcile (empty this realm's
+#                        entry; parity is then enforced in full) or an out-of-band write nobody
+#                        reviewed. Both need a human, and neither was distinguishable before.
+#     * names LOST    -> a Vault write REMOVED something the artifact used to carry. This is the
+#                        direction that makes a rebuild worse, and the old shape could not see it
+#                        at all: shrinking the artifact only ever GREW the difference, which read
+#                        as ordinary template drift.
+#     * a realm with NO baseline entry -> full parity required, no exceptions. That is the
+#                        post-reconcile steady state the runbook's close-out PR creates.
 #
 # WHAT IT DELIBERATELY DOES NOT DO
 #   It does not compare secret VALUES, and it must not: the template carries `__PLACEHOLDER__`
@@ -88,34 +108,35 @@ BUILTIN_CLIENTS = frozenset(
 BUILTIN_ROLES = frozenset({"offline_access", "uma_authorization", "uma_protection"})
 
 # ---------------------------------------------------------------------------
-# The measured 2026-08-03 gap (#3246). Every entry is a name the committed template declares
-# and the deployed import artifact does not carry, i.e. a name a cold-started cluster would
-# LOSE. Cleared by the Vault reconcile in docs/runbooks/0009-keycloak-realm-import-reconcile.md
-# — after which this dict must be emptied, and this script fails until it is.
+# What the deployed import artifact CARRIES — not what it lacks. Measured 2026-08-13 by decoding
+# the two projected Secrets, i.e. the exact bytes keycloak.yaml's `realm-import` volume mounts:
 #
-# There is deliberately no baseline for the other direction (a name in the import artifact that
-# git does not declare): none exists today, and one appearing is exactly the review-nobody-did
-# case a cold start would materialise.
+#   kubectl -n iam get secret keycloak-realm-import           -o jsonpath='{.data}'   (1951 B)
+#   kubectl -n iam get secret keycloak-customers-realm-import -o jsonpath='{.data}'   (6333 B)
+#
+# Byte-identical to the artifact #3246 measured on 2026-08-02, so this records a frozen object,
+# which is the property that makes it a usable baseline. Every name here is also declared by the
+# committed template — the artifact is a strict ANCESTOR — and check_realm_import_parity_test.py
+# asserts that, so an entry cannot drift into naming something git never reviewed.
+#
+# A realm listed here is in the #3246 gap: its `declaredNotImported` set is expected and is not a
+# finding. A realm NOT listed here is held to full parity. The reconcile in
+# docs/runbooks/0009-keycloak-realm-import-reconcile.md is what moves a realm from the first state
+# to the second: after the Vault write the artifact no longer matches this record, the run goes red
+# saying so, and the close-out PR DELETES that realm's entry rather than emptying its dimensions.
+# (An entry with empty sets is not the same statement — it would assert an empty artifact.)
 # ---------------------------------------------------------------------------
-KNOWN_STALE = {
+IMPORT_BASELINE = {
     "openbank": {
-        "roles": {
-            "ROLE_AUDITOR", "ROLE_COMPLIANCE", "ROLE_CREDIT_RISK", "ROLE_DEMO", "ROLE_KYC",
-            "ROLE_KYC_OPENER", "ROLE_KYC_REVIEWER", "ROLE_LENDING_OFFICER", "ROLE_PAYMENTS",
-            "ROLE_SUPERVISOR", "mcp-caller",
-        },
-        "clients": {
-            "apicurio-registry", "argocd", "goalert", "openbank-edge", "openbank-glitchtip",
-            "openbank-grafana", "openbank-mcp-service", "openbao",
-        },
-        "users": {
-            "compliance2@openbank.local", "compliance@openbank.local", "demo@openbank.local",
-            "service-account-openbank-edge", "service-account-openbank-services",
-        },
+        "roles": {"ROLE_ADMIN", "ROLE_API", "ROLE_OPERATOR", "ROLE_VIEWER"},
+        "clients": {"openbank-admin-ui", "openbank-services"},
+        "users": {"admin@openbank.local"},
     },
     "openbank-customers": {
-        "roles": set(),
-        "clients": {"customer-edge-admin", "openbank-edge-webauthn"},
+        # `defaultRoles` (the flat Keycloak <=12 spelling this artifact still uses) is not a role
+        # DECLARATION and _names does not read it; ROLE_CUSTOMER is declared under roles.realm.
+        "roles": {"ROLE_CUSTOMER"},
+        "clients": {"openbank-app"},
         "users": set(),
     },
 }
@@ -211,39 +232,63 @@ def main(argv=None) -> int:
             report["realms"][realm] = {"status": "unchecked"}
             continue
 
-        baseline = KNOWN_STALE.get(realm, {})
+        baseline = IMPORT_BASELINE.get(realm)
         entry = {"status": "checked", "inSync": True}
+        entry["importArtifactBaselined"] = baseline is not None
         for dim in DIMENSIONS:
             missing = want[dim] - have[dim]
             extra = have[dim] - want[dim]
-            known = set(baseline.get(dim, set()))
-            new_missing = sorted(missing - known)
-            healed = sorted(known - missing)
             entry[f"declaredNotImported/{dim}"] = sorted(missing)
             entry[f"importedNotDeclared/{dim}"] = sorted(extra)
-            entry[f"newSince3246/{dim}"] = new_missing
             if missing or extra:
                 entry["inSync"] = False
-            for n in new_missing:
-                findings.append(
-                    f"realm `{realm}`: {dim[:-1]} `{n}` is declared in the committed template "
-                    f"and is NOT in the import artifact Keycloak would read. A cold-started "
-                    f"cluster would not have it. This is NEW since #3246 — it is not in "
-                    f"KNOWN_STALE. Reconcile the Vault copy "
-                    f"(docs/runbooks/0009-keycloak-realm-import-reconcile.md).",
-                )
+
+            # A name the artifact carries and git declares nowhere. Never baselined, in either
+            # shape: a cold start would create it and no review ever saw it.
             for n in sorted(extra):
                 findings.append(
                     f"realm `{realm}`: {dim[:-1]} `{n}` is in the import artifact and declared "
                     f"NOWHERE in git. A cold start would create it and no review ever saw it. "
                     f"Add it to the template, or remove it from the Vault copy.",
                 )
-            for n in healed:
+
+            if baseline is None:
+                # No recorded gap for this realm: full parity, which is the post-reconcile state.
+                entry[f"importArtifactGained/{dim}"] = []
+                entry[f"importArtifactLost/{dim}"] = []
+                for n in sorted(missing):
+                    findings.append(
+                        f"realm `{realm}`: {dim[:-1]} `{n}` is declared in the committed template "
+                        f"and is NOT in the import artifact Keycloak would read. A cold-started "
+                        f"cluster would not have it, and this realm has no #3246 baseline entry, "
+                        f"so it is held to full parity. Reconcile the Vault copy "
+                        f"(docs/runbooks/0009-keycloak-realm-import-reconcile.md).",
+                    )
+                continue
+
+            # Baselined realm: the gap is #3246's known defect and grows with every template
+            # merge, so it is reported and not raised. What is raised is the ARTIFACT moving.
+            base = set(baseline.get(dim, set()))
+            gained = sorted(have[dim] - base)
+            lost = sorted(base - have[dim])
+            entry[f"importArtifactGained/{dim}"] = gained
+            entry[f"importArtifactLost/{dim}"] = lost
+            for n in gained:
+                if n in extra:
+                    continue  # already reported above, and more precisely
                 findings.append(
-                    f"realm `{realm}`: {dim[:-1]} `{n}` is listed in KNOWN_STALE but the import "
-                    f"artifact now carries it — the #3246 reconcile has happened. Delete this "
-                    f"entry from KNOWN_STALE in check-realm-import-parity.py; a baseline that "
-                    f"outlives its gap is a gate that is green about nothing.",
+                    f"realm `{realm}`: the import artifact now carries {dim[:-1]} `{n}`, which "
+                    f"the baseline recorded it did not — something has written to the Vault "
+                    f"copy. If this is the #3246 reconcile, delete this realm's entry from "
+                    f"IMPORT_BASELINE so parity is enforced in full "
+                    f"(docs/runbooks/0009-keycloak-realm-import-reconcile.md). If it is not, "
+                    f"an unreviewed write reached the artifact a rebuild would import.",
+                )
+            for n in lost:
+                findings.append(
+                    f"realm `{realm}`: the import artifact NO LONGER carries {dim[:-1]} `{n}`, "
+                    f"which the baseline recorded it did. A write to the Vault copy removed it, "
+                    f"so a cold-started cluster now reproduces strictly less than it did before.",
                 )
         report["realms"][realm] = entry
 
@@ -252,14 +297,15 @@ def main(argv=None) -> int:
         for f in findings:
             sys.stderr.write(f"::error title=Keycloak realm import parity::{f}\n")
         sys.stderr.write(
-            f"::error::check-realm-import-parity: {len(findings)} finding(s). The committed "
-            f"template and the artifact Keycloak would import disagree beyond the #3246 "
-            f"baseline.\n",
+            f"::error::check-realm-import-parity: {len(findings)} finding(s). The artifact "
+            f"Keycloak would import has moved away from its recorded baseline, or carries a "
+            f"name git declares nowhere.\n",
         )
         return 1
     checked = ", ".join(sorted(imported))
     print(
-        f"realm import parity: no drift beyond the #3246 baseline for {checked}.",
+        f"realm import parity: the import artifact matches its recorded baseline for {checked}; "
+        f"the #3246 gap itself is unchanged (see declaredNotImported/* in the report).",
         file=sys.stderr,
     )
     return 0
@@ -294,59 +340,81 @@ def _self_test() -> int:
         comp.mkdir(parents=True)
 
         def run(tmpl, imp, baseline):
+            """baseline=None models a realm with no IMPORT_BASELINE entry (full parity)."""
             (comp / "realm-template.json").write_text(json.dumps(tmpl))
             p = root / "imp.json"
             p.write_text(json.dumps(imp))
-            saved = dict(KNOWN_STALE)
-            KNOWN_STALE.clear()
-            KNOWN_STALE.update(baseline)
+            saved = dict(IMPORT_BASELINE)
+            IMPORT_BASELINE.clear()
+            if baseline is not None:
+                IMPORT_BASELINE.update(baseline)
             try:
                 return main(["--root", str(root), "--import", f"{tmpl['realm']}={p}"])
             finally:
-                KNOWN_STALE.clear()
-                KNOWN_STALE.update(saved)
+                IMPORT_BASELINE.clear()
+                IMPORT_BASELINE.update(saved)
 
-        empty = {"openbank": {d: set() for d in DIMENSIONS}}
+        def base(roles=(), clients=(), users=()):
+            return {"openbank": {"roles": set(roles), "clients": set(clients),
+                                 "users": set(users)}}
 
-        # 1. identical documents, empty baseline -> clean. The negative case: without it a
-        #    checker that always reports drift would pass every other case here.
+        # 1. identical documents, no baseline -> clean. The negative case: without it a checker
+        #    that always reports drift would pass every other case here.
         check("identical sets must be clean",
               run(_doc("openbank", ["R"], ["c"], ["u"]),
-                  _doc("openbank", ["R"], ["c"], ["u"]), empty) == 0)
+                  _doc("openbank", ["R"], ["c"], ["u"]), None) == 0)
 
-        # 2. a role in the template and not the import artifact, unbaselined -> red.
-        check("declared-not-imported role must be red",
-              run(_doc("openbank", ["R", "S"]), _doc("openbank", ["R"]), empty) == 1)
+        # 2. an unbaselined realm is held to full parity — a role the artifact lacks is red.
+        check("declared-not-imported role must be red without a baseline",
+              run(_doc("openbank", ["R", "S"]), _doc("openbank", ["R"]), None) == 1)
 
-        # 3. the same gap, baselined -> green. This is what keeps the first run off the alert.
+        # 3. the same gap, with the artifact matching its baseline -> green. This is what keeps
+        #    the first run off the alert while #3246's Vault write is outstanding.
         check("baselined gap must be green",
-              run(_doc("openbank", ["R", "S"]), _doc("openbank", ["R"]),
-                  {"openbank": {"roles": {"S"}, "clients": set(), "users": set()}}) == 0)
+              run(_doc("openbank", ["R", "S"]), _doc("openbank", ["R"]), base(roles=["R"])) == 0)
 
-        # 4. a baseline entry whose gap has closed -> red. Without this the baseline would
-        #    silently become permanent once the reconcile lands.
-        check("stale baseline entry must be red",
+        # 4. THE REGRESSION THIS SHAPE EXISTS FOR (#4028): the template gains a name while the
+        #    artifact is unchanged. That is the same one gap, one entry larger — it must NOT be
+        #    reported as new drift. Under the old difference-keyed baseline this returned 1, and
+        #    the CronJob was red nightly from 2026-08-07 because of it.
+        check("template growth against an unchanged artifact must stay green",
+              run(_doc("openbank", ["R", "S", "T"]), _doc("openbank", ["R"]),
+                  base(roles=["R"])) == 0)
+
+        # 5. the artifact GAINS a template-declared name -> red. This is the reconcile landing
+        #    (or an unreviewed Vault write); either way the baseline must not outlive it.
+        check("artifact gaining a name must be red",
               run(_doc("openbank", ["R", "S"]), _doc("openbank", ["R", "S"]),
-                  {"openbank": {"roles": {"S"}, "clients": set(), "users": set()}}) == 1)
+                  base(roles=["R"])) == 1)
 
-        # 5. a name in the import artifact that git does not declare -> red, never baselined.
+        # 6. the artifact LOSES a name it used to carry -> red. The old shape could not see this
+        #    at all: a shrinking artifact only ever grew the difference, which read as template
+        #    drift and was silenced by baselining the name.
+        check("artifact losing a name must be red",
+              run(_doc("openbank", ["R", "S"]), _doc("openbank", []),
+                  base(roles=["R"])) == 1)
+
+        # 7. a name in the import artifact that git does not declare -> red, never baselined.
         check("imported-not-declared must be red",
-              run(_doc("openbank", ["R"]), _doc("openbank", ["R", "GHOST"]), empty) == 1)
+              run(_doc("openbank", ["R"]), _doc("openbank", ["R", "GHOST"]), None) == 1)
 
-        # 6. same for clients and users, since each dimension is compared separately and a
-        #    loop that dropped one would still pass cases 1-5.
+        # 8. same for clients and users, since each dimension is compared separately and a
+        #    loop that dropped one would still pass the cases above.
         check("client dimension must be compared",
-              run(_doc("openbank", ["R"], ["a"]), _doc("openbank", ["R"], []), empty) == 1)
+              run(_doc("openbank", ["R"], ["a"]), _doc("openbank", ["R"], []), None) == 1)
         check("user dimension must be compared",
-              run(_doc("openbank", ["R"], [], ["u"]), _doc("openbank", ["R"], [], []), empty) == 1)
+              run(_doc("openbank", ["R"], [], ["u"]), _doc("openbank", ["R"], [], []), None) == 1)
+        check("client dimension must be compared against the baseline",
+              run(_doc("openbank", ["R"], ["a"]), _doc("openbank", ["R"], ["a"]),
+                  base(roles=["R"], clients=[])) == 1)
 
-        # 7. built-ins on the live/import side must never register as drift.
+        # 9. built-ins on the live/import side must never register as drift.
         check("builtin clients must be ignored",
               run(_doc("openbank", ["R"], ["a"]),
-                  _doc("openbank", ["R"], ["a", "account", "admin-cli"]), empty) == 0)
+                  _doc("openbank", ["R"], ["a", "account", "admin-cli"]), None) == 0)
         check("builtin roles must be ignored",
               run(_doc("openbank", ["R"]),
-                  _doc("openbank", ["R", "offline_access", "default-roles-openbank"]), empty) == 0)
+                  _doc("openbank", ["R", "offline_access", "default-roles-openbank"]), None) == 0)
 
         # 8. a realm supplied under the wrong name must abort, not compare.
         (comp / "realm-template.json").write_text(json.dumps(_doc("openbank", ["R"])))

--- a/docs/runbooks/0009-keycloak-realm-import-reconcile.md
+++ b/docs/runbooks/0009-keycloak-realm-import-reconcile.md
@@ -158,20 +158,26 @@ kubectl -n iam get externalsecret keycloak-realm-import \
   -o jsonpath='{.status.conditions}'
 ```
 
-Then re-run the pre-flight comparison. It must now go **red** with a "listed in
-KNOWN_STALE but the import artifact now carries it" finding for every reconciled
-name — that is the check telling you the baseline has outlived its gap, not a
-regression.
+Then re-run the pre-flight comparison. It must now go **red** with a "the import
+artifact now carries ..." finding for every reconciled name — that is the check
+telling you the artifact has moved off its recorded baseline, not a regression.
+(Measured 2026-08-13 against the rendered templates: 27 such findings across both
+realms.)
 
 ## Close-out (a PR, and it is required)
 
-Empty `KNOWN_STALE` in `.github/scripts/check-realm-import-parity.py`. Until that
-lands, the `keycloak-realm-drift` CronJob fails nightly and `KubeJobFailed` fires.
-The failure is deliberate: a baseline that survives its own reconcile is a gate that
-is green about nothing, and the only way anyone learns the write happened is for the
-detector to say so.
+**Delete** the two realm entries from `IMPORT_BASELINE` in
+`.github/scripts/check-realm-import-parity.py` — do not merely empty their dimension
+sets. `IMPORT_BASELINE` records what the artifact *carries*, so an entry with empty
+sets asserts an empty artifact; an absent entry is what means "no known gap, hold
+this realm to full parity".
 
-With `KNOWN_STALE` empty, the next role, client or user added to a template and not
+Until that PR lands, the `keycloak-realm-drift` CronJob fails nightly and
+`KubeJobFailed` fires. The failure is deliberate: a baseline that survives its own
+reconcile is a gate that is green about nothing, and the only way anyone learns the
+write happened is for the detector to say so.
+
+With both entries gone, the next role, client or user added to a template and not
 propagated to Vault is red on the following night's run — which is the property this
 whole exercise buys, and the thing neither of the two older comparisons can provide.
 

--- a/openbank-infra/CLAUDE.md
+++ b/openbank-infra/CLAUDE.md
@@ -33,9 +33,16 @@ out of it (they are path-scoped, not less important — several are live-inciden
   `keycloak-realm-drift` CronJob off the SAME projected Secrets Keycloak mounts — never a second
   copy, or it drifts from the one that deploys. It reads NAMES only: the template carries
   `__PLACEHOLDER__` where the artifact carries real client secrets, and the report is a ConfigMap.
-  Today's gap is baselined in its `KNOWN_STALE` (#2540's ordering point: a detector shipped before
-  the reconcile is an alert that is the resting state from minute one, clearable only by a Vault
-  write). The reconcile procedure is `docs/runbooks/0009-keycloak-realm-import-reconcile.md`; the
+  Today's gap is baselined in its `IMPORT_BASELINE` (#2540's ordering point: a detector shipped
+  before the reconcile is an alert that is the resting state from minute one, clearable only by a
+  Vault write). **Baseline the FROZEN side, never the difference.** The first version baselined the
+  gap — a function of both sides — so every legitimate template addition read as new drift: #4028
+  declared one service-account user and the CronJob went red nightly for six days on a run where
+  the drift had not changed, with "append the name to the baseline" as its only remedy. The
+  baseline now records what the import artifact CARRIES, so template growth is silent and the
+  artifact MOVING (a Vault write, in either direction) is the finding. Generalises past Keycloak:
+  any baseline keyed to `A - B` where only `B` is frozen will fire on changes to `A`.
+  The reconcile procedure is `docs/runbooks/0009-keycloak-realm-import-reconcile.md`; the
   `vault kv put` recipe in `components/external-secrets/README.md` reads the LIVE Secret back, so
   re-running it as maintenance can only re-store the stale ancestor.
 - **ArgoCD does NOT diff hook resources — so anything a hook reads from its own manifest can never

--- a/openbank-infra/scripts/check_realm_import_parity_test.py
+++ b/openbank-infra/scripts/check_realm_import_parity_test.py
@@ -9,11 +9,14 @@ The script's own `--self-test` proves the COMPARISON is falsifiable: it feeds sy
 documents that must be flagged and one pair that must not. That is run here so a change
 to the script cannot land without it.
 
-What synthetic fixtures cannot check is whether KNOWN_STALE still describes the REAL
-committed templates. A baseline entry naming a role no template declares can never clear
-— the gap it describes does not exist, so the reconcile can never close it and the entry
-is permanent dead weight that also silences the dimension it sits in. That check has to
-read the actual files in the repo, so it lives here.
+What synthetic fixtures cannot check is whether IMPORT_BASELINE still describes the REAL
+committed templates. The baseline records what the deployed import artifact CARRIES, and
+that artifact is a strict ancestor of the template, so every baselined name must also be
+declared by a committed template. A name that is not is either a mis-transcribed baseline
+or an artifact entry git never reviewed — and in the second case the checker's own
+`importedNotDeclared` leg should have raised it, so the entry would be masking exactly the
+finding it exists to preserve. That check has to read the actual files in the repo, so it
+lives here.
 """
 
 import json
@@ -45,36 +48,39 @@ class SelfTest(unittest.TestCase):
 
 
 class BaselineDescribesRealTemplates(unittest.TestCase):
-    """Every KNOWN_STALE name must be declared by a committed template for that realm."""
+    """Every IMPORT_BASELINE name must be declared by a committed template for that realm."""
 
     def setUp(self):
         self.mod = _load_module()
         self.declared = self.mod.template_names(REPO)
 
     def test_every_baselined_realm_has_a_template(self):
-        for realm in self.mod.KNOWN_STALE:
+        for realm in self.mod.IMPORT_BASELINE:
             self.assertIn(
                 realm, self.declared,
-                f"KNOWN_STALE names realm {realm!r} but no *realm-template*.json declares it",
+                f"IMPORT_BASELINE names realm {realm!r} but no *realm-template*.json declares it",
             )
 
     def test_every_baselined_name_is_declared(self):
-        for realm, dims in self.mod.KNOWN_STALE.items():
+        for realm, dims in self.mod.IMPORT_BASELINE.items():
             for dim, names in dims.items():
                 unknown = sorted(set(names) - self.declared[realm][dim])
                 self.assertEqual(
                     unknown, [],
-                    f"KNOWN_STALE[{realm!r}][{dim!r}] names {unknown}, which the committed "
-                    f"template does not declare. Such an entry can never clear — the gap it "
-                    f"claims does not exist — and it silences a real gap of the same name.",
+                    f"IMPORT_BASELINE[{realm!r}][{dim!r}] names {unknown}, which the committed "
+                    f"template does not declare. The import artifact is a strict ancestor of "
+                    f"the template, so either the baseline was mis-transcribed, or the artifact "
+                    f"holds a name nobody reviewed — and that second case is one this checker's "
+                    f"importedNotDeclared leg must raise, not one the baseline may absorb.",
                 )
 
     def test_dimensions_are_the_ones_the_checker_compares(self):
-        for realm, dims in self.mod.KNOWN_STALE.items():
+        for realm, dims in self.mod.IMPORT_BASELINE.items():
             self.assertEqual(
                 sorted(dims), sorted(self.mod.DIMENSIONS),
-                f"KNOWN_STALE[{realm!r}] must declare every dimension explicitly (an omitted "
-                f"one reads as 'no known gap' and is indistinguishable from a decision",
+                f"IMPORT_BASELINE[{realm!r}] must declare every dimension explicitly (an omitted "
+                f"one reads as 'the artifact carries nothing in this dimension', which is a much "
+                f"stronger claim than the silence it looks like)",
             )
 
 


### PR DESCRIPTION
## What

`check-realm-import-parity.py` baselined the **difference** between the committed realm template
and the artifact Keycloak would import. A difference is a function of *both* sides, and only one of
them is frozen — so every legitimate addition to the template landed as an unbaselined name and was
reported as `NEW since #3246`: new drift, on a run where nothing about the drift had changed.

This changes the baseline to record what the import artifact **carries** — the frozen side.

## The regression this fixes, measured

`#4028` declared `service-account-openbank-mcp-service` in the template on 2026-08-07 — a correct,
additive, template-only PR that #2540 had asked for. `keycloak-realm-drift` has failed every night
since, on that one name:

```
$ python3 <origin/main copy> --import openbank=<real projected Secret> ...
rc=1
::error::realm `openbank`: user `service-account-openbank-mcp-service` ... This is NEW since #3246

$ python3 <this branch>       --import openbank=<real projected Secret> ...
rc=0   the import artifact matches its recorded baseline; the #3246 gap itself is unchanged
```

Its only remedy was to hand-append the name to the baseline, which trains "append a name to silence
a red" — how a baseline rots. The detector was firing on the wrong event.

## What is a finding now

The gap itself (`declaredNotImported/*`) is still reported in full — 11 roles / 8 clients / 6 users
for `openbank`, 2 clients for `openbank-customers` — and is not raised while the artifact is
unchanged. It is #3246's one known defect and it grows with every template merge by construction.
What is raised is the **artifact moving**:

| condition | meaning | old shape |
|---|---|---|
| names **gained** | a Vault write happened — the #3246 reconcile, or an unreviewed write | conflated, via `healed` |
| names **lost** | a write REMOVED something; a rebuild now reproduces strictly less | **invisible** — a shrinking artifact only grew the difference, reading as template drift |
| **no baseline entry** for a realm | full parity required — the post-reconcile steady state | `KNOWN_STALE` emptied per-dimension |

The "lost" direction is the one the old shape could not see at all.

## Verification

**Against the real projected Secrets** (`kubectl -n iam get secret keycloak-realm-import` /
`keycloak-customers-realm-import`, 1951 B / 6333 B — byte-identical to #3246's 2026-08-02 reading,
so the baseline records a genuinely frozen object): old code exits 1, new code exits 0, same gap
reported.

**Falsified in both directions on real data**, not only on fixtures:

- feeding the *rendered templates* as the artifact (simulating the reconcile landing) -> **red**,
  27 `now carries` findings telling you to delete the entries;
- deleting the two baseline entries with that same input -> **green**, full parity.

So the runbook's close-out step stays falsifiable. `--self-test` gains the #4028 case explicitly
(template growth against an unchanged artifact must stay green — it returned 1 before) plus the
artifact-gained and artifact-lost cases; the companion suite in `openbank-infra/scripts/` still
asserts every baselined name is template-declared, which the strict-ancestor shape guarantees.

**Local Keycloak import, since #3246's remaining step depends on it and it had not been done.**
Both committed templates rendered and booted against `quay.io/keycloak/keycloak:26.6.3` (the tag
`keycloak.yaml` runs):

```
Realm 'openbank-customers' imported
Realm 'openbank' imported
KC-SERVICES0032: Import finished successfully      (zero ERROR/WARN)
```

- `openbank` reproduces all **14 roles / 10 clients**, with role mappings exactly as declared
  (`demo@openbank.local` -> `['ROLE_VIEWER']` only, i.e. a rebuild does not reproduce the live
  over-grant);
- a `client_credentials` token for `openbank-services` carries `realm_access.roles = ['ROLE_API']`
  — the gitops template's grant, confirming it is the least-privileged of the tracked realm JSONs;
- `openbank-customers` grants `ROLE_CUSTOMER` via the modern `defaultRole` composite, which settles
  the deprecated-`defaultRoles` question left open on #3246: converging Vault to the repo fixes
  that schema drift, and the current artifact's `<=12` spelling is the risk.

## Scope

Repo-only. No realm JSON, `.rego` or `rules.yaml` change, so no OPA bundle regeneration is
triggered. Nothing was written to Vault, the cluster or Keycloak; all cluster reads were read-only,
and the local Keycloak was a throwaway container with rendered placeholder values.

Refs #3246
Refs #2540
