### PR TITLE
fix(ci): stop the event-contract gate hiding internal data classes

### DIFF
--- a/.github/scripts/check-event-contract-code-agreement.py
+++ b/.github/scripts/check-event-contract-code-agreement.py
@@ -112,7 +112,17 @@ EVENT_TYPE_CONST_RE = re.compile(
 )
 
 # A top-level `data class Name(` opening a primary constructor.
-DATA_CLASS_RE = re.compile(r"^data class\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(", re.MULTILINE)
+#
+# The visibility/modality modifiers are NOT optional decoration to allow: anchoring on a bare
+# `^data class` made every `internal data class` invisible to this gate — 19 of the fleet's 1317
+# top-level data classes, and a contract for one of them therefore reported "no class declares
+# that event type" about a class that plainly does (billing's AnnualFeeSummaryReadyPayload, #4129).
+# A detector keyed on one spelling reports its blind spot as a finding about the code, which is
+# worse than not looking: it sends the author to fix something that is not wrong.
+DATA_CLASS_RE = re.compile(
+    r"^(?:(?:internal|private|public|sealed|abstract|open|final)\s+)*data class\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(",
+    re.MULTILINE,
+)
 
 # The hand-built-outbox idiom (fraud-service, case-coordinator-agent): the payload is a raw
 # string template or a `mapOf(...)` literal, not a `data class`, so DATA_CLASS_RE never fires —
@@ -751,6 +761,26 @@ def self_test() -> int:
         if old not in text:
             raise AssertionError(f"self-test fixture stale: {old!r} not in {path}")
         path.write_text(text.replace(old, new, 1), encoding="utf-8")
+
+    # The `internal` modifier must not hide a producer. Without the modifier-tolerant
+    # DATA_CLASS_RE this case does not merely go undetected — the gate reports the WRONG thing
+    # ("no class declares that event type") about a class that plainly does, which is how a
+    # correct PR gets sent to fix something that is not broken (#4129).
+    case(
+        "an internal data class is still a producer",
+        "openbank-notification-service",
+        lambda t: edit(
+            t / "openbank-notification-service" / "src/main/kotlin/com/openbank/notification/domain/model/NotificationOutcome.kt",
+            "data class NotificationOutcomeEvent(",
+            "internal data class NotificationOutcomeEvent(",
+        )
+        or edit(
+            t / CONTRACTS_DIRNAME / "openbank-notification-service" / "asyncapi.yaml",
+            "        notificationId:\n          type: string",
+            "        notificationIdRenamed:\n          type: string",
+        ),
+        "does not carry",
+    )
 
     # A: a channel address the service does not produce.
     case(


### PR DESCRIPTION
## The gate reported the wrong thing about correct code

`DATA_CLASS_RE` was anchored on a bare `^data class`, so every **`internal data class`** was invisible to this gate. Measured across the fleet: **19 of 1317 top-level data classes** are declared that way.

The failure mode is worse than a missed check. When a contract names a message whose producer is one of those 19, the gate does not stay quiet — it reports:

> message `X` is declared in the contract but no class in `…/src/main` declares that event type

about a class that plainly does. That sends the author to fix something that is not broken. Found on #4129, where `billing`'s `internal data class AnnualFeeSummaryReadyPayload` declares its `EVENT_TYPE` exactly as the gate documents, and was told it did not exist.

## The fix

`DATA_CLASS_RE` now tolerates the visibility and modality modifiers Kotlin allows before `data class`. Nothing else changes: the constructor-property extraction, the hand-built-outbox idiom and the three checks are untouched.

## Falsified in both directions, not merely observed green

A new self-test case marks the notification-service fixture's producer `internal` **and** renames a contract property, so the gate must still report the property disagreement:

- with the fix: `self-test: all 13 case(s) detected.`
- with `DATA_CLASS_RE` reverted to `^data class`: `FAIL [an internal data class is still a producer]: expected exit 1 containing 'does not carry'` → `1 of 13 case(s) FAILED`

That is the assertion that matters. A case which merely goes *undetected* without the fix would be weaker — this one shows the gate saying the wrong thing, which is the actual defect.

The gate also still passes on `origin/main` unchanged.

## What this does not fix

#4129 has two further, genuine disagreements — `billing.fee.post-intent.v1` and `billing.fee.reversal-intent.v1` are emitted with no message in the contract. Those are real and belong to that PR's author: adding a contract for one event turns on checking for **all** of the service's events, which is correct behaviour and is how they surfaced.

Refs #4129
