### PR TITLE
docs(qrlesspay): make the SDK a family of native implementations, and say it ships nowhere yet

### DIFF
--- a/docs/specs/qrlesspay-sdk.md
+++ b/docs/specs/qrlesspay-sdk.md
@@ -11,10 +11,13 @@ its own public repository**, that any bank can drop into its existing mobile app
 
 **Goals**
 
-- One audited implementation of the wire profile (beacon codec, CBOR bundle,
-  Ed25519, verification order, proximity gate) shared by every adopter — the
-  protocol's security properties live in reviewed code, not in each bank's
-  re-implementation.
+- A bank can adopt QRlessPay **in the language its app is already written in** —
+  native Swift, native Kotlin, React Native, Flutter or Kotlin Multiplatform —
+  without taking on a foreign runtime to do it.
+- The wire profile's security properties (beacon codec, CBOR bundle, Ed25519,
+  verification order, proximity gate, single use) are guaranteed by a shared
+  **conformance suite** that every implementation must pass, rather than by
+  every adopter linking the same binary.
 - Payer and payee roles, iOS + Android, with the same feature-negotiation and
   graceful-downgrade behaviour (UWB → RSSI, SAS optional) on both.
 - UI-less core: banks keep their own design system, confirmation screens and SCA.
@@ -55,52 +58,89 @@ API that invites one. Normative statement: wire spec §11.
 - Trademark note: "QRlessPay" name usage policy documented so forks can claim
   conformance without implying endorsement.
 
-## 3. Architecture — one core, thin bindings
+## 3. Architecture — a family of native SDKs, one conformance suite
 
-Layered so the security-critical logic exists **once**:
+The obvious design is one Kotlin Multiplatform core with thin bindings on top, so
+the security-critical logic exists exactly once. That is the right shape for a
+*product*, and the wrong one for a *standard*.
+
+A bank with a pure-Swift app will not add a Kotlin runtime and an XCFramework to
+its binary to accept payments, and one that has standardised on React Native does
+not want a KMP toolchain in its build. A profile whose only real implementation
+is KMP is a profile with one implementation — which is the thing ADR-0095's
+standardisation ambition is trying not to be. And the moment a second bank
+implements from the spec (which the spec explicitly invites: §9 defines
+conformance for anyone), the "single core" guarantee is already gone; the only
+question is whether the second implementation was checked against anything.
+
+So the shared artifact is **the conformance suite, not the code**:
 
 ```
-┌─────────────────────────────────────────────────────────┐
-│  Bindings: Swift API (SPM) · Kotlin/Android (Maven) ·   │
-│  React Native (TS, autolinked module) · Flutter (Dart)  │
-├─────────────────────────────────────────────────────────┤
-│  Transport adapters (per platform):                     │
-│  BLE advertise/scan · GATT server/client · UWB ranging  │
-├─────────────────────────────────────────────────────────┤
-│  PROTOCOL CORE (Kotlin Multiplatform, no platform deps) │
-│  beacon codec · CBOR bundle codec · Ed25519 sign/verify │
-│  SPAYD parse/build · verification state machine ·       │
-│  SAS derivation (X25519+HKDF) · proximity policy        │
-└─────────────────────────────────────────────────────────┘
+┌──────────────────────────────────────────────────────────────────┐
+│  CONFORMANCE SUITE  (the normative artifact — language-neutral)  │
+│  golden vectors as JSON: adverts, bundles, signatures, SAS       │
+│  derivations, and a large NEGATIVE corpus · cross-implementation │
+│  interop matrix · two-device lab script                          │
+└──────────────────────────────────────────────────────────────────┘
+        ▲              ▲              ▲              ▲
+┌───────┴──────┐┌──────┴───────┐┌─────┴────────┐┌────┴────────────┐
+│  Swift SDK   ││ Kotlin/       ││  KMP SDK     ││  React Native / │
+│  (SPM)       ││ Android (AAR) ││ (AAR + XCF)  ││  Flutter        │
+│  CoreBluetooth││ android.blue-││ for KMP apps ││  bind the two   │
+│  NearbyInter. ││ tooth, core- ││ e.g. this    ││  NATIVE SDKs,   │
+│  swift-crypto ││ uwb, Tink    ││ platform's   ││  not the KMP one│
+└──────────────┘└──────────────┘└──────────────┘└─────────────────┘
 ```
 
-- **Protocol core = Kotlin Multiplatform.** It already exists, proven in
-  production shape, inside the `openbank-app` KMP client (ADR-0095 client
-  implementation) — the SDK is an **extraction**, not a rewrite. Pure-Kotlin
-  crypto deps (kotlincrypto Ed25519/SHA-256) keep the core free of JNI/native
-  surprises. Compiled out as: Android AAR + iOS XCFramework.
-- **Bindings stay thin.** A binding may only: expose idiomatic types, forward
-  events, host the platform BLE/UWB adapter. It must NOT re-implement any
-  verification step — the state machine in the core is the single place the spec
-  §3 verification order (sid/kh binding → signature → exp/nonce → SPAYD parse →
-  proximity → confirmation hand-off) is encoded, so a binding cannot skip a step
-  or reorder it.
+- **Swift and Kotlin SDKs are first-class implementations, not wrappers.** Each
+  is idiomatic for its platform, uses its platform's own crypto (swift-crypto /
+  Tink or the platform providers) and ships no foreign runtime.
+- **The KMP SDK is a peer, not the substrate.** It is the natural choice for a
+  KMP app — this platform's own client is one — and it is where the existing,
+  production-shaped implementation in `openbank-app` gets extracted to. It is
+  simply not privileged over the others.
+- **React Native and Flutter bind the native SDKs**, not the KMP one. Both
+  ecosystems already ship native modules, so this is the shortest path and it
+  avoids stacking two runtimes to reach one radio.
+
+### What this costs, and what pays for it
+
+Four implementations means four chances to get the verification order wrong, and
+four crypto reviews instead of one. That cost is real and it is the reason the
+conformance suite is listed as a goal above rather than as tooling:
+
+- The vectors are **executable in every language** and weighted towards the
+  **negative** cases — a wrong `kh` binding, a bad signature, an expired or
+  replayed bundle, a truncated CBOR, an oversize SPAYD. Implementations do not
+  drift on the happy path; they drift on which failures they notice.
+- The **interop matrix** runs every implementation against every other as payer
+  and payee, so "it works with itself" cannot be mistaken for conformance.
+- Each implementation carries its own review, and §7's gates apply per
+  implementation rather than once for the family.
 
 ### Per-target packaging
 
-| Target | Artifact | BLE/UWB access |
-|---|---|---|
-| Android (Kotlin/Java) | Maven Central AAR | native (android.bluetooth, androidx.core.uwb) |
-| iOS (Swift) | SPM package wrapping the XCFramework | native (CoreBluetooth, NearbyInteraction) |
-| React Native | npm package (TS types), autolinks the two native artifacts | via native module |
-| Flutter | pub.dev plugin (Dart API), platform channels to the same artifacts | via plugin |
-| Web | **not supported** (payee impossible; payer's Web Bluetooth GATT is Chrome-only and cannot meet the proximity gate) — documented, not shimmed | — |
+| Target | Artifact | Implementation | BLE/UWB access |
+|---|---|---|---|
+| iOS (Swift) | SPM package | native Swift | CoreBluetooth, NearbyInteraction |
+| Android (Kotlin/Java) | Maven Central AAR | native Kotlin | android.bluetooth, androidx.core.uwb |
+| Kotlin Multiplatform | AAR + XCFramework | shared Kotlin | via expect/actual to both of the above APIs |
+| React Native | npm package (TS types) | binds the Swift + Kotlin SDKs | via native module |
+| Flutter | pub.dev plugin (Dart API) | binds the Swift + Kotlin SDKs | via platform channels |
+| Web | **not supported** — documented, not shimmed | — | payee role impossible (no Web Bluetooth peripheral API); payer's GATT is Chrome-only and cannot meet the proximity gate |
 
-React Native and Flutter get first-class bindings because that is what most CZ/EU
-bank apps are actually written in; both delegate to the identical native cores,
-so interop and security review cover them for free.
+Priority order for building them, on adoption reach rather than effort: **Swift
+and Kotlin first** (they are what the RN and Flutter bindings stand on, so
+nothing else can ship before them), then **React Native**, then **KMP**
+(extraction, and this platform's own client already has the code), then
+**Flutter**.
 
-## 4. Public API sketch (core semantics, per-language idioms)
+## 4. Public API sketch — semantics, not signatures
+
+Written in Kotlin below because it has to be written in something. Each SDK is
+idiomatic for its own platform (Swift uses `async`/`AsyncSequence`, TypeScript a
+promise plus an event emitter), and what is normative is the **semantics** — the
+states, the outcome type, the ordering — not these names.
 
 ```kotlin
 // Payee — "Receive nearby" screen scope
@@ -124,16 +164,24 @@ when (outcome) {
 }
 ```
 
-Contract points the API enforces by construction:
+Contract points every implementation must enforce by construction — these are the
+ones a conformance vector cannot check, so they are review items:
 
 - `Verified.proposal` carries the **signed** SPAYD values only — advert
   `name`/`amt` hints are unreachable from the proposal type (spec §2 warning).
 - There is no "skip proximity" or "skip verification" knob. Test builds use an
   injected fake transport, not relaxed checks.
+- Single-use tracking is a **required argument**, not an optional one. This
+  platform's client shipped the check as "the caller's responsibility" and no
+  caller ever took it; an API that lets an adopter omit it will be omitted.
 - The SDK ends at the proposal. Confirmation UI, VOP lookup and SCA are the
   bank's, keeping the mandatory §6 gate outside SDK code.
 - Typed `Rejected.reason` mirrors the spec failure taxonomy so telemetry is
   comparable across banks.
+- The payer-side duplicate and same-name warnings are **surfaced, not decided**:
+  the SDK reports "this device opened an identical proposal N seconds ago" and
+  "these tiles share a display name", and the bank's UI chooses the wording. A
+  refused or repeated tap must never be silent.
 
 ## 5. Platform truth the SDK must encode (from the shipped client)
 
@@ -155,9 +203,19 @@ behaviour + docs so every adopter doesn't rediscover them:
 
 ## 6. Conformance & test strategy
 
-- **Golden vectors** in the repo: beacon payloads, CBOR bundles (valid + a
-  malformed corpus: truncation, oversize SPAYD, bad `kh`, expired, replayed),
-  Ed25519 test keys, SAS derivation vectors. Every binding runs the same vectors.
+This is the load-bearing section, not an appendix: with several independent
+implementations it is the only thing that makes them one profile rather than
+several dialects.
+
+- **Golden vectors** as language-neutral JSON in the repo: beacon payloads, CBOR
+  bundles (valid + a malformed corpus: truncation, oversize SPAYD, bad `kh`,
+  expired, replayed), Ed25519 test keys, SAS derivation vectors. Every
+  implementation runs the same file, and the negative cases outnumber the
+  positive ones on purpose — implementations agree on the happy path and diverge
+  on which failures they notice.
+- **Cross-implementation interop matrix**: every implementation against every
+  other, in both roles. Self-interop proves nothing; a shared misreading of the
+  spec is invisible until a second implementation disagrees.
 - **Protocol fuzzing** of the CBOR decoder in CI (threat model §8 gate 2 asks for
   this anyway — the SDK repo is where it runs continuously).
 - **Loopback interop harness**: in-process payee↔payer over a fake transport for
@@ -175,13 +233,29 @@ independent crypto review, CBOR fuzzing, ADR-0030 second approval, DPIA
 model §8, items 1–5). The repo can go public earlier as clearly-labelled
 pre-release; `1.0.0` waits for the gates.
 
+**Per implementation, not once for the family.** The crypto review and the
+fuzzing are properties of code, so a second implementation does not inherit the
+first one's review — each reaches `1.0.0` on its own evidence, and the version
+numbers are therefore independent. Passing the conformance suite is necessary
+and not sufficient: it establishes that an implementation agrees with the
+others, not that its key handling is sound.
+
 ## 8. Open questions
 
 1. Repo host & org: under the OpenBank GitHub org, or a neutral foundation-style
    org to ease adoption by competitor banks?
 2. Maven/npm/pub/SPM publishing identities & signing keys — who holds them
    (release engineering decision, not in this doc).
-3. Kotlin/JS or WASM build of the core for a future web *payer* experiment —
-   deferred until Web Bluetooth reality changes.
+3. A WASM build for a future web *payer* experiment — deferred until Web
+   Bluetooth reality changes.
 4. Whether the optional UI kit (nearby-tiles list + SAS comparison sheet) ships
    as a second artifact in v1.x.
+5. One repository holding every implementation, or one per language? A monorepo
+   makes the conformance suite trivially shared and every change visible across
+   implementations; separate repos make each one's release cadence and review
+   independent, which matters more once implementations reach `1.0.0` on
+   different dates.
+6. Whether a bank's own from-scratch implementation can claim conformance by
+   publishing suite output, or whether that needs a verification step someone
+   operates — the difference between an open profile and a certified one, and
+   the point at which the ČBA/EPC ambition needs an actual body behind it.

--- a/openbank-admin-ui/src/app/docs/qrlesspay/page.tsx
+++ b/openbank-admin-ui/src/app/docs/qrlesspay/page.tsx
@@ -179,20 +179,47 @@ export default function QrlessPayPage() {
         </div>
         <div className="card" style={{ padding: 14, background: 'var(--accent-bg)', border: '1px solid var(--accent-border)', display: 'flex', flexDirection: 'column', gap: 8 }}>
           <div style={{ fontWeight: 700, fontSize: 13, color: INK }}>
-            {t('Plánovaná publikace SDK', 'Planned SDK publication')}
+            {t('Dostupnost SDK — zatím nikde', 'SDK availability — nothing published yet')}
           </div>
           <div style={{ fontSize: 12.5, color: SUB, lineHeight: 1.6 }}>
             {t(
-              'Jádro protokolu je Kotlin Multiplatform (jedna auditovaná implementace ověřování), nad ním tenké idiomatické vazby: Android (Kotlin, Maven), iOS (Swift, SPM), React Native (TypeScript, npm) a Flutter (Dart, pub.dev) — obě mobilní cross-platform vazby delegují na stejná nativní jádra. Web není podporován (Web Bluetooth neumí roli příjemce). Banky doplní pouze svůj platební backend (IBAN rail) a vlastní potvrzovací UI + SCA. Cíl: standard kompatibilní s ČBA a EPC pro mezibankovní proximity platby bez kódu.',
-              'The protocol core is Kotlin Multiplatform (one audited verification implementation) with thin idiomatic bindings on top: Android (Kotlin, Maven), iOS (Swift, SPM), React Native (TypeScript, npm) and Flutter (Dart, pub.dev) — both cross-platform bindings delegate to the same native cores. Web is unsupported (Web Bluetooth cannot do the payee role). Banks plug in only their own payment backend (IBAN rail) plus their own confirmation UI + SCA. Goal: a ČBA and EPC-compatible standard for interbank proximity payments without a QR code.',
+              'Žádný balíček zatím není publikovaný a repozitář neexistuje — níže je návrh, ne changelog. Plán: rodina nativních SDK, ne jedno KMP jádro s tenkými obaly. Banka s čistě Swift aplikací si do binárky nepřidá Kotlin runtime, aby mohla přijímat platby, a profil, který má jedinou reálnou implementaci, není standard. Sdíleným artefaktem je proto conformance suite (jazykově neutrální vektory + interop matice), ne kód. Cena: čtyři implementace = čtyři krypto review, každá si 1.0.0 zaslouží vlastními důkazy.',
+              'Nothing is published and the repository does not exist yet — what follows is a proposal, not a changelog. The plan is a family of native SDKs rather than one KMP core with thin wrappers: a bank with a pure-Swift app will not add a Kotlin runtime to its binary to accept payments, and a profile with a single real implementation is not a standard. The shared artifact is therefore the conformance suite (language-neutral vectors + an interop matrix), not the code. The cost: four implementations means four crypto reviews, and each earns 1.0.0 on its own evidence.',
+            )}
+          </div>
+          <div style={{ overflowX: 'auto' }}>
+            <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 12.5, minWidth: 460 }}>
+              <thead>
+                <tr style={{ textAlign: 'left', color: SUB }}>
+                  <th style={{ padding: '6px 8px', fontWeight: 700 }}>{t('Platforma', 'Platform')}</th>
+                  <th style={{ padding: '6px 8px', fontWeight: 700 }}>{t('Balíček', 'Package')}</th>
+                  <th style={{ padding: '6px 8px', fontWeight: 700 }}>{t('Implementace', 'Implementation')}</th>
+                  <th style={{ padding: '6px 8px', fontWeight: 700 }}>{t('Stav', 'Status')}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {SDK_TARGETS.map((row, i) => (
+                  <tr key={i} style={{ borderTop: '1px solid var(--border)' }}>
+                    <td style={{ padding: '6px 8px', color: INK, fontWeight: 600 }}>{row.platform}</td>
+                    <td style={{ padding: '6px 8px', color: SUB }}>{row.pkg}</td>
+                    <td style={{ padding: '6px 8px', color: SUB }}>{t(row.implCs, row.implEn)}</td>
+                    <td style={{ padding: '6px 8px', color: SUB }}>{t(row.statusCs, row.statusEn)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+          <div style={{ fontSize: 12.5, color: SUB, lineHeight: 1.6 }}>
+            {t(
+              'Pořadí stavby podle dosahu, ne podle pracnosti: Swift a Kotlin první (stojí na nich vazby pro React Native i Flutter), pak React Native, pak KMP (extrakce — kód už běží v naší vlastní aplikaci), nakonec Flutter. Banky doplní jen svůj platební rail a vlastní potvrzovací UI + SCA.',
+              'Build order by reach rather than effort: Swift and Kotlin first (the React Native and Flutter bindings stand on them), then React Native, then KMP (an extraction — the code already runs in our own app), then Flutter. Banks plug in only their own payment rail plus their own confirmation UI and SCA.',
             )}
           </div>
           <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
-            <Tag>KMP / Apache-2.0</Tag>
-            <Tag>{t('Swift · Kotlin · TypeScript · Dart', 'Swift · Kotlin · TypeScript · Dart')}</Tag>
+            <Tag>Apache-2.0</Tag>
+            <Tag>{t('Swift · Kotlin · TypeScript · Dart · KMP', 'Swift · Kotlin · TypeScript · Dart · KMP')}</Tag>
             <Tag>ČBA / EPC</Tag>
             <Tag>{t('Otevřený protokol', 'Open protocol')}</Tag>
-            <Tag>{t('Mezibankovní', 'Interbank')}</Tag>
             <a href="https://github.com/JiRaska/open-bank-oss/blob/main/docs/specs/qrlesspay-sdk.md" target="_blank" rel="noopener noreferrer" style={linkBtn}>{t('Návrh SDK (spec)', 'SDK proposal (spec)')}</a>
           </div>
         </div>
@@ -277,6 +304,15 @@ const LAYERS: { Icon: React.ElementType; req: boolean; threatCs: string; threatE
   { Icon: ArrowLeftRight, req: false, threatCs: 'Dvojitá platba / dva stejní odesílatelé', threatEn: 'Duplicate payment / two identical senders', mitCs: 'Varování na zařízení plátce: „tohle jsi zaplatil před chvílí“ a upozornění, když dvě dlaždice nesou stejné jméno (maskovaný IBAN už při výběru). Bez serveru.', mitEn: 'Payer-device warnings: “you paid this a moment ago”, and an alert when two tiles share a display name (masked IBAN shown at the point of choice). No server involved.' },
   { Icon: EyeOff, req: true, threatCs: 'Soukromí', threatEn: 'Privacy', mitCs: 'Po vzduchu jen křestní jméno + efemérní id; IBAN jen přes GATT read, který plátce aktivně vyvolá; rotující id + privacy MAC.', mitEn: 'Only first name + ephemeral id on air; IBAN only via the payer-initiated GATT read; rotating id + privacy MAC.' },
   { Icon: ShieldCheck, req: false, threatCs: 'Vysoká částka / MITM', threatEn: 'High value / MITM', mitCs: 'Volitelný SAS — 4-místný kód z efemérního DH, lidé ho porovnají; defeats MITM bez PKI.', mitEn: 'Optional SAS — a 4-digit code from an ephemeral DH that the humans compare; defeats MITM without PKI.' },
+]
+
+const SDK_TARGETS: { platform: string; pkg: string; implCs: string; implEn: string; statusCs: string; statusEn: string }[] = [
+  { platform: 'iOS', pkg: 'SPM', implCs: 'nativní Swift', implEn: 'native Swift', statusCs: 'navrženo — 1. v pořadí', statusEn: 'proposed — first up' },
+  { platform: 'Android', pkg: 'Maven Central (AAR)', implCs: 'nativní Kotlin', implEn: 'native Kotlin', statusCs: 'navrženo — 1. v pořadí', statusEn: 'proposed — first up' },
+  { platform: 'React Native', pkg: 'npm', implCs: 'vazba na nativní SDK', implEn: 'binds the native SDKs', statusCs: 'navrženo — 2. v pořadí', statusEn: 'proposed — second' },
+  { platform: 'Kotlin Multiplatform', pkg: 'AAR + XCFramework', implCs: 'sdílený Kotlin', implEn: 'shared Kotlin', statusCs: 'kód existuje v naší aplikaci, nevytažen', statusEn: 'code exists in our app, not extracted' },
+  { platform: 'Flutter', pkg: 'pub.dev', implCs: 'vazba na nativní SDK', implEn: 'binds the native SDKs', statusCs: 'navrženo — poslední', statusEn: 'proposed — last' },
+  { platform: 'Web', pkg: '—', implCs: 'nepodporováno', implEn: 'unsupported', statusCs: 'Web Bluetooth neumí roli příjemce', statusEn: 'Web Bluetooth cannot do the payee role' },
 ]
 
 const COMPARE: { axisCs: string; axisEn: string; qrCs: string; qrEn: string; blCs: string; blEn: string; win: 'qr' | 'bl' | 'tie' }[] = [


### PR DESCRIPTION
## Why the architecture changed

The previous proposal was one Kotlin Multiplatform core with thin bindings, so the security-critical logic existed exactly once. That is the right shape for a **product** and the wrong one for a **standard**.

A bank with a pure-Swift app will not add a Kotlin runtime and an XCFramework to its binary in order to accept payments, and one that has standardised on React Native does not want a KMP toolchain in its build. A profile whose only real implementation is KMP is a profile with one implementation — which is precisely what ADR-0095's standardisation ambition is trying not to be.

And the single-core guarantee is weaker than it looks: the wire spec already invites anyone to implement from §9, so it is gone the moment a second bank does. The only question left is whether their implementation was checked against anything.

## What replaces it

**The shared artifact is the conformance suite, not the code.**

- Golden vectors as language-neutral JSON, deliberately weighted towards the **negative** cases — implementations agree on the happy path and diverge on which failures they notice.
- A **cross-implementation interop matrix**, every implementation against every other in both roles. Self-interop proves nothing: a shared misreading of the spec is invisible until a second implementation disagrees.

**Swift and Kotlin become first-class native implementations**, each idiomatic and shipping no foreign runtime. **React Native and Flutter bind those**, not the KMP one — both ecosystems already ship native modules, so this avoids stacking two runtimes to reach one radio. **KMP stays a peer**: the natural choice for a KMP app, which is what this platform's own client is, and where the existing production-shaped code gets extracted from. It is simply no longer privileged.

Build order by reach rather than effort: Swift and Kotlin first (the RN and Flutter bindings stand on them, so nothing else can ship before them), then React Native, then KMP, then Flutter.

## The cost, stated rather than buried

Four implementations means four chances to get the verification order wrong and four crypto reviews instead of one. That is why the conformance suite is listed as a **goal** rather than as tooling, and why §7 now says the rollout gates apply **per implementation**: a crypto review is a property of code, so a second implementation does not inherit the first one's. Passing the suite is necessary and not sufficient — it establishes that an implementation agrees with the others, not that its key handling is sound.

Two contract points were also added to §4 from what this platform has since learned: single-use tracking must be a **required** argument (our own client shipped it as "the caller's responsibility" and no caller ever took it — an API that lets an adopter omit it will be omitted), and the duplicate/same-name warnings are **surfaced, not decided** by the SDK.

## Admin-UI honesty fix

The card said *"Planned SDK publication"* above a list of package ecosystems, which reads like something a bank could go and fetch. It now leads with **"SDK availability — nothing published yet"** and carries a per-platform table with an explicit status column, including the one row that is not a plan: KMP, where the code already exists in our own app but has not been extracted.

## Verification

`npm run type-check` clean; `npm test` **105 files, 1277 tests passing**.

Rendered the page to static HTML and screenshotted the SDK section rather than trusting jsdom — the repo's own rule is that a CSS or layout regression passes `tsc`, `eslint` and the mount-only smoke suite. The table renders with all six rows, correct columns, and no overflow at 1000px. The temporary dump harness was deleted before commit and the suite re-run after removing it.

Docs-only plus one admin-ui page; no service code, no API surface, no migration.

Refs ADR-0095

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Linked issues

Refs #4830 — this is the documentation half of that issue; the two payer-side guards it tracks are implemented in JiRaska/openbank-app#449.
