### PR TITLE
chore(campaign): enable graph activation

### DIFF
--- a/openbank-infra/gitops/components/campaign/campaign-service.yaml
+++ b/openbank-infra/gitops/components/campaign/campaign-service.yaml
@@ -129,10 +129,10 @@ spec:
             # queue until the compatible image is restored.
             - name: OPENBANK_CAMPAIGN_DECISION_TASK_QUEUE
               value: openbank-campaign-decision
-            # Expand first: deploy and observe the isolated graph worker before a separately
-            # reviewed GitOps change enables graph-campaign activation.
+            # The isolated graph worker is live and healthy. This separately reviewed step admits
+            # graph-campaign activation without changing the replay-compatible legacy queue.
             - name: OPENBANK_CAMPAIGN_EXPLICIT_GRAPH_ACTIVATION_ENABLED
-              value: "false"
+              value: "true"
             - name: CAMPAIGN_WORKER_ENABLED
               value: "true"
             # ADR-0198: live per-send consent check (fail-closed). Declared as an


### PR DESCRIPTION
## Summary
- Enables explicit decision-graph campaign activation after the isolated Temporal queue proved healthy in the live campaign-service rollout.
- Leaves the legacy queue untouched and retains the separately reviewed rollback boundary.

## Evidence
- campaign-service deployment is Available (1/1) on the graph-capable image.
- both `openbank-campaign` and `openbank-campaign-decision` Temporal pollers started.
- Flyway applied V13/V14 successfully; graph activation was still false during that verification.

## Validation
- `git diff --check origin/main...HEAD`
- `kubectl apply --dry-run=client --validate=false -f openbank-infra/gitops/components/campaign/campaign-service.yaml`

Refs #4781