### PR TITLE
fix(infra): stop three recurring alert false positives and bound the build cache

### DIFF
--- a/openbank-infra/gitops/apps/kyverno.yaml
+++ b/openbank-infra/gitops/apps/kyverno.yaml
@@ -83,24 +83,36 @@ spec:
         # values — nesting cleanupJobs under cleanupController silently no-ops it.
         # Follow-up: bitnamilegacy is a frozen archive; move to a self-hosted
         # kubectl+shell image in ECR for a maintained long-term base.
+        # ttlSecondsAfterFinished (chart value, per cleanup job) — a finished Job object
+        # self-deletes after 48h. failedJobsHistoryLimit alone does NOT clear a tombstone:
+        # it caps how many failed Jobs are kept, so the LAST failure survives forever even
+        # after every later run succeeded, and KubeJobFailed keeps firing on that dead
+        # object. Measured 2026-08-16: 9 of 25 firing alerts were KubeJobFailed and 7 were
+        # stale this way, two of them these kyverno cleanup jobs (which run every 5-10 min,
+        # so the surviving tombstone was hours behind a long line of successes).
         cleanupJobs:
           admissionReports:
+            ttlSecondsAfterFinished: 172800
             image:
               repository: docker.io/bitnamilegacy/kubectl
               tag: 1.28.5
           clusterAdmissionReports:
+            ttlSecondsAfterFinished: 172800
             image:
               repository: docker.io/bitnamilegacy/kubectl
               tag: 1.28.5
           ephemeralReports:
+            ttlSecondsAfterFinished: 172800
             image:
               repository: docker.io/bitnamilegacy/kubectl
               tag: 1.28.5
           clusterEphemeralReports:
+            ttlSecondsAfterFinished: 172800
             image:
               repository: docker.io/bitnamilegacy/kubectl
               tag: 1.28.5
           updateRequests:
+            ttlSecondsAfterFinished: 172800
             image:
               repository: docker.io/bitnamilegacy/kubectl
               tag: 1.28.5

--- a/openbank-infra/gitops/components/admin-ui/cost-collector.yaml
+++ b/openbank-infra/gitops/components/admin-ui/cost-collector.yaml
@@ -89,6 +89,9 @@ spec:
   startingDeadlineSeconds: 600
   jobTemplate:
     spec:
+      # 48h self-delete so a failed Job cannot become a permanent KubeJobFailed tombstone;
+      # rationale in openbank-infra/gitops/components/observability/cronjob-rum-attribute-audit.yaml.
+      ttlSecondsAfterFinished: 172800
       backoffLimit: 2
       activeDeadlineSeconds: 300
       template:

--- a/openbank-infra/gitops/components/admin-ui/tier-classifier.yaml
+++ b/openbank-infra/gitops/components/admin-ui/tier-classifier.yaml
@@ -84,6 +84,9 @@ spec:
   startingDeadlineSeconds: 600
   jobTemplate:
     spec:
+      # 48h self-delete so a failed Job cannot become a permanent KubeJobFailed tombstone;
+      # rationale in openbank-infra/gitops/components/observability/cronjob-rum-attribute-audit.yaml.
+      ttlSecondsAfterFinished: 172800
       activeDeadlineSeconds: 900
       backoffLimit: 1
       template:

--- a/openbank-infra/gitops/components/analytics/cronjob-gate-health-puller.yaml
+++ b/openbank-infra/gitops/components/analytics/cronjob-gate-health-puller.yaml
@@ -29,6 +29,9 @@ spec:
   failedJobsHistoryLimit: 1
   jobTemplate:
     spec:
+      # 48h self-delete so a failed Job cannot become a permanent KubeJobFailed tombstone;
+      # rationale in openbank-infra/gitops/components/observability/cronjob-rum-attribute-audit.yaml.
+      ttlSecondsAfterFinished: 172800
       activeDeadlineSeconds: 300
       template:
         metadata:

--- a/openbank-infra/gitops/components/finops-scaledown/cronjob-scale-down.yaml
+++ b/openbank-infra/gitops/components/finops-scaledown/cronjob-scale-down.yaml
@@ -49,6 +49,9 @@ spec:
   failedJobsHistoryLimit: 1
   jobTemplate:
     spec:
+      # 48h self-delete so a failed Job cannot become a permanent KubeJobFailed tombstone;
+      # rationale in openbank-infra/gitops/components/observability/cronjob-rum-attribute-audit.yaml.
+      ttlSecondsAfterFinished: 172800
       activeDeadlineSeconds: 600
       template:
         metadata:

--- a/openbank-infra/gitops/components/finops-scaledown/cronjob-scale-up.yaml
+++ b/openbank-infra/gitops/components/finops-scaledown/cronjob-scale-up.yaml
@@ -44,6 +44,9 @@ spec:
   failedJobsHistoryLimit: 1
   jobTemplate:
     spec:
+      # 48h self-delete so a failed Job cannot become a permanent KubeJobFailed tombstone;
+      # rationale in openbank-infra/gitops/components/observability/cronjob-rum-attribute-audit.yaml.
+      ttlSecondsAfterFinished: 172800
       activeDeadlineSeconds: 600
       template:
         metadata:

--- a/openbank-infra/gitops/components/gradle-build-cache/gradle-build-cache.yaml
+++ b/openbank-infra/gitops/components/gradle-build-cache/gradle-build-cache.yaml
@@ -181,11 +181,46 @@ spec:
           command: ["/bin/sh", "-c"]
           args:
             - |
+              # HIGH-WATER MARK (added 2026-08-16). The 14d age pass alone does not bound
+              # the disk: it deletes whatever happens to be old, and says nothing about how
+              # much is left. Measured 2026-08-16 the PVC was 100% full with /data/cache at
+              # 48.9G of 50Gi, KubePersistentVolumeFillingUp had been critical for two days,
+              # and the sidecar's own log showed the failure in plain sight — ten consecutive
+              # passes reading "removed 33/11/5/25/20/38/54/43 entries older than 14d,
+              # 50073MB -> 50073MB". It was deleting real files every time and the total never
+              # moved, because inflow over six hours matched whatever aged out. An age policy
+              # is a retention policy, not a capacity policy, and only the second one can keep
+              # a fixed-size volume from filling.
+              #
+              # So: keep the 14d pass as the normal steady state, then walk the age threshold
+              # DOWN (10, 7, 5, 3, 2, 1 days) until usage is under the high-water mark. Oldest
+              # entries still go first, which is the same ordering the age pass already used —
+              # this only makes the cut-off adaptive instead of fixed. `df` on the mount, not
+              # `du` on the tree, is what the alert reads and what actually runs out.
+              #
+              # BusyBox `find` has no -printf and Alpine has no GNU sort -z, so a true
+              # oldest-first walk is not available here; the descending-threshold loop is the
+              # portable equivalent and needs no extra tooling in the image.
+              HIGH_WATER=80   # percent used; evict down to this
               while true; do
                 before=$(du -sm /data/cache 2>/dev/null | cut -f1)
                 deleted=$(find /data/cache -type f -mtime +14 -delete -print 2>/dev/null | wc -l)
+                used=$(df -P /data/cache | awk 'NR==2 {print $5+0}')
+                extra=0
+                for days in 10 7 5 3 2 1; do
+                  [ "${used}" -le "${HIGH_WATER}" ] && break
+                  n=$(find /data/cache -type f -mtime +${days} -delete -print 2>/dev/null | wc -l)
+                  extra=$(( extra + n ))
+                  used=$(df -P /data/cache | awk 'NR==2 {print $5+0}')
+                  echo "evictor: high-water pass at ${days}d removed ${n}, now ${used}% used"
+                done
                 after=$(du -sm /data/cache 2>/dev/null | cut -f1)
-                echo "evictor: removed ${deleted} entries older than 14d, ${before}MB -> ${after}MB"
+                echo "evictor: removed ${deleted} entries older than 14d (+${extra} by high-water), ${before}MB -> ${after}MB, ${used}% used"
+                # Above the mark with nothing left older than a day means inflow alone fills
+                # the volume — eviction cannot fix that and the PVC genuinely needs to grow.
+                if [ "${used}" -gt "${HIGH_WATER}" ]; then
+                  echo "evictor: WARNING still ${used}% used after evicting everything older than 1d — the 50Gi PVC is undersized for current inflow, not merely unswept"
+                fi
                 sleep 21600
               done
           volumeMounts:

--- a/openbank-infra/gitops/components/infra-vuln-scanner/infra-vuln-scanner.yaml
+++ b/openbank-infra/gitops/components/infra-vuln-scanner/infra-vuln-scanner.yaml
@@ -241,6 +241,9 @@ spec:
   startingDeadlineSeconds: 600
   jobTemplate:
     spec:
+      # 48h self-delete so a failed Job cannot become a permanent KubeJobFailed tombstone;
+      # rationale in openbank-infra/gitops/components/observability/cronjob-rum-attribute-audit.yaml.
+      ttlSecondsAfterFinished: 172800
       # Grype scans can take several minutes per image if the vuln DB needs
       # refreshing. Allow up to 30 min total; fail cleanly rather than hang.
       activeDeadlineSeconds: 1800

--- a/openbank-infra/gitops/components/keycloak-realm-drift/keycloak-realm-drift.yaml
+++ b/openbank-infra/gitops/components/keycloak-realm-drift/keycloak-realm-drift.yaml
@@ -139,6 +139,9 @@ spec:
   startingDeadlineSeconds: 600
   jobTemplate:
     spec:
+      # 48h self-delete so a failed Job cannot become a permanent KubeJobFailed tombstone;
+      # rationale in openbank-infra/gitops/components/observability/cronjob-rum-attribute-audit.yaml.
+      ttlSecondsAfterFinished: 172800
       activeDeadlineSeconds: 600
       backoffLimit: 1
       template:

--- a/openbank-infra/gitops/components/observability/cronjob-journey-public-edge.yaml
+++ b/openbank-infra/gitops/components/observability/cronjob-journey-public-edge.yaml
@@ -116,6 +116,9 @@ spec:
   failedJobsHistoryLimit: 1
   jobTemplate:
     spec:
+      # 48h self-delete so a failed Job cannot become a permanent KubeJobFailed tombstone;
+      # rationale in openbank-infra/gitops/components/observability/cronjob-rum-attribute-audit.yaml.
+      ttlSecondsAfterFinished: 172800
       activeDeadlineSeconds: 240
       # No retry: a synthetic monitor that retries until it passes is measuring its own
       # persistence, not the platform's availability.

--- a/openbank-infra/gitops/components/observability/cronjob-rum-attribute-audit.yaml
+++ b/openbank-infra/gitops/components/observability/cronjob-rum-attribute-audit.yaml
@@ -38,6 +38,14 @@ spec:
   failedJobsHistoryLimit: 1
   jobTemplate:
     spec:
+      # ttlSecondsAfterFinished — a finished Job object self-deletes after 48h.
+      # failedJobsHistoryLimit alone does NOT clear a tombstone: it caps how many failed Jobs
+      # are kept, so the LAST failure survives forever even after every later run succeeded,
+      # and kube-prometheus-stack's KubeJobFailed keeps firing on that dead object. Measured
+      # 2026-08-16: 9 of 25 firing alerts were KubeJobFailed and 7 were stale this way — the
+      # oldest a rum-attribute-audit failure from 35 days earlier with 4 successes since.
+      # 48h keeps a real failure visible for a working day plus slack, then it clears itself.
+      ttlSecondsAfterFinished: 172800
       activeDeadlineSeconds: 600
       template:
         metadata:
@@ -92,8 +100,29 @@ spec:
                     # so a legitimately-empty attribute counts as 0 instead of aborting.
                     count=$(echo "$result" | { grep -o '"value"' || true; } | wc -l | tr -d ' ')
                     echo "{\"event\":\"rum-attribute-audit\",\"attribute\":\"${attr}\",\"unique_value_count\":${count},\"sample\":$(echo "$result" | head -c 512)}"
+                    case "$attr" in
+                      app.version|device.model|screen.name) MOBILE_TOTAL=$(( ${MOBILE_TOTAL:-0} + count )) ;;
+                    esac
                   done
-                  echo "{\"event\":\"rum-attribute-audit-done\"}"
+                  # RUM-INGEST LIVENESS (added 2026-08-16). The audit above is a cardinality
+                  # and PII allow-list check, and it answers exactly the same way for "the
+                  # allow-list holds" and "no RUM ever arrived" — zero values on every mobile
+                  # attribute reads as a clean run. Measured over a 168h window on 2026-08-16:
+                  # app.version, device.model, screen.name and x-correlation-id each had 0
+                  # unique values, os.type held only "linux" (server pods, no ios/android),
+                  # rum-gateway was exporting nothing but its own otelcol self-metrics, and
+                  # Prometheus held 0 `rum_*` series — yet this job had exited 0 on every run
+                  # since it was written. app.version, device.model and screen.name are emitted
+                  # ONLY by the mobile SDK, so their combined count is a direct measure of
+                  # whether the mobile pipeline delivered anything at all. Fail on zero: the
+                  # ttlSecondsAfterFinished above means the resulting KubeJobFailed clears
+                  # itself once ingest recovers, so this cannot become a permanent tombstone.
+                  if [ "${MOBILE_TOTAL:-0}" -eq 0 ]; then
+                    echo "{\"event\":\"rum-mobile-signal-absent\",\"lookback\":\"${LOOKBACK}\",\"detail\":\"app.version, device.model and screen.name all had 0 unique values — no mobile RUM reached Tempo in the window. Check the rum-gateway ingress, the app SDK exporter endpoint, and whether any build shipping the SDK is live.\"}"
+                    echo "{\"event\":\"rum-attribute-audit-done\",\"result\":\"fail\"}"
+                    exit 1
+                  fi
+                  echo "{\"event\":\"rum-attribute-audit-done\",\"result\":\"ok\"}"
               resources:
                 requests:
                   cpu: 10m

--- a/openbank-infra/gitops/components/observability/prometheus-rules-finops.yaml
+++ b/openbank-infra/gitops/components/observability/prometheus-rules-finops.yaml
@@ -54,16 +54,36 @@ spec:
         # Catches fast-rising namespaces even below the absolute threshold.
         # Uses a subquery for the baseline so we avoid the rate([7d]) long-window
         # anti-pattern (Prometheus rate() is designed for short windows).
+        #
+        # ABSOLUTE FLOOR (added 2026-08-16). A pure ratio has no scale, and the `+ 1`
+        # in the denominator makes a near-idle namespace trivially exceed 2x: a
+        # namespace averaging a few hundred B/s crosses the threshold the moment a
+        # CronJob pulls one container image. Measured on 4 simultaneously firing
+        # instances — release-steward, docs-truth-agent, authz-policy-auditor,
+        # finops-agent, all agent namespaces that are idle between scheduled runs —
+        # the "spike" rates were 17.6, 16.8, 18.4 and 32.9 KB/s. At 32.9 KB/s a
+        # namespace moves 2.8 GB/day, ~$0.12 in NAT egress; the alert exists to catch
+        # a 50 GB/day-class runaway, so those four carried no cost signal at all and
+        # were 4 of the 25 firing alerts. 1 MB/s (~86 GB/day, ~$3.70/day) is the floor
+        # below which a doubling cannot matter: it is above the D1 absolute alert's own
+        # 50 GB/day trigger point in rate terms, so D1b now only fires EARLY on
+        # something D1 would eventually catch — which is exactly its stated job.
         - alert: FinOpsNatEgressSpikeRelative
           expr: |
             (
-              sum by (namespace) (rate(container_network_transmit_bytes_total[5m]))
-            ) /
+              (
+                sum by (namespace) (rate(container_network_transmit_bytes_total[5m]))
+              ) /
+              (
+                avg_over_time(
+                  sum by (namespace) (rate(container_network_transmit_bytes_total[5m]))[7d:5m]
+                ) + 1
+              ) > 2
+            )
+            and
             (
-              avg_over_time(
-                sum by (namespace) (rate(container_network_transmit_bytes_total[5m]))[7d:5m]
-              ) + 1
-            ) > 2
+              sum by (namespace) (rate(container_network_transmit_bytes_total[5m])) > 1048576
+            )
           for: 20m
           labels:
             severity: warning

--- a/openbank-infra/gitops/components/openbao/db-rotation-job.yaml
+++ b/openbank-infra/gitops/components/openbao/db-rotation-job.yaml
@@ -48,6 +48,9 @@ spec:
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:
+      # 48h self-delete so a failed Job cannot become a permanent KubeJobFailed tombstone;
+      # rationale in openbank-infra/gitops/components/observability/cronjob-rum-attribute-audit.yaml.
+      ttlSecondsAfterFinished: 172800
       # Retry up to 2 times on transient OpenBao unavailability; alert on final failure.
       backoffLimit: 2
       # Hard deadline: if the script hasn't finished in 10 minutes something is wrong.

--- a/openbank-infra/gitops/components/openbao/openbao-agent-identity.yaml
+++ b/openbank-infra/gitops/components/openbao/openbao-agent-identity.yaml
@@ -143,6 +143,9 @@ spec:
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:
+      # 48h self-delete so a failed Job cannot become a permanent KubeJobFailed tombstone;
+      # rationale in openbank-infra/gitops/components/observability/cronjob-rum-attribute-audit.yaml.
+      ttlSecondsAfterFinished: 172800
       backoffLimit: 2
       activeDeadlineSeconds: 600
       template:

--- a/openbank-infra/gitops/components/openbao/openbao-document-signing-pki.yaml
+++ b/openbank-infra/gitops/components/openbao/openbao-document-signing-pki.yaml
@@ -138,6 +138,9 @@ spec:
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:
+      # 48h self-delete so a failed Job cannot become a permanent KubeJobFailed tombstone;
+      # rationale in openbank-infra/gitops/components/observability/cronjob-rum-attribute-audit.yaml.
+      ttlSecondsAfterFinished: 172800
       backoffLimit: 2
       activeDeadlineSeconds: 600
       template:

--- a/openbank-infra/gitops/components/openbao/secret-rotator-cronjob.yaml
+++ b/openbank-infra/gitops/components/openbao/secret-rotator-cronjob.yaml
@@ -200,6 +200,9 @@ spec:
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:
+      # 48h self-delete so a failed Job cannot become a permanent KubeJobFailed tombstone;
+      # rationale in openbank-infra/gitops/components/observability/cronjob-rum-attribute-audit.yaml.
+      ttlSecondsAfterFinished: 172800
       backoffLimit: 2
       # Hard deadline: 15 minutes covers full fleet rotation with KC API latency.
       activeDeadlineSeconds: 900

--- a/openbank-infra/gitops/components/sbom-drift-scanner/sbom-drift-scanner.yaml
+++ b/openbank-infra/gitops/components/sbom-drift-scanner/sbom-drift-scanner.yaml
@@ -394,6 +394,9 @@ spec:
   startingDeadlineSeconds: 600
   jobTemplate:
     spec:
+      # 48h self-delete so a failed Job cannot become a permanent KubeJobFailed tombstone;
+      # rationale in openbank-infra/gitops/components/observability/cronjob-rum-attribute-audit.yaml.
+      ttlSecondsAfterFinished: 172800
       activeDeadlineSeconds: 600
       backoffLimit: 1
       template:

--- a/openbank-infra/gitops/components/temporal/temporal-namespace-reconcile.yaml
+++ b/openbank-infra/gitops/components/temporal/temporal-namespace-reconcile.yaml
@@ -58,6 +58,9 @@ spec:
   startingDeadlineSeconds: 600
   jobTemplate:
     spec:
+      # 48h self-delete so a failed Job cannot become a permanent KubeJobFailed tombstone;
+      # rationale in openbank-infra/gitops/components/observability/cronjob-rum-attribute-audit.yaml.
+      ttlSecondsAfterFinished: 172800
       # The wait loop is 60 × 5s; allow one pass plus registration headroom.
       activeDeadlineSeconds: 600
       # No retry: a second attempt would find the namespaces this one just created and


### PR DESCRIPTION
## What

Observability sweep over Alertmanager, Loki, GlitchTip and the RUM pipeline (2026-08-16, sandbox). 25 alerts were firing. This PR fixes the three recurring **false-positive classes** it found and one capacity bug; the true positives it also surfaced are listed at the bottom and are **not** in this diff.

## 1. `KubeJobFailed` tombstones — 9 of 25 firing alerts, 7 of them stale

`failedJobsHistoryLimit` caps how many failed Jobs are *kept*; it never deletes the last one. So a single failure survives forever even after every later run succeeded, and the alert keeps firing on a dead object. Measured:

| CronJob | failed Job age | successful runs since |
|---|---|---|
| `rum-attribute-audit` | 35 d | 4 |
| `openbao-document-signing-sync` | 14 d | 2 |
| `kyverno-cleanup-cluster-ephemeral-reports` | 31 h | yes (6 min old) |
| `kyverno-cleanup-update-requests` | 9 d | yes (6 min old) |
| `sbom-drift-scanner`, `journey-public-edge`, `arc-stuck-runner-reaper` | 10 h – 2 d | yes |

0 of 20 live CronJobs set `ttlSecondsAfterFinished`. This adds `172800` (48 h) to all 15 in-repo CronJobs, and to the 5 kyverno cleanup jobs through the chart's own per-job value — verified against a real `helm template kyverno/kyverno --version 3.2.6` render, which emits `ttlSecondsAfterFinished: 172800` on the rendered CronJob.

48 h keeps a genuine failure visible for a working day plus slack, then it clears itself. A job that keeps failing still alerts on its next failure.

The 7 stale Job objects were deleted live while investigating.

## 2. `FinOpsNatEgressSpikeRelative` — 4 of 25 firing alerts

A pure ratio has no scale, and the `+ 1` in the denominator lets a near-idle namespace exceed 2x on one container image pull. The four firing namespaces are all agent namespaces that sit idle between scheduled runs:

```
finops-agent          32.9 KB/s
authz-policy-auditor  18.4 KB/s
release-steward       17.6 KB/s
docs-truth-agent      16.8 KB/s
```

At 32.9 KB/s a namespace moves 2.8 GB/day — about **$0.12/day** in NAT egress, against an alert written for a 50 GB/day-class runaway. Adds a 1 MB/s absolute floor (~86 GB/day, ~$3.70/day).

Checked against live Prometheus, both directions:

- with the floor: **0** namespaces firing (was 4)
- known-positive control — namespaces that crossed 1 MB/s at any point in 7 d: **3** (`kube-system`, `observability`, `registry-cache`, 179/179/23 five-minute buckets). The alert is quieter, not dead.

## 3. `gradle-build-cache` PVC 100 % full

`KubePersistentVolumeFillingUp` critical for two days; 48.9 G of a 50 Gi PVC. The evictor's own log had been showing the failure the whole time:

```
evictor: removed 33 entries older than 14d, 50073MB -> 50073MB
evictor: removed 11 entries older than 14d, 50073MB -> 50073MB
evictor: removed  5 entries older than 14d, 50073MB -> 50073MB   (x10 passes)
```

It deleted real files every pass and the total never moved: inflow over six hours matched whatever aged out. **An age policy is a retention policy, not a capacity policy** — only the second bounds a fixed-size volume.

Adds a high-water pass: after the 14 d sweep, walk the age threshold down (10, 7, 5, 3, 2, 1 d) until `df` reports under 80 %. `df` on the mount, not `du` on the tree — that is what the alert reads. BusyBox `find` has no `-printf` and Alpine has no `sort -z`, so a descending-threshold loop is the portable stand-in for oldest-first.

Run live during this change: **100 % -> 38 %**, one pass at 10 d removing 19 293 files. Also logs an explicit warning when still over the mark after evicting everything older than a day, since that means the PVC is genuinely undersized rather than unswept.

## 4. `rum-attribute-audit` exits 0 on an empty pipeline

Over a 168 h window the audit reported, and passed:

```
app.version        unique_value_count: 0
device.model       unique_value_count: 0
screen.name        unique_value_count: 0
x-correlation-id   unique_value_count: 0
os.type            unique_value_count: 1   ("linux" — server pods, no ios/android)
```

Corroborated: `rum-gateway` exports nothing but its own otelcol self-metrics, and Prometheus holds **0** `rum_*` series. No mobile RUM has reached Tempo.

The job is a PII allow-list check, and it answers identically for "the allow-list holds" and "no RUM ever arrived" — so it had been green on every run. It now fails when `app.version`, `device.model` and `screen.name` are *all* zero (these three are emitted only by the mobile SDK). Both branches were exercised in the real `curlimages/curl:8.7.1` image on-cluster. The `ttlSecondsAfterFinished` from part 1 means the resulting `KubeJobFailed` cannot become a permanent tombstone.

## Also fixed live, no diff

- **54 failed CNPG `Backup` objects** deleted (oldest 58 d, none holding a `backupId`, i.e. no data). They were being re-reconciled forever — 35 `cnpg-system` errors/24 h.
- **`consent-db` `pg_stat_wal` scan error**, 2 892 log lines/24 h and 96 % of that namespace's errors: PG18 leaves `stats_reset` NULL until first reset, which the CNPG collector cannot scan. `pg_stat_reset_shared('wal')` fixed it. Loki confirms consent-db was the only cluster in the fleet in that state.

## True positives found, NOT fixed here

Each needs a decision or a credential I should not supply:

1. **`case-coordinator-db` has had no backups since 2026-08-12.** Its Pod Identity association is declared in `db-backups.tf` but absent in AWS (65 live associations, this one missing), so every WAL archive fails `Unable to locate credentials`. The `db-backup-associations` scheduled gate **has correctly been red for three days** naming this exact cluster — it needs `tofu apply` (adds only, 0 destroy). The observability gap is that a red scheduled gate on `main` reaches nobody.
2. **`KeycloakRealmDrift` is real drift**, not noise: `CATALOG_SCOPE_AUTHOR/PUBLISH/READ` are declared in the template and not issued by the live realm, behind 9/1/15 `@RolesAllowed` sites; `service-account-openbank-services` holds `ROLE_OPERATOR` the template does not grant.
3. **`secret-rotator` fails** `failed to obtain Keycloak admin token` (recovered from Loki — the pods are GC'd). The endpoint and the `admin-cli` password grant both work; the credentials at `openbank/keycloak/admin` in OpenBao do not authenticate.
4. **`notification-service-fcm` ExternalSecret** cannot find `FCM_SERVICE_ACCOUNT_JSON` — 178 errors/24 h, `notifications` ArgoCD app Degraded, and the likely tail of `PushChannelSilent` plus GlitchTip's `PushRegistrationFailed`.
5. **`FxFixingAgeAbsent`**: `ledger-fx-revaluation` reports success 23.5 h ago but never emits `openbank_fx_fixing_age_seconds`.

Refs #1759
