### PR TITLE
fix(product-catalog): three native-image defects blocking main-red #4797

### DIFF
--- a/openbank-product-catalog/Dockerfile.native
+++ b/openbank-product-catalog/Dockerfile.native
@@ -29,10 +29,25 @@ COPY . /build
 
 ENV GRADLE_OPTS="-Xmx2g -Xms256m -XX:MaxMetaspaceSize=512m"
 USER root
+# --initialize-at-run-time=com.openbank.libs.domain.identifiers.Ids (#4797): Ids is a
+# Kotlin `object`, so its `generator: TimeBasedEpochGenerator` val runs in <clinit> and,
+# by native-image's default of eager build-time class initialization, is created DURING
+# the image build and baked into the image heap as a constant. SVM explicitly disallows
+# a Random/SplittableRandom instance there (a build-time seed would be frozen and reused
+# on every boot of the produced binary, defeating the point of a random generator) and
+# fails the whole build:
+#   "Detected an instance of Random/SplittableRandom class in the image heap ...
+#    reading field com.fasterxml.uuid.impl.TimeBasedEpochGenerator._random"
+# Deferring Ids to native-image RUNTIME initialization is GraalVM's own documented fix
+# for exactly this diagnostic, and is scoped to this Dockerfile only — Ids is used by
+# 30+ services that all run in plain JVM mode, where this never applies, so nothing
+# about their behaviour changes. Verified by re-running this build: without the flag,
+# fails at the native-image link stage with the error above; with it, that stage passes.
 RUN chmod +x gradlew && \
     ./gradlew :openbank-product-catalog:quarkusBuild \
       -Dquarkus.package.type=native \
       -Dquarkus.native.enabled=true \
+      -Dquarkus.native.additional-build-args=--initialize-at-run-time=com.openbank.libs.domain.identifiers.Ids \
       -Dorg.gradle.java.installations.auto-detect=false \
       --no-daemon \
       --console=plain

--- a/openbank-product-catalog/src/main/kotlin/com/openbank/productcatalog/infrastructure/ProductReflectionRegistration.kt
+++ b/openbank-product-catalog/src/main/kotlin/com/openbank/productcatalog/infrastructure/ProductReflectionRegistration.kt
@@ -15,7 +15,6 @@ import com.openbank.productcatalog.domain.MultiCurrencyConfig
 import com.openbank.productcatalog.domain.OverdraftConfig
 import com.openbank.productcatalog.domain.OverdraftType
 import com.openbank.productcatalog.domain.Product
-import com.openbank.productcatalog.domain.catalog.CatalogChangeEvent
 import com.openbank.productcatalog.domain.ProductStatus
 import com.openbank.productcatalog.domain.ProductType
 import com.openbank.productcatalog.domain.ProductVersion
@@ -23,6 +22,7 @@ import com.openbank.productcatalog.domain.SavingsConfig
 import com.openbank.productcatalog.domain.TermDepositConfig
 import com.openbank.productcatalog.domain.TermsAndConditions
 import com.openbank.productcatalog.domain.WithdrawalNotice
+import com.openbank.productcatalog.domain.catalog.CatalogChangeEvent
 import io.quarkus.runtime.annotations.RegisterForReflection
 
 /**

--- a/openbank-product-catalog/src/main/kotlin/com/openbank/productcatalog/infrastructure/ProductReflectionRegistration.kt
+++ b/openbank-product-catalog/src/main/kotlin/com/openbank/productcatalog/infrastructure/ProductReflectionRegistration.kt
@@ -15,6 +15,7 @@ import com.openbank.productcatalog.domain.MultiCurrencyConfig
 import com.openbank.productcatalog.domain.OverdraftConfig
 import com.openbank.productcatalog.domain.OverdraftType
 import com.openbank.productcatalog.domain.Product
+import com.openbank.productcatalog.domain.catalog.CatalogChangeEvent
 import com.openbank.productcatalog.domain.ProductStatus
 import com.openbank.productcatalog.domain.ProductType
 import com.openbank.productcatalog.domain.ProductVersion
@@ -31,6 +32,7 @@ import io.quarkus.runtime.annotations.RegisterForReflection
 @RegisterForReflection(
     targets = [
         Product::class,
+        CatalogChangeEvent::class,
         Fee::class,
         InterestTier::class,
         CardConfig::class,

--- a/openbank-product-catalog/src/main/resources/application.yaml
+++ b/openbank-product-catalog/src/main/resources/application.yaml
@@ -1,6 +1,17 @@
 quarkus:
   application:
     name: openbank-product-catalog
+  # CatalogPackSeeder.register loads these via javaClass.getResourceAsStream at RUNTIME
+  # (#4797). Native-image excludes classpath resources by default -- only what is
+  # explicitly registered gets bundled into the binary -- so the plain-JVM build ships
+  # them for free and the native one silently drops them, failing at first boot with
+  # "catalog pack resource ... is missing" rather than at build time. Scoped to exactly
+  # the directory the seeder reads; a broader "**" include would work but would also
+  # bundle files (openapi.yaml, application.yaml itself) with no reason to ship inside
+  # a native binary.
+  native:
+    resources:
+      includes: "catalog-packs/**"
   http:
     port: 8104
     limits:


### PR DESCRIPTION
## What this fixes

`main` has been red on `Product Catalog Native Build (T1 enabler smoke test)` since 2026-08-09T19:35Z — 9 consecutive failed runs, tracked as #4797. This branch fixes it with a **real green dispatch**, not an assertion: [run 31943947852](https://github.com/JiRaska/open-bank-oss/actions/runs/31943947852), dispatched on this exact branch, `conclusion: success`.

Not a merge gate (this workflow is explicitly diagnostic-only, never added to required checks per its own header), but `main-red-watch` tracks it and files/refreshes #4797 while it stays red.

## Three sequential, distinct native-image defects — each only visible after fixing the last

| # | error | root cause | fix |
|---|---|---|---|
| 1 | `Detected an instance of Random/SplittableRandom class in the image heap` | `Ids` is a Kotlin `object`; its `TimeBasedEpochGenerator` val runs in `<clinit>`, and native-image's default eager build-time class init bakes a frozen-seed `Random` into the image heap — SVM explicitly disallows this | `--initialize-at-run-time=com.openbank.libs.domain.identifiers.Ids`, scoped to `Dockerfile.native` only (30+ services use `Ids` in plain JVM mode, unaffected) |
| 2 | `catalog pack resource /catalog-packs/banking/deposit-v1.schema.json is missing` | `CatalogPackSeeder.register` loads 4 schema files via `getResourceAsStream` at runtime; native-image excludes classpath resources by default, JVM mode ships them for free | `quarkus.native.resources.includes: "catalog-packs/**"` |
| 3 | `KotlinReflectionInternalError: Unresolved class: CatalogChangeEvent` | Jackson serializes `CatalogChangeEvent` via kotlin-reflect; native-image strips reflection metadata unless registered | Added to the existing `ProductReflectionRegistration.kt`'s `@RegisterForReflection` list — same file, same pattern already used for 18 other domain types, this one was just never added when #4501 introduced the class |

All three trace to the same root: this is the **first** native-image build this dependency graph has ever gone through (the Dockerfile's own header: "no service has run under GraalVM native before"), so each fix surfaces the next never-before-exercised path.

## A mistake caught mid-session, worth recording

My first dispatch failed with the ORIGINAL error — because I pushed from a stale local checkout instead of the worktree where I'd made the edit, so the fix was never actually on the branch. Caught by reading the failed run's own `docker build` command line (missing the flag I thought I'd added), not by assuming success. Every commit after that was confirmed present on `origin/<branch>` via `git show` before the next dispatch.

## Verification

Each of the three fixes was confirmed by **actually dispatching this workflow** after each commit — not local reasoning alone:
- dispatch 1: original error (mis-push, no code change reached CI)
- dispatch 2: fix 1 present, error moves to #2
- dispatch 3: fix 1+2 present, error moves to #3
- dispatch 4 ([31943947852](https://github.com/JiRaska/open-bank-oss/actions/runs/31943947852)): fix 1+2+3 present — **green**

`compileKotlin` also run locally on fix 3, clean.

Refs #4797

🤖 Generated with [Claude Code](https://claude.com/claude-code)
