### PR TITLE
fix(infra): give six services an OIDC client they can actually mint from

### DIFF
--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -2676,6 +2676,28 @@ gates:
     selftest_expect: pass
     run: |
       python3 .github/scripts/check-roles-allowed-realm.py
+  # The sibling of the gate above, one layer earlier: that one asks whether the role a caller
+  # NEEDS can exist, this one whether the caller can present a token at all. An outbound client
+  # annotated @RegisterProvider(OidcClientRequest*Filter) mints from `quarkus.oidc-client`, a
+  # different extension from `quarkus.oidc` (inbound) that shares its three field names and
+  # differs by one hyphen. Missing it, or leaving its auth-server-url on the localhost default
+  # in a pod (where localhost is the service itself), sends every outbound call out bare and the
+  # callee answers 401 — not 403, so the natural first hypothesis sends you to Keycloak instead.
+  # Found by observability sweep 2026-08-16: ledger's daily FX revaluation had failed on every
+  # run it ever made and only an absent() alert noticed; settlement (money-path) had no block.
+  # The gate resolves the interpolation rather than matching an env NAME — the fleet spells the
+  # deployed override three ways and a name-match draft failed 16 correct services.
+  - id: oidc-client-configured
+    name: "outbound OIDC filter ⇒ a client it can actually mint from (enforced)"
+    group: security
+    mode: enforced
+    rationale: "An unmintable outbound token fails as a 401 from the CALLEE, which reads as an authorization problem and sends the reader to Keycloak; no test can catch it because a mock port, a @QuarkusTest security context and a pact mock server all supply the very token the real client cannot obtain (#3921: ledger's daily FX revaluation had never once succeeded, and settlement, money-path, had no client block at all)."
+    review_after: "2027-02-16"
+    min_subjects: 25   # 30 modules register the filter today (2026-08-16)
+    selftest: python3 .github/scripts/check-oidc-client-configured.py --self-test
+    selftest_expect: pass
+    run: |
+      python3 .github/scripts/check-oidc-client-configured.py
   # Keycloak realm templates must be IMPORTABLE (issue #3246). The three existing realm checks
   # all compare NAME SETS — @RolesAllowed vs template, template vs live, template vs the import
   # artifact — and every one of them is perfectly happy with a document Keycloak refuses to

--- a/.github/scripts/check-oidc-client-configured.py
+++ b/.github/scripts/check-oidc-client-configured.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+#
+# Guard: a service that PRESENTS an OIDC token must be able to mint one IN THE CLUSTER.
+#
+# WHY THIS EXISTS
+#   An outbound REST client annotated `@RegisterProvider(OidcClientRequestReactiveFilter::class)`
+#   attaches a bearer token minted by the DEFAULT OidcClient — `quarkus.oidc-client.*`. That is a
+#   different extension from `quarkus.oidc.*`, which is the inbound resource-server side that
+#   VALIDATES tokens arriving here. The two blocks carry the same three field names
+#   (auth-server-url, client-id, credentials.secret) and differ by one hyphen.
+#
+#   With no `quarkus.oidc-client`, nothing errors at build time and nothing errors at boot. The
+#   filter has no client to mint from, the request leaves unauthenticated, and the callee answers
+#   401. The status code is the tell and is easy to misread: 401 means no token AT ALL, where a
+#   role problem would be 403 — so the obvious hypothesis ("the service account is missing a
+#   role") sends you into Keycloak, which is the wrong place entirely.
+#
+#   Measured 2026-08-16: 32 modules registered the filter and 27 configured the client.
+#   openbank-ledger-service's daily FX revaluation had failed `Received: 'Unauthorized, status
+#   code 401'` on every run it ever made — `openbank_workflow_success_recorded{workflow=
+#   "ledger-fx-revaluation"} = 0` — and the only thing that noticed was FxFixingAgeAbsent, an
+#   `absent()` alert on a gauge the run never got far enough to register.
+#   openbank-settlement-service, money-path, had neither block at all.
+#
+# THE INVARIANT IS ABOUT THE DEPLOYED VALUE, NOT THE SPELLING
+#   Every service defaults auth-server-url to localhost so local dev works. In a pod, localhost
+#   is the pod itself (`quarkus.http.port` is 8080), so an unsubstituted default does not fail
+#   loudly either — it POSTs the token request to this very service, gets a 404, and the outbound
+#   call goes out bare. Identical symptom to the missing block.
+#
+#   So the check is: whatever env vars the value interpolates must actually be set on this
+#   module's deployed workload. The fleet spells that three different ways and all three are
+#   correct — QUARKUS_OIDC_AUTH_SERVER_URL (26 services, reusing the inbound URL), KEYCLOAK_URL
+#   (campaign), and a literal + QUARKUS_OIDC_CLIENT_AUTH_SERVER_URL override (balance-service).
+#   Checking for any ONE of those names would have failed 16 correct services; the first draft of
+#   this gate did exactly that, and only a live `kubectl get deploy` disproved it. Resolving the
+#   interpolation instead needs no list and admits any future spelling.
+#
+#   Nothing else could catch this. A unit test mocks the port; a @QuarkusTest supplies its own
+#   security context; a consumer pact's mock server answers whatever is asked and never inspects
+#   the Authorization header. The defect exists only between a real client and a real provider.
+#
+# Run:  python3 .github/scripts/check-oidc-client-configured.py [--root .] [--self-test]
+
+import argparse
+import pathlib
+import re
+import sys
+
+import yaml
+
+import gatelib
+
+FILTER_RE = re.compile(r"@RegisterProvider\s*\(\s*OidcClientRequest(?:Reactive)?Filter::class")
+# `  oidc-client:` at quarkus-child depth, then its auth-server-url, ignoring deeper occurrences
+# (`quarkus.rest-client.<x>.oidc-client.enabled`, and the `%test` profile's disable block).
+OIDC_CLIENT_URL_RE = re.compile(r"^  oidc-client:\s*$\n(?:^ {4}.*$\n)*?^ {4}auth-server-url:\s*(.+)$", re.M)
+OIDC_CLIENT_KEY_RE = re.compile(r"^  oidc-client:\s*$", re.M)
+ENV_REF_RE = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)")
+OVERRIDE_ENV = "QUARKUS_OIDC_CLIENT_AUTH_SERVER_URL"
+WORKLOAD_KINDS = {"Deployment", "Rollout", "StatefulSet"}
+
+# Library modules ship the filter for consumers to register; they have no application.yaml and no
+# workload of their own. Derived from the name rather than enumerated per module.
+LIBRARY_PREFIXES = ("openbank-libs",)
+
+
+def modules_registering_filter(root: pathlib.Path):
+    """Modules with at least one @RegisterProvider(OidcClientRequest*Filter) in main sources."""
+    found = {}
+    for f in sorted(root.glob("openbank-*/src/main/kotlin/**/*.kt")):
+        if not FILTER_RE.search(f.read_text()):
+            continue
+        module = f.relative_to(root).parts[0]
+        if module.startswith(LIBRARY_PREFIXES):
+            continue
+        found.setdefault(module, []).append(str(f.relative_to(root)))
+    return found
+
+
+def oidc_client_url(root: pathlib.Path, module: str):
+    """(configured?, raw auth-server-url or None) for this module's default OidcClient."""
+    p = root / module / "src/main/resources/application.yaml"
+    if not p.is_file():
+        return False, None
+    text = p.read_text()
+    if not OIDC_CLIENT_KEY_RE.search(text):
+        return False, None
+    m = OIDC_CLIENT_URL_RE.search(text)
+    return True, (m.group(1).strip() if m else None)
+
+
+def workload_env(root: pathlib.Path):
+    """{workload name: set of env var names it sets}, over every gitops manifest.
+
+    Indexed by workload rather than by file because eleven payments services share one file, so a
+    per-file answer would let one service's env vouch for another's.
+    """
+    index = {}
+    for p in sorted((root / "openbank-infra/gitops").rglob("*.yaml")):
+        try:
+            docs = list(yaml.safe_load_all(p.read_text()))
+        except yaml.YAMLError:
+            continue
+        for d in docs:
+            if not isinstance(d, dict) or d.get("kind") not in WORKLOAD_KINDS:
+                continue
+            name = (d.get("metadata") or {}).get("name")
+            spec = ((d.get("spec") or {}).get("template") or {}).get("spec") or {}
+            names = {e.get("name") for c in spec.get("containers") or [] for e in c.get("env") or []}
+            if name:
+                index.setdefault(name, set()).update(names)
+    return index
+
+
+def self_test() -> int:
+    import tempfile
+
+    fails: list[str] = []
+    with tempfile.TemporaryDirectory() as td:
+        root = pathlib.Path(td)
+        gitops = root / "openbank-infra/gitops/components"
+        gitops.mkdir(parents=True)
+
+        def service(name, *, filter_registered=True, url=None, env=(), reactive=True, workload=None):
+            kt = root / f"openbank-{name}-service/src/main/kotlin/com/openbank/{name}"
+            kt.mkdir(parents=True)
+            variant = "OidcClientRequestReactiveFilter" if reactive else "OidcClientRequestFilter"
+            (kt / "C.kt").write_text(
+                f"@RegisterProvider({variant}::class)\ninterface C\n" if filter_registered else "interface C\n")
+            res = root / f"openbank-{name}-service/src/main/resources"
+            res.mkdir(parents=True)
+            cfg = "quarkus:\n  oidc:\n    auth-server-url: ${INBOUND:http://localhost:8080}\n"
+            if url is not None:
+                # a deeper `oidc-client` key must NOT be mistaken for the real one
+                cfg += (f"  oidc-client:\n    auth-server-url: {url}\n    client-id: openbank-services\n"
+                        "  rest-client:\n    x:\n      oidc-client:\n        enabled: false\n")
+            (res / "application.yaml").write_text(cfg)
+            wl = workload or f"{name}-service"
+            envs = "".join(f"            - name: {e}\n              value: v\n" for e in env)
+            gitops.joinpath(f"{name}.yaml").write_text(
+                "kind: Deployment\nmetadata:\n  name: " + wl +
+                "\nspec:\n  template:\n    spec:\n      containers:\n        - name: app\n          env:\n"
+                + (envs or "            - name: UNRELATED\n              value: v\n"))
+
+        service("good", url="${KC_URL:http://localhost:8080}/realms/openbank", env=["KC_URL"])
+        service("altspelling", url="${OTHER_URL:http://localhost:8080}/realms/x", env=["OTHER_URL"])
+        service("override", url="http://localhost:8080/realms/openbank", env=[OVERRIDE_ENV])
+        service("noblock", url=None, env=["KC_URL"])                                  # DEFECT 1
+        service("bareliteral", url="http://localhost:8080/realms/openbank", env=[])   # DEFECT 2
+        service("unsetvar", url="${MISSING:http://localhost:8080}/realms/x", env=[])  # DEFECT 3
+        service("blocking", url="${KC_URL:http://localhost:8080}/x", env=["KC_URL"], reactive=False)
+        service("nofilter", filter_registered=False, url=None, env=[])
+        service("noworkload", url="${KC_URL:http://localhost:8080}/x", env=["KC_URL"], workload="other-name")
+
+        lib = root / "openbank-libs-runtime/src/main/kotlin/com/openbank/libs"
+        lib.mkdir(parents=True)
+        (lib / "L.kt").write_text("@RegisterProvider(OidcClientRequestReactiveFilter::class)\ninterface L\n")
+
+        mods = modules_registering_filter(root)
+        want = {f"openbank-{n}-service" for n in
+                ("good", "altspelling", "override", "noblock", "bareliteral", "unsetvar", "blocking", "noworkload")}
+        if set(mods) != want:
+            fails.append(f"corpus wrong: {sorted(mods)} — libs must be excluded, nofilter out of "
+                         f"scope, the non-reactive filter variant in scope")
+
+        # The deeper rest-client `oidc-client:` key must not be picked up as the block's URL.
+        ok, url = oidc_client_url(root, "openbank-good-service")
+        if not ok or url != "${KC_URL:http://localhost:8080}/realms/openbank":
+            fails.append(f"url extraction wrong for good: configured={ok} url={url!r}")
+        if oidc_client_url(root, "openbank-noblock-service") != (False, None):
+            fails.append("a module with no oidc-client block must read as unconfigured")
+
+        env_index = workload_env(root)
+        if env_index.get("good-service") != {"KC_URL"}:
+            fails.append(f"workload env index wrong: {env_index.get('good-service')}")
+
+        found = dict(evaluate(root, mods, env_index))
+        for m, must_fail in (("good", False), ("altspelling", False), ("override", False),
+                             ("blocking", False), ("noblock", True), ("bareliteral", True),
+                             ("unsetvar", True), ("noworkload", True)):
+            key = f"openbank-{m}-service"
+            if (key in found) != must_fail:
+                fails.append(f"{key}: expected finding={must_fail}, got {found.get(key, 'none')!r}")
+
+    if fails:
+        for f in fails:
+            sys.stderr.write(f"::error::self-test: {f}\n")
+        sys.stderr.write(f"self-test FAILED ({len(fails)} case(s))\n")
+        return 1
+    print("self-test ok: oidc-client-configured is falsifiable (15 cases)")
+    return 0
+
+
+def evaluate(root: pathlib.Path, modules, env_index):
+    """Yield (module, finding) for every module that cannot mint a token in the cluster."""
+    for module, sites in sorted(modules.items()):
+        where = ", ".join(sites[:2]) + (", …" if len(sites) > 2 else "")
+        configured, url = oidc_client_url(root, module)
+        if not configured:
+            yield module, (
+                f"{module} registers OidcClientRequest*Filter ({where}) but its application.yaml "
+                f"declares no `quarkus.oidc-client` block. The filter has no client to mint from, "
+                f"so every outbound call leaves WITHOUT a token and the callee answers 401 — not "
+                f"403, because there is no token to be missing a role."
+            )
+            continue
+
+        workload = module.removeprefix("openbank-")
+        env = env_index.get(workload)
+        if env is None:
+            yield module, (
+                f"{module} configures `quarkus.oidc-client`, but no gitops workload is named "
+                f"`{workload}`, so this guard cannot tell whether the deployed pod resolves the "
+                f"auth-server-url — UNCHECKED, not clean. Name the workload after the module or "
+                f"teach this script the mapping."
+            )
+            continue
+        if OVERRIDE_ENV in env:
+            continue
+
+        refs = set(ENV_REF_RE.findall(url or ""))
+        if not refs:
+            yield module, (
+                f"{module}'s `quarkus.oidc-client.auth-server-url` is the literal {url!r} and its "
+                f"workload sets neither an interpolated variable nor {OVERRIDE_ENV}. In a pod "
+                f"localhost:8080 is the service ITSELF, so the token request 404s and the outbound "
+                f"call goes out bare — same 401 as having no block at all."
+            )
+            continue
+        missing = sorted(r for r in refs if r not in env)
+        if missing:
+            yield module, (
+                f"{module}'s `quarkus.oidc-client.auth-server-url` interpolates {', '.join(missing)}, "
+                f"which the `{workload}` workload does not set, so it falls back to its localhost "
+                f"default — in a pod that is the service itself. Set the variable, or "
+                f"{OVERRIDE_ENV}."
+            )
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--root", default=".")
+    ap.add_argument("--self-test", action="store_true")
+    args = ap.parse_args()
+    if args.self_test:
+        return self_test()
+
+    root = pathlib.Path(args.root).resolve()
+    modules = modules_registering_filter(root)
+    findings = [f for _, f in evaluate(root, modules, workload_env(root))]
+
+    gatelib.subjects(len(modules), "modules registering an OIDC client filter")
+
+    if findings:
+        for f in findings:
+            sys.stderr.write(f"::error title=OIDC client configured::{f}\n")
+        sys.stderr.write(f"::error::check-oidc-client-configured: {len(findings)} module(s) cannot mint the token they present.\n")
+        return 1
+
+    print(f"oidc-client parity: {len(modules)} module(s) register an outbound OIDC filter; every one "
+          f"declares quarkus.oidc-client and its deployed workload resolves the auth-server-url "
+          f"away from localhost.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/threat-models/openbank-ledger-service.md
+++ b/docs/threat-models/openbank-ledger-service.md
@@ -237,6 +237,23 @@ set) apply equally to the new `ledger.approval.decide` action.
 
 ## 8. Change log
 
+- **2026-08-16** — Outbound OIDC client was never configured (#3921, follow-up to the 2026-08-09
+  entry below). That entry's "Same … OIDC client-credentials posture" line described a posture
+  that did not exist: `application.yaml` declared `quarkus.oidc` (inbound, validates tokens
+  arriving here) and no `quarkus.oidc-client` (outbound, mints the token `FxServiceClient`'s
+  `OidcClientRequestReactiveFilter` attaches). The two blocks share three field names and differ
+  by one hyphen, so the gap read as configured on inspection. Effect: every `FxServiceClient` call
+  left with no `Authorization` header at all — a 401 from fx-service, not a 403 — and the daily FX
+  revaluation had failed on **every run it ever made**
+  (`openbank_workflow_success_recorded{workflow="ledger-fx-revaluation"} = 0`; caught only by
+  `FxFixingAgeAbsent`, an `absent()` alert on a gauge the run never got far enough to register).
+  Fixed by adding `quarkus.oidc-client` with `auth-server-url:
+  ${QUARKUS_OIDC_AUTH_SERVER_URL:http://localhost:8080/realms/openbank}` — the same variable the
+  inbound `quarkus.oidc` block already reads, and which the deployed workload already sets, so no
+  gitops change was needed. **No new trust boundary**: the edge, host, route, authz posture and
+  Vault-projected `OIDC_CLIENT_SECRET` (S2 above) are unchanged — this restores the M2M identity
+  the edge was always meant to present, rather than adding a capability. Enforced fleet-wide by
+  `check-oidc-client-configured.py` (six services fixed; ledger and settlement money-path).
 - **2026-08-09** — Outbound client edge + posting semantics (#3921, correctness half). Two changes to
   the money path, and the second is the one that needs the scrutiny.
   **(a) Outbound edge.** `FxServiceClient.getRate` now sends `asOf=<business day>` alongside

--- a/docs/threat-models/openbank-settlement-service.md
+++ b/docs/threat-models/openbank-settlement-service.md
@@ -65,7 +65,7 @@ replacing the former in-memory stub), so settlement state is durable across rest
 | ID | Threat | Mitigation |
 |----|--------|------------|
 | S1 | Attacker impersonates Temporal server, injects malicious workflow tasks | mTLS between Temporal server and workers (both directions); OPA activity interceptor (`OpaActivityInterceptor`) rejects tasks not matching policy |
-| S2 | Attacker impersonates settlement-service to call balance/ledger | Service mesh mTLS (SPIFFE identity); OPA authz on REST receivers |
+| S2 | Attacker impersonates settlement-service to call balance/ledger | Corrected 2026-08-16 (#3921) — see note below. `debit-port`/`credit-port`/`ledger-port` are `OidcClientRequestReactiveFilter`-backed REST clients (`BalanceRestClient`, `LedgerRestClient`) that attach a client-credentials bearer token from `quarkus.oidc-client`, the confidential `openbank-services` Keycloak client (`OIDC_CLIENT_SECRET` Vault-projected, never in git); OPA authz on the balance/ledger REST receivers checks that identity |
 
 ### T — Tampering
 
@@ -185,3 +185,21 @@ replacing the former in-memory stub), so settlement state is durable across rest
 - ADR-0034 (OPA unified authz — `OpaActivityInterceptor`)
 - ADR-0101 (Temporal durable execution — this migration)
 - Settlement money-bug (2026-06-19, root cause: missing intermediate-state timeout in hand-rolled saga)
+
+## Change log
+
+- **2026-08-16** (#3921) — S2's mitigation was corrected and the outbound OIDC client was
+  configured for the first time; both belong together. The prior text credited "Service mesh mTLS
+  (SPIFFE identity)" for the debit/credit/ledger port calls — no service mesh is deployed anywhere
+  in this platform, so that line described a control that does not exist. The real mechanism is
+  `quarkus.oidc-client` client-credentials on each `OidcClientRequest*Filter`-backed REST client,
+  and `application.yaml` had **no `quarkus.oidc-client` block at all** — only `quarkus.oidc`
+  (inbound; validates tokens arriving at settlement-service). So the actual state before this fix
+  was neither mesh mTLS nor OIDC: every settlement→balance and settlement→ledger call left with no
+  `Authorization` header, and the callee's 401 (not 403 — no token to be missing a role) was the
+  only signal. Fixed by adding the block with `auth-server-url:
+  ${QUARKUS_OIDC_AUTH_SERVER_URL:http://localhost:8080/realms/openbank}`, the same variable the
+  inbound block already reads and the deployed workload already sets — no gitops change needed.
+  **No new trust boundary**: this restores the M2M identity the ports were always meant to
+  present, on the existing edges, against the existing confidential client. Enforced fleet-wide by
+  `check-oidc-client-configured.py` (six services fixed; ledger and settlement money-path).

--- a/openbank-campaign-service/src/main/resources/application.yaml
+++ b/openbank-campaign-service/src/main/resources/application.yaml
@@ -31,6 +31,21 @@ quarkus:
   oidc:
     auth-server-url: ${KEYCLOAK_URL:http://localhost:8080}/realms/openbank
     client-id: openbank-services
+  # OIDC CLIENT (outbound M2M) — the token this service PRESENTS when it calls another.
+  # Distinct from `quarkus.oidc` above, which is the inbound resource-server side that VALIDATES
+  # tokens arriving here. The two blocks carry the same three field names and differ by one
+  # hyphen, which is how this went missing: the config reads correct at a glance and configures
+  # the wrong half. Any client annotated `@RegisterProvider(OidcClientRequestReactiveFilter)`
+  # mints its bearer token from HERE, and with no `quarkus.oidc-client` the filter has no client
+  # to mint from, so the call leaves unauthenticated and the callee answers 401 — not 403, which
+  # is the tell: there is no token at all, rather than a token missing a role.
+  # Enforced by .github/scripts/check-oidc-client-configured.py.
+  oidc-client:
+    auth-server-url: ${KEYCLOAK_URL:http://localhost:8080}/realms/openbank
+    client-id: openbank-services
+    credentials:
+      secret: ${OIDC_CLIENT_SECRET:CHANGE_ME_LOCAL_DEV_ONLY}
+
   # Health probes and the Prometheus scrape live on the management interface, not the
   # application port — the Deployment probes /q/health/{live,ready} on 8085 and the
   # PodMonitor scrapes the same port. Without this block nothing listens there, so the

--- a/openbank-engagement-service/src/main/resources/application.yaml
+++ b/openbank-engagement-service/src/main/resources/application.yaml
@@ -21,8 +21,11 @@ quarkus:
     auth-server-url: ${KEYCLOAK_URL:http://localhost:8080}/realms/openbank
     client-id: openbank-services
   # Outbound M2M token for the consent-service check (ContactPolicyGate's consent port).
+  # Its inbound block two lines up reads KEYCLOAK_URL, which is what the workload sets; this
+  # one read QUARKUS_OIDC_AUTH_SERVER_URL, which it does not — so the outbound URL silently
+  # fell back to localhost, i.e. this pod, and the consent check went out unauthenticated.
   oidc-client:
-    auth-server-url: ${QUARKUS_OIDC_AUTH_SERVER_URL:http://localhost:8080}/realms/openbank
+    auth-server-url: ${KEYCLOAK_URL:http://localhost:8080}/realms/openbank
     client-id: openbank-services
     credentials:
       secret: ${OIDC_CLIENT_SECRET:CHANGE_ME_LOCAL_DEV_ONLY}

--- a/openbank-finrep-service/src/main/resources/application.yaml
+++ b/openbank-finrep-service/src/main/resources/application.yaml
@@ -17,6 +17,21 @@ quarkus:
     tls:
       verification: none
 
+  # OIDC CLIENT (outbound M2M) — the token this service PRESENTS when it calls another.
+  # Distinct from `quarkus.oidc` above, which is the inbound resource-server side that VALIDATES
+  # tokens arriving here. The two blocks carry the same three field names and differ by one
+  # hyphen, which is how this went missing: the config reads correct at a glance and configures
+  # the wrong half. Any client annotated `@RegisterProvider(OidcClientRequestReactiveFilter)`
+  # mints its bearer token from HERE, and with no `quarkus.oidc-client` the filter has no client
+  # to mint from, so the call leaves unauthenticated and the callee answers 401 — not 403, which
+  # is the tell: there is no token at all, rather than a token missing a role.
+  # Enforced by .github/scripts/check-oidc-client-configured.py.
+  oidc-client:
+    auth-server-url: ${QUARKUS_OIDC_AUTH_SERVER_URL:http://localhost:8080/realms/openbank}
+    client-id: openbank-services
+    credentials:
+      secret: ${OIDC_CLIENT_SECRET:CHANGE_ME_LOCAL_DEV_ONLY}
+
   rest-client:
     ledger-service:
       url: ${LEDGER_SERVICE_URL:http://ledger-service.ledger.svc:8101}

--- a/openbank-ledger-service/src/main/resources/application.yaml
+++ b/openbank-ledger-service/src/main/resources/application.yaml
@@ -57,6 +57,21 @@ quarkus:
   redis:
     hosts: redis://localhost:6379
 
+  # OIDC CLIENT (outbound M2M) — the token this service PRESENTS when it calls another.
+  # Distinct from `quarkus.oidc` above, which is the inbound resource-server side that VALIDATES
+  # tokens arriving here. The two blocks carry the same three field names and differ by one
+  # hyphen, which is how this went missing: the config reads correct at a glance and configures
+  # the wrong half. Any client annotated `@RegisterProvider(OidcClientRequestReactiveFilter)`
+  # mints its bearer token from HERE, and with no `quarkus.oidc-client` the filter has no client
+  # to mint from, so the call leaves unauthenticated and the callee answers 401 — not 403, which
+  # is the tell: there is no token at all, rather than a token missing a role.
+  # Enforced by .github/scripts/check-oidc-client-configured.py.
+  oidc-client:
+    auth-server-url: ${QUARKUS_OIDC_AUTH_SERVER_URL:http://localhost:8080/realms/openbank}
+    client-id: openbank-services
+    credentials:
+      secret: ${OIDC_CLIENT_SECRET:CHANGE_ME_LOCAL_DEV_ONLY}
+
   rest-client:
     fx-service:
       url: ${FX_SERVICE_URL:http://localhost:8119}

--- a/openbank-onboarding-service/src/main/resources/application.yaml
+++ b/openbank-onboarding-service/src/main/resources/application.yaml
@@ -42,6 +42,21 @@ quarkus:
       secret: ${OIDC_CLIENT_SECRET:CHANGE_ME_LOCAL_DEV_ONLY}
     tls:
       verification: none
+  # OIDC CLIENT (outbound M2M) — the token this service PRESENTS when it calls another.
+  # Distinct from `quarkus.oidc` above, which is the inbound resource-server side that VALIDATES
+  # tokens arriving here. The two blocks carry the same three field names and differ by one
+  # hyphen, which is how this went missing: the config reads correct at a glance and configures
+  # the wrong half. Any client annotated `@RegisterProvider(OidcClientRequestReactiveFilter)`
+  # mints its bearer token from HERE, and with no `quarkus.oidc-client` the filter has no client
+  # to mint from, so the call leaves unauthenticated and the callee answers 401 — not 403, which
+  # is the tell: there is no token at all, rather than a token missing a role.
+  # Enforced by .github/scripts/check-oidc-client-configured.py.
+  oidc-client:
+    auth-server-url: ${QUARKUS_OIDC_AUTH_SERVER_URL:http://localhost:8080/realms/openbank}
+    client-id: openbank-services
+    credentials:
+      secret: ${OIDC_CLIENT_SECRET:CHANGE_ME_LOCAL_DEV_ONLY}
+
   rest-client:
     # Local-dev default ONLY — the in-cluster URL comes from PARTY_SERVICE_URL on the Deployment
     # (openbank-infra/gitops/components/onboarding/onboarding-service.yaml), as customer-edge,

--- a/openbank-settlement-service/src/main/resources/application.yaml
+++ b/openbank-settlement-service/src/main/resources/application.yaml
@@ -27,6 +27,21 @@ quarkus:
     category:
       "com.openbank":
         level: DEBUG
+  # OIDC CLIENT (outbound M2M) — the token this service PRESENTS when it calls another.
+  # Distinct from `quarkus.oidc` above, which is the inbound resource-server side that VALIDATES
+  # tokens arriving here. The two blocks carry the same three field names and differ by one
+  # hyphen, which is how this went missing: the config reads correct at a glance and configures
+  # the wrong half. Any client annotated `@RegisterProvider(OidcClientRequestReactiveFilter)`
+  # mints its bearer token from HERE, and with no `quarkus.oidc-client` the filter has no client
+  # to mint from, so the call leaves unauthenticated and the callee answers 401 — not 403, which
+  # is the tell: there is no token at all, rather than a token missing a role.
+  # Enforced by .github/scripts/check-oidc-client-configured.py.
+  oidc-client:
+    auth-server-url: ${QUARKUS_OIDC_AUTH_SERVER_URL:http://localhost:8080/realms/openbank}
+    client-id: openbank-services
+    credentials:
+      secret: ${OIDC_CLIENT_SECRET:CHANGE_ME_LOCAL_DEV_ONLY}
+
   rest-client:
     # Local-dev defaults ONLY. The in-cluster URLs are supplied by the Rollout's env
     # (BALANCE_SERVICE_URL / LEDGER_SERVICE_URL in


### PR DESCRIPTION
## What

Six services register an outbound OIDC token filter and cannot mint the token. Plus a gate so a seventh cannot.

Found chasing `FxFixingAgeAbsent`, the last open alert from the 2026-08-16 observability sweep.

## The defect

A REST client annotated `@RegisterProvider(OidcClientRequestReactiveFilter::class)` mints its bearer token from **`quarkus.oidc-client`**. That is a different extension from **`quarkus.oidc`**, the inbound resource-server side that *validates* tokens arriving at the service. The two blocks carry the same three field names — `auth-server-url`, `client-id`, `credentials.secret` — and differ by one hyphen.

Nothing errors at build time. Nothing errors at boot. The filter has no client, the request leaves unauthenticated, and the callee answers **401**. The status code is the tell and is easy to misread: 401 means *no token at all*, where a role problem would be 403 — so the obvious first hypothesis ("the service account is missing a role") sends you into Keycloak, which is the wrong place entirely.

### How it surfaced

`openbank-ledger-service` had `quarkus.oidc` and no `quarkus.oidc-client`. Its daily FX revaluation:

```
Daily FX revaluation failed: Received: 'Unauthorized, status code 401'   (2026-08-14 13:00)
Daily FX revaluation failed: Received: 'Unauthorized, status code 401'   (2026-08-15 13:00)
```

```
openbank_workflow_success_recorded{workflow="ledger-fx-revaluation"}    = 0
openbank_workflow_last_success_age_seconds                              = 25.24h
```

It had **never once succeeded**. The 25.24h is exactly the pod's own age (start `2026-08-15T07:19`) — the registration seed, not a run. Only the 0/1 `success_recorded` series separates those two, which is precisely why it exists.

The only thing that noticed at all was `FxFixingAgeAbsent` — an `absent()` alert on a gauge that `FxFixingFreshnessGauge` registers lazily inside `resolveLeg`, which the run never reached.

`openbank-settlement-service`, money-path, had neither block.

### Nothing else could have caught it

A unit test mocks the port. A `@QuarkusTest` supplies its own security context. A consumer pact's mock server answers whatever is asked and never inspects the `Authorization` header. The mismatch exists only between a real client and a real provider — which is why this is a config gate and not more tests.

## The fix — six services

| Service | Was | Now |
|---|---|---|
| campaign | no `oidc-client` block | `${KEYCLOAK_URL:…}/realms/openbank` |
| engagement | interpolated `QUARKUS_OIDC_AUTH_SERVER_URL`, workload sets `KEYCLOAK_URL` | `${KEYCLOAK_URL:…}/realms/openbank` |
| finrep | no block | `${QUARKUS_OIDC_AUTH_SERVER_URL:…}` |
| ledger | no block | `${QUARKUS_OIDC_AUTH_SERVER_URL:…}` |
| onboarding | no block | `${QUARKUS_OIDC_AUTH_SERVER_URL:…}` |
| settlement | no block | `${QUARKUS_OIDC_AUTH_SERVER_URL:…}` |

engagement is the instructive one: it *had* the block, pointing at a variable its workload does not set, so the value fell back to the localhost default — and **in a pod, `localhost:8080` is the service itself**, which 404s the token request and sends the call out bare. Identical symptom, different spelling.

Each service now reads the variable its **own inbound block already reads**, verified against the live workload env. Consequently **no gitops change is needed** — every one of the six already sets the variable it now interpolates.

## The gate — checks the deployed value, not the spelling

`check-oidc-client-configured.py`, enforced. Two conditions:

1. registering the filter ⇒ a `quarkus.oidc-client` block exists;
2. every env var its `auth-server-url` interpolates is set on that module's **deployed workload** (or `QUARKUS_OIDC_CLIENT_AUTH_SERVER_URL` overrides it outright).

**Condition 2 is the whole design, and I got it wrong first.** The initial draft matched a single env *name*, `QUARKUS_OIDC_CLIENT_AUTH_SERVER_URL`, and reported **16 correctly-configured services as broken**. A live `kubectl get deploy party-service` disproved it: the fleet spells this three ways and all three work —

- `${QUARKUS_OIDC_AUTH_SERVER_URL:…}` — 26 services, reusing the inbound URL
- `${KEYCLOAK_URL:…}` — campaign, engagement
- a bare literal plus a `QUARKUS_OIDC_CLIENT_AUTH_SERVER_URL` override — balance-service

Resolving the interpolation instead of matching a name needs no list and admits a fourth spelling nobody has invented yet.

Other design points:

- **corpus derived from the annotation** — a new client that needs a token is in scope the day it is written; a module that stops registering the filter leaves scope by itself. Library modules (`openbank-libs*`) are excluded by prefix: they ship the filter for consumers and have no workload.
- **workload env indexed per workload, not per file** — `payments-services.yaml` holds eleven services, so a per-file answer would let one service's env vouch for another's.
- **an unfindable workload is reported UNCHECKED**, not passed quietly.

Self-test: 15 cases. Three distinct defects (no block; bare localhost literal with no override; interpolated variable the workload does not set), both filter variants, the library exclusion, a deeper `rest-client.<x>.oidc-client` key that must not be mistaken for the real block, and the unfindable-workload case.

Gate output on this branch:

```
oidc-client parity: 30 module(s) register an outbound OIDC filter; every one declares
quarkus.oidc-client and its deployed workload resolves the auth-server-url away from localhost.
```

Local `run-gates.py --all`: **148/149 pass**. The one failure is `api-contract-gate`, which wants `sudo` to install oasdiff locally and reproduces identically on a clean `origin/main` worktree; this branch touches no `openapi.yaml`.

## Review notes

- **Money-path**: ledger and settlement are in `rules.yaml: money_path_services`.
- The behaviour change is that six services now *present* a token where they previously presented none. Whether each callee then *authorizes* `service-account-openbank-services` is a separate question this PR does not answer — the realm JSONs in this tree disagree about which roles that account holds, so a 401 turning into a 403 for some path would be a real (and much more legible) finding, not a regression from this change.
- No gitops manifests are touched.

Refs #3921
