### PR TITLE
fix(party): bump the API contract version to 1.16.0

### DIFF
--- a/openbank-party-service/src/main/resources/openapi.yaml
+++ b/openbank-party-service/src/main/resources/openapi.yaml
@@ -6,7 +6,7 @@ info:
   # major == openbank.api.version == URL /api/v1 (ADR-0048). Minor bump (1.8 -> 1.9): additive
   # only — a new PATCH /api/v1/parties/approvals/{id} endpoint and an additional 202 response
   # on POST /{id}/merge (ADR-0155 four-eyes). No existing response or schema changed.
-  version: 1.15.0
+  version: 1.16.0
   description: Legal entity and individual party management with document storage.
   license:
     name: Apache-2.0


### PR DESCRIPTION
## What

`openbank-party-service`'s `openapi.yaml` is on main with an `info.version` that does not match the change it makes. Fixed forward: **1.15.0 → 1.16.0**.

This is the residual race `ci.yml`'s diff-base comment names — two spec PRs each classify green against their own base, and the second lands without a re-run. The PR-time gate cannot see it.

## Re-classified the current tip first, not the commit that raised the issue

A later spec merge can already have moved the version, and a further bump would then **overstate** the contract — a version consumers cannot distinguish from a real change, which ADR-0048 forbids as firmly as the understatement.

Checked rather than assumed:

- finding still stands on tip `09d4cbaf7`
- live main is at `1.15.0`
- **no open PR touches this spec**, so `1.16.0` is free

## The gate reports the *least* unmet requirement — one reading understates the bump

This is the part worth recording. The original error was:

```
editorial API change requires an info.version PATCH bump, but it moved 1.15.0 -> 1.15.0
```

Acting on that alone gives `1.15.1`. Re-running the classifier at `1.15.1` then says:

```
additive API change requires an info.version MINOR bump, but it moved 1.15.0 -> 1.15.1
```

The change is **both**, and while the PATCH bar was unmet the message named only that one. So the error text is not the requirement — the correct bump is `1.16.0`, and only re-running after the first bump revealed it. The issue's own *"bump only if it STILL reports the spec"* instruction is what caught this.

## Verification

Exit code read **directly**, not through a pipe — `| tail` masks it, and the first run here printed `::error::` while reporting `EXIT=0`, which was `tail`'s.

After the bump: **exit 0**, and party classifies as `additive change, info.version 1.15.0 -> 1.16.0 — OK (required >= MINOR)`.

Closes #4808

🤖 Generated with [Claude Code](https://claude.com/claude-code)
