### PR TITLE
fix(ci): raise the verification-metadata heap to 8g (#4907)

### DIFF
--- a/.github/scripts/check-verification-metadata-complete.py
+++ b/.github/scripts/check-verification-metadata-complete.py
@@ -107,7 +107,22 @@ def artifact_set(path: pathlib.Path) -> set[str]:
 
 # `--write-verification-metadata` OOMs at Gradle's default heap: measured, it dies
 # with `Java heap space` even on a single module. This is not optional tuning.
-GRADLE_HEAP = "-Dorg.gradle.jvmargs=-Xmx6g"
+#
+# 6g was not enough either (#4907): `openbank-libs-runtime` — the largest shared dependency graph
+# in the tree — still died with `Java heap space` under
+# `--refresh-dependencies --write-verification-metadata sha256`, twice, including a clean re-run.
+# That blocks a required context on ANY pull request that touches a libs module's build file.
+#
+# Before raising it, the mechanism was verified rather than assumed: `org.gradle.jvmargs` passed as
+# `-D` on the command line is a classic place for a setting to be silently dropped. An init script
+# printing the build JVM's Runtime.maxMemory() reports 6144 MB with this flag and 3072 MB without
+# it (the gradle.properties default), so the value does reach the build JVM. The flag works; the
+# number was too small.
+#
+# 8g is a STEP, not a measured threshold — the local reproduction needed to find the real figure did
+# not complete. `ubuntu-latest` has 16 GB, so 8g leaves headroom for the launcher and the Kotlin
+# daemons. If this recurs, raise the number; do not re-litigate whether the flag applies.
+GRADLE_HEAP = "-Dorg.gradle.jvmargs=-Xmx8g"
 
 
 def regenerate(modules: list[str]) -> None:


### PR DESCRIPTION
## The failure

`verification-metadata` is a **required context**, and it dies with `Java heap space` on any PR that
touches a libs module's build file. Observed on #4308, twice, including a clean re-run:

```
A build operation failed.
    Java heap space
check-verification-metadata: regenerating for 1 module(s): openbank-libs-runtime
```

`openbank-libs-runtime` is the largest shared dependency graph in the tree, re-resolved and re-hashed
under `--refresh-dependencies --write-verification-metadata sha256`. 6g does not cover it.

## The mechanism was verified before the number was changed

`org.gradle.jvmargs` passed as `-D` on the command line is a classic place for a setting to be
silently dropped — and *"the flag never applied"* would have been a much better story than *"the
number was too small"*. It is not what happens. An init script printing the build JVM's
`Runtime.maxMemory()`:

| invocation | build-JVM max heap |
|---|---|
| `-Dorg.gradle.jvmargs=-Xmx6g --no-daemon` | **6144 MB** |
| no flag (`gradle.properties` `-Xmx3g`) | **3072 MB** |

The value reaches the build JVM. The flag works; 6g was simply not enough.

## 8g is a step, not a measured threshold

Said plainly in the code comment too. I tried to reproduce locally to find the figure that *does*
work; the run did not finish in the time available, so **no threshold was established**.
`ubuntu-latest` has 16 GB, so 8g leaves headroom for the launcher and the Kotlin daemons.

If it recurs, raise the number — the comment now says exactly that, specifically so the next reader
does not spend the time I did re-checking whether the flag applies.

## The gate itself is unchanged, deliberately

Its message already separates *"I could not answer"* from *"the metadata is incomplete"*:

> Gradle failed (gradle exited 1); this says nothing about whether the metadata is complete. Re-run,
> and if it persists treat it as a build problem, not a metadata problem.

That sentence is what sent this to the right diagnosis instead of a hunt for missing pins. **The gate
is not the bug** and should keep behaving exactly like this.

## Blast radius

Not specific to #4308. The job only runs when a build file changed, and libs-runtime is a dependency
of most of the fleet — so any PR adding a dependency there hits the same wall and cannot merge on a
required context.

## Verification

`--selftest` OK (parser, verdict algebra, both plugin shapes proven both ways), the empty-modules
no-op path still exits 0, `gates (registry)` 26/26.

Closes #4907
