### PR TITLE
fix(campaign): bind audience approval to version

### DIFF
--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/rest/AudienceResource.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/rest/AudienceResource.kt
@@ -46,7 +46,7 @@ class AudienceResource(private val service: AudienceService, private val jwt: Js
 
     @POST
     @Path("/{name}/{version}/approve")
-    @Authorize(action = "campaign.activate", resource = "#name")
+    @Authorize(action = "campaign.activate", resource = "#name@#version")
     suspend fun approve(@PathParam("name") name: String, @PathParam("version") version: Int): Response =
         lifecycle { service.summary(service.approve(name, version, jwt.audiencePrincipal())) }
 

--- a/openbank-libs-runtime/src/main/kotlin/com/openbank/libs/authz/AuthorizeInterceptor.kt
+++ b/openbank-libs-runtime/src/main/kotlin/com/openbank/libs/authz/AuthorizeInterceptor.kt
@@ -382,6 +382,13 @@ class AuthorizeInterceptor {
 
     private fun extractResource(ctx: InvocationContext, annotation: Authorize, expr: String): ResourceRef? {
         if (!expr.startsWith("#")) return null
+        if ('@' in expr) {
+            val parts = expr.split('@')
+            if (parts.size != 2 || parts.any { !it.startsWith("#") }) return null
+            val name = extractResource(ctx, annotation, parts[0]) ?: return null
+            val version = extractResource(ctx, annotation, parts[1]) ?: return null
+            return name.copy(id = "${name.id}@${version.id}")
+        }
         // "#param" -> whole parameter; "#param.field" -> one property of that parameter
         // (ADR-0206), resolved via the parameter's own primary-constructor properties —
         // one level deep only, no nested paths.

--- a/openbank-libs-runtime/src/test/kotlin/com/openbank/libs/authz/AuthorizeInterceptorTest.kt
+++ b/openbank-libs-runtime/src/test/kotlin/com/openbank/libs/authz/AuthorizeInterceptorTest.kt
@@ -110,6 +110,10 @@ class AuthorizeInterceptorTest {
     @Authorize(action = "consent.grant", resource = "#request.granteeId")
     fun dummyMethodWithNullableFieldResource(request: DummyRequestWithNullableField?) = Unit
 
+    @Suppress("UnusedParameter")
+    @Authorize(action = "campaign.activate", resource = "#name@#version")
+    fun dummyMethodWithVersionedResource(name: String, version: Int) = Unit
+
     private val annotatedMethod: Method =
         AuthorizeInterceptorTest::class.java.getDeclaredMethod("dummyMethod")
 
@@ -132,6 +136,13 @@ class AuthorizeInterceptorTest {
         AuthorizeInterceptorTest::class.java.getDeclaredMethod(
             "dummyMethodWithNullableFieldResource",
             DummyRequestWithNullableField::class.java,
+        )
+
+    private val annotatedMethodWithVersionedResource: Method =
+        AuthorizeInterceptorTest::class.java.getDeclaredMethod(
+            "dummyMethodWithVersionedResource",
+            String::class.java,
+            Int::class.java,
         )
 
     @Test
@@ -175,6 +186,20 @@ class AuthorizeInterceptorTest {
         assertThat(capturedQuery).hasSize(1)
         assertThat(capturedQuery[0].resource?.id).isEqualTo("party-service:marketing-comms")
         assertThat(capturedQuery[0].resource?.type).isEqualTo("consent")
+    }
+
+    @Test
+    fun `versioned resource expression binds approval to the immutable version`() {
+        every { identity.roles } returns emptySet()
+        val capturedQuery = mutableListOf<AuthzQuery>()
+        wirePdp(object : PolicyDecisionPoint {
+            override suspend fun allow(query: AuthzQuery): AuthzDecision {
+                capturedQuery += query
+                return AuthzDecision(allow = true, reason = "ok", policyVersion = "test")
+            }
+        })
+        interceptor.authorize(makeCtx(annotatedMethodWithVersionedResource, "offer", 2))
+        assertThat(capturedQuery.single().resource?.id).isEqualTo("offer@2")
     }
 
     @Test


### PR DESCRIPTION
Refs #4886\n\nBinds four-eyes approval authorization to immutable audience name and version, preventing an approval for one audience version from authorising another. Adds a focused authz regression test.