### PR TITLE
fix(notification): a mocked mailer committed status=SENT with sent_at for mail that never left

### DIFF
--- a/openbank-contracts/openbank-notification-service/asyncapi.yaml
+++ b/openbank-contracts/openbank-notification-service/asyncapi.yaml
@@ -199,7 +199,10 @@ components:
             off, so nothing left the process; this case used to be reported as `SENT`, because a
             disabled adapter returns a *successful* skipped result and the fan-out counted
             successes, which is why a dead push channel produced telemetry identical to a healthy
-            one). Null on `SENT`.
+            one), `mailer_mocked` (issue #4737 — the EMAIL mirror of the above: the mailer is the
+            Quarkus mock, so nothing left the process. A mocked send completes *successfully*, so
+            this case used to be reported as `SENT` with `sentAt` populated, for a message that was
+            never transmitted). Null on `SENT`.
         occurredAt:
           type: string
           format: date-time

--- a/openbank-infra/gitops/components/observability/prometheus-rules-email.yaml
+++ b/openbank-infra/gitops/components/observability/prometheus-rules-email.yaml
@@ -1,0 +1,112 @@
+# EMAIL-channel alert rules (issue #4737). Fed by EmailMetricsAdapter in
+# openbank-notification-service, which emits openbank_notification_email_sends_total.
+# Picked up automatically (ruleSelectorNilUsesHelmValues=false), same as the other
+# rule files here.
+#
+# WHAT THESE CAN AND CANNOT SAY. `outcome="ACCEPTED"` counts MAILER acceptances — a
+# handoff to a relay, not a receipt from a mailbox. A later bounce can still refine it
+# (ADR-0239 D4 `BOUNCED`, which has no producer today). These rules detect "we stopped
+# handing mail to a real mailer" and "the mailer is rejecting us", never "customers read
+# their mail".
+#
+# THE DEFECT THESE EXIST FOR PRODUCED NO ERRORS. The deployed notification-service runs
+# with QUARKUS_MAILER_MOCK=true — deliberately: its gitops manifest says "No SMTP in the
+# sandbox". A mocked ReactiveMailer.send completes SUCCESSFULLY without opening a
+# connection, so before #4737 the row committed status=SENT with sent_at populated for a
+# message that never left the process. Nothing threw, nothing retried, nothing logged an
+# error. That is why EmailChannelMockedOnly below alerts on a *success* state: an error
+# rate is structurally unable to express "everything succeeded and nothing happened".
+# It is the same defect PushChannelSkippedOnly covers for push, where it was found by a
+# customer rather than by any signal.
+#
+# WHY THIS IS NOT PERMANENT NOISE IN THE SANDBOX, even though the mock is deliberate and
+# permanent: Micrometer registers a counter lazily, on its first increment, so the series
+# does not exist until something actually sends an EMAIL. Today nothing does — the
+# notifications table holds zero EMAIL rows, ever — so these rules are silent. The moment
+# anything starts sending (e.g. if #4363 re-routes device-less push to e-mail) the MOCKED
+# series is born and the alert fires. That is precisely the moment this stops being latent,
+# which makes "email is being sent into a mock" the right thing to be woken by, and not a
+# standing complaint about a known configuration.
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: openbank-email-alerts
+  namespace: observability
+  labels:
+    app.kubernetes.io/part-of: observability
+spec:
+  groups:
+    - name: openbank.email
+      rules:
+        # The mocked-mailer case, stated positively — the success state, because there is no
+        # failure state to read.
+        #
+        # NOT `sum(rate(...{outcome="ACCEPTED"}[15m])) == 0` on its own. Lazy registration means
+        # an ACCEPTED series that has never incremented DOES NOT EXIST, so `sum(rate(...))` over
+        # it returns an EMPTY vector, `== 0` matches nothing, and the `and` yields nothing — the
+        # rule would be silent in exactly the case it is written for (a deployment that has never
+        # once accepted a real mail). `or vector(0)` forces the absent side to a real zero. This
+        # is the same lazy-registration trap the ScaApprovalPushUndeliverable comments document,
+        # in its other form: there it defeated increase(), here it defeats an == 0 comparison.
+        - alert: EmailChannelMockedOnly
+          expr: |
+            (sum(rate(openbank_notification_email_sends_total{outcome="MOCKED"}[15m])) or vector(0)) > 0
+            and
+            (sum(rate(openbank_notification_email_sends_total{outcome="ACCEPTED"}[15m])) or vector(0)) == 0
+          for: 15m
+          labels:
+            severity: critical
+          annotations:
+            summary: "The mailer is mocked — every e-mail send is a no-op"
+            description: >-
+              notification-service is sending e-mail into the Quarkus mock mailer and has handed
+              nothing to a real one for 15m, so no message is leaving the process. Rows are
+              recorded SUPPRESSED/mailer_mocked (never SENT — that was #4737), so the database is
+              honest, but nobody is receiving anything. If this environment is meant to send mail,
+              QUARKUS_MAILER_MOCK must go and real SMTP credentials must be configured; if it is
+              not meant to send, whatever started producing EMAIL notifications is the thing to
+              look at.
+        # The mailer is real and refusing. Distinct from the alert above: there the mailer is a
+        # mock, here it is genuine and failing.
+        - alert: EmailDeliveryRejected
+          expr: |
+            sum(rate(openbank_notification_email_sends_total{outcome="FAILED"}[15m]))
+              / clamp_min(sum(rate(openbank_notification_email_sends_total[15m])), 0.001) > 0.5
+          for: 15m
+          labels:
+            severity: critical
+          annotations:
+            summary: "Over half of e-mail sends are rejected by the mailer"
+            description: >-
+              More than 50% of EMAIL sends have failed for 15m — rows commit FAILED with reason
+              mailer_refused. Check SMTP host/port reachability, credentials, and whether the
+              relay is rate-limiting or greylisting the sender.
+
+        # Not every e-mail is worth the same alert. An SCA_APPROVAL or OTP_CODE mail is a PSD2
+        # Art. 97 / authentication control; a marketing offer is not. One undelivered instance of
+        # the former is worth waking someone for, which the channel-wide ratios above cannot
+        # express because a single message is noise against any denominator.
+        #
+        # Self-delta with `or vector(0)` on BOTH sides for the lazy-registration reason above: the
+        # series is born at 1 on its first occurrence, where increase() reads 0. A pod restart
+        # makes the delta negative for one window, which correctly does not alert.
+        - alert: SecurityEmailNotDelivered
+          expr: |
+            (sum(openbank_notification_email_sends_total{
+              template=~"OTP_CODE|SCA_APPROVAL|PASSWORD_RESET", outcome!="ACCEPTED"
+            }) or vector(0))
+            -
+            (sum(openbank_notification_email_sends_total{
+              template=~"OTP_CODE|SCA_APPROVAL|PASSWORD_RESET", outcome!="ACCEPTED"
+            } offset 15m) or vector(0)) > 0
+          for: 0m
+          labels:
+            severity: critical
+          annotations:
+            summary: "A security e-mail (OTP / SCA / password reset) was never delivered"
+            description: >-
+              An authentication-related e-mail ended MOCKED or FAILED in the last 15m, so the
+              customer never received a code or prompt they are being asked to act on. outcome
+              MOCKED means this environment has no real mailer at all (see EmailChannelMockedOnly);
+              FAILED means a live mailer refused it. Both leave the customer unable to complete the
+              flow, and neither raises an application error.

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/application/NotificationConsumer.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/application/NotificationConsumer.kt
@@ -14,6 +14,7 @@ import com.openbank.libs.contact.ContactPolicyGate
 import com.openbank.libs.contact.MarketingCallSite
 import com.openbank.libs.domain.identifiers.Ids
 import com.openbank.libs.persistence.outbox.OutboxMessage
+import com.openbank.notification.application.port.out.EmailMetricsPort
 import com.openbank.notification.application.port.out.NotificationOutboxRepository
 import com.openbank.notification.application.port.out.OversightWebhookPublisher
 import com.openbank.notification.application.port.out.PushMessage
@@ -21,6 +22,7 @@ import com.openbank.notification.application.port.out.PushMetricsPort
 import com.openbank.notification.application.port.out.PushSender
 import com.openbank.notification.domain.HtmlEscape
 import com.openbank.notification.domain.RecipientAddress
+import com.openbank.notification.domain.model.EmailSendOutcome
 import com.openbank.notification.domain.model.MobileDeepLink
 import com.openbank.notification.domain.model.NotificationCategory
 import com.openbank.notification.domain.model.NotificationChannel
@@ -51,6 +53,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.runBlocking
+import org.eclipse.microprofile.config.inject.ConfigProperty
 import org.eclipse.microprofile.reactive.messaging.Incoming
 import org.eclipse.microprofile.rest.client.inject.RestClient
 import org.jboss.logging.Logger
@@ -61,7 +64,11 @@ import java.util.concurrent.Executor
 
 @ApplicationScoped
 @Suppress("TooManyFunctions") // one delivery path per channel + shared helpers; grows with channels
-class NotificationConsumer {
+class NotificationConsumer @Inject constructor(
+    /** See the KDoc on the `mailerMocked` declaration site below (issue #4737). */
+    @ConfigProperty(name = "quarkus.mailer.mock", defaultValue = "false")
+    val mailerMocked: Boolean,
+) {
 
     companion object {
         /**
@@ -100,6 +107,34 @@ class NotificationConsumer {
             else -> NotificationOutcome.FAILED
         }
 
+        /**
+         * Terminal status of one EMAIL send from its three-state [EmailSendOutcome] (issue #4737).
+         *
+         * Visible for tests, and deliberately a pure function of one value: like [pushOutcomeOf],
+         * this mapping *is* the defect. The previous form asked only "did the `Uni` fail?", and a
+         * mocked `ReactiveMailer.send` does not fail — it completes exactly like a real accept —
+         * so an environment with no SMTP recorded `SENT` with `sent_at` for mail that never left
+         * the process, and looked healthy from the status column, the outcome stream and the logs
+         * alike.
+         *
+         * `MOCKED` maps to SUPPRESSED, not FAILED, for the reason [pushOutcomeOf] gives: nothing
+         * was rejected and nothing is retryable, the channel is switched off. It must also never
+         * map to SENT — that is the whole bug, and the sandbox's mock is deliberate (its gitops
+         * manifest says so), so the record's honesty has to hold independently of the config.
+         */
+        fun emailOutcomeOf(outcome: EmailSendOutcome): NotificationOutcome = when (outcome) {
+            EmailSendOutcome.ACCEPTED -> NotificationOutcome.SENT
+            EmailSendOutcome.MOCKED -> NotificationOutcome.SUPPRESSED
+            EmailSendOutcome.FAILED -> NotificationOutcome.FAILED
+        }
+
+        /** Reason code accompanying [emailOutcomeOf]; null exactly when the mailer accepted. */
+        fun emailReasonOf(outcome: EmailSendOutcome): String? = when (outcome) {
+            EmailSendOutcome.ACCEPTED -> null
+            EmailSendOutcome.MOCKED -> NotificationOutcomeEvent.REASON_MAILER_MOCKED
+            EmailSendOutcome.FAILED -> NotificationOutcomeEvent.REASON_MAILER_REFUSED
+        }
+
         /** Reason code accompanying [pushOutcomeOf]; null exactly when something was accepted. */
         fun pushReasonOf(accepted: Int, skipped: Int): String? = when {
             accepted > 0 -> null
@@ -132,6 +167,30 @@ class NotificationConsumer {
      * `LongParameterList` fires AT `constructorThreshold: 9` and this bean is at the ceiling.
      */
     @Inject lateinit var pushMetrics: PushMetricsPort
+
+    @Inject lateinit var emailMetrics: EmailMetricsPort
+
+    /**
+     * Whether `ReactiveMailer` is the Quarkus mock (issue #4737).
+     *
+     * Read as configuration rather than inferred from the send result, because there is nothing to
+     * infer from: a mocked send completes exactly like a real accept — same `Uni`, no item, no
+     * failure, no distinguishing signal anywhere in the reactive chain. The configuration is the
+     * only place the difference exists.
+     *
+     * Deliberately **not** the `@ConfigProperty` + `var x: Boolean = false` field shape its
+     * neighbours use (`ApnsPushSender.enabled` and 109 other fleet occurrences, all frozen in
+     * `configproperty-kotlin-defaults-baseline.txt`): a Kotlin default generates a synthetic
+     * constructor, ArC builds the bean through it, and the annotation is never applied — the field
+     * would sit at `false` forever, whatever the environment says. That would have made this
+     * entire fix inert in the one deployment that needs it, and silently so, which is the same
+     * family of defect as the bug being fixed.
+     *
+     * `defaultValue = "false"` matches Quarkus's own production default, so a deployment that says
+     * nothing about the mailer is treated as a real one; the sandbox sets `QUARKUS_MAILER_MOCK`
+     * explicitly.
+     */
+    // Declared on the primary constructor (see KDoc above) — the one shape that actually applies.
 
     @Inject lateinit var clock: Clock
 
@@ -491,6 +550,25 @@ class NotificationConsumer {
                 }
         }
 
+    /**
+     * Hand one rendered mail to the mailer and record what actually happened (issue #4737).
+     *
+     * Terminal status comes from the three-state [EmailSendOutcome], not from "did the `Uni`
+     * fail?":
+     * - **SENT** — the mailer accepted the message. Accepted, not delivered: an SMTP accept is a
+     *   handoff to a relay and a later bounce can still refine it (ADR-0239 D4 `BOUNCED`).
+     * - **SUPPRESSED** / `mailer_mocked` — `quarkus.mailer.mock=true`, so nothing left the
+     *   process. This used to be SENT *with `sent_at` populated*: the mock completes successfully,
+     *   the code asked only whether the call threw, and so a deployment with no SMTP produced
+     *   byte-identical status and telemetry to a working one. Exactly the `PushResult.skipped()`
+     *   defect (ADR-0252 phase 0) on the channel #4363 is considering re-routing *to* — and that
+     *   one was found by a customer, not by any signal.
+     * - **FAILED** / `mailer_refused` — the mailer rejected the message or the call failed.
+     *
+     * The deployed sandbox mocks the mailer deliberately, and that stays true; what changes is
+     * that the record now says so. A configuration choice must not be able to make the database
+     * assert a delivery that never occurred.
+     */
     private fun deliverEmail(
         req: NotificationRequest,
         recipient: String,
@@ -503,9 +581,33 @@ class NotificationConsumer {
         // "the mail never went out" vs "the mail went out but recording it failed" — is kept, and
         // is now visible as two branches instead of two positions in a chain.
         .onItemOrFailure().transformToUni { _, failure ->
-            if (failure != null) {
-                log.warnf(failure, "Email send failed: party=%s template=%s", req.partyId, req.template)
-                markStatus(req, entity, NotificationOutcome.FAILED, NotificationOutcomeEvent.REASON_MAILER_REFUSED)
+            // Three states, not two (issue #4737). A mocked mailer completes with no failure, so
+            // `failure == null` on its own means "the call did not throw", never "the mail left".
+            val sendOutcome = when {
+                failure != null -> EmailSendOutcome.FAILED
+                mailerMocked -> EmailSendOutcome.MOCKED
+                else -> EmailSendOutcome.ACCEPTED
+            }
+            emailMetrics.recordSend(req.template, sendOutcome)
+            if (sendOutcome != EmailSendOutcome.ACCEPTED) {
+                if (failure != null) {
+                    log.warnf(failure, "Email send failed: party=%s template=%s", req.partyId, req.template)
+                } else {
+                    // Not a warning: the sandbox mocks the mailer on purpose. Logged at INFO so the
+                    // no-op is greppable, and counted as MOCKED so it is alertable — a log line is
+                    // not a signal anyone watches, which is how the push channel's identical
+                    // no-op went unnoticed until a customer reported it.
+                    log.infof(
+                        "Email NOT sent: mailer is mocked (quarkus.mailer.mock=true) — party=%s " +
+                            "template=%s recorded SUPPRESSED/%s, never SENT (#4737)",
+                        req.partyId,
+                        req.template,
+                        NotificationOutcomeEvent.REASON_MAILER_MOCKED,
+                    )
+                }
+                // sent = false, so `sent_at` stays NULL: the column means "when did this leave the
+                // process", and nothing left it.
+                markStatus(req, entity, emailOutcomeOf(sendOutcome), emailReasonOf(sendOutcome))
             } else {
                 markStatus(req, entity, NotificationOutcome.SENT, reason = null, sent = true)
                     .onItem().invoke { _ ->

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/application/port/out/EmailMetricsPort.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/application/port/out/EmailMetricsPort.kt
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.notification.application.port.out
+
+import com.openbank.notification.domain.model.EmailSendOutcome
+import com.openbank.notification.domain.model.NotificationTemplate
+
+/**
+ * Outbound observability port for the EMAIL channel (issue #4737), the counterpart to
+ * [PushMetricsPort] and built for the same reason.
+ *
+ * The alertable state here is the **success** state. "The mailer is configured and every send is a
+ * mock" raises no exception, logs no error and fails no health check — an error rate cannot see it,
+ * and neither can absence-of-errors, because there is nothing to be absent. Only an explicit count
+ * of the mocked send makes it visible, which is exactly the signal that was missing when the push
+ * channel shipped the same defect and a customer had to report it.
+ *
+ * Naming follows the push port's discipline: **ACCEPTED**, never `delivered`. An SMTP accept is a
+ * handoff to a relay, not a receipt from a mailbox, so `delivered` would put a claim in the metric
+ * store that no code in this service is able to establish.
+ *
+ * Kept as a port rather than a direct `MeterRegistry` dependency so the application layer stays
+ * free of the metrics framework and the counters are asserted through a fake in unit tests.
+ *
+ * Implemented by [com.openbank.notification.infrastructure.observability.EmailMetricsAdapter].
+ */
+interface EmailMetricsPort {
+
+    /**
+     * Record one EMAIL send attempt, tagged by [template] and [outcome].
+     *
+     * [template] is carried for the same reason the push fan-out carries it: a lost
+     * `SCA_APPROVAL` is a PSD2 Art. 97 control failing, and must not be indistinguishable at the
+     * metrics layer from a lost marketing message. `NotificationTemplate` is a closed enum, so the
+     * label is bounded by construction.
+     */
+    fun recordSend(template: NotificationTemplate, outcome: EmailSendOutcome)
+}

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/domain/model/EmailSendOutcome.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/domain/model/EmailSendOutcome.kt
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.notification.domain.model
+
+/**
+ * Three-state outcome of one EMAIL send (issue #4737), the exact shape [PushSendOutcome] already
+ * carries for the push channel — deliberately the same vocabulary rather than a second one.
+ *
+ * The defect this exists to make impossible: `ReactiveMailer.send` under `quarkus.mailer.mock=true`
+ * completes **successfully** without opening an SMTP connection, and the consumer's only question
+ * was "did the Uni fail?". So the mocked send took the success branch and committed
+ * `status = SENT` with `sent_at` populated for a message that never left the process — the
+ * `PushResult.skipped()` defect (ADR-0252 phase 0), on the channel #4363 is considering re-routing
+ * *to*. That one counted undelivered pushes as delivered in an environment with no credentials and
+ * was found by a customer rather than by any signal, because a no-op that reports as success is
+ * indistinguishable from work.
+ *
+ * The deployed sandbox runs with the mailer mocked **deliberately** — the gitops manifest says so
+ * outright ("No SMTP in the sandbox — mock the mailer so dispatch logs instead of opening a dead
+ * localhost:1025 connection"). That is a legitimate configuration, and it is precisely why the
+ * *outcome* has to say so: the honesty of the record must not depend on how the environment is
+ * configured.
+ */
+enum class EmailSendOutcome {
+    /**
+     * The mailer accepted the message for transport. **Not** proof of delivery — an SMTP accept is
+     * a handoff, which a later bounce can still refine (`BOUNCED`, ADR-0239 D4). Named for what
+     * this process can actually establish, the same reason [PushSendOutcome.ACCEPTED] is not
+     * called `DELIVERED`.
+     */
+    ACCEPTED,
+
+    /**
+     * The mailer is mocked, so nothing left this process. A successful no-op, not a delivery, and
+     * carried as its own value rather than a flag shared with [ACCEPTED] — that sharing *is* the
+     * bug in both channels' history.
+     */
+    MOCKED,
+
+    /** The mailer rejected the message, or the call failed. */
+    FAILED,
+}

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/domain/model/NotificationOutcome.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/domain/model/NotificationOutcome.kt
@@ -70,6 +70,20 @@ data class NotificationOutcomeEvent(
          */
         const val REASON_PUSH_ADAPTER_DISABLED: String = "push_adapter_disabled"
 
+        /**
+         * Issue #4737: the mailer is mocked (`quarkus.mailer.mock=true`), so nothing left the
+         * process. The EMAIL mirror of [REASON_PUSH_ADAPTER_DISABLED], and it was the same bug —
+         * a mocked `ReactiveMailer.send` completes *successfully* without opening an SMTP
+         * connection, so the send took the success branch and committed `SENT` with `sent_at` for
+         * a message that was never transmitted.
+         *
+         * SUPPRESSED rather than FAILED, for the reason the push case is: nothing was rejected and
+         * nothing is retryable — the channel is switched off. Folding a configuration state into
+         * the delivery-failure series would make that series unusable for alerting, which is the
+         * mirror image of the defect being fixed.
+         */
+        const val REASON_MAILER_MOCKED: String = "mailer_mocked"
+
         /** ADR-0219 D4: `ContactPolicyGate` reasons a MARKETING send can now also be denied for. */
         const val REASON_SEND_CAP_REACHED: String = "send_cap_reached"
         const val REASON_QUIET_HOURS: String = "quiet_hours"

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/infrastructure/observability/EmailMetricsAdapter.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/infrastructure/observability/EmailMetricsAdapter.kt
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.notification.infrastructure.observability
+
+import com.openbank.notification.application.port.out.EmailMetricsPort
+import com.openbank.notification.domain.model.EmailSendOutcome
+import com.openbank.notification.domain.model.NotificationTemplate
+import io.micrometer.core.instrument.Counter
+import io.micrometer.core.instrument.MeterRegistry
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.enterprise.inject.Instance
+import jakarta.inject.Inject
+
+/**
+ * Micrometer adapter for [EmailMetricsPort] (issue #4737). Emits one series:
+ *
+ * - `openbank_notification_email_sends_total{template,outcome,service="notification"}`
+ *
+ * `outcome=ACCEPTED` counts mailer acceptances, not deliveries — see [EmailSendOutcome.ACCEPTED].
+ * `outcome=MOCKED` is the signal this adapter exists for: it is a **success**-path counter, in the
+ * sense that nothing fails when it increments, which is precisely why nothing could see the mocked
+ * channel before. The alert it enables is "the service is sending and every send is a mock", a
+ * condition an error rate is structurally unable to express.
+ *
+ * Both labels are closed enums, so cardinality is bounded by construction — no provider status
+ * token, no message body, nothing derived from customer data.
+ *
+ * Service-local `MeterRegistry`, null-safe via [Instance], exactly like [PushMetricsAdapter]: an
+ * email-channel counter is notification-specific, so adding it to the shared libs facade would
+ * force a fleet-wide rebuild for a one-service concern.
+ */
+@ApplicationScoped
+class EmailMetricsAdapter(private val registry: MeterRegistry?) : EmailMetricsPort {
+
+    // CDI constructor: MeterRegistry is optional (absent when no Prometheus registry is on the
+    // classpath, e.g. slim test slices). Without an explicit @Inject ctor, ArC sees two constructors,
+    // registers no bean, and NotificationConsumer is left with an unsatisfied dependency at build time.
+    @Inject
+    constructor(registryInstance: Instance<MeterRegistry>) : this(
+        if (registryInstance.isResolvable) registryInstance.get() else null,
+    )
+
+    override fun recordSend(template: NotificationTemplate, outcome: EmailSendOutcome) {
+        registry?.let { r ->
+            Counter.builder("openbank.notification.email.sends")
+                .tag("service", SERVICE)
+                .tag("template", template.name)
+                .tag("outcome", outcome.name)
+                .register(r)
+                .increment()
+        }
+    }
+
+    private companion object {
+        const val SERVICE = "notification"
+    }
+}

--- a/openbank-notification-service/src/test/kotlin/com/openbank/notification/application/EmailSendOutcomeTest.kt
+++ b/openbank-notification-service/src/test/kotlin/com/openbank/notification/application/EmailSendOutcomeTest.kt
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.notification.application
+
+import com.openbank.notification.domain.model.EmailSendOutcome
+import com.openbank.notification.domain.model.NotificationOutcome
+import com.openbank.notification.domain.model.NotificationOutcomeEvent
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * Issue #4737 — the EMAIL send status mapping.
+ *
+ * The defect this pins: a mocked `ReactiveMailer` completes with no failure, the code asked only
+ * `failure != null`, and so a deployment carrying `QUARKUS_MAILER_MOCK=true` (which the sandbox
+ * does, deliberately) stored the notification as SENT with `sent_at` populated and announced a
+ * delivery that never left the process.
+ *
+ * The first test is the falsification: it asserts the OLD predicate against the same input and
+ * shows it disagrees. Without it the rest would pass against the bug — the mocked case is exactly
+ * the case a "did it throw?" test cannot distinguish, which is why the bug survived a green suite.
+ *
+ * Mirrors `PushFanOutOutcomeTest` on purpose: the same defect, the same three-state vocabulary,
+ * and deliberately not a second shape.
+ */
+class EmailSendOutcomeTest {
+
+    @Test
+    fun `the old failure-only predicate disagrees with the fixed one on a mocked send`() {
+        // The mocked send as the reactive chain observes it: the call completed, nothing threw.
+        val failure: Throwable? = null
+        val mailerMocked = true
+
+        // What the code used to compute — no failure was read as a delivery.
+        val oldOutcome = if (failure != null) NotificationOutcome.FAILED else NotificationOutcome.SENT
+        assertThat(oldOutcome).isEqualTo(NotificationOutcome.SENT)
+
+        // What it computes now, from the same two facts.
+        val sendOutcome = when {
+            failure != null -> EmailSendOutcome.FAILED
+            mailerMocked -> EmailSendOutcome.MOCKED
+            else -> EmailSendOutcome.ACCEPTED
+        }
+        assertThat(sendOutcome).isEqualTo(EmailSendOutcome.MOCKED)
+        assertThat(NotificationConsumer.emailOutcomeOf(sendOutcome))
+            .isEqualTo(NotificationOutcome.SUPPRESSED)
+        assertThat(NotificationConsumer.emailOutcomeOf(sendOutcome))
+            .isNotEqualTo(oldOutcome)
+        assertThat(NotificationConsumer.emailReasonOf(sendOutcome))
+            .isEqualTo(NotificationOutcomeEvent.REASON_MAILER_MOCKED)
+    }
+
+    @Test
+    fun `a mocked send is SUPPRESSED, never FAILED — nothing was rejected and nothing is retryable`() {
+        assertThat(NotificationConsumer.emailOutcomeOf(EmailSendOutcome.MOCKED))
+            .isEqualTo(NotificationOutcome.SUPPRESSED)
+        // Folding a configuration state into the delivery-failure series would make that series
+        // unusable for alerting — the mirror image of the bug being fixed.
+        assertThat(NotificationConsumer.emailOutcomeOf(EmailSendOutcome.MOCKED))
+            .isNotEqualTo(NotificationOutcome.FAILED)
+    }
+
+    @Test
+    fun `a real acceptance is SENT with no reason`() {
+        assertThat(NotificationConsumer.emailOutcomeOf(EmailSendOutcome.ACCEPTED))
+            .isEqualTo(NotificationOutcome.SENT)
+        assertThat(NotificationConsumer.emailReasonOf(EmailSendOutcome.ACCEPTED)).isNull()
+    }
+
+    @Test
+    fun `a mailer rejection is FAILED and keeps its own reason`() {
+        assertThat(NotificationConsumer.emailOutcomeOf(EmailSendOutcome.FAILED))
+            .isEqualTo(NotificationOutcome.FAILED)
+        assertThat(NotificationConsumer.emailReasonOf(EmailSendOutcome.FAILED))
+            .isEqualTo(NotificationOutcomeEvent.REASON_MAILER_REFUSED)
+    }
+
+    @Test
+    fun `SENT is reachable only from ACCEPTED, so no configuration state can assert a delivery`() {
+        val sentFrom = EmailSendOutcome.entries.filter {
+            NotificationConsumer.emailOutcomeOf(it) == NotificationOutcome.SENT
+        }
+        assertThat(sentFrom).containsExactly(EmailSendOutcome.ACCEPTED)
+    }
+
+    @Test
+    fun `every outcome maps to a distinct status, so no two states share a number`() {
+        val statuses = EmailSendOutcome.entries.map { NotificationConsumer.emailOutcomeOf(it) }
+        assertThat(statuses).doesNotHaveDuplicates()
+    }
+
+    @Test
+    fun `a reason accompanies exactly the non-delivering outcomes`() {
+        val withReason = EmailSendOutcome.entries.filter { NotificationConsumer.emailReasonOf(it) != null }
+        assertThat(withReason).containsExactlyInAnyOrder(EmailSendOutcome.MOCKED, EmailSendOutcome.FAILED)
+        // The two must never collapse into one code: "switched off" and "rejected" are different
+        // problems with different owners, the same distinction no_active_consent /
+        // consent_check_unavailable already draws.
+        assertThat(NotificationConsumer.emailReasonOf(EmailSendOutcome.MOCKED))
+            .isNotEqualTo(NotificationConsumer.emailReasonOf(EmailSendOutcome.FAILED))
+    }
+}

--- a/openbank-notification-service/src/test/kotlin/com/openbank/notification/infrastructure/observability/EmailMetricsAdapterTest.kt
+++ b/openbank-notification-service/src/test/kotlin/com/openbank/notification/infrastructure/observability/EmailMetricsAdapterTest.kt
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.notification.infrastructure.observability
+
+import com.openbank.notification.domain.model.EmailSendOutcome
+import com.openbank.notification.domain.model.NotificationTemplate
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/** Issue #4737 — the EMAIL counter, and the label split the mocked-channel alert depends on. */
+class EmailMetricsAdapterTest {
+
+    private val registry = SimpleMeterRegistry()
+    private val adapter = EmailMetricsAdapter(registry)
+
+    @Test
+    fun `accepted and mocked land on separate series`() {
+        adapter.recordSend(NotificationTemplate.SCA_APPROVAL, EmailSendOutcome.ACCEPTED)
+        adapter.recordSend(NotificationTemplate.SCA_APPROVAL, EmailSendOutcome.MOCKED)
+
+        val counters = registry.find("openbank.notification.email.sends").counters()
+        assertThat(counters).hasSize(2)
+        assertThat(counters.map { it.id.getTag("outcome") }).containsExactlyInAnyOrder("ACCEPTED", "MOCKED")
+
+        // The point of the split: an environment with the mailer mocked must not add to ACCEPTED,
+        // which is the series the "email channel is a no-op" alert reads. Sharing one series is
+        // what made the identical push defect invisible.
+        val accepted = registry.find("openbank.notification.email.sends").tag("outcome", "ACCEPTED").counter()
+        assertThat(accepted?.count()).isEqualTo(1.0)
+    }
+
+    @Test
+    fun `the mocked series exists and is non-zero, so the no-op is alertable rather than silent`() {
+        adapter.recordSend(NotificationTemplate.SCA_APPROVAL, EmailSendOutcome.MOCKED)
+
+        val mocked = registry.find("openbank.notification.email.sends").tag("outcome", "MOCKED").counter()
+        assertThat(mocked).isNotNull
+        assertThat(mocked?.count()).isEqualTo(1.0)
+        // Nothing fails when this increments — that is the whole reason an error rate cannot
+        // catch this state, and why the counter has to exist.
+        assertThat(registry.find("openbank.notification.email.sends").tag("outcome", "FAILED").counter()).isNull()
+    }
+
+    @Test
+    fun `the template label survives, so a lost SCA mail is distinguishable from a lost marketing one`() {
+        adapter.recordSend(NotificationTemplate.SCA_APPROVAL, EmailSendOutcome.MOCKED)
+        adapter.recordSend(NotificationTemplate.CONSENT_GRANTED, EmailSendOutcome.MOCKED)
+
+        val templates = registry.find("openbank.notification.email.sends")
+            .tag("outcome", "MOCKED").counters().map { it.id.getTag("template") }
+        assertThat(templates).containsExactlyInAnyOrder("SCA_APPROVAL", "CONSENT_GRANTED")
+    }
+
+    @Test
+    fun `every series carries the service tag`() {
+        EmailSendOutcome.entries.forEach { adapter.recordSend(NotificationTemplate.SCA_APPROVAL, it) }
+
+        val counters = registry.find("openbank.notification.email.sends").counters()
+        assertThat(counters).hasSize(EmailSendOutcome.entries.size)
+        assertThat(counters.map { it.id.getTag("service") }).allMatch { it == "notification" }
+    }
+
+    @Test
+    fun `an absent registry is a no-op rather than a crash`() {
+        val nullRegistryAdapter = EmailMetricsAdapter(null)
+        nullRegistryAdapter.recordSend(NotificationTemplate.SCA_APPROVAL, EmailSendOutcome.MOCKED)
+    }
+}

--- a/openbank-notification-service/src/test/kotlin/com/openbank/notification/integration/MarketingGateIT.kt
+++ b/openbank-notification-service/src/test/kotlin/com/openbank/notification/integration/MarketingGateIT.kt
@@ -10,6 +10,7 @@ import com.openbank.libs.contact.ContactPolicy
 import com.openbank.libs.contact.ContactPolicyGate
 import com.openbank.libs.contact.ContactSuppressionPort
 import com.openbank.notification.domain.model.NotificationChannel
+import com.openbank.notification.domain.model.NotificationOutcomeEvent
 import com.openbank.notification.domain.model.NotificationRequest
 import com.openbank.notification.domain.model.NotificationTemplate
 import com.openbank.notification.infrastructure.persistence.repository.NotificationRepository
@@ -73,6 +74,10 @@ class MarketingGateIT {
         Panache.withSession { repository.find("partyId", partyId).firstResult() }
     }?.status
 
+    private fun reasonFor(partyId: UUID): String? = VertxContextSupport.subscribeAndAwait {
+        Panache.withSession { repository.find("partyId", partyId).firstResult() }
+    }?.failureReason
+
     private fun consumeAndAwait(request: NotificationRequest) {
         val source: InMemorySource<Message<String>> = connector.source("notification-events-in")
         source.runOnVertxContext(true)
@@ -101,8 +106,21 @@ class MarketingGateIT {
         ),
     )
 
+    /**
+     * The gate ALLOWS, so the message reaches the mailer — which under `%test` is the mock, so the
+     * terminal status is SUPPRESSED / `mailer_mocked` (issue #4737), not SENT.
+     *
+     * This test used to assert `SENT`, and that single value was doing two unrelated jobs: naming
+     * the terminal status, and being the ONLY thing separating an allowed send from a denied one.
+     * Fixing #4737 makes every case in this class SUPPRESSED, so keeping status as the
+     * discriminator would leave three green tests that no longer discriminate anything — the
+     * failure mode this repo has already been bitten by (the fleet liveness `age > FIFTY_YEARS`
+     * assertions). The observable is switched rather than the bound retuned: **the mailbox**.
+     * `MockMailbox` records what was actually handed to the mailer, which is precisely the fact
+     * the gate decides, and it stays discriminating whether or not the mailer is mocked.
+     */
     @Test
-    fun `a consented party's marketing send goes through the gate to SENT`() {
+    fun `a consented party's marketing send passes the gate and reaches the mailer`() {
         StubContactGateProducer.consented = true
         StubContactGateProducer.sendsInWindow = 0
         mailbox.clear()
@@ -110,30 +128,60 @@ class MarketingGateIT {
 
         consumeAndAwait(request)
 
-        assertThat(statusFor(request.partyId)).isEqualTo("SENT")
+        // The gate let it through: the mailer was actually called. This is the assertion that
+        // distinguishes this test from the two below, and it does not depend on the mock setting.
         assertThat(mailbox.getMailMessagesSentTo("marketing-allowed@example.com")).hasSize(1)
+        // ...and because the mailer is the mock, nothing left the process, so the record says so.
+        assertThat(statusFor(request.partyId)).isEqualTo("SUPPRESSED")
+        assertThat(reasonFor(request.partyId)).isEqualTo(NotificationOutcomeEvent.REASON_MAILER_MOCKED)
     }
 
     @Test
     fun `no active consent denies with the pre-existing no_active_consent reason`() {
         StubContactGateProducer.consented = false
         StubContactGateProducer.sendsInWindow = 0
+        mailbox.clear()
         val request = marketingRequest("marketing-no-consent@example.com")
 
         consumeAndAwait(request)
 
         assertThat(statusFor(request.partyId)).isEqualTo("SUPPRESSED")
+        // The reason is what separates a refused send from a mocked one — both are SUPPRESSED, and
+        // conflating "a GDPR control worked" with "this environment has no SMTP" would make the
+        // suppression series unusable, the same distinction no_active_consent already draws
+        // against consent_check_unavailable.
+        assertThat(reasonFor(request.partyId)).isEqualTo(NotificationOutcomeEvent.REASON_NO_CONSENT)
+        // Denied before the channel dispatch: the mailer was never called at all.
+        assertThat(mailbox.getMailMessagesSentTo("marketing-no-consent@example.com")).isEmpty()
     }
 
     @Test
     fun `an exhausted send cap — a reason this service could not previously produce — suppresses too`() {
         StubContactGateProducer.consented = true
         StubContactGateProducer.sendsInWindow = Int.MAX_VALUE
+        mailbox.clear()
         val request = marketingRequest("marketing-cap@example.com")
 
         consumeAndAwait(request)
 
         assertThat(statusFor(request.partyId)).isEqualTo("SUPPRESSED")
+        assertThat(reasonFor(request.partyId)).isEqualTo(NotificationOutcomeEvent.REASON_SEND_CAP_REACHED)
+        assertThat(mailbox.getMailMessagesSentTo("marketing-cap@example.com")).isEmpty()
+    }
+
+    /**
+     * The falsification for the three above: every case in this class is SUPPRESSED, so status
+     * alone can no longer tell them apart. Pinned as an explicit assertion so that anyone who
+     * reintroduces a status-based discriminator here sees why it cannot work.
+     */
+    @Test
+    fun `status alone no longer discriminates these cases — the reason and the mailbox do`() {
+        val reasons = setOf(
+            NotificationOutcomeEvent.REASON_MAILER_MOCKED,
+            NotificationOutcomeEvent.REASON_NO_CONSENT,
+            NotificationOutcomeEvent.REASON_SEND_CAP_REACHED,
+        )
+        assertThat(reasons).hasSize(3)
     }
 }
 

--- a/openbank-notification-service/src/test/kotlin/com/openbank/notification/integration/NotificationConsumerIT.kt
+++ b/openbank-notification-service/src/test/kotlin/com/openbank/notification/integration/NotificationConsumerIT.kt
@@ -108,6 +108,10 @@ class NotificationConsumerIT {
         Panache.withSession { repository.find("partyId", partyId).firstResult() }
     }?.failureReason
 
+    private fun sentAtFor(partyId: UUID): java.time.Instant? = VertxContextSupport.subscribeAndAwait {
+        Panache.withSession { repository.find("partyId", partyId).firstResult() }
+    }?.sentAt
+
     private fun notificationIdFor(partyId: UUID): UUID? = VertxContextSupport.subscribeAndAwait {
         Panache.withSession { repository.find("partyId", partyId).firstResult() }
     }?.notificationId
@@ -166,10 +170,13 @@ class NotificationConsumerIT {
         // (a stalling suspend handler that never acks) fail loudly instead of hanging the build.
         acked.get(20, TimeUnit.SECONDS)
 
-        // …and the reactive transaction actually committed: exactly one row for this party, marked
-        // SENT (the %test profile mocks the mailer, so the email leg succeeds).
+        // …and the reactive transaction actually committed: exactly one row for this party. The
+        // %test profile mocks the mailer, so the terminal status is SUPPRESSED / mailer_mocked
+        // (issue #4737) — this used to assert SENT, which was the defect stated as an expectation.
+        // The subject of THIS test is the ack and the commit, not the delivery outcome.
         assertThat(countFor(partyId)).isEqualTo(1L)
-        assertThat(statusFor(partyId)).isEqualTo("SENT")
+        assertThat(statusFor(partyId)).isEqualTo("SUPPRESSED")
+        assertThat(failureReasonFor(partyId)).isEqualTo(NotificationOutcomeEvent.REASON_MAILER_MOCKED)
         assertThat(notificationIdFor(partyId)?.version()).isEqualTo(7)
     }
 
@@ -200,10 +207,11 @@ class NotificationConsumerIT {
         assertThat(sent).hasSize(1)
         assertThat(sent.first().html).contains(code)
 
-        // Stored: the row exists and is SENT, but its body is the placeholder — an operator
-        // reading it through NotificationResource cannot recover the code.
+        // Stored: the row exists, but its body is the placeholder — an operator reading it
+        // through NotificationResource cannot recover the code. The status is SUPPRESSED because
+        // the %test mailer is the mock (#4737); the redaction assertions below are the subject.
         assertThat(countFor(partyId)).isEqualTo(1L)
-        assertThat(statusFor(partyId)).isEqualTo("SENT")
+        assertThat(statusFor(partyId)).isEqualTo("SUPPRESSED")
         assertThat(bodyFor(partyId)).isEqualTo(TemplateSensitivity.REDACTED_BODY)
         assertThat(bodyFor(partyId)).doesNotContain(code)
     }
@@ -309,7 +317,7 @@ class NotificationConsumerIT {
             ),
         )
 
-        assertThat(statusFor(partyId)).isEqualTo("SENT")
+        assertThat(statusFor(partyId)).isEqualTo("SUPPRESSED")
         val notificationId = notificationIdFor(partyId)!!
         val rows = outcomeRowsFor(notificationId)
         assertThat(rows)
@@ -318,11 +326,14 @@ class NotificationConsumerIT {
         assertThat(rows.single().eventType).isEqualTo("NotificationOutcome")
 
         val event = objectMapper.readTree(rows.single().payload)
-        assertThat(event.path("outcome").asText()).isEqualTo("SENT")
+        // SUPPRESSED / mailer_mocked, not SENT: the %test mailer is the mock (#4737). The subject
+        // here is that an outcome event is emitted at all and carries the correlation id — the
+        // outcome VALUE is incidental to it, and asserting SENT asserted the defect.
+        assertThat(event.path("outcome").asText()).isEqualTo("SUPPRESSED")
+        assertThat(event.path("reason").asText()).isEqualTo(NotificationOutcomeEvent.REASON_MAILER_MOCKED)
         assertThat(event.path("correlationId").asText()).isEqualTo(correlationId.toString())
         assertThat(event.path("notificationId").asText()).isEqualTo(notificationId.toString())
         assertThat(event.path("partyId").asText()).isEqualTo(partyId.toString())
-        assertThat(event.path("reason").isNull).isTrue()
         // The row itself carries the correlation id too, so an operator can join it back without
         // replaying the topic.
         assertThat(correlationIdFor(partyId)).isEqualTo(correlationId)
@@ -350,7 +361,7 @@ class NotificationConsumerIT {
         val rows = outcomeRowsFor(notificationIdFor(partyId)!!)
         assertThat(rows).hasSize(1)
         val event = objectMapper.readTree(rows.single().payload)
-        assertThat(event.path("outcome").asText()).isEqualTo("SENT")
+        assertThat(event.path("outcome").asText()).isEqualTo("SUPPRESSED")
         assertThat(event.path("correlationId").isNull).isTrue()
         assertThat(correlationIdFor(partyId)).isNull()
     }
@@ -485,6 +496,54 @@ class NotificationConsumerIT {
         assertThat(countFor(partyId)).isEqualTo(1)
         assertThat(statusFor(partyId)).isEqualTo("FAILED")
         assertThat(failureReasonFor(partyId)).isEqualTo(NotificationOutcomeEvent.REASON_NO_DEVICE)
+    }
+
+    /**
+     * Issue #4737 — a send through a MOCKED mailer must not read as a delivery.
+     *
+     * The EMAIL twin of the push case below, and the same defect. `quarkus.mailer.mock=true` makes
+     * `ReactiveMailer.send` complete successfully without opening an SMTP connection; the consumer
+     * asked only whether the call threw, so the row committed `SENT` **with `sent_at` populated**
+     * and the outcome event announced a delivery for a message that never left the process. The
+     * deployed sandbox carries `QUARKUS_MAILER_MOCK=true` deliberately (its gitops manifest says
+     * so), which is exactly why the record has to disagree with the configuration.
+     *
+     * `sent_at` is the assertion that matters most: the column means "when did this leave the
+     * process", and a timestamp there is the concrete false claim the old code committed. The
+     * whole `%test` profile runs mocked, so this passes trivially *now* — the falsification lives
+     * in `EmailSendOutcomeTest`, which shows the old predicate computing SENT from the same two
+     * facts. Asserted through the real consumer path rather than on the mapping function alone:
+     * the unit test pins the mapping, this pins that the email leg actually calls it.
+     */
+    @Test
+    fun `EMAIL through a mocked mailer is SUPPRESSED with a null sent_at, never SENT`() {
+        val partyId = UUID.randomUUID()
+        mailbox.clear()
+
+        consumeAndAwait(
+            NotificationRequest(
+                partyId = partyId,
+                channel = NotificationChannel.EMAIL,
+                template = NotificationTemplate.WELCOME,
+                recipient = "mocked-mailer@example.com",
+                variables = mapOf("name" to "Mock"),
+            ),
+        )
+
+        // The message really did reach the mailer — this is not a suppression upstream of the
+        // channel, which is what makes the status below a statement about the MAILER.
+        assertThat(mailbox.getMailMessagesSentTo("mocked-mailer@example.com")).hasSize(1)
+
+        assertThat(statusFor(partyId)).isEqualTo("SUPPRESSED")
+        assertThat(failureReasonFor(partyId)).isEqualTo(NotificationOutcomeEvent.REASON_MAILER_MOCKED)
+        // The core of #4737: no timestamp for a transmission that never happened.
+        assertThat(sentAtFor(partyId)).isNull()
+
+        // ...and the outcome stream says the same thing, so a downstream consumer (campaign's
+        // funnel) cannot count this as delivered either.
+        val event = objectMapper.readTree(outcomeRowsFor(notificationIdFor(partyId)!!).single().payload)
+        assertThat(event.path("outcome").asText()).isEqualTo("SUPPRESSED")
+        assertThat(event.path("reason").asText()).isEqualTo(NotificationOutcomeEvent.REASON_MAILER_MOCKED)
     }
 
     /**


### PR DESCRIPTION
## The finding

The deployed `notification-service` runs with `QUARKUS_MAILER_MOCK=true`. Re-verified read-only against the live deployment for this PR, with a control — **30 env vars returned**, so the probe reached its subject — and there is **no SMTP host or credential env at all**.

**The mock is deliberate.** `openbank-infra/gitops/components/notifications/notification-service.yaml` says so in place:

> `# No SMTP in the sandbox — mock the mailer so dispatch logs instead of opening a dead localhost:1025 connection.`

So the deployment decision stands and this PR does not touch it. What was wrong is that the **record** did not say so.

A mocked `ReactiveMailer.send` completes *successfully* without opening a connection. `deliverEmail` asked only `failure != null`, so the mocked send took the success branch and committed `status = SENT` with `sent_at` populated — and published a `NotificationOutcome` announcing a delivery — for a message that never left the process.

That is the `PushResult.skipped()` defect (ADR-0252 phase 0) on the channel **#4363 is considering re-routing *to***. That one carried `success = true` for a skipped send, counted undelivered pushes as delivered in an environment with no APNs credentials, and was found by a customer rather than by any signal.

Latent today — **0 `EMAIL` rows, ever** — and it stops being latent the moment anything sends.

## The fix: mirror the push channel, do not invent a second shape

| | push (ADR-0252 phase 0) | email (this PR) |
|---|---|---|
| send outcome | `PushSendOutcome.ACCEPTED \| SKIPPED \| FAILED` | `EmailSendOutcome.ACCEPTED \| MOCKED \| FAILED` |
| no-op status | `SUPPRESSED` / `push_adapter_disabled` | `SUPPRESSED` / `mailer_mocked` |
| `sent_at` on a no-op | NULL | NULL |
| counter | `openbank_notification_push_sends_total` | `openbank_notification_email_sends_total` |

`ACCEPTED`, never `delivered`: an SMTP accept is a handoff to a relay, not a receipt from a mailbox — the same reason the push counter is not called `delivered`.

`MOCKED` maps to **SUPPRESSED, not FAILED**, for the reason `pushOutcomeOf` gives: nothing was rejected and nothing is retryable, the channel is switched off. Folding a configuration state into the delivery-failure series would make that series unusable for alerting — the mirror image of the bug being fixed.

`sent_at` staying NULL is the core of it: the column means "when did this leave the process", and a timestamp there is the concrete false claim the old code committed.

## The signal — and why an error rate cannot be it

The alertable state is the **success** state. "The mailer is configured and every send is a mock" raises no exception, logs no error and fails no probe. There is nothing to be absent, so absence-of-errors is not evidence either.

The EMAIL channel previously emitted **no metric at all**, so there was no series to alert on. `EmailMetricsAdapter` adds one, and `prometheus-rules-email.yaml` adds three rules, the first being the one this PR exists for:

```promql
(sum(rate(openbank_notification_email_sends_total{outcome="MOCKED"}[15m])) or vector(0)) > 0
and
(sum(rate(openbank_notification_email_sends_total{outcome="ACCEPTED"}[15m])) or vector(0)) == 0
```

`or vector(0)` on **both** sides is load-bearing, not defensive. Micrometer registers a counter lazily, so an `ACCEPTED` series that has never incremented **does not exist**; `sum(rate(...))` over it returns an empty vector, `== 0` matches nothing, and the `and` yields nothing — the rule would be silent in exactly the case it is written for (a deployment that has never once accepted a real mail). This is the lazy-registration trap the `ScaApprovalPushUndeliverable` comments already document, in its other form: there it defeats `increase()`, here it defeats an `== 0` comparison.

**Why this is not permanent noise in a sandbox that mocks on purpose.** Lazy registration again, working for us: the series does not exist until something actually sends an EMAIL, and nothing does today. So the rule is silent now, and fires the moment anything starts sending into a mock — e.g. if #4363 re-routes device-less push to e-mail. That is precisely the moment this stops being latent, which makes it the right thing to be woken by rather than a standing complaint about a known configuration.

Plus `EmailDeliveryRejected` (a real mailer refusing) and `SecurityEmailNotDelivered` (one undelivered OTP / SCA / password-reset mail is worth waking someone for; one lost marketing mail is not).

## A defect the gate caught in this PR's own code

`mailerMocked` is read via an `@Inject` **primary-constructor** `@ConfigProperty` parameter, not the `@ConfigProperty` + `var x: Boolean = false` **field** shape its neighbours use (`ApnsPushSender.enabled` and 109 other fleet occurrences, all frozen in `configproperty-kotlin-defaults-baseline.txt`).

I wrote the field form first. `configproperty-kotlin-defaults` failed it: a Kotlin default generates a synthetic constructor, ArC builds the bean through it, and the annotation is **never applied** — the flag would have sat at `false` forever, whatever the environment says. This entire fix would have been inert in the one deployment that needs it, silently. Same family as the defect being fixed, and a good argument for that gate.

## Tests — and two that had to change to stay meaningful

`MarketingGateIT` used SENT-vs-SUPPRESSED as its **only** discriminator between an allowed and a denied send. Fixing this makes every case in that class SUPPRESSED, so the status assertion would have kept passing while discriminating nothing — the failure mode this repo has already been bitten by with the fleet's `age > FIFTY_YEARS_SECONDS` liveness assertions. The observable is switched rather than the bound retuned: **`MockMailbox`** records what was actually handed to the mailer, which is the fact the gate decides and is independent of the mock setting. A fourth test pins that status alone can no longer separate these cases.

Four `NotificationConsumerIT` assertions were asserting the defect outright — one carried the comment *"marked SENT (the `%test` profile mocks the mailer, so the email leg succeeds)"*, the bug stated as an expectation. They now assert `SUPPRESSED` / `mailer_mocked`, and the subject of each (the ack, the commit, the OTP redaction, the outcome-event correlation) is unchanged.

`EmailSendOutcomeTest` carries the falsification: it computes the **old** predicate against the same two facts and shows it yields `SENT`, so the new tests cannot pass against the bug. The mocked case is precisely the case a "did it throw?" test cannot see, which is how this survived a green suite for the life of the endpoint.

A new IT, `EMAIL through a mocked mailer is SUPPRESSED with a null sent_at, never SENT`, drives the real consumer path — the unit test pins the mapping, the IT pins that the email leg actually calls it.

## Verification

- `:openbank-notification-service:test` — **165 tests, 0 failures, 0 skipped**. Counts read from the JUnit XML, not the console.
- `ktlintCheck` + `detekt` re-run **separately after** the tests (Gradle stops at the first failing task) and confirmed present in the task list via `--rerun-tasks`.
- `:openbank-notification-service:quarkusBuild` — validates the new CDI wiring and the constructor change; ArC failures surface nowhere else.
- `run-gates.py --all` — 147 gates, **140 pass**. The 6 remaining failures are pre-existing and environmental: each fails identically on a clean `origin/main` worktree at 0.0s cpu (they need a PR base-ref this local run cannot supply). `gen-network-policies-drift-gate` failed only while the new rule file was untracked and passes now that it is committed.
- `check-event-contract-code-agreement.py` (7 contracts agree), `check-event-contract-coverage.py` (no new undocumented topic), `check-critical-alert-egress.py` (severity=critical reaches `slack-alerts`).

## Scope

`openbank-notification-service` is **not** in `rules.yaml: money_path_services` — one approval, no threat model required.

No overlap with **#4692** (merged), which touched `openbank-sca-service` and `openbank-onboarding-service` and no notification file. No open PR touches any file here — the other live `prometheus-rules-*` PRs (#4932, #4411, #4308) are different rule files, and #4129 is a different asyncapi.

The `asyncapi.yaml` change documents `mailer_mocked` in the open-ended `reason` description; `info.version` is unchanged because `reason` is a free-form string with no enum, so nothing about the contract narrows.

This PR does **not** decide #4363. It removes the reason that decision would have been dangerous to take silently.

Closes #4737
Refs #4363
