### PR TITLE
fix(audit): publish a percentile histogram for the chain-verify timer

### DIFF
--- a/openbank-audit-service/src/main/kotlin/com/openbank/audit/infrastructure/observability/AuditChainIntegrityGauge.kt
+++ b/openbank-audit-service/src/main/kotlin/com/openbank/audit/infrastructure/observability/AuditChainIntegrityGauge.kt
@@ -6,6 +6,7 @@ package com.openbank.audit.infrastructure.observability
 import com.openbank.audit.infrastructure.persistence.AuditRepository
 import io.micrometer.core.instrument.Gauge
 import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.Timer
 import io.quarkus.runtime.Startup
 import io.quarkus.scheduler.Scheduled
 import jakarta.annotation.PostConstruct
@@ -143,7 +144,13 @@ class AuditChainIntegrityGauge {
             log.errorf(ex, "audit chain verification failed to run — leaving previous gauge values in place")
             return
         }
-        registry.timer("openbank.audit.chain.verify.duration")
+        // publishPercentileHistogram() is what makes the _bucket series exist at all -- the bare
+        // registry.timer(name).record(...) shortcut this replaced only emits _count/_sum, so no
+        // dashboard panel keyed on openbank_audit_chain_verify_duration_seconds_bucket could ever
+        // render (#5049). Percentiles/histogram config match the fleet's DomainMetrics convention
+        // (see AnaCreditMetricsAdapter etc.) rather than inventing a local shape.
+        DURATION_TIMER
+            .register(registry)
             .record(System.nanoTime() - startedAt, java.util.concurrent.TimeUnit.NANOSECONDS)
 
         intact.set(if (result.intact) 1 else 0)
@@ -167,5 +174,16 @@ class AuditChainIntegrityGauge {
                 result.firstBrokenEntryId,
             )
         }
+    }
+
+    private companion object {
+        const val P50 = 0.5
+        const val P95 = 0.95
+        const val P99 = 0.99
+
+        val DURATION_TIMER: Timer.Builder = Timer.builder("openbank.audit.chain.verify.duration")
+            .publishPercentiles(P50, P95, P99)
+            .publishPercentileHistogram()
+            .description("Wall time of one audit hash-chain verification sweep")
     }
 }

--- a/openbank-audit-service/src/test/kotlin/com/openbank/audit/infrastructure/observability/AuditChainIntegrityGaugeTest.kt
+++ b/openbank-audit-service/src/test/kotlin/com/openbank/audit/infrastructure/observability/AuditChainIntegrityGaugeTest.kt
@@ -112,6 +112,33 @@ class AuditChainIntegrityGaugeTest {
     }
 
     @Test
+    fun `verification duration publishes percentiles, not just count and sum`() {
+        // #5049: openbank_audit_chain_verify_duration_seconds_bucket has zero series in
+        // Prometheus because the timer never called publishPercentileHistogram(). A registry
+        // that only got count/sum would report a non-null timer here too -- percentileValues()
+        // is what distinguishes "the Timer.builder(...).publishPercentiles(...) config is
+        // actually active" from "a bare timer exists", so assert that, not merely presence.
+        // (HistogramSnapshot.histogramCounts() -- the more direct-looking assertion -- was tried
+        // first and rejected: it is EMPTY on SimpleMeterRegistry regardless of
+        // publishPercentileHistogram(), confirmed with a throwaway diagnostic against this exact
+        // registry type before writing this assertion. That histogram flavor is specific to
+        // registries like Atlas; Prometheus's own _bucket series come from the same underlying
+        // config but are only materialized by PrometheusMeterRegistry.scrape(), which is not
+        // reachable from a plain unit test in this module. percentileValues() is the strongest
+        // claim actually falsifiable here.)
+        val repo = mockk<AuditRepository>()
+        coEvery { repo.verifyChain(any()) } returns
+            ChainVerification(intact = true, checked = 1, unchained = 0, firstBrokenEntryId = null)
+        val (g, registry) = gauge(repo)
+
+        runBlocking { g.verify() }
+
+        val timer = registry.find("openbank.audit.chain.verify.duration").timer()
+            ?: error("timer openbank.audit.chain.verify.duration not registered")
+        assertThat(timer.takeSnapshot().percentileValues()).isNotEmpty()
+    }
+
+    @Test
     fun `disabled means no verification is attempted at all`() {
         val repo = mockk<AuditRepository>()
         coEvery { repo.verifyChain(any()) } returns


### PR DESCRIPTION
## What

`openbank_audit_chain_verify_duration_seconds_bucket` has zero series in Prometheus — one of the two findings from #5049's triage that wasn't a naming/grep miss. The base timer is confirmed **live** (non-zero `_count`/`_sum`, since verification runs hourly); it just never called `.publishPercentileHistogram()`, so Prometheus's `_bucket` series was never emitted.

## Fix

```kotlin
registry.timer(name).record(...)
```
→
```kotlin
Timer.builder(name)
    .publishPercentiles(P50, P95, P99)
    .publishPercentileHistogram()
    .description(...)
    .register(registry)
```

Matches the fleet's established convention (`AnaCreditMetricsAdapter`, `FinrepMetricsAdapter`, …) rather than inventing a local shape. `P50`/`P95`/`P99` as named constants in a `private companion object` — detekt's `MagicNumber` rule fires on the bare literal triple otherwise (a documented fleet-wide footgun for exactly this pattern).

## Verification — including a wrong turn caught before it shipped

Added a test asserting the timer's snapshot carries histogram data.

**First attempt** asserted `HistogramSnapshot.histogramCounts().isNotEmpty()`. Built a throwaway diagnostic against a bare `SimpleMeterRegistry` with `publishPercentileHistogram()` enabled and confirmed `histogramCounts()` is **empty regardless** — that API surfaces a different histogram flavor (e.g. Atlas), and Prometheus's own `_bucket` wire format is only materialized by `PrometheusMeterRegistry.scrape()`, not reachable from a plain unit test in this module (the Prometheus registry class isn't on this module's test classpath — Quarkus extension wiring, not a plain Gradle dependency).

**Rewrote** the assertion against `percentileValues()`, which the same diagnostic confirmed *is* populated by `publishPercentiles(...)` — the strongest claim actually falsifiable at this test level.

**Falsified both ways**: red against unfixed `origin/main` (assertion genuinely fails without the fix), green after restoring the fix.

Full module: **113 tests / 0 failures / 0 errors / 0 skipped**. `ktlintCheck` + `detekt` clean (re-run with `--rerun-tasks`, not `UP-TO-DATE`).

Refs #5049

🤖 Generated with [Claude Code](https://claude.com/claude-code)
