### PR TITLE
docs(infra): script the Keycloak realm-import render-and-verify step (#3246)

### DIFF
--- a/docs/runbooks/0009-keycloak-realm-import-reconcile.md
+++ b/docs/runbooks/0009-keycloak-realm-import-reconcile.md
@@ -77,8 +77,9 @@ survives in it.
 2. **Read the committed templates, and know they carry placeholders.** Every client
    secret and user password in `realm-template.json` is a `__PLACEHOLDER__` token
    (this is asserted by `check_realm_import_parity_test.py` and must stay true — the
-   repo is public). The write below substitutes real values in a local shell; the
-   substituted file must never be committed, echoed, or left on disk.
+   repo is public). The substitution below must never be committed, echoed, or left
+   on disk — see the script in step 4, which enforces this rather than relying on
+   the operator remembering it.
 
 3. **Collect the real values from the live realm, not from memory.** For each client
    the template declares, the live secret is the authority:
@@ -103,43 +104,69 @@ survives in it.
    name only. This is a template defect the reconcile surfaces; it is not caused by
    it.
 
-4. **Verify the substituted file against a LOCAL Keycloak before writing it to
-   Vault.** Import runs on cold start only, so a malformed template ships silently
-   and is discovered by the rebuild it was meant to survive. The realm-JSON shapes
-   are version-specific traps (authorization policies want `config` maps; a scope
-   permission is `type: "scope"`; the `token-exchange` scope must be declared before
-   a permission references it; a client description over 255 chars fails the whole
-   import):
+4. **Render and verify against a LOCAL Keycloak before writing anything to
+   Vault — use `openbank-infra/scripts/render-verify-keycloak-realm-import.sh`,
+   not a hand-run `docker` command.** Import runs on cold start only, so a
+   malformed template ships silently and is discovered by the rebuild it was meant
+   to survive; the realm-JSON shapes are version-specific traps (authorization
+   policies want `config` maps; a scope permission is `type: "scope"`; the
+   `token-exchange` scope must be declared before a permission references it; a
+   client description over 255 chars fails the whole import). The script exists
+   because those traps, and "don't leave the substituted file on disk," are easy to
+   get right once and easy to skip under time pressure the next time:
 
    ```sh
-   docker run --rm -v /tmp/ob-realm-substituted.json:/opt/keycloak/data/import/realm.json \
-     quay.io/keycloak/keycloak:<the version keycloak.yaml runs> start-dev --import-realm
+   ADMINUI_CLIENT_SECRET=... ARGOCD_CLIENT_SECRET=... EDGE_CLIENT_SECRET=... \
+   GLITCHTIP_CLIENT_SECRET=... GOALERT_CLIENT_SECRET=... MCP_OBO_CLIENT_SECRET=... \
+   OPENBAO_CLIENT_SECRET=... SERVICES_CLIENT_SECRET=... ADMIN_USER_PASSWORD=... \
+   DEMO_USER_PASSWORD=... COMPLIANCE_USER_PASSWORD=... COMPLIANCE2_USER_PASSWORD=... \
+   ADMIN_HOST=admin.openbank.local \
+     ./openbank-infra/scripts/render-verify-keycloak-realm-import.sh openbank
+
+   CUSTOMER_EDGE_ADMIN_CLIENT_SECRET=... EDGE_WEBAUTHN_CLIENT_SECRET=... \
+     ./openbank-infra/scripts/render-verify-keycloak-realm-import.sh openbank-customers
    ```
 
-   Watch for `Realm 'openbank' imported` and no `ERROR`. Then mint a token for one
-   client and inspect the JWT's roles — an import that "succeeds" with a dropped
-   role block prints nothing useful.
+   It fails closed: any placeholder without an env var stops the run before
+   anything is written to disk, and the rendered file is a mode-600 temp file
+   removed by a trap that fires on every exit path (success, failure, or Ctrl-C) —
+   never a file you have to remember to delete. It resolves the Keycloak version to
+   test against from `keycloak.yaml` itself, boots that version against the
+   rendered file, and reports PASS only on `KC-SERVICES0032: Import finished
+   successfully` with zero `ERROR` lines. What it does **not** replace: minting a
+   token and inspecting the JWT's roles by hand for at least one client per realm —
+   an import that "succeeds" with a dropped role block prints nothing useful, and
+   only a real token proves the role block survived. (Verified this way for both
+   realms while preparing this runbook update — see the PR that landed the script.)
 
 ## Procedure (owner-gated — a Vault write, not a PR)
 
-Run from a trusted shell. Do not echo the values; do not leave the substituted file
-behind.
+Run from a trusted shell. Use the step-4 script with `--out` to produce a verified
+(boot-tested) render and keep it only as long as the write needs it — that is the
+one deliberate exception to "never leave the substituted file on disk," and the
+script still refuses to hand you a file that skipped the boot test (see
+`OutFlagRefusedWithoutBootVerification` in
+`render_verify_keycloak_realm_import_test.py`).
 
 ```sh
-# 1. openbank realm
+# 1. openbank realm — render, boot-verify, and keep the render just long enough
+#    to write it (re-supply the same env vars as the pre-flight step above)
+./openbank-infra/scripts/render-verify-keycloak-realm-import.sh \
+  --out /tmp/ob-realm-verified.json openbank
 vault kv put openbank/keycloak-realm-import \
-  openbank-realm.json=@/tmp/ob-realm-substituted.json
+  openbank-realm.json=@/tmp/ob-realm-verified.json
+shred -u /tmp/ob-realm-verified.json 2>/dev/null; rm -f /tmp/ob-realm-verified.json
 
 # 2. openbank-customers realm. The KV key and property are declared in
 #    es-keycloak-customers-realm.yaml (`keycloak-customers-realm-import` /
 #    `openbank-customers-realm.json`); re-read them before writing, and note the
 #    ClusterSecretStore's mount path prefixes the key. The property name IS the
 #    mounted filename and Keycloak scans the directory for *.json.
+./openbank-infra/scripts/render-verify-keycloak-realm-import.sh \
+  --out /tmp/ob-customers-verified.json openbank-customers
 vault kv put openbank/keycloak-customers-realm-import \
-  openbank-customers-realm.json=@/tmp/ob-customers-substituted.json
-
-# 3. clean up
-shred -u /tmp/ob-realm-substituted.json /tmp/ob-customers-substituted.json
+  openbank-customers-realm.json=@/tmp/ob-customers-verified.json
+shred -u /tmp/ob-customers-verified.json 2>/dev/null; rm -f /tmp/ob-customers-verified.json
 ```
 
 > The `vault kv put` recipe in

--- a/openbank-infra/scripts/render-verify-keycloak-realm-import.sh
+++ b/openbank-infra/scripts/render-verify-keycloak-realm-import.sh
@@ -1,0 +1,289 @@
+#!/usr/bin/env bash
+# Render a committed Keycloak realm template with its real secret/password
+# values and verify the result actually imports — before anyone writes it to
+# Vault. Issue #3246, runbook docs/runbooks/0009-keycloak-realm-import-reconcile.md.
+#
+# WHY THIS SCRIPT EXISTS
+#   #3246 found the deployed `keycloak-realm-import` / `keycloak-customers-realm-import`
+#   Secrets are a stale ANCESTOR of the committed templates (4 roles / 2 clients vs
+#   14 / 10 for `openbank`), because `--import-realm` runs on Keycloak's cold start
+#   only and skips a realm that already exists — so the templates have never once
+#   been what a rebuild actually imports. Runbook 0009's fix is a Vault write, and
+#   it is owner-gated: only the owner holds the credentials the templates
+#   placeholder-out (`__ADMINUI_CLIENT_SECRET__` and friends). But the runbook's
+#   pre-write verification step — substitute, boot a throwaway Keycloak, confirm no
+#   ERROR, never leave the substituted file on disk — was a multi-step manual
+#   recipe with real ways to get it wrong (skip the boot test, forget to shred the
+#   temp file, use a Keycloak version the cluster doesn't actually run). This script
+#   is that recipe, made repeatable and safe by construction:
+#     - every placeholder must be supplied via env var or the script refuses to run
+#       (no accidental empty-string substitution);
+#     - the substituted file lives ONLY in a mode-600 temp file, deleted (best-effort
+#       shred, then rm) by a trap that fires on ANY exit path, including a failed
+#       import or an interrupted run;
+#     - the file is never echoed, logged, or written under the repo;
+#     - it does not, and cannot, write to Vault — with or without `--out` (below),
+#       the `vault kv put` itself is always a separate, manual, owner-run command.
+#       That is deliberate, not an oversight: bundling the write into this script
+#       would turn "this script has a bug" into "this script silently wrote wrong
+#       secret data to Vault," and the whole reason a boot-only PASS is not enough
+#       (see USAGE note on token minting below) is that a script cannot fully judge
+#       its own output — a human reading a decoded JWT still has to.
+#
+# USAGE
+#   # openbank realm — every __PLACEHOLDER__ in realm-template.json needs its env var
+#   ADMINUI_CLIENT_SECRET=... ARGOCD_CLIENT_SECRET=... EDGE_CLIENT_SECRET=... \
+#   GLITCHTIP_CLIENT_SECRET=... GOALERT_CLIENT_SECRET=... MCP_OBO_CLIENT_SECRET=... \
+#   OPENBAO_CLIENT_SECRET=... SERVICES_CLIENT_SECRET=... ADMIN_USER_PASSWORD=... \
+#   DEMO_USER_PASSWORD=... COMPLIANCE_USER_PASSWORD=... COMPLIANCE2_USER_PASSWORD=... \
+#   ADMIN_HOST=admin.openbank.local \
+#     ./openbank-infra/scripts/render-verify-keycloak-realm-import.sh openbank
+#
+#   # openbank-customers realm
+#   CUSTOMER_EDGE_ADMIN_CLIENT_SECRET=... EDGE_WEBAUTHN_CLIENT_SECRET=... \
+#     ./openbank-infra/scripts/render-verify-keycloak-realm-import.sh openbank-customers
+#
+#   # Keep the verified render just long enough to run `vault kv put` yourself —
+#   # otherwise a PASS shreds it and there is nothing left to point the write at:
+#     ./openbank-infra/scripts/render-verify-keycloak-realm-import.sh --out /tmp/ob.json openbank
+#
+# Set SKIP_IMPORT_TEST=1 to render and placeholder-check only (no Docker needed);
+# --out is refused in that mode, since it would hand you a file that never passed
+# the boot verification.
+# Requires: python3, and (unless SKIP_IMPORT_TEST=1) docker.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+KEYCLOAK_DIR="${REPO_ROOT}/openbank-infra/gitops/components/keycloak"
+KEYCLOAK_MANIFEST="${KEYCLOAK_DIR}/keycloak.yaml"
+
+usage() {
+  echo "Usage: $0 [--out <path>] <openbank|openbank-customers>" >&2
+  echo "  --out <path>  after a PASS, copy the verified render there (mode 600) instead of" >&2
+  echo "                shredding it — for feeding straight into 'vault kv put ... @<path>'." >&2
+  echo "                Without it (the default) nothing survives the run; this is the" >&2
+  echo "                pre-flight verification step, not the write itself." >&2
+  exit 2
+}
+
+OUT_PATH=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --out)
+      [[ $# -ge 2 ]] || usage
+      OUT_PATH="$2"
+      shift 2
+      ;;
+    -*)
+      usage
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
+[[ $# -eq 1 ]] || usage
+REALM="$1"
+
+case "$REALM" in
+  openbank)
+    TEMPLATE="${KEYCLOAK_DIR}/realm-template.json"
+    IMPORT_FILENAME="openbank-realm.json"
+    ;;
+  openbank-customers)
+    TEMPLATE="${KEYCLOAK_DIR}/customers-realm-template.json"
+    IMPORT_FILENAME="openbank-customers-realm.json"
+    ;;
+  *)
+    usage
+    ;;
+esac
+
+[[ -f "$TEMPLATE" ]] || { echo "ERROR: template not found: $TEMPLATE" >&2; exit 1; }
+
+# --- collect placeholders, refuse to run with any unset -------------------
+# (portable form, not `mapfile` — this needs to run on bash 3.2 too, macOS's default)
+PLACEHOLDERS=()
+while IFS= read -r line; do
+  [[ -n "$line" ]] && PLACEHOLDERS+=("$line")
+done < <(grep -oE '__[A-Z0-9_]+__' "$TEMPLATE" | sort -u)
+if [[ ${#PLACEHOLDERS[@]} -eq 0 ]]; then
+  echo "ERROR: no __PLACEHOLDER__ tokens found in $TEMPLATE — refusing to run blind" \
+    "(this script's whole point is substituting them, so zero found means the wrong file)." >&2
+  exit 1
+fi
+
+missing=()
+for ph in "${PLACEHOLDERS[@]}"; do
+  envname="${ph#__}"
+  envname="${envname%__}"
+  if [[ -z "${!envname:-}" ]]; then
+    missing+=("$envname")
+  fi
+done
+if [[ ${#missing[@]} -gt 0 ]]; then
+  echo "ERROR: missing env var(s) for these placeholders in $(basename "$TEMPLATE"):" >&2
+  printf '  %s\n' "${missing[@]}" >&2
+  echo "Set every one — the runbook's standing rule is that an empty substitution" \
+    "is worse than a stopped script, not a smaller version of the same problem." >&2
+  exit 1
+fi
+
+# --- render into a private temp file, always cleaned up --------------------
+TMPFILE="$(mktemp "${TMPDIR:-/tmp}/ob-realm-render.XXXXXX.json")"
+chmod 600 "$TMPFILE"
+cleanup() {
+  if [[ -f "$TMPFILE" ]]; then
+    # shred if available (best-effort — tmpfs/APFS may not honor overwrite),
+    # rm -f always, regardless.
+    command -v shred >/dev/null 2>&1 && shred -u "$TMPFILE" 2>/dev/null
+    rm -f "$TMPFILE"
+  fi
+}
+trap cleanup EXIT INT TERM
+
+python3 - "$TEMPLATE" "$TMPFILE" "${PLACEHOLDERS[@]}" <<'PYEOF'
+import sys
+
+template_path, out_path = sys.argv[1], sys.argv[2]
+placeholders = sys.argv[3:]
+
+text = open(template_path, encoding="utf-8").read()
+for ph in placeholders:
+    envname = ph.strip("_")
+    import os
+
+    text = text.replace(ph, os.environ[envname])
+
+with open(out_path, "w", encoding="utf-8") as f:
+    f.write(text)
+PYEOF
+
+echo "Rendered $(basename "$TEMPLATE") -> temp file (not printed, not committed)."
+
+# --- sanity: still valid JSON, and no placeholder token survived ----------
+python3 -c "import json,sys; json.load(open(sys.argv[1]))" "$TMPFILE" \
+  || { echo "ERROR: rendered file is not valid JSON — substitution broke it" >&2; exit 1; }
+
+if grep -qE '__[A-Z0-9_]+__' "$TMPFILE"; then
+  echo "ERROR: a __PLACEHOLDER__ token survived substitution — refusing to treat this" \
+    "as ready for import (would ship a literal placeholder string as a secret)." >&2
+  exit 1
+fi
+echo "OK: rendered file is valid JSON with no surviving placeholder tokens."
+
+if [[ "${SKIP_IMPORT_TEST:-}" == "1" ]]; then
+  if [[ -n "$OUT_PATH" ]]; then
+    echo "ERROR: --out with SKIP_IMPORT_TEST=1 would hand you a file that never passed the" \
+      "Keycloak boot verification — refusing. Drop SKIP_IMPORT_TEST or drop --out." >&2
+    exit 1
+  fi
+  echo "SKIP_IMPORT_TEST=1 set — not running the Keycloak boot verification."
+  echo "Per runbook 0009, do NOT write this to Vault without that step passing first."
+  exit 0
+fi
+
+command -v docker >/dev/null 2>&1 || {
+  echo "ERROR: docker not found and SKIP_IMPORT_TEST is not set." >&2
+  echo "Runbook 0009's standing rule: verify against a local Keycloak before writing" \
+    "to Vault, because --import-realm runs on cold start only and a broken template" \
+    "ships silently. Install docker, or re-run with SKIP_IMPORT_TEST=1 and run the" \
+    "boot test some other way before proceeding." >&2
+  exit 1
+}
+
+# --- resolve the Keycloak version the cluster actually runs ----------------
+CLUSTER_TAG="$(grep -oE 'openbank-keycloak:[0-9][A-Za-z0-9.-]*' "$KEYCLOAK_MANIFEST" \
+  | head -1 | cut -d: -f2 || true)"
+KC_VERSION="$(grep -oE '^[0-9]+\.[0-9]+\.[0-9]+' <<<"$CLUSTER_TAG" || true)"
+if [[ -z "$KC_VERSION" ]]; then
+  echo "ERROR: could not read a Keycloak version out of $KEYCLOAK_MANIFEST" \
+    "(looked for openbank-keycloak:<version>). Refusing to guess a version to test" \
+    "against — an import test against the wrong version is worse than no test." >&2
+  exit 1
+fi
+echo "Cluster runs openbank-keycloak:${CLUSTER_TAG} -> testing against public" \
+  "quay.io/keycloak/keycloak:${KC_VERSION} (the private ECR image cannot be pulled" \
+  "from an arbitrary machine; same upstream version, same import code path)."
+
+IMPORT_LOG="$(mktemp "${TMPDIR:-/tmp}/ob-realm-import-log.XXXXXX")"
+trap 'cleanup; rm -f "$IMPORT_LOG"' EXIT INT TERM
+
+set +e
+docker run --rm \
+  -v "${TMPFILE}:/opt/keycloak/data/import/realm.json:ro" \
+  "quay.io/keycloak/keycloak:${KC_VERSION}" \
+  start-dev --import-realm \
+  >"$IMPORT_LOG" 2>&1 &
+DOCKER_PID=$!
+
+# The container runs a dev server after import; it never exits on its own.
+# Poll the log for the completion marker or an error, then stop it.
+STATUS="timeout"
+for _ in $(seq 1 90); do
+  if grep -q "KC-SERVICES0032: Import finished successfully" "$IMPORT_LOG" 2>/dev/null; then
+    STATUS="imported"
+    break
+  fi
+  if grep -qE '^[0-9-]+.*ERROR' "$IMPORT_LOG" 2>/dev/null; then
+    STATUS="error"
+    break
+  fi
+  if ! kill -0 "$DOCKER_PID" 2>/dev/null; then
+    STATUS="exited"
+    break
+  fi
+  sleep 2
+done
+kill "$DOCKER_PID" >/dev/null 2>&1
+wait "$DOCKER_PID" 2>/dev/null
+set -e
+
+echo "--- import log (realm names/roles only where matched; no secret values are logged" \
+  "by Keycloak's import) ---"
+grep -E "Realm '.*' imported|ERROR|WARN" "$IMPORT_LOG" || true
+echo "--- end import log ---"
+
+case "$STATUS" in
+  imported)
+    echo "PASS: ${REALM} rendered template imported cleanly against" \
+      "quay.io/keycloak/keycloak:${KC_VERSION}, zero ERROR lines."
+    echo
+    if [[ "$REALM" == "openbank" ]]; then
+      VAULT_KEY="openbank/keycloak-realm-import"
+    else
+      VAULT_KEY="openbank/keycloak-customers-realm-import"
+    fi
+    echo "Per runbook 0009, the owner-gated write is now:"
+    if [[ -n "$OUT_PATH" ]]; then
+      cp "$TMPFILE" "$OUT_PATH"
+      chmod 600 "$OUT_PATH"
+      echo "  vault kv put ${VAULT_KEY} \\"
+      echo "    ${IMPORT_FILENAME}=@${OUT_PATH}"
+      echo
+      echo "This script does NOT run that command — it only wrote the verified render to" \
+        "${OUT_PATH} because you passed --out. Run the vault kv put above yourself, then" \
+        "shred ${OUT_PATH} immediately: shred -u ${OUT_PATH} 2>/dev/null; rm -f ${OUT_PATH}"
+    else
+      echo "  vault kv put ${VAULT_KEY} \\"
+      echo "    ${IMPORT_FILENAME}=@<path-to-a-render>"
+      echo
+      echo "This script does not perform that write, and — no --out was given — the" \
+        "verified render is about to be shredded rather than left for you to point" \
+        "vault kv put at. Re-run with --out /some/path to keep it just long enough to" \
+        "run the write, then delete it yourself (or let this script's own next" \
+        "invocation shred it for you)."
+    fi
+    ;;
+  error)
+    echo "FAIL: ERROR lines seen during import — do NOT write this to Vault." >&2
+    exit 1
+    ;;
+  *)
+    echo "FAIL: import did not report success within the wait budget (status=${STATUS})." \
+      "Re-run with a longer wait or inspect docker logs manually — do NOT write this" \
+      "to Vault." >&2
+    exit 1
+    ;;
+esac

--- a/openbank-infra/scripts/render_verify_keycloak_realm_import_test.py
+++ b/openbank-infra/scripts/render_verify_keycloak_realm_import_test.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+"""Tests for render-verify-keycloak-realm-import.sh (issue #3246).
+
+CI has no Vault credentials and no reason to boot a Keycloak container on every PR, so this
+runs the script with SKIP_IMPORT_TEST=1 throughout — it checks the parts that do not need
+Docker: placeholder discovery against the REAL committed templates, refusal on a missing env
+var, successful substitution leaving no placeholder token behind, and that nothing is left in
+the temp directory afterward. The Docker-backed boot verification itself was run manually
+against quay.io/keycloak/keycloak:26.6.3 for both realms while preparing this change (see the
+PR description) — that step is inherently not something a hosted CI runner should be trusted
+to gate on, since a container that merely BOOTS proves nothing about a broken template if the
+runner has no way to also mint and inspect a token, which is exactly the gap runbook 0009 warns
+about ("an import that succeeds with a dropped role block prints nothing useful").
+"""
+
+import os
+import pathlib
+import subprocess
+import sys
+import tempfile
+import unittest
+
+REPO = pathlib.Path(__file__).resolve().parents[2]
+SCRIPT = REPO / "openbank-infra" / "scripts" / "render-verify-keycloak-realm-import.sh"
+KEYCLOAK_DIR = REPO / "openbank-infra" / "gitops" / "components" / "keycloak"
+
+REALMS = {
+    "openbank": KEYCLOAK_DIR / "realm-template.json",
+    "openbank-customers": KEYCLOAK_DIR / "customers-realm-template.json",
+}
+
+
+def _placeholders(template_path: pathlib.Path) -> set:
+    import re
+
+    return set(re.findall(r"__[A-Z0-9_]+__", template_path.read_text()))
+
+
+def _run(realm: str, env_extra: dict, tmp_home: str):
+    env = dict(os.environ)
+    env.update(env_extra)
+    env["SKIP_IMPORT_TEST"] = "1"
+    env["TMPDIR"] = tmp_home
+    return subprocess.run(
+        [str(SCRIPT), realm],
+        cwd=str(REPO),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+class ScriptExists(unittest.TestCase):
+    def test_present_and_executable(self):
+        self.assertTrue(SCRIPT.exists(), f"{SCRIPT} missing")
+        self.assertTrue(os.access(SCRIPT, os.X_OK), f"{SCRIPT} is not executable (chmod +x)")
+
+
+class MissingEnvVarRefusal(unittest.TestCase):
+    """The script must refuse to run — not substitute an empty string — for any unset
+    placeholder env var. An empty-string secret in a rendered realm is a worse failure than a
+    stopped script: it imports cleanly and produces a client nobody can authenticate as.
+    """
+
+    def test_no_env_vars_set_fails_and_names_every_placeholder(self):
+        for realm, template in REALMS.items():
+            with self.subTest(realm=realm), tempfile.TemporaryDirectory() as tmp_home:
+                result = _run(realm, {}, tmp_home)
+                self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
+                expected = {p.strip("_") for p in _placeholders(template)}
+                for name in expected:
+                    self.assertIn(
+                        name, result.stderr,
+                        f"missing-var message for {realm} did not name {name}",
+                    )
+
+    def test_one_missing_var_still_fails(self):
+        # openbank has >1 placeholder; supply all but one and confirm it still refuses.
+        template = REALMS["openbank"]
+        names = sorted(p.strip("_") for p in _placeholders(template))
+        self.assertGreater(len(names), 1, "expected openbank template to have >1 placeholder")
+        env = {n: "dummy" for n in names[:-1]}
+        with tempfile.TemporaryDirectory() as tmp_home:
+            result = _run("openbank", env, tmp_home)
+            self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertIn(names[-1], result.stderr)
+
+
+class SuccessfulRender(unittest.TestCase):
+    """With every placeholder supplied, the script must render valid JSON with no surviving
+    placeholder token, and leave nothing behind in the temp directory.
+    """
+
+    def test_renders_cleanly_for_every_realm(self):
+        for realm, template in REALMS.items():
+            with self.subTest(realm=realm), tempfile.TemporaryDirectory() as tmp_home:
+                names = {p.strip("_") for p in _placeholders(template)}
+                env = {n: f"dummy-{n.lower()}" for n in names}
+                result = _run(realm, env, tmp_home)
+                self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+                self.assertIn("no surviving placeholder tokens", result.stdout)
+                # Nothing left behind: the trap must have cleaned up regardless of exit path.
+                leftovers = list(pathlib.Path(tmp_home).glob("ob-realm-render.*"))
+                self.assertEqual(
+                    leftovers, [],
+                    f"render-verify script left temp file(s) behind: {leftovers}",
+                )
+
+
+class UnknownRealmRejected(unittest.TestCase):
+    def test_unknown_realm_argument_fails_fast(self):
+        with tempfile.TemporaryDirectory() as tmp_home:
+            result = _run("not-a-real-realm", {}, tmp_home)
+            self.assertNotEqual(result.returncode, 0)
+
+
+class OutFlagRefusedWithoutBootVerification(unittest.TestCase):
+    """`--out` hands the caller a file meant to be fed straight to `vault kv put`. In
+    SKIP_IMPORT_TEST mode that file never passed the Keycloak boot check, so the combination
+    must be refused rather than silently producing a file that looks verified and is not.
+    """
+
+    def test_out_plus_skip_import_test_is_refused(self):
+        template = REALMS["openbank"]
+        names = {p.strip("_") for p in _placeholders(template)}
+        env = {n: f"dummy-{n.lower()}" for n in names}
+        with tempfile.TemporaryDirectory() as tmp_home:
+            out_path = os.path.join(tmp_home, "would-be-output.json")
+            env_full = dict(os.environ)
+            env_full.update(env)
+            env_full["SKIP_IMPORT_TEST"] = "1"
+            env_full["TMPDIR"] = tmp_home
+            result = subprocess.run(
+                [str(SCRIPT), "--out", out_path, "openbank"],
+                cwd=str(REPO),
+                env=env_full,
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+            self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertFalse(
+                os.path.exists(out_path),
+                "refused run must not have written the --out path anyway",
+            )
+
+
+if __name__ == "__main__":
+    if sys.platform == "win32":
+        raise SystemExit("this test drives a bash script; not applicable on Windows runners")
+    unittest.main()


### PR DESCRIPTION
## What this is

Refs #3246. **Not** `Closes` — the issue is about the deployed `keycloak-realm-import` /
`keycloak-customers-realm-import` Secrets being a stale ancestor of the committed realm
templates, and the fix is an **owner-gated Vault write** (runbook 0009) that only the owner
can perform (real client secrets, real user passwords). That step is out of scope for a PR by
design, and remains outstanding after this change.

## Re-measured before touching anything (2026-08-16, `origin/main` @ `7d857cd8e`, live sandbox)

```
$ kubectl -n iam get secret keycloak-realm-import           (decode openbank-realm.json)
  1951 B   realm=openbank             roles=4  clients=2  users=1
$ kubectl -n iam get secret keycloak-customers-realm-import (decode openbank-customers-realm.json)
  6333 B   realm=openbank-customers   roles=1  clients=1  users=0
$ wc -c openbank-infra/gitops/components/keycloak/{realm-template.json,customers-realm-template.json}
  14105  realm-template.json
  13358  customers-realm-template.json
```

Byte-identical to every prior measurement on this issue back to 2026-08-02. Running the
existing detector against these live secrets:

```
$ python3 .github/scripts/check-realm-import-parity.py --root . \
    --import openbank=<live-secret> --import openbank-customers=<live-secret>
realm import parity: the import artifact matches its recorded baseline for openbank,
openbank-customers; the #3246 gap itself is unchanged (see declaredNotImported/* in the report).
```
Exit 0 — `IMPORT_BASELINE` (fixed by #4732) still describes reality, and every prerequisite
this issue's thread called out (templates importable since #3858, detector baseline-shape
fixed by #4732, secret-less customers clients placeholdered) is confirmed already landed.

**So there is nothing left to fix in the templates, the detector, or the gate.** What's left
is the write, plus reducing the risk of getting the pre-write verification wrong when someone
does perform it.

## What this PR adds

`openbank-infra/scripts/render-verify-keycloak-realm-import.sh` — turns runbook 0009's manual
pre-write recipe ("substitute the placeholders by hand, boot a throwaway Keycloak, remember to
shred the file before you forget") into a script that:

- **Refuses to run** if any `__PLACEHOLDER__` in the template lacks its env var — never
  silently substitutes an empty string for a missing secret.
- **Never leaves a rendered file on disk** by default: it's a mode-600 temp file removed by a
  trap that fires on every exit path (success, failure, Ctrl-C). Pass `--out <path>` to keep
  the *verified* render just long enough to hand to `vault kv put`; `--out` is refused under
  `SKIP_IMPORT_TEST=1` because that combination would hand back a file that never passed the
  boot check.
- **Resolves the Keycloak version to test against from `keycloak.yaml` itself** (not a
  hardcoded guess), boots a real `quay.io/keycloak/keycloak:<version>` container against the
  render, and passes only on `KC-SERVICES0032: Import finished successfully` with zero `ERROR`
  lines.
- **Never touches Vault.** The write stays a separate, explicit, owner-run `vault kv put` —
  deliberately not bundled in, so a script defect can produce a bad render, never a bad write.

`docs/runbooks/0009-keycloak-realm-import-reconcile.md` updated to reference the script in
place of the hand-run `docker run` recipe, including the `--out` flow for the actual write step.

`openbank-infra/scripts/render_verify_keycloak_realm_import_test.py` — CI-safe unit tests
(`SKIP_IMPORT_TEST=1` throughout, no Docker/Vault/cluster needed): missing-placeholder refusal
names every real placeholder in both committed templates, successful render leaves nothing in
`$TMPDIR`, `--out` + `SKIP_IMPORT_TEST=1` is refused. 6/6 pass locally
(`python3 -m unittest openbank-infra/scripts/render_verify_keycloak_realm_import_test.py`).
Not wired into a CI workflow — this matches the existing, unwired state of its two siblings
(`check_realm_import_parity_test.py`, `check_realm_role_parity_test.py`), since neither of
those scripts is a PR-time gate either (both run only from the `keycloak-realm-drift`
CronJob). Wiring that family into CI is a separate, larger question this PR doesn't take on.

## What I actually verified, and how

Docker is available on this machine, so the Keycloak boot verification the issue's own
standing rule requires ("verify against a local Keycloak before writing to Vault... `docker
run ... start-dev --import-realm`, then mint a token and inspect the JWT") was run for real,
not skipped:

```
$ ADMINUI_CLIENT_SECRET=... [... all 13 openbank placeholders, dummy values] \
    ./openbank-infra/scripts/render-verify-keycloak-realm-import.sh openbank
...
INFO  [org.keycloak.exportimport.util.ImportUtils] (main) Realm 'openbank' imported
PASS: openbank rendered template imported cleanly against quay.io/keycloak/keycloak:26.6.3,
zero ERROR lines.

$ CUSTOMER_EDGE_ADMIN_CLIENT_SECRET=... EDGE_WEBAUTHN_CLIENT_SECRET=... \
    ./openbank-infra/scripts/render-verify-keycloak-realm-import.sh openbank-customers
...
INFO  [org.keycloak.exportimport.util.ImportUtils] (main) Realm 'openbank-customers' imported
PASS: openbank-customers rendered template imported cleanly against
quay.io/keycloak/keycloak:26.6.3, zero ERROR lines.
```

Both against `quay.io/keycloak/keycloak:26.6.3` — the version `keycloak.yaml` runs (the
private ECR image `openbank-keycloak:26.6.3-optimized` isn't pullable from an arbitrary
machine; same upstream version, same import code path). Also exercised `--out`: it produced a
mode-600 file (`14 roles / 10 clients` for `openbank`, confirmed via `jq`), which I then
manually deleted — proving the "hand to `vault kv put`, then clean up" flow actually works.

**One thing I did NOT verify, and am saying so rather than implying otherwise:** minting a
token and inspecting its JWT claims. The dummy secrets used for this boot test (`dummy1`,
`dummy2`, ...) are not the real client secrets, so a `client_credentials` grant against them
would fail for a reason unrelated to the template's correctness. The 2026-08-13 issue comment
already did that exercise once, with real substituted values, against the same Keycloak
version, and confirmed role mappings, default roles, and a `client_credentials` mint for
`openbank-services` all matched the template. This PR's contribution is making the *next* such
verification (the one that has to happen again once real secrets are in hand for the actual
Vault write) mechanical instead of a five-step manual recipe.

**Also not done, and out of scope for a PR:** the Vault write itself (`vault kv put
openbank/keycloak-realm-import ...` / `.../keycloak-customers-realm-import`). It requires real
client secrets and user passwords that only the owner holds, and both the issue thread and
runbook 0009 are explicit that this is deliberately not something automation performs.

## Constraints observed

- No secrets, real or placeholder-adjacent, were written to any tracked file — the script
  requires them as env vars at run time and never logs, echoes, or persists a rendered value
  without an explicit `--out`, and even then the caller is told to shred it immediately.
- Nothing in the cluster or AWS was mutated. All `kubectl` calls in this PR's preparation were
  read-only (`get secret`, decode, diff).
- The rendered/imported test artifacts used only disposable dummy strings (`dummy1`, `dummyPW1`,
  ...), never real credentials.

## Closes / Refs

Refs #3246. Closing it requires the Vault write; this PR doesn't attempt that.
