### PR TITLE
fix(domestic-payment): put the authenticated actor on the wire for domestic.payment.created

### DIFF
--- a/docs/asyncapi/openbank-events.yaml
+++ b/docs/asyncapi/openbank-events.yaml
@@ -1131,6 +1131,14 @@ components:
         occurredAt:
           type: string
           format: date-time
+        initiatedByPartyId:
+          type: string
+          format: uuid
+          description: >-
+            The authenticated caller who submitted this payment (from the JWT), or absent for a
+            payment created without one. Added #3994: AuditConsumer already reads this exact key
+            as its third-priority actor spelling (ADR-0021's transaction.initiated convention), so
+            no consumer change was needed to recover actor attribution for this event.
 
     DomesticPaymentStatusChangedPayload:
       type: object

--- a/openbank-domestic-payment/src/main/kotlin/com/openbank/domestic/application/usecase/DomesticPaymentService.kt
+++ b/openbank-domestic-payment/src/main/kotlin/com/openbank/domestic/application/usecase/DomesticPaymentService.kt
@@ -155,6 +155,7 @@ class DomesticPaymentService(
             technicalAccountCode = technicalAccountCode,
             statementLabel = command.statementLabel?.trim()?.ifBlank { null },
             endToEndId = command.endToEndId?.trim()?.ifBlank { null } ?: generateEndToEndId(command.priority),
+            initiatedByPartyId = command.actorId,
             rejectReason = null,
             rejectDetail = null,
             submittedAt = null,

--- a/openbank-domestic-payment/src/main/kotlin/com/openbank/domestic/domain/event/DomesticPaymentEvents.kt
+++ b/openbank-domestic-payment/src/main/kotlin/com/openbank/domestic/domain/event/DomesticPaymentEvents.kt
@@ -26,6 +26,14 @@ data class DomesticPaymentCreatedEvent(
     val priority: DomesticPaymentPriority,
     val endToEndId: String,
     val occurredAt: Instant,
+    /**
+     * The authenticated caller who submitted this payment, or `null` when there was none (issue
+     * #3994). Named `initiatedByPartyId`, not `actorId`: it is the same spelling
+     * `transaction.initiated` already uses (ADR-0021) and that `AuditConsumer.resolveActor` already
+     * reads as its third-priority actor key, so this recovers actor attribution for domestic
+     * payments with no consumer-side change.
+     */
+    val initiatedByPartyId: UUID?,
 )
 
 data class DomesticPaymentStatusChangedEvent(
@@ -51,4 +59,5 @@ fun DomesticPayment.toCreatedEvent(clock: Clock) = DomesticPaymentCreatedEvent(
     priority = priority,
     endToEndId = endToEndId,
     occurredAt = Instant.now(clock),
+    initiatedByPartyId = initiatedByPartyId,
 )

--- a/openbank-domestic-payment/src/main/kotlin/com/openbank/domestic/domain/model/DomesticPayment.kt
+++ b/openbank-domestic-payment/src/main/kotlin/com/openbank/domestic/domain/model/DomesticPayment.kt
@@ -75,6 +75,16 @@ data class DomesticPayment(
      * construction site has to change.
      */
     val schemeDispatchedAt: Instant? = null,
+    /**
+     * The authenticated caller who submitted this payment, straight off the JWT
+     * (`CreateDomesticPaymentCommand.actorId`), or `null` for a payment created without an
+     * authenticated actor (e.g. a batch/system-initiated import). Carried on the payment so
+     * [com.openbank.domestic.domain.event.toCreatedEvent] can put it on the wire — previously the
+     * command's `actorId` was used to derive [transferScope] and then discarded, so every domestic
+     * payment's `DomesticPaymentCreatedEvent` named no actor even though the identity was already
+     * authenticated and in hand (issue #3994).
+     */
+    val initiatedByPartyId: UUID? = null,
 ) {
     fun transitionTo(
         targetStatus: DomesticPaymentStatus,

--- a/openbank-domestic-payment/src/test/kotlin/com/openbank/domestic/application/usecase/DomesticPaymentServiceTemporalTest.kt
+++ b/openbank-domestic-payment/src/test/kotlin/com/openbank/domestic/application/usecase/DomesticPaymentServiceTemporalTest.kt
@@ -86,6 +86,29 @@ class DomesticPaymentServiceTemporalTest {
     }
 
     @Test
+    fun `createPayment carries the command's actorId onto the persisted payment as initiatedByPartyId`() {
+        val actorId = UUID.randomUUID()
+        coEvery { repo.findByIdempotencyKey(any()) } returns null
+
+        val result = runBlocking { service.createPayment(command(actorId = actorId)) }
+
+        // #3994: the JWT-authenticated caller was already derived for transferScope and then
+        // discarded before reaching the wire — this is what makes it survive onto the payment so
+        // DomesticPaymentCreatedEvent (and, via AuditConsumer's existing initiatedByPartyId
+        // fallback, the audit trail) can name an actor.
+        assertThat(result.initiatedByPartyId).isEqualTo(actorId)
+    }
+
+    @Test
+    fun `createPayment leaves initiatedByPartyId null when the command carries no actor`() {
+        coEvery { repo.findByIdempotencyKey(any()) } returns null
+
+        val result = runBlocking { service.createPayment(command(actorId = null)) }
+
+        assertThat(result.initiatedByPartyId).isNull()
+    }
+
+    @Test
     fun `createPayment derives EXTERNAL scope for a non-own-bank creditor`() {
         coEvery { repo.findByIdempotencyKey(any()) } returns null
 

--- a/openbank-domestic-payment/src/test/kotlin/com/openbank/domestic/domain/event/DomesticPaymentEventsTest.kt
+++ b/openbank-domestic-payment/src/test/kotlin/com/openbank/domestic/domain/event/DomesticPaymentEventsTest.kt
@@ -18,7 +18,7 @@ import java.util.UUID
 
 class DomesticPaymentEventsTest {
 
-    private fun payment() = DomesticPayment(
+    private fun payment(initiatedByPartyId: UUID? = UUID.randomUUID()) = DomesticPayment(
         id = UUID.randomUUID(),
         idempotencyKey = "idem-event",
         status = DomesticPaymentStatus.VALIDATED,
@@ -46,6 +46,7 @@ class DomesticPaymentEventsTest {
         settledAt = null,
         createdAt = Instant.parse("2026-06-01T09:00:00Z"),
         updatedAt = Instant.parse("2026-06-01T09:00:00Z"),
+        initiatedByPartyId = initiatedByPartyId,
     )
 
     @Test
@@ -68,6 +69,16 @@ class DomesticPaymentEventsTest {
         assertThat(event.priority).isEqualTo(DomesticPaymentPriority.URGENT)
         assertThat(event.endToEndId).isEqualTo("DOMU42")
         assertThat(event.occurredAt).isEqualTo(now)
+        assertThat(event.initiatedByPartyId).isEqualTo(payment.initiatedByPartyId)
+    }
+
+    @Test
+    fun `toCreatedEvent carries no actor when the payment was created without one`() {
+        val payment = payment(initiatedByPartyId = null)
+
+        val event = payment.toCreatedEvent(Clock.fixed(Instant.parse("2026-06-01T10:00:00Z"), ZoneOffset.UTC))
+
+        assertThat(event.initiatedByPartyId).isNull()
     }
 
     @Test


### PR DESCRIPTION
## What this is

One item of the producer sweep the last comment on #3994 left open, after the consumer-side fixes
(#4693, and the earlier source-service fix) landed. Scoped to the single item the issue itself
flagged **"highest value"**: domestic-payment.

## The gap

`CreateDomesticPaymentCommand.actorId` is populated straight from the JWT
(`DomesticPaymentResource.kt`), and was already being used server-side to derive `transferScope`
(`DomesticPaymentService.deriveTransferScope`) — then discarded. `DomesticPaymentCreatedEvent` never
carried it, so every `domestic.payment.created` audit row named no actor even though the identity
was authenticated and in hand at the point the event was built.

## The fix

- `DomesticPayment` gains a nullable `initiatedByPartyId: UUID?` field, set from
  `command.actorId` in `buildReceivedPayment`.
- `DomesticPaymentCreatedEvent` gains the same field, populated in `toCreatedEvent`.
- **No consumer change.** `AuditConsumer.resolveActor` already reads `initiatedByPartyId` as its
  third-priority actor spelling (the same key `transaction.initiated` uses per ADR-0021), so this
  recovers attribution for `domestic.payment.created` rows without touching `openbank-audit-service`.
- Additive, nullable, backward compatible — no `openapi.yaml`/API-contract change, no DB migration
  (the field only needs to survive from command to event within the single `createPayment` call; it
  is not persisted or reconstructed from storage).
- `docs/asyncapi/openbank-events.yaml`'s `DomesticPaymentCreatedPayload` schema updated to match.

`DomesticPaymentStatusChangedEvent` is intentionally untouched — its transitions are mostly
workflow/scheme-driven (screening, scheme submission, settlement), not necessarily by the payment's
original submitter, and the issue's producer table calls out the *created* event specifically.

## Measured (live sandbox, read-only, today)

```
SELECT source_service_source, count(*) FROM audit_entries GROUP BY 1;
  NULL   | 1784   <- pre-fix rows, never backfilled by design (#3994 decision)
  TOPIC  |  142
  EVENT  |   60

SELECT (actor_id IS NULL), count(*) FROM audit_entries WHERE source_service_source IS NOT NULL GROUP BY 1;
  false  |  167   (82.7% of post-fix rows already name an actor, thanks to #4693)
  true   |   35

SELECT source_service, (actor_id IS NULL), count(*) FROM audit_entries WHERE source_service='domestic-payment' GROUP BY 1,2;
  domestic-payment | true | 4    <- confirms the gap this PR closes
```

The overall 76%/77% headline in the issue title is stored-record history and stays true forever
(forward-only was the deliberate #3994 decision — `no_update_audit` makes a backfill a no-op). What
moves is the rate on *new* rows, and domestic-payment's `created` events are now part of that.

## Not in this PR — left to the issue

Per the issue's per-producer table, still open:
- **consent-service** — `Suppression.createdBy`/`revokedBy`
- **dispute-service** — `Dispute.resolvedBy`
- **statement-service** — the REST caller of `period.restated.v1`
- **account-service** — `WithdrawalProposal.decidedBy` on `SavingsWithdrawalApproved`

Each is a different producer, different event, different reviewers — bundling them would make this
PR harder to review for what it actually is. Suggest #3994 stays open for those; happy to follow up
with one PR per item if wanted.

## Verification

- `./gradlew :openbank-domestic-payment:compileKotlin :openbank-domestic-payment:compileTestKotlin` — clean.
- `./gradlew :openbank-domestic-payment:test --tests DomesticPaymentEventsTest --tests DomesticPaymentServiceTemporalTest --tests DomesticPaymentServiceTest` — 12/12 passing, 0 skipped (read from JUnit XML, not `| tail`).
- `./gradlew :openbank-domestic-payment:ktlintCheck :openbank-domestic-payment:detekt` — clean.
- Did **not** run the full module `quarkusBuild`/integration-test suite (Temporal + Postgres +
  Kafka dev services) in this session — flag if that's wanted before merge.

Closes: none (partial fix). Refs #3994.
