### PR TITLE
fix(product-catalog): serialise the bank-v1 mapping check

### DIFF
--- a/openbank-product-catalog/src/main/kotlin/com/openbank/productcatalog/infrastructure/persistence/BankV1CompatibilityProjector.kt
+++ b/openbank-product-catalog/src/main/kotlin/com/openbank/productcatalog/infrastructure/persistence/BankV1CompatibilityProjector.kt
@@ -35,7 +35,9 @@ class BankV1CompatibilityProjector(
     private val clock: Clock,
 ) {
     fun ensureMapped(session: Mutiny.Session, product: Product, legacyCode: String?, actorId: String): Uni<Boolean> =
-        session.find(BankV1ProductMappingEntity::class.java, UUID.fromString(product.id)).flatMap { existing ->
+        lockLegacyProduct(session, product).flatMap {
+            session.find(BankV1ProductMappingEntity::class.java, UUID.fromString(product.id))
+        }.flatMap { existing ->
             if (existing == null) {
                 createMapping(session, product, legacyCode, actorId).replaceWith(true)
             } else {
@@ -43,8 +45,41 @@ class BankV1CompatibilityProjector(
             }
         }
 
+    /**
+     * Serialises "is this legacy product mapped yet?" against every other reconciler, by taking the
+     * row lock on `products` BEFORE reading `bank_v1_product_mapping`.
+     *
+     * Without it the check is a read-then-insert with no mutual exclusion: two reconcilers each read
+     * "no mapping" under READ COMMITTED (neither sees the other's uncommitted rows) and both run
+     * [createMapping], whose first INSERT is `catalog_specifications` keyed by the canonical product
+     * id — so the loser dies on `catalog_specifications_pkey`. That is not hypothetical timing: a pod
+     * runs the [BankV1CompatibilityBackfill] startup pass and its scheduled reconciliation, and a
+     * rolling deploy or a KEDA 0 -> N scale-up runs the startup pass on every replica at once.
+     *
+     * Locking rather than tolerating the unique violation is deliberate. The loser blocks, and once
+     * the winner commits it re-reads and finds the mapping, so it reconciles instead of skipping —
+     * whereas swallowing a 23505 would also swallow the genuinely broken state where a specification
+     * exists for a product that has no mapping, which must still fail loudly. Same lock order as
+     * [projectLegacy], so the two cannot deadlock. See [ProductCatalogSeeder] for the sibling race on
+     * the seed itself, which is tolerated instead because its loser has nothing left to do.
+     *
+     * Locks through a query, NOT `session.find(entity, id, PESSIMISTIC_WRITE)`: for an entity already
+     * managed in this session, that form emits a version-checked lock statement that names the
+     * `@Version` **property** rather than its column — `... where id = $1 and revision = $2 for no key
+     * update` against a table whose column is `row_version` — so every call fails with
+     * `column "revision" does not exist (42703)`. [projectLegacy] already uses this query form.
+     */
+    private fun lockLegacyProduct(session: Mutiny.Session, product: Product): Uni<ProductEntity?> = session.createQuery(
+        "FROM ProductEntity WHERE id = :id",
+        ProductEntity::class.java,
+    ).setParameter("id", UUID.fromString(product.id))
+        .setLockMode(LockModeType.PESSIMISTIC_WRITE)
+        .singleResultOrNull
+
     fun syncDraft(session: Mutiny.Session, previous: Product, product: Product, actorId: String): Uni<Void> =
-        session.find(BankV1ProductMappingEntity::class.java, UUID.fromString(product.id)).flatMap { existing ->
+        lockLegacyProduct(session, product).flatMap {
+            session.find(BankV1ProductMappingEntity::class.java, UUID.fromString(product.id))
+        }.flatMap { existing ->
             if (existing == null) {
                 createMapping(session, product, null, actorId)
             } else {

--- a/openbank-product-catalog/src/test/kotlin/com/openbank/productcatalog/BankV1CompatibilityConcurrencyIT.kt
+++ b/openbank-product-catalog/src/test/kotlin/com/openbank/productcatalog/BankV1CompatibilityConcurrencyIT.kt
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.productcatalog
+
+import com.openbank.libs.testing.containers.PostgresTestResource
+import com.openbank.productcatalog.infrastructure.persistence.BankV1CompatibilityBackfill
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.common.ResourceArg
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.junit.QuarkusTestProfile
+import io.quarkus.test.junit.TestProfile
+import io.quarkus.test.security.TestSecurity
+import jakarta.inject.Inject
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatCode
+import org.junit.jupiter.api.Test
+import java.util.concurrent.CyclicBarrier
+import java.util.concurrent.Executors
+import java.util.concurrent.Future
+import java.util.concurrent.TimeUnit
+import javax.sql.DataSource
+
+/**
+ * Two reconcilers mapping the same legacy products at once must not collide (issue #4896).
+ *
+ * The production shape is a rolling deploy or a KEDA 0 -> N scale-up: every replica runs the
+ * [BankV1CompatibilityBackfill] startup pass, and each pod also runs the scheduled reconciliation.
+ * `ensureMapped` reads `bank_v1_product_mapping` and inserts when it is absent, so without a row
+ * lock on `products` both reconcilers read "unmapped" under READ COMMITTED and both insert
+ * `catalog_specifications` keyed by the canonical product id — the loser dies with
+ * `duplicate key value violates unique constraint "catalog_specifications_pkey" (23505)`.
+ *
+ * Its own profile, so this gets its own application and its own database: the truncate below strips
+ * the whole v2 projection, which would destroy every other test class's fixtures if it shared one.
+ */
+@QuarkusTest
+@QuarkusTestResource(
+    value = PostgresTestResource::class,
+    initArgs = [ResourceArg(name = "db", value = "openbank_catalog_concurrency")],
+)
+@TestProfile(BankV1CompatibilityConcurrencyIT.ConcurrentReconciliationProfile::class)
+@TestSecurity(user = "concurrency-operator", roles = ["ROLE_OPERATOR"])
+class BankV1CompatibilityConcurrencyIT {
+    @Inject
+    lateinit var dataSource: DataSource
+
+    @Inject
+    lateinit var backfill: BankV1CompatibilityBackfill
+
+    /** Keeps the scheduled reconciliation out of the way — this test drives the concurrency itself. */
+    class ConcurrentReconciliationProfile : QuarkusTestProfile {
+        override fun getConfigOverrides(): Map<String, String> = mapOf(
+            "quarkus.scheduler.enabled" to "false",
+            "openbank.catalog.bank-v1-reconcile-initial-delay" to "24h",
+        )
+    }
+
+    @Test
+    fun `concurrent reconcilers map every legacy product exactly once`() {
+        stripCompatibilityProjection()
+        val products = scalar("SELECT COUNT(*) FROM products")
+        assertThat(products)
+            .describedAs("the seeded catalogue must give both reconcilers real work to collide over")
+            .isGreaterThan(0)
+
+        val pool = Executors.newFixedThreadPool(RECONCILERS)
+        try {
+            val barrier = CyclicBarrier(RECONCILERS)
+            val runs: List<Future<Int>> = (1..RECONCILERS).map {
+                pool.submit<Int> {
+                    barrier.await(BARRIER_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                    backfill.run()
+                }
+            }
+            runs.forEach { run ->
+                assertThatCode { run.get(RUN_TIMEOUT_SECONDS, TimeUnit.SECONDS) }
+                    .describedAs("a reconciler that loses the race must wait for the winner, not fail")
+                    .doesNotThrowAnyException()
+            }
+        } finally {
+            pool.shutdownNow()
+        }
+
+        assertThat(scalar("SELECT COUNT(*) FROM bank_v1_product_mapping")).isEqualTo(products)
+        assertThat(scalar("SELECT COUNT(*) FROM catalog_specifications")).isEqualTo(products)
+    }
+
+    /** Drops the whole v2 projection so the next reconciliation has to rebuild it from `products`. */
+    private fun stripCompatibilityProjection() = dataSource.connection.use { connection ->
+        connection.createStatement().use { statement ->
+            statement.execute("TRUNCATE TABLE bank_v1_product_mapping, catalog_specifications CASCADE")
+        }
+    }
+
+    private fun scalar(sql: String): Long = dataSource.connection.use { connection ->
+        connection.createStatement().use { statement ->
+            statement.executeQuery(sql).use { rows ->
+                check(rows.next())
+                rows.getLong(1)
+            }
+        }
+    }
+
+    private companion object {
+        const val RECONCILERS = 2
+        const val BARRIER_TIMEOUT_SECONDS = 30L
+        const val RUN_TIMEOUT_SECONDS = 120L
+    }
+}


### PR DESCRIPTION
## The defect

`BankV1CompatibilityProjector.ensureMapped` is a read-then-insert with no mutual exclusion:

```kotlin
session.find(BankV1ProductMappingEntity::class.java, productId).flatMap { existing ->
    if (existing == null) createMapping(...) else reconcileMapping(...)
}
```

Under READ COMMITTED neither of two concurrent reconcilers sees the other's uncommitted rows, so
both take the `existing == null` branch and both run `createMapping`, whose first INSERT is
`catalog_specifications` keyed by the **canonical product id**. The loser dies with

```
duplicate key value violates unique constraint "catalog_specifications_pkey" (23505)
```

Two reconcilers are the normal case, not an exotic one. `BankV1CompatibilityBackfill` runs a pass
on `StartupEvent` **and** a `@Scheduled` pass on the same beans, and in production a rolling deploy
or a KEDA `0 -> N` scale-up runs the startup pass on every replica at once — which is exactly the
"an old pod may commit after every new pod completed startup" case the scheduled pass was added for.

## Which of the three it is

It is **"insert if absent, update if present" done unsafely** — not an upstream re-delivery, and not
a row left behind by a preceding test.

Measured, not assumed. Instrumenting `createMapping`, the startup pass and each scheduled tick on
clean `origin/main` shows every application boot in this module starting from an **empty database**:
`ProductCatalogSeeder` seeds the 15 canonical products and the startup backfill maps all 15
(`onStart mapped=15`, on each restart). So there is no leftover `catalog_specifications` row from an
earlier test class to trip over — the second writer is a *live concurrent reconciler*, and the only
thing the rest of the module contributes is the machine load that lets the scheduled tick interleave
with the startup pass instead of following it.

`merge` would be the wrong fix here. `persist`-vs-`merge` is about updating an existing aggregate;
this entity is genuinely new, and `merge` would overwrite whatever specification already holds that
id. Tolerating the 23505 would be wrong for a second reason: it also swallows the genuinely broken
state where a specification exists for a product that has **no** mapping, which must still fail.

## The fix

Take the `products` row lock before reading the mapping, so "is this product mapped yet?" is
serialised across every reconciler. The loser blocks; once the winner commits it re-reads, finds the
mapping and reconciles normally — no exception and nothing skipped. Same lock order as
`projectLegacy`, so the two cannot deadlock.

`ProductCatalogSeeder` documents the sibling race on the seed itself and tolerates its unique
violation instead; that is correct *there*, because its loser has nothing left to do. The comment in
the diff says which is which so the next reader does not copy the wrong one.

## Verification

Whole-module runs — an isolated run of the named test is not a reproduction, it passes against the
broken code.

| run | code | result |
| --- | --- | --- |
| `:openbank-product-catalog:test` | clean `origin/main` | BUILD SUCCESSFUL, **but** `catalog_specifications_pkey (23505)` logged and a scheduled tick aborted |
| `:openbank-product-catalog:test` (instrumented, same base) | clean `origin/main` | BUILD SUCCESSFUL, 6 occurrences of the same 23505 |
| `--tests '*BankV1CompatibilityConcurrencyIT*'` | without the fix | **FAILED** — 1 test, 1 failed, 23505 |
| `--tests '*BankV1CompatibilityConcurrencyIT*'` | with the fix | BUILD SUCCESSFUL in 1m 5s |
| `:openbank-product-catalog:test` | with the fix | BUILD SUCCESSFUL in 5m 36s |
| `:openbank-product-catalog:test` | with the fix, after `ktlintFormat` | BUILD SUCCESSFUL in 4m 44s |

Counts read from the JUnit XML, not the console: **25 classes, 97 tests, 1 skipped, 0 failures,
0 errors**. The one skip is the pre-existing `ProductCatalogPactBrokerProviderVerificationTest`
broker gate, also skipped on the baseline run (which was 96 tests — this PR adds one).
`catalog_specifications_pkey` and `42703` both appear **0** times in the final log.

Lint gates re-run on their own afterwards, and `ktlintMainSourceSetCheck`,
`ktlintTestSourceSetCheck` and `detekt` all appear in the executed task list: BUILD SUCCESSFUL.

The honest reading of the first two rows: on this machine the race fires but
`CatalogReconciliationSchedulerVertxContextIT` still recovers on a later 1s tick, so the failure the
issue reports is the *flaky* manifestation of it. That is why this PR adds a test that reproduces the
collision deterministically rather than relying on the scheduler IT to catch it again —
`BankV1CompatibilityConcurrencyIT` strips the v2 projection and starts two reconcilers on a barrier,
and it is **red on the current `main` code and green with the fix**.

It carries its own `@TestProfile` (so it gets its own application and its own database — the truncate
would otherwise destroy every other test class's fixtures) and its own `PostgresTestResource` db arg,
declared the same way as the module's eight existing ones. That the new resource does not disturb the
rest of the module is not argued from the annotation, it is the whole-module run above.

One thing the instrumentation settled on the way past, worth recording because it is the opposite of
what the module's `initArgs = [ResourceArg(name = "db", ...)]` convention suggests: every application
restart in this module starts from an **empty** database, and `ProductCatalogSeeder` re-seeds the 15
canonical products each time. So `assertThat(count("products")).isZero()` in the standalone boot tests
is measuring isolation that really exists, and no test class in this module inherits another's rows.

## Scope

`openbank-product-catalog` is **not** in `rules.yaml: money_path_services`.

Closes #4896
