### PR TITLE
fix(ci): pass quarkus.redis.hosts explicitly in the authenticated-fuzz harness

### DIFF
--- a/.github/workflows/api-fuzz-authenticated.yml
+++ b/.github/workflows/api-fuzz-authenticated.yml
@@ -293,6 +293,19 @@ jobs:
           # Services for default datasource as it has explicit configuration"). Kafka is lazy
           # behind the outbox, so no broker is needed to serve a request. What was left was an
           # observability stack and a Kafka image, pulled on every one of 18 jobs, for nothing.
+          #
+          # REDIS HOST IS PASSED EXPLICITLY, not left to each service's own application.yaml
+          # (#3039). 24 of the 25 services that inject a ReactiveRedisDataSource hardcode
+          # `quarkus.redis.hosts: redis://localhost:6379` in their own application.yaml, which
+          # happens to already match this harness's fuzz-redis container — so passing nothing
+          # here looked equivalent to passing the right value. fraud-service is the one
+          # exception: it has no redis config at all (relies on `QUARKUS_REDIS_HOSTS` being
+          # injected in every real environment), and with Dev Services off it has nothing to
+          # fall back to — `FeatureStoreConfig.onlineFeatureStore` needs a
+          # ReactiveRedisDataSource CDI bean that never activates, and boot fails with
+          # `InactiveBeanException: Bean is not active`. Same shape as the datasource/OIDC args
+          # above: state what the harness actually provisions, don't depend on it happening to
+          # agree with whatever each service's own config says.
           echo "==> [${svc}] starting quarkusDev with OIDC on"
           ./gradlew ":${svc}:quarkusDev" \
             -Dquarkus.console.basic=true --console=plain --quiet \
@@ -303,6 +316,7 @@ jobs:
             -Dquarkus.oidc.auth-server-url=http://localhost:8543/realms/openbank \
             -Dquarkus.oidc.client-id=openbank-services \
             -Dquarkus.oidc.credentials.secret="${OIDC_CLIENT_SECRET}" \
+            -Dquarkus.redis.hosts=redis://localhost:6379 \
             -Dquarkus.devservices.enabled=false \
             ${TEMPORAL_ARGS} \
             > "fuzz-reports/${svc}-boot.log" 2>&1 &


### PR DESCRIPTION
## What

Passes `-Dquarkus.redis.hosts=redis://localhost:6379` explicitly to the `quarkusDev` boot
command in `api-fuzz-authenticated.yml`, the same way the harness already passes explicit
`-D` overrides for the datasource and OIDC.

## Why

Issue #3039 has been re-triaged many times as the harness's other boot-failure causes were
fixed (Keycloak port move #3079, Temporal provisioning #4530, coverage-as-fraction #4695,
disabling unrelated Dev Services image pulls #4703). Re-measured on a **fresh full-matrix
dispatch of `main`** today (run
[31952049629](https://github.com/JiRaska/open-bank-oss/actions/runs/31952049629)): 18 jobs,
8 failures. Discriminating by artifact contents (a service that reaches the fuzzer emits
`<svc>-auth-fuzz.log` + `<svc>-auth-junit.xml`; one that dies at boot emits the boot log
alone) — 7 of those 8 already reach the fuzzer and fail on genuine findings (out of scope
here, tracked separately). **`openbank-fraud-service` is the one real boot failure left.**

Its full boot log (previously invisible under the old 60-line tail, now readable via the
existing ERROR/`Caused by:` grep from #3079) names the cause directly:

```
ERROR [io.qu.ru.Application] Failed to start application: java.lang.RuntimeException: Failed to start quarkus
Caused by: io.quarkus.arc.InactiveBeanException: Bean is not active: SYNTHETIC bean [class=io.quarkus.redis.datasource.ReactiveRedisDataSource, ...]
```

`FeatureStoreConfig.onlineFeatureStore` (`openbank-fraud-service`) needs a
`ReactiveRedisDataSource` CDI bean. 24 of the 25 services in the fleet that inject this bean
hardcode `quarkus.redis.hosts: redis://localhost:6379` directly in their own
`application.yaml`, which happens to already agree with the harness's `fuzz-redis` container
— so the harness never needed to pass anything, and that agreement read as if it were the
mechanism. `openbank-fraud-service` has no Redis config at all (it depends on
`QUARKUS_REDIS_HOSTS` being injected in every real deployment, and previously fell back to
Dev Services in local/dev mode). With Dev Services off (#4703) it has nothing left to fall
back to, and boot fails.

This is the same shape as the Kafka `group.id` dotted-key trap documented in this repo's
`CLAUDE.md`: several services look correct for the same reason, until one isn't. The fix
states what the harness provisions explicitly rather than depending on incidental agreement
with each service's own config.

## Verification — real dispatch, not local reasoning

Dispatched this branch: run
[31952916776](https://github.com/JiRaska/open-bank-oss/actions/runs/31952916776).

- `openbank-fraud-service` now boots and reaches the fuzzer: **163 test cases generated, 163
  passed, 0 server errors** (one unrelated schema-validation warning).
- All 18 jobs now reach the fuzz step — **zero boot failures**, discriminated the same way
  (artifact contents), confirmed for `openbank-account-service` and `openbank-fraud-service`
  (both booted cleanly) and `openbank-transaction-service` / `openbank-interest-service`
  (booted, artifact carries a genuine fuzz report).
- The run's overall conclusion is still `failure` — 8 services now fail on genuine
  authenticated-fuzz findings (server errors on generated input). That is the fuzz lane
  doing its job, not a harness gap, and is explicitly out of scope for this PR (see below).

## Scope

This PR is the harness fix only. It does **not** touch the 7-8 services returning genuine
5xx findings under authenticated fuzz (ledger, balance, fx, swift, interest, lending,
transaction, consent — the set moves slightly between runs, consistent with the issue
thread's own note that timing/contention shifts which services land where). Those are
already partly tracked (#3625, #3658, #3660, #3923) and deserve their own triage, not a fold
into this harness PR.

Refs #3039
