### PR TITLE
fix(admin-ui): stage readiness policy in image build

### DIFF
--- a/openbank-admin-ui/Dockerfile
+++ b/openbank-admin-ui/Dockerfile
@@ -98,10 +98,11 @@ FROM alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec4
 WORKDIR /collect
 COPY . /repo
 RUN set -e; \
-    mkdir -p /governance-bundle/adr /governance-bundle/threat-models /governance-bundle/agents; \
+    mkdir -p /governance-bundle/adr /governance-bundle/threat-models /governance-bundle/agents /governance-src/openbank-libs/governance; \
     cp /repo/docs/adr/*.md /governance-bundle/adr/ 2>/dev/null || true; \
     cp /repo/docs/threat-models/*.md /governance-bundle/threat-models/ 2>/dev/null || true; \
     cp /repo/docs/agents/*.md /governance-bundle/agents/ 2>/dev/null || true; \
+    cp /repo/openbank-libs/governance/rules.yaml /governance-src/openbank-libs/governance/rules.yaml; \
     echo "── governance bundle: $(ls /governance-bundle/adr | wc -l) ADR(s), $(ls /governance-bundle/threat-models | wc -l) threat model(s), $(ls /governance-bundle/agents | wc -l) agent charter(s) ──"; \
     find /governance-bundle -name '*.md' | sort
 
@@ -226,6 +227,10 @@ COPY openbank-admin-ui/ ./
 # The origination Kotlin, at the repo-relative path the generator expects (#3283). It resolves
 # against --repo, which defaults to the parent of the admin-ui directory — here, /.
 COPY --from=origination-collector /origination-src/openbank-libs-domain /openbank-libs-domain
+# The readiness collector derives money-path policy from this authoritative source. Keep the
+# single file it reads at its repo-relative path; otherwise prebuild cannot distinguish a missing
+# policy from an empty policy and correctly refuses to produce a misleading scorecard.
+COPY --from=governance-collector /governance-src/openbank-libs/governance/rules.yaml /openbank-libs/governance/rules.yaml
 ENV NEXT_TELEMETRY_DISABLED=1
 ENV NEXT_STANDALONE=true
 # Source-map upload to GlitchTip (#3235). The token arrives as a BuildKit SECRET, not a build arg:


### PR DESCRIPTION
## What changed

Stages the authoritative `openbank-libs/governance/rules.yaml` at the repo-relative path expected by the Admin UI prebuild collector.

## Why

The Admin UI ARM deploy failed before image push because the collector correctly rejected a missing money-path policy. This was a Docker build-context staging defect, not a campaign-functionality failure.

## Validation

- `docker buildx build --platform linux/arm64 --target build --progress=quiet --output type=cacheonly -f openbank-admin-ui/Dockerfile .`

The same ARM64 target that previously failed now completes successfully.

## Linked issues

Closes #4765