### PR TITLE
feat(campaign): enable reusable campaign drafts

### DIFF
--- a/openbank-admin-ui/src/app/api/campaigns/[id]/duplicate/route.ts
+++ b/openbank-admin-ui/src/app/api/campaigns/[id]/duplicate/route.ts
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+// Reuse is deliberately a dedicated route, not an action in `[id]/actions`: lifecycle actions
+// change the source campaign, while this endpoint produces a new maker-owned DRAFT and must never
+// share a state transition's closed action list or error semantics.
+
+import { NextResponse } from 'next/server'
+import { auth } from '@/auth'
+import { serverSvcUrl } from '@/lib/services/bff'
+
+export const dynamic = 'force-dynamic'
+
+export async function POST(_req: Request, ctx: { params: Promise<{ id: string }> }) {
+  const session = await auth()
+  if (!session?.user?.accessToken) {
+    return NextResponse.json({ error: 'unauthenticated' }, { status: 401 })
+  }
+  const { id } = await ctx.params
+  try {
+    const response = await fetch(
+      serverSvcUrl('campaign-service', 'campaign', 8128, `/api/v1/campaigns/${encodeURIComponent(id)}/duplicate`),
+      {
+        method: 'POST',
+        headers: { authorization: `Bearer ${session.user.accessToken}` },
+        signal: AbortSignal.timeout(8000),
+        cache: 'no-store',
+      },
+    )
+    const text = await response.text()
+    const payload = text ? JSON.parse(text) : {}
+    return NextResponse.json(
+      response.ok
+        ? { state: 'ok', campaign: payload }
+        : { state: response.status === 401 || response.status === 403 ? 'forbidden' : 'rejected', ...payload },
+      { status: 200 },
+    )
+  } catch {
+    return NextResponse.json({ state: 'unreachable' }, { status: 200 })
+  }
+}

--- a/openbank-admin-ui/src/app/campaigns/[id]/page.tsx
+++ b/openbank-admin-ui/src/app/campaigns/[id]/page.tsx
@@ -6,6 +6,7 @@
 
 import { useEffect, useState } from 'react'
 import Link from 'next/link'
+import { useRouter } from 'next/navigation'
 import { ArrowLeft, Megaphone } from 'lucide-react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
@@ -150,6 +151,7 @@ function deliveryTone(status: string): Tone {
 
 export default function CampaignDetailPage({ params }: { params: Promise<{ id: string }> }) {
   const { t, language } = useLanguage()
+  const router = useRouter()
   // Params are unwrapped in an effect rather than with React `use()`. `use()` suspends until the
   // promise settles, which forces every caller — including tests — to provide a Suspense boundary
   // and, in jsdom, leaves the tree on the fallback indefinitely. An effect keeps the page mountable
@@ -197,6 +199,34 @@ export default function CampaignDetailPage({ params }: { params: Promise<{ id: s
   // maker != checker on activate. The UI renders capability, the policy decides it.
   const [actionError, setActionError] = useState<string | null>(null)
   const [acting, setActing] = useState(false)
+  const [duplicating, setDuplicating] = useState(false)
+
+  /**
+   * Reuse does not change the source campaign. The server makes a separate DRAFT owned by this
+   * maker and Studio then reloads the real stored definition for review — never a browser copy of
+   * an ACTIVE journey or its history.
+   */
+  const duplicateAsDraft = () => {
+    if (!id) return
+    setDuplicating(true)
+    setActionError(null)
+    fetch(`/api/campaigns/${encodeURIComponent(id)}/duplicate`, { method: 'POST' })
+      .then(r => r.json())
+      .then((d: { state: string; campaign?: { id: string }; error?: string }) => {
+        if (d.state === 'ok' && d.campaign?.id) {
+          router.push(`/campaigns/new?draft=${encodeURIComponent(d.campaign.id)}`)
+          return
+        }
+        setActionError(
+          d.error ??
+          (d.state === 'forbidden'
+            ? t('Nemáte oprávnění založit nový koncept z této kampaně.', 'You are not permitted to create a new draft from this campaign.')
+            : t('Koncept se nepodařilo založit. Zdrojová cesta se nezměnila.', 'The draft could not be created. The source journey is unchanged.')),
+        )
+      })
+      .catch(() => setActionError(t('Campaign-service neodpovídá.', 'Campaign-service is not responding.')))
+      .finally(() => setDuplicating(false))
+  }
 
   const runAction = (action: string) => {
     setActing(true)
@@ -504,6 +534,25 @@ export default function CampaignDetailPage({ params }: { params: Promise<{ id: s
             </span>
           )}
         </div>
+      )}
+
+      {!loading && !unavailable && c && (
+        <aside className="rounded-xl border border-indigo-100 bg-indigo-50/50 p-3 text-sm" data-testid="campaign-reuse-draft">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div>
+              <p className="font-semibold text-foreground">{t('Použít cestu jako výchozí bod', 'Use this journey as a starting point')}</p>
+              <p className="mt-0.5 text-xs text-muted-foreground">
+                {t(
+                  'Vznikne nový koncept k vaší úpravě. Stav, schválení, příjemci a výsledky této kampaně se nikdy nekopírují.',
+                  'A new draft opens for your edits. This campaign’s state, approval, recipients and results are never copied.',
+                )}
+              </p>
+            </div>
+            <button type="button" className="btn btn-secondary" onClick={duplicateAsDraft} disabled={duplicating}>
+              {duplicating ? t('Zakládám koncept…', 'Creating draft…') : t('Vytvořit kopii jako koncept', 'Create draft copy')}
+            </button>
+          </div>
+        </aside>
       )}
 
       {actionError && <p className="text-sm text-red-600">{actionError}</p>}

--- a/openbank-admin-ui/src/test/campaign-detail-bff.test.ts
+++ b/openbank-admin-ui/src/test/campaign-detail-bff.test.ts
@@ -132,4 +132,29 @@ describe('campaign detail bundle', () => {
       }),
     )
   })
+
+  it('creates a reusable campaign draft with the caller token and no browser-supplied identity', async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      status: 201,
+      text: async () => JSON.stringify({ id: 'copy-123', state: 'DRAFT', name: 'Copy of spring offer' }),
+    }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { POST } = await import('@/app/api/campaigns/[id]/duplicate/route')
+    const res = await POST(
+      new Request('http://x/api/campaigns/abc/duplicate', { method: 'POST' }),
+      { params: Promise.resolve({ id: 'abc' }) },
+    )
+
+    expect(await res.json()).toMatchObject({ state: 'ok', campaign: { id: 'copy-123', state: 'DRAFT' } })
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining('/api/v1/campaigns/abc/duplicate'),
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({ authorization: 'Bearer tok' }),
+      }),
+    )
+    expect(fetchMock.mock.calls[0]?.[1]).not.toHaveProperty('body')
+  })
 })

--- a/openbank-admin-ui/src/test/campaign-studio.test.tsx
+++ b/openbank-admin-ui/src/test/campaign-studio.test.tsx
@@ -10,7 +10,9 @@ import { LanguageProvider } from '@/lib/i18n/LanguageContext'
 import CampaignDetailPage from '@/app/campaigns/[id]/page'
 import NewCampaignPage from '@/app/campaigns/new/page'
 
-vi.mock('next/navigation', () => ({ useRouter: () => ({ push: vi.fn() }), useSearchParams: () => new URLSearchParams() }))
+const routerPush = vi.hoisted(() => vi.fn())
+
+vi.mock('next/navigation', () => ({ useRouter: () => ({ push: routerPush }), useSearchParams: () => new URLSearchParams() }))
 
 const CAMPAIGN_ID = '7b1f1d5e-0d2a-4a6a-8f7e-2c1b9a0d3e4f'
 
@@ -84,7 +86,10 @@ function renderDetail() {
 }
 
 describe('campaign studio', () => {
-  beforeEach(() => vi.unstubAllGlobals())
+  beforeEach(() => {
+    vi.unstubAllGlobals()
+    routerPush.mockReset()
+  })
 
   /**
    * ADR-0221 D1 step 2: the audience is a picker over versioned segment artifacts, and ADR-0201 D1
@@ -239,6 +244,27 @@ describe('campaign studio', () => {
     await waitFor(() => expect(screen.getByText('Submit for approval')).toBeTruthy(), { timeout: 8000 })
     // The whole point of four eyes: the author never sees the button that would let them skip it.
     expect(screen.queryByText('Approve and activate')).toBeNull()
+  }, 15000)
+
+  it('reuses a campaign as a new editable draft without changing the viewed campaign', async () => {
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      if (url.includes(`/api/campaigns/${CAMPAIGN_ID}/duplicate`)) {
+        expect(init?.method).toBe('POST')
+        return { ok: true, status: 200, json: async () => ({ state: 'ok', campaign: { id: 'draft-copy-123' } }) }
+      }
+      return { ok: true, status: 200, json: async () => detail('ACTIVE') }
+    })
+    vi.stubGlobal('fetch', fetchMock)
+    renderDetail()
+
+    await waitFor(() => expect(screen.getByTestId('campaign-reuse-draft')).toBeTruthy(), { timeout: 8000 })
+    fireEvent.click(screen.getByRole('button', { name: 'Create draft copy' }))
+
+    await waitFor(() => expect(routerPush).toHaveBeenCalledWith('/campaigns/new?draft=draft-copy-123'))
+    expect(fetchMock).toHaveBeenCalledWith(
+      `/api/campaigns/${CAMPAIGN_ID}/duplicate`,
+      { method: 'POST' },
+    )
   }, 15000)
 
   it('turns server-attributed app attention into a per-surface campaign funnel', async () => {

--- a/openbank-admin-ui/src/test/campaigns-console.test.tsx
+++ b/openbank-admin-ui/src/test/campaigns-console.test.tsx
@@ -14,6 +14,10 @@ import { SessionProvider } from '@/components/auth/SessionProvider'
 import CampaignsPage from '@/app/campaigns/page'
 import CampaignDetailPage from '@/app/campaigns/[id]/page'
 
+// CampaignDetailPage can now take an operator to the newly created draft. The console tests render
+// that client page outside Next's App Router, so provide exactly the router capability it uses.
+vi.mock('next/navigation', () => ({ useRouter: () => ({ push: vi.fn() }) }))
+
 const CAMPAIGN_ID = '019fb939-3e0a-7716-a1ed-7854754c8786'
 
 const LIST = {

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/usecase/CampaignService.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/usecase/CampaignService.kt
@@ -38,6 +38,9 @@ import java.util.UUID
  */
 data class EnrolmentOutcome(val enrolled: Int, val failed: Int)
 
+/** A missing campaign is distinct from a source definition that is no longer reusable. */
+class CampaignNotFoundException(id: UUID) : NoSuchElementException("campaign $id not found")
+
 /**
  * Campaign lifecycle use cases (ADR-0200). State transitions are deterministic domain operations;
  * four-eyes approval for activation is enforced at the REST layer (`campaign.activate`,
@@ -104,6 +107,30 @@ class CampaignService(
         )
         return campaigns.save(
             existing.revise(definition.copy(segmentRef = resolvedSegment)),
+        )
+    }
+
+    /**
+     * Reuses a reviewed journey as a fresh maker-owned draft.  It deliberately delegates to
+     * [createDraft] instead of copying the aggregate: a reusable campaign must pass today's
+     * segment, conversion-rule and trigger catalogues again, and may never inherit an approval, lifecycle
+     * state, enrolment, delivery record or active Temporal schedule.  A recurring schedule remains a
+     * visible DRAFT setting only; it still cannot exist in Temporal until the new draft passes
+     * its own four-eyes activation.
+     */
+    suspend fun duplicateAsDraft(id: UUID, createdBy: String): Campaign {
+        val source = campaigns.findById(id) ?: throw CampaignNotFoundException(id)
+        return createDraft(
+            name = "Copy of ${source.name}",
+            goal = source.goal,
+            segmentRef = source.segmentRef,
+            steps = source.steps,
+            createdBy = createdBy,
+            stopCondition = source.stopCondition,
+            conversionRule = source.conversionRule,
+            holdoutPercent = source.holdoutPercent,
+            schedule = source.schedule,
+            trigger = source.trigger,
         )
     }
 

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/rest/CampaignResource.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/rest/CampaignResource.kt
@@ -4,6 +4,7 @@
 
 package com.openbank.campaign.infrastructure.rest
 
+import com.openbank.campaign.application.usecase.CampaignNotFoundException
 import com.openbank.campaign.application.usecase.CampaignService
 import com.openbank.campaign.domain.model.CampaignDefinition
 import com.openbank.campaign.domain.model.CampaignSchedule
@@ -203,6 +204,24 @@ class CampaignResource(private val service: CampaignService, private val jwt: Js
             ),
         ).build()
     }.getOrElse { Response.status(Response.Status.CONFLICT).entity(mapOf("error" to it.message)).build() }
+
+    /**
+     * Starts a new, maker-owned DRAFT from an existing campaign definition. The source is never
+     * edited or reactivated: authoring continues in Studio, where the marketer can review every
+     * copied surface and entry setting before a separate approver sees the new campaign.
+     */
+    @POST
+    @Path("/{id}/duplicate")
+    @Authorize(action = "campaign.create", resource = "#id")
+    suspend fun duplicate(@PathParam("id") id: UUID): Response = try {
+        Response.status(Response.Status.CREATED).entity(service.duplicateAsDraft(id, jwt.principalName())).build()
+    } catch (_: CampaignNotFoundException) {
+        Response.status(Response.Status.NOT_FOUND).build()
+    } catch (e: NoSuchElementException) {
+        Response.status(Response.Status.CONFLICT).entity(mapOf("error" to e.message)).build()
+    } catch (e: IllegalArgumentException) {
+        Response.status(Response.Status.CONFLICT).entity(mapOf("error" to e.message)).build()
+    }
 
     @POST
     @Path("/{id}/submit")

--- a/openbank-campaign-service/src/main/resources/openapi.yaml
+++ b/openbank-campaign-service/src/main/resources/openapi.yaml
@@ -4,7 +4,7 @@ openapi: 3.1.0
 info:
   title: Campaign Service API
   # major == openbank.api.version == URL /api/v1 (ADR-0048).
-  version: 1.33.0
+  version: 1.34.0
   description: >-
     Campaign management first slice (ADR-0200 / ADR-0209 D3): deterministic, versioned segments;
     per-enrolment Temporal journeys; consent-gated delivery through notification-service.
@@ -275,6 +275,29 @@ paths:
                 $ref: '#/components/schemas/Campaign'
         '409':
           description: Campaign is not a draft, caller is not its maker, or the definition is invalid
+  /api/v1/campaigns/{id}/duplicate:
+    post:
+      tags: [Campaigns]
+      summary: Reuse a campaign definition as a fresh draft
+      description: >-
+        Creates a new maker-owned DRAFT from the source definition. It does not copy lifecycle
+        state, approval, enrolments, sends, outcomes or other runtime history; the new campaign
+        must pass its own four-eyes approval before it can run. Current catalogues are validated
+        again so an obsolete segment, trigger or conversion rule cannot be copied into a draft.
+      operationId: duplicateCampaignAsDraft
+      parameters:
+        - $ref: '#/components/parameters/CampaignId'
+      responses:
+        '201':
+          description: New reusable campaign draft
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Campaign'
+        '404':
+          description: Source campaign not found
+        '409':
+          description: Source definition cannot be used with the current reviewed catalogues
   /api/v1/campaigns/{id}/submit:
     post:
       tags: [Campaigns]

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/CampaignDraftRevisionTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/CampaignDraftRevisionTest.kt
@@ -12,12 +12,14 @@ import com.openbank.campaign.application.port.out.SegmentRegistry
 import com.openbank.campaign.application.usecase.CampaignService
 import com.openbank.campaign.domain.model.Campaign
 import com.openbank.campaign.domain.model.CampaignDefinition
+import com.openbank.campaign.domain.model.CampaignSchedule
 import com.openbank.campaign.domain.model.CampaignState
 import com.openbank.campaign.domain.model.CampaignStep
 import com.openbank.campaign.domain.model.Channel
 import com.openbank.campaign.domain.model.Segment
 import com.openbank.campaign.domain.model.SegmentRef
 import com.openbank.campaign.domain.model.SegmentRule
+import com.openbank.campaign.domain.model.StopCondition
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
@@ -74,6 +76,40 @@ class CampaignDraftRevisionTest {
             )
         }
         coVerify(exactly = 1) { campaigns.save(any()) }
+    }
+
+    @Test
+    fun `reuse makes a fresh draft from a running definition without its lifecycle`(): Unit = runBlocking {
+        val source = draft.copy(
+            state = CampaignState.ACTIVE,
+            createdBy = "original-maker@openbank.test",
+            approvedBy = "checker@openbank.test",
+            stopCondition = StopCondition(maxSendsPerParty = 2),
+            conversionRule = "ACCOUNT_OPENED",
+            holdoutPercent = 10,
+            schedule = CampaignSchedule("DAILY_MORNING"),
+            trigger = "ACCOUNT_OPENED",
+        )
+        val campaigns = mockk<CampaignRepository>()
+        coEvery { campaigns.findById(campaignId) } returns source
+        coEvery { campaigns.save(any()) } answers { firstArg<Campaign>() }
+
+        val copied = service(campaigns).duplicateAsDraft(campaignId, "new-maker@openbank.test")
+
+        assertThat(copied.id).isNotEqualTo(source.id)
+        assertThat(copied.name).isEqualTo("Copy of Savings nudge")
+        assertThat(copied.state).isEqualTo(CampaignState.DRAFT)
+        assertThat(copied.createdBy).isEqualTo("new-maker@openbank.test")
+        assertThat(copied.approvedBy).isNull()
+        assertThat(copied.steps).isEqualTo(source.steps)
+        assertThat(copied.stopCondition).isEqualTo(source.stopCondition)
+        assertThat(copied.conversionRule).isEqualTo(source.conversionRule)
+        assertThat(copied.holdoutPercent).isEqualTo(source.holdoutPercent)
+        assertThat(copied.schedule).isEqualTo(source.schedule)
+        assertThat(copied.trigger).isEqualTo(source.trigger)
+        assertThat(source.state).isEqualTo(CampaignState.ACTIVE)
+        assertThat(source.approvedBy).isEqualTo("checker@openbank.test")
+        coVerify(exactly = 1) { campaigns.save(copied) }
     }
 
     private fun service(campaigns: CampaignRepository): CampaignService {

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/integration/CampaignRestContractIT.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/integration/CampaignRestContractIT.kt
@@ -66,8 +66,8 @@ class CampaignRestContractIT {
         override fun stop() = InMemoryConnector.clear()
     }
 
-    private fun draftBody(name: String) = """
-        {"name":"$name","goal":"prove the HTTP contract","segmentName":"actives","segmentVersion":1,
+    private fun draftBody(name: String, segmentName: String = "actives") = """
+        {"name":"$name","goal":"prove the HTTP contract","segmentName":"$segmentName","segmentVersion":1,
          "steps":[{"order":1,"template":"MARKETING_PRODUCT_OFFER",
                    "variables":{"offerTitle":"T","offerText":"X","ctaText":"Go"},"delaySeconds":0}]}
     """.trimIndent()
@@ -84,6 +84,33 @@ class CampaignRestContractIT {
     }
 
     private fun submit(id: String) = When { post("/api/v1/campaigns/$id/submit") } Then { statusCode(200) }
+
+    private fun insertLegacySegment(name: String) {
+        dataSource.connection.use { connection ->
+            connection.prepareStatement(
+                """
+                INSERT INTO segments (id, name, version, rules_json, created_at)
+                VALUES (?, ?, ?, ?, ?)
+                """.trimIndent(),
+            ).use { statement ->
+                statement.setObject(1, UUID.randomUUID())
+                statement.setString(2, name)
+                statement.setInt(3, 1)
+                statement.setString(4, """[{"type":"PartyStatusIs","status":"ACTIVE"}]""")
+                statement.setObject(5, OffsetDateTime.now())
+                statement.executeUpdate()
+            }
+        }
+    }
+
+    private fun deleteSegment(name: String) {
+        dataSource.connection.use { connection ->
+            connection.prepareStatement("DELETE FROM segments WHERE name = ? AND version = 1").use { statement ->
+                statement.setString(1, name)
+                statement.executeUpdate()
+            }
+        }
+    }
 
     @Test
     fun `maker can revise an unsubmitted draft through the HTTP contract`() {
@@ -106,6 +133,60 @@ class CampaignRestContractIT {
         } Then {
             statusCode(200)
             body("name", equalTo(revisedName))
+        }
+    }
+
+    @Test
+    fun `operator can reuse a reviewed definition as an independent draft through the HTTP contract`() {
+        val sourceName = "source-${UUID.randomUUID()}"
+        val sourceId = createDraft(sourceName)
+        submit(sourceId)
+
+        val copiedId = When {
+            post("/api/v1/campaigns/$sourceId/duplicate")
+        } Then {
+            statusCode(201)
+            body("name", equalTo("Copy of $sourceName"))
+            body("state", equalTo("DRAFT"))
+            // TestSecurity supplies the operator role but no JWT subject; the resource deliberately
+            // falls back to `unknown` rather than trusting a browser-provided maker field.
+            body("createdBy", equalTo("unknown"))
+            body("approvedBy", nullValue())
+        } Extract {
+            path<String>("id")
+        }
+
+        assertThat(copiedId).isNotEqualTo(sourceId)
+        When {
+            get("/api/v1/campaigns/$sourceId")
+        } Then {
+            statusCode(200)
+            body("name", equalTo(sourceName))
+            body("state", equalTo("PENDING_APPROVAL"))
+        }
+    }
+
+    @Test
+    fun `reuse reports a stale source definition as conflict rather than source not found`() {
+        val staleSegment = "retired-${UUID.randomUUID()}"
+        insertLegacySegment(staleSegment)
+        val sourceId = Given {
+            contentType("application/json")
+            body(draftBody("stale-${UUID.randomUUID()}", staleSegment))
+        } When {
+            post("/api/v1/campaigns")
+        } Then {
+            statusCode(201)
+        } Extract {
+            path<String>("id")
+        }
+        deleteSegment(staleSegment)
+
+        When {
+            post("/api/v1/campaigns/$sourceId/duplicate")
+        } Then {
+            statusCode(409)
+            body("error", equalTo("segment $staleSegment@1 not found"))
         }
     }
 


### PR DESCRIPTION
## What changed

- adds a safe `POST /api/v1/campaigns/{id}/duplicate` contract and a Studio action to reuse a campaign as a new maker-owned draft
- preserves the reusable definition while never copying approval, lifecycle state, enrolments, delivery history or an active Temporal schedule
- validates the current segment, conversion-rule and trigger catalogues; a stale source definition returns a clear `409`
- forwards only the authenticated bearer through the Admin UI BFF

## Why

Marketing can build from a proven journey without treating a running campaign as a template that can be restarted. Every copy is reviewed and activated independently.

Refs #4476

## Validation

- `./gradlew :openbank-campaign-service:test --tests com.openbank.campaign.application.CampaignDraftRevisionTest --tests com.openbank.campaign.integration.CampaignRestContractIT`
- `./gradlew :openbank-campaign-service:ktlintCheck :openbank-campaign-service:detekt`
- `npm run test -- --run src/test/campaign-detail-bff.test.ts src/test/campaign-studio.test.tsx`
- `npm run type-check`
- independent review; stale-reference contract finding addressed and regression-tested