### PR TITLE
feat(campaign): explain live launch guardrails

### DIFF
--- a/openbank-admin-ui/src/app/api/campaigns/guardrails/route.ts
+++ b/openbank-admin-ui/src/app/api/campaigns/guardrails/route.ts
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import { NextResponse } from 'next/server'
+import { auth } from '@/auth'
+import { serverSvcUrl } from '@/lib/services/bff'
+
+export const dynamic = 'force-dynamic'
+
+/** The live platform guardrails shown in Studio; never a locally copied policy default. */
+export async function GET() {
+  const session = await auth()
+  if (!session?.user?.accessToken) return NextResponse.json({ error: 'unauthenticated' }, { status: 401 })
+  try {
+    const res = await fetch(serverSvcUrl('campaign-service', 'campaign', 8128, '/api/v1/campaigns/guardrails'), {
+      headers: { authorization: `Bearer ${session.user.accessToken}` },
+      signal: AbortSignal.timeout(4000),
+      cache: 'no-store',
+    })
+    if (!res.ok) {
+      return NextResponse.json({ guardrails: null, state: res.status === 401 || res.status === 403 ? 'unauthorized' : 'unreachable' })
+    }
+    return NextResponse.json({ guardrails: await res.json(), state: 'ok' })
+  } catch {
+    return NextResponse.json({ guardrails: null, state: 'unreachable' })
+  }
+}

--- a/openbank-admin-ui/src/app/campaigns/new/page.tsx
+++ b/openbank-admin-ui/src/app/campaigns/new/page.tsx
@@ -19,7 +19,7 @@ import {
 } from '@/components/campaigns/JourneyEditor'
 import { StepEditor } from '@/components/campaigns/StepEditor'
 import { CampaignExperiencePreview } from '@/components/campaigns/CampaignExperiencePreview'
-import { CampaignLaunchReadiness } from '@/components/campaigns/CampaignLaunchReadiness'
+import { CampaignLaunchReadiness, type CampaignContactGuardrails } from '@/components/campaigns/CampaignLaunchReadiness'
 import {
   JourneyRecipePicker,
   type JourneyRecipe,
@@ -99,6 +99,7 @@ export default function NewCampaignPage() {
   const [triggers, setTriggers] = useState<CampaignTrigger[]>([])
   const [contentCatalogue, setContentCatalogue] = useState<CampaignTemplate[]>([])
   const [contentCatalogueState, setContentCatalogueState] = useState<'loading' | 'ok' | 'unavailable'>('loading')
+  const [guardrails, setGuardrails] = useState<CampaignContactGuardrails | null>(null)
   const [entryMode, setEntryMode] = useState<EntryMode>('MANUAL')
   const [cadence, setCadence] = useState('')
   const [trigger, setTrigger] = useState('')
@@ -246,11 +247,13 @@ export default function NewCampaignPage() {
       fetch('/api/campaigns/cadences').then(r => r.json()),
       fetch('/api/campaigns/triggers').then(r => r.json()),
       fetch('/api/campaigns/templates').then(r => r.json()),
+      fetch('/api/campaigns/guardrails').then(r => r.json()),
     ])
-      .then(([cadenceResponse, triggerResponse, templateResponse]: [
+      .then(([cadenceResponse, triggerResponse, templateResponse, guardrailResponse]: [
         { items?: Cadence[]; state?: string },
         { items?: CampaignTrigger[]; state?: string },
         { items?: CampaignTemplate[]; state?: string },
+        { guardrails?: CampaignContactGuardrails | null; state?: string },
       ]) => {
         if (cadenceResponse.state === 'ok') setCadences(cadenceResponse.items ?? [])
         if (triggerResponse.state === 'ok') setTriggers(triggerResponse.items ?? [])
@@ -261,6 +264,7 @@ export default function NewCampaignPage() {
         } else {
           setContentCatalogueState('unavailable')
         }
+        if (guardrailResponse.state === 'ok' && guardrailResponse.guardrails) setGuardrails(guardrailResponse.guardrails)
       })
       .catch(() => {
         setEntryUnavailable(true)
@@ -718,6 +722,8 @@ export default function NewCampaignPage() {
             conversionRule={conversionRule}
             contentExperiment={contentExperiment}
             steps={steps}
+            stopAfter={stopAfter}
+            guardrails={guardrails}
           />
         </div>
 

--- a/openbank-admin-ui/src/components/campaigns/CampaignLaunchReadiness.tsx
+++ b/openbank-admin-ui/src/components/campaigns/CampaignLaunchReadiness.tsx
@@ -16,6 +16,15 @@ interface ReadinessItem {
   detail: string
 }
 
+/** Live platform policy from campaign-service, deliberately separate from a campaign's own stop cap. */
+export interface CampaignContactGuardrails {
+  maxSendsPerParty: number
+  sendWindowHours: number
+  quietHoursStart: number
+  quietHoursEnd: number
+  timeZone: string
+}
+
 /**
  * Turns platform constraints into a launch conversation at the point of authoring.
  *
@@ -32,6 +41,8 @@ export function CampaignLaunchReadiness({
   conversionRule,
   contentExperiment,
   steps,
+  stopAfter,
+  guardrails,
 }: {
   audienceChosen: boolean
   audienceSize: number | null
@@ -40,11 +51,14 @@ export function CampaignLaunchReadiness({
   conversionRule: string | null
   contentExperiment: boolean
   steps: EditorStep[]
+  stopAfter: number | null
+  guardrails: CampaignContactGuardrails | null
 }) {
   const { t, language } = useLanguage()
   const n = (value: number) => value.toLocaleString(language === 'cs' ? 'cs-CZ' : 'en-GB')
   const appPlacement = steps.find(step => step.channel === 'PUSH' || step.channel === 'BANNER')
   const readyCount = [audienceChosen, entryConfigured, !incomplete, !contentExperiment || conversionRule !== null].filter(Boolean).length
+  const hour = (value: number) => `${String(value).padStart(2, '0')}:00`
 
   const items: ReadinessItem[] = [
     audienceChosen
@@ -70,7 +84,18 @@ export function CampaignLaunchReadiness({
     appPlacement
       ? { id: 'destination', state: 'ready', label: t('Krok v aplikaci má bezpečný cíl', 'In-app step has a safe destination'), detail: t('Jen schválený deep link; žádná URL z kampaně.', 'An approved deep link only; no campaign-entered URL.') }
       : { id: 'destination', state: 'attention', label: t('Cesta zatím nemá krok v aplikaci', 'Journey has no in-app step yet'), detail: t('Přidejte push nebo banner, pokud má kampaň přivést lidi zpět do aplikace.', 'Add a push or banner if the campaign should bring people back into the app.') },
-    { id: 'policy', state: 'ready', label: t('Ochrana kontaktu zůstává zapnutá', 'Contact protection stays on'), detail: t('Souhlas, tiché hodiny a frekvenční limit se ověřují při doručení.', 'Consent, quiet hours and frequency limits are checked at delivery.') },
+    stopAfter !== null
+      ? { id: 'journey-cap', state: 'ready', label: t('Cesta má vlastní limit', 'Journey has its own cap'), detail: t(`Jedna osoba skončí po ${n(stopAfter)} odesláních v této cestě.`, `A person exits this journey after ${n(stopAfter)} sends.`) }
+      : { id: 'journey-cap', state: 'attention', label: t('Cesta nemá vlastní limit', 'Journey has no own cap'), detail: t('Platí stále platformní ochrana níže; vlastní limit je další kontrola, ne její náhrada.', 'The platform protection below still applies; an own cap is an additional control, not a replacement.') },
+    guardrails
+      ? {
+          id: 'policy', state: 'ready', label: t('Ochrana kontaktu je potvrzená', 'Contact protection is confirmed'),
+          detail: t(
+            `E-mail a push: max. ${n(guardrails.maxSendsPerParty)} kontaktů na osobu za ${n(guardrails.sendWindowHours)} h; tiché hodiny ${hour(guardrails.quietHoursStart)}–${hour(guardrails.quietHoursEnd)} (${guardrails.timeZone}). Souhlas se znovu ověřuje před odesláním.`,
+            `Email and push: max ${n(guardrails.maxSendsPerParty)} contacts per person in ${n(guardrails.sendWindowHours)} h; quiet hours ${hour(guardrails.quietHoursStart)}–${hour(guardrails.quietHoursEnd)} (${guardrails.timeZone}). Consent is rechecked before send.`,
+          ),
+        }
+      : { id: 'policy', state: 'attention', label: t('Ochranu kontaktu se nepodařilo ověřit', 'Contact protection could not be confirmed'), detail: t('Návrh můžete připravit, ale před odesláním ověřte aktuální limity. Souhlas se vždy kontroluje živě při doručení.', 'You can prepare the draft, but verify the current limits before sending. Consent is always checked live at delivery.') },
   ]
 
   return (

--- a/openbank-admin-ui/src/test/campaign-entry-catalogues-bff.test.ts
+++ b/openbank-admin-ui/src/test/campaign-entry-catalogues-bff.test.ts
@@ -16,6 +16,8 @@ describe('campaign entry catalogue BFF', () => {
       status: 200,
       json: async () => url.endsWith('/cadences')
         ? [{ cadence: 'DAILY_MORNING', humanForm: 'every day at 09:00', zone: 'Europe/Prague' }]
+        : url.endsWith('/guardrails')
+          ? { maxSendsPerParty: 2, sendWindowHours: 168, quietHoursStart: 21, quietHoursEnd: 8, timeZone: 'Europe/Prague' }
         : url.endsWith('/templates')
           ? [{ template: 'MARKETING_PRODUCT_OFFER_BANNER', channel: 'BANNER', variables: ['offerTitle'], inAppSurface: 'HOME_BANNER' }]
           : [{ trigger: 'ACCOUNT_OPENED', humanForm: 'when an account is opened' }],
@@ -25,6 +27,7 @@ describe('campaign entry catalogue BFF', () => {
     const { GET: cadences } = await import('@/app/api/campaigns/cadences/route')
     const { GET: triggers } = await import('@/app/api/campaigns/triggers/route')
     const { GET: templates } = await import('@/app/api/campaigns/templates/route')
+    const { GET: guardrails } = await import('@/app/api/campaigns/guardrails/route')
 
     await expect((await cadences()).json()).resolves.toEqual({
       items: [{ cadence: 'DAILY_MORNING', humanForm: 'every day at 09:00', zone: 'Europe/Prague' }],
@@ -38,6 +41,10 @@ describe('campaign entry catalogue BFF', () => {
       items: [{ template: 'MARKETING_PRODUCT_OFFER_BANNER', channel: 'BANNER', variables: ['offerTitle'], inAppSurface: 'HOME_BANNER' }],
       state: 'ok',
     })
+    await expect((await guardrails()).json()).resolves.toEqual({
+      guardrails: { maxSendsPerParty: 2, sendWindowHours: 168, quietHoursStart: 21, quietHoursEnd: 8, timeZone: 'Europe/Prague' },
+      state: 'ok',
+    })
     expect(fetchMock).toHaveBeenCalledWith(
       'http://campaign/api/v1/campaigns/cadences',
       expect.objectContaining({ headers: { authorization: 'Bearer token' } }),
@@ -48,6 +55,10 @@ describe('campaign entry catalogue BFF', () => {
     )
     expect(fetchMock).toHaveBeenCalledWith(
       'http://campaign/api/v1/campaigns/templates',
+      expect.objectContaining({ headers: { authorization: 'Bearer token' } }),
+    )
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://campaign/api/v1/campaigns/guardrails',
       expect.objectContaining({ headers: { authorization: 'Bearer token' } }),
     )
   })

--- a/openbank-admin-ui/src/test/campaign-experience-preview.test.tsx
+++ b/openbank-admin-ui/src/test/campaign-experience-preview.test.tsx
@@ -83,6 +83,8 @@ describe('campaign launch readiness', () => {
           conversionRule={null}
           contentExperiment={false}
           steps={[{ ...push, channel: 'EMAIL', mobileDestination: undefined }]}
+          stopAfter={null}
+          guardrails={{ maxSendsPerParty: 2, sendWindowHours: 168, quietHoursStart: 21, quietHoursEnd: 8, timeZone: 'Europe/Prague' }}
         />
       </LanguageProvider>,
     )
@@ -90,6 +92,7 @@ describe('campaign launch readiness', () => {
     expect(container.querySelector('[data-readiness="audience"][data-state="waiting"]')).toBeTruthy()
     expect(container.querySelector('[data-readiness="content"][data-state="waiting"]')).toBeTruthy()
     expect(container.querySelector('[data-readiness="policy"][data-state="ready"]')).toBeTruthy()
+    expect(screen.getByText(/max 2 contacts per person in 168 h/)).toBeTruthy()
     expect(screen.getByText(/Journey has no in-app step/)).toBeTruthy()
   })
 })

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/rest/CampaignContactGuardrailResource.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/rest/CampaignContactGuardrailResource.kt
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.campaign.infrastructure.rest
+
+import com.openbank.libs.authz.Authorize
+import com.openbank.libs.contact.ContactPolicy
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.ws.rs.GET
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.core.Response
+import org.eclipse.microprofile.config.inject.ConfigProperty
+
+/** The delivery guardrails Studio can show without pretending to predict a changing person-level decision. */
+data class CampaignContactGuardrails(
+    val maxSendsPerParty: Int,
+    val sendWindowHours: Long,
+    val quietHoursStart: Int,
+    val quietHoursEnd: Int,
+    val timeZone: String,
+)
+
+/**
+ * The current platform contact rules for a campaign author.
+ *
+ * This is deliberately a policy explanation, not a reach forecast. Consent, suppression state and
+ * the rolling send count are person-specific and change between authoring and delivery; showing a
+ * count of people we "expect" to pass would turn that temporal fact into a false promise. The
+ * workflow still re-checks those facts immediately before every outbound handoff.
+ */
+@Path("/api/v1/campaigns/guardrails")
+@ApplicationScoped
+class CampaignContactGuardrailResource(
+    @ConfigProperty(name = "openbank.campaign.max-sends-per-party-per-week", defaultValue = "2")
+    private val maxSendsPerParty: Int,
+    @ConfigProperty(name = "openbank.campaign.quiet-hours-start", defaultValue = "21")
+    private val quietHoursStart: Int,
+    @ConfigProperty(name = "openbank.campaign.quiet-hours-end", defaultValue = "8")
+    private val quietHoursEnd: Int,
+) {
+
+    @GET
+    @Authorize(action = "campaign.read", resource = "#id")
+    suspend fun guardrails(): Response {
+        val platformDefaults = ContactPolicy()
+        return Response.ok(
+            CampaignContactGuardrails(
+                maxSendsPerParty = maxSendsPerParty,
+                sendWindowHours = platformDefaults.sendWindowSeconds / SECONDS_PER_HOUR,
+                quietHoursStart = quietHoursStart,
+                quietHoursEnd = quietHoursEnd,
+                timeZone = platformDefaults.quietZone,
+            ),
+        ).build()
+    }
+
+    private companion object {
+        const val SECONDS_PER_HOUR = 3_600L
+    }
+}

--- a/openbank-campaign-service/src/main/resources/openapi.yaml
+++ b/openbank-campaign-service/src/main/resources/openapi.yaml
@@ -4,7 +4,7 @@ openapi: 3.1.0
 info:
   title: Campaign Service API
   # major == openbank.api.version == URL /api/v1 (ADR-0048).
-  version: 1.32.0
+  version: 1.33.0
   description: >-
     Campaign management first slice (ADR-0200 / ADR-0209 D3): deterministic, versioned segments;
     per-enrolment Temporal journeys; consent-gated delivery through notification-service.
@@ -217,6 +217,24 @@ paths:
                       type: string
                       nullable: true
                       enum: [HOME_BANNER, HOME_CAROUSEL, PRODUCT_FEED, REWARDS_HUB]
+  /api/v1/campaigns/guardrails:
+    get:
+      tags: [Campaigns]
+      summary: Current outbound-contact guardrails for Campaign Studio
+      operationId: campaignContactGuardrails
+      description: >-
+        The active platform limit and quiet period for outbound campaign contacts. This is not a
+        forecast of the audience that will be allowed: consent, suppression and rolling counts are
+        evaluated live for each person immediately before delivery. In-app placements have their
+        own rendering-time impression policy and are not counted as outbound sends here.
+        NOTE the literal path segment: it must keep matching ahead of /api/v1/campaigns/{id}.
+      responses:
+        '200':
+          description: Current platform contact policy, safe to explain but not override from Studio
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CampaignContactGuardrails'
   /api/v1/campaigns/{id}:
     get:
       tags: [Campaigns]
@@ -869,6 +887,19 @@ components:
         cap ends the journey as STOPPED_MAX_SENDS. Absent means the journey runs every step.
       properties:
         maxSendsPerParty: { type: integer, minimum: 1 }
+    CampaignContactGuardrails:
+      type: object
+      required: [maxSendsPerParty, sendWindowHours, quietHoursStart, quietHoursEnd, timeZone]
+      description: >-
+        Platform-wide rules currently applied to every e-mail or push handoff. They are observable
+        to explain a launch, never author-editable. Consent and party-specific counts remain live
+        checks at delivery, so this object never claims how many people will receive a campaign.
+      properties:
+        maxSendsPerParty: { type: integer, minimum: 1, example: 2 }
+        sendWindowHours: { type: integer, minimum: 1, example: 168 }
+        quietHoursStart: { type: integer, minimum: 0, maximum: 23, example: 21 }
+        quietHoursEnd: { type: integer, minimum: 0, maximum: 23, example: 8 }
+        timeZone: { type: string, example: Europe/Prague }
     ApprovalRequest:
       type: object
       deprecated: true

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/integration/CampaignRestContractIT.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/integration/CampaignRestContractIT.kt
@@ -609,6 +609,21 @@ class CampaignRestContractIT {
         }
     }
 
+    /** Studio explains the live policy values but never turns them into a person-level delivery promise. */
+    @Test
+    fun `the contact guardrails are served with the active platform values`() {
+        When {
+            get("/api/v1/campaigns/guardrails")
+        } Then {
+            statusCode(200)
+            body("maxSendsPerParty", org.hamcrest.Matchers.equalTo(2))
+            body("sendWindowHours", org.hamcrest.Matchers.equalTo(168))
+            body("quietHoursStart", org.hamcrest.Matchers.equalTo(21))
+            body("quietHoursEnd", org.hamcrest.Matchers.equalTo(8))
+            body("timeZone", org.hamcrest.Matchers.equalTo("Europe/Prague"))
+        }
+    }
+
     /** A trigger key survives the round trip, so a campaign can declare what wakes it. */
     @Test
     fun `a campaign can declare a trigger and reads it back`() {


### PR DESCRIPTION
## What changed

- serves the current outbound contact cap and quiet-period policy from campaign-service
- shows verified policy, campaign-specific stop cap, and the live-consent caveat in Campaign Studio
- keeps person-level consent, suppression, and rolling-count decisions at delivery time rather than inventing a reach forecast

## Why

The launch panel previously said that guardrails existed but could not show the active values. Marketers now see the actual reviewable policy without gaining a bypass or a misleading delivery guarantee.

Refs #4476

## Verification

- `./gradlew --no-daemon :openbank-campaign-service:test --tests com.openbank.campaign.integration.CampaignRestContractIT --console=plain` (31 tests, 0 failures/skips)
- `./gradlew :openbank-campaign-service:compileKotlin :openbank-campaign-service:ktlintCheck`
- `npm test -- --run src/test/campaign-entry-catalogues-bff.test.ts src/test/campaign-experience-preview.test.tsx src/test/campaign-studio.test.tsx` (21 passed)
- `npm run type-check`
- `npm run lint -- --quiet`