### PR TITLE
fix(case-coordinator): the signal denial stops echoing the caller's agentId (#4834)

### DIFF
--- a/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/infrastructure/rest/CaseCoordinatorResource.kt
+++ b/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/infrastructure/rest/CaseCoordinatorResource.kt
@@ -153,7 +153,11 @@ class CaseCoordinatorResource(
         if (!temporalConfig.enabled()) return temporalUnavailable()
         if (!capable(type, agentId)) {
             return Response.status(Response.Status.FORBIDDEN)
-                .entity(errorBody("signal '$type' denied for agent '$agentId'")).build()
+                // agentId is NOT echoed (#4834), matching the openCase denial. It is free-form
+                // request-body input, and reflecting it verbatim tells the caller nothing it did
+                // not just send. `type` stays: reaching this line means capable() already matched
+                // it against the four known signal literals, so it is a bounded server-side value.
+                .entity(errorBody("signal '$type' denied for the requested agent")).build()
         }
         return deliver(id, type, agentId, request)
     }

--- a/openbank-case-coordinator-agent/src/test/kotlin/com/openbank/casecoordinator/infrastructure/rest/CaseCoordinatorResourceDenialTest.kt
+++ b/openbank-case-coordinator-agent/src/test/kotlin/com/openbank/casecoordinator/infrastructure/rest/CaseCoordinatorResourceDenialTest.kt
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+
+package com.openbank.casecoordinator.infrastructure.rest
+
+import com.openbank.casecoordinator.application.CaseCapabilityGate
+import com.openbank.casecoordinator.application.CaseOpenService
+import com.openbank.casecoordinator.application.CaseThreadService
+import com.openbank.libs.temporal.TemporalConfig
+import io.mockk.every
+import io.mockk.mockk
+import io.quarkus.security.identity.SecurityIdentity
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * The denial bodies must not reflect caller-supplied input back (#4834).
+ *
+ * A plain unit test rather than a `@QuarkusTest`: `signal()` returns 503 before reaching the
+ * capability check whenever Temporal is disabled, and Temporal is disabled in `%test` — so the
+ * denial branch is unreachable over HTTP in this module's IT profile. Constructing the resource
+ * directly is what actually exercises it.
+ */
+class CaseCoordinatorResourceDenialTest {
+
+    private val openService = mockk<CaseOpenService>()
+    private val threadService = mockk<CaseThreadService>()
+    private val gate = mockk<CaseCapabilityGate>()
+    private val temporalConfig = mockk<TemporalConfig>()
+    private val identity = mockk<SecurityIdentity>(relaxed = true)
+
+    private val resource = CaseCoordinatorResource(
+        openService,
+        threadService,
+        gate,
+        mockk(relaxed = true),
+        temporalConfig,
+        identity,
+    )
+
+    @Test
+    fun `a denied signal does not echo the caller's agentId back`() {
+        every { temporalConfig.enabled() } returns true
+        every { gate.canContribute(any()) } returns false
+
+        val marker = "spoofed-agent-DEADBEEF"
+        val response = resource.signal(
+            "case-incident-response-acct-1",
+            CaseCoordinatorResource.SignalRequest(type = "contribute", agentId = marker, summary = "x"),
+        )
+
+        assertThat(response.status).isEqualTo(403)
+        val body = response.entity.toString()
+        assertThat(body)
+            .describedAs("the denial must still say WHY, or this test would pass on an empty body")
+            .contains("contribute")
+        assertThat(body)
+            .describedAs("caller-supplied agentId must not be reflected into the response")
+            .doesNotContain(marker)
+    }
+}


### PR DESCRIPTION
## The change

`POST /cases/{caseId}/signals` reflected the request body's `agentId` verbatim into its 403:

```kotlin
errorBody("signal '$type' denied for agent '$agentId'")
```

Same untrusted-value-reflected shape #4833 removed from the `openCase` denial, and it tells the
caller nothing it did not just send.

**`$type` deliberately stays.** Reaching that line means `capable()` already matched it against the
four known signal literals (`join` / `contribute` / `supersede` / `request-synthesis`) and returned
false — anything else throws before it — so it is a bounded server-side value, not caller input. The
asymmetry is documented in place so the next reader does not "fix" the half that is already safe.

## Why a unit test and not a `@QuarkusTest`

Worth stating, because the IT would have looked like better coverage and been worthless here:

`signal()` returns **503 before reaching the capability check** whenever Temporal is disabled, and
Temporal is disabled in `%test`. So this branch is **unreachable over HTTP in this module's IT
profile** — an integration test would have passed without ever executing the line it claims to
cover. Constructing the resource directly is what actually exercises it.

The test carries a known-positive guard: the denial must still contain `"contribute"`, so an empty
or generic body cannot pass as clean.

**Falsified** — restoring the echo reddens it:

```
CaseCoordinatorResourceDenialTest > a denied signal does not echo the caller's agentId back() FAILED
```

## Scope

This is the small half of #4834, the half that needed no design decision.

**The larger half stays open.** `agentId` still selects five capability checks and becomes the
contribution's *author* inside the workflow, on a value the caller asserts rather than proves. Both
routes to closing that are blocked on facts measured and recorded on the issue:

- `openbank-case-coordinator-agent` has **no `openbank-libs-domain` / `openbank-libs-runtime`
  dependency**, so `@Authorize` — an InterceptorBinding living in libs-domain — is not available to
  this module at all
- there is **no `opa` sidecar** in its gitops component

So ADR-0244 D9's OPA gate is its own piece of work, and copying agent-service's
`AgentIdentityBinding` would create a second hand-maintained authorisation primitive. Neither
belongs in this fix.

## Verification

`detekt`, `ktlintCheck`, `koverVerify`, `test` — **31 tests, 0 failures, 0 skipped**.

Refs #4834, #4833
