### PR TITLE
docs(qrlesspay): formal readiness assessment, and surface it in the console

### DIFF
--- a/docs/compliance/qrlesspay-readiness.md
+++ b/docs/compliance/qrlesspay-readiness.md
@@ -1,0 +1,158 @@
+<!--
+SPDX-License-Identifier: Apache-2.0
+Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+-->
+# QRlessPay — readiness assessment: security, compliance, legal, standardisation
+
+- **Date:** 2026-08-14 · **Status:** assessment, not an approval
+- **Subject:** QRlessPay ([ADR-0095](../adr/0095-qrlesspay-ble-proximity-spayd-payments.md)) ·
+  [wire spec v1](../specs/qrlesspay-v1.md) · [threat model](../threat-models/qrlesspay.md) ·
+  [SDK proposal](../specs/qrlesspay-sdk.md)
+- **Purpose:** answer, in one document, what a bank's security function, compliance function and
+  counsel will each ask — including the questions we would rather they did not.
+
+This is a self-assessment by the implementing team. It is **not** a substitute for the independent
+reviews it recommends, and it is deliberately written to surface objections rather than to survive
+them.
+
+## 1. Executive position
+
+For **internal deployment**, nothing structural is missing: the capability is code-complete, dormant
+behind an enforced flag, and gated on four reviews that are already named in the threat model §8.
+Those gates are the whole remaining distance.
+
+For the **standard ambition** (ČBA, and beyond), the technical architecture is well suited — no
+backend, no registry, a conformance suite, and a threat model that states its own limits. What is
+entirely absent is the **legal and institutional layer**: DPIA, patent clearance, Bluetooth SIG
+identifier allocation, trademark, and a neutral governance body. None of it is hard; all of it has
+long lead times, and none of it has started.
+
+The single most likely thing to *change the design* rather than merely delay it is the DPIA (§4).
+
+## 2. What the design gets right, stated plainly
+
+These are the points that will earn credit in review, and they are load-bearing:
+
+- **No money moves in this protocol.** QRlessPay transfers a payment *proposal*. Settlement runs on
+  the existing IBAN/instant rail with unchanged SCA in the payer's app. This single property is why
+  most of the regulatory surface below is thin.
+- **No server, no registry, no trust anchor** (spec §11). Verification uses the bytes in hand plus
+  the device's own clock, radio and history. Nothing to operate, nothing to breach, nothing to
+  subpoena.
+- **The threat model does not oversell.** It states that identity is at parity with a QR scan,
+  calls the baseline phishing-grade absent VoP, and now records that ceiling as permanent rather
+  than pending. Reviewers distrust optimistic threat models far more than modest ones.
+- **The IBAN is never broadcast.** It travels only in the payer-initiated GATT read.
+- **Controls are enforced where they cannot be forgotten** — the RSSI gate and single-use check live
+  in the protocol core, not in a screen.
+
+## 3. Security review — expected outcome: pass, with the §8 gates as conditions
+
+### 3.1 Already satisfied
+
+| Concern | Position |
+|---|---|
+| Payload integrity | Ed25519 over `version‖sid‖nonce‖exp‖pk‖spayd`; advert↔bundle bound by `SHA-256(pk)[:2]` |
+| Replay | Single-use `(sid, nonce)` per device, enforced inside `verify`, checked after the signature so a forged payload cannot burn a session |
+| Wire format | Canonical CBOR, definite lengths, integer keys; the decoder rejects non-canonical integers, indefinite lengths, unknown/duplicate keys, truncation and trailing bytes before any cryptography runs |
+| Cross-implementation agreement | Two independent implementations (Kotlin, Swift) produce byte-identical output and verify each other's signatures |
+| Key handling | Per-session Ed25519, memory-only, regenerated per request screen |
+
+### 3.2 Open, and genuinely blocking
+
+1. **Independent cryptographic review** — nobody outside the implementing team has examined seed
+   handling, key lifetime, or comparison behaviour. *Threat model §8.1.*
+2. **Continuous CBOR fuzzing** — the decoder is new money-path code. Its strictness is unit-tested
+   and has never been fuzzed. *§8.2.*
+3. **ADR-0030 security review + second approval.** *§8.3.*
+4. **Two concurrent `CBCentralManager` instances have never been run in this app.** Scanning is not
+   an exclusive radio resource the way advertising is, so it is *expected* to work — that word is
+   doing real work in this sentence and only a two-device lab run removes it. *§8.6.*
+5. **Warning efficacy is unmeasured.** We wrote "a warning nobody reads is not a control either" and
+   have not tested the duplicate-payment and same-name warnings with users.
+
+### 3.3 The objection we should raise ourselves
+
+The RSSI proximity gate is spoofable by raising transmit power, and UWB — the only cryptographic
+answer — is a hardware minority and does not interoperate between Apple and Android. On *physical
+targeting*, QRlessPay is weaker than aiming a camera at a visible code. The threat model says so;
+this document repeats it because a reviewer who finds it themselves will assume it was hidden.
+
+## 4. Data protection — the highest-risk area
+
+**The advert broadcasts a first name to every device in radio range**, including people with no
+relationship to either party.
+
+- Lawful basis for payer and payee is performance of the requested payment. **It does not extend to
+  bystanders**, who are not party to anything and cannot object to a radio broadcast they cannot
+  see.
+- The mitigating facts are real: user-initiated, screen-open-only, ephemeral rotating identifiers,
+  platform private MAC, first name only, no IBAN, and no more than a name badge or a printed QR
+  card already discloses.
+- **Expected outcome:** defensible, but a formal DPIA is required and will plausibly land on
+  **initials-only as the default** rather than as an opt-out. Plan for that rather than defending
+  the current default.
+- **Also required, and not yet done:** retention and record position for the payer-side history
+  (device-local, never transmitted — likely out of scope for controller obligations, but that must
+  be *concluded*, not assumed), and transparency copy explaining what is broadcast and when.
+
+**European Accessibility Act** (applicable to banking services since June 2025): the warnings and
+any SAS comparison must work under VoiceOver/TalkBack. Unaddressed today, and it will block an
+internal release independently of anything above.
+
+## 5. Payments compliance — expected outcome: pass
+
+| Question | Position |
+|---|---|
+| New payment service under PSD2? | No — a proposal is transferred; the payment is an ordinary credit transfer initiated in the payer's own app. **Counsel must confirm.** |
+| SCA | Unchanged. Mandatory, in the payer's app, after explicit confirmation. |
+| Dynamic linking (PSD2 RTS Art. 5) | Satisfied: amount and payee shown and authorised come from the signed bundle the payer verified. |
+| AML / sanctions screening | Unchanged — screening happens on the rail, not here. |
+| VoP (EU Instant Payments Regulation) | Applies to euro/SEPA only. **Not deployed for CZK domestic**, so it must be treated as absent on that rail. |
+| New ČNB licence or notification | Most likely none. **Counsel must confirm** — this is a legal conclusion, not an engineering one. |
+
+**The open item compliance will press on: misdirected-payment liability.** If a payer pays the
+wrong "Jiří", who bears it? Our position is parity with a QR scan — the payer confirmed name and
+masked IBAN. Two things must become formal rather than implicit:
+
+1. The decision to **warn rather than block** on duplicate payments and ambiguous names is a
+   deliberate acceptance of residual risk, currently recorded only in a pull request. It needs
+   business sign-off.
+2. Customer-facing terms should state the payer's confirmation is the authorising act.
+
+## 6. Legal, IP and standardisation — the least developed area
+
+1. **Bluetooth SIG identifiers.** The service UUIDs are placeholders and the 16-bit alias `0xF0B2`
+   is unallocated — effectively squatting. Immaterial for a pilot; mandatory before third parties
+   implement. Requires SIG membership and fees.
+2. **Patents.** Proximity payments is densely patented. A standard offered to other banks needs a
+   freedom-to-operate search and an IPR policy (royalty-free or FRAND commitment from
+   contributors). No bank's counsel will approve adoption without one.
+3. **Trademark.** "QRlessPay" is unregistered. File before publication, or someone else can.
+4. **Licensing hygiene.** Apache-2.0 throughout, contributor terms (DCO or CLA) decided before the
+   first external contribution — not after.
+5. **Governance.** Neither EPC nor ČBA adopts one bank's repository. A standard needs neutral
+   ownership of the specification, a change-control process, and a decision on whether conformance
+   is **self-declared** (publish suite output) or **certified** (someone operates the certification).
+   That question is the difference between an open profile and a standard, and it is the point at
+   which this needs an institution rather than a repository.
+
+## 7. Recommended sequence
+
+Ordered so that work which can *change the design* happens before work that builds on it.
+
+1. **DPIA** and **independent cryptographic review** — either can alter the design; everything else
+   is cheaper afterwards.
+2. **Two-device lab run** (dual `CBCentralManager`, per-device peripheral-role compatibility) and
+   **CBOR fuzzing in CI** — both are prerequisites for §8 and neither needs anyone external.
+3. **Decisions**: SAS default-on, high-value threshold, initials-only default, accessibility.
+4. **Bluetooth SIG allocation** and **trademark filing** — start early, long lead times, cheap.
+5. **ADR-0030 second approval**, then pilot.
+6. **Patent search** and **governance model** — only once a second institution is genuinely
+   interested; doing this speculatively burns money on an option nobody has taken up.
+
+## 8. What this document is not
+
+It is not an approval, and no section of it should be cited as one. The reviews in §3.2 and §4 are
+the approval; this only argues that they are the right ones and that nothing else is hiding behind
+them.

--- a/openbank-admin-ui/src/app/docs/qrlesspay-readiness/page.tsx
+++ b/openbank-admin-ui/src/app/docs/qrlesspay-readiness/page.tsx
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+'use client'
+
+import Link from 'next/link'
+import { ShieldCheck, ScrollText, Scale, Lock, Landmark, ListOrdered, Info } from 'lucide-react'
+import { useLanguage } from '@/lib/i18n/LanguageContext'
+
+const ACCENT = '#6366f1'
+const INK = 'var(--text-primary)'
+const SUB = 'var(--text-secondary)'
+
+type Bilingual = [string, string]
+type Verdict = 'pass' | 'conditional' | 'risk' | 'missing'
+
+const VERDICT_STYLE: Record<Verdict, { color: string; bg: string; border: string; cs: string; en: string }> = {
+  pass: { color: '#059669', bg: '#ecfdf5', border: '#6ee7b7', cs: 'projde', en: 'pass' },
+  conditional: { color: '#d97706', bg: '#fffbeb', border: '#fcd34d', cs: 'projde s podmínkami', en: 'pass with conditions' },
+  risk: { color: '#dc2626', bg: '#fef2f2', border: '#fecaca', cs: 'může změnit návrh', en: 'may change the design' },
+  missing: { color: '#64748b', bg: '#f8fafc', border: '#cbd5e1', cs: 'nezačato', en: 'not started' },
+}
+
+type Area = { id: string; Icon: React.ElementType; title: Bilingual; verdict: Verdict; summary: Bilingual; items: { label: Bilingual; note: Bilingual }[] }
+
+const AREAS: Area[] = [
+  {
+    id: 'security',
+    Icon: ShieldCheck,
+    title: ['Bezpečnostní review banky', 'Bank security review'],
+    verdict: 'conditional',
+    summary: [
+      'Nic strukturálního nechybí. Podmínkou jsou čtyři brány, které si threat model §8 ukládá sám — a security oddělení by si je vyžádalo tak jako tak.',
+      'Nothing structural is missing. The conditions are the four gates the threat model §8 sets for itself — which a security function would demand anyway.',
+    ],
+    items: [
+      { label: ['Nezávislé krypto review', 'Independent cryptographic review'], note: ['Nikdo mimo tým neprověřil práci se seedem, životnost klíče ani porovnávání.', 'Nobody outside the team has examined seed handling, key lifetime or comparison behaviour.'] },
+      { label: ['Fuzzing CBOR dekodéru', 'CBOR decoder fuzzing'], note: ['Nový money-path kód. Striktnost je pokrytá unit testy, fuzzer nikdy neběžel.', 'New money-path code. Strictness is unit-tested; a fuzzer has never run against it.'] },
+      { label: ['Dvě souběžné CBCentralManager instance', 'Two concurrent CBCentralManager instances'], note: ['Aplikace je nikdy neběžela současně. Očekáváme, že to jde — a „očekáváme" odstraní jen test na dvou zařízeních.', 'The app has never run two at once. It is expected to work, and only a two-device lab run removes the word “expected”.'] },
+      { label: ['Účinnost varování', 'Warning efficacy'], note: ['Sami jsme napsali, že varování, které nikdo nečte, není kontrola. Netestováno s uživateli.', 'We wrote that a warning nobody reads is not a control. It has not been tested with users.'] },
+    ],
+  },
+  {
+    id: 'gdpr',
+    Icon: Lock,
+    title: ['Ochrana osobních údajů', 'Data protection'],
+    verdict: 'risk',
+    summary: [
+      'Nejrizikovější oblast a jediná, která pravděpodobně změní samotný návrh. Advert vysílá křestní jméno komukoli v dosahu, včetně lidí bez jakéhokoli vztahu k platbě.',
+      'The highest-risk area, and the one most likely to change the design itself. The advert broadcasts a first name to everyone in range, including people with no relationship to the payment.',
+    ],
+    items: [
+      { label: ['Právní základ nepokrývá kolemjdoucí', 'Lawful basis does not cover bystanders'], note: ['Plnění smlouvy pokrývá plátce a příjemce. Kolemjdoucí nejsou stranou ničeho.', 'Performance of a contract covers payer and payee. Bystanders are party to nothing.'] },
+      { label: ['DPIA vyžadována', 'DPIA required'], note: ['Pozice je obhajitelná, ale nejspíš dopadne na „jen iniciály" jako výchozí stav, ne jako opt-out. Počítat s tím.', 'The position is defensible but will plausibly land on initials-only as the default rather than an opt-out. Plan for it.'] },
+      { label: ['European Accessibility Act', 'European Accessibility Act'], note: ['Od června 2025 na bankovní služby. Varování a SAS musí fungovat pod VoiceOver/TalkBack. Neřešeno.', 'Applies to banking services since June 2025. Warnings and SAS must work under VoiceOver/TalkBack. Unaddressed.'] },
+    ],
+  },
+  {
+    id: 'payments',
+    Icon: Scale,
+    title: ['Platební compliance (PSD2, AML, ČNB)', 'Payments compliance (PSD2, AML, ČNB)'],
+    verdict: 'pass',
+    summary: [
+      'Nejsilnější místo návrhu: QRlessPay nikdy nehýbe penězi. Přenáší návrh platby, samotná platba jde existujícím railem s nezměněnou SCA.',
+      'The strongest part of the design: QRlessPay never moves money. It transfers a proposal; the payment itself runs on the existing rail with unchanged SCA.',
+    ],
+    items: [
+      { label: ['Nová platební služba dle PSD2?', 'A new payment service under PSD2?'], note: ['Nejspíš ne. Závěr ale musí potvrdit právník — není inženýrský.', 'Most likely not. That conclusion is counsel’s to make, not engineering’s.'] },
+      { label: ['SCA a dynamic linking', 'SCA and dynamic linking'], note: ['Beze změny. Částka i příjemce pocházejí z podepsaného bundle, který si plátce ověřil.', 'Unchanged. Amount and payee come from the signed bundle the payer verified.'] },
+      { label: ['Odpovědnost za chybnou platbu', 'Misdirected-payment liability'], note: ['Rozhodnutí „varovat, ne blokovat" je vědomé přijetí rizika. Dnes žije jen v pull requestu, potřebuje byznys sign-off.', 'The decision to warn rather than block is a deliberate risk acceptance. It lives only in a pull request and needs business sign-off.'] },
+    ],
+  },
+  {
+    id: 'legal',
+    Icon: Landmark,
+    title: ['Právo, IP a standardizace', 'Legal, IP and standardisation'],
+    verdict: 'missing',
+    summary: [
+      'Technicky je architektura na standard stavěná dobře. Celá právně-institucionální vrstva ale chybí — nic z toho není těžké, všechno má dlouhé lhůty a nic nezačalo.',
+      'Technically the architecture suits a standard well. The entire legal and institutional layer is absent — none of it is hard, all of it has long lead times, and none has started.',
+    ],
+    items: [
+      { label: ['Bluetooth SIG identifikátory', 'Bluetooth SIG identifiers'], note: ['UUID jsou placeholdery a 16bitový alias je fakticky obsazený bez přidělení. Pro pilot jedno, pro cizí implementátory povinné.', 'The UUIDs are placeholders and the 16-bit alias is squatted. Immaterial for a pilot, mandatory before third parties implement.'] },
+      { label: ['Patentová rešerše a IPR politika', 'Patent search and IPR policy'], note: ['Proximity payments je hustě patentované pole. Bez rešerše a závazku (royalty-free nebo FRAND) to žádná banka nepřijme.', 'Proximity payments is densely patented. No bank adopts it without a search and a royalty-free or FRAND commitment.'] },
+      { label: ['Ochranná známka', 'Trademark'], note: ['„QRlessPay" není registrovaná. Podat před publikací, jinak ji zaregistruje někdo jiný.', '“QRlessPay” is unregistered. File before publication, or someone else will.'] },
+      { label: ['Neutrální governance', 'Neutral governance'], note: ['EPC ani ČBA nepřijmou repozitář jedné banky. Otevřená otázka: self-certifikace, nebo certifikační autorita?', 'Neither EPC nor ČBA adopts one bank’s repository. Open question: self-declared conformance, or a certifying body?'] },
+    ],
+  },
+]
+
+const SEQUENCE: Bilingual[] = [
+  ['DPIA a nezávislé krypto review — obojí může změnit návrh, všechno ostatní je pak levnější.', 'DPIA and independent cryptographic review — either can change the design; everything else is cheaper afterwards.'],
+  ['Test na dvou zařízeních a fuzzing v CI — prerekvizity §8, nikoho externího nepotřebují.', 'Two-device lab run and fuzzing in CI — §8 prerequisites, neither needs anyone external.'],
+  ['Rozhodnutí: SAS default, hodnotový práh, jen iniciály, přístupnost.', 'Decisions: SAS default, high-value threshold, initials-only, accessibility.'],
+  ['Bluetooth SIG a ochranná známka — levné, dlouhé lhůty, začít brzy.', 'Bluetooth SIG and trademark — cheap, long lead times, start early.'],
+  ['ADR-0030 druhé schválení, pak pilot.', 'ADR-0030 second approval, then pilot.'],
+  ['Patenty a governance — až s prvním vážným zájemcem; dělat to spekulativně znamená platit za opci, kterou nikdo nevyužil.', 'Patents and governance — only with a genuinely interested second institution; doing it speculatively buys an option nobody has taken up.'],
+]
+
+export default function QrlessPayReadinessPage() {
+  const { t } = useLanguage()
+
+  return (
+    <div>
+      <div className="page-header">
+        <div className="breadcrumb">
+          <span>OpenBank</span><span className="breadcrumb-sep">/</span>
+          <span>{t('Dokumentace', 'Docs')}</span><span className="breadcrumb-sep">/</span>
+          <Link href="/docs/qrlesspay" style={{ color: 'inherit' }}>QRlessPay</Link>
+          <span className="breadcrumb-sep">/</span>
+          <span className="breadcrumb-current">{t('Připravenost', 'Readiness')}</span>
+        </div>
+        <h1 className="page-title" style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <ScrollText size={18} style={{ color: ACCENT }} />
+          {t('QRlessPay — posouzení připravenosti', 'QRlessPay — readiness assessment')}
+        </h1>
+        <p className="page-subtitle">
+          {t(
+            'Co se zeptá bezpečnost, compliance a právníci — včetně otázek, které bychom raději neslyšeli. Sebehodnocení implementačního týmu, ne schválení.',
+            'What security, compliance and counsel will each ask — including the questions we would rather they did not. A self-assessment by the implementing team, not an approval.',
+          )}
+        </p>
+      </div>
+
+      <div className="card" style={{ padding: 14, marginBottom: 16, background: 'var(--accent-bg)', border: '1px solid var(--accent-border)', display: 'flex', gap: 10 }}>
+        <Info size={16} style={{ color: ACCENT, flexShrink: 0, marginTop: 1 }} />
+        <div style={{ fontSize: 13, color: INK, lineHeight: 1.55 }}>
+          {t(
+            'Tento dokument není schválení a nesmí se jako schválení citovat. Schválením jsou ta review, která doporučuje — tady se jen tvrdí, že jsou to ta správná a že se za nimi nic neschovává.',
+            'This document is not an approval and must not be cited as one. The approval is the set of reviews it recommends; this only argues that they are the right ones and that nothing else is hiding behind them.',
+          )}
+        </div>
+      </div>
+
+      {AREAS.map((area) => {
+        const v = VERDICT_STYLE[area.verdict]
+        return (
+          <div key={area.id} className="card" style={{ padding: 20, marginBottom: 16 }}>
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8, flexWrap: 'wrap' }}>
+              <h2 style={{ fontSize: 15, fontWeight: 700, color: INK, margin: 0, display: 'flex', alignItems: 'center', gap: 7 }}>
+                <area.Icon size={15} style={{ color: ACCENT }} /> {t(area.title[0], area.title[1])}
+              </h2>
+              <span style={{ fontSize: 11, fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.04em', color: v.color, background: v.bg, border: `1px solid ${v.border}`, padding: '2px 9px', borderRadius: 20 }}>
+                {t(v.cs, v.en)}
+              </span>
+            </div>
+            <p style={{ fontSize: 12.5, color: SUB, margin: '6px 0 14px', lineHeight: 1.6 }}>
+              {t(area.summary[0], area.summary[1])}
+            </p>
+            <div style={{ display: 'grid', gap: 8 }}>
+              {area.items.map((item, i) => (
+                <div key={i} style={{ borderLeft: `3px solid ${v.border}`, paddingLeft: 10 }}>
+                  <div style={{ fontSize: 12.5, fontWeight: 700, color: INK }}>{t(item.label[0], item.label[1])}</div>
+                  <div style={{ fontSize: 12.5, color: SUB, lineHeight: 1.5 }}>{t(item.note[0], item.note[1])}</div>
+                </div>
+              ))}
+            </div>
+          </div>
+        )
+      })}
+
+      <div className="card" style={{ padding: 20, marginBottom: 16 }}>
+        <h2 style={{ fontSize: 15, fontWeight: 700, color: INK, margin: 0, display: 'flex', alignItems: 'center', gap: 7 }}>
+          <ListOrdered size={15} style={{ color: ACCENT }} /> {t('Doporučené pořadí', 'Recommended sequence')}
+        </h2>
+        <p style={{ fontSize: 12.5, color: SUB, margin: '4px 0 14px' }}>
+          {t('Seřazeno tak, aby práce, která může změnit návrh, proběhla dřív než ta, která na něm staví.', 'Ordered so that work which can change the design happens before work that builds on it.')}
+        </p>
+        <ol style={{ margin: 0, paddingLeft: 18, color: SUB, fontSize: 13, lineHeight: 1.75 }}>
+          {SEQUENCE.map((step, i) => <li key={i}>{t(step[0], step[1])}</li>)}
+        </ol>
+      </div>
+
+      <div className="card" style={{ padding: 20 }}>
+        <h2 style={{ fontSize: 15, fontWeight: 700, color: INK, margin: '0 0 12px' }}>{t('Dokumenty', 'Documents')}</h2>
+        <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+          <a href="https://github.com/JiRaska/open-bank-oss/blob/main/docs/compliance/qrlesspay-readiness.md" target="_blank" rel="noopener noreferrer" style={linkBtn}>{t('Plné posouzení (Markdown)', 'Full assessment (Markdown)')}</a>
+          <Link href="/docs/qrlesspay" style={linkBtn}>{t('QRlessPay — přehled', 'QRlessPay — overview')}</Link>
+          <a href="https://github.com/JiRaska/open-bank-oss/blob/main/docs/threat-models/qrlesspay.md" target="_blank" rel="noopener noreferrer" style={linkBtn}>{t('Threat model', 'Threat model')}</a>
+          <a href="https://github.com/JiRaska/open-bank-oss/blob/main/docs/specs/qrlesspay-sdk.md" target="_blank" rel="noopener noreferrer" style={linkBtn}>{t('Návrh SDK', 'SDK proposal')}</a>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+const linkBtn: React.CSSProperties = { fontSize: 12.5, fontWeight: 600, color: ACCENT, background: 'var(--accent-bg)', border: '1px solid var(--accent-border)', padding: '6px 12px', borderRadius: 8, textDecoration: 'none' }

--- a/openbank-admin-ui/src/app/docs/qrlesspay/page.tsx
+++ b/openbank-admin-ui/src/app/docs/qrlesspay/page.tsx
@@ -4,7 +4,7 @@
 'use client'
 
 import Link from 'next/link'
-import { Bluetooth, ShieldCheck, Radio, KeyRound, ScanLine, Info, Circle, CheckCircle, ArrowLeftRight, EyeOff, Hash } from 'lucide-react'
+import { Bluetooth, ShieldCheck, Radio, KeyRound, ScanLine, Info, Circle, CheckCircle, ArrowLeftRight, EyeOff, Hash, ScrollText } from 'lucide-react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 
 const ACCENT = '#6366f1'
@@ -45,6 +45,9 @@ export default function QrlessPayPage() {
           <Pill color={ACCENT} bg="var(--accent-bg)" border="var(--accent-border)" Icon={Hash} label="ADR-0095" />
         </Link>
         <Pill color="#7c3aed" bg="#f5f3ff" border="#ddd6fe" Icon={ShieldCheck} label={t('money-path', 'money-path')} />
+        <Link href="/docs/qrlesspay-readiness" style={{ textDecoration: 'none' }}>
+          <Pill color="#d97706" bg="#fffbeb" border="#fcd34d" Icon={ScrollText} label={t('Posouzení připravenosti', 'Readiness assessment')} />
+        </Link>
       </div>
 
       {/* What it is */}


### PR DESCRIPTION
A formal readiness assessment for QRlessPay, plus a console page so it is a click away rather than a file someone has to know exists.

## What it is

One document answering what a bank's **security function**, **compliance function** and **counsel** each ask. Written to surface objections rather than to survive them — a reviewer who finds a weakness themselves assumes it was hidden, so the weak axes are stated before anyone asks.

It is explicitly **not an approval**, and says so twice: the approval is the set of reviews it recommends. This only argues those are the right ones and that nothing else is hiding behind them.

## The four verdicts, and why they differ

| Area | Verdict | Why |
|---|---|---|
| Bank security review | **pass with conditions** | Nothing structural missing; the conditions are the four gates the threat model §8 already sets for itself |
| Payments compliance (PSD2, AML, ČNB) | **pass** | The protocol never moves money — it transfers a proposal, settlement runs on the existing rail with unchanged SCA. This one property is why most of the regulatory surface is thin |
| Data protection | **may change the design** | The advert broadcasts a first name to everyone in radio range |
| Legal, IP, standardisation | **not started** | Placeholder Bluetooth SIG identifiers, no patent search, unregistered name, no governance body |

**Data protection is the one worth reading closely.** Lawful basis for payer and payee is performance of the requested payment; it does not extend to **bystanders**, who are party to nothing and cannot object to a broadcast they cannot see. The position is defensible — user-initiated, screen-open-only, ephemeral identifiers, first name only, no IBAN, no more than a name badge discloses — but the DPIA will plausibly land on **initials-only as the default** rather than as an opt-out. Better to plan for that than to defend the current default.

Also flagged there and not previously tracked anywhere: the **European Accessibility Act** has applied to banking services since June 2025, and the warnings and any SAS comparison must work under VoiceOver/TalkBack. That will block an internal release independently of everything else.

## Two implicit decisions made explicit

Both currently live only in a pull request body, which is not where a risk acceptance belongs:

1. **Warning rather than blocking** on duplicate payments and ambiguous names is a deliberate acceptance of residual risk. Needs business sign-off.
2. **Misdirected-payment liability** — our position is parity with a QR scan, and customer terms should state that the payer's confirmation is the authorising act.

## Sequencing

Ordered so work that can *change the design* happens before work that builds on it: DPIA and crypto review first, then the lab run and fuzzing, then the open parameter decisions, then the long-lead cheap items (Bluetooth SIG, trademark), then ADR-0030 and pilot. Patents and governance are deliberately **last** — doing them speculatively buys an option nobody has taken up.

## Console page

`/docs/qrlesspay-readiness`, reachable from a pill on the QRlessPay overview. Same four verdicts, same sequencing, links out to the full Markdown, the threat model and the SDK proposal.

## Verification

`npm run type-check` clean, `npx eslint` clean on both touched pages, `npm test` **105 files / 1282 tests passing** — up from 1277, because the render-smoke glob picks up a new page automatically and the i18n and layout-shell guards cover it without being told.

Rendered the page to static HTML and screenshotted it rather than trusting jsdom, per the repo's own rule that a CSS or layout regression passes `tsc`, `eslint` and the mount-only smoke suite. Cards, verdict badges, rules and all five links check out.

One probe correction worth recording: my first check reported the verdict badges missing. They were not — `innerText` applies `text-transform: uppercase`, so a case-sensitive match against the source strings found nothing. The page was right and the probe was wrong.

Docs plus one new console page; no service code, no API surface, no migration.

Refs ADR-0095

## Linked issues

Refs #4830 — the readiness view of the same capability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
