### PR TITLE
fix(delegation): record expiration sweep liveness

### DIFF
--- a/.github/scripts/check-scheduler-liveness.py
+++ b/.github/scripts/check-scheduler-liveness.py
@@ -71,7 +71,6 @@ BASELINE = [
     # non-money-path
     "openbank-agent-service/src/main/kotlin/com/openbank/agent/application/OversightService.kt",
     "openbank-agent-service/src/main/kotlin/com/openbank/agent/infrastructure/observability/AgentMetricsAdapter.kt",
-    "openbank-delegation-service/src/main/kotlin/com/openbank/delegation/infrastructure/DelegationExpirationJob.kt",
     "openbank-dispute-service/src/main/kotlin/com/openbank/dispute/infrastructure/observability/ComplaintDeadlineGauge.kt",
     "openbank-onboarding-service/src/main/kotlin/com/openbank/onboarding/infrastructure/observability/OnboardingFunnelGauge.kt",
     "openbank-pid-service/src/main/kotlin/com/openbank/pid/infrastructure/crypto/TrustedListService.kt",

--- a/openbank-delegation-service/src/main/kotlin/com/openbank/delegation/infrastructure/DelegationExpirationJob.kt
+++ b/openbank-delegation-service/src/main/kotlin/com/openbank/delegation/infrastructure/DelegationExpirationJob.kt
@@ -6,14 +6,19 @@ package com.openbank.delegation.infrastructure
 
 import com.openbank.delegation.application.port.out.DelegationRepository
 import com.openbank.delegation.domain.event.DelegationExpired
+import com.openbank.libs.observability.DomainMetrics
+import com.openbank.libs.observability.WorkflowLivenessRecorder
 import io.quarkus.logging.Log
+import io.quarkus.runtime.StartupEvent
 import io.quarkus.scheduler.Scheduled
 import io.smallrye.mutiny.Multi
 import io.smallrye.mutiny.Uni
 import io.smallrye.mutiny.coroutines.awaitSuspending
 import jakarta.enterprise.context.ApplicationScoped
+import jakarta.enterprise.event.Observes
 import jakarta.inject.Inject
 import java.time.Clock
+import java.time.Duration
 import java.time.OffsetDateTime
 
 /**
@@ -31,6 +36,16 @@ class DelegationExpirationJob {
 
     @Inject
     lateinit var clock: Clock
+
+    @Inject
+    lateinit var domainMetrics: DomainMetrics
+
+    private var liveness: WorkflowLivenessRecorder? = null
+
+    /** Registers the boot-seeded ADR-0237 heartbeat before the first hourly sweep. */
+    fun registerLiveness(@Observes @Suppress("UNUSED_PARAMETER") event: StartupEvent) {
+        liveness = domainMetrics.registerWorkflowLiveness(WORKFLOW_NAME, EXPECTED_INTERVAL)
+    }
 
     /**
      * `suspend fun` — the fleet convention (rules.yaml: scheduled_methods), and here it is load
@@ -54,9 +69,15 @@ class DelegationExpirationJob {
             Log.errorf(e, "delegation.expiration.sweep FAILED threshold=%s", threshold)
             return
         }
+        liveness?.recordSuccess()
         if (count > 0) {
             Log.infof("delegation.expiration.sweep expired=%d threshold=%s", count, threshold)
         }
+    }
+
+    companion object {
+        private const val WORKFLOW_NAME = "delegation-expiration-sweep"
+        private val EXPECTED_INTERVAL: Duration = Duration.ofHours(1)
     }
 
     internal fun buildSweepPipeline(threshold: OffsetDateTime): Uni<Int> = delegationRepo.findExpiredActive(threshold)

--- a/openbank-delegation-service/src/test/kotlin/com/openbank/delegation/infrastructure/DelegationExpirationJobLivenessTest.kt
+++ b/openbank-delegation-service/src/test/kotlin/com/openbank/delegation/infrastructure/DelegationExpirationJobLivenessTest.kt
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.delegation.infrastructure
+
+import com.openbank.delegation.application.port.out.DelegationRepository
+import com.openbank.libs.observability.DomainMetrics
+import com.openbank.libs.observability.WorkflowLivenessRecorder
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import io.quarkus.runtime.StartupEvent
+import io.smallrye.mutiny.Uni
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+
+class DelegationExpirationJobLivenessTest {
+
+    private val repository = mockk<DelegationRepository>()
+    private val metrics = mockk<DomainMetrics>()
+    private val liveness = mockk<WorkflowLivenessRecorder>(relaxed = true)
+    private val job = DelegationExpirationJob().also {
+        it.delegationRepo = repository
+        it.clock = Clock.fixed(Instant.parse("2026-08-16T05:00:00Z"), ZoneOffset.UTC)
+        it.domainMetrics = metrics
+    }
+
+    @Test
+    fun `registers heartbeat and records success after completed sweep`(): Unit = runBlocking {
+        every { metrics.registerWorkflowLiveness(any(), any()) } returns liveness
+        every { repository.findExpiredActive(any()) } returns Uni.createFrom().item(emptyList())
+
+        job.registerLiveness(StartupEvent())
+        job.sweepExpiredGrants()
+
+        verify(exactly = 1) { metrics.registerWorkflowLiveness("delegation-expiration-sweep", any()) }
+        verify(exactly = 1) { liveness.recordSuccess() }
+    }
+
+    @Test
+    fun `caught repository failure records no liveness success`(): Unit = runBlocking {
+        every { metrics.registerWorkflowLiveness(any(), any()) } returns liveness
+        every { repository.findExpiredActive(any()) } returns
+            Uni.createFrom().failure(IllegalStateException("db down"))
+
+        job.registerLiveness(StartupEvent())
+        job.sweepExpiredGrants()
+
+        verify(exactly = 0) { liveness.recordSuccess() }
+    }
+}


### PR DESCRIPTION
Refs #3345

Registers the hourly delegation-expiration scheduler with ADR-0237 workflow liveness at startup and records success only after its reactive sweep completes. Adds success and caught-failure coverage, and removes this scheduler from the ratchet baseline.

Validation: scheduler-liveness self-test and ratchet pass; CI is authoritative for the targeted Gradle test.