### PR TITLE
fix(campaign): allow graph migration catch-up

### DIFF
--- a/openbank-infra/gitops/components/campaign/campaign-service.yaml
+++ b/openbank-infra/gitops/components/campaign/campaign-service.yaml
@@ -72,6 +72,12 @@ spec:
               value: jdbc:postgresql://campaign-db-rw.campaign.svc:5432/openbank_campaigns
             - name: QUARKUS_DATASOURCE_REACTIVE_URL
               value: vertx-reactive:postgresql://campaign-db-rw.campaign.svc:5432/openbank_campaigns
+            # V15 (Stories) was deployed before the additive graph migrations V13/V14.  Flyway
+            # otherwise refuses to start rather than backfilling those safe, additive columns.
+            # Keep this explicit until all environments have recorded V13/V14; then remove it in
+            # a separately reviewed cleanup rather than making out-of-order migrations implicit.
+            - name: QUARKUS_FLYWAY_OUT_OF_ORDER
+              value: "true"
             - name: DB_USER
               value: openbank
             - name: DB_PASSWORD


### PR DESCRIPTION
## Root cause

Stories migration V15 reached the live database before graph migrations V13/V14. Flyway therefore rejected the graph image before readiness.

## Change

Temporarily enable Flyway out-of-order execution in the campaign GitOps deployment so only the already-reviewed, additive V13/V14 migrations can catch up. Graph activation remains disabled.

## Validation

- git diff --check
- kubectl apply --dry-run=client --validate=false -f openbank-infra/gitops/components/campaign/campaign-service.yaml
- Live pod evidence: Flyway validation reported V13/V14 as resolved but unapplied.

Refs #4781