### PR TITLE
fix(campaign): project story engagement

### DIFF
--- a/openbank-campaign-service/src/main/resources/db/migration/V15__campaign_engagement_stories_surface.sql
+++ b/openbank-campaign-service/src/main/resources/db/migration/V15__campaign_engagement_stories_surface.sql
@@ -1,0 +1,21 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+-- See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+--
+-- Stories are already a closed app surface in the campaign API and message contracts.  This is an
+-- expand-only correction to the aggregate projection's older CHECK constraint: without it, a
+-- legitimate attributable STORY event reaches the campaign consumer but PostgreSQL rejects its
+-- projection row and the Kafka record retries forever.
+--
+-- Mixed-version safety: existing readers and writers remain valid; this only admits the new
+-- closed value.  Rollback of application code is safe with this widened constraint left in place.
+-- Do NOT restore the former constraint while STORY rows exist: that would require deleting derived
+-- history, which is a separate, explicitly authorised retention operation rather than rollback.
+
+ALTER TABLE campaign_engagement_event
+    DROP CONSTRAINT campaign_engagement_event_surface_check;
+
+ALTER TABLE campaign_engagement_event
+    ADD CONSTRAINT campaign_engagement_event_surface_check CHECK (
+        surface IN ('HOME_BANNER', 'HOME_CAROUSEL', 'STORIES', 'PRODUCT_FEED', 'REWARDS_HUB')
+    );

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/infrastructure/kafka/CampaignEngagementConsumerTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/infrastructure/kafka/CampaignEngagementConsumerTest.kt
@@ -49,6 +49,17 @@ class CampaignEngagementConsumerTest {
     }
 
     @Test
+    fun `projects a server-attributed story without treating it as a generic banner`(): Unit = runBlocking {
+        coEvery { repository.record(any()) } returns true
+
+        consumer().onEvent(attributedEvent().replace("HOME_CAROUSEL", "STORIES"))
+
+        val event = slot<CampaignEngagementEvent>()
+        coVerify(exactly = 1) { repository.record(capture(event)) }
+        assertThat(event.captured.surface).isEqualTo(InAppSurface.STORIES)
+    }
+
+    @Test
     fun `organic and client-forbidden conversion events never enter campaign reporting`(): Unit = runBlocking {
         consumer().onEvent("""{"eventId":"$eventId","type":"IMPRESSION","slot":"HOME_BANNER"}""")
         consumer().onEvent(attributedEvent().replace("IMPRESSION", "CONVERSION"))

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/integration/CampaignRestContractIT.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/integration/CampaignRestContractIT.kt
@@ -299,6 +299,32 @@ class CampaignRestContractIT {
         }
     }
 
+    /**
+     * Real Flyway-backed projection fixture.  This deliberately writes the closed `STORIES` value
+     * through PostgreSQL rather than only mocking the Kafka consumer: a stale CHECK constraint
+     * otherwise keeps unit tests green while every live story event retries at the consumer.
+     */
+    private fun insertStoryEngagement(campaignId: UUID) {
+        dataSource.connection.use { connection ->
+            connection.prepareStatement(
+                """
+                INSERT INTO campaign_engagement_event
+                    (event_id, campaign_id, step_order, channel, surface, type, occurred_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                """.trimIndent(),
+            ).use { statement ->
+                statement.setObject(1, UUID.randomUUID())
+                statement.setObject(2, campaignId)
+                statement.setInt(3, 0)
+                statement.setString(4, "BANNER")
+                statement.setString(5, "STORIES")
+                statement.setString(6, "IMPRESSION")
+                statement.setObject(7, OffsetDateTime.now())
+                statement.executeUpdate()
+            }
+        }
+    }
+
     @Test
     @TestSecurity(user = "service-account-openbank-edge", roles = ["ROLE_API"])
     fun `interaction validation resolves only server-owned context for the owning party`() {
@@ -336,6 +362,24 @@ class CampaignRestContractIT {
             get("/api/v1/campaigns/interactions/$interactionRef")
         } Then {
             statusCode(404)
+        }
+    }
+
+    @Test
+    fun `campaign engagement reports attributable story attention through the HTTP contract`() {
+        val campaignId = UUID.randomUUID()
+        insertCampaignForSendLog(campaignId)
+        insertStoryEngagement(campaignId)
+
+        When {
+            get("/api/v1/campaigns/$campaignId/engagement")
+        } Then {
+            statusCode(200)
+            body("[0].stepOrder", equalTo(0))
+            body("[0].channel", equalTo("BANNER"))
+            body("[0].surface", equalTo("STORIES"))
+            body("[0].type", equalTo("IMPRESSION"))
+            body("[0].count", equalTo(1))
         }
     }
 


### PR DESCRIPTION
## Summary

Fix the campaign engagement projection so app Story impressions and clicks are admitted and appear in the campaign attention view.

## Root cause

`STORIES` is a closed, already-emittable in-app campaign surface, but the older PostgreSQL CHECK constraint for `campaign_engagement_event.surface` omitted it. The campaign consumer could therefore parse a valid Story event and then retry forever when its aggregate projection was rejected.

## Change and rollout safety

- Adds an expand-only Flyway migration that admits `STORIES`; existing values and readers remain valid.
- Does not remove history or require a destructive rollback. Application-code rollback remains safe while the widened constraint is present.
- Adds consumer coverage plus a Flyway-backed HTTP contract regression, so the schema and reporting route are exercised together.

## Validation

- `./gradlew :openbank-campaign-service:build` (all Campaign Service test XMLs green; 198 tests, 0 failures)
- `./gradlew :openbank-campaign-service:ktlintCheck :openbank-campaign-service:detekt`
- `git diff --check`

Refs #4480
