### PR TITLE
feat(engagement): prepare campaign story placements

### DIFF
--- a/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/domain/model/CampaignBannerPlacement.kt
+++ b/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/domain/model/CampaignBannerPlacement.kt
@@ -43,9 +43,9 @@ data class CampaignBannerPlacement(
         fun templateFor(slot: SurfaceSlot): String = when (slot) {
             SurfaceSlot.HOME_BANNER -> PRODUCT_OFFER_BANNER_TEMPLATE
             SurfaceSlot.HOME_CAROUSEL -> "MARKETING_PRODUCT_OFFER_CAROUSEL"
+            SurfaceSlot.STORIES -> "MARKETING_PRODUCT_OFFER_STORY"
             SurfaceSlot.PRODUCT_FEED -> "MARKETING_PRODUCT_OFFER_PRODUCT_FEED"
             SurfaceSlot.REWARDS_HUB -> "MARKETING_PRODUCT_OFFER_REWARDS_HUB"
-            SurfaceSlot.STORIES -> error("campaign placements do not render in STORIES")
         }
 
         fun contentIdFor(slot: SurfaceSlot): String = "CAMPAIGN_${slot.name}"
@@ -55,13 +55,14 @@ data class CampaignBannerPlacement(
         private fun typeFor(slot: SurfaceSlot): SurfaceContentType = when (slot) {
             SurfaceSlot.HOME_BANNER -> SurfaceContentType.BANNER
             SurfaceSlot.HOME_CAROUSEL -> SurfaceContentType.CAROUSEL
+            SurfaceSlot.STORIES -> SurfaceContentType.STORY
             SurfaceSlot.PRODUCT_FEED, SurfaceSlot.REWARDS_HUB -> SurfaceContentType.CARD
-            SurfaceSlot.STORIES -> error("campaign placements do not render in STORIES")
         }
 
         private val campaignSlots = setOf(
             SurfaceSlot.HOME_BANNER,
             SurfaceSlot.HOME_CAROUSEL,
+            SurfaceSlot.STORIES,
             SurfaceSlot.PRODUCT_FEED,
             SurfaceSlot.REWARDS_HUB,
         )

--- a/openbank-engagement-service/src/test/kotlin/com/openbank/engagement/infrastructure/kafka/CampaignBannerPlacementConsumerTest.kt
+++ b/openbank-engagement-service/src/test/kotlin/com/openbank/engagement/infrastructure/kafka/CampaignBannerPlacementConsumerTest.kt
@@ -6,6 +6,7 @@ package com.openbank.engagement.infrastructure.kafka
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.openbank.engagement.application.port.out.CampaignBannerPlacementRepository
 import com.openbank.engagement.domain.model.CampaignBannerPlacement
+import com.openbank.engagement.domain.model.SurfaceContentType
 import com.openbank.engagement.domain.model.SurfaceSlot
 import io.mockk.coVerify
 import io.mockk.mockk
@@ -29,5 +30,18 @@ class CampaignBannerPlacementConsumerTest {
         val placement = slot<CampaignBannerPlacement>()
         coVerify(exactly = 1) { repository.save(capture(placement)) }
         assertThat(placement.captured.slot).isEqualTo(SurfaceSlot.HOME_BANNER)
+    }
+
+    @Test
+    fun `story command is kept as a first party story placement`(): Unit = runBlocking {
+        val interactionRef = UUID.randomUUID()
+        CampaignBannerPlacementConsumer(repository, ObjectMapper()).consume(
+            """{"interactionRef":"$interactionRef","partyId":"${UUID.randomUUID()}","campaignId":"${UUID.randomUUID()}","stepOrder":1,"template":"MARKETING_PRODUCT_OFFER_STORY","variables":{"offerTitle":"Offer","offerText":"Details","ctaText":"Open"},"deepLink":"openbank://products","inAppSurface":"STORIES"}""",
+        )
+
+        val placement = slot<CampaignBannerPlacement>()
+        coVerify(exactly = 1) { repository.save(capture(placement)) }
+        assertThat(placement.captured.slot).isEqualTo(SurfaceSlot.STORIES)
+        assertThat(placement.captured.toSurfaceContent().type).isEqualTo(SurfaceContentType.STORY)
     }
 }


### PR DESCRIPTION
## Summary
- render campaign placements on the existing Stories surface
- map Story placements to the reviewed Story template and surface-content type
- cover the campaign command consumer end to end

## Rollout
This is the expand step only. Campaign Service and Admin UI do not emit or expose STORIES until this service version is deployed, avoiding dropped placement commands during a mixed-version rollout.

## Verification
- CampaignBannerPlacementConsumerTest
- engagement-service ktlintCheck and detekt

Refs #4476