### PR TITLE
feat(admin-ui): make campaign touchpoints actionable

### DIFF
--- a/openbank-admin-ui/CLAUDE.md
+++ b/openbank-admin-ui/CLAUDE.md
@@ -287,3 +287,13 @@ npx eslint .            # lint
   SVG that no node box exceeds 1120. Also: every `kind: async` edge **must** carry a `topic` — the
   manifest test enforces it, so a colliding topic caption is fixed by shortening the node label, not
   by dropping the topic.
+
+<!-- BEGIN:nextjs-agent-rules -->
+
+# This is NOT the Next.js you know
+
+This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` (resolved from this file's directory; in monorepos the `next` package may not be visible from the repo root) before writing any code. Heed deprecation notices.
+
+This block is written and re-added by `next dev` — verify at `node_modules/next/dist/server/lib/generate-agent-files.js`. Removing it from a diff only re-creates the uncommitted change; committing it with your work keeps the tree clean.
+
+<!-- END:nextjs-agent-rules -->

--- a/openbank-admin-ui/src/app/campaigns/new/page.tsx
+++ b/openbank-admin-ui/src/app/campaigns/new/page.tsx
@@ -365,9 +365,29 @@ export default function NewCampaignPage() {
   // A campaign is an experience across surfaces, not a list of transport rows. Keep this compact
   // overview next to the canvas so a marketer can scan the whole customer footprint without
   // opening every node. It is derived solely from the steps that will be sent to campaign-service.
-  const experienceSurfaces = (['PUSH', 'BANNER', 'EMAIL'] as EditorChannel[])
-    .map(channel => ({ channel, count: steps.filter(step => step.channel === channel).length }))
-    .filter(({ count }) => count > 0)
+  const surfaceLabel = (surface: EditorInAppSurface) => {
+    const labels: Record<EditorInAppSurface, [string, string]> = {
+      HOME_BANNER: ['Banner na domovské obrazovce', 'Home banner'],
+      HOME_CAROUSEL: ['Carousel na domovské obrazovce', 'Home carousel'],
+      STORIES: ['Příběh v aplikaci', 'In-app story'],
+      PRODUCT_FEED: ['Feed produktů', 'Product feed'],
+      REWARDS_HUB: ['Centrum odměn', 'Rewards hub'],
+    }
+    const [cs, en] = labels[surface]
+    return t(cs, en)
+  }
+
+  const destinationLabel = (destination: NonNullable<EditorStep['mobileDestination']>) => {
+    const labels: Record<NonNullable<EditorStep['mobileDestination']>, [string, string]> = {
+      HOME: ['Domov', 'Home'],
+      SAVINGS: ['Spoření', 'Savings'],
+      CARDS: ['Karty', 'Cards'],
+      PAYMENTS: ['Platby', 'Payments'],
+      PRODUCT_HUB: ['Produkty', 'Products'],
+    }
+    const [cs, en] = labels[destination]
+    return t(cs, en)
+  }
 
   const setContentExperimentEnabled = (enabled: boolean) => {
     setContentExperiment(enabled)
@@ -700,15 +720,37 @@ export default function NewCampaignPage() {
           <div>
             <p className="campaign-composer-eyebrow"><PanelsTopLeft className="h-3.5 w-3.5" /> {t('Zážitek napříč aplikací', 'Experience across the app')}</p>
             <h3>{t('Co lidé skutečně uvidí', 'What people will actually see')}</h3>
-            <p>{t('Jen plochy z této cesty. Nic se nedoplňuje domněnkou.', 'Only surfaces in this journey. Nothing is inferred.')}</p>
+            <p>{t('Vyberte moment a náhled telefonu se přepne. Jen kroky z této cesty, nic nedoplňujeme domněnkou.', 'Choose a moment to switch the phone preview. Only steps in this journey; nothing is inferred.')}</p>
           </div>
           <div className="campaign-surface-map-items" data-testid="campaign-surface-map">
-            {experienceSurfaces.length === 0 ? (
+            {steps.length === 0 ? (
               <span className="campaign-surface-map-empty">{t('Přidejte první ověřený krok.', 'Add the first reviewed step.')}</span>
-            ) : experienceSurfaces.map(({ channel, count }) => {
-              const Icon = channel === 'PUSH' ? BellRing : channel === 'BANNER' ? PanelsTopLeft : Mail
-              const label = channel === 'PUSH' ? t('Push', 'Push') : channel === 'BANNER' ? t('Banner v aplikaci', 'In-app banner') : t('E-mail', 'Email')
-              return <span key={channel} data-surface={channel}><Icon className="h-3.5 w-3.5" /> {label}<strong>{count}</strong></span>
+            ) : steps.map((step, index) => {
+              const Icon = step.channel === 'PUSH' ? BellRing : step.channel === 'BANNER' ? PanelsTopLeft : Mail
+              const channel = step.channel === 'PUSH' ? t('Push do aplikace', 'App push') : step.channel === 'BANNER' ? t('Banner v aplikaci', 'In-app banner') : t('E-mail', 'Email')
+              const detail = step.channel === 'BANNER'
+                ? surfaceLabel(step.inAppSurface ?? 'HOME_BANNER')
+                : step.channel === 'PUSH'
+                  ? t(`Otevře: ${destinationLabel(step.mobileDestination ?? 'HOME')}`, `Opens: ${destinationLabel(step.mobileDestination ?? 'HOME')}`)
+                  : t('Schválená šablona', 'Approved template')
+              return (
+                <button
+                  key={`${step.channel}-${index}`}
+                  type="button"
+                  data-surface={step.channel}
+                  data-touchpoint={index}
+                  data-selected={selected === index ? 'true' : 'false'}
+                  aria-pressed={selected === index}
+                  onClick={() => setSelected(index)}
+                >
+                  <span className="campaign-surface-map-icon"><Icon className="h-3.5 w-3.5" /></span>
+                  <span className="campaign-surface-map-copy">
+                    <strong>{t(`Krok ${index + 1}: ${channel}`, `Step ${index + 1}: ${channel}`)}</strong>
+                    <small>{detail}</small>
+                  </span>
+                  <span className="campaign-surface-map-open">{t('Náhled', 'Preview')}</span>
+                </button>
+              )
             })}
           </div>
         </aside>

--- a/openbank-admin-ui/src/app/globals.css
+++ b/openbank-admin-ui/src/app/globals.css
@@ -460,13 +460,19 @@ main {
 .campaign-workbench-status { display: inline-flex; align-items: center; gap: .4rem; flex: 0 0 auto; padding: .43rem .62rem; border: 1px solid #e0e4ff; border-radius: 99px; background: #f5f5ff; color: #5550be; font-size: .69rem; font-weight: 800; }
 .campaign-workbench-status span { width: .42rem; height: .42rem; border-radius: 99px; background: #7c72ff; box-shadow: 0 0 0 .22rem rgba(124,114,255,.12); }
 .campaign-journey-workbench > .space-y-0 > div:first-child { border-color: #d7dded; box-shadow: 0 12px 25px rgba(58, 65, 113, .06); }
-.campaign-surface-map { display: flex; align-items: center; justify-content: space-between; gap: 1rem; margin-top: 1rem; padding: .85rem .95rem; border: 1px solid #e1e6f5; border-radius: .95rem; background: linear-gradient(105deg, #f8f9ff 0%, #fff 48%, #f6fffd 100%); }
+.campaign-surface-map { display: grid; gap: .75rem; margin-top: 1rem; padding: .9rem .95rem .95rem; border: 1px solid #e1e6f5; border-radius: .95rem; background: linear-gradient(105deg, #f8f9ff 0%, #fff 48%, #f6fffd 100%); }
 .campaign-surface-map h3 { color: var(--campaign-ink); font-size: .84rem; font-weight: 780; letter-spacing: -.02em; }
 .campaign-surface-map > div > p:last-child { margin-top: .18rem; color: var(--campaign-muted); font-size: .69rem; }
-.campaign-surface-map-items { display: flex; flex-wrap: wrap; justify-content: flex-end; gap: .42rem; }
-.campaign-surface-map-items > span { display: inline-flex; align-items: center; gap: .32rem; padding: .38rem .48rem; border: 1px solid #e0e5f5; border-radius: .58rem; background: rgba(255,255,255,.86); color: #42516b; font-size: .68rem; font-weight: 750; white-space: nowrap; }
-.campaign-surface-map-items svg { color: var(--campaign-violet); }
-.campaign-surface-map-items strong { display: inline-grid; min-width: 1.15rem; height: 1.15rem; place-items: center; border-radius: 99px; background: #edeaff; color: #5e57cf; font-size: .61rem; }
+.campaign-surface-map-items { display: grid; gap: .45rem; grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr)); }
+.campaign-surface-map-items > button { align-items: center; appearance: none; background: rgba(255,255,255,.83); border: 1px solid #e0e5f5; border-radius: .7rem; color: #42516b; cursor: pointer; display: flex; gap: .5rem; min-width: 0; padding: .48rem .52rem; text-align: left; transition: border-color .16s ease, box-shadow .16s ease, transform .16s ease, background .16s ease; }
+.campaign-surface-map-items > button:hover { background: #fff; border-color: rgba(99,91,255,.4); box-shadow: 0 6px 15px rgba(53, 61, 130, .07); transform: translateY(-1px); }
+.campaign-surface-map-items > button:focus-visible { outline: 2px solid var(--campaign-violet); outline-offset: 2px; }
+.campaign-surface-map-items > button[data-selected='true'] { background: linear-gradient(145deg, #f3f2ff, #fff); border-color: var(--campaign-violet); box-shadow: 0 0 0 2px rgba(99,91,255,.12); }
+.campaign-surface-map-icon { align-items: center; background: #eeecff; border-radius: .55rem; color: var(--campaign-violet); display: inline-flex; flex: 0 0 auto; height: 2rem; justify-content: center; width: 2rem; }
+.campaign-surface-map-copy { display: grid; gap: .1rem; min-width: 0; }
+.campaign-surface-map-copy strong { color: #33425d; font-size: .68rem; font-weight: 800; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.campaign-surface-map-copy small { color: #718097; font-size: .61rem; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.campaign-surface-map-open { color: #635bff; font-size: .6rem; font-weight: 800; margin-left: auto; }
 .campaign-surface-map-empty { color: var(--campaign-muted) !important; font-weight: 650 !important; }
 .campaign-measurement-grid { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: .7rem; margin-top: 1rem; }
 .campaign-measurement-card {
@@ -608,8 +614,8 @@ main {
   .campaign-brief-card .campaign-section-heading { margin-bottom: .8rem; }
   .campaign-brief-card .input + .input { margin-top: .65rem !important; }
   .campaign-measurement-grid { grid-template-columns: 1fr; }
-  .campaign-workbench-heading, .campaign-composer-footer, .campaign-surface-map { align-items: flex-start; flex-direction: column; }
-  .campaign-surface-map-items { justify-content: flex-start; }
+  .campaign-workbench-heading, .campaign-composer-footer { align-items: flex-start; flex-direction: column; }
+  .campaign-surface-map-items { grid-template-columns: 1fr; }
   .campaign-recipe-heading { align-items: flex-start; flex-direction: column; }
   .campaign-recipe-heading > span { text-align: left; }
   .campaign-composer-footer-actions { justify-content: flex-start; }

--- a/openbank-admin-ui/src/test/campaign-studio.test.tsx
+++ b/openbank-admin-ui/src/test/campaign-studio.test.tsx
@@ -136,6 +136,16 @@ describe('campaign studio', () => {
 
     await waitFor(() => expect(document.querySelector('[data-surface="BANNER"]')).toBeTruthy(), { timeout: 8000 })
     expect(document.querySelector('[data-surface="PUSH"]')).toBeNull()
+    // A rail is only useful when it selects an actual moment, not when it repeats the selected
+    // canvas node. Add a second step, then switch the preview back to the first touchpoint.
+    fireEvent.click(document.querySelector('[data-add-step="true"]')!)
+    await waitFor(() => expect(document.querySelector('[data-touchpoint="1"]')).toBeTruthy(), { timeout: 8000 })
+    const firstTouchpoint = document.querySelector('[data-touchpoint="0"]') as HTMLButtonElement
+    const secondTouchpoint = document.querySelector('[data-touchpoint="1"]') as HTMLButtonElement
+    expect(secondTouchpoint.getAttribute('aria-pressed')).toBe('true')
+    fireEvent.click(firstTouchpoint)
+    expect(firstTouchpoint.getAttribute('aria-pressed')).toBe('true')
+    expect(secondTouchpoint.getAttribute('aria-pressed')).toBe('false')
   }, 15000)
 
   /**


### PR DESCRIPTION
## What changed

- replaces channel counters in Campaign Studio with an ordered, selectable customer-touchpoint rail
- each card names the actual app surface or deep-link destination from the authored step
- selecting a touchpoint switches the existing phone preview, including keyboard-visible focus treatment
- keeps the compact rail single-column and legible on a 390 px viewport

## Why

The campaign journey needed to communicate the customer experience, not just implementation channels. This gives marketers a direct, truthful bridge between the canvas and the app preview without inventing delivery or engagement data.

## Validation

- npx vitest run src/test/campaign-studio.test.tsx (20/20)
- npm run type-check
- npm run lint
- npx playwright test campaign-visual-contract.spec.ts --reporter=dot (2/2)

Refs #4712