### PR TITLE
feat(admin-ui): derive a qrless-pay status signal, and make the deriver testable

### DIFF
--- a/openbank-admin-ui/scripts/generate-app-status.mjs
+++ b/openbank-admin-ui/scripts/generate-app-status.mjs
@@ -26,7 +26,7 @@
 // hand in #25. `deriveCapabilityStatus` below computes a `derivedStatus` for the
 // SUBSET of capabilities that are cheap presence/shape checks against the app
 // source (tls-pinning, sca-device-key, auth-pkce, credential-storage,
-// diagnostics, payment-initiation). It is diffed against the curatorial `status`
+// diagnostics, payment-initiation, qrless-pay). It is diffed against the curatorial `status`
 // in --check mode and printed as a `::warning` on disagreement — advisory, not
 // enforced (unlike the derived-facts diff below): status has genuinely ambiguous
 // cases (e.g. an iOS-live/Android-stub split) the curator must still be able to
@@ -61,7 +61,7 @@
 
 import { readFileSync, writeFileSync, existsSync } from 'fs'
 import path from 'path'
-import { fileURLToPath } from 'url'
+import { fileURLToPath, pathToFileURL } from 'url'
 import { parse as parseYaml } from 'yaml'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
@@ -158,7 +158,7 @@ function deriveFromCode(appRepo) {
 // returns null (never guesses) and is surfaced as a gap; the capability's
 // derivedStatus itself is then also null and is skipped in the drift diff — an
 // absent signal has no verdict, exactly like the derived-facts layer.
-function deriveCapabilityStatus(appRepo, certPinningConfigured) {
+export function deriveCapabilityStatus(appRepo, certPinningConfigured) {
   const gaps = []
   const read = (rel) => {
     const p = path.join(appRepo, rel)
@@ -234,6 +234,38 @@ function deriveCapabilityStatus(appRepo, certPinningConfigured) {
     signals['payment-initiation'] = src === null ? null : wired ? 'live' : 'planned'
   }
 
+  // qrless-pay: two independent halves, and the interesting one is a switch.
+  // PAYEE is live when RequestScreen actually advertises a minted session
+  // (startReceiving); it is the QR-equivalent surface and ships on. PAYER is held
+  // behind NearPay.PAYER_DISCOVERY_ENABLED, off until the threat-model §8 rollout
+  // gates are met. Both halves on ⇒ live, exactly one ⇒ partial, neither ⇒ planned.
+  //
+  // This capability is here because it rotted twice in one week (openbank-app #445,
+  // #455): the yaml said `planned`/"NO implementation" while the protocol core, both
+  // transports and the payee surface were merged, and the correction was itself stale
+  // four PRs later. Both were single-field drifts of exactly the kind this signal sees.
+  //
+  // A MISSING flag constant is null, never a status. The constant exists precisely
+  // because dormancy used to rest on nothing happening to call startDiscovery — a
+  // control any refactor removes without noticing. If it is gone, this check has no
+  // verdict, and saying so is the honest answer; guessing the safer-looking one would
+  // hide the removal it is here to notice.
+  {
+    const proto = read('shared/src/commonMain/kotlin/tech/openbank/app/payment/nearpay/NearPay.kt')
+    const request = read('composeApp/src/commonMain/kotlin/tech/openbank/app/ui/RequestScreen.kt')
+    const flag = proto === null ? null : proto.match(/PAYER_DISCOVERY_ENABLED\s*=\s*(true|false)/)
+    if (proto !== null && !flag) {
+      gaps.push('NearPay.PAYER_DISCOVERY_ENABLED not found in NearPay.kt — qrless-pay derivedStatus signal unavailable')
+    }
+    if (proto === null || request === null || !flag) {
+      signals['qrless-pay'] = null
+    } else {
+      const payerOn = flag[1] === 'true'
+      const payeeWired = /startReceiving\s*\(/.test(request)
+      signals['qrless-pay'] = payerOn && payeeWired ? 'live' : payerOn || payeeWired ? 'partial' : 'planned'
+    }
+  }
+
   return { signals, gaps }
 }
 
@@ -251,148 +283,154 @@ function loadDeclared(appRepo) {
   }
 }
 
-// ── Join ─────────────────────────────────────────────────────────────────────
-const { derived, gaps: derivedGaps } = deriveFromCode(APP_REPO)
-const { declared, gaps: declaredGaps } = loadDeclared(APP_REPO)
-const { signals: statusSignals, gaps: statusGaps } = deriveCapabilityStatus(APP_REPO, derived.certPinningConfigured)
+// CLI entrypoint only — importing this module (tests) must not read the app repo,
+// write the artefact or exit the process.
+function main() {
+  // ── Join ─────────────────────────────────────────────────────────────────────
+  const { derived, gaps: derivedGaps } = deriveFromCode(APP_REPO)
+  const { declared, gaps: declaredGaps } = loadDeclared(APP_REPO)
+  const { signals: statusSignals, gaps: statusGaps } = deriveCapabilityStatus(APP_REPO, derived.certPinningConfigured)
 
-// Attach derivedStatus only to capabilities we have a signal for; everything
-// else (ui-stack, shared-domain, customer-edge, keycloak-realm, crash-monitoring,
-// qrless-pay, dossier) stays purely curatorial — no cheap code check calls those,
-// and guessing one would be exactly the fabricated-value ADR-0074 forbids.
-const capabilities = (declared?.capabilities ?? []).map((c) =>
-  Object.prototype.hasOwnProperty.call(statusSignals, c.id) ? { ...c, derivedStatus: statusSignals[c.id] } : c,
-)
-const decisionMissing = capabilities.filter((c) => c.decisionMissing === true)
-const byStatus = capabilities.reduce((acc, c) => {
-  acc[c.status] = (acc[c.status] || 0) + 1
-  return acc
-}, {})
-// status vs derivedStatus disagreement — the rot signal issue #26 exists to catch.
-// null derivedStatus (signal source unavailable) is never compared: no verdict.
-const statusDrift = capabilities.filter((c) => c.derivedStatus != null && c.derivedStatus !== c.status)
-
-const out = {
-  schema: 'openbank.appstatus/v1',
-  // generatedAt is intentionally omitted to keep the artefact diff-stable in CI
-  // (the content check in ADR-0074 diffs the derived block, not a timestamp).
-  app: declared?.app ?? { name: 'openbank-app' },
-  asOf: declared?.asOf ?? null,
-  // Stable repo identifier (not a local filesystem path) — keeps the artefact
-  // byte-identical regardless of WHERE the app source is checked out in CI, so the
-  // content check diffs source-derived facts, not the runner's directory layout.
-  appRepo: declared?.app?.repo ?? 'JiRaska/openbank-app',
-  derived,
-  capabilities,
-  summary: {
-    total: capabilities.length,
-    byStatus,
-    decisionMissing: decisionMissing.map((c) => c.id),
-  },
-  gaps: [...derivedGaps, ...declaredGaps, ...statusGaps],
-}
-
-const serialized = JSON.stringify(out, null, 2) + '\n'
-
-function summarize() {
-  console.log(
-    `  derived: ${derived.sourceAvailable ? `version=${derived.version} useFakeData=${derived.useFakeData} edge=${derived.edgeBaseUrl}` : 'SOURCE UNAVAILABLE'}`,
+  // Attach derivedStatus only to capabilities we have a signal for; everything
+  // else (ui-stack, shared-domain, customer-edge, keycloak-realm, crash-monitoring,
+  // dossier) stays purely curatorial — no cheap code check calls those, and guessing
+  // one would be exactly the fabricated-value ADR-0074 forbids.
+  const capabilities = (declared?.capabilities ?? []).map((c) =>
+    Object.prototype.hasOwnProperty.call(statusSignals, c.id) ? { ...c, derivedStatus: statusSignals[c.id] } : c,
   )
-  console.log(`  capabilities: ${capabilities.length} (${Object.entries(byStatus).map(([k, v]) => `${k}=${v}`).join(', ')})`)
-  if (decisionMissing.length) console.log(`  decision-missing: ${decisionMissing.map((c) => c.id).join(', ')}`)
-  if (statusDrift.length) {
-    console.log(`  ⚠ status drift: ${statusDrift.length}`)
-    for (const c of statusDrift) console.log(`    - ${c.id}: yaml says '${c.status}' but code looks '${c.derivedStatus}'`)
-  }
-  if (out.gaps.length) console.log(`  ⚠ gaps: ${out.gaps.length}\n    - ${out.gaps.join('\n    - ')}`)
-}
+  const decisionMissing = capabilities.filter((c) => c.decisionMissing === true)
+  const byStatus = capabilities.reduce((acc, c) => {
+    acc[c.status] = (acc[c.status] || 0) + 1
+    return acc
+  }, {})
+  // status vs derivedStatus disagreement — the rot signal issue #26 exists to catch.
+  // null derivedStatus (signal source unavailable) is never compared: no verdict.
+  const statusDrift = capabilities.filter((c) => c.derivedStatus != null && c.derivedStatus !== c.status)
 
-// Print one ::warning per drifted capability (issue #26). Always advisory,
-// independent of --enforce: unlike the derived-facts diff, curatorial `status`
-// is allowed to legitimately override a single code signal (e.g. an iOS-live/
-// Android-stub split the curator judges still `partial`) — a human call, so a
-// disagreement is a prompt to re-check the yaml, not necessarily a bug.
-function reportStatusDrift() {
-  for (const c of statusDrift) {
+  const out = {
+    schema: 'openbank.appstatus/v1',
+    // generatedAt is intentionally omitted to keep the artefact diff-stable in CI
+    // (the content check in ADR-0074 diffs the derived block, not a timestamp).
+    app: declared?.app ?? { name: 'openbank-app' },
+    asOf: declared?.asOf ?? null,
+    // Stable repo identifier (not a local filesystem path) — keeps the artefact
+    // byte-identical regardless of WHERE the app source is checked out in CI, so the
+    // content check diffs source-derived facts, not the runner's directory layout.
+    appRepo: declared?.app?.repo ?? 'JiRaska/openbank-app',
+    derived,
+    capabilities,
+    summary: {
+      total: capabilities.length,
+      byStatus,
+      decisionMissing: decisionMissing.map((c) => c.id),
+    },
+    gaps: [...derivedGaps, ...declaredGaps, ...statusGaps],
+  }
+
+  const serialized = JSON.stringify(out, null, 2) + '\n'
+
+  function summarize() {
     console.log(
-      `::warning title=app-status status drift::dossier status is stale: ${c.id} code looks '${c.derivedStatus}' but yaml says '${c.status}'`,
+      `  derived: ${derived.sourceAvailable ? `version=${derived.version} useFakeData=${derived.useFakeData} edge=${derived.edgeBaseUrl}` : 'SOURCE UNAVAILABLE'}`,
     )
-  }
-}
-
-// Read the committed artefact's `derived` block (the layer the content check
-// governs), tolerating an absent/garbled file by returning null.
-function committedDerived(file) {
-  try {
-    return JSON.parse(readFileSync(file, 'utf8')).derived ?? null
-  } catch {
-    return null
-  }
-}
-
-// Field-by-field diff of two `derived` objects — the README-vs-code drift this
-// check exists to catch surfaces here (e.g. useFakeData: false → true).
-function diffDerived(committed, fresh) {
-  const keys = Array.from(new Set([...Object.keys(committed ?? {}), ...Object.keys(fresh ?? {})])).sort()
-  const lines = []
-  for (const k of keys) {
-    const a = JSON.stringify(committed?.[k])
-    const b = JSON.stringify(fresh?.[k])
-    if (a !== b) lines.push(`    ${k}: committed=${a} → regenerated=${b}`)
-  }
-  return lines
-}
-
-// ── --check: regenerate and diff the derived block (ADR-0074 invariant 5) ─────
-if (CHECK) {
-  console.log(`app-status check (advisory${ENFORCE ? '→ENFORCE' : ''}) against ${path.relative(process.cwd(), AGAINST)}`)
-  summarize()
-
-  if (!derived.sourceAvailable) {
-    // No app checkout ⇒ nothing to compare. Degrade to a skip, never a failure:
-    // a content check that can't see the source has no verdict to give.
-    console.log('::warning title=app-status::app source unavailable — skipping derived-block content check (no openbank-app checkout)')
-    process.exit(0)
+    console.log(`  capabilities: ${capabilities.length} (${Object.entries(byStatus).map(([k, v]) => `${k}=${v}`).join(', ')})`)
+    if (decisionMissing.length) console.log(`  decision-missing: ${decisionMissing.map((c) => c.id).join(', ')}`)
+    if (statusDrift.length) {
+      console.log(`  ⚠ status drift: ${statusDrift.length}`)
+      for (const c of statusDrift) console.log(`    - ${c.id}: yaml says '${c.status}' but code looks '${c.derivedStatus}'`)
+    }
+    if (out.gaps.length) console.log(`  ⚠ gaps: ${out.gaps.length}\n    - ${out.gaps.join('\n    - ')}`)
   }
 
-  // Status drift (issue #26) is checked whenever the source IS available,
-  // independent of the derived-facts diff below and never gated by --enforce
-  // (see reportStatusDrift). Report it before the facts-diff early-exits so a
-  // clean facts-diff doesn't hide a stale curatorial status.
-  reportStatusDrift()
+  // Print one ::warning per drifted capability (issue #26). Always advisory,
+  // independent of --enforce: unlike the derived-facts diff, curatorial `status`
+  // is allowed to legitimately override a single code signal (e.g. an iOS-live/
+  // Android-stub split the curator judges still `partial`) — a human call, so a
+  // disagreement is a prompt to re-check the yaml, not necessarily a bug.
+  function reportStatusDrift() {
+    for (const c of statusDrift) {
+      console.log(
+        `::warning title=app-status status drift::dossier status is stale: ${c.id} code looks '${c.derivedStatus}' but yaml says '${c.status}'`,
+      )
+    }
+  }
 
-  const committed = committedDerived(AGAINST)
-  if (committed === null) {
-    console.log(`::warning title=app-status::no committed artefact at ${path.relative(process.cwd(), AGAINST)} to diff against — first run?`)
+  // Read the committed artefact's `derived` block (the layer the content check
+  // governs), tolerating an absent/garbled file by returning null.
+  function committedDerived(file) {
+    try {
+      return JSON.parse(readFileSync(file, 'utf8')).derived ?? null
+    } catch {
+      return null
+    }
+  }
+
+  // Field-by-field diff of two `derived` objects — the README-vs-code drift this
+  // check exists to catch surfaces here (e.g. useFakeData: false → true).
+  function diffDerived(committed, fresh) {
+    const keys = Array.from(new Set([...Object.keys(committed ?? {}), ...Object.keys(fresh ?? {})])).sort()
+    const lines = []
+    for (const k of keys) {
+      const a = JSON.stringify(committed?.[k])
+      const b = JSON.stringify(fresh?.[k])
+      if (a !== b) lines.push(`    ${k}: committed=${a} → regenerated=${b}`)
+    }
+    return lines
+  }
+
+  // ── --check: regenerate and diff the derived block (ADR-0074 invariant 5) ─────
+  if (CHECK) {
+    console.log(`app-status check (advisory${ENFORCE ? '→ENFORCE' : ''}) against ${path.relative(process.cwd(), AGAINST)}`)
+    summarize()
+
+    if (!derived.sourceAvailable) {
+      // No app checkout ⇒ nothing to compare. Degrade to a skip, never a failure:
+      // a content check that can't see the source has no verdict to give.
+      console.log('::warning title=app-status::app source unavailable — skipping derived-block content check (no openbank-app checkout)')
+      process.exit(0)
+    }
+
+    // Status drift (issue #26) is checked whenever the source IS available,
+    // independent of the derived-facts diff below and never gated by --enforce
+    // (see reportStatusDrift). Report it before the facts-diff early-exits so a
+    // clean facts-diff doesn't hide a stale curatorial status.
+    reportStatusDrift()
+
+    const committed = committedDerived(AGAINST)
+    if (committed === null) {
+      console.log(`::warning title=app-status::no committed artefact at ${path.relative(process.cwd(), AGAINST)} to diff against — first run?`)
+      process.exit(ENFORCE ? 1 : 0)
+    }
+
+    const drift = diffDerived(committed, derived)
+    if (drift.length === 0) {
+      console.log('  ✓ derived block matches the committed app-status.json')
+      process.exit(0)
+    }
+
+    // Drift found — this is the signal the ADR wants. GitHub renders ::warning/::error
+    // annotations inline on the PR; the body is also printed for the PR-comment step.
+    const level = ENFORCE ? 'error' : 'warning'
+    console.log(`::${level} title=app-status derived drift::the committed app-status.json no longer matches openbank-app source (${drift.length} field(s)). Regenerate & publish.`)
+    console.log('  derived-block drift:')
+    for (const l of drift) console.log(l)
     process.exit(ENFORCE ? 1 : 0)
   }
 
-  const drift = diffDerived(committed, derived)
-  if (drift.length === 0) {
-    console.log('  ✓ derived block matches the committed app-status.json')
+  // ── write mode ────────────────────────────────────────────────────────────────
+  // Guard the transport copy: a run WITHOUT the app source must not overwrite a
+  // committed artefact with a null-derived stub (that would silently erase the
+  // transported facts). Only refuse when there is something to lose.
+  if (!derived.sourceAvailable && existsSync(OUT)) {
+    console.log(`app-status: app source unavailable — PRESERVING committed ${path.relative(process.cwd(), OUT)} (not clobbering with a null-derived stub)`)
+    summarize()
     process.exit(0)
   }
 
-  // Drift found — this is the signal the ADR wants. GitHub renders ::warning/::error
-  // annotations inline on the PR; the body is also printed for the PR-comment step.
-  const level = ENFORCE ? 'error' : 'warning'
-  console.log(`::${level} title=app-status derived drift::the committed app-status.json no longer matches openbank-app source (${drift.length} field(s)). Regenerate & publish.`)
-  console.log('  derived-block drift:')
-  for (const l of drift) console.log(l)
-  process.exit(ENFORCE ? 1 : 0)
-}
+  writeFileSync(OUT, serialized)
 
-// ── write mode ────────────────────────────────────────────────────────────────
-// Guard the transport copy: a run WITHOUT the app source must not overwrite a
-// committed artefact with a null-derived stub (that would silently erase the
-// transported facts). Only refuse when there is something to lose.
-if (!derived.sourceAvailable && existsSync(OUT)) {
-  console.log(`app-status: app source unavailable — PRESERVING committed ${path.relative(process.cwd(), OUT)} (not clobbering with a null-derived stub)`)
+  console.log(`app-status → ${path.relative(process.cwd(), OUT)}`)
   summarize()
-  process.exit(0)
 }
 
-writeFileSync(OUT, serialized)
-
-console.log(`app-status → ${path.relative(process.cwd(), OUT)}`)
-summarize()
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) main()

--- a/openbank-admin-ui/src/test/app-status-qrless-signal.test.ts
+++ b/openbank-admin-ui/src/test/app-status-qrless-signal.test.ts
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import { describe, expect, it } from 'vitest'
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import path from 'path'
+// @ts-expect-error - plain .mjs build script, no type declarations by design
+import { deriveCapabilityStatus } from '../../scripts/generate-app-status.mjs'
+
+// The `qrless-pay` derivedStatus signal (ADR-0074 / issue #26), tested on the paths that
+// actually rotted rather than only the happy one.
+//
+// Why this capability got a signal at all: the curatorial `status` for it was wrong twice in
+// one week. openbank-app #445 found `planned` + "NO implementation" in the yaml while the
+// protocol core, both BLE transports and the payee surface were merged and shipping; #455 then
+// found #445's own correction stale four PRs later, after the payer path was wired behind a
+// switch and replay defence landed. Both were exactly the single-field drift this signal sees.
+//
+// The interesting case is the LAST one below. The payer half is dormant because of an explicit
+// `PAYER_DISCOVERY_ENABLED` constant, and that constant exists because dormancy used to rest on
+// nothing happening to call `startDiscovery` — a control any refactor removes without noticing.
+// So a missing flag must read as "no verdict", not as a status: if this check answered `partial`
+// when the switch is gone, it would place a reassuring green tick on the removal it exists to
+// catch. Nothing else in the pipeline would notice either — the --check mode diffs the `derived`
+// block, and the curatorial narrative is prose no gate reads.
+
+interface Signals {
+  signals: Record<string, string | null>
+  gaps: string[]
+}
+
+const NEARPAY_KT = 'shared/src/commonMain/kotlin/tech/openbank/app/payment/nearpay/NearPay.kt'
+const REQUEST_KT = 'composeApp/src/commonMain/kotlin/tech/openbank/app/ui/RequestScreen.kt'
+
+/** NearPay.kt reduced to the one constant the signal reads. */
+const nearPay = (flag: string) => `package tech.openbank.app.payment.nearpay
+
+object NearPay {
+    const val MAX_TTL_SECONDS = 90L
+    const val RSSI_GATE_DBM = -70
+${flag}
+}
+`
+
+/** RequestScreen.kt with the payee half advertising a minted session. */
+const PAYEE_WIRED = `class RequestScreen {
+    val nearPayCtrl = nearPayController()
+    fun go() { nearPayCtrl.startReceiving(firstName = "J", spayd = s, amountMinor = null) }
+}
+`
+
+/** RequestScreen.kt that imports the controller but never advertises. */
+const PAYEE_ABSENT = `class RequestScreen {
+    val nearPayCtrl = nearPayController()
+}
+`
+
+/** Build a throwaway app repo holding only the files this signal reads. */
+function signalFor(files: Record<string, string | null>): Signals {
+  const repo = mkdtempSync(path.join(tmpdir(), 'app-status-qrless-'))
+  try {
+    for (const [rel, body] of Object.entries(files)) {
+      if (body === null) continue // absent on purpose
+      const abs = path.join(repo, rel)
+      mkdirSync(path.dirname(abs), { recursive: true })
+      writeFileSync(abs, body)
+    }
+    // certPinningConfigured is unrelated to this capability; null keeps tls-pinning at "no verdict".
+    return deriveCapabilityStatus(repo, null) as Signals
+  } finally {
+    rmSync(repo, { recursive: true, force: true })
+  }
+}
+
+const qrless = (files: Record<string, string | null>) => signalFor(files).signals['qrless-pay']
+
+describe('app-status qrless-pay derivedStatus', () => {
+  it('reads partial when the payee advertises and the payer switch is off', () => {
+    // The state that actually shipped, and the one the yaml must agree with today.
+    expect(
+      qrless({
+        [NEARPAY_KT]: nearPay('    const val PAYER_DISCOVERY_ENABLED = false'),
+        [REQUEST_KT]: PAYEE_WIRED,
+      }),
+    ).toBe('partial')
+  })
+
+  it('reads live once the payer switch is flipped on', () => {
+    expect(
+      qrless({
+        [NEARPAY_KT]: nearPay('    const val PAYER_DISCOVERY_ENABLED = true'),
+        [REQUEST_KT]: PAYEE_WIRED,
+      }),
+    ).toBe('live')
+  })
+
+  it('reads partial when only the payer half is on', () => {
+    expect(
+      qrless({
+        [NEARPAY_KT]: nearPay('    const val PAYER_DISCOVERY_ENABLED = true'),
+        [REQUEST_KT]: PAYEE_ABSENT,
+      }),
+    ).toBe('partial')
+  })
+
+  it('reads planned when neither half is on', () => {
+    expect(
+      qrless({
+        [NEARPAY_KT]: nearPay('    const val PAYER_DISCOVERY_ENABLED = false'),
+        [REQUEST_KT]: PAYEE_ABSENT,
+      }),
+    ).toBe('planned')
+  })
+
+  it('contradicts a yaml still claiming planned once the payee ships — the #445 drift', () => {
+    // #445's actual finding, reduced: the protocol was merged and the payee was live while the
+    // dossier said `planned`. Any answer other than `planned` makes the drift visible; asserting
+    // the exact value is the first case's job.
+    const signal = qrless({
+      [NEARPAY_KT]: nearPay('    const val PAYER_DISCOVERY_ENABLED = false'),
+      [REQUEST_KT]: PAYEE_WIRED,
+    })
+    expect(signal).not.toBe('planned')
+    expect(signal).not.toBeNull()
+  })
+
+  it('has NO verdict when the payer switch is gone, and says why', () => {
+    // A refactor that deletes the constant must not read as a status. See the header.
+    const out = signalFor({
+      [NEARPAY_KT]: nearPay('    // PAYER_DISCOVERY_ENABLED removed by a refactor'),
+      [REQUEST_KT]: PAYEE_WIRED,
+    })
+    expect(out.signals['qrless-pay']).toBeNull()
+    expect(out.gaps.some(g => g.includes('PAYER_DISCOVERY_ENABLED'))).toBe(true)
+  })
+
+  it('has no verdict when a source file is missing entirely', () => {
+    expect(qrless({ [NEARPAY_KT]: null, [REQUEST_KT]: PAYEE_WIRED })).toBeNull()
+    expect(qrless({ [NEARPAY_KT]: nearPay('    const val PAYER_DISCOVERY_ENABLED = false'), [REQUEST_KT]: null })).toBeNull()
+  })
+
+  it('does not fabricate a verdict for the purely curatorial capabilities', () => {
+    // ADR-0074: a capability with no cheap code check must carry no derivedStatus at all,
+    // so the join can tell "no signal" apart from "signal says null".
+    const { signals } = signalFor({
+      [NEARPAY_KT]: nearPay('    const val PAYER_DISCOVERY_ENABLED = false'),
+      [REQUEST_KT]: PAYEE_WIRED,
+    })
+    for (const id of ['ui-stack', 'shared-domain', 'customer-edge', 'keycloak-realm', 'crash-monitoring', 'dossier']) {
+      expect(Object.prototype.hasOwnProperty.call(signals, id), `${id} must stay curatorial`).toBe(false)
+    }
+  })
+})


### PR DESCRIPTION
## Why

`qrless-pay`'s curatorial `status` was wrong twice in one week — both times the single-field drift issue #26 created `derivedStatus` to catch:

- **JiRaska/openbank-app#445** — `app-status.yaml` said `planned` + "NO implementation" while the protocol core, both BLE transports and the payee surface were merged and shipping in release builds. The same claim also sat on the **public** `docs/VULNERABILITY-DISCLOSURE.md`, routing security researchers away from live code.
- **JiRaska/openbank-app#455** — #445's own correction went stale four PRs later, once the payer path was wired behind a switch and replay defence landed.

Nothing caught either. `--check` diffs the `derived` block; the capability narrative is prose no gate reads.

## The signal

| payee advertises (`RequestScreen` → `startReceiving`) | payer switch (`NearPay.PAYER_DISCOVERY_ENABLED`) | derivedStatus |
|---|---|---|
| yes | on | `live` |
| yes | off | `partial` ← today |
| no | on | `partial` |
| no | off | `planned` |

Advisory, like every other status signal — a `::warning`, never a failure.

**A missing flag constant yields `null`, never a status.** That constant exists precisely because dormancy used to rest on nothing happening to call `startDiscovery` — a control any refactor removes without noticing. If this check answered `partial` when the switch is gone, it would put a green tick on the removal it exists to notice. It records a gap instead.

## The refactor, and why it is most of the diff

`git diff` is 286 lines; **`git diff -w` is 46**. The rest is re-indentation from wrapping the CLI half in `main()`.

`deriveCapabilityStatus` is now exported and the side-effecting tail sits behind a `process.argv[1]` entrypoint guard — the same shape `generate-governance.mjs` already uses, so importing the module no longer reads the app repo, writes the artefact, or exits. Spawning the script per test case was the alternative and is explicitly ruled out by the sibling test's own note: it slowed the shared vitest pool enough to tip unrelated render-smoke tests over their 5 s timeout.

## Verification

- 8 new tests in `src/test/app-status-qrless-signal.test.ts`, covering all four status combinations, both missing-source cases, the deleted-switch case, the #445 drift shape, and that purely curatorial capabilities still carry no `derivedStatus` key at all
- **Mutation-checked**: pinning the signal to a constant `'partial'` fails 2 of the 8, so they are not vacuous
- `derived-artifact-determinism` + `generate-governance` + the new file: 38 passed
- Both CLI modes re-run by hand against a real openbank-app checkout, plus the source-unavailable preserve path — output identical apart from the new `derivedStatus`, and it agrees with the yaml (`partial` / `partial`)
- eslint clean on both files

## Not included

`openbank-admin-ui/app-status.json` is **not** regenerated here. Publishing it is `app-status-refresh.yml`'s job, and baking it from a local sibling checkout is exactly the cross-filesystem shortcut this script's own header rules out. The next cron run picks up the new `derivedStatus` along with the pending `version` drift (committed `0.22.0` → `0.23.0`).