### PR TITLE
feat(admin-ui): unify operator workspace

### DIFF
--- a/openbank-admin-ui/src/app/api/agent/catalog-reviews/route.ts
+++ b/openbank-admin-ui/src/app/api/agent/catalog-reviews/route.ts
@@ -37,10 +37,20 @@ export async function POST(request: NextRequest) {
       signal: AbortSignal.timeout(35_000),
       cache: 'no-store',
     })
+    if (!response.ok) {
+      // A missing/offline model is an intentional operator state, not an
+      // infrastructure detail. Preserve only this narrow, documented contract;
+      // every other agent error stays behind the generic BFF envelope.
+      const failure = await response.json().catch(() => null) as { error?: unknown } | null
+      if (response.status === 503 && failure?.error === 'model unavailable') {
+        return NextResponse.json({ error: 'model unavailable' }, { status: 503 })
+      }
+      return NextResponse.json({ error: 'upstream_error' }, { status: response.status })
+    }
     return NextResponse.json(await response.json(), { status: response.status })
-  } catch (error) {
+  } catch {
     return NextResponse.json(
-      { error: error instanceof Error ? error.message : 'agent_unreachable' },
+      { error: 'agent_unreachable' },
       { status: 502 },
     )
   }

--- a/openbank-admin-ui/src/app/api/agent/chat/route.ts
+++ b/openbank-admin-ui/src/app/api/agent/chat/route.ts
@@ -37,11 +37,12 @@ export async function POST(req: NextRequest) {
       cache: 'no-store',
     })
     clearTimeout(timer)
+    if (!res.ok) return NextResponse.json({ reply: '', model: '', toolCalls: [], error: 'agent_unreachable' }, { status: res.status })
     const data = await res.json()
     return NextResponse.json(data, { status: res.status })
-  } catch (e) {
+  } catch {
     return NextResponse.json(
-      { reply: '', model: '', toolCalls: [], error: e instanceof Error ? e.message : 'agent_unreachable' },
+      { reply: '', model: '', toolCalls: [], error: 'agent_unreachable' },
       { status: 502 },
     )
   }
@@ -57,8 +58,9 @@ export async function GET() {
       headers: { Authorization: `Bearer ${accessToken}` },
       cache: 'no-store',
     })
+    if (!res.ok) return NextResponse.json({ default: '', models: [], error: 'agent_unreachable' }, { status: res.status })
     return NextResponse.json(await res.json(), { status: res.status })
-  } catch (e) {
-    return NextResponse.json({ default: '', models: [], error: e instanceof Error ? e.message : 'agent_unreachable' }, { status: 502 })
+  } catch {
+    return NextResponse.json({ default: '', models: [], error: 'agent_unreachable' }, { status: 502 })
   }
 }

--- a/openbank-admin-ui/src/app/api/agent/mcp/route.ts
+++ b/openbank-admin-ui/src/app/api/agent/mcp/route.ts
@@ -53,11 +53,17 @@ export async function POST(req: NextRequest) {
       cache: 'no-store',
     })
     clearTimeout(timer)
+    if (!res.ok) {
+      return NextResponse.json(
+        { jsonrpc: '2.0', id: null, error: { code: -32603, message: 'agent_unreachable' } },
+        { status: res.status },
+      )
+    }
     const data = await res.json()
     return NextResponse.json(data, { status: res.status })
-  } catch (e) {
+  } catch {
     return NextResponse.json(
-      { jsonrpc: '2.0', id: null, error: { code: -32603, message: e instanceof Error ? e.message : 'agent_unreachable' } },
+      { jsonrpc: '2.0', id: null, error: { code: -32603, message: 'agent_unreachable' } },
       { status: 502 },
     )
   }

--- a/openbank-admin-ui/src/app/api/agent/obo-mcp/route.ts
+++ b/openbank-admin-ui/src/app/api/agent/obo-mcp/route.ts
@@ -140,11 +140,17 @@ export async function POST(req: NextRequest) {
       cache: 'no-store',
     })
     clearTimeout(timer)
+    if (!res.ok) {
+      return NextResponse.json(
+        { jsonrpc: '2.0', id: null, error: { code: -32603, message: 'mcp_unreachable' } },
+        { status: res.status },
+      )
+    }
     const data = await res.json()
     return NextResponse.json(data, { status: res.status })
-  } catch (e) {
+  } catch {
     return NextResponse.json(
-      { jsonrpc: '2.0', id: null, error: { code: -32603, message: e instanceof Error ? e.message : 'mcp_unreachable' } },
+      { jsonrpc: '2.0', id: null, error: { code: -32603, message: 'mcp_unreachable' } },
       { status: 502 },
     )
   }

--- a/openbank-admin-ui/src/app/api/agent/proposals/route.ts
+++ b/openbank-admin-ui/src/app/api/agent/proposals/route.ts
@@ -34,9 +34,10 @@ export async function GET(req: NextRequest) {
       signal: ctrl.signal,
     })
     clearTimeout(timer)
+    if (!res.ok) return NextResponse.json({ error: 'upstream_error' }, { status: res.status })
     return NextResponse.json(await res.json(), { status: res.status })
-  } catch (e) {
-    return NextResponse.json({ error: e instanceof Error ? e.message : 'agent_unreachable' }, { status: 502 })
+  } catch {
+    return NextResponse.json({ error: 'agent_unreachable' }, { status: 502 })
   }
 }
 
@@ -59,8 +60,9 @@ export async function POST(req: NextRequest) {
       cache: 'no-store',
     })
     clearTimeout(timer)
+    if (!res.ok) return NextResponse.json({ error: 'upstream_error' }, { status: res.status })
     return NextResponse.json(await res.json(), { status: res.status })
-  } catch (e) {
-    return NextResponse.json({ error: e instanceof Error ? e.message : 'agent_unreachable' }, { status: 502 })
+  } catch {
+    return NextResponse.json({ error: 'agent_unreachable' }, { status: 502 })
   }
 }

--- a/openbank-admin-ui/src/app/api/devops/decide/route.ts
+++ b/openbank-admin-ui/src/app/api/devops/decide/route.ts
@@ -3,6 +3,7 @@
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 
 import { NextRequest, NextResponse } from 'next/server'
+import { auth } from '@/auth'
 
 export const dynamic = 'force-dynamic'
 
@@ -12,11 +13,6 @@ export const dynamic = 'force-dynamic'
 // `platform-admin` until #2418 — a role no Keycloak realm has ever issued, so the endpoint 403'd
 // for everyone).
 //
-// NOTE: the fetch below sends no Authorization header, unlike the sibling proxies under
-// src/app/api/agent/ and src/app/api/svc/. An unauthenticated request cannot satisfy any
-// @RolesAllowed, so this path stays broken on the agent side even now that the role name is real —
-// the M2M token story is issue #2442. Do not read the corrected comment as "this works".
-
 function devopsBase(): string {
   if (process.env.SERVICES_HOST === 'container') {
     return 'http://devops-agent.devops-agent.svc:8142'
@@ -25,6 +21,9 @@ function devopsBase(): string {
 }
 
 export async function POST(req: NextRequest) {
+  const accessToken = (await auth())?.user?.accessToken
+  if (!accessToken) return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+
   const { id, action } = (await req.json()) as { id?: string; action?: string }
   if (!id || (action !== 'approve' && action !== 'reject')) {
     return NextResponse.json({ error: 'id and action (approve|reject) are required' }, { status: 400 })
@@ -32,14 +31,14 @@ export async function POST(req: NextRequest) {
   try {
     const res = await fetch(`${devopsBase()}/api/v1/devops/findings/${encodeURIComponent(id)}/${action}`, {
       method: 'POST',
+      headers: { Authorization: `Bearer ${accessToken}` },
       signal: AbortSignal.timeout(10_000),
     })
     if (!res.ok) {
-      return NextResponse.json({ error: `devops-agent returned ${res.status}` }, { status: res.status })
+      return NextResponse.json({ error: 'upstream_error' }, { status: res.status })
     }
     return NextResponse.json({ finding: await res.json() })
-  } catch (e) {
-    const msg = e instanceof Error ? e.message : String(e)
-    return NextResponse.json({ error: `decision failed: ${msg}` }, { status: 502 })
+  } catch {
+    return NextResponse.json({ error: 'upstream_unreachable' }, { status: 502 })
   }
 }

--- a/openbank-admin-ui/src/app/api/devops/insights/route.ts
+++ b/openbank-admin-ui/src/app/api/devops/insights/route.ts
@@ -3,6 +3,7 @@
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 
 import { NextResponse } from 'next/server'
+import { auth } from '@/auth'
 
 export const dynamic = 'force-dynamic'
 
@@ -49,8 +50,12 @@ function devopsBase(): string {
 }
 
 export async function GET() {
+  const accessToken = (await auth())?.user?.accessToken
+  if (!accessToken) return NextResponse.json({ findings: [], available: false, reason: 'unauthorized' }, { status: 401 })
+
   try {
     const res = await fetch(`${devopsBase()}/api/v1/devops/findings`, {
+      headers: { Authorization: `Bearer ${accessToken}` },
       signal: AbortSignal.timeout(10_000),
     })
     if (!res.ok) return NextResponse.json({ findings: [], available: false })

--- a/openbank-admin-ui/src/app/api/product-catalog/[id]/activate/route.ts
+++ b/openbank-admin-ui/src/app/api/product-catalog/[id]/activate/route.ts
@@ -1,14 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
-import { NextRequest, NextResponse } from 'next/server'
-
-const BASE = process.env.PRODUCT_CATALOG_URL ?? 'http://openbank-product-catalog:8104'
+import { NextRequest } from 'next/server'
+import { productCatalogUpstream } from '@/lib/productCatalog/upstream'
 
 export async function POST(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params
-  const res = await fetch(`${BASE}/api/v1/products/${id}/activate`, {
-    method: 'POST', headers: { Accept: 'application/json' },
-    cache: 'no-store', signal: AbortSignal.timeout(10_000),
-  })
-  const data = await res.json().catch(() => ({ error: 'Invalid JSON' }))
-  return NextResponse.json(data, { status: res.status })
+  return productCatalogUpstream(`/api/v1/products/${encodeURIComponent(id)}/activate`, { method: 'POST' })
 }

--- a/openbank-admin-ui/src/app/api/product-catalog/[id]/deactivate/route.ts
+++ b/openbank-admin-ui/src/app/api/product-catalog/[id]/deactivate/route.ts
@@ -1,14 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
-import { NextRequest, NextResponse } from 'next/server'
-
-const BASE = process.env.PRODUCT_CATALOG_URL ?? 'http://openbank-product-catalog:8104'
+import { NextRequest } from 'next/server'
+import { productCatalogUpstream } from '@/lib/productCatalog/upstream'
 
 export async function POST(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params
-  const res = await fetch(`${BASE}/api/v1/products/${id}/deactivate`, {
-    method: 'POST', headers: { Accept: 'application/json' },
-    cache: 'no-store', signal: AbortSignal.timeout(10_000),
-  })
-  const data = await res.json().catch(() => ({ error: 'Invalid JSON' }))
-  return NextResponse.json(data, { status: res.status })
+  return productCatalogUpstream(`/api/v1/products/${encodeURIComponent(id)}/deactivate`, { method: 'POST' })
 }

--- a/openbank-admin-ui/src/app/api/product-catalog/[id]/route.ts
+++ b/openbank-admin-ui/src/app/api/product-catalog/[id]/route.ts
@@ -1,27 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
-import { NextRequest, NextResponse } from 'next/server'
-
-const BASE = process.env.PRODUCT_CATALOG_URL ?? 'http://openbank-product-catalog:8104'
-
-async function proxy(path: string, method = 'GET', body?: string) {
-  const res = await fetch(`${BASE}${path}`, {
-    method,
-    headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
-    body: method !== 'GET' && body ? body : undefined,
-    cache: 'no-store',
-    signal: AbortSignal.timeout(10_000),
-  })
-  const data = await res.json().catch(() => ({ error: 'Invalid JSON' }))
-  return NextResponse.json(data, { status: res.status })
-}
+import { NextRequest } from 'next/server'
+import { productCatalogUpstream } from '@/lib/productCatalog/upstream'
 
 export async function GET(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params
-  return proxy(`/api/v1/products/${id}`)
+  return productCatalogUpstream(`/api/v1/products/${encodeURIComponent(id)}`)
 }
 
 export async function PUT(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params
   const body = await req.text()
-  return proxy(`/api/v1/products/${id}`, 'PUT', body)
+  return productCatalogUpstream(`/api/v1/products/${encodeURIComponent(id)}`, { method: 'PUT', body })
 }

--- a/openbank-admin-ui/src/app/api/product-catalog/fees/route.ts
+++ b/openbank-admin-ui/src/app/api/product-catalog/fees/route.ts
@@ -1,26 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
+import { productCatalogUpstream } from '@/lib/productCatalog/upstream'
 
 // Fees are served by the product catalog (system of record for pricing). The
 // admin UI fetches them here instead of hardcoding a price list in the web tier.
-const BASE = process.env.PRODUCT_CATALOG_URL ?? 'http://openbank-product-catalog:8104'
-
 export const dynamic = 'force-dynamic'
 
 export async function GET(req: NextRequest) {
   const search = req.nextUrl.search
-  try {
-    const res = await fetch(`${BASE}/api/v1/fees${search}`, {
-      headers: { Accept: 'application/json' },
-      cache: 'no-store',
-      signal: AbortSignal.timeout(10_000),
-    })
-    const data = await res.json().catch(() => ({ error: 'Invalid JSON' }))
-    return NextResponse.json(data, { status: res.status, headers: { 'Cache-Control': 'no-store' } })
-  } catch (err: unknown) {
-    const detail = err instanceof Error ? err.message : String(err)
-    return NextResponse.json({ error: 'upstream_unreachable', detail }, { status: 502 })
-  }
+  return productCatalogUpstream(`/api/v1/fees${search}`)
 }

--- a/openbank-admin-ui/src/app/api/product-catalog/route.ts
+++ b/openbank-admin-ui/src/app/api/product-catalog/route.ts
@@ -1,26 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
-import { NextRequest, NextResponse } from 'next/server'
-
-const BASE = process.env.PRODUCT_CATALOG_URL ?? 'http://openbank-product-catalog:8104'
-
-async function proxy(path: string, method = 'GET', body?: string) {
-  const res = await fetch(`${BASE}${path}`, {
-    method,
-    headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
-    body: method !== 'GET' && body ? body : undefined,
-    cache: 'no-store',
-    signal: AbortSignal.timeout(10_000),
-  })
-  const data = await res.json().catch(() => ({ error: 'Invalid JSON' }))
-  return NextResponse.json(data, { status: res.status })
-}
+import { NextRequest } from 'next/server'
+import { productCatalogUpstream } from '@/lib/productCatalog/upstream'
 
 export async function GET(req: NextRequest) {
   const search = req.nextUrl.search
-  return proxy(`/api/v1/products${search}`)
+  return productCatalogUpstream(`/api/v1/products${search}`)
 }
 
 export async function POST(req: NextRequest) {
   const body = await req.text()
-  return proxy('/api/v1/products', 'POST', body)
+  return productCatalogUpstream('/api/v1/products', { method: 'POST', body })
 }

--- a/openbank-admin-ui/src/app/globals.css
+++ b/openbank-admin-ui/src/app/globals.css
@@ -118,7 +118,11 @@
   --input: 214 32% 91%;
   --ring: 239 84% 67%;
   --radius: 8px;
-  --border: 214 32% 91%;
+  /* This token is consumed directly by 500+ application call sites
+   * (`border: 1px solid var(--border)`). It must consequently be a real CSS
+   * colour, not a Tailwind HSL triplet. The triplet silently makes those
+   * declarations invalid and leaves cards, fields and tables borderless. */
+  --border: #e2e8f0;
 }
 
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -894,3 +898,108 @@ main {
 }
 .data-table tbody tr:last-child td { border-bottom: none; }
 .data-table tbody tr:hover td { background: var(--surface-2); }
+
+/* ── Operator workspace system ────────────────────────────────────────────
+ * These are deliberately global primitives: 102 operator routes already use
+ * the shared card, page-header, table, input and button vocabulary. Improving
+ * that vocabulary upgrades the whole console without inventing a competing
+ * stylesheet for every domain page (ADR-0208 D1/D2). */
+main {
+  background:
+    radial-gradient(circle at 88% -12%, rgba(129, 140, 248, .10), transparent 26rem),
+    linear-gradient(180deg, #fbfcff 0%, var(--bg) 34rem);
+  scroll-behavior: smooth;
+}
+
+:where(button, a, input, select, textarea, [tabindex]):focus-visible {
+  outline: 3px solid rgba(99, 102, 241, .42);
+  outline-offset: 2px;
+}
+
+.page-header {
+  gap: 20px;
+  margin-bottom: 24px;
+  padding: 22px 24px;
+  border: 1px solid rgba(203, 213, 225, .82);
+  border-radius: var(--r-xl);
+  background:
+    radial-gradient(circle at 96% 0%, rgba(129, 140, 248, .16), transparent 15rem),
+    linear-gradient(125deg, #ffffff 0%, #f8faff 100%);
+  box-shadow: 0 12px 28px rgba(30, 41, 59, .055);
+}
+.page-title { font-size: clamp(24px, 2.4vw, 31px); line-height: 1.15; letter-spacing: -.045em; }
+.page-subtitle { max-width: 760px; margin-top: 8px; line-height: 1.55; }
+.breadcrumb { margin-bottom: 12px; }
+
+.card,
+.stat-card {
+  border-color: rgba(203, 213, 225, .82);
+  box-shadow: 0 7px 18px rgba(15, 23, 42, .035), 0 1px 2px rgba(15, 23, 42, .025);
+}
+.card:hover,
+.stat-card:hover {
+  border-color: rgba(129, 140, 248, .38);
+  box-shadow: 0 14px 30px rgba(30, 41, 59, .08), 0 1px 2px rgba(15, 23, 42, .03);
+}
+.stat-card { padding: 20px; }
+.stat-value { font-size: clamp(27px, 2.3vw, 34px); line-height: 1.08; }
+.stat-label { font-weight: 650; letter-spacing: .01em; }
+.stat-hint { margin-top: 7px; line-height: 1.45; }
+
+.table,
+.data-table {
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: var(--r-lg);
+  background: var(--surface);
+  box-shadow: var(--shadow-xs);
+}
+.table th,
+.data-table th {
+  padding: 12px 16px;
+  color: #64748b;
+  background: #f8fafc;
+}
+.table td,
+.data-table td { padding: 15px 16px; }
+.table tbody tr,
+.data-table tbody tr { transition: background .16s ease; }
+.table tbody tr:hover,
+.data-table tbody tr:hover { background: #f8faff; }
+
+.input {
+  min-height: 40px;
+  border-color: #cbd5e1;
+  border-radius: 9px;
+  background: rgba(255, 255, 255, .94);
+}
+.input:focus { border-color: var(--accent); box-shadow: 0 0 0 4px rgba(99, 102, 241, .13); }
+
+.btn { min-height: 36px; border-radius: 9px; font-weight: 700; }
+.btn-primary { box-shadow: 0 5px 12px rgba(79, 70, 229, .20), inset 0 1px 0 rgba(255,255,255,.16); }
+.btn-secondary { border-color: #cbd5e1; }
+.badge,
+.pill { font-weight: 750; }
+
+.empty-state {
+  border: 1px dashed #cbd5e1;
+  border-radius: var(--r-xl);
+  background: linear-gradient(135deg, rgba(255,255,255,.96), rgba(248,250,252,.9));
+}
+
+@media (max-width: 840px) {
+  .page-header { align-items: stretch; padding: 18px; }
+  .page-header > :last-child:not(:only-child) { align-self: flex-start; }
+  .table,
+  .data-table { display: block; overflow-x: auto; -webkit-overflow-scrolling: touch; }
+}
+
+@media (max-width: 560px) {
+  .page-header { display: block; }
+  .page-header > :last-child { margin-top: 14px; }
+  .stat-card { padding: 17px; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after { scroll-behavior: auto !important; animation-duration: .01ms !important; animation-iteration-count: 1 !important; transition-duration: .01ms !important; }
+}

--- a/openbank-admin-ui/src/lib/productCatalog/upstream.ts
+++ b/openbank-admin-ui/src/lib/productCatalog/upstream.ts
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import { NextResponse } from 'next/server'
+import { auth } from '@/auth'
+
+const BASE = process.env.PRODUCT_CATALOG_URL ?? 'http://openbank-product-catalog:8104'
+
+/**
+ * ADR-0056 bearer relay for the legacy product-catalog BFF routes.
+ *
+ * The browser session cookie authenticates the admin UI, but product-catalog
+ * authorizes the operator from the OIDC bearer. Calling it anonymously made
+ * every catalogue mutation fail at the backend and exposed arbitrary upstream
+ * error bodies to the UI. Keep the relay here so the list, detail, fees and
+ * lifecycle routes cannot drift apart again.
+ */
+export async function productCatalogUpstream(
+  path: string,
+  init: { method?: string; body?: string } = {},
+): Promise<NextResponse> {
+  const accessToken = (await auth())?.user?.accessToken
+  if (!accessToken) return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+
+  try {
+    const headers = new Headers({ Accept: 'application/json', Authorization: `Bearer ${accessToken}` })
+    if (init.body !== undefined) headers.set('Content-Type', 'application/json')
+    const response = await fetch(`${BASE}${path}`, {
+      method: init.method ?? 'GET',
+      headers,
+      body: init.body,
+      cache: 'no-store',
+      signal: AbortSignal.timeout(10_000),
+    })
+
+    if (!response.ok) {
+      return NextResponse.json({ error: 'upstream_error' }, { status: response.status })
+    }
+    return NextResponse.json(await response.json(), {
+      status: response.status,
+      headers: { 'Cache-Control': 'no-store' },
+    })
+  } catch {
+    return NextResponse.json({ error: 'upstream_unreachable' }, { status: 502 })
+  }
+}

--- a/openbank-admin-ui/src/test/devops-bff-auth.test.ts
+++ b/openbank-admin-ui/src/test/devops-bff-auth.test.ts
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import { NextRequest } from 'next/server'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/auth', () => ({ auth: vi.fn() }))
+
+import { auth } from '@/auth'
+
+describe('DevOps HITL BFF bearer relay', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.mocked(auth).mockResolvedValue({ user: { accessToken: 'operator-token', roles: ['ROLE_ADMIN'] } } as never)
+  })
+  afterEach(() => vi.restoreAllMocks())
+
+  it('relays the bearer for a human decision', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify({ id: 'finding-1' }), { status: 200 }))
+    vi.stubGlobal('fetch', fetchMock)
+    const { POST } = await import('@/app/api/devops/decide/route')
+
+    const response = await POST(new NextRequest('http://localhost/api/devops/decide', {
+      method: 'POST', body: JSON.stringify({ id: 'finding-1', action: 'approve' }),
+    }))
+
+    expect(response.status).toBe(200)
+    expect(new Headers(fetchMock.mock.calls[0][1].headers).get('Authorization')).toBe('Bearer operator-token')
+  })
+
+  it('does not call the agent without an operator session', async () => {
+    vi.mocked(auth).mockResolvedValue(null as never)
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+    const { POST } = await import('@/app/api/devops/decide/route')
+
+    const response = await POST(new NextRequest('http://localhost/api/devops/decide', { method: 'POST', body: '{}' }))
+
+    expect(response.status).toBe(401)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+})

--- a/openbank-admin-ui/src/test/product-catalog-bff-auth.test.ts
+++ b/openbank-admin-ui/src/test/product-catalog-bff-auth.test.ts
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import { NextRequest } from 'next/server'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/auth', () => ({ auth: vi.fn() }))
+
+import { auth } from '@/auth'
+
+const SESSION = { user: { accessToken: 'operator-token', roles: ['ROLE_ADMIN'] } }
+
+function lastFetchCall() {
+  const mock = vi.mocked(global.fetch)
+  return mock.mock.calls[mock.mock.calls.length - 1] as [string, RequestInit]
+}
+
+describe('product-catalog BFF bearer relay', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.mocked(auth).mockResolvedValue(SESSION as never)
+  })
+  afterEach(() => vi.restoreAllMocks())
+
+  it('relays the operator bearer on lifecycle mutation and keeps the id in one path segment', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({ status: 'ACTIVE' }), { status: 200 })))
+    const { POST } = await import('@/app/api/product-catalog/[id]/activate/route')
+
+    const response = await POST(new NextRequest('http://localhost/api/product-catalog/a/activate', { method: 'POST' }), {
+      params: Promise.resolve({ id: 'a/b' }),
+    })
+
+    expect(response.status).toBe(200)
+    const [url, init] = lastFetchCall()
+    expect(String(url)).toContain('/api/v1/products/a%2Fb/activate')
+    expect(new Headers(init.headers).get('Authorization')).toBe('Bearer operator-token')
+  })
+
+  it('refuses a request with no session without calling product-catalog', async () => {
+    vi.mocked(auth).mockResolvedValue(null as never)
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+    const { GET } = await import('@/app/api/product-catalog/fees/route')
+
+    const response = await GET(new NextRequest('http://localhost/api/product-catalog/fees'))
+
+    expect(response.status).toBe(401)
+    await expect(response.json()).resolves.toEqual({ error: 'unauthorized' })
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('does not expose an upstream failure body', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('catalog database unavailable', { status: 500 })))
+    const { GET } = await import('@/app/api/product-catalog/route')
+
+    const response = await GET(new NextRequest('http://localhost/api/product-catalog'))
+
+    expect(response.status).toBe(500)
+    await expect(response.json()).resolves.toEqual({ error: 'upstream_error' })
+  })
+})

--- a/openbank-admin-ui/tailwind.config.ts
+++ b/openbank-admin-ui/tailwind.config.ts
@@ -14,7 +14,11 @@ const config: Config = {
   theme: {
     extend: {
       colors: {
-        border: 'hsl(var(--border))',
+        // --border is a direct-use CSS colour because the application also
+        // consumes it as `border-color: var(--border)` in shared primitives.
+        // Wrapping a hex token in hsl() makes Tailwind's border-border utility
+        // invalid, so this must follow the same direct-token contract as accent.
+        border: 'var(--border)',
         input: 'hsl(var(--input))',
         ring: 'hsl(var(--ring))',
         background: 'hsl(var(--background))',


### PR DESCRIPTION
Closes #4820

## What changed

- Applies one polished operator-workspace visual system to shared cards, headers, tables, fields, actions and empty states used throughout the admin console.
- Corrects the shared --border token, previously overridden by an invalid direct-use HSL triplet across 500+ call sites.
- Adds visible keyboard focus, reduced-motion behavior and responsive table handling.
- Repairs bearer relay for product-catalog lifecycle BFF routes and the DevOps HITL path.
- Ensures agent BFF failures do not expose upstream internals; preserves only the explicit model-unavailable operator state.

## Verification

- npm run lint: passes with pre-existing warnings only
- npm run type-check: passed
- npm test: 105 files and 1,274 tests passed
- npm run build: webpack production build passed
- ui-primitives E2E was attempted; local Turbopack cannot follow the temporary external node_modules symlink in this isolated worktree. CI installs dependencies locally and executes this required E2E gate.

## Security

No new browser-to-cluster path was added. The changed BFF routes now require an operator bearer before they call OIDC-gated services and return stable generic error envelopes.