### PR TITLE
feat(admin-ui): guide campaign attention decisions

### DIFF
--- a/openbank-admin-ui/src/app/campaigns/[id]/page.tsx
+++ b/openbank-admin-ui/src/app/campaigns/[id]/page.tsx
@@ -737,7 +737,13 @@ export default function CampaignDetailPage({ params }: { params: Promise<{ id: s
             )}
           </section>
 
-          {detail?.sources?.engagement === 'ok' && <CampaignAttentionFunnel metrics={engagement} />}
+          {detail?.sources?.engagement === 'ok' && (
+            <CampaignAttentionFunnel
+              metrics={engagement}
+              hasMeasuredOutcome={c.conversionRule !== null && c.conversionRule !== undefined}
+              hasHoldout={(c.holdoutPercent ?? 0) > 0}
+            />
+          )}
 
           <section className="space-y-2">
             <h2 className="text-sm font-semibold">{t('Čtyři oči', 'Four-eyes')}</h2>

--- a/openbank-admin-ui/src/app/globals.css
+++ b/openbank-admin-ui/src/app/globals.css
@@ -563,6 +563,13 @@ main {
 .campaign-attention-heading h2 { color: #17223a; font-size: 1.05rem; font-weight: 800; letter-spacing: -.025em; margin-top: .18rem; }
 .campaign-attention-heading > span { background: #e9f7f6; border: 1px solid #bee9e4; border-radius: 99px; color: #14746f; font-size: .63rem; font-weight: 800; padding: .32rem .55rem; white-space: nowrap; }
 .campaign-attention-intro { color: var(--text-secondary); font-size: .72rem; line-height: 1.45; margin-top: .55rem; max-width: 46rem; }
+.campaign-attention-insight { align-items: flex-start; background: linear-gradient(125deg, #f4f2ff, #f8fbff); border: 1px solid #dcd7ff; border-radius: .85rem; color: #273552; display: flex; gap: .65rem; margin-top: .82rem; padding: .72rem .78rem; }
+.campaign-attention-insight > svg { color: #625bd2; flex: 0 0 auto; height: 1rem; margin-top: .08rem; width: 1rem; }
+.campaign-attention-insight > div { display: grid; gap: .12rem; min-width: 0; }
+.campaign-attention-insight p { color: #6256af; font-size: .6rem; font-weight: 800; letter-spacing: .08em; text-transform: uppercase; }
+.campaign-attention-insight strong { color: #263250; font-size: .78rem; font-weight: 800; line-height: 1.25; }
+.campaign-attention-insight span { color: #66738a; font-size: .69rem; line-height: 1.4; }
+.campaign-attention-insight small { color: #4c5a75; font-size: .64rem; font-variant-numeric: tabular-nums; margin-top: .12rem; }
 .campaign-attention-empty { background: rgba(255,255,255,.75); border: 1px dashed #cdd8e8; border-radius: .75rem; color: var(--text-secondary); font-size: .73rem; margin-top: .85rem; padding: .72rem .8rem; }
 .campaign-attention-grid { display: grid; gap: .65rem; grid-template-columns: repeat(auto-fit, minmax(14rem, 1fr)); margin-top: .9rem; }
 .campaign-attention-card { background: rgba(255,255,255,.88); border: 1px solid #e1e8f3; border-radius: .85rem; min-width: 0; padding: .8rem; }

--- a/openbank-admin-ui/src/components/campaigns/CampaignAttentionFunnel.tsx
+++ b/openbank-admin-ui/src/components/campaigns/CampaignAttentionFunnel.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
 
-import { Eye, MousePointer2, X } from 'lucide-react'
+import { Eye, Lightbulb, MousePointer2, X } from 'lucide-react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 
 export type CampaignAttentionMetric = {
@@ -21,6 +21,12 @@ type AttentionRow = {
   dismissals: number
 }
 
+type SurfaceEvidence = {
+  surface: CampaignAttentionMetric['surface']
+  impressions: number
+  clicks: number
+}
+
 function labels(t: (cs: string, en: string) => string) {
   return {
     channel: { PUSH: t('Push do aplikace', 'App push'), BANNER: t('Obsah v aplikaci', 'In-app content') },
@@ -33,8 +39,23 @@ function labels(t: (cs: string, en: string) => string) {
   }
 }
 
-/** Shows only verified app events; a delivery handoff is never treated as a made-up impression. */
-export function CampaignAttentionFunnel({ metrics }: { metrics: CampaignAttentionMetric[] }) {
+/**
+ * Shows only verified app events; a delivery handoff is never treated as a made-up impression.
+ *
+ * The resulting prompt is deliberately an *evidence* next step, not a recommendation engine:
+ * app attention can help someone decide what to inspect next, but cannot establish product value
+ * or causal lift. That distinction is important enough to live beside the numbers rather than in
+ * a tooltip at the bottom of the screen.
+ */
+export function CampaignAttentionFunnel({
+  metrics,
+  hasMeasuredOutcome,
+  hasHoldout,
+}: {
+  metrics: CampaignAttentionMetric[]
+  hasMeasuredOutcome: boolean
+  hasHoldout: boolean
+}) {
   const { t, language } = useLanguage()
   const copy = labels(t)
   const rows = new Map<string, AttentionRow>()
@@ -48,7 +69,47 @@ export function CampaignAttentionFunnel({ metrics }: { metrics: CampaignAttentio
   }
   const ordered = [...rows.values()].sort((a, b) => a.stepOrder - b.stepOrder || a.channel.localeCompare(b.channel) || a.surface.localeCompare(b.surface))
   const formatNumber = (value: number) => value.toLocaleString(language === 'cs' ? 'cs-CZ' : 'en-GB')
-  const formatRate = (clicks: number, impressions: number) => impressions > 0 ? `${((clicks / impressions) * 100).toFixed(1)} %` : '—'
+  // These are independent aggregate events, not a deduplicated impression → click funnel. The
+  // ratio is therefore a compact comparison of event volumes, and is intentionally allowed to
+  // exceed 100% when the app records clicks without a prior impression event.
+  const formatEventRatio = (clicks: number, impressions: number) => impressions > 0 ? `${((clicks / impressions) * 100).toFixed(1)} %` : '—'
+  const evidenceBySurface = new Map<CampaignAttentionMetric['surface'], SurfaceEvidence>()
+  for (const row of ordered) {
+    const evidence = evidenceBySurface.get(row.surface) ?? { surface: row.surface, impressions: 0, clicks: 0 }
+    evidence.impressions += row.impressions
+    evidence.clicks += row.clicks
+    evidenceBySurface.set(row.surface, evidence)
+  }
+  const observed = [...evidenceBySurface.values()]
+    .filter(surface => surface.impressions > 0)
+    // Select an app surface by all of its observed rows, never by the most flattering individual
+    // step or channel. A rate can help exploration, but does not imply a winning funnel.
+    .sort((a, b) => b.impressions - a.impressions || b.clicks - a.clicks)[0]
+  const observedDescription = observed
+    ? t(
+      `${formatNumber(observed.clicks)} událostí otevření; ${formatNumber(observed.impressions)} událostí zobrazení na ploše ${copy.surface[observed.surface]} (poměr událostí ${formatEventRatio(observed.clicks, observed.impressions)}).`,
+      `${formatNumber(observed.clicks)} click events; ${formatNumber(observed.impressions)} impression events on ${copy.surface[observed.surface]} (event ratio ${formatEventRatio(observed.clicks, observed.impressions)}).`,
+    )
+    : null
+  const insight = !observed
+    ? {
+      title: t('Počkejte na první ověřené zobrazení', 'Wait for the first verified exposure'),
+      detail: t('Dokud aplikace nepotvrdí zobrazení, není z čeho posuzovat obsah ani plochu.', 'Until the app confirms an exposure, there is no basis to assess the content or surface.'),
+    }
+    : !hasMeasuredOutcome
+      ? {
+        title: t('Než zvolíte vítěznou plochu, změřte cíl', 'Set a measurable outcome before choosing a surface'),
+        detail: t('Otevření ukazuje pozornost v aplikaci; samo o sobě není bankovní výsledek.', 'A tap shows attention in the app; it is not a banking outcome on its own.'),
+      }
+      : !hasHoldout
+        ? {
+          title: t('Porovnejte pozornost se skutečným výsledkem', 'Compare attention with the real outcome'),
+          detail: t('Před změnou cesty ověřte, zda se pozorovaná odezva potkává s měřeným cílem. Tohle srovnání ještě neprokazuje příčinu.', 'Before changing the journey, check whether observed attention aligns with the measured outcome. That comparison does not establish causality yet.'),
+        }
+        : {
+          title: t('Ověřte účinek přes kontrolní skupinu', 'Validate the effect with the control group'),
+          detail: t('Pozornost určí, co zkoumat; teprve kontrolní skupina ukáže, zda cesta přidala skutečnou hodnotu.', 'Attention tells you what to investigate; only the control group can show whether the journey added real value.'),
+        }
 
   return (
     <section className="campaign-attention-funnel" data-testid="campaign-attention-funnel">
@@ -57,6 +118,15 @@ export function CampaignAttentionFunnel({ metrics }: { metrics: CampaignAttentio
         <span>{t('bez domněnek', 'no inference')}</span>
       </div>
       <p className="campaign-attention-intro">{t('Imprese, otevření a zavření jsou připsané jen přes ověřený odkaz kampaně. Nejsou to lidé ani obchodní konverze.', 'Impressions, taps and dismissals are shown only for a verified campaign reference. They are neither people nor business conversions.')}</p>
+      <aside className="campaign-attention-insight" data-testid="campaign-attention-next-evidence">
+        <Lightbulb aria-hidden="true" />
+        <div>
+          <p>{t('Další krok s daty', 'Next evidence step')}</p>
+          <strong>{insight.title}</strong>
+          <span>{insight.detail}</span>
+          {observedDescription && <small>{observedDescription}</small>}
+        </div>
+      </aside>
       {ordered.length === 0 ? (
         <p className="campaign-attention-empty">{t('Zatím nepřišla žádná přiřaditelná odezva z aplikace.', 'No attributable app response has arrived yet.')}</p>
       ) : (
@@ -65,11 +135,11 @@ export function CampaignAttentionFunnel({ metrics }: { metrics: CampaignAttentio
             <article key={`${row.stepOrder}-${row.channel}-${row.surface}`} className="campaign-attention-card">
               <div className="campaign-attention-card-heading"><span>{t(`Krok ${row.stepOrder}`, `Step ${row.stepOrder}`)}</span><strong>{copy.surface[row.surface]}</strong><small>{copy.channel[row.channel]}</small></div>
               <div className="campaign-attention-metrics">
-                <div><Eye aria-hidden="true" /><strong>{formatNumber(row.impressions)}</strong><span>{t('viděno', 'seen')}</span></div>
-                <div><MousePointer2 aria-hidden="true" /><strong>{formatNumber(row.clicks)}</strong><span>{t('otevřeno', 'tapped')}</span></div>
-                <div><X aria-hidden="true" /><strong>{formatNumber(row.dismissals)}</strong><span>{t('zavřeno', 'dismissed')}</span></div>
+                <div><Eye aria-hidden="true" /><strong>{formatNumber(row.impressions)}</strong><span>{t('události zobrazení', 'impression events')}</span></div>
+                <div><MousePointer2 aria-hidden="true" /><strong>{formatNumber(row.clicks)}</strong><span>{t('události otevření', 'click events')}</span></div>
+                <div><X aria-hidden="true" /><strong>{formatNumber(row.dismissals)}</strong><span>{t('události zavření', 'dismiss events')}</span></div>
               </div>
-              <p>{t('Míra otevření', 'Tap rate')} <strong>{formatRate(row.clicks, row.impressions)}</strong></p>
+              <p>{t('Poměr událostí otevření / zobrazení', 'Click-event / impression-event ratio')} <strong>{formatEventRatio(row.clicks, row.impressions)}</strong></p>
             </article>
           ))}
         </div>

--- a/openbank-admin-ui/src/test/campaign-studio.test.tsx
+++ b/openbank-admin-ui/src/test/campaign-studio.test.tsx
@@ -261,6 +261,82 @@ describe('campaign studio', () => {
     expect(funnel.getByText('Home banner')).toBeTruthy()
     expect(funnel.getByText('120')).toBeTruthy()
     expect(funnel.getByText('15.0 %')).toBeTruthy()
+    expect(funnel.getByText('Click-event / impression-event ratio')).toBeTruthy()
+    expect(within(screen.getByTestId('campaign-attention-next-evidence')).getByText('Set a measurable outcome before choosing a surface')).toBeTruthy()
+    expect(funnel.getByText(/18 click events; 120 impression events on Home banner/)).toBeTruthy()
+  }, 15000)
+
+  it('keeps independent app events out of a made-up attention funnel', async () => {
+    const active = detail('ACTIVE')
+    vi.stubGlobal('fetch', mockFetch({
+      [`/api/campaigns/${CAMPAIGN_ID}`]: {
+        ...active,
+        engagement: [
+          { stepOrder: 1, channel: 'BANNER', surface: 'HOME_BANNER', type: 'IMPRESSION', count: 12 },
+          { stepOrder: 1, channel: 'BANNER', surface: 'HOME_BANNER', type: 'CLICK', count: 18 },
+          // An independently observed click is valid, but does not create an exposure path.
+          { stepOrder: 2, channel: 'PUSH', surface: 'PRODUCT_FEED', type: 'CLICK', count: 3 },
+        ],
+        sources: { ...active.sources, engagement: 'ok' },
+      },
+    }))
+    renderDetail()
+
+    await waitFor(() => expect(screen.getByTestId('campaign-attention-funnel')).toBeTruthy(), { timeout: 8000 })
+    const funnel = within(screen.getByTestId('campaign-attention-funnel'))
+    expect(funnel.getByText('150.0 %')).toBeTruthy()
+    expect(funnel.getByText(/18 click events; 12 impression events on Home banner \(event ratio 150.0 %\)/)).toBeTruthy()
+    expect(funnel.getAllByText('Click-event / impression-event ratio')).toHaveLength(2)
+  }, 15000)
+
+  it('chooses next evidence from all observed rows on an app surface', async () => {
+    const active = detail('ACTIVE')
+    vi.stubGlobal('fetch', mockFetch({
+      [`/api/campaigns/${CAMPAIGN_ID}`]: {
+        ...active,
+        engagement: [
+          { stepOrder: 1, channel: 'PUSH', surface: 'HOME_BANNER', type: 'IMPRESSION', count: 80 },
+          { stepOrder: 2, channel: 'BANNER', surface: 'HOME_BANNER', type: 'IMPRESSION', count: 80 },
+          { stepOrder: 1, channel: 'BANNER', surface: 'HOME_CAROUSEL', type: 'IMPRESSION', count: 150 },
+        ],
+        sources: { ...active.sources, engagement: 'ok' },
+      },
+    }))
+    renderDetail()
+
+    await waitFor(() => expect(screen.getByTestId('campaign-attention-next-evidence')).toBeTruthy(), { timeout: 8000 })
+    expect(within(screen.getByTestId('campaign-attention-next-evidence')).getByText(/0 click events; 160 impression events on Home banner/)).toBeTruthy()
+  }, 15000)
+
+  it('uses holdout results, not app taps, for an incrementality decision', async () => {
+    const active = detail('ACTIVE')
+    vi.stubGlobal('fetch', mockFetch({
+      [`/api/campaigns/${CAMPAIGN_ID}`]: {
+        ...active,
+        campaign: { ...active.campaign, conversionRule: 'ACCOUNT_OPENED', holdoutPercent: 10 },
+        engagement: [{ stepOrder: 1, channel: 'BANNER', surface: 'HOME_CAROUSEL', type: 'IMPRESSION', count: 40 }],
+        sources: { ...active.sources, engagement: 'ok' },
+      },
+    }))
+    renderDetail()
+
+    await waitFor(() => expect(screen.getByTestId('campaign-attention-next-evidence')).toBeTruthy(), { timeout: 8000 })
+    expect(screen.getByText('Validate the effect with the control group')).toBeTruthy()
+  }, 15000)
+
+  it('does not fabricate a surface insight before the app confirms an exposure', async () => {
+    const active = detail('ACTIVE')
+    vi.stubGlobal('fetch', mockFetch({
+      [`/api/campaigns/${CAMPAIGN_ID}`]: {
+        ...active,
+        engagement: [],
+        sources: { ...active.sources, engagement: 'ok' },
+      },
+    }))
+    renderDetail()
+
+    await waitFor(() => expect(screen.getByTestId('campaign-attention-next-evidence')).toBeTruthy(), { timeout: 8000 })
+    expect(screen.getByText('Wait for the first verified exposure')).toBeTruthy()
   }, 15000)
 
   it('submits an opted-in consent fallback as part of the step definition', async () => {


### PR DESCRIPTION
Refs #4476

## What changes
- turns verified per-surface app attention into an explicit next evidence step
- distinguishes no exposure, attention-only, measured outcome, and holdout-backed evaluation
- keeps click/tap signals separate from business conversion and causal claims

## Verification
- `npm test -- --run src/test/campaign-studio.test.tsx` (17 passing)
- `npm run type-check`
- `npm run lint -- --quiet`
- `git diff --check`