### PR TITLE
fix(ci): the bypass watch must escalate its own blindness, not only its findings (#4791)

### DIFF
--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -1411,7 +1411,7 @@ gates:
     name: "the merged-past-red-check watch keeps its window, its key and its escalation (issue #4240, enforced)"
     group: registry
     mode: enforced
-    min_subjects: 6   # D1-D6, applied to the one watch workflow. 0 means the workflow moved.
+    min_subjects: 7   # D1-D7, applied to the one watch workflow. 0 means the workflow moved.
     selftest: |
       python3 .github/scripts/check-merged-past-red-check.py --self-test
     selftest_expect: pass

--- a/.github/scripts/check-merged-past-red-check.py
+++ b/.github/scripts/check-merged-past-red-check.py
@@ -102,6 +102,12 @@ own pull_request lane is only a fast echo. The rules:
       nobody pushes, and the bypass is by definition the last push.
   D6  It must read the ruleset token from a secret and skip loudly when it is unset, never
       fall back to GITHUB_TOKEN and report an empty window.
+  D7  It must escalate its OWN blindness, not only its findings (#4791). D4 covers "these merges
+      bypassed a check"; D7 covers "I could not look". The escalation step must not be gated on
+      the scan having succeeded, and the blind state needs its own marker so it can never close
+      or overwrite the findings issue. Without D7 the only signal is a red scheduled run — which
+      is the #4019 blind spot this file's ESCALATION section already rejects, and which this
+      watch then reproduced for 87 consecutive real runs.
 
 WHAT THIS CANNOT DO
 -------------------
@@ -316,7 +322,9 @@ def _strip_comments(text: str) -> str:
 # The declaration lane's corpus: one workflow file, six rules applied to it. Reported through
 # gatelib.subjects so a vanished workflow reads as "this gate examined nothing" rather than as a
 # pass — the #4339 failure mode, where a moved path turns a gate into a green no-op.
-RULE_IDS = ("D1", "D2", "D3", "D4", "D5", "D6")
+BLIND_MARKER = "<!-- merged-past-red-check-blind -->"
+
+RULE_IDS = ("D1", "D2", "D3", "D4", "D5", "D6", "D7")
 
 
 def check_declaration(root: Path, report_subjects: bool = False) -> tuple[int, list[str]]:
@@ -374,6 +382,20 @@ def check_declaration(root: Path, report_subjects: bool = False) -> tuple[int, l
         fails.append(
             "D6: the scan is not run with --require-token, so a missing secret would report "
             "an unread window as clean."
+        )
+
+    # D7 — the escalation must cover the watch's own blindness (#4791). Both halves are
+    # required: a condition that excludes the cannot-answer code, and a distinct marker so the
+    # blind issue and the findings issue cannot overwrite one another.
+    if re.search(r"outputs\.code\s*!=\s*['\"]1['\"]", body):
+        fails.append(
+            "D7: escalation is gated on the scan succeeding, so it is skipped in exactly the case "
+            "where the watch went blind — leaving a red scheduled run as the only signal (#4019)."
+        )
+    if BLIND_MARKER not in body:
+        fails.append(
+            f"D7: no distinct `{BLIND_MARKER}` marker — the blind state would share an issue with "
+            "the findings state, and a later clean window would close it."
         )
 
     # THIS script must still be the thing that keys on `failing`, not on the suite result.
@@ -498,9 +520,35 @@ def self_test() -> int:
         code, fails = check_declaration(Path(td))
         if code == 0:
             bad.append("declaration passed a workflow with no time_period, no pagination, no issue")
-        for want in ("D1", "D2", "D3", "D4", "D5", "D6"):
+        for want in ("D1", "D2", "D3", "D4", "D5", "D6", "D7"):
             if not any(f.startswith(want) for f in fails):
                 bad.append(f"declaration did not raise {want} against the deliberately broken file")
+
+        # 8d. D7, falsified on its own rather than only inside the everything-broken file.
+        #     Each half must fire alone, because each alone rebuilds the blind spot: gating the
+        #     escalation on the scan succeeding skips it when blind, and a shared marker lets a
+        #     clean window close the blind issue.
+        gated = (
+            "on:\n  schedule:\n    - cron: '17 6 * * *'\n"
+            "jobs:\n  x:\n    permissions:\n      issues: write\n    steps:\n"
+            "      - run: gh api --paginate repos/o/r/rulesets/rule-suites?time_period=month\n"
+            "      - run: python3 .github/scripts/check-merged-past-red-check.py --scan"
+            " --require-token\n"
+            "        env:\n          T: ${{ secrets.RULESET_AUDIT_TOKEN }}\n"
+            "      - uses: actions/github-script@v9\n"
+            "        if: ${{ steps.verdict.outputs.code != '1' }}\n"
+            f"        # {BLIND_MARKER}\n"
+        )
+        p.write_text(gated)
+        _, fails = check_declaration(Path(td))
+        if not any("gated on the scan succeeding" in f for f in fails):
+            bad.append("D7 accepted an escalation gated on `outputs.code != '1'`")
+
+        p.write_text(gated.replace(f"        # {BLIND_MARKER}\n", "").replace(
+            "        if: ${{ steps.verdict.outputs.code != '1' }}\n", ""))
+        _, fails = check_declaration(Path(td))
+        if not any("distinct" in f and f.startswith("D7") for f in fails):
+            bad.append("D7 accepted a workflow with no distinct blind marker")
 
         # 8b. A workflow whose ONLY defect is the default window must still fail D1 — the
         #     single-rule falsification, not just the everything-broken one.
@@ -525,7 +573,7 @@ def self_test() -> int:
         return 1
     print(
         f"self-test: {len(SIGNAL_DETAILS)} signal + {len(BENIGN_DETAILS)} benign detail strings, "
-        "dedup, rule-type scoping, suite-result scoping and 3 declaration falsifications all "
+        "dedup, rule-type scoping, suite-result scoping and 5 declaration falsifications all "
         "behaved as required"
     )
     return 0
@@ -552,7 +600,7 @@ def main() -> int:
         for f in fails:
             print(f"::error::{f}")
         if code == 0:
-            print(f"declaration holds: {WORKFLOW} satisfies D1-D6")
+            print(f"declaration holds: {WORKFLOW} satisfies D1-D7")
         return code
     if args.scan:
         return scan(args)

--- a/.github/workflows/merged-past-red-check-watch.yml
+++ b/.github/workflows/merged-past-red-check-watch.yml
@@ -59,7 +59,7 @@ concurrency:
 jobs:
   # PR lane: offline, cheap, and the only lane that runs on a PR. It proves the
   # classifier separates the 7 from the 22 and that the workflow still satisfies
-  # D1-D6, then measures what the CI identity can actually read.
+  # D1-D7, then measures what the CI identity can actually read.
   declaration:
     name: merged-past-red-check declaration
     if: ${{ github.event_name == 'pull_request' }}
@@ -71,7 +71,7 @@ jobs:
       - name: Self-test the classifier
         run: python3 .github/scripts/check-merged-past-red-check.py --self-test
 
-      - name: The watch still satisfies D1-D6
+      - name: The watch still satisfies D1-D7
         run: python3 .github/scripts/check-merged-past-red-check.py --check-declaration
 
       # Measured, never assumed: can the identity CI runs as read this endpoint?
@@ -133,28 +133,92 @@ jobs:
             *) echo "::error::Unexpected exit $code."; exit "$code" ;;
           esac
 
+      # `!cancelled()`, and NOT gated on the scan succeeding (#4791). The previous condition was
+      # `steps.verdict.outputs.code != '1'` — so escalation was skipped in exactly the case where
+      # the watch had gone BLIND, and the only signal left was a red scheduled run. This file's own
+      # docstring names why that is not enough: "a red scheduled workflow is addressed to nobody —
+      # that is the #4019 lesson this repo already paid for". It then reproduced it: 87 of 87 real
+      # runs red on a token without Administration:read, and nobody addressed.
       - name: Escalate or stand down
-        if: ${{ github.event_name != 'workflow_dispatch' && steps.verdict.outputs.code != '1' }}
+        if: ${{ !cancelled() && github.event_name != 'workflow_dispatch' && steps.verdict.outcome != 'skipped' }}
+        env:
+          VERDICT_CODE: ${{ steps.verdict.outputs.code }}
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const fs = require('fs')
-            const v = JSON.parse(fs.readFileSync('/tmp/merged-past-red.json', 'utf8'))
             const LABEL = 'fleet-health'
             const marker = '<!-- merged-past-red-check -->'
+            // A SEPARATE marker on purpose: "the watch is blind" and "these merges bypassed a
+            // check" are different states with different fixes, and one must never close or
+            // overwrite the other's issue.
+            const blindMarker = '<!-- merged-past-red-check-blind -->'
             const REOPEN_WINDOW_DAYS = 14
 
             // Find by MARKER, not by title: the title carries a count and moves.
-            const findByMarker = async (state) => {
+            const findByMarker = async (state, m) => {
               const issues = await github.paginate(github.rest.issues.listForRepo, {
                 ...context.repo, state, labels: LABEL, per_page: 100,
                 sort: 'updated', direction: 'desc',
               })
-              return issues.find(i => (i.body || '').includes(marker))
+              return issues.find(i => (i.body || '').includes(m))
             }
 
+            // ── the watch could not answer (#4791) ────────────────────────────────────────
+            // Escalated, not merely logged. "Could not answer" is NOT "nothing was bypassed",
+            // and the whole control is absent for as long as it lasts.
+            if (process.env.VERDICT_CODE === '1') {
+              const bTitle = 'The merged-past-red-check watch cannot answer — the bypass detector is blind'
+              const bBody = [
+                blindMarker,
+                '## This watch could not read the ruleset bypass log',
+                '',
+                '`rulesets/rule-suites` returned an error, so **no verdict was produced** — neither',
+                'clean nor dirty. For as long as this holds, nothing is checking whether a PR was',
+                'merged past an actively failing required check (#4240).',
+                '',
+                'Most likely `secrets.RULESET_AUDIT_TOKEN` is unset or lacks **Administration: read**.',
+                'A workflow `GITHUB_TOKEN` cannot hold that permission — `permissions:` has no',
+                '`administration:` key — so this needs a PAT or GitHub App token that does.',
+                '',
+                'This issue is refreshed while the watch stays blind and is closed by the watch',
+                'itself on the first run that produces a verdict.',
+                '',
+                `_Automated: \`${context.workflow}\` run ${context.runId} (issue #4791)._`,
+              ].join('\n')
+
+              const openBlind = await findByMarker('open', blindMarker)
+              if (openBlind) {
+                await github.rest.issues.update({
+                  ...context.repo, issue_number: openBlind.number, title: bTitle, body: bBody,
+                })
+                core.info(`refreshed blind #${openBlind.number}`)
+              } else {
+                const created = await github.rest.issues.create({
+                  ...context.repo, title: bTitle, body: bBody, labels: [LABEL],
+                })
+                core.info(`opened blind #${created.data.number}`)
+              }
+              return
+            }
+
+            // A verdict exists, so the watch is not blind: stand the blind issue down first.
+            const openBlind = await findByMarker('open', blindMarker)
+            if (openBlind) {
+              await github.rest.issues.createComment({
+                ...context.repo, issue_number: openBlind.number,
+                body: `The watch produced a verdict again — closing. _(\`${context.workflow}\` run ${context.runId})_`,
+              })
+              await github.rest.issues.update({
+                ...context.repo, issue_number: openBlind.number, state: 'closed',
+              })
+              core.info(`closed blind #${openBlind.number}`)
+            }
+
+            const v = JSON.parse(fs.readFileSync('/tmp/merged-past-red.json', 'utf8'))
+
             if (v.status !== 'dirty') {
-              const open = await findByMarker('open')
+              const open = await findByMarker('open', marker)
               if (open) {
                 await github.rest.issues.createComment({
                   ...context.repo, issue_number: open.number,
@@ -199,13 +263,13 @@ jobs:
               `_Automated: \`${context.workflow}\` run ${context.runId} (issue #4240)._`,
             ].join('\n')
 
-            const open = await findByMarker('open')
+            const open = await findByMarker('open', marker)
             if (open) {
               await github.rest.issues.update({ ...context.repo, issue_number: open.number, title, body })
               core.info(`refreshed #${open.number}`)
               return
             }
-            const closed = await findByMarker('closed')
+            const closed = await findByMarker('closed', marker)
             const fresh = closed && closed.closed_at &&
               (Date.now() - Date.parse(closed.closed_at)) < REOPEN_WINDOW_DAYS * 864e5
             if (fresh) {


### PR DESCRIPTION
## The escalation was skipped in exactly the case that needed it

```yaml
if: ${{ github.event_name != 'workflow_dispatch' && steps.verdict.outputs.code != '1' }}
```

Code `1` is exactly *"the watch could not answer"*. So the step that opens an issue was skipped
whenever the detector had gone **blind**, leaving a red scheduled run as the only signal.

The script's own docstring says why that is not enough:

> a red scheduled workflow is addressed to nobody — that is the #4019 lesson this repo already paid
> for, and reproducing it here would mean the detector for an invisible failure is itself an
> invisible failure

It then reproduced it. **87 of 87** push/schedule runs failed on a `RULESET_AUDIT_TOKEN` without
`Administration: read`, as far back as the API returns, and nothing addressed it. The control that
catches a merge past a red required check (#4240) was absent that whole time, and its absence looked
like routine CI noise.

## What changes

Escalation now runs on `!cancelled()` and branches on the verdict:

| verdict | action |
|---|---|
| code `1` — cannot answer | open/refresh an issue saying **the watch is blind**, under its own `<!-- merged-past-red-check-blind -->` marker |
| any real verdict | close that blind issue first, then the existing findings logic — unchanged |

**The marker is separate on purpose.** "The watch is blind" and "these merges bypassed a check" are
different states with different fixes; a clean window must never close the blind issue.
`findByMarker` now takes the marker as an argument instead of closing over one.

**The job still goes red.** This adds a reader, it does not soften the signal.

## D7, so it stays true

Encoded in the declaration gate rather than left to whoever edits the workflow next — the property
is invisible in review, and each half alone rebuilds the blind spot:

- **D7a** — escalation must not be gated on `outputs.code != '1'`
- **D7b** — the blind state needs its own marker

### Falsified against the real thing, not just a fixture

Run against `origin/main`'s actual copy of the workflow:

```
exit 1
  D7: escalation is gated on the scan succeeding, so it is skipped in exactly the case where …
  D7: no distinct `<!-- merged-past-red-check-blind -->` marker — the blind state would share …
```

…and it holds against the patched copy. Plus two single-rule fixtures so each half fires alone, and
removing the D7 rule body reddens all three checks:

```
self-test FAILED: declaration did not raise D7 against the deliberately broken file
self-test FAILED: D7 accepted an escalation gated on `outputs.code != '1'`
self-test FAILED: D7 accepted a workflow with no distinct blind marker
```

## Counts updated, because a stale one is the drift this gate exists to stop

`min_subjects` 6 → 7 in `gates.yaml`, and the `D1-D6` strings in the workflow, the script's success
line and the gate comment now read `D1-D7`. The self-test summary said "3 declaration
falsifications" and now says 5.

## Verification

- `merged-past-red-check-declaration` gate: **PASS**, `SUBJECTS=7`
- self-test: PASS
- gate groups: gitops 27/28, registry 26/26, security 12/12 — the one non-pass is the pre-existing
  `loki-rule-load-test`, identical on clean `main`

## Scope

This does **not** fix the token. `RULESET_AUDIT_TOKEN` exists but lacks `Administration: read`, and
granting it is a credential/permission change for a human. What this changes is that the next time
the watch cannot answer — for that reason or any other — it says so somewhere a person will see,
instead of only going red.

Refs #4791, #4240, #4019
