### PR TITLE
feat(admin-ui): unify compliance workspaces

### DIFF
--- a/openbank-admin-ui/src/app/disputes/page.tsx
+++ b/openbank-admin-ui/src/app/disputes/page.tsx
@@ -11,6 +11,7 @@ import { svcUrl } from '@/lib/services/bff'
 import { useServiceResource } from '@/lib/services/useServiceResource'
 import { DataUnavailable } from '@/components/feedback/DataUnavailable'
 import { ServiceStatusBadge } from '@/components/feedback/ServiceStatusBadge'
+import { PageHeader, StatCard, StatusBadge, type Tone } from '@/components/ui'
 
 interface Dispute {
   id: string; referenceNumber: string; disputeType: string; status: string
@@ -37,13 +38,6 @@ export default function DisputesPage() {
   const resolved = disputes.filter(d => ['RESOLVED', 'CLOSED', 'CHARGEBACK_ISSUED'].includes(d.status))
   const slaBreached = disputes.filter(d => d.slaDeadline && new Date(d.slaDeadline) < new Date() && !['RESOLVED', 'CLOSED'].includes(d.status))
 
-  const statusBadgeClass = (s: string) => {
-    if (['RESOLVED', 'CLOSED'].includes(s)) return 'badge badge-success'
-    if (['CHARGEBACK_ISSUED'].includes(s)) return 'badge badge-warning'
-    if (['REJECTED'].includes(s)) return 'badge badge-danger'
-    return 'badge badge-info'
-  }
-
   const slaStatus = (deadline: string, status: string) => {
     if (['RESOLVED', 'CLOSED'].includes(status)) return null
     if (!deadline) return null
@@ -58,16 +52,11 @@ export default function DisputesPage() {
   return (
     <AuthGuard permission="compliance:view">
       <div style={{ padding: '28px 32px', maxWidth: '1400px', animation: 'fadeIn 0.2s ease-out' }}>
-        <div className="page-header" style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between' }}>
-          <div>
-            <h1 className="page-title">
-              {t('Reklamace & Spory', 'Disputes & Complaints')}
-            </h1>
-            <p className="page-subtitle">
-              {t('Správa sporů — chargeback · SLA 45 dní · PSD2 čl. 73', 'Dispute management — chargeback · SLA 45 days · PSD2 Art. 73')}
-            </p>
-          </div>
-          <ServiceStatusBadge
+        <PageHeader
+          title={t('Reklamace & Spory', 'Disputes & Complaints')}
+          subtitle={t('Správa sporů — chargeback · SLA 45 dní · PSD2 čl. 73', 'Dispute management — chargeback · SLA 45 days · PSD2 Art. 73')}
+          icon={<MessageSquareWarning size={18} aria-hidden="true" />}
+          actions={<ServiceStatusBadge
             label="dispute-service :8135"
             loading={loading}
             waking={waking}
@@ -78,8 +67,8 @@ export default function DisputesPage() {
               down: t('dispute-service neodpovídá', 'dispute-service is not responding'),
               checking: t('Zjišťuji stav služby…', 'Checking service…'),
             }}
-          />
-        </div>
+          />}
+        />
 
         {slaBreached.length > 0 && (
           <div style={{ marginBottom: '20px', padding: '12px 16px', borderRadius: '8px',
@@ -94,17 +83,12 @@ export default function DisputesPage() {
 
         <div className="grid-4" style={{ marginBottom: '24px' }}>
           {[
-            { label: t('Spory celkem', 'Total disputes'), value: disputes.length, icon: <MessageSquareWarning size={16} />, color: 'var(--accent)' },
-            { label: t('Otevřené', 'Open'), value: open.length, icon: <Clock size={16} />, color: 'var(--warning)' },
-            { label: t('Vyřešené', 'Resolved'), value: resolved.length, icon: <CheckCircle2 size={16} />, color: 'var(--success)' },
-            { label: t('SLA porušení', 'SLA breaches'), value: slaBreached.length, icon: <Timer size={16} />, color: 'var(--danger)' },
+            { label: t('Spory celkem', 'Total disputes'), value: disputes.length, icon: <MessageSquareWarning size={16} />, tone: undefined },
+            { label: t('Otevřené', 'Open'), value: open.length, icon: <Clock size={16} />, tone: 'warning' },
+            { label: t('Vyřešené', 'Resolved'), value: resolved.length, icon: <CheckCircle2 size={16} />, tone: 'success' },
+            { label: t('SLA porušení', 'SLA breaches'), value: slaBreached.length, icon: <Timer size={16} />, tone: 'danger' },
           ].map(k => (
-            <div key={k.label} className="stat-card">
-              <div style={{ width: '32px', height: '32px', borderRadius: '8px', background: `${k.color}18`,
-                display: 'flex', alignItems: 'center', justifyContent: 'center', color: k.color, marginBottom: '10px' }}>{k.icon}</div>
-              <div style={{ fontSize: '28px', fontWeight: 800, color: 'var(--text-primary)', letterSpacing: '-0.03em' }}>{k.value}</div>
-              <div style={{ fontSize: '12px', color: 'var(--text-secondary)', fontWeight: 500 }}>{k.label}</div>
-            </div>
+            <StatCard key={k.label} label={k.label} value={k.value} icon={k.icon} tone={k.tone as Tone | undefined} />
           ))}
         </div>
 
@@ -143,7 +127,7 @@ export default function DisputesPage() {
                       {(d.amount ?? 0).toLocaleString('cs-CZ', { minimumFractionDigits: 2 })} {d.currency}
                     </td>
                     <td>
-                      <span className={statusBadgeClass(d.status)}>{d.status}</span>
+                      <StatusBadge status={d.status} />
                     </td>
                     <td>{slaStatus(d.slaDeadline, d.status)}</td>
                     <td style={{ color: 'var(--text-tertiary)' }}>{d.createdAt ? new Date(d.createdAt).toLocaleString('cs-CZ') : '—'}</td>

--- a/openbank-admin-ui/src/app/onboarding/page.tsx
+++ b/openbank-admin-ui/src/app/onboarding/page.tsx
@@ -10,6 +10,7 @@ import { classifyBffFailure, svcUrl } from '@/lib/services/bff'
 import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
 import { ClipboardList, RefreshCw, ChevronRight, X, TrendingUp } from 'lucide-react'
 import Link from 'next/link'
+import { PageHeader } from '@/components/ui'
 
 const SVC = 'onboarding-service'
 
@@ -159,22 +160,12 @@ export default function OnboardingPage() {
 
   return (
     <div>
-      {/* Page header */}
-      <div className="page-header">
-        <div>
-          <div className="breadcrumb">
-            <span>OpenBank</span><span className="breadcrumb-sep">/</span>
-            <span className="breadcrumb-current">{t('Onboarding', 'Onboarding')}</span>
-          </div>
-          <h1 className="page-title" style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-            <ClipboardList size={18} style={{ color: 'var(--accent)' }} />
-            {t('Onboarding cockpit', 'Onboarding Cockpit')}
-          </h1>
-          <p className="page-subtitle">
-            {t('Přehled průběhu onboardingu zákazníků — fáze po fázi', 'Customer onboarding funnel — stage by stage')}
-          </p>
-        </div>
-        <div style={{ display: 'flex', gap: '8px' }}>
+      <PageHeader
+        title={t('Onboarding cockpit', 'Onboarding Cockpit')}
+        subtitle={t('Přehled průběhu onboardingu zákazníků — fáze po fázi', 'Customer onboarding funnel — stage by stage')}
+        icon={<ClipboardList size={18} aria-hidden="true" />}
+        breadcrumb={<div className="breadcrumb"><span>OpenBank</span><span className="breadcrumb-sep">/</span><span className="breadcrumb-current">{t('Onboarding', 'Onboarding')}</span></div>}
+        actions={<div style={{ display: 'flex', gap: '8px' }}>
           <Link href="/onboarding/analytics" className="btn btn-secondary" style={{ textDecoration: 'none' }}>
             <TrendingUp size={13} style={{ color: 'var(--accent)' }} />
             {t('Konverze', 'Conversion')}
@@ -183,8 +174,8 @@ export default function OnboardingPage() {
             <RefreshCw size={13} style={{ animation: loading ? 'spin 1s linear infinite' : 'none' }} />
             {t('Obnovit', 'Refresh')}
           </button>
-        </div>
-      </div>
+        </div>}
+      />
 
       {/* KPI funnel tiles */}
       {countsUnavail ? (

--- a/openbank-admin-ui/src/app/sanctions/page.tsx
+++ b/openbank-admin-ui/src/app/sanctions/page.tsx
@@ -14,6 +14,7 @@ import { classifyBffFailure } from '@/lib/services/bff'
 import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
 import { ServiceStatusBadge } from '@/components/feedback/ServiceStatusBadge'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
+import { PageHeader, StatCard, type Tone } from '@/components/ui'
 
 interface SanctionCheck {
   id: string; name: string; entityType: string; status: string
@@ -480,16 +481,11 @@ export default function SanctionsPage() {
   return (
     <AuthGuard permission="compliance:view">
       <div style={{ padding: '28px 32px', maxWidth: '1400px', animation: 'fadeIn 0.2s ease-out' }}>
-        <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', marginBottom: '24px' }}>
-          <div>
-            <h1 style={{ fontSize: '24px', fontWeight: 800, color: 'var(--text-primary)', letterSpacing: '-0.03em', marginBottom: '4px' }}>
-              {t('Prověření sankcí', 'Sanctions Screening')}
-            </h1>
-            <p style={{ fontSize: '13px', color: 'var(--text-secondary)' }}>
-              {t('OFAC SDN · EU Consolidated · UN · HM Treasury · PEP · ČNB', 'OFAC SDN · EU Consolidated · UN · HM Treasury · PEP · ČNB')}
-            </p>
-          </div>
-          <ServiceStatusBadge
+        <PageHeader
+          title={t('Prověření sankcí', 'Sanctions Screening')}
+          subtitle={t('OFAC SDN · EU Consolidated · UN · HM Treasury · PEP · ČNB', 'OFAC SDN · EU Consolidated · UN · HM Treasury · PEP · ČNB')}
+          icon={<ShieldAlert size={18} aria-hidden="true" />}
+          actions={<ServiceStatusBadge
             label="sanctions-service :8123"
             loading={loading}
             unavailable={checksUnavail}
@@ -499,8 +495,8 @@ export default function SanctionsPage() {
               down: t('sanctions-service neodpovídá', 'sanctions-service is not responding'),
               checking: t('Zjišťuji stav služby…', 'Checking service…'),
             }}
-          />
-        </div>
+          />}
+        />
 
         {hits.length > 0 && (
           <div style={{ marginBottom: '20px', padding: '12px 16px', borderRadius: '8px',
@@ -515,17 +511,12 @@ export default function SanctionsPage() {
 
         <div className="grid-4" style={{ marginBottom: '24px' }}>
           {[
-            { label: t('Kontrol celkem', 'Total Checks'), value: checks.length, icon: <ShieldAlert size={16} />, color: 'var(--accent)' },
-            { label: t('Shody (HIT)', 'Matches (HIT)'), value: hits.length, icon: <AlertTriangle size={16} />, color: 'var(--danger)' },
-            { label: t('Čisté', 'Clear'), value: clear.length, icon: <CheckCircle2 size={16} />, color: 'var(--success)' },
-            { label: t('Čeká na review', 'Pending Review'), value: pending.length, icon: <Clock size={16} />, color: 'var(--warning)' },
+            { label: t('Kontrol celkem', 'Total Checks'), value: checks.length, icon: <ShieldAlert size={16} />, tone: undefined },
+            { label: t('Shody (HIT)', 'Matches (HIT)'), value: hits.length, icon: <AlertTriangle size={16} />, tone: 'danger' },
+            { label: t('Čisté', 'Clear'), value: clear.length, icon: <CheckCircle2 size={16} />, tone: 'success' },
+            { label: t('Čeká na review', 'Pending Review'), value: pending.length, icon: <Clock size={16} />, tone: 'warning' },
           ].map(k => (
-            <div key={k.label} className="stat-card">
-              <div style={{ width: '32px', height: '32px', borderRadius: '8px', background: `${k.color}18`,
-                display: 'flex', alignItems: 'center', justifyContent: 'center', color: k.color, marginBottom: '10px' }}>{k.icon}</div>
-              <div style={{ fontSize: '28px', fontWeight: 800, color: 'var(--text-primary)', letterSpacing: '-0.03em' }}>{k.value}</div>
-              <div style={{ fontSize: '12px', color: 'var(--text-secondary)', fontWeight: 500 }}>{k.label}</div>
-            </div>
+            <StatCard key={k.label} label={k.label} value={k.value} icon={k.icon} tone={k.tone as Tone | undefined} />
           ))}
         </div>
 


### PR DESCRIPTION
## What changed

- Moves Disputes, Sanctions and Onboarding onto the shared PageHeader.
- Reuses shared StatCard for compliance summaries.
- Reuses the central status vocabulary on disputes.

## Safety

No API URL, request body, approval header, four-eyes decision, filter or mutation handler changes.

## Validation

- 137 targeted tests passed, including render smoke and sanctions BFF four-eyes coverage.
- TypeScript type-check passed.

## Linked issues

N/A — presentation consolidation of existing compliance workflows; no independent backlog item is created.