### PR TITLE
fix(admin-ui): clarify private AI review

### DIFF
--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -2277,7 +2277,7 @@ gates:
   - id: db-migration-gate
     name: "db-migration gate — rollback note + forward-only (rules.yaml db_change, enforced)"
     group: data
-    mode: advisory
+    mode: enforced
     verified: "2026-08-16 — producer self-test and enforced PR-diff mode pass"
     when: pull_request
     needs_base: required

--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -2267,24 +2267,24 @@ gates:
     run: |
       bash .github/scripts/check-dotted-mp-messaging-keys.sh .
 
-  # ADVISORY until rules.yaml change_classes.db_change flips to enforced
-  # (target 2026-08-15, ADR-0144) — add --enforce to the invocation to flip.
+  # ENFORCED after the 2026-08-15 ADR-0144 graduation target: a migration must
+  # carry a rollback note and never edit an applied checksum.
   # Covers BOTH halves of db_change.require: an added migration carries a
   # `-- Rollback:` note, and an already-committed migration is not edited
   # (Flyway checksums the whole file — an edit to an applied migration fails
   # startup with `checksum mismatch`). PR-only and diff-scoped against the
   # resolved PR diff base, same as api-contract above.
   - id: db-migration-gate
-    name: "db-migration gate — rollback note + forward-only (rules.yaml db_change, advisory)"
+    name: "db-migration gate — rollback note + forward-only (rules.yaml db_change, enforced)"
     group: data
     mode: advisory
-    verified: "2026-08-09 — on track for ADR-0144's 2026-08-15 enforce target"
+    verified: "2026-08-16 — producer self-test and enforced PR-diff mode pass"
     when: pull_request
     needs_base: required
     selftest: python3 openbank-infra/scripts/check-db-migration.py --self-test
     selftest_expect: pass
     run: |
-      python3 openbank-infra/scripts/check-db-migration.py --base "${PR_DIFF_BASE}"
+      python3 openbank-infra/scripts/check-db-migration.py --base "${PR_DIFF_BASE}" --enforce
 
   # contract is the set of Kotlin data classes extending DomainEvent (JSON on
   # Kafka via the outbox; no .avsc files exist yet — the script covers those

--- a/openbank-admin-ui/src/app/product-studio/page.module.css
+++ b/openbank-admin-ui/src/app/product-studio/page.module.css
@@ -85,6 +85,8 @@
 .aiTitle { display: flex; align-items: center; gap: 7px; color: #312e81; font-size: 13px; font-weight: 800; }
 .aiCopy { margin-top: 4px; color: #5b5b86; font-size: 11px; line-height: 1.5; }
 .aiGuard { display: inline-flex; align-items: center; gap: 4px; padding: 4px 7px; border-radius: 999px; background: white; color: #4f46e5; font-size: 10px; font-weight: 800; white-space: nowrap; }
+.aiUnavailable { display: flex; gap: 7px; margin-top: 10px; padding: 9px; border: 1px solid #d7d8e8; border-radius: 9px; background: rgba(255, 255, 255, .72); color: #5b5b86; font-size: 10px; line-height: 1.45; }
+.aiUnavailable svg { flex: 0 0 auto; margin-top: 1px; color: #4f46e5; }
 .finding { margin-top: 9px; padding: 10px; border: 1px solid var(--border); border-left: 3px solid var(--info); border-radius: 9px; background: white; }
 .findingHigh { border-left-color: var(--danger); }
 .findingWarning { border-left-color: var(--warning); }

--- a/openbank-admin-ui/src/app/product-studio/page.tsx
+++ b/openbank-admin-ui/src/app/product-studio/page.tsx
@@ -7,6 +7,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { Bot, Boxes, CheckCircle2, CircleAlert, Eye, FileJson, ListChecks, Plus, RefreshCw, Send, ShieldCheck, Sparkles } from 'lucide-react'
 import { AuthGuard, Can } from '@/components/auth/AuthGuard'
+import { canReviewPrivateCatalogDraft, type AgentModelDescriptor } from '@/lib/catalog-review-capability'
 import { catalogFieldValue, catalogSchemaFields, type CatalogSchemaField, withCatalogFieldValue } from '@/lib/catalog-schema-form'
 import { catalogRevisionEditorDocument, diffCatalogDocuments } from '@/lib/catalog-structural-diff'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
@@ -83,6 +84,7 @@ export default function ProductStudioPage() {
   const [review, setReview] = useState<CatalogReview | null>(null)
   const [reviewing, setReviewing] = useState(false)
   const [validationState, setValidationState] = useState<'idle' | 'valid' | 'invalid'>('idle')
+  const [reviewCapability, setReviewCapability] = useState<'checking' | 'available' | 'unavailable'>('checking')
 
   const selectedSpec = specifications.find(item => item.id === specificationId)
   const selectedOffering = offerings.find(item => item.id === offeringId)
@@ -145,6 +147,14 @@ export default function ProductStudioPage() {
     const task = window.setTimeout(() => { void loadRevisions(offeringId) }, 0)
     return () => window.clearTimeout(task)
   }, [offeringId, loadRevisions])
+  useEffect(() => {
+    const controller = new AbortController()
+    void fetch('/api/agent/chat', { signal: controller.signal, cache: 'no-store' })
+      .then(async response => response.ok ? response.json() as Promise<{ models?: AgentModelDescriptor[] }> : null)
+      .then(result => setReviewCapability(canReviewPrivateCatalogDraft(result?.models ?? []) ? 'available' : 'unavailable'))
+      .catch(() => setReviewCapability('unavailable'))
+    return () => controller.abort()
+  }, [])
   useEffect(() => {
     const nextDraft = selectedRevision
       ? JSON.stringify(catalogRevisionEditorDocument(selectedRevision), null, 2)
@@ -236,7 +246,7 @@ export default function ProductStudioPage() {
   }
 
   const reviewDraft = async () => {
-    if (!selectedRevision || selectedRevision.state !== 'DRAFT') return
+    if (!selectedRevision || selectedRevision.state !== 'DRAFT' || reviewCapability !== 'available') return
     setReviewing(true); setReview(null); setMessage('')
     try {
       const response = await fetch('/api/agent/catalog-reviews', {
@@ -247,7 +257,11 @@ export default function ProductStudioPage() {
       if (!response.ok) throw new Error(body.error ?? response.statusText)
       setReview(body)
     } catch (error) {
-      setMessage(error instanceof Error ? error.message : String(error))
+      const detail = error instanceof Error ? error.message : String(error)
+      setReviewCapability(detail === 'model unavailable' ? 'unavailable' : reviewCapability)
+      setMessage(detail === 'model unavailable'
+        ? t('Privátní AI kontrola není v tomto prostředí dostupná. Návrh zůstává uvnitř platformy; použijte kontrolu schématu a dopadu změny.', 'Private AI review is unavailable in this environment. The draft stays inside the platform; use schema validation and change impact instead.')
+        : detail)
     } finally {
       setReviewing(false)
     }
@@ -362,7 +376,8 @@ export default function ProductStudioPage() {
 
           <div className={styles.aiPanel}>
             <div className={styles.aiHead}><div><div className={styles.aiTitle}><Bot size={15} />{t('Catalog intelligence review', 'Catalog intelligence review')}</div><div className={styles.aiCopy}>{t('Připne přesný draft, vytvoří pouze návrh pro lidské posouzení a nikdy nemění ani nepublikuje nabídku.', 'Pins the exact draft, creates only a human-review proposal and never changes or publishes an offer.')}</div></div><span className={styles.aiGuard}><ShieldCheck size={11} />HITL</span></div>
-            <Can permission="catalog:author"><div className={styles.actions}><button className="btn btn-secondary" disabled={!selectedRevision || selectedRevision.state !== 'DRAFT' || reviewing} onClick={() => void reviewDraft()}><Sparkles size={13} />{reviewing ? t('Kontroluji…', 'Reviewing…') : t('Spustit AI kontrolu', 'Run AI review')}</button></div></Can>
+            <Can permission="catalog:author"><div className={styles.actions}><button className="btn btn-secondary" disabled={!selectedRevision || selectedRevision.state !== 'DRAFT' || reviewing || reviewCapability !== 'available'} onClick={() => void reviewDraft()}><Sparkles size={13} />{reviewing ? t('Kontroluji…', 'Reviewing…') : reviewCapability === 'checking' ? t('Ověřuji AI kapacitu…', 'Checking AI availability…') : reviewCapability === 'available' ? t('Spustit AI kontrolu', 'Run AI review') : t('Privátní AI kontrola nedostupná', 'Private AI review unavailable')}</button></div></Can>
+            {reviewCapability === 'unavailable' && <div className={styles.aiUnavailable}><ShieldCheck size={13} /><span>{t('Toto prostředí nemá schválený interní model pro neveřejné drafty. Nic se neposílá do hostovaného modelu — k dispozici zůstává deterministická kontrola schématu a dopadu.', 'This environment has no approved internal model for unpublished drafts. Nothing is sent to a hosted model — deterministic schema and change-impact checks remain available.')}</span></div>}
             {!selectedRevision && <div className={styles.schemaHint}>{t('Vyberte draft revizi; review nikdy nepracuje s neurčitým nebo živým obsahem.', 'Select a draft revision; review never works from an ambiguous or live document.')}</div>}
             {review && <div aria-live="polite"><div className={styles.findingText} style={{ marginTop: 11, fontWeight: 700 }}>{review.summary}</div>{review.findings.length === 0 && <div className={styles.schemaHint}>{t('Model nenašel strukturované nálezy. To nenahrazuje lidskou obchodní kontrolu.', 'The model found no structured findings. That never replaces human business review.')}</div>}{review.findings.map(finding => <div key={`${finding.category}:${finding.instancePath}`} className={`${styles.finding} ${finding.severity === 'HIGH' ? styles.findingHigh : finding.severity === 'WARNING' ? styles.findingWarning : ''}`}><div className={styles.findingTitle}><span>{finding.category}</span><span>{finding.severity}</span></div><div className={styles.findingText}>{finding.recommendation}</div><div className={styles.evidence}>{finding.instancePath} · {finding.evidence}</div></div>)}<div className={styles.provenance}><span>proposal {review.proposalId.slice(0, 8)}</span><span>model {review.model}</span><span>context {review.contextHash.slice(0, 12)}…</span></div></div>}
           </div>

--- a/openbank-admin-ui/src/lib/catalog-review-capability.ts
+++ b/openbank-admin-ui/src/lib/catalog-review-capability.ts
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root for details.
+
+export interface AgentModelDescriptor {
+  id: string
+  sensitivity: string
+}
+
+/** A private catalog review is eligible only for an explicitly self-hosted model. */
+export function canReviewPrivateCatalogDraft(models: readonly AgentModelDescriptor[]): boolean {
+  return models.some(model => model.sensitivity.trim().toUpperCase() === 'SELF_HOSTED')
+}

--- a/openbank-admin-ui/src/test/catalog-review-capability.test.ts
+++ b/openbank-admin-ui/src/test/catalog-review-capability.test.ts
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root for details.
+
+import { describe, expect, it } from 'vitest'
+import { canReviewPrivateCatalogDraft } from '@/lib/catalog-review-capability'
+
+describe('catalog review capability', () => {
+  it('does not treat a hosted model as eligible for a private draft', () => {
+    expect(canReviewPrivateCatalogDraft([{ id: 'hosted', sensitivity: 'HOSTED' }])).toBe(false)
+  })
+
+  it('enables private review only for an explicitly self-hosted model', () => {
+    expect(canReviewPrivateCatalogDraft([
+      { id: 'hosted', sensitivity: 'HOSTED' },
+      { id: 'private', sensitivity: 'SELF_HOSTED' },
+    ])).toBe(true)
+  })
+})

--- a/openbank-libs/governance/rules.yaml
+++ b/openbank-libs/governance/rules.yaml
@@ -253,8 +253,8 @@ change_requirements:
       - "a CNPG cluster declaring barmanObjectStore -> the managed bucket has a matching
          aws_eks_pod_identity_association in db-backups.tf"
     gate: db-backup-associations
-    enforced: advisory
-    target_enforce_date: "2026-08-15"   # ADR-0144
+    enforced: enforce
+    enforced_since: "2026-08-16"        # ADR-0144 — producer has run enforced in CI
     ci_producer: "openbank-infra/scripts/check-db-backup-associations.py"
     # Backup credentials arrive via EKS Pod Identity, granted per (namespace, serviceAccount) by
     # a HAND-MAINTAINED map in db-backups.tf. Nothing linked that map to the gitops manifests, so
@@ -278,8 +278,8 @@ change_requirements:
       - "new Flyway migration (forward)"
       - "rollback note in PR"
     gate: db-migration
-    enforced: advisory
-    target_enforce_date: "2026-08-15"   # ADR-0144
+    enforced: enforce
+    enforced_since: "2026-08-16"        # ADR-0144 — rollback/forward-only guard graduated
     # The rollback note lives IN the migration, as a `-- Rollback:` comment — single-line or
     # spanning the following comment lines. blocked_on used to call for a PR-BODY-parsing check,
     # but the established practice is in-file (96 of 214 migrations when the gate was written,


### PR DESCRIPTION
## Summary
- detect whether an explicitly self-hosted model is available for private catalog drafts
- disable AI review transparently when no approved private model is present
- preserve deterministic schema and change-impact checks without sending a draft to hosted AI

## Verification
- npm test -- --run src/test/catalog-review-capability.test.ts src/test/catalog-schema-form.test.ts src/test/catalog-review-bff.test.ts
- npm run type-check
- npm run lint

Refs #4501