### PR TITLE
fix(ci): invoke the verification-metadata sweep once per module, not per shard

### DIFF
--- a/.github/scripts/check-verification-metadata-complete.py
+++ b/.github/scripts/check-verification-metadata-complete.py
@@ -107,7 +107,22 @@ def artifact_set(path: pathlib.Path) -> set[str]:
 
 # `--write-verification-metadata` OOMs at Gradle's default heap: measured, it dies
 # with `Java heap space` even on a single module. This is not optional tuning.
-GRADLE_HEAP = "-Dorg.gradle.jvmargs=-Xmx6g"
+#
+# 6g was not enough either (#4907): `openbank-libs-runtime` — the largest shared dependency graph
+# in the tree — still died with `Java heap space` under
+# `--refresh-dependencies --write-verification-metadata sha256`, twice, including a clean re-run.
+# That blocks a required context on ANY pull request that touches a libs module's build file.
+#
+# Before raising it, the mechanism was verified rather than assumed: `org.gradle.jvmargs` passed as
+# `-D` on the command line is a classic place for a setting to be silently dropped. An init script
+# printing the build JVM's Runtime.maxMemory() reports 6144 MB with this flag and 3072 MB without
+# it (the gradle.properties default), so the value does reach the build JVM. The flag works; the
+# number was too small.
+#
+# 8g is a STEP, not a measured threshold — the local reproduction needed to find the real figure did
+# not complete. `ubuntu-latest` has 16 GB, so 8g leaves headroom for the launcher and the Kotlin
+# daemons. If this recurs, raise the number; do not re-litigate whether the flag applies.
+GRADLE_HEAP = "-Dorg.gradle.jvmargs=-Xmx8g"
 
 
 def regenerate(modules: list[str]) -> None:

--- a/.github/scripts/check-verification-metadata-complete.py
+++ b/.github/scripts/check-verification-metadata-complete.py
@@ -126,32 +126,53 @@ GRADLE_HEAP = "-Dorg.gradle.jvmargs=-Xmx8g"
 
 
 def regenerate(modules: list[str]) -> None:
-    """Run the metadata writer for the given modules, in place.
+    """Run the metadata writer for each module IN ITS OWN Gradle invocation, in place.
 
-    Raises RegenerationFailed if Gradle itself failed. That is deliberately NOT the
-    same outcome as "a gap was found": a crashed build proves nothing either way,
-    and reporting it as a gap would send the author chasing entries that are fine.
+    Raises RegenerationFailed if Gradle itself failed on any module. That is
+    deliberately NOT the same outcome as "a gap was found": a crashed build proves
+    nothing either way, and reporting it as a gap would send the author chasing
+    entries that are fine.
+
+    ONE INVOCATION PER MODULE, not one invocation for the whole list (#4793). The
+    periodic sweep passes several modules per shard (`--shard I/N` strides a sorted
+    list, so a shard can land `openbank-libs-runtime` next to two or three others by
+    coincidence of alphabetical distance, not by any weighting). Bundling them into a
+    single `./gradlew ... target1 target2 target3` command line means ONE JVM holds
+    every module's resolved dependency graph in memory AT THE SAME TIME — so even
+    after #4907 raised the heap enough for libs-runtime ALONE, shard 4 still died: it
+    was libs-runtime plus three more modules in one process. Invoking Gradle once per
+    module releases the JVM (and its heap) between modules, so the peak footprint is
+    bounded by the single largest module in the shard, not their sum — the same bound
+    the PR-gate case (always exactly one module) already runs under successfully.
     """
-    targets = [f":{module}:{task}" for module in modules for task in tasks_for(module)]
-    result = subprocess.run(
-        ["./gradlew", "--write-verification-metadata", "sha256",
-         # Without this the check is vacuous on CI. A warm Gradle cache does not
-         # re-resolve metadata artifacts, so nothing gets re-hashed and the run
-         # reports "no gaps" even when an entry is demonstrably missing — measured:
-         # delete a known entry, run without --refresh-dependencies, and it passes.
-         # CI always has a warm cache (`actions/setup-java` with `cache: gradle`).
-         "--refresh-dependencies",
-         *targets, GRADLE_HEAP, "--no-daemon", "--console=plain", "-q"],
-        check=False,
-    )
-    if result.returncode != 0:
-        raise RegenerationFailed(result.returncode)
+    failures: list[tuple[str, int]] = []
+    for module in modules:
+        targets = [f":{module}:{task}" for task in tasks_for(module)]
+        result = subprocess.run(
+            ["./gradlew", "--write-verification-metadata", "sha256",
+             # Without this the check is vacuous on CI. A warm Gradle cache does not
+             # re-resolve metadata artifacts, so nothing gets re-hashed and the run
+             # reports "no gaps" even when an entry is demonstrably missing — measured:
+             # delete a known entry, run without --refresh-dependencies, and it passes.
+             # CI always has a warm cache (`actions/setup-java` with `cache: gradle`).
+             "--refresh-dependencies",
+             *targets, GRADLE_HEAP, "--no-daemon", "--console=plain", "-q"],
+            check=False,
+        )
+        if result.returncode != 0:
+            failures.append((module, result.returncode))
+    if failures:
+        raise RegenerationFailed(failures)
 
 
 class RegenerationFailed(RuntimeError):
-    def __init__(self, code: int) -> None:
-        super().__init__(f"gradle exited {code}")
-        self.code = code
+    def __init__(self, failures: list[tuple[str, int]]) -> None:
+        detail = ", ".join(f"{module} (exit {code})" for module, code in failures)
+        super().__init__(f"gradle failed for: {detail}")
+        self.failures = failures
+        # Kept for callers that only cared about "did it fail" before this change —
+        # the first module's code, which is what a single-module (PR-gate) call always was.
+        self.code = failures[0][1]
 
 
 def selftest() -> int:


### PR DESCRIPTION
## What this fixes

Issue #4793 / #4907's root cause on the **periodic sweep** specifically (`verification-metadata-drift.yml`), stacked on #4909's parent commit (raises the PR-gate's single-module heap 6g→8g).

## The mechanism, not just the symptom

`check-verification-metadata-complete.py`'s `regenerate()` passed **every module in a shard** as targets on a single `./gradlew --write-verification-metadata` command line. Shard 4/18 regenerates `openbank-anacredit-service`, `openbank-dispute-service`, `openbank-libs-runtime` and `openbank-simulation` — and #4907 already established `openbank-libs-runtime` **alone** needs 8g. Bundling it with three more modules in one JVM means that JVM holds all four dependency graphs simultaneously. Raising the heap fixes the one-module (PR-gate) case; it does not fix a shard that bundles the fleet's largest module with others.

`--shard I/N` strides an alphabetically sorted list with no weighting for known-expensive modules, so whichever shard `openbank-libs-runtime` lands in is **fixed** — this was not a flake, it would fail identically every night.

## The fix

`regenerate()` now invokes Gradle **once per module** instead of once per shard, collecting failures across the loop. Each module gets a released JVM before the next starts, so peak heap is bounded by the shard's single largest module, not their sum — the same footprint the PR-gate's single-module case already runs under successfully.

`RegenerationFailed` now carries the full `(module, exit code)` list rather than one code (kept as `.code` for compatibility — nothing else in the file reads it).

## Verification

Local reproduction was attempted but the machine had two other concurrent Gradle builds running at the time — this repo's own notes flag that as unreliable, so it wasn't trusted either way (a background single-module smoke run did later finish clean, consistent with but not the real test).

**The real test: a live dispatch of the full 18-shard sweep on this branch.** [Run 31951337395](https://github.com/JiRaska/open-bank-oss/actions/runs/31951337395) — **all 18 shards green**, including shard 4/18, the exact one that OOMed in the run this issue was filed from. The only non-`success` job is `Raise issue on drift`, correctly `skipped` since there was nothing to report.

Refs #4793
Refs #4907
