### PR TITLE
fix(case-coordinator): authorise the asserted agent identity against the caller (#4834)

### DIFF
--- a/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/application/CaseCapabilityGate.kt
+++ b/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/application/CaseCapabilityGate.kt
@@ -19,6 +19,31 @@ import jakarta.enterprise.context.ApplicationScoped
 @ApplicationScoped
 class CaseCapabilityGate(private val config: CaseCoordinatorConfig) {
 
+    /**
+     * Which agent identities each verified role may act as, parsed once from
+     * `openbank.case-coordinator.case.identity-bindings`. Deny-by-default and no wildcard: an
+     * unparseable entry, an unknown role or an empty agent list all yield "assert nothing".
+     */
+    private val identityBindings: Map<String, Set<String>> = parseBindings(config.case().identityBindings())
+
+    /**
+     * True when a caller holding [roles] is permitted to ACT AS [agentId] (#4834).
+     *
+     * Every other method on this gate answers "does this agent identity hold this capability".
+     * None of them can answer "is the caller that agent", and before this existed nothing did —
+     * the identity came from the request body, so the capability decisions ran on a claim. This
+     * is the missing half: prove the caller first (the bearer, enforced by `@RolesAllowed`), then
+     * decide which identity that proof entitles it to assert. Same separation `McpEndpoint`
+     * documents for `X-Agent-Id`.
+     *
+     * Not a general authorisation primitive and deliberately not modelled as one: it is a
+     * role-to-identity binding local to this service's two write endpoints, and ADR-0244 D9's own
+     * answer — the same OPA gate every contribution passes — replaces it rather than layering on
+     * it. This closes the claim-versus-proof hole in the meantime.
+     */
+    fun permitsAssertedIdentity(roles: Set<String>, agentId: String): Boolean =
+        roles.any { role -> identityBindings[role]?.contains(agentId) == true }
+
     fun canOpenCase(agentId: String): Boolean = agentId in config.case().openAgents()
 
     fun canJoinCase(agentId: String): Boolean = agentId in config.case().swarmAgents()
@@ -28,4 +53,12 @@ class CaseCapabilityGate(private val config: CaseCoordinatorConfig) {
     fun canPreempt(agentId: String): Boolean = agentId in config.case().openAgents()
 
     fun canRequestSynthesis(agentId: String): Boolean = agentId in config.case().openAgents()
+
+    private fun parseBindings(raw: String): Map<String, Set<String>> = raw.split(';').mapNotNull { entry ->
+        val parts = entry.split('=', limit = 2)
+        if (parts.size != 2) return@mapNotNull null
+        val role = parts[0].trim()
+        val agents = parts[1].split(',').map { it.trim() }.filter { it.isNotEmpty() }.toSet()
+        if (role.isEmpty() || agents.isEmpty()) null else role to agents
+    }.toMap()
 }

--- a/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/infrastructure/config/CaseCoordinatorConfig.kt
+++ b/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/infrastructure/config/CaseCoordinatorConfig.kt
@@ -43,6 +43,25 @@ interface CaseCoordinatorConfig {
         @WithDefault("case-coordinator")
         fun swarmAgents(): Set<String>
 
+        /**
+         * Which agent identity an authenticated caller may ACT AS, keyed by the caller's verified
+         * role: `ROLE_A=agent1,agent2;ROLE_B=agent3`. Deny-by-default — a role with no entry may
+         * assert no agent identity at all, and there is deliberately no wildcard.
+         *
+         * This is a different question from [openAgents]/[swarmAgents], and the distinction is the
+         * whole point (#4834). Those lists say which agent identities hold a capability; this one
+         * says which of them a given caller is allowed to claim to be. Without it the capability
+         * lists were consulted against a string taken from the request body, so the decision tested
+         * an asserted identity rather than a proved one.
+         *
+         * The default binds both admitted roles to the single chartered opener, which is exactly
+         * today's reachable set — so this changes no behaviour now. What it changes is later: the
+         * config comment above says the capability lists are expected to grow, and a new entry
+         * there no longer becomes assertable by every operator on its own.
+         */
+        @WithDefault("ROLE_ADMIN=case-coordinator;ROLE_OPERATOR=case-coordinator")
+        fun identityBindings(): String
+
         @WithDefault("INCIDENT_RESPONSE")
         fun enabledClasses(): Set<CaseClass>
 

--- a/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/infrastructure/rest/CaseCoordinatorResource.kt
+++ b/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/infrastructure/rest/CaseCoordinatorResource.kt
@@ -122,6 +122,12 @@ class CaseCoordinatorResource(
         // the header only names which.
         val callerPrincipal = identity.principal?.name?.takeIf { it.isNotBlank() } ?: "anonymous"
 
+        // …and the identity it may CLAIM is decided against the roles it proved, before any
+        // capability decision runs on the claim (#4834). `canOpenCase(openedBy)` asks whether the
+        // named agent holds `case.open`; it cannot ask whether the caller is that agent, so on its
+        // own it tests an assertion. Deny-by-default, and the value is not echoed back.
+        if (!gate.permitsAssertedIdentity(identity.roles, openedBy)) return assertedIdentityDenied()
+
         return when (
             val result = openService.open(callerPrincipal, openedBy, caseClass, subjectRef, dispositionTarget)
         ) {
@@ -150,6 +156,12 @@ class CaseCoordinatorResource(
         requireNotNull(request) { "request body is required" }
         val type = requireNotNull(request.type) { "type is required" }
         val agentId = requireNotNull(request.agentId) { "agentId is required" }
+        // Authorisation before availability, deliberately ahead of the Temporal check (#4834). The
+        // claimed agentId is carried into the workflow as the AUTHOR of the contribution, which is
+        // the guarantee ADR-0244 rests on — "who detected is never who coordinated" — so it must be
+        // one the caller proved it may act as, not one it named. Answering 503 first would also
+        // make the decision unobservable wherever Temporal is off.
+        if (!gate.permitsAssertedIdentity(identity.roles, agentId)) return assertedIdentityDenied()
         if (!temporalConfig.enabled()) return temporalUnavailable()
         if (!capable(type, agentId)) {
             return Response.status(Response.Status.FORBIDDEN)
@@ -201,6 +213,15 @@ class CaseCoordinatorResource(
                 .entity(errorBody("no running case with id '$id'")).build()
         }
     }
+
+    /**
+     * The asserted agent identity is not one this caller's roles may act as. The requested id is
+     * NOT echoed, for the same reason the other denials stopped echoing it (#4215): it is
+     * free-form request input, and repeating it back tells the caller nothing it did not send.
+     */
+    private fun assertedIdentityDenied(): Response = Response.status(Response.Status.FORBIDDEN)
+        .entity(errorBody("the authenticated caller may not act as the requested agent identity"))
+        .build()
 
     private fun temporalUnavailable(): Response = Response.status(Response.Status.SERVICE_UNAVAILABLE)
         .entity(errorBody("Temporal case workflows are disabled (openbank.temporal.enabled=false)"))

--- a/openbank-case-coordinator-agent/src/main/resources/openapi.yaml
+++ b/openbank-case-coordinator-agent/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: Case Coordinator Agent API
-  version: 1.0.0
+  version: 1.1.0
   description: >-
     Agent-swarm case coordination (ADR-0244): opens durable Temporal case workflows, accepts
     mid-flight agent signals (join / contribute / supersede / request-synthesis), and projects
@@ -67,7 +67,9 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorBody'
         '403':
-          description: case.open denied by the capability gate, or case class not enabled
+          description: >-
+            The authenticated caller may not act as the requested `openedBy` agent identity, or
+            case.open is denied by the capability gate, or the case class is not enabled.
           content:
             application/json:
               schema:
@@ -175,7 +177,9 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorBody'
         '403':
-          description: Signal type denied for this agent by the capability gate
+          description: >-
+            The authenticated caller may not act as the requested `agentId`, or the signal type is
+            denied for that agent by the capability gate.
           content:
             application/json:
               schema:
@@ -222,7 +226,10 @@ components:
           description: Stable subject reference; part of the deduplicating workflow id
         openedBy:
           type: string
-          description: Agent id opening the case (capability-gated)
+          description: >-
+            Agent identity the call REQUESTS to act as. It is not an identity claim the server
+            believes: the caller is proved by its bearer token, and this value is authorised
+            against that caller's verified roles before any capability decision uses it.
         dispositionTarget:
           type: string
           description: What the case is deciding about (alert, incident, proposal lineage)
@@ -243,6 +250,10 @@ components:
           enum: [join, contribute, supersede, request-synthesis]
         agentId:
           type: string
+          description: >-
+            Agent identity the signal REQUESTS to act as, and the recorded author of the
+            contribution. Authorised against the authenticated caller's verified roles before the
+            capability gate consults it.
         role:
           type: string
           description: Participant role for join signals

--- a/openbank-case-coordinator-agent/src/test/kotlin/com/openbank/casecoordinator/application/CaseCapabilityGateTest.kt
+++ b/openbank-case-coordinator-agent/src/test/kotlin/com/openbank/casecoordinator/application/CaseCapabilityGateTest.kt
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+
+package com.openbank.casecoordinator.application
+
+import com.openbank.casecoordinator.infrastructure.config.CaseCoordinatorConfig
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * Parsing and deny-by-default for the role-to-identity binding (#4834). The IT alongside this
+ * proves the binding is actually CONSULTED over real HTTP; this proves it says the right thing,
+ * including for inputs an operator can produce by mistyping a ConfigMap.
+ */
+class CaseCapabilityGateTest {
+
+    private fun gateWith(bindings: String): CaseCapabilityGate {
+        val group = mockk<CaseCoordinatorConfig.CaseGroup>()
+        every { group.identityBindings() } returns bindings
+        val config = mockk<CaseCoordinatorConfig>()
+        every { config.case() } returns group
+        return CaseCapabilityGate(config)
+    }
+
+    @Test
+    fun `a bound role may act as the identities it is bound to, and no others`() {
+        val gate = gateWith("ROLE_OPERATOR=case-coordinator,incident-triage;ROLE_VIEWER=case-coordinator")
+
+        assertThat(gate.permitsAssertedIdentity(setOf("ROLE_OPERATOR"), "incident-triage")).isTrue()
+        assertThat(gate.permitsAssertedIdentity(setOf("ROLE_VIEWER"), "incident-triage")).isFalse()
+    }
+
+    @Test
+    fun `a role with no entry may assert nothing`() {
+        val gate = gateWith("ROLE_OPERATOR=case-coordinator")
+
+        assertThat(gate.permitsAssertedIdentity(setOf("ROLE_ADMIN"), "case-coordinator")).isFalse()
+        assertThat(gate.permitsAssertedIdentity(emptySet(), "case-coordinator")).isFalse()
+    }
+
+    @Test
+    fun `there is no wildcard - a star is an agent id like any other`() {
+        // Deliberate divergence from agent-service's AgentIdentityBinding: a wildcard here would
+        // restore exactly the property this closes, one config edit at a time.
+        val gate = gateWith("ROLE_ADMIN=*")
+
+        assertThat(gate.permitsAssertedIdentity(setOf("ROLE_ADMIN"), "case-coordinator")).isFalse()
+    }
+
+    @Test
+    fun `a malformed or empty binding denies rather than opening up`() {
+        assertThat(gateWith("").permitsAssertedIdentity(setOf("ROLE_ADMIN"), "case-coordinator")).isFalse()
+        assertThat(gateWith("ROLE_ADMIN").permitsAssertedIdentity(setOf("ROLE_ADMIN"), "case-coordinator")).isFalse()
+        assertThat(gateWith("ROLE_ADMIN=").permitsAssertedIdentity(setOf("ROLE_ADMIN"), "case-coordinator")).isFalse()
+        assertThat(gateWith("=case-coordinator").permitsAssertedIdentity(setOf(""), "case-coordinator")).isFalse()
+    }
+
+    @Test
+    fun `whitespace around a ConfigMap entry does not silently break the binding`() {
+        val gate = gateWith(" ROLE_OPERATOR = case-coordinator , incident-triage ")
+
+        assertThat(gate.permitsAssertedIdentity(setOf("ROLE_OPERATOR"), "incident-triage")).isTrue()
+    }
+}

--- a/openbank-case-coordinator-agent/src/test/kotlin/com/openbank/casecoordinator/infrastructure/rest/CaseAssertedIdentityIT.kt
+++ b/openbank-case-coordinator-agent/src/test/kotlin/com/openbank/casecoordinator/infrastructure/rest/CaseAssertedIdentityIT.kt
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+
+package com.openbank.casecoordinator.infrastructure.rest
+
+import com.openbank.casecoordinator.PostgresTestResource
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.junit.QuarkusTestProfile
+import io.quarkus.test.junit.TestProfile
+import io.quarkus.test.security.TestSecurity
+import io.restassured.RestAssured.given
+import io.restassured.http.ContentType
+import org.hamcrest.Matchers.containsString
+import org.hamcrest.Matchers.not
+import org.junit.jupiter.api.Test
+
+/**
+ * The agent identity a call ACTS AS must be authorised against the identity it PROVED (#4834).
+ *
+ * Driven over real HTTP so the principal and its roles are real: a unit test that constructs the
+ * resource and hands it a mock `SecurityIdentity` cannot tell an enforced binding from a
+ * decorative one, because the mock supplies whatever roles the test wants either way.
+ *
+ * The profile is what makes the defect observable at all. On the shipped defaults `openAgents`
+ * holds exactly one entry, so the only string that passes `canOpenCase` is also the only string
+ * anyone is bound to — the hole is real but inert, and no assertion can separate the two. This
+ * profile grants the capability list a second chartered agent (`incident-triage`) and binds
+ * `ROLE_OPERATOR` to only the first, which is precisely the state the config comment says is
+ * coming ("swarm join/contribute grants are deliberate follow-up charter work").
+ *
+ * Read the pairs, not the single status. Temporal is disabled in `%test`, so an authorised call
+ * cannot reach 201 — it stops at 503 Unavailable. That is the point of the control in each test:
+ * 503 means "every authorisation decision in the path accepted this call", 403 means one refused
+ * it. Before the fix BOTH members of each pair answered 503 — the asserted identity was believed.
+ */
+@QuarkusTest
+@QuarkusTestResource(PostgresTestResource::class)
+@TestProfile(CaseAssertedIdentityIT.TwoCharteredAgentsProfile::class)
+class CaseAssertedIdentityIT {
+
+    /**
+     * Literal values only, never a randomised id: a `QuarkusTestProfile` loads in a different
+     * classloader from the test class, so anything computed in a companion object initialises
+     * twice and the scheduler/config sees one value while the assertion sees another.
+     */
+    class TwoCharteredAgentsProfile : QuarkusTestProfile {
+        override fun getConfigOverrides(): Map<String, String> = mapOf(
+            "openbank.case-coordinator.case.open-agents" to "case-coordinator,incident-triage",
+            "openbank.case-coordinator.case.swarm-agents" to "case-coordinator,incident-triage",
+            "openbank.case-coordinator.case.identity-bindings" to "ROLE_OPERATOR=case-coordinator",
+        )
+    }
+
+    private fun openCase(openedBy: String) = given()
+        .contentType(ContentType.JSON)
+        .body(
+            mapOf(
+                "caseClass" to "INCIDENT_RESPONSE",
+                "subjectRef" to "acct-4834",
+                "openedBy" to openedBy,
+                "dispositionTarget" to "alert-4834",
+            ),
+        )
+        .`when`().post("/api/v1/case-coordinator/cases")
+        .then()
+
+    private fun signal(agentId: String) = given()
+        .contentType(ContentType.JSON)
+        .body(mapOf("type" to "contribute", "agentId" to agentId, "summary" to "s"))
+        .`when`().post("/api/v1/case-coordinator/cases/case-incident-response-acct-4834/signals")
+        .then()
+
+    @Test
+    @TestSecurity(user = "operator-1", roles = ["ROLE_OPERATOR"])
+    fun `openCase refuses an agent identity the caller's role is not bound to`() {
+        openCase("incident-triage").statusCode(403)
+    }
+
+    @Test
+    @TestSecurity(user = "operator-1", roles = ["ROLE_OPERATOR"])
+    fun `openCase still accepts the agent identity the caller's role IS bound to`() {
+        // The must-ALLOW control: 503 is the Temporal-disabled stop, reached only after every
+        // authorisation decision passed. Without it a blanket 403 would satisfy the test above.
+        openCase("case-coordinator").statusCode(503)
+    }
+
+    @Test
+    @TestSecurity(user = "operator-1", roles = ["ROLE_OPERATOR"])
+    fun `a denied openCase does not echo the asserted identity back`() {
+        openCase("incident-triage")
+            .statusCode(403)
+            .body("error", not(containsString("incident-triage")))
+    }
+
+    @Test
+    @TestSecurity(user = "operator-1", roles = ["ROLE_OPERATOR"])
+    fun `signal refuses an agent identity the caller's role is not bound to`() {
+        signal("incident-triage").statusCode(403)
+    }
+
+    @Test
+    @TestSecurity(user = "operator-1", roles = ["ROLE_OPERATOR"])
+    fun `signal still accepts the agent identity the caller's role IS bound to`() {
+        signal("case-coordinator").statusCode(503)
+    }
+
+    @Test
+    @TestSecurity(user = "admin-1", roles = ["ROLE_ADMIN"])
+    fun `a role with no binding at all may assert no agent identity`() {
+        // Deny-by-default: the profile binds only ROLE_OPERATOR, so ROLE_ADMIN — which the
+        // endpoint's @RolesAllowed still admits — can assert nothing. An unbound role must not
+        // fall through to "allowed".
+        openCase("case-coordinator").statusCode(403)
+    }
+}

--- a/openbank-case-coordinator-agent/src/test/kotlin/com/openbank/casecoordinator/infrastructure/rest/CaseCoordinatorResourceDenialTest.kt
+++ b/openbank-case-coordinator-agent/src/test/kotlin/com/openbank/casecoordinator/infrastructure/rest/CaseCoordinatorResourceDenialTest.kt
@@ -43,6 +43,10 @@ class CaseCoordinatorResourceDenialTest {
     @Test
     fun `a denied signal does not echo the caller's agentId back`() {
         every { temporalConfig.enabled() } returns true
+        // The identity binding must PASS here, or the response under test is the wrong denial:
+        // this test is about the capability branch, and the asserted-identity branch now runs
+        // first (#4834) and carries its own, differently-worded body.
+        every { gate.permitsAssertedIdentity(any(), any()) } returns true
         every { gate.canContribute(any()) } returns false
 
         val marker = "spoofed-agent-DEADBEEF"


### PR DESCRIPTION
## The invariant that was missing

`POST /api/v1/case-coordinator/cases` and `POST /api/v1/case-coordinator/cases/{caseId}/signals`
took the agent identity to act as (`openedBy` / `agentId`) from the **request body**, and fed it
unchanged into five capability decisions — `canOpenCase`, `canJoinCase`, `canContribute`,
`canPreempt`, `canRequestSynthesis` — and, for a signal, into the workflow as the recorded **author**
of the contribution.

Those lists answer *"does this agent identity hold this capability"*. Nothing in the service answered
*"is the caller that agent"*. So every one of the five decisions tested an **asserted** identity
rather than a **proved** one, and the attribution ADR-0244 rests on — *"who detected is never who
coordinated"* — was decorative.

Latent, not live, and the issue's own follow-up comment establishes why: the capability lists ship
with a single entry, so the only string that passes any gate is the only string anyone would be
bound to. The defect is that the property stops holding the moment a config list grows, with nothing
anywhere to notice — and the same config comment says that growth is planned work.

## The fix

Adds the missing half rather than changing the existing one: a deny-by-default **role-to-identity
binding** (`openbank.case-coordinator.case.identity-bindings`, `ROLE_A=agent1,agent2;ROLE_B=agent3`),
consulted at the edge before any capability decision runs on the requested identity.

The separation is the one `McpEndpoint` already documents for `X-Agent-Id`: the bearer proves **who**
is calling, the body field only names **which** chartered identity to act as, and that request is now
authorised against the caller's verified roles.

- **No wildcard**, deliberately diverging from `agent-service`'s `AgentIdentityBinding` — a wildcard
  restores exactly the property this closes, one config edit at a time.
- **Deny-by-default**: an unknown role, an unparseable entry or an empty agent list all mean "assert
  nothing". Covered by unit tests, including inputs an operator produces by mistyping a ConfigMap.
- **Nothing reachable today changes.** The defaults bind both admitted roles to the single chartered
  opener, which is the whole of today's reachable set.
- **Authorisation before availability** on the signal path — the check moved ahead of the Temporal
  availability check, because a 503 answered first makes the decision unobservable wherever Temporal
  is off.
- The requested identity is **not echoed** in the denial body, matching #4833 / #4863.

### Why not OPA, and why not a shared primitive

ADR-0244 D9's own answer is the shared OPA gate, and that remains the right destination — it needs
the sidecar, a bundle, and a libs dependency this module has never had. This is scoped as the interim
binding that closes the claim-versus-proof hole, local to this service's two write endpoints, and it
is *replaced* by that work rather than layered under it. That is stated in the KDoc so the next
reader does not mistake it for a general authorisation primitive.

## Verification — red first

`CaseAssertedIdentityIT` drives real HTTP with a real principal (`@TestSecurity`), under a profile
that grants the capability lists a second chartered agent and binds the caller to only the first —
the state the config comment says is coming. A unit test handing the resource a mock
`SecurityIdentity` cannot distinguish an enforced binding from a decorative one, so it is not used
for this.

Measured on this branch, same test both times:

| | before | after |
|---|---|---|
| caller asserts an identity it is **not** bound to | **503** | **403** |
| caller asserts the identity it **is** bound to (control) | 503 | 503 |

Before the fix both rows read 503 — every authorisation decision in the path accepted the request,
and it stopped only at the Temporal-disabled check. The control row is what stops a blanket denial
from passing the test. 4 of 6 assertions were red before the fix, 6/6 green after.

Full module gate: **42 tests, 0 skipped, 0 failures** (skipped read explicitly — a boot failure
reports every `@QuarkusTest` as skipped, and an earlier iteration of this branch did exactly that).
`ktlintCheck`, `detekt`, `koverVerify` and `quarkusBuild` (CDI wiring) all green.
`run-gates.py --all` with `PR_DIFF_BASE` set: 145 pass, the one failure being the api-contract gate's
`sudo install` of oasdiff in a local shell — `check-api-contract.py` itself passes against a local
oasdiff.

## API contract (ADR-0048)

`openapi.yaml`: the two 403 descriptions now state the identity condition, and the two identity
fields describe what they actually are (a *request* to act as an identity, not a believed claim).
`oasdiff` classifies this **additive**, so `info.version` moves `1.0.0 -> 1.1.0`, within the same URL
major. The field stays `required` — dropping it would break the contract for no gain, since the
service still needs to know which chartered identity is being requested.

Not a money-path service and no trust-boundary threat model exists for it; the
`threat-model-updated-on-trust-boundary-change` gate passes.

Closes #4834
Refs #4215, #4240, #4833, #4863
