### PR TITLE
feat(party): declare materiality on PARTY_UPDATED events (ADR-0256 D1)

### DIFF
--- a/docs/asyncapi/openbank-events.yaml
+++ b/docs/asyncapi/openbank-events.yaml
@@ -3,7 +3,7 @@
 asyncapi: 3.0.0
 info:
   title: OpenBank Async Event API
-  version: 1.0.0
+  version: 1.1.0
   description: |
     Kafka event streams across all OpenBank services.
     All topics follow the naming convention: openbank.{domain}.{aggregate}.{event}
@@ -616,6 +616,25 @@ components:
               type: string
             legalName:
               type: string
+            materiality:
+              type: string
+              enum: [MATERIAL, NON_MATERIAL, NO_CHANGE]
+              description: >-
+                PARTY_UPDATED only. Publisher-declared materiality of the master-data change
+                (ADR-0256 D1, issue #4458) — never inferred by a consumer from the payload.
+                MATERIAL is the only value that is a KYC re-screening trigger
+                (PARTY_DATA_CHANGED); NON_MATERIAL covers contact details, trading name, address
+                and preferences; NO_CHANGE is an update that moved no compared field and is
+                deliberately NOT folded into NON_MATERIAL. Additive since party-service
+                openapi 1.15.0 — absent on events published before it, and on every event type
+                other than PARTY_UPDATED.
+            materialFields:
+              type: array
+              items:
+                type: string
+              description: >-
+                The changed fields that made the event MATERIAL (subset of legalName,
+                dateOfBirth, nationality, partyType). Empty for NON_MATERIAL and NO_CHANGE.
 
     ConsentEventPayload:
       allOf:

--- a/openbank-party-service/src/main/kotlin/com/openbank/party/application/port/in/PartyPort.kt
+++ b/openbank-party-service/src/main/kotlin/com/openbank/party/application/port/in/PartyPort.kt
@@ -70,12 +70,25 @@ data class MergePartyCommand(
     val approvalReference: String?,
 )
 
+/**
+ * A PATCH of a party record: every field is optional and null means "leave as it is".
+ *
+ * [legalName], [dateOfBirth] and [nationality] are the MATERIAL master-data fields (ADR-0256 D1,
+ * #4458). They are here — and were not before — because the materiality classification on
+ * `PARTY_UPDATED` is otherwise a branch nothing can reach: the only editable fields were contact
+ * details, so every event this service could ever emit would be `NON_MATERIAL` while the contract
+ * advertised a trigger. `legalName` was already documented in `openapi.yaml` and silently ignored
+ * by the handler; this makes the spec true.
+ */
 data class UpdatePartyCommand(
     val id: UUID,
     val email: String?,
     val phone: String?,
     val address: Address?,
     val tradingName: String?,
+    val legalName: String? = null,
+    val dateOfBirth: String? = null,
+    val nationality: String? = null,
 )
 
 /**

--- a/openbank-party-service/src/main/kotlin/com/openbank/party/application/port/out/PartyPorts.kt
+++ b/openbank-party-service/src/main/kotlin/com/openbank/party/application/port/out/PartyPorts.kt
@@ -5,6 +5,7 @@
 package com.openbank.party.application.port.out
 
 import com.openbank.party.domain.model.Party
+import com.openbank.party.domain.model.PartyChangeMateriality
 import com.openbank.party.domain.model.PartyDocument
 import com.openbank.party.domain.model.PartyDocumentFile
 import com.openbank.party.domain.model.PartyEvent
@@ -175,3 +176,16 @@ interface PartyAccountGuardPort {
 // events are now written to `party_outbox` inside the state-change transaction (see
 // [PartyRepository.save] with a [PartyEvent]) and relayed by `PartyOutboxDispatcher`. Two
 // publishers on the same topic would race, and only one of them can be atomic.
+
+/**
+ * Counts party master-data changes by their materiality classification (ADR-0256 D1, #4458).
+ *
+ * A port rather than a direct `MeterRegistry` call so the use case stays framework-free, and a
+ * dedicated counter rather than a flag on an existing one because the whole point of the
+ * classification is that its three outcomes are separable: an environment where every update is
+ * `NO_CHANGE`, and one where a name edit path exists but never fires `MATERIAL`, look identical
+ * on any success/failure metric and different on this one.
+ */
+interface PartyChangeMetricsPort {
+    fun changeClassified(materiality: PartyChangeMateriality)
+}

--- a/openbank-party-service/src/main/kotlin/com/openbank/party/application/usecase/PartyService.kt
+++ b/openbank-party-service/src/main/kotlin/com/openbank/party/application/usecase/PartyService.kt
@@ -52,6 +52,8 @@ class PartyService : PartyUseCase {
 
     @Inject lateinit var metrics: DomainMetrics
 
+    @Inject lateinit var changeMetrics: PartyChangeMetricsPort
+
     @Inject lateinit var clock: Clock
 
     /** ADR-0072: pepper for RČ blind index. Optional — dedup is silently skipped when absent. */
@@ -185,11 +187,18 @@ class PartyService : PartyUseCase {
             phone = cmd.phone ?: party.phone,
             address = cmd.address ?: party.address,
             tradingName = cmd.tradingName ?: party.tradingName,
+            legalName = cmd.legalName ?: party.legalName,
+            dateOfBirth = cmd.dateOfBirth ?: party.dateOfBirth,
+            nationality = cmd.nationality ?: party.nationality,
             updatedAt = Instant.now(clock),
         )
+        // ADR-0256 D1 / #4458: the publisher declares materiality, computed from this diff. The
+        // event is published either way — account-service reconciles on PARTY_UPDATED regardless
+        // — but only MATERIAL is a KYC re-screening trigger, and NO_CHANGE is its own outcome.
+        changeMetrics.changeClassified(PartyChange.classify(party, updated).materiality)
         val saved = partyRepo.update(
             updated,
-            PartyEvents.updated(updated, Instant.now(clock), PartyActor.system("party-api")),
+            PartyEvents.updated(party, updated, Instant.now(clock), PartyActor.system("party-api")),
         )
         return saved
     }

--- a/openbank-party-service/src/main/kotlin/com/openbank/party/domain/model/PartyChange.kt
+++ b/openbank-party-service/src/main/kotlin/com/openbank/party/domain/model/PartyChange.kt
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.party.domain.model
+
+/**
+ * How much a party master-data change matters to downstream compliance (ADR-0256 D1, issue #4458).
+ *
+ * Declared by the PUBLISHER and put on the wire, never inferred by a consumer from a generic
+ * update payload: kyc-service's deferred `PARTY_DATA_CHANGED` re-screening trigger fires on
+ * [MATERIAL] only, and "which fields does a contact-preference edit touch" is not a question a
+ * consumer of a flat envelope can answer.
+ *
+ * Three values, not a boolean, for the reason `PushSendOutcome` has ACCEPTED/SKIPPED/FAILED
+ * (ADR-0252 phase 0, #4348): a *no-op* update — a PATCH whose every field was null or unchanged —
+ * is a third outcome, and folding it into [NON_MATERIAL] would let "nothing happened" and
+ * "something happened that KYC does not care about" share one count. The metric
+ * `openbank.parties.change.classified` is tagged with this enum's name, so an environment whose
+ * updates are all no-ops is visibly different from one that is quietly never seeing name changes.
+ */
+enum class PartyChangeMateriality {
+    /** At least one field in [PartyChange.MATERIAL_FIELDS] changed — a KYC re-screening trigger. */
+    MATERIAL,
+
+    /** Something changed, none of it material — contact details, trading name, address, preferences. */
+    NON_MATERIAL,
+
+    /** Nothing changed at all. Not a trigger, and deliberately not counted as a non-material change. */
+    NO_CHANGE,
+}
+
+/**
+ * The result of comparing a party record before and after an update.
+ *
+ * [changedFields] is every field that moved (material or not) and [materialFields] is the subset
+ * that made the change material; both are sorted so the envelope is byte-stable for a given diff.
+ */
+data class PartyChangeClassification(
+    val materiality: PartyChangeMateriality,
+    val changedFields: List<String>,
+    val materialFields: List<String>,
+)
+
+/**
+ * Classifies a party update by comparing the two records, field by field.
+ *
+ * The material set is CLOSED and matches ADR-0256 D1's wording — name, date of birth, residency
+ * country. The fourth member the ADR names, the beneficial-owner set, is **not** here because
+ * party-service does not model beneficial owners at all; adding the key with nothing behind it
+ * would be a classification that can never fire while reading as covered. It joins this set the
+ * day the model does.
+ *
+ * `partyType` is material too and is not in the ADR's list: an INDIVIDUAL becoming a COMPANY
+ * changes which identity checks apply, which is the same reason name and DOB are there.
+ *
+ * Deliberately excluded from BOTH sets: `status`, `kycStatus`, `amlStatus` and `updatedAt`. Those
+ * are lifecycle state, not master data — they already have their own events
+ * (`KYC_STATUS_CHANGED`), and letting a KYC verdict classify itself as a material party change
+ * would make kyc-service re-trigger on its own output.
+ */
+object PartyChange {
+
+    /** ADR-0256 D1's material master-data fields, as they appear in the wire envelope. */
+    val MATERIAL_FIELDS: Set<String> = linkedSetOf("legalName", "dateOfBirth", "nationality", "partyType")
+
+    private val COMPARED: List<Pair<String, (Party) -> Any?>> = listOf(
+        "legalName" to { p: Party -> p.legalName },
+        "dateOfBirth" to { p: Party -> p.dateOfBirth },
+        "nationality" to { p: Party -> p.nationality },
+        "partyType" to { p: Party -> p.partyType },
+        "tradingName" to { p: Party -> p.tradingName },
+        "email" to { p: Party -> p.email },
+        "phone" to { p: Party -> p.phone },
+        "address" to { p: Party -> p.address },
+        "discoverable" to { p: Party -> p.discoverable },
+        "consentMarketing" to { p: Party -> p.consentMarketing },
+    )
+
+    fun classify(before: Party, after: Party): PartyChangeClassification {
+        val changed = COMPARED.filter { (_, read) -> read(before) != read(after) }.map { it.first }.sorted()
+        val material = changed.filter { it in MATERIAL_FIELDS }
+        val materiality = when {
+            changed.isEmpty() -> PartyChangeMateriality.NO_CHANGE
+            material.isNotEmpty() -> PartyChangeMateriality.MATERIAL
+            else -> PartyChangeMateriality.NON_MATERIAL
+        }
+        return PartyChangeClassification(materiality, changed, material)
+    }
+}

--- a/openbank-party-service/src/main/kotlin/com/openbank/party/domain/model/PartyEvent.kt
+++ b/openbank-party-service/src/main/kotlin/com/openbank/party/domain/model/PartyEvent.kt
@@ -76,7 +76,24 @@ object PartyEvents {
 
     fun created(party: Party, at: Instant, actor: PartyActor): PartyEvent = lifecycle("PARTY_CREATED", party, at, actor)
 
-    fun updated(party: Party, at: Instant, actor: PartyActor): PartyEvent = lifecycle("PARTY_UPDATED", party, at, actor)
+    /**
+     * A master-data update, carrying its own materiality classification (ADR-0256 D1, #4458).
+     *
+     * [before] is the record as it was; the classification is computed here rather than taken as
+     * a parameter so no call site can declare a materiality the diff does not support. The two
+     * added keys (`materiality`, `materialFields`) are ADDITIVE — existing consumers parse the
+     * same fields they always did, and the wire schema version is a minor bump.
+     */
+    fun updated(before: Party, party: Party, at: Instant, actor: PartyActor): PartyEvent {
+        val classification = PartyChange.classify(before, party)
+        val base = lifecycle("PARTY_UPDATED", party, at, actor)
+        return base.copy(
+            envelope = LinkedHashMap(base.envelope).apply {
+                put("materiality", classification.materiality.name)
+                put("materialFields", classification.materialFields)
+            },
+        )
+    }
 
     fun kycStatusChanged(party: Party, at: Instant, actor: PartyActor): PartyEvent =
         lifecycle("KYC_STATUS_CHANGED", party, at, actor)

--- a/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/metrics/MicrometerPartyChangeMetricsAdapter.kt
+++ b/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/metrics/MicrometerPartyChangeMetricsAdapter.kt
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.party.infrastructure.metrics
+
+import com.openbank.party.application.port.out.PartyChangeMetricsPort
+import com.openbank.party.domain.model.PartyChangeMateriality
+import io.micrometer.core.instrument.Counter
+import io.micrometer.core.instrument.MeterRegistry
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.enterprise.inject.Instance
+import jakarta.inject.Inject
+
+/**
+ * `openbank.parties.change.classified{materiality=MATERIAL|NON_MATERIAL|NO_CHANGE}`.
+ *
+ * The registry is resolved through [Instance] the way `DomainMetrics` does it: a test profile
+ * without the Micrometer extension must not fail bean construction, and a metric that cannot be
+ * recorded is not a reason to reject a party update.
+ */
+@ApplicationScoped
+class MicrometerPartyChangeMetricsAdapter : PartyChangeMetricsPort {
+
+    @Inject
+    lateinit var registryInstance: Instance<MeterRegistry>
+
+    override fun changeClassified(materiality: PartyChangeMateriality) {
+        val registry = if (registryInstance.isResolvable) registryInstance.get() else return
+        Counter.builder(METRIC)
+            .tags("materiality", materiality.name)
+            .register(registry)
+            .increment()
+    }
+
+    private companion object {
+        const val METRIC = "openbank.parties.change.classified"
+    }
+}

--- a/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/rest/PartyResource.kt
+++ b/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/rest/PartyResource.kt
@@ -174,10 +174,19 @@ class PartyResource {
     @Path("/{id}")
     @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN")
     @Authorize(action = "party.update", resource = "#id")
-    @Operation(summary = "Update party contact details")
+    @Operation(summary = "Update party contact details or material master data")
     suspend fun updateParty(@PathParam("id") id: UUID, req: UpdatePartyRequest): Response {
         val party = partyUseCase.updateParty(
-            UpdatePartyCommand(id, req.email, req.phone, req.address?.toDomain(), req.tradingName),
+            UpdatePartyCommand(
+                id = id,
+                email = req.email,
+                phone = req.phone,
+                address = req.address?.toDomain(),
+                tradingName = req.tradingName,
+                legalName = req.legalName,
+                dateOfBirth = req.dateOfBirth,
+                nationality = req.nationality,
+            ),
         )
         return Response.ok(party.toResponse()).build()
     }
@@ -585,11 +594,19 @@ data class CreatePartyRequest(
     }
 }
 
+/**
+ * All fields optional; null leaves the stored value alone. `legalName`, `dateOfBirth` and
+ * `nationality` are the MATERIAL master-data fields — editing one classifies the emitted
+ * `PARTY_UPDATED` as MATERIAL (ADR-0256 D1, #4458).
+ */
 data class UpdatePartyRequest(
     val email: String?,
     val phone: String?,
     val tradingName: String?,
     val address: AddressRequest?,
+    val legalName: String? = null,
+    val dateOfBirth: String? = null,
+    val nationality: String? = null,
 )
 
 /** ADR-0179. [approvalReference] links the ledger ADJUSTMENT journal that swept the balances. */

--- a/openbank-party-service/src/main/resources/openapi.yaml
+++ b/openbank-party-service/src/main/resources/openapi.yaml
@@ -6,7 +6,7 @@ info:
   # major == openbank.api.version == URL /api/v1 (ADR-0048). Minor bump (1.8 -> 1.9): additive
   # only — a new PATCH /api/v1/parties/approvals/{id} endpoint and an additional 202 response
   # on POST /{id}/merge (ADR-0155 four-eyes). No existing response or schema changed.
-  version: 1.14.0
+  version: 1.15.0
   description: Legal entity and individual party management with document storage.
   license:
     name: Apache-2.0
@@ -627,8 +627,24 @@ components:
 
     UpdatePartyRequest:
       type: object
+      description: >-
+        PATCH body — every field is optional and an omitted field leaves the stored value alone.
+        legalName, dateOfBirth and nationality are MATERIAL master data (ADR-0256 D1): changing
+        one classifies the emitted PARTY_UPDATED event as MATERIAL, which is a KYC re-screening
+        trigger. email, phone, tradingName and address are NON_MATERIAL.
       properties:
         legalName:
+          type: string
+        dateOfBirth:
+          type: string
+          format: date
+        nationality:
+          type: string
+          description: ISO 3166-1 alpha-2 residency/nationality country code.
+        email:
+          type: string
+          format: email
+        phone:
           type: string
         tradingName:
           type: string

--- a/openbank-party-service/src/test/kotlin/com/openbank/party/application/usecase/PartyServiceConsentTest.kt
+++ b/openbank-party-service/src/test/kotlin/com/openbank/party/application/usecase/PartyServiceConsentTest.kt
@@ -32,6 +32,7 @@ class PartyServiceConsentTest {
         documentRepo = mockk()
         documentFileRepo = mockk()
         metrics = mockk(relaxed = true)
+        changeMetrics = mockk(relaxed = true)
         gdprAggregation = mockk(relaxed = true)
         rcPepper = Optional.empty()
         clock = Clock.fixed(now, ZoneOffset.UTC)

--- a/openbank-party-service/src/test/kotlin/com/openbank/party/application/usecase/PartyServiceMarketingConsentTest.kt
+++ b/openbank-party-service/src/test/kotlin/com/openbank/party/application/usecase/PartyServiceMarketingConsentTest.kt
@@ -47,6 +47,7 @@ class PartyServiceMarketingConsentTest {
         documentRepo = mockk()
         documentFileRepo = mockk()
         metrics = mockk(relaxed = true)
+        changeMetrics = mockk(relaxed = true)
         gdprAggregation = mockk(relaxed = true)
         marketingConsentForwarding = mockk()
         marketingConsentTracking = mockk()

--- a/openbank-party-service/src/test/kotlin/com/openbank/party/application/usecase/PartyServiceMergeTest.kt
+++ b/openbank-party-service/src/test/kotlin/com/openbank/party/application/usecase/PartyServiceMergeTest.kt
@@ -40,6 +40,7 @@ class PartyServiceMergeTest {
         gdprAggregation = mockk(relaxed = true)
         accountGuard = mockk()
         metrics = mockk(relaxed = true)
+        changeMetrics = mockk(relaxed = true)
         rcPepper = Optional.empty()
         clock = Clock.fixed(now, ZoneOffset.UTC)
     }

--- a/openbank-party-service/src/test/kotlin/com/openbank/party/application/usecase/PartyServiceTest.kt
+++ b/openbank-party-service/src/test/kotlin/com/openbank/party/application/usecase/PartyServiceTest.kt
@@ -55,13 +55,7 @@ class PartyServiceTest {
 
     @Test
     fun `createParty saves and publishes event`(): Unit = runBlocking {
-        val service = PartyService().apply {
-            partyRepo = mockk()
-            documentRepo = mockk()
-            metrics = mockk(relaxed = true)
-            rcPepper = Optional.empty()
-            clock = Clock.fixed(now, ZoneOffset.UTC)
-        }
+        val service = newService()
 
         val savedPartySlot = slot<Party>()
         coEvery { service.partyRepo.findByEmail("alice@example.com") } returns null
@@ -126,13 +120,7 @@ class PartyServiceTest {
 
     @Test
     fun `createParty throws PartyAlreadyExistsException when email exists`(): Unit = runBlocking {
-        val service = PartyService().apply {
-            partyRepo = mockk()
-            documentRepo = mockk()
-            metrics = mockk(relaxed = true)
-            rcPepper = Optional.empty()
-            clock = Clock.fixed(now, ZoneOffset.UTC)
-        }
+        val service = newService()
 
         coEvery { service.partyRepo.findByEmail("alice@example.com") } returns sampleParty()
 
@@ -725,6 +713,7 @@ class PartyServiceTest {
         documentRepo = mockk()
         documentFileRepo = mockk()
         metrics = mockk(relaxed = true)
+        changeMetrics = mockk(relaxed = true)
         gdprAggregation = mockk(relaxed = true)
         rcPepper = Optional.empty()
         clock = Clock.fixed(now, ZoneOffset.UTC)

--- a/openbank-party-service/src/test/kotlin/com/openbank/party/domain/model/PartyChangeMaterialityContractTest.kt
+++ b/openbank-party-service/src/test/kotlin/com/openbank/party/domain/model/PartyChangeMaterialityContractTest.kt
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.party.domain.model
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * The materiality classification boundary (ADR-0256 D1, issue #4458).
+ *
+ * Two things are asserted here and both are deliberate:
+ *
+ * 1. **The SERIALIZED body**, not the classification object and not the outbox row's columns.
+ *    sca-service put `eventType` in the outbox COLUMN and not in the payload; its producer test
+ *    asserted the column, stayed green, and the consumer's parser read `""` and returned early —
+ *    a branch that never once executed in production while the events sat SENT. A consumer of
+ *    `openbank.party.events` sees the payload bytes and nothing else, so that is what is pinned.
+ * 2. **The boundary in both directions.** A test that only proves a name change is MATERIAL
+ *    passes against a classifier that returns MATERIAL unconditionally — which is the version of
+ *    this feature that re-screens every customer who corrects their phone number.
+ */
+class PartyChangeMaterialityContractTest {
+
+    // Mirrors the RUNNING producer's mapper. `findAndRegisterModules()` alone is NOT that mapper:
+    // it leaves WRITE_DATES_AS_TIMESTAMPS on, so `occurredAt` serializes as `1.7866E9` and a test
+    // written against it would assert a wire shape no consumer ever receives (Quarkus defaults
+    // `quarkus.jackson.write-dates-as-timestamps` to false). The `Z` assertion below is the one
+    // that caught it; `PartyOutboxWriteIT` re-asserts it against the real serialized outbox row.
+    private val mapper = ObjectMapper().findAndRegisterModules()
+        .disable(com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+    private val at = Instant.parse("2026-08-14T08:00:00Z")
+
+    private fun party() = Party(
+        id = UUID.fromString("11111111-1111-1111-1111-111111111111"),
+        partyType = PartyType.INDIVIDUAL,
+        status = PartyStatus.ACTIVE,
+        legalName = "Jan Novák",
+        tradingName = null,
+        dateOfBirth = "1990-01-01",
+        nationality = "CZ",
+        taxId = null,
+        registrationNumber = null,
+        email = "jan@example.cz",
+        phone = "+420111222333",
+        address = null,
+        kycStatus = KycStatus.APPROVED,
+        createdAt = at,
+        updatedAt = at,
+        amlStatus = AmlStatus.CLEARED,
+    )
+
+    private fun envelope(before: Party, after: Party) = mapper.readTree(
+        mapper.writeValueAsString(
+            PartyEvents.updated(before, after, at, PartyActor.system("party-api")).envelope,
+        ),
+    )
+
+    @Test
+    fun `a legal-name change is MATERIAL on the wire and names the field that made it so`() {
+        val json = envelope(party(), party().copy(legalName = "Jan Novotný"))
+
+        assertThat(json.get("eventType").asText()).isEqualTo("PARTY_UPDATED")
+        assertThat(json.get("materiality").asText()).isEqualTo("MATERIAL")
+        assertThat(json.get("materialFields").map { it.asText() }).containsExactly("legalName")
+    }
+
+    @Test
+    fun `date of birth and residency country are material too`() {
+        assertThat(envelope(party(), party().copy(dateOfBirth = "1990-01-02")).get("materiality").asText())
+            .isEqualTo("MATERIAL")
+        assertThat(envelope(party(), party().copy(nationality = "SK")).get("materiality").asText())
+            .isEqualTo("MATERIAL")
+    }
+
+    @Test
+    fun `contact-only and address-only edits are NON_MATERIAL and must never trigger a re-screen`() {
+        listOf(
+            party().copy(email = "jan.novak@example.cz"),
+            party().copy(phone = "+420999888777"),
+            party().copy(tradingName = "Novák Consulting"),
+            party().copy(
+                address = Address("Dlouhá 1", null, "Praha", "11000", "CZ"),
+            ),
+            party().copy(consentMarketing = true),
+        ).forEach { after ->
+            val json = envelope(party(), after)
+            assertThat(json.get("materiality").asText())
+                .describedAs("materiality for %s", json.toString())
+                .isEqualTo("NON_MATERIAL")
+            assertThat(json.get("materialFields")).isEmpty()
+        }
+    }
+
+    /**
+     * The third outcome, and the reason this is an enum rather than a boolean: an update that
+     * moved nothing is not the same event as one that moved something KYC does not care about.
+     * A shared "not material" flag would let a no-op PATCH storm read as ordinary contact churn.
+     */
+    @Test
+    fun `an update that changes nothing is NO_CHANGE, not NON_MATERIAL`() {
+        val json = envelope(party(), party().copy(updatedAt = at.plusSeconds(60)))
+
+        assertThat(json.get("materiality").asText()).isEqualTo("NO_CHANGE")
+        assertThat(json.get("materialFields")).isEmpty()
+    }
+
+    /**
+     * Lifecycle state has its own events. If a KYC verdict projected onto the party record could
+     * classify itself as a material party change, kyc-service would re-trigger on its own output.
+     */
+    @Test
+    fun `a KYC or AML status projection is not a material master-data change`() {
+        val json = envelope(party(), party().copy(kycStatus = KycStatus.EXPIRED, amlStatus = AmlStatus.BLOCKED))
+
+        assertThat(json.get("materiality").asText()).isEqualTo("NO_CHANGE")
+    }
+
+    @Test
+    fun `the classification is additive - the fields consumers already parse are untouched`() {
+        val json = envelope(party(), party().copy(legalName = "Jan Novotný"))
+
+        assertThat(json.get("partyId").asText()).isEqualTo("11111111-1111-1111-1111-111111111111")
+        assertThat(json.get("partyType").asText()).isEqualTo("INDIVIDUAL")
+        assertThat(json.get("status").asText()).isEqualTo("ACTIVE")
+        assertThat(json.get("legalName").asText()).isEqualTo("Jan Novotný")
+        assertThat(json.get("actorId").asText()).isEqualTo("system:party-service:party-api")
+        assertThat(json.has("aggregateId")).isFalse()
+    }
+
+    /**
+     * `occurredAt` (never `timestamp`) and it must render with a `Z` offset:
+     * `AuditConsumer.eventTime()` parses with `Instant.parse`, which rejects a non-`Z` offset and
+     * falls back to ingest time behind nothing louder than a warning. Recency, not non-nullity —
+     * `isNotNull()` passes happily against 1970-01-01.
+     */
+    @Test
+    fun `the event time is occurredAt, renders as Z, and is recent`() {
+        val before = Instant.now().minusSeconds(1)
+        val event = PartyEvents.updated(
+            party(),
+            party().copy(legalName = "Jan Novotný"),
+            Instant.now(java.time.Clock.systemUTC()),
+            PartyActor.system("party-api"),
+        )
+        val json = mapper.readTree(mapper.writeValueAsString(event.envelope))
+
+        assertThat(json.has("timestamp")).isFalse()
+        assertThat(json.get("occurredAt").asText()).endsWith("Z")
+        assertThat(event.occurredAt).isBetween(before, Instant.now().plusSeconds(1))
+    }
+
+    @Test
+    fun `no other event type carries a materiality claim it did not compute`() {
+        listOf(
+            PartyEvents.created(party(), at, PartyActor.system("party-api")),
+            PartyEvents.kycStatusChanged(party(), at, PartyActor.system("kyc-status-projection")),
+            PartyEvents.erased(party().id, at),
+            PartyEvents.merged(party(), UUID.randomUUID(), at, PartyActor.system("party-merge")),
+        ).forEach { event ->
+            val json = mapper.readTree(mapper.writeValueAsString(event.envelope))
+            assertThat(json.has("materiality"))
+                .describedAs("%s must not declare a materiality", event.eventType)
+                .isFalse()
+        }
+    }
+}

--- a/openbank-party-service/src/test/kotlin/com/openbank/party/domain/model/PartyEventEnvelopeContractTest.kt
+++ b/openbank-party-service/src/test/kotlin/com/openbank/party/domain/model/PartyEventEnvelopeContractTest.kt
@@ -78,6 +78,7 @@ class PartyEventEnvelopeContractTest {
     @Test
     fun `PARTY_UPDATED to ACTIVE carries the status field account-service reconciles on`() {
         val event = PartyEvents.updated(
+            individual(),
             individual().copy(status = PartyStatus.ACTIVE),
             at,
             PartyActor.system("party-api"),

--- a/openbank-party-service/src/test/kotlin/com/openbank/party/integration/PartyOutboxWriteIT.kt
+++ b/openbank-party-service/src/test/kotlin/com/openbank/party/integration/PartyOutboxWriteIT.kt
@@ -114,6 +114,52 @@ class PartyOutboxWriteIT {
         assertThat(payload).doesNotContain("\"aggregateId\"")
     }
 
+    private fun patchParty(id: UUID, body: String) {
+        Given {
+            contentType("application/json")
+            body(body)
+        } When {
+            patch("/api/v1/parties/$id")
+        } Then {
+            statusCode(200)
+        }
+    }
+
+    /**
+     * ADR-0256 D1 / #4458. The claim is about the PAYLOAD, not the row's columns: sca-service
+     * wrote `eventType` to `sca_outbox.event_type` and not into the body, its test asserted the
+     * column, and the consumer's parser silently read `""` for 15 SENT events. A consumer of
+     * `openbank.party.events` sees these bytes and nothing else.
+     */
+    @Test
+    @TestSecurity(user = "outbox-it", roles = ["ROLE_ADMIN", "ROLE_OPERATOR"])
+    fun `a material master-data edit is declared MATERIAL in the serialized outbox payload`() {
+        val id = createParty("outbox-material-${UUID.randomUUID()}@example.cz")
+
+        patchParty(id, """{"legalName":"Renamed Probe"}""")
+
+        val updated = outboxRows(id).single { it.first == "PARTY_UPDATED" }
+        assertThat(updated.second).contains("\"materiality\":\"MATERIAL\"")
+        assertThat(updated.second).contains("\"materialFields\":[\"legalName\"]")
+        assertThat(updated.second).contains("\"legalName\":\"Renamed Probe\"")
+        // `occurredAt` (never `timestamp`), and it must render with a `Z` offset: AuditConsumer
+        // parses with Instant.parse, which rejects any other offset and silently falls back to
+        // ingest time. This is the REAL producer mapper, not a test-local one.
+        assertThat(updated.second).containsPattern("\"occurredAt\":\"[0-9T:.\\-]+Z\"")
+    }
+
+    @Test
+    @TestSecurity(user = "outbox-it", roles = ["ROLE_ADMIN", "ROLE_OPERATOR"])
+    fun `a contact-only edit is declared NON_MATERIAL and is not a re-screening trigger`() {
+        val id = createParty("outbox-nonmaterial-${UUID.randomUUID()}@example.cz")
+
+        patchParty(id, """{"phone":"+420999888777"}""")
+
+        val updated = outboxRows(id).single { it.first == "PARTY_UPDATED" }
+        assertThat(updated.second).contains("\"materiality\":\"NON_MATERIAL\"")
+        assertThat(updated.second).contains("\"materialFields\":[]")
+    }
+
     @Test
     @TestSecurity(user = "outbox-it", roles = ["ROLE_ADMIN", "ROLE_KYC"])
     fun `a KYC status change writes KYC_STATUS_CHANGED alongside the updated row`() {


### PR DESCRIPTION
## What

ADR-0256 D1 ships its trigger catalogue with `PARTY_DATA_CHANGED` **deferred**: kyc-service cannot consume it until party-service declares materiality in its own event contract. This lands that contract.

## The classification

`PartyChange.classify(before, after)` compares a closed field set and returns one of three outcomes:

| outcome | fields | KYC re-screening trigger |
|---|---|---|
| `MATERIAL` | `legalName`, `dateOfBirth`, `nationality`, `partyType` | yes |
| `NON_MATERIAL` | `email`, `phone`, `address`, `tradingName`, `discoverable`, `consentMarketing` | no |
| `NO_CHANGE` | nothing moved | no |

Three values, not a boolean, for `PushSendOutcome.ACCEPTED / SKIPPED / FAILED`'s reason: a no-op PATCH and an edit KYC does not care about must not share a count — in the return type or in `openbank.parties.change.classified{materiality=...}`.

Two deliberate exclusions, both documented in the classifier's KDoc:

- **Beneficial-owner set** — ADR-0256 names it and party-service does not model beneficial owners at all. Adding the key with nothing behind it would be a classification that can never fire while reading as covered.
- **`status` / `kycStatus` / `amlStatus`** — lifecycle state with its own events. If a KYC verdict projected onto the party record could classify itself as a material party change, kyc-service would re-trigger on its own output.

## The serialized shape

`PARTY_UPDATED` gains two additive keys; every other event type is byte-identical and asserts that it declares no materiality.

```json
{"eventType":"PARTY_UPDATED","partyId":"…","partyType":"INDIVIDUAL","status":"ACTIVE",
 "kycStatus":"APPROVED","legalName":"Jan Novotný","email":"…","occurredAt":"2026-08-14T08:00:00Z",
 "actorId":"system:party-service:party-api","actorType":"SYSTEM",
 "materiality":"MATERIAL","materialFields":["legalName"]}
```

## Why the API surface moved

`updateParty` now accepts `legalName`, `dateOfBirth`, `nationality`. Without them the `MATERIAL` branch is **unreachable in production** — the only editable fields were contact details, so every event this service could emit would be `NON_MATERIAL` while the contract advertised a trigger. `openapi.yaml` already documented `legalName` on `UpdatePartyRequest` and the handler silently ignored it; the spec is now true. `info.version` 1.14.0 → 1.15.0 (additive), read off live `origin/main`. No DB change, no migration.

## How the shape is proved

- `PartyChangeMaterialityContractTest` asserts the **serialized body**, never the classification object — sca-service put `eventType` in `sca_outbox.event_type` and not in the payload, its producer test asserted the column, and the consumer's parser read `""` for 15 `SENT` events. Both boundary directions are covered: a test that only proves a name change is MATERIAL passes against a classifier that returns MATERIAL unconditionally.
- `PartyOutboxWriteIT` re-proves it against the **real producer**: RestAssured PATCH → JDBC read of `party_outbox.payload`, MATERIAL and NON_MATERIAL cases. 4 tests, all green.
- `occurredAt` (never `timestamp`), asserted to end in `Z` and to be *recent*, not non-null. This caught a real trap while writing it: a test-local `ObjectMapper().findAndRegisterModules()` leaves `WRITE_DATES_AS_TIMESTAMPS` on and renders `occurredAt` as `1.7866E9`, which `AuditConsumer.eventTime()`'s `Instant.parse` rejects — the test would have pinned a wire shape no consumer receives. The mapper now mirrors the Quarkus default and the IT re-asserts `Z` on the real bytes.

## Contract coverage — stated plainly

`openbank.party.events` stays **grandfathered** in `.github/event-contract-baseline.txt`; the new fields are documented in `docs/asyncapi/openbank-events.yaml` (1.0.0 → 1.1.0), which no gate validates.

A per-service `openbank-contracts/openbank-party-service/asyncapi.yaml` is **not** added on purpose: `check-event-contract-code-agreement.py` resolves event types from `override val eventType` / `const val EVENT_TYPE` and payload properties from a data class's primary constructor. Party's envelope is a hand-built `LinkedHashMap` with inline string literals, so a contract file would be structurally unverifiable by that gate — the estate blind spot, not a fix for it. Making party detectable means restructuring the envelope builders, which is its own change.

Gates run locally, all green: `check-event-contract-coverage.py`, `check-event-contract-code-agreement.py`, `check-event-schema-compat.py --base origin/main`, `check-domain-event-occuredat.sh`.

## Verification

`./gradlew :openbank-party-service:build` — BUILD SUCCESSFUL, `quarkusBuild` included (CDI/ArC wiring of the new `PartyChangeMetricsPort` adapter surfaces only there). JUnit XML: **161 tests, 0 failures, 1 skipped** — the skip is the pre-existing broker-gated `PartyEventPactProviderVerificationTest`. `ktlintCheck` and `detekt` re-run separately afterwards and appear in the task list.

party-service is **not** in `rules.yaml: money_path_services`, so the 2-approval + threat-model rule does not apply.

Closes #4458
