### PR TITLE
feat(campaign): add planning radar

### DIFF
--- a/openbank-admin-ui/src/app/api/campaigns/planning/route.ts
+++ b/openbank-admin-ui/src/app/api/campaigns/planning/route.ts
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+import { NextResponse } from 'next/server'
+import { auth } from '@/auth'
+import { serverSvcUrl } from '@/lib/services/bff'
+
+export const dynamic = 'force-dynamic'
+
+/**
+ * The server owns cadence interpretation. This proxy deliberately does not calculate a date from a
+ * browser clock or duplicate a cron expression: stale UI code must not invent the next campaign run.
+ */
+export async function GET() {
+  const session = await auth()
+  if (!session?.user?.accessToken) return NextResponse.json({ error: 'unauthenticated' }, { status: 401 })
+  try {
+    const res = await fetch(serverSvcUrl('campaign-service', 'campaign', 8128, '/api/v1/campaigns/planning'), {
+      headers: { authorization: `Bearer ${session.user.accessToken}` },
+      signal: AbortSignal.timeout(4000),
+      cache: 'no-store',
+    })
+    if (!res.ok) {
+      return NextResponse.json({
+        items: [],
+        state: res.status === 401 || res.status === 403 ? 'unauthorized' : res.status === 404 ? 'unavailable' : 'unreachable',
+      })
+    }
+    return NextResponse.json({ items: await res.json(), state: 'ok' })
+  } catch {
+    return NextResponse.json({ items: [], state: 'unreachable' })
+  }
+}

--- a/openbank-admin-ui/src/app/campaigns/page.tsx
+++ b/openbank-admin-ui/src/app/campaigns/page.tsx
@@ -45,6 +45,7 @@ import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
 import { PageHeader, StatCard, StatusBadge } from '@/components/ui'
 import { StageBoard, summariseBy, type StageDef } from '@/components/flow/StageBoard'
+import { CampaignPlanningBoard, type CampaignPlan } from '@/components/campaigns/CampaignPlanningBoard'
 
 /** `/api/v1/campaigns/summary` (#3296). Null when the deployed service predates the endpoint —
  *  the page then keeps saying reach is not available rather than showing zeros that look like
@@ -105,6 +106,8 @@ export default function CampaignsPage() {
   const [summary, setSummary] = useState<Record<string, CampaignSummary> | null>(null)
   const [engagement, setEngagement] = useState<Record<string, CampaignEngagement>>({})
   const [engagementState, setEngagementState] = useState<'ok' | 'unavailable'>('unavailable')
+  const [planning, setPlanning] = useState<CampaignPlan[]>([])
+  const [planningState, setPlanningState] = useState<'loading' | 'ok' | 'unavailable'>('loading')
   const [unavailable, setUnavailable] = useState<UnavailableKind | null>(null)
   const [loading, setLoading] = useState(true)
   const [search, setSearch] = useState('')
@@ -136,6 +139,20 @@ export default function CampaignsPage() {
       })
       .catch(() => setUnavailable('unreachable'))
       .finally(() => setLoading(false))
+  }, [])
+
+  useEffect(() => {
+    fetch('/api/campaigns/planning')
+      .then(r => r.json())
+      .then((d: { items?: CampaignPlan[]; state?: string }) => {
+        if (d.state === 'ok') {
+          setPlanning(d.items ?? [])
+          setPlanningState('ok')
+        } else {
+          setPlanningState('unavailable')
+        }
+      })
+      .catch(() => setPlanningState('unavailable'))
   }, [])
 
   const fmtDate = (iso: string | null | undefined) =>
@@ -343,6 +360,8 @@ export default function CampaignsPage() {
               </div>
             </div>
           </section>
+
+          <CampaignPlanningBoard items={planning} state={planningState} />
 
           <section className="campaign-decision-desk" aria-label={t('Dnešní priority kampaní', 'Today’s campaign priorities')} data-testid="campaign-decision-desk">
             <div className="campaign-decision-queue">

--- a/openbank-admin-ui/src/app/globals.css
+++ b/openbank-admin-ui/src/app/globals.css
@@ -689,6 +689,31 @@ main {
 @media (max-width: 900px) { .campaign-control-room, .campaign-decision-desk { grid-template-columns: 1fr; } }
 @media (max-width: 560px) { .campaign-control-hero { min-height: auto; padding: 1.05rem; } .campaign-control-hero-copy { display: grid; } .campaign-control-create { justify-self: start; } .campaign-control-flow { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); margin-top: 1rem; } .campaign-flow-arrow { display: none; } }
 
+/* ── Campaign planning radar ── */
+.campaign-planning-board { background: linear-gradient(120deg, #fff 0%, #f8fafc 58%, #eef2ff 100%); border: 1px solid var(--border); border-radius: var(--r-2xl); box-shadow: var(--shadow-sm); overflow: hidden; }
+.campaign-plan-head { align-items: flex-start; border-bottom: 1px solid var(--border); display: flex; justify-content: space-between; padding: 1rem 1.15rem .9rem; }
+.campaign-plan-head p { align-items: center; color: var(--ob-accent-text); display: flex; font-size: .63rem; font-weight: 800; gap: .35rem; letter-spacing: .09em; text-transform: uppercase; }
+.campaign-plan-head h2 { font-size: 1rem; font-weight: 800; letter-spacing: -.02em; margin-top: .18rem; }
+.campaign-plan-head > span { background: #eef2ff; border: 1px solid #c7d2fe; border-radius: 99px; color: #4338ca; font-size: .62rem; font-weight: 800; padding: .3rem .52rem; }
+.campaign-plan-grid { display: grid; grid-template-columns: minmax(0, 1.45fr) minmax(14rem, .55fr); }
+.campaign-plan-upcoming { padding: .72rem; }
+.campaign-plan-card { align-items: center; border: 1px solid transparent; border-radius: .72rem; color: inherit; display: grid; gap: .65rem; grid-template-columns: 1.6rem minmax(0, 1fr) auto; padding: .6rem; text-decoration: none; transition: background .16s ease, border-color .16s ease, transform .16s ease; }
+.campaign-plan-card:hover { background: #fff; border-color: #c7d2fe; transform: translateX(2px); }
+.campaign-plan-index { color: #6366f1; font-family: var(--font-mono); font-size: .62rem; font-weight: 800; }
+.campaign-plan-copy { display: grid; min-width: 0; }
+.campaign-plan-copy strong { font-size: .76rem; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.campaign-plan-copy small { color: var(--text-secondary); font-size: .63rem; margin-top: .1rem; }
+.campaign-plan-card time { background: #eef2ff; border-radius: .48rem; color: #3730a3; font-size: .62rem; font-variant-numeric: tabular-nums; font-weight: 800; padding: .36rem .45rem; white-space: nowrap; }
+.campaign-plan-footnote, .campaign-plan-empty { color: var(--text-secondary); font-size: .64rem; line-height: 1.4; margin: .58rem .15rem .1rem; }
+.campaign-plan-aside { background: rgba(238,242,255,.56); border-left: 1px solid var(--border); padding: 1rem; }
+.campaign-plan-aside > div { align-items: center; display: flex; gap: .38rem; }
+.campaign-plan-aside > div svg { color: #6366f1; }
+.campaign-plan-aside strong { font-size: .72rem; }
+.campaign-plan-aside > div span { align-items: center; background: #4338ca; border-radius: 99px; color: #fff; display: inline-flex; font-size: .62rem; font-weight: 800; height: 1.22rem; justify-content: center; margin-left: auto; min-width: 1.22rem; }
+.campaign-plan-aside > p { color: #5b5b86; font-size: .64rem; line-height: 1.42; margin-top: .54rem; }
+.campaign-plan-events { align-items: flex-start; border-top: 1px solid #c7d2fe; color: #4338ca; display: flex; font-size: .62rem; gap: .35rem; line-height: 1.35; margin-top: .7rem; padding-top: .65rem; }
+@media (max-width: 700px) { .campaign-plan-grid { grid-template-columns: 1fr; } .campaign-plan-aside { border-left: 0; border-top: 1px solid var(--border); } .campaign-plan-head { gap: .5rem; } .campaign-plan-head > span { font-size: .56rem; } }
+
 /* ── Campaign outcome brief ── */
 .campaign-outcome-brief { background: linear-gradient(110deg, #111827 0%, #172554 56%, #312e81 100%); border-radius: var(--r-xl); box-shadow: var(--shadow-lg); color: #fff; display: grid; grid-template-columns: minmax(0, 1fr) minmax(13.5rem, .32fr); overflow: hidden; }
 .campaign-outcome-main { padding: 1.25rem; }

--- a/openbank-admin-ui/src/components/campaigns/CampaignPlanningBoard.tsx
+++ b/openbank-admin-ui/src/components/campaigns/CampaignPlanningBoard.tsx
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+'use client'
+
+import Link from 'next/link'
+import { CalendarDays, Radio, Sparkles } from 'lucide-react'
+import { useLanguage } from '@/lib/i18n/LanguageContext'
+
+export interface CampaignPlan {
+  campaignId: string
+  name: string
+  state: string
+  entry: 'SCHEDULED' | 'EVENT' | 'MANUAL'
+  cadence?: string | null
+  cadenceHumanForm?: string | null
+  zone?: string | null
+  nextScheduledWindowAt?: string | null
+  endAt?: string | null
+  trigger?: string | null
+}
+
+/**
+ * A marketer-facing plan, not a fabricated execution log. The Campaign service calculates each
+ * declared window from its reviewed cadence; this component only formats that evidence and keeps
+ * inactive/event-driven entries visibly distinct from a planned run.
+ */
+export function CampaignPlanningBoard({
+  items,
+  state,
+}: {
+  items: CampaignPlan[]
+  state: 'loading' | 'ok' | 'unavailable'
+}) {
+  const { t, language } = useLanguage()
+  const formatter = new Intl.DateTimeFormat(language === 'cs' ? 'cs-CZ' : 'en-GB', {
+    weekday: 'short', day: 'numeric', month: 'short', hour: '2-digit', minute: '2-digit', timeZone: 'Europe/Prague',
+  })
+  const scheduled = items.filter(item => item.entry === 'SCHEDULED')
+  const upcoming = scheduled.filter(item => item.nextScheduledWindowAt).slice(0, 3)
+  const notLive = scheduled.filter(item => !item.nextScheduledWindowAt && item.state !== 'ACTIVE')
+  const noNextWindow = scheduled.filter(item => !item.nextScheduledWindowAt && item.state === 'ACTIVE')
+  const events = items.filter(item => item.entry === 'EVENT').slice(0, 2)
+
+  return (
+    <section className="campaign-planning-board" aria-label={t('Plán kampaní', 'Campaign plan')} data-testid="campaign-planning-board">
+      <div className="campaign-plan-head">
+        <div>
+          <p><CalendarDays size={14} /> {t('Plánovací radar', 'Planning radar')}</p>
+          <h2>{t('Kdy se příště může něco stát', 'When something can happen next')}</h2>
+        </div>
+        <span>{t('Europe/Prague', 'Europe/Prague')}</span>
+      </div>
+
+      {state === 'loading' && <p className="campaign-plan-empty">{t('Načítám plán…', 'Loading the plan…')}</p>}
+      {state === 'unavailable' && (
+        <p className="campaign-plan-empty" data-testid="campaign-plan-unavailable">
+          {t('Plán zatím není dostupný. Neznamená to, že nic neběží.', 'The plan is not available yet. It does not mean nothing is running.')}
+        </p>
+      )}
+      {state === 'ok' && (
+        <div className="campaign-plan-grid">
+          <div className="campaign-plan-upcoming">
+            {upcoming.length > 0 ? upcoming.map((item, index) => (
+              <Link href={`/campaigns/${item.campaignId}`} key={`${item.campaignId}-${item.entry}`} className="campaign-plan-card" data-plan-campaign={item.campaignId}>
+                <span className="campaign-plan-index">0{index + 1}</span>
+                <span className="campaign-plan-copy">
+                  <strong>{item.name}</strong>
+                  <small>{item.cadenceHumanForm}</small>
+                </span>
+                <time dateTime={item.nextScheduledWindowAt ?? undefined}>
+                  {item.nextScheduledWindowAt ? formatter.format(new Date(item.nextScheduledWindowAt)) : '—'}
+                </time>
+              </Link>
+            )) : (
+              <p className="campaign-plan-empty">{t('Žádná aktivní pravidelná cesta zatím nemá další okno.', 'No active recurring journey has a next window yet.')}</p>
+            )}
+            <p className="campaign-plan-footnote">
+              {t('Jsou to deklarovaná okna cadence, ne slíbená doručení ani odhad překryvu audience.', 'These are declared cadence windows, not promised sends or an audience-overlap estimate.')}
+            </p>
+          </div>
+          <aside className="campaign-plan-aside">
+            <div>
+              <Sparkles size={14} />
+              <strong>{t('Ještě neběží', 'Not live yet')}</strong>
+              <span>{notLive.length}</span>
+            </div>
+            <p>{notLive.length > 0
+              ? t('Naplánované koncepty, čekající na druhé oči nebo pozastavené cesty nemají vypsané další okno.', 'Scheduled drafts, approval work and paused journeys do not show a next window.')
+              : t('Všechny pravidelné cesty jsou buď živé, nebo bez čekajícího schválení.', 'Every recurring journey is either live or has no pending approval work.')}
+            </p>
+            {noNextWindow.length > 0 && (
+              <div className="campaign-plan-events" data-testid="campaign-plan-no-next-window">
+                <CalendarDays size={13} />
+                <span>{noNextWindow.length} {t('aktivní pravidelné cesty už nemají další deklarované okno.', 'active recurring journeys have no next declared window.')}</span>
+              </div>
+            )}
+            {events.length > 0 && (
+              <div className="campaign-plan-events">
+                <Radio size={13} />
+                <span>{events.length} {t('eventové vstupy reagují až na produktovou událost.', 'event entries react only to a product event.')}</span>
+              </div>
+            )}
+          </aside>
+        </div>
+      )}
+    </section>
+  )
+}

--- a/openbank-admin-ui/src/test/campaign-planning-board.test.tsx
+++ b/openbank-admin-ui/src/test/campaign-planning-board.test.tsx
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+import { describe, expect, it } from 'vitest'
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { LanguageProvider } from '@/lib/i18n/LanguageContext'
+import { CampaignPlanningBoard } from '@/components/campaigns/CampaignPlanningBoard'
+
+function renderBoard(items: React.ComponentProps<typeof CampaignPlanningBoard>['items'], state: 'loading' | 'ok' | 'unavailable' = 'ok') {
+  return render(React.createElement(LanguageProvider, null, React.createElement(CampaignPlanningBoard, { items, state })))
+}
+
+describe('CampaignPlanningBoard', () => {
+  it('shows only an active declared cadence as a next window and calls it a window, not delivery', () => {
+    renderBoard([
+      {
+        campaignId: 'live', name: 'Savings pulse', state: 'ACTIVE', entry: 'SCHEDULED',
+        cadence: 'DAILY_MORNING', cadenceHumanForm: 'every day at 09:00', zone: 'Europe/Prague',
+        nextScheduledWindowAt: '2026-02-04T08:00:00Z',
+      },
+      {
+        campaignId: 'review', name: 'Card offer', state: 'PENDING_APPROVAL', entry: 'SCHEDULED',
+        cadence: 'WEEKLY_MONDAY_MORNING', cadenceHumanForm: 'every Monday at 09:00', zone: 'Europe/Prague',
+      },
+      { campaignId: 'event', name: 'Welcome', state: 'ACTIVE', entry: 'EVENT', trigger: 'ACCOUNT_OPENED' },
+    ])
+
+    expect(screen.getByTestId('campaign-planning-board').textContent).toMatch(/Savings pulse.*every day at 09:00/)
+    expect(screen.getByTestId('campaign-planning-board').textContent).toMatch(/Not live yet.*1/)
+    expect(screen.getByTestId('campaign-planning-board').textContent).toMatch(/declared cadence windows.*not promised sends/i)
+    expect(document.querySelector('[data-plan-campaign="review"]')).toBeNull()
+  })
+
+  it('renders an unavailable planning source as unknown rather than an empty schedule', () => {
+    renderBoard([], 'unavailable')
+    expect(screen.getByTestId('campaign-plan-unavailable').textContent).toMatch(/does not mean nothing is running/i)
+  })
+
+  it('does not call an active schedule without another window not live yet', () => {
+    renderBoard([{
+      campaignId: 'ended', name: 'Closed cadence', state: 'ACTIVE', entry: 'SCHEDULED',
+      cadence: 'DAILY_MORNING', cadenceHumanForm: 'every day at 09:00', endAt: '2026-02-03T08:00:00Z',
+    }])
+
+    expect(screen.getByTestId('campaign-plan-no-next-window').textContent).toMatch(/no next declared window/i)
+    expect(screen.getByTestId('campaign-planning-board').textContent).toMatch(/Not live yet.*0/)
+  })
+})

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/usecase/CampaignPlanningQuery.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/usecase/CampaignPlanningQuery.kt
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+package com.openbank.campaign.application.usecase
+
+import com.openbank.campaign.application.port.out.CampaignRepository
+import com.openbank.campaign.domain.model.CampaignState
+import com.openbank.campaign.domain.model.ScheduleCatalog
+import jakarta.enterprise.context.ApplicationScoped
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * A portfolio-level planning projection for marketers.
+ *
+ * It deliberately returns the next *declared schedule window*, not a promised send and not an
+ * audience-overlap estimate. Temporal owns actual execution, and evaluating cross-campaign overlap
+ * without the same live segment snapshot would manufacture a certainty the bank does not have.
+ */
+@ApplicationScoped
+class CampaignPlanningQuery(private val campaigns: CampaignRepository) {
+
+    suspend fun items(now: Instant = Instant.now()): List<CampaignPlan> = campaigns.list()
+        .flatMap { campaign ->
+            val schedule = campaign.schedule
+            buildList {
+                if (schedule != null) {
+                    val cadence = requireNotNull(ScheduleCatalog[schedule.cadence])
+                    val active = campaign.state == CampaignState.ACTIVE
+                    val nextWindow = if (active) ScheduleCatalog.nextWindowAfter(schedule.cadence, now) else null
+                    add(
+                        CampaignPlan(
+                            campaignId = campaign.id,
+                            name = campaign.name,
+                            state = campaign.state.name,
+                            entry = CampaignEntry.SCHEDULED,
+                            cadence = schedule.cadence,
+                            cadenceHumanForm = cadence.humanForm,
+                            zone = ScheduleCatalog.ZONE,
+                            nextScheduledWindowAt = nextWindow?.takeIf { candidate ->
+                                schedule.endAt?.let { candidate < it } ?: true
+                            },
+                            endAt = schedule.endAt,
+                        ),
+                    )
+                }
+                campaign.trigger?.let { trigger ->
+                    add(
+                        CampaignPlan(
+                            campaignId = campaign.id,
+                            name = campaign.name,
+                            state = campaign.state.name,
+                            entry = CampaignEntry.EVENT,
+                            trigger = trigger,
+                        ),
+                    )
+                }
+                if (schedule == null && campaign.trigger == null) {
+                    add(
+                        CampaignPlan(
+                            campaignId = campaign.id,
+                            name = campaign.name,
+                            state = campaign.state.name,
+                            entry = CampaignEntry.MANUAL,
+                        ),
+                    )
+                }
+            }
+        }
+        .sortedWith(compareBy<CampaignPlan> { it.nextScheduledWindowAt == null }.thenBy { it.nextScheduledWindowAt })
+}
+
+data class CampaignPlan(
+    val campaignId: UUID,
+    val name: String,
+    val state: String,
+    val entry: CampaignEntry,
+    val cadence: String? = null,
+    val cadenceHumanForm: String? = null,
+    val zone: String? = null,
+    val nextScheduledWindowAt: Instant? = null,
+    val endAt: Instant? = null,
+    val trigger: String? = null,
+)
+
+enum class CampaignEntry { SCHEDULED, EVENT, MANUAL }

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/domain/model/ScheduleCatalog.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/domain/model/ScheduleCatalog.kt
@@ -4,6 +4,13 @@
 
 package com.openbank.campaign.domain.model
 
+import java.time.DayOfWeek
+import java.time.Instant
+import java.time.LocalTime
+import java.time.ZoneId
+import java.time.ZonedDateTime
+import java.time.temporal.TemporalAdjusters
+
 /**
  * When a recurring campaign re-evaluates its segment and enrols whoever newly qualifies.
  *
@@ -39,7 +46,9 @@ object ScheduleCatalog {
      *   derived from it: a rendered cron is a different sentence in every library, and this string
      *   is what a marketer approves.
      */
-    data class Cadence(val cron: String, val humanForm: String)
+    enum class Recurrence { DAILY, WEEKLY_MONDAY, MONTHLY_FIRST }
+
+    data class Cadence(val cron: String, val humanForm: String, val recurrence: Recurrence)
 
     /**
      * The catalogue. Deliberately coarse — nothing finer than daily.
@@ -49,12 +58,39 @@ object ScheduleCatalog {
      * party. The cheapest way to keep that honest is to not offer the frequency in the first place.
      */
     val ALL: Map<String, Cadence> = mapOf(
-        "DAILY_MORNING" to Cadence("0 9 * * *", "every day at 09:00"),
-        "WEEKLY_MONDAY_MORNING" to Cadence("0 9 * * MON", "every Monday at 09:00"),
-        "MONTHLY_FIRST_MORNING" to Cadence("0 9 1 * *", "on the 1st of each month at 09:00"),
+        "DAILY_MORNING" to Cadence("0 9 * * *", "every day at 09:00", Recurrence.DAILY),
+        "WEEKLY_MONDAY_MORNING" to Cadence("0 9 * * MON", "every Monday at 09:00", Recurrence.WEEKLY_MONDAY),
+        "MONTHLY_FIRST_MORNING" to Cadence("0 9 1 * *", "on the 1st of each month at 09:00", Recurrence.MONTHLY_FIRST),
     )
 
     fun exists(cadence: String): Boolean = cadence in ALL
 
     operator fun get(cadence: String): Cadence? = ALL[cadence]
+
+    /**
+     * The next declared marketing window, calculated from the same closed cadence the Temporal
+     * scheduler receives. This is a planning projection, not a delivery promise: Temporal remains
+     * the authority for whether a run starts and whether anybody is eligible when it does.
+     */
+    fun nextWindowAfter(cadence: String, after: Instant): Instant {
+        val rule = requireNotNull(this[cadence]) { "unknown cadence '$cadence'" }
+        val now = after.atZone(ZoneId.of(ZONE))
+        val atNine = LocalTime.of(MORNING_HOUR, 0)
+        fun candidate(day: ZonedDateTime): ZonedDateTime = day.with(atNine)
+        val next = when (rule.recurrence) {
+            Recurrence.DAILY -> candidate(now).takeIf { it.isAfter(now) } ?: candidate(now.plusDays(1))
+            Recurrence.WEEKLY_MONDAY -> {
+                val monday = now.with(TemporalAdjusters.nextOrSame(DayOfWeek.MONDAY))
+                candidate(monday).takeIf { it.isAfter(now) } ?: candidate(monday.plusWeeks(1))
+            }
+            Recurrence.MONTHLY_FIRST -> {
+                val first = now.with(TemporalAdjusters.firstDayOfMonth())
+                candidate(first).takeIf { it.isAfter(now) }
+                    ?: candidate(now.plusMonths(1).with(TemporalAdjusters.firstDayOfMonth()))
+            }
+        }
+        return next.toInstant()
+    }
+
+    private const val MORNING_HOUR = 9
 }

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/rest/CampaignPlanningResource.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/rest/CampaignPlanningResource.kt
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+package com.openbank.campaign.infrastructure.rest
+
+import com.openbank.campaign.application.usecase.CampaignPlanningQuery
+import com.openbank.libs.authz.Authorize
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.ws.rs.GET
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.core.Response
+
+/**
+ * Read-only campaign planning view. The literal segment takes precedence over the campaign id
+ * template, and uses a collection-level authorisation scope because there is no single campaign id.
+ */
+@Path("/api/v1/campaigns/planning")
+@ApplicationScoped
+class CampaignPlanningResource(private val planning: CampaignPlanningQuery) {
+
+    @GET
+    @Authorize(action = "campaign.read", resource = "")
+    suspend fun planning(): Response = Response.ok(planning.items()).build()
+}

--- a/openbank-campaign-service/src/main/resources/openapi.yaml
+++ b/openbank-campaign-service/src/main/resources/openapi.yaml
@@ -4,7 +4,7 @@ openapi: 3.1.0
 info:
   title: Campaign Service API
   # major == openbank.api.version == URL /api/v1 (ADR-0048).
-  version: 1.36.0
+  version: 1.37.0
   description: >-
     Campaign management first slice (ADR-0200 / ADR-0209 D3): deterministic, versioned segments;
     per-enrolment Temporal journeys; consent-gated delivery through notification-service.
@@ -138,6 +138,25 @@ paths:
               schema:
                 type: array
                 items: { $ref: '#/components/schemas/CampaignSummary' }
+  /api/v1/campaigns/planning:
+    get:
+      tags: [Campaigns]
+      operationId: campaignPlanning
+      summary: Declared campaign entry plan
+      description: >-
+        Portfolio planning projection for scheduled, event-driven and manual campaigns. A scheduled
+        entry's nextScheduledWindowAt is calculated from the reviewed cadence in Europe/Prague; it
+        is not a delivery promise, audience-overlap estimate, or proof that Temporal started it.
+        Inactive schedules intentionally return no next window. NOTE the literal segment must keep
+        matching ahead of /api/v1/campaigns/{id}.
+      responses:
+        '200':
+          description: Planned campaign entries without party-level data
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: '#/components/schemas/CampaignPlan' }
   /api/v1/campaigns/cadences:
     get:
       tags: [Campaigns]
@@ -673,6 +692,26 @@ components:
           format: int64
           description: Sum of the ADR-0200 D6 suppression outcomes (cap, quiet hours, consent).
         failed: { type: integer, format: int64 }
+    CampaignPlan:
+      type: object
+      required: [campaignId, name, state, entry]
+      properties:
+        campaignId: { type: string, format: uuid }
+        name: { type: string }
+        state: { type: string, enum: [DRAFT, PENDING_APPROVAL, ACTIVE, PAUSED, CLOSED] }
+        entry: { type: string, enum: [SCHEDULED, EVENT, MANUAL] }
+        cadence: { type: string, nullable: true }
+        cadenceHumanForm: { type: string, nullable: true }
+        zone: { type: string, nullable: true, example: Europe/Prague }
+        nextScheduledWindowAt:
+          type: string
+          format: date-time
+          nullable: true
+          description: >-
+            Next declared schedule window only for an ACTIVE scheduled campaign. Null is explicit
+            for inactive, expired, event-driven and manual entries; it is never a zero timestamp.
+        endAt: { type: string, format: date-time, nullable: true }
+        trigger: { type: string, nullable: true }
     Campaign:
       type: object
       properties:

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/usecase/CampaignPlanningQueryTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/usecase/CampaignPlanningQueryTest.kt
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+package com.openbank.campaign.application.usecase
+
+import com.openbank.campaign.application.port.out.CampaignRepository
+import com.openbank.campaign.domain.model.Campaign
+import com.openbank.campaign.domain.model.CampaignSchedule
+import com.openbank.campaign.domain.model.CampaignState
+import com.openbank.campaign.domain.model.CampaignStep
+import com.openbank.campaign.domain.model.Channel
+import com.openbank.campaign.domain.model.SegmentRef
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.UUID
+
+class CampaignPlanningQueryTest {
+    private val campaigns = mockk<CampaignRepository>()
+    private val query = CampaignPlanningQuery(campaigns)
+
+    @Test
+    fun `projects only live non-expired schedules as a next declared window`(): Unit = runBlocking {
+        val now = Instant.parse("2026-02-03T08:30:00Z")
+        val live = campaign("live", CampaignState.ACTIVE, schedule = CampaignSchedule("DAILY_MORNING"))
+        val waiting = campaign("waiting", CampaignState.PENDING_APPROVAL, schedule = CampaignSchedule("DAILY_MORNING"))
+        val ended = campaign(
+            "ended",
+            CampaignState.ACTIVE,
+            // The next daily 09:00 Prague window is exactly this instant. The scheduler treats
+            // endAt as inclusive, so the planning projection must not advertise it as runnable.
+            schedule = CampaignSchedule("DAILY_MORNING", endAt = Instant.parse("2026-02-04T08:00:00Z")),
+        )
+        val event = campaign("event", CampaignState.ACTIVE, trigger = "ACCOUNT_OPENED")
+        val dualEntry = campaign(
+            "dual-entry",
+            CampaignState.ACTIVE,
+            schedule = CampaignSchedule("WEEKLY_MONDAY_MORNING"),
+            trigger = "ACCOUNT_OPENED",
+        )
+        coEvery { campaigns.list() } returns listOf(waiting, event, ended, live, dualEntry)
+
+        val plans = query.items(now).associateBy { it.campaignId }
+
+        assertThat(plans[live.id]?.nextScheduledWindowAt).isEqualTo(Instant.parse("2026-02-04T08:00:00Z"))
+        assertThat(plans[live.id]?.entry).isEqualTo(CampaignEntry.SCHEDULED)
+        assertThat(plans[waiting.id]?.nextScheduledWindowAt).isNull()
+        assertThat(plans[ended.id]?.nextScheduledWindowAt).isNull()
+        assertThat(plans[event.id]?.entry).isEqualTo(CampaignEntry.EVENT)
+        assertThat(plans[event.id]?.nextScheduledWindowAt).isNull()
+        assertThat(query.items(now).filter { it.campaignId == dualEntry.id }.map { it.entry })
+            .containsExactlyInAnyOrder(CampaignEntry.SCHEDULED, CampaignEntry.EVENT)
+    }
+
+    private fun campaign(
+        name: String,
+        state: CampaignState,
+        schedule: CampaignSchedule? = null,
+        trigger: String? = null,
+    ) = Campaign(
+        id = UUID.randomUUID(),
+        name = name,
+        goal = "plan safely",
+        segmentRef = SegmentRef("actives", 1),
+        steps = listOf(CampaignStep(1, "MARKETING_PRODUCT_OFFER_PUSH", Channel.PUSH, mapOf("offerTitle" to "T"), 0)),
+        schedule = schedule,
+        trigger = trigger,
+        state = state,
+        createdBy = "maker",
+        approvedBy = null,
+        createdAt = Instant.EPOCH,
+        updatedAt = Instant.EPOCH,
+    )
+}

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/domain/CampaignScheduleTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/domain/CampaignScheduleTest.kt
@@ -55,6 +55,20 @@ class CampaignScheduleTest {
 class ScheduleCatalogTest {
 
     @Test
+    fun `planning windows follow the reviewed Prague cadence after its morning slot`() {
+        // Winter avoids a hidden system-zone dependency while still proving the catalogue uses
+        // Europe/Prague rather than UTC. 09:30 Prague means today's 09:00 slot is already gone.
+        val afterMorning = Instant.parse("2026-02-03T08:30:00Z")
+
+        assertThat(ScheduleCatalog.nextWindowAfter("DAILY_MORNING", afterMorning))
+            .isEqualTo(Instant.parse("2026-02-04T08:00:00Z"))
+        assertThat(ScheduleCatalog.nextWindowAfter("WEEKLY_MONDAY_MORNING", afterMorning))
+            .isEqualTo(Instant.parse("2026-02-09T08:00:00Z"))
+        assertThat(ScheduleCatalog.nextWindowAfter("MONTHLY_FIRST_MORNING", afterMorning))
+            .isEqualTo(Instant.parse("2026-03-01T08:00:00Z"))
+    }
+
+    @Test
     fun `every cadence declares a five-field cron and a human sentence`() {
         ScheduleCatalog.ALL.forEach { (key, cadence) ->
             assertThat(cadence.cron.trim().split(Regex("\\s+")))

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/integration/CampaignRestContractIT.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/integration/CampaignRestContractIT.kt
@@ -679,6 +679,39 @@ class CampaignRestContractIT {
         }
     }
 
+    @Test
+    fun `planning keeps a submitted recurring campaign visibly unplanned until activation`() {
+        val name = "planned-${UUID.randomUUID()}"
+        val id = Given {
+            contentType("application/json")
+            body(
+                draftBody(name).replace(
+                    "\"steps\":[",
+                    "\"schedule\":{\"cadence\":\"DAILY_MORNING\"},\"steps\":[",
+                ),
+            )
+        } When {
+            post("/api/v1/campaigns")
+        } Then {
+            statusCode(201)
+        } Extract {
+            path<String>("id")
+        }
+        submit(id)
+
+        When {
+            get("/api/v1/campaigns/planning")
+        } Then {
+            statusCode(200)
+            body("find { it.campaignId == '$id' }.entry", equalTo("SCHEDULED"))
+            body("find { it.campaignId == '$id' }.cadence", equalTo("DAILY_MORNING"))
+            body("find { it.campaignId == '$id' }.zone", equalTo("Europe/Prague"))
+            // A schedule is created only after four-eyes activation. Rendering a date here would
+            // make an unapproved campaign look operationally live.
+            body("find { it.campaignId == '$id' }.nextScheduledWindowAt", nullValue())
+        }
+    }
+
     /** Studio reads the exact catalogue the aggregate validates, including authenticated app placement. */
     @Test
     fun `the template catalogue serves channels declared variables and in-app surfaces`() {


### PR DESCRIPTION
## What
- adds a server-owned planning projection for scheduled, event-driven and manual campaigns
- exposes declared Europe/Prague cadence windows in Campaign Studio
- keeps inactive, expired and unavailable data visibly unknown rather than inventing delivery or overlap

## Safety
- no audience-overlap estimate or promised-send semantics
- next window exists only for active, non-expired schedules; the end boundary matches the scheduler
- a campaign with schedule plus event trigger appears as both entry sources
- collection read remains campaign.read-authorized

## Verification
- Campaign Service focused tests, ktlint and detekt passed
- Campaign Planning Board tests: 12 passed
- ESLint, TypeScript and production Next build passed

Refs #4476