### PR TITLE
feat(admin-ui): unify control workspaces

### DIFF
--- a/openbank-admin-ui/src/app/devops/page.tsx
+++ b/openbank-admin-ui/src/app/devops/page.tsx
@@ -19,6 +19,7 @@ import type { AgentFinding } from '@/components/agent/AgentInsightsPanel'
 import { QualityGateHealthPanel } from '@/components/devops/QualityGateHealthPanel'
 import type { TestResultsResponse, ServiceTestResult } from '@/lib/types/test-results'
 import type { DevOpsFinding } from '@/app/api/devops/insights/route'
+import { PageHeader } from '@/components/ui/PageHeader'
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -315,24 +316,12 @@ function DevOpsContent() {
   return (
     <div style={{ padding: '28px 32px', maxWidth: '1400px', animation: 'fadeIn 0.2s ease-out' }}>
 
-      {/* Header */}
-      <div style={{ marginBottom: '24px', display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between' }}>
-        <div>
-          <div className="breadcrumb">
-            <span>OpenBank</span><span className="breadcrumb-sep">/</span>
-            <span className="breadcrumb-current">DevOps</span>
-          </div>
-          <h1 style={{ fontSize: '24px', fontWeight: 800, color: 'var(--text-primary)', margin: '8px 0 4px', letterSpacing: '-0.03em' }}>
-            {t('DevOps metriky', 'DevOps Metrics')}
-          </h1>
-          <p style={{ fontSize: '13px', color: 'var(--text-secondary)', margin: 0 }}>
-            {t(
-              'DORA metriky, pokrytí testy a zdraví pipeline — Google State of DevOps 2023',
-              'DORA metrics, test coverage, and pipeline health — Google State of DevOps 2023',
-            )}
-          </p>
-        </div>
-        <div style={{ display: 'flex', alignItems: 'center', gap: '12px', flexWrap: 'wrap', justifyContent: 'flex-end' }}>
+      <PageHeader
+        breadcrumb={<div className="breadcrumb"><span>OpenBank</span><span className="breadcrumb-sep">/</span><span className="breadcrumb-current">DevOps</span></div>}
+        icon={<GitBranch size={20} aria-hidden="true" />}
+        title={t('DevOps metriky', 'DevOps Metrics')}
+        subtitle={t('DORA metriky, pokrytí testy a zdraví pipeline — Google State of DevOps 2023', 'DORA metrics, test coverage, and pipeline health — Google State of DevOps 2023')}
+        actions={<div style={{ display: 'flex', alignItems: 'center', gap: '12px', flexWrap: 'wrap', justifyContent: 'flex-end' }}>
           {dora && (
             <div style={{ display: 'flex', gap: '6px' }}>
               <SourceChip available={dora.sources.git} label="Git" />
@@ -354,8 +343,8 @@ function DevOpsContent() {
             <RefreshCw size={13} style={{ animation: loading ? 'spin 0.8s linear infinite' : 'none' }} />
             {t('Obnovit', 'Refresh')}
           </button>
-        </div>
-      </div>
+        </div>}
+      />
 
       {loading && !dora ? (
         <div style={{ display: 'flex', alignItems: 'center', gap: '10px', padding: '40px', color: 'var(--text-tertiary)' }}>

--- a/openbank-admin-ui/src/app/security/page.tsx
+++ b/openbank-admin-ui/src/app/security/page.tsx
@@ -9,6 +9,7 @@ import { Shield, RefreshCw, CheckCircle2, XCircle, AlertTriangle } from 'lucide-
 import { AuthGuard } from '@/components/auth/AuthGuard'
 import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
 import { summarizeReachable, serviceVerdict } from '@/lib/security/summary'
+import { PageHeader } from '@/components/ui/PageHeader'
 
 // Envelope returned by /api/security (never 500s — see that route): either the
 // scanner answered with a report, or it's unavailable with a typed reason that
@@ -132,21 +133,11 @@ export default function SecurityPage() {
   return (
     <AuthGuard permission="system:view">
       <div style={{ padding: '28px 32px', maxWidth: '1400px', animation: 'fadeIn 0.2s ease-out' }}>
-        <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', marginBottom: '28px' }}>
-          <div>
-            <h1 style={{ fontSize: '24px', fontWeight: 800, color: 'var(--text-primary)', letterSpacing: '-0.03em', marginBottom: '4px' }}>
-              {t('Bezpečnostní skener', 'Security Scanner')}
-            </h1>
-            <p style={{ fontSize: '13px', color: 'var(--text-secondary)' }}>
-              {t('OWASP Top 10 · EBA ICT · CVE skenování — všechny mikroservisy', 'OWASP Top 10 · EBA ICT · CVE scanning — all microservices')}
-            </p>
-            <p style={{ fontSize: '11px', color: 'var(--text-tertiary)', marginTop: '4px', display: 'flex', alignItems: 'center', gap: '5px' }}>
-              <Shield size={11} style={{ flexShrink: 0 }} />
-              {t('Skeny běží automaticky v CI/CD pipeline (Trivy · CodeQL · Gitleaks). Tato stránka zobrazuje poslední výsledky — pouze ke čtení.',
-                 'Scans run automatically in the CI/CD pipeline (Trivy · CodeQL · Gitleaks). This page is a read-only view of the latest results.')}
-            </p>
-          </div>
-          <div style={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
+        <PageHeader
+          icon={<Shield size={20} aria-hidden="true" />}
+          title={t('Bezpečnostní skener', 'Security Scanner')}
+          subtitle={t('OWASP Top 10 · EBA ICT · CVE skenování — všechny mikroservisy', 'OWASP Top 10 · EBA ICT · CVE scanning — all microservices')}
+          actions={<div style={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
             {report?.generatedAt && (
               <span style={{ fontSize: '11px', color: 'var(--text-tertiary)', marginRight: '8px' }}>
                 {t('Poslední sken:', 'Last scan:')} {formatDate(report.generatedAt)}
@@ -165,8 +156,12 @@ export default function SecurityPage() {
               <RefreshCw size={13} style={{ animation: loading ? 'spin 0.8s linear infinite' : 'none' }} />
               {t('Obnovit', 'Refresh')}
             </button>
-          </div>
-        </div>
+          </div>}
+        />
+        <p style={{ fontSize: '11px', color: 'var(--text-tertiary)', marginTop: '-20px', marginBottom: '28px', display: 'flex', alignItems: 'center', gap: '5px' }}>
+          <Shield size={11} aria-hidden="true" style={{ flexShrink: 0 }} />
+          {t('Skeny běží automaticky v CI/CD pipeline (Trivy · CodeQL · Gitleaks). Tato stránka zobrazuje poslední výsledky — pouze ke čtení.', 'Scans run automatically in the CI/CD pipeline (Trivy · CodeQL · Gitleaks). This page is a read-only view of the latest results.')}
+        </p>
 
         {criticalCount > 0 && (
           <div style={{ marginBottom: '20px', padding: '12px 16px', borderRadius: '8px',

--- a/openbank-admin-ui/src/app/settings/page.tsx
+++ b/openbank-admin-ui/src/app/settings/page.tsx
@@ -10,6 +10,7 @@ import { useSession } from 'next-auth/react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { AuthGuard } from '@/components/auth/AuthGuard'
 import { ROLE_LABELS } from '@/lib/auth/roles'
+import { PageHeader } from '@/components/ui/PageHeader'
 
 type Tab = 'profile' | 'notifications' | 'security' | 'api' | 'regional'
 
@@ -20,17 +21,12 @@ export default function SettingsPage() {
   return (
     <AuthGuard permission="settings:view">
     <div>
-      <div className="page-header">
-        <div>
-          <div className="breadcrumb">
-            <span>OpenBank</span>
-            <span className="breadcrumb-sep">/</span>
-            <span className="breadcrumb-current">{t('Nastavení', 'Settings')}</span>
-          </div>
-          <h1 className="page-title">{t('Nastavení', 'Settings')}</h1>
-          <p className="page-subtitle">{t('Spravujte předvolby účtu a konfiguraci systému', 'Manage your account preferences and system configuration')}</p>
-        </div>
-      </div>
+      <PageHeader
+        breadcrumb={<div className="breadcrumb"><span>OpenBank</span><span className="breadcrumb-sep">/</span><span className="breadcrumb-current">{t('Nastavení', 'Settings')}</span></div>}
+        icon={<User size={20} aria-hidden="true" />}
+        title={t('Nastavení', 'Settings')}
+        subtitle={t('Spravujte předvolby účtu a konfiguraci systému', 'Manage your account preferences and system configuration')}
+      />
 
       <div style={{ display: 'flex', gap: '20px', alignItems: 'flex-start' }}>
         {/* Sidebar nav */}


### PR DESCRIPTION
## Summary

- standardize DevOps, Security Scanner, and Settings on the shared accessible PageHeader primitive
- preserve data loading, RBAC, refresh controls, and security scan read-only semantics
- intentionally retain the separate pre-login privacy notice layout

## Validation

- `npm run type-check`
- `git diff --check`

## Linked issues

N/A — incremental administration UI consistency delivery; no standalone issue is required.