### PR TITLE
fix(admin-ui): make campaign preview CTA non-interactive

### DIFF
--- a/openbank-admin-ui/src/app/globals.css
+++ b/openbank-admin-ui/src/app/globals.css
@@ -586,7 +586,7 @@ main {
 .campaign-phone-banner { background: linear-gradient(135deg, #fef3c7 0%, #ffedd5 46%, #fae8ff 100%); box-shadow: inset 0 1px 0 rgba(255,255,255,.75), 0 8px 18px rgba(217,119,6,.12); }
 .campaign-phone-hero span { color: #4f46e5; display: block; font-size: 0.43rem; font-weight: 800; text-transform: uppercase; }
 .campaign-phone-hero strong { display: block; font-size: 0.62rem; line-height: 1.15; margin: 0.28rem 0; }
-.campaign-phone-hero button { background: #4f46e5; border: 0; border-radius: 0.4rem; color: #fff; font-size: 0.45rem; font-weight: 700; padding: 0.28rem 0.42rem; }
+.campaign-phone-cta { background: #4f46e5; border-radius: 0.4rem; color: #fff; display: inline-block; font-size: 0.45rem; font-weight: 700; padding: 0.28rem 0.42rem; }
 .campaign-phone-row { display: flex; gap: 0.28rem; margin-top: 0.58rem; }
 .campaign-phone-row span { background: #e2e8f0; border-radius: 0.25rem; height: 1.45rem; flex: 1; }
 .campaign-push-card { background: rgba(255,255,255,0.95); border: 1px solid rgba(255,255,255,0.75); border-radius: 0.9rem; box-shadow: 0 12px 28px rgba(0,0,0,.18); color: #0f172a; display: flex; gap: 0.48rem; max-width: 15.5rem; padding: 0.62rem; transform: rotate(-2deg); }

--- a/openbank-admin-ui/src/app/globals.css
+++ b/openbank-admin-ui/src/app/globals.css
@@ -586,7 +586,7 @@ main {
 .campaign-phone-banner { background: linear-gradient(135deg, #fef3c7 0%, #ffedd5 46%, #fae8ff 100%); box-shadow: inset 0 1px 0 rgba(255,255,255,.75), 0 8px 18px rgba(217,119,6,.12); }
 .campaign-phone-hero span { color: #4f46e5; display: block; font-size: 0.43rem; font-weight: 800; text-transform: uppercase; }
 .campaign-phone-hero strong { display: block; font-size: 0.62rem; line-height: 1.15; margin: 0.28rem 0; }
-.campaign-phone-cta { background: #4f46e5; border-radius: 0.4rem; color: #fff; display: inline-block; font-size: 0.45rem; font-weight: 700; padding: 0.28rem 0.42rem; }
+.campaign-phone-hero .campaign-phone-cta { background: #4f46e5; border-radius: 0.4rem; color: #fff; display: inline-block; font-size: 0.45rem; font-weight: 700; padding: 0.28rem 0.42rem; text-transform: none; }
 .campaign-phone-row { display: flex; gap: 0.28rem; margin-top: 0.58rem; }
 .campaign-phone-row span { background: #e2e8f0; border-radius: 0.25rem; height: 1.45rem; flex: 1; }
 .campaign-push-card { background: rgba(255,255,255,0.95); border: 1px solid rgba(255,255,255,0.75); border-radius: 0.9rem; box-shadow: 0 12px 28px rgba(0,0,0,.18); color: #0f172a; display: flex; gap: 0.48rem; max-width: 15.5rem; padding: 0.62rem; transform: rotate(-2deg); }

--- a/openbank-admin-ui/src/components/campaigns/CampaignExperiencePreview.tsx
+++ b/openbank-admin-ui/src/components/campaigns/CampaignExperiencePreview.tsx
@@ -73,7 +73,9 @@ export function CampaignExperiencePreview({
             <div className={`campaign-phone-hero${isBanner ? ` campaign-phone-banner campaign-phone-${inAppSurface.toLowerCase()}` : ''}`} data-preview-surface={isBanner ? inAppSurface : undefined}>
               <span>{isBanner ? (language === 'cs' ? surface.cs : surface.en) : t('Doporučeno pro vás', 'Recommended for you')}</span>
               <strong>{headline}</strong>
-              <button type="button" tabIndex={-1}>{t('Zjistit víc', 'Explore')}</button>
+              {/* This previews a customer CTA; it is not an action in Admin UI. A real button here
+                  would be announced to assistive technology while doing nothing. */}
+              <span className="campaign-phone-cta">{t('Zjistit víc', 'Explore')}</span>
             </div>
             <div className="campaign-phone-row"><span /><span /><span /></div>
           </div>

--- a/openbank-admin-ui/src/test/campaign-experience-preview.test.tsx
+++ b/openbank-admin-ui/src/test/campaign-experience-preview.test.tsx
@@ -30,6 +30,8 @@ describe('campaign customer experience preview', () => {
     expect(screen.getByText(/Summer saving → Savings/)).toBeTruthy()
     expect(container.querySelector('[data-preview-channel="PUSH"]')).toBeTruthy()
     expect(screen.getByText('openbank://savings')).toBeTruthy()
+    expect(container.querySelector('.campaign-phone-cta')).toBeTruthy()
+    expect(screen.queryByRole('button', { name: 'Explore' })).toBeNull()
   })
 
   it('does not pretend an email is a push notification', () => {

--- a/openbank-admin-ui/src/test/campaign-experience-preview.test.tsx
+++ b/openbank-admin-ui/src/test/campaign-experience-preview.test.tsx
@@ -3,6 +3,7 @@
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 
 import React from 'react'
+import { readFileSync } from 'node:fs'
 import { describe, expect, it } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import { LanguageProvider } from '@/lib/i18n/LanguageContext'
@@ -30,8 +31,18 @@ describe('campaign customer experience preview', () => {
     expect(screen.getByText(/Summer saving → Savings/)).toBeTruthy()
     expect(container.querySelector('[data-preview-channel="PUSH"]')).toBeTruthy()
     expect(screen.getByText('openbank://savings')).toBeTruthy()
-    expect(container.querySelector('.campaign-phone-cta')).toBeTruthy()
+    const cta = container.querySelector<HTMLElement>('.campaign-phone-cta')!
+    expect(cta).toBeTruthy()
     expect(screen.queryByRole('button', { name: 'Explore' })).toBeNull()
+
+    // This test deliberately loads the real cascade. The CTA shares the generic hero's `span`
+    // selector, so checking the class alone would miss an equally-coloured label on its own fill.
+    const style = document.createElement('style')
+    style.textContent = readFileSync('src/app/globals.css', 'utf8')
+    document.head.append(style)
+    expect(getComputedStyle(cta).color).toBe('rgb(255, 255, 255)')
+    expect(getComputedStyle(cta).display).toBe('inline-block')
+    style.remove()
   })
 
   it('does not pretend an email is a push notification', () => {


### PR DESCRIPTION
## What changed

- renders the simulated customer CTA as static preview content rather than a focusable action
- preserves the visual CTA treatment
- proves the preview does not expose a non-functional button to assistive technology

## Why

A focusable button in a preview announced an action that Admin UI cannot perform. The preview should describe the customer experience without creating a false control.

## Validation

- `npm test -- --run src/test/campaign-experience-preview.test.tsx` (6 passing)
- `npm run type-check`
- `npx eslint src/components/campaigns/CampaignExperiencePreview.tsx src/test/campaign-experience-preview.test.tsx`
- `git diff --check`

Refs #4712