### PR TITLE
docs(sanctions): correct the screening-event contract — the discriminator is a header

### DIFF
--- a/docs/asyncapi/openbank-events.yaml
+++ b/docs/asyncapi/openbank-events.yaml
@@ -183,12 +183,25 @@ channels:
   sanctions-events:
     address: openbank.sanctions.screening.event
     description: |
-      Sanctions check lifecycle events. TWO distinct event types share this channel and
-      `eventType` is the discriminator — a consumer must switch on it, not on payload shape:
+      Sanctions check lifecycle events. TWO distinct event types share this channel:
         - `SanctionChecked`  — an automated screening produced a status from list matching.
         - `SanctionReviewed` — a human analyst manually dispositioned an existing check.
       Until #1035 both paths emitted `SanctionChecked`, so the two facts were indistinguishable
-      from the envelope and no consumer could route them apart.
+      and no consumer could route them apart.
+
+      **The discriminator is the `ce-type` Kafka HEADER, not a body field.** This channel is
+      outbox-relayed: `SanctionsRepositoryImpl` writes `OutboxMessage(eventType = ...)` and the
+      body is the serialised `SanctionsCheck` aggregate plus `occurredAt` — nothing else. The
+      dispatcher moves `eventType` onto the header `ce-type`
+      (`OutboxKafkaHeaders.HEADER_EVENT_TYPE`), so the body carries no `eventType` at all.
+
+      A consumer that takes `payload: String` and reads `node.path("eventType")` — the
+      `PartyEventConsumer` idiom, which works only because party HAND-BUILDS its payload with
+      the key in it — gets `""` here, matches no branch, and silently discards 100% of messages
+      with no error and no log line. Take `Message<String>` and read the header instead
+      (`AuditConsumer` is the correct in-fleet reference shape), and give the
+      unrecognised/missing-header outcome its own counter: the failure state of this channel is
+      indistinguishable from success at every other layer. Refs #1035, #1916.
     messages:
       SanctionsScreeningEvent:
         $ref: '#/components/messages/SanctionsScreeningEvent'
@@ -412,7 +425,9 @@ components:
     SanctionsScreeningEvent:
       name: SanctionsScreeningEvent
       title: Sanctions Screening Event
-      description: 'eventType: SanctionChecked — emitted by SanctionsService.screen'
+      description: >-
+        `ce-type` header = `SanctionChecked` — emitted by SanctionsService.screen. The type is a
+        HEADER, not a body field; see the channel description.
       contentType: application/json
       payload:
         $ref: '#/components/schemas/SanctionsScreeningEventPayload'
@@ -421,9 +436,10 @@ components:
       name: SanctionsReviewEvent
       title: Sanctions Review Outcome Event
       description: >-
-        eventType: SanctionReviewed — emitted by SanctionsService.review when an analyst
-        dispositions a check. Same payload shape as the screening event (the payload is the
-        serialised aggregate), but `reviewedBy` / `reviewNote` / `reviewedAt` are populated and
+        `ce-type` header = `SanctionReviewed` — emitted by SanctionsService.review when an
+        analyst dispositions a check. The type is a HEADER, not a body field; see the channel
+        description. Same payload shape as the screening event (the payload is the serialised
+        aggregate), but `reviewedBy` / `reviewNote` / `reviewedAt` are populated and
         `occurredAt` is the review instant rather than the screening instant.
       contentType: application/json
       payload:
@@ -853,26 +869,96 @@ components:
               type: number
 
     SanctionsScreeningEventPayload:
-      allOf:
-        - $ref: '#/components/schemas/EventEnvelope'
-        - type: object
-          properties:
-            screeningId:
-              type: string
-              format: uuid
-            partyId:
-              type: string
-              format: uuid
-            subjectName:
-              type: string
-            screeningType:
-              type: string
-              enum: [PARTY_ONBOARDING, PAYMENT_COUNTERPARTY, PERIODIC_REVIEW]
-            result:
-              type: string
-              enum: [CLEAR, HIT, POTENTIAL_MATCH, PENDING_REVIEW]
-            listNames:
-              type: array
-              items:
-                type: string
-              description: Sanctions lists that produced a hit (e.g. EU, OFAC, UN)
+      # NOT built on EventEnvelope, and that is deliberate: this channel is outbox-relayed, so
+      # the body is the serialised `SanctionsCheck` aggregate plus `occurredAt` and carries none
+      # of the envelope fields. `eventType` rides in the `ce-type` Kafka header (see the channel
+      # description). The previous version of this schema declared `eventType`, `aggregateId`,
+      # `correlationId` and six body fields (`screeningId`, `partyId`, `subjectName`,
+      # `screeningType`, `result`, `listNames`) that the producer has never emitted — a consumer
+      # written against it discards every message. Derived by reading the serialised type
+      # (`domain/model/SanctionsCheck.kt`), not by grepping for quoted JSON keys, which cannot
+      # see a serialised data class. Refs #1035, #1916.
+      type: object
+      required: [id, entityType, name, status, overallScore, checkedAt, occurredAt]
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: The sanctions check id; also the outbox `aggregateId` / `ce-id` header.
+        idempotencyKey:
+          type: string
+        entityType:
+          type: string
+          enum: [INDIVIDUAL, ORGANIZATION, VESSEL, AIRCRAFT]
+        name:
+          type: string
+        aliases:
+          type: array
+          items:
+            type: string
+        dateOfBirth:
+          type: [string, 'null']
+        nationality:
+          type: [string, 'null']
+        identifiers:
+          type: object
+          additionalProperties:
+            type: string
+          description: e.g. passport, taxId.
+        status:
+          type: string
+          enum: [CLEAR, HIT, POTENTIAL_HIT, WHITELISTED, ESCALATED]
+        matches:
+          type: array
+          items:
+            $ref: '#/components/schemas/SanctionsMatch'
+        overallScore:
+          type: number
+          description: 0.0-1.0. `isHighRisk()` is HIT, or POTENTIAL_HIT with score > 0.85.
+        checkedLists:
+          type: array
+          items:
+            type: string
+            enum: [OFAC_SDN, EU_CONSOLIDATED, UN_CONSOLIDATED, HM_TREASURY, FATF_HIGH_RISK, PEP_GLOBAL, CNB_DOMESTIC]
+        reviewedBy:
+          type: [string, 'null']
+          description: Populated only on `SanctionReviewed`.
+        reviewNote:
+          type: [string, 'null']
+          description: Populated only on `SanctionReviewed`.
+        checkedAt:
+          type: string
+          format: date-time
+        reviewedAt:
+          type: [string, 'null']
+          format: date-time
+        occurredAt:
+          type: string
+          format: date-time
+          description: >-
+            The event instant, added by the producer on top of the aggregate: `checkedAt` for
+            `SanctionChecked`, `reviewedAt` (falling back to `checkedAt`) for `SanctionReviewed`.
+
+    SanctionsMatch:
+      type: object
+      required: [listType, matchType, matchScore, matchedName]
+      properties:
+        listType:
+          type: string
+          enum: [OFAC_SDN, EU_CONSOLIDATED, UN_CONSOLIDATED, HM_TREASURY, FATF_HIGH_RISK, PEP_GLOBAL, CNB_DOMESTIC]
+        matchType:
+          type: string
+          enum: [EXACT, FUZZY, PHONETIC, ALIAS]
+        matchScore:
+          type: number
+          description: 0.0-1.0.
+        matchedName:
+          type: string
+        matchedId:
+          type: [string, 'null']
+        listEntryDate:
+          type: [string, 'null']
+        programs:
+          type: array
+          items:
+            type: string


### PR DESCRIPTION
## What

`docs/asyncapi/openbank-events.yaml` documented `openbank.sanctions.screening.event` in a way that
makes a consumer author write a consumer that discards every message — and confirms them while they
do it. This corrects that one channel. Docs only.

## The defect

The channel description said:

> `eventType` is the discriminator — a consumer must switch on it, not on payload shape

without saying it is a **header**, and the payload schema declared it as a required **body** field:

```
EventEnvelope:                  required: [eventType, aggregateId, occurredAt, correlationId]
SanctionsScreeningEventPayload: allOf: [EventEnvelope, {screeningId, partyId, subjectName,
                                                        screeningType, result, listNames}]
```

The channel is outbox-relayed. `SanctionsRepositoryImpl.saveWithEvent` / `.updateWithEvent` write
`OutboxMessage(eventType = ...)`; the payload is `mapper.valueToTree(check)` plus `occurredAt` — the
bare `SanctionsCheck` aggregate. `KafkaSanctionsOutboxEventPublisher` then puts the type on the Kafka
header `ce-type` (`OutboxKafkaHeaders.HEADER_EVENT_TYPE`). The body has never carried `eventType`.

Of the ten fields the contract declared, exactly one — `occurredAt` — is emitted. Not a drift: the
two documents describe different events.

The consequence is the silent one. A consumer copying the `PartyEventConsumer` idiom
(`node.path("eventType").asText()`, which works there only because party hand-builds its payload with
the key in it) reads `""`, matches no `when` branch, and returns having done nothing — for 100% of
messages, with no exception, no error and no log line, while the producer's rows sit `SENT`.

## What changed

- **Channel description** — states that the discriminator is the `ce-type` header, why (outbox
  relay), what the body actually is, and that `AuditConsumer` is the correct in-fleet reference
  shape, not `PartyEventConsumer`. Adds the note that the unrecognised/missing-header outcome needs
  its own counter, because this channel's failure state is indistinguishable from success at every
  other layer.
- **`SanctionsScreeningEventPayload`** — replaced with the fields actually on the wire, no longer
  built on `EventEnvelope`. Derived by reading the serialised type
  (`openbank-sanctions-service/src/main/kotlin/com/openbank/sanctions/domain/model/SanctionsCheck.kt`),
  **not** by grepping quoted JSON keys — a grep cannot see a serialised data class. A comment in
  place records what the old schema claimed, so the correction cannot be silently undone.
- **`SanctionsMatch`** — added, for the `matches` array.
- **Both message descriptions** — say the type is a header.

## Blast radius: none

This file is read by no gate. `check-event-contract-coverage.py` and
`check-event-contract-code-agreement.py` both scope to `openbank-contracts/<service>/asyncapi.yaml`
(verified in both scripts), and `openbank-sanctions-service:openbank.sanctions.screening.event` is in
`.github/event-contract-baseline.txt`. No service, wire format, `.avsc` or enforced contract is
touched. YAML parses and all 22 local `$ref`s resolve.

`openbank-sanctions-service` is money-path, but no code in it is modified — the diff is one file
under `docs/`.

## What this does NOT fix

**18 of the 21 payload schemas in this document are built on `EventEnvelope`**, so they all make the
same "`eventType` is in the body" claim. That claim is false for every outbox-relayed producer. Only
the sanctions channel was verified and corrected here; the other 17 are unaudited.

And the document is **entirely ungated** — nothing in `.github/` reads it, so it drifted here without
any signal and can drift again tomorrow. That is the argument, not the exception: see the decision
comment on #1916.

Refs #1035
Refs #1916

🤖 Generated with [Claude Code](https://claude.com/claude-code)
