### PR TITLE
fix(ci): make the ADR-registry self-test diagnostic able to vary, and match bytes

### DIFF
--- a/.github/scripts/check-adr-registry.sh
+++ b/.github/scripts/check-adr-registry.sh
@@ -98,25 +98,60 @@ if [ "${1:-}" = "--self-test" ]; then
     cp "$REAL_ADR/lib-frontmatter.sh" "$REAL_ADR/tags.txt" "$REAL_ADR/known-repos.txt" "$d/" 2>/dev/null
     echo "$d"
   }
+  # Print captured gate output as INERT log lines. `$out` is full of `::error::` /
+  # `::warning::` workflow commands, and interpolating it into an `echo "::error::… $out"`
+  # hands those embedded lines straight back to the Actions runner, which re-parses each one
+  # as its own command. That is what made the #4850 log read as self-contradictory: the
+  # single `expect` failure rendered as three unrelated annotations
+  # (`##[error]self-test: …`, then a stray `##[warning]…`, then `##[error]check-adr-registry:
+  # ADR registry has integrity violations`), so the evidence for one case looked like output
+  # from somewhere else entirely. Neutralising `::` and prefixing every line keeps a
+  # multi-line capture readable as ONE block.
+  show_out() { # show_out <what> <text>
+    printf '  [%s] %s\n' "$1" "----------------------------------------" >&2
+    printf '%s\n' "$2" | sed -e 's/::/:!:/g' -e "s/^/  [$1] /" >&2
+  }
+
   expect() { # expect <label> <adr-dir> <want-rc> [substring]
-    local label="$1" d="$2" want="$3" sub="${4:-}" out rc
+    local label="$1" d="$2" want="$3" sub="${4:-}" out rc mrc=0
     # cd OUT of this repo: see the note above about check 5's repo-wide git grep.
     out=$(cd "$td" && bash "$SELF" "$d" 2>&1); rc=$?
+    # The match is evaluated HERE, not inside the `elif`, for one reason: its exit status has
+    # to survive into the diagnostic. #4854 printed `PIPESTATUS` from inside the branch, where
+    # the most recent pipeline is the preceding `echo` — so it reported `0` unconditionally,
+    # on a path only reachable because grep returned non-zero. A diagnostic that cannot vary
+    # is not evidence.
+    #
+    # `LC_ALL=C` closes the last untested candidate for #4850. GNU grep's matching is
+    # locale-dependent even under `-F`, and `$out` is not pure ASCII (`err` writes an em dash,
+    # and every fixture path is interpolated), so an encoding the runner's locale rejects can
+    # make an ASCII pattern silently miss a line that contains it. That is the shape of the
+    # one observed failure: an assertion that a substring was absent from output the log shows
+    # containing it, on a job that passed on re-run with no code change. It is not confirmed
+    # to be the cause — it could not be reproduced — but byte matching is what this assertion
+    # always meant, and it removes the variable.
+    #
+    # (#4854 already removed the earlier candidate, a `printf | grep -q` pipeline whose `-q`
+    # early exit can SIGPIPE the writer under `set -o pipefail`. The here-string below keeps
+    # that closed.)
+    if [ -n "$sub" ]; then LC_ALL=C grep -qF -- "$sub" <<<"$out" || mrc=$?; fi
     if [ "$rc" -ne "$want" ]; then
-      echo "::error::self-test: $label — want rc=$want got $rc: $out" >&2; fails=$((fails+1))
-    # Here-string, NOT `printf | grep -q` (#4850). Under `set -o pipefail` a `-q` early exit can
-    # SIGPIPE the writer and the pipeline then reports failure even though grep matched — this
-    # repo documents that footgun, and services-ci.yml carries the same note. It is written here
-    # as a precaution, not as a diagnosis: the one observed failure (#4850) could not be
-    # reproduced under bash 3.2 or 5.2 with the match at the head of a 5 MB payload, so the
-    # mechanism is unconfirmed. Removing the pipeline costs nothing and closes the candidate.
-    elif [ -n "$sub" ] && ! grep -qF -- "$sub" <<<"$out"; then
-      # Carry the evidence, so a recurrence diagnoses itself instead of needing a repro. The
-      # failure this replaces printed an $out that visibly CONTAINED the substring it said was
-      # missing, and nothing in the log could explain the contradiction.
-      echo "::error::self-test: $label — rc right, reason wrong (no '$sub'): $out" >&2
-      echo "::error::self-test: matcher PIPESTATUS=${PIPESTATUS[*]-n/a}; \$out as bytes:" >&2
-      od -c <<<"$out" | head -20 >&2
+      echo "::error::self-test: $label — want rc=$want got $rc (gate output below)" >&2
+      show_out "$label" "$out"
+      fails=$((fails+1))
+    elif [ "$mrc" -ne 0 ]; then
+      # Carry the evidence, so a recurrence diagnoses itself instead of needing a repro:
+      # grep's REAL status, the locale it ran under, both byte lengths, and the bytes of both
+      # sides. Dumping `$sub` matters as much as dumping `$out` — the assertion is a
+      # comparison, and #4850 could not be settled precisely because only one side was ever
+      # visible.
+      echo "::error::self-test: $label — rc right, reason wrong (no '$sub')" >&2
+      echo "::error::self-test: grep rc=$mrc LC_ALL=C; \${#out}=${#out} \${#sub}=${#sub}; LANG=${LANG:-unset} LC_ALL(env)=${LC_ALL:-unset}" >&2
+      show_out "$label" "$out"
+      echo "  [$label] \$out as bytes:" >&2
+      od -c <<<"$out" >&2
+      echo "  [$label] \$sub as bytes:" >&2
+      od -c <<<"$sub" >&2
       fails=$((fails+1))
     fi
   }


### PR DESCRIPTION
Closes #4850

## What the real job log actually shows

#4850 was filed with the mechanism unconfirmed, and #4854 landed the two remediations it
asked for. Pulling the raw log for the one occurrence
(`actions/jobs/94754443674`) settles part of it and leaves the rest open. The failure block is:

```
##[error]self-test: a duplicate ADR number is caught — rc right, reason wrong (no 'duplicate ADR number'): ::error title=ADR registry::duplicate ADR number 0001 shared by: 0001-first.md,0001-other.md — renumber all but one to the next free number.
##[warning]check-adr-registry: /tmp/tmp.cypMQaicGU/dupe/adr/gen-index.sh missing — skipping index freshness check.
##[error]check-adr-registry: ADR registry has integrity violations (see above).
self-test FAILED (1 case(s))
```

Those are not three findings. They are **one** `expect` failure: lines 2 and 3 are lines 2 and 3
of the captured `$out`. `$out` is full of `::error::` / `::warning::` workflow commands, and
interpolating it into `echo "::error::... $out"` hands the embedded lines straight back to the
Actions runner, which re-parses each one as its own command and emits it as a separate
annotation. So the evidence for one case rendered as output from somewhere else, which is a
large part of why the log read as unexplainable.

It does **not** explain the assertion itself: line 1 of `$out` is inline and does contain
`duplicate ADR number`. That contradiction is still real and this PR does not claim to have
solved it.

## What is fixed

1. **The diagnostic #4854 added cannot vary.** It printed
   `PIPESTATUS=${PIPESTATUS[*]-n/a}` from *inside* the failure branch, where the most recent
   pipeline is the preceding `echo` — not the matcher. Measured:

   ```
   $ bash -c 'set +e; out="hello"; if ! grep -qF -- "zzz" <<<"$out"; then echo "PIPESTATUS=${PIPESTATUS[*]}"; fi'
   PIPESTATUS=0
   ```

   `0`, on a path only reachable because grep returned non-zero. A diagnostic that cannot vary is
   not evidence. The match now runs before the branch and its real status is carried in, with both
   byte lengths, the locale, and `od -c` of **both** sides — dumping `$sub` matters as much as
   `$out`, since the assertion is a comparison and only one side was ever visible.

2. **Captured output is now inert.** Printed as one labelled block with `::` rewritten to `:!:`,
   so the runner cannot re-parse it and a multi-line capture stays readable as one thing.

3. **`LC_ALL=C` on the matcher** — the last untested candidate. GNU grep's matching is
   locale-dependent even under `-F`, and `$out` is not pure ASCII (`err` writes an em dash; every
   fixture path is interpolated), so an encoding the runner's locale rejects can make an ASCII
   pattern silently miss a line that contains it. **Not confirmed as the cause — not reproduced.**
   Byte matching is what this assertion always meant, so it removes the variable.
   (#4854's here-string keeps the earlier SIGPIPE candidate closed.)

## What I falsified, and how

Every direction was run and its **exit code read directly**, not through a pipe.

| # | Condition | Expected | Measured |
|---|---|---|---|
| 1 | unmodified gate | self-test passes | `self-test ok: ... (25 cases)`, exit **0** |
| 2 | dup check emits a *different* message (rc still 1) | the substring branch fires | `self-test FAILED (1 case(s))`, exit **1** |
| 3 | dup check disabled entirely (rc becomes 0) | the want-rc branch fires | `self-test FAILED (1 case(s))`, exit **1** |
| — | real gate over `docs/adr/` | clean | exit **0** |
| — | `shellcheck -S warning` | clean | exit **0** |

Direction 2 is the one that matters — it is the exact shape of the #4850 signature, and it is what
the new diagnostic is for. It now prints:

```
::error::self-test: a duplicate ADR number is caught — rc right, reason wrong (no 'duplicate ADR number')
::error::self-test: grep rc=1 LC_ALL=C; ${#out}=384 ${#sub}=20; LANG=unset LC_ALL(env)=unset
  [a duplicate ADR number is caught] :!:error title=ADR registry:!:SABOTAGE-wrong-reason 0001 shared by: ...
  [a duplicate ADR number is caught] :!:warning:!:check-adr-registry: ... gen-index.sh missing ...
  [a duplicate ADR number is caught] :!:error:!:check-adr-registry: ADR registry has integrity violations (see above).
  [a duplicate ADR number is caught] $out as bytes:  <od -c ...>
  [a duplicate ADR number is caught] $sub as bytes:  <od -c ...>
```

`grep rc=1` where #4854 printed `0`, all three captured lines held together as one block, and both
sides of the comparison in bytes.

The matcher was also run against a known-positive and a known-negative rather than trusting its
silence — `LC_ALL=C grep -qF` over a line carrying the em dash returns 0, and over a
non-matching line returns 1.

## What I could NOT verify

- **The original root cause.** Still unconfirmed. Line 1 of `$out` demonstrably contains the
  substring, and no mechanism I could reproduce explains grep missing it. The locale hypothesis is
  closed by construction, not by measurement — if `LC_ALL=C` was the fix, nothing here will ever
  tell us so.
- **That this stops a recurrence.** It cannot. It makes the *next* occurrence self-diagnosing,
  which is remediation item 1 of the issue done properly.
- **Behaviour on the CI runner's own locale.** Local runs report `LANG=unset`; the new message
  records `LANG`/`LC_ALL` precisely so a recurrence carries that fact instead of needing this
  question asked again.

Docs/CI-only change to one script — no service path touched, so no version bump.
