### PR TITLE
feat(bcp): commit the DR restore manifest templates

### DIFF
--- a/.github/workflows/dr-restore-verify.yml
+++ b/.github/workflows/dr-restore-verify.yml
@@ -71,22 +71,32 @@ jobs:
           kubectl create namespace "$NS"
           RESTORE_START=$(date -u +%s)
 
-          # WIRING: apply the CNPG recovery Cluster (bootstrap.recovery from the ledger-db
-          # barman S3 store) + an ephemeral ledger-service Deployment (OUTBOX_DISPATCH_ENABLED
-          # =false, OIDC off) into $NS. Templates tracked in the design doc's remaining wiring.
-          echo "::error::WIRING INCOMPLETE: CNPG recovery Cluster + ledger-service manifests for \$NS are not yet in-repo (docs/bcp/automated-dr-restore.md). Failing rather than reporting a hollow PASS."
-          exit 1
+          # Manifest templates: openbank-infra/gitops/dr-restore-templates/ (#4757). The
+          # remaining wiring item is the runner label above (`runs-on: ubuntu-latest`
+          # never reaches this far — the gate step exits first), which is an
+          # infrastructure-provisioning decision, not something this step can supply.
+          TEMPLATES="openbank-infra/gitops/dr-restore-templates"
+          IMAGE="$(kubectl get rollout ledger-service -n ledger \
+            -o jsonpath='{.spec.template.spec.containers[0].image}')"
+          [ -n "$IMAGE" ] || { echo "::error::could not read the live ledger-service image — refusing to restore an unspecified build."; exit 1; }
 
-          # --- The verification below is the intended shape once the manifests land: ---
-          # kubectl -n "$NS" wait --for=condition=Ready cluster/ledger-db-restored --timeout=30m
-          # kubectl -n "$NS" rollout status deploy/ledger-service --timeout=10m
-          # kubectl -n "$NS" port-forward svc/ledger-service 18101:8101 &
-          # PF=$!; sleep 5
-          # BODY="$(curl -sf "http://localhost:18101/api/v1/ledger/close/trial-balance?fiscalYear=${FY}")"
-          # kill "$PF" || true
-          # RESTORE_END=$(date -u +%s); RTO=$(( RESTORE_END - RESTORE_START ))
-          # BALANCED="$(printf '%s' "$BODY" | python3 -c 'import sys,json;print(json.load(sys.stdin)["balanced"])')"
-          # if [ "$BALANCED" != "True" ]; then
-          #   echo "::error::restored ledger is UNBALANCED — backup integrity FAILED"; exit 1
+          sed "s#\${NS}#${NS}#g" "$TEMPLATES/cnpg-recovery-cluster.yaml.tmpl" | kubectl apply -f -
+          sed "s#\${NS}#${NS}#g; s#\${IMAGE}#${IMAGE}#g" "$TEMPLATES/ledger-service-dr-check.yaml.tmpl" | kubectl apply -f -
+
+          kubectl -n "$NS" wait --for=condition=Ready cluster/ledger-db-restored --timeout=30m
+          kubectl -n "$NS" rollout status deploy/ledger-service-dr-check --timeout=10m
+          kubectl -n "$NS" port-forward svc/ledger-service-dr-check 18101:8101 &
+          PF=$!; sleep 5
+          BODY="$(curl -sf "http://localhost:18101/api/v1/ledger/close/trial-balance?fiscalYear=${FY}")"
+          kill "$PF" || true
+          RESTORE_END=$(date -u +%s); RTO=$(( RESTORE_END - RESTORE_START ))
+          BALANCED="$(printf '%s' "$BODY" | python3 -c 'import sys,json;print(json.load(sys.stdin)["balanced"])')"
+          if [ "$BALANCED" != "True" ]; then
+            echo "::error::restored ledger is UNBALANCED — backup integrity FAILED"; exit 1
+          fi
+
+          echo "RTO_SECONDS=${RTO}" >> "$GITHUB_STEP_SUMMARY"
+          echo "RPO: measured from the backup's WAL target, not computed here (bare RTO only)." >> "$GITHUB_STEP_SUMMARY"
+          echo "restore verified: balanced=true, RTO=${RTO}s"
           # fi
           # echo "::notice::DR restore verified: balanced=true, RTO=${RTO}s (append to docs/bcp/dr-test-log.md)"

--- a/openbank-infra/gitops/dr-restore-templates/README.md
+++ b/openbank-infra/gitops/dr-restore-templates/README.md
@@ -1,0 +1,50 @@
+# DR restore templates (docs/bcp/automated-dr-restore.md)
+
+Templates for the two manifests `dr-restore-verify.yml` needs, applied into a
+throwaway `dr-verify-<run-id>` namespace and torn down at the end of the run.
+Design and full context: `docs/bcp/automated-dr-restore.md`.
+
+`${NS}` is substituted by the workflow (`envsubst` or `sed`) at apply time — the
+templates are not applied as-is.
+
+## Status — NOT verified against a live restore
+
+These are derived from `openbank-infra/gitops/components/ledger/postgres.yaml` and
+`.../ledger-service.yaml`, stripped to what a read-only trial-balance check needs, and
+from reading `application.yaml`'s profile toggles for the pieces that must be off. They
+have not been applied to a real cluster and booted — that needs the cluster-capable
+runner tracked separately in #4757, and no session without one should claim this is
+proven. Treat a first real run as the actual test, not this file.
+
+## What was deliberately left out of the ledger-service ephemeral Deployment
+
+Compared to the live `Rollout` (`ledger-service.yaml`), all removed for a reason stated
+in `docs/bcp/automated-dr-restore.md`'s isolation section:
+
+- **No Kafka.** `openbank.outbox.dispatch-enabled: "false"` stops the outbox dispatcher
+  from ever calling the emitter, so the `KAFKA_*` env block (mTLS keystore/truststore
+  secrets that do not exist in a throwaway namespace) is not needed to boot. Left
+  entirely unset rather than pointed at PLAINTEXT — a restored pod must not be able to
+  publish, even by accident, and an unreachable broker at default config is a boot
+  hazard this avoids outright.
+- **No OIDC.** `QUARKUS_OIDC_TENANT_ENABLED=false` disables the resource-server tenant.
+  The only call this Deployment needs to serve is the read-only trial-balance endpoint;
+  requiring a live Keycloak reachable from a throwaway namespace would be one more
+  cross-namespace dependency for zero benefit.
+- **No Redis.** The four-eyes `ApprovalStore` is not exercised by a read-only restore
+  check. `QUARKUS_REDIS_HOSTS` left unset; if this later needs `POST` paths, add it
+  back rather than assume it is unused forever.
+- **No OPA sidecar.** `AUTHZ_ENFORCE` defaults `false`, and the sidecar exists to
+  enforce the base allow/deny; a namespace with one throwaway pod calling itself
+  in-cluster is not the surface that decision protects.
+- **Plain `Deployment`, not `Rollout`.** No canary makes sense for a pod that lives for
+  one CI job and is deleted at the end of it; Argo Rollouts CRDs may also not be
+  installed in every runner's target context.
+
+## Image
+
+The template pins no tag. The workflow step must set it to the same image the LIVE
+`ledger-service` Rollout is currently running (`kubectl get rollout ledger-service -n
+ledger -o jsonpath='{.spec.template.spec.containers[0].image}'`) at apply time — a
+stale pinned tag here would silently test a different build than the one in
+production, which defeats the point of a restore drill.

--- a/openbank-infra/gitops/dr-restore-templates/cnpg-recovery-cluster.yaml.tmpl
+++ b/openbank-infra/gitops/dr-restore-templates/cnpg-recovery-cluster.yaml.tmpl
@@ -1,0 +1,38 @@
+# Recovery Cluster for the DR restore drill (docs/bcp/automated-dr-restore.md).
+# Restores ledger-db's barman S3 archive into a throwaway namespace, read-only.
+# Substitute ${NS} before applying. Derived from
+# openbank-infra/gitops/components/ledger/postgres.yaml — same image, same storage
+# class, half the instance count (a restore check does not need HA), no
+# ScheduledBackup (this cluster is deleted at the end of the run, not backed up).
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: ledger-db-restored
+  namespace: ${NS}
+spec:
+  instances: 1
+  imageName: ghcr.io/cloudnative-pg/postgresql:18.1
+  storage:
+    storageClass: gp3
+    size: 2Gi
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: "1"
+      memory: 512Mi
+  # Read-only recovery from the LIVE ledger-db archive. `externalClusters` names the
+  # source barman store; `bootstrap.recovery` tells CNPG to initialize FROM it rather
+  # than run initdb. Credentials via EKS Pod Identity on this namespace's CNPG
+  # ServiceAccount, granted read-only against the ledger-db backup prefix — the
+  # restore must not be able to write back to the source bucket path it reads from.
+  bootstrap:
+    recovery:
+      source: ledger-db-source
+  externalClusters:
+    - name: ledger-db-source
+      barmanObjectStore:
+        destinationPath: s3://openbank-sandbox-db-backups/ledger-db
+        s3Credentials:
+          inheritFromIAMRole: true

--- a/openbank-infra/gitops/dr-restore-templates/ledger-service-dr-check.yaml.tmpl
+++ b/openbank-infra/gitops/dr-restore-templates/ledger-service-dr-check.yaml.tmpl
@@ -1,0 +1,75 @@
+# Ephemeral ledger-service Deployment for the DR restore drill
+# (docs/bcp/automated-dr-restore.md). Serves ONLY the read-only trial-balance
+# check against the just-restored ledger-db-restored cluster. Substitute ${NS}
+# and ${IMAGE} before applying — see this directory's README for what was
+# deliberately left out and why, and for how ${IMAGE} must be resolved (the
+# LIVE production tag, not a stale pin).
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ledger-service-dr-check
+  namespace: ${NS}
+  labels:
+    app.kubernetes.io/name: ledger-service-dr-check
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: ledger-service-dr-check
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: ledger-service-dr-check
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 100
+        runAsGroup: 101
+        fsGroup: 101
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: ledger-service
+          image: ${IMAGE}
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8101
+            - name: management
+              containerPort: 8085
+          env:
+            - name: QUARKUS_DATASOURCE_JDBC_URL
+              value: jdbc:postgresql://ledger-db-restored-rw.${NS}.svc:5432/openbank_ledger
+            - name: QUARKUS_DATASOURCE_REACTIVE_URL
+              value: vertx-reactive:postgresql://ledger-db-restored-rw.${NS}.svc:5432/openbank_ledger
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: ledger-db-restored-app
+                  key: password
+            # The whole point of the isolation guarantee: dispatch off means the outbox
+            # dispatcher never calls the Kafka emitter, so this restored pod cannot
+            # publish, no matter what a bug elsewhere in the request path might attempt.
+            - name: OPENBANK_OUTBOX_DISPATCH_ENABLED
+              value: "false"
+            # No live Keycloak in a throwaway namespace; the drill calls only the
+            # read-only trial-balance endpoint, which does not need auth for this check.
+            - name: QUARKUS_OIDC_TENANT_ENABLED
+              value: "false"
+            # Flyway must NOT run here: this is already-migrated restored data, and a
+            # restore drill exists to prove the backup, not to re-migrate it.
+            - name: QUARKUS_FLYWAY_MIGRATE_AT_START
+              value: "false"
+          readinessProbe:
+            httpGet:
+              path: /q/health/ready
+              port: management
+            initialDelaySeconds: 10
+            periodSeconds: 5
+          resources:
+            requests:
+              cpu: 250m
+              memory: 512Mi
+            limits:
+              cpu: "1"
+              memory: 1Gi


### PR DESCRIPTION
## What this closes, and what it does not

Item 2 of #4757's scope: *"The CNPG recovery Cluster + ledger-service manifests are committed."* Item 1 — a deploy-pool self-hosted runner with `kubectl` + IRSA — is an **infrastructure-provisioning decision**, not a repo edit, and stays open (the issue's own "Why this is not a code change" section says so).

## The two templates

`openbank-infra/gitops/dr-restore-templates/`:

- **`cnpg-recovery-cluster.yaml.tmpl`** — `bootstrap.recovery` from the ledger-db barman S3 archive. Derived from the live `postgres.yaml`'s image/storage class, at 1 instance (no HA needed for a restore check) and no `ScheduledBackup` (this cluster is deleted at the end of the run).
- **`ledger-service-dr-check.yaml.tmpl`** — a plain `Deployment`, not a `Rollout`: no canary makes sense for a one-job pod, and Argo Rollout CRDs may not exist in every runner's target context. Serves only the read-only trial-balance endpoint.

## What was deliberately left out, and why (full detail in the templates' README)

| removed vs. the live Rollout | why |
|---|---|
| Kafka — unset entirely, not PLAINTEXT | `OUTBOX_DISPATCH_ENABLED=false` means the dispatcher never calls the emitter; leaving Kafka config unset rather than pointed at a reachable-but-wrong broker means a bug elsewhere in the request path cannot make this pod publish by accident |
| OIDC | `QUARKUS_OIDC_TENANT_ENABLED=false` — the only call this pod serves is the read-only trial-balance endpoint |
| Redis | four-eyes `ApprovalStore` isn't exercised by a read-only check |
| OPA sidecar | nothing here needs the base allow/deny decision it enforces |
| Flyway migrate-at-start | the restored data is already migrated; this is a drill, not a re-migration |

## Workflow wiring

`dr-restore-verify.yml`'s restore step now applies the templates (`sed`-substituting `${NS}`, and `${IMAGE}` resolved from the **live** `ledger-service` Rollout at apply time — so the drill tests the build actually in production, not a stale pin) instead of exiting on `WIRING INCOMPLETE`. The commented-out verification shape that was already written below the old stub is now live code, unchanged in substance.

## Verification, and its limit stated plainly

YAML parses (both templates substituted, and the workflow file). `actionlint` is clean — it caught a missing `fi` on my first pass, from a comment block that became live shell; fixed.

**What this does NOT establish:** that these manifests actually boot a working `ledger-service` pod against a real restored cluster. That needs the runner from item 1, and applying manifests into a live cluster is a mutation this session does not perform. The README says this explicitly and names the first real dispatch as the actual test — not this PR.

Refs #4757

🤖 Generated with [Claude Code](https://claude.com/claude-code)
