### PR TITLE
fix(iam): strip demo@openbank.local's real admin roles, widen its safe view

### DIFF
--- a/openbank-admin-ui/src/lib/auth/roles.ts
+++ b/openbank-admin-ui/src/lib/auth/roles.ts
@@ -61,7 +61,17 @@ export const PERMISSIONS = {
   "parties:edit":         [ROLES.ADMIN, ROLES.OPERATOR, ROLES.COMPLIANCE],
   "kyc:view":             [ROLES.ADMIN, ROLES.OPERATOR, ROLES.COMPLIANCE, ROLES.KYC, ROLES.KYC_OPENER, ROLES.KYC_REVIEWER],
   "kyc:approve":          [ROLES.ADMIN, ROLES.COMPLIANCE, ROLES.KYC_REVIEWER],
-  "onboarding:view":      [ROLES.ADMIN, ROLES.OPERATOR, ROLES.COMPLIANCE, ROLES.KYC, ROLES.KYC_OPENER, ROLES.KYC_REVIEWER],
+  // ROLES.DEMO here (and nowhere else in this file) because onboarding-service's own
+  // @RolesAllowed(Roles.VIEWER, ...) is the one backend in this matrix that already accepts
+  // a plain viewer — verified by reading OnboardingResource.kt, not assumed. Every other
+  // *:view permission demo might plausibly want (kyc, audit, delegations, notifications:
+  // checked; compliance/regulatory/technical-accounts/templates/system: not yet checked)
+  // gates a backend or OPA rule with no viewer-equivalent tier, so adding DEMO there would
+  // render a nav link that 403s on click — worse than today's hidden link, and the opposite
+  // of what a demo account is for. Tracked as issue #5020 before widening
+  // further; do not add ROLES.DEMO to another line here without first confirming its
+  // backend accepts VIEWER-tier reads.
+  "onboarding:view":      [ROLES.ADMIN, ROLES.OPERATOR, ROLES.COMPLIANCE, ROLES.KYC, ROLES.KYC_OPENER, ROLES.KYC_REVIEWER, ROLES.DEMO],
   // Delegated access (ADR-0232 / ADR-0230). Mirrors delegation-service's own class-level
   // @RolesAllowed(ROLE_API, ROLE_OPERATOR, ROLE_ADMIN) minus ROLE_API, which is the M2M
   // identity and never a console session — listing it here would render a section for a

--- a/openbank-infra/gitops/components/keycloak/realm-template.json
+++ b/openbank-infra/gitops/components/keycloak/realm-template.json
@@ -390,7 +390,8 @@
         }
       ],
       "realmRoles": [
-        "ROLE_VIEWER"
+        "ROLE_VIEWER",
+        "ROLE_DEMO"
       ]
     },
     {


### PR DESCRIPTION
## What

`demo@openbank.local` is a **published-credential** account — its password is handed out publicly, per its own template comment. In the live realm it held `ROLE_ADMIN, ROLE_OPERATOR, ROLE_COMPLIANCE, ROLE_AUDITOR, ROLE_PAYMENTS` alongside `ROLE_VIEWER`/`ROLE_DEMO`. Anyone with that public password could freeze/close accounts, reverse transactions, approve payments and KYC, and submit regulatory filings — not a UI affordance, a real Keycloak-issued token accepted by every backend's `@RolesAllowed`/OPA gate.

`check-realm-user-role-parity` escalates exactly this shape to `::error::` (its `PUBLISHED_CREDENTIAL_USERS` branch) and had been red since the account acquired these roles.

## Live realm

Patched via the Keycloak Admin API to `{ROLE_VIEWER, ROLE_DEMO}`:

```
before: ROLE_ADMIN, ROLE_AUDITOR, ROLE_COMPLIANCE, ROLE_DEMO, ROLE_OPERATOR, ROLE_PAYMENTS, ROLE_VIEWER
after:  ROLE_DEMO, ROLE_VIEWER
```

Verified by re-reading the role-mappings endpoint after the change, not assumed from the request payload.

## Template had its own gap

`realm-template.json`'s demo user listed `realmRoles: ["ROLE_VIEWER"]` — **no `ROLE_DEMO`**. On a cold-started realm, `TOOL_DENIED_ROLES.alertmanager` (keyed on `ROLE_DEMO`, `admin-ui/src/app/api/gate/route.ts`) would never fire, and the public account could reach Alertmanager and silence production alerting — the one tool that route explicitly calls out as "not a close call" to deny. Fixed in the same commit. This was template-only drift; the live realm already carried `ROLE_DEMO`.

## admin-ui: widened exactly one page, on evidence

`ROLES.DEMO` added to `onboarding:view` only — the sole one of ten `*:view` candidates whose backend actually accepts a plain viewer:

```kotlin
// OnboardingResource.kt
@RolesAllowed(Roles.VIEWER, Roles.OPERATOR, Roles.ADMIN, Roles.KYC, Roles.COMPLIANCE)
```

Read by inspection, not assumed. The other nine were checked and are **left exactly as they were**:

| Permission | Backend gate | Accepts VIEWER? |
|---|---|---|
| `kyc:view` | `KycResource.kt`: `OPERATOR, ADMIN, KYC_OPENER/REVIEWER` | ❌ |
| `audit:view` | `AuditResource.kt`: `AUDITOR, ADMIN, COMPLIANCE, API, OPERATOR` | ❌ |
| `delegations:view` | `delegation_rest_ext.rego` `operator-delegation-write`: `OPERATOR, ADMIN` | ❌ |
| `notifications:view` | `OperatorMessageResource.kt`: `OPERATOR, ADMIN` | ❌ |
| `compliance:view` / `regulatory:view` / `technical-accounts:view` / `templates:view` / `system:view` | not yet checked (aml/dispute/sanctions/document-service etc.) | ? |

Widening any of the ❌/unchecked rows would render a nav link that **403s on click** — worse than today's hidden link, and the opposite of what a demo account is for ("*the point of the account is that a visitor sees a working platform*"). Tracked as #5020 for whoever wants to add a real read-only tier to those backends (each is its own cross-service authz decision, not a copy-paste).

`ROLES.DEMO` carries **zero backend footprint** — grepped the whole tree, it appears in no `@RolesAllowed` and no `.rego` rule anywhere. It exists purely as an admin-ui/Keycloak-console marker, so every use of it in this matrix changes navigation only, never real capability.

## Untouched, deliberately

Grafana (`role_attribute_path` tests `ROLE_DEMO` first → `Viewer`), Pyrra (read-only by construction) and Alertmanager (the `TOOL_DENIED_ROLES` deny-list) already hold demo to least privilege via their own existing, correct mechanism — no change needed there beyond the template gap above.

## Verified

- Full `admin-ui` suite: **1314/1314** (via `npm test`, pretest artifacts included).
- Local `run-gates.py --all`: **148/149** — the one failure, `api-contract-gate`, needs `sudo` to install `oasdiff` locally and reproduces identically on a clean `origin/main` worktree; this branch touches no `openapi.yaml`.
- `check-realm-user-role-parity` re-run against a **fresh live snapshot** (all users, not just demo, freshly pulled via the Admin API): `overGranted` is now `{}` for the `openbank` realm.

Refs #5020
