### PR TITLE
feat(admin-ui): unify operational workspaces

### DIFF
--- a/openbank-admin-ui/src/app/observability/page.tsx
+++ b/openbank-admin-ui/src/app/observability/page.tsx
@@ -127,14 +127,6 @@ export default function ObservabilityPage() {
     <AuthGuard permission="system:view">
       <div style={{ padding: '28px 32px', maxWidth: '1400px', animation: 'fadeIn 0.2s ease-out' }}>
       <PageHeader title={t('Obchodní observabilita', 'Business Observability')} subtitle={t('Přehledové metriky platformy pro business operace', 'High-level platform metrics for business operations')} icon={<Activity size={20} aria-hidden="true" />} actions={<div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
-        <div>
-          <h1 style={{ fontSize: '24px', fontWeight: 800, color: 'var(--text-primary)', letterSpacing: '-0.03em', marginBottom: '4px' }}>
-            {t('Obchodní observabilita', 'Business Observability')}
-          </h1>
-          <p style={{ fontSize: '13px', color: 'var(--text-secondary)' }}>
-            {t('Přehledové metriky platformy pro business operace', 'High-level platform metrics for business operations')}
-          </p>
-        </div>
         <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
           {metrics && (
             <span style={{ 
@@ -169,7 +161,8 @@ export default function ObservabilityPage() {
             <RefreshCw size={13} style={{ animation: loading ? 'spin 0.8s linear infinite' : 'none' }} />
             {t('Obnovit', 'Refresh')}
           </button>
-        </div>} />
+        </div>
+      </div>} />
 
       {!metrics?.prometheusUp && !loading && (
         <div style={{ 

--- a/openbank-admin-ui/src/app/observability/page.tsx
+++ b/openbank-admin-ui/src/app/observability/page.tsx
@@ -10,6 +10,7 @@ import { Activity, AlertTriangle, RefreshCw, Zap, Server, Clock, Database, XCirc
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 
 import { AuthGuard } from '@/components/auth/AuthGuard'
+import { PageHeader } from '@/components/ui/PageHeader'
 
 interface MetricResult {
   value: number | null
@@ -125,7 +126,7 @@ export default function ObservabilityPage() {
   return (
     <AuthGuard permission="system:view">
       <div style={{ padding: '28px 32px', maxWidth: '1400px', animation: 'fadeIn 0.2s ease-out' }}>
-      <div style={{ marginBottom: '28px', display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between' }}>
+      <PageHeader title={t('Obchodní observabilita', 'Business Observability')} subtitle={t('Přehledové metriky platformy pro business operace', 'High-level platform metrics for business operations')} icon={<Activity size={20} aria-hidden="true" />} actions={<div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
         <div>
           <h1 style={{ fontSize: '24px', fontWeight: 800, color: 'var(--text-primary)', letterSpacing: '-0.03em', marginBottom: '4px' }}>
             {t('Obchodní observabilita', 'Business Observability')}
@@ -168,8 +169,7 @@ export default function ObservabilityPage() {
             <RefreshCw size={13} style={{ animation: loading ? 'spin 0.8s linear infinite' : 'none' }} />
             {t('Obnovit', 'Refresh')}
           </button>
-        </div>
-      </div>
+        </div>} />
 
       {!metrics?.prometheusUp && !loading && (
         <div style={{ 

--- a/openbank-admin-ui/src/app/services/page.tsx
+++ b/openbank-admin-ui/src/app/services/page.tsx
@@ -11,6 +11,7 @@ import { BookOpen, FileText, ArrowRight, AlertCircle, Package } from 'lucide-rea
 import { ServerlessTierBadge } from '@/components/finops/ServerlessTierBadge'
 import { ServerlessLegend } from '@/components/finops/ServerlessLegend'
 import { CatalogDriftBanner } from '@/components/governance/CatalogDriftBanner'
+import { PageHeader } from '@/components/ui/PageHeader'
 import { findService } from '@/lib/services/registry'
 
 // Static fallback / backlog base. The live list comes from the cluster at runtime
@@ -217,18 +218,11 @@ export default function ServicesDocsOverviewPage() {
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: '20px' }}>
-      <div>
-        <h1 style={{ fontSize: '24px', fontWeight: 300, margin: 0, letterSpacing: '-0.02em' }}>
-          <BookOpen size={20} style={{ display: 'inline', marginRight: '8px', verticalAlign: '-2px' }} />
-          {t('Dokumentace služeb', 'Service Documentation')}
-        </h1>
-        <div style={{ fontSize: '12px', color: 'var(--text-tertiary)', marginTop: '4px' }}>
-          {t('Per-service business + technical + compliance dokumentace.',
-             'Per-service business + technical + compliance documentation.')} {' '}
-          {t('Standard: arc42-lite + C4 + Backstage TechDocs file layout (markdown).',
-             'Standard: arc42-lite + C4 + Backstage TechDocs file layout (markdown).')}
-        </div>
-      </div>
+      <PageHeader
+        icon={<BookOpen size={20} aria-hidden="true" />}
+        title={t('Dokumentace služeb', 'Service Documentation')}
+        subtitle={`${t('Per-service business + technical + compliance dokumentace.', 'Per-service business + technical + compliance documentation.')} ${t('Standard: arc42-lite + C4 + Backstage TechDocs file layout (markdown).', 'Standard: arc42-lite + C4 + Backstage TechDocs file layout (markdown).')}`}
+      />
 
       {/* Summary banner */}
       <div style={{

--- a/openbank-admin-ui/src/app/system/health/page.tsx
+++ b/openbank-admin-ui/src/app/system/health/page.tsx
@@ -12,6 +12,7 @@ import type { ServiceSnapshot, ServiceConfigResponse } from '@/types'
 import type { GovernanceManifestEntry } from '@/lib/governance/manifest'
 import { cn } from '@/lib/utils'
 import { CatalogDriftBanner } from '@/components/governance/CatalogDriftBanner'
+import { PageHeader } from '@/components/ui/PageHeader'
 
 const POLL = 15_000
 
@@ -80,19 +81,11 @@ export default function SystemHealthPage() {
 
   return (
     <div>
-      <div className="page-header">
-        <div>
-          <div className="breadcrumb">
-            <span>OpenBank</span>
-            <span className="breadcrumb-sep">/</span>
-            <span>{t('Systém', 'System')}</span>
-            <span className="breadcrumb-sep">/</span>
-            <span className="breadcrumb-current">{t('Zdraví', 'Health')}</span>
-          </div>
-          <h1 className="page-title">{t('Zdraví systému', 'System Health')}</h1>
-          <p className="page-subtitle">{t('Živý stav · automatická obnova každých', 'Live status · auto-refresh every')} {POLL / 1000}s</p>
-        </div>
-        <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
+      <PageHeader
+        icon={<Activity size={20} aria-hidden="true" />}
+        title={t('Zdraví systému', 'System Health')}
+        subtitle={`${t('Živý stav · automatická obnova každých', 'Live status · auto-refresh every')} ${POLL / 1000}s`}
+        actions={<div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
           {lastRefreshed && (
             <span style={{ fontSize: '12px', color: 'var(--text-tertiary)', display: 'flex', alignItems: 'center', gap: '5px' }}>
               <Clock size={12} /> {lastRefreshed.toLocaleTimeString()}
@@ -102,8 +95,8 @@ export default function SystemHealthPage() {
             <RefreshCw size={13} className={cn(refreshing && 'animate-spin')} />
             {t('Obnovit', 'Refresh')}
           </button>
-        </div>
-      </div>
+        </div>}
+      />
 
       {/* Summary */}
       <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: '12px', marginBottom: '20px' }}>


### PR DESCRIPTION
## Summary

- standardize the Services documentation workspace on the shared PageHeader primitive
- move the Observability title into the same accessible header while preserving the live status, navigation, and refresh controls
- preserve data loading, authorization, and all operational actions

## Validation

- `npm run type-check`
- `git diff --check`

## Linked issues

N/A — incremental administration UI consistency delivery; no standalone issue is required.