### PR TITLE
chore(gitops): deploy Product Catalog platform

### DIFF
--- a/openbank-infra/gitops/components/accounts/product-catalog.yaml
+++ b/openbank-infra/gitops/components/accounts/product-catalog.yaml
@@ -79,7 +79,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: product-catalog
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-product-catalog:sandbox-216d50cb
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-product-catalog:sandbox-cdd4af29
           imagePullPolicy: IfNotPresent
           ports:
             - name: http


### PR DESCRIPTION
## Deployment

Pins the Product Catalog sandbox workload to the already built, signed, scanned, SBOM-attested and Pact-gated `sandbox-cdd4af29` image.

## Why this PR exists

The standard Auto deploy run completed the build and contract gate, but its GitHub App PR creation failed because it was dispatched from a historical recovery ref. This is the same normal GitOps manifest change, created from current `main` with a signed commit.

## Evidence

- Auto deploy build, signing, Trivy, SBOM and can-i-deploy: green
- Provider Pact verification: green
- Only `openbank-infra/gitops/components/accounts/product-catalog.yaml` changes

Refs #4501