### PR TITLE
fix(finrep): deploy frozen ledger snapshot build

### DIFF
--- a/openbank-infra/gitops/components/finrep/finrep-service.yaml
+++ b/openbank-infra/gitops/components/finrep/finrep-service.yaml
@@ -42,7 +42,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: finrep-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-finrep-service:sandbox-5e5d9070
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-finrep-service:sandbox-22d81208
           imagePullPolicy: IfNotPresent
           ports:
             - name: http


### PR DESCRIPTION
## Summary

Deploy the already signed and attested FINREP image built from the frozen Ledger snapshot change.

## Type of change

- [x] fix (bug fix)

## Linked issues

Refs #4826, #4885

## Changes

- Update only the FINREP GitOps image tag to `sandbox-22d812083c1c1f5d177e4718bdb1e95e12c6f06e`.

## Definition of Done

- [x] GitOps manifest YAML parses successfully.
- [x] Diff is limited to the FINREP image tag.
- [x] Existing image signature and attestation were verified by the deployment pipeline.

## Security checklist

- [x] No secrets, tokens, passwords, or PII added.
- [x] No dependencies changed.

## Compliance impact

- [x] CNB reporting

The deployment enables FINREP to consume the previously verified frozen Ledger snapshot. No report data or regulatory mapping changes are included.

## Rollout / Rollback

- Deployment strategy: rolling
- Rollback plan: revert this single image-tag change through the normal GitOps PR workflow.
- Data migration reversible: N/A

## Reviewer notes

The target image already passed the standard build, signature, scan, SBOM attestation and Pact deployment gates; this PR contains no source or runtime-configuration changes.