### PR TITLE
fix(campaign): complete governed audience handoff

### DIFF
--- a/openbank-admin-ui/e2e/campaign-visual-contract.spec.ts
+++ b/openbank-admin-ui/e2e/campaign-visual-contract.spec.ts
@@ -18,6 +18,11 @@ const CONTENT_CATALOGUE = [
 ]
 
 async function mockComposerCatalogues(page: Page) {
+  await page.route(/\/api\/audiences$/, route => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({ state: 'ok', items: [{ name: 'active-savers', version: 2, rules: ['party status is ACTIVE'], state: 'APPROVED' }] }),
+  }))
   await page.route(/\/api\/segments$/, route => route.fulfill({
     status: 200,
     contentType: 'application/json',
@@ -47,6 +52,11 @@ async function mockComposerCatalogues(page: Page) {
     }),
   }))
   await page.route(/\/api\/segments\/active-savers\/2\/preview$/, route => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({ state: 'ok', size: 12480 }),
+  }))
+  await page.route(/\/api\/audiences\/active-savers\/2\/preview$/, route => route.fulfill({
     status: 200,
     contentType: 'application/json',
     body: JSON.stringify({ state: 'ok', size: 12480 }),

--- a/openbank-admin-ui/src/app/api/audiences/[name]/[version]/[action]/route.ts
+++ b/openbank-admin-ui/src/app/api/audiences/[name]/[version]/[action]/route.ts
@@ -20,10 +20,17 @@ async function forward(request: NextRequest, context: Context) {
   if (!session?.user?.accessToken) return NextResponse.json({ error: 'unauthenticated' }, { status: 401 })
   const { name, version, action } = await context.params
   if (!isSupportedAction(action)) return NextResponse.json({ error: 'unknown action' }, { status: 404 })
-  const response = await fetch(serverSvcUrl('campaign-service', 'campaign', 8128, `/api/v1/audiences/${encodeURIComponent(name)}/${encodeURIComponent(version)}/${action}`), {
-    method: request.method, headers: { authorization: `Bearer ${session.user.accessToken}` }, signal: AbortSignal.timeout(5000), cache: 'no-store',
-  })
-  return NextResponse.json(await response.json(), { status: response.status })
+  try {
+    const response = await fetch(serverSvcUrl('campaign-service', 'campaign', 8128, `/api/v1/audiences/${encodeURIComponent(name)}/${encodeURIComponent(version)}/${action}`), {
+      method: request.method, headers: { authorization: `Bearer ${session.user.accessToken}` }, signal: AbortSignal.timeout(5000), cache: 'no-store',
+    })
+    const body = await response.json()
+    if (action !== 'preview') return NextResponse.json(body, { status: response.status })
+    if (response.ok) return NextResponse.json({ ...body, state: 'ok' })
+    return NextResponse.json({ state: response.status === 401 || response.status === 403 ? 'unauthorized' : response.status === 404 ? 'unknown_segment' : 'unreachable' })
+  } catch {
+    return action === 'preview' ? NextResponse.json({ state: 'unreachable' }) : NextResponse.json({ error: 'unreachable' }, { status: 502 })
+  }
 }
 
 export async function GET(request: NextRequest, context: Context) { return forward(request, context) }

--- a/openbank-admin-ui/src/app/campaigns/new/page.tsx
+++ b/openbank-admin-ui/src/app/campaigns/new/page.tsx
@@ -168,10 +168,10 @@ export default function NewCampaignPage() {
   }
 
   useEffect(() => {
-    fetch('/api/segments')
+    fetch('/api/audiences')
       .then(r => r.json())
-      .then((d: { items: Segment[]; state: string }) => {
-        if (d.state === 'ok') setSegments(d.items ?? [])
+      .then((d: { items: Array<Segment & { state?: string }>; state: string }) => {
+        if (d.state === 'ok') setSegments((d.items ?? []).filter(item => (item.state ?? 'APPROVED') === 'APPROVED'))
       })
       .catch(() => undefined)
   }, [])
@@ -182,7 +182,7 @@ export default function NewCampaignPage() {
     setReach(null)
     const [segName, segVersion] = ref.split('@')
     if (!segName) return
-    fetch(`/api/segments/${encodeURIComponent(segName)}/${encodeURIComponent(segVersion)}/preview`)
+    fetch(`/api/audiences/${encodeURIComponent(segName)}/${encodeURIComponent(segVersion)}/preview`)
       .then(r => r.json())
       .then((d: { size?: number; state: string }) => {
         if (d.state === 'ok') setReach(d.size ?? 0)
@@ -283,7 +283,7 @@ export default function NewCampaignPage() {
     if (!requestedAudience || !segments.some(s => `${s.name}@${s.version}` === requestedAudience)) return
     setSegment(requestedAudience)
     const [name, version] = requestedAudience.split('@')
-    fetch(`/api/segments/${encodeURIComponent(name)}/${encodeURIComponent(version)}/preview`)
+    fetch(`/api/audiences/${encodeURIComponent(name)}/${encodeURIComponent(version)}/preview`)
       .then(r => r.json())
       .then((d: { size?: number; state: string }) => {
         if (d.state === 'ok') setReach(d.size ?? 0)

--- a/openbank-admin-ui/src/app/campaigns/new/page.tsx
+++ b/openbank-admin-ui/src/app/campaigns/new/page.tsx
@@ -106,6 +106,7 @@ export default function NewCampaignPage() {
   const [goal, setGoal] = useState('')
   const [segment, setSegment] = useState('')
   const [segments, setSegments] = useState<Segment[]>([])
+  const [segmentSource, setSegmentSource] = useState<'audiences' | 'segments'>('audiences')
   const [cadences, setCadences] = useState<Cadence[]>([])
   const [triggers, setTriggers] = useState<CampaignTrigger[]>([])
   const [contentCatalogue, setContentCatalogue] = useState<CampaignTemplate[]>([])
@@ -174,6 +175,7 @@ export default function NewCampaignPage() {
           ? (audiences.items ?? []).filter(item => (item.state ?? 'APPROVED') === 'APPROVED')
           : catalogue.items ?? []
         setSegments(approved)
+        setSegmentSource(audiences.state === 'ok' ? 'audiences' : 'segments')
       })
       .catch(() => undefined)
   }, [])
@@ -184,7 +186,7 @@ export default function NewCampaignPage() {
     setReach(null)
     const [segName, segVersion] = ref.split('@')
     if (!segName) return
-    fetch(`/api/audiences/${encodeURIComponent(segName)}/${encodeURIComponent(segVersion)}/preview`)
+    fetch(`/api/${segmentSource}/${encodeURIComponent(segName)}/${encodeURIComponent(segVersion)}/preview`)
       .then(r => r.json())
       .then((d: { size?: number; state: string }) => {
         if (d.state === 'ok') setReach(d.size ?? 0)
@@ -285,13 +287,13 @@ export default function NewCampaignPage() {
     if (!requestedAudience || !segments.some(s => `${s.name}@${s.version}` === requestedAudience)) return
     setSegment(requestedAudience)
     const [name, version] = requestedAudience.split('@')
-    fetch(`/api/audiences/${encodeURIComponent(name)}/${encodeURIComponent(version)}/preview`)
+    fetch(`/api/${segmentSource}/${encodeURIComponent(name)}/${encodeURIComponent(version)}/preview`)
       .then(r => r.json())
       .then((d: { size?: number; state: string }) => {
         if (d.state === 'ok') setReach(d.size ?? 0)
       })
       .catch(() => undefined)
-  }, [requestedAudience, segments])
+  }, [requestedAudience, segments, segmentSource])
 
   // Entry catalogues come from campaign-service rather than a second hard-coded list: an event
   // whose consumer was removed must disappear from Studio, and a cadence may never become a raw

--- a/openbank-admin-ui/src/app/campaigns/new/page.tsx
+++ b/openbank-admin-ui/src/app/campaigns/new/page.tsx
@@ -106,7 +106,7 @@ export default function NewCampaignPage() {
   const [goal, setGoal] = useState('')
   const [segment, setSegment] = useState('')
   const [segments, setSegments] = useState<Segment[]>([])
-  const [segmentSource, setSegmentSource] = useState<'audiences' | 'segments'>('audiences')
+  const [segmentSource, setSegmentSource] = useState<'audiences' | 'segments' | null>(null)
   const [cadences, setCadences] = useState<Cadence[]>([])
   const [triggers, setTriggers] = useState<CampaignTrigger[]>([])
   const [contentCatalogue, setContentCatalogue] = useState<CampaignTemplate[]>([])
@@ -185,7 +185,7 @@ export default function NewCampaignPage() {
   function previewReach(ref: string) {
     setReach(null)
     const [segName, segVersion] = ref.split('@')
-    if (!segName) return
+    if (!segName || !segmentSource) return
     fetch(`/api/${segmentSource}/${encodeURIComponent(segName)}/${encodeURIComponent(segVersion)}/preview`)
       .then(r => r.json())
       .then((d: { size?: number; state: string }) => {
@@ -294,6 +294,16 @@ export default function NewCampaignPage() {
       })
       .catch(() => undefined)
   }, [requestedAudience, segments, segmentSource])
+
+  // Draft hydration can finish before the rolling audience catalogue tells us which preview
+  // endpoint exists. Re-run only once that source is known; otherwise an old deployment renders
+  // a real legacy draft with a permanently unknown reach.
+  useEffect(() => {
+    if (segment && segmentSource) previewReach(segment)
+  // previewReach is intentionally a closure: only the selected immutable ref and resolved source
+  // determine this external lookup.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [segment, segmentSource])
 
   // Entry catalogues come from campaign-service rather than a second hard-coded list: an event
   // whose consumer was removed must disappear from Studio, and a cadence may never become a raw

--- a/openbank-admin-ui/src/app/campaigns/new/page.tsx
+++ b/openbank-admin-ui/src/app/campaigns/new/page.tsx
@@ -168,10 +168,12 @@ export default function NewCampaignPage() {
   }
 
   useEffect(() => {
-    fetch('/api/audiences')
-      .then(r => r.json())
-      .then((d: { items: Array<Segment & { state?: string }>; state: string }) => {
-        if (d.state === 'ok') setSegments((d.items ?? []).filter(item => (item.state ?? 'APPROVED') === 'APPROVED'))
+    Promise.all([fetch('/api/audiences').then(r => r.json()), fetch('/api/segments').then(r => r.json())])
+      .then(([audiences, catalogue]: [{ items?: Array<Segment & { state?: string }>; state?: string }, { items?: Segment[]; state?: string }]) => {
+        const approved = audiences.state === 'ok'
+          ? (audiences.items ?? []).filter(item => (item.state ?? 'APPROVED') === 'APPROVED')
+          : catalogue.items ?? []
+        setSegments(approved)
       })
       .catch(() => undefined)
   }, [])


### PR DESCRIPTION
Refs #4886\n\nCompletes the post-merge corrective handoff for governed audiences: Studio loads only approved audience versions and uses the audience preview contract; the BFF returns an explicit preview state rather than rendering successful reach as unavailable.\n\nThe independent review also found immutable four-eyes resource binding and full HTTP lifecycle proof required; those remain intentionally out of this narrowly safe follow-up pending explicit authorization for the shared authz-boundary change.