### PR TITLE
feat(gates): add the CNPG backup-declared gate, sibling to db-backup-association

### DIFF
--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -556,6 +556,52 @@ gates:
     run: |
       python3 openbank-infra/scripts/check-db-backup-associations.py --enforce
 
+  # The sibling of the gate above, for the case that gate CANNOT see.
+  #
+  # `check-db-backup-associations` scans for clusters that declare a `barmanObjectStore` and
+  # skips the rest — `if not dest: continue`. So its subject set is "databases that asked to be
+  # backed up", and a database that never asked is not a mismatched pair, so it is skipped. The
+  # gate built to make an unrecoverable database visible is structurally blind to the most
+  # unrecoverable kind.
+  #
+  # Measured against the sandbox on 2026-08-16, both directions agreeing: 59 live CNPG clusters,
+  # 57 with a recovery point, 0 declared-but-unrecoverable, and 2 with no backup declared at all.
+  # The enforced sibling reported clean across all of it, correctly and uselessly. The two are
+  # `engagement-db` and `glitchtip-pg`; a gitops scan finds only the first, because the second is
+  # deployed by a third-party chart and is outside this tree entirely — which is a real limit of
+  # any gitops-scoped check and is written into the script header rather than left to be
+  # discovered.
+  #
+  # ADVISORY, not enforced, and the reason is specific rather than caution: enforcing it today
+  # would fail every PR on one open question — whether engagement-db should be backed up or is
+  # genuinely disposable — that is an owner's decision and not a contributor's to unblock. The
+  # exemption is an ANNOTATION ON THE CLUSTER (`openbank.io/backup-exempt-reason`), deliberately
+  # not a list kept beside the manifests: a separate list drifts from what it describes and
+  # nothing notices, which is the defect this repo keeps re-finding.
+  - id: cnpg-backup-declared-gate
+    name: "CNPG backup-declared gate — every cluster declares a backup or says why not (advisory)"
+    group: gitops
+    mode: advisory
+    rationale: >-
+      db-backup-association-gate only inspects clusters that already declare a
+      barmanObjectStore, so a database that never asked to be backed up is invisible to it.
+      This covers that case: no recovery point at all, which is the worse one.
+    review_after: "2026-09-15"
+    verified: >-
+      2026-08-16 — measured against the sandbox with two independent probes that agree:
+      59 live CNPG clusters, 57 with a recovery point, 0 declared-but-unrecoverable, and 2
+      with no backup declared at all, while the enforced sibling reported clean across all
+      of it. A gitops scan of this tree finds 58 subjects and exactly 1 of those 2
+      (engagement-db); glitchtip-pg is deployed by a third-party chart and is out of reach
+      of any gitops-scoped check. Self-test falsified in both directions — it fires on a
+      cluster with no backup and on an empty exemption reason, and stays silent on a
+      declared backup, a reasoned exemption and a non-CNPG kind: Cluster.
+    min_subjects: 50
+    selftest: python3 openbank-infra/scripts/check-cnpg-backup-declared.py --self-test
+    selftest_expect: pass
+    run: |
+      python3 openbank-infra/scripts/check-cnpg-backup-declared.py
+
   # A probed or scraped port must be a port the service opens (issue #2872, item 1).
   #
   # Rolling campaign-service into the sandbox hit five defects that each kill the pod or its

--- a/openbank-infra/scripts/check-cnpg-backup-declared.py
+++ b/openbank-infra/scripts/check-cnpg-backup-declared.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Every CNPG Cluster in gitops declares a backup, or says in place why it does not.
+
+WHY THIS EXISTS, AND WHY check-db-backup-associations.py CANNOT DO IT.
+
+That gate asserts a declared backup is correctly wired: a cluster declaring
+`barmanObjectStore` must have a matching `aws_eks_pod_identity_association` in
+db-backups.tf, or its WAL archiving fails silently. It is enforced, and it works.
+
+Its subject set, though, is exactly "clusters that declare a barmanObjectStore" -- the
+scan does `if not dest: continue`. A cluster with no backup block at all is not a
+mismatched pair, so it is skipped, and skipped is indistinguishable from clean. The
+gate that exists to make an unrecoverable database visible therefore cannot see the
+most unrecoverable kind: the one that never asked to be backed up.
+
+Measured against the sandbox on 2026-08-16: 59 live CNPG clusters, 57 with a recovery
+point, 0 declared-but-unrecoverable -- and 2 with no backup declared at all. The
+sibling gate reported clean on all of it, correctly and uselessly.
+
+WHAT THIS ASSERTS
+
+For every CNPG Cluster manifest under gitops, one of:
+  * `spec.backup.barmanObjectStore.destinationPath` is set -- the other gate takes over
+    from there and checks it is actually wired; or
+  * the metadata carries `openbank.io/backup-exempt-reason: "<why>"`, non-empty.
+
+The exemption is an ANNOTATION ON THE CLUSTER, deliberately, not an entry in a list
+kept beside the manifests. A separate list is free to drift from the thing it
+describes and nothing notices -- which is the defect this repo keeps re-finding. An
+annotation moves with the file, is visible to anyone reading the manifest, and cannot
+outlive the cluster it excuses.
+
+WHAT IT CANNOT SEE, STATED SO NOBODY READS ITS SILENCE AS COVERAGE
+
+A database that is not in gitops at all. `glitchtip-pg` in the observability namespace
+is live and has no backup, and it is deployed by a third-party chart rather than by a
+manifest in this tree, so no gitops-scoped check can reach it. This gate's subject is
+the gitops tree, and that is a smaller set than "the databases that exist". Comparing
+the two needs cluster access and belongs in a runtime control, not here.
+"""
+from __future__ import annotations
+
+import argparse
+import pathlib
+import sys
+
+import yaml
+
+CNPG_API_PREFIX = "postgresql.cnpg.io/"
+EXEMPT_ANNOTATION = "openbank.io/backup-exempt-reason"
+
+
+def cnpg_clusters(gitops_dir: pathlib.Path):
+    """Yield (name, namespace, relpath, destinationPath, exempt_reason) per CNPG Cluster."""
+    for path in sorted(gitops_dir.rglob("*.yaml")):
+        try:
+            docs = list(yaml.safe_load_all(path.read_text()))
+        except yaml.YAMLError:
+            continue
+        for doc in docs:
+            if not isinstance(doc, dict):
+                continue
+            if doc.get("kind") != "Cluster":
+                continue
+            if not str(doc.get("apiVersion", "")).startswith(CNPG_API_PREFIX):
+                continue
+            meta = doc.get("metadata") or {}
+            spec = doc.get("spec") or {}
+            dest = (
+                ((spec.get("backup") or {}).get("barmanObjectStore") or {}).get("destinationPath", "")
+            )
+            reason = ((meta.get("annotations") or {}).get(EXEMPT_ANNOTATION) or "").strip()
+            yield (
+                meta.get("name", "<unnamed>"),
+                meta.get("namespace", "<no-namespace>"),
+                str(path),
+                dest,
+                reason,
+            )
+
+
+def check(gitops_dir: pathlib.Path) -> tuple[int, int]:
+    findings = 0
+    subjects = 0
+    for name, ns, rel, dest, reason in cnpg_clusters(gitops_dir):
+        subjects += 1
+        if dest:
+            continue
+        if reason:
+            print(f"  exempt: {ns}/{name} — {reason}")
+            continue
+        findings += 1
+        print(
+            f"::error file={rel}::CNPG Cluster {ns}/{name} declares no "
+            f"spec.backup.barmanObjectStore, so it has no recovery point and nothing else "
+            f"reports it — check-db-backup-associations only inspects clusters that DO declare "
+            f"one. Either add a barmanObjectStore, or annotate the cluster with "
+            f'{EXEMPT_ANNOTATION}: "<why this database is disposable>".'
+        )
+    return subjects, findings
+
+
+def self_test() -> int:
+    """Falsify in both directions: the gate must FIRE on a bare cluster and must NOT on the others.
+
+    A self-test that only builds a passing case proves the gate can be silent, which is
+    the one thing never in doubt.
+    """
+    import tempfile
+
+    cases = [
+        ("declares a backup", {
+            "apiVersion": "postgresql.cnpg.io/v1", "kind": "Cluster",
+            "metadata": {"name": "a", "namespace": "n"},
+            "spec": {"backup": {"barmanObjectStore": {"destinationPath": "s3://x"}}},
+        }, 0),
+        ("no backup, no reason — MUST fire", {
+            "apiVersion": "postgresql.cnpg.io/v1", "kind": "Cluster",
+            "metadata": {"name": "b", "namespace": "n"},
+            "spec": {"instances": 1},
+        }, 1),
+        ("no backup, exempt with a reason", {
+            "apiVersion": "postgresql.cnpg.io/v1", "kind": "Cluster",
+            "metadata": {"name": "c", "namespace": "n",
+                         "annotations": {EXEMPT_ANNOTATION: "scratch data, rebuilt on boot"}},
+            "spec": {"instances": 1},
+        }, 0),
+        ("empty reason is not a reason — MUST fire", {
+            "apiVersion": "postgresql.cnpg.io/v1", "kind": "Cluster",
+            "metadata": {"name": "d", "namespace": "n",
+                         "annotations": {EXEMPT_ANNOTATION: "   "}},
+            "spec": {"instances": 1},
+        }, 1),
+        ("a non-CNPG kind: Cluster is not a subject", {
+            "apiVersion": "cluster.x-k8s.io/v1", "kind": "Cluster",
+            "metadata": {"name": "e", "namespace": "n"}, "spec": {},
+        }, 0),
+    ]
+    failures = 0
+    for label, doc, want in cases:
+        with tempfile.TemporaryDirectory() as d:
+            p = pathlib.Path(d)
+            (p / "m.yaml").write_text(yaml.safe_dump(doc))
+            _, got = check(p)
+        status = "ok" if got == want else "FAIL"
+        if got != want:
+            failures += 1
+        print(f"  {status:4}  want={want} got={got}  {label}")
+    print("self-test: PASS" if not failures else f"self-test: FAIL ({failures})")
+    return 1 if failures else 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--gitops", default="openbank-infra/gitops")
+    ap.add_argument("--self-test", action="store_true")
+    ap.add_argument("--enforce", action="store_true")
+    args = ap.parse_args()
+
+    if args.self_test:
+        return self_test()
+
+    gitops = pathlib.Path(args.gitops)
+    if not gitops.is_dir():
+        print(f"::error::{gitops} is not a directory — refusing to report clean on an unread tree.")
+        return 1
+
+    subjects, findings = check(gitops)
+    print(f"SUBJECTS={subjects}  # CNPG Cluster manifests under {gitops}")
+    if subjects == 0:
+        print("::error::found no CNPG Cluster manifests at all — that is a broken scan, not a clean tree.")
+        return 1
+    if findings:
+        print(f"{findings} CNPG cluster(s) with no declared backup and no stated reason.")
+        return 1 if args.enforce else 0
+    print("OK: every CNPG cluster in gitops declares a backup or says why it does not.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/openbank-libs/governance/rules.yaml
+++ b/openbank-libs/governance/rules.yaml
@@ -272,6 +272,36 @@ change_requirements:
     # cannot key a for_each; a tofu plan of that design read "0 to add, 35 to destroy"), and
     # yamldecode cannot parse the 30-of-42 multi-doc manifests. Same lesson as the OPA generator
     # gate (#1184): the list must be checked mechanically, not remembered.
+  cnpg_backup_declared:
+    applies_to: "every CNPG Cluster manifest under openbank-infra/gitops"
+    requires:
+      - "spec.backup.barmanObjectStore.destinationPath is set, OR the cluster carries
+         openbank.io/backup-exempt-reason with a non-empty reason"
+    gate: cnpg-backup-declared
+    enforced: advisory
+    target_enforce_date: "2026-09-15"
+    ci_producer: "openbank-infra/scripts/check-cnpg-backup-declared.py"
+    # The sibling of db_backup_association, for the case that rule CANNOT see. Its producer
+    # scans for clusters that DECLARE a barmanObjectStore and skips the rest (`if not dest:
+    # continue`), so a database that never asked to be backed up is not a mismatched pair and
+    # is passed over. The rule that exists to make an unrecoverable database visible is
+    # therefore blind to the most unrecoverable kind.
+    #
+    # Measured against the sandbox 2026-08-16, two independent probes agreeing: 59 live CNPG
+    # clusters, 57 with a recovery point, 0 declared-but-unrecoverable, 2 with no backup
+    # declared at all -- while db_backup_association reported clean across all of it.
+    #
+    # The exemption is an ANNOTATION ON THE CLUSTER, not an entry in a list kept beside the
+    # manifests: a separate list is free to drift from what it describes with nothing to
+    # notice, and an annotation cannot outlive the cluster it excuses.
+    #
+    # Advisory until 2026-09-15 for one specific reason, not caution: exactly one cluster is
+    # in scope and unresolved -- engagement-db -- and whether it should be backed up or is
+    # genuinely disposable is an owner's decision, not something a contributor should settle
+    # to unblock a gate. Enforcing before that answer would fail every PR on an open question.
+    # glitchtip-pg is live and also unbacked, but is deployed by a third-party chart and is
+    # outside the gitops tree, so no gitops-scoped rule can reach it; that gap needs a runtime
+    # control and is not silently counted as covered here.
   db_change:
     detect: ["src/main/resources/db/migration/*.sql", "Flyway/Liquibase changeset"]
     require:


### PR DESCRIPTION
## What #3975 asked, and what changed since it was filed

The issue's original count was 3 unrecoverable clusters. Re-measured against the sandbox: **2**, not 3 — `litellm-db` now has a recovery point.

## Why `db-backup-association-gate` (enforced) cannot see the remaining 2

That gate scans for CNPG clusters that **declare** a `barmanObjectStore` and skips the rest:

```python
if not dest:
    continue
```

A database that never asked to be backed up is not a mismatched pair, so it is passed over. The gate built to make an unrecoverable database visible is structurally blind to the most unrecoverable kind: the one with no backup block at all.

## Measurement — two independent probes agreeing

| | count |
|---|---|
| live CNPG clusters (sandbox) | 59 |
| with a recovery point | 57 |
| declared-but-unrecoverable (what the enforced gate checks) | 0 |
| **no backup declared at all** | **2** — `engagement-db`, `glitchtip-pg` |

A gitops-tree scan finds **58** subjects and exactly **1** of those 2: `engagement-db`. `glitchtip-pg` is deployed by a third-party chart, outside the gitops tree — stated as a limit in the script's own header rather than silently counted as covered.

## Why advisory, and why this specific date

Exactly one cluster is unresolved, and whether it should be backed up or is genuinely disposable is an **owner's decision**, not something a contributor should settle just to unblock a gate. `review_after: 2026-09-15`.

## Exemption is an annotation, not a list

`openbank.io/backup-exempt-reason` lives **on the cluster manifest**, deliberately — not as an entry in a separate list kept beside the manifests. A separate list is free to drift from what it describes with nothing to notice, which is a defect this repo keeps re-finding. An annotation moves with the file and cannot outlive the cluster it excuses.

## Verification

- Self-test falsified in **both** directions: fires on a bare cluster and on an empty exemption reason (both MUST-fire cases caught), stays silent on a declared backup, a reasoned exemption, and a non-CNPG `kind: Cluster`.
- All four meta-gates re-run individually and green: `advisory-gate-registration`, `advisory-finding-staleness`, `gate-lifecycle-metadata`, `gate-subject-floor`.
- Full `run-gates.py --all` compared against the same tooling run on unmodified `origin/main`: **identical pre-existing findings on both sides** (`over-budget` ×2, `slow` ×2, `loki-rule-load-test`, `api-contract-gate`), none introduced by this change.

Refs #3975

🤖 Generated with [Claude Code](https://claude.com/claude-code)
