### PR TITLE
fix(agent): make oversight scheduler live

### DIFF
--- a/.github/scripts/check-scheduler-liveness.py
+++ b/.github/scripts/check-scheduler-liveness.py
@@ -69,7 +69,6 @@ ALLOWLIST = {
 # exit 1, which `mode: advisory` then converted to a warning; nothing else noticed.
 BASELINE = [
     # non-money-path
-    "openbank-agent-service/src/main/kotlin/com/openbank/agent/application/OversightService.kt",
     "openbank-agent-service/src/main/kotlin/com/openbank/agent/infrastructure/observability/AgentMetricsAdapter.kt",
     "openbank-dispute-service/src/main/kotlin/com/openbank/dispute/infrastructure/observability/ComplaintDeadlineGauge.kt",
     "openbank-onboarding-service/src/main/kotlin/com/openbank/onboarding/infrastructure/observability/OnboardingFunnelGauge.kt",

--- a/openbank-agent-service/src/main/kotlin/com/openbank/agent/application/OversightService.kt
+++ b/openbank-agent-service/src/main/kotlin/com/openbank/agent/application/OversightService.kt
@@ -9,12 +9,16 @@ import com.openbank.agent.application.port.`in`.ProposalQueries
 import com.openbank.agent.domain.model.ChatMessage
 import com.openbank.agent.domain.model.ChatRole
 import com.openbank.agent.domain.policy.AgentIdentity
+import com.openbank.libs.observability.DomainMetrics
+import com.openbank.libs.observability.WorkflowLivenessRecorder
+import io.quarkus.runtime.StartupEvent
 import io.quarkus.scheduler.Scheduled
 import jakarta.enterprise.context.ApplicationScoped
+import jakarta.enterprise.event.Observes
 import jakarta.inject.Inject
-import kotlinx.coroutines.runBlocking
 import org.eclipse.microprofile.config.inject.ConfigProperty
 import org.jboss.logging.Logger
+import java.time.Duration
 
 /**
  * The first autonomous control-plane agent (ADR-0031 D9 phase 2): a scheduled oversight sweep
@@ -41,17 +45,23 @@ class OversightService {
 
     @Inject lateinit var injectionGuard: PromptInjectionGuard
 
+    @Inject lateinit var domainMetrics: DomainMetrics
+
     @ConfigProperty(name = "agent.oversight.enabled", defaultValue = "false")
     var enabled: Boolean = false
 
     private val log = Logger.getLogger(OversightService::class.java)
+    private var liveness: WorkflowLivenessRecorder? = null
+
+    fun registerLiveness(@Observes @Suppress("UNUSED_PARAMETER") event: StartupEvent) {
+        if (enabled) liveness = domainMetrics.registerWorkflowLiveness(WORKFLOW_NAME, EXPECTED_INTERVAL)
+    }
 
     @Scheduled(cron = "{agent.oversight.cron}", concurrentExecution = Scheduled.ConcurrentExecution.SKIP)
-    fun scheduledSweep() {
+    suspend fun scheduledSweep() {
         if (!enabled) return
-        // Worker thread (Quarkus scheduler), same bridge as ChatEndpoint: keeps the blocking
-        // OPA/MCP clients legal and the audit context on this thread.
-        runBlocking { sweep(trigger = "scheduled") }
+        sweep(trigger = "scheduled")
+        liveness?.recordSuccess()
     }
 
     suspend fun sweep(trigger: String): AgentChatService.ChatOutcome {
@@ -82,6 +92,8 @@ class OversightService {
         RegisteredPromptTemplates.oversightPrompt(pendingTitles)
 
     companion object {
+        private const val WORKFLOW_NAME = "agent-oversight-sweep"
+        private val EXPECTED_INTERVAL: Duration = Duration.ofHours(1)
         val OVERSIGHT_IDENTITY = AgentIdentity(agentId = "compliance-officer", plane = "control")
         const val SWEEP_REQUEST =
             "Run the compliance oversight sweep now. Check sanctions screenings pending review, " +

--- a/openbank-agent-service/src/test/kotlin/com/openbank/agent/application/OversightServiceTest.kt
+++ b/openbank-agent-service/src/test/kotlin/com/openbank/agent/application/OversightServiceTest.kt
@@ -7,10 +7,14 @@ package com.openbank.agent.application
 
 import com.openbank.agent.domain.proposal.AgentProposal
 import com.openbank.agent.domain.proposal.ProposalState
+import com.openbank.libs.observability.DomainMetrics
+import com.openbank.libs.observability.WorkflowLivenessRecorder
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
+import io.quarkus.runtime.StartupEvent
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -70,33 +74,43 @@ class OversightServiceTest {
     }
 
     @Test
-    fun `scheduled sweep is a no-op until oversight is enabled`() {
+    fun `scheduled sweep is a no-op until oversight is enabled`(): Unit = runBlocking {
         val chat = mockk<AgentChatService>()
+        val metrics = mockk<DomainMetrics>()
         val service = OversightService().apply {
             chatService = chat
             proposals = mockk()
             injectionGuard = mockk()
             enabled = false
+            domainMetrics = metrics
         }
 
+        service.registerLiveness(StartupEvent())
         service.scheduledSweep()
 
         coVerify(exactly = 0) { chat.run(any(), any(), any(), any(), any()) }
+        verify(exactly = 0) { metrics.registerWorkflowLiveness(any(), any()) }
     }
 
     @Test
-    fun `scheduled sweep runs with the scheduled trigger when enabled`() {
+    fun `scheduled sweep runs with the scheduled trigger when enabled`(): Unit = runBlocking {
         val chat = mockk<AgentChatService>()
+        val metrics = mockk<DomainMetrics>()
+        val liveness = mockk<WorkflowLivenessRecorder>(relaxed = true)
         coEvery { chat.run(any(), any(), any(), any(), any()) } returns outcome()
         val service = OversightService().apply {
             chatService = chat
             proposals = mockk { every { listPending() } returns emptyList() }
             injectionGuard = mockk { every { sanitizeInline(any(), any()) } answers { firstArg() } }
             enabled = true
+            domainMetrics = metrics
         }
+        every { metrics.registerWorkflowLiveness(any(), any()) } returns liveness
 
+        service.registerLiveness(StartupEvent())
         service.scheduledSweep()
 
         coVerify(exactly = 1) { chat.run(any(), any(), any(), any(), trigger = "scheduled") }
+        verify(exactly = 1) { liveness.recordSuccess() }
     }
 }

--- a/openbank-libs/governance/rules.yaml
+++ b/openbank-libs/governance/rules.yaml
@@ -1476,12 +1476,6 @@ scheduled_methods:
   # idiom as the ktlint/detekt baselines and event_consumer_liveness.allowlist. A stale entry
   # is itself a violation.
   runblocking_allowlist:
-    - method: "openbank-agent-service/src/main/kotlin/com/openbank/agent/application/OversightService.kt#scheduledSweep"
-      reason: >-
-        agent-service has NO Hibernate Reactive on its classpath (build.gradle.kts: the
-        proposals store is plain Agroal JDBC, deliberately not the reactive stack). The sweep
-        drives blocking OPA/MCP/LLM clients and needs to stay on a worker thread — the same
-        bridge ChatEndpoint uses. `suspend` here would move blocking I/O onto an event loop.
     - method: "openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/infrastructure/reconcile/ReconciliationJob.kt#scheduled"
       reason: >-
         analytics-sink deliberately DROPS hibernate-reactive-panache, reactive-pg-client and


### PR DESCRIPTION
Refs #3345

Converts the scheduled oversight sweep to the required suspend flow, registers ADR-0237 liveness only when it is enabled, and records success after a completed sweep. Removes it from the scheduler-liveness baseline.

Validation: scheduler-liveness ratchet and diff check pass; required CI is authoritative.