### PR TITLE
fix(sepa-payment,domestic-payment): emit sanctions screening/hit metrics

### DIFF
--- a/openbank-domestic-payment/src/main/kotlin/com/openbank/domestic/application/workflow/DomesticPaymentActivitiesImpl.kt
+++ b/openbank-domestic-payment/src/main/kotlin/com/openbank/domestic/application/workflow/DomesticPaymentActivitiesImpl.kt
@@ -27,6 +27,7 @@ import com.openbank.domestic.domain.screening.ScreeningMatchStatus
 import com.openbank.domestic.domain.screening.ScreeningPolicy
 import com.openbank.domestic.domain.screening.ScreeningResult
 import com.openbank.domestic.domain.screening.ScreeningRole
+import com.openbank.libs.observability.DomainMetrics
 import com.openbank.libs.persistence.outbox.OutboxMessage
 import io.quarkus.vertx.VertxContextSupport
 import io.smallrye.mutiny.coroutines.asUni
@@ -55,6 +56,7 @@ open class DomesticPaymentActivitiesImpl(
     private val schemeGatewayPort: SchemeGatewayPort,
     private val settlementPort: SettlementPort,
     private val clock: Clock,
+    private val metrics: DomainMetrics,
     @ConfigProperty(name = "openbank.domestic.scheme-submission.enabled", defaultValue = "false")
     private val schemeSubmissionEnabled: Boolean,
 ) : DomesticPaymentActivities {
@@ -85,6 +87,19 @@ open class DomesticPaymentActivitiesImpl(
             log.warnf(ex, "Sanctions screening unavailable for payment %s; returning REVIEW", paymentId)
             openCaseQuietly(payment, AmlCaseRiskLevel.MEDIUM, ALERT_SCREENING_UNAVAILABLE, ex.message, null)
             return@vtx ScreeningDecision.REVIEW
+        }
+
+        // Issue #5049: openbank_sanctions_screenings_total / openbank_sanctions_hits_total had NO
+        // call site anywhere in this class -- see SepaPaymentActivitiesImpl.screenPayment for why
+        // sanctions-service itself cannot record these (no "role" concept of its own).
+        for (result in results) {
+            metrics.sanctionsScreening(result.role.name.lowercase())
+            val severity = when (result.status) {
+                ScreeningMatchStatus.HIT, ScreeningMatchStatus.ESCALATED -> "block"
+                ScreeningMatchStatus.POTENTIAL_HIT -> "review"
+                ScreeningMatchStatus.CLEAR, ScreeningMatchStatus.WHITELISTED -> null
+            }
+            if (severity != null) metrics.sanctionsHit(result.role.name.lowercase(), severity)
         }
 
         val decision = applySddPolicy(payment, ScreeningPolicy.decide(results), paymentId)

--- a/openbank-domestic-payment/src/test/kotlin/com/openbank/domestic/application/workflow/DomesticPaymentActivitiesImplTest.kt
+++ b/openbank-domestic-payment/src/test/kotlin/com/openbank/domestic/application/workflow/DomesticPaymentActivitiesImplTest.kt
@@ -30,6 +30,7 @@ import com.openbank.domestic.domain.screening.ScreeningMatchStatus
 import com.openbank.domestic.domain.screening.ScreeningResult
 import com.openbank.domestic.domain.screening.ScreeningRole.CREDITOR
 import com.openbank.domestic.domain.screening.ScreeningRole.DEBTOR
+import com.openbank.libs.observability.DomainMetrics
 import com.openbank.libs.persistence.outbox.OutboxMessage
 import io.mockk.coEvery
 import io.mockk.coJustRun
@@ -38,6 +39,7 @@ import io.mockk.coVerifyOrder
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
+import io.mockk.verify
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
@@ -61,6 +63,7 @@ class DomesticPaymentActivitiesImplTest {
     private lateinit var fraudScoringPort: FraudScoringPort
     private lateinit var schemeGatewayPort: SchemeGatewayPort
     private lateinit var settlementPort: SettlementPort
+    private lateinit var metrics: DomainMetrics
 
     private lateinit var activities: DomesticPaymentActivitiesImpl
     private lateinit var activitiesWithScheme: DomesticPaymentActivitiesImpl
@@ -72,6 +75,7 @@ class DomesticPaymentActivitiesImplTest {
         screeningPort = mockk()
         amlCasePort = mockk()
         fraudScoringPort = mockk()
+        metrics = mockk(relaxed = true)
         activities = object : DomesticPaymentActivitiesImpl(
             paymentRepository,
             eventPublisher,
@@ -81,6 +85,7 @@ class DomesticPaymentActivitiesImplTest {
             schemeGatewayPort = mockk(),
             settlementPort = mockk(),
             clock = Clock.systemUTC(),
+            metrics = metrics,
             schemeSubmissionEnabled = false,
         ) {
             override fun <T> vtx(block: suspend () -> T): T = runBlocking { block() }
@@ -102,6 +107,7 @@ class DomesticPaymentActivitiesImplTest {
             schemeGatewayPort = schemeGatewayPort,
             settlementPort = settlementPort,
             clock = Clock.systemUTC(),
+            metrics = metrics,
             schemeSubmissionEnabled = true,
         ) {
             override fun <T> vtx(block: suspend () -> T): T = runBlocking { block() }
@@ -120,6 +126,51 @@ class DomesticPaymentActivitiesImplTest {
 
         assertThat(decision).isEqualTo(ScreeningDecision.CLEAR)
         coVerify(exactly = 0) { amlCasePort.openCase(any()) }
+    }
+
+    // Issue #5049: openbank_sanctions_screenings_total / openbank_sanctions_hits_total had NO
+    // call site anywhere in this class -- see the sepa-payment equivalent for why
+    // sanctions-service itself cannot record these (no "role" concept of its own).
+    @Test
+    fun `screenPayment records sanctionsScreening for both roles and no hit when both are clear`() {
+        val payment = payment()
+        coEvery { paymentRepository.findById(payment.id) } returns payment
+        coEvery { screeningPort.screen(any(), any(), any()) } answers {
+            ScreeningResult(firstArg(), secondArg(), ScreeningMatchStatus.CLEAR, 0.0, null)
+        }
+
+        activities.screenPayment(payment.id)
+
+        verify(exactly = 1) { metrics.sanctionsScreening("debtor") }
+        verify(exactly = 1) { metrics.sanctionsScreening("creditor") }
+        verify(exactly = 0) { metrics.sanctionsHit(any(), any()) }
+    }
+
+    @Test
+    fun `screenPayment records a block-severity hit only for the debtor that HIT`() {
+        val payment = payment()
+        coEvery { paymentRepository.findById(payment.id) } returns payment
+        coEvery { screeningPort.screen(payment.debtorName, DEBTOR, any()) } returns
+            ScreeningResult(payment.debtorName, DEBTOR, ScreeningMatchStatus.HIT, 0.99, "OFAC:123")
+        coEvery { screeningPort.screen(payment.creditorName, CREDITOR, any()) } returns
+            ScreeningResult(payment.creditorName, CREDITOR, ScreeningMatchStatus.CLEAR, 0.0, null)
+        coJustRun { amlCasePort.openCase(any()) }
+
+        activities.screenPayment(payment.id)
+
+        verify(exactly = 1) { metrics.sanctionsHit("debtor", "block") }
+        verify(exactly = 0) { metrics.sanctionsHit("creditor", any()) }
+    }
+
+    @Test
+    fun `screenPayment records nothing when screening is skipped for an own-accounts transfer`() {
+        val payment = payment().copy(transferScope = DomesticTransferScope.OWN_ACCOUNTS)
+        coEvery { paymentRepository.findById(payment.id) } returns payment
+
+        activities.screenPayment(payment.id)
+
+        verify(exactly = 0) { metrics.sanctionsScreening(any()) }
+        verify(exactly = 0) { metrics.sanctionsHit(any(), any()) }
     }
 
     @Test

--- a/openbank-sepa-payment/src/main/kotlin/com/openbank/sepa/application/workflow/SepaPaymentActivitiesImpl.kt
+++ b/openbank-sepa-payment/src/main/kotlin/com/openbank/sepa/application/workflow/SepaPaymentActivitiesImpl.kt
@@ -4,6 +4,7 @@
 
 package com.openbank.sepa.application.workflow
 
+import com.openbank.libs.observability.DomainMetrics
 import com.openbank.sepa.application.port.out.AmlCasePort
 import com.openbank.sepa.application.port.out.AmlCaseRiskLevel
 import com.openbank.sepa.application.port.out.FraudScoreCommand
@@ -51,6 +52,7 @@ open class SepaPaymentActivitiesImpl(
     private val schemeGatewayPort: SchemeGatewayPort,
     private val settlementPort: SettlementPort,
     private val clock: Clock,
+    private val metrics: DomainMetrics,
     @ConfigProperty(name = "openbank.sepa.scheme-submission.enabled", defaultValue = "false")
     private val schemeSubmissionEnabled: Boolean,
 ) : SepaPaymentActivities {
@@ -76,6 +78,23 @@ open class SepaPaymentActivitiesImpl(
                 matchedEntity = null,
             )
             return@runOnVertxContext ScreeningDecision.REVIEW
+        }
+
+        // openbank_sanctions_screenings_total / openbank_sanctions_hits_total had NO call site
+        // anywhere in this class before (issue #5049): sanctions-service itself has no "role"
+        // concept of its own (its EntityType is INDIVIDUAL/ORGANIZATION/VESSEL/AIRCRAFT, an
+        // orthogonal axis to debtor/creditor), so DomainMetrics.sanctionsScreening/sanctionsHit
+        // can only be recorded HERE, by the caller that knows which side of the payment each
+        // screened name is. One event per screened entity, not per payment -- results always
+        // has exactly one entry per role (debtor, creditor).
+        for (result in results) {
+            metrics.sanctionsScreening(result.role.name.lowercase())
+            val severity = when (result.status) {
+                ScreeningMatchStatus.HIT, ScreeningMatchStatus.ESCALATED -> "block"
+                ScreeningMatchStatus.POTENTIAL_HIT -> "review"
+                ScreeningMatchStatus.CLEAR, ScreeningMatchStatus.WHITELISTED -> null
+            }
+            if (severity != null) metrics.sanctionsHit(result.role.name.lowercase(), severity)
         }
 
         val decision = ScreeningPolicy.decide(results)

--- a/openbank-sepa-payment/src/test/kotlin/com/openbank/sepa/application/workflow/SepaPaymentActivitiesImplTest.kt
+++ b/openbank-sepa-payment/src/test/kotlin/com/openbank/sepa/application/workflow/SepaPaymentActivitiesImplTest.kt
@@ -5,6 +5,7 @@
 package com.openbank.sepa.application.workflow
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.libs.observability.DomainMetrics
 import com.openbank.sepa.application.port.out.AmlCasePort
 import com.openbank.sepa.application.port.out.FraudScoreOutcome
 import com.openbank.sepa.application.port.out.FraudScoringPort
@@ -32,6 +33,7 @@ import io.mockk.coJustRun
 import io.mockk.coVerify
 import io.mockk.mockk
 import io.mockk.slot
+import io.mockk.verify
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
@@ -50,6 +52,7 @@ class SepaPaymentActivitiesImplTest {
     private lateinit var fraudScoringPort: FraudScoringPort
     private lateinit var schemeGatewayPort: SchemeGatewayPort
     private lateinit var settlementPort: SettlementPort
+    private lateinit var metrics: DomainMetrics
     private lateinit var activities: SepaPaymentActivitiesImpl
 
     private val clock = Clock.systemUTC()
@@ -86,6 +89,7 @@ class SepaPaymentActivitiesImplTest {
         fraudScoringPort = mockk()
         schemeGatewayPort = mockk()
         settlementPort = mockk()
+        metrics = mockk(relaxed = true)
         activities = TestableActivities(
             paymentRepository,
             screeningPort,
@@ -94,6 +98,7 @@ class SepaPaymentActivitiesImplTest {
             schemeGatewayPort,
             settlementPort,
             clock = clock,
+            metrics = metrics,
             schemeSubmissionEnabled = true,
         )
         coJustRun { amlCasePort.openCase(any()) }
@@ -126,6 +131,53 @@ class SepaPaymentActivitiesImplTest {
 
         assertThat(result).isEqualTo(ScreeningDecision.BLOCK)
         coVerify { amlCasePort.openCase(any()) }
+    }
+
+    // Issue #5049: openbank_sanctions_screenings_total / openbank_sanctions_hits_total had NO
+    // call site anywhere in this class -- sanctions-service itself has no "role" concept of its
+    // own, so these can only be recorded here, by the caller that knows which side of the
+    // payment each screened name is.
+    @Test
+    fun `screenPayment records sanctionsScreening for both roles and no hit when both are clear`() {
+        coEvery { paymentRepository.findById(paymentId) } returns payment
+        coEvery { screeningPort.screen(any(), ScreeningRole.DEBTOR, any()) } returns
+            ScreeningResult("Alice", ScreeningRole.DEBTOR, ScreeningMatchStatus.CLEAR, 0.0, null)
+        coEvery { screeningPort.screen(any(), ScreeningRole.CREDITOR, any()) } returns
+            ScreeningResult("Bob", ScreeningRole.CREDITOR, ScreeningMatchStatus.CLEAR, 0.0, null)
+
+        activities.screenPayment(paymentId)
+
+        verify(exactly = 1) { metrics.sanctionsScreening("debtor") }
+        verify(exactly = 1) { metrics.sanctionsScreening("creditor") }
+        verify(exactly = 0) { metrics.sanctionsHit(any(), any()) }
+    }
+
+    @Test
+    fun `screenPayment records a block-severity hit only for the debtor that HIT`() {
+        coEvery { paymentRepository.findById(paymentId) } returns payment
+        coEvery { screeningPort.screen(any(), ScreeningRole.DEBTOR, any()) } returns
+            ScreeningResult("Alice", ScreeningRole.DEBTOR, ScreeningMatchStatus.HIT, 0.99, "SanctionedEntity")
+        coEvery { screeningPort.screen(any(), ScreeningRole.CREDITOR, any()) } returns
+            ScreeningResult("Bob", ScreeningRole.CREDITOR, ScreeningMatchStatus.CLEAR, 0.0, null)
+
+        activities.screenPayment(paymentId)
+
+        verify(exactly = 1) { metrics.sanctionsHit("debtor", "block") }
+        verify(exactly = 0) { metrics.sanctionsHit("creditor", any()) }
+    }
+
+    @Test
+    fun `screenPayment records review-severity for a POTENTIAL_HIT, not block`() {
+        coEvery { paymentRepository.findById(paymentId) } returns payment
+        coEvery { screeningPort.screen(any(), ScreeningRole.DEBTOR, any()) } returns
+            ScreeningResult("Alice", ScreeningRole.DEBTOR, ScreeningMatchStatus.POTENTIAL_HIT, 0.7, "MaybeMatch")
+        coEvery { screeningPort.screen(any(), ScreeningRole.CREDITOR, any()) } returns
+            ScreeningResult("Bob", ScreeningRole.CREDITOR, ScreeningMatchStatus.CLEAR, 0.0, null)
+
+        activities.screenPayment(paymentId)
+
+        verify(exactly = 1) { metrics.sanctionsHit("debtor", "review") }
+        verify(exactly = 0) { metrics.sanctionsHit("debtor", "block") }
     }
 
     @Test
@@ -253,6 +305,7 @@ class SepaPaymentActivitiesImplTest {
             schemeGatewayPort,
             settlementPort,
             clock = clock,
+            metrics = metrics,
             schemeSubmissionEnabled = false,
         )
         coEvery { paymentRepository.findById(paymentId) } returns validated
@@ -282,6 +335,7 @@ class SepaPaymentActivitiesImplTest {
         schemeGatewayPort,
         settlementPort,
         clock = Clock.fixed(fixedInstant, ZoneOffset.UTC),
+        metrics = metrics,
         schemeSubmissionEnabled = true,
     )
 
@@ -350,6 +404,7 @@ private class TestableActivities(
     schemeGatewayPort: SchemeGatewayPort,
     settlementPort: SettlementPort,
     clock: Clock,
+    metrics: DomainMetrics,
     schemeSubmissionEnabled: Boolean,
 ) : SepaPaymentActivitiesImpl(
     paymentRepository,
@@ -359,6 +414,7 @@ private class TestableActivities(
     schemeGatewayPort,
     settlementPort,
     clock,
+    metrics,
     schemeSubmissionEnabled,
 ) {
     override fun <T> runOnVertxContext(block: suspend () -> T): T = runBlocking { block() }


### PR DESCRIPTION
## What

Second real gap from #5049's payments round (first was #5068, domestic-payment's missing `paymentCompleted`). This one is `openbank_sanctions_screenings_total`/`openbank_sanctions_hits_total`.

## Why sanctions-service itself can't record these

`DomainMetrics.sanctionsScreening(role)`/`sanctionsHit(role, severity)` require `role ∈ {debtor, creditor, beneficiary}`. `sanctions-service`'s own domain has no such concept — its `EntityType` is `INDIVIDUAL`/`ORGANIZATION`/`VESSEL`/`AIRCRAFT`, an orthogonal axis. Confirmed: `DomainMetrics` isn't even injected anywhere in `sanctions-service` except the shared `AbstractOutboxBacklogGauge` base class. "Debtor" vs "creditor" is a **payment-side** concept — only the caller invoking `screeningPort.screen(name, role, ...)` knows which side of a payment is being screened.

## One rail already gets this right

`sepa-instant`'s `SctInstPaymentService.applyDecision()` already calls both methods correctly — every screened result records `sanctionsScreening(role)`, and every non-`CLEAR` result records `sanctionsHit(role, severity)`. Read the code, didn't assume — no change needed there.

## Two rails didn't

`sepa-payment`'s and `domestic-payment`'s `screenPayment` Temporal activities call `screeningPort.screen()` for both debtor and creditor, use the results to decide `CLEAR`/`REVIEW`/`BLOCK` and open AML cases on a hit — but never recorded either metric, anywhere. `openbank_sanctions_screenings_total`/`_hits_total` could never have a sample for these two rails regardless of real traffic.

## The fix

One screening event per screened entity; for any non-`CLEAR`/non-`WHITELISTED` result, one hit event with severity derived from the match status — same mapping `sepa-instant` already uses:

```kotlin
for (result in results) {
    metrics.sanctionsScreening(result.role.name.lowercase())
    val severity = when (result.status) {
        ScreeningMatchStatus.HIT, ScreeningMatchStatus.ESCALATED -> "block"
        ScreeningMatchStatus.POTENTIAL_HIT -> "review"
        ScreeningMatchStatus.CLEAR, ScreeningMatchStatus.WHITELISTED -> null
    }
    if (severity != null) metrics.sanctionsHit(result.role.name.lowercase(), severity)
}
```

Both `*ActivitiesImpl` classes needed `DomainMetrics` added to their constructor — wasn't there before.

## Tests — 3 new cases per service

- both entities clear → two `sanctionsScreening` calls, zero `sanctionsHit`
- a `HIT` on the debtor → `sanctionsHit("debtor", "block")`, nothing for the creditor
- `domestic-payment` additionally: an `OWN_ACCOUNTS`/`TECHNICAL_ACCOUNT` transfer skips screening entirely (early-return before `screeningPort.screen` is ever called) — neither metric should fire, and now a test pins that

## Verified

- `sepa-payment`: **17/17** (was 14) · `domestic-payment`: **36/36** (was 33) — `./gradlew :openbank-sepa-payment:test :openbank-domestic-payment:test`.
- `ktlintCheck`, `detekt` — clean on both.
- `quarkusBuild` — green on both. Catches CDI/ArC wiring breaks from the new constructor parameter that unit tests can't (per this repo's own documented pitfall).
- Local `run-gates.py --all`: **148/149** (the one failure, `api-contract-gate`, needs `sudo` locally and reproduces on a clean `origin/main` worktree; this PR touches no `openapi.yaml`).

## Review note

Both `sepa-payment` and `domestic-payment` are `money_path_services` — 2 approvals. No trust-boundary change (no new listener/port/auth key), so `threat-model-updated-on-trust-boundary-change` correctly doesn't fire.

Refs #5049
