### PR TITLE
fix(product-catalog): isolate reconciliation conflicts

### DIFF
--- a/openbank-product-catalog/src/main/kotlin/com/openbank/productcatalog/infrastructure/persistence/BankV1CompatibilityBackfill.kt
+++ b/openbank-product-catalog/src/main/kotlin/com/openbank/productcatalog/infrastructure/persistence/BankV1CompatibilityBackfill.kt
@@ -37,7 +37,7 @@ class BankV1CompatibilityBackfill(
     @Suppress("UnusedParameter")
     fun onStart(@Observes @Priority(Interceptor.Priority.APPLICATION + STARTUP_PRIORITY_OFFSET) event: StartupEvent) {
         if (!bankCompatibilityEnabled) return
-        val mapped = run()
+        val mapped = runLenient()
         liveness.recordSuccess()
         if (mapped > 0) log.info("Mapped $mapped legacy banking product(s) into the v2 catalog.")
     }
@@ -45,6 +45,19 @@ class BankV1CompatibilityBackfill(
     fun run(): Int {
         if (!bankCompatibilityEnabled) return 0
         return VertxContextSupport.subscribeAndAwait { reconcile(failOnConflict = true) }?.changed ?: 0
+    }
+
+    /**
+     * A compatibility conflict is fail-closed for that product, never for the whole catalog.
+     * Operators can resolve it through the catalog evidence trail while unrelated products stay
+     * available during a rollout.
+     */
+    internal fun runLenient(): Int {
+        val result = VertxContextSupport.subscribeAndAwait {
+            reconcile(failOnConflict = false)
+        } ?: ReconciliationResult()
+        logConflicts(result)
+        return result.changed
     }
 
     /**
@@ -66,8 +79,12 @@ class BankV1CompatibilityBackfill(
         if (result.changed > 0) {
             log.info("Reconciled ${result.changed} banking product(s) after a mixed-version write.")
         }
-        result.conflicts.forEach { log.error("Banking compatibility reconciliation conflict: ${it.message}") }
+        logConflicts(result)
         liveness.recordSuccess()
+    }
+
+    private fun logConflicts(result: ReconciliationResult) {
+        result.conflicts.forEach { log.error("Banking compatibility reconciliation conflict: ${it.message}") }
     }
 
     private fun reconcile(failOnConflict: Boolean): Uni<ReconciliationResult> = sessions.withSession { session ->

--- a/openbank-product-catalog/src/test/kotlin/com/openbank/productcatalog/CatalogBankCompatibilityTest.kt
+++ b/openbank-product-catalog/src/test/kotlin/com/openbank/productcatalog/CatalogBankCompatibilityTest.kt
@@ -18,6 +18,7 @@ import io.restassured.RestAssured.given
 import jakarta.inject.Inject
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatCode
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.hamcrest.Matchers.equalTo
 import org.junit.jupiter.api.Test
@@ -87,6 +88,25 @@ class CatalogBankCompatibilityTest {
         runBlocking { backfill.reconcileAfterRollingWriters() }
         assertThat(legacyName(latestDraft(offeringId))).isEqualTo("Changed by P0 rollback")
         assertThat(backfill.run()).isZero()
+    }
+
+    @Test
+    fun `startup reconciliation keeps unrelated catalog products available on a banking draft conflict`() {
+        val productId = createLegacyDraft("CURRENT_DUPLICATE_DRAFT")
+        val offeringId = mappedOffering(productId)
+        val duplicateId = duplicateDraft(latestDraft(offeringId))
+
+        try {
+            assertThatCode { backfill.runLenient() }.doesNotThrowAnyException()
+            given().get("/api/v1/products/$productId").then().statusCode(200)
+        } finally {
+            dataSource.connection.use { connection ->
+                connection.prepareStatement("DELETE FROM catalog_revisions WHERE id = ?").use { statement ->
+                    statement.setObject(1, duplicateId)
+                    assertThat(statement.executeUpdate()).isEqualTo(1)
+                }
+            }
+        }
     }
 
     @Test
@@ -532,6 +552,25 @@ class CatalogBankCompatibilityTest {
             .body("""{"code":"$code","name":"$code","type":"CURRENT","currency":"EUR"}""")
             .post("/api/v1/products").then().statusCode(201).extract()
         return UUID.fromString(response.jsonPath().getString("id"))
+    }
+
+    private fun duplicateDraft(sourceId: UUID): UUID {
+        val duplicateId = UUID.randomUUID()
+        dataSource.connection.use { connection ->
+            connection.prepareStatement(
+                "INSERT INTO catalog_revisions " +
+                    "(id, offering_id, revision_no, schema_id, schema_version, state, content, effective_from, " +
+                    "effective_to, maker_id, checker_id, reason, content_hash, created_at, updated_at, lock_version) " +
+                    "SELECT ?, offering_id, revision_no + 1, schema_id, schema_version, 'DRAFT', content, " +
+                    "effective_from, effective_to, maker_id, NULL, NULL, NULL, now(), now(), 0 " +
+                    "FROM catalog_revisions WHERE id = ?",
+            ).use { statement ->
+                statement.setObject(1, duplicateId)
+                statement.setObject(2, sourceId)
+                assertThat(statement.executeUpdate()).isEqualTo(1)
+            }
+        }
+        return duplicateId
     }
 
     private fun publishLatestDraft(offeringId: UUID, checker: String) {


### PR DESCRIPTION
## Summary
- preserve fail-closed reconciliation per conflicted banking product
- keep the catalog process available when historical data has duplicate banking drafts
- cover startup-path behavior with a real PostgreSQL regression

## Verification
- `./gradlew :openbank-product-catalog:ktlintCheck :openbank-product-catalog:detekt :openbank-product-catalog:test --tests com.openbank.productcatalog.CatalogBankCompatibilityTest`

Refs #4505