### PR TITLE
ci(gates): let a contract declare an event type as not published

### DIFF
--- a/.github/scripts/check-event-contract-code-agreement.py
+++ b/.github/scripts/check-event-contract-code-agreement.py
@@ -653,11 +653,38 @@ def check_contract(path: pathlib.Path) -> list[str]:
             f'`const val EVENT_TYPE = "{name}"`). Either the producer was renamed and the contract '
             f"was not, or this message describes an event that is never emitted."
         )
-    for name in sorted(set(declared) - ordinary_doc_names):
+    # An outbox is not necessarily a Kafka producer. billing-service dispatches ON eventType:
+    # `billing.fee.post-intent.v1` and `...reversal-intent.v1` are posted to ledger-service over
+    # REST via LedgerPostingPort, and only `billing.annual-fee-summary.ready` reaches the Kafka
+    # emitter (LedgerOutboxEventPublisher.dispatch). Demanding a channel message for the REST ones
+    # would document as published events two things that never touch a topic — which is the
+    # opposite of this gate's purpose, and which billing's contract header already forbids in prose.
+    #
+    # So a contract may declare `x-openbank-not-published` with a REASON per event type. The reason
+    # is required: a bare list would become a silent mute, and the next reader needs to know why an
+    # emitted-looking type is exempt rather than merely that someone exempted it.
+    not_published = doc.get("x-openbank-not-published") or {}
+    if not isinstance(not_published, dict):
+        errors.append(
+            f"{rel}: x-openbank-not-published must be a mapping of event type -> reason, so each "
+            f"exemption carries why it is not a published event. A bare list is a silent mute."
+        )
+        not_published = {}
+    for name, reason in not_published.items():
+        if not isinstance(reason, str) or not reason.strip():
+            errors.append(f"{rel}: x-openbank-not-published[{name}] has no reason.")
+        if name not in declared:
+            errors.append(
+                f"{rel}: x-openbank-not-published lists `{name}`, but no producer in "
+                f"{service}/src/main declares that event type — a stale exemption."
+            )
+    for name in sorted(set(declared) - ordinary_doc_names - set(not_published)):
         info = declared[name]
         errors.append(
             f"{rel}: {info['path']} declares event type `{name}` ({info['class'] or 'hand-built outbox'}) "
-            f"and the contract has no message for it — an emitted event no consumer has been told about."
+            f"and the contract has no message for it — an emitted event no consumer has been told about. "
+            f"If it is not published to a topic at all (an outbox row dispatched by another transport), "
+            f"declare it under x-openbank-not-published with a reason."
         )
 
     # ---- C. payload properties vs constructor properties --------------------------------


### PR DESCRIPTION
## What

`check-event-contract-code-agreement` assumes every `eventType` in a producer is an event published to a topic. An outbox is a delivery mechanism, not a publication, and billing-service is the counterexample: `LedgerOutboxEventPublisher.dispatch` branches on eventType, and only one of its three reaches Kafka.

| eventType | transport |
|---|---|
| `billing.fee.post-intent.v1` | REST -> `LedgerPostingPort.post` |
| `billing.fee.reversal-intent.v1` | REST -> `LedgerPostingPort.postReversal` |
| `billing.annual-fee-summary.ready` | Kafka emitter |

The gate reported the first two as *"an emitted event no consumer has been told about"*. Both findings are wrong, and the only way to clear them was to write channel messages for two payloads that never touch a topic — asserting a Kafka contract with no publisher behind it. billing's contract header already forbade that in prose; the gate cannot read prose.

## Change

A contract may declare `x-openbank-not-published` as a mapping of event type to **reason**:

- the reason is **required**, and a bare list is rejected — an exemption whose entries carry no justification is a silent mute;
- a listed type with **no producer** is reported as a stale exemption, so the escape hatch cannot outlive what it excuses.

## Falsification

Run in all four directions, not only the green one:

| case | result |
|---|---|
| declaration removed | 2 findings (both types undocumented) |
| stale entry added | stale flagged **and** its real counterpart reverts to undocumented |
| bare list instead of mapping | rejected |
| restored | clean |

Against unmodified `origin/main`, all **7** existing contracts still agree — the feature is opt-in, and no contract that does not use it changes behaviour.

## Why this is its own PR

It is a fleet-wide change to what a gate means. Landing it inside the billing feature PR that surfaced it would have hidden that from review. #4129 carries the contract-side declaration and stays red on this gate until this merges.

Refs #4129

🤖 Generated with [Claude Code](https://claude.com/claude-code)
