### PR TITLE
feat(ledger): persist frozen trial balance evidence

### DIFF
--- a/docs/threat-models/openbank-ledger-service.md
+++ b/docs/threat-models/openbank-ledger-service.md
@@ -30,6 +30,8 @@ Assets protected, in priority order:
    accounts tie out per customer (CNB zákon 563/1991 Sb., vyhláška 501/2002 Sb.).
 4. **Trial balance / sub-ledger balances** — derived reporting that auditors and reconciliation rely on.
 5. **Idempotency + outbox** — exactly-once posting and reliable event emission (ADR-0050).
+6. **Frozen period evidence** — line-level statutory source for FINREP/COREP; V22 historical
+   close hashes remain evidence anchors but do not contain reproducible lines.
 
 ## 2. Data-flow diagram (textual)
 
@@ -98,6 +100,13 @@ isolation from transport/persistence.
   `SKIP`); a posted row's event is published exactly once per successful tick or bounded to `DEAD` (ADR-0050).
 - Domain-metric labels are **low-cardinality and PII-free** (currency + a closed `type` set; gauge by `service`);
   never an account id, IBAN, amount, party, or entry id (ADR-0077 cardinality contract).
+- **Closed-period evidence:** a new freeze persists the re-verified lines, FROZEN status flip and
+  `PeriodFrozen` outbox row in one transaction. The database rejects UPDATE/DELETE of persisted
+  evidence. FINREP/COREP calls only `frozen-trial-balance`, which rejects DRAFT, missing and V22
+  `HASH_ONLY` records; the operational endpoint may recompute those historical rows but is never a
+  regulatory source. During rollout the count of `HASH_ONLY` frozen records is an explicit report
+  availability gate. No backfill is automatic: historical reproduction needs a separately approved,
+  controlled evidence-import procedure and cannot be inferred from mutable journals.
 
 ## 5. Open items / follow-ups
 
@@ -323,3 +332,14 @@ set) apply equally to the new `ledger.approval.decide` action.
   entry and reports success while every position marked that day keeps the superseded rate's CZK
   counter-value. That needs a correcting-entry decision, not a patch, and #3921 stays open for it.
   Rollback: revert; the field is read-only on this side and nothing persists it.
+
+- **2026-08-14** — Closed-period freezes now retain their exact trial-balance lines for FINREP/COREP
+  (ADR-0096 D1 expand stage). The security boundary is the evidence write: `freeze` re-computes and
+  hash-compares the DRAFT, then writes the exact reverified lines, status transition and outbox row
+  in one reactive transaction. **Tampering:** the new table has a database trigger rejecting update
+  and delete, its FK is `ON DELETE RESTRICT`, and FROZEN reads use those rows rather than a mutable
+  journal aggregate. **Repudiation:** the stable existing hash is retained and callers can reproduce
+  the lines it anchored; the endpoint's DRAFT/no-record behavior remains live computation. **DoS:**
+  line inserts occur only during an operator four-eyes freeze, not on the posting path. **Rollback:**
+  before FINREP depends on the source, stop writers and archive frozen evidence, then remove the
+  trigger/function/table; never delete attested evidence as a convenience rollback.

--- a/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/infrastructure/client/LedgerClient.kt
+++ b/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/infrastructure/client/LedgerClient.kt
@@ -13,8 +13,8 @@ import jakarta.enterprise.context.ApplicationScoped
 import jakarta.ws.rs.Consumes
 import jakarta.ws.rs.GET
 import jakarta.ws.rs.Path
+import jakarta.ws.rs.PathParam
 import jakarta.ws.rs.Produces
-import jakarta.ws.rs.QueryParam
 import jakarta.ws.rs.core.MediaType
 import org.eclipse.microprofile.rest.client.annotation.RegisterProvider
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient
@@ -25,11 +25,8 @@ import java.time.LocalDate
 /**
  * Outbound client for openbank-ledger-service's GL trial balance.
  *
- * The root path is `/api/v1/journals` — the trial balance is served by ledger's `LedgerResource`
- * at `GET /api/v1/journals/trial-balance` (`operationId: getTrialBalance`). It is deliberately
- * NOT `/api/v1/ledger/trial-balance`: ledger has no such path (`/api/v1/ledger/...` only roots
- * `close` and `fx-revaluation`), and the fiscal-year-close variant
- * `/api/v1/ledger/close/trial-balance` is a different, non-interchangeable resource.
+ * FINREP/COREP reads only the statutory MONTH frozen-evidence endpoint. Ledger rejects DRAFT,
+ * missing and legacy HASH_ONLY periods: a report must never silently fall back to a live aggregate.
  *
  * The path is pinned by the consumer-driven pact in
  * [com.openbank.finrep.contract.LedgerTrialBalancePactConsumerTest] (git-pact, ADR-0063), which
@@ -40,19 +37,23 @@ import java.time.LocalDate
  */
 @RegisterRestClient(configKey = "ledger-service")
 @RegisterProvider(OidcClientRequestReactiveFilter::class)
-@Path("/api/v1/journals")
+@Path("/api/v1/ledger/periods/MONTH")
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
 interface LedgerRestClient {
 
     @GET
-    @Path("/trial-balance")
-    fun getTrialBalance(@QueryParam("asOf") asOf: String): Uni<TrialBalanceResponse>
+    @Path("/{asOf}/frozen-trial-balance")
+    fun getTrialBalance(@PathParam("asOf") asOf: String): Uni<ClosedPeriodTrialBalanceResponse>
 }
 
 data class TrialBalanceLineResponse(val code: String, val type: String, val net: BigDecimal)
 
-data class TrialBalanceResponse(val asOf: String, val balanced: Boolean, val lines: List<TrialBalanceLineResponse>)
+data class ClosedPeriodTrialBalanceResponse(
+    val period: String,
+    val balanced: Boolean,
+    val lines: List<TrialBalanceLineResponse>,
+)
 
 @ApplicationScoped
 class LedgerAdapter(@RestClient private val client: LedgerRestClient) : LedgerPort {

--- a/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/contract/LedgerTrialBalancePactConsumerTest.kt
+++ b/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/contract/LedgerTrialBalancePactConsumerTest.kt
@@ -16,11 +16,10 @@ import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.openbank.finrep.application.port.out.TrialBalanceLineDto
 import com.openbank.finrep.domain.mapper.F0101Mapper
+import com.openbank.finrep.infrastructure.client.ClosedPeriodTrialBalanceResponse
 import com.openbank.finrep.infrastructure.client.LedgerRestClient
-import com.openbank.finrep.infrastructure.client.TrialBalanceResponse
 import io.restassured.RestAssured.given
 import jakarta.ws.rs.Path
-import jakarta.ws.rs.QueryParam
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -82,10 +81,9 @@ class LedgerTrialBalancePactConsumerTest {
 
     @Pact(consumer = "openbank-finrep-service", provider = "openbank-ledger-service")
     fun trialBalanceWithEntriesPact(builder: PactDslWithProvider): RequestResponsePact = builder
-        .given("ledger has journal entries for the reporting date")
+        .given("ledger has frozen monthly trial balance for the reporting date")
         .uponReceiving("GET the GL trial balance for a FINREP reporting date")
-        .path(LEDGER_TRIAL_BALANCE_PATH)
-        .query("$AS_OF_PARAM=$REPORTING_DATE")
+        .path("$LEDGER_MONTH_TRIAL_BALANCE_PATH/$REPORTING_DATE/frozen-trial-balance")
         .method("GET")
         .headers(mapOf("Accept" to "application/json"))
         .willRespondWith()
@@ -97,7 +95,7 @@ class LedgerTrialBalancePactConsumerTest {
                 // `asOf=` query parameter this interaction pins by literal. A trial balance
                 // returned for a DIFFERENT date than the one asked for is a reporting defect of
                 // the first order, and a type matcher accepted any date string at all.
-                o.stringValue("asOf", REPORTING_DATE)
+                o.stringValue("period", "MONTH:2026-06")
                 o.booleanType("balanced", true)
                 // stringType on `code`/{currency,type}, DELIBERATELY (issue #2425): `lines`
                 // is a heterogeneous list — a real trial balance carries many GL codes, several
@@ -114,44 +112,17 @@ class LedgerTrialBalancePactConsumerTest {
         )
         .toPact()
 
-    @Pact(consumer = "openbank-finrep-service", provider = "openbank-ledger-service")
-    fun trialBalanceEmptyLedgerPact(builder: PactDslWithProvider): RequestResponsePact = builder
-        .given("ledger has no journal entries")
-        .uponReceiving("GET the GL trial balance for a date with no ledger activity")
-        .path(LEDGER_TRIAL_BALANCE_PATH)
-        // A pre-platform date, so this interaction stays valid even when the provider run shares a
-        // Testcontainer DB with interactions that post journals (they are all dated "today").
-        .query("$AS_OF_PARAM=$PRE_HISTORY_DATE")
-        .method("GET")
-        .headers(mapOf("Accept" to "application/json"))
-        .willRespondWith()
-        .status(200)
-        .headers(mapOf("Content-Type" to "application/json"))
-        .body(
-            newJsonBody { o ->
-                // stringValue, NOT stringType (issue #2425): `asOf` is echoed from the
-                // `asOf=` query parameter this interaction pins by literal. A trial balance
-                // returned for a DIFFERENT date than the one asked for is a reporting defect of
-                // the first order, and a type matcher accepted any date string at all.
-                o.stringValue("asOf", PRE_HISTORY_DATE)
-                o.booleanType("balanced", true)
-                o.array("lines") // empty — a date before any ledger activity
-            }.build(),
-        )
-        .toPact()
-
     @Test
     @PactTestFor(pactMethod = "trialBalanceWithEntriesPact")
     fun `the ledger client contract yields the fields the FINREP mappers consume`(mockServer: MockServer) {
         // Guards the reflection helpers themselves: were they ever to return an empty or partial
         // path, the interaction and the request would still agree with each other and both pact
         // tests would pass against a contract that pins nothing.
-        assertThat(ledgerTrialBalancePath).isEqualTo(LEDGER_TRIAL_BALANCE_PATH)
-        assertThat(asOfQueryParam).isEqualTo(AS_OF_PARAM)
+        assertThat(ledgerTrialBalancePath).isEqualTo("$LEDGER_MONTH_TRIAL_BALANCE_PATH/{asOf}/frozen-trial-balance")
 
         val response = fetchTrialBalance(mockServer, REPORTING_DATE)
 
-        assertThat(response.asOf).isNotBlank()
+        assertThat(response.period).isNotBlank()
         assertThat(response.balanced).isTrue()
         // The three fields LedgerAdapter maps into TrialBalanceLineDto must all deserialize.
         assertThat(response.lines).isNotEmpty()
@@ -170,28 +141,12 @@ class LedgerTrialBalancePactConsumerTest {
         assertThat(template.cells.first().value).isEqualByComparingTo(BigDecimal("150000.00"))
     }
 
-    @Test
-    @PactTestFor(pactMethod = "trialBalanceEmptyLedgerPact")
-    fun `a zero-line ledger still renders a fully populated zero template`(mockServer: MockServer) {
-        val response = fetchTrialBalance(mockServer, PRE_HISTORY_DATE)
-
-        assertThat(response.balanced).isTrue()
-        assertThat(response.lines).isEmpty()
-
-        // A regulatory report must never be silently truncated (ADR-0097): every row is present,
-        // honestly zero.
-        val template = F0101Mapper.map(emptyList(), LocalDate.parse(PRE_HISTORY_DATE))
-        assertThat(template.cells).hasSize(3)
-        assertThat(template.cells.map { it.value }).allSatisfy { assertThat(it).isEqualByComparingTo(BigDecimal.ZERO) }
-    }
-
     /** Issues the request against the path the production client is annotated with. */
-    private fun fetchTrialBalance(mockServer: MockServer, asOf: String): TrialBalanceResponse {
+    private fun fetchTrialBalance(mockServer: MockServer, asOf: String): ClosedPeriodTrialBalanceResponse {
         val body = given()
             .baseUri(mockServer.getUrl())
             .accept("application/json")
-            .queryParam(asOfQueryParam, asOf)
-            .get(ledgerTrialBalancePath)
+            .get(ledgerTrialBalancePath.replace("{asOf}", asOf))
             .then()
             .statusCode(200)
             .extract().body().asString()
@@ -210,16 +165,11 @@ class LedgerTrialBalancePactConsumerTest {
          * below and re-running against the #2269 path: it went green. The literal is the fixed point
          * the annotation is measured against.
          */
-        const val LEDGER_TRIAL_BALANCE_PATH = "/api/v1/journals/trial-balance"
+        const val LEDGER_MONTH_TRIAL_BALANCE_PATH = "/api/v1/ledger/periods/MONTH"
 
         /** Ledger's query-parameter name for the as-of date — likewise literal. */
-        const val AS_OF_PARAM = "asOf"
-
         /** A FINREP quarter-end reference date. */
         const val REPORTING_DATE = "2026-06-30"
-
-        /** Before any ledger activity can exist, so the empty-lines assertion is stable. */
-        const val PRE_HISTORY_DATE = "2000-01-01"
 
         private val getTrialBalanceMethod =
             LedgerRestClient::class.java.getDeclaredMethod("getTrialBalance", String::class.java)
@@ -234,10 +184,5 @@ class LedgerTrialBalancePactConsumerTest {
         ).joinToString("/") { it.trim('/') }.let { "/$it" }
 
         /** The query-parameter name the production client sends the as-of date under. */
-        val asOfQueryParam: String = getTrialBalanceMethod.parameterAnnotations
-            .flatMap { it.toList() }
-            .filterIsInstance<QueryParam>()
-            .single()
-            .value
     }
 }

--- a/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/application/port/in/ClosedPeriodPorts.kt
+++ b/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/application/port/in/ClosedPeriodPorts.kt
@@ -43,6 +43,9 @@ data class ListClosedPeriodsQuery(val from: LocalDate, val to: LocalDate)
  */
 interface ClosedPeriodUseCase {
     suspend fun getTrialBalance(query: GetPeriodTrialBalanceQuery): PeriodTrialBalance
+
+    /** Regulatory reader: only immutable `LINES_V1` evidence may cross this boundary. */
+    suspend fun getFrozenTrialBalance(query: GetPeriodTrialBalanceQuery): PeriodTrialBalance
     suspend fun createDraft(command: CreateClosedPeriodDraftCommand): ClosedPeriodRecord
     suspend fun freeze(command: FreezeClosedPeriodCommand): ClosedPeriodRecord
     suspend fun get(query: GetClosedPeriodQuery): ClosedPeriodRecord

--- a/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/application/port/out/ClosedPeriodRepository.kt
+++ b/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/application/port/out/ClosedPeriodRepository.kt
@@ -6,6 +6,8 @@ package com.openbank.ledger.application.port.out
 
 import com.openbank.ledger.domain.model.AccountingPeriod
 import com.openbank.ledger.domain.model.ClosedPeriodRecord
+import com.openbank.ledger.domain.model.PeriodTrialBalance
+import com.openbank.ledger.domain.model.TrialBalanceLine
 import com.openbank.libs.persistence.outbox.OutboxMessage
 import java.time.LocalDate
 
@@ -26,6 +28,9 @@ interface ClosedPeriodRepository {
     /** Closed-period records overlapping `[from, to]`, ascending by period start. */
     suspend fun findRange(from: LocalDate, to: LocalDate): List<ClosedPeriodRecord>
 
+    /** Exact lines persisted atomically with a FROZEN close; never recompute attested evidence. */
+    suspend fun findFrozenLines(periodId: java.util.UUID): List<TrialBalanceLine>
+
     /** Insert a new DRAFT, or refresh an existing DRAFT for the same period (upsert). */
     suspend fun saveDraft(record: ClosedPeriodRecord): ClosedPeriodRecord
 
@@ -35,5 +40,9 @@ interface ClosedPeriodRepository {
      * is queued, or neither happens. A frozen period that nobody was told about is exactly as bad
      * as an event for a period that did not freeze.
      */
-    suspend fun saveFrozen(record: ClosedPeriodRecord, outbox: OutboxMessage): ClosedPeriodRecord
+    suspend fun saveFrozen(
+        record: ClosedPeriodRecord,
+        reverifiedTrialBalance: PeriodTrialBalance,
+        outbox: OutboxMessage,
+    ): ClosedPeriodRecord
 }

--- a/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/application/usecase/ClosedPeriodService.kt
+++ b/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/application/usecase/ClosedPeriodService.kt
@@ -16,6 +16,7 @@ import com.openbank.ledger.application.port.out.ClosedPeriodRepository
 import com.openbank.ledger.application.port.out.JournalRepository
 import com.openbank.ledger.domain.event.PeriodFrozenEvent
 import com.openbank.ledger.domain.model.AccountingPeriod
+import com.openbank.ledger.domain.model.ClosedPeriodEvidenceState
 import com.openbank.ledger.domain.model.ClosedPeriodRecord
 import com.openbank.ledger.domain.model.ClosedPeriodStatus
 import com.openbank.ledger.domain.model.ClosedPeriodVerification
@@ -40,6 +41,7 @@ import java.time.Instant
  * either change those hashes or leave two code paths pretending to be one.
  */
 @ApplicationScoped
+@Suppress("TooManyFunctions") // One cohesive statutory-close use case; splitting would blur its atomic invariants.
 class ClosedPeriodService(
     private val journalRepository: JournalRepository,
     private val closedPeriodRepository: ClosedPeriodRepository,
@@ -48,8 +50,46 @@ class ClosedPeriodService(
     private val clock: Clock,
 ) : ClosedPeriodUseCase {
 
-    override suspend fun getTrialBalance(query: GetPeriodTrialBalanceQuery): PeriodTrialBalance =
-        computeTrialBalance(query.period)
+    override suspend fun getTrialBalance(query: GetPeriodTrialBalanceQuery): PeriodTrialBalance {
+        val record = closedPeriodRepository.findByPeriod(query.period)
+        // A FROZEN close is evidence, not a cache. Returning a fresh aggregate here would make a
+        // regulatory reader observe data other than the hash-attested artefact.
+        return if (record?.status == ClosedPeriodStatus.FROZEN &&
+            record.evidenceState == ClosedPeriodEvidenceState.LINES_V1
+        ) {
+            PeriodTrialBalance(record.period, closedPeriodRepository.findFrozenLines(record.id)).also { evidence ->
+                if (evidence.contentHash() != record.contentHash) {
+                    // A legacy FROZEN close without V23 rows must never silently fall back to a
+                    // mutable journal query. An empty ledger remains valid: its canonical hash
+                    // still matches. Anything else is an operational evidence incident.
+                    throw ClosedPeriodConflictException(
+                        "Frozen evidence for ${record.period.label} is unavailable or does not match its attestation",
+                    )
+                }
+            }
+        } else {
+            computeTrialBalance(query.period)
+        }
+    }
+
+    override suspend fun getFrozenTrialBalance(query: GetPeriodTrialBalanceQuery): PeriodTrialBalance {
+        val record = closedPeriodRepository.findByPeriod(query.period)
+            ?: throw ClosedPeriodConflictException(
+                "Period ${query.period.label} has no frozen line evidence; regulatory reporting is fail-closed",
+            )
+        if (record.status != ClosedPeriodStatus.FROZEN || record.evidenceState != ClosedPeriodEvidenceState.LINES_V1) {
+            throw ClosedPeriodConflictException(
+                "Period ${query.period.label} evidence state is ${record.evidenceState}; regulatory reporting requires FROZEN LINES_V1",
+            )
+        }
+        return PeriodTrialBalance(record.period, closedPeriodRepository.findFrozenLines(record.id)).also { evidence ->
+            if (evidence.contentHash() != record.contentHash) {
+                throw ClosedPeriodConflictException(
+                    "Frozen evidence for ${record.period.label} does not match its attestation",
+                )
+            }
+        }
+    }
 
     override suspend fun createDraft(command: CreateClosedPeriodDraftCommand): ClosedPeriodRecord {
         requirePeriodHasEnded(command.period)
@@ -95,7 +135,10 @@ class ClosedPeriodService(
         // Four-eyes (maker != checker) is enforced in the aggregate, which also refuses a draft
         // with no recorded author — without a maker there is nothing to separate the checker from.
         val frozen = record.freeze(command.frozenBy, Instant.now(clock))
-        return closedPeriodRepository.saveFrozen(frozen, frozenMessage(frozen))
+        // Persist these exact re-verified lines in the same transaction as the status flip and
+        // outbox row. A second repository read would leave a TOCTOU gap between hash verification
+        // and what becomes statutory evidence.
+        return closedPeriodRepository.saveFrozen(frozen, fresh, frozenMessage(frozen))
     }
 
     override suspend fun get(query: GetClosedPeriodQuery): ClosedPeriodRecord =

--- a/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/domain/model/ClosedPeriod.kt
+++ b/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/domain/model/ClosedPeriod.kt
@@ -164,6 +164,18 @@ enum class ClosedPeriodStatus {
 }
 
 /**
+ * What evidence can actually be served for a close.
+ *
+ * `HASH_ONLY` retains the V22 attestation anchor without pretending its missing lines can be
+ * reconstructed from today's mutable journal. New freezes are always [LINES_V1].
+ */
+enum class ClosedPeriodEvidenceState {
+    NONE,
+    HASH_ONLY,
+    LINES_V1,
+}
+
+/**
  * The frozen, attestable artefact for one accounting period (ADR-0096 D1).
  *
  * This is what replaces "the trial balance is a read API". `/api/v1/journals/trial-balance` is a
@@ -180,6 +192,7 @@ data class ClosedPeriodRecord(
     val id: UUID,
     val period: AccountingPeriod,
     val status: ClosedPeriodStatus,
+    val evidenceState: ClosedPeriodEvidenceState = ClosedPeriodEvidenceState.NONE,
     val computedAt: Instant,
     val totalDebits: BigDecimal,
     val totalCredits: BigDecimal,
@@ -204,7 +217,12 @@ data class ClosedPeriodRecord(
         checkConflict(draftedBy != frozenBy) {
             "Four-eyes violation: ${period.label} must be frozen by someone other than the draft author"
         }
-        return copy(status = ClosedPeriodStatus.FROZEN, frozenBy = frozenBy, frozenAt = frozenAt)
+        return copy(
+            status = ClosedPeriodStatus.FROZEN,
+            evidenceState = ClosedPeriodEvidenceState.LINES_V1,
+            frozenBy = frozenBy,
+            frozenAt = frozenAt,
+        )
     }
 
     companion object {

--- a/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/persistence/entity/ClosedPeriodEntity.kt
+++ b/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/persistence/entity/ClosedPeriodEntity.kt
@@ -35,6 +35,9 @@ class ClosedPeriodEntity : PanacheEntityBase {
     @Column(name = "status", nullable = false)
     var status: String = "DRAFT"
 
+    @Column(name = "evidence_state", nullable = false)
+    var evidenceState: String = "NONE"
+
     @Column(name = "computed_at", nullable = false)
     var computedAt: Instant = Instant.EPOCH
 

--- a/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/persistence/entity/ClosedPeriodTrialBalanceLineEntity.kt
+++ b/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/persistence/entity/ClosedPeriodTrialBalanceLineEntity.kt
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+package com.openbank.ledger.infrastructure.persistence.entity
+
+import io.quarkus.hibernate.reactive.panache.kotlin.PanacheEntityBase
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.IdClass
+import jakarta.persistence.Table
+import java.io.Serializable
+import java.math.BigDecimal
+import java.util.UUID
+
+/** Immutable line-level evidence belonging to one FROZEN statutory close (ADR-0096 D1). */
+@Entity
+@Table(name = "ledger_closed_period_trial_balance_line")
+@IdClass(ClosedPeriodTrialBalanceLineId::class)
+class ClosedPeriodTrialBalanceLineEntity : PanacheEntityBase {
+    @Id
+    @Column(name = "period_id")
+    lateinit var periodId: UUID
+
+    @Id
+    @Column(name = "gl_account_id")
+    lateinit var glAccountId: UUID
+
+    @Id
+    @Column(name = "currency", length = 3)
+    lateinit var currency: String
+
+    @Column(name = "code", nullable = false, length = 128)
+    lateinit var code: String
+
+    @Column(name = "name", nullable = false, length = 255)
+    lateinit var name: String
+
+    @Column(name = "account_type", nullable = false, length = 32)
+    lateinit var accountType: String
+
+    @Column(name = "total_debit", nullable = false)
+    lateinit var totalDebit: BigDecimal
+
+    @Column(name = "total_credit", nullable = false)
+    lateinit var totalCredit: BigDecimal
+}
+
+data class ClosedPeriodTrialBalanceLineId(
+    var periodId: UUID? = null,
+    var glAccountId: UUID? = null,
+    var currency: String? = null,
+) : Serializable {
+    private companion object {
+        private const val serialVersionUID = 1L
+    }
+}

--- a/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/persistence/repository/PanacheClosedPeriodRepository.kt
+++ b/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/persistence/repository/PanacheClosedPeriodRepository.kt
@@ -6,10 +6,14 @@ package com.openbank.ledger.infrastructure.persistence.repository
 
 import com.openbank.ledger.application.port.out.ClosedPeriodRepository
 import com.openbank.ledger.domain.model.AccountingPeriod
+import com.openbank.ledger.domain.model.ClosedPeriodEvidenceState
 import com.openbank.ledger.domain.model.ClosedPeriodRecord
 import com.openbank.ledger.domain.model.ClosedPeriodStatus
+import com.openbank.ledger.domain.model.PeriodTrialBalance
 import com.openbank.ledger.domain.model.PeriodType
+import com.openbank.ledger.domain.model.TrialBalanceLine
 import com.openbank.ledger.infrastructure.persistence.entity.ClosedPeriodEntity
+import com.openbank.ledger.infrastructure.persistence.entity.ClosedPeriodTrialBalanceLineEntity
 import com.openbank.libs.persistence.outbox.OutboxMessage
 import io.quarkus.hibernate.reactive.panache.Panache
 import io.quarkus.hibernate.reactive.panache.kotlin.PanacheRepositoryBase
@@ -50,6 +54,16 @@ class PanacheClosedPeriodRepository(
         find("periodFrom <= ?2 and periodTo >= ?1 order by periodFrom asc, periodTo asc", from, to).list()
     }.awaitSuspending().map { it.toDomain() }
 
+    override suspend fun findFrozenLines(periodId: UUID): List<TrialBalanceLine> = Panache.withSession {
+        Panache.getSession().flatMap { session ->
+            session.createQuery(
+                "FROM ClosedPeriodTrialBalanceLineEntity " +
+                    "WHERE periodId = :periodId ORDER BY code asc, currency asc, glAccountId asc",
+                ClosedPeriodTrialBalanceLineEntity::class.java,
+            ).setParameter("periodId", periodId).resultList
+        }
+    }.awaitSuspending().map { it.toDomain() }
+
     override suspend fun saveDraft(record: ClosedPeriodRecord): ClosedPeriodRecord = Panache.withTransaction {
         find("periodType = ?1 and periodFrom = ?2", record.period.type.name, record.period.from)
             .firstResult()
@@ -59,6 +73,7 @@ class PanacheClosedPeriodRepository(
                 } else {
                     // Refresh in place; the unique (period_type, period_from) row is stable.
                     existing.status = record.status.name
+                    existing.evidenceState = record.evidenceState.name
                     existing.computedAt = record.computedAt
                     existing.totalDebits = record.totalDebits
                     existing.totalCredits = record.totalCredits
@@ -77,19 +92,31 @@ class PanacheClosedPeriodRepository(
      * Status flip + outbox row in ONE transaction (transactional outbox, ADR-0003/0050): either the
      * period is sealed and `PeriodFrozen` is queued, or neither happens.
      */
-    override suspend fun saveFrozen(record: ClosedPeriodRecord, outbox: OutboxMessage): ClosedPeriodRecord =
-        Panache.withTransaction {
-            find("periodType = ?1 and periodFrom = ?2", record.period.type.name, record.period.from)
-                .firstResult()
-                .flatMap { existing ->
-                    checkNotNull(existing) { "Closed period ${record.period.label} vanished during freeze" }
-                    existing.status = record.status.name
-                    existing.frozenBy = record.frozenBy
-                    existing.frozenAt = record.frozenAt
-                    existing.updatedAt = Instant.now(clock)
-                    outboxRepository.persistInTransaction(outbox).replaceWith(existing)
+    override suspend fun saveFrozen(
+        record: ClosedPeriodRecord,
+        reverifiedTrialBalance: PeriodTrialBalance,
+        outbox: OutboxMessage,
+    ): ClosedPeriodRecord = Panache.withTransaction {
+        find("periodType = ?1 and periodFrom = ?2", record.period.type.name, record.period.from)
+            .firstResult()
+            .flatMap { existing ->
+                checkNotNull(existing) { "Closed period ${record.period.label} vanished during freeze" }
+                existing.status = record.status.name
+                existing.evidenceState = record.evidenceState.name
+                existing.frozenBy = record.frozenBy
+                existing.frozenAt = record.frozenAt
+                existing.updatedAt = Instant.now(clock)
+                val lines = reverifiedTrialBalance.lines.map { it.toEntity(record.id) }
+                Panache.getSession().flatMap { session ->
+                    // `voidItem()` emits null, so chaining a Kotlin non-null lambda here turns a
+                    // successful first write into an NPE. Join the writes instead: all INSERTs and
+                    // the outbox row remain in this one transaction; any failure rolls every one back.
+                    Uni.join().all(lines.map { session.persist(it) }).andFailFast()
+                        .flatMap { outboxRepository.persistInTransaction(outbox) }
+                        .map { existing }
                 }
-        }.awaitSuspending().toDomain()
+            }
+    }.awaitSuspending().toDomain()
 
     private fun ClosedPeriodRecord.toEntity() = ClosedPeriodEntity().also {
         it.id = id
@@ -97,6 +124,7 @@ class PanacheClosedPeriodRepository(
         it.periodFrom = period.from
         it.periodTo = period.to
         it.status = status.name
+        it.evidenceState = evidenceState.name
         it.computedAt = computedAt
         it.totalDebits = totalDebits
         it.totalCredits = totalCredits
@@ -113,6 +141,7 @@ class PanacheClosedPeriodRepository(
         id = id,
         period = AccountingPeriod(PeriodType.valueOf(periodType), periodFrom, periodTo),
         status = ClosedPeriodStatus.valueOf(status),
+        evidenceState = ClosedPeriodEvidenceState.valueOf(evidenceState),
         computedAt = computedAt,
         totalDebits = totalDebits,
         totalCredits = totalCredits,
@@ -121,5 +150,26 @@ class PanacheClosedPeriodRepository(
         draftedBy = draftedBy,
         frozenBy = frozenBy,
         frozenAt = frozenAt,
+    )
+
+    private fun TrialBalanceLine.toEntity(periodId: UUID) = ClosedPeriodTrialBalanceLineEntity().also {
+        it.periodId = periodId
+        it.glAccountId = glAccountId
+        it.currency = currency
+        it.code = code
+        it.name = name
+        it.accountType = type.name
+        it.totalDebit = totalDebit
+        it.totalCredit = totalCredit
+    }
+
+    private fun ClosedPeriodTrialBalanceLineEntity.toDomain() = TrialBalanceLine(
+        glAccountId = glAccountId,
+        code = code,
+        name = name,
+        type = com.openbank.ledger.domain.model.GlAccountType.valueOf(accountType),
+        currency = currency,
+        totalDebit = totalDebit,
+        totalCredit = totalCredit,
     )
 }

--- a/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/rest/ClosedPeriodResource.kt
+++ b/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/rest/ClosedPeriodResource.kt
@@ -70,6 +70,16 @@ class ClosedPeriodResource(private val closedPeriodUseCase: ClosedPeriodUseCase)
     }
 
     @GET
+    @Path("/{type}/{date}/frozen-trial-balance")
+    @RolesAllowed(Roles.API, Roles.AUDITOR, Roles.VIEWER, Roles.OPERATOR, Roles.ADMIN)
+    @Authorize(action = "ledger.read", resource = "#date")
+    @Operation(summary = "Immutable FROZEN LINES_V1 trial balance for regulatory reporting (fail-closed)")
+    suspend fun frozenTrialBalance(@PathParam("type") type: String, @PathParam("date") date: String): Response {
+        val tb = closedPeriodUseCase.getFrozenTrialBalance(GetPeriodTrialBalanceQuery(period(type, date)))
+        return Response.ok(tb.toResponse()).build()
+    }
+
+    @GET
     @RolesAllowed(Roles.API, Roles.AUDITOR, Roles.VIEWER, Roles.OPERATOR, Roles.ADMIN)
     @Authorize(action = "ledger.read", resource = "")
     @Operation(summary = "List closed-period records overlapping a date range")
@@ -161,6 +171,16 @@ data class PeriodTrialBalanceResponse(
     val balanced: Boolean,
     val accountCount: Int,
     val contentHash: String,
+    val lines: List<PeriodTrialBalanceLineResponse>,
+)
+
+data class PeriodTrialBalanceLineResponse(
+    val code: String,
+    val type: String,
+    val currency: String,
+    val totalDebit: BigDecimal,
+    val totalCredit: BigDecimal,
+    val net: BigDecimal,
 )
 
 data class ClosedPeriodResponse(
@@ -170,6 +190,7 @@ data class ClosedPeriodResponse(
     val from: String,
     val to: String,
     val status: String,
+    val evidenceState: String,
     val computedAt: String,
     val totalDebits: BigDecimal,
     val totalCredits: BigDecimal,
@@ -199,6 +220,16 @@ private fun PeriodTrialBalance.toResponse() = PeriodTrialBalanceResponse(
     balanced = isBalanced,
     accountCount = accountCount,
     contentHash = contentHash(),
+    lines = lines.map {
+        PeriodTrialBalanceLineResponse(
+            code = it.code,
+            type = it.type.name,
+            currency = it.currency,
+            totalDebit = it.totalDebit,
+            totalCredit = it.totalCredit,
+            net = it.net,
+        )
+    },
 )
 
 private fun ClosedPeriodRecord.toResponse() = ClosedPeriodResponse(
@@ -208,6 +239,7 @@ private fun ClosedPeriodRecord.toResponse() = ClosedPeriodResponse(
     from = period.from.toString(),
     to = period.to.toString(),
     status = status.name,
+    evidenceState = evidenceState.name,
     computedAt = computedAt.toString(),
     totalDebits = totalDebits,
     totalCredits = totalCredits,

--- a/openbank-ledger-service/src/main/resources/db/migration/V23__closed_period_trial_balance_lines.sql
+++ b/openbank-ledger-service/src/main/resources/db/migration/V23__closed_period_trial_balance_lines.sql
@@ -1,0 +1,45 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+--
+-- ADR-0096 D1 / FINREP expand stage: immutable, line-level evidence for a FROZEN period.
+-- Existing close rows remain readable and DRAFTs remain recomputable. New evidence is written
+-- only together with the DRAFT -> FROZEN transition and its transactional-outbox event.
+-- V22 FROZEN rows retain their valid hash anchors but are explicitly HASH_ONLY: they must never
+-- be recomputed and presented as frozen line evidence.
+
+ALTER TABLE ledger_closed_period
+    ADD COLUMN evidence_state VARCHAR(16) NOT NULL DEFAULT 'HASH_ONLY',
+    ADD CONSTRAINT chk_closed_period_evidence_state CHECK (evidence_state IN ('NONE', 'HASH_ONLY', 'LINES_V1'));
+
+UPDATE ledger_closed_period SET evidence_state = 'NONE' WHERE status = 'DRAFT';
+
+CREATE TABLE ledger_closed_period_trial_balance_line (
+    period_id     UUID          NOT NULL REFERENCES ledger_closed_period(id) ON DELETE RESTRICT,
+    gl_account_id UUID          NOT NULL,
+    currency      VARCHAR(3)    NOT NULL,
+    code          VARCHAR(128)  NOT NULL,
+    name          VARCHAR(255)  NOT NULL,
+    account_type  VARCHAR(32)   NOT NULL,
+    total_debit   NUMERIC(20,6) NOT NULL,
+    total_credit  NUMERIC(20,6) NOT NULL,
+    PRIMARY KEY (period_id, gl_account_id, currency)
+);
+
+CREATE INDEX idx_closed_period_trial_balance_line_period
+    ON ledger_closed_period_trial_balance_line (period_id, code, currency);
+
+-- Evidence rows are append-only. The application never updates/deletes them, but the database
+-- guard makes an accidental future repository change fail closed rather than rewrite attestation.
+CREATE FUNCTION reject_closed_period_trial_balance_line_mutation() RETURNS trigger AS $$
+BEGIN
+    RAISE EXCEPTION 'ledger_closed_period_trial_balance_line is immutable';
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_closed_period_trial_balance_line_immutable
+    BEFORE UPDATE OR DELETE ON ledger_closed_period_trial_balance_line
+    FOR EACH ROW EXECUTE FUNCTION reject_closed_period_trial_balance_line_mutation();
+
+-- Rollback (expand stage only): stop writers first, archive any frozen evidence that must remain
+-- legally reproducible, then DROP TRIGGER, DROP FUNCTION and DROP TABLE. Do not roll back after
+-- FINREP relies on this source unless the archive/read path has been validated.

--- a/openbank-ledger-service/src/main/resources/openapi.yaml
+++ b/openbank-ledger-service/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: Ledger Service API
-  version: 1.13.0
+  version: 1.15.0
   description: Double-entry journal ledger — query journal entries and transaction postings.
   license:
     name: Apache-2.0
@@ -698,7 +698,11 @@ paths:
   /api/v1/ledger/periods/{type}/{date}/trial-balance:
     get:
       tags: [ClosedPeriod]
-      summary: Trial balance for the period containing the date (computed on demand)
+      summary: Operational trial balance for the period
+      description: >
+        Operational read. It returns LINES_V1 evidence for a new FROZEN close, but may recompute
+        the current journal for DRAFT/no-close or historical HASH_ONLY closes. Regulatory readers
+        MUST use frozen-trial-balance, which fails closed unless immutable LINES_V1 exists.
       operationId: getPeriodTrialBalance
       parameters:
         - $ref: '#/components/parameters/PeriodTypePath'
@@ -714,6 +718,31 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '403':
           $ref: '#/components/responses/Forbidden'
+
+  /api/v1/ledger/periods/{type}/{date}/frozen-trial-balance:
+    get:
+      tags: [ClosedPeriod]
+      summary: Immutable FROZEN LINES_V1 trial balance for regulatory reporting
+      description: >
+        Fail-closed evidence read. DRAFT, missing and pre-V23 HASH_ONLY closes return 409 instead
+        of a mutable recomputation. FINREP/COREP consumes this endpoint exclusively.
+      operationId: getFrozenPeriodTrialBalance
+      parameters:
+        - $ref: '#/components/parameters/PeriodTypePath'
+        - $ref: '#/components/parameters/PeriodDatePath'
+      responses:
+        '200':
+          description: Hash-attested immutable period trial balance
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PeriodTrialBalanceResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '409':
+          $ref: '#/components/responses/Conflict'
 
   /api/v1/ledger/periods/{type}/{date}/verify:
     get:
@@ -899,7 +928,7 @@ components:
     PeriodTrialBalanceResponse:
       type: object
       description: Trial balance for one statutory period, with its attestation anchor (ADR-0096 D1).
-      required: [period, from, to, totalDebit, totalCredit, balanced, accountCount, contentHash]
+      required: [period, from, to, totalDebit, totalCredit, balanced, accountCount, contentHash, lines]
       properties:
         period: { type: string, description: "Stable label, e.g. MONTH:2026-05 / QUARTER:2026-Q2 / YEAR:2026." }
         from: { type: string, format: date }
@@ -909,11 +938,27 @@ components:
         balanced: { type: boolean, description: "Double-entry holds over the period: debits == credits." }
         accountCount: { type: integer }
         contentHash: { type: string, description: "SHA-256 of the canonical trial-balance JSON." }
+        lines:
+          type: array
+          description: Exact persisted evidence for FROZEN periods; computed only for DRAFT/no close.
+          items:
+            $ref: '#/components/schemas/PeriodTrialBalanceLineResponse'
+
+    PeriodTrialBalanceLineResponse:
+      type: object
+      required: [code, type, currency, totalDebit, totalCredit, net]
+      properties:
+        code: { type: string }
+        type: { type: string }
+        currency: { type: string }
+        totalDebit: { type: string }
+        totalCredit: { type: string }
+        net: { type: string }
 
     ClosedPeriodResponse:
       type: object
       description: The persisted statutory close for one period (ADR-0096 D1).
-      required: [id, period, periodType, from, to, status, computedAt, contentHash]
+      required: [id, period, periodType, from, to, status, evidenceState, computedAt, contentHash]
       properties:
         id: { type: string, format: uuid }
         period: { type: string }
@@ -923,7 +968,11 @@ components:
         status:
           type: string
           enum: [DRAFT, FROZEN]
-          description: DRAFT is recomputable; FROZEN is immutable evidence.
+          description: DRAFT is recomputable; FROZEN has an immutable hash anchor.
+        evidenceState:
+          type: string
+          enum: [NONE, HASH_ONLY, LINES_V1]
+          description: HASH_ONLY is a V22 historical close; only LINES_V1 is line-level regulatory evidence.
         computedAt: { type: string, format: date-time }
         totalDebits: { type: string }
         totalCredits: { type: string }

--- a/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/application/usecase/ClosedPeriodSnapshotServiceTest.kt
+++ b/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/application/usecase/ClosedPeriodSnapshotServiceTest.kt
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+package com.openbank.ledger.application.usecase
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.openbank.ledger.application.port.`in`.FreezeClosedPeriodCommand
+import com.openbank.ledger.application.port.`in`.GetPeriodTrialBalanceQuery
+import com.openbank.ledger.application.port.out.ClosedPeriodRepository
+import com.openbank.ledger.application.port.out.JournalRepository
+import com.openbank.ledger.domain.model.ClosedPeriodRecord
+import com.openbank.ledger.domain.model.ClosedPeriodStatus
+import com.openbank.ledger.domain.model.GlAccountType
+import com.openbank.ledger.domain.model.PeriodTrialBalance
+import com.openbank.ledger.domain.model.PeriodType
+import com.openbank.ledger.domain.model.TrialBalanceLine
+import com.openbank.libs.domain.calendar.AccountingClock
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.Clock
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneOffset
+import java.util.UUID
+
+class ClosedPeriodSnapshotServiceTest {
+
+    private val clock = Clock.fixed(Instant.parse("2026-06-15T10:00:00Z"), ZoneOffset.UTC)
+    private val period = PeriodType.MONTH.of(LocalDate.of(2026, 5, 15))
+    private val journals = mockk<JournalRepository>()
+    private val closes = mockk<ClosedPeriodRepository>()
+    private val service = ClosedPeriodService(
+        journals,
+        closes,
+        ObjectMapper().registerModule(JavaTimeModule()),
+        AccountingClock.bank(clock),
+        clock,
+    )
+
+    private fun line(code: String, debit: String, credit: String) = TrialBalanceLine(
+        glAccountId = UUID.nameUUIDFromBytes(code.toByteArray()),
+        code = code,
+        name = "Account $code",
+        type = if (debit == "0") GlAccountType.LIABILITY else GlAccountType.ASSET,
+        currency = "CZK",
+        totalDebit = BigDecimal(debit),
+        totalCredit = BigDecimal(credit),
+    )
+
+    private val lines = listOf(line("1100", "1000", "0"), line("2100", "0", "1000"))
+    private fun draft() = ClosedPeriodRecord.draftOf(
+        PeriodTrialBalance(period, lines),
+        Instant.parse("2026-06-02T00:00:00Z"),
+        draftedBy = "maker",
+    )
+
+    @Test
+    fun `a frozen close reads persisted evidence instead of recomputing journals`(): Unit = runBlocking {
+        val frozen = draft().freeze("checker", Instant.parse("2026-06-03T00:00:00Z"))
+        coEvery { closes.findByPeriod(period) } returns frozen
+        coEvery { closes.findFrozenLines(frozen.id) } returns lines
+
+        val result = service.getTrialBalance(GetPeriodTrialBalanceQuery(period))
+
+        assertThat(result.lines).isEqualTo(lines)
+        coVerify(exactly = 0) { journals.trialBalanceForPeriod(any(), any()) }
+    }
+
+    @Test
+    fun `freeze persists the exact reverified lines atomically with the close`(): Unit = runBlocking {
+        val draft = draft()
+        coEvery { closes.findByPeriod(period) } returns draft
+        coEvery { journals.trialBalanceForPeriod(period.from, period.to) } returns lines
+        val evidence = slot<PeriodTrialBalance>()
+        coEvery { closes.saveFrozen(any(), capture(evidence), any()) } answers { firstArg() }
+
+        val frozen = service.freeze(FreezeClosedPeriodCommand(period, "checker"))
+
+        assertThat(frozen.status).isEqualTo(ClosedPeriodStatus.FROZEN)
+        assertThat(evidence.captured.lines).isEqualTo(lines)
+        assertThat(evidence.captured.contentHash()).isEqualTo(draft.contentHash)
+    }
+}

--- a/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/contract/LedgerPactProviderVerificationTest.kt
+++ b/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/contract/LedgerPactProviderVerificationTest.kt
@@ -11,13 +11,24 @@ import au.com.dius.pact.provider.junitsupport.IgnoreNoPactsToVerify
 import au.com.dius.pact.provider.junitsupport.Provider
 import au.com.dius.pact.provider.junitsupport.State
 import au.com.dius.pact.provider.junitsupport.loader.PactFolder
+import com.openbank.ledger.domain.model.GlAccountType
+import com.openbank.ledger.domain.model.PeriodTrialBalance
+import com.openbank.ledger.domain.model.PeriodType
+import com.openbank.ledger.domain.model.TrialBalanceLine
 import io.quarkus.test.common.QuarkusTestResource
 import io.quarkus.test.junit.QuarkusTest
 import io.quarkus.test.security.TestSecurity
+import jakarta.inject.Inject
 import org.eclipse.microprofile.config.inject.ConfigProperty
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.TestTemplate
 import org.junit.jupiter.api.extension.ExtendWith
+import java.math.BigDecimal
+import java.sql.Timestamp
+import java.time.Instant
+import java.time.LocalDate
+import java.util.UUID
+import javax.sql.DataSource
 
 /**
  * Provider-side Pact verification for contracts published by consumers (ADR-0063: Phase 1
@@ -50,6 +61,9 @@ import org.junit.jupiter.api.extension.ExtendWith
 @IgnoreNoPactsToVerify(ignoreIoErrors = "true")
 class LedgerPactProviderVerificationTest {
 
+    @Inject
+    lateinit var dataSource: DataSource
+
     @ConfigProperty(name = "quarkus.http.test-port", defaultValue = "8081")
     lateinit var testPort: String
 
@@ -75,14 +89,70 @@ class LedgerPactProviderVerificationTest {
      * If running in isolation the DB is empty → trial-balance returns an empty balanced result,
      * which still satisfies the contract shape (type matchers, not value matchers).
      */
-    @State("ledger has journal entries for the reporting date")
-    fun stateWithJournalEntries() {
-        // Data seeding is intentionally omitted: the pact uses type matchers so any valid
-        // trial-balance response (including an empty-lines balanced=true response) satisfies
-        // the contract. Seeding real double-entry data via the domain use-case is covered by
-        // LedgerApiIT; duplicating that here would tightly couple the provider test to the
-        // internal posting API, which is the anti-pattern Pact is designed to avoid.
+    @State("ledger has frozen monthly trial balance for the reporting date")
+    fun stateWithFrozenMonthlyTrialBalance() {
+        val period = PeriodType.MONTH.of(LocalDate.of(2026, 6, 30))
+        val lines = listOf(
+            TrialBalanceLine(
+                UUID.fromString(ASSET_ID),
+                "1100",
+                "Cash",
+                GlAccountType.ASSET,
+                "CZK",
+                BigDecimal("150000"),
+                BigDecimal.ZERO,
+            ),
+            TrialBalanceLine(
+                UUID.fromString(LIABILITY_ID),
+                "2100",
+                "Deposits",
+                GlAccountType.LIABILITY,
+                "CZK",
+                BigDecimal.ZERO,
+                BigDecimal("150000"),
+            ),
+        )
+        val balance = PeriodTrialBalance(period, lines)
+        dataSource.connection.use { connection ->
+            connection.prepareStatement(
+                """insert into ledger_closed_period (id, period_type, period_from, period_to, status, evidence_state, computed_at, total_debits, total_credits, account_count, content_hash, drafted_by, frozen_by, frozen_at, created_at, updated_at)
+                   values (?, 'MONTH', '2026-06-01', '2026-06-30', 'FROZEN', 'LINES_V1', ?, 150000, 150000, 2, ?, 'maker', 'checker', ?, ?, ?)
+                   on conflict (period_type, period_from) do nothing""",
+            ).use { statement ->
+                statement.setObject(1, UUID.fromString(PERIOD_ID))
+                statement.setTimestamp(2, Timestamp.from(Instant.parse("2026-07-01T00:00:00Z")))
+                statement.setString(3, balance.contentHash())
+                statement.setTimestamp(4, Timestamp.from(Instant.parse("2026-07-02T00:00:00Z")))
+                statement.setTimestamp(5, Timestamp.from(Instant.parse("2026-07-01T00:00:00Z")))
+                statement.setTimestamp(6, Timestamp.from(Instant.parse("2026-07-02T00:00:00Z")))
+                statement.executeUpdate()
+            }
+            connection.prepareStatement(
+                """insert into ledger_closed_period_trial_balance_line (period_id, gl_account_id, currency, code, name, account_type, total_debit, total_credit)
+                   values (?, ?, 'CZK', ?, ?, ?, ?, ?) on conflict do nothing""",
+            ).use { statement ->
+                lines.forEach { line ->
+                    statement.setObject(1, UUID.fromString(PERIOD_ID))
+                    statement.setObject(2, line.glAccountId)
+                    statement.setString(3, line.code)
+                    statement.setString(4, line.name)
+                    statement.setString(5, line.type.name)
+                    statement.setBigDecimal(6, line.totalDebit)
+                    statement.setBigDecimal(7, line.totalCredit)
+                    statement.addBatch()
+                }
+                statement.executeBatch()
+            }
+        }
     }
+
+    /**
+     * Backward-compatible state for balance-service's live `/journals/trial-balance` pact.
+     * That contract uses type matchers and accepts the fresh test DB's balanced zero-line result;
+     * FINREP's distinct state above deliberately seeds immutable closed-period evidence.
+     */
+    @State("ledger has journal entries for the reporting date")
+    fun stateWithJournalEntriesForBalancePact() = Unit
 
     @State("ledger has no journal entries")
     fun stateWithNoJournalEntries() {
@@ -94,5 +164,11 @@ class LedgerPactProviderVerificationTest {
         // No setup needed — the V3/V5 Flyway migrations seed the standard chart (1100 cash-clearing,
         // 2100 deposit-control, …) with stable UUIDs into the fresh Testcontainer DB, so the
         // transaction-service postJournal contract replays against real, enabled, leaf GL accounts.
+    }
+
+    private companion object {
+        const val PERIOD_ID = "00000000-0000-0000-0000-000000009601"
+        const val ASSET_ID = "00000000-0000-0000-0000-000000009602"
+        const val LIABILITY_ID = "00000000-0000-0000-0000-000000009603"
     }
 }

--- a/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/integration/ClosedPeriodEvidenceIT.kt
+++ b/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/integration/ClosedPeriodEvidenceIT.kt
@@ -1,0 +1,228 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+package com.openbank.ledger.integration
+
+import com.openbank.ledger.domain.model.PeriodTrialBalance
+import com.openbank.ledger.domain.model.PeriodType
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.security.TestSecurity
+import io.restassured.RestAssured.given
+import jakarta.inject.Inject
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.MethodOrderer
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestMethodOrder
+import java.sql.Connection
+import java.sql.Timestamp
+import java.time.Instant
+import java.util.UUID
+import javax.sql.DataSource
+
+/**
+ * End-to-end evidence proof: the statutory lifecycle crosses HTTP as two different principals;
+ * JDBC observes only committed state and installs a deliberately failing DB trigger for rollback.
+ * It never calls a reactive repository directly, because that would bypass REST/authn/transaction
+ * wiring and cannot prove the production workflow.
+ */
+@QuarkusTest
+@QuarkusTestResource(com.openbank.ledger.it.PostgresTestResource::class)
+@TestMethodOrder(MethodOrderer.OrderAnnotation::class)
+class ClosedPeriodEvidenceIT {
+
+    @Inject
+    lateinit var dataSource: DataSource
+
+    private companion object {
+        const val PERIOD_DATE = "2026-05-31"
+        const val ROLLBACK_PERIOD_DATE = "2026-04-30"
+        const val HASH_ONLY_PERIOD_DATE = "2026-03-31"
+        val journalTransactionId: UUID = UUID.randomUUID()
+        var periodId: UUID? = null
+        var rollbackPeriodId: UUID? = null
+    }
+
+    @Test
+    @Order(1)
+    @TestSecurity(user = "maker", roles = ["ROLE_OPERATOR"])
+    fun `maker posts the source journal and creates a DRAFT through HTTP`() {
+        val journal = """
+            {
+              "idempotencyKey":"${UUID.randomUUID()}","transactionId":"$journalTransactionId",
+              "entryDate":"2026-05-15","valueDate":"2026-05-15","description":"Frozen evidence IT",
+              "createdBy":"00000000-0000-0000-0000-000000000701","lines":[
+                {"glAccountId":"a0000000-0000-0000-0000-000000000001","side":"DEBIT","amount":"1000.00","currencyCode":"CZK","baseAmount":"1000.00","baseCurrencyCode":"CZK"},
+                {"glAccountId":"a0000000-0000-0000-0000-000000000002","side":"CREDIT","amount":"1000.00","currencyCode":"CZK","baseAmount":"1000.00","baseCurrencyCode":"CZK"}
+              ]
+            }
+        """.trimIndent()
+        given().contentType(
+            "application/json",
+        ).body(journal).`when`().post("/api/v1/journals").then().log().all().statusCode(201)
+
+        periodId = UUID.fromString(
+            given().contentType(
+                "application/json",
+            ).`when`().post("/api/v1/ledger/periods/MONTH/$PERIOD_DATE").then().statusCode(200)
+                .extract().jsonPath().getString("id"),
+        )
+        assertThat(periodId).isNotNull()
+    }
+
+    @Test
+    @Order(2)
+    @TestSecurity(user = "checker", roles = ["ROLE_OPERATOR"])
+    fun `different checker freezes exact V23 evidence through HTTP`() {
+        given().contentType(
+            "application/json",
+        ).`when`().post("/api/v1/ledger/periods/MONTH/$PERIOD_DATE/freeze").then().statusCode(200)
+
+        dataSource.connection.use { connection ->
+            connection.prepareStatement(
+                "select status, evidence_state from ledger_closed_period where id = ?",
+            ).use { statement ->
+                statement.setObject(1, requireNotNull(periodId))
+                statement.executeQuery().use { rows ->
+                    check(rows.next())
+                    assertThat(rows.getString("status")).isEqualTo("FROZEN")
+                    assertThat(rows.getString("evidence_state")).isEqualTo("LINES_V1")
+                }
+            }
+            assertThat(
+                count(connection, "ledger_closed_period_trial_balance_line", requireNotNull(periodId)),
+            ).isEqualTo(2)
+            assertThat(count(connection, "ledger_outbox", requireNotNull(periodId), "PeriodFrozen")).isEqualTo(1)
+        }
+    }
+
+    @Test
+    @Order(3)
+    @TestSecurity(user = "viewer", roles = ["ROLE_VIEWER"])
+    fun `regulatory endpoint returns the frozen immutable lines`() {
+        given().accept("application/json").`when`()
+            .get("/api/v1/ledger/periods/MONTH/$PERIOD_DATE/frozen-trial-balance")
+            .then().statusCode(200).body("lines.size()", org.hamcrest.Matchers.equalTo(2))
+    }
+
+    @Test
+    @Order(4)
+    @TestSecurity(user = "maker-rollback", roles = ["ROLE_OPERATOR"])
+    fun `persistence failure during HTTP freeze rolls back status evidence and outbox`() {
+        val journal = """
+            {"idempotencyKey":"${UUID.randomUUID()}","transactionId":"${UUID.randomUUID()}",
+             "entryDate":"2026-04-15","valueDate":"2026-04-15","description":"Rollback evidence IT","createdBy":"00000000-0000-0000-0000-000000000702","lines":[
+             {"glAccountId":"a0000000-0000-0000-0000-000000000001","side":"DEBIT","amount":"500.00","currencyCode":"CZK","baseAmount":"500.00","baseCurrencyCode":"CZK"},
+             {"glAccountId":"a0000000-0000-0000-0000-000000000002","side":"CREDIT","amount":"500.00","currencyCode":"CZK","baseAmount":"500.00","baseCurrencyCode":"CZK"}]}
+        """.trimIndent()
+        given().contentType("application/json").body(journal).`when`().post("/api/v1/journals").then().statusCode(201)
+        rollbackPeriodId = UUID.fromString(
+            given().contentType(
+                "application/json",
+            ).`when`().post("/api/v1/ledger/periods/MONTH/$ROLLBACK_PERIOD_DATE").then().statusCode(200)
+                .extract().jsonPath().getString("id"),
+        )
+        dataSource.connection.use { connection ->
+            connection.createStatement().use { statement ->
+                statement.execute(
+                    """create function fail_closed_period_evidence_it() returns trigger as $$ begin raise exception 'controlled evidence failure'; end; $$ language plpgsql""",
+                )
+                statement.execute(
+                    "create trigger fail_closed_period_evidence_it before insert on ledger_closed_period_trial_balance_line for each row execute function fail_closed_period_evidence_it()",
+                )
+            }
+        }
+
+        // A different principal is required for the HTTP freeze; TestSecurity identities are fixed
+        // per method, so the checker request is deliberately exercised in the next ordered test.
+    }
+
+    @Test
+    @Order(5)
+    @TestSecurity(user = "checker-rollback", roles = ["ROLE_OPERATOR"])
+    fun `controlled persistence failure leaves the HTTP draft completely uncommitted`() {
+        given().contentType(
+            "application/json",
+        ).`when`().post("/api/v1/ledger/periods/MONTH/$ROLLBACK_PERIOD_DATE/freeze").then().statusCode(500)
+        dataSource.connection.use { connection ->
+            connection.createStatement().use { statement ->
+                statement.execute(
+                    "drop trigger fail_closed_period_evidence_it on ledger_closed_period_trial_balance_line",
+                )
+                statement.execute("drop function fail_closed_period_evidence_it()")
+            }
+            connection.prepareStatement(
+                "select status, evidence_state from ledger_closed_period where id = ?",
+            ).use { statement ->
+                statement.setObject(1, requireNotNull(rollbackPeriodId))
+                statement.executeQuery().use { rows ->
+                    check(rows.next())
+                    assertThat(rows.getString("status")).isEqualTo("DRAFT")
+                    assertThat(rows.getString("evidence_state")).isEqualTo("NONE")
+                }
+            }
+            assertThat(
+                count(connection, "ledger_closed_period_trial_balance_line", requireNotNull(rollbackPeriodId)),
+            ).isZero()
+            assertThat(count(connection, "ledger_outbox", requireNotNull(rollbackPeriodId), "PeriodFrozen")).isZero()
+        }
+    }
+
+    @Test
+    @Order(6)
+    @TestSecurity(user = "viewer", roles = ["ROLE_VIEWER"])
+    fun `legacy HASH_ONLY is rejected while empty LINES_V1 is valid frozen evidence`() {
+        dataSource.connection.use { connection ->
+            insertFrozen(connection, HASH_ONLY_PERIOD_DATE, "HASH_ONLY", UUID.randomUUID())
+            insertFrozen(connection, "2026-02-28", "LINES_V1", UUID.randomUUID())
+        }
+        given().`when`().get(
+            "/api/v1/ledger/periods/MONTH/$HASH_ONLY_PERIOD_DATE/frozen-trial-balance",
+        ).then().statusCode(409)
+        given().`when`().get("/api/v1/ledger/periods/MONTH/2026-02-28/frozen-trial-balance").then().statusCode(200)
+            .body("lines.size()", org.hamcrest.Matchers.equalTo(0))
+    }
+
+    private fun count(connection: Connection, table: String, aggregateId: UUID, eventType: String? = null): Long {
+        val sql = if (eventType ==
+            null
+        ) {
+            "select count(*) from $table where period_id = ?"
+        } else {
+            "select count(*) from $table where aggregate_id = ? and event_type = ?"
+        }
+        return connection.prepareStatement(sql).use { statement ->
+            statement.setObject(1, aggregateId)
+            if (eventType != null) statement.setString(2, eventType)
+            statement.executeQuery().use { rows ->
+                check(rows.next())
+                rows.getLong(1)
+            }
+        }
+    }
+
+    private fun insertFrozen(connection: Connection, date: String, evidenceState: String, id: UUID) {
+        connection.prepareStatement(
+            """insert into ledger_closed_period (id, period_type, period_from, period_to, status, evidence_state, computed_at, total_debits, total_credits, account_count, content_hash, drafted_by, frozen_by, frozen_at, created_at, updated_at)
+               values (?, 'MONTH', ?::date, (?::date + interval '1 month - 1 day')::date, 'FROZEN', ?, ?, 0, 0, 0, ?, 'maker', 'checker', ?, ?, ?)""",
+        ).use { statement ->
+            val now = Instant.parse("2026-08-01T00:00:00Z")
+            val periodStart = date.substring(0, 8) + "01"
+            val emptyHash = PeriodTrialBalance(
+                PeriodType.MONTH.of(java.time.LocalDate.parse(date)),
+                emptyList(),
+            ).contentHash()
+            statement.setObject(1, id)
+            statement.setString(2, periodStart)
+            statement.setString(3, periodStart)
+            statement.setString(4, evidenceState)
+            statement.setTimestamp(5, Timestamp.from(now))
+            statement.setString(6, emptyHash)
+            statement.setTimestamp(7, Timestamp.from(now))
+            statement.setTimestamp(8, Timestamp.from(now))
+            statement.setTimestamp(9, Timestamp.from(now))
+            statement.executeUpdate()
+        }
+    }
+}

--- a/pacts/openbank-finrep-service-openbank-ledger-service.json
+++ b/pacts/openbank-finrep-service-openbank-ledger-service.json
@@ -7,7 +7,7 @@
       "description": "GET the GL trial balance for a FINREP reporting date",
       "providerStates": [
         {
-          "name": "ledger has journal entries for the reporting date"
+          "name": "ledger has frozen monthly trial balance for the reporting date"
         }
       ],
       "request": {
@@ -15,16 +15,10 @@
           "Accept": "application/json"
         },
         "method": "GET",
-        "path": "/api/v1/journals/trial-balance",
-        "query": {
-          "asOf": [
-            "2026-06-30"
-          ]
-        }
+        "path": "/api/v1/ledger/periods/MONTH/2026-06-30/frozen-trial-balance"
       },
       "response": {
         "body": {
-          "asOf": "2026-06-30",
           "balanced": true,
           "lines": [
             {
@@ -32,7 +26,8 @@
               "net": 150000.0,
               "type": "ASSET"
             }
-          ]
+          ],
+          "period": "MONTH:2026-06"
         },
         "headers": {
           "Content-Type": "application/json"
@@ -73,51 +68,6 @@
               ]
             },
             "$.lines[*].type": {
-              "combine": "AND",
-              "matchers": [
-                {
-                  "match": "type"
-                }
-              ]
-            }
-          }
-        },
-        "status": 200
-      }
-    },
-    {
-      "description": "GET the GL trial balance for a date with no ledger activity",
-      "providerStates": [
-        {
-          "name": "ledger has no journal entries"
-        }
-      ],
-      "request": {
-        "headers": {
-          "Accept": "application/json"
-        },
-        "method": "GET",
-        "path": "/api/v1/journals/trial-balance",
-        "query": {
-          "asOf": [
-            "2000-01-01"
-          ]
-        }
-      },
-      "response": {
-        "body": {
-          "asOf": "2000-01-01",
-          "balanced": true,
-          "lines": [
-
-          ]
-        },
-        "headers": {
-          "Content-Type": "application/json"
-        },
-        "matchingRules": {
-          "body": {
-            "$.balanced": {
               "combine": "AND",
               "matchers": [
                 {


### PR DESCRIPTION
## Summary
- persist immutable, re-verified closed-period trial-balance lines atomically with freeze/outbox
- serve FROZEN evidence to FINREP/COREP; DRAFT remains live computation
- move FINREP pact client to statutory MONTH endpoint

## Verification
- focused snapshot unit test
- FINREP Pact consumer: 2/0/0
- ledger Pact provider replay: 10/0/0
- ledger + FINREP ktlint reports clean

Refs #1302