### PR TITLE
fix(admin-ui): derive readiness money-path set from rules.yaml

### DIFF
--- a/openbank-admin-ui/scripts/collect-prod-readiness.mjs
+++ b/openbank-admin-ui/scripts/collect-prod-readiness.mjs
@@ -38,15 +38,56 @@ const OUT    = path.resolve(getArg('--out', path.resolve(__dirname, '..', 'prod-
 const TODAY  = process.env.READINESS_TODAY ?? new Date().toISOString().slice(0, 10)
 
 // ---------------------------------------------------------------------------
-// Money-path services (mirrors rules.yaml: money_path_services).
-// Short names (strip openbank-…-service).
+// Money-path services — DERIVED from rules.yaml: money_path_services.
+//
+// This used to be a hand-copied literal of 14 short names "mirroring" rules.yaml. It drifted,
+// exactly as CLAUDE.md says a second copy of a governance list always does: rules.yaml declared
+// 23 and this file listed 14, so NINE declared money-path services (billing, delegation,
+// interest, psd2, sanctions, sdd, settlement, standing-order, vop) were scored with the LENIENT
+// non-money-path gate — and billing and sdd therefore read GO in the shipped matrix, billing
+// being a service rules.yaml itself records as still gated on "real-env e2e verification +
+// four-eyes enforcement flip" (#2365).
+//
+// The Python collector fixed precisely this under #2364 (gitops_facts.money_path_services) —
+// but the deploy build runs THIS file (package.json `prebuild`, admin-ui-deploy.yml), so the
+// fix landed in the copy CI never executes and the shipped artifact kept the stale literal.
+// Deriving is the only form that cannot drift again.
+//
+// Throws when the list cannot be read: an empty set would make every service non-money-path and
+// silently relax the gate for all of them — the reassuring-answer-from-a-broken-probe failure
+// this repo keeps finding. Failing the build is the correct outcome.
 // ---------------------------------------------------------------------------
-const MONEY_PATH = new Set([
-  'ledger', 'transaction', 'account', 'balance',
-  'sepa-payment', 'sepa-instant', 'domestic-payment',
-  'clearing', 'swift', 'fx',
-  'lending', 'sca', 'consent', 'fraud',
-])
+function moneyPathServices() {
+  const rules = path.join(REPO, 'openbank-libs', 'governance', 'rules.yaml')
+  const text = readText(rules)
+  if (!text.includes('money_path_services:')) {
+    throw new Error(
+      `money_path_services not found in ${rules} — refusing to score with an empty money-path ` +
+      `set, which would relax the gate for every service`,
+    )
+  }
+  const out = new Set()
+  for (const line of text.split('money_path_services:')[1].split('\n')) {
+    const m = line.match(/^\s+-\s+openbank-([a-z0-9-]+?)(?:-service)?\s*(?:#.*)?$/)
+    if (m) { out.add(m[1]); continue }
+    // dedented out of the list
+    if (line.trim() && !line.trim().startsWith('#') && !line.startsWith('    ')) break
+  }
+  if (out.size === 0) {
+    throw new Error(
+      `money_path_services in ${rules} parsed to an empty set — refusing to score, since that ` +
+      `would silently relax the gate for every service`,
+    )
+  }
+  return out
+}
+
+let _moneyPath = null
+/** Memoised money-path set. Lazy so the throw lands at collect time, not import time. */
+function moneyPath() {
+  if (_moneyPath === null) _moneyPath = moneyPathServices()
+  return _moneyPath
+}
 
 const DIMENSIONS = [
   { code: 'C1', name: 'Kód' },
@@ -63,7 +104,19 @@ const DIMENSIONS = [
 // ---------------------------------------------------------------------------
 // helpers
 // ---------------------------------------------------------------------------
+/**
+ * The module's directory, whichever naming shape it uses.
+ *
+ * openbank-sepa-payment, openbank-sepa-instant and openbank-domestic-payment carry no `-service`
+ * suffix, so the `-service`-only form resolved to a path that does not exist and every scorer
+ * read 0 for them. Falls back to the `-service` shape so a caller reporting on a missing module
+ * still gets a sensible path. Mirrors gitops_facts.module_dir.
+ */
 function svcDir(short) {
+  for (const shape of [`openbank-${short}-service`, `openbank-${short}`]) {
+    const candidate = path.join(REPO, shape)
+    try { if (statSync(candidate).isDirectory()) return candidate } catch { /* next shape */ }
+  }
   return path.join(REPO, `openbank-${short}-service`)
 }
 
@@ -339,7 +392,7 @@ const SCORERS = [
 // Gate logic
 // ---------------------------------------------------------------------------
 function computeGate(short, scores) {
-  const mp = MONEY_PATH.has(short)
+  const mp = moneyPath().has(short)
   const critical = new Set(['C1', 'C5', 'C7'])
   for (const { code } of DIMENSIONS) {
     const need = mp && critical.has(code) ? 3 : 2
@@ -351,16 +404,30 @@ function computeGate(short, scores) {
 // ---------------------------------------------------------------------------
 // Service discovery
 // ---------------------------------------------------------------------------
+/**
+ * Every module the matrix scores: the `-service` modules PLUS every declared money-path one.
+ *
+ * The `openbank-*-service` glob alone missed openbank-sepa-payment, openbank-sepa-instant and
+ * openbank-domestic-payment — three released components which rules.yaml declares money-path and
+ * which move SEPA and domestic payments. They had no row at all, so every headline this collector
+ * produced silently excluded them (#2364, fixed in the Python collector only; #2365).
+ *
+ * Deliberately NOT widened to every module carrying a governance.yaml: that is a scoping decision
+ * about what the matrix covers, not a correctness fix. Mirrors prod-readiness-collector.all_services.
+ */
 function allServices() {
-  const out = []
+  const out = new Set()
   for (const entry of readdirSync(REPO).sort()) {
     const m = entry.match(/^openbank-(.+)-service$/)
     if (!m) continue
     const d = path.join(REPO, entry)
     try { if (!statSync(d).isDirectory()) continue } catch { continue }
-    out.push(m[1])
+    out.add(m[1])
   }
-  return out
+  for (const short of moneyPath()) {
+    try { if (statSync(svcDir(short)).isDirectory()) out.add(short) } catch { /* absent module */ }
+  }
+  return [...out].sort()
 }
 
 // ---------------------------------------------------------------------------
@@ -375,7 +442,7 @@ function collectService(short) {
     evidence[code] = ev
   }
   const gate = computeGate(short, scores)
-  return { service: short, money_path: MONEY_PATH.has(short), scores, evidence, gate }
+  return { service: short, money_path: moneyPath().has(short), scores, evidence, gate }
 }
 
 // ---------------------------------------------------------------------------

--- a/openbank-admin-ui/src/test/prod-readiness-money-path.test.ts
+++ b/openbank-admin-ui/src/test/prod-readiness-money-path.test.ts
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import { execFileSync } from 'child_process'
+import { mkdtempSync, readFileSync, writeFileSync, mkdirSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import path from 'path'
+import { afterAll, describe, expect, it } from 'vitest'
+
+// The readiness collector's money-path set decides which services face the STRICT gate
+// (C1/C5/C7 >= 3) rather than the lenient one (all >= 2). It used to be a hand-copied literal
+// "mirroring" rules.yaml, and it drifted: rules.yaml declared 23 money-path services, the
+// literal listed 14. Nine were scored leniently — billing and sdd read GO in the shipped
+// matrix — and three suffixless modules (sepa-payment, sepa-instant, domestic-payment) had no
+// row at all. Both defects were fixed in the Python collector under #2364, but the deploy build
+// runs the .mjs, so the shipped artifact kept the stale literal (#2365).
+//
+// These tests assert the property that makes a repeat impossible: the set is DERIVED, every
+// declared money-path service gets a row and the strict gate, and an unreadable list fails loudly
+// instead of relaxing the gate for everyone.
+
+const REPO = path.resolve(__dirname, '..', '..', '..')
+const SCRIPT = path.join(REPO, 'openbank-admin-ui', 'scripts', 'collect-prod-readiness.mjs')
+const tmps: string[] = []
+
+function declaredMoneyPath(): Set<string> {
+  const text = readFileSync(path.join(REPO, 'openbank-libs', 'governance', 'rules.yaml'), 'utf-8')
+  const out = new Set<string>()
+  for (const line of text.split('money_path_services:')[1].split('\n')) {
+    const m = line.match(/^\s+-\s+openbank-([a-z0-9-]+?)(?:-service)?\s*(?:#.*)?$/)
+    if (m) { out.add(m[1]); continue }
+    if (line.trim() && !line.trim().startsWith('#') && !line.startsWith('    ')) break
+  }
+  return out
+}
+
+function runCollector(repo = REPO): { service: string; money_path: boolean; gate: string }[] {
+  const dir = mkdtempSync(path.join(tmpdir(), 'readiness-'))
+  tmps.push(dir)
+  const out = path.join(dir, 'prod-readiness.json')
+  execFileSync('node', [SCRIPT, '--repo', repo, '--out', out], { stdio: 'pipe' })
+  const doc = JSON.parse(readFileSync(out, 'utf-8'))
+  return doc.services ?? doc
+}
+
+describe('readiness collector money-path set', () => {
+  afterAll(() => { for (const d of tmps) rmSync(d, { recursive: true, force: true }) })
+
+  const services = runCollector()
+  const byName = new Map(services.map(s => [s.service, s]))
+  const declared = declaredMoneyPath()
+
+  it('declares a non-trivial money-path set (guards the parser itself)', () => {
+    // A known-positive: if this parse silently returned {} the assertions below would all
+    // pass vacuously, which is the exact failure this test exists to prevent.
+    expect(declared.size).toBeGreaterThan(15)
+    expect(declared.has('ledger')).toBe(true)
+  })
+
+  it('scores a row for every service rules.yaml declares money-path', () => {
+    const missing = [...declared].filter(s => !byName.has(s))
+    expect(missing).toEqual([])
+  })
+
+  it('marks every declared money-path service money_path, with no drift in either direction', () => {
+    const collected = new Set(services.filter(s => s.money_path).map(s => s.service))
+    expect([...collected].sort()).toEqual([...declared].sort())
+  })
+
+  it('applies the strict gate: no declared money-path service reads GO without bank-grade C1/C5/C7', () => {
+    // billing and sdd read GO before the fix purely because they were absent from the literal.
+    const scored = services.filter(s => s.money_path) as unknown as
+      { service: string; gate: string; scores: Record<string, number> }[]
+    for (const s of scored) {
+      if (s.gate === 'GO') {
+        for (const c of ['C1', 'C5', 'C7']) expect(s.scores[c]).toBeGreaterThanOrEqual(3)
+      }
+    }
+  })
+
+  it('refuses to score when the money-path list cannot be read, instead of relaxing the gate', () => {
+    const fake = mkdtempSync(path.join(tmpdir(), 'readiness-norules-'))
+    tmps.push(fake)
+    mkdirSync(path.join(fake, 'openbank-libs', 'governance'), { recursive: true })
+    writeFileSync(path.join(fake, 'openbank-libs', 'governance', 'rules.yaml'), 'other_key: []\n')
+    mkdirSync(path.join(fake, 'openbank-ledger-service'), { recursive: true })
+    expect(() => runCollector(fake)).toThrow()
+  })
+})


### PR DESCRIPTION
## What

The production-readiness collector's money-path set decides which services face the **strict** gate (`C1/C5/C7 >= 3`) rather than the lenient one (all `>= 2`). It was a hand-copied literal of 14 short names "mirroring" `rules.yaml`, and it drifted — `rules.yaml` declares **23**.

This is the `#2365` NO-GO gate itself, and it was not evaluating half the population it exists to gate.

## Measured on `origin/main`

Two independent defects in `openbank-admin-ui/scripts/collect-prod-readiness.mjs`:

1. **Nine declared money-path services were scored with the lenient gate** — `billing`, `delegation`, `interest`, `psd2`, `sanctions`, `sdd`, `settlement`, `standing-order`, `vop`. Two of them read **GO** in the shipped matrix:

   | service | `money_path` before | gate before | gate after | Python collector |
   | --- | --- | --- | --- | --- |
   | `billing` | `false` | **GO** | NO-GO | NO-GO |
   | `sdd` | `false` | **GO** | NO-GO | NO-GO |

   `billing` is a service `rules.yaml` itself records as still gated on *"real-env e2e verification + four-eyes enforcement flip"*.

2. **Three suffixless modules had no row at all** — `openbank-sepa-payment`, `openbank-sepa-instant`, `openbank-domestic-payment` — because discovery matched only `^openbank-(.+)-service$` and `svcDir()` only built the `-service` shape.

Both were fixed in `prod-readiness-collector.py` under #2364. But the deploy build runs **this `.mjs`** (`package.json` `prebuild`, `admin-ui-deploy.yml`), so the fix landed in the copy CI never executes and the shipped artifact kept the stale literal. `route.ts`'s comment claiming the deploy build runs the `.py` is what made this invisible.

## Before / after

```
money-path rows        11  ->  23      (Python reference: 23)
critical cells >= 3     3/33 -> 3/69   (the denominator #2365 counts)
money-path reading GO   billing, sdd -> none
```

No score changes for any service that was already money-path, and the gate verdict now agrees with the Python collector for **all 23**. The pre-existing `.mjs`/`.py` scorer divergence on `fraud` and `fx` is untouched and out of scope.

## How

Mirrors the reference implementations rather than re-copying a list:

- `moneyPathServices()` parses `rules.yaml: money_path_services` (`gitops_facts.money_path_services`)
- `svcDir()` resolves either directory shape (`gitops_facts.module_dir`)
- `allServices()` adds every declared money-path module regardless of suffix (`prod-readiness-collector.all_services`)

An unreadable or empty list now **throws**. An empty set would have made every service non-money-path and silently relaxed the gate for all of them — the reassuring-answer-from-a-broken-probe failure this repo keeps finding, so failing the build is the correct outcome.

## Tests

`src/test/prod-readiness-money-path.test.ts` asserts the *property*, not the list, so the literal cannot come back:

- every declared money-path service gets a row
- the collected money-path set equals the declared set **in both directions**
- no money-path service reads GO without bank-grade `C1/C5/C7`
- an unreadable list fails loudly rather than relaxing the gate
- a known-positive guard on the parser itself, so the other assertions cannot pass vacuously

**Validated against the pre-fix collector: 3 of the 5 go red.** Full suite green (95 files / 1218 tests), lint 0 errors.

## Not in scope

`prod-readiness-collector.py` still uses the crude `365/30` date arithmetic for TTL decay that #3929 fixed in the `.mjs` — it counts `ledger.pentest` as fresh on 2026-08-17 and `consent.pentest` on 2026-08-19, one day past each real expiry. Reported on #2365; not fixed here to keep this diff to the money-path set.

Refs #2365
