### PR TITLE
fix(campaign): report stale segment drafts as conflicts

### DIFF
--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/usecase/CampaignService.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/usecase/CampaignService.kt
@@ -41,6 +41,9 @@ data class EnrolmentOutcome(val enrolled: Int, val failed: Int)
 /** A missing campaign is distinct from a source definition that is no longer reusable. */
 class CampaignNotFoundException(id: UUID) : NoSuchElementException("campaign $id not found")
 
+/** A reviewed catalogue entry required by a draft is missing or no longer available. */
+class CampaignReferenceNotFoundException(message: String) : NoSuchElementException(message)
+
 /**
  * Campaign lifecycle use cases (ADR-0200). State transitions are deterministic domain operations;
  * four-eyes approval for activation is enforced at the REST layer (`campaign.activate`,
@@ -141,7 +144,7 @@ class CampaignService(
         trigger: String?,
     ): SegmentRef {
         val segment = segments.load(segmentRef.name, segmentRef.version)
-            ?: throw NoSuchElementException("segment ${segmentRef.name}@${segmentRef.version} not found")
+            ?: throw CampaignReferenceNotFoundException("segment ${segmentRef.name}@${segmentRef.version} not found")
         // Rejected here rather than at the consumer: a campaign carrying a key nobody watches would
         // be approved, run, and report nothing, and the first person to notice would be whoever
         // asked why it converted zero people (ADR-0245 D1).

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/rest/CampaignResource.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/rest/CampaignResource.kt
@@ -5,6 +5,7 @@
 package com.openbank.campaign.infrastructure.rest
 
 import com.openbank.campaign.application.usecase.CampaignNotFoundException
+import com.openbank.campaign.application.usecase.CampaignReferenceNotFoundException
 import com.openbank.campaign.application.usecase.CampaignService
 import com.openbank.campaign.domain.model.CampaignDefinition
 import com.openbank.campaign.domain.model.CampaignSchedule
@@ -174,7 +175,7 @@ class CampaignResource(private val service: CampaignService, private val jwt: Js
 
     @POST
     @Authorize(action = "campaign.create", resource = "#request.name")
-    suspend fun create(request: CreateCampaignRequest): Response {
+    suspend fun create(request: CreateCampaignRequest): Response = try {
         val createdBy = jwt.principalName()
         val campaign = service.createDraft(
             request.name,
@@ -188,7 +189,9 @@ class CampaignResource(private val service: CampaignService, private val jwt: Js
             request.schedule?.let { CampaignSchedule(it.cadence, it.endAt) },
             request.trigger,
         )
-        return Response.status(Response.Status.CREATED).entity(campaign).build()
+        Response.status(Response.Status.CREATED).entity(campaign).build()
+    } catch (e: CampaignReferenceNotFoundException) {
+        Response.status(Response.Status.CONFLICT).entity(mapOf("error" to e.message)).build()
     }
 
     /** The authenticated maker may revise only the unsubmitted definition. */

--- a/openbank-campaign-service/src/main/resources/openapi.yaml
+++ b/openbank-campaign-service/src/main/resources/openapi.yaml
@@ -4,7 +4,7 @@ openapi: 3.1.0
 info:
   title: Campaign Service API
   # major == openbank.api.version == URL /api/v1 (ADR-0048).
-  version: 1.34.0
+  version: 1.35.0
   description: >-
     Campaign management first slice (ADR-0200 / ADR-0209 D3): deterministic, versioned segments;
     per-enrolment Temporal journeys; consent-gated delivery through notification-service.
@@ -116,6 +116,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Campaign'
+        '409':
+          description: A reviewed segment reference is no longer available
   /api/v1/campaigns/summary:
     get:
       tags: [Campaigns]

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/integration/CampaignRestContractIT.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/integration/CampaignRestContractIT.kt
@@ -113,6 +113,21 @@ class CampaignRestContractIT {
     }
 
     @Test
+    fun `create reports a missing segment as a configuration conflict`() {
+        val missingSegment = "missing-${UUID.randomUUID()}"
+
+        Given {
+            contentType("application/json")
+            body(draftBody("missing-segment-${UUID.randomUUID()}", missingSegment))
+        } When {
+            post("/api/v1/campaigns")
+        } Then {
+            statusCode(409)
+            body("error", equalTo("segment $missingSegment@1 not found"))
+        }
+    }
+
+    @Test
     fun `maker can revise an unsubmitted draft through the HTTP contract`() {
         val id = createDraft()
         val revisedName = "revised-${UUID.randomUUID()}"


### PR DESCRIPTION
## Summary
- distinguish a missing campaign from a stale reviewed segment reference
- return the documented 409 configuration conflict when a new draft references a missing segment
- add a real HTTP contract regression test and document the 409 response

## Verification
- CampaignRestContractIT
- campaign-service ktlintCheck and detekt

Refs #4476