### PR TITLE
docs(qrlesspay): the SDK is published — correct the console and the architecture doc

### DIFF
--- a/docs/specs/qrlesspay-sdk.md
+++ b/docs/specs/qrlesspay-sdk.md
@@ -1,6 +1,19 @@
 # QRlessPay SDK — open-source reference SDK proposal
 
-Status: Proposal (v0) · Protocol: [qrlesspay-v1](qrlesspay-v1.md) · Decision: [ADR-0095](../adr/0095-qrlesspay-ble-proximity-spayd-payments.md)
+Status: **Implemented** — this document is the architecture; the code is at
+[github.com/JiRaska/qrlesspay-sdk](https://github.com/JiRaska/qrlesspay-sdk) (Apache-2.0, `v0.1.0`).
+Protocol: [qrlesspay-v1](qrlesspay-v1.md) · Decision: [ADR-0095](../adr/0095-qrlesspay-ble-proximity-spayd-payments.md)
+
+> **What shipped against this document, and what did not.** Native Swift and Kotlin cores that agree
+> byte for byte, BLE transports on both platforms, a React Native binding, UWB and SAS, an example
+> iOS app, and the conformance suite this document argues for — 3 positive vectors, 20 negative
+> cases, 19 UWB cases, run by both implementations, with CI regenerating and diffing them. Flutter
+> is not started. Nothing is published to a package registry, and nothing has run on real hardware.
+>
+> The suite justified itself before it was finished: building the second implementation found that
+> the reference CBOR encoding did not match §3 of the spec — text keys, integer arrays, 326 B
+> against 197 B — so anything written from the spec could not read it. A round-trip test could not
+> have found it, which is the argument of §3 of this document restated as a fact.
 
 QRlessPay is an open, bank-agnostic BLE profile. For it to become a standard
 (ČBA/EPC ambition, ADR-0095), other banks must be able to adopt it in weeks, not

--- a/openbank-admin-ui/src/app/docs/qrlesspay/page.tsx
+++ b/openbank-admin-ui/src/app/docs/qrlesspay/page.tsx
@@ -182,12 +182,12 @@ export default function QrlessPayPage() {
         </div>
         <div className="card" style={{ padding: 14, background: 'var(--accent-bg)', border: '1px solid var(--accent-border)', display: 'flex', flexDirection: 'column', gap: 8 }}>
           <div style={{ fontWeight: 700, fontSize: 13, color: INK }}>
-            {t('Dostupnost SDK — zatím nikde', 'SDK availability — nothing published yet')}
+            {t('SDK — veřejné, v0.1.0', 'SDK — public, v0.1.0')}
           </div>
           <div style={{ fontSize: 12.5, color: SUB, lineHeight: 1.6 }}>
             {t(
-              'Žádný balíček zatím není publikovaný a repozitář neexistuje — níže je návrh, ne changelog. Plán: rodina nativních SDK, ne jedno KMP jádro s tenkými obaly. Banka s čistě Swift aplikací si do binárky nepřidá Kotlin runtime, aby mohla přijímat platby, a profil, který má jedinou reálnou implementaci, není standard. Sdíleným artefaktem je proto conformance suite (jazykově neutrální vektory + interop matice), ne kód. Cena: čtyři implementace = čtyři krypto review, každá si 1.0.0 zaslouží vlastními důkazy.',
-              'Nothing is published and the repository does not exist yet — what follows is a proposal, not a changelog. The plan is a family of native SDKs rather than one KMP core with thin wrappers: a bank with a pure-Swift app will not add a Kotlin runtime to its binary to accept payments, and a profile with a single real implementation is not a standard. The shared artifact is therefore the conformance suite (language-neutral vectors + an interop matrix), not the code. The cost: four implementations means four crypto reviews, and each earns 1.0.0 on its own evidence.',
+              'Repozitář je veřejný pod Apache-2.0, otagovaný v0.1.0, CI zelená. Rodina nativních SDK, ne jedno KMP jádro s tenkými obaly: banka s čistě Swift aplikací si do binárky nepřidá Kotlin runtime, aby mohla přijímat platby, a profil s jedinou reálnou implementací není standard. Sdíleným artefaktem je conformance suite, ne kód — a ta se vyplatila hned: druhá implementace odhalila, že CBOR kódování referenční implementace neodpovídalo specifikaci (326 B proti 197 B a vzájemně nečitelné), což round-trip test principiálně vidět nemohl. Do 1.0 chybí nezávislé krypto review, fuzzing, DPIA a schválení podle ADR-0030 — a hlavně běh na dvou fyzických zařízeních, který zatím neproběhl.',
+              'The repository is public under Apache-2.0, tagged v0.1.0, CI green. A family of native SDKs rather than one KMP core with thin wrappers: a bank with a pure-Swift app will not add a Kotlin runtime to its binary to accept payments, and a profile with a single real implementation is not a standard. The shared artifact is the conformance suite, not the code — and it paid for itself immediately: the second implementation found that the reference CBOR encoding did not match the spec (326 B against 197 B, and mutually unreadable), which a round-trip test structurally cannot see. Reaching 1.0 needs independent cryptographic review, fuzzing, a DPIA and ADR-0030 approval — and above all a two-device run on real hardware, which has not happened.',
             )}
           </div>
           <div style={{ overflowX: 'auto' }}>
@@ -214,8 +214,8 @@ export default function QrlessPayPage() {
           </div>
           <div style={{ fontSize: 12.5, color: SUB, lineHeight: 1.6 }}>
             {t(
-              'Pořadí stavby podle dosahu, ne podle pracnosti: Swift a Kotlin první (stojí na nich vazby pro React Native i Flutter), pak React Native, pak KMP (extrakce — kód už běží v naší vlastní aplikaci), nakonec Flutter. Banky doplní jen svůj platební rail a vlastní potvrzovací UI + SCA.',
-              'Build order by reach rather than effort: Swift and Kotlin first (the React Native and Flutter bindings stand on them), then React Native, then KMP (an extraction — the code already runs in our own app), then Flutter. Banks plug in only their own payment rail plus their own confirmation UI and SCA.',
+              'Součástí je i ukázková iOS aplikace — obě role na jedné obrazovce, zároveň nosič pro test na dvou zařízeních. Banky doplní jen svůj platební rail a vlastní potvrzovací UI + SCA; SDK končí u ověřeného návrhu platby a peníze nehýbe.',
+              'It ships with an example iOS app — both roles on one screen, and the harness for the two-device run. Banks plug in only their own payment rail plus their own confirmation UI and SCA; the SDK stops at a verified proposal and moves no money.',
             )}
           </div>
           <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
@@ -223,7 +223,8 @@ export default function QrlessPayPage() {
             <Tag>{t('Swift · Kotlin · TypeScript · Dart · KMP', 'Swift · Kotlin · TypeScript · Dart · KMP')}</Tag>
             <Tag>ČBA / EPC</Tag>
             <Tag>{t('Otevřený protokol', 'Open protocol')}</Tag>
-            <a href="https://github.com/JiRaska/open-bank-oss/blob/main/docs/specs/qrlesspay-sdk.md" target="_blank" rel="noopener noreferrer" style={linkBtn}>{t('Návrh SDK (spec)', 'SDK proposal (spec)')}</a>
+            <a href="https://github.com/JiRaska/qrlesspay-sdk" target="_blank" rel="noopener noreferrer" style={linkBtn}>{t('SDK na GitHubu →', 'SDK on GitHub →')}</a>
+            <a href="https://github.com/JiRaska/open-bank-oss/blob/main/docs/specs/qrlesspay-sdk.md" target="_blank" rel="noopener noreferrer" style={linkBtn}>{t('Architektura SDK (spec)', 'SDK architecture (spec)')}</a>
           </div>
         </div>
       </Section>
@@ -310,11 +311,11 @@ const LAYERS: { Icon: React.ElementType; req: boolean; threatCs: string; threatE
 ]
 
 const SDK_TARGETS: { platform: string; pkg: string; implCs: string; implEn: string; statusCs: string; statusEn: string }[] = [
-  { platform: 'iOS', pkg: 'SPM', implCs: 'nativní Swift', implEn: 'native Swift', statusCs: 'navrženo — 1. v pořadí', statusEn: 'proposed — first up' },
-  { platform: 'Android', pkg: 'Maven Central (AAR)', implCs: 'nativní Kotlin', implEn: 'native Kotlin', statusCs: 'navrženo — 1. v pořadí', statusEn: 'proposed — first up' },
-  { platform: 'React Native', pkg: 'npm', implCs: 'vazba na nativní SDK', implEn: 'binds the native SDKs', statusCs: 'navrženo — 2. v pořadí', statusEn: 'proposed — second' },
-  { platform: 'Kotlin Multiplatform', pkg: 'AAR + XCFramework', implCs: 'sdílený Kotlin', implEn: 'shared Kotlin', statusCs: 'kód existuje v naší aplikaci, nevytažen', statusEn: 'code exists in our app, not extracted' },
-  { platform: 'Flutter', pkg: 'pub.dev', implCs: 'vazba na nativní SDK', implEn: 'binds the native SDKs', statusCs: 'navrženo — poslední', statusEn: 'proposed — last' },
+  { platform: 'iOS', pkg: 'SPM', implCs: 'nativní Swift', implEn: 'native Swift', statusCs: 'hotovo — jádro + BLE transport, 28 testů', statusEn: 'done — core + BLE transport, 28 tests' },
+  { platform: 'Android', pkg: 'AAR', implCs: 'Kotlin', implEn: 'Kotlin', statusCs: 'hotovo — jádro + BLE transport, 27 testů', statusEn: 'done — core + BLE transport, 27 tests' },
+  { platform: 'Kotlin Multiplatform', pkg: 'AAR + XCFramework', implCs: 'sdílený Kotlin', implEn: 'shared Kotlin', statusCs: 'hotovo — buildí se, bajtově shodné CBOR se Swiftem', statusEn: 'done — builds, byte-identical CBOR to Swift' },
+  { platform: 'React Native', pkg: 'npm', implCs: 'vazba na nativní SDK', implEn: 'binds the native SDKs', statusCs: 'API a oba mosty napsané; kompilují se až v hostitelské aplikaci', statusEn: 'API and both bridges written; they compile inside a host app' },
+  { platform: 'Flutter', pkg: 'pub.dev', implCs: 'vazba na nativní SDK', implEn: 'binds the native SDKs', statusCs: 'nezačato', statusEn: 'not started' },
   { platform: 'Web', pkg: '—', implCs: 'nepodporováno', implEn: 'unsupported', statusCs: 'Web Bluetooth neumí roli příjemce', statusEn: 'Web Bluetooth cannot do the payee role' },
 ]
 


### PR DESCRIPTION
The SDK is public. The console still said it did not exist.

## What was wrong

`/docs/qrlesspay` led with **"SDK availability — nothing published yet"** and *"the repository does not exist yet"*, and every row of the platform table read *proposed*. All of it was true when written. None of it is now: the SDK is public under Apache-2.0 at [github.com/JiRaska/qrlesspay-sdk](https://github.com/JiRaska/qrlesspay-sdk), tagged `v0.1.0`, CI green across five jobs.

An operator page that **understates** shipped work is the same defect as one that overstates it. It just fails in the safer-looking direction, which is the direction nobody goes back to check.

## What the page says now

A link to the repository, and a status table carrying what each target actually is rather than what was planned:

| Target | Was | Is |
|---|---|---|
| iOS / Swift | proposed — first up | done — core + BLE transport, 28 tests |
| Android / Kotlin | proposed — first up | done — core + BLE transport, 27 tests |
| Kotlin Multiplatform | code exists, not extracted | done — builds, byte-identical CBOR to Swift |
| React Native | proposed — second | API and both bridges written; they compile inside a host app |
| Flutter | proposed — last | not started |

**Kept prominent, because a status page is exactly where this gets quietly dropped:** reaching 1.0 needs independent cryptographic review, fuzzing, a DPIA and ADR-0030 approval — and nothing has run on two physical devices. Every transport is still driven by loopback and unit tests.

## The architecture doc

`docs/specs/qrlesspay-sdk.md` is restated as **implemented** rather than proposed, with what shipped against it and what did not.

It also records that the conformance suite justified itself before it was finished. Building the second implementation found that the reference CBOR encoding did not match §3 of the wire spec — text keys from Kotlin property names, byte arrays as integer arrays, 326 B against 197 B, and mutually unreadable. A round-trip test structurally cannot find that, which is the document's own argument restated as a fact rather than a prediction.

## Verification

`npm run type-check` clean, `npx eslint` clean on the touched page, `npm test` **105 files / 1289 tests passing**.

Docs plus one console page; no service code, no API surface, no migration.

Refs ADR-0095

## Linked issues

Refs #4883 — the SDK now implements the UWB and SAS wire bits proposed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
