### PR TITLE
feat(admin-ui): summarise swarm decisions

### DIFF
--- a/openbank-admin-ui/src/app/iaops/cases/[caseId]/page.tsx
+++ b/openbank-admin-ui/src/app/iaops/cases/[caseId]/page.tsx
@@ -173,10 +173,10 @@ export default function IaopsCaseThreadPage() {
 
           {(() => {
             const brief = deriveCaseDecisionBrief(thread)
-            const stage = brief.stage === 'ready_for_human'
+            const stage = brief.stage === 'proposal_recorded'
               ? {
-                  title: t('Připraveno pro člověka', 'Ready for a human'),
-                  detail: t('Koordinátor předal jeden návrh do schvalovací fronty. Rozhodnutí stále náleží člověku.', 'The coordinator sent one proposal to the approval queue. The decision still belongs to a human.'),
+                  title: t('Návrh zaznamenán ve vlákně', 'Proposal recorded in the thread'),
+                  detail: t('Koordinátor vytvořil proposal event. Stav doručení a lidského rozhodnutí tato stránka nesleduje.', 'The coordinator created a proposal event. This page does not track delivery or the human decision.'),
                   tone: 'var(--accent-text)', bg: 'var(--accent-bg)', border: 'var(--accent-border)',
                 }
               : brief.stage === 'needs_convergence'
@@ -200,9 +200,9 @@ export default function IaopsCaseThreadPage() {
                     </div>
                     <h2 id="case-decision-brief-title" style={{ margin: '5px 0 0', color: 'var(--text-primary)', fontSize: '15px', letterSpacing: '-.015em' }}>{stage.title}</h2>
                   </div>
-                  {brief.stage === 'ready_for_human' && (
+                  {brief.stage === 'proposal_recorded' && (
                     <Link href="/approvals" style={{ display: 'inline-flex', alignItems: 'center', gap: '5px', padding: '7px 10px', borderRadius: '8px', color: 'var(--accent-text)', background: 'var(--accent-bg)', fontSize: '11px', fontWeight: 750, textDecoration: 'none' }}>
-                      {t('Otevřít HITL frontu', 'Open HITL queue')}
+                      {t('Přejít do HITL fronty', 'Go to HITL queue')}
                     </Link>
                   )}
                 </div>

--- a/openbank-admin-ui/src/app/iaops/cases/[caseId]/page.tsx
+++ b/openbank-admin-ui/src/app/iaops/cases/[caseId]/page.tsx
@@ -7,10 +7,11 @@
 import { useCallback, useEffect, useState } from 'react'
 import Link from 'next/link'
 import { useParams } from 'next/navigation'
-import { ArrowLeft, Bot, CheckCircle2, CircleDot, FileText, Flag, GitMerge, RefreshCw, Sparkles, TriangleAlert } from 'lucide-react'
+import { ArrowLeft, Bot, CheckCircle2, CircleDot, FileText, Flag, GitMerge, RefreshCw, Sparkles, TriangleAlert, UsersRound } from 'lucide-react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { DataUnavailable } from '@/components/feedback/DataUnavailable'
 import type { UnavailableKind } from '@/components/feedback/DataUnavailable'
+import { deriveCaseDecisionBrief } from '@/lib/governance/caseDecisionBrief'
 
 type CaseStatus = 'OPEN' | 'CONVERGING' | 'CONTESTED' | 'SYNTHESIZED' | 'CLOSED'
 type EntryType = 'CASE_OPENED' | 'CONTRIBUTION' | 'PROPOSAL_EMITTED'
@@ -169,6 +170,64 @@ export default function IaopsCaseThreadPage() {
             <span>{t('Deadline', 'Deadline')}: <strong style={{ color: 'var(--text-secondary)' }}>{fmt(thread.deadlineAtEpochMs)}</strong></span>
             <span>{t('Míra sporu', 'Contested rate')}: <strong style={{ color: 'var(--text-secondary)' }}>{Math.round(thread.contestedRate * 100)} %</strong></span>
           </div>
+
+          {(() => {
+            const brief = deriveCaseDecisionBrief(thread)
+            const stage = brief.stage === 'ready_for_human'
+              ? {
+                  title: t('Připraveno pro člověka', 'Ready for a human'),
+                  detail: t('Koordinátor předal jeden návrh do schvalovací fronty. Rozhodnutí stále náleží člověku.', 'The coordinator sent one proposal to the approval queue. The decision still belongs to a human.'),
+                  tone: 'var(--accent-text)', bg: 'var(--accent-bg)', border: 'var(--accent-border)',
+                }
+              : brief.stage === 'needs_convergence'
+                ? {
+                    title: t('Neshoda zůstává viditelná', 'Dissent remains visible'),
+                    detail: t('Příspěvky si odporují; koordinátor zatím nepředstírá shodu ani nevydal návrh.', 'Inputs conflict; the coordinator does not pretend there is agreement or emit a proposal yet.'),
+                    tone: 'var(--warning-text)', bg: 'var(--warning-bg)', border: 'var(--warning-border)',
+                  }
+                : {
+                    title: brief.contributorCount > 0 ? t('Koordinátor porovnává podklady', 'The coordinator is comparing inputs') : t('Čeká se na řízené podklady', 'Waiting for governed inputs'),
+                    detail: t('Tato stránka shrnuje jen příspěvky, které už ve vlákně jsou — nic sama nedoplňuje.', 'This page summarises only contributions already in the thread — it adds nothing itself.'),
+                    tone: 'var(--blue)', bg: 'var(--info-bg)', border: 'var(--border)',
+                  }
+
+            return (
+              <section aria-labelledby="case-decision-brief-title" style={{ marginBottom: '18px', padding: '16px 18px', borderRadius: '14px', background: 'var(--surface)', border: '1px solid var(--border)' }}>
+                <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: '12px', flexWrap: 'wrap' }}>
+                  <div>
+                    <div style={{ display: 'inline-flex', alignItems: 'center', gap: '6px', color: 'var(--accent-text)', fontSize: '10px', fontWeight: 800, letterSpacing: '.08em', textTransform: 'uppercase' }}>
+                      <UsersRound size={13} /> {t('Rozhodovací přehled', 'Decision brief')}
+                    </div>
+                    <h2 id="case-decision-brief-title" style={{ margin: '5px 0 0', color: 'var(--text-primary)', fontSize: '15px', letterSpacing: '-.015em' }}>{stage.title}</h2>
+                  </div>
+                  {brief.stage === 'ready_for_human' && (
+                    <Link href="/approvals" style={{ display: 'inline-flex', alignItems: 'center', gap: '5px', padding: '7px 10px', borderRadius: '8px', color: 'var(--accent-text)', background: 'var(--accent-bg)', fontSize: '11px', fontWeight: 750, textDecoration: 'none' }}>
+                      {t('Otevřít HITL frontu', 'Open HITL queue')}
+                    </Link>
+                  )}
+                </div>
+                <p style={{ margin: '8px 0 14px', color: 'var(--text-secondary)', fontSize: '12px', lineHeight: 1.5 }}>{stage.detail}</p>
+                <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(140px, 1fr))', gap: '8px' }}>
+                  <div style={{ padding: '9px 10px', borderRadius: '10px', background: stage.bg, border: `1px solid ${stage.border}` }}>
+                    <div style={{ color: 'var(--text-tertiary)', fontSize: '10px', fontWeight: 700 }}>{t('Další krok', 'Next step')}</div>
+                    <div style={{ marginTop: '3px', color: stage.tone, fontSize: '11px', fontWeight: 800 }}>{stage.title}</div>
+                  </div>
+                  <div style={{ padding: '9px 10px', borderRadius: '10px', background: 'var(--surface-2)', border: '1px solid var(--border)' }}>
+                    <div style={{ color: 'var(--text-tertiary)', fontSize: '10px', fontWeight: 700 }}>{t('Role s příspěvkem', 'Contributing roles')}</div>
+                    <div style={{ marginTop: '3px', color: 'var(--text-primary)', fontSize: '11px', fontWeight: 800 }}>{brief.contributorCount}</div>
+                  </div>
+                  <div style={{ padding: '9px 10px', borderRadius: '10px', background: 'var(--surface-2)', border: '1px solid var(--border)' }}>
+                    <div style={{ color: 'var(--text-tertiary)', fontSize: '10px', fontWeight: 700 }}>{t('Odkazy na důkazy', 'Evidence references')}</div>
+                    <div style={{ marginTop: '3px', color: 'var(--text-primary)', fontSize: '11px', fontWeight: 800 }}>{brief.evidenceRefCount}</div>
+                  </div>
+                  <div style={{ padding: '9px 10px', borderRadius: '10px', background: brief.contestedContributionCount > 0 ? 'var(--warning-bg)' : 'var(--surface-2)', border: `1px solid ${brief.contestedContributionCount > 0 ? 'var(--warning-border)' : 'var(--border)'}` }}>
+                    <div style={{ color: 'var(--text-tertiary)', fontSize: '10px', fontWeight: 700 }}>{t('Označené nesouhlasy', 'Marked dissent')}</div>
+                    <div style={{ marginTop: '3px', color: brief.contestedContributionCount > 0 ? 'var(--warning-text)' : 'var(--text-primary)', fontSize: '11px', fontWeight: 800 }}>{brief.contestedContributionCount}</div>
+                  </div>
+                </div>
+              </section>
+            )
+          })()}
 
           {thread.status === 'CONTESTED' && (
             <div style={{

--- a/openbank-admin-ui/src/lib/governance/caseDecisionBrief.ts
+++ b/openbank-admin-ui/src/lib/governance/caseDecisionBrief.ts
@@ -17,7 +17,7 @@ export interface CaseThreadForBrief {
   entries: CaseThreadEntry[]
 }
 
-export type DecisionBriefStage = 'ready_for_human' | 'needs_convergence' | 'gathering_evidence'
+export type DecisionBriefStage = 'proposal_recorded' | 'needs_convergence' | 'gathering_evidence'
 
 export interface CaseDecisionBrief {
   stage: DecisionBriefStage
@@ -36,7 +36,7 @@ export function deriveCaseDecisionBrief(thread: CaseThreadForBrief): CaseDecisio
   const proposalEmitted = thread.entries.some(entry => entry.type === 'PROPOSAL_EMITTED')
 
   return {
-    stage: proposalEmitted ? 'ready_for_human' : thread.status === 'CONTESTED' ? 'needs_convergence' : 'gathering_evidence',
+    stage: proposalEmitted ? 'proposal_recorded' : thread.status === 'CONTESTED' ? 'needs_convergence' : 'gathering_evidence',
     contributorCount,
     evidenceRefCount,
     contestedContributionCount,

--- a/openbank-admin-ui/src/lib/governance/caseDecisionBrief.ts
+++ b/openbank-admin-ui/src/lib/governance/caseDecisionBrief.ts
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+export type CaseStatus = 'OPEN' | 'CONVERGING' | 'CONTESTED' | 'SYNTHESIZED' | 'CLOSED'
+export type CaseEntryType = 'CASE_OPENED' | 'CONTRIBUTION' | 'PROPOSAL_EMITTED'
+
+export interface CaseThreadEntry {
+  type: CaseEntryType
+  actor?: string
+  evidenceRefs?: string[]
+  superseded?: boolean
+  contested?: boolean
+}
+
+export interface CaseThreadForBrief {
+  status: CaseStatus
+  entries: CaseThreadEntry[]
+}
+
+export type DecisionBriefStage = 'ready_for_human' | 'needs_convergence' | 'gathering_evidence'
+
+export interface CaseDecisionBrief {
+  stage: DecisionBriefStage
+  contributorCount: number
+  evidenceRefCount: number
+  contestedContributionCount: number
+}
+
+// This deliberately derives only from the read-only thread returned by the
+// coordinator. It is a plain-language summary, never a new decision signal.
+export function deriveCaseDecisionBrief(thread: CaseThreadForBrief): CaseDecisionBrief {
+  const activeContributions = thread.entries.filter(entry => entry.type === 'CONTRIBUTION' && !entry.superseded)
+  const contributorCount = new Set(activeContributions.map(entry => entry.actor).filter((actor): actor is string => Boolean(actor))).size
+  const evidenceRefCount = new Set(activeContributions.flatMap(entry => entry.evidenceRefs ?? [])).size
+  const contestedContributionCount = activeContributions.filter(entry => entry.contested).length
+  const proposalEmitted = thread.entries.some(entry => entry.type === 'PROPOSAL_EMITTED')
+
+  return {
+    stage: proposalEmitted ? 'ready_for_human' : thread.status === 'CONTESTED' ? 'needs_convergence' : 'gathering_evidence',
+    contributorCount,
+    evidenceRefCount,
+    contestedContributionCount,
+  }
+}

--- a/openbank-admin-ui/src/test/case-decision-brief.test.ts
+++ b/openbank-admin-ui/src/test/case-decision-brief.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, it } from 'vitest'
 import { deriveCaseDecisionBrief } from '@/lib/governance/caseDecisionBrief'
 
 describe('case decision brief', () => {
-  it('shows a human hand-off only after the coordinator emitted a proposal', () => {
+  it('reports only a proposal event after the coordinator emitted one', () => {
     const brief = deriveCaseDecisionBrief({
       status: 'SYNTHESIZED',
       entries: [
@@ -16,7 +16,7 @@ describe('case decision brief', () => {
     })
 
     expect(brief).toEqual({
-      stage: 'ready_for_human',
+      stage: 'proposal_recorded',
       contributorCount: 1,
       evidenceRefCount: 2,
       contestedContributionCount: 0,

--- a/openbank-admin-ui/src/test/case-decision-brief.test.ts
+++ b/openbank-admin-ui/src/test/case-decision-brief.test.ts
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+import { describe, expect, it } from 'vitest'
+import { deriveCaseDecisionBrief } from '@/lib/governance/caseDecisionBrief'
+
+describe('case decision brief', () => {
+  it('shows a human hand-off only after the coordinator emitted a proposal', () => {
+    const brief = deriveCaseDecisionBrief({
+      status: 'SYNTHESIZED',
+      entries: [
+        { type: 'CONTRIBUTION', actor: 'aml-agent', evidenceRefs: ['alert-17', 'policy-9'] },
+        { type: 'CONTRIBUTION', actor: 'fraud-agent', evidenceRefs: ['alert-17'], superseded: true },
+        { type: 'PROPOSAL_EMITTED' },
+      ],
+    })
+
+    expect(brief).toEqual({
+      stage: 'ready_for_human',
+      contributorCount: 1,
+      evidenceRefCount: 2,
+      contestedContributionCount: 0,
+    })
+  })
+
+  it('keeps dissent visible when the case still needs convergence', () => {
+    const brief = deriveCaseDecisionBrief({
+      status: 'CONTESTED',
+      entries: [
+        { type: 'CONTRIBUTION', actor: 'aml-agent', evidenceRefs: ['alert-17'], contested: true },
+        { type: 'CONTRIBUTION', actor: 'fraud-agent', evidenceRefs: ['trace-4'] },
+      ],
+    })
+
+    expect(brief).toEqual({
+      stage: 'needs_convergence',
+      contributorCount: 2,
+      evidenceRefCount: 2,
+      contestedContributionCount: 1,
+    })
+  })
+
+  it('does not imply evidence exists before any specialist contributes', () => {
+    expect(deriveCaseDecisionBrief({ status: 'OPEN', entries: [{ type: 'CASE_OPENED' }] })).toEqual({
+      stage: 'gathering_evidence',
+      contributorCount: 0,
+      evidenceRefCount: 0,
+      contestedContributionCount: 0,
+    })
+  })
+})


### PR DESCRIPTION
## What changed

Adds a plain-language, read-only decision brief above the swarm case timeline.

- shows whether the case is gathering governed inputs, resolving dissent, or ready for human review;
- counts active contributing roles and unique evidence references;
- keeps marked dissent visible;
- links to the HITL queue only after the coordinator emitted a proposal.

## Guardrails

The brief derives only from the existing case-coordinator thread. It creates no decision and does not hide superseded or contested history from the detailed timeline.

Closes #5075

## Validation

- focused decision-brief unit tests
- TypeScript type-check
- ESLint