### PR TITLE
feat(admin-ui): preview market-matched offers

### DIFF
--- a/openbank-admin-ui/src/app/product-studio/page.module.css
+++ b/openbank-admin-ui/src/app/product-studio/page.module.css
@@ -116,10 +116,24 @@
 .diffList { max-height: 178px; overflow: auto; margin: 10px 0 0; padding-left: 18px; color: var(--text-secondary); }
 .diffList li { margin: 4px 0; font-size: 11px; }
 .preview { display: flex; flex-direction: column; min-height: 100%; padding: 20px; border-radius: 15px; background: linear-gradient(145deg, #f8fafc, #eef2ff); }
+.previewContext { margin-bottom: 12px; padding: 11px; border: 1px solid #d9d8ee; border-radius: 11px; background: linear-gradient(135deg, #fbfbff, #f4f8ff); }
+.previewContextTitle { display: flex; align-items: center; gap: 6px; color: #3730a3; font-size: 11px; font-weight: 800; }
+.previewContext p { margin: 5px 0 9px; color: #5b5b86; font-size: 10px; line-height: 1.45; }
+.previewContextGrid { display: grid; grid-template-columns: 1fr 1fr; gap: 7px; }
+.previewContextGrid label { display: grid; gap: 3px; color: var(--text-tertiary); font-size: 9px; font-weight: 800; letter-spacing: .04em; text-transform: uppercase; }
+.previewContextGrid input { min-width: 0; font-size: 11px; }
+.selectionList { display: grid; gap: 5px; margin-bottom: 12px; }
+.selection { display: grid; grid-template-columns: 28px 1fr auto; align-items: center; gap: 8px; width: 100%; padding: 9px; border: 1px solid #d6dfef; border-radius: 10px; background: white; color: var(--text-primary); cursor: pointer; text-align: left; }
+.selection:hover, .selectionActive { border-color: var(--ob-accent-border); background: var(--ob-accent-light); }
+.selectionRank { display: grid; width: 23px; height: 23px; place-items: center; border-radius: 50%; background: var(--surface-2); color: var(--text-secondary); font-size: 10px; font-weight: 800; }
+.selectionCopy { min-width: 0; }
+.selectionCopy strong, .selectionCopy small { display: block; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.selectionCopy strong { font-size: 11px; }
+.selectionCopy small { margin-top: 2px; color: var(--text-tertiary); font-family: var(--font-mono); font-size: 9px; }
 .previewEyebrow { color: var(--ob-accent-text); font-size: 10px; font-weight: 800; letter-spacing: .09em; text-transform: uppercase; }
 .previewName { margin-top: 8px; font-size: 22px; letter-spacing: -.035em; }
 .previewCopy { margin-top: 6px; color: var(--text-secondary); font-size: 12px; line-height: 1.6; }
 .previewFoot { margin-top: auto; padding-top: 18px; color: var(--text-tertiary); font-size: 11px; }
 .message { margin: 14px 0; padding: 11px 13px; border-radius: 10px; border: 1px solid var(--border); background: var(--surface); color: var(--text-secondary); white-space: pre-wrap; font-family: var(--font-sans); font-size: 12px; }
 @media (max-width: 1120px) { .workspace { grid-template-columns: 1fr 1fr; } .workspace > :last-child { grid-column: span 2; } .metrics { grid-template-columns: repeat(2, 1fr); } }
-@media (max-width: 760px) { .hero { padding: 20px; } .heroTop, .lowerGrid { display: block; } .refresh { margin-top: 16px; } .journey { grid-template-columns: 1fr 1fr; } .journeyStep:nth-child(2) { border-right: 0; } .journeyStep:nth-child(-n+2) { border-bottom: 1px solid var(--border); } .workspace, .fieldGrid, .marketGrid, .compositionControls { grid-template-columns: 1fr; } .workspace > :last-child { grid-column: auto; } .lowerGrid > * { margin-bottom: 14px; } }
+@media (max-width: 760px) { .hero { padding: 20px; } .heroTop, .lowerGrid { display: block; } .refresh { margin-top: 16px; } .journey { grid-template-columns: 1fr 1fr; } .journeyStep:nth-child(2) { border-right: 0; } .journeyStep:nth-child(-n+2) { border-bottom: 1px solid var(--border); } .workspace, .fieldGrid, .marketGrid, .compositionControls, .previewContextGrid { grid-template-columns: 1fr; } .workspace > :last-child { grid-column: auto; } .lowerGrid > * { margin-bottom: 14px; } }

--- a/openbank-admin-ui/src/app/product-studio/page.tsx
+++ b/openbank-admin-ui/src/app/product-studio/page.tsx
@@ -17,6 +17,7 @@ import {
   removeOfferingRelationship,
   type MarketContextInput,
 } from '@/lib/catalog-offer-composition'
+import { selectOffersForMarket } from '@/lib/catalog-offer-selection'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import {
   catalogV2Operation, type CatalogSchema, type Offering, type OfferingRequest, type ProductRevision,
@@ -101,6 +102,7 @@ export default function ProductStudioPage() {
   const [newSpecCode, setNewSpecCode] = useState('')
   const [newOfferingCode, setNewOfferingCode] = useState('')
   const [marketContextInput, setMarketContextInput] = useState<MarketContextInput>(defaultMarketContextInput)
+  const [previewContextInput, setPreviewContextInput] = useState<MarketContextInput>(defaultMarketContextInput)
   const [relationshipTargetId, setRelationshipTargetId] = useState('')
   const [relationshipKind, setRelationshipKind] = useState<RelationshipKind>('BUNDLE')
   const [publishReason, setPublishReason] = useState('')
@@ -138,6 +140,13 @@ export default function ProductStudioPage() {
   )
   const liveDocument = publishedRevision ? catalogRevisionEditorDocument(publishedRevision) : null
   const structuralDiff = diffCatalogDocuments(liveDocument, parsedDraft)
+  const offerSelections = useMemo(
+    () => selectOffersForMarket(
+      offerings.filter(item => !specificationId || item.specificationId === specificationId),
+      marketContextFromInput(previewContextInput),
+    ),
+    [offerings, specificationId, previewContextInput],
+  )
   const draftCount = revisions.filter(item => item.state === 'DRAFT').length
   const publishedCount = revisions.filter(item => item.state === 'PUBLISHED').length
   const readiness = [
@@ -235,6 +244,10 @@ export default function ProductStudioPage() {
 
   const updateMarketContext = (field: keyof MarketContextInput, value: string) => {
     setMarketContextInput(current => ({ ...current, [field]: value }))
+  }
+
+  const updatePreviewContext = (field: keyof MarketContextInput, value: string) => {
+    setPreviewContextInput(current => ({ ...current, [field]: value }))
   }
 
   const addRelationship = () => {
@@ -464,8 +477,27 @@ export default function ProductStudioPage() {
       </section>
 
       <section className={`card ${styles.panel}`}>
-        <div className={styles.panelHead}><div><div className={styles.panelKicker}>{t('Pohled zákazníka', 'Customer view')}</div><h2 className={styles.panelTitle}><Boxes size={15} />{t('Kontextový náhled', 'Contextual preview')}</h2></div><span className="badge badge-neutral">{selectedOffering?.market.countries?.join(', ') || t('globální', 'global')}</span></div>
-        <div className={styles.panelBody}><div className={styles.preview}><div className={styles.previewEyebrow}>{selectedOffering?.market.channels?.join(' · ') || t('Všechny kanály', 'All channels')}</div><h3 className={styles.previewName}>{String((parsedDraft?.name as Record<string, string> | undefined)?.[language] ?? (parsedDraft?.name as Record<string, string> | undefined)?.en ?? selectedOffering?.code ?? '—')}</h3><p className={styles.previewCopy}>{String((parsedDraft?.description as Record<string, string> | undefined)?.[language] ?? (parsedDraft?.description as Record<string, string> | undefined)?.en ?? t('Doplňte popis, aby byl dopad nabídky srozumitelný pro zákazníka i kontrolora.', 'Add a description so the offer is understandable to both customer and reviewer.'))}</p><div className={styles.previewFoot}>{t('Trh:', 'Market:')} {selectedOffering?.market.countries?.join(', ') || t('všechny země', 'all countries')} · {t('Ceny:', 'Prices:')} {Array.isArray(parsedDraft?.prices) ? parsedDraft.prices.length : 0}</div></div></div>
+        <div className={styles.panelHead}><div><div className={styles.panelKicker}>{t('Pohled zákazníka', 'Customer view')}</div><h2 className={styles.panelTitle}><Boxes size={15} />{t('Kontextový náhled', 'Contextual preview')}</h2></div><span className="badge badge-neutral">{offerSelections.length} {t('shod', 'matches')}</span></div>
+        <div className={styles.panelBody}>
+          <div className={styles.previewContext}>
+            <div className={styles.previewContextTitle}><LockKeyhole size={13} />{t('Simulovaný tržní kontext', 'Simulated market context')}</div>
+            <p>{t('Pouze obchodní kritéria; žádné ID zákazníka, profil ani rozhodnutí o způsobilosti.', 'Business criteria only; no customer ID, profile or eligibility decision.')}</p>
+            <div className={styles.previewContextGrid}>
+              <label><span>{t('Značka', 'Brand')}</span><input className="input" value={previewContextInput.brands} onChange={event => updatePreviewContext('brands', event.target.value)} placeholder="retail" /></label>
+              <label><span>{t('Země', 'Country')}</span><input className="input" value={previewContextInput.countries} onChange={event => updatePreviewContext('countries', event.target.value)} placeholder="CZ" /></label>
+              <label><span>{t('Kanál', 'Channel')}</span><input className="input" value={previewContextInput.channels} onChange={event => updatePreviewContext('channels', event.target.value)} placeholder="WEB" /></label>
+              <label><span>{t('Segment', 'Segment')}</span><input className="input" value={previewContextInput.segments} onChange={event => updatePreviewContext('segments', event.target.value)} placeholder="employee" /></label>
+              <label><span>{t('Jazyk', 'Locale')}</span><input className="input" value={previewContextInput.locales} onChange={event => updatePreviewContext('locales', event.target.value)} placeholder="cs-CZ" /></label>
+            </div>
+          </div>
+          <div className={styles.selectionList} aria-live="polite">
+            {offerSelections.length === 0 && <div className={styles.schemaHint}>{t('Žádná nabídka přesně neodpovídá. Rozšiřte pouze vědomě tržní kontext — neveřejné nabídky se bez shody nezobrazují.', 'No offer matches exactly. Broaden market context only deliberately — private offers never appear without a match.')}</div>}
+            {offerSelections.slice(0, 5).map((selection, index) => <button key={selection.offering.id} className={`${styles.selection} ${selection.offering.id === offeringId ? styles.selectionActive : ''}`} onClick={() => setOfferingId(selection.offering.id)}>
+              <span className={styles.selectionRank}>#{index + 1}</span><span className={styles.selectionCopy}><strong>{selection.offering.code}</strong><small>{selection.reasons.join(' · ')}</small></span><span className="badge badge-info">{selection.specificity === 0 ? t('globální', 'global') : t('shoda', 'match')}</span>
+            </button>)}
+          </div>
+          <div className={styles.preview}><div className={styles.previewEyebrow}>{selectedOffering?.market.channels?.join(' · ') || t('Všechny kanály', 'All channels')}</div><h3 className={styles.previewName}>{String((parsedDraft?.name as Record<string, string> | undefined)?.[language] ?? (parsedDraft?.name as Record<string, string> | undefined)?.en ?? selectedOffering?.code ?? '—')}</h3><p className={styles.previewCopy}>{String((parsedDraft?.description as Record<string, string> | undefined)?.[language] ?? (parsedDraft?.description as Record<string, string> | undefined)?.en ?? t('Doplňte popis, aby byl dopad nabídky srozumitelný pro zákazníka i kontrolora.', 'Add a description so the offer is understandable to both customer and reviewer.'))}</p><div className={styles.previewFoot}>{t('Trh:', 'Market:')} {selectedOffering?.market.countries?.join(', ') || t('všechny země', 'all countries')} · {t('Ceny:', 'Prices:')} {Array.isArray(parsedDraft?.prices) ? parsedDraft.prices.length : 0}</div></div>
+        </div>
       </section>
     </div>
   </AuthGuard>

--- a/openbank-admin-ui/src/lib/catalog-offer-selection.ts
+++ b/openbank-admin-ui/src/lib/catalog-offer-selection.ts
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+import type { MarketContext, Offering } from '@/lib/product-catalog-v2'
+
+const dimensions = ['brands', 'countries', 'channels', 'segments', 'locales'] as const
+
+type MarketDimension = typeof dimensions[number]
+
+export interface OfferSelection {
+  offering: Offering
+  /** More constrained matching offers rank before broad offers; ties are stable by code. */
+  specificity: number
+  reasons: string[]
+}
+
+/**
+ * Deterministic availability preview for Product Studio.
+ *
+ * It deliberately receives no customer identifier or behavioural data. A restricted offer is
+ * included only when every restriction has an explicit matching market value, avoiding both
+ * private-offer leakage and an implicit "all customers" fallback.
+ */
+export function selectOffersForMarket(
+  offerings: Offering[],
+  context: MarketContext,
+): OfferSelection[] {
+  return offerings.flatMap(offering => {
+    const reasons: string[] = []
+    let specificity = 0
+
+    for (const dimension of dimensions) {
+      const restrictions = offering.market[dimension] ?? []
+      if (!restrictions.length) continue
+
+      const supplied = context[dimension] ?? []
+      const matched = supplied.filter(value => restrictions.includes(value))
+      if (!matched.length) return []
+
+      specificity += 1
+      reasons.push(`${dimension}:${matched.join(', ')}`)
+    }
+
+    if (!reasons.length) reasons.push('global')
+    return [{ offering, specificity, reasons }]
+  }).sort((left, right) =>
+    right.specificity - left.specificity ||
+    left.offering.code.localeCompare(right.offering.code) ||
+    left.offering.id.localeCompare(right.offering.id),
+  )
+}

--- a/openbank-admin-ui/src/test/catalog-offer-selection.test.ts
+++ b/openbank-admin-ui/src/test/catalog-offer-selection.test.ts
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+import { describe, expect, it } from 'vitest'
+import { selectOffersForMarket } from '@/lib/catalog-offer-selection'
+import type { Offering } from '@/lib/product-catalog-v2'
+
+const offering = (code: string, market: Offering['market']): Offering => ({
+  id: `${code}-id`, specificationId: 'specification-id', code, market, revision: 0,
+})
+
+describe('catalog offer selection', () => {
+  it('selects only explicit market matches and ranks the most specific offer first', () => {
+    const result = selectOffersForMarket([
+      offering('GLOBAL', { brands: [], countries: [], channels: [], segments: [], locales: [] }),
+      offering('CZ_WEB', { brands: [], countries: ['CZ'], channels: ['WEB'], segments: [], locales: [] }),
+      offering('CZ_WEB_EMPLOYEE', { brands: [], countries: ['CZ'], channels: ['WEB'], segments: ['employee'], locales: [] }),
+      offering('DE_ONLY', { brands: [], countries: ['DE'], channels: [], segments: [], locales: [] }),
+    ], {
+      brands: [], countries: ['CZ'], channels: ['WEB'], segments: ['employee'], locales: ['en'],
+    })
+
+    expect(result.map(item => item.offering.code)).toEqual(['CZ_WEB_EMPLOYEE', 'CZ_WEB', 'GLOBAL'])
+    expect(result[0]).toMatchObject({ specificity: 3, reasons: ['countries:CZ', 'channels:WEB', 'segments:employee'] })
+  })
+
+  it('does not widen a private offer when the required context is absent', () => {
+    const result = selectOffersForMarket([
+      offering('EMPLOYEE', { brands: [], countries: ['CZ'], channels: [], segments: ['employee'], locales: [] }),
+    ], { brands: [], countries: ['CZ'], channels: [], segments: [], locales: ['en'] })
+
+    expect(result).toEqual([])
+  })
+})


### PR DESCRIPTION
Refs #4505

Adds a deterministic Product Studio market-context preview for offers. It accepts only explicit commercial dimensions, ranks exact matches with human-readable reasons, and keeps private offers hidden unless every restriction matches. No customer identifiers, behavioural data, or hosted model calls are involved.

Proof: targeted Vitest selector scenarios and `npm run type-check`.