### PR TITLE
fix(ci): name the real reason rule-suites 403s — fine-grained PATs, not permissions (#4791)

### DIFF
--- a/.github/scripts/check-merged-past-red-check.py
+++ b/.github/scripts/check-merged-past-red-check.py
@@ -75,10 +75,22 @@ TOKEN IDENTITY -- read this before assuming the runtime lane works
 `rulesets/rule-suites` requires the repository **Administration: read** permission. The Actions
 `permissions:` block has no `administration:` key at all -- there is no way to grant a job's
 `GITHUB_TOKEN` that scope, so the workflow token CANNOT read this endpoint no matter how the job
-is written. The runtime lane therefore needs a PAT (or GitHub App token) in
-`secrets.RULESET_AUDIT_TOKEN`, and the workflow's `capability` step probes the endpoint with the
-plain `GITHUB_TOKEN` on every PR so that this claim is measured under the identity CI actually
-uses, not asserted from documentation. When the secret is absent the runtime lane SKIPS loudly
+is written. The runtime lane therefore needs a token in `secrets.RULESET_AUDIT_TOKEN`, and the
+workflow's `capability` step probes the endpoint with the plain `GITHUB_TOKEN` on every PR so that
+this claim is measured under the identity CI actually uses, not asserted from documentation.
+
+That permission is necessary and NOT sufficient, and the 403 does not tell you so (#4791). The
+REPOSITORY-level endpoint does not accept fine-grained PATs at all: GitHub's "endpoints available
+for fine-grained personal access tokens" lists the ORG-level `/orgs/{org}/rulesets/rule-suites`
+and not this one. Measured both ways -- a fine-grained token scoped to this repo WITH `Read access
+to administration and metadata` answers `403 Resource not accessible by personal access token`,
+while a classic PAT carrying `repo` returns the rows. So the secret must hold a CLASSIC PAT with
+`repo`, or a GitHub App installation token with Administration:read.
+
+This cost real time: the error text used to say "unset or lacks Administration:read", which reads
+as a permissions problem and sends the reader to grant a permission the token already had. A
+diagnostic that names the WRONG cause confidently is worse than one that says only "I could not
+read it" -- the message now names what the 403 can and cannot distinguish. When the secret is absent the runtime lane SKIPS loudly
 rather than reporting a clean window -- a permission-shaped absence is indistinguishable from a
 real one, and it always fails in the direction of a confident wrong answer.
 

--- a/.github/workflows/merged-past-red-check-watch.yml
+++ b/.github/workflows/merged-past-red-check-watch.yml
@@ -16,11 +16,21 @@
 # ESCALATION, not redness (#4019): a red scheduled workflow is addressed to
 # nobody, which is the very blind spot this closes. One issue, refreshed in place.
 #
-# TOKEN. rule-suites needs Administration:read. The Actions `permissions:` block
-# has no `administration:` key, so a job's GITHUB_TOKEN can NEVER read it — the
-# runtime lane uses secrets.RULESET_AUDIT_TOKEN and skips loudly without it. The
-# `capability` step measures that claim under the CI identity on every PR instead
+# TOKEN. rule-suites needs Administration:read, and the Actions `permissions:`
+# block has no `administration:` key, so a job's GITHUB_TOKEN can NEVER read it.
+# The `capability` step measures that under the CI identity on every PR instead
 # of asserting it from documentation.
+#
+# The permission is necessary and NOT sufficient: the REPOSITORY-level rule-suites
+# endpoint does not accept fine-grained PATs at all. GitHub's own
+# "endpoints available for fine-grained personal access tokens" lists the ORG-level
+# `/orgs/{org}/rulesets/rule-suites` and not this one. Measured both ways (#4791):
+# a fine-grained token scoped to this repo WITH `Read access to administration and
+# metadata` still answers 403 `Resource not accessible by personal access token`,
+# while a classic PAT carrying `repo` returns the rows. So RULESET_AUDIT_TOKEN must
+# be a CLASSIC PAT with `repo`, or a GitHub App installation token with
+# Administration:read — granting more permission to a fine-grained token cannot
+# work, and the 403 says nothing about which permissions it holds.
 #
 # WHY IT IS NOT A REQUIRED CHECK. Scheduled and paths-filtered workflows cannot be
 # required contexts here. The BINDING copy of the declaration half is the
@@ -127,7 +137,10 @@ jobs:
             0) : ;;
             1) echo "::error::The watch could not answer. That is a failure of THIS WATCH,"
                echo "::error::not a 'nothing was bypassed' verdict. Most likely"
-               echo "::error::secrets.RULESET_AUDIT_TOKEN is unset or lacks Administration:read."
+               echo "::error::secrets.RULESET_AUDIT_TOKEN is unset, or is a FINE-GRAINED PAT."
+               echo "::error::The repo-level rule-suites endpoint does not accept fine-grained"
+               echo "::error::tokens no matter what permissions they carry (#4791) — use a classic"
+               echo "::error::PAT with 'repo', or a GitHub App token with Administration:read."
                exit 1 ;;
             2) echo "::warning::a merge past an actively failing required check — escalating." ;;
             *) echo "::error::Unexpected exit $code."; exit "$code" ;;
@@ -177,9 +190,20 @@ jobs:
                 'clean nor dirty. For as long as this holds, nothing is checking whether a PR was',
                 'merged past an actively failing required check (#4240).',
                 '',
-                'Most likely `secrets.RULESET_AUDIT_TOKEN` is unset or lacks **Administration: read**.',
-                'A workflow `GITHUB_TOKEN` cannot hold that permission — `permissions:` has no',
-                '`administration:` key — so this needs a PAT or GitHub App token that does.',
+                'Either `secrets.RULESET_AUDIT_TOKEN` is unset, or it is a **fine-grained** PAT.',
+                '',
+                'The permission is not the usual culprit, and the 403 does not report one: the',
+                '**repository**-level rule-suites endpoint does not accept fine-grained tokens at',
+                'all. GitHub lists only the org-level `/orgs/{org}/rulesets/rule-suites` as',
+                'available to them. Measured both ways (#4791) — a fine-grained token scoped to',
+                'this repo *with* `Read access to administration and metadata` still answers',
+                '`403 Resource not accessible by personal access token`, while a classic PAT with',
+                '`repo` returns the rows.',
+                '',
+                'So this needs a **classic PAT with `repo`**, or a GitHub App installation token',
+                'with Administration:read. Adding permissions to a fine-grained token cannot fix it.',
+                'A workflow `GITHUB_TOKEN` cannot be used either — `permissions:` has no',
+                '`administration:` key.',
                 '',
                 'This issue is refreshed while the watch stays blind and is closed by the watch',
                 'itself on the first run that produces a verdict.',


### PR DESCRIPTION
## The watch told everyone the wrong thing

```
secrets.RULESET_AUDIT_TOKEN is unset or lacks Administration:read.
```

That reads as a permissions problem and sends the reader to grant a permission the token **already
held**. It cost real time — I repeated it as a diagnosis, filed it as the fix in #4791, and it was
wrong. The owner's token page shows `Read access to administration and metadata`, and the endpoint
still 403s.

## Measured, both ways

| token | result |
|---|---|
| fine-grained PAT scoped to this repo, **with** `Read access to administration and metadata` | `403 Resource not accessible by personal access token` |
| classic PAT carrying `repo` | **200**, rows returned |

GitHub's own [endpoints available for fine-grained personal access tokens](https://docs.github.com/en/rest/authentication/endpoints-available-for-fine-grained-personal-access-tokens)
lists the **org**-level `/orgs/{org}/rulesets/rule-suites` and **not** the repository-level one this
watch uses.

So no amount of permission on a fine-grained token can work, and **the 403 says nothing about which
permissions it holds** — which is exactly what made the old message misleading rather than merely
incomplete.

## What changes

**Text only.** No logic, no rules, no gate behaviour, no D-rule touched.

- workflow header comment
- the runtime `::error::` lines
- the blind-issue body (the text now sitting in #4815)

All three now say: unset, **or a fine-grained token**; use a classic PAT with `repo`, or a GitHub App
installation token with `Administration:read`; adding permissions to a fine-grained token cannot fix
it.

The script's `TOKEN IDENTITY` section records the same, plus why it is written down: *a diagnostic
that names the WRONG cause confidently is worse than one that says only "I could not read it"*. The
message now states what the 403 can and cannot distinguish.

The `capability` step is unchanged and was always right — it measures `GITHUB_TOKEN` against the
endpoint on every PR rather than asserting from docs. This adds the second half of that discipline,
for the runtime identity.

## Verification

- self-test: **PASS**
- `merged-past-red-check-declaration`: **PASS**, `SUBJECTS=7`, D1-D7
- registry 26/26, security 12/12

## Still needed from a human

The token itself. `RULESET_AUDIT_TOKEN` must be replaced with a classic PAT carrying `repo`, or a
GitHub App installation token with `Administration:read`. That is a credential change; flagging, not
doing.

Once it lands, #4815 closes itself — the escalation added in #4810 stands the blind issue down on
the first run that produces a verdict.

Refs #4791, #4815
