### PR TITLE
feat(admin-ui): unify operator surfaces

### DIFF
--- a/openbank-admin-ui/src/app/accounts/layout.tsx
+++ b/openbank-admin-ui/src/app/accounts/layout.tsx
@@ -2,19 +2,10 @@
 // Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 
-import { Sidebar } from "@/components/layout/Sidebar"
-import { Header } from "@/components/layout/Header"
+import { AppShell } from "@/components/layout/AppShell"
 
 export default function uaccountsLayout({ children }: { children: React.ReactNode }) {
   return (
-    <div style={{ display: "flex", height: "100vh", overflow: "hidden" }}>
-      <Sidebar />
-      <div style={{ flex: 1, display: "flex", flexDirection: "column", overflow: "hidden" }}>
-        <Header />
-        <main style={{ flex: 1, overflowY: "auto", padding: "24px", background: "var(--bg)" }}>
-          {children}
-        </main>
-      </div>
-    </div>
+    <AppShell>{children}</AppShell>
   )
 }

--- a/openbank-admin-ui/src/app/aml/layout.tsx
+++ b/openbank-admin-ui/src/app/aml/layout.tsx
@@ -2,19 +2,10 @@
 // Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 
-import { Sidebar } from "@/components/layout/Sidebar"
-import { Header } from "@/components/layout/Header"
+import { AppShell } from "@/components/layout/AppShell"
 
 export default function Layout({ children }: { children: React.ReactNode }) {
   return (
-    <div style={{ display: "flex", height: "100vh", overflow: "hidden" }}>
-      <Sidebar />
-      <div style={{ flex: 1, display: "flex", flexDirection: "column", overflow: "hidden" }}>
-        <Header />
-        <main style={{ flex: 1, overflowY: "auto", background: "var(--bg)" }}>
-          {children}
-        </main>
-      </div>
-    </div>
+    <AppShell>{children}</AppShell>
   )
 }

--- a/openbank-admin-ui/src/app/approvals/layout.tsx
+++ b/openbank-admin-ui/src/app/approvals/layout.tsx
@@ -2,19 +2,10 @@
 // Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 
-import { Sidebar } from "@/components/layout/Sidebar"
-import { Header } from "@/components/layout/Header"
+import { AppShell } from "@/components/layout/AppShell"
 
 export default function ApprovalsLayout({ children }: { children: React.ReactNode }) {
   return (
-    <div style={{ display: "flex", height: "100vh", overflow: "hidden" }}>
-      <Sidebar />
-      <div style={{ flex: 1, display: "flex", flexDirection: "column", overflow: "hidden" }}>
-        <Header />
-        <main style={{ flex: 1, overflowY: "auto", padding: "24px", background: "var(--bg)" }}>
-          {children}
-        </main>
-      </div>
-    </div>
+    <AppShell>{children}</AppShell>
   )
 }

--- a/openbank-admin-ui/src/app/audit/layout.tsx
+++ b/openbank-admin-ui/src/app/audit/layout.tsx
@@ -2,19 +2,10 @@
 // Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 
-import { Sidebar } from "@/components/layout/Sidebar"
-import { Header } from "@/components/layout/Header"
+import { AppShell } from "@/components/layout/AppShell"
 
 export default function Layout({ children }: { children: React.ReactNode }) {
   return (
-    <div style={{ display: "flex", height: "100vh", overflow: "hidden" }}>
-      <Sidebar />
-      <div style={{ flex: 1, display: "flex", flexDirection: "column", overflow: "hidden" }}>
-        <Header />
-        <main style={{ flex: 1, overflowY: "auto", padding: "24px", background: "var(--bg)" }}>
-          {children}
-        </main>
-      </div>
-    </div>
+    <AppShell>{children}</AppShell>
   )
 }

--- a/openbank-admin-ui/src/app/campaigns/layout.tsx
+++ b/openbank-admin-ui/src/app/campaigns/layout.tsx
@@ -2,19 +2,10 @@
 // Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 
-import { Sidebar } from "@/components/layout/Sidebar"
-import { Header } from "@/components/layout/Header"
+import { AppShell } from "@/components/layout/AppShell"
 
 export default function Layout({ children }: { children: React.ReactNode }) {
   return (
-    <div style={{ display: "flex", height: "100vh", overflow: "hidden" }}>
-      <Sidebar />
-      <div style={{ flex: 1, display: "flex", flexDirection: "column", overflow: "hidden" }}>
-        <Header />
-        <main style={{ flex: 1, overflowY: "auto", padding: "24px", background: "var(--bg)" }}>
-          {children}
-        </main>
-      </div>
-    </div>
+    <AppShell>{children}</AppShell>
   )
 }

--- a/openbank-admin-ui/src/app/cards/layout.tsx
+++ b/openbank-admin-ui/src/app/cards/layout.tsx
@@ -2,19 +2,10 @@
 // Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 
-import { Sidebar } from "@/components/layout/Sidebar"
-import { Header } from "@/components/layout/Header"
+import { AppShell } from "@/components/layout/AppShell"
 
 export default function Layout({ children }: { children: React.ReactNode }) {
   return (
-    <div style={{ display: "flex", height: "100vh", overflow: "hidden" }}>
-      <Sidebar />
-      <div style={{ flex: 1, display: "flex", flexDirection: "column", overflow: "hidden" }}>
-        <Header />
-        <main style={{ flex: 1, overflowY: "auto", background: "var(--bg)" }}>
-          {children}
-        </main>
-      </div>
-    </div>
+    <AppShell>{children}</AppShell>
   )
 }

--- a/openbank-admin-ui/src/app/clearing/layout.tsx
+++ b/openbank-admin-ui/src/app/clearing/layout.tsx
@@ -2,19 +2,10 @@
 // Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 
-import { Sidebar } from "@/components/layout/Sidebar"
-import { Header } from "@/components/layout/Header"
+import { AppShell } from "@/components/layout/AppShell"
 
 export default function Layout({ children }: { children: React.ReactNode }) {
   return (
-    <div style={{ display: "flex", height: "100vh", overflow: "hidden" }}>
-      <Sidebar />
-      <div style={{ flex: 1, display: "flex", flexDirection: "column", overflow: "hidden" }}>
-        <Header />
-        <main style={{ flex: 1, overflowY: "auto", background: "var(--bg)" }}>
-          {children}
-        </main>
-      </div>
-    </div>
+    <AppShell>{children}</AppShell>
   )
 }

--- a/openbank-admin-ui/src/app/consents/layout.tsx
+++ b/openbank-admin-ui/src/app/consents/layout.tsx
@@ -2,19 +2,10 @@
 // Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 
-import { Sidebar } from "@/components/layout/Sidebar"
-import { Header } from "@/components/layout/Header"
+import { AppShell } from "@/components/layout/AppShell"
 
 export default function Layout({ children }: { children: React.ReactNode }) {
   return (
-    <div style={{ display: "flex", height: "100vh", overflow: "hidden" }}>
-      <Sidebar />
-      <div style={{ flex: 1, display: "flex", flexDirection: "column", overflow: "hidden" }}>
-        <Header />
-        <main style={{ flex: 1, overflowY: "auto", padding: "24px", background: "var(--bg)" }}>
-          {children}
-        </main>
-      </div>
-    </div>
+    <AppShell>{children}</AppShell>
   )
 }

--- a/openbank-admin-ui/src/app/customer-360/layout.tsx
+++ b/openbank-admin-ui/src/app/customer-360/layout.tsx
@@ -2,19 +2,10 @@
 // Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 
-import { Sidebar } from "@/components/layout/Sidebar"
-import { Header } from "@/components/layout/Header"
+import { AppShell } from "@/components/layout/AppShell"
 
 export default function Layout({ children }: { children: React.ReactNode }) {
   return (
-    <div style={{ display: "flex", height: "100vh", overflow: "hidden" }}>
-      <Sidebar />
-      <div style={{ flex: 1, display: "flex", flexDirection: "column", overflow: "hidden" }}>
-        <Header />
-        <main style={{ flex: 1, overflowY: "auto", padding: "24px", background: "var(--bg)" }}>
-          {children}
-        </main>
-      </div>
-    </div>
+    <AppShell>{children}</AppShell>
   )
 }

--- a/openbank-admin-ui/src/app/dashboard/layout.tsx
+++ b/openbank-admin-ui/src/app/dashboard/layout.tsx
@@ -2,19 +2,10 @@
 // Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 
-import { Sidebar } from "@/components/layout/Sidebar"
-import { Header } from "@/components/layout/Header"
+import { AppShell } from "@/components/layout/AppShell"
 
 export default function udashboardLayout({ children }: { children: React.ReactNode }) {
   return (
-    <div style={{ display: "flex", height: "100vh", overflow: "hidden" }}>
-      <Sidebar />
-      <div style={{ flex: 1, display: "flex", flexDirection: "column", overflow: "hidden" }}>
-        <Header />
-        <main style={{ flex: 1, overflowY: "auto", padding: "24px", background: "var(--bg)" }}>
-          {children}
-        </main>
-      </div>
-    </div>
+    <AppShell>{children}</AppShell>
   )
 }

--- a/openbank-admin-ui/src/app/day-end/layout.tsx
+++ b/openbank-admin-ui/src/app/day-end/layout.tsx
@@ -2,19 +2,10 @@
 // Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 
-import { Sidebar } from "@/components/layout/Sidebar"
-import { Header } from "@/components/layout/Header"
+import { AppShell } from "@/components/layout/AppShell"
 
 export default function DayEndLayout({ children }: { children: React.ReactNode }) {
   return (
-    <div style={{ display: "flex", height: "100vh", overflow: "hidden" }}>
-      <Sidebar />
-      <div style={{ flex: 1, display: "flex", flexDirection: "column", overflow: "hidden" }}>
-        <Header />
-        <main style={{ flex: 1, overflowY: "auto", padding: "24px", background: "var(--bg)" }}>
-          {children}
-        </main>
-      </div>
-    </div>
+    <AppShell>{children}</AppShell>
   )
 }

--- a/openbank-admin-ui/src/app/delegations/layout.tsx
+++ b/openbank-admin-ui/src/app/delegations/layout.tsx
@@ -2,19 +2,10 @@
 // Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 
-import { Sidebar } from "@/components/layout/Sidebar"
-import { Header } from "@/components/layout/Header"
+import { AppShell } from "@/components/layout/AppShell"
 
 export default function DelegationsLayout({ children }: { children: React.ReactNode }) {
   return (
-    <div style={{ display: "flex", height: "100vh", overflow: "hidden" }}>
-      <Sidebar />
-      <div style={{ flex: 1, display: "flex", flexDirection: "column", overflow: "hidden" }}>
-        <Header />
-        <main style={{ flex: 1, overflowY: "auto", padding: "24px", background: "var(--bg)" }}>
-          {children}
-        </main>
-      </div>
-    </div>
+    <AppShell>{children}</AppShell>
   )
 }

--- a/openbank-admin-ui/src/app/devops/layout.tsx
+++ b/openbank-admin-ui/src/app/devops/layout.tsx
@@ -2,19 +2,10 @@
 // Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 
-import { Sidebar } from "@/components/layout/Sidebar"
-import { Header } from "@/components/layout/Header"
+import { AppShell } from "@/components/layout/AppShell"
 
 export default function DevOpsLayout({ children }: { children: React.ReactNode }) {
   return (
-    <div style={{ display: "flex", height: "100vh", overflow: "hidden" }}>
-      <Sidebar />
-      <div style={{ flex: 1, display: "flex", flexDirection: "column", overflow: "hidden" }}>
-        <Header />
-        <main style={{ flex: 1, overflowY: "auto", padding: "24px", background: "var(--bg)" }}>
-          {children}
-        </main>
-      </div>
-    </div>
+    <AppShell>{children}</AppShell>
   )
 }

--- a/openbank-admin-ui/src/app/disputes/layout.tsx
+++ b/openbank-admin-ui/src/app/disputes/layout.tsx
@@ -2,19 +2,10 @@
 // Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 
-import { Sidebar } from "@/components/layout/Sidebar"
-import { Header } from "@/components/layout/Header"
+import { AppShell } from "@/components/layout/AppShell"
 
 export default function Layout({ children }: { children: React.ReactNode }) {
   return (
-    <div style={{ display: "flex", height: "100vh", overflow: "hidden" }}>
-      <Sidebar />
-      <div style={{ flex: 1, display: "flex", flexDirection: "column", overflow: "hidden" }}>
-        <Header />
-        <main style={{ flex: 1, overflowY: "auto", background: "var(--bg)" }}>
-          {children}
-        </main>
-      </div>
-    </div>
+    <AppShell>{children}</AppShell>
   )
 }

--- a/openbank-admin-ui/src/app/docs/layout.tsx
+++ b/openbank-admin-ui/src/app/docs/layout.tsx
@@ -2,19 +2,10 @@
 // Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 
-import { Sidebar } from "@/components/layout/Sidebar"
-import { Header } from "@/components/layout/Header"
+import { AppShell } from "@/components/layout/AppShell"
 
 export default function DocsLayout({ children }: { children: React.ReactNode }) {
   return (
-    <div style={{ display: "flex", height: "100vh", overflow: "hidden" }}>
-      <Sidebar />
-      <div style={{ flex: 1, display: "flex", flexDirection: "column", overflow: "hidden" }}>
-        <Header />
-        <main style={{ flex: 1, overflowY: "auto", padding: "24px", background: "var(--bg)" }}>
-          {children}
-        </main>
-      </div>
-    </div>
+    <AppShell>{children}</AppShell>
   )
 }

--- a/openbank-admin-ui/src/app/docs/release-notes/[service]/ReleaseNotes.module.css
+++ b/openbank-admin-ui/src/app/docs/release-notes/[service]/ReleaseNotes.module.css
@@ -1,0 +1,82 @@
+.releaseList {
+  display: grid;
+  gap: 1rem;
+}
+
+.releaseCard {
+  position: relative;
+  overflow: hidden;
+  padding: 1.25rem;
+  border: 1px solid var(--border);
+  border-radius: 1rem;
+  background: linear-gradient(125deg, #fff 0%, #fbfcff 68%, #f6f5ff 100%);
+  box-shadow: var(--shadow-sm);
+}
+
+.releaseCard::before {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: 3px;
+  content: '';
+  background: linear-gradient(180deg, #818cf8, #6366f1);
+}
+
+.releaseHead {
+  display: flex;
+  align-items: center;
+  gap: .65rem;
+  min-width: 0;
+  margin-bottom: .9rem;
+}
+
+.releaseTag {
+  flex: 0 0 auto;
+  padding: .3rem .5rem;
+  color: var(--accent-text);
+  background: var(--accent-bg);
+  border: 1px solid var(--accent-border);
+  border-radius: .45rem;
+  font-family: var(--font-mono);
+  font-size: .72rem;
+  font-weight: 800;
+  letter-spacing: -.02em;
+}
+
+.releaseName {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--text-primary);
+  font-size: .9rem;
+  font-weight: 750;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.releaseMeta {
+  display: flex;
+  align-items: center;
+  gap: .7rem;
+  margin-left: auto;
+  color: var(--text-tertiary);
+  font-size: .72rem;
+  white-space: nowrap;
+}
+
+.sourceLink {
+  display: inline-flex;
+  align-items: center;
+  gap: .28rem;
+  color: var(--accent-text);
+  text-decoration: none;
+}
+.sourceLink:hover { text-decoration: underline; }
+
+.releaseBody :global(.markdown) { margin-top: .35rem; }
+
+@media (max-width: 640px) {
+  .releaseCard { padding: 1rem; }
+  .releaseHead { align-items: flex-start; flex-wrap: wrap; }
+  .releaseMeta { width: 100%; margin-left: 0; }
+}

--- a/openbank-admin-ui/src/app/docs/release-notes/[service]/page.tsx
+++ b/openbank-admin-ui/src/app/docs/release-notes/[service]/page.tsx
@@ -14,6 +14,7 @@ import { MermaidEnhancer } from '@/components/docs/MermaidEnhancer'
 import { fetchReleaseNotes, SERVICE_RE } from '@/lib/docs/releases'
 import { prettyLabel } from '@/lib/discovery'
 import { LANG_COOKIE } from '@/lib/i18n/LanguageContext'
+import styles from './ReleaseNotes.module.css'
 
 interface PageProps {
   params: Promise<{ service: string }>
@@ -90,34 +91,29 @@ export default async function ReleaseNotesPage({ params }: PageProps) {
           )}
         </div>
       ) : (
-        <div style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
+        <div className={styles.releaseList}>
           {releases.map(rel => (
-            <div key={rel.tag} className="card" style={{ padding: '20px' }}>
-              <div style={{ display: 'flex', alignItems: 'center', gap: '10px', marginBottom: '12px', flexWrap: 'wrap' }}>
-                <span style={{
-                  fontFamily: 'JetBrains Mono, monospace', fontSize: '13px', fontWeight: 700,
-                  color: 'var(--accent)', background: 'var(--accent-bg)', padding: '2px 8px',
-                  borderRadius: '6px',
-                }}>{rel.tag}</span>
-                <span style={{ fontSize: '14px', fontWeight: 600, color: 'var(--text-primary)' }}>{rel.name}</span>
-                {rel.publishedAt && (
-                  <span style={{ marginLeft: 'auto', fontSize: '12px', color: 'var(--text-tertiary)' }}>
-                    {formatDate(rel.publishedAt, lang)}
-                  </span>
-                )}
-                <a href={rel.url} target="_blank" rel="noreferrer"
-                  style={{ display: 'inline-flex', alignItems: 'center', gap: '4px', fontSize: '11px', color: 'var(--text-tertiary)' }}>
-                  <ExternalLink size={11} /> GitHub
-                </a>
+            <article key={rel.tag} className={styles.releaseCard}>
+              <div className={styles.releaseHead}>
+                <span className={styles.releaseTag}>{rel.tag}</span>
+                <span className={styles.releaseName}>{rel.name}</span>
+                <div className={styles.releaseMeta}>
+                  {rel.publishedAt && <span>{formatDate(rel.publishedAt, lang)}</span>}
+                  <a href={rel.url} target="_blank" rel="noreferrer" className={styles.sourceLink}>
+                    <ExternalLink size={12} /> GitHub
+                  </a>
+                </div>
               </div>
               {rel.body
                 ? (
-                  <MermaidEnhancer contentKey={`release-${service}-${rel.tag}`}>
-                    <MarkdownView markdown={rel.body} serviceName={service} />
-                  </MermaidEnhancer>
+                  <div className={styles.releaseBody}>
+                    <MermaidEnhancer contentKey={`release-${service}-${rel.tag}`}>
+                      <MarkdownView markdown={rel.body} serviceName={service} />
+                    </MermaidEnhancer>
+                  </div>
                 )
                 : <p style={{ fontSize: '12px', color: 'var(--text-tertiary)' }}>{t('Bez popisu.', 'No description.')}</p>}
-            </div>
+            </article>
           ))}
         </div>
       )}

--- a/openbank-admin-ui/src/app/document-templates/layout.tsx
+++ b/openbank-admin-ui/src/app/document-templates/layout.tsx
@@ -2,19 +2,10 @@
 // Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 
-import { Sidebar } from "@/components/layout/Sidebar"
-import { Header } from "@/components/layout/Header"
+import { AppShell } from "@/components/layout/AppShell"
 
 export default function Layout({ children }: { children: React.ReactNode }) {
   return (
-    <div style={{ display: "flex", height: "100vh", overflow: "hidden" }}>
-      <Sidebar />
-      <div style={{ flex: 1, display: "flex", flexDirection: "column", overflow: "hidden" }}>
-        <Header />
-        <main style={{ flex: 1, overflowY: "auto", padding: "24px", background: "var(--bg)" }}>
-          {children}
-        </main>
-      </div>
-    </div>
+    <AppShell>{children}</AppShell>
   )
 }

--- a/openbank-admin-ui/src/app/feedback/layout.tsx
+++ b/openbank-admin-ui/src/app/feedback/layout.tsx
@@ -2,19 +2,10 @@
 // Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 
-import { Sidebar } from "@/components/layout/Sidebar"
-import { Header } from "@/components/layout/Header"
+import { AppShell } from "@/components/layout/AppShell"
 
 export default function FeedbackLayout({ children }: { children: React.ReactNode }) {
   return (
-    <div style={{ display: "flex", height: "100vh", overflow: "hidden" }}>
-      <Sidebar />
-      <div style={{ flex: 1, display: "flex", flexDirection: "column", overflow: "hidden" }}>
-        <Header />
-        <main style={{ flex: 1, overflowY: "auto", padding: "24px", background: "var(--bg)" }}>
-          {children}
-        </main>
-      </div>
-    </div>
+    <AppShell>{children}</AppShell>
   )
 }

--- a/openbank-admin-ui/src/app/fees/layout.tsx
+++ b/openbank-admin-ui/src/app/fees/layout.tsx
@@ -2,19 +2,10 @@
 // Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 
-import { Sidebar } from "@/components/layout/Sidebar"
-import { Header } from "@/components/layout/Header"
+import { AppShell } from "@/components/layout/AppShell"
 
 export default function Layout({ children }: { children: React.ReactNode }) {
   return (
-    <div style={{ display: "flex", height: "100vh", overflow: "hidden" }}>
-      <Sidebar />
-      <div style={{ flex: 1, display: "flex", flexDirection: "column", overflow: "hidden" }}>
-        <Header />
-        <main style={{ flex: 1, overflowY: "auto", padding: "24px", background: "var(--bg)" }}>
-          {children}
-        </main>
-      </div>
-    </div>
+    <AppShell>{children}</AppShell>
   )
 }

--- a/openbank-admin-ui/src/app/finops/layout.tsx
+++ b/openbank-admin-ui/src/app/finops/layout.tsx
@@ -2,19 +2,10 @@
 // Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 
-import { Sidebar } from "@/components/layout/Sidebar"
-import { Header } from "@/components/layout/Header"
+import { AppShell } from "@/components/layout/AppShell"
 
 export default function FinOpsLayout({ children }: { children: React.ReactNode }) {
   return (
-    <div style={{ display: "flex", height: "100vh", overflow: "hidden" }}>
-      <Sidebar />
-      <div style={{ flex: 1, display: "flex", flexDirection: "column", overflow: "hidden" }}>
-        <Header />
-        <main style={{ flex: 1, overflowY: "auto", padding: "24px", background: "var(--bg)" }}>
-          {children}
-        </main>
-      </div>
-    </div>
+    <AppShell>{children}</AppShell>
   )
 }

--- a/openbank-admin-ui/src/app/fraud/layout.tsx
+++ b/openbank-admin-ui/src/app/fraud/layout.tsx
@@ -2,19 +2,10 @@
 // Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 
-import { Sidebar } from "@/components/layout/Sidebar"
-import { Header } from "@/components/layout/Header"
+import { AppShell } from "@/components/layout/AppShell"
 
 export default function udashboardLayout({ children }: { children: React.ReactNode }) {
   return (
-    <div style={{ display: "flex", height: "100vh", overflow: "hidden" }}>
-      <Sidebar />
-      <div style={{ flex: 1, display: "flex", flexDirection: "column", overflow: "hidden" }}>
-        <Header />
-        <main style={{ flex: 1, overflowY: "auto", padding: "24px", background: "var(--bg)" }}>
-          {children}
-        </main>
-      </div>
-    </div>
+    <AppShell>{children}</AppShell>
   )
 }

--- a/openbank-admin-ui/src/app/fraud/page.tsx
+++ b/openbank-admin-ui/src/app/fraud/page.tsx
@@ -9,9 +9,11 @@
 'use client'
 
 import { useCallback, useEffect, useState } from 'react'
-import { RefreshCw, ShieldAlert } from 'lucide-react'
+import { RefreshCw, ShieldAlert, CircleAlert, Clock3 } from 'lucide-react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
-import { svcUrl } from '@/lib/services/bff'
+import { classifyBffFailure, svcUrl } from '@/lib/services/bff'
+import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
+import { PageHeader, StatCard, StatusBadge, type Tone } from '@/components/ui'
 
 type ScoredRecord = {
   scoreId: string
@@ -26,27 +28,31 @@ type ScoredRecord = {
   createdAt: string
 }
 
-function scoreTone(score: number): { color: string; bg: string } {
-  if (score >= 80) return { color: '#dc2626', bg: '#fef2f2' }
-  if (score >= 50) return { color: '#d97706', bg: '#fffbeb' }
-  return { color: '#059669', bg: '#ecfdf5' }
+function scoreTone(score: number): Tone {
+  if (score >= 80) return 'danger'
+  if (score >= 50) return 'warning'
+  return 'success'
 }
 
 export default function FraudPage() {
-  const { t } = useLanguage()
+  const { t, language } = useLanguage()
   const [rows, setRows] = useState<ScoredRecord[]>([])
   const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
+  const [unavailable, setUnavailable] = useState<{ kind: UnavailableKind } | null>(null)
 
   const load = useCallback(async () => {
     setLoading(true)
     try {
       const res = await fetch(svcUrl('fraud-service', '/api/v1/fraud/review-queue', { limit: '50' }), { cache: 'no-store' })
-      if (!res.ok) throw new Error(String(res.status))
-      setRows(await res.json())
-      setError(null)
+      if (!res.ok) {
+        setUnavailable({ kind: await classifyBffFailure(res) })
+        return
+      }
+      const data = await res.json() as unknown
+      setRows(Array.isArray(data) ? data as ScoredRecord[] : [])
+      setUnavailable(null)
     } catch {
-      setError('unreachable')
+      setUnavailable({ kind: 'unreachable' })
     } finally {
       setLoading(false)
     }
@@ -54,37 +60,31 @@ export default function FraudPage() {
 
   useEffect(() => { void load() }, [load])
 
+  const critical = rows.filter(row => row.score >= 80).length
+  const elevated = rows.filter(row => row.score >= 50 && row.score < 80).length
+
   return (
     <div>
-      <div className="page-header">
-        <div>
-          <div className="breadcrumb">
-            <span>OpenBank</span><span className="breadcrumb-sep">/</span>
-            <span className="breadcrumb-current">{t('Fraud', 'Fraud')}</span>
-          </div>
-          <h1 className="page-title" style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-            <ShieldAlert size={18} style={{ color: 'var(--accent)' }} />
-            {t('Fraud review fronta', 'Fraud review queue')}
-          </h1>
-          <p className="page-subtitle">
-            {t(
-              'Platby označené enginem jako REVIEW (ADR-0230). Čtecí přehled — rozhodnutí patří do compliance toku, ne na klik.',
-              'Payments flagged REVIEW by the engine (ADR-0230). Read-only — resolution belongs to the compliance flow, not to a click.',
-            )}
-          </p>
-        </div>
-        <button onClick={load} disabled={loading} className="btn btn-secondary" style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 12 }}>
+      <PageHeader
+        title={t('Fraud review fronta', 'Fraud review queue')}
+        subtitle={t(
+          'Platby označené enginem jako REVIEW. Rozhodnutí zůstává ve čtyřočkovém compliance toku.',
+          'Payments flagged REVIEW by the engine. Resolution remains in the four-eyes compliance flow.',
+        )}
+        icon={<ShieldAlert size={20} style={{ color: 'var(--accent)' }} />}
+        actions={<button onClick={load} disabled={loading} className="btn btn-secondary btn-sm">
           <RefreshCw size={14} className={loading ? 'animate-spin' : ''} /> {t('Obnovit', 'Refresh')}
-        </button>
-      </div>
+        </button>}
+      />
 
-      {error && (
-        <div className="card" style={{ padding: 12, marginBottom: 16, borderLeft: '3px solid var(--danger)', color: 'var(--danger)', fontSize: 13 }}>
-          {t('fraud-service je nedostupný.', 'fraud-service is unreachable.')}
-        </div>
-      )}
+      {!unavailable && <section style={{ display: 'grid', gridTemplateColumns: 'repeat(3, minmax(0, 1fr))', gap: 16, marginBottom: 16 }} aria-label={t('Souhrn fronty', 'Queue summary')}>
+        <StatCard label={t('Čeká na posouzení', 'Awaiting review')} value={rows.length} hint={t('maximálně 50 nejnovějších záznamů', 'up to 50 most recent records')} icon={<Clock3 size={15} />} tone={rows.length ? 'warning' : 'neutral'} />
+        <StatCard label={t('Kritické skóre', 'Critical score')} value={critical} hint={t('skóre 80 a více', 'score 80 and above')} icon={<CircleAlert size={15} />} tone={critical ? 'danger' : 'neutral'} />
+        <StatCard label={t('Zvýšené skóre', 'Elevated score')} value={elevated} hint={t('skóre 50–79', 'score 50–79')} icon={<ShieldAlert size={15} />} tone={elevated ? 'warning' : 'neutral'} />
+      </section>}
 
       <div className="card" style={{ padding: 0, overflow: 'hidden' }}>
+        {unavailable ? <DataUnavailable kind={unavailable.kind} service="fraud-service" feature={t('Fraud review fronta', 'Fraud review queue')} lang={language} dense /> : (
         <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 13 }}>
           <thead>
             <tr style={{ background: 'var(--surface-2)', textAlign: 'left' }}>
@@ -109,9 +109,7 @@ export default function FraudPage() {
                     {r.accountId ? `${r.accountId.slice(0, 8)}…` : '—'}
                   </td>
                   <td style={{ padding: '10px 14px' }}>
-                    <span style={{ fontWeight: 800, color: tone.color, background: tone.bg, padding: '2px 8px', borderRadius: 10, fontSize: 12 }}>
-                      {r.score}
-                    </span>
+                    <StatusBadge status={String(r.score)} label={String(r.score)} tone={tone} />
                   </td>
                   <td style={{ padding: '10px 14px', fontSize: 11, color: 'var(--text-tertiary)', fontFamily: 'var(--font-mono)' }}>
                     {r.ruleVersion}
@@ -129,6 +127,7 @@ export default function FraudPage() {
             )}
           </tbody>
         </table>
+        )}
       </div>
     </div>
   )

--- a/openbank-admin-ui/src/app/fx/layout.tsx
+++ b/openbank-admin-ui/src/app/fx/layout.tsx
@@ -2,19 +2,10 @@
 // Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 
-import { Sidebar } from "@/components/layout/Sidebar"
-import { Header } from "@/components/layout/Header"
+import { AppShell } from "@/components/layout/AppShell"
 
 export default function Layout({ children }: { children: React.ReactNode }) {
   return (
-    <div style={{ display: "flex", height: "100vh", overflow: "hidden" }}>
-      <Sidebar />
-      <div style={{ flex: 1, display: "flex", flexDirection: "column", overflow: "hidden" }}>
-        <Header />
-        <main style={{ flex: 1, overflowY: "auto", background: "var(--bg)" }}>
-          {children}
-        </main>
-      </div>
-    </div>
+    <AppShell>{children}</AppShell>
   )
 }

--- a/openbank-admin-ui/src/app/globals.css
+++ b/openbank-admin-ui/src/app/globals.css
@@ -144,6 +144,42 @@ main {
   animation: fadeIn 0.4s ease-out;
 }
 
+/* ── Operator application shell ── */
+.ob-app-shell {
+  display: flex;
+  height: 100dvh;
+  min-height: 0;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 100% 0%, rgba(129, 140, 248, .10), transparent 30rem),
+    radial-gradient(circle at 5% 100%, rgba(45, 212, 191, .06), transparent 32rem),
+    var(--bg);
+}
+.ob-app-frame {
+  display: flex;
+  min-width: 0;
+  flex: 1;
+  flex-direction: column;
+  overflow: hidden;
+}
+.ob-app-content {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+  padding: clamp(1rem, 2vw, 2rem);
+  background: transparent;
+}
+.ob-app-content > * {
+  width: min(100%, 1600px);
+  margin-inline: auto;
+}
+
+@media (max-width: 860px) {
+  .ob-app-shell { display: block; overflow: auto; }
+  .ob-app-frame { min-height: 100dvh; }
+  .ob-app-content { padding: 1rem; }
+}
+
 /* ── Scrollbar ── */
 ::-webkit-scrollbar { width: 5px; height: 5px; }
 ::-webkit-scrollbar-track { background: transparent; }

--- a/openbank-admin-ui/src/app/iaops/layout.tsx
+++ b/openbank-admin-ui/src/app/iaops/layout.tsx
@@ -2,19 +2,10 @@
 // Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 
-import { Sidebar } from "@/components/layout/Sidebar"
-import { Header } from "@/components/layout/Header"
+import { AppShell } from "@/components/layout/AppShell"
 
 export default function IAOpsLayout({ children }: { children: React.ReactNode }) {
   return (
-    <div style={{ display: "flex", height: "100vh", overflow: "hidden" }}>
-      <Sidebar />
-      <div style={{ flex: 1, display: "flex", flexDirection: "column", overflow: "hidden" }}>
-        <Header />
-        <main style={{ flex: 1, overflowY: "auto", padding: "24px", background: "var(--bg)" }}>
-          {children}
-        </main>
-      </div>
-    </div>
+    <AppShell>{children}</AppShell>
   )
 }

--- a/openbank-admin-ui/src/app/identity-cases/layout.tsx
+++ b/openbank-admin-ui/src/app/identity-cases/layout.tsx
@@ -2,19 +2,10 @@
 // Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 
-import { Sidebar } from "@/components/layout/Sidebar"
-import { Header } from "@/components/layout/Header"
+import { AppShell } from "@/components/layout/AppShell"
 
 export default function Layout({ children }: { children: React.ReactNode }) {
   return (
-    <div style={{ display: "flex", height: "100vh", overflow: "hidden" }}>
-      <Sidebar />
-      <div style={{ flex: 1, display: "flex", flexDirection: "column", overflow: "hidden" }}>
-        <Header />
-        <main style={{ flex: 1, overflowY: "auto", padding: "24px", background: "var(--bg)" }}>
-          {children}
-        </main>
-      </div>
-    </div>
+    <AppShell>{children}</AppShell>
   )
 }

--- a/openbank-admin-ui/src/app/infrastructure/layout.tsx
+++ b/openbank-admin-ui/src/app/infrastructure/layout.tsx
@@ -2,19 +2,10 @@
 // Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 
-import { Sidebar } from "@/components/layout/Sidebar"
-import { Header } from "@/components/layout/Header"
+import { AppShell } from "@/components/layout/AppShell"
 
 export default function InfrastructureLayout({ children }: { children: React.ReactNode }) {
   return (
-    <div style={{ display: "flex", height: "100vh", overflow: "hidden" }}>
-      <Sidebar />
-      <div style={{ flex: 1, display: "flex", flexDirection: "column", overflow: "hidden" }}>
-        <Header />
-        <main style={{ flex: 1, overflowY: "auto", padding: "24px", background: "var(--bg)" }}>
-          {children}
-        </main>
-      </div>
-    </div>
+    <AppShell>{children}</AppShell>
   )
 }

--- a/openbank-admin-ui/src/app/interest/layout.tsx
+++ b/openbank-admin-ui/src/app/interest/layout.tsx
@@ -2,19 +2,10 @@
 // Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 
-import { Sidebar } from "@/components/layout/Sidebar"
-import { Header } from "@/components/layout/Header"
+import { AppShell } from "@/components/layout/AppShell"
 
 export default function Layout({ children }: { children: React.ReactNode }) {
   return (
-    <div style={{ display: "flex", height: "100vh", overflow: "hidden" }}>
-      <Sidebar />
-      <div style={{ flex: 1, display: "flex", flexDirection: "column", overflow: "hidden" }}>
-        <Header />
-        <main style={{ flex: 1, overflowY: "auto", background: "var(--bg)" }}>
-          {children}
-        </main>
-      </div>
-    </div>
+    <AppShell>{children}</AppShell>
   )
 }

--- a/openbank-admin-ui/src/app/kyc/layout.tsx
+++ b/openbank-admin-ui/src/app/kyc/layout.tsx
@@ -2,19 +2,10 @@
 // Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 
-import { Sidebar } from "@/components/layout/Sidebar"
-import { Header } from "@/components/layout/Header"
+import { AppShell } from "@/components/layout/AppShell"
 
 export default function Layout({ children }: { children: React.ReactNode }) {
   return (
-    <div style={{ display: "flex", height: "100vh", overflow: "hidden" }}>
-      <Sidebar />
-      <div style={{ flex: 1, display: "flex", flexDirection: "column", overflow: "hidden" }}>
-        <Header />
-        <main style={{ flex: 1, overflowY: "auto", padding: "24px", background: "var(--bg)" }}>
-          {children}
-        </main>
-      </div>
-    </div>
+    <AppShell>{children}</AppShell>
   )
 }

--- a/openbank-admin-ui/src/app/ledger/layout.tsx
+++ b/openbank-admin-ui/src/app/ledger/layout.tsx
@@ -2,19 +2,10 @@
 // Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 
-import { Sidebar } from "@/components/layout/Sidebar"
-import { Header } from "@/components/layout/Header"
+import { AppShell } from "@/components/layout/AppShell"
 
 export default function uledgerLayout({ children }: { children: React.ReactNode }) {
   return (
-    <div style={{ display: "flex", height: "100vh", overflow: "hidden" }}>
-      <Sidebar />
-      <div style={{ flex: 1, display: "flex", flexDirection: "column", overflow: "hidden" }}>
-        <Header />
-        <main style={{ flex: 1, overflowY: "auto", padding: "24px", background: "var(--bg)" }}>
-          {children}
-        </main>
-      </div>
-    </div>
+    <AppShell>{children}</AppShell>
   )
 }

--- a/openbank-admin-ui/src/app/lending/layout.tsx
+++ b/openbank-admin-ui/src/app/lending/layout.tsx
@@ -2,19 +2,10 @@
 // Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 
-import { Sidebar } from "@/components/layout/Sidebar"
-import { Header } from "@/components/layout/Header"
+import { AppShell } from "@/components/layout/AppShell"
 
 export default function udashboardLayout({ children }: { children: React.ReactNode }) {
   return (
-    <div style={{ display: "flex", height: "100vh", overflow: "hidden" }}>
-      <Sidebar />
-      <div style={{ flex: 1, display: "flex", flexDirection: "column", overflow: "hidden" }}>
-        <Header />
-        <main style={{ flex: 1, overflowY: "auto", padding: "24px", background: "var(--bg)" }}>
-          {children}
-        </main>
-      </div>
-    </div>
+    <AppShell>{children}</AppShell>
   )
 }

--- a/openbank-admin-ui/src/app/notifications/layout.tsx
+++ b/openbank-admin-ui/src/app/notifications/layout.tsx
@@ -2,19 +2,10 @@
 // Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 
-import { Sidebar } from "@/components/layout/Sidebar"
-import { Header } from "@/components/layout/Header"
+import { AppShell } from "@/components/layout/AppShell"
 
 export default function Layout({ children }: { children: React.ReactNode }) {
   return (
-    <div style={{ display: "flex", height: "100vh", overflow: "hidden" }}>
-      <Sidebar />
-      <div style={{ flex: 1, display: "flex", flexDirection: "column", overflow: "hidden" }}>
-        <Header />
-        <main style={{ flex: 1, overflowY: "auto", padding: "24px", background: "var(--bg)" }}>
-          {children}
-        </main>
-      </div>
-    </div>
+    <AppShell>{children}</AppShell>
   )
 }

--- a/openbank-admin-ui/src/app/observability/layout.tsx
+++ b/openbank-admin-ui/src/app/observability/layout.tsx
@@ -2,19 +2,10 @@
 // Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 
-import { Sidebar } from "@/components/layout/Sidebar"
-import { Header } from "@/components/layout/Header"
+import { AppShell } from "@/components/layout/AppShell"
 
 export default function ObservabilityLayout({ children }: { children: React.ReactNode }) {
   return (
-    <div style={{ display: "flex", height: "100vh", overflow: "hidden" }}>
-      <Sidebar />
-      <div style={{ flex: 1, display: "flex", flexDirection: "column", overflow: "hidden" }}>
-        <Header />
-        <main style={{ flex: 1, overflowY: "auto", padding: "24px", background: "var(--bg)" }}>
-          {children}
-        </main>
-      </div>
-    </div>
+    <AppShell>{children}</AppShell>
   )
 }

--- a/openbank-admin-ui/src/app/onboarding/layout.tsx
+++ b/openbank-admin-ui/src/app/onboarding/layout.tsx
@@ -2,19 +2,10 @@
 // Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 
-import { Sidebar } from "@/components/layout/Sidebar"
-import { Header } from "@/components/layout/Header"
+import { AppShell } from "@/components/layout/AppShell"
 
 export default function Layout({ children }: { children: React.ReactNode }) {
   return (
-    <div style={{ display: "flex", height: "100vh", overflow: "hidden" }}>
-      <Sidebar />
-      <div style={{ flex: 1, display: "flex", flexDirection: "column", overflow: "hidden" }}>
-        <Header />
-        <main style={{ flex: 1, overflowY: "auto", padding: "24px", background: "var(--bg)" }}>
-          {children}
-        </main>
-      </div>
-    </div>
+    <AppShell>{children}</AppShell>
   )
 }

--- a/openbank-admin-ui/src/app/parties/layout.tsx
+++ b/openbank-admin-ui/src/app/parties/layout.tsx
@@ -2,19 +2,10 @@
 // Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 
-import { Sidebar } from "@/components/layout/Sidebar"
-import { Header } from "@/components/layout/Header"
+import { AppShell } from "@/components/layout/AppShell"
 
 export default function Layout({ children }: { children: React.ReactNode }) {
   return (
-    <div style={{ display: "flex", height: "100vh", overflow: "hidden" }}>
-      <Sidebar />
-      <div style={{ flex: 1, display: "flex", flexDirection: "column", overflow: "hidden" }}>
-        <Header />
-        <main style={{ flex: 1, overflowY: "auto", padding: "24px", background: "var(--bg)" }}>
-          {children}
-        </main>
-      </div>
-    </div>
+    <AppShell>{children}</AppShell>
   )
 }

--- a/openbank-admin-ui/src/app/payments/layout.tsx
+++ b/openbank-admin-ui/src/app/payments/layout.tsx
@@ -2,19 +2,10 @@
 // Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 
-import { Sidebar } from "@/components/layout/Sidebar"
-import { Header } from "@/components/layout/Header"
+import { AppShell } from "@/components/layout/AppShell"
 
 export default function Layout({ children }: { children: React.ReactNode }) {
   return (
-    <div style={{ display: "flex", height: "100vh", overflow: "hidden" }}>
-      <Sidebar />
-      <div style={{ flex: 1, display: "flex", flexDirection: "column", overflow: "hidden" }}>
-        <Header />
-        <main style={{ flex: 1, overflowY: "auto", padding: "24px", background: "var(--bg)" }}>
-          {children}
-        </main>
-      </div>
-    </div>
+    <AppShell>{children}</AppShell>
   )
 }

--- a/openbank-admin-ui/src/app/pid/layout.tsx
+++ b/openbank-admin-ui/src/app/pid/layout.tsx
@@ -2,19 +2,10 @@
 // Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 
-import { Sidebar } from "@/components/layout/Sidebar"
-import { Header } from "@/components/layout/Header"
+import { AppShell } from "@/components/layout/AppShell"
 
 export default function Layout({ children }: { children: React.ReactNode }) {
   return (
-    <div style={{ display: "flex", height: "100vh", overflow: "hidden" }}>
-      <Sidebar />
-      <div style={{ flex: 1, display: "flex", flexDirection: "column", overflow: "hidden" }}>
-        <Header />
-        <main style={{ flex: 1, overflowY: "auto", padding: "24px", background: "var(--bg)" }}>
-          {children}
-        </main>
-      </div>
-    </div>
+    <AppShell>{children}</AppShell>
   )
 }

--- a/openbank-admin-ui/src/app/product-catalog/layout.tsx
+++ b/openbank-admin-ui/src/app/product-catalog/layout.tsx
@@ -2,19 +2,10 @@
 // Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 
-import { Sidebar } from "@/components/layout/Sidebar"
-import { Header } from "@/components/layout/Header"
+import { AppShell } from "@/components/layout/AppShell"
 
 export default function Layout({ children }: { children: React.ReactNode }) {
   return (
-    <div style={{ display: "flex", height: "100vh", overflow: "hidden" }}>
-      <Sidebar />
-      <div style={{ flex: 1, display: "flex", flexDirection: "column", overflow: "hidden" }}>
-        <Header />
-        <main style={{ flex: 1, overflowY: "auto", padding: "24px", background: "var(--bg)" }}>
-          {children}
-        </main>
-      </div>
-    </div>
+    <AppShell>{children}</AppShell>
   )
 }

--- a/openbank-admin-ui/src/app/product-studio/layout.tsx
+++ b/openbank-admin-ui/src/app/product-studio/layout.tsx
@@ -2,15 +2,8 @@
 // Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 
-import { Header } from '@/components/layout/Header'
-import { Sidebar } from '@/components/layout/Sidebar'
+import { AppShell } from '@/components/layout/AppShell'
 
 export default function Layout({ children }: { children: React.ReactNode }) {
-  return <div style={{ display: 'flex', height: '100vh', overflow: 'hidden' }}>
-    <Sidebar />
-    <div style={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
-      <Header />
-      <main style={{ flex: 1, overflowY: 'auto', padding: 24, background: 'var(--bg)' }}>{children}</main>
-    </div>
-  </div>
+  return <AppShell>{children}</AppShell>
 }

--- a/openbank-admin-ui/src/app/regulatory/layout.tsx
+++ b/openbank-admin-ui/src/app/regulatory/layout.tsx
@@ -2,19 +2,10 @@
 // Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 
-import { Sidebar } from "@/components/layout/Sidebar"
-import { Header } from "@/components/layout/Header"
+import { AppShell } from "@/components/layout/AppShell"
 
 export default function RegulatoryLayout({ children }: { children: React.ReactNode }) {
   return (
-    <div style={{ display: "flex", height: "100vh", overflow: "hidden" }}>
-      <Sidebar />
-      <div style={{ flex: 1, display: "flex", flexDirection: "column", overflow: "hidden" }}>
-        <Header />
-        <main style={{ flex: 1, overflowY: "auto", padding: "24px", background: "var(--bg)" }}>
-          {children}
-        </main>
-      </div>
-    </div>
+    <AppShell>{children}</AppShell>
   )
 }

--- a/openbank-admin-ui/src/app/sanctions/layout.tsx
+++ b/openbank-admin-ui/src/app/sanctions/layout.tsx
@@ -2,19 +2,10 @@
 // Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 
-import { Sidebar } from "@/components/layout/Sidebar"
-import { Header } from "@/components/layout/Header"
+import { AppShell } from "@/components/layout/AppShell"
 
 export default function Layout({ children }: { children: React.ReactNode }) {
   return (
-    <div style={{ display: "flex", height: "100vh", overflow: "hidden" }}>
-      <Sidebar />
-      <div style={{ flex: 1, display: "flex", flexDirection: "column", overflow: "hidden" }}>
-        <Header />
-        <main style={{ flex: 1, overflowY: "auto", background: "var(--bg)" }}>
-          {children}
-        </main>
-      </div>
-    </div>
+    <AppShell>{children}</AppShell>
   )
 }

--- a/openbank-admin-ui/src/app/sdd/layout.tsx
+++ b/openbank-admin-ui/src/app/sdd/layout.tsx
@@ -2,19 +2,10 @@
 // Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 
-import { Sidebar } from "@/components/layout/Sidebar"
-import { Header } from "@/components/layout/Header"
+import { AppShell } from "@/components/layout/AppShell"
 
 export default function SddLayout({ children }: { children: React.ReactNode }) {
   return (
-    <div style={{ display: "flex", height: "100vh", overflow: "hidden" }}>
-      <Sidebar />
-      <div style={{ flex: 1, display: "flex", flexDirection: "column", overflow: "hidden" }}>
-        <Header />
-        <main style={{ flex: 1, overflowY: "auto", padding: "24px", background: "var(--bg)" }}>
-          {children}
-        </main>
-      </div>
-    </div>
+    <AppShell>{children}</AppShell>
   )
 }

--- a/openbank-admin-ui/src/app/sdd/page.tsx
+++ b/openbank-admin-ui/src/app/sdd/page.tsx
@@ -12,7 +12,9 @@
 import { useCallback, useEffect, useState } from 'react'
 import { RefreshCw, Repeat } from 'lucide-react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
-import { svcUrl } from '@/lib/services/bff'
+import { classifyBffFailure, svcUrl } from '@/lib/services/bff'
+import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
+import { PageHeader, StatusBadge } from '@/components/ui'
 
 type Mandate = {
   id: string
@@ -27,19 +29,12 @@ type Mandate = {
 // Mirrors MandateStatus in sdd-service — an omitted member is a filter an operator cannot select.
 const STATUSES = ['', 'PENDING_CONFIRMATION', 'ACTIVE', 'SUSPENDED', 'CANCELLED', 'EXPIRED'] as const
 
-const STATUS_TONE: Record<string, { color: string; bg: string }> = {
-  ACTIVE: { color: '#059669', bg: '#ecfdf5' },
-  PENDING_CONFIRMATION: { color: '#d97706', bg: '#fffbeb' },
-  SUSPENDED: { color: '#6b7280', bg: '#f9fafb' },
-  CANCELLED: { color: '#dc2626', bg: '#fef2f2' },
-}
-
 export default function SddPage() {
-  const { t } = useLanguage()
+  const { t, language } = useLanguage()
   const [status, setStatus] = useState('')
   const [rows, setRows] = useState<Mandate[]>([])
   const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
+  const [unavailable, setUnavailable] = useState<{ kind: UnavailableKind } | null>(null)
 
   const load = useCallback(async () => {
     setLoading(true)
@@ -47,11 +42,15 @@ export default function SddPage() {
       const res = await fetch(svcUrl('sdd-service', '/api/v1/sdd/mandates/recent', {
         limit: '50', ...(status ? { status } : {}),
       }), { cache: 'no-store' })
-      if (!res.ok) throw new Error(String(res.status))
-      setRows(await res.json())
-      setError(null)
+      if (!res.ok) {
+        setUnavailable({ kind: await classifyBffFailure(res) })
+        return
+      }
+      const data = await res.json() as unknown
+      setRows(Array.isArray(data) ? data as Mandate[] : [])
+      setUnavailable(null)
     } catch {
-      setError('unreachable')
+      setUnavailable({ kind: 'unreachable' })
     } finally {
       setLoading(false)
     }
@@ -61,35 +60,19 @@ export default function SddPage() {
 
   return (
     <div>
-      <div className="page-header">
-        <div>
-          <div className="breadcrumb">
-            <span>OpenBank</span><span className="breadcrumb-sep">/</span>
-            <span className="breadcrumb-current">{t('Inkasa (SDD)', 'Direct Debits (SDD)')}</span>
-          </div>
-          <h1 className="page-title" style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-            <Repeat size={18} style={{ color: 'var(--accent)' }} />
-            {t('Mandáty inkas', 'Direct debit mandates')}
-          </h1>
-          <p className="page-subtitle">
-            {t(
-              'Čtecí přehled mandátů (ADR-0230) včetně B2B fronty čekajících na potvrzení. Změny stavu patří do řízených toků, ne na klik.',
-              'Read-only mandate view (ADR-0230) incl. the B2B confirmation queue. Lifecycle changes belong to governed flows, not to a click.',
-            )}
-          </p>
-        </div>
-        <button onClick={load} disabled={loading} className="btn btn-secondary" style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 12 }}>
+      <PageHeader
+        title={t('Mandáty inkas', 'Direct debit mandates')}
+        subtitle={t(
+          'Čtecí přehled mandátů včetně B2B fronty čekajících na potvrzení. Změny stavu patří do řízených toků.',
+          'Read-only mandate view including the B2B confirmation queue. Lifecycle changes belong to governed flows.',
+        )}
+        icon={<Repeat size={20} style={{ color: 'var(--accent)' }} />}
+        actions={<button onClick={load} disabled={loading} className="btn btn-secondary btn-sm">
           <RefreshCw size={14} className={loading ? 'animate-spin' : ''} /> {t('Obnovit', 'Refresh')}
-        </button>
-      </div>
+        </button>}
+      />
 
-      {error && (
-        <div className="card" style={{ padding: 12, marginBottom: 16, borderLeft: '3px solid var(--danger)', color: 'var(--danger)', fontSize: 13 }}>
-          {t('sdd-service je nedostupný.', 'sdd-service is unreachable.')}
-        </div>
-      )}
-
-      <div style={{ display: 'flex', gap: 4, marginBottom: 14 }}>
+      {!unavailable && <div style={{ display: 'flex', gap: 4, marginBottom: 14 }}>
         <select
           value={status}
           onChange={e => setStatus(e.target.value)}
@@ -98,9 +81,10 @@ export default function SddPage() {
         >
           {STATUSES.map(s => <option key={s} value={s}>{s === '' ? t('Všechny stavy', 'All statuses') : s}</option>)}
         </select>
-      </div>
+      </div>}
 
       <div className="card" style={{ padding: 0, overflow: 'hidden' }}>
+        {unavailable ? <DataUnavailable kind={unavailable.kind} service="sdd-service" feature={t('Mandáty inkas', 'Direct debit mandates')} lang={language} dense /> : (
         <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 13 }}>
           <thead>
             <tr style={{ background: 'var(--surface-2)', textAlign: 'left' }}>
@@ -114,7 +98,6 @@ export default function SddPage() {
           </thead>
           <tbody>
             {rows.map(m => {
-              const tone = STATUS_TONE[m.status] ?? { color: 'var(--text-secondary)', bg: 'var(--surface-3)' }
               return (
                 <tr key={m.id} style={{ borderTop: '1px solid var(--border)' }}>
                   <td style={{ padding: '10px 14px', fontFamily: 'var(--font-mono)', fontSize: 12 }}>{m.umr ?? m.id.slice(0, 8)}</td>
@@ -122,9 +105,7 @@ export default function SddPage() {
                   <td style={{ padding: '10px 14px', fontFamily: 'var(--font-mono)', fontSize: 12 }}>{m.debtorIban ?? '—'}</td>
                   <td style={{ padding: '10px 14px' }}>{m.scheme ?? '—'}</td>
                   <td style={{ padding: '10px 14px' }}>
-                    <span style={{ fontWeight: 700, color: tone.color, background: tone.bg, padding: '2px 8px', borderRadius: 10, fontSize: 11 }}>
-                      {m.status}
-                    </span>
+                    <StatusBadge status={m.status} />
                   </td>
                   <td style={{ padding: '10px 14px', color: 'var(--text-tertiary)', fontSize: 12 }}>
                     {m.createdAt ? new Date(m.createdAt).toLocaleString() : '—'}
@@ -139,6 +120,7 @@ export default function SddPage() {
             )}
           </tbody>
         </table>
+        )}
       </div>
     </div>
   )

--- a/openbank-admin-ui/src/app/security/layout.tsx
+++ b/openbank-admin-ui/src/app/security/layout.tsx
@@ -2,19 +2,10 @@
 // Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 
-import { Sidebar } from "@/components/layout/Sidebar"
-import { Header } from "@/components/layout/Header"
+import { AppShell } from "@/components/layout/AppShell"
 
 export default function Layout({ children }: { children: React.ReactNode }) {
   return (
-    <div style={{ display: "flex", height: "100vh", overflow: "hidden" }}>
-      <Sidebar />
-      <div style={{ flex: 1, display: "flex", flexDirection: "column", overflow: "hidden" }}>
-        <Header />
-        <main style={{ flex: 1, overflowY: "auto", background: "var(--bg)" }}>
-          {children}
-        </main>
-      </div>
-    </div>
+    <AppShell>{children}</AppShell>
   )
 }

--- a/openbank-admin-ui/src/app/segments/layout.tsx
+++ b/openbank-admin-ui/src/app/segments/layout.tsx
@@ -2,19 +2,10 @@
 // Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 
-import { Sidebar } from "@/components/layout/Sidebar"
-import { Header } from "@/components/layout/Header"
+import { AppShell } from "@/components/layout/AppShell"
 
 export default function Layout({ children }: { children: React.ReactNode }) {
   return (
-    <div style={{ display: "flex", height: "100vh", overflow: "hidden" }}>
-      <Sidebar />
-      <div style={{ flex: 1, display: "flex", flexDirection: "column", overflow: "hidden" }}>
-        <Header />
-        <main style={{ flex: 1, overflowY: "auto", padding: "24px", background: "var(--bg)" }}>
-          {children}
-        </main>
-      </div>
-    </div>
+    <AppShell>{children}</AppShell>
   )
 }

--- a/openbank-admin-ui/src/app/sepa-instant/layout.tsx
+++ b/openbank-admin-ui/src/app/sepa-instant/layout.tsx
@@ -2,19 +2,10 @@
 // Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 
-import { Sidebar } from "@/components/layout/Sidebar"
-import { Header } from "@/components/layout/Header"
+import { AppShell } from "@/components/layout/AppShell"
 
 export default function Layout({ children }: { children: React.ReactNode }) {
   return (
-    <div style={{ display: "flex", height: "100vh", overflow: "hidden" }}>
-      <Sidebar />
-      <div style={{ flex: 1, display: "flex", flexDirection: "column", overflow: "hidden" }}>
-        <Header />
-        <main style={{ flex: 1, overflowY: "auto", background: "var(--bg)" }}>
-          {children}
-        </main>
-      </div>
-    </div>
+    <AppShell>{children}</AppShell>
   )
 }

--- a/openbank-admin-ui/src/app/services/layout.tsx
+++ b/openbank-admin-ui/src/app/services/layout.tsx
@@ -2,19 +2,10 @@
 // Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 
-import { Sidebar } from "@/components/layout/Sidebar"
-import { Header } from "@/components/layout/Header"
+import { AppShell } from "@/components/layout/AppShell"
 
 export default function ServicesLayout({ children }: { children: React.ReactNode }) {
   return (
-    <div style={{ display: "flex", height: "100vh", overflow: "hidden" }}>
-      <Sidebar />
-      <div style={{ flex: 1, display: "flex", flexDirection: "column", overflow: "hidden" }}>
-        <Header />
-        <main style={{ flex: 1, overflowY: "auto", padding: "24px", background: "var(--bg)" }}>
-          {children}
-        </main>
-      </div>
-    </div>
+    <AppShell>{children}</AppShell>
   )
 }

--- a/openbank-admin-ui/src/app/settings/layout.tsx
+++ b/openbank-admin-ui/src/app/settings/layout.tsx
@@ -2,19 +2,10 @@
 // Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 
-import { Sidebar } from '@/components/layout/Sidebar'
-import { Header } from '@/components/layout/Header'
+import { AppShell } from '@/components/layout/AppShell'
 
 export default function SettingsLayout({ children }: { children: React.ReactNode }) {
   return (
-    <div style={{ display: 'flex', height: '100vh', overflow: 'hidden' }}>
-      <Sidebar />
-      <div style={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
-        <Header />
-        <main style={{ flex: 1, overflowY: 'auto', padding: '24px', background: 'var(--bg)' }}>
-          {children}
-        </main>
-      </div>
-    </div>
+    <AppShell>{children}</AppShell>
   )
 }

--- a/openbank-admin-ui/src/app/standing-orders/layout.tsx
+++ b/openbank-admin-ui/src/app/standing-orders/layout.tsx
@@ -2,19 +2,10 @@
 // Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 
-import { Sidebar } from "@/components/layout/Sidebar"
-import { Header } from "@/components/layout/Header"
+import { AppShell } from "@/components/layout/AppShell"
 
 export default function Layout({ children }: { children: React.ReactNode }) {
   return (
-    <div style={{ display: "flex", height: "100vh", overflow: "hidden" }}>
-      <Sidebar />
-      <div style={{ flex: 1, display: "flex", flexDirection: "column", overflow: "hidden" }}>
-        <Header />
-        <main style={{ flex: 1, overflowY: "auto", background: "var(--bg)" }}>
-          {children}
-        </main>
-      </div>
-    </div>
+    <AppShell>{children}</AppShell>
   )
 }

--- a/openbank-admin-ui/src/app/swift/layout.tsx
+++ b/openbank-admin-ui/src/app/swift/layout.tsx
@@ -2,19 +2,10 @@
 // Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 
-import { Sidebar } from "@/components/layout/Sidebar"
-import { Header } from "@/components/layout/Header"
+import { AppShell } from "@/components/layout/AppShell"
 
 export default function Layout({ children }: { children: React.ReactNode }) {
   return (
-    <div style={{ display: "flex", height: "100vh", overflow: "hidden" }}>
-      <Sidebar />
-      <div style={{ flex: 1, display: "flex", flexDirection: "column", overflow: "hidden" }}>
-        <Header />
-        <main style={{ flex: 1, overflowY: "auto", background: "var(--bg)" }}>
-          {children}
-        </main>
-      </div>
-    </div>
+    <AppShell>{children}</AppShell>
   )
 }

--- a/openbank-admin-ui/src/app/system/layout.tsx
+++ b/openbank-admin-ui/src/app/system/layout.tsx
@@ -2,19 +2,10 @@
 // Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 
-import { Sidebar } from "@/components/layout/Sidebar"
-import { Header } from "@/components/layout/Header"
+import { AppShell } from "@/components/layout/AppShell"
 
 export default function usystemLayout({ children }: { children: React.ReactNode }) {
   return (
-    <div style={{ display: "flex", height: "100vh", overflow: "hidden" }}>
-      <Sidebar />
-      <div style={{ flex: 1, display: "flex", flexDirection: "column", overflow: "hidden" }}>
-        <Header />
-        <main style={{ flex: 1, overflowY: "auto", padding: "24px", background: "var(--bg)" }}>
-          {children}
-        </main>
-      </div>
-    </div>
+    <AppShell>{children}</AppShell>
   )
 }

--- a/openbank-admin-ui/src/app/technical-accounts/layout.tsx
+++ b/openbank-admin-ui/src/app/technical-accounts/layout.tsx
@@ -2,19 +2,10 @@
 // Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 
-import { Sidebar } from "@/components/layout/Sidebar"
-import { Header } from "@/components/layout/Header"
+import { AppShell } from "@/components/layout/AppShell"
 
 export default function TechnicalAccountsLayout({ children }: { children: React.ReactNode }) {
   return (
-    <div style={{ display: "flex", height: "100vh", overflow: "hidden" }}>
-      <Sidebar />
-      <div style={{ flex: 1, display: "flex", flexDirection: "column", overflow: "hidden" }}>
-        <Header />
-        <main style={{ flex: 1, overflowY: "auto", padding: "24px", background: "var(--bg)" }}>
-          {children}
-        </main>
-      </div>
-    </div>
+    <AppShell>{children}</AppShell>
   )
 }

--- a/openbank-admin-ui/src/app/temporal/layout.tsx
+++ b/openbank-admin-ui/src/app/temporal/layout.tsx
@@ -2,19 +2,10 @@
 // Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 
-import { Sidebar } from "@/components/layout/Sidebar"
-import { Header } from "@/components/layout/Header"
+import { AppShell } from "@/components/layout/AppShell"
 
 export default function TemporalLayout({ children }: { children: React.ReactNode }) {
   return (
-    <div style={{ display: "flex", height: "100vh", overflow: "hidden" }}>
-      <Sidebar />
-      <div style={{ flex: 1, display: "flex", flexDirection: "column", overflow: "hidden" }}>
-        <Header />
-        <main style={{ flex: 1, overflowY: "auto", padding: "24px", background: "var(--bg)" }}>
-          {children}
-        </main>
-      </div>
-    </div>
+    <AppShell>{children}</AppShell>
   )
 }

--- a/openbank-admin-ui/src/app/transactions/layout.tsx
+++ b/openbank-admin-ui/src/app/transactions/layout.tsx
@@ -2,19 +2,10 @@
 // Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 
-import { Sidebar } from "@/components/layout/Sidebar"
-import { Header } from "@/components/layout/Header"
+import { AppShell } from "@/components/layout/AppShell"
 
 export default function utransactionsLayout({ children }: { children: React.ReactNode }) {
   return (
-    <div style={{ display: "flex", height: "100vh", overflow: "hidden" }}>
-      <Sidebar />
-      <div style={{ flex: 1, display: "flex", flexDirection: "column", overflow: "hidden" }}>
-        <Header />
-        <main style={{ flex: 1, overflowY: "auto", padding: "24px", background: "var(--bg)" }}>
-          {children}
-        </main>
-      </div>
-    </div>
+    <AppShell>{children}</AppShell>
   )
 }

--- a/openbank-admin-ui/src/components/layout/AppShell.tsx
+++ b/openbank-admin-ui/src/components/layout/AppShell.tsx
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import type { ReactNode } from 'react'
+import { Header } from '@/components/layout/Header'
+import { Sidebar } from '@/components/layout/Sidebar'
+
+/**
+ * The single authenticated operator shell.
+ *
+ * Domain layouts used to copy this structure verbatim, which made the visual
+ * hierarchy and accessibility behaviour drift as each page family evolved.
+ * Keeping the shell here lets domain routes own only their content.
+ */
+export function AppShell({ children }: { children: ReactNode }) {
+  return (
+    <div className="ob-app-shell">
+      <Sidebar />
+      <div className="ob-app-frame">
+        <Header />
+        <main className="ob-app-content">{children}</main>
+      </div>
+    </div>
+  )
+}

--- a/openbank-admin-ui/src/components/ui/tone.ts
+++ b/openbank-admin-ui/src/components/ui/tone.ts
@@ -96,6 +96,7 @@ const TONE_BY_STATUS: Record<string, Tone> = {
   IN_PROGRESS: 'warning',
   PENDING: 'warning',
   PENDING_APPROVAL: 'warning',
+  PENDING_CONFIRMATION: 'warning',
   PENDING_EVIDENCE: 'warning',
   PENDING_REVIEW: 'warning',
   PENDING_SCA: 'warning',

--- a/openbank-admin-ui/src/test/layout-shell.guard.test.ts
+++ b/openbank-admin-ui/src/test/layout-shell.guard.test.ts
@@ -12,7 +12,7 @@
 // gone" — and it had to be fixed page-by-page (FinOps/DevOps shipped without one).
 //
 // The rule: every operator page resolves an app-shell layout — a `layout.tsx`
-// in its own directory or an ancestor (below `app/`) that renders <Sidebar>.
+// in its own directory or an ancestor (below `app/`) that renders <AppShell>.
 // This test is the executable form of that rule: it fails CI if a NEW page is
 // added without a shell layout in its route subtree, so the footgun can't recur.
 //
@@ -47,12 +47,12 @@ function walk(dir: string): string[] {
   return out
 }
 
-// A shell layout is one that renders the Sidebar. We check the source for a
-// <Sidebar reference rather than importing/executing it (the file is a server
-// component tree we don't want to render here).
+// A shell layout composes the shared AppShell. We check source rather than
+// importing/executing it (the file is a server component tree we don't want
+// to render here).
 function isShellLayout(layoutPath: string): boolean {
   if (!existsSync(layoutPath)) return false
-  return /\bSidebar\b/.test(readFileSync(layoutPath, 'utf8'))
+  return /\bAppShell\b/.test(readFileSync(layoutPath, 'utf8'))
 }
 
 // Walk up from the page's directory to (but NOT including) app/, looking for a
@@ -70,6 +70,12 @@ function hasShellLayoutInChain(pageFile: string): boolean {
 describe('admin-ui app-shell rule', () => {
   const pages = walk(APP_DIR)
 
+  it('keeps navigation and header inside the shared app shell', () => {
+    const shell = readFileSync(path.resolve(__dirname, '../components/layout/AppShell.tsx'), 'utf8')
+    expect(shell).toMatch(/<Sidebar\s*\/>/)
+    expect(shell).toMatch(/<Header\s*\/>/)
+  })
+
   it('discovers page files', () => {
     expect(pages.length).toBeGreaterThan(10)
   })
@@ -81,7 +87,7 @@ describe('admin-ui app-shell rule', () => {
     it(`${rel} renders inside the app shell (Sidebar + Header)`, () => {
       expect(
         hasShellLayoutInChain(file),
-        `${rel} has no app-shell layout in its route subtree — it will render WITHOUT the Sidebar/Header.\n\nAdd a layout.tsx to your route directory (copy src/app/dashboard/layout.tsx):\n  Sidebar + Header + scrollable <main>.\nIf the page is intentionally shell-less (an auth screen), add it to EXEMPT in this test.`,
+        `${rel} has no app-shell layout in its route subtree — it will render WITHOUT the Sidebar/Header.\n\nAdd a layout.tsx to your route directory that composes <AppShell>.\nIf the page is intentionally shell-less (an auth screen), add it to EXEMPT in this test.`,
       ).toBe(true)
     })
   }

--- a/openbank-admin-ui/src/test/ui-tone.test.ts
+++ b/openbank-admin-ui/src/test/ui-tone.test.ts
@@ -21,7 +21,7 @@ describe('statusTone (ADR-0208 D2)', () => {
   })
 
   it('maps in-flight statuses to warning', () => {
-    for (const s of ['PENDING', 'PENDING_SCA', 'PENDING_APPROVAL', 'PROCESSING', 'QUEUED', 'DRAFT']) {
+    for (const s of ['PENDING', 'PENDING_SCA', 'PENDING_APPROVAL', 'PENDING_CONFIRMATION', 'PROCESSING', 'QUEUED', 'DRAFT']) {
       expect(statusTone(s), s).toBe('warning')
     }
   })


### PR DESCRIPTION
## Delivered in this PR\n\n- consolidate 50 route layouts into one tested operator shell;\n- modernize the release-notes surface into a structured release timeline;\n- migrate Fraud and SDD console states to the shared status vocabulary and safe BFF unavailable states;\n- extend the status vocabulary for pending mandate confirmation.\n\n## Safety\n\n- preserves read-only governed console behaviour; no direct money-path mutations;\n- keeps BFF error classification client-safe and bilingual;\n- does not alter backend RBAC enforcement.\n\n## Validation\n\n- npm run type-check\n- npm test (105 files / 1277 tests)\n- npm run build (production webpack)\n\nRefs #4841