### PR TITLE
ci(gates): make the attestation gate's exit-2 branch falsifiable and unconditional

### DIFF
--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -600,6 +600,11 @@ gates:
       against a stub cosign and asserts exit 0, 1 and 2, so its red is reachable by
       construction; falsified in both directions (see the run: comment).
     budget_seconds: 30   # 0.3s locally — no network, no registry
+    rationale: "Without it the gate's exit-2 branch is unreachable on any PR that does not touch fleet-attestation.yml, and a probe failure silently reads as a fleet-wide supply-chain gap (#1915: one ECR throttle published as UNATTESTED against an image that verifies by hand)."
+    review_after: "2027-02-14"
+    # The corpus is the checker's own fixture set — its subjects are assertions, not files, so
+    # the floor is the number of cases that must run. It drops the day someone deletes one.
+    min_subjects: 14   # 15 today: 9 classifier + 5 end-to-end + 1 retry-count (2026-08-14)
     run: |
       # The gate IS the selftest here: the artifact under test is the classifier + exit-code
       # contract, not the fleet (verifying 62 real images needs ECR credentials this job does

--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -582,6 +582,33 @@ gates:
       python3 .github/scripts/check-probe-port-listener.py --enforce
 
   # ==== supplychain ====================================================
+  # The fleet SBOM-attestation gate lives in the path-filtered fleet-attestation.yml, which
+  # can never be a required check — so its own falsification must run somewhere
+  # unconditional, and this is it. The selftest needs no registry and no credentials: it
+  # drives the whole loop against a stub cosign and asserts the three exit codes, including
+  # the exit-2 ("the probe could not run") branch that no PR can produce on demand by
+  # summoning an ECR throttle. Without this entry the branch that #1915 added is exercised
+  # only when someone edits one of five paths.
+  - id: fleet-attestation-classifier
+    name: "fleet-attestation gate classifies a probe failure as UNKNOWN, not as a fleet gap (issue #1915, enforced)"
+    group: supplychain
+    mode: enforced
+    # The gate IS the harness: its `run:` is the checker's own falsification suite, so a
+    # separate `selftest:` would be the same command executed twice for one signal.
+    selftest_exempt: >-
+      is-a-test-suite — the run: below IS the self-test. It drives the gate's whole loop
+      against a stub cosign and asserts exit 0, 1 and 2, so its red is reachable by
+      construction; falsified in both directions (see the run: comment).
+    budget_seconds: 30   # 0.3s locally — no network, no registry
+    run: |
+      # The gate IS the selftest here: the artifact under test is the classifier + exit-code
+      # contract, not the fleet (verifying 62 real images needs ECR credentials this job does
+      # not have, and fleet-attestation.yml + auto-deploy.yml both do that with them).
+      # Falsified in both directions before wiring in: reverting the classifier's fallback to
+      # the pre-#1915 shape reddens 7 cases, and changing the final `exit 2` to `exit 1`
+      # reddens exactly the one case that asserts the distinction.
+      .github/scripts/check-fleet-attestations.sh --self-test
+
   - id: license-header-consistency
     name: "License header consistency (issue #2280, enforced)"
     group: supplychain

--- a/.github/scripts/check-fleet-attestations.sh
+++ b/.github/scripts/check-fleet-attestations.sh
@@ -100,10 +100,14 @@ classify_failure() {
 }
 
 selftest() {
-  local failures=0 got
+  # `cases` is the SUBJECT COUNT this gate reports (gates.yaml min_subjects). A checker whose
+  # corpus is its own fixtures examines nothing the day someone deletes them, and the floor is
+  # what makes that a failure instead of a faster green.
+  local failures=0 got cases=0
   check_case() {
     local name="$1" expected="$2" input="$3"
     got="$(classify_failure "$input")"
+    cases=$((cases + 1))
     if [ "$got" = "$expected" ]; then
       printf '  ok: %s (%s)\n' "$name" "$got"
     else
@@ -166,6 +170,7 @@ STUB
   run_fixture() {
     local name="$1" expected_exit="$2" expected_summary="$3"; shift 3
     local out code
+    cases=$((cases + 1))
     : > "$tmp/gitops/images.yaml"
     for img in "$@"; do
       printf 'image: %s/%s\n' "$reg" "$img" >> "$tmp/gitops/images.yaml"
@@ -223,6 +228,7 @@ STUB
   # at 3, the first three images retry once each and the fourth must not retry at all. Asserted
   # as a count, because a fixture that only greps the banner passes with the retry suppression
   # deleted — measured, not assumed.
+  cases=$((cases + 1))
   retries="$(printf '%s' "${LAST_OUT:-}" | grep -c '  retry ' || true)"
   if [ "$retries" -eq 3 ]; then
     printf '  ok: systemic outage stops retrying (3 retries, not 4)\n'
@@ -234,6 +240,7 @@ STUB
 
   rm -rf "$tmp"
 
+  printf 'SUBJECTS=%s\n' "$cases"
   if [ "$failures" -gt 0 ]; then
     printf 'selftest FAILED (%s case(s))\n' "$failures"
     return 1

--- a/.github/scripts/check-fleet-attestations.sh
+++ b/.github/scripts/check-fleet-attestations.sh
@@ -170,8 +170,12 @@ STUB
     for img in "$@"; do
       printf 'image: %s/%s\n' "$reg" "$img" >> "$tmp/gitops/images.yaml"
     done
+    # The threshold is passed EXPLICITLY rather than inherited: `VAR=x run_fixture` sets it on
+    # the function, not on the grandchild process, so an inherited value would silently be the
+    # default and the systemic case would prove nothing.
     out="$(GITOPS_DIR="$tmp/gitops" COSIGN_BIN="$stub" PLACEHOLDER_FILE="$tmp/none.txt" \
            VERIFY_ATTEMPTS=2 VERIFY_RETRY_SLEEP=0 FLEET_ATTEST_JSON="" \
+           SYSTEMIC_UNKNOWN_THRESHOLD="${fixture_threshold:-99}" \
            bash "$SELF" 2>&1)"
     code=$?
     if [ "$code" != "$expected_exit" ]; then
@@ -185,6 +189,7 @@ STUB
       failures=$((failures + 1))
       return
     fi
+    LAST_OUT="$out"
     printf '  ok: %s (exit %s)\n' "$name" "$code"
   }
 
@@ -206,6 +211,26 @@ STUB
   run_fixture "gap + probe failure -> exit 1 (gap wins)" 1 \
     "0 attested / 1 unattested / 0 absent / 0 allowlisted placeholder / 1 unknown" \
     "openbank-fixture-bare:t" "openbank-fixture-flaky:t"
+  # A TOTAL outage must short-circuit the retries rather than multiply them past the job
+  # timeout — a killed job reports no exit code at all, and the caller then cannot tell a gap
+  # from a probe failure, which is the whole distinction this file exists to keep.
+  fixture_threshold=3
+  run_fixture "systemic outage -> retries off, still exit 2" 2 \
+    "images in a row could not be probed: this is systemic" \
+    "openbank-fixture-flaky:1" "openbank-fixture-flaky:2" "openbank-fixture-flaky:3" \
+    "openbank-fixture-flaky:4"
+  # ...and the SHORT-CIRCUIT itself, which the message above cannot prove: with the threshold
+  # at 3, the first three images retry once each and the fourth must not retry at all. Asserted
+  # as a count, because a fixture that only greps the banner passes with the retry suppression
+  # deleted — measured, not assumed.
+  retries="$(printf '%s' "${LAST_OUT:-}" | grep -c '  retry ' || true)"
+  if [ "$retries" -eq 3 ]; then
+    printf '  ok: systemic outage stops retrying (3 retries, not 4)\n'
+  else
+    printf '  FAIL: systemic outage stops retrying — expected 3 retry lines, got %s\n' "$retries"
+    failures=$((failures + 1))
+  fi
+  fixture_threshold=""
 
   rm -rf "$tmp"
 
@@ -353,6 +378,16 @@ UNKNOWN=0
 UNATTESTED_IMAGES=()
 ABSENT_IMAGES=()
 UNKNOWN_IMAGES=()
+CONSECUTIVE_UNKNOWN=0
+RETRIES_DISABLED=0
+
+# Retry is per-image, so a TOTAL registry outage would multiply: 62 images x (attempts-1) x
+# sleep, on top of every call's own latency, which overruns the job timeout — and a killed
+# job produces no exit code at all, so the careful 1-vs-2 distinction is lost exactly when it
+# matters most. Retrying is worth it for a flaky registry and worthless for a dead one, so
+# after this many images in a row have failed the probe, stop retrying and let the run finish
+# and report exit 2 honestly.
+SYSTEMIC_UNKNOWN_THRESHOLD="${SYSTEMIC_UNKNOWN_THRESHOLD:-5}"
 
 for image in "${IMAGES[@]}"; do
   short="${image#"${ECR_REGISTRY}"/}"
@@ -371,6 +406,7 @@ for image in "${IMAGES[@]}"; do
     fi
     verdict="$(classify_failure "$err")"
     [ "$verdict" != "UNKNOWN" ] && break
+    [ "$RETRIES_DISABLED" -eq 1 ] && break
     [ "$attempt" -ge "$VERIFY_ATTEMPTS" ] && break
     printf '  retry %s/%s  %s  (probe failed, not a verdict)\n' \
       "$attempt" "$VERIFY_ATTEMPTS" "$short"
@@ -406,6 +442,19 @@ for image in "${IMAGES[@]}"; do
       UNKNOWN_IMAGES+=("$image")
       ;;
   esac
+
+  if [ "$verdict" = "UNKNOWN" ]; then
+    CONSECUTIVE_UNKNOWN=$((CONSECUTIVE_UNKNOWN + 1))
+    if [ "$RETRIES_DISABLED" -eq 0 ] && [ "$CONSECUTIVE_UNKNOWN" -ge "$SYSTEMIC_UNKNOWN_THRESHOLD" ]; then
+      RETRIES_DISABLED=1
+      printf '  ---- %s images in a row could not be probed: this is systemic, not flaky.\n' \
+        "$CONSECUTIVE_UNKNOWN"
+      printf '       Retries OFF for the rest of the run so it finishes inside the job timeout —\n'
+      printf '       a killed job reports NO exit code, which loses the gap-vs-probe distinction.\n'
+    fi
+  else
+    CONSECUTIVE_UNKNOWN=0
+  fi
 done
 
 FAIL=$((UNATTESTED + ABSENT))

--- a/.github/scripts/check-fleet-attestations.sh
+++ b/.github/scripts/check-fleet-attestations.sh
@@ -135,18 +135,139 @@ main.go:74: error during command execution: no matching attestations:'
   check_case "KMS unreachable" UNKNOWN \
     'Error: loading public key: getting signer: kms get: RequestCanceled: request context canceled'
 
+  # ---------------------------------------------------------------------------------------
+  # END-TO-END: the classifier is only half the fix. What the caller acts on is the EXIT
+  # CODE, and no PR can summon an ECR throttle to prove exit 2 is reachable — so the whole
+  # loop is driven here against a stub `cosign` that fails per-image in each way. Without
+  # this, the exit-2 branch is code nobody has ever run, which is the repo's oldest CI rule
+  # (a gate that has only ever passed is unfalsified) applied to the gate's own plumbing.
+  # ---------------------------------------------------------------------------------------
+  local tmp stub reg
+  tmp="$(mktemp -d)"
+  reg="$ECR_REGISTRY"
+  mkdir -p "$tmp/gitops"
+  stub="$tmp/cosign"
+  cat > "$stub" <<'STUB'
+#!/usr/bin/env bash
+# Stub cosign: version says v2 (the script refuses anything else), and each fixture image
+# fails the way its name declares. Deliberately writes to stderr, as the real one does.
+if [ "$1" = version ]; then echo "GitVersion: v2.4.3"; exit 0; fi
+img="${!#}"
+case "$img" in
+  *fixture-ok*)     echo "Verification for $img -- The signatures were verified"; exit 0 ;;
+  *fixture-gone*)   echo "Error: MANIFEST_UNKNOWN: manifest unknown" >&2; exit 1 ;;
+  *fixture-bare*)   echo "Error: no matching attestations:" >&2; exit 1 ;;
+  *fixture-flaky*)  echo "Error: TOOMANYREQUESTS: Rate exceeded" >&2; exit 1 ;;
+esac
+echo "Error: stub reached with an unexpected image: $img" >&2; exit 1
+STUB
+  chmod +x "$stub"
+
+  run_fixture() {
+    local name="$1" expected_exit="$2" expected_summary="$3"; shift 3
+    local out code
+    : > "$tmp/gitops/images.yaml"
+    for img in "$@"; do
+      printf 'image: %s/%s\n' "$reg" "$img" >> "$tmp/gitops/images.yaml"
+    done
+    out="$(GITOPS_DIR="$tmp/gitops" COSIGN_BIN="$stub" PLACEHOLDER_FILE="$tmp/none.txt" \
+           VERIFY_ATTEMPTS=2 VERIFY_RETRY_SLEEP=0 FLEET_ATTEST_JSON="" \
+           bash "$SELF" 2>&1)"
+    code=$?
+    if [ "$code" != "$expected_exit" ]; then
+      printf '  FAIL: %s — expected exit %s, got %s\n' "$name" "$expected_exit" "$code"
+      failures=$((failures + 1))
+      return
+    fi
+    if ! printf '%s' "$out" | grep -qF "$expected_summary"; then
+      printf '  FAIL: %s — exit %s correct, but summary missing: %s\n' \
+        "$name" "$code" "$expected_summary"
+      failures=$((failures + 1))
+      return
+    fi
+    printf '  ok: %s (exit %s)\n' "$name" "$code"
+  }
+
+  # Every declared image attested -> 0.
+  run_fixture "all attested -> exit 0" 0 \
+    "1 attested / 0 unattested / 0 absent / 0 allowlisted placeholder / 0 unknown" \
+    "openbank-fixture-ok:t"
+  # A real gap -> 1. Both fatal classes, so the summary carries each count.
+  run_fixture "unattested + absent -> exit 1" 1 \
+    "1 attested / 1 unattested / 1 absent / 0 allowlisted placeholder / 0 unknown" \
+    "openbank-fixture-ok:t" "openbank-fixture-bare:t" "openbank-fixture-gone:t"
+  # ONLY a probe failure -> 2, and crucially NOT 1: this is the case that used to be
+  # published as a fleet gap, and the exit code is the only thing the caller reads.
+  run_fixture "probe failure only -> exit 2 (not 1)" 2 \
+    "1 attested / 0 unattested / 0 absent / 0 allowlisted placeholder / 1 unknown" \
+    "openbank-fixture-ok:t" "openbank-fixture-flaky:t"
+  # A REAL gap alongside a probe failure must still be 1 — "could not run" never masks a
+  # verdict that was reached, or an unlucky throttle would downgrade a live outage.
+  run_fixture "gap + probe failure -> exit 1 (gap wins)" 1 \
+    "0 attested / 1 unattested / 0 absent / 0 allowlisted placeholder / 1 unknown" \
+    "openbank-fixture-bare:t" "openbank-fixture-flaky:t"
+
+  rm -rf "$tmp"
+
   if [ "$failures" -gt 0 ]; then
     printf 'selftest FAILED (%s case(s))\n' "$failures"
     return 1
   fi
-  printf 'selftest OK — classifier proven on all three classes, both directions.\n'
+  printf 'selftest OK — classifier proven on all three classes, and exit 0/1/2 driven end to end.\n'
   return 0
 }
 
-if [ "${1:-}" = "--selftest" ]; then
-  selftest
-  exit $?
-fi
+# ---------------------------------------------------------------------------------------
+# The LIVE control the stub cannot give: the UNATTESTED branch is matched on cosign's own
+# wording, so a wording change in a future cosign silently re-routes every real gap to
+# UNKNOWN — the gate would then exit 2 forever, never file a gap, and read as an infra
+# problem. Ask the real binary, against a real image in the real registry, for a verdict we
+# know is negative: the same image with an attestation type it has never carried. If that
+# does not classify as UNATTESTED, the vocabulary has moved and the gate is blind.
+# No side effects — verify-attestation is read-only.
+# ---------------------------------------------------------------------------------------
+vocabulary_control() {
+  local image="$1" err verdict
+  printf '==> Vocabulary control: %s with --type spdx (never attested; must read UNATTESTED)\n' \
+    "${image#"${ECR_REGISTRY}"/}"
+  if err="$(COSIGN_YES=true "$COSIGN_BIN_RESOLVED" verify-attestation \
+              --key "$COSIGN_KEY" --type spdx "$image" 2>&1)"; then
+    echo "ERROR: control image verified against a type it should not carry — the control is" >&2
+    echo "       no longer negative. Pick a type this fleet genuinely never attests." >&2
+    return 1
+  fi
+  verdict="$(classify_failure "$err")"
+  if [ "$verdict" != "UNATTESTED" ]; then
+    echo "ERROR: cosign's not-attested wording no longer classifies as UNATTESTED (got ${verdict})." >&2
+    echo "       Every real gap would now be reported as UNKNOWN and the gate would never fail" >&2
+    echo "       on one. Update classify_failure() against this output:" >&2
+    printf '%s\n' "$err" | sed 's/^/       | /' | tail -5 >&2
+    return 1
+  fi
+  printf '    OK — a known-negative verdict still reads UNATTESTED.\n'
+  return 0
+}
+
+SELF="$0"
+MODE=verify
+case "${1:-}" in
+  --selftest | --self-test)
+    selftest
+    exit $?
+    ;;
+  # Needs cosign + a real registry, so it runs as its own step in fleet-attestation.yml
+  # rather than inside the fleet loop — a vocabulary failure must be reported as itself,
+  # not as 62 UNKNOWN images.
+  --vocabulary-control)
+    MODE=vocabulary-control
+    ;;
+  "") ;;
+  *)
+    echo "ERROR: unknown argument: $1" >&2
+    echo "       usage: $0 [--selftest|--self-test|--vocabulary-control]" >&2
+    exit 1
+    ;;
+esac
 
 # cosign v2 is pinned on purpose: kyverno 3.2.6 discovers attestations only via the legacy
 # `sha256-<digest>.att` tag scheme; cosign v3 writes OCI 1.1 referrers it cannot read. This
@@ -213,6 +334,11 @@ fi
 
 echo "==> ${#IMAGES[@]} distinct openbank-* image(s) declared"
 echo
+
+if [ "$MODE" = vocabulary-control ]; then
+  vocabulary_control "${IMAGES[0]}"
+  exit $?
+fi
 
 is_allowed_placeholder() {
   [ -f "$PLACEHOLDER_FILE" ] || return 1

--- a/.github/workflows/fleet-attestation.yml
+++ b/.github/workflows/fleet-attestation.yml
@@ -85,6 +85,15 @@ jobs:
       - name: Login to Amazon ECR
         uses: aws-actions/amazon-ecr-login@d539f0932e70871a027e9d5a9d8fc38589180a64 # v2.1.6
 
+      # The one control the offline selftest cannot give. UNATTESTED is matched on cosign's
+      # own wording, so if a future cosign rewords it, every real gap silently re-routes to
+      # UNKNOWN: the gate would exit 2 forever, never file a gap, and read as an infra
+      # problem. This asks the real binary for a verdict we know is negative — a real fleet
+      # image with an attestation type it has never carried — and fails loudly if that stops
+      # reading as UNATTESTED. Read-only; verifies nothing about the fleet itself.
+      - name: Vocabulary control (cosign still says "not attested" the way we parse)
+        run: .github/scripts/check-fleet-attestations.sh --vocabulary-control
+
       - name: Verify every declared openbank-* image is attested
         id: gate
         env:
@@ -179,4 +188,87 @@ jobs:
             gh issue comment "$existing" --body "$BODY"
           else
             gh issue create --title "$TITLE" --body "$BODY" --label fleet-health --label "severity:high"
+          fi
+
+  # Exit 2 is NOT a fleet gap, so it must not reach `raise-issue` above — but it must not
+  # vanish either. A registry or credential failure that persists is how the gate stops
+  # covering anything at all, and the whole point of the exit-code split is lost if the only
+  # consequence is a red schedule nobody reads (this repo's own lesson: a red push/schedule
+  # run is addressed to nobody). Separate issue, separate title, lower severity: an
+  # infrastructure ticket, never a supply-chain one. Recurrence is visible as comments on the
+  # same issue; a clean scheduled run closes it below.
+  raise-probe-issue:
+    name: Raise issue on probe failure
+    needs: verify
+    if: ${{ failure() && github.event_name == 'schedule' && needs.verify.outputs.status == '2' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5  # API calls only
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Open or refresh the probe-failure issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        # Body written to a file, never passed via --body: backticks inside a double-quoted
+        # string are command substitution, and the failure is silent in the published text.
+        run: |
+          set -euo pipefail
+          TITLE="Fleet attestation gate could not run (probe failure, not a fleet gap)"
+          cat > "${RUNNER_TEMP}/body.md" <<EOF
+          The daily fleet-attestation gate exited **2**: for at least one image the probe could
+          not reach a verdict — an ECR throttle, a 5xx, expired credentials, DNS, or a cosign
+          failure — after its bounded retries.
+
+          **This is not a supply-chain finding.** It says nothing about whether any image is
+          attested. Do not rebuild or re-attest anything on the strength of it.
+
+          What it DOES mean: for as long as it persists, the fleet is **unchecked**. A real gap
+          appearing now would not be reported, because the gate never reached the images.
+
+          Run: ${RUN_URL} — the job summary and the fleet-attestation-report artifact name the
+          images the probe could not reach.
+
+          Triage: re-run the workflow. If it recurs, treat it as an infrastructure problem
+          (ECR limits, the OIDC role, cosign availability). If instead EVERY image reports
+          UNKNOWN, suspect the classifier's vocabulary rather than the registry — the
+          Vocabulary control step in the same job is the discriminator, and it fails on its own
+          when cosign's not-attested wording moves.
+
+          This issue is closed automatically by the next clean scheduled run.
+          EOF
+          existing=$(gh issue list --state open --search "$TITLE in:title" --json number --jq '.[0].number' || true)
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body-file "${RUNNER_TEMP}/body.md"
+          else
+            gh issue create --title "$TITLE" --body-file "${RUNNER_TEMP}/body.md" \
+              --label fleet-health --label "severity:medium"
+          fi
+
+  # A probe-failure issue that outlives the probe failure is the same disease as the red
+  # schedule nobody reads: it decays into background noise and the next one is ignored.
+  close-probe-issue:
+    name: Close probe-failure issue on a clean run
+    needs: verify
+    if: ${{ success() && github.event_name == 'schedule' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5  # API calls only
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Close it if one is open
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          TITLE="Fleet attestation gate could not run (probe failure, not a fleet gap)"
+          existing=$(gh issue list -R "${GITHUB_REPOSITORY}" --state open --search "$TITLE in:title" \
+            --json number --jq '.[0].number' || true)
+          if [ -n "$existing" ]; then
+            gh issue close "$existing" -R "${GITHUB_REPOSITORY}" \
+              --comment "The gate ran clean: ${RUN_URL}. The probe is reaching the registry again."
           fi

--- a/.github/workflows/fleet-attestation.yml
+++ b/.github/workflows/fleet-attestation.yml
@@ -144,13 +144,16 @@ jobs:
   # unread red schedule is how sbom-drift-scanner's `no-pod-found` sat unactioned. On the
   # scheduled run only (a PR failure is already visible to its author), file/refresh an
   # issue so the gap has an owner and a paper trail.
-  # `status != '2'` is the whole point of the exit-code split: a probe that could not run must
-  # not open (or bump) an issue asserting a latent admission failure. A 2 still leaves the
-  # scheduled run red, which is the honest signal for "unchecked".
+  # `status == '1'` — a POSITIVE condition, not `!= '2'`. The difference is what happens when
+  # the job dies without reporting at all (timeout, runner loss, an OOM): `status` is then the
+  # empty string, which satisfies `!= '2'` and would file a latent-admission-failure issue on
+  # the strength of no verdict whatsoever — the exact defect this whole PR is about, one layer
+  # up. Only an explicit 1 means "the gate reached a verdict and it is a gap"; every other
+  # failure is routed to raise-probe-issue below.
   raise-issue:
     name: Raise issue on gap
     needs: verify
-    if: ${{ failure() && github.event_name == 'schedule' && needs.verify.outputs.status != '2' }}
+    if: ${{ failure() && github.event_name == 'schedule' && needs.verify.outputs.status == '1' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5  # API calls only
     permissions:
@@ -200,7 +203,10 @@ jobs:
   raise-probe-issue:
     name: Raise issue on probe failure
     needs: verify
-    if: ${{ failure() && github.event_name == 'schedule' && needs.verify.outputs.status == '2' }}
+    # `!= '1'` is the complement of raise-issue above, so no failure mode falls between the
+    # two: an explicit 2, and also an empty status (the job died before it could report).
+    # An unchecked fleet needs an owner even when the reason is that nothing reported.
+    if: ${{ failure() && github.event_name == 'schedule' && needs.verify.outputs.status != '1' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5  # API calls only
     permissions:
@@ -212,15 +218,18 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          GATE_STATUS: ${{ needs.verify.outputs.status }}
         # Body written to a file, never passed via --body: backticks inside a double-quoted
         # string are command substitution, and the failure is silent in the published text.
         run: |
           set -euo pipefail
           TITLE="Fleet attestation gate could not run (probe failure, not a fleet gap)"
           cat > "${RUNNER_TEMP}/body.md" <<EOF
-          The daily fleet-attestation gate exited **2**: for at least one image the probe could
-          not reach a verdict — an ECR throttle, a 5xx, expired credentials, DNS, or a cosign
-          failure — after its bounded retries.
+          The daily fleet-attestation gate did not return a verdict. Either it exited **2** — for
+          at least one image the probe could not reach a verdict (ECR throttle, 5xx, expired
+          credentials, DNS, a cosign failure) after its bounded retries — or the job died before
+          it could report at all (timeout, runner loss). Exit code as reported by the job:
+          \`${GATE_STATUS:-<none — the job did not report>}\`.
 
           **This is not a supply-chain finding.** It says nothing about whether any image is
           attested. Do not rebuild or re-attest anything on the strength of it.

--- a/docs/runbooks/0011-kyverno-admission-rollback.md
+++ b/docs/runbooks/0011-kyverno-admission-rollback.md
@@ -129,7 +129,7 @@ red `1` still deserves the hand check: verify the named image by digest before r
 
 ### What to copy from this into the next probe
 
-Four rules, each of which this gate broke:
+Five rules, each of which this gate broke:
 
 1. **A checker that knows the difference must ENCODE the difference in the one thing its caller
    reads.** Knowing "this was a throttle, not a gap" is worth nothing if both outcomes exit `1`:
@@ -155,7 +155,21 @@ Four rules, each of which this gate broke:
    (a script that fails per-image the four ways) plus `check-fleet-attestations.sh --selftest`,
    which needs no registry and runs in the lint job on every PR. Falsify the selftest itself by
    reverting the classifier to the old fallback and confirming exactly the transient cases go
-   red — a classifier that has only ever agreed with you is unfalsified.
+   red — a classifier that has only ever agreed with you is unfalsified. Because
+   `fleet-attestation.yml` is path-filtered and can therefore never be a required check, that
+   selftest is *also* declared as gate `fleet-attestation-classifier` in
+   `.github/gates/gates.yaml`, so it runs unconditionally in `Validate manifests`.
+5. **A stub proves your parser, not the vocabulary — pair it with a live known-negative
+   control.** The fix in rule 2 buys correctness at the price of a new dependency: `UNATTESTED`
+   is now matched on cosign's own wording, so a future cosign that rewords it re-routes every
+   real gap to `UNKNOWN`. The gate would then exit `2` forever, never file a gap, and read as
+   an infrastructure problem — a strictly worse failure than the one being fixed, because it
+   fails in the reassuring direction. Nothing offline can catch that. The
+   `Vocabulary control` step does: it asks the real binary, in the real registry, for a verdict
+   it knows must be negative (a real fleet image with `--type spdx`, which nothing here
+   attests) and fails loudly if that stops classifying as `UNATTESTED`. Generalize: whenever a
+   verdict depends on parsing a third party's prose, keep one live case whose answer you
+   already know, or the parser is only ever tested against your own memory of the wording.
 
 ## 5. Related
 


### PR DESCRIPTION
Follow-up to #4694 (merged). That PR split the fleet-attestation gate's outcomes into
`0` / `1` / `2` (clean / real gap / could-not-run). Reviewing my own work, the split had two
holes and introduced one new risk. This closes all three.

## 1. The exit-2 branch was code nobody had run

No PR can summon an ECR throttle, so #4694's green run said nothing about the branch it added.
`--self-test` now drives the **whole loop** against a stub `cosign` and asserts every exit code:

| fixture | asserts |
|---|---|
| all attested | exit `0` |
| unattested + absent | exit `1` |
| probe failure **only** | exit `2`, never `1` — the case that used to be published as a fleet gap |
| real gap **+** probe failure | exit `1` — could-not-run must never mask a verdict that was reached |

Falsified in both directions, independently:
- reverting the classifier's fallback to the pre-#1915 shape reddens **7** cases;
- changing only the final `exit 2` to `exit 1` reddens **exactly the one** case that asserts the
  distinction (so the assertion tests the plumbing, not just the classifier).

## 2. The selftest ran only where it could never be required

`fleet-attestation.yml` is `paths:`-filtered, and a path-filtered workflow can never be a required
check — so the falsification only ran when someone touched one of five paths. It is now declared as
gate `fleet-attestation-classifier` in `.github/gates/gates.yaml` (group `supplychain`, enforced),
which is the established shape for exactly this. It carries `selftest_exempt: is-a-test-suite` per
#4590's new vocabulary: the gate's `run:` **is** the harness, so a separate `selftest:` would run
the same command twice for one signal.

## 3. The new risk the fix itself created — and the live control for it

`UNATTESTED` is now matched on cosign's own wording. A future cosign that rewords it would re-route
**every real gap** to `UNKNOWN`: the gate would exit `2` forever, never file a gap, and read as an
infrastructure problem. That is strictly worse than the bug being fixed, because it fails in the
reassuring direction — and no stub can catch it, since the stub speaks whatever dialect I taught it.

New `Vocabulary control` step: ask the real binary, in the real registry, for a verdict known to be
negative — a real fleet image with `--type spdx`, which nothing here attests — and fail loudly if
that stops classifying as `UNATTESTED`. Read-only; it asserts nothing about the fleet.

## 4. Escalation gap the split opened

Exit `2` no longer files a supply-chain issue (correct), which would have made a persistent probe
failure silent (not correct — while it persists, the fleet is **unchecked**). `raise-probe-issue`
files an infrastructure ticket instead: separate title, `severity:medium`, recurrence as comments,
and a clean scheduled run closes it via `close-probe-issue`.

## Verification

- `--self-test`: 13 cases green (9 classifier + 4 end-to-end), under macOS bash 3.2 and `bash:5.2`.
- `run-gates.py --only fleet-attestation-classifier` PASS; `--group supplychain` 20/21, the one
  failure being `release-scope-mismatch` refusing to run without `PR_DIFF_BASE` locally (unrelated,
  same on a clean `origin/main` worktree).
- `check-gate-selftest-declaration.py` clean (it caught the duplicate-command shape first — fixed,
  not baselined); `check-gh-repo-context.py` and `check-gate-invocation-reachability.py` clean;
  `actionlint`, `shellcheck -S warning`, `check-workflow-run-step-size.py` clean.
- Not verifiable pre-merge: the vocabulary control needs ECR credentials, so it runs for the first
  time on this PR's own `Verify fleet attestations` job — that job is the check to read.

Runbook §4 gains rule 5 (a stub proves your parser, not the vocabulary) and records that the
selftest is now unconditional.

## Linked issues

Refs #1915
---

**Update — two more holes, in this PR's own work (2nd commit).**

**A total registry outage overran the job timeout.** Retry is per-image, so 62 images ×
(attempts−1) × sleep, plus each call's latency, exceeds the 20-minute timeout — and a killed job
reports **no exit code at all**, losing the 1-vs-2 distinction exactly when the fleet is least
checked. Retrying is worth it for a flaky registry and worthless for a dead one: after
`SYSTEMIC_UNKNOWN_THRESHOLD` images in a row fail the probe (default 5), retries stop and the run
finishes and reports 2 honestly.

**The caller's condition was `!= '2'`** — which the *empty* status of a died-before-reporting job
also satisfies, so a timeout would have filed a latent-admission-failure issue on the strength of
no verdict whatsoever. That is this PR's own defect one layer up. `raise-issue` now requires an
explicit `== '1'`, `raise-probe-issue` takes the complement (so nothing falls between them), and
the probe issue prints the status it saw or says the job never reported one.

Worth flagging for review: the systemic fixture first asserted only the printed banner, and
**passed with the retry suppression deleted**. It now asserts the retry *count* (3, not 4), which
does go red when the short-circuit is removed.
