### PR TITLE
docs(psd2): record the #3658 request-format boundary change in the threat model

### DIFF
--- a/docs/threat-models/openbank-psd2-service.md
+++ b/docs/threat-models/openbank-psd2-service.md
@@ -72,6 +72,36 @@ requests, but the irreversible action lives downstream.
 
 ## 6. Change log
 
+- **2026-08-07 (#3658, recorded retroactively 2026-08-14)** — The required Berlin Group headers on
+  `AisResource` and `PisResource` changed from non-nullable `String` to `String?` plus an explicit
+  guard, so a **missing** `Consent-ID` / `Idempotency-Key` answers **400** instead of **500**.
+  Previously the non-nullable Kotlin signature made JAX-RS inject `null` and the request died in
+  `GenericExceptionMapper`; the exact case those headers exist to gate was the case the API answered
+  worst.
+
+  **Security posture is unchanged or improved, and this was verified rather than assumed:**
+  - Every REQUIRED header still rejects. `AisResource` guards inline
+    (`if (consentId.isNullOrBlank()) throw Psd2RequestFormatException(CONSENT_ID_REQUIRED)`);
+    all four `PisResource` initiation endpoints delegate to the shared `initiatePayment`, which
+    guards both `Consent-ID` and `Idempotency-Key` before any other work. Checked per endpoint, not
+    per file.
+  - The rejection is a `Psd2RequestFormatException`, i.e. the Berlin Group error shape, not a bare
+    `IllegalArgumentException` — correct for this surface.
+  - The other newly-nullable parameters (`dateFrom`, `dateTo`, `bookingStatus`, `limit`,
+    `afterCursor`) are genuinely optional query parameters and correctly carry no guard.
+  - No consent check is weakened, no new data flow, no new store, no endpoint added or removed.
+    The **I**nformation-disclosure and **S**poofing rows are untouched; what improves is the error
+    contract on the request-format boundary.
+
+  **Why this entry is late.** ADR-0030 D2's `threat-model-updated-on-trust-boundary-change` gate
+  fired on the PR and named this file. The PR was merged past it — the ruleset recorded a
+  `required_status_checks` bypass — so the gate's demand was never met and, unlike a red build,
+  nothing would ever ask again: the gate evaluates a diff, and that diff is long merged. Surfaced by
+  the `merged-past-red-check` watch (#4828) once it could read the bypass log for the first time
+  (#4791).
+
+  Rollback: none applicable — this records a change already on `main`.
+
 - **2026-06-15 (ADR-0090 P4)** — Added **QSEAL** message-signature verification
   (`QsealSignatureFilter` after the QWAC gate; `QsealVerifier` pure-JCA: `Digest` body binding +
   `Signature` verification over the canonical signing string via the `TPP-Signature-Certificate`


### PR DESCRIPTION
## A gate's demand that nothing would ever repeat

ADR-0030 D2's `threat-model-updated-on-trust-boundary-change` fired on #3658 and named this file:

```
threat-model-diff gate: openbank-psd2-service: trust-boundary change without a
docs/threat-models/openbank-psd2-service.md update
```

The PR was merged past it — the ruleset recorded a `required_status_checks` bypass — so the demand
was never met.

**Unlike a red build, nothing would ever ask again.** The gate evaluates a diff, and that diff is
long merged. Of the six merges the bypass watch found in #4828, this is the only one whose
consequence does not self-heal: a broken build goes red again, a missing PDP sidecar is caught up by
gitops, a derived-artifact drift is recomputed. A missing record just stays missing.

Surfaced by the `merged-past-red-check` watch the first time it could read the bypass log at all
(#4791).

## What the change actually was

Required Berlin Group headers on `AisResource` / `PisResource` moved from non-nullable `String` to
`String?` plus an explicit guard, so a **missing** `Consent-ID` / `Idempotency-Key` answers **400**
instead of **500**. The non-nullable Kotlin signature made JAX-RS inject `null` and the request die
in `GenericExceptionMapper` — the exact case those headers exist to gate was the case the API
answered worst.

## Verified, not assumed

Checked per **endpoint**, not per file:

- `AisResource` guards inline — `if (consentId.isNullOrBlank()) throw Psd2RequestFormatException(CONSENT_ID_REQUIRED)`
- all four `PisResource` initiation endpoints delegate to the shared `initiatePayment`, which guards
  **both** headers before any other work
- the rejection is a `Psd2RequestFormatException` — the Berlin Group error shape, not a bare
  `IllegalArgumentException`
- the other newly-nullable parameters (`dateFrom`, `dateTo`, `bookingStatus`, `limit`,
  `afterCursor`) are genuinely optional and correctly carry no guard

No consent check weakened, no new flow, no new store, no endpoint added or removed.

## How nearly this went wrong the other way

Recorded in the commit because it is the useful part:

1. A first pass grepped for `requireNotNull` and reported **every** header unguarded — psd2 throws
   its own exception instead.
2. A second split the file on `@POST` and reported PisResource's **eight** headers unguarded — they
   all delegate to one helper.

Both were artifacts of the probe, and either would have produced a confident false finding in a
security document. Only reading the endpoints settled it.

## Scope

**Documentation only.** The code change has been on `main` since 2026-08-07; this writes the record
that should have accompanied it.

`gates (security)` 12/12, `gates (registry)` 26/26.

Refs #3658, #4828, #4791
