### PR TITLE
ci(gates): make the fleet-attestation selftest say what it actually got

### DIFF
--- a/.github/scripts/check-fleet-attestations.sh
+++ b/.github/scripts/check-fleet-attestations.sh
@@ -183,14 +183,33 @@ STUB
            SYSTEMIC_UNKNOWN_THRESHOLD="${fixture_threshold:-99}" \
            bash "$SELF" 2>&1)"
     code=$?
+    # Both failure branches print what the run ACTUALLY produced, not only what was wanted.
+    # Everything needed to explain a failure exists in $out at this moment and nowhere after it:
+    # an assertion that records its expectation and discards the observation leaves the next
+    # reader with a re-run as their only move, which is how an intermittent gate stays
+    # undiagnosed (#4918).
+    fixture_diagnostics() {
+      local actual
+      actual="$(printf '%s' "$out" | grep -F '==> Fleet summary:' || true)"
+      if [ -n "$actual" ]; then
+        printf '        actual summary: %s\n' "${actual#*==> Fleet summary: }"
+      else
+        # No summary at all is a different fault from a wrong one — the script exited before it
+        # counted anything — so say which of the two happened rather than printing nothing.
+        printf '        no summary line was produced; last 20 lines of output:\n'
+        printf '%s\n' "$out" | tail -20 | sed 's/^/          | /'
+      fi
+    }
     if [ "$code" != "$expected_exit" ]; then
       printf '  FAIL: %s — expected exit %s, got %s\n' "$name" "$expected_exit" "$code"
+      fixture_diagnostics
       failures=$((failures + 1))
       return
     fi
     if ! printf '%s' "$out" | grep -qF "$expected_summary"; then
-      printf '  FAIL: %s — exit %s correct, but summary missing: %s\n' \
-        "$name" "$code" "$expected_summary"
+      printf '  FAIL: %s — exit %s correct, but summary missing\n' "$name" "$code"
+      printf '        expected summary: %s\n' "$expected_summary"
+      fixture_diagnostics
       failures=$((failures + 1))
       return
     fi


### PR DESCRIPTION
Closes the diagnosability half of #4918.

## The problem

`run_fixture` in `check-fleet-attestations.sh` asserted against a summary string and, on failure, printed **the string it wanted** — never the one the run produced:

```sh
printf '  FAIL: %s — exit %s correct, but summary missing: %s\n' \
  "$name" "$code" "$expected_summary"
```

When the gate failed intermittently on #4908, the log held the expectation and nothing else. Everything needed to explain the failure existed in `$out` at that moment and was discarded, so the only available response was a re-run — which passed, taking the occurrence with it.

## What changes

Both failure branches now report the observation, not just the expectation.

- **Wrong summary** → prints the actual `==> Fleet summary:` line beside the expected one.
- **Wrong exit code** → also prints the actual summary. It previously printed nothing at all.
- **No summary line** → dumps the last twenty lines of output. A missing summary means the script exited before counting anything, which is a *different* fault from counting wrongly, and the diagnostic now says which of the two happened instead of falling silent.

Nothing about the gate's behaviour moves: the classifier, the exit codes and every assertion are untouched. Only what a failure says about itself.

## Falsified, not assumed

A diagnostic that has only ever run against passing input proves nothing, so each branch was driven with a deliberately broken copy of the script:

| Broken how | What the new diagnostic printed |
|---|---|
| Expected summary changed to `9 attested / 9 …` | `actual summary: 0 attested / 1 unattested / 0 absent / 0 allowlisted placeholder / 1 unknown (probe failed) / 2 total` |
| `==> Fleet summary:` prefix renamed **and** expectation broken | `no summary line was produced; last 20 lines of output:` followed by the real `UNKNOWN (1) …` section naming the fixture image |
| Expected exit changed from `1` to `7` | `expected exit 7, got 1` **plus** the actual summary |

The unmodified selftest passes, and the `supplychain` gate group runs clean locally apart from `release-scope-mismatch`, which refuses to run without `PR_DIFF_BASE` rather than passing vacuously — correct behaviour, and the reason that one is checked in CI rather than here.

## One thing found while falsifying, deliberately not changed

The fixture assertion matches only the **counts**, not the `==> Fleet summary:` prefix. Renaming that prefix leaves every fixture green. That is arguably fine — the counts are the contract — but it is worth knowing before someone assumes the assertion pins the whole line, and it is why the fallback branch above exists at all.

## What this does not fix

The flake itself. #4918 stays open: the selftest is hermetic and 25 consecutive local runs pass, so whatever varies is environmental. This change is what makes the *next* occurrence answerable instead of re-runnable.

Refs #4918

🤖 Generated with [Claude Code](https://claude.com/claude-code)
