### PR TITLE
fix(infra): remove the unsatisfiable FCM ExternalSecret and the CATALOG_SCOPE realm roles

### DIFF
--- a/.github/scripts/check-roles-allowed-realm.py
+++ b/.github/scripts/check-roles-allowed-realm.py
@@ -104,6 +104,44 @@ def realm_roles(root: pathlib.Path, errors):
     return names, files
 
 
+AUGMENTOR_MARKERS = ("SecurityIdentityAugmentor", "addRoles")
+
+
+def augmentor_roles(root: pathlib.Path):
+    """Role names a `SecurityIdentityAugmentor` synthesises per request, and so no realm issues.
+
+    A third source of roles exists alongside the realm and the annotation, and this gate could
+    not see it: Quarkus lets a `SecurityIdentityAugmentor` add roles to the identity AFTER the
+    token is verified. `CatalogScopeIdentityAugmentor` does exactly that — it derives
+    CATALOG_SCOPE_READ/AUTHOR/PUBLISH from the token's OAuth `scope` claim, and its KDoc says
+    why: *"without trusting a tenant claim or OPA"*. The scope-to-role mapping is meant to be
+    the ONLY path to those roles.
+
+    Before this, the only way to satisfy this gate was to declare them as realm roles, which is
+    the one thing that must not happen: a realm role is assignable in the admin console, so an
+    operator could grant CATALOG_SCOPE_PUBLISH to a user directly and reach every
+    `@RolesAllowed(CATALOG_SCOPE_PUBLISH)` endpoint with a token carrying no catalog scope at
+    all — the exact bypass the augmentor exists to prevent. And declaring them put the two
+    checks in direct conflict: `check-realm-role-parity` (template vs LIVE realm) then reported
+    all three as declared-and-never-issued, failing the keycloak-realm-drift CronJob daily,
+    because a role that only ever exists at runtime cannot appear in a live realm dump either.
+    Both gates were right about their own comparison and both were blind to the same third
+    source (2026-08-16).
+
+    DERIVED, not a list. A file counts only if it both implements `SecurityIdentityAugmentor`
+    and calls `addRoles`, and only the constants in that file are admitted. Delete the augmentor
+    and its roles stop being known here, so the 25 catalog sites go red again — which is the
+    correct verdict at that point, since nothing would issue them any more.
+    """
+    names = set()
+    for f in sorted(root.glob("openbank-*/src/main/kotlin/**/*.kt")):
+        text = f.read_text()
+        if not all(marker in text for marker in AUGMENTOR_MARKERS):
+            continue
+        names |= {value for _, value in CONST_RE.findall(text)}
+    return names
+
+
 def role_constants(root: pathlib.Path):
     constants = {}
     for qualifier, relative_path in (("Roles", ROLES_KT), ("CatalogRoles", CATALOG_ROLES_KT)):
@@ -174,13 +212,33 @@ def self_test() -> int:
             '@RolesAllowed(Roles.GHOST)\nfun d() {}\n\n'                           # constant, unknown
             '@RolesAllowed("ROLE_OPERATOR", "ROLE_TYPO2")\nfun e() {}\n\n'         # partial
             '@RolesAllowed(CatalogRoles.AUTHOR)\nfun g() {}\n\n'                  # catalog constant
+            '@RolesAllowed("ROLE_DERIVED_AT_RUNTIME")\nfun h() {}\n\n'            # augmentor-issued
             '// @RolesAllowed("ROLE_IN_A_COMMENT")\nfun f() {}\n'                   # prose
+        )
+
+        # A real augmentor: implements SecurityIdentityAugmentor AND calls addRoles, so the role
+        # it synthesises has an issuer even though no realm declares it. The CatalogRoles fixture
+        # above is the NEGATIVE control for the same rule — constants only, neither marker — so
+        # ROLE_CATALOG_AUTHOR must stay dead. Without that pair the new branch could admit every
+        # constant in the tree and this self-test would still pass.
+        aug = root / "openbank-y/src/main/kotlin/com/openbank/y"
+        aug.mkdir(parents=True)
+        (aug / "ScopeAugmentor.kt").write_text(
+            'object DerivedRoles {\n  const val SCOPED: String = "ROLE_DERIVED_AT_RUNTIME"\n}\n'
+            'class ScopeAugmentor : SecurityIdentityAugmentor {\n'
+            '  override fun augment(i: SecurityIdentity) = builder(i).addRoles(setOf(DerivedRoles.SCOPED)).build()\n'
+            '}\n'
         )
 
         errors: list = []
         known, files = realm_roles(root, errors)
         if known != {"ROLE_OPERATOR", "ROLE_API"}:
             fails.append(f"realm roles wrong: {sorted(known)}")
+        derived = augmentor_roles(root)
+        if derived != {"ROLE_DERIVED_AT_RUNTIME"}:
+            fails.append(f"augmentor-derived roles wrong: {sorted(derived)} "
+                         f"(want exactly the constants of files carrying BOTH markers)")
+        known |= derived
         consts = role_constants(root)
         expected_consts = {
             "Roles.OPERATOR": "ROLE_OPERATOR",
@@ -199,9 +257,11 @@ def self_test() -> int:
             if want not in alldead:
                 fails.append(f"{want} should be reported as not in the realm; dead={alldead}")
         # Known roles must NOT be — a gate that flags valid roles is one nobody keeps.
-        for notdead in ("ROLE_OPERATOR",):
+        # ROLE_DERIVED_AT_RUNTIME is in no realm at all; it must pass purely on having an
+        # augmentor that issues it, which is the whole point of the new branch.
+        for notdead in ("ROLE_OPERATOR", "ROLE_DERIVED_AT_RUNTIME"):
             if notdead in alldead:
-                fails.append(f"{notdead} is a real realm role and must not be reported dead")
+                fails.append(f"{notdead} has an issuer and must not be reported dead")
         # The CONSTANT must be resolved to its value. Unresolved it compares as "Roles.GHOST",
         # which is in no realm either — right verdict, wrong reason, and it would mask a
         # resolver that had stopped working entirely.
@@ -234,7 +294,7 @@ def self_test() -> int:
             sys.stderr.write(f"::error::self-test: {f}\n")
         sys.stderr.write(f"self-test FAILED ({len(fails)} case(s))\n")
         return 1
-    print("self-test ok: @RolesAllowed realm parity is falsifiable (13 cases)")
+    print("self-test ok: @RolesAllowed realm parity is falsifiable (16 cases)")
     return 0
 
 
@@ -250,6 +310,8 @@ def main() -> int:
 
     errors = []
     known, realm_files = realm_roles(root, errors)
+    derived = augmentor_roles(root)
+    known |= derived
     consts = role_constants(root)
 
     unreachable, partial, checked = [], [], 0
@@ -286,7 +348,9 @@ def main() -> int:
 
     print(
         f"roles-allowed parity: {checked} @RolesAllowed site(s) checked against "
-        f"{len(known)} role(s) from {', '.join(realm_files)}; every named role is issued by a realm.",
+        f"{len(known)} role(s) — {len(known) - len(derived)} from {', '.join(realm_files)} and "
+        f"{len(derived)} synthesised by a SecurityIdentityAugmentor "
+        f"({', '.join(sorted(derived)) or 'none'}); every named role has an issuer.",
     )
     return 0
 

--- a/openbank-infra/gitops/components/keycloak/README.md
+++ b/openbank-infra/gitops/components/keycloak/README.md
@@ -138,6 +138,39 @@ the user consents, Keycloak fires the `openbank-rum` audience mapper, adding
 `audience=openbank-rum`; tokens with only `aud=openbank-app` are rejected 401 —
 server-side enforcement without custom OTel processors.
 
+### `roles.realm[CATALOG_SCOPE_*]` — removed, deliberately
+
+`realm-template.json` declared `CATALOG_SCOPE_READ`, `CATALOG_SCOPE_AUTHOR` and
+`CATALOG_SCOPE_PUBLISH` as realm roles. They are gone as of 2026-08-16 and must not come
+back. They are **runtime-derived internal roles, not grantable realm roles**:
+`CatalogScopeIdentityAugmentor` in openbank-product-catalog synthesises them per request
+from the token's OAuth `scope` claim (`catalog:read` / `catalog:author` /
+`catalog:publish`), and its own KDoc says why — *"without trusting a tenant claim or
+OPA"*. The scope-to-role mapping is meant to be the only path to those roles.
+
+Declaring them in the realm makes them assignable in the Keycloak admin console, so an
+operator could grant `CATALOG_SCOPE_PUBLISH` to a user directly and reach every
+`@RolesAllowed(CATALOG_SCOPE_PUBLISH)` endpoint with a token carrying no catalog scope
+at all. That is the exact bypass the augmentor exists to prevent, which makes "create the
+role" the wrong half of the parity checker's own remediation hint (*"Create the role …
+or delete the declaration"*) — here it is always the delete.
+
+Removing them also clears three `check-realm-role-parity` findings that had been failing
+the `keycloak-realm-drift` CronJob (`declaredNotLive` + `namedByCodeButNotLive`, 9/1/15
+`@RolesAllowed` sites respectively).
+
+**Separate and still open — the reason those 25 sites are unreachable is NOT these
+roles.** `catalog:read|author|publish` is not declared as a client scope in either realm
+template: `realm-template.json` has `clientScopes: []`, and `customers-realm-template.json`
+carries `profile`, `accounts:read`, `payments:initiate`, `statements:read`,
+`sca:enroll-device`, `sca:decide`, `telemetry:rum` — no catalog scope. So no token from a
+cold-started realm can carry the scope the augmentor reads, and the augmentor returns the
+identity unchanged. Whether the *live* realm has such a scope is unverified here on
+purpose: `check-realm-role-parity` states its own blind spot (`doesNotVerify:
+"client-role assignments; group membership; …"`) and client scopes are outside it, so
+nothing in this repo currently measures it. Wiring the scope is an authorization design
+decision (default vs optional scope, and which clients may request it), not a drift fix.
+
 ### `clients[openbank-edge-webauthn].description`
 
 Shortened to fit Keycloak's 255-char cap. In full: service-account client for

--- a/openbank-infra/gitops/components/keycloak/realm-template.json
+++ b/openbank-infra/gitops/components/keycloak/realm-template.json
@@ -35,18 +35,6 @@
         "description": "Bank operator"
       },
       {
-        "name": "CATALOG_SCOPE_READ",
-        "description": "Catalog read permission derived from the catalog:read OAuth scope"
-      },
-      {
-        "name": "CATALOG_SCOPE_AUTHOR",
-        "description": "Catalog author permission derived from the catalog:author OAuth scope"
-      },
-      {
-        "name": "CATALOG_SCOPE_PUBLISH",
-        "description": "Catalog publication permission derived from the catalog:publish OAuth scope"
-      },
-      {
         "name": "ROLE_VIEWER",
         "description": "Read-only access"
       },

--- a/openbank-infra/gitops/components/notifications/fcm-externalsecret.yaml
+++ b/openbank-infra/gitops/components/notifications/fcm-externalsecret.yaml
@@ -10,40 +10,71 @@
 # scope). It lives ONLY in Vault, never in Git or the Deployment manifest; only this
 # reference does. Same shape as apns-externalsecret.yaml.
 #
-# Until an operator writes the Vault key the ExternalSecret stays pending and the
-# Secret is absent — which is fine: the Deployment's secretKeyRefs are `optional:true`,
-# the pod starts, and FCM_ENABLED stays "false" until delivery is actually wanted, so a
-# not-yet-seeded Vault records Android pushes as skipped, never as failures. To enable
-# delivery: write the Vault key, flip FCM_ENABLED to "true" in notification-service.yaml,
-# and restart notification-service so the secret env is re-read.
+# ─────────────────────────────────────────────────────────────────────────────
+# THE RESOURCE BELOW IS DELIBERATELY COMMENTED OUT UNTIL THE VAULT KEY EXISTS.
 #
-#   bao kv patch openbank/notification-service \
-#     FCM_SERVICE_ACCOUNT_JSON=@openbank-android-fcm.json
+# This block used to say: "Until an operator writes the Vault key the ExternalSecret
+# stays pending and the Secret is absent — which is fine". ESO has no such pending
+# state. A `data[].remoteRef.property` that the remote object does not carry is a HARD
+# error, not a wait:
+#
+#   could not get secret data from provider
+#   error retrieving secret at .data[0], key: notification-service,
+#   err: cannot find secret data for key: "FCM_SERVICE_ACCOUNT_JSON"
+#
+# So the resource has been re-reconciling and re-failing on the 1h refreshInterval
+# since it was written. Measured 2026-08-16: SecretSyncedError / Ready=False, 178
+# external-secrets error lines in 24h (the single largest error source in that
+# namespace), and the `notifications` ArgoCD Application permanently Degraded — which
+# is the part that costs, because a Degraded app is how a REAL notifications problem
+# would announce itself and it was already showing that colour.
+#
+# Nothing was gained for it. FCM_ENABLED is "false" in notification-service.yaml, the
+# Deployment's secretKeyRef is `optional: true`, and the Secret has never existed, so
+# the pod behaves identically with and without this ExternalSecret. The only difference
+# it makes is the error.
+#
+# The claim was also the wrong shape structurally: an ExternalSecret is a request for a
+# credential, so declaring one for a credential nobody has put in the vault is declaring
+# a permanent failure. Note the trap for the reverse direction too — do NOT "fix" this by
+# seeding a placeholder value, which would make the Secret exist and the error disappear
+# while FcmPushSender would then hold a credential that cannot authenticate.
+#
+# TO ENABLE ANDROID PUSH, all three steps, in order:
+#   1. bao kv patch openbank/notification-service \
+#        FCM_SERVICE_ACCOUNT_JSON=@openbank-android-fcm.json
+#   2. uncomment the resource below
+#   3. set FCM_ENABLED: "true" in notification-service.yaml and restart
+#      notification-service so the secret env is re-read
+#
+# Step 1 before step 2 — reversing them recreates exactly the state this change removes.
 #
 # FCM_PROJECT_ID is optional (falls back to project_id inside the service-account JSON)
 # and is set inline in the Deployment env only if an override is ever needed.
-apiVersion: external-secrets.io/v1beta1
-kind: ExternalSecret
-metadata:
-  name: notification-service-fcm
-  namespace: notifications
-spec:
-  refreshInterval: 1h
-  secretStoreRef:
-    kind: ClusterSecretStore
-    name: vault-kv
-  target:
-    name: notification-service-fcm
-    creationPolicy: Owner
-    deletionPolicy: Retain
-    template:
-      engineVersion: v2
-      mergePolicy: Merge
-      metadata:
-        annotations:
-          argocd.argoproj.io/compare-options: IgnoreExtraneous
-  data:
-    - secretKey: FCM_SERVICE_ACCOUNT_JSON
-      remoteRef:
-        key: notification-service
-        property: FCM_SERVICE_ACCOUNT_JSON
+# ─────────────────────────────────────────────────────────────────────────────
+#
+# apiVersion: external-secrets.io/v1beta1
+# kind: ExternalSecret
+# metadata:
+#   name: notification-service-fcm
+#   namespace: notifications
+# spec:
+#   refreshInterval: 1h
+#   secretStoreRef:
+#     kind: ClusterSecretStore
+#     name: vault-kv
+#   target:
+#     name: notification-service-fcm
+#     creationPolicy: Owner
+#     deletionPolicy: Retain
+#     template:
+#       engineVersion: v2
+#       mergePolicy: Merge
+#       metadata:
+#         annotations:
+#           argocd.argoproj.io/compare-options: IgnoreExtraneous
+#   data:
+#     - secretKey: FCM_SERVICE_ACCOUNT_JSON
+#       remoteRef:
+#         key: notification-service
+#         property: FCM_SERVICE_ACCOUNT_JSON


### PR DESCRIPTION
## What

Two permanently-failing declarations from the 2026-08-16 observability sweep. Both asserted a state their own machinery cannot produce.

## 1. FCM — an ExternalSecret that can only fail

`fcm-externalsecret.yaml` said:

> Until an operator writes the Vault key the ExternalSecret stays pending and the Secret is absent — which is fine

ESO has no such pending state. A `data[].remoteRef.property` the remote object does not carry is a **hard error**:

```
could not get secret data from provider
error retrieving secret at .data[0], key: notification-service,
err: cannot find secret data for key: "FCM_SERVICE_ACCOUNT_JSON"
```

Measured on the cluster:

- `SecretSyncedError` / `Ready=False`, re-failing on the 1h `refreshInterval` since it was written
- **178 external-secrets error lines / 24h** — the single largest error source in that namespace
- the `notifications` ArgoCD Application permanently **Degraded**

The last one is what actually costs. A Degraded app is how a *real* notifications problem would announce itself, and it was already showing that colour.

Nothing was gained for it. `FCM_ENABLED` is `"false"` in `notification-service.yaml`, the Deployment's `secretKeyRef` is `optional: true`, and the Secret has never existed — so the pod behaves identically with and without this ExternalSecret. The only difference it made was the error.

The resource is commented out, keeping the doc block, with the enable recipe **in order** — Vault key first, then uncomment, then flip `FCM_ENABLED` — because the reverse order recreates exactly this state. Also flagged in place: do not "fix" it by seeding a placeholder, which makes the Secret exist and the error vanish while `FcmPushSender` would hold a credential that cannot authenticate.

The path `openbank/notification-service` is verified to be otherwise healthy — `notification-service-apns` (`APNS_KEY_ID`/`TEAM_ID`/`PRIVATE_KEY`) and `notification-webhook` read the same object and sync fine. The FCM property simply is not there.

## 2. `CATALOG_SCOPE_*` — a realm role that must not be a realm role

`realm-template.json` declared `CATALOG_SCOPE_READ` / `AUTHOR` / `PUBLISH` as realm roles. They are **runtime-derived**: `CatalogScopeIdentityAugmentor` synthesises them per request from the token's OAuth `scope` claim, and its own KDoc says why — *"without trusting a tenant claim or OPA"*. The scope-to-role mapping is meant to be the only path to them.

Declaring them as realm roles makes them assignable in the Keycloak admin console. An operator could grant `CATALOG_SCOPE_PUBLISH` to a user directly and reach every `@RolesAllowed(CATALOG_SCOPE_PUBLISH)` endpoint with a token carrying no catalog scope at all — the exact bypass the augmentor exists to prevent.

### Two gates disagreed, and both were blind to the same third source

| Gate | Compares | Verdict on `CATALOG_SCOPE_*` |
|---|---|---|
| `check-realm-role-parity` (drift CronJob) | template vs **live** realm | declared and never issued → 3 errors, failing `keycloak-realm-drift` daily |
| `check-roles-allowed-realm` | annotation vs **template** | not declared anywhere → 25 errors if you just delete them |

Both were right about their own comparison. A role that only ever exists at runtime cannot appear in a live realm dump, so the first can never go green while it is declared; and the second required a declaration, so the declaration was the workaround that broke the first. The realm was never the right place for either verdict.

So `check-roles-allowed-realm` learns the third source: a role is also *issued* when a file that both implements `SecurityIdentityAugmentor` **and** calls `addRoles` declares it as a constant.

**Derived from the sources, not a hand-kept list** — nothing to maintain, and it cannot rot into a mute button. Falsified both ways:

- self-test gains a positive fixture (an augmentor whose role is in no realm must pass) and keeps the existing constants-only `CatalogRoles` fixture as the negative control, so a branch that admitted every constant in the tree would fail. 13 → 16 cases.
- deleting the real augmentor from the working tree was measured to produce exactly **25 errors**, then restored.

Gate output now names what it trusted:

```
roles-allowed parity: 445 @RolesAllowed site(s) checked against 22 role(s) —
19 from customers-realm-template.json, realm-template.json and 3 synthesised by a
SecurityIdentityAugmentor (CATALOG_SCOPE_AUTHOR, CATALOG_SCOPE_PUBLISH, CATALOG_SCOPE_READ)
```

Local `run-gates.py --all`: 146/148 pass. The two failures (`loki-rule-load-test` self-test needs `BASE_REF`, `api-contract-gate` wants `sudo` to install oasdiff) reproduce identically on a clean `origin/main` worktree.

## Found while here, NOT fixed

**The 25 catalog `@RolesAllowed` sites are still unreachable, and these roles were never the reason.** `catalog:read|author|publish` is declared as a client scope in **neither** realm template — `realm-template.json` has `clientScopes: []`, and `customers-realm-template.json` carries `profile`, `accounts:read`, `payments:initiate`, `statements:read`, `sca:enroll-device`, `sca:decide`, `telemetry:rum`. No token from a cold-started realm can carry the scope the augmentor reads, so it returns the identity unchanged. Whether the *live* realm has such a scope is deliberately not asserted here: `check-realm-role-parity` states its own blind spot (`doesNotVerify: "client-role assignments; group membership; …"`) and client scopes fall outside it, so nothing in this repo measures it today. Wiring the scope is an authorization design decision — default vs optional, and which clients may request it — not a drift fix.

**`demo@openbank.local` keeps the `keycloak-realm-drift` job red.** It has PUBLISHED credentials and holds `ROLE_ADMIN, ROLE_AUDITOR, ROLE_COMPLIANCE, ROLE_DEMO, ROLE_OPERATOR, ROLE_PAYMENTS`; the template grants it `ROLE_VIEWER`. `check-realm-user-role-parity` escalates over-grant to `::error::` specifically for accounts in `PUBLISHED_CREDENTIAL_USERS`, which is the correct call — a publicly-handed-out login is a platform admin. Reducing it is a product decision about what the demo must still be able to do, so it is untouched.

Refs #2404
