### PR TITLE
fix(ledger): verify pending FINREP pact

### DIFF
--- a/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/contract/LedgerPactBrokerProviderVerificationTest.kt
+++ b/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/contract/LedgerPactBrokerProviderVerificationTest.kt
@@ -59,7 +59,7 @@ import javax.sql.DataSource
 @QuarkusTestResource(com.openbank.ledger.it.PostgresRedpandaTestResource::class)
 @TestSecurity(user = "pact-verifier", roles = ["ROLE_API", "ROLE_OPERATOR"])
 @Provider("openbank-ledger-service")
-@PactBroker
+@PactBroker(enablePendingPacts = "true")
 @IgnoreNoPactsToVerify(ignoreIoErrors = "true")
 @EnabledIfSystemProperty(named = "pactbroker.url", matches = ".+")
 class LedgerPactBrokerProviderVerificationTest {


### PR DESCRIPTION
## Summary
- include pending consumer pacts in Ledger's broker-backed provider verification
- allow the approved deployed-version overlay flow to publish FINREP's verification result

## Verification
- git diff --check
- Ledger test compilation is running locally; GitHub Actions is authoritative for broker-backed verification

## Linked issues
Refs #2549, #4826, #4885

No runtime, broker, or deployment state was changed.