### PR TITLE
feat(admin-ui): render agent outcome metrics with their denominator

### DIFF
--- a/openbank-admin-ui/src/app/iaops/agents/[agentId]/page.tsx
+++ b/openbank-admin-ui/src/app/iaops/agents/[agentId]/page.tsx
@@ -15,6 +15,7 @@ import type { UnavailableKind } from '@/components/feedback/DataUnavailable'
 import { AgentPortrait, getAgentPersona } from '@/components/agent/AgentIdentity'
 import { AgentBodyAnalysis, AgentMeshMap } from '@/components/agent/AgentDiagnostics'
 import type { AgentDiagnostic, AgentMeshSummary } from '@/lib/governance/agentDiagnostics'
+import { OutcomeMetricsCard } from '@/components/agent/AgentOutcomes'
 
 // ── Types (mirror /api/iaops/agents/[agentId]) ─────────────────────────────
 interface Schedule { daily: string | null; reactive: string | null }
@@ -137,7 +138,6 @@ function Card({ children }: { children: React.ReactNode }) {
     </div>
   )
 }
-
 const STATE_PILL: Record<string, { color: string; bg: string }> = {
   PROPOSED: { color: '#d97706', bg: '#fef9c3' },
   APPROVED: { color: '#16a34a', bg: '#dcfce7' },
@@ -345,6 +345,9 @@ function AgentDetailContent() {
               </div>
             </Card>
           )}
+
+          {/* Outcome metrics (#4462) — every figure carries its own denominator. */}
+          {data.proposals.available && <OutcomeMetricsCard items={data.proposals.items} />}
 
           {/* Proposal history */}
           <Card>

--- a/openbank-admin-ui/src/components/agent/AgentOutcomes.tsx
+++ b/openbank-admin-ui/src/components/agent/AgentOutcomes.tsx
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+'use client'
+
+import { Sparkles } from 'lucide-react'
+import { useLanguage } from '@/lib/i18n/LanguageContext'
+import {
+  deriveAgentOutcomes,
+  formatLatency,
+  MIN_DECIDED_FOR_RATE,
+  PROPOSAL_PAGE_CAP,
+  type ProposalOutcomeInput,
+} from '@/lib/governance/agentOutcomes'
+
+function Card({ children }: { children: React.ReactNode }) {
+  return (
+    <div style={{ background: 'var(--surface)', border: '1px solid var(--border)',
+      borderRadius: 'var(--r-lg)', padding: '20px 24px', marginBottom: '20px' }}>
+      {children}
+    </div>
+  )
+}
+
+
+// ── Outcome metrics (#4462) ────────────────────────────────────────────────
+// Acceptance rate and review latency for one charter, from the ADR-0031 D4 proposal
+// store. Every figure is rendered WITH its denominator, and the denominators differ:
+// the rate is over decided proposals, the latency over decided proposals whose two
+// timestamps are both usable. A rate without its coverage would be the UI version of
+// a gate that passes without reaching its subject, so the coverage line is not
+// optional chrome — it is the reason this panel can be shown at all.
+function Figure({ label, value, sub }: { label: string; value: string; sub: string }) {
+  return (
+    <div style={{ flex: '1 1 140px' }}>
+      <div style={{ fontSize: '10px', textTransform: 'uppercase', letterSpacing: '0.04em', color: 'var(--text-tertiary)' }}>{label}</div>
+      <div style={{ fontSize: '22px', fontWeight: 700, color: 'var(--text-primary)', lineHeight: 1.3 }}>{value}</div>
+      <div style={{ fontSize: '11px', color: 'var(--text-tertiary)' }}>{sub}</div>
+    </div>
+  )
+}
+
+export function OutcomeMetricsCard({ items }: { items: ProposalOutcomeInput[] }) {
+  const { t } = useLanguage()
+  const m = deriveAgentOutcomes(items)
+
+  return (
+    <Card>
+      <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '4px' }}>
+        <Sparkles size={14} style={{ color: '#6366f1' }} />
+        <span style={{ fontSize: '13px', fontWeight: 700 }}>{t('Výsledky návrhů', 'Proposal outcomes')}</span>
+      </div>
+      <p style={{ fontSize: '11px', color: 'var(--text-tertiary)', margin: '0 0 14px' }}>
+        {t(
+          'Z úložiště návrhů (ADR-0031 D4), ne z auditní stopy — rozhodnutí tam nese schvalovatele i čas u 100 % případů.',
+          'From the proposal store (ADR-0031 D4), not the audit trail — a decision there carries its approver and its time on 100% of rows.',
+        )}
+      </p>
+
+      {items.length === 0 ? (
+        <div style={{ fontSize: '12px', color: 'var(--text-tertiary)' }}>
+          {t('Žádné návrhy — není co měřit.', 'No proposals — nothing to measure.')}
+        </div>
+      ) : (
+        <>
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: '20px' }}>
+            <Figure
+              label={t('Míra schválení', 'Approval rate')}
+              value={m.approvalRate === null ? t('nedostatek dat', 'insufficient data') : `${Math.round(m.approvalRate * 100)}%`}
+              sub={m.approvalRate === null
+                ? t(`${m.decided} rozhodnuto, potřeba ${MIN_DECIDED_FOR_RATE}`, `${m.decided} decided, needs ${MIN_DECIDED_FOR_RATE}`)
+                : t(`${m.approved} z ${m.decided} rozhodnutých`, `${m.approved} of ${m.decided} decided`)}
+            />
+            <Figure
+              label={t('Latence — medián', 'Review latency — median')}
+              value={m.latencyP50Seconds === null ? t('nedostatek dat', 'insufficient data') : formatLatency(m.latencyP50Seconds)}
+              sub={t(`${m.latencySamples} vzorků`, `${m.latencySamples} samples`)}
+            />
+            <Figure
+              label={t('Latence — p95', 'Review latency — p95')}
+              value={m.latencyP95Seconds === null ? t('nedostatek dat', 'insufficient data') : formatLatency(m.latencyP95Seconds)}
+              sub={t(`${m.latencySamples} vzorků`, `${m.latencySamples} samples`)}
+            />
+          </div>
+
+          {/* Coverage — the denominator, stated rather than implied. */}
+          <div style={{ marginTop: '14px', paddingTop: '12px', borderTop: '1px solid var(--border)', fontSize: '11px', color: 'var(--text-secondary)', lineHeight: 1.7 }}>
+            <div>
+              {t(
+                `Pokrytí: ${m.decided} z ${m.total} návrhů rozhodnuto (${m.pending} stále čeká a do žádné míry nevstupuje).`,
+                `Coverage: ${m.decided} of ${m.total} proposals decided (${m.pending} still pending, and in no rate's denominator).`,
+              )}
+            </div>
+            <div>
+              {t(
+                `Latence měřena na ${m.latencySamples} z ${m.decided} rozhodnutých${m.latencyExcluded > 0 ? `; ${m.latencyExcluded} vyřazeno pro nepoužitelné časy` : ''}.`,
+                `Latency measured over ${m.latencySamples} of ${m.decided} decided${m.latencyExcluded > 0 ? `; ${m.latencyExcluded} excluded for unusable timestamps` : ''}.`,
+              )}
+            </div>
+            {m.lastDecisionAt && (
+              <div>
+                {t('Poslední rozhodnutí: ', 'Last decision: ')}
+                {new Date(m.lastDecisionAt).toISOString().slice(0, 10)}
+                {m.pending > 0 && t(
+                  ` — ${m.pending} návrhů od té doby nebo dříve stále čeká.`,
+                  ` — ${m.pending} proposals still awaiting a reviewer.`,
+                )}
+              </div>
+            )}
+            {m.truncated && (
+              <div style={{ color: '#d97706' }}>
+                {t(
+                  `Seznam dosáhl stropu ${PROPOSAL_PAGE_CAP} položek — čísla platí pro toto okno, ne pro celou historii.`,
+                  `The list hit the ${PROPOSAL_PAGE_CAP}-row page cap — these figures describe that window, not the full history.`,
+                )}
+              </div>
+            )}
+          </div>
+        </>
+      )}
+    </Card>
+  )
+}
+

--- a/openbank-admin-ui/src/lib/governance/agentOutcomes.ts
+++ b/openbank-admin-ui/src/lib/governance/agentOutcomes.ts
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+// Per-charter agent outcome metrics (issue #4462), derived from the ADR-0031 D4 HITL
+// proposal store — NOT from the audit trail.
+//
+// WHY NOT THE AUDIT TRAIL. The issue proposes sourcing this from `AuditEvent` records.
+// That source cannot carry it honestly: 71% of live audit rows name no actor at all
+// (`actor_id IS NULL`; ADR-0133 chain, #3994, PR #4693 recovered the SOURCE-service half
+// but the ACTOR half is a genuine producer-side omission), so an acceptance rate computed
+// over the attributable rows would be the rate of whichever flows happen to populate the
+// field — a biased sample wearing a measurement's clothes.
+//
+// `agent_proposal` has no such gap. `decided_by` and `decided_at` are written by the same
+// transaction that sets the terminal state (ProposalService), so EVERY decided proposal is
+// fully attributed and fully timed. Measured on the live store 2026-08-13: 73 proposals,
+// 41 decided, 41 of 41 carrying both `decided_by` and `decided_at` — 100% attribution.
+//
+// The denominator problem is therefore a different one, and it is real: 32 of 73 proposals
+// (44%) have never been decided. A rate over the decided 41 is an honest statement about
+// decided proposals and a dishonest one about proposals, so [AgentOutcomeMetrics] carries
+// its own coverage and the UI is required to render it beside the number.
+
+/** The proposal fields the metrics need — the shape /api/iaops/agents/[agentId] already returns. */
+export interface ProposalOutcomeInput {
+  state: string
+  proposedAt: string
+  decidedAt: string | null
+}
+
+export interface AgentOutcomeMetrics {
+  /** Every proposal this charter has ever raised (within the page cap — see [truncated]). */
+  total: number
+  /** Reached a terminal state. The acceptance-rate denominator. */
+  decided: number
+  /** Still PROPOSED. Not in any denominator; rendered so the rate cannot be read as fleet-wide. */
+  pending: number
+  approved: number
+  rejected: number
+  /**
+   * approved / decided, 0..1 — or null when [decided] is below [MIN_DECIDED_FOR_RATE].
+   * Never approved / total: an undecided proposal is not a rejected one.
+   */
+  approvalRate: number | null
+  /** Median and 95th percentile decision latency, seconds. Null below the sample threshold. */
+  latencyP50Seconds: number | null
+  latencyP95Seconds: number | null
+  /**
+   * Decided proposals that yielded a usable latency — its own denominator, which is NOT
+   * [decided]: a row whose timestamps are unparseable, pre-2000 (the `Instant.EPOCH`-default
+   * trap, #3882) or negative-duration is excluded rather than folded in as a zero.
+   */
+  latencySamples: number
+  /** Decided rows excluded from the latency sample, and why they must be visible. */
+  latencyExcluded: number
+  /** True when [decided] < [MIN_DECIDED_FOR_RATE]: show "insufficient data", never a 100%. */
+  insufficientData: boolean
+  /**
+   * The proposal list hit the API page cap, so [total] is a floor and every rate is computed
+   * over a truncated window. ProposalResource caps `?state=all` at 100 rows per agent.
+   */
+  truncated: boolean
+  /** Most recent decision, ISO. A queue that is fed but not reviewed shows up here, not in the rate. */
+  lastDecisionAt: string | null
+}
+
+/**
+ * Below this many decided proposals no rate is reported (issue #4462 acceptance criterion:
+ * "a charter with <N proposals in window shows insufficient data, never a misleading 100%").
+ * Five is the smallest count at which a single decision cannot move the rate by 50 points.
+ */
+export const MIN_DECIDED_FOR_RATE = 5
+
+/** The API page cap ProposalResource applies to `?state=all` (MAX_LIST). */
+export const PROPOSAL_PAGE_CAP = 100
+
+/** Timestamps at or before this are a data-class default, not an event time (#3882). */
+const IMPLAUSIBLY_OLD_MS = Date.UTC(2000, 0, 1)
+
+function parseInstant(value: string | null | undefined): number | null {
+  if (!value) return null
+  const ms = Date.parse(value)
+  if (!Number.isFinite(ms)) return null
+  return ms > IMPLAUSIBLY_OLD_MS ? ms : null
+}
+
+/**
+ * Nearest-rank percentile over an ascending array — no interpolation, so every reported
+ * value is a latency some proposal actually had.
+ */
+function percentile(sortedAscending: number[], fraction: number): number {
+  const rank = Math.ceil(fraction * sortedAscending.length)
+  return sortedAscending[Math.min(Math.max(rank, 1), sortedAscending.length) - 1]
+}
+
+export function deriveAgentOutcomes(proposals: ProposalOutcomeInput[]): AgentOutcomeMetrics {
+  const approved = proposals.filter(p => p.state === 'APPROVED').length
+  const rejected = proposals.filter(p => p.state === 'REJECTED').length
+  const decided = approved + rejected
+  const pending = proposals.length - decided
+
+  const latencies: number[] = []
+  let latencyExcluded = 0
+  let lastDecisionMs: number | null = null
+  for (const p of proposals) {
+    if (p.state !== 'APPROVED' && p.state !== 'REJECTED') continue
+    const from = parseInstant(p.proposedAt)
+    const to = parseInstant(p.decidedAt)
+    if (from === null || to === null || to < from) {
+      latencyExcluded += 1
+      continue
+    }
+    latencies.push((to - from) / 1000)
+    if (lastDecisionMs === null || to > lastDecisionMs) lastDecisionMs = to
+  }
+  latencies.sort((a, b) => a - b)
+
+  const enoughToRate = decided >= MIN_DECIDED_FOR_RATE
+  const enoughToTime = latencies.length >= MIN_DECIDED_FOR_RATE
+
+  return {
+    total: proposals.length,
+    decided,
+    pending,
+    approved,
+    rejected,
+    approvalRate: enoughToRate ? approved / decided : null,
+    latencyP50Seconds: enoughToTime ? percentile(latencies, 0.5) : null,
+    latencyP95Seconds: enoughToTime ? percentile(latencies, 0.95) : null,
+    latencySamples: latencies.length,
+    latencyExcluded,
+    insufficientData: !enoughToRate,
+    truncated: proposals.length >= PROPOSAL_PAGE_CAP,
+    lastDecisionAt: lastDecisionMs === null ? null : new Date(lastDecisionMs).toISOString(),
+  }
+}
+
+/** "2 d 12 h" / "3 h 5 m" / "45 s" — a latency a reviewer can read without dividing. */
+export function formatLatency(seconds: number): string {
+  if (seconds < 60) return `${Math.round(seconds)} s`
+  if (seconds < 3600) return `${Math.floor(seconds / 60)} m`
+  if (seconds < 86400) {
+    const h = Math.floor(seconds / 3600)
+    const m = Math.floor((seconds % 3600) / 60)
+    return m === 0 ? `${h} h` : `${h} h ${m} m`
+  }
+  const d = Math.floor(seconds / 86400)
+  const h = Math.floor((seconds % 86400) / 3600)
+  return h === 0 ? `${d} d` : `${d} d ${h} h`
+}

--- a/openbank-admin-ui/src/test/agent-outcomes-card.test.tsx
+++ b/openbank-admin-ui/src/test/agent-outcomes-card.test.tsx
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+// The panel's contract is not "renders a number" — it is "never renders a rate without
+// the denominator that rate is over" (#4462). These tests assert the coverage line,
+// because that line is the whole reason the figure is publishable.
+
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { OutcomeMetricsCard } from '@/components/agent/AgentOutcomes'
+import { LanguageProvider } from '@/lib/i18n/LanguageContext'
+import type { ProposalOutcomeInput } from '@/lib/governance/agentOutcomes'
+
+const HOUR = 3600_000
+
+function decided(approved: number, rejected: number, hours = 2): ProposalOutcomeInput[] {
+  const base = Date.UTC(2026, 5, 10, 12)
+  return Array.from({ length: approved + rejected }, (_, i) => ({
+    state: i < approved ? 'APPROVED' : 'REJECTED',
+    proposedAt: new Date(base + i * HOUR).toISOString(),
+    decidedAt: new Date(base + i * HOUR + hours * HOUR).toISOString(),
+  }))
+}
+
+function pending(n: number): ProposalOutcomeInput[] {
+  return Array.from({ length: n }, (_, i) => ({
+    state: 'PROPOSED',
+    proposedAt: new Date(Date.UTC(2026, 7, 1, i)).toISOString(),
+    decidedAt: null,
+  }))
+}
+
+/** The panel reads its labels from the language context; the provider defaults to English. */
+function renderCard(ui: React.ReactElement) {
+  return render(<LanguageProvider>{ui}</LanguageProvider>)
+}
+
+describe('OutcomeMetricsCard', () => {
+  it('renders the rate WITH its denominator and the pending proposals it excludes', () => {
+    renderCard(<OutcomeMetricsCard items={[...decided(6, 2), ...pending(12)]} />)
+
+    expect(screen.getByText('75%')).toBeTruthy()
+    expect(screen.getByText('6 of 8 decided')).toBeTruthy()
+    expect(screen.getByText(/Coverage: 8 of 20 proposals decided \(12 still pending/)).toBeTruthy()
+  })
+
+  it('shows insufficient data instead of a 100% built on two decisions', () => {
+    renderCard(<OutcomeMetricsCard items={decided(2, 0)} />)
+
+    expect(screen.queryByText('100%')).toBeNull()
+    expect(screen.getAllByText('insufficient data').length).toBeGreaterThan(0)
+    expect(screen.getByText('2 decided, needs 5')).toBeTruthy()
+  })
+
+  it('states the latency sample separately, since it is a different denominator', () => {
+    const rows = [
+      ...decided(5, 0, 2),
+      { state: 'APPROVED', proposedAt: '1970-01-01T00:00:00Z', decidedAt: '2026-06-10T12:00:00Z' },
+    ]
+
+    renderCard(<OutcomeMetricsCard items={rows} />)
+
+    expect(screen.getByText(/Latency measured over 5 of 6 decided; 1 excluded for unusable timestamps/)).toBeTruthy()
+    expect(screen.getAllByText('5 samples').length).toBe(2)
+    // p50 and p95 are both 2 h here — the point is that neither absorbed the epoch row.
+    expect(screen.getAllByText('2 h').length).toBe(2)
+  })
+
+  it('has nothing to measure and says so rather than rendering a zero', () => {
+    renderCard(<OutcomeMetricsCard items={[]} />)
+
+    expect(screen.getByText('No proposals — nothing to measure.')).toBeTruthy()
+    expect(screen.queryByText(/Coverage:/)).toBeNull()
+    expect(screen.queryByText('0%')).toBeNull()
+  })
+})

--- a/openbank-admin-ui/src/test/agent-outcomes.test.ts
+++ b/openbank-admin-ui/src/test/agent-outcomes.test.ts
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import { describe, it, expect } from 'vitest'
+import {
+  deriveAgentOutcomes,
+  formatLatency,
+  MIN_DECIDED_FOR_RATE,
+  PROPOSAL_PAGE_CAP,
+  type ProposalOutcomeInput,
+} from '@/lib/governance/agentOutcomes'
+
+const HOUR = 3600_000
+
+function proposal(state: string, proposedAt: string, decidedAt: string | null = null): ProposalOutcomeInput {
+  return { state, proposedAt, decidedAt }
+}
+
+/** n decided proposals, each taking `hours` to decide, `approvedCount` of them approved. */
+function decidedSet(approvedCount: number, rejectedCount: number, hours = 1): ProposalOutcomeInput[] {
+  const base = Date.UTC(2026, 5, 10, 12, 0, 0)
+  const rows: ProposalOutcomeInput[] = []
+  for (let i = 0; i < approvedCount + rejectedCount; i++) {
+    const from = base + i * HOUR
+    rows.push(proposal(
+      i < approvedCount ? 'APPROVED' : 'REJECTED',
+      new Date(from).toISOString(),
+      new Date(from + hours * HOUR).toISOString(),
+    ))
+  }
+  return rows
+}
+
+describe('deriveAgentOutcomes — the denominator', () => {
+  it('rates approvals over DECIDED proposals, never over all proposals', () => {
+    // 6 approved, 2 rejected, 12 never decided. approved/total would read 30%.
+    const rows = [...decidedSet(6, 2), ...Array.from({ length: 12 }, (_, i) =>
+      proposal('PROPOSED', new Date(Date.UTC(2026, 6, 1, i)).toISOString()))]
+
+    const m = deriveAgentOutcomes(rows)
+
+    expect(m.total).toBe(20)
+    expect(m.decided).toBe(8)
+    expect(m.pending).toBe(12)
+    expect(m.approvalRate).toBeCloseTo(6 / 8, 10)
+    expect(m.approvalRate).not.toBeCloseTo(6 / 20, 3)
+  })
+
+  it('reports insufficient data rather than a misleading 100% on a thin sample', () => {
+    const m = deriveAgentOutcomes(decidedSet(MIN_DECIDED_FOR_RATE - 1, 0))
+
+    expect(m.decided).toBe(MIN_DECIDED_FOR_RATE - 1)
+    expect(m.insufficientData).toBe(true)
+    expect(m.approvalRate).toBeNull()
+    expect(m.latencyP50Seconds).toBeNull()
+    expect(m.latencyP95Seconds).toBeNull()
+  })
+
+  it('reports a rate at exactly the threshold', () => {
+    const m = deriveAgentOutcomes(decidedSet(MIN_DECIDED_FOR_RATE, 0))
+
+    expect(m.insufficientData).toBe(false)
+    expect(m.approvalRate).toBe(1)
+  })
+
+  it('has no proposals to measure and says so without dividing by zero', () => {
+    const m = deriveAgentOutcomes([])
+
+    expect(m).toMatchObject({ total: 0, decided: 0, pending: 0, approvalRate: null, latencySamples: 0 })
+    expect(m.insufficientData).toBe(true)
+  })
+})
+
+describe('deriveAgentOutcomes — latency and its own, different denominator', () => {
+  it('computes p50 and p95 by nearest rank, so each figure is a latency some proposal had', () => {
+    const base = Date.UTC(2026, 5, 10, 12)
+    // Latencies 1..10 hours.
+    const rows = Array.from({ length: 10 }, (_, i) => proposal(
+      'APPROVED',
+      new Date(base).toISOString(),
+      new Date(base + (i + 1) * HOUR).toISOString(),
+    ))
+
+    const m = deriveAgentOutcomes(rows)
+
+    expect(m.latencySamples).toBe(10)
+    expect(m.latencyP50Seconds).toBe(5 * 3600)
+    expect(m.latencyP95Seconds).toBe(10 * 3600)
+  })
+
+  it('EXCLUDES an epoch-default timestamp instead of reporting a 56-year review', () => {
+    // `Instant.EPOCH` as a data-class default is a lie that isNotNull() agrees with (#3882);
+    // folded into the sample it would drag p95 to decades and read as a real outlier.
+    const rows = [
+      ...decidedSet(5, 0, 2),
+      proposal('APPROVED', '1970-01-01T00:00:00Z', '2026-06-10T12:00:00Z'),
+    ]
+
+    const m = deriveAgentOutcomes(rows)
+
+    expect(m.decided).toBe(6)
+    expect(m.latencySamples).toBe(5)
+    expect(m.latencyExcluded).toBe(1)
+    expect(m.latencyP95Seconds).toBe(2 * 3600)
+    // The excluded row still counts toward the acceptance rate — it IS a decision.
+    expect(m.approvalRate).toBe(1)
+  })
+
+  it('excludes a negative and an unparseable duration rather than counting them as zero', () => {
+    const rows = [
+      ...decidedSet(5, 0, 3),
+      proposal('APPROVED', '2026-06-10T12:00:00Z', '2026-06-10T11:00:00Z'),
+      proposal('REJECTED', '2026-06-10T12:00:00Z', 'not-a-date'),
+      proposal('REJECTED', '2026-06-10T12:00:00Z', null),
+    ]
+
+    const m = deriveAgentOutcomes(rows)
+
+    expect(m.decided).toBe(8)
+    expect(m.latencySamples).toBe(5)
+    expect(m.latencyExcluded).toBe(3)
+    expect(m.latencyP50Seconds).toBe(3 * 3600)
+  })
+
+  it('reports the last decision, which is how a fed-but-unreviewed queue becomes visible', () => {
+    const rows = [
+      ...decidedSet(5, 0),
+      proposal('PROPOSED', '2026-08-07T20:30:00Z'),
+    ]
+
+    const m = deriveAgentOutcomes(rows)
+
+    expect(m.pending).toBe(1)
+    expect(m.lastDecisionAt).not.toBeNull()
+    // Recency, not non-nullity: the decision must be the newest decided row's time.
+    expect(Date.parse(m.lastDecisionAt as string)).toBe(Date.UTC(2026, 5, 10, 12 + 4 + 1))
+  })
+})
+
+describe('deriveAgentOutcomes — truncation', () => {
+  it('flags a page-capped list, because the figures then describe a window and not a history', () => {
+    const uncapped = deriveAgentOutcomes(decidedSet(PROPOSAL_PAGE_CAP - 1, 0))
+    const capped = deriveAgentOutcomes(decidedSet(PROPOSAL_PAGE_CAP, 0))
+
+    expect(uncapped.truncated).toBe(false)
+    expect(capped.truncated).toBe(true)
+  })
+})
+
+describe('formatLatency', () => {
+  it('renders each magnitude in a unit a reviewer reads without dividing', () => {
+    expect(formatLatency(45)).toBe('45 s')
+    expect(formatLatency(90)).toBe('1 m')
+    expect(formatLatency(3600)).toBe('1 h')
+    expect(formatLatency(3900)).toBe('1 h 5 m')
+    expect(formatLatency(86400)).toBe('1 d')
+    expect(formatLatency(217336)).toBe('2 d 12 h')
+  })
+})


### PR DESCRIPTION
## What

Per-charter **approval rate** and **review latency** for AI agents, rendered on `/iaops/agents/<id>` — with the coverage figure printed beside every number.

Refs #4462.

## The measurement that decided the design

The issue proposes computing this from `AuditEvent` records. **That source cannot carry an acceptance-rate-by-actor honestly today.** Measured on the live audit database:

| | rows |
|---|---|
| audit rows total | 1879 |
| rows with `actor_id IS NULL` | **1341 (71%)** |

PR #4693 (merged) fixed the *source-service* half of attribution and recovered three unread actor spellings (`reviewedBy`, `changedBy`, `actorKind`), but what remains is a genuine producer-side omission, not a consumer bug — and `actor_id` is chain-hashed into `record_hash`, so fabricating one is not a lesser evil than an honest NULL. A rate over the attributable 29% would be the acceptance rate of whichever flows happen to populate the field: a biased sample wearing a measurement's clothes.

**`agent_proposal` (ADR-0031 D4) has no such gap.** `decided_by` and `decided_at` are written by the same transaction that sets the terminal state, so every decided proposal is fully attributed and fully timed. Measured on `openbank_agent` 2026-08-13:

| charter | total | decided | pending | approval | latency samples | p50 | p95 | last decision |
|---|---|---|---|---|---|---|---|---|
| `compliance-officer` | 60 | 30 | 30 | 16/30 = **53.3%** | 30 of 30 | 2 d 12 h | 2 d 14 h | 2026-06-16 |
| `ui-assistant` | 13 | 11 | 2 | 7/11 = **63.6%** | 11 of 11 | 2 d 8 h | 12 d 23 h | 2026-06-30 |

41 of 41 decided rows carry both `decided_by` and `decided_at`; 0 rows are pre-2000 (the `Instant.EPOCH`-default trap, #3882) and 0 have a negative duration. Timestamps here are the store's own `TIMESTAMPTZ` columns, not an `AuditConsumer` ingest-time substitution — the `occurredAt`/ingest ambiguity of #3914 does not reach this path.

## The denominator that IS a problem, and is now on screen

**32 of 73 proposals (44%) have never been decided.** A rate over the decided 41 is an honest statement about decided proposals and a dishonest one about proposals. So the panel renders, under every figure:

> Coverage: 41 of 73 proposals decided (32 still pending, and in no rate's denominator).
> Latency measured over 41 of 41 decided.
> Last decision: 2026-06-30 — 32 proposals still awaiting a reviewer.

The `lastDecisionAt` line is not decoration: the queue is still being fed (newest proposal 2026-08-07) while the newest decision is 2026-06-30. **A queue fed but not reviewed is invisible in an approval rate and visible here** — the rate would happily read 56% forever.

Latency keeps its **own, smaller denominator**: a decided row whose timestamps are unparseable, pre-2000 or negative-duration is *excluded and counted*, never folded in as a zero. Today that count is 0, which is the point — a probe that cannot express the failure is a probe that reports clean.

## What is NOT built, and why

- **"approved without modification"** (issue item 1) — `ProposalState` is `PROPOSED → APPROVED | REJECTED`. There is no modification concept in the aggregate, so "without modification" is not representable; this ships as **approval rate** and says so.
- **Per-model breakdown** — `model_id` is NULL on **73 of 73** rows. Nothing to group by.
- **Post-merge incident correlation** (issue item 3) — no link exists between a proposal and a merged PR or a compliance-incident ticket. Building it is a new write path, which the issue's own acceptance criteria exclude ("no new write path"). Left for a follow-up.

Issue #4462 stays open until items 1 (modification tracking) and 3 land, hence `Refs`, not `Closes`.

## Acceptance criteria

- [x] Metrics computed from an existing store — no new write path, no schema change, no new network call (the detail page already fetches `?state=all` for this agent)
- [x] Displayed per-charter in the admin-ui governance view
- [x] `<5` decided proposals renders **"insufficient data"**, never a misleading 100% — with `N decided, needs 5` beside it
- [x] No change to `agents.yaml` or the prompt registry

## Verification

- `npm test` (with the `pretest` artifact bake): **96 files, 1233 tests, all pass** — 14 of them new.
- The metric tests were **falsified against a broken implementation** before being trusted: changing the rate to `approved / total` and removing the timestamp guard turns 3 of 10 red; restoring turns them green again.
- `npx tsc --noEmit`: clean. `npm run lint`: 0 errors; total warnings 98 → 95 (three removed, none added).

## Overlap

PR #4693 touches `AuditConsumer`/`AuditEntry` and is **already merged**; this PR touches neither and shares no file with it. Its finding is what redirected this work off the audit trail and onto the proposal store, and is cited above.
