### PR TITLE
feat(admin-ui): guide catalog authoring

### DIFF
--- a/openbank-admin-ui/src/app/product-studio/page.module.css
+++ b/openbank-admin-ui/src/app/product-studio/page.module.css
@@ -52,8 +52,30 @@
 .revision:hover { background: var(--surface-2); border-color: var(--border); }
 .revisionSelected { background: var(--ob-accent-light); border-color: var(--ob-accent-border); }
 .draftBanner { display: flex; gap: 9px; padding: 11px; border: 1px solid var(--ob-accent-border); border-radius: 10px; background: var(--ob-accent-light); color: var(--ob-accent-text); font-size: 11px; line-height: 1.5; }
+.guidedForm { margin-top: 10px; padding: 12px; border: 1px solid #d8d5ff; border-radius: 12px; background: linear-gradient(135deg, #fbfbff, #f3f8ff); }
+.guidedHead { display: grid; gap: 3px; color: #312e81; font-size: 12px; font-weight: 800; }
+.guidedHead span { display: inline-flex; align-items: center; gap: 6px; }
+.guidedHead small { color: #5b5b86; font-size: 10px; font-weight: 500; line-height: 1.45; }
+.fieldGrid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 9px; margin-top: 11px; }
+.field { display: grid; gap: 4px; color: var(--text-secondary); font-size: 10px; font-weight: 800; letter-spacing: .03em; }
+.field b { color: var(--danger); }
+.field small { color: var(--text-tertiary); font-size: 10px; font-weight: 500; letter-spacing: 0; }
+.expertDetails { margin-top: 12px; }
+.expertDetails summary { cursor: pointer; color: var(--text-secondary); font-size: 11px; font-weight: 800; }
+.expertDetails .editor { margin-top: 9px; }
 .editor { min-height: 320px; resize: vertical; font-family: var(--font-mono); font-size: 11px; line-height: 1.55; }
 .actions { display: flex; flex-wrap: wrap; gap: 7px; margin-top: 10px; }
+.approvalPanel { margin-top: 14px; padding: 13px; border: 1px solid #b9dfce; border-radius: 12px; background: linear-gradient(135deg, #f4fffa, #effcf7); }
+.approvalHead { display: flex; align-items: center; gap: 7px; color: #166534; font-size: 12px; font-weight: 800; }
+.approvalPanel p { margin: 6px 0 9px; color: #3f6655; font-size: 11px; line-height: 1.5; }
+.approvalMeta { display: flex; flex-wrap: wrap; gap: 6px 12px; margin-bottom: 9px; color: #47715d; font-size: 10px; }
+.approvalMeta b { color: #166534; }
+.readiness { margin-bottom: 12px; padding: 11px; border: 1px solid var(--border); border-radius: 12px; background: var(--surface-2); }
+.readinessHead { display: flex; align-items: center; gap: 7px; margin-bottom: 6px; color: var(--text-primary); font-size: 11px; font-weight: 800; }
+.readinessRow { display: grid; grid-template-columns: 16px 1fr auto; align-items: center; gap: 5px; padding: 4px 0; color: var(--text-secondary); font-size: 10px; }
+.readinessRow svg { color: var(--success-text); }
+.readinessRow:has(svg[data-lucide="circle-alert"]) svg { color: var(--warning-text); }
+.readinessRow b { color: var(--text-tertiary); font-size: 9px; letter-spacing: .04em; text-transform: uppercase; }
 .insightGrid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 7px; margin-bottom: 12px; }
 .insight { padding: 9px; border: 1px solid var(--border); border-radius: 10px; background: var(--surface-2); }
 .insight b { display: block; color: var(--text-primary); font-size: 16px; letter-spacing: -.03em; }
@@ -80,4 +102,4 @@
 .previewFoot { margin-top: auto; padding-top: 18px; color: var(--text-tertiary); font-size: 11px; }
 .message { margin: 14px 0; padding: 11px 13px; border-radius: 10px; border: 1px solid var(--border); background: var(--surface); color: var(--text-secondary); white-space: pre-wrap; font-family: var(--font-sans); font-size: 12px; }
 @media (max-width: 1120px) { .workspace { grid-template-columns: 1fr 1fr; } .workspace > :last-child { grid-column: span 2; } .metrics { grid-template-columns: repeat(2, 1fr); } }
-@media (max-width: 760px) { .hero { padding: 20px; } .heroTop, .lowerGrid { display: block; } .refresh { margin-top: 16px; } .journey { grid-template-columns: 1fr 1fr; } .journeyStep:nth-child(2) { border-right: 0; } .journeyStep:nth-child(-n+2) { border-bottom: 1px solid var(--border); } .workspace { grid-template-columns: 1fr; } .workspace > :last-child { grid-column: auto; } .lowerGrid > * { margin-bottom: 14px; } }
+@media (max-width: 760px) { .hero { padding: 20px; } .heroTop, .lowerGrid { display: block; } .refresh { margin-top: 16px; } .journey { grid-template-columns: 1fr 1fr; } .journeyStep:nth-child(2) { border-right: 0; } .journeyStep:nth-child(-n+2) { border-bottom: 1px solid var(--border); } .workspace, .fieldGrid { grid-template-columns: 1fr; } .workspace > :last-child { grid-column: auto; } .lowerGrid > * { margin-bottom: 14px; } }

--- a/openbank-admin-ui/src/app/product-studio/page.tsx
+++ b/openbank-admin-ui/src/app/product-studio/page.tsx
@@ -5,8 +5,9 @@
 'use client'
 
 import { useCallback, useEffect, useMemo, useState } from 'react'
-import { Bot, Boxes, CheckCircle2, Eye, FileJson, Plus, RefreshCw, Send, ShieldCheck, Sparkles } from 'lucide-react'
+import { Bot, Boxes, CheckCircle2, CircleAlert, Eye, FileJson, ListChecks, Plus, RefreshCw, Send, ShieldCheck, Sparkles } from 'lucide-react'
 import { AuthGuard, Can } from '@/components/auth/AuthGuard'
+import { catalogFieldValue, catalogSchemaFields, type CatalogSchemaField, withCatalogFieldValue } from '@/lib/catalog-schema-form'
 import { catalogRevisionEditorDocument, diffCatalogDocuments } from '@/lib/catalog-structural-diff'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import {
@@ -81,6 +82,7 @@ export default function ProductStudioPage() {
   const [newSpecSchema, setNewSpecSchema] = useState('')
   const [review, setReview] = useState<CatalogReview | null>(null)
   const [reviewing, setReviewing] = useState(false)
+  const [validationState, setValidationState] = useState<'idle' | 'valid' | 'invalid'>('idle')
 
   const selectedSpec = specifications.find(item => item.id === specificationId)
   const selectedOffering = offerings.find(item => item.id === offeringId)
@@ -93,10 +95,23 @@ export default function ProductStudioPage() {
     () => schemas.filter(item => !selectedSpec || item.id === selectedSpec.schemaRef.id),
     [schemas, selectedSpec],
   )
+  const activeSchema = selectedRevision
+    ? schemas.find(item => item.id === selectedRevision.schemaRef.id && item.version === selectedRevision.schemaRef.version)
+    : compatibleSchemas.at(-1)
+  const guidedFields = useMemo(
+    () => catalogSchemaFields(activeSchema?.document),
+    [activeSchema],
+  )
   const liveDocument = publishedRevision ? catalogRevisionEditorDocument(publishedRevision) : null
   const structuralDiff = diffCatalogDocuments(liveDocument, parsedDraft)
   const draftCount = revisions.filter(item => item.state === 'DRAFT').length
   const publishedCount = revisions.filter(item => item.state === 'PUBLISHED').length
+  const readiness = [
+    { label: t('Čitelný návrh', 'Readable draft'), ready: Boolean(parsedDraft) },
+    { label: t('Schéma ověřeno', 'Schema verified'), ready: validationState === 'valid' },
+    { label: t('Živá reference k porovnání', 'Live baseline available'), ready: Boolean(publishedRevision) },
+    { label: t('Rozdíly návrhu jsou viditelné', 'Draft differences are visible'), ready: Boolean(parsedDraft && structuralDiff.length > 0) },
+  ]
 
   const load = useCallback(async () => {
     setBusy(true); setMessage('')
@@ -137,6 +152,15 @@ export default function ProductStudioPage() {
     const task = window.setTimeout(() => setDraftText(nextDraft), 0)
     return () => window.clearTimeout(task)
   }, [selectedRevision])
+
+  const updateGuidedField = (field: CatalogSchemaField, raw: string | boolean) => {
+    if (!parsedDraft) return
+    const value = field.type === 'boolean' ? raw === true : field.type === 'integer' || field.type === 'number'
+      ? (raw === '' ? '' : Number(raw)) : raw
+    setDraftText(JSON.stringify(withCatalogFieldValue(parsedDraft, field.path, value), null, 2))
+    setValidationState('idle')
+    setReview(null)
+  }
 
   const run = async (work: () => Promise<unknown>, success: string) => {
     setBusy(true); setMessage('')
@@ -197,8 +221,9 @@ export default function ProductStudioPage() {
         pathParameters: { id: body.schemaRef.id, version: body.schemaRef.version },
         body: { attributes: body.attributes },
       })
+      setValidationState(result.valid ? 'valid' : 'invalid')
       setMessage(result.valid ? t('Schéma je validní', 'Schema validation passed') : result.violations.map(v => `${v.instancePath}: ${v.message}`).join('\n'))
-    } catch (error) { setMessage(error instanceof Error ? error.message : String(error)) }
+    } catch (error) { setValidationState('invalid'); setMessage(error instanceof Error ? error.message : String(error)) }
   }
 
   const publish = () => {
@@ -278,7 +303,7 @@ export default function ProductStudioPage() {
             </select>
             <div style={{ display: 'flex', gap: 7, marginTop: 7 }}><input className="input" value={newSpecCode} onChange={e => setNewSpecCode(e.target.value)} placeholder="TERM_LIFE" /><button className="btn btn-secondary" onClick={createSpecification} aria-label={t('Vytvořit specifikaci', 'Create specification')}><Plus size={13} /></button></div>
           </Can>
-          <div className={styles.schemaHint}>{t('Aktivní schema:', 'Active schema:')} <strong>{compatibleSchemas.at(-1) ? `${compatibleSchemas.at(-1)!.id}:${compatibleSchemas.at(-1)!.version}` : '—'}</strong><br />{t('Formulář respektuje verzi schématu; publikovaný obsah se nemění.', 'The form respects its schema version; published content never mutates.')}</div>
+          <div className={styles.schemaHint}>{t('Aktivní schema:', 'Active schema:')} <strong>{activeSchema ? `${activeSchema.id}:${activeSchema.version}` : '—'}</strong><br />{t('Formulář respektuje verzi schématu; publikovaný obsah se nemění.', 'The form respects its schema version; published content never mutates.')}</div>
         </div>
       </section>
 
@@ -303,12 +328,26 @@ export default function ProductStudioPage() {
         <div className={styles.panelHead}><div><div className={styles.panelKicker}>{t('Pracovní revize', 'Working revision')}</div><h2 className={styles.panelTitle}><Send size={15} />{t('Návrh řízený schématem', 'Schema-governed draft')}</h2></div>{selectedRevision && <Badge state={selectedRevision.state} />}</div>
         <div className={styles.panelBody}>
           <div className={styles.draftBanner}><CheckCircle2 size={15} /><span>{selectedRevision?.state === 'DRAFT' ? t('Draft lze ukládat a ověřovat. Publikaci provede jiný uživatel.', 'This draft can be saved and checked. A different user performs publication.') : t('Toto je neměnný historický záznam.', 'This is an immutable historical record.')}</span></div>
-          <label className={styles.smallLabel}>{t('Expert režim · úplný dokument', 'Expert mode · full document')}</label>
           <Can permission="catalog:author" fallback={<textarea className={`input ${styles.editor}`} value={draftText} disabled />}>
-            <textarea className={`input ${styles.editor}`} value={draftText} onChange={e => setDraftText(e.target.value)} disabled={!selectedRevision || selectedRevision.state !== 'DRAFT'} />
+            {guidedFields.length > 0 && parsedDraft && <div className={styles.guidedForm}>
+              <div className={styles.guidedHead}><span><Sparkles size={13} />{t('Průvodce povinnými údaji', 'Guided essentials')}</span><small>{t('Pouze skalární pole; pole a složité struktury zůstávají níže v expertním dokumentu.', 'Scalar fields only; arrays and complex structures remain in the expert document below.')}</small></div>
+              <div className={styles.fieldGrid}>{guidedFields.map(field => {
+                const value = catalogFieldValue(parsedDraft, field.path)
+                const id = `catalog-field-${field.path.join('-')}`
+                return <label key={id} className={styles.field}><span>{field.label}{field.required && <b aria-label={t('Povinné', 'Required')}> *</b>}</span>
+                  {field.type === 'boolean' ? <input id={id} type="checkbox" checked={value === true} onChange={event => updateGuidedField(field, event.target.checked)} disabled={selectedRevision?.state !== 'DRAFT'} />
+                    : field.choices.length > 0 ? <select id={id} className="input" value={String(value ?? '')} onChange={event => updateGuidedField(field, event.target.value)} disabled={selectedRevision?.state !== 'DRAFT'}><option value="">{t('Vyberte hodnotu', 'Select a value')}</option>{field.choices.map(choice => <option key={choice}>{choice}</option>)}</select>
+                      : <input id={id} className="input" inputMode={field.type === 'integer' || field.type === 'number' ? 'decimal' : undefined} value={String(value ?? '')} onChange={event => updateGuidedField(field, event.target.value)} disabled={selectedRevision?.state !== 'DRAFT'} />}
+                  {field.description && <small>{field.description}</small>}
+                </label>
+              })}</div>
+            </div>}
+            <details className={styles.expertDetails}><summary>{t('Expert režim · úplný dokument', 'Expert mode · full document')}</summary>
+              <textarea className={`input ${styles.editor}`} value={draftText} onChange={e => { setDraftText(e.target.value); setValidationState('idle'); setReview(null) }} disabled={!selectedRevision || selectedRevision.state !== 'DRAFT'} />
+            </details>
             <div className={styles.actions}><button className="btn btn-secondary" disabled={!selectedRevision} onClick={() => void validateDraft()}><CheckCircle2 size={13} />{t('Ověřit schéma', 'Validate schema')}</button><button className="btn btn-primary" disabled={!selectedRevision || selectedRevision.state !== 'DRAFT'} onClick={saveDraft}><Send size={13} />{t('Uložit draft', 'Save draft')}</button></div>
           </Can>
-          <Can permission="catalog:publish"><div style={{ borderTop: '1px solid var(--border)', marginTop: 14, paddingTop: 14 }}><label className={styles.smallLabel}>{t('Nezávislé schválení', 'Independent approval')}</label><div style={{ display: 'flex', gap: 7 }}><input className="input" value={publishReason} onChange={e => setPublishReason(e.target.value)} placeholder={t('Důvod schválení', 'Approval reason')} /><button className="btn btn-primary" disabled={!selectedRevision || selectedRevision.state !== 'DRAFT'} onClick={publish}><ShieldCheck size={13} />{t('Publikovat', 'Publish')}</button></div></div></Can>
+          <Can permission="catalog:publish"><div className={styles.approvalPanel}><div className={styles.approvalHead}><ShieldCheck size={15} /><span>{t('Nezávislé schválení', 'Independent approval')}</span></div><p>{t('Publikace je nevratné rozhodnutí. Služba ověří, že autor a schvalovatel jsou rozdílné identity — tento formulář to nemůže obejít.', 'Publication is an irreversible decision. The service verifies that maker and checker are different identities — this form cannot bypass it.')}</p><div className={styles.approvalMeta}><span>{t('Autor draftu', 'Draft maker')}: <b>{selectedRevision?.makerId ?? '—'}</b></span><span>{t('Stav ověření', 'Validation')}: <b>{validationState === 'valid' ? t('ověřeno', 'verified') : t('čeká na ověření', 'awaiting validation')}</b></span></div><div style={{ display: 'flex', gap: 7 }}><input className="input" value={publishReason} onChange={e => setPublishReason(e.target.value)} placeholder={t('Důvod schválení', 'Approval reason')} /><button className="btn btn-primary" disabled={!selectedRevision || selectedRevision.state !== 'DRAFT' || !publishReason.trim()} onClick={publish}><ShieldCheck size={13} />{t('Publikovat', 'Publish')}</button></div></div></Can>
         </div>
       </section>
     </div>
@@ -317,6 +356,7 @@ export default function ProductStudioPage() {
       <section className={`card ${styles.panel}`}>
         <div className={styles.panelHead}><div><div className={styles.panelKicker}>{t('Dopad změny', 'Change impact')}</div><h2 className={styles.panelTitle}><Eye size={15} />{t('Draft proti živé nabídce', 'Draft against live offer')}</h2></div><span className={`badge ${structuralDiff.length ? 'badge-warning' : 'badge-success'}`}>{structuralDiff.length ? t(`${structuralDiff.length} změn`, `${structuralDiff.length} changes`) : t('Bez rozdílu', 'No difference')}</span></div>
         <div className={styles.panelBody}>
+          <div className={styles.readiness}><div className={styles.readinessHead}><ListChecks size={15} />{t('Připravenost k rozhodnutí', 'Decision readiness')}</div>{readiness.map(item => <div className={styles.readinessRow} key={item.label}><span>{item.ready ? <CheckCircle2 size={13} /> : <CircleAlert size={13} />}</span><span>{item.label}</span><b>{item.ready ? t('hotovo', 'ready') : t('čeká', 'pending')}</b></div>)}</div>
           <div className={styles.insightGrid}><div className={styles.insight}><b>{structuralDiff.length}</b><span>{t('změněných cest', 'changed paths')}</span></div><div className={styles.insight}><b>{parsedDraft ? '✓' : '—'}</b><span>{t('čitelnost draftu', 'draft parseability')}</span></div><div className={styles.insight}><b>{publishedRevision ? 'LIVE' : '—'}</b><span>{t('referenční revize', 'reference revision')}</span></div></div>
           {structuralDiff.length === 0 ? <div className={styles.schemaHint}>{t('Žádná strukturální změna proti živé revizi. Před publikací vždy ověřte obchodní význam.', 'No structural change from the live revision. Always verify business meaning before publication.')}</div> : <ul className={styles.diffList}>{structuralDiff.map(entry => <li key={`${entry.kind}:${entry.path}`}><strong>{entry.kind}</strong> <code>{entry.path}</code></li>)}</ul>}
 

--- a/openbank-admin-ui/src/lib/catalog-schema-form.ts
+++ b/openbank-admin-ui/src/lib/catalog-schema-form.ts
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root for details.
+
+export type CatalogSchemaScalar = 'boolean' | 'integer' | 'number' | 'string'
+
+export interface CatalogSchemaField {
+  path: string[]
+  label: string
+  type: CatalogSchemaScalar
+  required: boolean
+  choices: string[]
+  description?: string
+}
+
+type JsonSchema = {
+  type?: string
+  properties?: Record<string, JsonSchema>
+  required?: string[]
+  enum?: unknown[]
+  description?: string
+}
+
+const scalarTypes = new Set<CatalogSchemaScalar>(['boolean', 'integer', 'number', 'string'])
+
+/**
+ * Produces a deliberately small, safe form surface from a trusted pack schema. Complex arrays
+ * remain in expert JSON mode; scalar fields nested in objects become approachable controls.
+ */
+export function catalogSchemaFields(document: unknown, maxDepth = 3): CatalogSchemaField[] {
+  const root = asSchema(document)
+  return collect(root, [], true, maxDepth)
+}
+
+function collect(node: JsonSchema, prefix: string[], required: boolean, depth: number): CatalogSchemaField[] {
+  if (scalarTypes.has(node.type as CatalogSchemaScalar)) {
+    return [{
+      path: prefix,
+      label: prefix.join(' · '),
+      type: node.type as CatalogSchemaScalar,
+      required,
+      choices: Array.isArray(node.enum) ? node.enum.filter((value): value is string => typeof value === 'string') : [],
+      description: node.description,
+    }]
+  }
+  if (node.type !== 'object' || depth <= 0 || !node.properties) return []
+  const requiredKeys = new Set(node.required ?? [])
+  return Object.entries(node.properties).flatMap(([key, child]) =>
+    collect(child, [...prefix, key], required && requiredKeys.has(key), depth - 1))
+}
+
+function asSchema(value: unknown): JsonSchema {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as JsonSchema : {}
+}
+
+export function catalogFieldValue(document: Record<string, unknown> | null, path: string[]): unknown {
+  let cursor: unknown = document?.attributes
+  for (const key of path) {
+    if (!cursor || typeof cursor !== 'object' || Array.isArray(cursor)) return undefined
+    cursor = (cursor as Record<string, unknown>)[key]
+  }
+  return cursor
+}
+
+/** Immutable update of a scalar below the editor envelope's `attributes` object. */
+export function withCatalogFieldValue(
+  document: Record<string, unknown>, path: string[], value: unknown,
+): Record<string, unknown> {
+  const attributes = isObject(document.attributes) ? document.attributes : {}
+  const nextAttributes = setAtPath(attributes, path, value)
+  return { ...document, attributes: nextAttributes }
+}
+
+function setAtPath(source: Record<string, unknown>, [head, ...tail]: string[], value: unknown): Record<string, unknown> {
+  if (!head) return source
+  if (tail.length === 0) return { ...source, [head]: value }
+  const child = isObject(source[head]) ? source[head] : {}
+  return { ...source, [head]: setAtPath(child, tail, value) }
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+}

--- a/openbank-admin-ui/src/test/catalog-schema-form.test.ts
+++ b/openbank-admin-ui/src/test/catalog-schema-form.test.ts
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root for details.
+
+import { describe, expect, it } from 'vitest'
+import { catalogFieldValue, catalogSchemaFields, withCatalogFieldValue } from '@/lib/catalog-schema-form'
+
+describe('catalog schema form', () => {
+  const schema = {
+    type: 'object', required: ['coverage', 'premiumModel'], properties: {
+      coverage: { type: 'object', required: ['amount'], properties: {
+        amount: { type: 'string' }, currency: { type: 'string', enum: ['EUR', 'CZK'] },
+      } },
+      premiumModel: { type: 'string', enum: ['FIXED', 'CALCULATED'] },
+      perils: { type: 'array', items: { type: 'string' } },
+    },
+  }
+
+  it('exposes only scalar controls from trusted schema objects', () => {
+    expect(catalogSchemaFields(schema)).toEqual([
+      expect.objectContaining({ path: ['coverage', 'amount'], required: true, type: 'string' }),
+      expect.objectContaining({ path: ['coverage', 'currency'], choices: ['EUR', 'CZK'], required: false }),
+      expect.objectContaining({ path: ['premiumModel'], choices: ['FIXED', 'CALCULATED'], required: true }),
+    ])
+  })
+
+  it('updates a nested attribute without changing unrelated expert JSON', () => {
+    const original = { attributes: { coverage: { amount: '1000', currency: 'EUR' }, perils: [{ code: 'DEATH' }] } }
+    const next = withCatalogFieldValue(original, ['coverage', 'amount'], '1200')
+    expect(catalogFieldValue(next, ['coverage', 'amount'])).toBe('1200')
+    expect(next).toEqual({ attributes: { coverage: { amount: '1200', currency: 'EUR' }, perils: [{ code: 'DEATH' }] } })
+    expect(original.attributes.coverage.amount).toBe('1000')
+  })
+})


### PR DESCRIPTION
## What changed

- Adds schema-guided scalar controls to Product Studio while preserving full expert JSON for complex structures.
- Makes draft readiness, live-change impact, validation state, and the enforced maker-checker boundary explicit.
- Adds focused form tests.

## Verification

- `npm test -- --run src/test/catalog-schema-form.test.ts src/test/catalog-structural-diff.test.ts`
- `npm run type-check`
- `npm run lint`

Refs #4501