### PR TITLE
feat(campaign): add governed audience composer

### DIFF
--- a/openbank-admin-ui/src/app/api/audiences/[name]/[version]/[action]/route.ts
+++ b/openbank-admin-ui/src/app/api/audiences/[name]/[version]/[action]/route.ts
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+import { NextRequest, NextResponse } from 'next/server'
+import { auth } from '@/auth'
+import { serverSvcUrl } from '@/lib/services/bff'
+
+export const dynamic = 'force-dynamic'
+
+type Context = { params: Promise<{ name: string; version: string; action: 'preview' | 'submit' | 'approve' }> }
+
+async function forward(request: NextRequest, context: Context) {
+  const session = await auth()
+  if (!session?.user?.accessToken) return NextResponse.json({ error: 'unauthenticated' }, { status: 401 })
+  const { name, version, action } = await context.params
+  if (!['preview', 'submit', 'approve'].includes(action)) return NextResponse.json({ error: 'unknown action' }, { status: 404 })
+  const response = await fetch(serverSvcUrl('campaign-service', 'campaign', 8128, `/api/v1/audiences/${encodeURIComponent(name)}/${encodeURIComponent(version)}/${action}`), {
+    method: request.method, headers: { authorization: `Bearer ${session.user.accessToken}` }, signal: AbortSignal.timeout(5000), cache: 'no-store',
+  })
+  return NextResponse.json(await response.json(), { status: response.status })
+}
+
+export async function GET(request: NextRequest, context: Context) { return forward(request, context) }
+export async function POST(request: NextRequest, context: Context) { return forward(request, context) }

--- a/openbank-admin-ui/src/app/api/audiences/[name]/[version]/[action]/route.ts
+++ b/openbank-admin-ui/src/app/api/audiences/[name]/[version]/[action]/route.ts
@@ -7,13 +7,19 @@ import { serverSvcUrl } from '@/lib/services/bff'
 
 export const dynamic = 'force-dynamic'
 
-type Context = { params: Promise<{ name: string; version: string; action: 'preview' | 'submit' | 'approve' }> }
+type Context = { params: Promise<{ name: string; version: string; action: string }> }
+const supportedActions = ['preview', 'submit', 'approve'] as const
+type SupportedAction = (typeof supportedActions)[number]
+
+function isSupportedAction(action: string): action is SupportedAction {
+  return supportedActions.includes(action as SupportedAction)
+}
 
 async function forward(request: NextRequest, context: Context) {
   const session = await auth()
   if (!session?.user?.accessToken) return NextResponse.json({ error: 'unauthenticated' }, { status: 401 })
   const { name, version, action } = await context.params
-  if (!['preview', 'submit', 'approve'].includes(action)) return NextResponse.json({ error: 'unknown action' }, { status: 404 })
+  if (!isSupportedAction(action)) return NextResponse.json({ error: 'unknown action' }, { status: 404 })
   const response = await fetch(serverSvcUrl('campaign-service', 'campaign', 8128, `/api/v1/audiences/${encodeURIComponent(name)}/${encodeURIComponent(version)}/${action}`), {
     method: request.method, headers: { authorization: `Bearer ${session.user.accessToken}` }, signal: AbortSignal.timeout(5000), cache: 'no-store',
   })

--- a/openbank-admin-ui/src/app/api/audiences/route.ts
+++ b/openbank-admin-ui/src/app/api/audiences/route.ts
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+import { NextRequest, NextResponse } from 'next/server'
+import { auth } from '@/auth'
+import { serverSvcUrl } from '@/lib/services/bff'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET() {
+  const session = await auth()
+  if (!session?.user?.accessToken) return NextResponse.json({ error: 'unauthenticated' }, { status: 401 })
+  try {
+    const response = await fetch(serverSvcUrl('campaign-service', 'campaign', 8128, '/api/v1/audiences'), {
+      headers: { authorization: `Bearer ${session.user.accessToken}` }, signal: AbortSignal.timeout(4000), cache: 'no-store',
+    })
+    if (!response.ok) return NextResponse.json({ items: [], state: response.status === 401 || response.status === 403 ? 'unauthorized' : response.status === 404 ? 'not_deployed' : 'unreachable' })
+    return NextResponse.json({ items: await response.json(), state: 'ok' })
+  } catch { return NextResponse.json({ items: [], state: 'unreachable' }) }
+}
+
+export async function POST(request: NextRequest) {
+  const session = await auth()
+  if (!session?.user?.accessToken) return NextResponse.json({ error: 'unauthenticated' }, { status: 401 })
+  const response = await fetch(serverSvcUrl('campaign-service', 'campaign', 8128, '/api/v1/audiences'), {
+    method: 'POST', headers: { authorization: `Bearer ${session.user.accessToken}`, 'content-type': 'application/json' }, body: await request.text(), signal: AbortSignal.timeout(5000), cache: 'no-store',
+  })
+  return NextResponse.json(await response.json(), { status: response.status })
+}

--- a/openbank-admin-ui/src/app/segments/new/page.tsx
+++ b/openbank-admin-ui/src/app/segments/new/page.tsx
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+'use client'
+
+import { useState } from 'react'
+import Link from 'next/link'
+import { useRouter } from 'next/navigation'
+import { ArrowLeft, CheckCircle2, ShieldCheck, Users } from 'lucide-react'
+import { useLanguage } from '@/lib/i18n/LanguageContext'
+import { PageHeader } from '@/components/ui'
+
+/** A deliberately small, typed composer. It sends no query language or arbitrary JSON path. */
+export default function NewAudiencePage() {
+  const { t } = useLanguage()
+  const router = useRouter()
+  const [name, setName] = useState('')
+  const [status, setStatus] = useState('ACTIVE')
+  const [minDays, setMinDays] = useState('')
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const create = async () => {
+    setSaving(true); setError(null)
+    const rules: Array<Record<string, unknown>> = [{ type: 'PARTY_STATUS_IS', status }]
+    if (minDays.trim() !== '') rules.push({ type: 'TENURE_AT_LEAST_DAYS', minDays: Number(minDays) })
+    try {
+      const response = await fetch('/api/audiences', { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ name, rules }) })
+      if (!response.ok) throw new Error((await response.json()).error ?? 'Unable to create audience')
+      router.push('/segments')
+    } catch (e) { setError(e instanceof Error ? e.message : 'Unable to create audience') } finally { setSaving(false) }
+  }
+
+  const validName = /^[a-z0-9][a-z0-9-]*$/.test(name)
+  const validTenure = minDays.trim() === '' || (Number.isInteger(Number(minDays)) && Number(minDays) >= 0)
+
+  return (
+    <div className="mx-auto max-w-4xl space-y-6">
+      <Link href="/segments" className="inline-flex items-center gap-2 text-sm font-medium text-slate-500 transition hover:text-violet-700"><ArrowLeft className="h-4 w-4" />{t('Zpět do knihovny publik', 'Back to audience library')}</Link>
+      <PageHeader title={t('Nové publikum', 'New audience')} subtitle={t('Sestavte bezpečný návrh z pravidel, která platforma umí skutečně vyhodnotit.', 'Compose a safe draft from rules the platform can actually evaluate.')} icon={<Users className="h-6 w-6" />} />
+      <section className="grid gap-5 lg:grid-cols-[1fr_.72fr]">
+        <form onSubmit={e => { e.preventDefault(); void create() }} className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+          <p className="text-xs font-bold uppercase tracking-[.12em] text-violet-700">{t('Návrh publika', 'Audience draft')}</p>
+          <h2 className="mt-2 text-xl font-semibold tracking-tight text-slate-900">{t('Koho chcete oslovit?', 'Who should enter?')}</h2>
+          <label className="mt-6 block text-sm font-semibold text-slate-700">{t('Název', 'Name')}<input value={name} onChange={e => setName(e.target.value)} placeholder="new-savers" className="mt-2 w-full rounded-xl border border-slate-200 px-3 py-2.5 font-mono text-sm outline-none transition focus:border-violet-500 focus:ring-4 focus:ring-violet-100" /></label>
+          <p className="mt-1 text-xs text-slate-500">{t('Malá písmena, čísla a pomlčky. Po schválení dostane tento název neměnnou verzi.', 'Lowercase letters, digits and hyphens. Approval creates an immutable version under this name.')}</p>
+          <fieldset className="mt-6 space-y-4"><legend className="text-sm font-semibold text-slate-700">{t('Pravidla výběru', 'Selection rules')}</legend>
+            <label className="block rounded-xl border border-violet-100 bg-violet-50/50 p-4 text-sm text-slate-700"><span className="font-semibold">{t('Stav zákazníka', 'Customer status')}</span><select value={status} onChange={e => setStatus(e.target.value)} className="mt-3 block w-full rounded-lg border border-violet-200 bg-white px-3 py-2"><option value="ACTIVE">{t('Aktivní', 'Active')}</option><option value="PENDING_KYC">{t('Čeká na KYC', 'Pending KYC')}</option><option value="SUSPENDED">{t('Pozastavený', 'Suspended')}</option></select></label>
+            <label className="block rounded-xl border border-slate-200 p-4 text-sm text-slate-700"><span className="font-semibold">{t('Minimální délka vztahu (volitelné)', 'Minimum relationship age (optional)')}</span><input inputMode="numeric" value={minDays} onChange={e => setMinDays(e.target.value)} placeholder="30" className="mt-3 block w-full rounded-lg border border-slate-200 px-3 py-2" /><span className="mt-2 block text-xs text-slate-500">{t('Prázdné = bez omezení podle délky vztahu.', 'Blank = no relationship-age restriction.')}</span></label>
+          </fieldset>
+          {error && <p role="alert" className="mt-4 rounded-xl bg-rose-50 p-3 text-sm text-rose-700">{error}</p>}
+          <button disabled={!validName || !validTenure || saving} className="mt-6 inline-flex items-center gap-2 rounded-xl bg-slate-900 px-4 py-2.5 text-sm font-semibold text-white transition hover:bg-violet-700 disabled:cursor-not-allowed disabled:opacity-40"><CheckCircle2 className="h-4 w-4" />{saving ? t('Ukládám…', 'Saving…') : t('Vytvořit návrh', 'Create draft')}</button>
+        </form>
+        <aside className="rounded-2xl border border-emerald-100 bg-[linear-gradient(160deg,#f6fffb,#fff)] p-6 shadow-sm"><ShieldCheck className="h-6 w-6 text-emerald-600" /><h2 className="mt-4 text-lg font-semibold tracking-tight text-slate-900">{t('Co se stane dál', 'What happens next')}</h2><ol className="mt-4 space-y-4 text-sm leading-6 text-slate-600"><li><strong className="text-slate-900">1. {t('Návrh', 'Draft')}</strong><br />{t('Můžete bezpečně zkontrolovat aktuální dosah stejným evaluátorem jako při zařazení do kampaně.', 'You can safely check current reach with the same evaluator used for campaign enrolment.')}</li><li><strong className="text-slate-900">2. {t('Schválení', 'Approval')}</strong><br />{t('Jiný člověk schválí přesnou, verzovanou definici. Autor ji nemůže schválit sám.', 'A different person approves the exact versioned definition. The maker cannot approve it.')}</li><li><strong className="text-slate-900">3. {t('Použití', 'Use')}</strong><br />{t('Teprve schválené publikum lze vybrat do kampaně; souhlas a limity se stále ověřují při doručení.', 'Only an approved audience can be chosen in a campaign; consent and caps are still checked at delivery.')}</li></ol></aside>
+      </section>
+    </div>
+  )
+}

--- a/openbank-admin-ui/src/app/segments/page.tsx
+++ b/openbank-admin-ui/src/app/segments/page.tsx
@@ -4,9 +4,9 @@
 
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import Link from 'next/link'
-import { ArrowRight, Clock3, ShieldCheck, Sparkles, Users } from 'lucide-react'
+import { ArrowRight, Clock3, Plus, ShieldCheck, Sparkles, Users } from 'lucide-react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
 import { PageHeader } from '@/components/ui'
@@ -19,6 +19,9 @@ interface Segment {
   name: string
   version: number
   rules: string[]
+  state: 'DRAFT' | 'PENDING_APPROVAL' | 'APPROVED'
+  createdBy: string
+  approvedBy?: string | null
 }
 
 interface Preview {
@@ -34,21 +37,23 @@ export default function SegmentsPage() {
   const [loading, setLoading] = useState(true)
   const [previews, setPreviews] = useState<Record<string, Preview | 'loading'>>({})
 
-  useEffect(() => {
-    fetch('/api/segments')
-      .then(r => r.json())
-      .then((d: { items: Segment[]; state: string }) => {
-        if (d.state !== 'ok') {
-          setUnavailable(
-            d.state === 'unauthorized' ? 'unauthorized' : d.state === 'not_deployed' ? 'not_deployed' : 'unreachable',
-          )
-          return
-        }
-        setItems(d.items ?? [])
-      })
-      .catch(() => setUnavailable('unreachable'))
-      .finally(() => setLoading(false))
+  const loadAudiences = useCallback(() => {
+    fetch('/api/audiences').then(r => r.json()).then((d: { items: Segment[]; state: string }) => {
+      if (d.state !== 'ok') { setUnavailable(d.state === 'unauthorized' ? 'unauthorized' : d.state === 'not_deployed' ? 'not_deployed' : 'unreachable'); return }
+      setItems(d.items ?? [])
+    }).catch(() => setUnavailable('unreachable')).finally(() => setLoading(false))
   }, [])
+
+  useEffect(() => {
+    loadAudiences()
+  }, [loadAudiences])
+
+  const lifecycle = (s: Segment, action: 'submit' | 'approve') => {
+    fetch(`/api/audiences/${encodeURIComponent(s.name)}/${s.version}/${action}`, { method: 'POST' }).then(r => {
+      if (!r.ok) throw new Error()
+      loadAudiences()
+    }).catch(() => setUnavailable('unreachable'))
+  }
 
   const key = (s: Segment) => `${s.name}@${s.version}`
 
@@ -57,7 +62,7 @@ export default function SegmentsPage() {
   const loadPreview = (s: Segment) => {
     const k = key(s)
     setPreviews(p => ({ ...p, [k]: 'loading' }))
-    fetch(`/api/segments/${encodeURIComponent(s.name)}/${s.version}/preview`)
+    fetch(`/api/audiences/${encodeURIComponent(s.name)}/${s.version}/preview`)
       .then(r => r.json())
       .then((d: Preview) => setPreviews(p => ({ ...p, [k]: d })))
       .catch(() => setPreviews(p => ({ ...p, [k]: { state: 'unreachable' } })))
@@ -82,7 +87,7 @@ export default function SegmentsPage() {
   const audiencePurpose = (s: Segment) => {
     if (s.name === 'actives') return t('Široký výchozí okruh pro ověřenou produktovou nabídku.', 'A broad default audience for a verified product offer.')
     if (s.name === 'actives-tenured-30d') return t('Stabilnější publikum pro nabídky po prvním měsíci vztahu.', 'A more established audience for offers after the first month of a relationship.')
-    return t('Verzované publikum z katalogu kampaní.', 'A versioned audience from the campaign catalogue.')
+    return t('Verzované publikum s dohledatelným schválením.', 'A versioned audience with traceable approval.')
   }
 
   const renderPreview = (s: Segment) => {
@@ -134,6 +139,7 @@ export default function SegmentsPage() {
           'Choose an audience by intent, verify its current reach, then go straight to designing the journey.',
         )}
         icon={<Users className="h-6 w-6" />}
+        actions={<Link href="/segments/new" className="inline-flex items-center gap-2 rounded-xl bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-violet-700"><Plus className="h-4 w-4" />{t('Vytvořit publikum', 'Create audience')}</Link>}
       />
 
       {loading && <p className="text-sm text-muted-foreground">{t('Načítám…', 'Loading…')}</p>}
@@ -157,7 +163,7 @@ export default function SegmentsPage() {
             <div className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
               <ShieldCheck className="h-5 w-5 text-emerald-600" />
               <p className="mt-3 text-sm font-semibold text-slate-900">{t('Bezpečné publikum', 'Safe audiences')}</p>
-              <p className="mt-1 text-xs leading-5 text-slate-500">{t('Definice jsou verzované a reviewované v kódu. Souhlas a frekvenční ochrany se vyhodnotí znovu při odeslání.', 'Definitions are versioned and reviewed in code. Consent and frequency protections are evaluated again at send time.')}</p>
+              <p className="mt-1 text-xs leading-5 text-slate-500">{t('Pravidla jsou uzavřená a typovaná. Verze se stává použitelnou až po schválení jiným člověkem; souhlas a frekvenční ochrany se vyhodnotí znovu při odeslání.', 'Rules are closed and typed. A version becomes targetable only after a different person approves it; consent and frequency protections are evaluated again at send time.')}</p>
             </div>
           </section>
 
@@ -166,7 +172,7 @@ export default function SegmentsPage() {
               <article key={key(s)} className="group rounded-2xl border border-slate-200 bg-white p-5 shadow-sm transition duration-200 hover:-translate-y-0.5 hover:border-violet-200 hover:shadow-lg hover:shadow-violet-950/5" data-audience-card={key(s)}>
                 <div className="flex items-start justify-between gap-4">
                   <div>
-                    <p className="text-[.68rem] font-bold uppercase tracking-[.12em] text-slate-400">{t('Verzované publikum', 'Versioned audience')} · v{s.version}</p>
+                    <p className="text-[.68rem] font-bold uppercase tracking-[.12em] text-slate-400">{s.state === 'APPROVED' ? t('Schválené publikum', 'Approved audience') : s.state === 'PENDING_APPROVAL' ? t('Čeká na schválení', 'Awaiting approval') : t('Rozpracované publikum', 'Draft audience')} · v{s.version}</p>
                     <h2 className="mt-1 text-lg font-semibold tracking-tight text-slate-900">{audienceName(s)}</h2>
                     <p className="mt-1 text-sm leading-5 text-slate-500">{audiencePurpose(s)}</p>
                   </div>
@@ -182,13 +188,13 @@ export default function SegmentsPage() {
 
                 <div className="mt-4 flex flex-wrap items-center justify-between gap-3">
                   <div className="min-h-8">{renderPreview(s)}</div>
-                  <Link
+                  {s.state === 'APPROVED' ? <Link
                     href={`/campaigns/new?audience=${encodeURIComponent(key(s))}`}
                     className="inline-flex items-center gap-1.5 rounded-lg bg-slate-900 px-3 py-2 text-xs font-semibold text-white transition hover:bg-violet-700"
                     data-use-audience={key(s)}
                   >
                     {t('Použít v kampani', 'Use in campaign')} <ArrowRight className="h-3.5 w-3.5" />
-                  </Link>
+                  </Link> : s.state === 'DRAFT' ? <button onClick={() => lifecycle(s, 'submit')} className="rounded-lg bg-violet-700 px-3 py-2 text-xs font-semibold text-white transition hover:bg-violet-800">{t('Odeslat ke schválení', 'Submit for approval')}</button> : <button onClick={() => lifecycle(s, 'approve')} className="rounded-lg bg-emerald-600 px-3 py-2 text-xs font-semibold text-white transition hover:bg-emerald-700">{t('Schválit publikum', 'Approve audience')}</button>}
                 </div>
                 <p className="mt-3 flex items-center gap-1.5 text-[.68rem] text-slate-400"><Clock3 className="h-3 w-3" />{t('Dosah se mění s aktuálním stavem; verze pravidel zůstává stejná.', 'Reach changes with current state; the rule version stays fixed.')}</p>
               </article>

--- a/openbank-admin-ui/src/app/segments/page.tsx
+++ b/openbank-admin-ui/src/app/segments/page.tsx
@@ -40,7 +40,9 @@ export default function SegmentsPage() {
   const loadAudiences = useCallback(() => {
     fetch('/api/audiences').then(r => r.json()).then((d: { items: Segment[]; state: string }) => {
       if (d.state !== 'ok') { setUnavailable(d.state === 'unauthorized' ? 'unauthorized' : d.state === 'not_deployed' ? 'not_deployed' : 'unreachable'); return }
-      setItems(d.items ?? [])
+      // Older catalogue rows were approved before lifecycle metadata existed. Treating an omitted
+      // state as a draft would remove a previously targetable audience during a rolling rollout.
+      setItems((d.items ?? []).map(item => ({ ...item, state: item.state ?? 'APPROVED' })))
     }).catch(() => setUnavailable('unreachable')).finally(() => setLoading(false))
   }, [])
 

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/port/out/Ports.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/port/out/Ports.kt
@@ -12,6 +12,7 @@ import com.openbank.campaign.domain.model.Enrolment
 import com.openbank.campaign.domain.model.ExperimentCohort
 import com.openbank.campaign.domain.model.InAppSurface
 import com.openbank.campaign.domain.model.Segment
+import com.openbank.campaign.domain.model.Audience
 import com.openbank.campaign.domain.model.SendOutcome
 import com.openbank.campaign.domain.model.SendRecord
 import java.time.Instant
@@ -229,6 +230,18 @@ interface SegmentRegistry {
     suspend fun load(name: String, version: Int): Segment?
     suspend fun save(segment: Segment): Segment
     suspend fun list(): List<Segment>
+}
+
+/**
+ * Lifecycle store for marketer-authored audiences. Its approved projection is intentionally kept
+ * separate from [SegmentRegistry]: campaign execution must not accidentally load a draft merely
+ * because it has a valid typed rule shape.
+ */
+interface AudienceRegistry {
+    suspend fun load(name: String, version: Int): Audience?
+    suspend fun list(): List<Audience>
+    suspend fun nextVersion(name: String): Int
+    suspend fun save(audience: Audience): Audience
 }
 
 /** ADR-0210: evaluates a segment against the silver layer and returns matching party ids. */

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/port/out/Ports.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/port/out/Ports.kt
@@ -4,6 +4,7 @@
 
 package com.openbank.campaign.application.port.out
 
+import com.openbank.campaign.domain.model.Audience
 import com.openbank.campaign.domain.model.Campaign
 import com.openbank.campaign.domain.model.Channel
 import com.openbank.campaign.domain.model.ContentVariant
@@ -12,7 +13,6 @@ import com.openbank.campaign.domain.model.Enrolment
 import com.openbank.campaign.domain.model.ExperimentCohort
 import com.openbank.campaign.domain.model.InAppSurface
 import com.openbank.campaign.domain.model.Segment
-import com.openbank.campaign.domain.model.Audience
 import com.openbank.campaign.domain.model.SendOutcome
 import com.openbank.campaign.domain.model.SendRecord
 import java.time.Instant

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/usecase/AudienceService.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/usecase/AudienceService.kt
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+package com.openbank.campaign.application.usecase
+
+import com.openbank.campaign.application.port.out.AudienceRegistry
+import com.openbank.campaign.application.port.out.SegmentEvaluationPort
+import com.openbank.campaign.domain.model.Audience
+import com.openbank.campaign.domain.model.AudienceState
+import com.openbank.campaign.domain.model.Segment
+import com.openbank.campaign.domain.model.SegmentCatalog
+import com.openbank.campaign.domain.model.SegmentRule
+import jakarta.enterprise.context.ApplicationScoped
+import java.time.Clock
+import java.time.Instant
+
+data class AudienceSummary(
+    val name: String,
+    val version: Int,
+    val rules: List<String>,
+    val state: AudienceState,
+    val createdBy: String,
+    val approvedBy: String?,
+)
+
+data class AudienceReach(val name: String, val version: Int, val size: Int, val asOf: Instant)
+
+/**
+ * Governs the authoring lifecycle around the existing closed segment DSL.
+ *
+ * Creating a draft does not make it campaign-targetable. The same typed rules can be previewed to
+ * help the maker, but only the separate checker's immutable APPROVED version is visible to the
+ * campaign path.
+ */
+@ApplicationScoped
+class AudienceService(
+    private val audiences: AudienceRegistry,
+    private val evaluation: SegmentEvaluationPort,
+    private val clock: Clock,
+) {
+    suspend fun list(): List<AudienceSummary> = audiences.list().map(::summary)
+
+    fun summary(audience: Audience) = AudienceSummary(
+        name = audience.segment.name,
+        version = audience.segment.version,
+        rules = audience.segment.rules.map { it.describe() },
+        state = audience.state,
+        createdBy = audience.createdBy,
+        approvedBy = audience.approvedBy,
+    )
+
+    suspend fun create(name: String, rules: List<SegmentRule>, maker: String): Audience {
+        require(SegmentCatalog.ALL.none { it.name == name }) { "a catalogue audience already owns '$name'" }
+        val version = audiences.nextVersion(name)
+        val now = clock.instant()
+        return audiences.save(
+            Audience(
+                segment = Segment(name, version, rules),
+                state = AudienceState.DRAFT,
+                createdBy = maker,
+                createdAt = now,
+                updatedAt = now,
+            ),
+        )
+    }
+
+    suspend fun submit(name: String, version: Int, maker: String): Audience =
+        audiences.load(name, version)?.let { audiences.save(it.submit(maker)) }
+            ?: throw NoSuchElementException("audience $name@$version not found")
+
+    suspend fun approve(name: String, version: Int, checker: String): Audience =
+        audiences.load(name, version)?.let { audiences.save(it.approve(checker)) }
+            ?: throw NoSuchElementException("audience $name@$version not found")
+
+    suspend fun preview(name: String, version: Int): AudienceReach? {
+        val audience = audiences.load(name, version) ?: return null
+        return AudienceReach(name, version, evaluation.evaluate(audience.segment).size, clock.instant())
+    }
+}

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/domain/model/Audience.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/domain/model/Audience.kt
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+package com.openbank.campaign.domain.model
+
+import java.time.Instant
+
+/**
+ * A marketer-authored audience wraps the same closed [Segment] DSL used by the catalogue.
+ *
+ * The mutable stage is deliberately separate from [Segment]: a campaign may only ever pin an
+ * approved, immutable segment version. No free-form predicates, JSON paths, or SQL enter this
+ * model; [Segment]'s constructor remains the one place that validates source support.
+ */
+data class Audience(
+    val segment: Segment,
+    val state: AudienceState,
+    val createdBy: String,
+    val approvedBy: String? = null,
+    val createdAt: Instant,
+    val updatedAt: Instant,
+) {
+    fun submit(actor: String): Audience {
+        require(actor == createdBy) { "only the audience maker can submit this draft" }
+        require(state == AudienceState.DRAFT) { "only a DRAFT audience can be submitted" }
+        return copy(state = AudienceState.PENDING_APPROVAL, updatedAt = Instant.now())
+    }
+
+    fun approve(approver: String): Audience {
+        require(state == AudienceState.PENDING_APPROVAL) { "only a PENDING_APPROVAL audience can be approved" }
+        require(approver != createdBy) { "maker/checker: the approver must differ from the creator" }
+        return copy(state = AudienceState.APPROVED, approvedBy = approver, updatedAt = Instant.now())
+    }
+
+    companion object {
+        fun catalogue(segment: Segment): Audience = Audience(
+            segment = segment,
+            state = AudienceState.APPROVED,
+            createdBy = "catalogue",
+            approvedBy = "catalogue",
+            createdAt = Instant.EPOCH,
+            updatedAt = Instant.EPOCH,
+        )
+    }
+}
+
+enum class AudienceState { DRAFT, PENDING_APPROVAL, APPROVED }

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/persistence/Persistence.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/persistence/Persistence.kt
@@ -6,6 +6,7 @@ package com.openbank.campaign.infrastructure.persistence
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
+import com.openbank.campaign.application.port.out.AudienceRegistry
 import com.openbank.campaign.application.port.out.CampaignContentExperimentRepository
 import com.openbank.campaign.application.port.out.CampaignEngagementEvent
 import com.openbank.campaign.application.port.out.CampaignEngagementEventType
@@ -16,7 +17,6 @@ import com.openbank.campaign.application.port.out.CampaignExperimentRepository
 import com.openbank.campaign.application.port.out.CampaignInteractionAttribution
 import com.openbank.campaign.application.port.out.CampaignOutcomeCount
 import com.openbank.campaign.application.port.out.CampaignRepository
-import com.openbank.campaign.application.port.out.AudienceRegistry
 import com.openbank.campaign.application.port.out.ContentVariantMetrics
 import com.openbank.campaign.application.port.out.ConversionContext
 import com.openbank.campaign.application.port.out.EnrolmentRepository
@@ -24,9 +24,9 @@ import com.openbank.campaign.application.port.out.ExperimentCohortMetrics
 import com.openbank.campaign.application.port.out.SegmentRegistry
 import com.openbank.campaign.application.port.out.SendLogRepository
 import com.openbank.campaign.application.port.out.StepOutcomeCount
-import com.openbank.campaign.domain.model.Campaign
 import com.openbank.campaign.domain.model.Audience
 import com.openbank.campaign.domain.model.AudienceState
+import com.openbank.campaign.domain.model.Campaign
 import com.openbank.campaign.domain.model.CampaignDecision
 import com.openbank.campaign.domain.model.CampaignSchedule
 import com.openbank.campaign.domain.model.CampaignState
@@ -790,7 +790,8 @@ class PanacheAudienceRegistry(private val mapper: ObjectMapper) :
     override suspend fun list(): List<Audience> {
         val stored = Panache.withSession { listAll() }.awaitSuspending().map { it.toAudience(mapper) }
         val catalogueKeys = SegmentCatalog.ALL.map { it.name to it.version }.toSet()
-        return SegmentCatalog.ALL.map(Audience::catalogue) + stored.filterNot { (it.segment.name to it.segment.version) in catalogueKeys }
+        return SegmentCatalog.ALL.map(Audience::catalogue) +
+            stored.filterNot { (it.segment.name to it.segment.version) in catalogueKeys }
     }
 
     override suspend fun nextVersion(name: String): Int {

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/persistence/Persistence.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/persistence/Persistence.kt
@@ -16,6 +16,7 @@ import com.openbank.campaign.application.port.out.CampaignExperimentRepository
 import com.openbank.campaign.application.port.out.CampaignInteractionAttribution
 import com.openbank.campaign.application.port.out.CampaignOutcomeCount
 import com.openbank.campaign.application.port.out.CampaignRepository
+import com.openbank.campaign.application.port.out.AudienceRegistry
 import com.openbank.campaign.application.port.out.ContentVariantMetrics
 import com.openbank.campaign.application.port.out.ConversionContext
 import com.openbank.campaign.application.port.out.EnrolmentRepository
@@ -24,6 +25,8 @@ import com.openbank.campaign.application.port.out.SegmentRegistry
 import com.openbank.campaign.application.port.out.SendLogRepository
 import com.openbank.campaign.application.port.out.StepOutcomeCount
 import com.openbank.campaign.domain.model.Campaign
+import com.openbank.campaign.domain.model.Audience
+import com.openbank.campaign.domain.model.AudienceState
 import com.openbank.campaign.domain.model.CampaignDecision
 import com.openbank.campaign.domain.model.CampaignSchedule
 import com.openbank.campaign.domain.model.CampaignState
@@ -258,6 +261,17 @@ class SegmentEntity : PanacheEntityBase() {
 
     @Column(nullable = false)
     lateinit var createdAt: Instant
+
+    @Column(nullable = false, length = 32)
+    lateinit var state: String
+
+    @Column(nullable = false)
+    lateinit var createdBy: String
+
+    var approvedBy: String? = null
+
+    @Column(nullable = false)
+    lateinit var updatedAt: Instant
 }
 
 @ApplicationScoped
@@ -729,7 +743,10 @@ class PanacheSegmentRegistry(private val mapper: ObjectMapper) :
      * approved campaign reaches, with no version bump and no trace.
      */
     override suspend fun load(name: String, version: Int): Segment? = SegmentCatalog.find(name, version)
-        ?: Panache.withSession { find("name = ?1 and version = ?2", name, version).firstResult<SegmentEntity>() }
+        ?: Panache.withSession {
+            find("name = ?1 and version = ?2 and state = ?3", name, version, AudienceState.APPROVED.name)
+                .firstResult<SegmentEntity>()
+        }
             .awaitSuspending()?.let { Segment(it.name, it.version, SegmentRuleSerde.read(mapper, it.rulesJson)) }
 
     override suspend fun save(segment: Segment): Segment {
@@ -741,6 +758,10 @@ class PanacheSegmentRegistry(private val mapper: ObjectMapper) :
                     version = segment.version
                     rulesJson = SegmentRuleSerde.write(mapper, segment.rules)
                     createdAt = Instant.now()
+                    state = AudienceState.APPROVED.name
+                    createdBy = "legacy-catalogue"
+                    approvedBy = "legacy-catalogue"
+                    updatedAt = createdAt
                 },
             )
         }.awaitSuspending()
@@ -748,10 +769,66 @@ class PanacheSegmentRegistry(private val mapper: ObjectMapper) :
     }
 
     override suspend fun list(): List<Segment> {
-        val legacy = Panache.withSession { listAll() }.awaitSuspending()
+        val legacy = Panache.withSession { list("state", AudienceState.APPROVED.name) }.awaitSuspending()
             .map { Segment(it.name, it.version, SegmentRuleSerde.read(mapper, it.rulesJson)) }
         val catalogKeys = SegmentCatalog.ALL.map { it.name to it.version }.toSet()
         return SegmentCatalog.ALL + legacy.filterNot { (it.name to it.version) in catalogKeys }
+    }
+}
+
+/** Database-backed audiences are mutable only through their governed lifecycle. */
+@ApplicationScoped
+class PanacheAudienceRegistry(private val mapper: ObjectMapper) :
+    AudienceRegistry,
+    PanacheRepository<SegmentEntity> {
+
+    override suspend fun load(name: String, version: Int): Audience? =
+        SegmentCatalog.find(name, version)?.let(Audience::catalogue)
+            ?: Panache.withSession { find("name = ?1 and version = ?2", name, version).firstResult<SegmentEntity>() }
+                .awaitSuspending()?.toAudience(mapper)
+
+    override suspend fun list(): List<Audience> {
+        val stored = Panache.withSession { listAll() }.awaitSuspending().map { it.toAudience(mapper) }
+        val catalogueKeys = SegmentCatalog.ALL.map { it.name to it.version }.toSet()
+        return SegmentCatalog.ALL.map(Audience::catalogue) + stored.filterNot { (it.segment.name to it.segment.version) in catalogueKeys }
+    }
+
+    override suspend fun nextVersion(name: String): Int {
+        val stored = Panache.withSession { list("name", name) }.awaitSuspending().map { it.version }
+        val catalogue = SegmentCatalog.ALL.filter { it.name == name }.map { it.version }
+        return (stored + catalogue).maxOrNull()?.plus(1) ?: 1
+    }
+
+    override suspend fun save(audience: Audience): Audience {
+        val existingId = Panache.withSession {
+            find("name = ?1 and version = ?2", audience.segment.name, audience.segment.version)
+                .firstResult<SegmentEntity>()
+        }.awaitSuspending()?.id
+        Panache.withTransaction {
+            Panache.getSession().flatMap { session -> session.merge(audience.toEntity(mapper, existingId)) }
+        }.awaitSuspending()
+        return audience
+    }
+
+    private fun SegmentEntity.toAudience(mapper: ObjectMapper) = Audience(
+        segment = Segment(name, version, SegmentRuleSerde.read(mapper, rulesJson)),
+        state = AudienceState.valueOf(state),
+        createdBy = createdBy,
+        approvedBy = approvedBy,
+        createdAt = createdAt,
+        updatedAt = updatedAt,
+    )
+
+    private fun Audience.toEntity(mapper: ObjectMapper, existingId: UUID?) = SegmentEntity().apply {
+        id = existingId ?: Ids.newId()
+        name = segment.name
+        version = segment.version
+        rulesJson = SegmentRuleSerde.write(mapper, segment.rules)
+        state = this@toEntity.state.name
+        createdBy = this@toEntity.createdBy
+        approvedBy = this@toEntity.approvedBy
+        createdAt = this@toEntity.createdAt
+        updatedAt = this@toEntity.updatedAt
     }
 }
 

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/rest/AudienceResource.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/rest/AudienceResource.kt
@@ -31,7 +31,9 @@ class AudienceResource(private val service: AudienceService, private val jwt: Js
     @Consumes(MediaType.APPLICATION_JSON)
     @Authorize(action = "campaign.create", resource = "")
     suspend fun create(request: CreateAudienceRequest): Response = try {
-        Response.status(201).entity(service.summary(service.create(request.name, request.toRules(), jwt.audiencePrincipal()))).build()
+        Response.status(
+            201,
+        ).entity(service.summary(service.create(request.name, request.toRules(), jwt.audiencePrincipal()))).build()
     } catch (e: IllegalArgumentException) {
         Response.status(Response.Status.BAD_REQUEST).entity(mapOf("error" to e.message)).build()
     }
@@ -71,8 +73,16 @@ data class CreateAudienceRequest(val name: String, val rules: List<AudienceRuleR
 /** The wire rule vocabulary is deliberately smaller than the domain's unsupported rule set. */
 data class AudienceRuleRequest(val type: AudienceRuleType, val status: String? = null, val minDays: Long? = null) {
     fun toRule(): SegmentRule = when (type) {
-        AudienceRuleType.PARTY_STATUS_IS -> SegmentRule.PartyStatusIs(requireNotNull(status) { "PARTY_STATUS_IS requires status" })
-        AudienceRuleType.TENURE_AT_LEAST_DAYS -> SegmentRule.TenureAtLeastDays(requireNotNull(minDays) { "TENURE_AT_LEAST_DAYS requires minDays" })
+        AudienceRuleType.PARTY_STATUS_IS -> SegmentRule.PartyStatusIs(
+            requireNotNull(status) {
+                "PARTY_STATUS_IS requires status"
+            },
+        )
+        AudienceRuleType.TENURE_AT_LEAST_DAYS -> SegmentRule.TenureAtLeastDays(
+            requireNotNull(minDays) {
+                "TENURE_AT_LEAST_DAYS requires minDays"
+            },
+        )
     }
 }
 

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/rest/AudienceResource.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/rest/AudienceResource.kt
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+package com.openbank.campaign.infrastructure.rest
+
+import com.openbank.campaign.application.usecase.AudienceService
+import com.openbank.campaign.domain.model.SegmentRule
+import com.openbank.libs.authz.Authorize
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.ws.rs.Consumes
+import jakarta.ws.rs.GET
+import jakarta.ws.rs.POST
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.PathParam
+import jakarta.ws.rs.Produces
+import jakarta.ws.rs.core.MediaType
+import jakarta.ws.rs.core.Response
+import org.eclipse.microprofile.jwt.JsonWebToken
+
+/** A closed, separately approved audience lifecycle; never a free-form query endpoint. */
+@Path("/api/v1/audiences")
+@Produces(MediaType.APPLICATION_JSON)
+@ApplicationScoped
+class AudienceResource(private val service: AudienceService, private val jwt: JsonWebToken) {
+
+    @GET
+    @Authorize(action = "campaign.read", resource = "")
+    suspend fun list(): Response = Response.ok(service.list()).build()
+
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Authorize(action = "campaign.create", resource = "")
+    suspend fun create(request: CreateAudienceRequest): Response = try {
+        Response.status(201).entity(service.summary(service.create(request.name, request.toRules(), jwt.audiencePrincipal()))).build()
+    } catch (e: IllegalArgumentException) {
+        Response.status(Response.Status.BAD_REQUEST).entity(mapOf("error" to e.message)).build()
+    }
+
+    @POST
+    @Path("/{name}/{version}/submit")
+    @Authorize(action = "campaign.submit", resource = "#name")
+    suspend fun submit(@PathParam("name") name: String, @PathParam("version") version: Int): Response =
+        lifecycle { service.summary(service.submit(name, version, jwt.audiencePrincipal())) }
+
+    @POST
+    @Path("/{name}/{version}/approve")
+    @Authorize(action = "campaign.activate", resource = "#name")
+    suspend fun approve(@PathParam("name") name: String, @PathParam("version") version: Int): Response =
+        lifecycle { service.summary(service.approve(name, version, jwt.audiencePrincipal())) }
+
+    @GET
+    @Path("/{name}/{version}/preview")
+    @Authorize(action = "campaign.read", resource = "#name")
+    suspend fun preview(@PathParam("name") name: String, @PathParam("version") version: Int): Response =
+        service.preview(name, version)?.let { Response.ok(it).build() }
+            ?: Response.status(Response.Status.NOT_FOUND).entity(mapOf("error" to "unknown audience")).build()
+
+    private suspend fun lifecycle(action: suspend () -> Any): Response = try {
+        Response.ok(action()).build()
+    } catch (_: NoSuchElementException) {
+        Response.status(Response.Status.NOT_FOUND).entity(mapOf("error" to "unknown audience")).build()
+    } catch (e: IllegalArgumentException) {
+        Response.status(Response.Status.CONFLICT).entity(mapOf("error" to e.message)).build()
+    }
+}
+
+data class CreateAudienceRequest(val name: String, val rules: List<AudienceRuleRequest>) {
+    fun toRules(): List<SegmentRule> = rules.map { it.toRule() }
+}
+
+/** The wire rule vocabulary is deliberately smaller than the domain's unsupported rule set. */
+data class AudienceRuleRequest(val type: AudienceRuleType, val status: String? = null, val minDays: Long? = null) {
+    fun toRule(): SegmentRule = when (type) {
+        AudienceRuleType.PARTY_STATUS_IS -> SegmentRule.PartyStatusIs(requireNotNull(status) { "PARTY_STATUS_IS requires status" })
+        AudienceRuleType.TENURE_AT_LEAST_DAYS -> SegmentRule.TenureAtLeastDays(requireNotNull(minDays) { "TENURE_AT_LEAST_DAYS requires minDays" })
+    }
+}
+
+enum class AudienceRuleType { PARTY_STATUS_IS, TENURE_AT_LEAST_DAYS }
+
+private fun JsonWebToken.audiencePrincipal(): String = name ?: subject ?: "unknown"

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/rest/AudienceResource.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/rest/AudienceResource.kt
@@ -31,9 +31,9 @@ class AudienceResource(private val service: AudienceService, private val jwt: Js
     @Consumes(MediaType.APPLICATION_JSON)
     @Authorize(action = "campaign.create", resource = "")
     suspend fun create(request: CreateAudienceRequest): Response = try {
-        Response.status(
-            201,
-        ).entity(service.summary(service.create(request.name, request.toRules(), jwt.audiencePrincipal()))).build()
+        Response.status(Response.Status.CREATED)
+            .entity(service.summary(service.create(request.name, request.toRules(), jwt.audiencePrincipal())))
+            .build()
     } catch (e: IllegalArgumentException) {
         Response.status(Response.Status.BAD_REQUEST).entity(mapOf("error" to e.message)).build()
     }

--- a/openbank-campaign-service/src/main/resources/db/migration/V16__governed_audience_lifecycle.sql
+++ b/openbank-campaign-service/src/main/resources/db/migration/V16__governed_audience_lifecycle.sql
@@ -1,0 +1,15 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- A marketer-created audience is a typed, versioned segment that needs its own maker/checker
+-- lifecycle. Existing rows predate an authoring path; retain their historical targetability as
+-- approved legacy versions rather than changing any campaign reference during the rollout.
+--
+-- ROLLBACK:
+-- The added columns are additive. A binary rollback may ignore them safely; remove them only after
+-- no deployment needs the governed-audience lifecycle and after retaining the audit data elsewhere.
+
+ALTER TABLE segments ADD COLUMN state TEXT NOT NULL DEFAULT 'APPROVED';
+ALTER TABLE segments ADD COLUMN created_by TEXT NOT NULL DEFAULT 'legacy-catalogue';
+ALTER TABLE segments ADD COLUMN approved_by TEXT;
+ALTER TABLE segments ADD COLUMN updated_at TIMESTAMPTZ NOT NULL DEFAULT now();
+
+CREATE INDEX idx_segments_state_name_version ON segments (state, name, version);

--- a/openbank-campaign-service/src/main/resources/openapi.yaml
+++ b/openbank-campaign-service/src/main/resources/openapi.yaml
@@ -4,7 +4,7 @@ openapi: 3.1.0
 info:
   title: Campaign Service API
   # major == openbank.api.version == URL /api/v1 (ADR-0048).
-  version: 1.38.0
+  version: 1.39.0
   description: >-
     Campaign management first slice (ADR-0200 / ADR-0209 D3): deterministic, versioned segments;
     per-enrolment Temporal journeys; consent-gated delivery through notification-service.
@@ -608,6 +608,78 @@ paths:
         '400':
           description: Unrecognised `outcome`
 
+  /api/v1/audiences:
+    get:
+      tags: [Audiences]
+      summary: List governed audience versions, including drafts awaiting approval
+      operationId: listAudiences
+      responses:
+        '200':
+          description: Audience versions
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: '#/components/schemas/AudienceSummary' }
+    post:
+      tags: [Audiences]
+      summary: Create a typed audience draft
+      operationId: createAudience
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/CreateAudienceRequest' }
+      responses:
+        '201':
+          description: Draft audience
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Audience' }
+        '400': { description: Invalid or unsupported closed rule }
+
+  /api/v1/audiences/{name}/{version}/submit:
+    post:
+      tags: [Audiences]
+      summary: Submit the maker's draft for independent approval
+      operationId: submitAudience
+      parameters:
+        - $ref: '#/components/parameters/AudienceName'
+        - $ref: '#/components/parameters/AudienceVersion'
+      responses:
+        '200': { description: Audience submitted }
+        '404': { description: Unknown audience version }
+        '409': { description: Lifecycle or maker constraint rejected the submission }
+
+  /api/v1/audiences/{name}/{version}/approve:
+    post:
+      tags: [Audiences]
+      summary: Independently approve an immutable audience version
+      operationId: approveAudience
+      parameters:
+        - $ref: '#/components/parameters/AudienceName'
+        - $ref: '#/components/parameters/AudienceVersion'
+      responses:
+        '200': { description: Audience approved and targetable by campaigns }
+        '404': { description: Unknown audience version }
+        '409': { description: Lifecycle or maker/checker constraint rejected approval }
+
+  /api/v1/audiences/{name}/{version}/preview:
+    get:
+      tags: [Audiences]
+      summary: Preview a draft or approved audience with the production evaluator
+      operationId: previewAudience
+      parameters:
+        - $ref: '#/components/parameters/AudienceName'
+        - $ref: '#/components/parameters/AudienceVersion'
+      responses:
+        '200':
+          description: Cohort size at a point in time
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/AudienceReach' }
+        '404': { description: Unknown audience version }
+
   /api/v1/segments:
     get:
       tags: [Segments]
@@ -656,6 +728,16 @@ paths:
 
 components:
   parameters:
+    AudienceName:
+      name: name
+      in: path
+      required: true
+      schema: { type: string, pattern: '^[a-z0-9][a-z0-9-]*$' }
+    AudienceVersion:
+      name: version
+      in: path
+      required: true
+      schema: { type: integer, minimum: 1 }
     CampaignId:
       name: id
       in: path
@@ -1166,6 +1248,50 @@ components:
           type: array
           items: { type: string }
           description: What the segment selects, in words.
+
+    AudienceSummary:
+      type: object
+      required: [name, version, rules, state, createdBy]
+      properties:
+        name: { type: string }
+        version: { type: integer, minimum: 1 }
+        rules:
+          type: array
+          items: { type: string }
+        state: { type: string, enum: [DRAFT, PENDING_APPROVAL, APPROVED] }
+        createdBy: { type: string }
+        approvedBy: { type: [string, 'null'] }
+
+    Audience:
+      allOf:
+        - $ref: '#/components/schemas/AudienceSummary'
+
+    AudienceReach:
+      type: object
+      required: [name, version, size, asOf]
+      properties:
+        name: { type: string }
+        version: { type: integer, minimum: 1 }
+        size: { type: integer, minimum: 0 }
+        asOf: { type: string, format: date-time }
+
+    CreateAudienceRequest:
+      type: object
+      required: [name, rules]
+      properties:
+        name: { type: string, pattern: '^[a-z0-9][a-z0-9-]*$' }
+        rules:
+          type: array
+          minItems: 1
+          items: { $ref: '#/components/schemas/AudienceRule' }
+
+    AudienceRule:
+      type: object
+      required: [type]
+      properties:
+        type: { type: string, enum: [PARTY_STATUS_IS, TENURE_AT_LEAST_DAYS] }
+        status: { type: string }
+        minDays: { type: integer, minimum: 0 }
 
     SegmentPreview:
       type: object

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/domain/AudienceLifecycleTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/domain/AudienceLifecycleTest.kt
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+package com.openbank.campaign.domain
+
+import com.openbank.campaign.domain.model.Audience
+import com.openbank.campaign.domain.model.AudienceState
+import com.openbank.campaign.domain.model.Segment
+import com.openbank.campaign.domain.model.SegmentRule
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.Instant
+
+class AudienceLifecycleTest {
+
+    private fun draft() = Audience(
+        segment = Segment("new-savers", 1, listOf(SegmentRule.PartyStatusIs("ACTIVE"))),
+        state = AudienceState.DRAFT,
+        createdBy = "maker",
+        createdAt = Instant.now(),
+        updatedAt = Instant.now(),
+    )
+
+    @Test
+    fun `only the maker can submit an audience draft`() {
+        assertThrows<IllegalArgumentException> { draft().submit("other") }
+        assertEquals(AudienceState.PENDING_APPROVAL, draft().submit("maker").state)
+    }
+
+    @Test
+    fun `maker cannot approve the submitted audience`() {
+        val pending = draft().submit("maker")
+        assertThrows<IllegalArgumentException> { pending.approve("maker") }
+        assertEquals(AudienceState.APPROVED, pending.approve("checker").state)
+    }
+
+    @Test
+    fun `approved audience cannot return to the mutable submission path`() {
+        val approved = draft().submit("maker").approve("checker")
+        assertThrows<IllegalArgumentException> { approved.submit("maker") }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds typed, marketer-authored audience drafts with reach preview, maker/checker approval, and immutable targetable versions.
- Preserves existing code catalogue and excludes database drafts from campaign targeting.
- Adds a marketer-facing composer and audience-library lifecycle states.

## Validation
- `./gradlew :openbank-campaign-service:compileKotlin`
- `./gradlew :openbank-campaign-service:test --tests com.openbank.campaign.domain.AudienceLifecycleTest`
- `npx eslint src/app/segments/page.tsx src/app/segments/new/page.tsx src/app/api/audiences/route.ts src/app/api/audiences/[name]/[version]/[action]/route.ts`
- `git diff --check`

Closes #4886