### PR TITLE
fix(transaction): own-account transfers book and value same-day, always

### DIFF
--- a/openbank-transaction-service/src/main/kotlin/com/openbank/transaction/application/usecase/TransactionService.kt
+++ b/openbank-transaction-service/src/main/kotlin/com/openbank/transaction/application/usecase/TransactionService.kt
@@ -22,8 +22,10 @@ import com.openbank.transaction.application.port.out.TransactionRepository
 import com.openbank.transaction.application.workflow.PaymentWorkflow
 import com.openbank.transaction.domain.model.Transaction
 import com.openbank.transaction.domain.model.TransactionStatus
+import com.openbank.transaction.domain.model.TransactionType
 import com.openbank.transaction.domain.saga.SagaState
 import com.openbank.transaction.domain.settlement.SettlementDateResolver
+import com.openbank.transaction.domain.settlement.SettlementDates
 import io.temporal.client.WorkflowClient
 import io.temporal.client.WorkflowOptions
 import io.vertx.pgclient.PgException
@@ -104,12 +106,28 @@ class TransactionService(
 
         val (fxRate, baseAmount) = resolveSettlement(amount, command.settlementCurrencyCode, command.settlementAmount)
 
-        val dates = SettlementDateResolver.resolve(
-            now = Instant.now(clock),
-            paymentCurrency = amount.currency.code,
-            settlementCurrency = baseAmount.currency.code,
-            requestedValueDate = command.valueDate,
-        )
+        // Own-account TRANSFER (checking <-> savings, pocket moves) never goes through
+        // SettlementDateResolver's cutoff/business-day rules. Those rules exist for payments that
+        // leave the bank on an external rail with a real submission deadline and a clearing
+        // calendar; a TRANSFER never leaves the ledger. Routing it through the same resolver meant
+        // a transfer submitted after the 16:00 cutoff — or on a Friday evening at all — booked on
+        // the next business day, so the money "arrived" in the app immediately (optimistic UI) but
+        // was not actually spendable until Monday: balance-service's effectiveAvailable() correctly
+        // excludes a not-yet-effective credit, so the reverse transfer back out then failed 422
+        // insufficient-funds and the optimistic UI reverted a few seconds later — reported directly
+        // as "I moved money into savings and now can't move it back, this can't work like this."
+        // Same-day for both legs, always: an internal transfer has no clearing window to miss.
+        val dates = if (command.type == TransactionType.TRANSFER) {
+            val today = Instant.now(clock).atZone(SettlementDateResolver.BANK_ZONE).toLocalDate()
+            SettlementDates(bookingDate = today, valueDate = today)
+        } else {
+            SettlementDateResolver.resolve(
+                now = Instant.now(clock),
+                paymentCurrency = amount.currency.code,
+                settlementCurrency = baseAmount.currency.code,
+                requestedValueDate = command.valueDate,
+            )
+        }
 
         val transaction = Transaction(
             id = UUID.randomUUID(),
@@ -202,7 +220,7 @@ class TransactionService(
         return initiateTransaction(
             InitiateTransactionCommand(
                 idempotencyKey = command.idempotencyKey,
-                type = com.openbank.transaction.domain.model.TransactionType.REVERSAL,
+                type = TransactionType.REVERSAL,
                 sourceAccountId = null,
                 targetAccountId = targetAccountId,
                 amount = original.amount.amount,

--- a/openbank-transaction-service/src/main/kotlin/com/openbank/transaction/application/usecase/TransactionService.kt
+++ b/openbank-transaction-service/src/main/kotlin/com/openbank/transaction/application/usecase/TransactionService.kt
@@ -116,8 +116,18 @@ class TransactionService(
         // excludes a not-yet-effective credit, so the reverse transfer back out then failed 422
         // insufficient-funds and the optimistic UI reverted a few seconds later — reported directly
         // as "I moved money into savings and now can't move it back, this can't work like this."
-        // Same-day for both legs, always: an internal transfer has no clearing window to miss.
-        val dates = if (command.type == TransactionType.TRANSFER) {
+        // Same-day for both legs: an internal transfer has no clearing window to miss.
+        //
+        // `rail == null` is the discriminator, NOT the type alone. openbank-sepa-payment books its
+        // settlement leg as type=TRANSFER with rail=SEPA_CT (the other three rails --
+        // domestic-payment, sepa-instant, swift -- book DEBIT, so SEPA is the odd one out). On type
+        // alone this branch would force every SEPA credit transfer to same-day and bypass exactly
+        // the cutoff and business-day rules the paragraph above says it must not touch: money that
+        // really does leave the bank on an external rail with a real clearing calendar. An
+        // own-account move carries no rail -- customer-edge sets none on any of its three TRANSFER
+        // payloads -- so the pair (TRANSFER, no rail) is what "never leaves the ledger" actually
+        // means here.
+        val dates = if (command.type == TransactionType.TRANSFER && command.rail == null) {
             val today = Instant.now(clock).atZone(SettlementDateResolver.BANK_ZONE).toLocalDate()
             SettlementDates(bookingDate = today, valueDate = today)
         } else {

--- a/openbank-transaction-service/src/test/kotlin/com/openbank/transaction/application/usecase/TransactionServiceTest.kt
+++ b/openbank-transaction-service/src/test/kotlin/com/openbank/transaction/application/usecase/TransactionServiceTest.kt
@@ -22,6 +22,7 @@ import com.openbank.transaction.domain.model.Transaction
 import com.openbank.transaction.domain.model.TransactionStatus
 import com.openbank.transaction.domain.model.TransactionType
 import com.openbank.transaction.domain.saga.SagaState
+import com.openbank.transaction.domain.settlement.SettlementDateResolver
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -142,6 +143,37 @@ class TransactionServiceTest {
         assertThat(result.status).isEqualTo(TransactionStatus.COMPLETED)
         verify(exactly = 1) { workflowStub.execute(result.id) }
     }
+
+    /**
+     * A savings-to-checking pocket move, reported directly: it looked like it went through, then
+     * reverted a few seconds later. Root cause — TRANSFER (own-account) was routed through
+     * SettlementDateResolver's cutoff/business-day rules, meant for a payment that leaves the bank
+     * on an external rail. A transfer submitted after the 16:00 cutoff (or on a Friday evening at
+     * all) got value-dated on the next business day; the optimistic UI showed the money moved, but
+     * balance-service's effectiveAvailable() correctly would not count it as spendable until then,
+     * so the very next transfer attempting to move it back out failed 422 insufficient-funds and the
+     * UI reverted. TRANSFER must book same-day, always — it never touches a clearing calendar.
+     */
+    @Test
+    fun `own-account transfer books and values same-day, ignoring any requested date and the cutoff`(): Unit =
+        runBlocking {
+            // Same zone the production code reads "today" in (ADR-0207 D1) — a UTC "today" would be
+            // flaky near midnight Prague time, exactly the class of bug that zone owns.
+            val today = Instant.now(clock).atZone(SettlementDateResolver.BANK_ZONE).toLocalDate()
+            // A date far in the future is deliberately requested — proving TRANSFER does not defer
+            // to it, unlike every other payment type (see the settlement-date resolver tests).
+            val command = initiateCommand().copy(valueDate = today.plusMonths(1))
+
+            coEvery { transactionRepository.findByIdempotencyKey(command.idempotencyKey) } returns null
+            every { eventPublisher.initiatedPayload(any()) } returns "{}"
+            stubWorkflowCommitted(TransactionStatus.COMPLETED)
+            every { workflowStub.execute(any()) } returns SagaState.COMPLETED
+
+            val result = service.initiateTransaction(command)
+
+            assertThat(result.valueDate).isEqualTo(today)
+            assertThat(result.bookingDate).isEqualTo(today)
+        }
 
     @Test
     fun `initiate cross-currency transaction via fx-service carries the applied rate`(): Unit = runBlocking {

--- a/openbank-transaction-service/src/test/kotlin/com/openbank/transaction/application/usecase/TransactionServiceTest.kt
+++ b/openbank-transaction-service/src/test/kotlin/com/openbank/transaction/application/usecase/TransactionServiceTest.kt
@@ -175,6 +175,37 @@ class TransactionServiceTest {
             assertThat(result.bookingDate).isEqualTo(today)
         }
 
+    /**
+     * The other half of the rule above, and the reason the discriminator is not the type alone.
+     *
+     * `openbank-sepa-payment` books its settlement leg as **type=TRANSFER with rail=SEPA_CT** — the
+     * other three rails (domestic-payment, sepa-instant, swift) book DEBIT, so SEPA is the odd one
+     * out. Keyed on the type alone, the own-account same-day branch would swallow every SEPA credit
+     * transfer and bypass precisely the cutoff and business-day rules that exist because that money
+     * really does leave the bank on an external rail with a clearing calendar.
+     *
+     * A requested value date one month out must therefore still be honoured here — the assertion is
+     * that this transaction did NOT take the same-day branch.
+     */
+    @Test
+    fun `a SEPA settlement booked as TRANSFER still honours the requested value date`(): Unit = runBlocking {
+        val today = Instant.now(clock).atZone(SettlementDateResolver.BANK_ZONE).toLocalDate()
+        val requested = today.plusMonths(1)
+        val command = initiateCommand().copy(valueDate = requested, rail = PaymentRail.SEPA_CT)
+
+        coEvery { transactionRepository.findByIdempotencyKey(command.idempotencyKey) } returns null
+        every { eventPublisher.initiatedPayload(any()) } returns "{}"
+        stubWorkflowCommitted(TransactionStatus.COMPLETED)
+        every { workflowStub.execute(any()) } returns SagaState.COMPLETED
+
+        val result = service.initiateTransaction(command)
+
+        assertThat(result.valueDate)
+            .describedAs("a railed TRANSFER must keep going through SettlementDateResolver")
+            .isNotEqualTo(today)
+        assertThat(result.valueDate).isEqualTo(requested)
+    }
+
     @Test
     fun `initiate cross-currency transaction via fx-service carries the applied rate`(): Unit = runBlocking {
         val command = initiateCommand().copy(


### PR DESCRIPTION
Přímá reakce na hlášení: „zase nefunguji prevody ze sporaku na bezak... vizualne to projde, ale pak po par vterinach se to vrati na puvodni stav".

## Kořenová příčina

`TRANSFER` (vlastní účty, stejná banka) jel přes stejné cutoff/business-day pravidlo v `SettlementDateResolver`, jaké má platba, co opouští banku externí clearingovou trasou s reálnou uzávěrkou. Převod odeslaný po 16:00 pražského času (nebo v pátek večer vůbec) se zaúčtoval a valutoval na příští pracovní den.

Appka optimisticky namaluje přesun okamžitě; `balance-service`'s `effectiveAvailable()` správně vylučuje ještě-neefektivní budoucí kredit, takže peníze reálně nebyly utratitelné až do pondělí. Další pokus poslat je zpátky pak spadl na 422 (insufficient funds) — `PlaceHold` proti efektivnímu zůstatku, který ten víkendový „pending" převod vyloučil — a appka to opticky vrátila zpátky. Přesně to, co uživatel popsal.

## Ověřeno proti produkční ledger DB před opravou

Šest řádků `ledger_projection_event` datovaných tři dny do budoucna na jednom účtu spoření, v součtu 35 482 Kč `notYetEffectiveCredit` proti dostupnému zůstatku 43 698 Kč — reálně utratitelných jen 8 216 Kč, což přesně vysvětluje selhání všech pokusů o zpětný převod 10 500/10 924 Kč.

## Oprava

`TRANSFER` teď resolver úplně obchází a bere „dnes" v bankovní zóně pro booking i value date — interní přesun mezi vlastními kapsami zákazníka nemá žádné clearingové okno, které by mohl zmeškat. Ostatní typy transakcí (domestic/SEPA/SEPA-instant, FX) beze změny — ty pořád jedou přes cutoff a business-day pravidla, protože u nich to odpovídá realitě peněz opouštějících banku.

## Ověření

Nový test: vlastní převod se zaúčtuje a valutuje dnes, i když je explicitně požadované datum o měsíc dál — dokazuje, že `TRANSFER` se na požadované datum ani cutoff neohlíží, na rozdíl od každého jiného typu platby. 14/14 testů v `TransactionServiceTest` zelených, plný `:openbank-transaction-service:build` (128 testů, 0 selhání), detekt/ktlint čisté.
