### PR TITLE
feat(ci): retain JUnit XML and record re-run flakes

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -66,6 +66,9 @@ labels:
   - name: main-red
     color: "b60205"
     description: "main-red watch (#4019): one open issue per watched workflow, closed when main goes green."
+  - name: flaky-test
+    color: "fbca04"
+    description: "Recorded by auto-retry-cancelled.yml (#4878) when a re-run turns a genuine failure green. Dedup marker for the flake-tracking issue."
 
   # --- Triage / workflow state ---------------------------------------------------------
   - name: triage

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -68,7 +68,7 @@ labels:
     description: "main-red watch (#4019): one open issue per watched workflow, closed when main goes green."
   - name: flaky-test
     color: "fbca04"
-    description: "Recorded by auto-retry-cancelled.yml (#4878) when a re-run turns a genuine failure green. Dedup marker for the flake-tracking issue."
+    description: "Recorded by auto-retry-cancelled.yml (#4878): a re-run turned a real failure green."
 
   # --- Triage / workflow state ---------------------------------------------------------
   - name: triage

--- a/.github/scripts/list-recorded-flakes.py
+++ b/.github/scripts/list-recorded-flakes.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""Thin read layer over the flake records `record-rerun-flake.py` writes (#4878).
+
+Not a dashboard, a gate, or an alert -- deliberately. #4878 asks only for the ABILITY to answer
+"which tests fail intermittently, and how often"; deciding what to threshold or alert on is
+explicit follow-up work once there is data to look at. This is the smallest thing that turns
+the tracking issue's comments back into a table a human (or a later tool) can read.
+
+Each flake is recorded as one comment on the open "Flaky test observations" issue
+(label `flaky-test`), with a human table plus a `<!-- flake-record:{json} -->` payload
+`record-rerun-flake.py`'s `render_comment` writes. This reads those payloads back out.
+
+USAGE
+    list-recorded-flakes.py --issue 1234                 # live: gh issue view --json comments
+    list-recorded-flakes.py --comments-file bodies.json   # offline: a JSON list of comment bodies
+    list-recorded-flakes.py --self-test
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from collections import Counter
+from pathlib import Path
+
+# `record-rerun-flake.py`'s filename is not a valid Python module name (hyphens), and this repo's
+# existing cross-script-import convention (`check-advisory-finding-staleness.py` -> `gatelib.py`)
+# is for a shared underscore-named module, not for reaching into another hyphenated CLI script.
+# The function is 10 lines and has its own self-test on both sides of the round-trip (write side
+# in record-rerun-flake.py, read side here) -- duplicating it is cheaper and more robust than an
+# importlib.util.spec_from_file_location workaround for one function.
+RECORD_MARKER = "<!-- flake-record:"
+
+
+def extract_records_from_comments(bodies: list[str]) -> list[dict]:
+    """The read-side of `record_rerun_flake.render_comment` -- pulls the JSON payload back out."""
+    out: list[dict] = []
+    for body in bodies:
+        idx = body.find(RECORD_MARKER)
+        if idx == -1:
+            continue
+        start = idx + len(RECORD_MARKER)
+        end = body.find("-->", start)
+        if end == -1:
+            continue
+        raw = body[start:end].strip()
+        try:
+            out.append(json.loads(raw))
+        except json.JSONDecodeError:
+            continue
+    return out
+
+
+def fetch_comment_bodies(issue: int) -> list[str]:
+    proc = subprocess.run(
+        ["gh", "issue", "view", str(issue), "--json", "comments"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(f"gh issue view {issue} failed: {proc.stderr.strip()[:400]}")
+    doc = json.loads(proc.stdout)
+    return [c.get("body", "") for c in doc.get("comments", [])]
+
+
+def summarize(records: list[dict]) -> str:
+    if not records:
+        return "No flakes recorded yet."
+
+    by_test: Counter[str] = Counter()
+    by_service: Counter[str] = Counter()
+    for r in records:
+        service = r.get("service") or r.get("job") or "n/a"
+        by_service[service] += 1
+        for t in r.get("tests") or []:
+            by_test[f"{t['classname']}#{t['name']}"] += 1
+        if not r.get("tests"):
+            by_test[f"(job-level only) {r.get('job')}"] += 1
+
+    lines = [f"{len(records)} flake record(s) total.", "", "By service:"]
+    for service, count in by_service.most_common():
+        lines.append(f"  {count:4d}  {service}")
+    lines.append("")
+    lines.append("By test:")
+    for test, count in by_test.most_common():
+        lines.append(f"  {count:4d}  {test}")
+    return "\n".join(lines)
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--issue", type=int)
+    parser.add_argument("--comments-file", type=Path)
+    parser.add_argument("--json", action="store_true", help="print raw records as JSON instead of a summary")
+    parser.add_argument("--self-test", action="store_true")
+    args = parser.parse_args(argv)
+
+    if args.self_test:
+        return self_test()
+
+    if args.issue is not None:
+        bodies = fetch_comment_bodies(args.issue)
+    elif args.comments_file is not None:
+        bodies = json.loads(args.comments_file.read_text(encoding="utf-8"))
+    else:
+        parser.error("one of --issue or --comments-file is required (or --self-test)")
+        return 2
+
+    records = extract_records_from_comments(bodies)
+    if args.json:
+        print(json.dumps(records, indent=2))
+    else:
+        print(summarize(records))
+    return 0
+
+
+def self_test() -> int:
+    failures: list[str] = []
+
+    def check(label: str, cond: bool) -> None:
+        if not cond:
+            failures.append(label)
+        print(f"  [{'ok ' if cond else 'FAIL'}] {label}")
+
+    r1 = {
+        "workflow": "Services CI",
+        "job": "build (openbank-transaction-service)",
+        "service": "openbank-transaction-service",
+        "run_id": 1,
+        "run_url": "u1",
+        "prev_attempt": 1,
+        "final_attempt": 2,
+        "head_sha": "a",
+        "head_branch": "main",
+        "detected_at": "t1",
+        "tests": [{"classname": "com.openbank.tx.OutboxClaimIT", "name": "a stale row is reclaimed", "kind": "failure", "message": "m"}],
+    }
+    r2 = {
+        "workflow": "Services CI",
+        "job": "build (openbank-standing-order-service)",
+        "service": "openbank-standing-order-service",
+        "run_id": 2,
+        "run_url": "u2",
+        "prev_attempt": 1,
+        "final_attempt": 2,
+        "head_sha": "b",
+        "head_branch": "main",
+        "detected_at": "t2",
+        "tests": [{"classname": "com.openbank.so.OutboxClaimIT", "name": "a stale row is reclaimed", "kind": "failure", "message": "m"}],
+    }
+    bodies = [
+        f"### Flake recorded\n<!-- flake-record:{json.dumps(r1)} -->\n",
+        "a human reply with no marker at all",
+        f"### Flake recorded\n<!-- flake-record:{json.dumps(r2)} -->\n",
+    ]
+
+    records = extract_records_from_comments(bodies)
+    check("recovers exactly the two machine-readable records, skipping the human comment", len(records) == 2)
+
+    summary = summarize(records)
+    check("summary counts 2 total", "2 flake record(s) total" in summary)
+    check("summary lists both services", "openbank-transaction-service" in summary and "openbank-standing-order-service" in summary)
+
+    check("summarize on an empty list says so rather than crashing", summarize([]) == "No flakes recorded yet.")
+
+    print()
+    if failures:
+        print(f"SELF-TEST FAILED ({len(failures)}):")
+        for f in failures:
+            print(f"  - {f}")
+        return 1
+    print("SELF-TEST PASSED")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/.github/scripts/record-rerun-flake.py
+++ b/.github/scripts/record-rerun-flake.py
@@ -1,0 +1,430 @@
+#!/usr/bin/env python3
+"""Record a flake at the one moment its evidence exists: a re-run turning a failure green (#4878).
+
+WHY THIS EXISTS
+----------------
+A re-run flips a run's `conclusion` away from `failure`, so any later query over run
+conclusions structurally cannot see a flake that someone re-ran green -- which is the entire
+population of interest. `auto-retry-cancelled.yml` already re-runs some failed runs (issue
+#2330/#2841); this script is invoked from that same workflow, at the moment it observes the
+RESULT of a re-run, to write the fact down before it is lost.
+
+THE DISTINCTION THIS SCRIPT MUST NOT COLLAPSE
+-----------------------------------------------
+`auto-retry-cancelled.yml` re-runs a job for one of two reasons, and only one of them is a
+flake candidate:
+
+  1. SPOT-KILL SIGNATURE: the job's `conclusion` is `failure`, it has at least one `cancelled`
+     step, and NO `failure` step. That is a runner reclaim, not the test disagreeing with
+     itself -- explained by infrastructure, not worth recording as a flake.
+  2. GENUINE FAILURE: the job has a `failure` step (with or without an accompanying `cancelled`
+     step from an unrelated sibling -- "mixed runs are the normal case", per that workflow's own
+     header). If THIS shape of job later succeeds on a later attempt of the same run, that is
+     exactly "was genuinely red, now green" -- record it.
+
+`has_spot_kill_signature` below is the same predicate `auto-retry-cancelled.yml` uses inline
+(bash, `select(.conclusion == "failure") | select(cancelled>0) | select(failure==0)`); kept as
+one Python predicate here so the two never drift silently apart.
+
+WHAT GETS WRITTEN, AND WHERE
+------------------------------
+Not a new dashboard, gate, or alert (out of scope for #4878 step 2 -- that is deferred to a
+follow-up once there is data to look at). Reuses the pattern this repo already has for
+cross-run bookkeeping that isn't a metric: `auto-retry-cancelled.yml`'s own `raise-issue` job
+and `main-red-watch.yml` both open-or-refresh a single tracking issue via
+`gh issue list --search "$TITLE in:title"`. This script renders a comment body for that same
+idiom -- one open "Flaky test observations" issue (label `flaky-test`, added to labels.yml),
+refreshed with one comment per detected flake. Each comment carries a human-readable table row
+AND a machine-readable JSON payload in an HTML comment, so `list-recorded-flakes.py` can read
+the population back out without re-parsing markdown prose.
+
+USAGE (invoked from the workflow; every subcommand is offline and side-effect-free)
+    record-rerun-flake.py classify   --jobs-file prev-jobs.json
+    record-rerun-flake.py parse-junit --path <dir-or-file>
+    record-rerun-flake.py render     --record run.json --tests tests.json --job job.json
+    record-rerun-flake.py --self-test
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from xml.etree import ElementTree as ET
+
+RECORD_MARKER = "<!-- flake-record:"
+
+
+# --------------------------------------------------------------------------------------------
+# Pure classification -- mirrors the bash predicate in auto-retry-cancelled.yml on purpose
+# --------------------------------------------------------------------------------------------
+
+
+def has_spot_kill_signature(job: dict) -> bool:
+    """True iff this job's failure is explained by a runner reclaim, not a real test result.
+
+    Same shape as the `killed` jq filter in auto-retry-cancelled.yml: `conclusion == failure`,
+    at least one `cancelled` step, and zero `failure` steps.
+    """
+    if (job.get("conclusion") or "").lower() != "failure":
+        return False
+    steps = job.get("steps") or []
+    cancelled = sum(1 for s in steps if (s.get("conclusion") or "").lower() == "cancelled")
+    failed = sum(1 for s in steps if (s.get("conclusion") or "").lower() == "failure")
+    return cancelled > 0 and failed == 0
+
+
+def find_flake_candidates(prev_jobs: list[dict]) -> list[dict]:
+    """Jobs from the PRIOR attempt that failed for a real reason (not a spot kill).
+
+    Called once the run's FINAL attempt has concluded `success` -- by construction, every job
+    returned here went from a genuine failure to a green run. That transition is the flake
+    signal; this function only identifies which prior-attempt jobs qualify.
+    """
+    return [
+        j
+        for j in prev_jobs
+        if (j.get("conclusion") or "").lower() == "failure" and not has_spot_kill_signature(j)
+    ]
+
+
+SERVICE_RE = re.compile(r"build \(([^)]+)\)")
+
+
+def extract_service(job_name: str) -> str | None:
+    """`build (openbank-transaction-service)` -> `openbank-transaction-service`.
+
+    Only Services CI job names carry this shape (the JUnit-XML-producing lane from #4983); a
+    Security-scan or Dependency-submission job name returns None, and the caller records the
+    flake at job granularity without a per-test breakdown rather than guessing.
+    """
+    m = SERVICE_RE.search(job_name or "")
+    return m.group(1) if m else None
+
+
+# --------------------------------------------------------------------------------------------
+# JUnit XML -- read only, tolerant of a directory of files (an extracted artifact zip)
+# --------------------------------------------------------------------------------------------
+
+
+def parse_junit_failures(xml_text: str) -> list[dict]:
+    """testcase elements carrying a <failure> or <error> child -> [{classname, name, message}]."""
+    try:
+        root = ET.fromstring(xml_text)
+    except ET.ParseError:
+        return []
+    out: list[dict] = []
+    for tc in root.iter("testcase"):
+        fail = tc.find("failure")
+        err = tc.find("error")
+        node = fail if fail is not None else err
+        if node is None:
+            continue
+        message = (node.get("message") or "").strip()
+        out.append(
+            {
+                "classname": tc.get("classname") or "",
+                "name": tc.get("name") or "",
+                "kind": "failure" if fail is not None else "error",
+                "message": message[:200],
+            }
+        )
+    return out
+
+
+def parse_junit_path(path: Path) -> list[dict]:
+    """A single .xml file or a directory (an extracted artifact download) -> failing testcases."""
+    if path.is_file():
+        return parse_junit_failures(path.read_text(encoding="utf-8", errors="replace"))
+    out: list[dict] = []
+    for f in sorted(path.rglob("*.xml")):
+        out.extend(parse_junit_failures(f.read_text(encoding="utf-8", errors="replace")))
+    return out
+
+
+def build_records(candidates: list[dict], context: dict, detected_at: str) -> list[dict]:
+    """Flake candidate jobs + run context -> one record per candidate, `tests` empty for now.
+
+    Pure: no artifact download happens here. The workflow step fills `tests` in afterwards
+    (via `merge_tests`) once it has tried to fetch and parse the matching JUnit XML artifact --
+    that part needs `gh run download`, which this function deliberately does not do, so it stays
+    testable offline like everything else here.
+    """
+    return [
+        {
+            "workflow": context["workflow"],
+            "job": job["name"],
+            "service": extract_service(job["name"]),
+            "run_id": context["run_id"],
+            "run_url": context["run_url"],
+            "prev_attempt": context["prev_attempt"],
+            "final_attempt": context["final_attempt"],
+            "head_sha": context.get("head_sha"),
+            "head_branch": context.get("head_branch"),
+            "detected_at": detected_at,
+            "tests": [],
+        }
+        for job in candidates
+    ]
+
+
+def merge_tests(record: dict, tests: list[dict]) -> dict:
+    """Attach parsed JUnit failures to a record built by `build_records`. Pure, order-preserving."""
+    merged = dict(record)
+    merged["tests"] = tests
+    return merged
+
+
+# --------------------------------------------------------------------------------------------
+# Rendering -- one issue comment per detected flake, human table + machine JSON
+# --------------------------------------------------------------------------------------------
+
+
+def render_comment(record: dict) -> str:
+    tests = record.get("tests") or []
+    if tests:
+        test_lines = "\n".join(f"  - `{t['classname']}#{t['name']}` ({t['kind']})" for t in tests)
+    else:
+        test_lines = "  - (no JUnit XML artifact found for this job/attempt -- job-level only)"
+
+    body = (
+        f"### Flake recorded: `{record['job']}`\n\n"
+        f"| | |\n|---|---|\n"
+        f"| workflow | `{record['workflow']}` |\n"
+        f"| service | `{record.get('service') or 'n/a'}` |\n"
+        f"| run | [{record['run_id']}]({record['run_url']}) |\n"
+        f"| failed at attempt | {record['prev_attempt']} |\n"
+        f"| green at attempt | {record['final_attempt']} |\n"
+        f"| head | `{(record.get('head_sha') or '')[:9]}` on `{record.get('head_branch') or ''}` |\n"
+        f"| detected | {record['detected_at']} |\n\n"
+        f"Tests found failing at the prior attempt:\n{test_lines}\n\n"
+        f"{RECORD_MARKER}{json.dumps(record, sort_keys=True)} -->\n"
+    )
+    return body
+
+
+def extract_records_from_comments(bodies: list[str]) -> list[dict]:
+    """The read-side of `render_comment` -- pulls the JSON payload back out of each comment."""
+    out: list[dict] = []
+    for body in bodies:
+        idx = body.find(RECORD_MARKER)
+        if idx == -1:
+            continue
+        start = idx + len(RECORD_MARKER)
+        end = body.find("-->", start)
+        if end == -1:
+            continue
+        raw = body[start:end].strip()
+        try:
+            out.append(json.loads(raw))
+        except json.JSONDecodeError:
+            continue
+    return out
+
+
+# --------------------------------------------------------------------------------------------
+# CLI
+# --------------------------------------------------------------------------------------------
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--self-test", action="store_true")
+    sub = parser.add_subparsers(dest="cmd")
+
+    p_classify = sub.add_parser("classify")
+    p_classify.add_argument("--jobs-file", required=True, type=Path)
+
+    p_junit = sub.add_parser("parse-junit")
+    p_junit.add_argument("--path", required=True, type=Path)
+
+    p_render = sub.add_parser("render")
+    p_render.add_argument("--record", required=True, type=Path)
+
+    p_build = sub.add_parser("build-records")
+    p_build.add_argument("--candidates", required=True, type=Path)
+    p_build.add_argument("--context", required=True, type=Path)
+    p_build.add_argument("--detected-at", required=True)
+
+    p_merge = sub.add_parser("merge-tests")
+    p_merge.add_argument("--record", required=True, type=Path)
+    p_merge.add_argument("--tests", required=True, type=Path)
+
+    args = parser.parse_args(argv)
+
+    if args.self_test:
+        return self_test()
+
+    if args.cmd == "classify":
+        jobs = json.loads(args.jobs_file.read_text(encoding="utf-8"))
+        print(json.dumps(find_flake_candidates(jobs), indent=2))
+        return 0
+
+    if args.cmd == "parse-junit":
+        print(json.dumps(parse_junit_path(args.path), indent=2))
+        return 0
+
+    if args.cmd == "render":
+        record = json.loads(args.record.read_text(encoding="utf-8"))
+        print(render_comment(record))
+        return 0
+
+    if args.cmd == "build-records":
+        candidates = json.loads(args.candidates.read_text(encoding="utf-8"))
+        context = json.loads(args.context.read_text(encoding="utf-8"))
+        print(json.dumps(build_records(candidates, context, args.detected_at), indent=2))
+        return 0
+
+    if args.cmd == "merge-tests":
+        record = json.loads(args.record.read_text(encoding="utf-8"))
+        tests = json.loads(args.tests.read_text(encoding="utf-8"))
+        print(json.dumps(merge_tests(record, tests), indent=2))
+        return 0
+
+    parser.print_help()
+    return 2
+
+
+# --------------------------------------------------------------------------------------------
+# Self-test
+# --------------------------------------------------------------------------------------------
+
+
+def _job(name: str, conclusion: str, steps: list[tuple[str, str]]) -> dict:
+    return {"name": name, "conclusion": conclusion, "steps": [{"name": n, "conclusion": c} for n, c in steps]}
+
+
+def self_test() -> int:
+    failures: list[str] = []
+
+    def check(label: str, cond: bool) -> None:
+        if not cond:
+            failures.append(label)
+        print(f"  [{'ok ' if cond else 'FAIL'}] {label}")
+
+    print("has_spot_kill_signature / find_flake_candidates")
+    spot_killed = _job(
+        "build (openbank-billing-service)",
+        "failure",
+        [("Set up job", "success"), ("Test", "cancelled")],
+    )
+    genuine = _job(
+        "build (openbank-transaction-service)",
+        "failure",
+        [("Set up job", "success"), ("Test", "failure")],
+    )
+    mixed_but_still_genuine = _job(
+        "build (openbank-standing-order-service)",
+        "failure",
+        [("Set up job", "success"), ("Test", "failure"), ("Cleanup", "cancelled")],
+    )
+    green = _job("build (openbank-ledger-service)", "success", [("Test", "success")])
+
+    check("a pure spot-kill (cancelled, no failure step) is NOT a flake candidate",
+          not has_spot_kill_signature(genuine) and has_spot_kill_signature(spot_killed))
+    check("a genuine failure step, even alongside an unrelated cancelled step, IS a candidate",
+          has_spot_kill_signature(mixed_but_still_genuine) is False)
+    check("a green job is never a candidate", not has_spot_kill_signature(green))
+
+    candidates = find_flake_candidates([spot_killed, genuine, mixed_but_still_genuine, green])
+    names = {c["name"] for c in candidates}
+    check(
+        "find_flake_candidates keeps only the genuinely-failed jobs, dropping the spot kill and "
+        "the green job",
+        names == {genuine["name"], mixed_but_still_genuine["name"]},
+    )
+
+    print("extract_service")
+    check(
+        "extracts the service from a Services CI job name",
+        extract_service("build (openbank-transaction-service)") == "openbank-transaction-service",
+    )
+    check("returns None for a job name with no build(...) shape", extract_service("Trivy fs scan") is None)
+
+    print("parse_junit_failures")
+    xml = """<?xml version="1.0"?>
+<testsuite name="s">
+  <testcase classname="com.openbank.tx.OutboxClaimIT" name="a stale row is reclaimed">
+    <failure message="expected DISPATCHED but was DISPATCHING">stack...</failure>
+  </testcase>
+  <testcase classname="com.openbank.tx.OutboxClaimIT" name="a fresh row is untouched"/>
+  <testcase classname="com.openbank.tx.OtherIT" name="boom">
+    <error message="connection reset"/>
+  </testcase>
+</testsuite>
+"""
+    parsed = parse_junit_failures(xml)
+    check("finds exactly the two failing/erroring testcases, not the passing one", len(parsed) == 2)
+    check(
+        "captures classname, name, and kind for a <failure>",
+        parsed[0] == {
+            "classname": "com.openbank.tx.OutboxClaimIT",
+            "name": "a stale row is reclaimed",
+            "kind": "failure",
+            "message": "expected DISPATCHED but was DISPATCHING",
+        },
+    )
+    check("captures an <error> as kind=error", parsed[1]["kind"] == "error")
+    check("malformed XML returns an empty list rather than raising", parse_junit_failures("<not-xml") == [])
+
+    print("build_records / merge_tests")
+    context = {
+        "workflow": "Services CI",
+        "run_id": 999,
+        "run_url": "https://example/run/999",
+        "prev_attempt": 1,
+        "final_attempt": 2,
+        "head_sha": "deadbeef01234567",
+        "head_branch": "main",
+    }
+    records = build_records([genuine, mixed_but_still_genuine], context, "2026-08-16T00:00:00Z")
+    check("one record per candidate job", len(records) == 2)
+    check(
+        "each record carries its job's extracted service and the shared run context",
+        records[0]["service"] == "openbank-transaction-service"
+        and records[0]["run_id"] == 999
+        and records[0]["prev_attempt"] == 1
+        and records[0]["final_attempt"] == 2,
+    )
+    check("tests starts empty -- filled in later by merge_tests, not here", records[0]["tests"] == [])
+
+    merged = merge_tests(records[0], [{"classname": "C", "name": "t", "kind": "failure", "message": "m"}])
+    check("merge_tests attaches tests without mutating other fields",
+          merged["service"] == records[0]["service"] and len(merged["tests"]) == 1)
+    check("merge_tests does not mutate its input record", records[0]["tests"] == [])
+
+    print("render_comment / extract_records_from_comments round-trip")
+    record = {
+        "workflow": "Services CI",
+        "job": "build (openbank-transaction-service)",
+        "service": "openbank-transaction-service",
+        "run_id": 123,
+        "run_url": "https://example/run/123",
+        "prev_attempt": 1,
+        "final_attempt": 2,
+        "head_sha": "abcdef0123456789",
+        "head_branch": "main",
+        "detected_at": "2026-08-16T00:00:00Z",
+        "tests": parsed[:1],
+    }
+    comment = render_comment(record)
+    check("rendered comment names the job", record["job"] in comment)
+    check("rendered comment embeds a machine-readable JSON payload", RECORD_MARKER in comment)
+    roundtrip = extract_records_from_comments([comment, "an unrelated human comment with no marker"])
+    check("exactly one record recovered from two comments, one with no marker", len(roundtrip) == 1)
+    check("the recovered record matches what was rendered", roundtrip[0] == record)
+
+    print()
+    if failures:
+        print(f"SELF-TEST FAILED ({len(failures)}):")
+        for f in failures:
+            print(f"  - {f}")
+        return 1
+    print("SELF-TEST PASSED")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/.github/workflows/_service-ci.yml
+++ b/.github/workflows/_service-ci.yml
@@ -688,12 +688,49 @@ jobs:
         continue-on-error: true
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: test-reports-${{ inputs.service }}
-          path: |
-            ${{ inputs.service }}/build/reports/tests
-            ${{ inputs.service }}/build/test-results
+          # `-a${{ github.run_attempt }}` is not cosmetic. An artifact name must be unique
+          # WITHIN A RUN, and re-running a failed job is a new attempt of the SAME run — so
+          # without the suffix the second upload collides and fails. `continue-on-error: true`
+          # then swallows it, which means that until now a re-run silently retained no reports
+          # at all: the case where you most want them.
+          name: test-reports-${{ inputs.service }}-a${{ github.run_attempt }}
+          # XML moved to the always-on step below, so this no longer duplicates it. Net upload
+          # on a failing build is unchanged; the HTML is what a human actually reads here.
+          path: ${{ inputs.service }}/build/reports/tests
           if-no-files-found: ignore
           retention-days: 7
+
+      # WHY THIS IS `always()` WHEN THE STEP ABOVE IS DELIBERATELY NOT (#4878).
+      #
+      # A flake cannot be counted in this repo. Re-running a failed run flips its conclusion
+      # away from `failure`, so a query over run conclusions structurally cannot see a flake
+      # that someone re-ran green -- which is the entire population of interest. And a green
+      # run retained nothing, so there was no denominator either: "how often does this test
+      # fail" had no answer at any effort.
+      #
+      # Both halves are fixed by retaining the JUnit XML per ATTEMPT. Attempt 1's failures and
+      # attempt 2's pass then sit side by side under the same run id, and a flake is no longer
+      # something that has to be noticed and reported at the moment of the re-run -- it is a
+      # difference between two artifacts, computable afterwards. That is the whole of this
+      # issue's point 2 obtained by retention rather than by another emitter that has to fire.
+      #
+      # The quota incident that made the step above `failure()` is respected: this uploads the
+      # XML ONLY, not the HTML reports. Measured on openbank-billing-service, that is 140 KB
+      # against 608 KB for the pair, and retention is 3 days rather than 7. Today's artifact
+      # estate is 2.4 GB across ~14.7k artifacts, so a full-fleet rebuild of ~28 services adds
+      # about 4 MB. What is NOT established here is the service-build rate per day, so the
+      # steady-state total is bounded by (rate x 140 KB x 3 days) and not stated as a figure --
+      # if artifact pressure returns, this retention is the dial, and it is the first thing to
+      # look at.
+      - name: Upload JUnit XML (every run — flake accounting)
+        if: always()
+        continue-on-error: true
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: junit-xml-${{ inputs.service }}-a${{ github.run_attempt }}
+          path: ${{ inputs.service }}/build/test-results/**/*.xml
+          if-no-files-found: ignore
+          retention-days: 3
           # Per-test-JVM Testcontainers own their lifecycle (start in @QuarkusTestResource,
           # stop() at teardown; Ryuk is disabled fleet-wide, so the resource tears them down
           # itself). On failure their stdout/stderr is captured in the test reports uploaded

--- a/.github/workflows/auto-retry-cancelled.yml
+++ b/.github/workflows/auto-retry-cancelled.yml
@@ -338,3 +338,156 @@ jobs:
             gh issue create --title "$TITLE" --body-file "${RUNNER_TEMP:-/tmp}/issue-body.md" \
               --label tech-debt --label "severity:high"
           fi
+
+  # ── Flake recording (issue #4878) ────────────────────────────────────────────
+  # Why this lives HERE, in the workflow that already re-runs things, and not in a new listener:
+  # the flake evidence exists exactly once, at the moment a re-run's FINAL attempt concludes --
+  # after that, a query over run conclusions sees only `success` and the fact that attempt 1 was
+  # genuinely red is gone. This job is the second `workflow_run` listener on the same three
+  # workflows (`retry` above is the first), triggered independently by the SAME event.
+  #
+  # NOT every re-run is a flake. `retry` re-runs a run for one of two reasons -- a whole-run
+  # spot-kill (`cancelled`, at least one job's steps show it was running when reclaimed) or a
+  # partial spot-kill (`failure`, at least one job has a `cancelled` step and no `failure` step).
+  # Neither of those is "the test disagreed with itself" -- it's a runner reclaim, explained by
+  # infrastructure. What #4878 asks to record is the OTHER shape: a job that failed for a real
+  # reason (a `failure` step, not merely a `cancelled` one) and later, on a subsequent attempt of
+  # the SAME run, went green with no source change in between. `record-rerun-flake.py` carries
+  # the exact predicate (`has_spot_kill_signature`) so the two workflows never drift apart on
+  # what counts as "explained by infra" vs "genuinely flaky".
+  #
+  # This does NOT depend on `retry` and does not require `retry` to have fired -- a run can also
+  # be re-run by a human (`gh run rerun --failed`), and that re-run is just as much evidence of a
+  # flake as an automatic one. Gating only on `run_attempt > 1` and the FINAL conclusion being
+  # `success` catches both.
+  record-flake:
+    name: Record a flake if a re-run turned a genuine failure green
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.run_attempt > 1
+    runs-on: ubuntu-latest
+    timeout-minutes: 5 # API + a handful of small artifact downloads
+    permissions:
+      contents: read
+      actions: read   # read prior-attempt jobs and download the JUnit XML artifact from #4983
+      issues: write   # the flake-tracking issue
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_REPO: ${{ github.repository }}
+      RUN_ID: ${{ github.event.workflow_run.id }}
+      RUN_URL: ${{ github.event.workflow_run.html_url }}
+      FINAL_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
+      WORKFLOW_NAME: ${{ github.event.workflow_run.name }}
+      HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+      HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          sparse-checkout: |
+            .github/scripts
+          sparse-checkout-cone-mode: false
+
+      - name: Find genuinely-failed jobs from the attempt this run just recovered from
+        id: classify
+        run: |
+          set -euo pipefail
+          PREV_ATTEMPT=$((FINAL_ATTEMPT - 1))
+          echo "prev-attempt=${PREV_ATTEMPT}" >> "${GITHUB_OUTPUT}"
+
+          gh api "repos/${GH_REPO}/actions/runs/${RUN_ID}/attempts/${PREV_ATTEMPT}/jobs?per_page=100" \
+            --jq '.jobs' > "${RUNNER_TEMP}/prev-jobs.json"
+
+          python3 .github/scripts/record-rerun-flake.py classify \
+            --jobs-file "${RUNNER_TEMP}/prev-jobs.json" > "${RUNNER_TEMP}/candidates.json"
+
+          count=$(python3 -c "import json,sys; print(len(json.load(open(sys.argv[1]))))" \
+            "${RUNNER_TEMP}/candidates.json")
+          echo "count=${count}" >> "${GITHUB_OUTPUT}"
+          if [ "${count}" -eq 0 ]; then
+            echo "Attempt ${PREV_ATTEMPT} of ${RUN_URL}: every failed job carried the spot-kill "
+            echo "signature (or none failed) -- explained by infrastructure, nothing to record."
+          else
+            echo "Attempt ${PREV_ATTEMPT} of ${RUN_URL}: ${count} job(s) failed for a real reason "
+            echo "and the run is now green at attempt ${FINAL_ATTEMPT} -- recording as flake(s)."
+          fi
+
+      - name: "Build one record per flake candidate, with JUnit XML if #4983's artifact exists"
+        if: steps.classify.outputs.count != '0'
+        id: build
+        run: |
+          set -euo pipefail
+          PREV_ATTEMPT="${{ steps.classify.outputs.prev-attempt }}"
+          DETECTED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+          cat > "${RUNNER_TEMP}/context.json" <<JSON
+          {
+            "workflow": "${WORKFLOW_NAME}",
+            "run_id": ${RUN_ID},
+            "run_url": "${RUN_URL}",
+            "prev_attempt": ${PREV_ATTEMPT},
+            "final_attempt": ${FINAL_ATTEMPT},
+            "head_sha": "${HEAD_SHA}",
+            "head_branch": "${HEAD_BRANCH}"
+          }
+          JSON
+
+          python3 .github/scripts/record-rerun-flake.py build-records \
+            --candidates "${RUNNER_TEMP}/candidates.json" \
+            --context "${RUNNER_TEMP}/context.json" \
+            --detected-at "${DETECTED_AT}" > "${RUNNER_TEMP}/records.json"
+
+          mkdir -p "${RUNNER_TEMP}/comments"
+          i=0
+          jq -c '.[]' "${RUNNER_TEMP}/records.json" | while read -r record; do
+            i=$((i + 1))
+            echo "${record}" > "${RUNNER_TEMP}/record-${i}.json"
+            service=$(echo "${record}" | jq -r '.service // empty')
+
+            # `-a<PREV_ATTEMPT>` matches the naming #4983 gave the JUnit-XML-only upload; only
+            # Services CI job names resolve to a service (see `extract_service`'s docstring), so
+            # a Security-scan or Dependency-submission job legitimately has no such artifact --
+            # `continue-on-error` there is expected, not a failure of this step.
+            tests_file="${RUNNER_TEMP}/tests-${i}.json"
+            echo "[]" > "${tests_file}"
+            if [ -n "${service}" ]; then
+              artifact_dir="${RUNNER_TEMP}/junit-${i}"
+              if gh run download "${RUN_ID}" -n "junit-xml-${service}-a${PREV_ATTEMPT}" \
+                   -D "${artifact_dir}" 2>"${RUNNER_TEMP}/download-${i}.log"; then
+                python3 .github/scripts/record-rerun-flake.py parse-junit \
+                  --path "${artifact_dir}" > "${tests_file}"
+              else
+                echo "No junit-xml-${service}-a${PREV_ATTEMPT} artifact on ${RUN_URL} (may have expired, or the job failed before producing test output); recording at job level only."
+              fi
+            fi
+
+            merged=$(python3 .github/scripts/record-rerun-flake.py merge-tests \
+              --record "${RUNNER_TEMP}/record-${i}.json" --tests "${tests_file}")
+            echo "${merged}" > "${RUNNER_TEMP}/comments/record-${i}.json"
+          done
+
+      - name: Open or refresh the flake-tracking issue, one comment per recorded flake
+        if: steps.classify.outputs.count != '0'
+        run: |
+          set -euo pipefail
+          TITLE="Flaky test observations (recorded from CI re-run evidence)"
+          existing=$(gh issue list --state open --search "$TITLE in:title" --json number --jq '.[0].number' || true)
+          if [ -z "${existing}" ]; then
+            printf '%s\n' \
+              "This issue is a running log, not something to action directly (#4878)." \
+              "" \
+              "Each comment below is one job that failed for a real reason (not a runner reclaim -- see auto-retry-cancelled.yml's \`record-flake\` job) and went green on a later attempt of the SAME run, with no source change in between. That is the definition of a flake this repo can act on." \
+              "" \
+              "Read it back with \`.github/scripts/list-recorded-flakes.py --issue <this-issue-number>\`." \
+              "" \
+              "Deciding what to DO with this data (thresholds, alerts, the 29-copy \`*OutboxClaimIT\` construction) is explicitly out of scope for #4878 -- this issue exists so that decision has evidence to work from." \
+              > "${RUNNER_TEMP}/issue-body.md"
+            existing=$(gh issue create --title "$TITLE" --body-file "${RUNNER_TEMP}/issue-body.md" \
+              --label flaky-test --label tech-debt | grep -oE '[0-9]+$')
+          fi
+
+          for f in "${RUNNER_TEMP}"/comments/record-*.json; do
+            [ -e "$f" ] || continue
+            python3 .github/scripts/record-rerun-flake.py render --record "$f" \
+              > "${RUNNER_TEMP}/comment-body.md"
+            gh issue comment "${existing}" --body-file "${RUNNER_TEMP}/comment-body.md"
+          done


### PR DESCRIPTION
## What

Implements step 1 of #4878, and — added in a second commit — an explicit step 2.

A flaky test cannot be counted here, for two independent reasons:

- **A re-run erases the evidence.** Re-running a failed run flips its `conclusion` away from `failure`, so a query over run conclusions structurally cannot see a flake that someone re-ran green — the entire population of interest.
- **A green run retained nothing**, so there was no denominator either. *"How often does this test fail"* had no answer at any effort.

Both fall out of retaining the JUnit XML **per attempt**. Attempt 1's failures and attempt 2's pass then sit side by side under the same run id, and a flake stops being something that must be noticed and reported at the moment of the re-run — it becomes a difference between two artifacts, computable afterwards.

## A live defect found on the way

An artifact name must be unique **within a run**, and re-running a failed job is a new attempt of the *same* run. So `test-reports-<service>` collided on the second upload and failed — and `continue-on-error: true` swallowed it.

**Until now a re-run retained no test reports at all**, which is exactly the case where they are most wanted, and nothing anywhere said so. Both steps now carry `-a${{ github.run_attempt }}`.

## Respecting the quota incident

The existing step is `failure()` deliberately: uploading reports on every service build was a dominant driver of artifact-storage churn and hit the quota. That is respected, not reverted.

| | XML only (new step) | HTML + XML (old pair) |
|---|---|---|
| size, measured on `openbank-billing-service` | **140 KB** | 608 KB |
| retention | 3 days | 7 days |

Estate today: **2.4 GB across ~14.7k artifacts**. A full-fleet rebuild of ~28 services adds about **4 MB**. Volume on a *failing* build is unchanged — the HTML step no longer duplicates the XML the new step now owns.

**What is not established:** the service-build rate per day. So the steady-state total is left as a bound — `rate x 140 KB x 3 days` — rather than stated as a figure I did not measure. The comment names retention as the dial if artifact pressure returns.

## Step 2, added: record a flake explicitly when a re-run turns a genuine failure green

The original version of this PR argued step 2 "falls out for free" from per-attempt retention alone — true for someone willing to diff two artifacts by hand, but the issue asks for an explicit record, and `auto-retry-cancelled.yml` is named as the natural place to emit it. This commit does that, without weakening the first argument (per-attempt XML retention is still what makes the record possible to build).

`auto-retry-cancelled.yml` gets a second `workflow_run` listener, `record-flake`, independent of the existing `retry` job (a run can also be re-run by a human via `gh run rerun --failed`, which is just as much evidence). It fires when a run's **final** attempt concludes `success` after `run_attempt > 1`, fetches the **prior** attempt's jobs, and keeps only the ones that failed for a real reason — a `failure` step, not merely a `cancelled` one. That predicate (`has_spot_kill_signature`) is the same one `retry` uses inline to tell a runner reclaim apart from a genuine break, kept in one Python function (`.github/scripts/record-rerun-flake.py`) so the two workflows can't drift apart on the definition. **A spot-kill retry is not a flake** — it's explained by infrastructure, and this deliberately does not record it as one.

For a Services CI job that resolves to a service name, it tries to download the `junit-xml-<service>-a<attempt>` artifact this PR's first commit now retains, and parses out the failing test class/method. A Security-scan or Dependency-submission job has no such artifact and is recorded at job granularity only — expected, not a failure of the step.

Each flake is recorded as a comment (human-readable table + a `<!-- flake-record:{...} -->` JSON payload) on one open **"Flaky test observations"** issue (new `flaky-test` label in `labels.yml`), reusing the open-or-refresh tracking-issue idiom this same file's own `raise-issue` job and `main-red-watch.yml` already use for cross-run bookkeeping — not a new mechanism.

`.github/scripts/list-recorded-flakes.py` is a thin read layer: it recovers the JSON payloads from the tracking issue's comments and prints a by-service / by-test count summary. Deliberately not a dashboard, gate, or alert — per the issue's "then, and only then" scoping on step 3.

### Verification

- `.github/scripts/record-rerun-flake.py --self-test` and `.github/scripts/list-recorded-flakes.py --self-test` — pure logic (classification, JUnit parsing, record building, render/read round-trip) covered offline.
- Ran the full classify → build-records → merge-tests → render pipeline end-to-end against fixture data outside the self-test, to check the CLI wiring the workflow step actually calls.
- `actionlint` and `yamllint` (with this repo's CI config) on the changed workflow file, clean — caught one real defect this way: an unquoted step `name:` containing `#4983's` was YAML-comment-truncated (space before `#` starts a comment in a plain scalar), so the step name would have silently rendered short. Quoted it.
- `ruff check --select E9,F,B` (the exact pinned version and rule set `python-lint` in `gates.yaml` runs) on both new scripts, clean.

## Not in scope

Step 3 of the issue — deciding about the 29 copies of `*OutboxClaimIT`. That needs the data this PR now collects on both ends (retention + explicit flake records). Worth recording as a live datapoint for the environmental hypothesis: while running an unrelated integration test on a machine with several concurrent Gradle builds, a Testcontainers-backed IT failed with `SocketTimeoutException` — a failure with no relation to the assertion under test.

Also out of scope, deliberately: any dashboard, threshold, or alert over the recorded flakes. `list-recorded-flakes.py` is read-only.

Refs #4878

🤖 Generated with [Claude Code](https://claude.com/claude-code)
