### PR TITLE
fix(tpp-registry): write TPP lifecycle events to the outbox nothing wrote to

### DIFF
--- a/.github/scripts/check-outbox-has-writer.py
+++ b/.github/scripts/check-outbox-has-writer.py
@@ -7,7 +7,7 @@
 # A service that ships an outbox must write to it (issue #4007).
 #
 # THE DEFECT THIS CATCHES
-# Five services ship the whole transactional-outbox apparatus — a `*OutboxDispatcher`, a backlog
+# Four services ship the whole transactional-outbox apparatus — a `*OutboxDispatcher`, a backlog
 # gauge, a Flyway migration for the table, `openbank.outbox.dispatch-enabled: true` — and construct
 # no `OutboxMessage` anywhere in `src/main`. The dispatcher polls a table nothing writes to, forever.
 #
@@ -40,15 +40,15 @@
 # comment.
 #
 # RATCHET, NOT A BIG BANG
-# The five below are real and each needs a per-service decision (wire it, or delete the apparatus)
+# The four below are real and each needs a per-service decision (wire it, or delete the apparatus)
 # that is not this gate's to make. They are baselined against #4007 so the gate can be ENFORCED
 # today: a sixth service cannot be added quietly. A baseline entry that becomes covered is reported
 # too, so the list keeps meaning something rather than silently becoming permanent.
 #
-# The list started at eight. Three have left it, and only two of those were fixes: `party` (#4158)
-# and `kyc` (#4378) were wired onto their outbox and their direct emitters retired, while
-# `billing` was never a violation at all — see its note in BASELINE. Worth separating, because a
-# shrinking baseline reads as progress and one third of this one was a measurement error.
+# The list started at eight. Four have left it, and only three of those were fixes: `party`
+# (#4158), `kyc` (#4378) and `tpp-registry` (#4007) were wired onto their outbox, while `billing`
+# was never a violation at all — see its note in BASELINE. Worth separating, because a shrinking
+# baseline reads as progress and one of these four was a measurement error, not a repair.
 
 from __future__ import annotations
 
@@ -77,7 +77,15 @@ BASELINE = {
     # is gone. Removing an entry from this list is the definition of done for that service.
     "openbank-pid-service": "#4007 — dispatcher + gauge, no OutboxMessage construction",
     "openbank-psd2-service": "#4007 — dispatcher + gauge, no OutboxMessage construction",
-    "openbank-tpp-registry-service": "#4007 — dispatcher + gauge, no OutboxMessage construction",
+    # openbank-tpp-registry-service was wired instead of deleted (#4007): TPP_REGISTERED and
+    # TPP_BLACKLISTED now go through tpp_outbox in the same transaction as the tpp_entries row
+    # (TppRepositoryImpl.save/update, which take the event as a REQUIRED parameter so there is no
+    # eventless overload to bypass). Wired rather than deleted because every other end of the arrow
+    # already existed and only the write did not: the KafkaTopic, the write ACL, the
+    # event-contract baseline entry and the gitops headers all assert a producer for
+    # openbank.tpp.registry.event. Proven by TppOutboxWriteIT — a real-DB IT, because a mocked
+    # repository cannot tell whether an outbox row was written.
+    # Removing an entry from this list is the definition of done for that service.
 }
 
 DISPATCHER_RE = re.compile(r"class\s+\w*OutboxDispatcher\b")
@@ -96,8 +104,8 @@ ENTITY_CONSTRUCTION_RE = re.compile(r"\b\w*OutboxEntity\s*\(\s*\)")
 # the DRAIN side. That mapper is plumbing, in the same category as the data-class declaration
 # above: counting it would mark all 34 dispatcher-shipping services as writers and silently retire
 # the gate — the same failure the SQL predicate's `\w*outbox\w*` narrowness exists to avoid.
-# Verified against the tree: for audit, balance, pid, psd2 and tpp-registry the ONLY
-# `*OutboxEntity()` construction is that mapper, so all five stay violations.
+# Verified against the tree: for audit, balance, pid and psd2 the ONLY `*OutboxEntity()`
+# construction is that mapper, so all four stay violations.
 OUTBOX_ADAPTER_RE = re.compile(r"Outbox\w*RepositoryImpl\.kt$")
 
 

--- a/openbank-tpp-registry-service/CLAUDE.md
+++ b/openbank-tpp-registry-service/CLAUDE.md
@@ -1,0 +1,50 @@
+# openbank-tpp-registry-service — service notes
+
+The PSD2 third-party-provider directory: registration, status transitions, and the eIDAS licence
+check `psd2-service` calls per request (`GET /api/v1/tpp-registry/check`).
+
+## Two package roots, on purpose — and the trap that came with them
+
+The tree has two disjoint roots and no import used to cross between them:
+
+- `com.openbank.tppregistry.*` — the registry itself (domain, use case, REST, persistence)
+- `com.openbank.tpp.*` — the transactional-outbox apparatus (dispatcher, backlog gauge, Kafka
+  publisher, entity, repository)
+
+That split is why **the outbox shipped complete and nothing ever wrote to it** (issue #4007). The
+table, the `@Scheduled` dispatcher, the atomic `FOR UPDATE SKIP LOCKED` claim, the backlog gauge,
+`openbank.outbox.dispatch-enabled: true`, the `KafkaTopic` resource and the write ACL all existed;
+`persistInTransaction` had exactly one occurrence in `src/main` — its own declaration, no caller.
+Unlike `party` or `balance` there was no second direct emitter either, so nothing had ever been
+produced to `openbank.tpp.registry.event` at all, and no consumer could notice.
+
+**Decision: wired, not deleted.** Every other end of the arrow already existed and only the write
+did not, and the service's own docs listed the wiring as the next follow-up. `TppEvents` builds
+`TPP_REGISTERED` and `TPP_BLACKLISTED`; `TppRepository.save`/`update` take the event as a
+**required parameter**, so there is deliberately no eventless overload for a future call site to
+bypass, and `TppRepositoryImpl` persists the aggregate row and the outbox row in one
+`Panache.withTransaction`.
+
+- **A mocked repository cannot see any of this.** The unit tests were green for the whole life of
+  the defect. Only `TppOutboxWriteIT` — REST in, plain JDBC out, dispatcher switched off — can
+  distinguish "wrote the row" from "did not". Falsify it before trusting it: delete the
+  `persistInTransaction` call and both tests must go red with `Expected size: 1 but was: 0`.
+- The IT sets `authz.enforce=false`: the blacklist endpoint carries `@Authorize`, and an OPA
+  sidecar the interceptor cannot reach fails **closed** with 503 (not 403), which would otherwise
+  look like an authorization bug.
+
+## `tpp_entries_seq` vs the V1 seed rows
+
+`V1__init.sql` declares `id BIGSERIAL` and then seeds three TPPs, so ids 1..3 come from the
+implicit `tpp_entries_id_seq`. Panache allocates from `tpp_entries_seq`, which `V4` created with
+the default `START 1`. Nothing reconciled them, so the **first** registration through
+`POST /api/v1/tpp-registry` was a deterministic
+`duplicate key value violates unique constraint "tpp_entries_pkey"` → 500, on every database that
+ran the seed. `V7` fixes it with a `setval` past `MAX(id)`.
+
+Why it went unnoticed for the life of the service, and the general lesson: measured on the sandbox
+2026-08-16, `tpp_entries_seq` read `last_value = 1, is_called = f` — **the sequence had never been
+called**, so no registration had ever been attempted in a deployed environment. An unexercised
+write path is not an absent defect, and an empty table is evidence of nothing on its own. Note the
+`n_live_tup` trap in the same measurement: `pg_stat_user_tables` reported 0 rows for *every* table
+including `flyway_schema_history`, while `count(*)` reported 3 and 5. Use `count(*)`.

--- a/openbank-tpp-registry-service/src/main/kotlin/com/openbank/tppregistry/application/port/out/TppRepository.kt
+++ b/openbank-tpp-registry-service/src/main/kotlin/com/openbank/tppregistry/application/port/out/TppRepository.kt
@@ -6,6 +6,7 @@ package com.openbank.tppregistry.application.port.out
 
 import com.openbank.tppregistry.domain.model.EbaRegisterSyncState
 import com.openbank.tppregistry.domain.model.TppEntry
+import com.openbank.tppregistry.domain.model.TppEvent
 import com.openbank.tppregistry.domain.model.TppRole
 import com.openbank.tppregistry.domain.model.TppStatus
 
@@ -14,21 +15,26 @@ import com.openbank.tppregistry.domain.model.TppStatus
  *
  * Backs the PSD2 third-party-provider directory: registration, status transitions (e.g.
  * blacklisting), filtered listing, and the bookkeeping of the periodic EBA register synchronisation.
+ *
+ * [save] and [update] take the [TppEvent] describing the change as a REQUIRED parameter, and there
+ * is deliberately no eventless overload (issue #4007): the implementation writes the aggregate row
+ * and the `tpp_outbox` row in one transaction, so a caller that could persist without an event
+ * would be the exact dual-write this service shipped for its whole life.
  */
 interface TppRepository {
 
     suspend fun findByTppId(tppId: String): TppEntry?
 
-    suspend fun save(entry: TppEntry): TppEntry
+    suspend fun save(entry: TppEntry, event: TppEvent): TppEntry
 
-    suspend fun update(entry: TppEntry): TppEntry
+    suspend fun update(entry: TppEntry, event: TppEvent): TppEntry
 
     suspend fun list(
         countryCode: String?,
         role: TppRole?,
         status: TppStatus?,
         limit: Int,
-        afterCursor: String?
+        afterCursor: String?,
     ): List<TppEntry>
 
     suspend fun saveSyncState(state: EbaRegisterSyncState)

--- a/openbank-tpp-registry-service/src/main/kotlin/com/openbank/tppregistry/application/usecase/TppRegistryService.kt
+++ b/openbank-tpp-registry-service/src/main/kotlin/com/openbank/tppregistry/application/usecase/TppRegistryService.kt
@@ -66,19 +66,22 @@ class TppRegistryService(private val repo: TppRepository, private val clock: Clo
             blacklistedAt = null,
             blacklistReason = null,
         )
-        return repo.save(entry)
+        // The event travels with the aggregate into ONE transaction (issue #4007) — the registry
+        // row and TPP_REGISTERED commit together, or neither does.
+        return repo.save(entry, TppEvents.registered(entry))
     }
 
     override suspend fun blacklistTpp(cmd: BlacklistTppCommand): TppEntry {
         val tpp = repo.findByTppId(cmd.tppId)
             ?: throw TppNotFoundException("TPP ${cmd.tppId} not found")
+        val now = OffsetDateTime.now(clock)
         val updated = tpp.copy(
             status = TppStatus.BLACKLISTED,
-            blacklistedAt = OffsetDateTime.now(clock),
+            blacklistedAt = now,
             blacklistReason = cmd.reason,
-            updatedAt = OffsetDateTime.now(clock),
+            updatedAt = now,
         )
-        return repo.update(updated)
+        return repo.update(updated, TppEvents.blacklisted(updated, now))
     }
 
     override suspend fun getTpp(query: GetTppQuery): TppEntry =

--- a/openbank-tpp-registry-service/src/main/kotlin/com/openbank/tppregistry/domain/model/TppEvent.kt
+++ b/openbank-tpp-registry-service/src/main/kotlin/com/openbank/tppregistry/domain/model/TppEvent.kt
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.tppregistry.domain.model
+
+import java.time.Instant
+import java.time.OffsetDateTime
+
+/**
+ * A TPP-registry lifecycle event, together with the exact flat JSON envelope that goes on the wire
+ * (topic `openbank.tpp.registry.event`).
+ *
+ * [envelope] is deliberately the whole message body rather than a set of typed fields — the
+ * envelope IS the contract a consumer parses. Serialization happens in the infrastructure layer,
+ * so this stays framework-free (ADR-0002).
+ */
+data class TppEvent(
+    val eventType: String,
+    val aggregateId: java.util.UUID,
+    val occurredAt: Instant,
+    val envelope: Map<String, Any?>,
+)
+
+/**
+ * Builds the TPP-registry lifecycle events (issue #4007).
+ *
+ * Before this existed, `tpp_outbox` had a dispatcher, a backlog gauge, an atomic-claim query,
+ * `dispatch-enabled: true`, a `KafkaTppOutboxEventPublisher`, a `KafkaTopic` resource and a write
+ * ACL — and **no writer at all**. Unlike `party` and `balance`, there was not even a second direct
+ * emitter to make the events arrive anyway: `tpp-events-out` is wired only to the outbox publisher,
+ * so nothing has ever been produced to `openbank.tpp.registry.event`.
+ *
+ * The events are built here rather than in the repository so both the use case and the persistence
+ * adapter can see them, and so the *only* way to persist a TPP is to hand over the event that
+ * describes the change — [TppRepository.save] and [TppRepository.update] take one as a required
+ * parameter, which is why there is no eventless overload to bypass.
+ */
+object TppEvents {
+
+    const val TPP_REGISTERED = "TPP_REGISTERED"
+    const val TPP_BLACKLISTED = "TPP_BLACKLISTED"
+
+    fun registered(entry: TppEntry): TppEvent = TppEvent(
+        eventType = TPP_REGISTERED,
+        aggregateId = entry.id,
+        occurredAt = entry.registeredAt.toInstant(),
+        envelope = linkedMapOf(
+            "eventType" to TPP_REGISTERED,
+            "entryId" to entry.id,
+            "tppId" to entry.tppId,
+            "name" to entry.name,
+            "countryCode" to entry.countryCode,
+            "nca" to entry.nca,
+            "roles" to entry.roles.map { it.name }.sorted(),
+            "status" to entry.status.name,
+            "occurredAt" to entry.registeredAt.toInstant(),
+        ),
+    )
+
+    /**
+     * A blacklisting is the event this registry exists to broadcast: psd2-service authorises every
+     * TPP call against `checkAuthorization`, so a revoked provider must become visible to anything
+     * holding a cached decision. It carries `blacklistReason` because an operator reading a
+     * downstream alert needs to know why, and the reason is short free text supplied by that same
+     * operator — never customer data.
+     */
+    fun blacklisted(entry: TppEntry, at: OffsetDateTime): TppEvent = TppEvent(
+        eventType = TPP_BLACKLISTED,
+        aggregateId = entry.id,
+        occurredAt = at.toInstant(),
+        envelope = linkedMapOf(
+            "eventType" to TPP_BLACKLISTED,
+            "entryId" to entry.id,
+            "tppId" to entry.tppId,
+            "status" to entry.status.name,
+            "blacklistReason" to entry.blacklistReason,
+            "blacklistedAt" to entry.blacklistedAt?.toInstant(),
+            "occurredAt" to at.toInstant(),
+        ),
+    )
+}

--- a/openbank-tpp-registry-service/src/main/kotlin/com/openbank/tppregistry/infrastructure/persistence/repository/TppRepositoryImpl.kt
+++ b/openbank-tpp-registry-service/src/main/kotlin/com/openbank/tppregistry/infrastructure/persistence/repository/TppRepositoryImpl.kt
@@ -4,8 +4,15 @@
 
 package com.openbank.tppregistry.infrastructure.persistence.repository
 
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.libs.persistence.outbox.OutboxMessage
+import com.openbank.tpp.application.port.out.TppOutboxRepository
 import com.openbank.tppregistry.application.port.out.TppRepository
-import com.openbank.tppregistry.domain.model.*
+import com.openbank.tppregistry.domain.model.EbaRegisterSyncState
+import com.openbank.tppregistry.domain.model.TppEntry
+import com.openbank.tppregistry.domain.model.TppEvent
+import com.openbank.tppregistry.domain.model.TppRole
+import com.openbank.tppregistry.domain.model.TppStatus
 import com.openbank.tppregistry.infrastructure.persistence.entity.EbaSyncStateEntity
 import com.openbank.tppregistry.infrastructure.persistence.entity.TppEntryEntity
 import io.quarkus.hibernate.reactive.panache.Panache
@@ -20,18 +27,29 @@ class TppEntryPanacheRepo : PanacheRepository<TppEntryEntity>
 class EbaSyncStatePanacheRepo : PanacheRepository<EbaSyncStateEntity>
 
 @ApplicationScoped
-class TppRepositoryImpl(private val tppRepo: TppEntryPanacheRepo, private val syncRepo: EbaSyncStatePanacheRepo) :
-    TppRepository {
+class TppRepositoryImpl(
+    private val tppRepo: TppEntryPanacheRepo,
+    private val syncRepo: EbaSyncStatePanacheRepo,
+    private val outboxRepository: TppOutboxRepository,
+    private val objectMapper: ObjectMapper,
+) : TppRepository {
 
     override suspend fun findByTppId(tppId: String): TppEntry? =
         Panache.withSession { tppRepo.find("tppId", tppId).firstResult() }.awaitSuspending()?.toDomain()
 
-    override suspend fun save(entry: TppEntry): TppEntry = Panache.withTransaction {
+    // Aggregate row + outbox row in ONE transaction (issue #4007): the bare persist() inside
+    // persistInTransaction joins this session, so the registry entry and its event commit together
+    // or not at all. persist() and not merge() because TppEntryEntity extends PanacheEntity — the
+    // @Id is generated, so this is a genuine INSERT and the app-assigned-id trap that forces
+    // merge() elsewhere in the fleet does not apply. `tpp_id` is the business key, not the @Id.
+    override suspend fun save(entry: TppEntry, event: TppEvent): TppEntry = Panache.withTransaction {
         val entity = entry.toEntity()
-        tppRepo.persist(entity).replaceWith(entity.toDomain())
+        tppRepo.persist(entity)
+            .flatMap { outboxRepository.persistInTransaction(event.toOutboxMessage()) }
+            .replaceWith(entity.toDomain())
     }.awaitSuspending()
 
-    override suspend fun update(entry: TppEntry): TppEntry = Panache.withTransaction {
+    override suspend fun update(entry: TppEntry, event: TppEvent): TppEntry = Panache.withTransaction {
         tppRepo.find("tppId", entry.tppId).firstResult()
             .invoke { entity ->
                 if (entity != null) {
@@ -46,11 +64,23 @@ class TppRepositoryImpl(private val tppRepo: TppEntryPanacheRepo, private val sy
                     entity.qsealExpiresAt = entry.qsealExpiresAt
                 }
             }
-            .map { entity ->
-                entity?.toDomain()
-                    ?: throw IllegalStateException("TPP ${entry.tppId} not found for update")
+            .flatMap { entity ->
+                if (entity == null) {
+                    throw IllegalStateException("TPP ${entry.tppId} not found for update")
+                }
+                outboxRepository.persistInTransaction(event.toOutboxMessage()).replaceWith(entity.toDomain())
             }
     }.awaitSuspending()
+
+    // The outbox payload is the event's own flat envelope verbatim — the dispatcher relays these
+    // bytes to `openbank.tpp.registry.event` unchanged, plus the additive OutboxKafkaHeaders and a
+    // partition key.
+    private fun TppEvent.toOutboxMessage() = OutboxMessage(
+        aggregateId = aggregateId,
+        eventType = eventType,
+        payload = objectMapper.writeValueAsString(envelope),
+        createdAt = occurredAt,
+    )
 
     override suspend fun list(
         countryCode: String?,

--- a/openbank-tpp-registry-service/src/main/resources/db/migration/V7__tpp_entries_seq_past_seeded_rows.sql
+++ b/openbank-tpp-registry-service/src/main/resources/db/migration/V7__tpp_entries_seq_past_seeded_rows.sql
@@ -1,0 +1,34 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Advance tpp_entries_seq past the rows V1 seeded, so a registration can insert at all.
+--
+-- V1__init.sql creates `id BIGSERIAL PRIMARY KEY` and then seeds three TPPs, which take ids 1..3
+-- from the implicit BIGSERIAL sequence `tpp_entries_id_seq`. V4__hibernate_sequences.sql then
+-- created the sequence Panache actually allocates from — `tpp_entries_seq` — with the default
+-- START 1, and nothing ever reconciled the two. So the FIRST TPP ever registered through
+-- `POST /api/v1/tpp-registry` allocates an id inside the block that already contains the seeded
+-- rows and dies with:
+--
+--   duplicate key value violates unique constraint "tpp_entries_pkey" (23505)
+--
+-- surfacing as a 500 from the endpoint. It is not a race and not environment-specific: it is
+-- deterministic on any database that ran V1's seed, which is every one of them.
+--
+-- Why nobody has hit it: measured on the sandbox 2026-08-16, `tpp_entries` holds exactly the three
+-- seeded rows, `tpp_entries_id_seq.last_value = 3`, and `tpp_entries_seq` reads
+-- `last_value = 1, is_called = f` — the sequence Hibernate uses has NEVER been called, in the
+-- whole life of the service. Registration has therefore never been exercised in a deployed
+-- environment, and no test covered it either: the service's ITs read and boot, and the unit tests
+-- mock the repository, so the only thing that could see this is a real-DB write test. Adding one
+-- (TppOutboxWriteIT, issue #4007) is what found it.
+--
+-- setval to MAX(id) rather than a literal: with is_called = true the next `nextval` returns
+-- MAX(id) + 50, so the pooled block Hibernate hands out starts strictly above every existing row
+-- under either the `pooled` or the `pooled-lo` optimizer. GREATEST(..., 1) keeps it legal on an
+-- empty table, where the sequence minimum is 1.
+--
+-- Rollback: SELECT setval('tpp_entries_seq', 1, false);
+
+SELECT setval(
+    'tpp_entries_seq',
+    GREATEST((SELECT COALESCE(MAX(id), 0) FROM tpp_entries), 1)
+);

--- a/openbank-tpp-registry-service/src/main/resources/docs/02-architecture.cs.md
+++ b/openbank-tpp-registry-service/src/main/resources/docs/02-architecture.cs.md
@@ -66,7 +66,7 @@ Vzor transactional-outbox je zapojen end-to-end na úrovni infrastruktury:
 3. `KafkaTppOutboxEventPublisher` posílá `Record<String,String>` (náhodný klíč, payload) na topic `openbank.tpp.registry.event`.
 4. Při úspěchu se řádek označí `SENT`; při selhání `markFailed` zaznamená chybu a inkrementuje `attempt_count`.
 
-> **Přesná výhrada:** současný `TppRegistryService` zapisuje pouze do `TppRepository` — zatím **nevkládá** řádky do outboxu při register/blacklist. Outbox transport (tabulka, dispatcher, publisher, Kafka kanál) je plně přítomen a topic je nakonfigurován, ale **žádné doménové události se zatím nevypouštějí**. Toto je první follow-up k zapojení (např. `TppRegistered`, `TppBlacklisted`).
+> **Historie (issue #4007):** po většinu života této služby byl outbox transport plně přítomen — tabulka, dispatcher, publisher, Kafka kanál, zapisovací ACL, `dispatch-enabled: true` — a **nikdy nikdo nezapsal řádek**, takže `openbank.tpp.registry.event` neměl vůbec žádného producenta. `TppRegistryService` nyní emituje `TPP_REGISTERED` a `TPP_BLACKLISTED` (`TppEvents`); událost se předává do `TppRepository.save`/`update` jako POVINNÝ parametr, takže neexistuje bezudálostní varianta, kterou by šlo obejít. `TppOutboxWriteIT` proti reálné databázi dokazuje, že řádek vzniká ve stejné transakci jako změna stavu — mockovaný repozitář to poznat nedokáže, proto mezera přežila zelenou sadu testů.
 
 ## Souhrn klíčových portů
 

--- a/openbank-tpp-registry-service/src/main/resources/docs/02-architecture.en.md
+++ b/openbank-tpp-registry-service/src/main/resources/docs/02-architecture.en.md
@@ -61,12 +61,12 @@ Pure Kotlin, no framework imports:
 
 The transactional-outbox pattern is wired end-to-end at the infrastructure level:
 
-1. A domain event row would be written into `tpp_outbox` (status `PENDING`) in the same transaction as the aggregate change.
+1. `TppRepositoryImpl.save`/`update` write the event row into `tpp_outbox` (status `PENDING`) in the SAME `Panache.withTransaction` as the `tpp_entries` change, so the state change and the event commit together or not at all.
 2. `TppOutboxDispatcher.dispatchScheduledBatch()` runs every 5 s (batch size 25, `concurrentExecution = SKIP`), reads processable rows and calls `publishWithResilience`.
 3. `KafkaTppOutboxEventPublisher` sends a `Record<String,String>` (random key, payload) to topic `openbank.tpp.registry.event`.
 4. On success the row is marked `SENT`; on failure `markFailed` records the error and increments `attempt_count`.
 
-> **Accurate caveat:** the current `TppRegistryService` writes to `TppRepository` only — it does **not** yet insert outbox rows on register/blacklist. The outbox transport (table, dispatcher, publisher, Kafka channel) is fully present and the topic is configured, but **no domain events are emitted yet**. This is the first follow-up to wire (e.g. `TppRegistered`, `TppBlacklisted`).
+> **History (issue #4007):** for most of this service's life the outbox transport was fully present — table, dispatcher, publisher, Kafka channel, write ACL, `dispatch-enabled: true` — and **nothing ever wrote a row**, so `openbank.tpp.registry.event` had no producer at all. `TppRegistryService` now emits `TPP_REGISTERED` and `TPP_BLACKLISTED` (`TppEvents`), handed to `TppRepository.save`/`update` as a REQUIRED parameter so there is no eventless overload to bypass. `TppOutboxWriteIT` proves the row lands in the state-change transaction against a real database — a mocked repository cannot tell whether an outbox row was written, which is why the gap survived a green suite.
 
 ## Key ports summary
 

--- a/openbank-tpp-registry-service/src/main/resources/docs/04-data.cs.md
+++ b/openbank-tpp-registry-service/src/main/resources/docs/04-data.cs.md
@@ -67,12 +67,17 @@ Indexy: `idx_tpp_outbox_status_created_at(status, created_at ASC)` (pořadí dra
 | V1 | `V1__init.sql` | `tpp_entries`, `eba_sync_state`, indexy, 3 seed sandbox TPP | `DROP TABLE tpp_entries, eba_sync_state;` |
 | V3 | `V3__create_tpp_outbox.sql` | `tpp_outbox` + 2 indexy | `DROP TABLE tpp_outbox;` |
 | V4 | `V4__hibernate_sequences.sql` | sekvence `*_seq` (INCREMENT 50) vyžadované Panache při `generation:none` | `DROP SEQUENCE eba_sync_state_seq, tpp_entries_seq, tpp_outbox_seq;` |
+| V5 | `V5__tpp_outbox_claimed_at.sql` | `tpp_outbox.claimed_at` pro atomický claim `FOR UPDATE SKIP LOCKED` | `ALTER TABLE tpp_outbox DROP COLUMN claimed_at;` |
+| V6 | `V6__tpp_entries_entry_uuid.sql` | `tpp_entries.entry_uuid` — doménové id, odlišné od interního BIGSERIAL PK (#2340) | `ALTER TABLE tpp_entries DROP COLUMN entry_uuid;` |
+| V7 | `V7__tpp_entries_seq_past_seeded_rows.sql` | `setval` na `tpp_entries_seq` za seed řádky z V1 — bez toho první registrace koliduje na `tpp_entries_pkey` a vrací 500 (#4007) | `SELECT setval('tpp_entries_seq', 1, false);` |
 
 > **Poznámka:** ve stromě není `V2` (historie migrací jej přeskakuje). Komentář u V4 dokumentuje napříč-službový vzor (stejná vada opravena u party V6 a notification V4/V5): samotný `BIGSERIAL` vytvoří jen `<table>_id_seq`, ale Panache očekává `<table>_seq`.
 
 ### Seed data (V1)
 
 Tři sandbox/test TPP jsou vloženy pro local/dev: `CZ-CNB-SANDBOX-001` (AISP,PISP), `CZ-CNB-TEST-AISP` (AISP), `CZ-CNB-TEST-PISP` (PISP) — všechny `ACTIVE`, země `CZ`, NCA `CNB`.
+
+> Tyto tři dostanou id 1..3 z implicitní `tpp_entries_id_seq`, zatímco Panache alokuje z `tpp_entries_seq`, kterou V4 vytvořila od 1. Do V7 tak byla PRVNÍ registrace přes API zaručeně `duplicate key value violates unique constraint "tpp_entries_pkey"` → 500. Nikdo na to nenarazil: měřeno na sandboxu 2026-08-16, `tpp_entries_seq` měla `last_value = 1, is_called = f` — nikdy nebyla zavolána, takže registrace nebyla v nasazeném prostředí nikdy vyzkoušena (#4007).
 
 ## PII a klasifikace dat
 

--- a/openbank-tpp-registry-service/src/main/resources/docs/04-data.en.md
+++ b/openbank-tpp-registry-service/src/main/resources/docs/04-data.en.md
@@ -67,12 +67,17 @@ Indexes: `idx_tpp_outbox_status_created_at(status, created_at ASC)` (drain order
 | V1 | `V1__init.sql` | `tpp_entries`, `eba_sync_state`, indexes, 3 seed sandbox TPPs | `DROP TABLE tpp_entries, eba_sync_state;` |
 | V3 | `V3__create_tpp_outbox.sql` | `tpp_outbox` + 2 indexes | `DROP TABLE tpp_outbox;` |
 | V4 | `V4__hibernate_sequences.sql` | `*_seq` sequences (INCREMENT 50) required by Panache under `generation:none` | `DROP SEQUENCE eba_sync_state_seq, tpp_entries_seq, tpp_outbox_seq;` |
+| V5 | `V5__tpp_outbox_claimed_at.sql` | `tpp_outbox.claimed_at` for the atomic `FOR UPDATE SKIP LOCKED` claim | `ALTER TABLE tpp_outbox DROP COLUMN claimed_at;` |
+| V6 | `V6__tpp_entries_entry_uuid.sql` | `tpp_entries.entry_uuid` — the domain id, distinct from the internal BIGSERIAL PK (#2340) | `ALTER TABLE tpp_entries DROP COLUMN entry_uuid;` |
+| V7 | `V7__tpp_entries_seq_past_seeded_rows.sql` | `setval` on `tpp_entries_seq` past V1's seeded ids — without it the first registration collides on `tpp_entries_pkey` and answers 500 (#4007) | `SELECT setval('tpp_entries_seq', 1, false);` |
 
 > **Note:** there is no `V2` in the tree (migration history skips it). The V4 comment documents the cross-service pattern (same defect fixed for party V6 and notification V4/V5): `BIGSERIAL` alone only creates `<table>_id_seq`, but Panache expects `<table>_seq`.
 
 ### Seed data (V1)
 
 Three sandbox/test TPPs are inserted for local/dev: `CZ-CNB-SANDBOX-001` (AISP,PISP), `CZ-CNB-TEST-AISP` (AISP), `CZ-CNB-TEST-PISP` (PISP) — all `ACTIVE`, country `CZ`, NCA `CNB`.
+
+> These three take ids 1..3 from the implicit `tpp_entries_id_seq`, while Panache allocates from `tpp_entries_seq`, which V4 created starting at 1. Until V7 that made the FIRST registration through the API a guaranteed `duplicate key value violates unique constraint "tpp_entries_pkey"` → 500. Nobody had hit it: measured on the sandbox 2026-08-16, `tpp_entries_seq` read `last_value = 1, is_called = f` — never called, so no registration had ever been attempted in a deployed environment (#4007).
 
 ## PII & data classification
 

--- a/openbank-tpp-registry-service/src/main/resources/docs/05-operations.cs.md
+++ b/openbank-tpp-registry-service/src/main/resources/docs/05-operations.cs.md
@@ -73,7 +73,7 @@ _Toto jsou cílové návrhové SLO pro produkčně tvarované nasazení — v je
 1. `POST /api/v1/tpp-registry/{tppId}/blacklist` s `{ "reason": "<ref incidentu>" }` a `Idempotency-Key`.
 2. Ověř, že `GET /check` nyní vrací `403`. PSD2 plochy TPP při dalším volání odmítnou.
 
-### Outbox se nedraní (až budou události zapojeny)
+### Outbox se nedraní
 1. Dotaž `tpp_outbox WHERE status='PENDING' ORDER BY created_at` na backlog.
 2. Prohlédni `last_error` / `attempt_count` u `FAILED` řádků; ověř konektivitu Kafky (`tpp-events-out`).
 3. Dispatcher běží každých 5 s (`@Scheduled`, batch 25); zaseklý scheduler obnoví restart podu.

--- a/openbank-tpp-registry-service/src/main/resources/docs/05-operations.en.md
+++ b/openbank-tpp-registry-service/src/main/resources/docs/05-operations.en.md
@@ -73,7 +73,7 @@ _These are design-target SLOs for a production-shaped deployment — they are no
 1. `POST /api/v1/tpp-registry/{tppId}/blacklist` with `{ "reason": "<incident ref>" }` and an `Idempotency-Key`.
 2. Verify `GET /check` now returns `403`. PSD2 surfaces will reject the TPP on next call.
 
-### Outbox not draining (once events are wired)
+### Outbox not draining
 1. Query `tpp_outbox WHERE status='PENDING' ORDER BY created_at` for backlog.
 2. Inspect `last_error` / `attempt_count` on `FAILED` rows; check Kafka connectivity (`tpp-events-out`).
 3. The dispatcher runs every 5 s (`@Scheduled`, batch 25); a wedged scheduler is restored by a pod restart.

--- a/openbank-tpp-registry-service/src/main/resources/docs/README.cs.md
+++ b/openbank-tpp-registry-service/src/main/resources/docs/README.cs.md
@@ -20,7 +20,7 @@ Tuto dokumentaci publikuje služba přímo na management endpointu `/q/openbank/
 - **Tech stack:** Kotlin 2.3.20 / Quarkus 3.33.2 LTS / JDK 25 / PostgreSQL 16 / Hibernate Reactive (Panache)
 - **Port:** 8108 (aplikace), 8085 (management — `/q`)
 - **Perzistence:** PostgreSQL databáze `openbank_tpp_registry`, Flyway migrace V1/V3/V4
-- **Outbox:** `tpp_outbox` → Kafka topic `openbank.tpp.registry.event` (kanál `tpp-events-out`); dispatcher je přítomen, use case zatím žádné doménové události nevypouští (viz [02](./02-architecture.md))
+- **Outbox:** `tpp_outbox` → Kafka topic `openbank.tpp.registry.event` (kanál `tpp-events-out`); `TPP_REGISTERED` / `TPP_BLACKLISTED` se zapisují v transakci se změnou stavu (issue #4007, viz [02](./02-architecture.md))
 - **Idempotence:** hlavička `Idempotency-Key` → Redis (přes `openbank-libs` `IdempotencyStore`)
 - **Auth:** Keycloak OIDC, OPA sidecar autorizace (ADR-0034) v advisory režimu (`AUTHZ_ENFORCE=false` defaultně); `@Authorize` na mutaci blacklist
 - **Schopnost:** Open Banking (PSD2) — **není** money-path služba

--- a/openbank-tpp-registry-service/src/main/resources/docs/README.en.md
+++ b/openbank-tpp-registry-service/src/main/resources/docs/README.en.md
@@ -20,7 +20,7 @@ This documentation is published directly by the service at the management endpoi
 - **Tech stack:** Kotlin 2.3.20 / Quarkus 3.33.2 LTS / JDK 25 / PostgreSQL 16 / Hibernate Reactive (Panache)
 - **Port:** 8108 (app), 8085 (management — `/q`)
 - **Persistence:** PostgreSQL database `openbank_tpp_registry`, Flyway migrations V1/V3/V4
-- **Outbox:** `tpp_outbox` → Kafka topic `openbank.tpp.registry.event` (channel `tpp-events-out`); dispatcher present, no domain events emitted by the use case yet (see [02](./02-architecture.md))
+- **Outbox:** `tpp_outbox` → Kafka topic `openbank.tpp.registry.event` (channel `tpp-events-out`); `TPP_REGISTERED` / `TPP_BLACKLISTED` are written in the state-change transaction (issue #4007, see [02](./02-architecture.md))
 - **Idempotency:** `Idempotency-Key` header → Redis (via `openbank-libs` `IdempotencyStore`)
 - **Auth:** Keycloak OIDC, OPA sidecar authorization (ADR-0034) in advisory mode (`AUTHZ_ENFORCE=false` by default); `@Authorize` on the blacklist mutation
 - **Capability:** Open Banking (PSD2) — **not** a money-path service

--- a/openbank-tpp-registry-service/src/test/kotlin/com/openbank/tppregistry/application/usecase/TppRegistryServiceTest.kt
+++ b/openbank-tpp-registry-service/src/test/kotlin/com/openbank/tppregistry/application/usecase/TppRegistryServiceTest.kt
@@ -11,6 +11,8 @@ import com.openbank.tppregistry.application.port.`in`.RegisterTppCommand
 import com.openbank.tppregistry.application.port.out.TppRepository
 import com.openbank.tppregistry.domain.model.TppAuthorizationResult
 import com.openbank.tppregistry.domain.model.TppEntry
+import com.openbank.tppregistry.domain.model.TppEvent
+import com.openbank.tppregistry.domain.model.TppEvents
 import com.openbank.tppregistry.domain.model.TppRole
 import com.openbank.tppregistry.domain.model.TppStatus
 import io.mockk.coEvery
@@ -18,6 +20,7 @@ import io.mockk.coVerify
 import io.mockk.confirmVerified
 import io.mockk.mockk
 import io.mockk.slot
+import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
@@ -26,7 +29,6 @@ import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
 import java.util.UUID
-import kotlinx.coroutines.runBlocking
 
 class TppRegistryServiceTest {
 
@@ -108,7 +110,8 @@ class TppRegistryServiceTest {
     fun `registerTpp saves new entry`(): Unit = runBlocking {
         coEvery { repo.findByTppId("tpp-6") } returns null
         val saved = slot<TppEntry>()
-        coEvery { repo.save(capture(saved)) } answers { firstArg() }
+        val savedEvent = slot<TppEvent>()
+        coEvery { repo.save(capture(saved), capture(savedEvent)) } answers { firstArg() }
 
         val result = service.registerTpp(
             RegisterTppCommand(
@@ -127,8 +130,12 @@ class TppRegistryServiceTest {
         assertThat(saved.captured.status).isEqualTo(TppStatus.ACTIVE)
         assertThat(saved.captured.qwacSubjectDn).isEqualTo("CN=QWAC")
         assertThat(result).isEqualTo(saved.captured)
+        // The event is a REQUIRED parameter of save (issue #4007), so the use case cannot persist
+        // without one. What it carries is asserted for real against the DB in TppOutboxWriteIT.
+        assertThat(savedEvent.captured.eventType).isEqualTo(TppEvents.TPP_REGISTERED)
+        assertThat(savedEvent.captured.aggregateId).isEqualTo(saved.captured.id)
         coVerify(exactly = 1) { repo.findByTppId("tpp-6") }
-        coVerify(exactly = 1) { repo.save(any()) }
+        coVerify(exactly = 1) { repo.save(any(), any()) }
         confirmVerified(repo)
     }
 
@@ -154,7 +161,7 @@ class TppRegistryServiceTest {
             .hasMessage("TPP tpp-7 already registered")
 
         coVerify(exactly = 1) { repo.findByTppId("tpp-7") }
-        coVerify(exactly = 0) { repo.save(any()) }
+        coVerify(exactly = 0) { repo.save(any(), any()) }
         confirmVerified(repo)
     }
 
@@ -163,7 +170,8 @@ class TppRegistryServiceTest {
         val existing = sampleTpp(tppId = "tpp-8", status = TppStatus.ACTIVE)
         coEvery { repo.findByTppId("tpp-8") } returns existing
         val updated = slot<TppEntry>()
-        coEvery { repo.update(capture(updated)) } answers { firstArg() }
+        val updatedEvent = slot<TppEvent>()
+        coEvery { repo.update(capture(updated), capture(updatedEvent)) } answers { firstArg() }
 
         val result = service.blacklistTpp(BlacklistTppCommand("tpp-8", "fraud"))
 
@@ -172,8 +180,10 @@ class TppRegistryServiceTest {
         assertThat(updated.captured.blacklistReason).isEqualTo("fraud")
         assertThat(updated.captured.blacklistedAt).isNotNull()
         assertThat(result).isEqualTo(updated.captured)
+        assertThat(updatedEvent.captured.eventType).isEqualTo(TppEvents.TPP_BLACKLISTED)
+        assertThat(updatedEvent.captured.envelope["blacklistReason"]).isEqualTo("fraud")
         coVerify(exactly = 1) { repo.findByTppId("tpp-8") }
-        coVerify(exactly = 1) { repo.update(any()) }
+        coVerify(exactly = 1) { repo.update(any(), any()) }
         confirmVerified(repo)
     }
 
@@ -189,7 +199,7 @@ class TppRegistryServiceTest {
             .hasMessage("TPP tpp-9 not found")
 
         coVerify(exactly = 1) { repo.findByTppId("tpp-9") }
-        coVerify(exactly = 0) { repo.update(any()) }
+        coVerify(exactly = 0) { repo.update(any(), any()) }
         confirmVerified(repo)
     }
 

--- a/openbank-tpp-registry-service/src/test/kotlin/com/openbank/tppregistry/integration/TppOutboxWriteIT.kt
+++ b/openbank-tpp-registry-service/src/test/kotlin/com/openbank/tppregistry/integration/TppOutboxWriteIT.kt
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+package com.openbank.tppregistry.integration
+
+import com.openbank.tppregistry.it.PostgresRedisTestResource
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.security.TestSecurity
+import io.restassured.module.kotlin.extensions.Given
+import io.restassured.module.kotlin.extensions.Then
+import io.restassured.module.kotlin.extensions.When
+import jakarta.inject.Inject
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.util.UUID
+import javax.sql.DataSource
+
+/**
+ * Issue #4007: `tpp_outbox` shipped a dispatcher, a backlog gauge, an atomic-claim query,
+ * `openbank.outbox.dispatch-enabled: true`, a `KafkaTppOutboxEventPublisher`, a `KafkaTopic`
+ * resource and a write ACL — and **nothing ever wrote a row**. This service was the strictest
+ * instance of the pattern: two disjoint package roots (`com.openbank.tpp.*` holds the whole outbox
+ * apparatus, `com.openbank.tppregistry.*` holds the registry) with no import crossing between
+ * them, and — unlike `party` or `balance` — no second direct emitter either, so nothing has ever
+ * been produced to `openbank.tpp.registry.event` at all.
+ *
+ * Only a real-DB integration test can prove the fix. A unit test that mocks `TppRepository` cannot
+ * tell whether the implementation wrote an outbox row — that is exactly why the defect survived a
+ * fully green suite for the life of the service. The repository cannot be called directly either:
+ * a `Panache.withTransaction` reactive repo invoked from a bare `@QuarkusTest` thread throws
+ * "No current Vertx context found"; only a real HTTP request carries a Vert.x context. So this
+ * drives the REST endpoints with RestAssured and reads the row back over plain JDBC — the
+ * `PartyOutboxWriteIT` / `ConsentRevocationOutboxIT` / `LendingOutboxWriteIT` pattern.
+ *
+ * The dispatcher is switched off for the duration so it cannot claim a row (DISPATCHING) or mark
+ * it SENT before the assertion observes it — the claim under test is that the row is WRITTEN in
+ * the state-change transaction, not what happens to it afterwards.
+ */
+@QuarkusTest
+@QuarkusTestResource(TppOutboxWriteIT.DispatcherOffResource::class)
+@QuarkusTestResource(PostgresRedisTestResource::class)
+class TppOutboxWriteIT {
+
+    class DispatcherOffResource : QuarkusTestResourceLifecycleManager {
+        override fun start(): Map<String, String> = mapOf(
+            "openbank.outbox.dispatch-enabled" to "false",
+            // The blacklist endpoint carries @Authorize, and an OPA sidecar the interceptor cannot
+            // reach fails CLOSED — 503, not 403. Advisory mode here so the test measures the outbox
+            // write and not the absence of a PDP container; authorization itself is covered by
+            // TppRegistrySecurityTest. Same override as KycOutboxWriteIT.
+            "authz.enforce" to "false",
+        )
+        override fun stop() = Unit
+    }
+
+    @Inject
+    lateinit var dataSource: DataSource
+
+    private fun registerTpp(tppId: String) {
+        val body = """
+            {"tppId":"$tppId","name":"Outbox Probe","countryCode":"CZ","nca":"CNB",
+             "roles":["AISP"],"qwacSubjectDn":"CN=QWAC","qsealSubjectDn":null}
+        """.trimIndent()
+        Given {
+            contentType("application/json")
+            header("Idempotency-Key", UUID.randomUUID().toString())
+            body(body)
+        } When {
+            post("/api/v1/tpp-registry")
+        } Then {
+            statusCode(201)
+        }
+    }
+
+    /** The registry's own row, read independently of the outbox — both halves of the guarantee. */
+    private fun entryUuid(tppId: String): UUID? = dataSource.connection.use { conn ->
+        val ps = conn.prepareStatement("SELECT entry_uuid, status FROM tpp_entries WHERE tpp_id = ?")
+        ps.setString(1, tppId)
+        val rs = ps.executeQuery()
+        if (rs.next()) rs.getObject("entry_uuid", UUID::class.java) else null
+    }
+
+    private fun entryStatus(tppId: String): String? = dataSource.connection.use { conn ->
+        val ps = conn.prepareStatement("SELECT status FROM tpp_entries WHERE tpp_id = ?")
+        ps.setString(1, tppId)
+        val rs = ps.executeQuery()
+        if (rs.next()) rs.getString("status") else null
+    }
+
+    // conn.use closes the connection, cascading to its statement/result-set — kept flat to stay
+    // within detekt's NestedBlockDepth.
+    private fun outboxRows(aggregateId: UUID): List<Triple<String, String, String>> =
+        dataSource.connection.use { conn ->
+            val ps = conn.prepareStatement(
+                "SELECT event_type, payload, status FROM tpp_outbox WHERE aggregate_id = ? ORDER BY created_at",
+            )
+            ps.setObject(1, aggregateId)
+            val rs = ps.executeQuery()
+            val rows = mutableListOf<Triple<String, String, String>>()
+            while (rs.next()) {
+                rows += Triple(rs.getString("event_type"), rs.getString("payload"), rs.getString("status"))
+            }
+            rows
+        }
+
+    @Test
+    @TestSecurity(user = "outbox-it", roles = ["ROLE_ADMIN"])
+    fun `registering a TPP writes TPP_REGISTERED to the outbox in the same transaction as the row`() {
+        val tppId = "CZ-CNB-OUTBOX-${UUID.randomUUID().toString().take(8)}"
+        registerTpp(tppId)
+
+        val id = entryUuid(tppId)
+        assertThat(id).describedAs("tpp_entries.entry_uuid for %s", tppId).isNotNull()
+
+        val rows = outboxRows(id!!)
+        assertThat(rows).describedAs("tpp_outbox rows for %s", tppId).hasSize(1)
+        val (eventType, payload, status) = rows.single()
+        assertThat(eventType).isEqualTo("TPP_REGISTERED")
+        assertThat(status).isEqualTo("PENDING")
+        // The claim is about the PAYLOAD, not the row's columns: sca-service wrote `eventType` to
+        // `sca_outbox.event_type` and not into the body, its test asserted the column, and the
+        // consumer's parser silently read "" for 15 SENT events. A consumer of
+        // `openbank.tpp.registry.event` sees these bytes and nothing else.
+        assertThat(payload).contains("\"eventType\":\"TPP_REGISTERED\"")
+        assertThat(payload).contains("\"tppId\":\"$tppId\"")
+        assertThat(payload).contains("\"entryId\":\"$id\"")
+        assertThat(payload).contains("\"status\":\"ACTIVE\"")
+        assertThat(payload).contains("\"roles\":[\"AISP\"]")
+        // `occurredAt` (never `timestamp`), rendered with a `Z` offset: audit-service's consumer
+        // parses with Instant.parse, which rejects any other offset and silently falls back to
+        // ingest time. This is the REAL producer mapper, not a test-local one.
+        assertThat(payload).containsPattern("\"occurredAt\":\"[0-9T:.\\-]+Z\"")
+    }
+
+    @Test
+    @TestSecurity(user = "outbox-it", roles = ["ROLE_ADMIN", "ROLE_OPERATOR"])
+    fun `blacklisting a TPP writes TPP_BLACKLISTED alongside the updated row`() {
+        val tppId = "CZ-CNB-OUTBOX-${UUID.randomUUID().toString().take(8)}"
+        registerTpp(tppId)
+
+        Given {
+            contentType("application/json")
+            body("""{"reason":"licence revoked by NCA"}""")
+        } When {
+            post("/api/v1/tpp-registry/$tppId/blacklist")
+        } Then {
+            statusCode(200)
+        }
+
+        // Both halves of the guarantee, asserted against the DB rather than against a mock: the
+        // state change landed AND its event landed, in the same commit.
+        assertThat(entryStatus(tppId)).describedAs("tpp_entries.status").isEqualTo("BLACKLISTED")
+
+        val id = entryUuid(tppId)!!
+        val rows = outboxRows(id)
+        assertThat(rows.map { it.first }).containsExactly("TPP_REGISTERED", "TPP_BLACKLISTED")
+        val blacklisted = rows.last().second
+        assertThat(blacklisted).contains("\"eventType\":\"TPP_BLACKLISTED\"")
+        assertThat(blacklisted).contains("\"status\":\"BLACKLISTED\"")
+        assertThat(blacklisted).contains("\"blacklistReason\":\"licence revoked by NCA\"")
+        assertThat(blacklisted).containsPattern("\"blacklistedAt\":\"[0-9T:.\\-]+Z\"")
+    }
+}


### PR DESCRIPTION
## What

`openbank-tpp-registry-service` shipped the complete transactional-outbox apparatus and **nothing
ever wrote a row to it**. This wires it, and proves the wiring with a real-DB integration test.

`check-outbox-has-writer.py` baseline goes **5 → 4**, `0 stale`.

## The defect

Everything except the write existed: the `tpp_outbox` table (V3), a `@Scheduled`
`TppOutboxDispatcher`, an atomic `FOR UPDATE SKIP LOCKED` claim query with stale-claim reclaim, a
backlog gauge, `KafkaTppOutboxEventPublisher`, `openbank.outbox.dispatch-enabled: true`, the
`KafkaTopic` resource, the Kafka write ACL, an entry in `.github/event-contract-baseline.txt`, and
gitops headers asserting a producer. `persistInTransaction` had exactly **one** occurrence in
`src/main` — its own declaration, no caller.

The service is the strictest instance of the shape #4007 describes: two disjoint package roots
(`com.openbank.tpp.*` holds the outbox apparatus, `com.openbank.tppregistry.*` holds the registry)
with no import crossing between them. And unlike `party` or `balance` there was **no second direct
emitter** either, so `openbank.tpp.registry.event` has never had a producer at all — there was no
consumer anywhere in the fleet to notice a missing event.

## The decision: wired, not deleted

Every other end of the arrow already existed and only the write did not, and the service's own
docs listed the wiring as the next follow-up (`02-architecture.en.md` carried an honest *"no domain
events are emitted yet"* caveat). So:

- `TppEvents` builds `TPP_REGISTERED` and `TPP_BLACKLISTED` as flat envelopes, framework-free
  (ADR-0002), mirroring `PartyEvents` from #4158.
- `TppRepository.save`/`update` take the event as a **required parameter**. There is deliberately
  no eventless overload — a future call site cannot persist without an event, which is the
  structural version of the invariant rather than a comment asking for it.
- `TppRepositoryImpl` persists the `tpp_entries` row and the `tpp_outbox` row in one
  `Panache.withTransaction`.

The decision is recorded in a new `openbank-tpp-registry-service/CLAUDE.md`, which is the shape
#4007's closing condition asks for.

## Why an IT, and how it was falsified

A unit test that mocks `TppRepository` cannot tell whether an outbox row was written — that is
exactly why this survived a fully green suite for the life of the service. And the repository
cannot be called directly either: a `Panache.withTransaction` reactive repo invoked from a bare
`@QuarkusTest` thread throws *"No current Vertx context found"*. `TppOutboxWriteIT` therefore
drives the REST endpoints with RestAssured and reads the row back over plain JDBC — the
`PartyOutboxWriteIT` / `ConsentRevocationOutboxIT` / `LendingOutboxWriteIT` pattern — with the
dispatcher switched off so it cannot claim or drain the row before the assertion sees it.

**Falsified before being trusted.** With the `persistInTransaction` call removed, both tests go red
with exactly the right failure:

```
registering a TPP ... -> FAIL  Expected size: 1 but was: 0 in: []
blacklisting a TPP ... -> FAIL Expecting ["TPP_BLACKLISTED"] to contain exactly (and in same order): []
```

The assertions are on the serialized **payload**, not the row's columns — the sca-service defect
(`event_type` set on the column but absent from the body, consumer read `""` for 15 SENT events)
is the failure mode a column assertion cannot see.

## A second, pre-existing defect the test found

Writing the IT surfaced something unrelated to the outbox: **`POST /api/v1/tpp-registry` has never
worked on any seeded database.**

`V1__init.sql` declares `id BIGSERIAL PRIMARY KEY` and then seeds three sandbox TPPs, which take
ids 1..3 from the implicit `tpp_entries_id_seq`. `V4__hibernate_sequences.sql` created the sequence
Panache actually allocates from — `tpp_entries_seq` — with the default `START 1`, and nothing ever
reconciled the two. The first registration therefore allocates into the block that already holds
the seeded rows and dies with `duplicate key value violates unique constraint "tpp_entries_pkey"`
(23505), surfacing as a **500**. Deterministic, not a race, on every database that ran the seed.

Why nobody had hit it — measured read-only on the sandbox, 2026-08-16:

```
 max_entry_id | entries_seq | seq_called | bigserial_seq | outbox_seq
            3 |           1 | f          |             3 |          1
```

`tpp_entries_seq` reads `is_called = f`: the sequence Hibernate uses has **never been called** in
the life of the service, so registration had never been attempted in a deployed environment. The
only thing that could have seen this is a real-DB write test, and there wasn't one — the existing
ITs read and boot, and the unit tests mock the repository.

`V7__tpp_entries_seq_past_seeded_rows.sql` fixes it with a `setval` past `MAX(id)`, which lands the
next pooled block strictly above every existing row under either the `pooled` or `pooled-lo`
optimizer. It is a new migration, never applied anywhere, so the checksum rule is not in play.

## Measurement notes

- `pg_stat_user_tables.n_live_tup` reported **0 rows for every table**, including
  `flyway_schema_history`, while `count(*)` reported 3 entries and 5 migrations. A "nothing found"
  probe was a broken probe; the numbers above are all `count(*)` / direct sequence reads.
- The three rows in `tpp_entries` are **V1's seed data**, not API traffic — all three share one
  `registered_at`. So the empty `tpp_outbox` on its own proves nothing about the missing writer;
  the finding rests on the code (no `OutboxMessage` construction, no second emitter) and the
  never-called sequence.
- I could **not** read the `openbank.tpp.registry.event` end offset: plaintext 9092 is ACL-denied
  from the broker pod and a KafkaUser cert was out of scope for a read-only check. The claim "no
  producer has ever existed" rests on the code, not on a broker measurement.

## Verification

```
:openbank-tpp-registry-service:test :openbank-tpp-registry-service:quarkusBuild   BUILD SUCCESSFUL
JUnit XML: 26 tests, 0 failures, 0 errors, 1 skipped
```

The 1 skipped is the pre-existing `TppRegistryPactBrokerProviderVerificationTest`, gated on
`pactbroker.url` — unchanged by this PR. `quarkusBuild` is in the gate deliberately: this PR adds a
constructor injection point, and ArC/CDI wiring failures only surface there.
`ktlintCheck` + `detekt` green (the wildcard import in `TppRepositoryImpl` was expanded rather than
left for CI to find on a touched file).

```
$ python3 .github/scripts/check-outbox-has-writer.py ; echo rc=$?
check-outbox-has-writer: 34 service(s) ship a dispatcher; 4 without a writer
                         (4 baselined, 0 new, 0 stale baseline entries).
rc=0
```

## What this does NOT do

`audit`, `balance`, `pid` and `psd2` remain baselined. `balance` is money-path and needs its own PR
with a threat model; `pid` is a 14-publish-site refactor; `audit` and `psd2` have no second
publisher and no traffic to decide from, so they are the honest delete-the-apparatus candidates
(the sibling of #4940, which deletes security-scanner's).

Refs #4007
