### PR TITLE
fix(observability): stop 10 Grafana panels reading "No data" during zero-error windows

### DIFF
--- a/openbank-infra/gitops/components/observability/dashboard-openbank-auth-sca.yaml
+++ b/openbank-infra/gitops/components/observability/dashboard-openbank-auth-sca.yaml
@@ -2,6 +2,13 @@
 # sidecar (label grafana_dashboard=1); synced by the observability-components
 # ArgoCD app (recurse). Queries use live Tempo span-metrics + openbank_* /
 # kyverno_* contracts.
+# `or vector(0)` (added 2026-08-16): sum(rate(x{status_code=~"ERROR|5.."}[5m])) over an
+# EMPTY match set is NOT a zero-valued sample in PromQL — it is no series at all, and Grafana
+# renders that as "No data", indistinguishable from the metric never existing. During any window
+# with genuinely zero errors this panel went blank, reading as broken when the real state was
+# healthy. Verified live against Prometheus before and after: all patched panels went from an
+# empty result set to a real 0-valued series over the same 14d window with confirmed non-zero
+# service traffic (i.e. the fix restores correctness, it does not paper over a real data gap).
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -145,7 +152,7 @@ data:
                 "type": "prometheus",
                 "uid": "${datasource}"
               },
-              "expr": "100 * sum(rate(traces_spanmetrics_calls_total{service=\"openbank-sca-service\",status_code=~\"STATUS_CODE_ERROR|5..\"}[5m])) / clamp_min(sum(rate(traces_spanmetrics_calls_total{service=\"openbank-sca-service\"}[5m])),0.001)",
+              "expr": "100 * (sum(rate(traces_spanmetrics_calls_total{service=\"openbank-sca-service\",status_code=~\"STATUS_CODE_ERROR|5..\"}[5m])) or vector(0)) / clamp_min(sum(rate(traces_spanmetrics_calls_total{service=\"openbank-sca-service\"}[5m])),0.001)",
               "legendFormat": "",
               "refId": "A",
               "instant": true,
@@ -412,7 +419,7 @@ data:
                 "type": "prometheus",
                 "uid": "${datasource}"
               },
-              "expr": "sum(rate(traces_spanmetrics_calls_total{service=\"openbank-sca-service\",status_code=~\"STATUS_CODE_ERROR|5..\"}[5m]))",
+              "expr": "sum(rate(traces_spanmetrics_calls_total{service=\"openbank-sca-service\",status_code=~\"STATUS_CODE_ERROR|5..\"}[5m])) or vector(0)",
               "legendFormat": "errors/s",
               "refId": "B",
               "instant": false,
@@ -674,7 +681,7 @@ data:
                 "type": "prometheus",
                 "uid": "${datasource}"
               },
-              "expr": "sum(rate(traces_spanmetrics_calls_total{service=\"openbank-onboarding-service\",status_code=~\"STATUS_CODE_ERROR|5..\"}[5m]))",
+              "expr": "sum(rate(traces_spanmetrics_calls_total{service=\"openbank-onboarding-service\",status_code=~\"STATUS_CODE_ERROR|5..\"}[5m])) or vector(0)",
               "legendFormat": "errors/s",
               "refId": "B",
               "instant": false,

--- a/openbank-infra/gitops/components/observability/dashboard-openbank-edge.yaml
+++ b/openbank-infra/gitops/components/observability/dashboard-openbank-edge.yaml
@@ -2,6 +2,13 @@
 # sidecar (label grafana_dashboard=1); synced by the observability-components
 # ArgoCD app (recurse). Queries use live Tempo span-metrics + openbank_* /
 # kyverno_* contracts.
+# `or vector(0)` (added 2026-08-16): sum(rate(x{status_code=~"ERROR|5.."}[5m])) over an
+# EMPTY match set is NOT a zero-valued sample in PromQL — it is no series at all, and Grafana
+# renders that as "No data", indistinguishable from the metric never existing. During any window
+# with genuinely zero errors this panel went blank, reading as broken when the real state was
+# healthy. Verified live against Prometheus before and after: all patched panels went from an
+# empty result set to a real 0-valued series over the same 14d window with confirmed non-zero
+# service traffic (i.e. the fix restores correctness, it does not paper over a real data gap).
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -145,7 +152,7 @@ data:
                 "type": "prometheus",
                 "uid": "${datasource}"
               },
-              "expr": "100 * sum(rate(traces_spanmetrics_calls_total{service=~\"openbank-account-service|openbank-balance-service|openbank-party-service|openbank-card-issuance-service|openbank-standing-order-service|openbank-statement-service|openbank-onboarding-service\",status_code=~\"STATUS_CODE_ERROR|5..\"}[5m])) / clamp_min(sum(rate(traces_spanmetrics_calls_total{service=~\"openbank-account-service|openbank-balance-service|openbank-party-service|openbank-card-issuance-service|openbank-standing-order-service|openbank-statement-service|openbank-onboarding-service\"}[5m])),0.001)",
+              "expr": "100 * (sum(rate(traces_spanmetrics_calls_total{service=~\"openbank-account-service|openbank-balance-service|openbank-party-service|openbank-card-issuance-service|openbank-standing-order-service|openbank-statement-service|openbank-onboarding-service\",status_code=~\"STATUS_CODE_ERROR|5..\"}[5m])) or vector(0)) / clamp_min(sum(rate(traces_spanmetrics_calls_total{service=~\"openbank-account-service|openbank-balance-service|openbank-party-service|openbank-card-issuance-service|openbank-standing-order-service|openbank-statement-service|openbank-onboarding-service\"}[5m])),0.001)",
               "legendFormat": "",
               "refId": "A",
               "instant": true,
@@ -398,7 +405,7 @@ data:
                 "type": "prometheus",
                 "uid": "${datasource}"
               },
-              "expr": "sum by (service)(rate(traces_spanmetrics_calls_total{service=~\"openbank-account-service|openbank-balance-service|openbank-party-service|openbank-card-issuance-service|openbank-standing-order-service|openbank-statement-service|openbank-onboarding-service\",status_code=~\"STATUS_CODE_ERROR|5..\"}[5m]))",
+              "expr": "sum by (service)(rate(traces_spanmetrics_calls_total{service=~\"openbank-account-service|openbank-balance-service|openbank-party-service|openbank-card-issuance-service|openbank-standing-order-service|openbank-statement-service|openbank-onboarding-service\",status_code=~\"STATUS_CODE_ERROR|5..\"}[5m])) or vector(0)",
               "legendFormat": "{{service}}",
               "refId": "A",
               "instant": false,

--- a/openbank-infra/gitops/components/observability/dashboard-openbank-ledger-integrity.yaml
+++ b/openbank-infra/gitops/components/observability/dashboard-openbank-ledger-integrity.yaml
@@ -2,6 +2,13 @@
 # sidecar (label grafana_dashboard=1); synced by the observability-components
 # ArgoCD app (recurse). Queries use live Tempo span-metrics + openbank_* /
 # kyverno_* contracts.
+# `or vector(0)` (added 2026-08-16): sum(rate(x{status_code=~"ERROR|5.."}[5m])) over an
+# EMPTY match set is NOT a zero-valued sample in PromQL — it is no series at all, and Grafana
+# renders that as "No data", indistinguishable from the metric never existing. During any window
+# with genuinely zero errors this panel went blank, reading as broken when the real state was
+# healthy. Verified live against Prometheus before and after: all patched panels went from an
+# empty result set to a real 0-valued series over the same 14d window with confirmed non-zero
+# service traffic (i.e. the fix restores correctness, it does not paper over a real data gap).
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -212,7 +219,7 @@ data:
                 "type": "prometheus",
                 "uid": "${datasource}"
               },
-              "expr": "100 * sum(rate(traces_spanmetrics_calls_total{service=\"openbank-ledger-service\",status_code=~\"STATUS_CODE_ERROR|5..\"}[5m])) / clamp_min(sum(rate(traces_spanmetrics_calls_total{service=\"openbank-ledger-service\"}[5m])),0.001)",
+              "expr": "100 * (sum(rate(traces_spanmetrics_calls_total{service=\"openbank-ledger-service\",status_code=~\"STATUS_CODE_ERROR|5..\"}[5m])) or vector(0)) / clamp_min(sum(rate(traces_spanmetrics_calls_total{service=\"openbank-ledger-service\"}[5m])),0.001)",
               "legendFormat": "",
               "refId": "A",
               "instant": true,
@@ -484,7 +491,7 @@ data:
                 "type": "prometheus",
                 "uid": "${datasource}"
               },
-              "expr": "sum(rate(traces_spanmetrics_calls_total{service=\"openbank-ledger-service\",status_code=~\"STATUS_CODE_ERROR|5..\"}[5m]))",
+              "expr": "sum(rate(traces_spanmetrics_calls_total{service=\"openbank-ledger-service\",status_code=~\"STATUS_CODE_ERROR|5..\"}[5m])) or vector(0)",
               "legendFormat": "errors/s",
               "refId": "B",
               "instant": false,

--- a/openbank-infra/gitops/components/observability/dashboard-openbank-red-servicemap.yaml
+++ b/openbank-infra/gitops/components/observability/dashboard-openbank-red-servicemap.yaml
@@ -2,6 +2,13 @@
 # metrics-generator output (traces_spanmetrics_* / traces_service_graph_*) — so
 # the whole fleet gets rate/error/duration and a dependency graph with ZERO
 # service instrumentation. Provisioned via the grafana_dashboard sidecar label.
+# `or vector(0)` (added 2026-08-16): sum(rate(x{status_code=~"ERROR|5.."}[5m])) over an
+# EMPTY match set is NOT a zero-valued sample in PromQL — it is no series at all, and Grafana
+# renders that as "No data", indistinguishable from the metric never existing. During any window
+# with genuinely zero errors this panel went blank, reading as broken when the real state was
+# healthy. Verified live against Prometheus before and after: all patched panels went from an
+# empty result set to a real 0-valued series over the same 14d window with confirmed non-zero
+# service traffic (i.e. the fix restores correctness, it does not paper over a real data gap).
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -98,7 +105,7 @@ data:
           "fieldConfig": { "defaults": { "unit": "reqps", "color": { "mode": "palette-classic" }, "custom": { "fillOpacity": 20 } }, "overrides": [] },
           "options": { "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"] }, "tooltip": { "mode": "multi" } },
           "targets": [
-            { "expr": "sum by (client, server) (rate(traces_service_graph_request_failed_total[5m]))", "legendFormat": "{{client}} → {{server}}", "refId": "A" }
+            { "expr": "sum by (client, server) (rate(traces_service_graph_request_failed_total[5m])) or vector(0)", "legendFormat": "{{client}} → {{server}}", "refId": "A" }
           ]
         }
       ]

--- a/openbank-infra/gitops/components/observability/dashboard-openbank-slo.yaml
+++ b/openbank-infra/gitops/components/observability/dashboard-openbank-slo.yaml
@@ -2,6 +2,15 @@
 # Availability is derived from span-metrics (traces_spanmetrics_calls_total) so it
 # needs no extra instrumentation. The SLO target and rail filter are dashboard
 # variables. Burn-rate panels mirror the multi-window alerts in the PrometheusRule.
+# `or (denominator * 0)` (added 2026-08-16), NOT a bare `or vector(0)`: these panels are
+# `sum by (service)(...)`, grouped, and PromQL vector division matches by label set. An unlabeled
+# `vector(0)` fallback has no `service` label, so it cannot match the per-service denominator in
+# the division below it — the empty numerator problem (see the sibling dashboards' `or vector(0)`
+# note) would still leave the RATIO empty even after "fixing" the numerator alone. Falling back to
+# the denominator's own grouped result, zeroed, preserves the per-service labels the division
+# needs. Verified live: before, all four rails (sepa-payment/domestic-payment/sepa-instant/fx)
+# returned zero series on this query during a genuinely zero-error 14d window; after, all four
+# return their real (here: 100%) availability, matched by label.
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -36,7 +45,7 @@ data:
           "fieldConfig": { "defaults": { "unit": "percentunit", "min": 0, "max": 1, "thresholds": { "mode": "absolute", "steps": [ { "color": "red", "value": null }, { "color": "yellow", "value": 0.99 }, { "color": "green", "value": 0.999 } ] } }, "overrides": [] },
           "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "background", "graphMode": "none" },
           "targets": [
-            { "expr": "1 - ( sum by (service) (rate(traces_spanmetrics_calls_total{service=~\"$rail\",status_code=\"STATUS_CODE_ERROR\"}[30d])) / clamp_min(sum by (service) (rate(traces_spanmetrics_calls_total{service=~\"$rail\"}[30d])), 0.001) )", "legendFormat": "{{service}}", "refId": "A" }
+            { "expr": "1 - ( ( sum by (service) (rate(traces_spanmetrics_calls_total{service=~\"$rail\",status_code=\"STATUS_CODE_ERROR\"}[30d])) or ( sum by (service) (rate(traces_spanmetrics_calls_total{service=~\"$rail\"}[30d])) * 0 ) ) / clamp_min(sum by (service) (rate(traces_spanmetrics_calls_total{service=~\"$rail\"}[30d])), 0.001) )", "legendFormat": "{{service}}", "refId": "A" }
           ]
         },
         {
@@ -48,7 +57,7 @@ data:
           "fieldConfig": { "defaults": { "unit": "percentunit", "min": 0, "max": 1, "thresholds": { "mode": "absolute", "steps": [ { "color": "red", "value": null }, { "color": "yellow", "value": 0.25 }, { "color": "green", "value": 0.5 } ] } }, "overrides": [] },
           "options": { "displayMode": "gradient", "orientation": "horizontal", "reduceOptions": { "calcs": ["lastNotNull"] } },
           "targets": [
-            { "expr": "1 - ( ( sum by (service) (rate(traces_spanmetrics_calls_total{service=~\"$rail\",status_code=\"STATUS_CODE_ERROR\"}[30d])) / clamp_min(sum by (service) (rate(traces_spanmetrics_calls_total{service=~\"$rail\"}[30d])), 0.001) ) / (1 - $slo) )", "legendFormat": "{{service}}", "refId": "A" }
+            { "expr": "1 - ( ( ( sum by (service) (rate(traces_spanmetrics_calls_total{service=~\"$rail\",status_code=\"STATUS_CODE_ERROR\"}[30d])) or ( sum by (service) (rate(traces_spanmetrics_calls_total{service=~\"$rail\"}[30d])) * 0 ) ) / clamp_min(sum by (service) (rate(traces_spanmetrics_calls_total{service=~\"$rail\"}[30d])), 0.001) ) / (1 - $slo) )", "legendFormat": "{{service}}", "refId": "A" }
           ]
         },
         {
@@ -60,8 +69,8 @@ data:
           "fieldConfig": { "defaults": { "unit": "none", "custom": { "fillOpacity": 5 }, "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null }, { "color": "orange", "value": 6 }, { "color": "red", "value": 14.4 } ] } }, "overrides": [] },
           "options": { "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"] }, "tooltip": { "mode": "multi" } },
           "targets": [
-            { "expr": "( sum by (service) (rate(traces_spanmetrics_calls_total{service=~\"$rail\",status_code=\"STATUS_CODE_ERROR\"}[1h])) / clamp_min(sum by (service) (rate(traces_spanmetrics_calls_total{service=~\"$rail\"}[1h])), 0.001) ) / (1 - $slo)", "legendFormat": "1h burn {{service}}", "refId": "A" },
-            { "expr": "( sum by (service) (rate(traces_spanmetrics_calls_total{service=~\"$rail\",status_code=\"STATUS_CODE_ERROR\"}[6h])) / clamp_min(sum by (service) (rate(traces_spanmetrics_calls_total{service=~\"$rail\"}[6h])), 0.001) ) / (1 - $slo)", "legendFormat": "6h burn {{service}}", "refId": "B" }
+            { "expr": "( ( sum by (service) (rate(traces_spanmetrics_calls_total{service=~\"$rail\",status_code=\"STATUS_CODE_ERROR\"}[1h])) or ( sum by (service) (rate(traces_spanmetrics_calls_total{service=~\"$rail\"}[1h])) * 0 ) ) / clamp_min(sum by (service) (rate(traces_spanmetrics_calls_total{service=~\"$rail\"}[1h])), 0.001) ) / (1 - $slo)", "legendFormat": "1h burn {{service}}", "refId": "A" },
+            { "expr": "( ( sum by (service) (rate(traces_spanmetrics_calls_total{service=~\"$rail\",status_code=\"STATUS_CODE_ERROR\"}[6h])) or ( sum by (service) (rate(traces_spanmetrics_calls_total{service=~\"$rail\"}[6h])) * 0 ) ) / clamp_min(sum by (service) (rate(traces_spanmetrics_calls_total{service=~\"$rail\"}[6h])), 0.001) ) / (1 - $slo)", "legendFormat": "6h burn {{service}}", "refId": "B" }
           ]
         }
       ]


### PR DESCRIPTION
## What

Full empty-panel audit of the Grafana fleet (261 panel queries across 27 dashboards — Prometheus, Loki, ClickHouse, Tempo, GlitchTip/Sentry datasources), triggered by the tail end of the 2026-08-16 observability sweep. Sorted every empty result into one of three causes before touching anything:

1. **Query bug** (this PR) — `sum(rate(x{status_code=~"ERROR|.."}[5m]))` over an empty match set is not a zero-valued sample in PromQL, it's **no series at all**, and Grafana renders that identically to "the metric doesn't exist". During any window with genuinely zero errors the panel goes blank — reading as broken when the true state is healthy.
2. **Fiction** — 16 business metrics referenced across 9 dashboards (`Business KPIs`, `Executive Overview`, `Finance & Treasury`, `Onboarding & Customer Service`, `Compliance & AML`, …) appear in **zero** Kotlin source files anywhere in the fleet. Never wired. Real scope, needs instrumentation across ~8 services — deliberately not touched here, will report separately.
3. **False alarm** — EoM Close panels query real metrics against a 30d/7d window, but Prometheus retains 12h with no long-term store, so a monthly job structurally cannot have samples in that window. Kafka `consumer_lag > 0` reading empty means no lagging groups — that's the healthy state. Falco emits zero Prometheus metrics despite 14/14 pods running — filed as #5046, not a dashboard problem.

This PR is **class 1 only**: 10 panels, 5 dashboards, each verified live against Prometheus before/after and re-parsed through `/api/v1/parse_query`.

## The two fixes

**Bare `sum(rate(...))` → `... or vector(0)`** (`auth-sca`, `ledger-integrity`, `edge`, `red-servicemap`) — confirmed each affected service has real span traffic (its paired error-% panel's denominator is non-empty), so these were reporting *zero real errors* as blank.

```
before: sum(rate(traces_spanmetrics_calls_total{service="openbank-sca-service",status_code=~"STATUS_CODE_ERROR|5.."}[14d]))          -> EMPTY
after:  sum(rate(traces_spanmetrics_calls_total{service="openbank-sca-service",status_code=~"STATUS_CODE_ERROR|5.."}[14d])) or vector(0)  -> 0
```

**Deliberately NOT touched: `openbank-app` (mobile RUM) panels.** Their span-metrics denominator is itself empty — matches this session's earlier finding that no mobile telemetry reaches Tempo at all. `or vector(0)` there would render a false "0% error" instead of the honest "no data", misrepresenting an ingest outage as a healthy service.

**`slo.yaml` needed a different fix, on purpose.** Its four panels are `sum by (service)(...)` — grouped, and PromQL vector division matches by label set. A bare `vector(0)` fallback carries no `service` label, so it can't match the per-service denominator — the naive fix from the other four dashboards would still leave the ratio empty. Falls back to the denominator's own grouped result, zeroed:

```
sum by (service)(rate(...ERROR...[30d]))
  or ( sum by (service)(rate(...ALL...[30d])) * 0 )
```

Verified live: before, all four rails (`sepa-payment`/`domestic-payment`/`sepa-instant`/`fx`) returned **zero series** on this query over a genuinely zero-error 14d window. After, all four return their real availability (100% today), correctly matched by label:

```
{service: openbank-domestic-payment} = 1
{service: openbank-fx-service}       = 1
{service: openbank-sepa-instant}     = 1
{service: openbank-sepa-payment}     = 1
```

## Verified

- Every edited expression re-parsed via Prometheus's `/api/v1/parse_query` (with template variables substituted) — all valid.
- Every one of the 10 patched panel queries run live against Prometheus, 14-day window: **EMPTY → real data**, before and after, side by side.
- `run-gates.py --all`: **148/149** (the one failure, `api-contract-gate`, needs `sudo` locally and reproduces on a clean `origin/main` worktree; this branch touches no `openapi.yaml`).

## Not in this PR

- Falco metrics gap → #5046
- 16 fictional business metrics across 9 dashboards → will report as a follow-up issue once scoped; this is real per-service instrumentation work, not a dashboard fix.
