### PR TITLE
test(campaign): make the JDBC campaign fixture a campaign the aggregate can hydrate

### DIFF
--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/integration/CampaignRestContractIT.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/integration/CampaignRestContractIT.kt
@@ -273,6 +273,13 @@ class CampaignRestContractIT {
         return interactionRef
     }
 
+    /**
+     * A campaign row written straight through JDBC so a send-log / engagement row has something to
+     * hang off. It must still be a campaign the aggregate can hydrate: `steps_json` of `[]` violates
+     * `require(steps.isNotEmpty())`, and every read that loads the whole table — `GET
+     * /api/v1/campaigns/planning` — then answers 400 for the entire portfolio because of one row the
+     * HTTP API could never have created (#4825).
+     */
     private fun insertCampaignForSendLog(campaignId: UUID) {
         dataSource.connection.use { connection ->
             connection.prepareStatement(
@@ -288,7 +295,7 @@ class CampaignRestContractIT {
                 statement.setString(3, "prove private ownership validation")
                 statement.setString(4, "actives")
                 statement.setInt(5, 1)
-                statement.setString(6, "[]")
+                statement.setString(6, FIXTURE_STEPS_JSON)
                 statement.setInt(7, 0)
                 statement.setString(8, "ACTIVE")
                 statement.setString(9, "fixture")
@@ -1103,5 +1110,15 @@ class CampaignRestContractIT {
             statusCode(200)
             body("stopCondition", org.hamcrest.Matchers.nullValue())
         }
+    }
+
+    companion object {
+        /**
+         * The same single step [draftBody] posts. A JDBC-written fixture has to be a campaign the
+         * aggregate can hydrate, or it poisons every endpoint that lists the whole table.
+         */
+        private const val FIXTURE_STEPS_JSON =
+            "[{\"order\":1,\"template\":\"MARKETING_PRODUCT_OFFER\",\"channel\":\"EMAIL\"," +
+                "\"variables\":{\"offerTitle\":\"T\",\"offerText\":\"X\",\"ctaText\":\"Go\"},\"delaySeconds\":0}]"
     }
 }


### PR DESCRIPTION
## What

`CampaignRestContractIT > planning keeps a submitted recurring campaign visibly unplanned until activation()` fails on clean `origin/main`. `GET /api/v1/campaigns/planning` answers **400**, so the campaign is absent from the view and the three field assertions fall out of that one failure.

## Why it 400s — request validation, not a missing projection

Measured, not inferred. With `log().all()` on the failing request the body is:

```
{"traceId":"…","status":400,"code":"VALIDATION_ERROR",
 "message":"campaign must have at least one step","timestamp":"…"}
```

`insertCampaignForSendLog` writes a campaign row straight through JDBC with `steps_json = '[]'`. `Campaign`'s `init` block carries `require(steps.isNotEmpty())`, so hydrating that row throws `IllegalArgumentException`, and libs-runtime's `IllegalArgumentExceptionMapper` renders it as 400.

`CampaignPlanningQuery` calls `CampaignRepository.list()` — it is the first endpoint that hydrates **every** campaign. One row the HTTP API could never have created therefore 400s the whole portfolio view for everyone. Not a data-visibility bug and not a missing projection.

## Which merge broke it

`de344a5446ced7ed61df4318cdbf608de34f8232` — `fix(campaign): project story engagement (#4783)`.

Bisected by running the class at each commit:

| commit | result |
|---|---|
| `8e88e8512` `feat(campaign): add planning radar (#4787)` | `BUILD SUCCESSFUL` |
| `de344a544` `fix(campaign): project story engagement (#4783)` | `36 tests completed, 1 failed` |

The cause is in **campaign-service**, not in `openbank-libs-*`.

The poisoned fixture predates both. #4787 added the first endpoint that hydrates the whole table and was green because test ordering put the fixture insert *after* the planning test; #4783 added a second `insertCampaignForSendLog` call site, which shifted ordering so the bad row now lands first. The two merged 11 seconds apart (08:30:18 and 08:30:29), so neither branch ever ran against the other.

## The fix

The fixture is the defect: it asserts a shape the aggregate declares impossible. It now writes the same single step `draftBody` posts, so the row is a campaign the domain accepts. No assertion is weakened and no production code changes.

Not chosen, and worth naming: making `CampaignPlanningQuery` skip unhydratable rows. That would hide a genuinely corrupt row rather than report it, and no API path can create one.

## Verification

- **RED first** on clean `origin/main` (`c2415ddea`): `36 tests completed, 1 failed`.
- **GREEN** with the fix: `BUILD SUCCESSFUL`.
- Whole module, `./gradlew :openbank-campaign-service:build` → `BUILD SUCCESSFUL`. Totals read from the JUnit XML, not the console: **33 classes, 198 tests, 0 skipped, 0 failures, 0 errors**.
- `ktlintCheck` and `detekt` both appear in the executed task list (`ktlintMainSourceSetCheck`, `ktlintTestSourceSetCheck`, `detekt`), as does `koverVerify`.

## Scope

`openbank-campaign-service` is **not** in `rules.yaml: money_path_services`, so the two-approval + threat-model rule does not apply.

Test-only change, so no version bump and no release: `test` is a hidden type and `src/test` is in the package's `exclude-paths`.

Closes #4825
