### PR TITLE
feat(admin-ui): show confirmed campaign outcomes

### DIFF
--- a/openbank-admin-ui/src/app/campaigns/page.tsx
+++ b/openbank-admin-ui/src/app/campaigns/page.tsx
@@ -191,7 +191,11 @@ export default function CampaignsPage() {
     const sent = values.reduce((total, row) => total + row.sent, 0)
     const suppressed = values.reduce((total, row) => total + row.suppressed, 0)
     const failed = values.reduce((total, row) => total + row.failed, 0)
-    return { sent, suppressed, failed, affected: values.filter(row => row.failed > 0).length }
+    const converted = values.reduce(
+      (total, row) => total + (row.outcomes?.find(outcome => outcome.outcome === 'CONVERTED')?.count ?? 0),
+      0,
+    )
+    return { sent, suppressed, failed, converted, affected: values.filter(row => row.failed > 0).length }
   }, [summary])
 
   const decisionQueue = useMemo(
@@ -479,12 +483,13 @@ export default function CampaignsPage() {
                 </div>
                 {deliveryHealth.failed > 0 && <span className="rounded-full bg-rose-400/15 px-3 py-1 text-xs font-semibold text-rose-200">{deliveryHealth.affected} {t('kampaní s chybou', 'campaigns with failures')}</span>}
               </div>
-              <div className="mt-4 grid gap-3 sm:grid-cols-3">
+              <div className="mt-4 grid gap-3 sm:grid-cols-4">
                 <div className="rounded-lg bg-white/10 p-3"><p className="text-xs text-slate-300">{t('Odesláno', 'Sent')}</p><strong className="text-2xl">{deliveryHealth.sent}</strong></div>
                 <div className="rounded-lg bg-amber-300/10 p-3"><p className="text-xs text-amber-100">{t('Potlačeno politikou', 'Suppressed by policy')}</p><strong className="text-2xl">{deliveryHealth.suppressed}</strong></div>
                 <div className="rounded-lg bg-rose-400/10 p-3"><p className="text-xs text-rose-100">{t('Selhalo', 'Failed')}</p><strong className="text-2xl">{deliveryHealth.failed}</strong></div>
+                <div className="rounded-lg bg-emerald-300/10 p-3"><p className="text-xs text-emerald-100">{t('Potvrzené konverze', 'Confirmed conversions')}</p><strong className="text-2xl">{deliveryHealth.converted}</strong></div>
               </div>
-              <p className="mt-3 text-xs text-slate-300">{t('Potlačení chrání souhlas, klidové hodiny a frekvenční limit; není to nedoručený kontakt. Konverze zde nejsou odhadovány.', 'Suppression protects consent, quiet hours and frequency caps; it is not an undelivered contact. Conversions are not estimated here.')}</p>
+              <p className="mt-3 text-xs text-slate-300">{t('Potlačení chrání souhlas, klidové hodiny a frekvenční limit; není to nedoručený kontakt. Konverze jsou jen skutečné bankovní outcome události, nikdy kliky ani odhad.', 'Suppression protects consent, quiet hours and frequency caps; it is not an undelivered contact. Conversions are real banking outcome events only, never clicks or an estimate.')}</p>
             </section>
           )}
 

--- a/openbank-admin-ui/src/test/campaigns-console.test.tsx
+++ b/openbank-admin-ui/src/test/campaigns-console.test.tsx
@@ -22,7 +22,7 @@ const CAMPAIGN_ID = '019fb939-3e0a-7716-a1ed-7854754c8786'
 
 const LIST = {
   state: 'ok',
-  summary: [{ campaignId: CAMPAIGN_ID, enrolled: 80, sent: 40, suppressed: 32, failed: 3 }],
+  summary: [{ campaignId: CAMPAIGN_ID, enrolled: 80, sent: 40, suppressed: 32, failed: 3, outcomes: [{ outcome: 'CONVERTED', count: 5 }] }],
   items: [
     {
       id: CAMPAIGN_ID,
@@ -110,7 +110,8 @@ describe('campaign console', () => {
     expect(panel.textContent).toMatch(/Sent.*40/)
     expect(panel.textContent).toMatch(/Suppressed by policy.*32/)
     expect(panel.textContent).toMatch(/Failed.*3/)
-    expect(panel.textContent).toMatch(/Conversions are not estimated/i)
+    expect(panel.textContent).toMatch(/Confirmed conversions.*5/)
+    expect(panel.textContent).toMatch(/never clicks or an estimate/i)
   })
 
   it('a refused read does not render as an empty estate', async () => {


### PR DESCRIPTION
Depends on #4788. Adds only confirmed CONVERTED outcomes from the server aggregate; no clicks, inferred conversion, or derived rate. Verified with campaign console tests and TypeScript.