### PR TITLE
test(account): pin the legacy arm's missing grantor as a money-path invariant

### DIFF
--- a/openbank-account-service/src/test/kotlin/com/openbank/account/integration/LegacyArmOmitsGrantorIT.kt
+++ b/openbank-account-service/src/test/kotlin/com/openbank/account/integration/LegacyArmOmitsGrantorIT.kt
@@ -1,0 +1,249 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.account.integration
+
+import com.openbank.account.it.PostgresRedpandaRedisTestResource
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.security.TestSecurity
+import io.restassured.module.kotlin.extensions.Extract
+import io.restassured.module.kotlin.extensions.Given
+import io.restassured.module.kotlin.extensions.Then
+import io.restassured.module.kotlin.extensions.When
+import io.smallrye.reactive.messaging.memory.InMemoryConnector
+import io.smallrye.reactive.messaging.memory.InMemorySource
+import jakarta.enterprise.inject.Any
+import jakarta.inject.Inject
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+import java.util.UUID
+
+/**
+ * **A `LEGACY_AUTHORIZATION` answer carries NO `grantorPartyId`, and that omission is
+ * LOAD-BEARING on the money path** (issue #2993, ADR-0232 D1/D3/D5).
+ *
+ * ### What this pins, and why it is not a formatting test
+ *
+ * `authorizeDelegatedPayment` answers `authorized: true` for a row in the un-reconciled legacy
+ * `account_authorizations` table — the store ADR-0232 D1 exists to retire, which nothing
+ * back-fills, nothing writes through to, and nothing reconciles. That verdict reaches
+ * `CustomerEdgeResource.resolveDebitAuthority`, the domestic-payment route's debit guard, which
+ * refuses on `decision?.authorized != true || grantor == null`.
+ *
+ * So the ONLY thing standing between the legacy store and a live debit is the single line in
+ * [com.openbank.account.infrastructure.rest.DelegatedPaymentAuthorizationResource] that emits
+ * `delegationId`/`grantorPartyId` **exclusively** for the `DELEGATED` outcome. A legacy-only
+ * delegate cannot initiate a payment today only because that field is absent.
+ *
+ * **Nothing intended that.** The refusal falls out of the edge needing a grantor id to re-fetch
+ * the account as its owner — not out of anyone deciding the legacy store must not carry money.
+ * The property was entirely untested until this test and its customer-edge sibling
+ * (`LegacyDelegationArmRefusedIT`) existed.
+ *
+ * ### The direction a future change must NOT take
+ *
+ * The two arms of that response visibly disagree: one names its grant, the other does not. The
+ * obvious tidy-up — *"the response should always carry `grantorPartyId`; it is the account owner
+ * in both cases"* — is correct-looking, one line, and **silently puts an un-reconciled store on
+ * the money path**. Before this test, no test in the fleet would have gone red.
+ *
+ * Widening is the wrong direction. Until the ADR-0232 D1 dual-run exists (write-through, backfill,
+ * reconciliation — measured at zero on #2993 across five passes), the two stores can only be made
+ * to agree by trusting the **wider and unreconciled** one. The drift is the safer state: revoking
+ * a delegation grant does not close the legacy row, so a response that named a grantor for it
+ * would let money move under an authority the system of record has already withdrawn.
+ *
+ * If the arms must converge, converge them by *narrowing* — stop answering `authorized: true` for
+ * the legacy arm — or by building the dual-run first. Never by adding the field.
+ *
+ * ### Why this is an IT and not a unit test
+ *
+ * `AuthorizeDelegatedPaymentTest` covers the use case's verdict, and cannot see this: the
+ * omission happens in the resource's response assembly, one layer above it, and a test that calls
+ * the resource class cannot tell a served route from an unserved one nor observe what JAX-RS
+ * actually serialises. This drives the real route over real HTTP against a real row. That is also
+ * the only way to reach the reactive Panache repositories at all — a bare `@QuarkusTest` thread
+ * throws `No current Vertx context found`.
+ *
+ * Falsified, not assumed: adding `grantorPartyId` to the legacy branch of the resource turns
+ * `theLegacyArmOmitsTheGrantor` red here and flips the customer-edge sibling's 403 to a 201.
+ */
+@QuarkusTest
+@QuarkusTestResource(PostgresRedpandaRedisTestResource::class)
+@QuarkusTestResource(LegacyArmOmitsGrantorIT.InMemoryDelegationChannel::class)
+class LegacyArmOmitsGrantorIT {
+
+    class InMemoryDelegationChannel : QuarkusTestResourceLifecycleManager {
+        override fun start(): Map<String, String> =
+            InMemoryConnector.switchIncomingChannelsToInMemory("delegation-events-in")
+
+        override fun stop() = InMemoryConnector.clear()
+    }
+
+    @Any
+    @Inject
+    lateinit var connector: InMemoryConnector
+
+    private val ownerParty: UUID = UUID.randomUUID()
+    private val delegateParty: UUID = UUID.randomUUID()
+    private val grantId: UUID = UUID.randomUUID()
+    private val operator = "00000000-0000-0000-0000-0000000000aa"
+
+    // ── the invariant ──────────────────────────────────────────────────────────────────────
+
+    /**
+     * The legacy arm: authorized, and deliberately unattributed.
+     *
+     * Both halves are asserted because each carries a different half of the risk. `authorized`
+     * being true is what makes this look like a live over-grant; `grantorPartyId` being absent is
+     * the only reason it is not one. A test asserting either alone would stay green through the
+     * change that matters.
+     */
+    @Test
+    @TestSecurity(user = "00000000-0000-0000-0000-0000000000aa", roles = ["ROLE_OPERATOR"])
+    fun `the legacy authorization arm answers authorized with no grantor and no delegation id`() {
+        val accountId = openAccount()
+        grantLegacyPaymentRole(accountId)
+
+        val json = paymentAuthorization(accountId)
+
+        assertThat(json.getString("outcome"))
+            .describedAs("the row must be matched by the legacy disjunct, or this test proves nothing")
+            .isEqualTo("LEGACY_AUTHORIZATION")
+        assertThat(json.getBoolean("authorized"))
+            .describedAs("the legacy store still answers yes — this is the half that looks like an over-grant")
+            .isTrue()
+
+        // `getString` cannot distinguish an absent key from an explicit JSON null, and the edge
+        // treats both as a refusal — but only ABSENCE is what the resource is written to produce,
+        // so assert the key is not in the object at all. A future change that emits an explicit
+        // null would still be safe; one that emits a value must not pass unnoticed.
+        val fields: Map<String, kotlin.Any?> = json.getMap("$")
+        assertThat(fields)
+            .describedAs(
+                "grantorPartyId is the edge's debit gate: emitting it here puts the un-reconciled " +
+                    "legacy store on the money path. Widen only after the ADR-0232 D1 dual-run exists.",
+            )
+            .doesNotContainKey("grantorPartyId")
+        assertThat(fields).doesNotContainKey("delegationId")
+    }
+
+    // ── the positive control ───────────────────────────────────────────────────────────────
+
+    /**
+     * The control, and it is not optional: without it the assertion above passes just as happily
+     * against a resource that never emits `grantorPartyId` for anything — including a broken
+     * `DELEGATED` arm, which would be a customer-visible outage rather than an over-grant. This
+     * proves the endpoint CAN name a grantor, so the omission above is a property of the legacy
+     * arm and not of the endpoint.
+     */
+    @Test
+    @TestSecurity(user = "00000000-0000-0000-0000-0000000000aa", roles = ["ROLE_OPERATOR"])
+    fun `the delegated arm names the grant and the grantor`(): Unit = runBlocking {
+        val accountId = openAccount()
+        val source: InMemorySource<String> = connector.source("delegation-events-in")
+        // Mirror the real Kafka connector's Vert.x delivery context — without it the suspend
+        // @Incoming handler has no duplicated context for the Panache transaction.
+        source.runOnVertxContext(true)
+        source.send(delegationActivated(accountId))
+
+        val json = awaitOutcome(accountId, "DELEGATED")
+
+        assertThat(json.getBoolean("authorized")).isTrue()
+        assertThat(json.getString("grantorPartyId")).isEqualTo(ownerParty.toString())
+        assertThat(json.getString("delegationId")).isEqualTo(grantId.toString())
+    }
+
+    // ── fixtures ───────────────────────────────────────────────────────────────────────────
+
+    private fun openAccount(): UUID {
+        val id = Given {
+            contentType("application/json")
+            header("Idempotency-Key", UUID.randomUUID().toString())
+            body(
+                """
+                {"partyId":"$ownerParty","productId":"${UUID.randomUUID()}","accountType":"CURRENT",
+                 "currencyCode":"CZK","legalName":"Legacy Arm IT"}
+                """.trimIndent(),
+            )
+        } When {
+            post("/api/v1/accounts")
+        } Then {
+            statusCode(201)
+        } Extract {
+            jsonPath().getString("id")
+        }
+        return UUID.fromString(id)
+    }
+
+    /**
+     * A real row in `account_authorizations`, written through the real `AuthorizationResource` —
+     * the store ADR-0232 D1 retires, and the one still being written to today.
+     *
+     * `transactionLimit` is deliberately null: `withinLegacyTransactionLimit` treats a null as
+     * "no ceiling", which is the shape of most rows and the unbounded case.
+     */
+    private fun grantLegacyPaymentRole(accountId: UUID) {
+        Given {
+            contentType("application/json")
+            body(
+                """
+                {"partyId":"$delegateParty","role":"PAYMENT_ONLY","dailyLimit":null,"transactionLimit":null,
+                 "validFrom":"${LocalDate.now()}","validTo":null,"grantedBy":"$operator"}
+                """.trimIndent(),
+            )
+        } When {
+            post("/api/v1/accounts/$accountId/authorizations")
+        } Then {
+            statusCode(201)
+        }
+    }
+
+    /** The exact question customer-edge asks before a domestic debit, with the amount. */
+    private fun paymentAuthorization(accountId: UUID) = Given { this } When {
+        get(
+            "/api/v1/accounts/$accountId/delegation/payment-authorization" +
+                "?partyId=$delegateParty&amount=1500.00&currency=CZK",
+        )
+    } Then {
+        statusCode(200)
+    } Extract {
+        jsonPath()
+    }
+
+    /** The projection is event-fed, so the DELEGATED answer arrives asynchronously. */
+    private suspend fun awaitOutcome(accountId: UUID, outcome: String): io.restassured.path.json.JsonPath {
+        repeat(ATTEMPTS) {
+            val json = paymentAuthorization(accountId)
+            if (json.getString("outcome") == outcome) return json
+            delay(POLL_MILLIS)
+        }
+        throw AssertionError("outcome never became $outcome — the projection did not converge")
+    }
+
+    private fun delegationActivated(accountId: UUID): String =
+        """
+        {
+          "eventType": "DelegationActivated",
+          "aggregateId": "$grantId",
+          "grantorPartyId": "$ownerParty",
+          "granteePartyId": "$delegateParty",
+          "resourceType": "ACCOUNT",
+          "resourceId": "$accountId",
+          "capabilities": ["ACCOUNT_INITIATE_PAYMENT"],
+          "validFrom": "2026-01-01T00:00:00Z",
+          "occurredAt": "2026-08-01T12:00:00Z"
+        }
+        """.trimIndent()
+
+    private companion object {
+        const val ATTEMPTS = 40
+        const val POLL_MILLIS = 250L
+    }
+}

--- a/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/integration/LegacyDelegationArmRefusedIT.kt
+++ b/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/integration/LegacyDelegationArmRefusedIT.kt
@@ -1,0 +1,288 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.customeredge.integration
+
+import com.sun.net.httpserver.HttpExchange
+import com.sun.net.httpserver.HttpServer
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.security.TestSecurity
+import io.quarkus.test.security.oidc.Claim
+import io.quarkus.test.security.oidc.OidcSecurity
+import io.restassured.module.kotlin.extensions.Given
+import io.restassured.module.kotlin.extensions.Then
+import io.restassured.module.kotlin.extensions.When
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.net.InetSocketAddress
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * **A legacy-only delegate cannot initiate a domestic payment, and the ONLY reason is that
+ * account-service omits `grantorPartyId` from the `LEGACY_AUTHORIZATION` arm** (issue #2993,
+ * ADR-0232 D1/D3/D5).
+ *
+ * ### The property, stated exactly
+ *
+ * `AuthorizationService.authorizeDelegatedPayment` answers `authorized: true` for a row in the
+ * un-reconciled legacy `account_authorizations` table. Read alone, that is a live over-grant on
+ * the money path: nothing back-fills that store, nothing writes through to it, nothing reconciles
+ * it, and a revocation in delegation-service does not close a legacy row.
+ *
+ * It is not one — because `resolveDebitAuthority` refuses on
+ * `decision?.authorized != true || grantor == null`, and the legacy arm carries no grantor. The
+ * refusal is **incidental**: the edge needs a grantor id to re-fetch the account as its owner
+ * (account-service's `X-Customer-Party-Id` guard is an ownership guard and 404s a delegate). Nobody
+ * decided the legacy store must not carry a debit. That decision is simply absent, and until this
+ * test existed so was any check of it.
+ *
+ * ### What a maintainer must not do
+ *
+ * Making the two arms agree by **widening** — always emitting `grantorPartyId`, since it is the
+ * account owner either way — is a one-line, correct-looking change that silently puts an
+ * un-reconciled store on the money path. `theWideningControl` below measures exactly that: the
+ * same request, with the field present, succeeds and reaches the payment rail. That test is the
+ * evidence, not a warning in a comment.
+ *
+ * The drift between the arms is the safer state. Converge them by narrowing (stop answering
+ * `authorized: true` for the legacy arm) or after the ADR-0232 D1 dual-run exists — never by
+ * adding the field.
+ *
+ * ### Why this drives the real route
+ *
+ * `DelegatedDomesticPaymentTest` constructs [com.openbank.customeredge.infrastructure.rest.CustomerEdgeResource]
+ * directly, so it cannot see whether the route is served at all, cannot see JAX-RS injection, and
+ * builds its own upstream mock. This boots the service and speaks HTTP to a loopback stub, so what
+ * is under test is the deployed request path. The account-service half of the invariant — that the
+ * legacy arm really does omit the field — is pinned separately and against a real row by
+ * `LegacyArmOmitsGrantorIT` in openbank-account-service; neither test is sufficient alone, because
+ * this one's stub bodies are hand-written and that one cannot see the consequence.
+ */
+@QuarkusTest
+@QuarkusTestResource(LegacyDelegationArmRefusedIT.StubUpstreams::class)
+@TestSecurity(user = "customer:$DELEGATE_PARTY", roles = ["ROLE_CUSTOMER"])
+@OidcSecurity(claims = [Claim(key = "party_id", value = DELEGATE_PARTY)])
+class LegacyDelegationArmRefusedIT {
+
+    // ── the invariant ──────────────────────────────────────────────────────────────────────
+
+    /**
+     * The whole point. `authorized: true` from the legacy store, and the payment does not happen.
+     *
+     * The refusal is attributed, not merely counted: the debit-authority guard and the SCA gate
+     * both answer 403 on this route, so a bare `statusCode(403)` would pass just as well against a
+     * harness whose SCA stub was broken — proving nothing about delegation. Asserting the guard's
+     * own message, plus a zero call count on the payment rail, is what makes this test about the
+     * mechanism.
+     */
+    @Test
+    fun `a legacy-only delegate is refused and nothing reaches domestic-payment`() {
+        stubDecision(LEGACY_ARM)
+
+        Given {
+            contentType("application/json")
+            header("Idempotency-Key", UUID.randomUUID().toString())
+            header("X-SCA-Challenge-Id", SCA_ID)
+            body(paymentBody())
+        } When {
+            post("/customer/v1/domestic-payments")
+        } Then {
+            statusCode(403)
+            // `resolveDebitAuthority`'s own refusal, not `scaGate`'s SCA_REQUIRED / SCA_REJECTED.
+            body(org.hamcrest.Matchers.containsString("does not belong to caller"))
+        }
+
+        assertThat(StubUpstreams.hits(PAYMENTS_PATH))
+            .describedAs("a legacy-only delegate must not reach the payment rail")
+            .isZero()
+    }
+
+    // ── the positive control ───────────────────────────────────────────────────────────────
+
+    /**
+     * Without this the test above passes against a harness that 403s everything — a broken stub, a
+     * missing SCA consume, a route that is not served. It proves the fixture can produce a
+     * successful delegated payment, so the 403 above is attributable to the missing grantor.
+     */
+    @Test
+    fun `control - a delegated grant with a grantor reaches the payment rail`() {
+        stubDecision(DELEGATED_ARM)
+
+        Given {
+            contentType("application/json")
+            header("Idempotency-Key", UUID.randomUUID().toString())
+            header("X-SCA-Challenge-Id", SCA_ID)
+            body(paymentBody())
+        } When {
+            post("/customer/v1/domestic-payments")
+        } Then {
+            statusCode(201)
+        }
+
+        assertThat(StubUpstreams.hits(PAYMENTS_PATH)).isEqualTo(1)
+    }
+
+    /**
+     * The measurement behind this whole file: the legacy arm's verdict, unchanged, with
+     * `grantorPartyId` added — i.e. the tidy-up a maintainer would reach for to make the two arms
+     * agree. The payment **succeeds**.
+     *
+     * Read it as the cost of that one line, not as desired behaviour: `outcome` is still
+     * `LEGACY_AUTHORIZATION`, so this is the un-reconciled store moving money. It is also what
+     * falsifies the two tests above — they distinguish the arms by the field, not by luck.
+     *
+     * If a change makes this assertion fail, the widening has already happened somewhere else and
+     * the first test in this class is the one to trust.
+     */
+    @Test
+    fun `the widening control - a legacy arm carrying a grantor would move money`() {
+        stubDecision(WIDENED_LEGACY_ARM)
+
+        Given {
+            contentType("application/json")
+            header("Idempotency-Key", UUID.randomUUID().toString())
+            header("X-SCA-Challenge-Id", SCA_ID)
+            body(paymentBody())
+        } When {
+            post("/customer/v1/domestic-payments")
+        } Then {
+            statusCode(201)
+        }
+
+        assertThat(StubUpstreams.hits(PAYMENTS_PATH))
+            .describedAs("the absent grantorPartyId is the ONLY thing refusing the legacy arm today")
+            .isEqualTo(1)
+    }
+
+    // ── fixtures ───────────────────────────────────────────────────────────────────────────
+
+    @BeforeEach
+    fun resetStubs() {
+        StubUpstreams.reset()
+        // The account is owned by the GRANTOR. The edge's first call carries the delegate's party
+        // header and account-service's ownership guard 404s it — reproduced here rather than
+        // stubbed as a 200, because that 404 is what sends the route down the delegation branch at
+        // all. A fixture answering 200 to the delegate would test the owner path by accident.
+        StubUpstreams.stub(ACCOUNT_PATH) { partyHeader ->
+            if (partyHeader == GRANTOR_PARTY) {
+                200 to """{"id":"$ACCOUNT_ID","partyId":"$GRANTOR_PARTY","accountNumber":"$OWNER_IBAN"}"""
+            } else {
+                404 to """{"error":"Account not found"}"""
+            }
+        }
+        StubUpstreams.stub("/api/v1/parties/$GRANTOR_PARTY") { 200 to """{"legalName":"Grantor Name"}""" }
+        StubUpstreams.stub("/api/v1/parties/$DELEGATE_PARTY") { 200 to """{"legalName":"Delegate Name"}""" }
+        StubUpstreams.stub("/api/v1/sca/challenges/$SCA_ID/consume") { 200 to """{"status":"CONSUMED"}""" }
+        StubUpstreams.stub(PAYMENTS_PATH) { 201 to """{"id":"$PAYMENT_ID","status":"RECEIVED"}""" }
+    }
+
+    private fun stubDecision(body: String) =
+        StubUpstreams.stub("/api/v1/accounts/$ACCOUNT_ID/delegation/payment-authorization") { 200 to body }
+
+    private fun paymentBody() = """
+        {"debtorAccountId":"$ACCOUNT_ID","amount":"1500.00","currency":"CZK",
+         "creditorAccountNumber":"123456789/0800","creditorName":"Payee"}
+    """.trimIndent()
+
+    /**
+     * One loopback [HttpServer] standing in for every upstream the domestic-payment route calls.
+     * customer-edge is a BFF fronting its upstreams through one generic `UpstreamClient`, so there
+     * is no typed client to mock and no single container to boot.
+     *
+     * Handlers receive the inbound `X-Customer-Party-Id` so the ownership guard's party-dependent
+     * behaviour can be reproduced, and every request is counted — the count is what lets a test
+     * assert that nothing reached the payment rail, which a status code cannot.
+     */
+    class StubUpstreams : QuarkusTestResourceLifecycleManager {
+
+        override fun start(): Map<String, String> {
+            val s = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
+            s.createContext("/protocol/openid-connect/token") { ex ->
+                respond(ex, 200, """{"access_token":"stub-token","expires_in":300}""")
+            }
+            s.createContext("/") { ex ->
+                val path = ex.requestURI.path
+                counts.computeIfAbsent(path) { AtomicInteger() }.incrementAndGet()
+                val handler = routes[path]
+                if (handler == null) {
+                    respond(ex, 404, """{"error":"no stub registered for $path"}""")
+                } else {
+                    val (status, body) = handler(ex.requestHeaders.getFirst("X-Customer-Party-Id"))
+                    respond(ex, status, body)
+                }
+            }
+            s.executor = null
+            s.start()
+            server = s
+            val base = "http://127.0.0.1:${s.address.port}"
+            return mapOf(
+                "openbank.upstream.token-url" to base,
+                "openbank.edge.account-service-url" to base,
+                "openbank.edge.domestic-payment-service-url" to base,
+                "openbank.edge.sca-service-url" to base,
+                "openbank.edge.party-service-url" to base,
+            )
+        }
+
+        override fun stop() {
+            server?.stop(0)
+            server = null
+            routes.clear()
+            counts.clear()
+        }
+
+        private fun respond(ex: HttpExchange, status: Int, body: String) {
+            val bytes = body.toByteArray(Charsets.UTF_8)
+            ex.responseHeaders.add("Content-Type", "application/json")
+            ex.sendResponseHeaders(status, bytes.size.toLong())
+            ex.responseBody.use { it.write(bytes) }
+        }
+
+        companion object {
+            private var server: HttpServer? = null
+            private val routes = ConcurrentHashMap<String, (String?) -> Pair<Int, String>>()
+            private val counts = ConcurrentHashMap<String, AtomicInteger>()
+
+            fun stub(path: String, handler: (String?) -> Pair<Int, String>) {
+                routes[path] = handler
+            }
+
+            fun hits(path: String): Int = counts[path]?.get() ?: 0
+
+            fun reset() {
+                routes.clear()
+                counts.clear()
+            }
+        }
+    }
+
+    private companion object {
+        const val ACCOUNT_PATH = "/api/v1/accounts/$ACCOUNT_ID"
+        const val PAYMENTS_PATH = "/api/v1/domestic-payments"
+        const val OWNER_IBAN = "CZ6508000000192000145399"
+        const val SCA_ID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        const val PAYMENT_ID = "99999999-8888-7777-6666-555555555555"
+
+        /** What account-service answers today for an un-reconciled legacy row. No grantor. */
+        const val LEGACY_ARM = """{"authorized":true,"outcome":"LEGACY_AUTHORIZATION"}"""
+
+        /** An ADR-0232 delegation grant: authorized, attributed, re-evaluated on every request. */
+        const val DELEGATED_ARM =
+            """{"authorized":true,"outcome":"DELEGATED","delegationId":"$GRANT_ID","grantorPartyId":"$GRANTOR_PARTY"}"""
+
+        /** The one-line tidy-up this file exists to prevent. Not a supported response shape. */
+        const val WIDENED_LEGACY_ARM =
+            """{"authorized":true,"outcome":"LEGACY_AUTHORIZATION","grantorPartyId":"$GRANTOR_PARTY"}"""
+    }
+}
+
+internal const val DELEGATE_PARTY = "55555555-5555-5555-5555-555555555555"
+internal const val GRANTOR_PARTY = "66666666-6666-6666-6666-666666666666"
+internal const val ACCOUNT_ID = "77777777-7777-7777-7777-777777777777"
+internal const val GRANT_ID = "88888888-8888-8888-8888-888888888888"

--- a/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/integration/LegacyDelegationArmRefusedIT.kt
+++ b/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/integration/LegacyDelegationArmRefusedIT.kt
@@ -65,7 +65,10 @@ import java.util.concurrent.atomic.AtomicInteger
  * this one's stub bodies are hand-written and that one cannot see the consequence.
  */
 @QuarkusTest
-@QuarkusTestResource(LegacyDelegationArmRefusedIT.StubUpstreams::class)
+// restrictToAnnotatedClass: without it a QuarkusTestResource applies to EVERY test in the
+// module, so these loopback stubs were also injected into CustomerEdgeContractProviderVerificationTest,
+// which then pointed at a stub that serves none of its routes and failed with ConnectException.
+@QuarkusTestResource(LegacyDelegationArmRefusedIT.StubUpstreams::class, restrictToAnnotatedClass = true)
 @TestSecurity(user = "customer:$DELEGATE_PARTY", roles = ["ROLE_CUSTOMER"])
 @OidcSecurity(claims = [Claim(key = "party_id", value = DELEGATE_PARTY)])
 class LegacyDelegationArmRefusedIT {


### PR DESCRIPTION
## The invariant, and why it needed pinning now

`AuthorizationService.authorizeDelegatedPayment` answers `authorized: true` for a row in the legacy `account_authorizations` table — the store ADR-0232 D1 exists to retire, which nothing back-fills, nothing writes through to, and nothing reconciles (measured at zero across five passes on #2993). That verdict reaches `CustomerEdgeResource.resolveDebitAuthority`, the domestic-payment route's debit guard.

Read alone that is a live over-grant on the money path. **It is not one**, for exactly one reason: `DelegatedPaymentAuthorizationResource` emits `delegationId`/`grantorPartyId` only when the outcome is `DELEGATED`, and the edge refuses on `decision?.authorized != true || grantor == null`.

**Nothing intends that.** The refusal falls out of the edge needing a grantor id to re-fetch the account as its owner (account-service's `X-Customer-Party-Id` guard is an ownership guard and 404s a delegate). Nobody decided the legacy store must not carry a debit — that decision is simply absent, and so was any test of it on either side.

The risk is concrete and close: the two arms of that response visibly disagree, and the obvious tidy-up — *"the response should always carry `grantorPartyId`; it is the account owner in both cases"* — is one line, correct-looking, and silently puts an un-reconciled store on the money path. Before this PR no test in the fleet would have gone red. The ADR-0232 D1 migration this issue tracks is exactly the work that would tempt someone into it.

**Widening is the wrong direction.** The two stores can only be made to agree today by trusting the wider, unreconciled one — and revoking a delegation grant does not close a legacy row, so a response naming a grantor for the legacy arm would let money move under an authority the system of record has already withdrawn. The drift is the safer state. Converge by narrowing, or after the dual-run exists.

## What this adds

Two ITs, both driving the **real route over real HTTP**. Neither is sufficient alone, which is why both exist: the edge test's stub bodies are hand-written, and the account-service test cannot see the consequence.

**`LegacyArmOmitsGrantorIT`** (openbank-account-service) — writes a real `account_authorizations` row through the real `AuthorizationResource`, then asserts the payment-authorization response is `authorized: true`, `outcome: LEGACY_AUTHORIZATION`, and contains **neither** `grantorPartyId` **nor** `delegationId` as keys. Both halves are asserted deliberately: `authorized` being true is what makes this look like an over-grant, the absent field is the only reason it is not one, and a test asserting either alone stays green through the change that matters. Positive control: an event-fed `DELEGATED` grant names both, so the omission is a property of the legacy arm and not of the endpoint.

**`LegacyDelegationArmRefusedIT`** (openbank-customer-edge) — boots the edge against a loopback JDK `HttpServer` standing in for account-, party-, sca- and domestic-payment-service, and drives `POST /customer/v1/domestic-payments` as the delegate. Asserts **403** and, because the SCA gate answers 403 on this route too, asserts the **debit guard's own message** and a **zero call count on the payment rail** — a bare `statusCode(403)` would pass against a harness with a broken SCA stub and prove nothing about delegation. The fixture reproduces account-service's ownership 404 for the delegate rather than stubbing a 200, since that 404 is what sends the route down the delegation branch at all.

It carries two controls:
- **positive** — a `DELEGATED` verdict with a grantor reaches the rail at 201, so the 403 is attributable to the missing grantor and not to the harness;
- **widening** — the same legacy verdict with `grantorPartyId` added succeeds at **201**, with `outcome` still `LEGACY_AUTHORIZATION`. That is the measured cost of the tidy-up, in the test suite rather than in a comment nobody reads.

## Verification

Falsified, not assumed. Applying the realistic widening to production code (`grantorPartyId = account.partyId` on the legacy branch + emitting it in the resource) turns the account-service assertion **red** on the right assertion, while the `DELEGATED` control stays green. Reverted; this PR contains no production changes.

Counts read from the JUnit XML, not the console — a module that fails to boot reports its ITs as skipped, which reads like a pass:

```
LegacyDelegationArmRefusedIT  tests="3" skipped="0" failures="0" errors="0"
LegacyArmOmitsGrantorIT       tests="2" skipped="0" failures="0" errors="0"
```

`ktlintCheck` + `detekt` green on both modules, confirmed present in the task list (`--rerun-tasks`, since Gradle stops at the first failing task and an up-to-date task is not a task that ran).

## Modules touched, and the review this needs

| module | money-path? | change |
|---|---|---|
| `openbank-account-service` | **yes** (`rules.yaml: money_path_services`) | one new test file |
| `openbank-customer-edge` | no | one new test file |

**Test-only — no production code is modified.** Stating it plainly anyway: a test-only addition still touches a money-path module, so this needs 2 approvals + the threat-model rule per ADR-0030. Both paths are under `src/test`, which is in account-service's `exclude-paths`, so this releases nothing; `test` is a hidden type in any case.

## Scope, deliberately

This does **not** attempt the ADR-0232 D1 migration. That is money-path, multi-PR, and its shape depends on the still-open edge-adjudicates vs card-issuance-adjudicates fork tracked on #2990. This is the one bounded piece that is safe now and gets more dangerous the longer it waits — the migration is precisely what would tempt the widening.

No file overlap with #4634 (the store-disagreement counter), which touches `AuthorizationService.kt` and four unit tests; this PR touches neither.

Refs #2993
