### PR TITLE
fix(admin-ui): make campaign canvas keyboard-operable

### DIFF
--- a/openbank-admin-ui/src/components/campaigns/JourneyEditor.tsx
+++ b/openbank-admin-ui/src/components/campaigns/JourneyEditor.tsx
@@ -4,6 +4,7 @@
 
 'use client'
 
+import type { KeyboardEvent } from 'react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 
 /**
@@ -162,6 +163,14 @@ export function JourneyEditor({
 
   const colX = (i: number) => PAD + i * (NODE_W + GAP_X)
 
+  // SVG groups are not keyboard-operable by default. Keep the pointer canvas, but give its
+  // genuine controls the same Enter/Space contract as a native button.
+  const activateFromKeyboard = (event: KeyboardEvent<SVGGElement>, action: () => void) => {
+    if (event.key !== 'Enter' && event.key !== ' ') return
+    event.preventDefault()
+    action()
+  }
+
   /**
    * A connector, and the wait it represents.
    *
@@ -254,7 +263,7 @@ export function JourneyEditor({
       <svg
         viewBox={`0 0 ${width} ${height}`}
         style={{ width: '100%', minWidth: Math.min(width, 820), height: 'auto', display: 'block' }}
-        role="img"
+        role="group"
         aria-label={t('Plátno pro sestavení kampaně', 'Campaign builder canvas')}
       >
         <defs>
@@ -313,7 +322,10 @@ export function JourneyEditor({
                 filter="url(#je-shadow)"
                 style={{ cursor: 'pointer' }}
                 onClick={() => onSelect(isSelected ? null : i)}
+                onKeyDown={event => activateFromKeyboard(event, () => onSelect(isSelected ? null : i))}
                 role="button"
+                tabIndex={0}
+                aria-pressed={isSelected}
                 aria-label={t(`Upravit krok ${i + 1}`, `Edit step ${i + 1}`)}
                 data-step={i}
                 data-channel={step.channel}
@@ -362,7 +374,9 @@ export function JourneyEditor({
               <g
                 style={{ cursor: 'pointer' }}
                 onClick={() => onRemove(i)}
+                onKeyDown={event => activateFromKeyboard(event, () => onRemove(i))}
                 role="button"
+                tabIndex={0}
                 aria-label={t(`Odebrat krok ${i + 1}`, `Remove step ${i + 1}`)}
                 data-remove-step={i}
               >
@@ -422,7 +436,9 @@ export function JourneyEditor({
             <g
               style={{ cursor: 'pointer' }}
               onClick={onAdd}
+              onKeyDown={event => activateFromKeyboard(event, onAdd)}
               role="button"
+              tabIndex={0}
               aria-label={t('Přidat krok', 'Add a step')}
               data-add-step="true"
             >

--- a/openbank-admin-ui/src/test/journey-editor.test.tsx
+++ b/openbank-admin-ui/src/test/journey-editor.test.tsx
@@ -95,6 +95,29 @@ describe('campaign builder canvas', () => {
     expect(onAdd).toHaveBeenCalled()
   })
 
+  it('keeps canvas controls reachable and operable by keyboard', () => {
+    const onAdd = vi.fn()
+    const onRemove = vi.fn()
+    const onSelect = vi.fn()
+    const { container } = canvas([step(), step()], { onAdd, onRemove, onSelect })
+
+    const firstStep = container.querySelector('[data-step="0"]')!
+    expect(firstStep.getAttribute('tabindex')).toBe('0')
+    expect(firstStep.getAttribute('aria-pressed')).toBe('false')
+    fireEvent.keyDown(firstStep, { key: 'Enter' })
+    expect(onSelect).toHaveBeenCalledWith(0)
+
+    const removeSecond = container.querySelector('[data-remove-step="1"]')!
+    expect(removeSecond.getAttribute('tabindex')).toBe('0')
+    fireEvent.keyDown(removeSecond, { key: ' ' })
+    expect(onRemove).toHaveBeenCalledWith(1)
+
+    const add = container.querySelector('[data-add-step]')!
+    expect(add.getAttribute('tabindex')).toBe('0')
+    fireEvent.keyDown(add, { key: 'Enter' })
+    expect(onAdd).toHaveBeenCalledTimes(1)
+  })
+
   it('offers a delivery decision only when its two complementary paths fit', () => {
     const onAddDecision = vi.fn()
     const { container } = canvas([step()], { onAddDecision })


### PR DESCRIPTION
## What changed

- exposes Campaign Studio SVG canvas controls as keyboard-focusable buttons
- supports Enter and Space for selecting, adding, and removing a journey step
- preserves the pressed state for the selected step

## Why

The canvas used clickable SVG groups but no keyboard contract; it did not meet the accessible authoring acceptance criterion in #4712.

## Validation

- `npm test -- --run src/test/journey-editor.test.tsx` (14 passing)
- `npm run type-check`
- `npx eslint src/components/campaigns/JourneyEditor.tsx src/test/journey-editor.test.tsx`
- `git diff --check`

Refs #4712