### PR TITLE
fix(admin-ui): widen demo account to system:view (issue #5020)

### DIFF
--- a/openbank-admin-ui/src/lib/auth/roles.ts
+++ b/openbank-admin-ui/src/lib/auth/roles.ts
@@ -124,7 +124,17 @@ export const PERMISSIONS = {
   "opsmessage:compose":       [ROLES.ADMIN, ROLES.OPERATOR],
   "opsmessage:approve":       [ROLES.ADMIN, ROLES.OPERATOR],
   // System
-  "system:view":              [ROLES.ADMIN, ROLES.OPERATOR],
+  // ROLES.DEMO added 2026-08-16 (issue #5020), verified safe two independent ways before
+  // adding: middleware.ts's routeGuards array has a pattern for /system/config (ADMIN only,
+  // the mutation path — untouched) but NONE for the general /system/* view pages, so no
+  // route-level role check exists to conflict with; and every BFF route these pages call
+  // (finops/*, devops/*, security, observability/*, temporal/status) either has no
+  // permission check of its own at all, or (api/iaops/rca) checks this exact
+  // hasPermission(roles, 'system:view') — same source of truth, so widening it here widens
+  // consistently everywhere it is read. Unlike onboarding:view above, there is no backend
+  // @RolesAllowed/rego to have verified against, because these pages proxy telemetry
+  // (Prometheus, Holmes, k8s) rather than calling a service with its own RBAC.
+  "system:view":              [ROLES.ADMIN, ROLES.OPERATOR, ROLES.DEMO],
   "system:config":            [ROLES.ADMIN],
   // Docs
   "docs:view":                [ROLES.ADMIN, ROLES.OPERATOR, ROLES.VIEWER, ROLES.COMPLIANCE, ROLES.PAYMENTS, ROLES.AUDITOR],

--- a/openbank-admin-ui/src/test/roles.test.ts
+++ b/openbank-admin-ui/src/test/roles.test.ts
@@ -44,6 +44,36 @@ describe('hasPermission', () => {
     expect(hasPermission([ROLES.SUPERVISOR], 'audit:view')).toBe(true)
     expect(hasPermission([ROLES.SUPERVISOR], 'payments:create')).toBe(false)
   })
+
+  // Issue #5020: the demo account (ROLE_VIEWER + ROLE_DEMO only, no write-capable role — see
+  // fix/demo-account-viewer-only) is admitted to exactly the *:view permissions verified safe
+  // against their backend: onboarding-service accepts a plain VIEWER, and the system pages
+  // proxy telemetry with no backend RBAC of their own. It must NOT be admitted to any
+  // permission whose backend has no viewer-equivalent tier, or the nav would render a link
+  // that 403s on click — worse than hiding it. That verification lives in each permission's
+  // own comment in roles.ts; this test only pins the resulting boolean so a future edit that
+  // silently widens or narrows demo's reach is caught here.
+  it('admits the demo account to the two verified-safe view permissions, nothing else', () => {
+    expect(hasPermission([ROLES.DEMO], 'onboarding:view')).toBe(true)
+    expect(hasPermission([ROLES.DEMO], 'system:view')).toBe(true)
+    // Structurally blocked — no backend viewer tier exists (verified by reading the
+    // service's @RolesAllowed / rego, not assumed):
+    expect(hasPermission([ROLES.DEMO], 'kyc:view')).toBe(false)
+    expect(hasPermission([ROLES.DEMO], 'audit:view')).toBe(false)
+    expect(hasPermission([ROLES.DEMO], 'delegations:view')).toBe(false)
+    expect(hasPermission([ROLES.DEMO], 'notifications:view')).toBe(false)
+    expect(hasPermission([ROLES.DEMO], 'regulatory:view')).toBe(false)
+    expect(hasPermission([ROLES.DEMO], 'templates:view')).toBe(false)
+    // Deliberate policy exclusion, not a technical gap — dispute-service's own rego documents
+    // ROLE_VIEWER as excluded from compliance data on PII grounds; a product/compliance call,
+    // not something this matrix should silently widen.
+    expect(hasPermission([ROLES.DEMO], 'compliance:view')).toBe(false)
+    // Demo must never gain a write-capable permission, regardless of what view access it holds.
+    expect(hasPermission([ROLES.DEMO], 'accounts:create')).toBe(false)
+    expect(hasPermission([ROLES.DEMO], 'transactions:reverse')).toBe(false)
+    expect(hasPermission([ROLES.DEMO], 'payments:approve')).toBe(false)
+    expect(hasPermission([ROLES.DEMO], 'system:config')).toBe(false)
+  })
 })
 
 describe('hasRole', () => {


### PR DESCRIPTION
## What

Second and final safe widening from the #5020 verification pass. `onboarding:view` landed in `fix/demo-account-viewer-only` (#5022); this is `system:view` — the permission gating the `iaops`/`temporal`/`devops`/`finops`/`security`/`observability` tool pages.

## Why it's safe (verified two independent ways, same discipline as #5022)

1. **`middleware.ts`'s `routeGuards`** has a pattern for `/system/config` (`ROLE_ADMIN` only — the mutation path, untouched) but **none** for the general `/system/*` view pages. No route-level role check exists to conflict with.
2. **Every BFF route these pages call** (`finops/*`, `devops/*`, `security`, `observability/*`, `temporal/status`) either has no permission check of its own at all, or — `api/iaops/rca` — checks this exact `hasPermission(roles, 'system:view')`. Same source of truth, so widening it here widens consistently everywhere it's read.

Unlike `onboarding:view` (verified against `OnboardingResource.kt`'s real `@RolesAllowed`), there's no backend RBAC to check here at all: these pages proxy telemetry (Prometheus, Holmes, k8s) rather than calling a service with its own authorization. Confirmed by grepping every route handler under those paths for a role check — none exists to fail.

## Pinning test

Added to `roles.test.ts` — enumerates what the demo account can and cannot see, so a future edit that silently widens or narrows its reach is caught here rather than discovered live:

```ts
it('admits the demo account to the two verified-safe view permissions, nothing else', () => {
  expect(hasPermission([ROLES.DEMO], 'onboarding:view')).toBe(true)
  expect(hasPermission([ROLES.DEMO], 'system:view')).toBe(true)
  // Structurally blocked — no backend viewer tier exists:
  expect(hasPermission([ROLES.DEMO], 'kyc:view')).toBe(false)
  expect(hasPermission([ROLES.DEMO], 'audit:view')).toBe(false)
  expect(hasPermission([ROLES.DEMO], 'delegations:view')).toBe(false)
  expect(hasPermission([ROLES.DEMO], 'notifications:view')).toBe(false)
  expect(hasPermission([ROLES.DEMO], 'regulatory:view')).toBe(false)
  expect(hasPermission([ROLES.DEMO], 'templates:view')).toBe(false)
  // Deliberate policy exclusion, not a technical gap:
  expect(hasPermission([ROLES.DEMO], 'compliance:view')).toBe(false)
  // Never a write-capable permission:
  expect(hasPermission([ROLES.DEMO], 'accounts:create')).toBe(false)
  expect(hasPermission([ROLES.DEMO], 'transactions:reverse')).toBe(false)
  expect(hasPermission([ROLES.DEMO], 'payments:approve')).toBe(false)
  expect(hasPermission([ROLES.DEMO], 'system:config')).toBe(false)
})
```

`compliance:view` stays excluded on purpose, not as an oversight: `dispute-service`'s own `dispute_rest_ext.rego` documents `ROLE_VIEWER` as a **deliberate non-grant** on statutory-complaint PII grounds, and `compliance:view` gates `aml`/`disputes`/`sanctions` as one permission — widening it is a product/compliance call, not a technical gap this PR should close.

## Verified

- Full `admin-ui` suite: **1315/1315** (was 1314 — the +1 is this PR's own test).
- Local `run-gates.py --all`: **148/149** — the one failure, `api-contract-gate`, needs `sudo` to install `oasdiff` locally and reproduces identically on a clean `origin/main` worktree.

Refs #5020
