### PR TITLE
fix(ci): drop the pipeline from the ADR-registry self-test matcher, and make a recurrence self-diagnosing (#4850)

### DIFF
--- a/.github/scripts/check-adr-registry.sh
+++ b/.github/scripts/check-adr-registry.sh
@@ -104,8 +104,20 @@ if [ "${1:-}" = "--self-test" ]; then
     out=$(cd "$td" && bash "$SELF" "$d" 2>&1); rc=$?
     if [ "$rc" -ne "$want" ]; then
       echo "::error::self-test: $label — want rc=$want got $rc: $out" >&2; fails=$((fails+1))
-    elif [ -n "$sub" ] && ! printf '%s' "$out" | grep -qF -- "$sub"; then
-      echo "::error::self-test: $label — rc right, reason wrong (no '$sub'): $out" >&2; fails=$((fails+1))
+    # Here-string, NOT `printf | grep -q` (#4850). Under `set -o pipefail` a `-q` early exit can
+    # SIGPIPE the writer and the pipeline then reports failure even though grep matched — this
+    # repo documents that footgun, and services-ci.yml carries the same note. It is written here
+    # as a precaution, not as a diagnosis: the one observed failure (#4850) could not be
+    # reproduced under bash 3.2 or 5.2 with the match at the head of a 5 MB payload, so the
+    # mechanism is unconfirmed. Removing the pipeline costs nothing and closes the candidate.
+    elif [ -n "$sub" ] && ! grep -qF -- "$sub" <<<"$out"; then
+      # Carry the evidence, so a recurrence diagnoses itself instead of needing a repro. The
+      # failure this replaces printed an $out that visibly CONTAINED the substring it said was
+      # missing, and nothing in the log could explain the contradiction.
+      echo "::error::self-test: $label — rc right, reason wrong (no '$sub'): $out" >&2
+      echo "::error::self-test: matcher PIPESTATUS=${PIPESTATUS[*]-n/a}; \$out as bytes:" >&2
+      od -c <<<"$out" | head -20 >&2
+      fails=$((fails+1))
     fi
   }
 


### PR DESCRIPTION
## The failure this addresses

On #4847 the registry shard failed with an assertion its own evidence refutes:

```
self-test: a duplicate ADR number is caught — rc right, reason wrong (no 'duplicate ADR number'):
::error title=ADR registry::duplicate ADR number 0001 shared by: 0001-first.md,0001-other.md — …
```

The matcher said the substring was absent from output that **begins with it**. A re-run with no code
change passed. Full evidence in #4850.

## Two changes, and only one of them claims anything

**1. The matcher loses its pipeline.**

```diff
-    elif [ -n "$sub" ] && ! printf '%s' "$out" | grep -qF -- "$sub"; then
+    elif [ -n "$sub" ] && ! grep -qF -- "$sub" <<<"$out"; then
```

The old shape is the exact footgun this repo documents — under `set -o pipefail` a `-q` early exit
can SIGPIPE the writer, and the pipeline then reports failure even though grep matched.
`services-ci.yml` carries the same note.

**This is a precaution, not a diagnosis.** I could not reproduce it. With the match at the head of a
5 MB payload, so `grep -q` exits while the writer is still writing:

| shell | false negatives | PIPESTATUS |
|---|---|---|
| bash 3.2.57 (local) | 0 / 10 | `0` |
| bash 5.2 (docker, the CI shape) | 0 / 20 | `0` |

So the SIGPIPE explanation is a candidate that direct measurement did not support. Removing the
pipeline costs nothing and closes the candidate either way — it makes the hypothesis untestable in
the good direction.

**2. The failure path now carries its evidence** — `PIPESTATUS` and `od -c` of the captured output.

This is the half that matters, precisely *because* the mechanism is unknown. The original failure
printed a contradiction and nothing in the log could explain it; a recurrence now diagnoses itself
instead of needing a repro that may not exist.

## Falsified

Rewording the duplicate-collision message so it no longer contains the expected substring **still
reddens the case**, and the new diagnostic prints:

```
::error::self-test: a duplicate ADR number is caught — rc right, reason wrong (no 'duplicate ADR number'): …REWORDED collision on 0001…
::error::self-test: matcher PIPESTATUS=0; $out as bytes:
```

So the matcher was made shorter, not blunter.

## Verification

`--self-test` ok (25 cases), `gates (registry)` **26/26**, `shellcheck` PASS.

## Scope

CI script only. Touches `.github/scripts/`, so the repo's guard will want human review — as it
should.

Refs #4850, #4847
