### PR TITLE
fix(admin-ui): show unavailable AI review

### DIFF
--- a/openbank-admin-ui/src/app/api/agent/catalog-reviews/route.ts
+++ b/openbank-admin-ui/src/app/api/agent/catalog-reviews/route.ts
@@ -42,7 +42,12 @@ export async function POST(request: NextRequest) {
       // infrastructure detail. Preserve only this narrow, documented contract;
       // every other agent error stays behind the generic BFF envelope.
       const failure = await response.json().catch(() => null) as { error?: unknown } | null
-      if (response.status === 503 && failure?.error === 'model unavailable') {
+      // Agent Service returns the more specific public message below. Keep accepting the
+      // original short form while a rolling deployment may contain either version.
+      if (
+        response.status === 503 &&
+        (failure?.error === 'model unavailable' || failure?.error === 'catalog review model is unavailable')
+      ) {
         return NextResponse.json({ error: 'model unavailable' }, { status: 503 })
       }
       return NextResponse.json({ error: 'upstream_error' }, { status: response.status })

--- a/openbank-admin-ui/src/test/catalog-review-bff.test.ts
+++ b/openbank-admin-ui/src/test/catalog-review-bff.test.ts
@@ -63,7 +63,9 @@ describe('catalog review BFF', () => {
   })
 
   it('preserves an upstream model-unavailable result for an honest UI state', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({ error: 'model unavailable' }), { status: 503 })))
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      error: 'catalog review model is unavailable',
+    }), { status: 503 })))
     const { POST } = await import('@/app/api/agent/catalog-reviews/route')
 
     const response = await POST(request({ offeringId: OFFERING_ID, revisionId: REVISION_ID }))


### PR DESCRIPTION
## What changed

Maps the Agent Service catalog-review 503 response to the documented `model unavailable` UI state.

## Why

The deployed Agent Service returns `catalog review model is unavailable` when no eligible self-hosted model exists. The BFF only recognized an obsolete error string and rendered a generic `upstream_error`.

## Validation

- `npm test -- --run src/test/catalog-review-bff.test.ts`
- `npm run type-check`

Refs #4501