### PR TITLE
feat(accounts): let a customer rename an account (TOP-10 #10, part 1)

### DIFF
--- a/docs/threat-models/openbank-account-service.md
+++ b/docs/threat-models/openbank-account-service.md
@@ -86,6 +86,34 @@ not change any existing request's outcome until explicitly flipped.
 
 ## 6. Change log
 
+- **2026-08-16** — Account rename (TOP-10 #10, part 1): `PATCH /api/v1/accounts/{accountId}/nickname`
+  (`nickname` — nullable, VARCHAR(60)). No new trust boundary, no new service, no money movement —
+  same shape as the 2026-07-03 savings-goal entry below, which this mirrors field for field.
+  - **S (Spoofing):** identical path — the edge authenticates the customer JWT and forwards
+    `X-Customer-Party-Id`; account-service's `denyIfNotOwner` re-checks ownership as
+    defense-in-depth before accepting operator/service-role requests.
+  - **T (Tampering):** nickname is customer-authored free text — bounded to 60 chars (VARCHAR(60)
+    + app-side `require`), forwarded through the edge via Jackson re-serialization (not string
+    interpolation) so it cannot break out of the JSON body.
+  - **R (Repudiation):** no new event/audit trail — cosmetic customer preference, not a money-path
+    state transition; the `accounts.updated_at` / optimistic `version` bump is the only trace, same
+    as the goal fields.
+  - **I (Information disclosure):** returned only on the owning customer's own `GET /accounts/{id}`
+    (or operator/admin reads) — no new read endpoint. PII-adjacent (customer-authored text) —
+    nulled on GDPR Art. 17 erasure alongside `legalName`/goal fields (`anonymizeByPartyId`
+    extended, not a new erasure path).
+  - **D (Denial of service):** plain synchronous DB write through the existing `update()` path — no
+    new external call, no new failure mode beyond "account not found" (404).
+  - **E (Elevation of privilege):** none — reuses `account.update` (service-side) and
+    `customer.accounts.nickname.write` (edge-side, under the existing `customer.*` self-service OPA
+    rule — no new policy rule needed).
+  **Risk class = low** (customer-preference metadata, no money movement, no new trust boundary).
+  Flyway `V20__account_nickname.sql`: `nickname VARCHAR(60)`, nullable. Rollback: `ALTER TABLE
+  accounts DROP COLUMN nickname` + revert commit.
+  Money-path service (account-service is in `rules.yaml: money_path_services`) — this entry
+  satisfies the threat-model requirement for the 2-approval gate (rule #8); the change itself moves
+  no money and needs no additional compensating control beyond what's documented above.
+
 - **2026-08-09** — **`BalanceServiceClient` now reads and forwards a spendable figure the raw projection did not carry (#1745).** `effectiveAvailableAmount` on the wire is nullable and defaults to `availableAmount` when absent, so this service tolerates talking to an older balance-service during a rollout. **Risk class = none new**: this is a client-side interpretation change on an existing inbound field from an already-trusted M2M dependency (balance-service is inside this service's own trust boundary, not a new edge), no new endpoint, no new listener, no authorization change. The only new datum this service now trusts is a number it already trusted the shape of. Rollback: revert the mapping; the field is additive on balance-service's side and nothing here persists it.
 
 

--- a/openbank-account-service/src/main/kotlin/com/openbank/account/application/port/in/AccountPorts.kt
+++ b/openbank-account-service/src/main/kotlin/com/openbank/account/application/port/in/AccountPorts.kt
@@ -70,6 +70,9 @@ data class UpdateSavingsGoalCommand(
 )
 data class ClearSavingsGoalCommand(val accountId: UUID, val requestedBy: UUID)
 
+/** Set or clear the customer-chosen display label. Blank/null clears it. */
+data class RenameAccountCommand(val accountId: UUID, val nickname: String?, val requestedBy: UUID)
+
 interface AccountUseCase {
     suspend fun openAccount(command: OpenAccountCommand): Account
 
@@ -92,6 +95,7 @@ interface AccountUseCase {
     suspend fun resolvePocket(query: ResolvePocketQuery): PocketResolution
     suspend fun updateSavingsGoal(command: UpdateSavingsGoalCommand): Account
     suspend fun clearSavingsGoal(command: ClearSavingsGoalCommand): Account
+    suspend fun renameAccount(command: RenameAccountCommand): Account
 }
 
 data class GrantAuthorizationCommand(

--- a/openbank-account-service/src/main/kotlin/com/openbank/account/application/usecase/AccountService.kt
+++ b/openbank-account-service/src/main/kotlin/com/openbank/account/application/usecase/AccountService.kt
@@ -16,6 +16,7 @@ import com.openbank.account.application.port.`in`.ListAccountsQuery
 import com.openbank.account.application.port.`in`.ListActiveAccountsQuery
 import com.openbank.account.application.port.`in`.ListPocketsQuery
 import com.openbank.account.application.port.`in`.OpenAccountCommand
+import com.openbank.account.application.port.`in`.RenameAccountCommand
 import com.openbank.account.application.port.`in`.ResolvePocketQuery
 import com.openbank.account.application.port.`in`.SearchAccountsQuery
 import com.openbank.account.application.port.`in`.UnfreezeAccountCommand
@@ -392,6 +393,17 @@ class AccountService(
         )
     }
 
+    // Same "plain field update on the existing aggregate" shape as the savings goal above —
+    // the nickname is cosmetic customer-preference metadata, not a money-path transition, so
+    // no new event/topic either.
+    override suspend fun renameAccount(command: RenameAccountCommand): Account {
+        require(command.nickname == null || command.nickname.length <= NICKNAME_MAX_LENGTH) {
+            "Nickname must be at most $NICKNAME_MAX_LENGTH characters"
+        }
+        val account = requireAccount(command.accountId)
+        return accountRepository.update(account.rename(command.nickname))
+    }
+
     private suspend fun requireAccount(id: UUID): Account = accountRepository.findById(id)
         ?: throw AccountNotFoundException("Account not found: $id")
 
@@ -423,6 +435,9 @@ class AccountService(
     companion object {
         /** Matches the goal_name VARCHAR(120) column (ADR-0153, V13) — validated app-side too. */
         const val GOAL_NAME_MAX_LENGTH = 120
+
+        /** Matches the nickname VARCHAR(60) column (V20) — validated app-side too. */
+        const val NICKNAME_MAX_LENGTH = 60
 
         /**
          * Map the free-text close reason to a **closed, low-cardinality** set for the

--- a/openbank-account-service/src/main/kotlin/com/openbank/account/domain/model/Account.kt
+++ b/openbank-account-service/src/main/kotlin/com/openbank/account/domain/model/Account.kt
@@ -39,6 +39,12 @@ data class Account(
     val goalName: String? = null,
     val goalTargetMinorUnits: Long? = null,
     val goalTargetDate: LocalDate? = null,
+    /**
+     * Customer-chosen label for this account ("Dovolená", "Firemní"), shown instead of the
+     * generic account-type name. Purely cosmetic — never used for routing, matching, or any
+     * authorization decision. Null means "use the account-type default name".
+     */
+    val nickname: String? = null,
 ) {
     fun canDebit(amount: Money): Boolean {
         require(amount.currency == currency) { "Currency mismatch" }
@@ -71,6 +77,9 @@ data class Account(
         check(status == AccountStatus.PENDING_ACTIVATION) { "Cannot activate account in status $status" }
         return copy(status = AccountStatus.ACTIVE)
     }
+
+    /** Set or clear the customer-chosen label. Blank is treated as "clear" (revert to default). */
+    fun rename(nickname: String?): Account = copy(nickname = nickname?.trim()?.ifBlank { null })
 }
 
 enum class AccountType {

--- a/openbank-account-service/src/main/kotlin/com/openbank/account/infrastructure/persistence/entity/AccountEntities.kt
+++ b/openbank-account-service/src/main/kotlin/com/openbank/account/infrastructure/persistence/entity/AccountEntities.kt
@@ -82,6 +82,10 @@ class AccountEntity : PanacheEntityBase {
     @Column(name = "goal_target_date")
     var goalTargetDate: LocalDate? = null
 
+    /** Customer-chosen display label (V20). Null means "use the account-type default name". */
+    @Column(name = "nickname", length = 60)
+    var nickname: String? = null
+
     /** Stamped from the injected [java.time.Clock] in the repository layer (ADR-0100 — no wall-clock reads here). */
     @Column(name = "created_at", nullable = false, updatable = false)
     var createdAt: Instant = Instant.EPOCH

--- a/openbank-account-service/src/main/kotlin/com/openbank/account/infrastructure/persistence/repository/AccountRepositoryImpl.kt
+++ b/openbank-account-service/src/main/kotlin/com/openbank/account/infrastructure/persistence/repository/AccountRepositoryImpl.kt
@@ -166,13 +166,13 @@ class AccountRepositoryImpl(
     override suspend fun existsByIban(iban: Iban): Boolean =
         Panache.withSession { count("accountNumber", iban.value) }.awaitSuspending() > 0
 
-    // GDPR Art. 17: nulls legalName AND the goal fields (ADR-0153 — goal_name is
-    // customer-authored free text, PII-adjacent like legalName) for every account owned by
-    // the erased party.
+    // GDPR Art. 17: nulls legalName, the goal fields (ADR-0153 — goal_name is customer-authored
+    // free text, PII-adjacent like legalName) AND nickname (same reasoning: free text the
+    // customer chose, which can carry a name) for every account owned by the erased party.
     override suspend fun anonymizeByPartyId(partyId: UUID): Int = Panache.withTransaction {
         update(
             "legalName = null, goalName = null, goalTargetMinorUnits = null, goalTargetDate = null, " +
-                "updatedAt = ?2 WHERE partyId = ?1",
+                "nickname = null, updatedAt = ?2 WHERE partyId = ?1",
             partyId,
             clock.instant(),
         )
@@ -208,6 +208,9 @@ private fun AccountRepositoryImpl.versionMatchedUpdate(entity: AccountEntity) = 
         existing.goalName = entity.goalName
         existing.goalTargetMinorUnits = entity.goalTargetMinorUnits
         existing.goalTargetDate = entity.goalTargetDate
+        // Same round-trip-through-update() story as the goal fields above: only
+        // renameAccount in AccountService actually changes this.
+        existing.nickname = entity.nickname
         // Audit timestamp comes from the injected Clock, not the entity default (ADR-0100 /
         // #540): the @PreUpdate callback's EPOCH default is never overwritten by the DB
         // DEFAULT since Hibernate writes every insertable/updatable column explicitly.
@@ -236,6 +239,7 @@ private fun AccountEntity.toDomain() = Account(
     goalName = goalName,
     goalTargetMinorUnits = goalTargetMinorUnits,
     goalTargetDate = goalTargetDate,
+    nickname = nickname,
 )
 
 private fun Account.toEntity() = AccountEntity().also {
@@ -256,4 +260,5 @@ private fun Account.toEntity() = AccountEntity().also {
     it.goalName = goalName
     it.goalTargetMinorUnits = goalTargetMinorUnits
     it.goalTargetDate = goalTargetDate
+    it.nickname = nickname
 }

--- a/openbank-account-service/src/main/kotlin/com/openbank/account/infrastructure/rest/AccountResource.kt
+++ b/openbank-account-service/src/main/kotlin/com/openbank/account/infrastructure/rest/AccountResource.kt
@@ -17,6 +17,7 @@ import com.openbank.account.application.port.`in`.ListAccountsQuery
 import com.openbank.account.application.port.`in`.ListActiveAccountsQuery
 import com.openbank.account.application.port.`in`.ListPocketsQuery
 import com.openbank.account.application.port.`in`.OpenAccountCommand
+import com.openbank.account.application.port.`in`.RenameAccountCommand
 import com.openbank.account.application.port.`in`.ResolvePocketQuery
 import com.openbank.account.application.port.`in`.SearchAccountsQuery
 import com.openbank.account.application.port.`in`.UnfreezeAccountCommand
@@ -29,6 +30,7 @@ import com.openbank.account.infrastructure.rest.dto.FreezeAccountRequest
 import com.openbank.account.infrastructure.rest.dto.OpenAccountRequest
 import com.openbank.account.infrastructure.rest.dto.PocketResolutionResponse
 import com.openbank.account.infrastructure.rest.dto.PocketResponse
+import com.openbank.account.infrastructure.rest.dto.RenameAccountRequest
 import com.openbank.account.infrastructure.rest.dto.SavingsGoalRequest
 import com.openbank.libs.api.pagination.CursorPage
 import com.openbank.libs.authz.Authorize
@@ -44,6 +46,7 @@ import jakarta.ws.rs.DELETE
 import jakarta.ws.rs.DefaultValue
 import jakarta.ws.rs.GET
 import jakarta.ws.rs.HeaderParam
+import jakarta.ws.rs.PATCH
 import jakarta.ws.rs.POST
 import jakarta.ws.rs.PUT
 import jakarta.ws.rs.Path
@@ -372,6 +375,30 @@ class AccountResource(
         return Response.ok(account.toResponse()).build()
     }
 
+    @PATCH
+    @Path("/{accountId}/nickname")
+    @RolesAllowed(Roles.OPERATOR, Roles.ADMIN)
+    @Authorize(action = "account.update", resource = "#accountId")
+    @Operation(summary = "Set or clear the account's customer-chosen display label")
+    suspend fun renameAccount(
+        @PathParam("accountId") accountId: UUID,
+        request: RenameAccountRequest,
+        @HeaderParam(CUSTOMER_PARTY_HEADER) customerPartyId: UUID?,
+    ): Response {
+        customerPartyId?.let {
+            val account = accountUseCase.getAccount(GetAccountQuery(accountId))
+            denyIfNotOwner(account.partyId, it)?.let { deny -> return deny }
+        }
+        val account = accountUseCase.renameAccount(
+            RenameAccountCommand(
+                accountId = accountId,
+                nickname = request.nickname,
+                requestedBy = customerPartyId ?: operatorId(),
+            ),
+        )
+        return Response.ok(account.toResponse()).build()
+    }
+
     @GET
     @Path("/{accountId}/pockets/resolve")
     @RolesAllowed(Roles.API, Roles.VIEWER, Roles.OPERATOR, Roles.ADMIN)
@@ -485,6 +512,7 @@ private fun com.openbank.account.domain.model.Account.toResponse() = AccountResp
     goalName = goalName,
     goalTargetMinorUnits = goalTargetMinorUnits,
     goalTargetDate = goalTargetDate,
+    nickname = nickname,
 )
 
 private fun CursorPage<com.openbank.account.domain.model.Account>.toResponse() =

--- a/openbank-account-service/src/main/kotlin/com/openbank/account/infrastructure/rest/dto/AccountDtos.kt
+++ b/openbank-account-service/src/main/kotlin/com/openbank/account/infrastructure/rest/dto/AccountDtos.kt
@@ -41,12 +41,17 @@ data class AccountResponse(
     val goalName: String? = null,
     val goalTargetMinorUnits: Long? = null,
     val goalTargetDate: LocalDate? = null,
+    /** Customer-chosen display label. Null means "use the account-type default name". */
+    val nickname: String? = null,
 )
 
 data class AddPocketRequest(val currencyCode: String)
 
 /** PUT /{accountId}/goal body (ADR-0153). */
 data class SavingsGoalRequest(val name: String, val targetMinorUnits: Long, val targetDate: LocalDate? = null)
+
+/** PATCH /{accountId}/nickname body. Null/blank clears it. */
+data class RenameAccountRequest(val nickname: String?)
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 data class PocketResponse(

--- a/openbank-account-service/src/main/resources/db/migration/V20__account_nickname.sql
+++ b/openbank-account-service/src/main/resources/db/migration/V20__account_nickname.sql
@@ -1,0 +1,5 @@
+-- Customer-chosen display label for an account (rename feature).
+-- Rollback:
+--   ALTER TABLE accounts DROP COLUMN nickname;
+
+ALTER TABLE accounts ADD COLUMN nickname VARCHAR(60);

--- a/openbank-account-service/src/main/resources/openapi.yaml
+++ b/openbank-account-service/src/main/resources/openapi.yaml
@@ -5,7 +5,7 @@ info:
   title: Account Service API
   # API-contract axis (ADR-0048) — bumps are classified from the OpenAPI diff,
   # independently of the release version in version.txt.
-  version: 1.9.0
+  version: 1.10.0
   description: BIAN-aligned account lifecycle management — open, query, freeze, close accounts.
   contact:
     name: OpenBank Platform
@@ -591,6 +591,31 @@ paths:
         '403':
           $ref: '#/components/responses/Forbidden'
 
+  /api/v1/accounts/{accountId}/nickname:
+    patch:
+      tags: [Accounts]
+      summary: Set or clear the account's customer-chosen display label
+      operationId: renameAccount
+      security:
+        - bearerAuth: [ROLE_OPERATOR, ROLE_ADMIN]
+      parameters:
+        - $ref: '#/components/parameters/accountId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RenameAccountRequest'
+      responses:
+        '200':
+          description: Nickname set or cleared
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccountResponse'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
   /api/v1/accounts/approvals/{id}:
     patch:
       tags: [Accounts]
@@ -753,6 +778,17 @@ components:
           type: string
           format: date
           nullable: true
+        nickname:
+          type: string
+          nullable: true
+
+    RenameAccountRequest:
+      type: object
+      properties:
+        nickname:
+          type: string
+          nullable: true
+          maxLength: 60
 
     ProposeWithdrawalRequest:
       type: object

--- a/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
+++ b/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
@@ -946,6 +946,34 @@ class CustomerEdgeResource(
         )
     }
 
+    // --- Account rename ---
+    // Same class as the savings goal above: cosmetic customer preference, not a money
+    // movement — no SCA (ADR-0021 only scopes payments).
+
+    @PATCH
+    @Path("/accounts/{accountId}/nickname")
+    @Authorize(action = "customer.accounts.nickname.write", resource = "#accountId")
+    @Blocking
+    fun renameAccount(@PathParam("accountId") accountId: UUID, body: String): Response {
+        val customer = customer()
+        if (!ownsAccount(accountId, customer.partyId)) {
+            return forbidden("Account does not belong to caller")
+        }
+        // Re-serialize through Jackson (not raw string interpolation) — the nickname is
+        // customer-authored free text and must be JSON-escaped, not spliced into a template.
+        val node = runCatching { objectMapper.readTree(body) }.getOrNull() as? ObjectNode
+            ?: return badRequest("Malformed rename request body")
+        val nickname = node.get("nickname")?.takeIf { it.isTextual }?.asText()
+        val forwarded = objectMapper.createObjectNode().apply {
+            if (nickname != null) put("nickname", nickname) else putNull("nickname")
+        }
+        return upstream.patch(
+            "$accountServiceUrl/api/v1/accounts/$accountId/nickname",
+            customer.partyId.toString(),
+            objectMapper.writeValueAsString(forwarded),
+        )
+    }
+
     @GET
     @Path("/accounts/{accountId}/pockets/resolve")
     @Authorize(action = "customer.pockets.read", resource = "#accountId")

--- a/openbank-customer-edge/src/main/resources/openapi.yaml
+++ b/openbank-customer-edge/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: Customer Edge API
-  version: 1.36.0
+  version: 1.37.0
   description: >-
     Customer-facing edge proxy (ADR-0065). Single internet-facing entry point for the
     retail customer app. Validates JWTs from the openbank-customers Keycloak realm,
@@ -321,6 +321,31 @@ paths:
       responses:
         '200':
           description: Account with goal metadata cleared
+        '403':
+          description: Not the owner
+
+  /accounts/{accountId}/nickname:
+    patch:
+      tags: [Accounts]
+      summary: Set or clear the account's customer-chosen display label
+      operationId: renameAccount
+      security:
+        - customerOidc: [accounts:write]
+      parameters:
+        - {name: accountId, in: path, required: true, schema: {type: string, format: uuid}}
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                nickname: {type: string, nullable: true}
+      responses:
+        '200':
+          description: Account with updated nickname
+        '400':
+          description: Malformed request body
         '403':
           description: Not the owner
 
@@ -1984,6 +2009,9 @@ components:
         goalTargetDate:
           type: string
           format: date
+          nullable: true
+        nickname:
+          type: string
           nullable: true
 
     # Mirrors openbank-account-service AccountPage (GET /api/v1/accounts is cursor-paginated,


### PR DESCRIPTION
## Summary
- Adds `nickname` as cosmetic customer-authored metadata on `Account`, following the exact same shape as the existing savings-goal fields (ADR-0153): plain field update on the existing aggregate, no new event/topic.
- `PATCH /api/v1/accounts/{id}/nickname` on account-service (`@RolesAllowed(OPERATOR, ADMIN)`, `@Authorize(action="account.update")`, `denyIfNotOwner` via `X-Customer-Party-Id`) — mirrors `updateSavingsGoal`/`clearSavingsGoal` exactly.
- `PATCH /customer/v1/accounts/{id}/nickname` on customer-edge (`ownsAccount` check, forwards via existing `UpstreamClient.patch`, `action=customer.accounts.nickname.write` — covered by the existing `customer-self-action` rego rule for any `customer.*` action, **no new policy needed**).
- GDPR Art. 17 erasure now also nulls `nickname` alongside `legalName`/goal fields (same PII-adjacent reasoning as `goalName`).
- Migration `V20__account_nickname.sql`, both services' OpenAPI specs bumped with the new path + schema field (account-service 1.9.0→1.10.0, customer-edge 1.36.0→1.37.0).
- Threat-model updated (`docs/threat-models/openbank-account-service.md`) — STRIDE entry mirroring the savings-goal one, risk class low.

Closes #5007 (rename slice — set-primary and close remain open on that issue)

## Scope
Rename only, per this session's TOP-10 backlog scoping. `set-primary` and `close-account` are separate follow-ups — `close` already has a domain method (`Account.close()`) and an internal operator endpoint, but no customer-facing path; deliberately left out here.

## Test plan
- [x] `:openbank-account-service:compileKotlin/ktlintCheck/detekt/test` green
- [x] `:openbank-customer-edge:compileKotlin/ktlintCheck/detekt/test` green
- [x] `check-openapi-route-conformance.py --enforce` — 0 NEW findings against baseline