### PR TITLE
fix(consent): record expiration sweep liveness

### DIFF
--- a/.github/scripts/check-scheduler-liveness.py
+++ b/.github/scripts/check-scheduler-liveness.py
@@ -72,7 +72,6 @@ BASELINE = [
     "openbank-agent-service/src/main/kotlin/com/openbank/agent/application/OversightService.kt",
     "openbank-agent-service/src/main/kotlin/com/openbank/agent/infrastructure/observability/AgentMetricsAdapter.kt",
     "openbank-audit-service/src/main/kotlin/com/openbank/audit/application/AuditAnchorService.kt",
-    "openbank-consent-service/src/main/kotlin/com/openbank/consent/infrastructure/ConsentExpirationJob.kt",
     "openbank-delegation-service/src/main/kotlin/com/openbank/delegation/infrastructure/DelegationExpirationJob.kt",
     "openbank-dispute-service/src/main/kotlin/com/openbank/dispute/infrastructure/observability/ComplaintDeadlineGauge.kt",
     "openbank-onboarding-service/src/main/kotlin/com/openbank/onboarding/infrastructure/observability/OnboardingFunnelGauge.kt",

--- a/openbank-consent-service/src/main/kotlin/com/openbank/consent/infrastructure/ConsentExpirationJob.kt
+++ b/openbank-consent-service/src/main/kotlin/com/openbank/consent/infrastructure/ConsentExpirationJob.kt
@@ -6,14 +6,19 @@ package com.openbank.consent.infrastructure
 
 import com.openbank.consent.application.port.out.ConsentRepository
 import com.openbank.consent.domain.event.ConsentExpired
+import com.openbank.libs.observability.DomainMetrics
+import com.openbank.libs.observability.WorkflowLivenessRecorder
 import io.quarkus.logging.Log
+import io.quarkus.runtime.StartupEvent
 import io.quarkus.scheduler.Scheduled
 import io.smallrye.mutiny.Multi
 import io.smallrye.mutiny.Uni
 import io.smallrye.mutiny.coroutines.awaitSuspending
 import jakarta.enterprise.context.ApplicationScoped
+import jakarta.enterprise.event.Observes
 import jakarta.inject.Inject
 import java.time.Clock
+import java.time.Duration
 import java.time.OffsetDateTime
 
 /**
@@ -45,6 +50,16 @@ class ConsentExpirationJob {
     @Inject
     lateinit var clock: Clock
 
+    @Inject
+    lateinit var domainMetrics: DomainMetrics
+
+    private var liveness: WorkflowLivenessRecorder? = null
+
+    /** Registers the boot-seeded ADR-0237 heartbeat before the first hourly sweep. */
+    fun registerLiveness(@Observes @Suppress("UNUSED_PARAMETER") event: StartupEvent) {
+        liveness = domainMetrics.registerWorkflowLiveness(WORKFLOW_NAME, EXPECTED_INTERVAL)
+    }
+
     // TooGenericExceptionCaught: one bad tick must not kill the cron — ANY fault is logged and the
     // next hour retries, since every consent still past validTo is picked up again by definition.
     @Suppress("TooGenericExceptionCaught")
@@ -57,12 +72,18 @@ class ConsentExpirationJob {
         val threshold = OffsetDateTime.now(clock)
         try {
             val count = buildSweepPipeline(threshold).awaitSuspending()
+            liveness?.recordSuccess()
             if (count > 0) {
                 Log.infof("consent.expiration.sweep expired=%d threshold=%s", count, threshold)
             }
         } catch (err: Exception) {
             Log.errorf(err, "consent.expiration.sweep FAILED threshold=%s", threshold)
         }
+    }
+
+    companion object {
+        private const val WORKFLOW_NAME = "consent-expiration-sweep"
+        private val EXPECTED_INTERVAL: Duration = Duration.ofHours(1)
     }
 
     internal fun buildSweepPipeline(threshold: OffsetDateTime): Uni<Int> = consentRepo.findExpiredActive(threshold)

--- a/openbank-consent-service/src/test/kotlin/com/openbank/consent/infrastructure/ConsentExpirationJobTest.kt
+++ b/openbank-consent-service/src/test/kotlin/com/openbank/consent/infrastructure/ConsentExpirationJobTest.kt
@@ -11,11 +11,15 @@ import com.openbank.consent.domain.model.ConsentScope
 import com.openbank.consent.domain.model.ConsentStatus
 import com.openbank.consent.domain.model.GranteeType
 import com.openbank.libs.domain.event.DomainEvent
+import com.openbank.libs.observability.DomainMetrics
+import com.openbank.libs.observability.WorkflowLivenessRecorder
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
+import io.quarkus.runtime.StartupEvent
 import io.smallrye.mutiny.Uni
+import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.time.Clock
@@ -27,11 +31,14 @@ import java.util.UUID
 class ConsentExpirationJobTest {
 
     private val consentRepo = mockk<ConsentRepository>()
+    private val metrics = mockk<DomainMetrics>()
+    private val liveness = mockk<WorkflowLivenessRecorder>(relaxed = true)
     private val fixedClock = Clock.fixed(Instant.parse("2026-06-29T05:05:00Z"), ZoneOffset.UTC)
 
     private val job = ConsentExpirationJob().also {
         it.consentRepo = consentRepo
         it.clock = fixedClock
+        it.domainMetrics = metrics
     }
 
     private fun consent(
@@ -124,5 +131,29 @@ class ConsentExpirationJobTest {
         job.buildSweepPipeline(threshold).await().indefinitely()
 
         assertThat(thresholdSlot.captured).isEqualTo(threshold)
+    }
+
+    @Test
+    fun `sweep registers heartbeat and records success only after completed pipeline`(): Unit = runBlocking {
+        every { metrics.registerWorkflowLiveness(any(), any()) } returns liveness
+        every { consentRepo.findExpiredActive(any()) } returns Uni.createFrom().item(emptyList())
+
+        job.registerLiveness(StartupEvent())
+        job.sweepExpiredConsents()
+
+        verify(exactly = 1) { metrics.registerWorkflowLiveness("consent-expiration-sweep", any()) }
+        verify(exactly = 1) { liveness.recordSuccess() }
+    }
+
+    @Test
+    fun `sweep failure records no liveness success`(): Unit = runBlocking {
+        every { metrics.registerWorkflowLiveness(any(), any()) } returns liveness
+        every { consentRepo.findExpiredActive(any()) } returns
+            Uni.createFrom().failure(IllegalStateException("db down"))
+
+        job.registerLiveness(StartupEvent())
+        job.sweepExpiredConsents()
+
+        verify(exactly = 0) { liveness.recordSuccess() }
     }
 }


### PR DESCRIPTION
Refs #3345

Registers the hourly consent-expiration scheduler with ADR-0237 workflow liveness at startup and records success only after its reactive sweep completes. Adds success and swallowed-failure coverage, and removes this now-compliant scheduler from the ratchet baseline.

Validation: scheduler-liveness self-test and ratchet pass; Gradle local runner did not return a conclusive task result after daemon startup, so required CI remains authoritative.