### PR TITLE
fix(case-coordinator): key the open-rate quota on the caller, not on the identity it claims (#4834)

### DIFF
--- a/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/application/CaseOpenService.kt
+++ b/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/application/CaseOpenService.kt
@@ -59,16 +59,35 @@ class CaseOpenService(
     private val log = Logger.getLogger(CaseOpenService::class.java)
     private val openTimes = mutableMapOf<String, ArrayDeque<Long>>()
 
+    /**
+     * [callerPrincipal] is the AUTHENTICATED caller (SecurityIdentity), [openedBy] the agent
+     * identity the call claims to act as. They are different things and only one of them is
+     * evidence (#4834).
+     *
+     * The open-rate quota is keyed on [callerPrincipal] for exactly that reason. Keyed on
+     * [openedBy] it was keyed on a value the caller chooses, so the per-agent ceiling would be
+     * split into one fresh bucket per string the caller invents. That is inert today only because
+     * `openAgents()` holds a single entry, so one value passes the gate and there is one bucket —
+     * and the config comment says the list is expected to grow ("swarm join/contribute grants are
+     * deliberate follow-up charter work"). A ceiling that stops holding when a config list grows,
+     * with nothing to notice, is the defect; the allow-list size is not the fix.
+     */
     @Synchronized
-    fun open(openedBy: String, caseClass: CaseClass, subjectRef: String, dispositionTarget: String): CaseOpenResult {
+    fun open(
+        callerPrincipal: String,
+        openedBy: String,
+        caseClass: CaseClass,
+        subjectRef: String,
+        dispositionTarget: String,
+    ): CaseOpenResult {
         if (!temporalConfig.enabled()) return CaseOpenResult.Unavailable
         if (!gate.canOpenCase(openedBy) || caseClass !in config.case().enabledClasses()) {
             return CaseOpenResult.Denied
         }
         val now = clock.millis()
-        if (!consumeOpenQuota(openedBy, now)) return CaseOpenResult.RateLimited
+        if (!consumeOpenQuota(callerPrincipal, now)) return CaseOpenResult.RateLimited
         if (countRunningCases() >= config.case().maxConcurrent()) {
-            refundOpenQuota(openedBy, now)
+            refundOpenQuota(callerPrincipal, now)
             return CaseOpenResult.RateLimited
         }
 
@@ -97,14 +116,23 @@ class CaseOpenService(
             // workflowIdFor already strips everything outside [A-Za-z0-9_-], so it cannot carry a
             // newline, while openedBy arrives verbatim from the request body. CodeQL flagged both
             // arguments on this line; only this one was ever injectable.
-            log.infof("case opened: %s by %s (class %s)", workflowId, openedBy.sanitizeForLog(), caseClass)
+            // Both identities on the record: the agent the call CLAIMS to act as, and the
+            // principal that actually authenticated. Attribution that names only the claim cannot
+            // answer "who did this" when the two diverge (#4834).
+            log.infof(
+                "case opened: %s claimed-by %s principal %s (class %s)",
+                workflowId,
+                openedBy.sanitizeForLog(),
+                callerPrincipal.sanitizeForLog(),
+                caseClass,
+            )
             CaseOpenResult.Opened(workflowId)
         } catch (e: WorkflowExecutionAlreadyStarted) {
-            refundOpenQuota(openedBy, now)
+            refundOpenQuota(callerPrincipal, now)
             log.debugf(e, "case open dedup: %s already running on the server", workflowId)
             CaseOpenResult.Duplicate
         } catch (e: WorkflowServiceException) {
-            refundOpenQuota(openedBy, now)
+            refundOpenQuota(callerPrincipal, now)
             log.warnf(e, "Temporal start failed for %s", workflowId)
             CaseOpenResult.Unavailable
         }
@@ -113,8 +141,8 @@ class CaseOpenService(
     fun workflowIdFor(caseClass: CaseClass, subjectRef: String): String =
         "case-${caseClass.name.lowercase().replace('_', '-')}-${subjectRef.replace(Regex("[^A-Za-z0-9_-]"), "-")}"
 
-    private fun consumeOpenQuota(agentId: String, now: Long): Boolean {
-        val deque = openTimes.getOrPut(agentId) { ArrayDeque() }
+    private fun consumeOpenQuota(quotaKey: String, now: Long): Boolean {
+        val deque = openTimes.getOrPut(quotaKey) { ArrayDeque() }
         val windowStart = now - OPEN_WINDOW_MS
         while (deque.isNotEmpty() && deque.first() < windowStart) deque.removeFirst()
         if (deque.size >= config.case().maxOpensPerAgentPerHour()) return false
@@ -122,8 +150,8 @@ class CaseOpenService(
         return true
     }
 
-    private fun refundOpenQuota(agentId: String, now: Long) {
-        openTimes[agentId]?.remove(now)
+    private fun refundOpenQuota(quotaKey: String, now: Long) {
+        openTimes[quotaKey]?.remove(now)
     }
 
     private fun countRunningCases(): Int = try {

--- a/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/infrastructure/rest/CaseCoordinatorResource.kt
+++ b/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/infrastructure/rest/CaseCoordinatorResource.kt
@@ -17,6 +17,7 @@ import com.openbank.casecoordinator.domain.model.JoinSignal
 import com.openbank.casecoordinator.domain.model.SupersedeSignal
 import com.openbank.casecoordinator.domain.model.SynthesisRequest
 import com.openbank.libs.temporal.TemporalConfig
+import io.quarkus.security.identity.SecurityIdentity
 import io.smallrye.common.annotation.Blocking
 import io.temporal.client.WorkflowClient
 import io.temporal.client.WorkflowNotFoundException
@@ -45,6 +46,7 @@ class CaseCoordinatorResource(
     private val gate: CaseCapabilityGate,
     private val workflowClient: WorkflowClient,
     private val temporalConfig: TemporalConfig,
+    private val identity: SecurityIdentity,
 ) {
 
     data class Status(val service: String, val status: String)
@@ -113,7 +115,16 @@ class CaseCoordinatorResource(
         val openedBy = requireNotNull(request.openedBy) { "openedBy is required" }
         val dispositionTarget = requireNotNull(request.dispositionTarget) { "dispositionTarget is required" }
 
-        return when (val result = openService.open(openedBy, caseClass, subjectRef, dispositionTarget)) {
+        // The authenticated caller, not the body's claim. `openedBy` still names WHICH agent
+        // identity the call acts as (ADR-0244 D9 charter capability), but the open-rate quota is
+        // keyed on this instead — a ceiling keyed on a value the caller picks is not a ceiling
+        // (#4834). Same separation McpEndpoint documents for X-Agent-Id: the bearer proves who,
+        // the header only names which.
+        val callerPrincipal = identity.principal?.name?.takeIf { it.isNotBlank() } ?: "anonymous"
+
+        return when (
+            val result = openService.open(callerPrincipal, openedBy, caseClass, subjectRef, dispositionTarget)
+        ) {
             is CaseOpenResult.Opened -> Response.status(Response.Status.CREATED)
                 .entity(OpenCaseResponse(result.caseId)).build()
             CaseOpenResult.Denied -> Response.status(Response.Status.FORBIDDEN)

--- a/openbank-case-coordinator-agent/src/test/kotlin/com/openbank/casecoordinator/application/CaseOpenServiceTest.kt
+++ b/openbank-case-coordinator-agent/src/test/kotlin/com/openbank/casecoordinator/application/CaseOpenServiceTest.kt
@@ -49,6 +49,7 @@ class CaseOpenServiceTest {
 
     companion object {
         private const val COORDINATOR = "case-coordinator"
+        private const val PRINCIPAL = "svc-operator-1"
     }
 
     @BeforeEach
@@ -75,8 +76,11 @@ class CaseOpenServiceTest {
         service = CaseOpenService(workflowClient, temporalConfig, gate, config, clock)
     }
 
-    private fun open(agent: String = COORDINATOR, subject: String = "ingest-1"): CaseOpenResult =
-        service.open(agent, CaseClass.INCIDENT_RESPONSE, subject, "hitl-incident-queue")
+    private fun open(
+        agent: String = COORDINATOR,
+        subject: String = "ingest-1",
+        principal: String = PRINCIPAL,
+    ): CaseOpenResult = service.open(principal, agent, CaseClass.INCIDENT_RESPONSE, subject, "hitl-incident-queue")
 
     @Test
     fun `temporal disabled means unavailable without touching the gate`() {
@@ -95,7 +99,7 @@ class CaseOpenServiceTest {
     @Test
     fun `a disabled case class is denied even for the coordinator`() {
         assertThat(
-            service.open(COORDINATOR, CaseClass.FRAUD_INVESTIGATION, "case-7", "hitl-fraud-queue"),
+            service.open(PRINCIPAL, COORDINATOR, CaseClass.FRAUD_INVESTIGATION, "case-7", "hitl-fraud-queue"),
         ).isEqualTo(CaseOpenResult.Denied)
     }
 
@@ -104,6 +108,37 @@ class CaseOpenServiceTest {
         assertThat(open()).isInstanceOf(CaseOpenResult.Opened::class.java)
 
         assertThat(open(subject = "ingest-2")).isEqualTo(CaseOpenResult.RateLimited)
+    }
+
+    /**
+     * #4834: the open-rate quota must key on the AUTHENTICATED caller, not on the agent identity
+     * the request claims. Keyed on the claim, a caller splits its own ceiling into one bucket per
+     * string it invents.
+     *
+     * Driven through two DIFFERENT allow-listed agent ids from ONE principal: under the old
+     * keying those are two buckets and both opens succeed; under principal keying the second is
+     * rate-limited. `maxOpensPerAgentPerHour` is 1 in this fixture.
+     */
+    @Test
+    fun `the quota is keyed on the caller, not on the agent identity it claims`() {
+        every { gate.canOpenCase(any()) } returns true
+
+        assertThat(open(agent = "case-coordinator", subject = "a")).isInstanceOf(CaseOpenResult.Opened::class.java)
+        assertThat(open(agent = "some-other-agent", subject = "b"))
+            .describedAs("a second open from the SAME principal must not get a fresh bucket by renaming the agent")
+            .isEqualTo(CaseOpenResult.RateLimited)
+    }
+
+    /** The flip side: two genuinely different callers keep their own ceilings. */
+    @Test
+    fun `separate principals keep separate quotas`() {
+        every { gate.canOpenCase(any()) } returns true
+
+        assertThat(open(subject = "a", principal = "svc-operator-1"))
+            .isInstanceOf(CaseOpenResult.Opened::class.java)
+        assertThat(open(subject = "b", principal = "svc-operator-2"))
+            .describedAs("a different authenticated caller has its own ceiling")
+            .isInstanceOf(CaseOpenResult.Opened::class.java)
     }
 
     @Test
@@ -142,7 +177,7 @@ class CaseOpenServiceTest {
         jul.level = Level.ALL
         try {
             every { gate.canOpenCase(any()) } returns true
-            service.open("evil\r\nFATAL: forged entry", CaseClass.INCIDENT_RESPONSE, "acct-1", "ops")
+            service.open(PRINCIPAL, "evil\r\nFATAL: forged entry", CaseClass.INCIDENT_RESPONSE, "acct-1", "ops")
         } finally {
             jul.removeHandler(handler)
         }


### PR DESCRIPTION
## What was actually exploitable — less than I first claimed

I filed #4834 saying the per-agent quota "is evaded by varying one body field". **That was wrong**,
and the correction is already on the issue. `gate.canOpenCase(openedBy)` runs *before* the quota, and
`openAgents()` holds a single entry:

```kotlin
@WithDefault("case-coordinator")
fun openAgents(): Set<String>
```

No deployed override (checked on the live Deployment). So exactly one string reaches the quota and
there is one bucket. `POST /api/v1/cases` also has **no caller anywhere in the repo**.

## Why fix it anyway

It is latent, not live, and the timer is in the config's own comment:

> today ONLY case-coordinator holds any; swarm join/contribute grants are **deliberate follow-up
> charter work**

The day that list gains an entry, a caller picks its own quota bucket by renaming the agent — no code
change, nothing to notice. **A ceiling that stops holding when a config list grows is the defect; the
list's current size is not the fix.**

And it is cheapest now, precisely because nothing calls the endpoint yet.

## The change

- `open()` takes `callerPrincipal` (from `SecurityIdentity`) alongside `openedBy`, and the quota —
  consume plus both refund paths — keys on the principal. The private helpers' parameter is renamed
  `agentId` → `quotaKey`, so the code stops implying the key is an agent.
- `openedBy` still selects the charter capability (ADR-0244 D9: only a chartered agent with
  `case-open` may open one). What it no longer does is choose a rate bucket.
- The audit line carries **both** identities. Attribution naming only the claim cannot answer "who
  did this" when the two diverge.

**No API contract change** — `openedBy` stays in the request body, so no `openapi.yaml` bump.
`quarkus-oidc` was already a dependency; `SecurityIdentity` simply was not used.

Same separation `McpEndpoint` documents for `X-Agent-Id`: *the bearer proves WHO is calling; the
header still names WHICH agent identity to run, but it can no longer be forged by anything that
merely reached the pod.*

## Tests

Two, both falsified — keying the quota back on `openedBy` reddens exactly these and nothing else:

| test | asserts |
|---|---|
| `the quota is keyed on the caller, not on the agent identity it claims` | two **different** allow-listed agent ids from **one** principal share a bucket → second is `RateLimited`. Under the old keying both succeeded. |
| `separate principals keep separate quotas` | two different principals keep their own ceilings — so the fix is not "always deny the second open" |

## Still open, deliberately

A caller can still **claim** any allow-listed agent id — `canOpenCase` tests an asserted identity,
not a proved one. Closing that needs either the `AgentIdentityBinding` shape agent-service already
carries (role → permitted agent ids) or the OPA gate ADR-0244 D9 actually specifies for the open
call. Both are larger than this, and neither belongs inside a rate-limit fix. #4834 stays open for it.

## Verification

`detekt`, `ktlintCheck`, `koverVerify`, `test`, `quarkusBuild` (`--rerun-tasks`) — **30 tests,
0 failures, 0 skipped**.

Refs #4834, #4215, #4833
