### PR TITLE
fix(governance): preserve release gate self-test

### DIFF
--- a/.github/scripts/check-app-version-override.sh
+++ b/.github/scripts/check-app-version-override.sh
@@ -33,7 +33,7 @@ if [ "${1:-}" = "--self-test" ]; then
   expect() { local label="$1" want="$2" sub="${3:-}" out rc
     out=$(bash "$0" "$td" 2>&1); rc=$?
     if [ "$rc" -ne "$want" ]; then echo "::error::self-test: $label — want rc=$want got $rc: $out" >&2; fails=$((fails+1))
-    elif [ -n "$sub" ] && ! printf '%s' "$out" | grep -qF -- "$sub"; then
+    elif [ -n "$sub" ] && ! grep -qF -- "$sub" <<<"$out"; then
       echo "::error::self-test: $label — rc right, reason wrong (no '$sub'): $out" >&2; fails=$((fails+1)); fi; }
   reset() { rm -rf "$td"/openbank-x; }
 


### PR DESCRIPTION
## Summary
- avoid `pipefail` treating an early `grep -q` exit as a false self-test failure
- keep the release-version override rule and all six self-test cases intact

## Verification
- `bash .github/scripts/check-app-version-override.sh --self-test`
- `bash .github/scripts/check-app-version-override.sh .`

Refs #4505