### PR TITLE
ci(governance): bump verification-metadata gate heap 6g to 8g

### DIFF
--- a/.github/scripts/check-verification-metadata-complete.py
+++ b/.github/scripts/check-verification-metadata-complete.py
@@ -107,7 +107,12 @@ def artifact_set(path: pathlib.Path) -> set[str]:
 
 # `--write-verification-metadata` OOMs at Gradle's default heap: measured, it dies
 # with `Java heap space` even on a single module. This is not optional tuning.
-GRADLE_HEAP = "-Dorg.gradle.jvmargs=-Xmx6g"
+# 6g itself started OOMing on openbank-libs-runtime alone (2026-08-16, 3 consecutive
+# failed runs, `Multiple build operations failed. Java heap space` — the fleet's
+# heaviest shared dependency graph, resolved cold with no prior verification-metadata
+# to skip re-hashing). Bumped to 8g, still comfortably under the 16GB GitHub-hosted
+# ubuntu-24.04 runner's total memory.
+GRADLE_HEAP = "-Dorg.gradle.jvmargs=-Xmx8g"
 
 
 def regenerate(modules: list[str]) -> None:
@@ -318,7 +323,7 @@ def main() -> int:
           f"Regenerate locally and commit the additions: "
           f"./gradlew --write-verification-metadata sha256 "
           f"{' '.join(f':{m}:{t}' for m in modules for t in tasks_for(m))} "
-          f"-Dorg.gradle.jvmargs=-Xmx6g")
+          f"-Dorg.gradle.jvmargs=-Xmx8g")
     for key in missing:
         component, artifact = key.split("|", 1)
         print(f"  missing: {artifact}  ({component})")


### PR DESCRIPTION
## Summary
- `check-verification-metadata-complete.py`'s `GRADLE_HEAP` bumped 6g -> 8g.
- `openbank-libs-runtime` alone OOM'd this gate 3 consecutive times on PR #4308 (2026-08-16): `Multiple build operations failed. Java heap space` during the cold-cache `--write-verification-metadata` resolve. It's the fleet's heaviest shared dependency graph and has no prior verification-metadata artifact to skip re-hashing against — 6g (already documented as non-optional, not tuning) is no longer enough on its own.
- Fleet-wide fix: this gate runs on every PR, so any PR touching `openbank-libs-runtime` was going to hit the same wall.

## Test plan
- [x] `python3 -c "import ast; ast.parse(...)"` — syntax valid
- [x] Diff scope: single file, 7 insertions / 2 deletions, no unrelated changes
- [ ] Will be confirmed live once CI re-runs on #4308, which carries the same fix on its own branch
