### PR TITLE
ci(perf): state perf-gate scope as a fraction, and fail an empty scope

### DIFF
--- a/.github/workflows/perf-gate.yml
+++ b/.github/workflows/perf-gate.yml
@@ -44,27 +44,74 @@ jobs:
         run: |
           python3 - <<'PY'
           import json, os, pathlib, re
-          services = (os.environ.get("OVERRIDE") or "openbank-product-catalog").split()
-          matrix = []
+          # The declared v1 scope (ADR-0243, issue #3348). Kept as a named constant so the
+          # summary can say what the run was SUPPOSED to measure, not only what it did.
+          DECLARED = ["openbank-product-catalog"]
+          override = (os.environ.get("OVERRIDE") or "").split()
+          services = override or list(DECLARED)
+          matrix, skipped = [], []
           for svc in services:
               app = pathlib.Path(svc) / "src/main/resources/application.yaml"
               script = pathlib.Path(svc) / "src/test/k6" / f"{svc.replace('openbank-','').replace('-service','')}-smoke.js"
               if not app.is_file():
-                  print(f"::warning::perf-gate: {svc} skipped — no application.yaml")
+                  skipped.append((svc, "no application.yaml"))
                   continue
               if not script.is_file():
-                  print(f"::warning::perf-gate: {svc} skipped — no k6 script at {script}")
+                  skipped.append((svc, f"no k6 script at `{script}`"))
                   continue
               raw = app.read_text()
               port = re.search(r"^  http:\n(?:.*\n)?\s*port:\s*(\d+)", raw, re.M)
               db = re.search(r"(?:jdbc:)?(?:vertx-reactive:)?postgresql://[^/]+/([A-Za-z0-9_]+)", raw)
               if not port or not db:
-                  print(f"::warning::perf-gate: {svc} skipped — cannot derive port/DB")
+                  skipped.append((svc, "cannot derive port/DB"))
                   continue
               matrix.append({"service": svc, "port": int(port.group(1)), "db": db.group(1)})
+          for svc, why in skipped:
+              print(f"::warning::perf-gate: {svc} EXCLUDED — {why}")
+          print(f"perf-gate: {len(matrix)} service(s); {len(skipped)} excluded")
+
+          # A run's CONCLUSION is not a coverage statement. The fuzz lane proved it (#4695):
+          # its first-ever green had fuzzed ONE service because of a dispatch override, and
+          # read identically to a full pass. perf-gate carries the same two shapes — a
+          # `services:` input silently REPLACES the declared scope, and every candidate can be
+          # dropped by a `continue`, leaving a zero-length matrix that produces no jobs and no
+          # failure. "Latency was within budget" means nothing without the denominator, so it
+          # is printed where a reader lands.
+          denom = len(services)
+          summary = [
+              "## Performance gate scope",
+              "",
+              f"**{len(matrix)} of {denom} requested service(s) actually measured.**",
+              "",
+          ]
+          if override:
+              summary += [
+                  f"> ⚠️ **Scope was OVERRIDDEN by dispatch input** — this run does NOT measure "
+                  f"the declared v1 scope (`{' '.join(DECLARED)}`). "
+                  f"Requested: `{' '.join(override)}`",
+                  "",
+              ]
+              print(
+                  "::warning::perf-gate: scope OVERRIDDEN by dispatch input "
+                  f"({len(matrix)} of {denom} requested service(s)) — this run is not a coverage measurement"
+              )
+          if skipped:
+              summary += ["| Excluded | Why |", "|---|---|"]
+              summary += [f"| `{svc}` | {why} |" for svc, why in skipped]
+              summary += [""]
+          summary += ["Measured: " + (", ".join(f"`{m['service']}`" for m in matrix) or "_none_")]
+          with open(os.environ.get("GITHUB_STEP_SUMMARY", os.devnull), "a") as fh:
+              fh.write("\n".join(summary) + "\n")
+
+          # An empty scope must never read as a pass. A zero-length matrix runs no jobs and the
+          # workflow succeeds having measured nothing — the exact shape this repo keeps
+          # rediscovering. Fail here, where the reason is still in hand.
+          if not matrix:
+              print("::error::perf-gate: derived scope is EMPTY — nothing would be measured")
+              raise SystemExit(1)
+
           with open(os.environ["GITHUB_OUTPUT"], "a") as fh:
               fh.write("matrix=" + json.dumps(matrix) + "\n")
-          print(f"perf-gate: {len(matrix)} service(s)")
           PY
 
   perf:


### PR DESCRIPTION
## Which of the two exposures perf-gate has

**Both — and the second is reachable by a one-word typo in a dispatch input.**

1. **Override narrows/replaces the scope silently.** `OVERRIDE: ${{ github.event.inputs.services }}` replaces the declared v1 scope outright. Nothing in the run name, conclusion, or (until now) any step summary says a dispatch measured something other than the declared scope. This is the shape that produced the fuzz lane's misleading first green (#4695).
2. **Empty scope passes vacuously.** The derive step drops candidates with three `continue` branches emitting `::warning::` only. `matrix=[]` means `strategy.matrix.include` is zero-length, `perf` runs no jobs, and the workflow concludes **success** having measured nothing.

Exposure 2 is not theoretical here: `openbank-product-catalog/src/test/k6/product-catalog-smoke.js` is the **only** k6 smoke script in the tree, so *any* dispatch naming a different service derives an empty matrix — measured below, a `services: openbank-ledger-service` dispatch yields `0 of 1` and, on `main`, a green run.

**Has it already bitten?** No. Enumerating the workflow's runs client-side (`conclusion`, not `?status=success`, which matches nothing here) returns exactly **one** run ever: `31570530574`, scheduled 2026-08-12, `failure`. No green run exists to have been misread. The trap is laid, not sprung.

## Coverage

**Before: 1 of 1 declared service, with the run conclusion saying nothing about which number applied.**
**After: 1 of 1, stated as a fraction in the job summary, with an empty scope failing outright.**

This PR does **not** widen perf-gate's scope (that is #3348). It makes the denominator visible and removes the path where the lane is green about no subject at all.

## The change

In the `derive` step only — no k6 behaviour, no trigger, no service code:

- writes **`N of M requested service(s) actually measured`** plus the exclusion table to `$GITHUB_STEP_SUMMARY`;
- labels an overridden scope as an override (summary banner + `::warning::` that the run is not a coverage measurement), naming the declared v1 scope it replaced;
- **fails** an empty derived scope instead of emitting a zero-length matrix.

## Verification

The derive script was extracted from the workflow and run against four cases, two of them known-positives it must flag:

| Case | Expected | Got |
|---|---|---|
| default (no override) | rc=0, `1 of 1` | rc=0, `1 of 1`, measured `openbank-product-catalog` |
| `services: openbank-product-catalog openbank-ledger-service` | rc=0 + override label | rc=0, **`1 of 2`**, `scope OVERRIDDEN … not a coverage measurement`, ledger excluded (no k6 script) |
| `services: openbank-ledger-service` | **rc=1** | rc=1, `0 of 1`, `derived scope is EMPTY` |
| `services: openbank-does-not-exist` | **rc=1** | rc=1, `derived scope is EMPTY — nothing would be measured` |

`actionlint` was run per file (a newline-joined list arrives as one argument and errors), comparing **finding sets** branch-vs-`origin/main` rather than post-filtering: both are empty, i.e. no new findings. The linter was proved live against a known-positive first — a deliberately mis-indented workflow, which it reports as `could not parse as YAML [syntax-check]`, the exact class a post-filter for `SC` codes would have hidden.

`check-workflow-run-step-size.py` (largest run script 14568 / 19000) and `check-duplicate-yaml-keys.sh` both pass.

## The `budget_seconds` finding — split, not folded

The comment on #4705 reports a second surface: **only 13 of 145 gates declare `budget_seconds`**, so the gate-trend dashboard's "alert candidate" budget panel covers 4 shards and an alert over it would read fleet-wide while watching a tenth of the estate. Same *rule* — a scoped panel must print its denominator — but a different artifact set (`gates.yaml` + the Grafana dashboard, not a workflow), and it is a design decision about the alert, not a one-step guard. It is filed as its own issue (#4919) rather than widened into this lane. Nothing alerts off it today (zero Grafana-managed rules instance-wide), so nothing is regressing while it waits.

Kept there for whoever writes that alert: the `MAX(seconds)` proxy is ≤ real job wall time in all 8 shards, while `sum(seconds)` **exceeds** it in 5 of 8 (lint reads 61 s against 34 s real). Gates run concurrently, so `max` is the only one of the two that is a bound — an alert on the sum fires on healthy runs.

Closes #4705
