### PR TITLE
fix(domestic-payment): emit paymentCompleted/paymentProcessingDuration on terminal transitions

### DIFF
--- a/openbank-domestic-payment/src/main/kotlin/com/openbank/domestic/application/usecase/DomesticPaymentService.kt
+++ b/openbank-domestic-payment/src/main/kotlin/com/openbank/domestic/application/usecase/DomesticPaymentService.kt
@@ -24,6 +24,7 @@ import jakarta.enterprise.context.ApplicationScoped
 import jakarta.inject.Inject
 import org.eclipse.microprofile.config.inject.ConfigProperty
 import java.time.Clock
+import java.time.Duration
 import java.time.Instant
 import java.util.Locale
 import java.util.UUID
@@ -68,6 +69,13 @@ class DomesticPaymentService(
         private const val PAYMENT_STATUS_CHANGED_EVENT = "domestic.payment.status-changed"
 
         private const val OWN_BANK_CODE = "0000"
+
+        private val TERMINAL_STATUSES = setOf(
+            DomesticPaymentStatus.SETTLED,
+            DomesticPaymentStatus.REJECTED,
+            DomesticPaymentStatus.RETURNED,
+            DomesticPaymentStatus.CANCELLED,
+        )
     }
 
     /** Derive transferScope server-side — never trust the value from the client. */
@@ -189,6 +197,27 @@ class DomesticPaymentService(
         } catch (ex: IllegalArgumentException) {
             throw InvalidDomesticPaymentStateTransitionException(
                 ex.message ?: "Invalid domestic payment state transition",
+            )
+        }
+
+        // Only paymentSubmitted() was ever called for this rail (createPayment, above) --
+        // paymentCompleted()/paymentProcessingDuration() had no call site anywhere in this file, so
+        // openbank_payments_completed_total{type="domestic",...} and
+        // openbank_payment_processing_duration_seconds{type="domestic",...} could never have a
+        // sample regardless of how much domestic-payment traffic occurred (issue #5049). "settled"
+        // matches sepa-instant's existing convention for the same terminal concept -- both are
+        // covered by openbank-payment-sla's outcome=~"completed|settled" already, so no dashboard
+        // change is needed to read it.
+        if (updated.status in TERMINAL_STATUSES) {
+            val outcome = when (updated.status) {
+                DomesticPaymentStatus.SETTLED -> "settled"
+                else -> updated.status.name.lowercase()
+            }
+            metrics.paymentCompleted("domestic", updated.currency, outcome)
+            metrics.paymentProcessingDuration(
+                "domestic",
+                outcome,
+                Duration.between(updated.createdAt, Instant.now(clock)),
             )
         }
 

--- a/openbank-domestic-payment/src/test/kotlin/com/openbank/domestic/application/usecase/DomesticPaymentServiceTest.kt
+++ b/openbank-domestic-payment/src/test/kotlin/com/openbank/domestic/application/usecase/DomesticPaymentServiceTest.kt
@@ -18,6 +18,7 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import io.temporal.client.WorkflowClient
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
@@ -102,6 +103,68 @@ class DomesticPaymentServiceTest {
 
         coVerify(exactly = 0) { paymentRepository.update(any(), any()) }
     }
+
+    // Issue #5049: paymentCompleted()/paymentProcessingDuration() had NO call site anywhere in this
+    // class -- only paymentSubmitted() (in createPayment) was ever wired -- so
+    // openbank_payments_completed_total{type="domestic",...} and
+    // openbank_payment_processing_duration_seconds{type="domestic",...} could never have a sample
+    // no matter how much real domestic-payment traffic occurred. Nothing in this file asserted the
+    // metrics call before, which is exactly how the gap went unnoticed; these two cases are the
+    // falsifying pair -- a terminal transition must record, a non-terminal one must not.
+    @Test
+    fun `settling a payment records paymentCompleted and paymentProcessingDuration as settled`(): Unit = runBlocking {
+        val existing = payment(status = DomesticPaymentStatus.SENT_TO_CLEARING)
+        coEvery { paymentRepository.findById(existing.id) } returns existing
+
+        service.transitionStatus(
+            TransitionDomesticPaymentStatusCommand(
+                paymentId = existing.id,
+                targetStatus = DomesticPaymentStatus.SETTLED,
+                rejectReason = null,
+                rejectDetail = null,
+            ),
+        )
+
+        verify(exactly = 1) { metrics.paymentCompleted("domestic", existing.currency, "settled") }
+        verify(exactly = 1) { metrics.paymentProcessingDuration("domestic", "settled", any()) }
+    }
+
+    @Test
+    fun `rejecting a payment records paymentCompleted as rejected, not settled`(): Unit = runBlocking {
+        val existing = payment(status = DomesticPaymentStatus.RECEIVED)
+        coEvery { paymentRepository.findById(existing.id) } returns existing
+
+        service.transitionStatus(
+            TransitionDomesticPaymentStatusCommand(
+                paymentId = existing.id,
+                targetStatus = DomesticPaymentStatus.REJECTED,
+                rejectReason = com.openbank.domestic.domain.model.DomesticRejectReason.INVALID_ACCOUNT_NUMBER,
+                rejectDetail = "Account not found",
+            ),
+        )
+
+        verify(exactly = 1) { metrics.paymentCompleted("domestic", existing.currency, "rejected") }
+        verify(exactly = 0) { metrics.paymentCompleted("domestic", existing.currency, "settled") }
+    }
+
+    @Test
+    fun `a non-terminal transition records neither paymentCompleted nor paymentProcessingDuration`(): Unit =
+        runBlocking {
+            val existing = payment(status = DomesticPaymentStatus.RECEIVED)
+            coEvery { paymentRepository.findById(existing.id) } returns existing
+
+            service.transitionStatus(
+                TransitionDomesticPaymentStatusCommand(
+                    paymentId = existing.id,
+                    targetStatus = DomesticPaymentStatus.VALIDATED,
+                    rejectReason = null,
+                    rejectDetail = null,
+                ),
+            )
+
+            verify(exactly = 0) { metrics.paymentCompleted(any(), any(), any()) }
+            verify(exactly = 0) { metrics.paymentProcessingDuration(any(), any(), any()) }
+        }
 
     private fun createCommand(
         idempotencyKey: String = "dom-idem-1",


### PR DESCRIPTION
## What

Follow-up to #5049 (16 business metrics referenced by Grafana dashboards, never appearing in Prometheus). Investigating the "payments" group there split into two genuinely different situations — this PR fixes the real one.

## The 3 rails that were already fine

`sepa-payment`, `sepa-instant`, `fx-service` all call `DomainMetrics.paymentSubmitted`/`paymentCompleted` correctly, on the right code path, with the right labels. Confirmed:

- `DomainMetrics.counter()` calls `.increment()` on every invocation — no lazy-registration trap.
- A **sibling** metric from the same `DomainMetrics` instance, `openbank_outbox_backlog`, is live right now on `sepa-payment`'s own `/q/metrics` — the registry resolves fine in that pod.
- `sepa-payment`'s DB has 20 real payment rows, but the newest is **2026-06-23** — over two months old. The pod that's currently running started **19 hours ago**. No payment has been submitted through this rail in any pod's lifetime that's still alive to have incremented the counter.

Correctly wired, just dormant. No code change for these three — they'll self-populate the moment traffic returns.

## The one that wasn't

`openbank-domestic-payment`'s `transitionStatus()` — the **only** place a domestic payment reaches a terminal state (`SETTLED`/`REJECTED`/`RETURNED`/`CANCELLED`) — never called `paymentCompleted()` or `paymentProcessingDuration()` at all. `createPayment()`'s `paymentSubmitted()` call was the only one in the whole file. So `openbank_payments_completed_total{type="domestic",...}` and `openbank_payment_processing_duration_seconds{type="domestic",...}` could never have a sample **no matter how much real domestic-payment traffic occurred** — this one really was a wiring gap, not quiet traffic.

## The fix

Mirrors `sepa-payment`'s `persistTransition` (same shape: check the terminal-status set, derive `outcome` from the target status, record completion + processing duration from `createdAt`):

```kotlin
if (updated.status in TERMINAL_STATUSES) {
    val outcome = when (updated.status) {
        DomesticPaymentStatus.SETTLED -> "settled"
        else -> updated.status.name.lowercase()
    }
    metrics.paymentCompleted("domestic", updated.currency, outcome)
    metrics.paymentProcessingDuration("domestic", outcome, Duration.between(updated.createdAt, Instant.now(clock)))
}
```

`SETTLED` → `"settled"` matches `sepa-instant`'s existing convention for the same terminal concept — both are already covered by `openbank-payment-sla`'s `outcome=~"completed|settled"` query, so **no dashboard change is needed** to pick this up.

## Tests — there were none for this call before

Nothing in `DomesticPaymentServiceTest` asserted the metrics call in any form, for any outcome — which is exactly how a whole class of terminal transitions went silently unmetered. Added three:

- a terminal transition (`SENT_TO_CLEARING → SETTLED`) records both metrics with the right labels
- rejecting records `"rejected"`, never `"settled"`
- a non-terminal transition (`RECEIVED → VALIDATED`) records neither

## Verified

- `./gradlew :openbank-domestic-payment:test` — **5/5** (was 2/5; the 3 new tests are additive, nothing existing changed).
- `ktlintCheck`, `detekt` — clean.
- `quarkusBuild` — green. This is the check that would actually catch a CDI/ArC wiring break from the added call sites (per this repo's own documented pitfall: unit tests can't see that class of failure).
- Local `run-gates.py --all`: **148/149** (the one failure, `api-contract-gate`, needs `sudo` locally and reproduces on a clean `origin/main` worktree; this PR touches no `openapi.yaml`).

## Review note

`openbank-domestic-payment` is `money_path_services` (`rules.yaml`) — needs 2 approvals. No trust-boundary change here (no new listener/port/auth key), so `threat-model-updated-on-trust-boundary-change` correctly doesn't fire.

Refs #5049
