### PR TITLE
feat(product-catalog): govern bundles and private offers

### DIFF
--- a/openbank-admin-ui/src/app/product-studio/page.module.css
+++ b/openbank-admin-ui/src/app/product-studio/page.module.css
@@ -47,11 +47,29 @@
 .panelBody { padding: 15px 17px 17px; }
 .smallLabel { display: block; margin: 11px 0 5px; color: var(--text-tertiary); font-size: 10px; font-weight: 800; letter-spacing: .06em; text-transform: uppercase; }
 .schemaHint { margin-top: 10px; padding: 10px; border-radius: 10px; background: var(--surface-2); color: var(--text-secondary); font-size: 11px; line-height: 1.55; }
+.marketContext { margin-top: 10px; padding: 11px; border: 1px solid #d9d8ee; border-radius: 11px; background: linear-gradient(135deg, #fbfbff, #f4f8ff); }
+.marketTitle { display: flex; align-items: center; gap: 6px; color: #3730a3; font-size: 11px; font-weight: 800; }
+.marketContext p { margin: 5px 0 9px; color: #5b5b86; font-size: 10px; line-height: 1.45; }
+.marketGrid { display: grid; grid-template-columns: 1fr 1fr; gap: 7px; }
+.marketGrid label { display: grid; gap: 3px; color: var(--text-tertiary); font-size: 9px; font-weight: 800; letter-spacing: .04em; text-transform: uppercase; }
+.marketGrid input { min-width: 0; font-size: 11px; }
 .revisionList { display: flex; flex-direction: column; gap: 5px; margin-top: 13px; }
 .revision { width: 100%; display: flex; align-items: center; justify-content: space-between; padding: 10px; border: 1px solid transparent; border-radius: 10px; background: transparent; color: var(--text-primary); cursor: pointer; text-align: left; }
 .revision:hover { background: var(--surface-2); border-color: var(--border); }
 .revisionSelected { background: var(--ob-accent-light); border-color: var(--ob-accent-border); }
 .draftBanner { display: flex; gap: 9px; padding: 11px; border: 1px solid var(--ob-accent-border); border-radius: 10px; background: var(--ob-accent-light); color: var(--ob-accent-text); font-size: 11px; line-height: 1.5; }
+.composition { margin-top: 11px; padding: 12px; border: 1px solid #c9d7ef; border-radius: 12px; background: linear-gradient(135deg, #f7fbff, #f4f3ff); }
+.compositionHead { display: flex; justify-content: space-between; gap: 9px; }
+.compositionHead span { display: inline-flex; align-items: center; gap: 6px; color: #1e3a8a; font-size: 12px; font-weight: 800; }
+.compositionHead p { margin: 4px 0 0; color: #52607b; font-size: 10px; line-height: 1.45; }
+.compositionControls { display: grid; grid-template-columns: 118px minmax(0, 1fr) auto; gap: 7px; margin-top: 10px; }
+.compositionControls select { min-width: 0; font-size: 11px; }
+.compositionEmpty { margin-top: 9px; color: var(--text-tertiary); font-size: 10px; }
+.relationships { display: grid; gap: 5px; margin-top: 9px; }
+.relationship { display: flex; align-items: center; gap: 7px; min-width: 0; padding: 7px 8px; border: 1px solid #d6dfef; border-radius: 8px; background: rgba(255,255,255,.75); color: var(--text-secondary); font-size: 11px; }
+.relationship > span:nth-child(2) { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.removeRelationship { display: grid; width: 24px; height: 24px; margin-left: auto; place-items: center; border: 0; border-radius: 6px; background: transparent; color: var(--text-tertiary); cursor: pointer; }
+.removeRelationship:hover { background: #fee2e2; color: var(--danger); }
 .guidedForm { margin-top: 10px; padding: 12px; border: 1px solid #d8d5ff; border-radius: 12px; background: linear-gradient(135deg, #fbfbff, #f3f8ff); }
 .guidedHead { display: grid; gap: 3px; color: #312e81; font-size: 12px; font-weight: 800; }
 .guidedHead span { display: inline-flex; align-items: center; gap: 6px; }
@@ -104,4 +122,4 @@
 .previewFoot { margin-top: auto; padding-top: 18px; color: var(--text-tertiary); font-size: 11px; }
 .message { margin: 14px 0; padding: 11px 13px; border-radius: 10px; border: 1px solid var(--border); background: var(--surface); color: var(--text-secondary); white-space: pre-wrap; font-family: var(--font-sans); font-size: 12px; }
 @media (max-width: 1120px) { .workspace { grid-template-columns: 1fr 1fr; } .workspace > :last-child { grid-column: span 2; } .metrics { grid-template-columns: repeat(2, 1fr); } }
-@media (max-width: 760px) { .hero { padding: 20px; } .heroTop, .lowerGrid { display: block; } .refresh { margin-top: 16px; } .journey { grid-template-columns: 1fr 1fr; } .journeyStep:nth-child(2) { border-right: 0; } .journeyStep:nth-child(-n+2) { border-bottom: 1px solid var(--border); } .workspace, .fieldGrid { grid-template-columns: 1fr; } .workspace > :last-child { grid-column: auto; } .lowerGrid > * { margin-bottom: 14px; } }
+@media (max-width: 760px) { .hero { padding: 20px; } .heroTop, .lowerGrid { display: block; } .refresh { margin-top: 16px; } .journey { grid-template-columns: 1fr 1fr; } .journeyStep:nth-child(2) { border-right: 0; } .journeyStep:nth-child(-n+2) { border-bottom: 1px solid var(--border); } .workspace, .fieldGrid, .marketGrid, .compositionControls { grid-template-columns: 1fr; } .workspace > :last-child { grid-column: auto; } .lowerGrid > * { margin-bottom: 14px; } }

--- a/openbank-admin-ui/src/app/product-studio/page.tsx
+++ b/openbank-admin-ui/src/app/product-studio/page.tsx
@@ -5,11 +5,18 @@
 'use client'
 
 import { useCallback, useEffect, useMemo, useState } from 'react'
-import { Bot, Boxes, CheckCircle2, CircleAlert, Eye, FileJson, ListChecks, Plus, RefreshCw, Send, ShieldCheck, Sparkles } from 'lucide-react'
+import { Bot, Boxes, CheckCircle2, CircleAlert, Eye, FileJson, Link2, ListChecks, LockKeyhole, Plus, RefreshCw, Send, ShieldCheck, Sparkles, X } from 'lucide-react'
 import { AuthGuard, Can } from '@/components/auth/AuthGuard'
 import { canReviewPrivateCatalogDraft, type AgentModelDescriptor } from '@/lib/catalog-review-capability'
 import { catalogFieldValue, catalogSchemaFields, type CatalogSchemaField, withCatalogFieldValue } from '@/lib/catalog-schema-form'
 import { catalogRevisionEditorDocument, diffCatalogDocuments } from '@/lib/catalog-structural-diff'
+import {
+  addOfferingRelationship,
+  defaultMarketContextInput,
+  marketContextFromInput,
+  removeOfferingRelationship,
+  type MarketContextInput,
+} from '@/lib/catalog-offer-composition'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import {
   catalogV2Operation, type CatalogSchema, type Offering, type OfferingRequest, type ProductRevision,
@@ -64,6 +71,20 @@ interface CatalogReview {
   model: string
 }
 
+const relationshipKinds = ['BUNDLE', 'ADD_ON', 'REPLACEMENT', 'DEPENDENCY', 'COMPATIBLE_WITH'] as const
+type RelationshipKind = typeof relationshipKinds[number]
+
+interface DraftRelationship {
+  kind: RelationshipKind
+  targetOfferingId: string
+}
+
+function isDraftRelationship(value: unknown): value is DraftRelationship {
+  return Boolean(value) && typeof value === 'object' &&
+    relationshipKinds.includes((value as DraftRelationship).kind) &&
+    typeof (value as DraftRelationship).targetOfferingId === 'string'
+}
+
 export default function ProductStudioPage() {
   const { language } = useLanguage()
   const t = (cs: string, en: string) => language === 'cs' ? cs : en
@@ -79,6 +100,9 @@ export default function ProductStudioPage() {
   const [busy, setBusy] = useState(false)
   const [newSpecCode, setNewSpecCode] = useState('')
   const [newOfferingCode, setNewOfferingCode] = useState('')
+  const [marketContextInput, setMarketContextInput] = useState<MarketContextInput>(defaultMarketContextInput)
+  const [relationshipTargetId, setRelationshipTargetId] = useState('')
+  const [relationshipKind, setRelationshipKind] = useState<RelationshipKind>('BUNDLE')
   const [publishReason, setPublishReason] = useState('')
   const [newSpecSchema, setNewSpecSchema] = useState('')
   const [review, setReview] = useState<CatalogReview | null>(null)
@@ -93,6 +117,14 @@ export default function ProductStudioPage() {
   const parsedDraft = useMemo(() => {
     try { return draftText ? JSON.parse(draftText) as Record<string, unknown> : null } catch { return null }
   }, [draftText])
+  const draftRelationships = useMemo(
+    () => Array.isArray(parsedDraft?.relationships) ? parsedDraft.relationships.filter(isDraftRelationship) : [],
+    [parsedDraft],
+  )
+  const relationshipCandidates = useMemo(
+    () => offerings.filter(item => item.id !== selectedOffering?.id),
+    [offerings, selectedOffering?.id],
+  )
   const compatibleSchemas = useMemo(
     () => schemas.filter(item => !selectedSpec || item.id === selectedSpec.schemaRef.id),
     [schemas, selectedSpec],
@@ -194,11 +226,35 @@ export default function ProductStudioPage() {
     if (!selectedSpec || !newOfferingCode.trim()) return
     const body: OfferingRequest = {
       specificationId: selectedSpec.id, code: newOfferingCode.trim().toUpperCase(),
-      market: { countries: [], channels: [], brands: [], segments: [], locales: ['en'] },
+      market: marketContextFromInput(marketContextInput),
     }
     void run(() => catalogV2Operation('createOfferingV2', {
       body,
     }), t('Nabídka vytvořena', 'Offering created'))
+  }
+
+  const updateMarketContext = (field: keyof MarketContextInput, value: string) => {
+    setMarketContextInput(current => ({ ...current, [field]: value }))
+  }
+
+  const addRelationship = () => {
+    if (!parsedDraft || !selectedOffering || !relationshipTargetId) return
+    try {
+      setDraftText(JSON.stringify(addOfferingRelationship(parsedDraft, selectedOffering.id, {
+        kind: relationshipKind, targetOfferingId: relationshipTargetId,
+      }), null, 2))
+      setValidationState('idle')
+      setReview(null)
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : String(error))
+    }
+  }
+
+  const removeRelationship = (relationship: DraftRelationship) => {
+    if (!parsedDraft) return
+    setDraftText(JSON.stringify(removeOfferingRelationship(parsedDraft, relationship), null, 2))
+    setValidationState('idle')
+    setReview(null)
   }
 
   const createDraft = () => {
@@ -330,6 +386,17 @@ export default function ProductStudioPage() {
           </select>
           <Can permission="catalog:author">
             <div style={{ display: 'flex', gap: 7, marginTop: 8 }}><input className="input" value={newOfferingCode} onChange={e => setNewOfferingCode(e.target.value)} placeholder="TERM_LIFE_CZ_WEB" /><button className="btn btn-secondary" onClick={createOffering} aria-label={t('Vytvořit nabídku', 'Create offering')}><Plus size={13} /></button></div>
+            <div className={styles.marketContext}>
+              <div className={styles.marketTitle}><LockKeyhole size={13} /><span>{t('Dostupnost nabídky', 'Offer availability')}</span></div>
+              <p>{t('Neveřejná nabídka používá obchodní segment, nikoli identitu zákazníka. Katalog neobsahuje osobní údaje.', 'A private offer uses a commercial segment, never a customer identity. The catalog contains no personal data.')}</p>
+              <div className={styles.marketGrid}>
+                <label><span>{t('Značky', 'Brands')}</span><input className="input" value={marketContextInput.brands} onChange={event => updateMarketContext('brands', event.target.value)} placeholder="retail" /></label>
+                <label><span>{t('Země', 'Countries')}</span><input className="input" value={marketContextInput.countries} onChange={event => updateMarketContext('countries', event.target.value)} placeholder="CZ, DE" /></label>
+                <label><span>{t('Kanály', 'Channels')}</span><input className="input" value={marketContextInput.channels} onChange={event => updateMarketContext('channels', event.target.value)} placeholder="WEB, BRANCH" /></label>
+                <label><span>{t('Segmenty', 'Segments')}</span><input className="input" value={marketContextInput.segments} onChange={event => updateMarketContext('segments', event.target.value)} placeholder="employee, premium" /></label>
+                <label><span>{t('Lokality', 'Locales')}</span><input className="input" value={marketContextInput.locales} onChange={event => updateMarketContext('locales', event.target.value)} placeholder="cs-CZ, en" /></label>
+              </div>
+            </div>
             <button className="btn btn-primary" style={{ width: '100%', marginTop: 8 }} disabled={!selectedOffering} onClick={createDraft}><Plus size={13} />{t('Založit novou revizi', 'Create a new revision')}</button>
           </Can>
           <div className={styles.revisionList}>{revisions.length === 0 && <div className={styles.schemaHint}>{t('Vyberte nabídku a otevřete její rozhodovací historii.', 'Select an offer to open its decision history.')}</div>}{revisions.map(item => <button key={item.id} onClick={() => { setRevisionId(item.id); setReview(null) }} className={`${styles.revision} ${revisionId === item.id ? styles.revisionSelected : ''}`}>
@@ -343,6 +410,18 @@ export default function ProductStudioPage() {
         <div className={styles.panelBody}>
           <div className={styles.draftBanner}><CheckCircle2 size={15} /><span>{selectedRevision?.state === 'DRAFT' ? t('Draft lze ukládat a ověřovat. Publikaci provede jiný uživatel.', 'This draft can be saved and checked. A different user performs publication.') : t('Toto je neměnný historický záznam.', 'This is an immutable historical record.')}</span></div>
           <Can permission="catalog:author" fallback={<textarea className={`input ${styles.editor}`} value={draftText} disabled />}>
+            {parsedDraft && <div className={styles.composition}>
+              <div className={styles.compositionHead}><div><span><Link2 size={13} />{t('Složení nabídky', 'Offer composition')}</span><p>{t('Bundle přidá existující publikovatelnou nabídku jako komponentu. Služba při publikaci znovu ověří existenci, účinnost i cykly.', 'A bundle adds an existing publishable offer as a component. The service rechecks existence, effectiveness and cycles at publication.')}</p></div><span className="badge badge-neutral">{draftRelationships.length}</span></div>
+              {selectedRevision?.state === 'DRAFT' && <div className={styles.compositionControls}>
+                <select className="input" value={relationshipKind} onChange={event => setRelationshipKind(event.target.value as RelationshipKind)}>{relationshipKinds.map(kind => <option key={kind}>{kind}</option>)}</select>
+                <select className="input" value={relationshipTargetId} onChange={event => setRelationshipTargetId(event.target.value)}><option value="">{t('Vyberte nabídku', 'Select an offer')}</option>{relationshipCandidates.map(item => <option key={item.id} value={item.id}>{item.code}</option>)}</select>
+                <button className="btn btn-secondary" disabled={!relationshipTargetId} onClick={addRelationship}><Plus size={13} />{t('Přidat', 'Add')}</button>
+              </div>}
+              {draftRelationships.length === 0 ? <div className={styles.compositionEmpty}>{t('Žádné vazby. Samostatná nabídka zůstává beze změny.', 'No connections. A standalone offer remains unchanged.')}</div> : <div className={styles.relationships}>{draftRelationships.map(relationship => {
+                const target = offerings.find(item => item.id === relationship.targetOfferingId)
+                return <div className={styles.relationship} key={`${relationship.kind}:${relationship.targetOfferingId}`}><span className="badge badge-info">{relationship.kind}</span><span>{target?.code ?? relationship.targetOfferingId}</span>{selectedRevision?.state === 'DRAFT' && <button aria-label={t('Odebrat vazbu', 'Remove relationship')} className={styles.removeRelationship} onClick={() => removeRelationship(relationship)}><X size={13} /></button>}</div>
+              })}</div>}
+            </div>}
             {guidedFields.length > 0 && parsedDraft && <div className={styles.guidedForm}>
               <div className={styles.guidedHead}><span><Sparkles size={13} />{t('Průvodce povinnými údaji', 'Guided essentials')}</span><small>{t('Pouze skalární pole; pole a složité struktury zůstávají níže v expertním dokumentu.', 'Scalar fields only; arrays and complex structures remain in the expert document below.')}</small></div>
               <div className={styles.fieldGrid}>{guidedFields.map(field => {

--- a/openbank-admin-ui/src/lib/catalog-offer-composition.ts
+++ b/openbank-admin-ui/src/lib/catalog-offer-composition.ts
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import type { MarketContext, RevisionRequest } from '@/lib/product-catalog-v2'
+
+export type MarketContextInput = Record<keyof MarketContext, string>
+
+export const defaultMarketContextInput: MarketContextInput = {
+  brands: '', countries: '', channels: '', segments: '', locales: 'en',
+}
+
+const splitValues = (value: string, normalize: (entry: string) => string = entry => entry) =>
+  [...new Set(value.split(',').map(entry => normalize(entry.trim())).filter(Boolean))]
+
+/** Context keys describe an offer audience. They never contain a customer identifier or personal data. */
+export function marketContextFromInput(input: MarketContextInput): MarketContext {
+  return {
+    brands: splitValues(input.brands),
+    countries: splitValues(input.countries, entry => entry.toUpperCase()),
+    channels: splitValues(input.channels, entry => entry.toUpperCase()),
+    segments: splitValues(input.segments),
+    locales: splitValues(input.locales),
+  }
+}
+
+type Relationship = NonNullable<RevisionRequest['relationships']>[number]
+
+function relationshipsOf(document: Record<string, unknown>): Relationship[] {
+  return Array.isArray(document.relationships) ? document.relationships as Relationship[] : []
+}
+
+export function addOfferingRelationship(
+  document: Record<string, unknown>,
+  sourceOfferingId: string,
+  relationship: Relationship,
+): Record<string, unknown> {
+  if (relationship.targetOfferingId === sourceOfferingId) {
+    throw new Error('An offer cannot be a component of itself.')
+  }
+  const relationships = relationshipsOf(document)
+  if (relationships.some(item => item.kind === relationship.kind && item.targetOfferingId === relationship.targetOfferingId)) {
+    return document
+  }
+  return { ...document, relationships: [...relationships, relationship] }
+}
+
+export function removeOfferingRelationship(
+  document: Record<string, unknown>,
+  relationship: Relationship,
+): Record<string, unknown> {
+  return {
+    ...document,
+    relationships: relationshipsOf(document).filter(
+      item => item.kind !== relationship.kind || item.targetOfferingId !== relationship.targetOfferingId,
+    ),
+  }
+}

--- a/openbank-admin-ui/src/test/catalog-offer-composition.test.ts
+++ b/openbank-admin-ui/src/test/catalog-offer-composition.test.ts
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import { describe, expect, it } from 'vitest'
+import {
+  addOfferingRelationship,
+  defaultMarketContextInput,
+  marketContextFromInput,
+  removeOfferingRelationship,
+} from '@/lib/catalog-offer-composition'
+
+describe('catalog offer composition', () => {
+  it('turns a private offer audience into normalized market context without a customer identifier', () => {
+    expect(marketContextFromInput({
+      ...defaultMarketContextInput,
+      countries: 'cz, CZ', channels: 'web', segments: 'employee, employee', locales: 'cs-CZ, en',
+    })).toEqual({
+      brands: [], countries: ['CZ'], channels: ['WEB'], segments: ['employee'], locales: ['cs-CZ', 'en'],
+    })
+  })
+
+  it('adds and removes a bundle component without allowing a self-reference', () => {
+    const component = { kind: 'BUNDLE' as const, targetOfferingId: 'component-offering' }
+    const bundle = addOfferingRelationship({}, 'bundle-offering', component)
+
+    expect(bundle.relationships).toEqual([component])
+    expect(addOfferingRelationship(bundle, 'bundle-offering', component)).toBe(bundle)
+    expect(removeOfferingRelationship(bundle, component).relationships).toEqual([])
+    expect(() => addOfferingRelationship({}, 'bundle-offering', {
+      kind: 'BUNDLE', targetOfferingId: 'bundle-offering',
+    })).toThrow('cannot be a component of itself')
+  })
+})

--- a/openbank-product-catalog/src/main/kotlin/com/openbank/productcatalog/application/GenericCatalogService.kt
+++ b/openbank-product-catalog/src/main/kotlin/com/openbank/productcatalog/application/GenericCatalogService.kt
@@ -12,6 +12,7 @@ import com.openbank.productcatalog.domain.catalog.MarketContext
 import com.openbank.productcatalog.domain.catalog.ProductOffering
 import com.openbank.productcatalog.domain.catalog.ProductRevision
 import com.openbank.productcatalog.domain.catalog.ProductSpecification
+import com.openbank.productcatalog.domain.catalog.RelationshipKind
 import com.openbank.productcatalog.domain.catalog.RevisionContent
 import com.openbank.productcatalog.domain.catalog.RevisionState
 import com.openbank.productcatalog.domain.catalog.SchemaRef
@@ -94,6 +95,7 @@ class GenericCatalogService(
         }
         findSchema(schemaRef)
         validateOrThrow(schemaRef, content.attributes)
+        validateRelationshipReferences(offeringId, content)
         val now = Instant.now(clock)
         return repository.createDraft(
             ProductRevision(
@@ -133,6 +135,7 @@ class GenericCatalogService(
             throw CatalogConflictException("published revisions are immutable")
         }
         validateOrThrow(existing.schemaRef, content.attributes)
+        validateRelationshipReferences(existing.offeringId, content)
         return repository.updateDraft(
             existing.copy(
                 content = content,
@@ -159,6 +162,8 @@ class GenericCatalogService(
         }
         require(reason.isNotBlank()) { "publication reason must not be blank" }
         validateOrThrow(draft.schemaRef, draft.content.attributes)
+        val publicationAt = Instant.now(clock)
+        requirePublishableBundleComponents(draft, draft.effectiveFrom ?: publicationAt)
         val hash = catalogJson.sha256(catalogJson.toContentNode(draft.content))
         return repository.publishDraft(
             revisionId = revisionId,
@@ -166,7 +171,7 @@ class GenericCatalogService(
             checkerId = checkerId,
             reason = reason,
             contentHash = hash,
-            at = Instant.now(clock),
+            at = publicationAt,
         )
     }
 
@@ -190,6 +195,78 @@ class GenericCatalogService(
             throw CatalogPreconditionFailedException(
                 "revision ${revision.id} was modified (expected $expected, current ${revision.revision})",
             )
+        }
+    }
+
+    /**
+     * Relationships retain stable offering references rather than copying terms. Checking them
+     * while drafting makes invalid references visible before an approval is requested.
+     */
+    private suspend fun validateRelationshipReferences(offeringId: UUID, content: RevisionContent) {
+        val relationships = content.relationships
+        require(relationships.none { it.targetOfferingId == offeringId }) {
+            "an offering cannot reference itself"
+        }
+        require(relationships.distinctBy { it.kind to it.targetOfferingId }.size == relationships.size) {
+            "offering relationships must be unique"
+        }
+        relationships.forEach { relationship -> findOffering(relationship.targetOfferingId) }
+    }
+
+    /** A published bundle may contain only effective, published offerings and may not form a cycle. */
+    private suspend fun requirePublishableBundleComponents(draft: ProductRevision, effectiveAt: Instant) {
+        val bundleMarket = findOffering(draft.offeringId).market
+        draft.content.relationships
+            .filter { it.kind == RelationshipKind.BUNDLE }
+            .forEach { relationship ->
+                requirePublishedBundlePath(
+                    offeringId = relationship.targetOfferingId,
+                    effectiveAt = effectiveAt,
+                    path = setOf(draft.offeringId),
+                    bundleMarket = bundleMarket,
+                )
+            }
+    }
+
+    private suspend fun requirePublishedBundlePath(
+        offeringId: UUID,
+        effectiveAt: Instant,
+        path: Set<UUID>,
+        bundleMarket: MarketContext,
+    ) {
+        if (offeringId in path) {
+            throw CatalogConflictException("bundle relationships must not form a cycle")
+        }
+        requireBundleMarketCompatibility(bundleMarket, findOffering(offeringId).market, offeringId)
+        val component = repository.findPublished(offeringId, effectiveAt)
+            ?: throw CatalogConflictException("bundle component $offeringId is not published")
+        component.content.relationships
+            .filter { it.kind == RelationshipKind.BUNDLE }
+            .forEach { child ->
+                requirePublishedBundlePath(child.targetOfferingId, effectiveAt, path + offeringId, bundleMarket)
+            }
+    }
+
+    /** A bundle can narrow an audience, but it must never make a component available more broadly. */
+    private fun requireBundleMarketCompatibility(
+        bundle: MarketContext,
+        component: MarketContext,
+        componentOfferingId: UUID,
+    ) {
+        listOf(
+            "brands" to (bundle.brands to component.brands),
+            "countries" to (bundle.countries to component.countries),
+            "channels" to (bundle.channels to component.channels),
+            "segments" to (bundle.segments to component.segments),
+            "locales" to (bundle.locales to component.locales),
+        ).forEach { (dimension, audiences) ->
+            val (bundleAudience, componentAudience) = audiences
+            require(
+                componentAudience.isEmpty() ||
+                    (bundleAudience.isNotEmpty() && bundleAudience.all(componentAudience::contains)),
+            ) {
+                "bundle $dimension must not be broader than component $componentOfferingId"
+            }
         }
     }
 }

--- a/openbank-product-catalog/src/main/resources/openapi.yaml
+++ b/openbank-product-catalog/src/main/resources/openapi.yaml
@@ -4,7 +4,7 @@ openapi: 3.1.0
 info:
   title: Product Catalog API
   # API-contract version is independent of version.txt (ADR-0048); newest URL major is /api/v2.
-  version: 2.0.0
+  version: 2.1.0
   description: >-
     Industry-neutral, schema-governed catalog API with immutable four-eyes publication,
     exact decimal pricing, effective-dated reads and transactional audit/outbox. The
@@ -771,6 +771,9 @@ components:
     MarketContext:
       type: object
       additionalProperties: false
+      description: >-
+        Commercial availability context, never a customer identity. Restricted offers use controlled
+        segment keys; customer-specific eligibility and personalisation remain outside the catalog.
       properties:
         brands: { type: array, uniqueItems: true, items: { type: string } }
         countries: { type: array, uniqueItems: true, items: { type: string, pattern: '^[A-Z]{2}$' } }
@@ -831,6 +834,9 @@ components:
     OfferingRelationship:
       type: object
       additionalProperties: false
+      description: >-
+        A stable offering-to-offering relationship. BUNDLE components must exist and be published
+        and effective when the bundle is published; self-references and cycles are rejected.
       properties:
         kind: { type: string, enum: [BUNDLE, ADD_ON, REPLACEMENT, DEPENDENCY, COMPATIBLE_WITH] }
         targetOfferingId: { type: string, format: uuid }

--- a/openbank-product-catalog/src/test/kotlin/com/openbank/productcatalog/CatalogPlatformResourceTest.kt
+++ b/openbank-product-catalog/src/test/kotlin/com/openbank/productcatalog/CatalogPlatformResourceTest.kt
@@ -188,6 +188,28 @@ class CatalogPlatformResourceTest {
     }
 
     @Test
+    fun publishesOnlyBundlesWithPublishedNonCyclicComponents() {
+        val specificationId = createSpecification("INS_BUNDLE_E2E")
+        val componentOfferingId = createOffering(specificationId, "INS_BUNDLE_COMPONENT")
+        val componentRevisionId = createRevision(componentOfferingId, "Bundle component")
+        setMaker(componentRevisionId, "component-author")
+        publish(componentOfferingId, componentRevisionId)
+
+        val bundleOfferingId = createOffering(specificationId, "INS_BUNDLE_STARTER")
+        val bundleRevisionId = createRevision(
+            bundleOfferingId,
+            "Starter bundle",
+            "[{\"kind\":\"BUNDLE\",\"targetOfferingId\":\"$componentOfferingId\"}]",
+        )
+        setMaker(bundleRevisionId, "bundle-author")
+        publish(bundleOfferingId, bundleRevisionId)
+
+        assertSelfRelationshipIsRejected(bundleOfferingId)
+        assertUnpublishedBundleComponentIsRejected(specificationId)
+        assertBroaderBundleAudienceIsRejected(specificationId)
+    }
+
+    @Test
     fun acceptsOutboxWritesFromThePreviousV2BinaryDuringRollingDeployment() {
         val eventId = UUID.randomUUID()
         dataSource.connection.use { connection ->
@@ -436,28 +458,33 @@ class CatalogPlatformResourceTest {
             ).extract().jsonPath().getString("id"),
     )
 
-    private fun createOffering(specificationId: UUID, code: String): UUID = UUID.fromString(
-        (
-            Given {
-                contentType("application/json")
-                body(
-                    """{"specificationId":"$specificationId","code":"$code","market":""" +
-                        """{"countries":["CZ"],"channels":["WEB"],"locales":["cs-CZ"]}}""",
-                )
-            } When {
-                post("/api/v2/offerings")
-            } Then {
-                statusCode(201)
-                header("ETag", equalTo("\"0\""))
-            }
-            ).extract().jsonPath().getString("id"),
-    )
+    private fun createOffering(specificationId: UUID, code: String, market: String = DEFAULT_MARKET): UUID =
+        UUID.fromString(
+            (
+                Given {
+                    contentType("application/json")
+                    body(
+                        """{"specificationId":"$specificationId","code":"$code","market":$market}""",
+                    )
+                } When {
+                    post("/api/v2/offerings")
+                } Then {
+                    statusCode(201)
+                    header("ETag", equalTo("\"0\""))
+                }
+                ).extract().jsonPath().getString("id"),
+        )
 
-    private fun createRevision(offeringId: UUID, name: String, schemaVersion: Int = 2): UUID = UUID.fromString(
+    private fun createRevision(
+        offeringId: UUID,
+        name: String,
+        relationships: String = "[]",
+        schemaVersion: Int = 2,
+    ): UUID = UUID.fromString(
         (
             Given {
                 contentType("application/json")
-                body(revisionPayload(name, schemaVersion))
+                body(revisionPayload(name, relationships, schemaVersion))
             } When {
                 post("/api/v2/offerings/$offeringId/revisions")
             } Then {
@@ -468,11 +495,85 @@ class CatalogPlatformResourceTest {
             ).extract().jsonPath().getString("id"),
     )
 
-    private fun revisionPayload(name: String, schemaVersion: Int = 2): String =
+    private fun revisionPayload(name: String, relationships: String = "[]", schemaVersion: Int = 2): String =
         """{"schemaRef":{"id":"org.openbank.insurance.term-life","version":$schemaVersion},""" +
             """"name":{"en":"$name"},"attributes":${attributesFor(schemaVersion)},"prices":[{""" +
             """"code":"PREMIUM","kind":"AMOUNT","value":"$EXACT_PRICE","currency":"EUR","unit":"policy",""" +
-            """"cadence":"MONTHLY","taxTreatment":"EXEMPT"}]}"""
+            """"cadence":"MONTHLY","taxTreatment":"EXEMPT"}],"relationships":$relationships}"""
+
+    private fun publish(offeringId: UUID, revisionId: UUID) {
+        Given {
+            contentType("application/json")
+            body("{\"reason\":\"independent bundle component approval\"}")
+            header("If-Match", "\"0\"")
+        } When {
+            post("/api/v2/offerings/$offeringId/revisions/$revisionId/publish")
+        } Then {
+            statusCode(200)
+            body("state", equalTo("PUBLISHED"))
+        }
+    }
+
+    private fun assertSelfRelationshipIsRejected(bundleOfferingId: UUID) {
+        Given {
+            contentType("application/json")
+            body(
+                revisionPayload(
+                    "Self relationship",
+                    relationships = "[{\"kind\":\"BUNDLE\",\"targetOfferingId\":\"$bundleOfferingId\"}]",
+                ),
+            )
+        } When {
+            post("/api/v2/offerings/$bundleOfferingId/revisions")
+        } Then {
+            statusCode(400)
+        }
+    }
+
+    private fun assertUnpublishedBundleComponentIsRejected(specificationId: UUID) {
+        val unpublishedOfferingId = createOffering(specificationId, "INS_BUNDLE_UNPUBLISHED")
+        createRevision(unpublishedOfferingId, "Unpublished component")
+        val bundleOfferingId = createOffering(specificationId, "INS_BUNDLE_INVALID")
+        val bundleRevisionId = createRevision(
+            bundleOfferingId,
+            "Invalid bundle",
+            "[{\"kind\":\"BUNDLE\",\"targetOfferingId\":\"$unpublishedOfferingId\"}]",
+        )
+        setMaker(bundleRevisionId, "bundle-author")
+        publishExpecting(bundleOfferingId, bundleRevisionId, 409)
+    }
+
+    private fun assertBroaderBundleAudienceIsRejected(specificationId: UUID) {
+        val privateComponentOfferingId = createOffering(
+            specificationId,
+            "INS_BUNDLE_PRIVATE_COMPONENT",
+            """{"countries":["CZ"],"channels":["WEB"],"segments":["employee"],"locales":["cs-CZ"]}""",
+        )
+        val privateComponentRevisionId = createRevision(privateComponentOfferingId, "Employee component")
+        setMaker(privateComponentRevisionId, "private-component-author")
+        publish(privateComponentOfferingId, privateComponentRevisionId)
+        val broadBundleOfferingId = createOffering(specificationId, "INS_BUNDLE_BROAD")
+        val broadBundleRevisionId = createRevision(
+            broadBundleOfferingId,
+            "Broad bundle",
+            "[{\"kind\":\"BUNDLE\",\"targetOfferingId\":\"$privateComponentOfferingId\"}]",
+        )
+        setMaker(broadBundleRevisionId, "broad-bundle-author")
+        publishExpecting(broadBundleOfferingId, broadBundleRevisionId, 400)
+    }
+
+    private fun publishExpecting(offeringId: UUID, revisionId: UUID, status: Int) {
+        Given {
+            contentType("application/json")
+            body("{\"reason\":\"components are ready\"}")
+            header("If-Match", "\"0\"")
+        } When {
+            post("/api/v2/offerings/$offeringId/revisions/$revisionId/publish")
+        } Then {
+            statusCode(status)
+            if (status == 409) body("code", equalTo("CATALOG_CONFLICT"))
+        }
+    }
 
     private fun attributesFor(schemaVersion: Int): String =
         if (schemaVersion == 1) LEGACY_INSURANCE_ATTRIBUTES else INSURANCE_ATTRIBUTES
@@ -752,6 +853,7 @@ class CatalogPlatformResourceTest {
     private companion object {
         const val OUTBOX_FAILURE_ACTOR = "outbox-rollback-test-operator"
         const val EXACT_PRICE = "10000000000000000000.10"
+        const val DEFAULT_MARKET = """{"countries":["CZ"],"channels":["WEB"],"locales":["cs-CZ"]}"""
         const val LEGACY_INSURANCE_ATTRIBUTES =
             """{"coverage":{"amount":"100000.00","currency":"EUR"},"termYears":20,"premiumModel":"CALCULATED"}"""
         const val INSURANCE_ATTRIBUTES =


### PR DESCRIPTION
## Summary

- add a Product Studio flow for governed bundles and commercial audience context
- keep private offers customer-free: only controlled market segments, never party identifiers or PII
- reject self references, duplicate edges, unavailable bundle components, cycles, and audience broadening at the catalog boundary
- document the contract and cover the workflow with UI and real-PostgreSQL integration tests

## Validation

- `./gradlew :openbank-product-catalog:ktlintCheck :openbank-product-catalog:detekt`
- `./gradlew :openbank-product-catalog:compileTestKotlin`
- `npm test -- --run src/test/catalog-offer-composition.test.ts`
- `npm run type-check`

The local real-PostgreSQL test suite requires Docker, which is unavailable in this workspace; CI runs that suite on its runner.

Refs #4505
