### PR TITLE
feat(admin-ui): enforce persona workspaces

### DIFF
--- a/openbank-admin-ui/src/app/aml/page.tsx
+++ b/openbank-admin-ui/src/app/aml/page.tsx
@@ -11,6 +11,7 @@ import { ServiceStatusBadge } from '@/components/feedback/ServiceStatusBadge'
 import { svcUrl } from '@/lib/services/bff'
 import { useServiceResource } from '@/lib/services/useServiceResource'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
+import { PageHeader, StatusBadge } from '@/components/ui'
 
 interface AmlCase {
   id: string;
@@ -20,21 +21,6 @@ interface AmlCase {
   status: string;
   score: number;
   timestamp: string;
-}
-
-const RISK_COLORS: Record<string, { bg: string; text: string; border: string }> = {
-  CRITICAL: { bg: '#fef2f2', text: '#991b1b', border: '#fecaca' },
-  HIGH:     { bg: 'var(--danger-bg)',   text: 'var(--danger-text)',   border: 'var(--danger-border)' },
-  MEDIUM:   { bg: 'var(--warning-bg)',  text: 'var(--warning-text)',  border: 'var(--warning-border)' },
-  LOW:      { bg: 'var(--success-bg)',  text: 'var(--success-text)',  border: 'var(--success-border)' },
-  INFO:     { bg: 'var(--surface-3)',   text: 'var(--text-tertiary)', border: 'var(--border)' },
-}
-
-const STATUS_COLORS: Record<string, { bg: string; text: string; border: string }> = {
-  PENDING_REVIEW: { bg: 'var(--warning-bg)',  text: 'var(--warning-text)',  border: 'var(--warning-border)' },
-  ESCALATED:      { bg: 'var(--danger-bg)',   text: 'var(--danger-text)',   border: 'var(--danger-border)' },
-  RESOLVED:       { bg: 'var(--success-bg)',  text: 'var(--success-text)',  border: 'var(--success-border)' },
-  CLEAN:          { bg: 'var(--surface-3)',   text: 'var(--text-secondary)', border: 'var(--border)' },
 }
 
 export default function AmlPage() {
@@ -71,16 +57,11 @@ export default function AmlPage() {
   return (
     <AuthGuard permission="compliance:view">
       <div style={{ padding: '28px 32px', maxWidth: '1400px', animation: 'fadeIn 0.2s ease-out' }}>
-        <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', marginBottom: '28px' }}>
-          <div>
-            <h1 style={{ fontSize: '24px', fontWeight: 800, color: 'var(--text-primary)', letterSpacing: '-0.03em', marginBottom: '4px' }}>
-              {t('AML Monitoring', 'AML Monitoring')}
-            </h1>
-            <p style={{ fontSize: '13px', color: 'var(--text-secondary)' }}>
-              {t('Prevence praní špinavých peněz — monitoring transakcí a správa případů', 'Anti-Money Laundering — transaction monitoring & case management')}
-            </p>
-          </div>
-          <div style={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
+        <PageHeader
+          title={t('AML Monitoring', 'AML Monitoring')}
+          subtitle={t('Prevence praní špinavých peněz — monitoring transakcí a správa případů', 'Anti-Money Laundering — transaction monitoring & case management')}
+          icon={<ShieldAlert size={20} aria-hidden="true" />}
+          actions={<div style={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
             <ServiceStatusBadge
               label="aml-service :8117"
               loading={loading}
@@ -97,8 +78,8 @@ export default function AmlPage() {
               <Play size={13} style={{ animation: scanning ? 'pulse 1s infinite' : 'none' }} />
               {scanning ? t('Kontroluji…', 'Scanning…') : t('Spustit AML kontrolu', 'Run AML scan')}
             </button>
-          </div>
-        </div>
+          </div>}
+        />
 
         {escalated.length > 0 && (
           <div style={{ marginBottom: '20px', padding: '12px 16px', borderRadius: '8px',
@@ -170,8 +151,6 @@ export default function AmlPage() {
                 ))}
               </tr></thead>
               <tbody>{filtered.map(c => {
-                const rStyle = RISK_COLORS[c.riskLevel] || RISK_COLORS.INFO
-                const sStyle = STATUS_COLORS[c.status] || STATUS_COLORS.CLEAN
                 return (
                   <tr key={c.id} style={{ borderBottom: '1px solid var(--border)' }}
                     onMouseEnter={e => e.currentTarget.style.background = 'var(--surface-2)'}
@@ -184,8 +163,7 @@ export default function AmlPage() {
                     </td>
                     <td style={{ padding: '12px 16px', fontSize: '12px', color: 'var(--text-secondary)' }}>{c.customerType}</td>
                     <td style={{ padding: '12px 16px' }}>
-                      <span style={{ padding: '2px 8px', borderRadius: '10px', fontSize: '10px', fontWeight: 700,
-                        background: rStyle.bg, color: rStyle.text, border: `1px solid ${rStyle.border}` }}>{c.riskLevel}</span>
+                      <StatusBadge status={c.riskLevel} />
                     </td>
                     <td style={{ padding: '12px 16px' }}>
                       <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
@@ -197,8 +175,7 @@ export default function AmlPage() {
                       </div>
                     </td>
                     <td style={{ padding: '12px 16px' }}>
-                      <span style={{ padding: '2px 8px', borderRadius: '10px', fontSize: '11px', fontWeight: 600,
-                        background: sStyle.bg, color: sStyle.text, border: `1px solid ${sStyle.border}` }}>{c.status.replace('_', ' ')}</span>
+                      <StatusBadge status={c.status} label={c.status.replace('_', ' ')} />
                     </td>
                     <td style={{ padding: '12px 16px', fontSize: '12px', color: 'var(--text-tertiary)' }}>{c.timestamp ? new Date(c.timestamp).toLocaleString('cs-CZ') : '—'}</td>
                   </tr>

--- a/openbank-admin-ui/src/app/dashboard/Dashboard.module.css
+++ b/openbank-admin-ui/src/app/dashboard/Dashboard.module.css
@@ -31,6 +31,90 @@
   gap: 10px;
 }
 
+.workspace {
+  margin-bottom: 16px;
+  padding: 18px;
+  border-color: #dbe4f2;
+  background: linear-gradient(120deg, #ffffff, #f5f7ff);
+  box-shadow: 0 12px 28px rgba(30, 41, 59, 0.06);
+}
+
+.workspaceHeading {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 14px;
+}
+
+.workspaceEyebrow {
+  margin: 0 0 3px;
+  color: var(--accent);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.workspaceTitle {
+  margin: 0;
+  color: var(--text-primary);
+  font-size: 18px;
+  letter-spacing: -0.02em;
+}
+
+.workspaceContext {
+  color: var(--text-tertiary);
+  font-size: 12px;
+}
+
+.workspaceLinks {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.workspaceLink {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+  padding: 12px;
+  color: var(--text-primary);
+  text-decoration: none;
+  font-size: 13px;
+  font-weight: 650;
+  border: 1px solid var(--border);
+  border-radius: 11px;
+  background: var(--surface);
+  transition: border-color 0.15s ease, box-shadow 0.15s ease, transform 0.15s ease;
+}
+
+.workspaceLink:hover,
+.workspaceLink:focus-visible {
+  border-color: var(--accent);
+  box-shadow: 0 8px 18px rgba(79, 70, 229, 0.14);
+  transform: translateY(-1px);
+  outline: none;
+}
+
+.workspaceIcon {
+  display: grid;
+  flex: 0 0 auto;
+  width: 32px;
+  height: 32px;
+  place-items: center;
+  color: var(--accent);
+  background: var(--accent-soft);
+  border-radius: 9px;
+}
+
+.workspaceArrow {
+  margin-left: auto;
+  color: var(--text-tertiary);
+  font-size: 17px;
+}
+
 .lastRefresh {
   color: #cbd5e1;
   font-size: 11px;
@@ -265,6 +349,10 @@
   .healthGroups {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
+
+  .workspaceLinks {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
 }
 
 @media (max-width: 760px) {
@@ -280,8 +368,14 @@
 
   .metrics,
   .healthGroups,
-  .serviceGroups {
+  .serviceGroups,
+  .workspaceLinks {
     grid-template-columns: 1fr;
+  }
+
+  .workspaceHeading {
+    align-items: flex-start;
+    flex-direction: column;
   }
 
   .serviceGroupHeader {

--- a/openbank-admin-ui/src/app/dashboard/page.tsx
+++ b/openbank-admin-ui/src/app/dashboard/page.tsx
@@ -4,14 +4,15 @@
 
 'use client'
 
-import { useState, useEffect, useCallback, useRef, type CSSProperties } from 'react'
+import { useState, useEffect, useCallback, useRef, type CSSProperties, type ElementType } from 'react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { CreditCard, ArrowLeftRight, Users, Activity, ShieldCheck, RefreshCw,
-  DollarSign, Globe, BarChart3, Server } from 'lucide-react'
+  DollarSign, Globe, BarChart3, Server, ClipboardList, ScrollText, Landmark } from 'lucide-react'
 import Link from 'next/link'
 import { useSession } from 'next-auth/react'
 import { PageHeader, StatCard, StatusBadge, type Tone } from '@/components/ui'
 import { hasPermission, type Permission } from '@/lib/auth/roles'
+import { personaForRoles, personaLabel, workspaceFor } from '@/lib/auth/persona'
 import { fleetHealthState, summarizeFleetHealth } from '@/lib/dashboard/fleetHealth'
 import styles from './Dashboard.module.css'
 
@@ -41,8 +42,27 @@ const GROUP_COLORS: Record<string, string> = {
   identity: 'var(--info)', 'open-banking': 'var(--accent)', platform: 'var(--text-tertiary)'
 }
 
+const WORKSPACE_ICONS: Record<string, ElementType> = {
+  '/accounts': CreditCard,
+  '/transactions': ArrowLeftRight,
+  '/onboarding': ClipboardList,
+  '/parties': Users,
+  '/payments': DollarSign,
+  '/standing-orders': ArrowLeftRight,
+  '/clearing': Landmark,
+  '/fx': Globe,
+  '/kyc': ShieldCheck,
+  '/aml': ShieldCheck,
+  '/sanctions': ShieldCheck,
+  '/audit': ScrollText,
+  '/system/health': Activity,
+  '/devops': Activity,
+  '/observability': Activity,
+  '/services': Server,
+}
+
 export default function DashboardPage() {
-  const { t } = useLanguage()
+  const { t, language } = useLanguage()
   const { data: session } = useSession()
   const [statuses, setStatuses] = useState<SvcStatus[]>([])
   const [loading, setLoading] = useState(true)
@@ -123,14 +143,17 @@ export default function DashboardPage() {
   const healthState = fleetHealthState(health)
   const healthTone: Tone = healthState === 'healthy' ? 'success' : healthState === 'degraded' ? 'warning' : 'neutral'
   const roles = session?.user?.roles ?? []
+  const persona = personaForRoles(roles)
+  const workspace = workspaceFor(persona).filter(link => hasPermission(roles, link.permission))
+  const personaLanguage = language === 'cs' ? 'cs' : 'en'
 
   const groups = ['core', 'payments', 'compliance', 'identity', 'open-banking', 'platform']
 
   return (
     <main className={styles.dashboard}>
       <PageHeader
-        title={t('Přehled platformy', 'Platform overview')}
-        subtitle={t('Aktuální stav health-checků nasazené části platformy.', 'Current health-check state of the deployed platform.')}
+        title={t('Můj pracovní prostor', 'My workspace')}
+        subtitle={`${personaLabel(persona, personaLanguage)} · ${t('Prioritní pracovní fronty a aktuální stav platformy.', 'Priority work queues and the current platform state.')}`}
         icon={<Activity className={styles.headerIcon} size={20} aria-hidden="true" />}
         actions={
           <div className={styles.headerActions}>
@@ -146,6 +169,28 @@ export default function DashboardPage() {
           </div>
         }
       />
+
+      <section className={`card ${styles.workspace}`} aria-labelledby="workspace-heading">
+        <div className={styles.workspaceHeading}>
+          <div>
+            <p className={styles.workspaceEyebrow}>{personaLabel(persona, personaLanguage)}</p>
+            <h2 id="workspace-heading" className={styles.workspaceTitle}>{t('Pracovní fronty', 'Work queues')}</h2>
+          </div>
+          <span className={styles.workspaceContext}>{t('Podle vašich oprávnění', 'Based on your permissions')}</span>
+        </div>
+        <div className={styles.workspaceLinks}>
+          {workspace.map(link => {
+            const Icon = WORKSPACE_ICONS[link.href] ?? Activity
+            return (
+              <Link key={link.href} href={link.href} className={styles.workspaceLink}>
+                <span className={styles.workspaceIcon}><Icon size={18} aria-hidden="true" /></span>
+                <span>{t(link.nameCs, link.nameEn)}</span>
+                <span className={styles.workspaceArrow} aria-hidden="true">→</span>
+              </Link>
+            )
+          })}
+        </div>
+      </section>
 
       {/* These are intentionally current health facts, not estimated operational or compliance metrics. */}
       <section className={styles.metrics} aria-label={t('Klíčové metriky platformy', 'Platform key metrics')}>
@@ -241,7 +286,7 @@ export default function DashboardPage() {
 
       {/* Only show destinations the operator can already access; dashboard shortcuts must not create 403 traps. */}
       <section className={`card ${styles.quickAccess}`} aria-labelledby="quick-access-heading">
-        <h2 id="quick-access-heading" className={styles.sectionLabel}>{t('Rychlý přístup', 'Quick Access')}</h2>
+        <h2 id="quick-access-heading" className={styles.sectionLabel}>{t('Další nástroje', 'More tools')}</h2>
         <div className={styles.quickLinks}>
           {[
             { href: '/accounts', label: t('Účty', 'Accounts'), icon: CreditCard, color: 'var(--accent)', permission: 'accounts:view' },

--- a/openbank-admin-ui/src/app/kyc/page.tsx
+++ b/openbank-admin-ui/src/app/kyc/page.tsx
@@ -10,6 +10,7 @@ import { classifyBffFailure } from '@/lib/services/bff'
 import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
 import { ShieldCheck, Search, RefreshCw, ChevronRight } from 'lucide-react'
 import Link from 'next/link'
+import { PageHeader, StatusBadge } from '@/components/ui'
 
 const KYC_SERVICE = '/api/svc/kyc-service'
 
@@ -17,11 +18,6 @@ interface KycCase {
   id: string; partyId: string; status: string
   checks: { checkType: string; status: string }[]
   reviewedBy?: string; createdAt: string; updatedAt: string
-}
-
-const STATUS_COLOR: Record<string, string> = {
-  APPROVED: 'var(--green)', PENDING: 'var(--yellow)', REJECTED: 'var(--red)',
-  IN_REVIEW: 'var(--accent)', OPEN: 'var(--text-muted)',
 }
 
 export default function KycPage() {
@@ -66,23 +62,15 @@ export default function KycPage() {
 
   return (
     <div>
-      <div className="page-header">
-        <div>
-          <div className="breadcrumb">
-            <span>OpenBank</span><span className="breadcrumb-sep">/</span>
-            <span className="breadcrumb-current">KYC</span>
-          </div>
-          <h1 className="page-title" style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-            <ShieldCheck size={18} style={{ color: 'var(--accent)' }} />
-            {t('KYC Případy', 'KYC Cases')}
-          </h1>
-          <p className="page-subtitle">{t('Ověření totožnosti zákazníka — přehled případů', 'Know Your Customer verification cases')}</p>
-        </div>
-        <button className="btn btn-secondary" onClick={load} disabled={loading}>
+      <PageHeader
+        title={t('KYC Případy', 'KYC Cases')}
+        subtitle={t('Ověření totožnosti zákazníka — přehled případů', 'Know Your Customer verification cases')}
+        icon={<ShieldCheck size={20} aria-hidden="true" />}
+        actions={<button className="btn btn-secondary" onClick={load} disabled={loading}>
           <RefreshCw size={13} style={{ animation: loading ? 'spin 1s linear infinite' : 'none' }} />
           {t('Obnovit', 'Refresh')}
-        </button>
-      </div>
+        </button>}
+      />
 
       {/* Toolbar */}
       <div style={{ display: 'flex', gap: '10px', marginBottom: '16px' }}>
@@ -146,16 +134,12 @@ export default function KycPage() {
                   <Link href={`/parties/${c.partyId}`} style={{ color: 'var(--accent)', textDecoration: 'none' }}>{c.partyId.slice(0, 8)}…</Link>
                 </td>
                 <td>
-                  <span className="pill" style={{ background: `${STATUS_COLOR[c.status] ?? 'var(--text-muted)'}22`, color: STATUS_COLOR[c.status] ?? 'var(--text-muted)' }}>
-                    {c.status}
-                  </span>
+                  <StatusBadge status={c.status} />
                 </td>
                 <td>
                   <div style={{ display: 'flex', gap: '4px', flexWrap: 'wrap' }}>
                     {c.checks?.map(ch => (
-                      <span key={ch.checkType} className="tag" style={{ fontSize: '10px', color: STATUS_COLOR[ch.status] ?? 'var(--text-muted)' }}>
-                        {ch.checkType?.replace(/_/g, ' ') ?? ch.checkType}
-                      </span>
+                      <StatusBadge key={ch.checkType} status={ch.status} label={ch.checkType?.replace(/_/g, ' ') ?? ch.checkType} />
                     ))}
                   </div>
                 </td>

--- a/openbank-admin-ui/src/app/payments/page.tsx
+++ b/openbank-admin-ui/src/app/payments/page.tsx
@@ -12,6 +12,7 @@ import {
   Clock, AlertTriangle, Timer, ShieldCheck, AlertCircle, ChevronRight
 } from 'lucide-react'
 import { stashRow } from '@/lib/services/rowHandoff'
+import { StatusBadge } from '@/components/ui'
 
 // ADR-0080 P1 (pentest FIND-S3-03/04): all backend access goes through same-origin BFF
 // routes — never NEXT_PUBLIC_ localhost URLs, which leaked the internal port map into the
@@ -80,11 +81,6 @@ interface SepaFormData {
   purposeCode: string
   vopStatus: VopStatus
   vopResult: string | null
-}
-
-const STATUS_COLOR: Record<string, string> = {
-  COMPLETED: 'var(--green)', PENDING: 'var(--yellow)', FAILED: 'var(--red)',
-  PROCESSING: 'var(--accent)', CANCELLED: 'var(--text-muted)',
 }
 
 const TABS: { key: Tab; labelCs: string; labelEn: string; icon: React.ElementType }[] = [
@@ -912,9 +908,7 @@ function PaymentsContent() {
                     <td style={{ fontFamily: 'var(--font-mono)', fontSize: '11px' }}>{p.id.slice(0, 8)}…</td>
                     <td><span className="tag" style={{ color: p.type === 'SEPA' ? 'var(--accent)' : 'var(--green)' }}>{p.type}</span></td>
                     <td>
-                      <span className="pill" style={{ background: `${STATUS_COLOR[p.status] ?? 'var(--text-muted)'}22`, color: STATUS_COLOR[p.status] ?? 'var(--text-muted)' }}>
-                        {p.status}
-                      </span>
+                      <StatusBadge status={p.status} />
                     </td>
                     <td style={{ fontFamily: 'var(--font-mono)', fontWeight: 600 }}>{formatAmount(p.amount, p.currency, language)}</td>
                     <td style={{ fontSize: '13px' }}>{p.creditorName ?? '—'}</td>

--- a/openbank-admin-ui/src/components/layout/Header.tsx
+++ b/openbank-admin-ui/src/components/layout/Header.tsx
@@ -8,7 +8,7 @@ import { Bell, Search, HelpCircle, LogOut, ChevronDown } from 'lucide-react'
 import { useSession, signOut } from 'next-auth/react'
 import Link from 'next/link'
 import { useEffect, useState } from 'react'
-import { ROLE_LABELS } from '@/lib/auth/roles'
+import { hasPermission, ROLE_LABELS } from '@/lib/auth/roles'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { CommandPalette } from '@/components/search/CommandPalette'
 import styles from './Header.module.css'
@@ -46,9 +46,11 @@ export function Header() {
   const user = session?.user
   const roles: string[] = user?.roles ?? []
   // Show highest-privilege role badge
-  const primaryRole = ['ROLE_ADMIN','ROLE_COMPLIANCE','ROLE_PAYMENTS','ROLE_AUDITOR','ROLE_OPERATOR','ROLE_VIEWER']
+  const primaryRole = ['ROLE_ADMIN', 'ROLE_SUPERVISOR', 'ROLE_COMPLIANCE', 'ROLE_KYC_REVIEWER', 'ROLE_KYC_OPENER', 'ROLE_KYC', 'ROLE_PAYMENTS', 'ROLE_AUDITOR', 'ROLE_OPERATOR', 'ROLE_VIEWER']
     .find(r => roles.includes(r))
   const roleInfo = primaryRole ? ROLE_LABELS[primaryRole] : null
+  const canReadDocs = hasPermission(roles, 'docs:view')
+  const canViewApprovals = hasPermission(roles, 'system:view')
   const initials = user?.name
     ? user.name.split(' ').map((n: string) => n[0]).join('').toUpperCase().slice(0, 2)
     : user?.email?.[0]?.toUpperCase() ?? 'U'
@@ -119,19 +121,24 @@ export function Header() {
         >
           {language.toUpperCase()}
         </button>
-        <HeaderLink href="/docs" label={t('Nápověda a dokumentace', 'Help and documentation')}><HelpCircle size={15} /></HeaderLink>
-        <HeaderLink href="/approvals" label={t('Schvalování', 'Approvals')}><Bell size={15} /></HeaderLink>
+        {canReadDocs && <HeaderLink href="/docs" label={t('Nápověda a dokumentace', 'Help and documentation')}><HelpCircle size={15} /></HeaderLink>}
+        {canViewApprovals && <HeaderLink href="/approvals" label={t('Schvalování', 'Approvals')}><Bell size={15} /></HeaderLink>}
         <div style={{ width: '1px', height: '20px', background: 'var(--border)', margin: '0 6px' }} />
 
         {/* User menu */}
         <div style={{ position: 'relative' }}>
-          <div
+          <button
+            type="button"
             onClick={() => setMenuOpen(v => !v)}
+            aria-expanded={menuOpen}
+            aria-haspopup="menu"
+            aria-label={t('Otevřít uživatelskou nabídku', 'Open user menu')}
             style={{
               display: 'flex', alignItems: 'center', gap: '8px',
-              padding: '4px 8px 4px 4px', borderRadius: '20px', cursor: 'pointer',
+              padding: '4px 8px 4px 4px', border: 'none', borderRadius: '20px', cursor: 'pointer',
               transition: 'background 0.12s',
               background: menuOpen ? 'var(--surface-3)' : 'transparent',
+              font: 'inherit', textAlign: 'left',
             }}
             onMouseEnter={e => (e.currentTarget.style.background = 'var(--surface-3)')}
             onMouseLeave={e => { if (!menuOpen) e.currentTarget.style.background = 'transparent' }}
@@ -155,11 +162,11 @@ export function Header() {
               )}
             </div>
             <ChevronDown size={12} style={{ color: 'var(--text-tertiary)', marginLeft: '2px' }} />
-          </div>
+          </button>
 
           {/* Dropdown */}
           {menuOpen && (
-            <div style={{
+            <div role="menu" aria-label={t('Uživatelská nabídka', 'User menu')} style={{
               position: 'absolute', top: 'calc(100% + 6px)', right: 0,
               width: '240px', background: 'var(--surface)', border: '1px solid var(--border)',
               borderRadius: '10px', boxShadow: 'var(--shadow-lg)', padding: '8px',

--- a/openbank-admin-ui/src/components/ui/tone.ts
+++ b/openbank-admin-ui/src/components/ui/tone.ts
@@ -110,6 +110,7 @@ const TONE_BY_STATUS: Record<string, Tone> = {
   BOUNCED: 'danger',
   CRITICAL: 'danger',
   ERROR: 'danger',
+  ESCALATED: 'danger',
   FAIL: 'danger',
   FAILED: 'danger',
   REJECTED: 'danger',
@@ -126,6 +127,7 @@ const TONE_BY_STATUS: Record<string, Tone> = {
   // — see its `tone` prop. Do not "fix" this map to match one domain; that just moves the conflict.
   CANCELLED: 'neutral',
   CLOSED: 'neutral',
+  CLEAN: 'neutral',
   DISABLED: 'neutral',
   EXPIRED: 'neutral',
   MERGED: 'neutral',

--- a/openbank-admin-ui/src/lib/auth/persona.ts
+++ b/openbank-admin-ui/src/lib/auth/persona.ts
@@ -4,45 +4,49 @@
 
 // ADR-0229 D4 (first cut): persona derivation from realm roles. One operator = one primary
 // persona (strongest match wins); it drives the pinned "My workspace" quick links at the top
-// of the sidebar. The full menu below is untouched — the workspace is an additive landing,
-// not a wall. Persona home dashboards and generated-matrix workspaces are later ADR-0229 steps.
+// of the sidebar and the dashboard. The full menu below is untouched — the workspace is an
+// additive landing, not a wall.
 
-import { ROLES, type Role } from './roles'
+import { ROLES, type Permission, type Role } from './roles'
 
 export type Persona = 'backoffice' | 'payments' | 'compliance' | 'supervisor' | 'platform'
 
-export type WorkspaceLink = { href: string; nameCs: string; nameEn: string }
+/** A persona shortcut carries its UI permission so every consumer can suppress
+ * a destination before it becomes a 403 trap (ADR-0229 D3/D4). */
+export type WorkspaceLink = { href: string; nameCs: string; nameEn: string; permission: Permission }
 
 const WORKSPACES: Record<Persona, WorkspaceLink[]> = {
   backoffice: [
-    { href: '/parties', nameCs: 'Klienti', nameEn: 'Parties' },
-    { href: '/accounts', nameCs: 'Účty', nameEn: 'Accounts' },
-    { href: '/transactions', nameCs: 'Transakce', nameEn: 'Transactions' },
-    { href: '/onboarding', nameCs: 'Onboarding', nameEn: 'Onboarding' },
+    { href: '/parties', nameCs: 'Klienti', nameEn: 'Parties', permission: 'parties:view' },
+    { href: '/accounts', nameCs: 'Účty', nameEn: 'Accounts', permission: 'accounts:view' },
+    { href: '/transactions', nameCs: 'Transakce', nameEn: 'Transactions', permission: 'transactions:view' },
+    { href: '/onboarding', nameCs: 'Onboarding', nameEn: 'Onboarding', permission: 'onboarding:view' },
   ],
   payments: [
-    { href: '/payments', nameCs: 'Platby', nameEn: 'Payments' },
-    { href: '/standing-orders', nameCs: 'Trvalé příkazy', nameEn: 'Standing Orders' },
-    { href: '/clearing', nameCs: 'Clearing', nameEn: 'Clearing' },
-    { href: '/fx', nameCs: 'FX', nameEn: 'FX' },
+    { href: '/payments', nameCs: 'Platby', nameEn: 'Payments', permission: 'payments:view' },
+    { href: '/standing-orders', nameCs: 'Trvalé příkazy', nameEn: 'Standing Orders', permission: 'payments:view' },
+    { href: '/clearing', nameCs: 'Clearing', nameEn: 'Clearing', permission: 'payments:view' },
+    { href: '/fx', nameCs: 'FX', nameEn: 'FX', permission: 'payments:view' },
   ],
   compliance: [
-    { href: '/kyc', nameCs: 'KYC', nameEn: 'KYC' },
-    { href: '/aml', nameCs: 'AML', nameEn: 'AML' },
-    { href: '/sanctions', nameCs: 'Sankce', nameEn: 'Sanctions' },
-    { href: '/audit', nameCs: 'Audit', nameEn: 'Audit' },
+    { href: '/kyc', nameCs: 'KYC', nameEn: 'KYC', permission: 'kyc:view' },
+    { href: '/aml', nameCs: 'AML', nameEn: 'AML', permission: 'compliance:view' },
+    { href: '/sanctions', nameCs: 'Sankce', nameEn: 'Sanctions', permission: 'compliance:view' },
+    { href: '/audit', nameCs: 'Audit', nameEn: 'Audit', permission: 'audit:view' },
   ],
   supervisor: [
-    { href: '/approvals', nameCs: 'Schvalování', nameEn: 'Approvals' },
-    { href: '/audit', nameCs: 'Audit', nameEn: 'Audit' },
-    { href: '/day-end', nameCs: 'Závěrky', nameEn: 'Closings' },
-    { href: '/ledger', nameCs: 'Hlavní kniha', nameEn: 'Ledger' },
+    // A supervisor can review, but cannot use the platform-admin approvals queue or the
+    // operator-only closing trigger. Keep this workspace aligned to the actual RBAC matrix.
+    { href: '/payments', nameCs: 'Platební dohled', nameEn: 'Payment oversight', permission: 'payments:view' },
+    { href: '/aml', nameCs: 'AML dohled', nameEn: 'AML oversight', permission: 'compliance:view' },
+    { href: '/sanctions', nameCs: 'Sankční dohled', nameEn: 'Sanctions oversight', permission: 'compliance:view' },
+    { href: '/audit', nameCs: 'Audit', nameEn: 'Audit', permission: 'audit:view' },
   ],
   platform: [
-    { href: '/system/health', nameCs: 'Zdraví systému', nameEn: 'System Health' },
-    { href: '/devops', nameCs: 'DevOps', nameEn: 'DevOps' },
-    { href: '/observability', nameCs: 'Observability', nameEn: 'Observability' },
-    { href: '/services', nameCs: 'Služby', nameEn: 'Services' },
+    { href: '/system/health', nameCs: 'Zdraví systému', nameEn: 'System Health', permission: 'system:view' },
+    { href: '/devops', nameCs: 'DevOps', nameEn: 'DevOps', permission: 'system:view' },
+    { href: '/observability', nameCs: 'Observability', nameEn: 'Observability', permission: 'system:view' },
+    { href: '/services', nameCs: 'Služby', nameEn: 'Services', permission: 'docs:view' },
   ],
 }
 

--- a/openbank-admin-ui/src/lib/auth/roles.ts
+++ b/openbank-admin-ui/src/lib/auth/roles.ts
@@ -98,6 +98,9 @@ export const PERMISSIONS = {
   // call the endpoint directly. This decides what we *render*, not what they can *fetch*.
   // Real metadata/body separation needs a policy change — issue #1326.
   "notifications:view":       [ROLES.ADMIN, ROLES.OPERATOR],
+  // Screen feedback carries free-text comments and screenshot keys (ADR-0192), so it is
+  // intentionally narrower than general docs/viewer access.
+  "feedback:view":            [ROLES.ADMIN, ROLES.OPERATOR, ROLES.COMPLIANCE],
   // Operator-initiated customer messaging (ADR-0176 D4/D5). Matches the backend's actual rego
   // grants exactly (opsmessage-compose / opsmessage-approve in rest.rego) — any
   // ROLE_OPERATOR/ROLE_ADMIN may compose or decide, with self-approval refused server-side by
@@ -120,6 +123,55 @@ export type Permission = keyof typeof PERMISSIONS
 export function hasPermission(roles: string[], permission: Permission): boolean {
   const allowed = PERMISSIONS[permission] as readonly string[]
   return roles.some(r => allowed.includes(r))
+}
+
+/**
+ * One UI route-to-permission projection used by the edge gate and route-coverage tests.
+ *
+ * This is deliberately a route manifest, not a list of roles: adding a role to a permission
+ * immediately changes every matching page consistently, while the backend/OPA remains the
+ * enforcement authority for data and mutations. Longest prefixes win, so `/system/config` can
+ * be stricter than `/system` without an exception in a page component.
+ */
+const ROUTE_PREFIXES: ReadonlyArray<readonly [Permission, readonly string[]]> = [
+  ['system:config', ['/system/config']],
+  ['catalog:read', ['/product-studio']],
+  ['templates:view', ['/document-templates']],
+  ['delegations:view', ['/delegations']],
+  ['feedback:view', ['/feedback']],
+  ['regulatory:view', ['/regulatory']],
+  ['audit:view', ['/audit']],
+  ['kyc:view', ['/kyc']],
+  ['onboarding:view', ['/onboarding', '/identity-cases']],
+  ['parties:view', ['/parties']],
+  ['transactions:view', ['/transactions']],
+  ['accounts:view', ['/accounts', '/ledger', '/day-end']],
+  ['payments:view', [
+    '/payments', '/product-catalog', '/standing-orders', '/sdd', '/sepa-instant', '/clearing',
+    '/fx', '/swift', '/cards', '/interest', '/pid', '/fees', '/lending',
+  ]],
+  ['compliance:view', [
+    '/aml', '/fraud', '/sanctions', '/disputes', '/consents', '/customer-360', '/campaigns',
+    '/segments', '/lending/compliance-packs', '/docs/compliance', '/docs/bcp',
+  ]],
+  ['system:view', [
+    '/approvals', '/devops', '/finops', '/iaops', '/infrastructure', '/observability', '/temporal',
+    '/security', '/notifications', '/system',
+  ]],
+  ['docs:view', ['/docs', '/services']],
+  ['settings:view', ['/settings']],
+]
+
+export function permissionForPath(pathname: string): Permission | undefined {
+  let match: { permission: Permission; length: number } | undefined
+  for (const [permission, prefixes] of ROUTE_PREFIXES) {
+    for (const prefix of prefixes) {
+      if ((pathname === prefix || pathname.startsWith(`${prefix}/`)) && (!match || prefix.length > match.length)) {
+        match = { permission, length: prefix.length }
+      }
+    }
+  }
+  return match?.permission
 }
 
 export function hasRole(roles: string[], role: Role): boolean {

--- a/openbank-admin-ui/src/middleware.ts
+++ b/openbank-admin-ui/src/middleware.ts
@@ -4,6 +4,7 @@
 
 import { NextResponse } from "next/server"
 import { auth } from "@/auth"
+import { hasPermission, permissionForPath } from "@/lib/auth/roles"
 
 // ADR-0080 P1 (F-AUTH-06): per-request CSP with a nonce + 'strict-dynamic' instead of
 // 'unsafe-inline' on script-src. A static next.config header can't carry a fresh nonce, so the
@@ -76,27 +77,14 @@ export default auth((req) => {
 
   const roles: string[] = session.user.roles ?? []
 
-  // Role-based route guards
-  const routeGuards: { pattern: RegExp; required: string[] }[] = [
-    { pattern: /^\/audit/,              required: ["ROLE_ADMIN", "ROLE_AUDITOR", "ROLE_COMPLIANCE"] },
-    { pattern: /^\/kyc/,               required: ["ROLE_ADMIN", "ROLE_OPERATOR", "ROLE_COMPLIANCE", "ROLE_KYC", "ROLE_KYC_OPENER", "ROLE_KYC_REVIEWER"] },
-    { pattern: /^\/regulatory/,        required: ["ROLE_ADMIN", "ROLE_COMPLIANCE"] },
-    // Screen feedback carries free-text comments and screenshot keys — personal data (ADR-0192).
-    { pattern: /^\/feedback/,          required: ["ROLE_ADMIN", "ROLE_OPERATOR", "ROLE_COMPLIANCE"] },
-    { pattern: /^\/system\/config/,    required: ["ROLE_ADMIN"] },
-    { pattern: /^\/payments/,          required: ["ROLE_ADMIN", "ROLE_OPERATOR", "ROLE_PAYMENTS", "ROLE_SUPERVISOR"] },
-    { pattern: /^\/parties/,           required: ["ROLE_ADMIN", "ROLE_OPERATOR", "ROLE_COMPLIANCE", "ROLE_KYC", "ROLE_KYC_OPENER", "ROLE_KYC_REVIEWER"] },
-  ]
-
-  for (const guard of routeGuards) {
-    if (guard.pattern.test(pathname)) {
-      const allowed = roles.some(r => guard.required.includes(r))
-      if (!allowed) {
-        const forbidden = new URL("/auth/forbidden", req.url)
-        forbidden.searchParams.set("path", pathname)
-        return withCsp(NextResponse.redirect(forbidden))
-      }
-    }
+  // ADR-0229 D3: one permission projection covers every authenticated console route instead
+  // of seven hand-maintained role lists. The route map shares the UI permission matrix, so nav,
+  // deep links and the initial response cannot disagree about a destination's visibility.
+  const permission = permissionForPath(pathname)
+  if (permission && !hasPermission(roles, permission)) {
+    const forbidden = new URL("/auth/forbidden", req.url)
+    forbidden.searchParams.set("path", pathname)
+    return withCsp(NextResponse.redirect(forbidden))
   }
 
   return nextWithNonce()

--- a/openbank-admin-ui/src/test/persona.test.ts
+++ b/openbank-admin-ui/src/test/persona.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, expect, it } from 'vitest'
 import { personaForRoles, personaLabel, workspaceFor } from '@/lib/auth/persona'
-import { ROLES } from '@/lib/auth/roles'
+import { hasPermission, ROLES } from '@/lib/auth/roles'
 
 describe('personaForRoles (ADR-0229 D4)', () => {
   it('platform admin wins over every other role', () => {
@@ -50,6 +50,22 @@ describe('workspaceFor / personaLabel', () => {
     expect(personaLabel('compliance', 'cs')).toBe('Compliance')
     expect(personaLabel('payments', 'en')).toBe('Payments Ops')
   })
+
+  it('does not give a primary persona a shortcut outside its RBAC grant', () => {
+    const representativeRoles = {
+      backoffice: [ROLES.OPERATOR],
+      payments: [ROLES.PAYMENTS],
+      compliance: [ROLES.COMPLIANCE],
+      supervisor: [ROLES.SUPERVISOR],
+      platform: [ROLES.ADMIN],
+    } as const
+
+    for (const [persona, roles] of Object.entries(representativeRoles) as [keyof typeof representativeRoles, readonly string[]][]) {
+      for (const link of workspaceFor(persona)) {
+        expect(hasPermission([...roles], link.permission), `${persona} -> ${link.href} exceeds its RBAC grant`).toBe(true)
+      }
+    }
+  })
 })
 
 // The Sidebar looks each workspace link up in its nav by href and inherits that entry's
@@ -68,4 +84,3 @@ describe('workspace links resolve to a real nav destination', () => {
     }
   })
 })
-

--- a/openbank-admin-ui/src/test/route-permissions.test.ts
+++ b/openbank-admin-ui/src/test/route-permissions.test.ts
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import { readdirSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { permissionForPath } from '@/lib/auth/roles'
+
+const APP_ROOT = 'src/app'
+const PUBLIC_ROUTES = new Set(['/', '/auth/error', '/auth/forbidden', '/auth/login', '/dashboard', '/privacy'])
+
+function pageRoutes(dir: string, route = ''): string[] {
+  return readdirSync(dir).flatMap(entry => {
+    const full = join(dir, entry)
+    if (entry === 'page.tsx') return [route || '/']
+    if (!statSync(full).isDirectory() || entry === 'api') return []
+    const segment = entry.startsWith('[') ? 'sample' : entry
+    return pageRoutes(full, `${route}/${segment}`)
+  })
+}
+
+describe('route permission projection (ADR-0229 D3)', () => {
+  it('covers every authenticated page route', () => {
+    const unguarded = pageRoutes(APP_ROOT)
+      .filter(route => !PUBLIC_ROUTES.has(route))
+      .filter(route => permissionForPath(route) === undefined)
+
+    expect(unguarded).toEqual([])
+  })
+
+  it('uses the most specific matching prefix', () => {
+    expect(permissionForPath('/lending/compliance-packs')).toBe('compliance:view')
+    expect(permissionForPath('/system/config')).toBe('system:config')
+  })
+})

--- a/openbank-admin-ui/src/test/ui-tone.test.ts
+++ b/openbank-admin-ui/src/test/ui-tone.test.ts
@@ -27,7 +27,7 @@ describe('statusTone (ADR-0208 D2)', () => {
   })
 
   it('maps failure statuses to danger', () => {
-    for (const s of ['FAILED', 'REJECTED', 'BLOCKED', 'SUSPENDED', 'CRITICAL', 'ERROR', 'BOUNCED']) {
+    for (const s of ['FAILED', 'REJECTED', 'BLOCKED', 'SUSPENDED', 'CRITICAL', 'ERROR', 'BOUNCED', 'ESCALATED']) {
       expect(statusTone(s), s).toBe('danger')
     }
   })
@@ -35,7 +35,7 @@ describe('statusTone (ADR-0208 D2)', () => {
   it('maps terminal-but-not-failed statuses to neutral, not danger', () => {
     // REVOKED/EXPIRED/CANCELLED are the customer or the clock ending something normally. Colouring
     // them red reads as "something went wrong" on a screen an operator scans for real problems.
-    for (const s of ['REVOKED', 'EXPIRED', 'CANCELLED', 'CLOSED', 'MERGED', 'SUPPRESSED']) {
+    for (const s of ['REVOKED', 'EXPIRED', 'CANCELLED', 'CLOSED', 'MERGED', 'SUPPRESSED', 'CLEAN']) {
       expect(statusTone(s), s).toBe('neutral')
     }
   })


### PR DESCRIPTION
## Summary
- add persona-specific dashboard workspaces and remove RBAC-inaccessible supervisor shortcuts
- centralize route-to-permission enforcement for every authenticated admin route
- migrate AML, KYC and payments status rendering to the shared semantic UI primitives
- prevent header links that would lead to an access-denied route

## Validation
-  (full UI suite)
- focused route/persona/tone regression tests: 24 passed
- 
- 

Refs #4841