### PR TITLE
fix(case-coordinator): stop logging and echoing an unsanitised openedBy (#4215)

### DIFF
--- a/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/application/CaseOpenService.kt
+++ b/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/application/CaseOpenService.kt
@@ -93,7 +93,11 @@ class CaseOpenService(
         val stub = workflowClient.newUntypedWorkflowStub(WORKFLOW_TYPE, options)
         return try {
             stub.start(start)
-            log.infof("case opened: %s by %s (class %s)", workflowId, openedBy, caseClass)
+            // openedBy is sanitised, workflowId is not, and the asymmetry is the point (#4215):
+            // workflowIdFor already strips everything outside [A-Za-z0-9_-], so it cannot carry a
+            // newline, while openedBy arrives verbatim from the request body. CodeQL flagged both
+            // arguments on this line; only this one was ever injectable.
+            log.infof("case opened: %s by %s (class %s)", workflowId, openedBy.sanitizeForLog(), caseClass)
             CaseOpenResult.Opened(workflowId)
         } catch (e: WorkflowExecutionAlreadyStarted) {
             refundOpenQuota(openedBy, now)
@@ -138,5 +142,14 @@ class CaseOpenService(
     private companion object {
         const val WORKFLOW_TYPE = "CaseWorkflow"
         const val OPEN_WINDOW_MS = 3_600_000L
+
+        /**
+         * The fleet's log-injection guard (13 services carry the same idiom): CR/LF out, so a
+         * caller-supplied string cannot forge a log line. Deliberately INSIDE the companion rather
+         * than a top-level `private fun`: a top-level declaration placed above a class silently
+         * takes that class's annotation, which is how `McpEndpoint` lost its `@Path` and answered
+         * 404 on every call for the life of the endpoint.
+         */
+        fun String.sanitizeForLog(): String = replace('\n', '_').replace('\r', '_')
     }
 }

--- a/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/infrastructure/rest/CaseCoordinatorResource.kt
+++ b/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/infrastructure/rest/CaseCoordinatorResource.kt
@@ -117,7 +117,12 @@ class CaseCoordinatorResource(
             is CaseOpenResult.Opened -> Response.status(Response.Status.CREATED)
                 .entity(OpenCaseResponse(result.caseId)).build()
             CaseOpenResult.Denied -> Response.status(Response.Status.FORBIDDEN)
-                .entity(errorBody("case.open denied for '$openedBy' or class '$caseClass' not enabled")).build()
+                // The caller's own openedBy is NOT echoed back (#4215). It is free-form request
+                // input; reflecting it verbatim into a response body serves no diagnostic purpose
+                // the caller does not already have, and it is the same untrusted value the log
+                // line downstream had to sanitise. The class is a server-side enum, so it stays.
+                .entity(errorBody("case.open denied for the requested agent, or class not enabled"))
+                .build()
             CaseOpenResult.Duplicate -> Response.status(Response.Status.CONFLICT)
                 .entity(errorBody("a case for this class and subject already runs")).build()
             CaseOpenResult.RateLimited -> Response.status(HTTP_TOO_MANY_REQUESTS)

--- a/openbank-case-coordinator-agent/src/test/kotlin/com/openbank/casecoordinator/application/CaseOpenServiceTest.kt
+++ b/openbank-case-coordinator-agent/src/test/kotlin/com/openbank/casecoordinator/application/CaseOpenServiceTest.kt
@@ -24,6 +24,10 @@ import org.junit.jupiter.api.Test
 import java.time.Clock
 import java.time.Instant
 import java.time.ZoneOffset
+import java.util.logging.Handler
+import java.util.logging.Level
+import java.util.logging.LogRecord
+import java.util.logging.Logger as JulLogger
 
 /**
  * Case-open authority rules (ADR-0244 D9): capability, per-agent rate limit, dedup mapping.
@@ -111,6 +115,43 @@ class CaseOpenServiceTest {
         )
 
         assertThat(open()).isEqualTo(CaseOpenResult.Duplicate)
+    }
+
+    /**
+     * #4215: `openedBy` is free-form request-body input and was interpolated into the "case opened"
+     * line verbatim, so a caller could embed CRLF and forge log records. CodeQL flagged it and the
+     * finding was merged past unresolved.
+     *
+     * The assertion reads the REAL emitted record rather than calling the sanitiser directly — a
+     * test of the helper alone would stay green if the call site stopped using it, which is exactly
+     * the regression worth catching.
+     */
+    @Test
+    fun `a CRLF-laden openedBy cannot forge a log line`() {
+        val captured = mutableListOf<String>()
+        val jul = JulLogger.getLogger(CaseOpenService::class.java.name)
+        val handler = object : Handler() {
+            override fun publish(record: LogRecord) {
+                captured += java.text.MessageFormat.format(record.message, *(record.parameters ?: emptyArray()))
+                    .let { if (record.parameters == null) record.message else it }
+            }
+            override fun flush() = Unit
+            override fun close() = Unit
+        }
+        jul.addHandler(handler)
+        jul.level = Level.ALL
+        try {
+            every { gate.canOpenCase(any()) } returns true
+            service.open("evil\r\nFATAL: forged entry", CaseClass.INCIDENT_RESPONSE, "acct-1", "ops")
+        } finally {
+            jul.removeHandler(handler)
+        }
+
+        val all = captured.joinToString("\n")
+        assertThat(all).describedAs("something must have been logged, or this test proves nothing")
+            .contains("case opened")
+        assertThat(all).describedAs("CR/LF from request input must not reach the log verbatim")
+            .doesNotContain("\r").doesNotContain("evil\nFATAL")
     }
 
     @Test


### PR DESCRIPTION
## Four CodeQL alerts were merged past, and are still open on main

When #4215 was merged the ruleset recorded **two** overrides, not one:

```
"A conversation must be resolved before this pull request can be merged."
"Required status check \"Validate manifests\" is failing."
```

#4240 covered the second. The first was these four `java/log-injection` findings on
`CaseOpenService`, and alerts **415–418 are still `open` today**, on unchanged lines.

## Reviewed one by one, because they are not all real

| alert | line | argument | verdict |
|---|---|---|---|
| 417 | 100 | `workflowId` | **false positive** |
| 418 | 104 | `workflowId` | **false positive** |
| 415/416 | 96 | `workflowId`, `openedBy` | one of each |

`workflowId` comes from `workflowIdFor()`, which strips everything outside `[A-Za-z0-9_-]`:

```kotlin
"case-${caseClass.name.lowercase()…}-${subjectRef.replace(Regex("[^A-Za-z0-9_-]"), "-")}"
```

It cannot carry CR or LF. CodeQL cannot see through the regex.

**`openedBy` is real.** It arrives verbatim from the request body — `requireNotNull(request.openedBy)`,
no format, no sanitisation — and went straight into the `case opened` line. A caller can embed CRLF
and forge log records.

It also violates a convention this repo already writes down, in `LoggingStatementDeliveryAdapter`:

> the fleet convention (see `OnboardingDocumentService`) is to never log an untrusted free-form
> identifier verbatim (CodeQL java/log-injection)

## Changes

- `openedBy` sanitised at the log call with the fleet's existing idiom (CR/LF → `_`), carried by 13
  other services. **`workflowId` deliberately is not** — the asymmetry is documented in place so the
  next reader does not "fix" the false positives by adding noise.
- The sanitiser sits **inside the private companion object**, not as a top-level `private fun`. A
  top-level declaration above a class silently takes that class's annotation — which is how
  `McpEndpoint` lost its `@Path` and answered 404 on every call for the life of the endpoint.
- The denial response no longer echoes `openedBy` back. Same untrusted value, different exit.

## The test asserts the real log record

Not the helper. A test that calls `sanitizeForLog()` directly stays green if the call site stops
using it — which is the regression worth catching. It reads the emitted record through a JUL handler
and carries a known-positive guard (`"case opened"` must appear), so an empty capture cannot pass as
clean.

**Falsified:** dropping `.sanitizeForLog()` at the call site reddens exactly this test.

## Not in scope, and more serious

`openedBy` is not only logged. It is the **authorisation subject** and the **rate-limit key**:

```kotlin
if (!gate.canOpenCase(openedBy) …)      // canOpenCase(agentId) = agentId in openAgents()
if (!consumeOpenQuota(openedBy, now))   // per-agent hourly quota
```

…while being chosen by the caller. So the hourly quota is evaded by varying one body field, and the
capability check tests an identity the caller *asserts* rather than one it *proved*. The endpoint is
`@RolesAllowed("ROLE_ADMIN","ROLE_OPERATOR")`, so this is lateral rather than an escalation from
anonymous — but it is still caller-asserted identity used for authorisation.

Fixing it means taking the acting identity from the authenticated principal, which changes a
`required` field in `openapi.yaml`. That is an API-contract change and does not belong inside a
log-sanitisation commit. Reported separately.

## Verification

`detekt`, `ktlintCheck`, `koverVerify`, `test` — **28 tests, 0 failures, 0 skipped**.

One honest note: a first full-module run failed `CaseCoordinatorBootSmokeIT` on
`ContainerLaunchException: postgres:18-alpine`. It reproduced neither alone on this branch nor on a
clean `origin/main` worktree — contention with a parallel e2e container on this machine, not this
change.

Refs #4215, #4240, #4828
