### PR TITLE
feat(admin-ui): unify identity operations workspaces

### DIFF
--- a/openbank-admin-ui/src/app/aml/page.tsx
+++ b/openbank-admin-ui/src/app/aml/page.tsx
@@ -12,6 +12,7 @@ import { svcUrl } from '@/lib/services/bff'
 import { useServiceResource } from '@/lib/services/useServiceResource'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { PageHeader, StatusBadge } from '@/components/ui'
+import { StatCard } from '@/components/ui/StatCard'
 
 interface AmlCase {
   id: string;
@@ -106,14 +107,7 @@ export default function AmlPage() {
             { label: t('Vysoké riziko', 'High Risk'), value: highRisk.length, icon: <AlertTriangle size={16} />, color: 'var(--danger)' },
             { label: t('Čeká na review', 'Pending Review'), value: pending.length, icon: <Clock size={16} />, color: 'var(--warning)' },
             { label: t('Eskalováno', 'Escalated'), value: escalated.length, icon: <AlertOctagon size={16} />, color: '#dc2626' },
-          ].map(k => (
-            <div key={k.label} className="stat-card">
-              <div style={{ width: '32px', height: '32px', borderRadius: '8px', background: `${k.color}18`,
-                display: 'flex', alignItems: 'center', justifyContent: 'center', color: k.color, marginBottom: '10px' }}>{k.icon}</div>
-              <div style={{ fontSize: '28px', fontWeight: 800, color: 'var(--text-primary)', letterSpacing: '-0.03em' }}>{k.value}</div>
-              <div style={{ fontSize: '12px', color: 'var(--text-secondary)', fontWeight: 500 }}>{k.label}</div>
-            </div>
-          ))}
+          ].map(k => <StatCard key={k.label} label={k.label} value={k.value} icon={k.icon} tone={k.color === 'var(--danger)' || k.color === '#dc2626' ? 'danger' : k.color === 'var(--warning)' ? 'warning' : undefined} />)}
         </div>
 
         <div className="card">

--- a/openbank-admin-ui/src/app/identity-cases/page.tsx
+++ b/openbank-admin-ui/src/app/identity-cases/page.tsx
@@ -8,6 +8,7 @@ import { useState, useEffect, useCallback } from 'react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { classifyBffFailure, svcUrl } from '@/lib/services/bff'
 import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
+import { PageHeader } from '@/components/ui/PageHeader'
 import { Fingerprint, RefreshCw, ShieldAlert, Users, Check } from 'lucide-react'
 
 const SVC = 'pid-service'
@@ -241,34 +242,14 @@ export default function IdentityCasesPage() {
 
   return (
     <div>
-      <div className="page-header">
-        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
-          <div>
-            <div className="breadcrumb">
-              <span>OpenBank</span>
-              <span className="breadcrumb-sep">/</span>
-              <span>{t('Klienti', 'Customers')}</span>
-              <span className="breadcrumb-sep">/</span>
-              <span className="breadcrumb-current">{t('Ověření identity', 'Identity Verification')}</span>
-            </div>
-            <h1 className="page-title" style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-              <Fingerprint size={18} style={{ color: 'var(--accent)' }} />
-              {t('Ověření identity — čtyři oči', 'Identity Verification — Four-Eyes')}
-            </h1>
-            <p className="page-subtitle">
-              {t(
-                'Nejednoznačné identity z onboardingu (kolize RČ nebo jmenovci). Rozhodnutí vyžaduje dva různé schvalovatele (ADR-0072 / ADR-0030).',
-                'Ambiguous onboarding identities (RČ collisions or namesakes). A decision requires two distinct approvers (ADR-0072 / ADR-0030).',
-              )}
-            </p>
-          </div>
-          <button className="btn btn-secondary" onClick={load} disabled={loading} style={{ fontSize: '13px' }}>
-            <RefreshCw size={14} style={{ marginRight: '4px' }} />
-            {t('Obnovit', 'Refresh')}
-          </button>
-        </div>
-      </div>
-
+      <PageHeader
+        icon={<Fingerprint size={20} aria-hidden="true" />}
+        title={t('Ověření identity — čtyři oči', 'Identity Verification — Four-Eyes')}
+        subtitle={t('Nejednoznačné identity z onboardingu (kolize RČ nebo jmenovci). Rozhodnutí vyžaduje dva různé schvalovatele (ADR-0072 / ADR-0030).', 'Ambiguous onboarding identities (RČ collisions or namesakes). A decision requires two distinct approvers (ADR-0072 / ADR-0030).')}
+        actions={<button className="btn btn-secondary" onClick={load} disabled={loading} style={{ fontSize: '13px' }}>
+          <RefreshCw size={14} style={{ marginRight: '4px' }} />{t('Obnovit', 'Refresh')}
+        </button>}
+      />
       {unavail ? (
         <DataUnavailable kind={unavail} service="pid-service" feature={t('ověření identity', 'identity verification')} lang={language} />
       ) : cases.length === 0 && !loading ? (


### PR DESCRIPTION
## Summary

- Standardize AML KPI tiles and the Identity Cases page header on shared operator UI primitives.
- Preserve AML scan behavior, PID four-eyes decisions, BFF calls, and permissions.

## Validation

- `npm run type-check`
- `npm exec eslint src/app/aml/page.tsx src/app/identity-cases/page.tsx src/app/kyc/page.tsx`
- `npm test -- --run src/test/render-smoke.test.tsx src/test/ui-tone.test.ts`

## Linked issues

N/A — incremental delivery of the approved admin UI modernization.