### PR TITLE
feat(admin-ui): propose compatible bundle components

### DIFF
--- a/openbank-admin-ui/src/app/product-studio/page.module.css
+++ b/openbank-admin-ui/src/app/product-studio/page.module.css
@@ -64,6 +64,18 @@
 .compositionHead p { margin: 4px 0 0; color: #52607b; font-size: 10px; line-height: 1.45; }
 .compositionControls { display: grid; grid-template-columns: 118px minmax(0, 1fr) auto; gap: 7px; margin-top: 10px; }
 .compositionControls select { min-width: 0; font-size: 11px; }
+.bundleProposals { margin-top: 10px; padding: 9px; border: 1px dashed #b9c9e6; border-radius: 10px; background: rgba(255,255,255,.56); }
+.bundleProposalsHead { display: grid; gap: 3px; }
+.bundleProposalsHead span { display: inline-flex; align-items: center; gap: 6px; color: #3730a3; font-size: 11px; font-weight: 800; }
+.bundleProposalsHead small { color: #5b5b86; font-size: 10px; line-height: 1.4; }
+.bundleProposalEmpty { margin-top: 7px; color: var(--text-tertiary); font-size: 10px; }
+.bundleProposalList { display: grid; gap: 5px; margin-top: 8px; }
+.bundleProposal { display: flex; align-items: center; justify-content: space-between; gap: 8px; padding: 7px; border: 1px solid #d6dfef; border-radius: 8px; background: white; }
+.bundleProposal > div { min-width: 0; }
+.bundleProposal strong, .bundleProposal small { display: block; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.bundleProposal strong { color: var(--text-primary); font-size: 11px; }
+.bundleProposal small { margin-top: 2px; color: var(--text-tertiary); font-family: var(--font-mono); font-size: 9px; }
+.bundleProposal button { flex: 0 0 auto; padding: 6px 8px; font-size: 10px; }
 .compositionEmpty { margin-top: 9px; color: var(--text-tertiary); font-size: 10px; }
 .relationships { display: grid; gap: 5px; margin-top: 9px; }
 .relationship { display: flex; align-items: center; gap: 7px; min-width: 0; padding: 7px 8px; border: 1px solid #d6dfef; border-radius: 8px; background: rgba(255,255,255,.75); color: var(--text-secondary); font-size: 11px; }

--- a/openbank-admin-ui/src/app/product-studio/page.tsx
+++ b/openbank-admin-ui/src/app/product-studio/page.tsx
@@ -17,6 +17,7 @@ import {
   removeOfferingRelationship,
   type MarketContextInput,
 } from '@/lib/catalog-offer-composition'
+import { proposeBundleComponents } from '@/lib/catalog-bundle-proposals'
 import { selectOffersForMarket } from '@/lib/catalog-offer-selection'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import {
@@ -126,6 +127,12 @@ export default function ProductStudioPage() {
   const relationshipCandidates = useMemo(
     () => offerings.filter(item => item.id !== selectedOffering?.id),
     [offerings, selectedOffering?.id],
+  )
+  const bundleProposals = useMemo(
+    () => selectedOffering
+      ? proposeBundleComponents(selectedOffering, offerings, draftRelationships.map(item => item.targetOfferingId))
+      : [],
+    [draftRelationships, offerings, selectedOffering],
   )
   const compatibleSchemas = useMemo(
     () => schemas.filter(item => !selectedSpec || item.id === selectedSpec.schemaRef.id),
@@ -268,6 +275,19 @@ export default function ProductStudioPage() {
     setDraftText(JSON.stringify(removeOfferingRelationship(parsedDraft, relationship), null, 2))
     setValidationState('idle')
     setReview(null)
+  }
+
+  const applyBundleProposal = (targetOfferingId: string) => {
+    if (!parsedDraft || !selectedOffering) return
+    try {
+      setDraftText(JSON.stringify(addOfferingRelationship(parsedDraft, selectedOffering.id, {
+        kind: 'BUNDLE', targetOfferingId,
+      }), null, 2))
+      setValidationState('idle')
+      setReview(null)
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : String(error))
+    }
   }
 
   const createDraft = () => {
@@ -429,6 +449,18 @@ export default function ProductStudioPage() {
                 <select className="input" value={relationshipKind} onChange={event => setRelationshipKind(event.target.value as RelationshipKind)}>{relationshipKinds.map(kind => <option key={kind}>{kind}</option>)}</select>
                 <select className="input" value={relationshipTargetId} onChange={event => setRelationshipTargetId(event.target.value)}><option value="">{t('Vyberte nabídku', 'Select an offer')}</option>{relationshipCandidates.map(item => <option key={item.id} value={item.id}>{item.code}</option>)}</select>
                 <button className="btn btn-secondary" disabled={!relationshipTargetId} onClick={addRelationship}><Plus size={13} />{t('Přidat', 'Add')}</button>
+              </div>}
+              {selectedRevision?.state === 'DRAFT' && <div className={styles.bundleProposals}>
+                <div className={styles.bundleProposalsHead}>
+                  <span><Sparkles size={13} />{t('Doporučené komponenty', 'Suggested components')}</span>
+                  <small>{t('Deterministicky podle kompatibility trhu; návrh nic sám neuloží.', 'Deterministic market compatibility only; a proposal never saves itself.')}</small>
+                </div>
+                {bundleProposals.length === 0
+                  ? <div className={styles.bundleProposalEmpty}>{t('Žádná další bezpečně kompatibilní komponenta.', 'No further safely compatible component.')}</div>
+                  : <div className={styles.bundleProposalList}>{bundleProposals.slice(0, 3).map(proposal => <div className={styles.bundleProposal} key={proposal.offering.id}>
+                    <div><strong>{proposal.offering.code}</strong><small>{proposal.reasons.slice(0, 2).join(' · ')}</small></div>
+                    <button className="btn btn-secondary" onClick={() => applyBundleProposal(proposal.offering.id)}><Plus size={13} />{t('Navrhnout', 'Propose')}</button>
+                  </div>)}</div>}
               </div>}
               {draftRelationships.length === 0 ? <div className={styles.compositionEmpty}>{t('Žádné vazby. Samostatná nabídka zůstává beze změny.', 'No connections. A standalone offer remains unchanged.')}</div> : <div className={styles.relationships}>{draftRelationships.map(relationship => {
                 const target = offerings.find(item => item.id === relationship.targetOfferingId)

--- a/openbank-admin-ui/src/lib/catalog-bundle-proposals.ts
+++ b/openbank-admin-ui/src/lib/catalog-bundle-proposals.ts
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import type { MarketContext, Offering } from '@/lib/product-catalog-v2'
+
+export interface BundleProposal {
+  offering: Offering
+  reasons: string[]
+  specificity: number
+}
+
+const dimensions: Array<keyof MarketContext> = [
+  'brands', 'countries', 'channels', 'segments', 'locales',
+]
+
+/**
+ * Proposes components that are available wherever the source bundle is available.
+ * This deliberately uses only catalog market metadata, never customer data or an
+ * eligibility decision. The server remains the authority at publication time.
+ */
+export function proposeBundleComponents(
+  source: Offering,
+  offerings: Offering[],
+  existingTargetIds: string[] = [],
+): BundleProposal[] {
+  const existing = new Set(existingTargetIds)
+  return offerings.flatMap(offering => {
+    if (offering.id === source.id || existing.has(offering.id)) return []
+    const reasons: string[] = []
+    for (const dimension of dimensions) {
+      const bundleAudience = source.market[dimension] ?? []
+      const componentAudience = offering.market[dimension] ?? []
+      if (bundleAudience.length === 0) {
+        reasons.push(`${dimension}: bundle is global`)
+        continue
+      }
+      if (componentAudience.length === 0) {
+        reasons.push(`${dimension}: component is global`)
+        continue
+      }
+      if (!bundleAudience.every(value => componentAudience.includes(value))) return []
+      reasons.push(`${dimension}: compatible scope`)
+    }
+    const specificity = dimensions.filter(dimension => (offering.market[dimension] ?? []).length > 0).length
+    return [{ offering, reasons, specificity }]
+  }).sort((left, right) => right.specificity - left.specificity || left.offering.code.localeCompare(right.offering.code))
+}

--- a/openbank-admin-ui/src/test/catalog-bundle-proposals.test.ts
+++ b/openbank-admin-ui/src/test/catalog-bundle-proposals.test.ts
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import { describe, expect, it } from 'vitest'
+import { proposeBundleComponents } from '@/lib/catalog-bundle-proposals'
+import type { Offering } from '@/lib/product-catalog-v2'
+
+const market = (countries: string[] = [], channels: string[] = [], segments: string[] = []) => ({
+  brands: [], countries, channels, segments, locales: [],
+})
+const offer = (id: string, code: string, value = market()): Offering => ({
+  id, code, specificationId: 'spec', market: value, revision: 1,
+})
+
+describe('proposeBundleComponents', () => {
+  it('suggests global and wider-scoped components with an explanation', () => {
+    const source = offer('bundle', 'CZ_WEB_EMPLOYEE', market(['CZ'], ['WEB'], ['employee']))
+    const proposals = proposeBundleComponents(source, [
+      source,
+      offer('global', 'GLOBAL'),
+      offer('web', 'CZ_WEB', market(['CZ'], ['WEB'])),
+      offer('wrong-country', 'DE_WEB', market(['DE'], ['WEB'])),
+    ])
+
+    expect(proposals.map(proposal => proposal.offering.code)).toEqual(['CZ_WEB', 'GLOBAL'])
+    expect(proposals[0].reasons).toContain('countries: compatible scope')
+    expect(proposals[0].reasons).toContain('segments: component is global')
+  })
+
+  it('does not re-propose an existing relationship', () => {
+    const source = offer('bundle', 'CZ_WEB', market(['CZ'], ['WEB']))
+    expect(proposeBundleComponents(source, [offer('component', 'GLOBAL')], ['component'])).toEqual([])
+  })
+})


### PR DESCRIPTION
Refs #4505

Adds deterministic, proposal-only bundle component suggestions in Product Studio. Suggestions use only saved market-scope compatibility, never customer data or a model; an author must explicitly add, save, and send the draft through four-eyes publication.