### PR TITLE
feat(admin-ui): unify payment operations workspaces

### DIFF
--- a/openbank-admin-ui/src/app/cards/page.tsx
+++ b/openbank-admin-ui/src/app/cards/page.tsx
@@ -24,6 +24,9 @@ import { ConfirmTransitionDialog } from '@/components/cards/ConfirmTransitionDia
 import { CardOperationFeedback } from '@/components/cards/CardOperationFeedback'
 import { IssueCardDialog } from '@/components/cards/IssueCardDialog'
 import { useCardOperations } from '@/lib/cards/useCardOperations'
+import { PageHeader } from '@/components/ui/PageHeader'
+import { StatCard } from '@/components/ui/StatCard'
+import type { Tone } from '@/components/ui/tone'
 
 // Admin-UI rule #2: page the render. `GET /api/v1/cards` is an unpaginated
 // list-all on the service side, so the cap has to be applied here — a portfolio
@@ -96,16 +99,11 @@ export default function CardsPage() {
   return (
     <AuthGuard>
       <div style={{ padding: '28px 32px', maxWidth: '1400px', animation: 'fadeIn 0.2s ease-out' }}>
-        <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', marginBottom: '28px' }}>
-          <div>
-            <h1 style={{ fontSize: '24px', fontWeight: 800, color: 'var(--text-primary)', letterSpacing: '-0.03em', marginBottom: '4px' }}>
-              {t('Vydávání karet', 'Card Issuance')}
-            </h1>
-            <p style={{ fontSize: '13px', color: 'var(--text-secondary)' }}>
-              {t('Vydávání a správa platebních karet — PCI DSS Level 1', 'Card issuance and management — PCI DSS Level 1')}
-            </p>
-          </div>
-          <div style={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
+        <PageHeader
+          icon={<CreditCard size={20} aria-hidden="true" />}
+          title={t('Vydávání karet', 'Card Issuance')}
+          subtitle={t('Vydávání a správa platebních karet — PCI DSS Level 1', 'Card issuance and management — PCI DSS Level 1')}
+          actions={<div className="flex flex-wrap items-center gap-2">
             <ServiceStatusBadge
               label="card-issuance :8118"
               loading={loading}
@@ -124,26 +122,17 @@ export default function CardsPage() {
             <button className="btn btn-ghost btn-sm" onClick={reload} disabled={loading}>
               <RefreshCw size={13} /> {t('Obnovit', 'Refresh')}
             </button>
-          </div>
-        </div>
+          </div>}
+        />
 
         {/* KPIs */}
         <div className="grid-4" style={{ marginBottom: '24px' }}>
           {[
-            { label: t('Celkem karet', 'Total cards'), value: cards.length, icon: <CreditCard size={16} />, color: 'var(--accent)' },
-            { label: t('Aktivní', 'Active'), value: countBy('ACTIVE'), icon: <CheckCircle2 size={16} />, color: 'var(--success)' },
-            { label: t('Blokované', 'Blocked'), value: countBy('BLOCKED'), icon: <XCircle size={16} />, color: 'var(--danger)' },
-            { label: t('Čekající', 'Pending'), value: countBy('PENDING'), icon: <Clock size={16} />, color: 'var(--warning)' },
-          ].map(k => (
-            <div key={k.label} className="stat-card">
-              <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '10px' }}>
-                <div style={{ width: '32px', height: '32px', borderRadius: '8px', background: `${k.color}18`,
-                  display: 'flex', alignItems: 'center', justifyContent: 'center', color: k.color }}>{k.icon}</div>
-              </div>
-              <div style={{ fontSize: '28px', fontWeight: 800, color: 'var(--text-primary)', letterSpacing: '-0.03em' }}>{k.value}</div>
-              <div style={{ fontSize: '12px', color: 'var(--text-secondary)', fontWeight: 500 }}>{k.label}</div>
-            </div>
-          ))}
+            { label: t('Celkem karet', 'Total cards'), value: cards.length, icon: <CreditCard size={16} /> },
+            { label: t('Aktivní', 'Active'), value: countBy('ACTIVE'), icon: <CheckCircle2 size={16} />, tone: 'success' as Tone },
+            { label: t('Blokované', 'Blocked'), value: countBy('BLOCKED'), icon: <XCircle size={16} />, tone: 'danger' as Tone },
+            { label: t('Čekající', 'Pending'), value: countBy('PENDING'), icon: <Clock size={16} />, tone: 'warning' as Tone },
+          ].map(k => <StatCard key={k.label} label={k.label} value={k.value} icon={k.icon} tone={k.tone} />)}
         </div>
 
         <CardLifecycleMap current={highlightedCard?.status} />

--- a/openbank-admin-ui/src/app/clearing/page.tsx
+++ b/openbank-admin-ui/src/app/clearing/page.tsx
@@ -11,6 +11,9 @@ import { svcUrl } from '@/lib/services/bff'
 import { useServiceResource } from '@/lib/services/useServiceResource'
 import { DataUnavailable } from '@/components/feedback/DataUnavailable'
 import { ServiceStatusBadge } from '@/components/feedback/ServiceStatusBadge'
+import { PageHeader } from '@/components/ui/PageHeader'
+import { StatCard } from '@/components/ui/StatCard'
+import { StatusBadge } from '@/components/ui/StatusBadge'
 
 interface ClearingBatch {
   id: string; batchReference: string; paymentRail: string; status: string
@@ -36,25 +39,14 @@ export default function ClearingPage() {
   const pending = batches.filter(b => b.status === 'PENDING' || b.status === 'PROCESSING')
   const totalVolume = batches.reduce((s, b) => s + (b.totalAmount ?? 0), 0)
 
-  const statusColor = (s: string) => {
-    if (s === 'SETTLED') return { bg: 'var(--success-bg)', text: 'var(--success-text)', border: 'var(--success-border)' }
-    if (s === 'FAILED') return { bg: 'var(--danger-bg)', text: 'var(--danger-text)', border: 'var(--danger-border)' }
-    return { bg: 'var(--warning-bg)', text: 'var(--warning-text)', border: 'var(--warning-border)' }
-  }
-
   return (
     <AuthGuard permission="payments:view">
       <div style={{ padding: '28px 32px', maxWidth: '1400px', animation: 'fadeIn 0.2s ease-out' }}>
-        <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', marginBottom: '28px' }}>
-          <div>
-            <h1 style={{ fontSize: '24px', fontWeight: 800, color: 'var(--text-primary)', letterSpacing: '-0.03em', marginBottom: '4px' }}>
-              {t('Zúčtování & Vypořádání', 'Clearing & Settlement')}
-            </h1>
-            <p style={{ fontSize: '13px', color: 'var(--text-secondary)' }}>
-              {t('Mezibankovní zúčtování — SEPA · SWIFT · Domestic netting', 'Interbank clearing — SEPA · SWIFT · Domestic netting')}
-            </p>
-          </div>
-          <ServiceStatusBadge
+        <PageHeader
+          icon={<Layers size={20} aria-hidden="true" />}
+          title={t('Zúčtování & Vypořádání', 'Clearing & Settlement')}
+          subtitle={t('Mezibankovní zúčtování — SEPA · SWIFT · Domestic netting', 'Interbank clearing — SEPA · SWIFT · Domestic netting')}
+          actions={<ServiceStatusBadge
             label="clearing-service :8124"
             loading={loading}
             waking={waking}
@@ -65,23 +57,16 @@ export default function ClearingPage() {
               down: t('clearing-service neodpovídá', 'clearing-service is not responding'),
               checking: t('Zjišťuji stav služby…', 'Checking service…'),
             }}
-          />
-        </div>
+          />}
+        />
 
         <div className="grid-4" style={{ marginBottom: '24px' }}>
           {[
-            { label: t('Dávky celkem', 'Total batches'), value: batches.length, icon: <Layers size={16} />, color: 'var(--accent)' },
-            { label: t('Vypořádáno', 'Settled'), value: settled.length, icon: <CheckCircle2 size={16} />, color: 'var(--success)' },
-            { label: t('Čeká / Zpracovává', 'Pending / Processing'), value: pending.length, icon: <Clock size={16} />, color: 'var(--warning)' },
-            { label: t('Objem (EUR)', 'Volume (EUR)'), value: totalVolume.toLocaleString('cs-CZ', { maximumFractionDigits: 0 }), icon: <Banknote size={16} />, color: 'var(--accent-2)' },
-          ].map(k => (
-            <div key={k.label} className="stat-card">
-              <div style={{ width: '32px', height: '32px', borderRadius: '8px', background: `${k.color}18`,
-                display: 'flex', alignItems: 'center', justifyContent: 'center', color: k.color, marginBottom: '10px' }}>{k.icon}</div>
-              <div style={{ fontSize: '28px', fontWeight: 800, color: 'var(--text-primary)', letterSpacing: '-0.03em' }}>{k.value}</div>
-              <div style={{ fontSize: '12px', color: 'var(--text-secondary)', fontWeight: 500 }}>{k.label}</div>
-            </div>
-          ))}
+            { label: t('Dávky celkem', 'Total batches'), value: batches.length, icon: <Layers size={16} /> },
+            { label: t('Vypořádáno', 'Settled'), value: settled.length, icon: <CheckCircle2 size={16} />, tone: 'success' as const },
+            { label: t('Čeká / Zpracovává', 'Pending / Processing'), value: pending.length, icon: <Clock size={16} />, tone: 'warning' as const },
+            { label: t('Objem (EUR)', 'Volume (EUR)'), value: totalVolume.toLocaleString('cs-CZ', { maximumFractionDigits: 0 }), icon: <Banknote size={16} /> },
+          ].map(k => <StatCard key={k.label} label={k.label} value={k.value} icon={k.icon} tone={k.tone} />)}
         </div>
 
         <div className="card">
@@ -112,7 +97,6 @@ export default function ClearingPage() {
                 ))}
               </tr></thead>
               <tbody>{filtered.map(b => {
-                const sc = statusColor(b.status)
                 return (
                   <tr key={b.id} style={{ borderBottom: '1px solid var(--border)' }}
                     onMouseEnter={e => (e.currentTarget.style.background = 'var(--surface-2)')}
@@ -122,9 +106,7 @@ export default function ClearingPage() {
                     <td style={{ padding: '12px 16px', fontSize: '13px', color: 'var(--text-primary)' }}>{b.itemCount}</td>
                     <td style={{ padding: '12px 16px', fontSize: '13px', fontWeight: 600, color: 'var(--text-primary)' }}>{(b.totalAmount ?? 0).toLocaleString('cs-CZ', { minimumFractionDigits: 2 })}</td>
                     <td style={{ padding: '12px 16px', fontSize: '12px', color: 'var(--text-secondary)' }}>{b.currency}</td>
-                    <td style={{ padding: '12px 16px' }}>
-                      <span style={{ padding: '2px 8px', borderRadius: '10px', fontSize: '11px', fontWeight: 600, background: sc.bg, color: sc.text, border: `1px solid ${sc.border}` }}>{b.status}</span>
-                    </td>
+                    <td style={{ padding: '12px 16px' }}><StatusBadge status={b.status} tone={b.status === 'FAILED' ? 'danger' : b.status === 'SETTLED' ? 'success' : 'warning'} /></td>
                     <td style={{ padding: '12px 16px', fontSize: '12px', color: 'var(--text-tertiary)' }}>{b.createdAt ? new Date(b.createdAt).toLocaleString('cs-CZ') : '—'}</td>
                   </tr>
                 )

--- a/openbank-admin-ui/src/app/fees/page.tsx
+++ b/openbank-admin-ui/src/app/fees/page.tsx
@@ -10,6 +10,8 @@ import { AuthGuard } from '@/components/auth/AuthGuard'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { svcUrl, classifyBffFailure } from '@/lib/services/bff'
 import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
+import { PageHeader } from '@/components/ui/PageHeader'
+import { StatCard } from '@/components/ui/StatCard'
 
 // Shape served by openbank-product-catalog GET /api/v1/fees — the bank-wide fee
 // schedule, flattened from the per-product Fee model. The UI no longer hardcodes
@@ -105,41 +107,22 @@ export default function FeesPage() {
   return (
     <AuthGuard permission="payments:view">
       <div>
-        <div className="page-header">
-          <div>
-            <div className="breadcrumb">
-              <span>OpenBank</span><span className="breadcrumb-sep">/</span>
-              <span className="breadcrumb-current">{t('Poplatky', 'Fees')}</span>
-            </div>
-            <h1 className="page-title" style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-              <Receipt size={18} style={{ color: 'var(--accent)' }} />
-              {t('Ceník poplatků', 'Fee Schedule')}
-            </h1>
-            <p className="page-subtitle">
-              {t('Ceník poplatků ze service product-catalog', 'Fee schedule served by the product-catalog service')}
-            </p>
-          </div>
-          <div style={{ display: 'flex', gap: '8px' }}>
+        <PageHeader
+          icon={<Receipt size={20} aria-hidden="true" />}
+          title={t('Ceník poplatků', 'Fee Schedule')}
+          subtitle={t('Ceník poplatků ze service product-catalog', 'Fee schedule served by the product-catalog service')}
+          actions={<div className="flex gap-2">
             <button className="btn btn-secondary" onClick={() => void load()} disabled={loading}>
               <RefreshCw size={14} style={loading ? { animation: 'spin 1s linear infinite' } : undefined} />
               {t('Obnovit', 'Refresh')}
             </button>
-          </div>
-        </div>
+          </div>}
+        />
 
         <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: '12px', marginBottom: '20px' }}>
-          <div className="stat-card">
-            <div className="stat-value">{fees.length}</div>
-            <div className="stat-label">{t('Celkem poplatků', 'Total Fees')}</div>
-          </div>
-          <div className="stat-card">
-            <div className="stat-value" style={{ color: 'var(--green)' }}>{activeCount}</div>
-            <div className="stat-label">{t('Aktivní (na aktivním produktu)', 'Active (on active product)')}</div>
-          </div>
-          <div className="stat-card">
-            <div className="stat-value" style={{ color: 'var(--accent)' }}>{uniqueTypes.length}</div>
-            <div className="stat-label">{t('Kategorie poplatků', 'Fee Categories')}</div>
-          </div>
+          <StatCard label={t('Celkem poplatků', 'Total Fees')} value={fees.length} icon={<Receipt size={14} aria-hidden="true" />} />
+          <StatCard label={t('Aktivní (na aktivním produktu)', 'Active (on active product)')} value={activeCount} tone="success" />
+          <StatCard label={t('Kategorie poplatků', 'Fee Categories')} value={uniqueTypes.length} />
         </div>
 
         <div style={{ display: 'flex', gap: '10px', marginBottom: '16px', flexWrap: 'wrap' }}>


### PR DESCRIPTION
## Summary

- Standardize Cards, Clearing, and Fees headers and KPI tiles on the shared operator design vocabulary.
- Render clearing lifecycle status through the shared status badge.
- Preserve BFF calls, filters, payment actions, card lifecycle transitions, and permissions.

## Validation

- `npm run type-check`
- `npm exec eslint src/app/cards/page.tsx src/app/clearing/page.tsx src/app/fees/page.tsx`
- `npm test -- --run src/test/render-smoke.test.tsx src/test/ui-tone.test.ts`

## Linked issues

N/A — incremental delivery of the approved admin UI modernization.