### PR TITLE
fix(audit): record anchor capture liveness

### DIFF
--- a/.github/scripts/check-scheduler-liveness.py
+++ b/.github/scripts/check-scheduler-liveness.py
@@ -71,7 +71,6 @@ BASELINE = [
     # non-money-path
     "openbank-agent-service/src/main/kotlin/com/openbank/agent/application/OversightService.kt",
     "openbank-agent-service/src/main/kotlin/com/openbank/agent/infrastructure/observability/AgentMetricsAdapter.kt",
-    "openbank-audit-service/src/main/kotlin/com/openbank/audit/application/AuditAnchorService.kt",
     "openbank-delegation-service/src/main/kotlin/com/openbank/delegation/infrastructure/DelegationExpirationJob.kt",
     "openbank-dispute-service/src/main/kotlin/com/openbank/dispute/infrastructure/observability/ComplaintDeadlineGauge.kt",
     "openbank-onboarding-service/src/main/kotlin/com/openbank/onboarding/infrastructure/observability/OnboardingFunnelGauge.kt",

--- a/openbank-audit-service/src/main/kotlin/com/openbank/audit/application/AuditAnchorService.kt
+++ b/openbank-audit-service/src/main/kotlin/com/openbank/audit/application/AuditAnchorService.kt
@@ -8,11 +8,16 @@ import com.openbank.audit.application.port.out.AnchorSigner
 import com.openbank.audit.domain.model.AuditAnchor
 import com.openbank.audit.infrastructure.persistence.AuditAnchorRepository
 import com.openbank.audit.infrastructure.persistence.AuditRepository
+import com.openbank.libs.observability.DomainMetrics
+import com.openbank.libs.observability.WorkflowLivenessRecorder
+import io.quarkus.runtime.StartupEvent
 import io.quarkus.scheduler.Scheduled
 import jakarta.enterprise.context.ApplicationScoped
+import jakarta.enterprise.event.Observes
 import org.eclipse.microprofile.config.inject.ConfigProperty
 import org.jboss.logging.Logger
 import java.time.Clock
+import java.time.Duration
 import java.util.UUID
 
 /**
@@ -31,8 +36,15 @@ class AuditAnchorService(
     private val clock: Clock,
     @ConfigProperty(name = "openbank.audit.anchor.enabled", defaultValue = "true")
     private val enabled: Boolean,
+    private val domainMetrics: DomainMetrics,
 ) {
     private val log = Logger.getLogger(AuditAnchorService::class.java)
+    private var liveness: WorkflowLivenessRecorder? = null
+
+    /** Registers the boot-seeded ADR-0237 heartbeat before the first anchor capture. */
+    fun registerLiveness(@Observes @Suppress("UNUSED_PARAMETER") event: StartupEvent) {
+        liveness = domainMetrics.registerWorkflowLiveness(WORKFLOW_NAME, EXPECTED_INTERVAL)
+    }
 
     @Scheduled(
         every = "\${openbank.audit.anchor.interval:1h}",
@@ -43,6 +55,7 @@ class AuditAnchorService(
     suspend fun captureScheduled() {
         if (!enabled) return
         runCatching { captureAnchor() }
+            .onSuccess { liveness?.recordSuccess() }
             .onFailure { log.error("audit anchor capture failed", it) }
     }
 
@@ -120,6 +133,8 @@ class AuditAnchorService(
     suspend fun recent(limit: Int): List<AuditAnchor> = anchorRepo.recent(limit.coerceIn(1, MAX_ANCHOR_PAGE))
 
     private companion object {
+        const val WORKFLOW_NAME = "audit-anchor-capture"
+        val EXPECTED_INTERVAL: Duration = Duration.ofHours(1)
         const val STATUS_INTACT = "INTACT"
         const val STATUS_BROKEN = "BROKEN"
         const val MAX_ANCHOR_PAGE = 200

--- a/openbank-audit-service/src/test/kotlin/com/openbank/audit/application/AuditAnchorServiceLivenessTest.kt
+++ b/openbank-audit-service/src/test/kotlin/com/openbank/audit/application/AuditAnchorServiceLivenessTest.kt
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.audit.application
+
+import com.openbank.audit.application.port.out.AnchorSigner
+import com.openbank.audit.infrastructure.persistence.AuditAnchorRepository
+import com.openbank.audit.infrastructure.persistence.AuditRepository
+import com.openbank.libs.observability.DomainMetrics
+import com.openbank.libs.observability.WorkflowLivenessRecorder
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import io.quarkus.runtime.StartupEvent
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+
+class AuditAnchorServiceLivenessTest {
+
+    private val auditRepository = mockk<AuditRepository>()
+    private val anchorRepository = mockk<AuditAnchorRepository>()
+    private val signer = mockk<AnchorSigner>()
+    private val metrics = mockk<DomainMetrics>()
+    private val liveness = mockk<WorkflowLivenessRecorder>(relaxed = true)
+
+    private fun service(enabled: Boolean) = AuditAnchorService(
+        auditRepo = auditRepository,
+        anchorRepo = anchorRepository,
+        signer = signer,
+        clock = Clock.fixed(Instant.parse("2026-08-16T05:00:00Z"), ZoneOffset.UTC),
+        enabled = enabled,
+        domainMetrics = metrics,
+    )
+
+    @Test
+    fun `registers heartbeat and records success after completed capture`(): Unit = runBlocking {
+        val service = service(enabled = true)
+        every { metrics.registerWorkflowLiveness(any(), any()) } returns liveness
+        coEvery { auditRepository.chainHead() } returns null
+
+        service.registerLiveness(StartupEvent())
+        service.captureScheduled()
+
+        verify(exactly = 1) { metrics.registerWorkflowLiveness("audit-anchor-capture", any()) }
+        verify(exactly = 1) { liveness.recordSuccess() }
+    }
+
+    @Test
+    fun `caught capture failure records no liveness success`(): Unit = runBlocking {
+        val service = service(enabled = true)
+        every { metrics.registerWorkflowLiveness(any(), any()) } returns liveness
+        coEvery { auditRepository.chainHead() } throws IllegalStateException("db down")
+
+        service.registerLiveness(StartupEvent())
+        service.captureScheduled()
+
+        verify(exactly = 0) { liveness.recordSuccess() }
+    }
+
+    @Test
+    fun `disabled capture records no liveness success`(): Unit = runBlocking {
+        val service = service(enabled = false)
+        every { metrics.registerWorkflowLiveness(any(), any()) } returns liveness
+
+        service.registerLiveness(StartupEvent())
+        service.captureScheduled()
+
+        verify(exactly = 0) { liveness.recordSuccess() }
+    }
+}


### PR DESCRIPTION
Refs #3345

Registers audit-anchor capture with ADR-0237 workflow liveness and records success only after a completed capture. Disabled and failed captures do not report success. Adds focused coverage and removes the scheduler from the ratchet baseline.

Validation: scheduler-liveness self-test and ratchet pass; CI is authoritative for Gradle.