### PR TITLE
fix(observability): point openbank-soc's Falco panels at Loki, not Prometheus

### DIFF
--- a/openbank-infra/gitops/components/observability/dashboard-openbank-soc.yaml
+++ b/openbank-infra/gitops/components/observability/dashboard-openbank-soc.yaml
@@ -255,10 +255,10 @@ data:
         {
           "type": "stat",
           "title": "Falco priority≥Warning (5m)",
-          "description": "needs Falco metrics.enabled + SM (follow-up)",
+          "description": "Falco (ADR-0081) is deliberately Loki-only \u2014 json_output to stdout, tailed by Alloy, no Prometheus exporter (falco.yaml: \"zero-new-plumbing\"). falco_events_total has never existed and never will under this architecture; the fix (#5046) is this LogQL query, not a scrape config.",
           "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
+            "type": "loki",
+            "uid": "loki"
           },
           "gridPos": {
             "x": 18,
@@ -269,10 +269,10 @@ data:
           "targets": [
             {
               "datasource": {
-                "type": "prometheus",
-                "uid": "${datasource}"
+                "type": "loki",
+                "uid": "loki"
               },
-              "expr": "sum(increase(falco_events_total{priority=~\"Emergency|Alert|Critical|Error|Warning\"}[5m]))",
+              "expr": "sum(count_over_time({namespace=\"falco\"} | json | priority=~\"Emergency|Alert|Critical|Error|Warning\" [5m]))",
               "legendFormat": "",
               "refId": "A",
               "instant": true,
@@ -641,10 +641,10 @@ data:
         {
           "type": "table",
           "title": "Falco events by rule (1h)",
-          "description": "needs Falco metrics (follow-up)",
+          "description": "Falco (ADR-0081) is deliberately Loki-only \u2014 see the stat panel above for why. LogQL over the JSON body Alloy already ships (#5046).",
           "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
+            "type": "loki",
+            "uid": "loki"
           },
           "gridPos": {
             "x": 12,
@@ -655,10 +655,10 @@ data:
           "targets": [
             {
               "datasource": {
-                "type": "prometheus",
-                "uid": "${datasource}"
+                "type": "loki",
+                "uid": "loki"
               },
-              "expr": "topk(15, sum by (rule, priority) (increase(falco_events_total[1h])))",
+              "expr": "topk(15, sum by (rule, priority) (count_over_time({namespace=\"falco\"} | json [1h])))",
               "legendFormat": "",
               "refId": "A",
               "instant": true,


### PR DESCRIPTION
## What

`openbank-soc`'s two Falco panels queried `falco_events_total` in Prometheus, which has **zero series, ever**. Both panels already carried an honest `"needs Falco metrics.enabled + SM (follow-up)"` description — this is that follow-up.

## Why the metric doesn't exist — and why adding it is the wrong fix

`falco.yaml`'s own header states the architecture: *"Integration is deliberately zero-new-plumbing: json output to stdout → the Alloy DaemonSet already tails every pod and ships to Loki (structured metadata) → Grafana. Alerting on CRITICAL/EMERGENCY rules rides the existing Loki datasource; no falcosidekick, no new webhook surface."*

`prometheus_metrics_enabled` is unset (chart default `false`), no `ServiceMonitor` exists — both consistent with that deliberate design, not evidence of a missed wiring step. Adding a Prometheus scrape path would reinstate exactly the second telemetry pipeline this service was built to avoid.

## Fix

Both panels rewritten as **LogQL** over the JSON body Alloy already ships to Loki — no new plumbing, stays inside the stated architecture.

| panel | before | after |
|---|---|---|
| Falco priority≥Warning (5m) | `sum(increase(falco_events_total{priority=~"Emergency\|Alert\|Critical\|Error\|Warning"}[5m]))` | `sum(count_over_time({namespace="falco"} \| json \| priority=~"Emergency\|Alert\|Critical\|Error\|Warning" [5m]))` |
| Falco events by rule (1h) | `topk(15, sum by (rule, priority) (increase(falco_events_total[1h])))` | `topk(15, sum by (rule, priority) (count_over_time({namespace="falco"} \| json [1h])))` |

## Verification

Ran **against live Loki** (port-forward, read-only), not written blind:

```
sum(count_over_time({namespace="falco"} | json | priority=~"Emergency|Alert|Critical|Error|Warning" [5m]))
  -> [] (no Warning+ events right now — real result, not an error)

topk(15, sum by (rule, priority) (count_over_time({namespace="falco"} | json [1h])))
  -> {priority=Critical, rule="Drop and execute new binary in container"}: 21
     {priority=Notice, rule="Contact K8S API Server From Container"}: 978
```

Both queries confirmed against a real sample Falco log line first (`kubectl -n falco logs`), which showed `priority` and `rule` as top-level JSON fields — the `| json` pipeline stage extracts them directly, no relabeling needed. The dashboard JSON's `expr` strings were then extracted programmatically and diffed against these verified strings before committing, not retyped.

Refs #5046

🤖 Generated with [Claude Code](https://claude.com/claude-code)
