### PR TITLE
fix(pid): track trusted-list refresh liveness

### DIFF
--- a/.github/scripts/check-scheduler-liveness.py
+++ b/.github/scripts/check-scheduler-liveness.py
@@ -73,7 +73,6 @@ BASELINE = [
     "openbank-agent-service/src/main/kotlin/com/openbank/agent/infrastructure/observability/AgentMetricsAdapter.kt",
     "openbank-dispute-service/src/main/kotlin/com/openbank/dispute/infrastructure/observability/ComplaintDeadlineGauge.kt",
     "openbank-onboarding-service/src/main/kotlin/com/openbank/onboarding/infrastructure/observability/OnboardingFunnelGauge.kt",
-    "openbank-pid-service/src/main/kotlin/com/openbank/pid/infrastructure/crypto/TrustedListService.kt",
     "openbank-statement-service/src/main/kotlin/com/openbank/statement/infrastructure/metrics/CloseLastRunGauge.kt",
     "openbank-statement-service/src/main/kotlin/com/openbank/statement/infrastructure/scheduler/PeriodCloseScheduler.kt",
 ]

--- a/openbank-pid-service/src/main/kotlin/com/openbank/pid/infrastructure/crypto/TrustedListService.kt
+++ b/openbank-pid-service/src/main/kotlin/com/openbank/pid/infrastructure/crypto/TrustedListService.kt
@@ -5,10 +5,13 @@
 package com.openbank.pid.infrastructure.crypto
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.libs.observability.DomainMetrics
+import com.openbank.libs.observability.WorkflowLivenessRecorder
 import io.quarkus.logging.Log
 import io.quarkus.runtime.StartupEvent
 import io.quarkus.scheduler.Scheduled
 import io.smallrye.common.annotation.Blocking
+import jakarta.annotation.PostConstruct
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.enterprise.event.Observes
 import org.eclipse.microprofile.config.inject.ConfigProperty
@@ -54,7 +57,10 @@ class TrustedListService(
     private val trustStore: RefreshableTrustStore,
     private val objectMapper: ObjectMapper,
     private val clock: Clock,
+    private val domainMetrics: DomainMetrics,
 ) {
+    private var liveness: WorkflowLivenessRecorder? = null
+
     private val anchor: JsonWebKeySet? = anchorJwksJson
         .map { it.trim() }
         .filter { it.isNotEmpty() && it != "{}" }
@@ -74,6 +80,11 @@ class TrustedListService(
     @Suppress("UnusedParameter") // the StartupEvent is the CDI trigger; its value is not needed
     fun onStart(@Observes startup: StartupEvent) = refresh()
 
+    @PostConstruct
+    fun registerLiveness() {
+        liveness = domainMetrics.registerWorkflowLiveness(WORKFLOW_NAME, EXPECTED_INTERVAL)
+    }
+
     @Scheduled(every = "\${openbank.pid.eudi.trusted-list.refresh:1h}", delayed = "30s")
     @Blocking
     fun refresh() {
@@ -84,6 +95,7 @@ class TrustedListService(
         }
         val issuersJson = verifyAndExtract(source) ?: return // failure already logged; keep current trust
         trustStore.replaceDynamicTrust(issuersJson)
+        liveness?.recordSuccess()
         Log.info("EUDI Trusted List: trust store refreshed from the signed list")
     }
 
@@ -146,5 +158,7 @@ class TrustedListService(
         const val CLOCK_SKEW_SECONDS = 120L
         const val HTTP_OK_MIN = 200
         const val HTTP_OK_MAX = 299
+        const val WORKFLOW_NAME = "pid-trusted-list-refresh"
+        val EXPECTED_INTERVAL: Duration = Duration.ofHours(1)
     }
 }

--- a/openbank-pid-service/src/test/kotlin/com/openbank/pid/infrastructure/crypto/TrustedListServiceTest.kt
+++ b/openbank-pid-service/src/test/kotlin/com/openbank/pid/infrastructure/crypto/TrustedListServiceTest.kt
@@ -5,6 +5,9 @@
 package com.openbank.pid.infrastructure.crypto
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.libs.observability.DomainMetrics
+import com.openbank.libs.observability.WorkflowLivenessRecorder
+import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
@@ -60,8 +63,12 @@ class TrustedListServiceTest {
     private fun service(
         inlineList: String?,
         withAnchor: Boolean = true,
-    ): Pair<TrustedListService, RefreshableTrustStore> {
+    ): Triple<TrustedListService, RefreshableTrustStore, WorkflowLivenessRecorder> {
         val store = mockk<RefreshableTrustStore>(relaxed = true)
+        val liveness = mockk<WorkflowLivenessRecorder>(relaxed = true)
+        val metrics = mockk<DomainMetrics> {
+            every { registerWorkflowLiveness(any(), any()) } returns liveness
+        }
         val anchorJwks = if (withAnchor) {
             Optional.of("""{"keys":[${anchor.toJson(JsonWebKey.OutputControlLevel.PUBLIC_ONLY)}]}""")
         } else {
@@ -74,50 +81,54 @@ class TrustedListServiceTest {
             trustStore = store,
             objectMapper = mapper,
             clock = testClock,
+            domainMetrics = metrics,
         )
-        return svc to store
+        svc.registerLiveness()
+        return Triple(svc, store, liveness)
     }
 
     @Test
     fun `a list signed by the trust anchor is verified and its issuers pushed to the trust store`() {
-        val (svc, store) = service(signedList())
+        val (svc, store, liveness) = service(signedList())
         svc.refresh()
         val json = slot<String>()
         verify { store.replaceDynamicTrust(capture(json)) }
         assertThat(json.captured).contains("https://pid-issuer.cz")
+        verify { liveness.recordSuccess() }
     }
 
     @Test
     fun `a list signed by the wrong key is rejected and the trust store is NOT updated`() {
-        val (svc, store) = service(signedList(signer = attacker.privateKey))
+        val (svc, store, liveness) = service(signedList(signer = attacker.privateKey))
         svc.refresh()
         verify(exactly = 0) { store.replaceDynamicTrust(any()) }
+        verify(exactly = 0) { liveness.recordSuccess() }
     }
 
     @Test
     fun `an expired list is rejected`() {
-        val (svc, store) = service(signedList(exp = Instant.now(testClock).epochSecond - 7200))
+        val (svc, store, _) = service(signedList(exp = Instant.now(testClock).epochSecond - 7200))
         svc.refresh()
         verify(exactly = 0) { store.replaceDynamicTrust(any()) }
     }
 
     @Test
     fun `a list with no exp is rejected (must be time-bounded)`() {
-        val (svc, store) = service(signedList(exp = null))
+        val (svc, store, _) = service(signedList(exp = null))
         svc.refresh()
         verify(exactly = 0) { store.replaceDynamicTrust(any()) }
     }
 
     @Test
     fun `a list with no configured trust anchor is refused (fail-closed)`() {
-        val (svc, store) = service(signedList(), withAnchor = false)
+        val (svc, store, _) = service(signedList(), withAnchor = false)
         svc.refresh()
         verify(exactly = 0) { store.replaceDynamicTrust(any()) }
     }
 
     @Test
     fun `no source configured is inert (static config only)`() {
-        val (svc, store) = service(inlineList = null)
+        val (svc, store, _) = service(inlineList = null)
         svc.refresh()
         verify(exactly = 0) { store.replaceDynamicTrust(any()) }
     }


### PR DESCRIPTION
## What changed

- registers the signed EUDI Trusted List refresh as an ADR-0237 workflow
- records success only after signature verification and trust-store replacement
- proves successful and rejected refresh paths in the focused unit test

## Why

A failed or inert trusted-list refresh must not advance scheduler liveness; only a verified, applied list is a successful control run.

## Linked issues

Refs #3345

## Validation

- `TrustedListServiceTest`: 6 tests, 0 failures
- targeted PID Gradle test, KtLint and Detekt invoked locally