### PR TITLE
feat(outbox): wire openbank_outbox_dispatched_total (issue #5091 phase 1)

### DIFF
--- a/openbank-account-service/src/main/kotlin/com/openbank/account/infrastructure/outbox/AccountOutboxDispatcher.kt
+++ b/openbank-account-service/src/main/kotlin/com/openbank/account/infrastructure/outbox/AccountOutboxDispatcher.kt
@@ -4,6 +4,7 @@
 package com.openbank.account.infrastructure.outbox
 
 import com.openbank.account.application.port.out.AccountOutboxRepository
+import com.openbank.libs.observability.DomainMetrics
 import com.openbank.libs.persistence.outbox.AbstractOutboxDispatcher
 import com.openbank.libs.persistence.outbox.OutboxEntry
 import com.openbank.libs.persistence.outbox.OutboxEventPublisher
@@ -31,11 +32,16 @@ import org.eclipse.microprofile.faulttolerance.Timeout
 class AccountOutboxDispatcher(
     private val repo: AccountOutboxRepository,
     private val publisher: OutboxEventPublisher,
+    private val domainMetrics: DomainMetrics,
     @ConfigProperty(name = "openbank.outbox.dispatch-enabled", defaultValue = "false")
     private val dispatchEnabled: Boolean,
 ) : AbstractOutboxDispatcher() {
     override val outboxRepository: OutboxRepository get() = repo
     override val outboxEventPublisher: OutboxEventPublisher get() = publisher
+
+    // Issue #5091 phase 1: opts this dispatcher in to openbank_outbox_dispatched_total.
+    override val metrics: DomainMetrics get() = domainMetrics
+    override val service: String get() = "account"
 
     @Scheduled(
         every = "\${openbank.outbox.poll-interval:5s}",

--- a/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/outbox/LedgerOutboxDispatcher.kt
+++ b/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/outbox/LedgerOutboxDispatcher.kt
@@ -5,6 +5,7 @@ package com.openbank.ledger.infrastructure.outbox
 
 import com.openbank.ledger.infrastructure.messaging.KafkaLedgerOutboxEventPublisher
 import com.openbank.ledger.infrastructure.persistence.repository.LedgerOutboxRepositoryImpl
+import com.openbank.libs.observability.DomainMetrics
 import com.openbank.libs.persistence.outbox.AbstractOutboxDispatcher
 import com.openbank.libs.persistence.outbox.OutboxEntry
 import com.openbank.libs.persistence.outbox.OutboxEventPublisher
@@ -36,12 +37,17 @@ import org.eclipse.microprofile.faulttolerance.Timeout
 class LedgerOutboxDispatcher(
     private val repo: LedgerOutboxRepositoryImpl,
     private val publisher: KafkaLedgerOutboxEventPublisher,
+    private val domainMetrics: DomainMetrics,
     @ConfigProperty(name = "openbank.outbox.dispatch-enabled", defaultValue = "false")
     private val dispatchEnabled: Boolean,
 ) : AbstractOutboxDispatcher() {
 
     override val outboxRepository: OutboxRepository get() = repo
     override val outboxEventPublisher: OutboxEventPublisher get() = publisher
+
+    // Issue #5091 phase 1: opts this dispatcher in to openbank_outbox_dispatched_total.
+    override val metrics: DomainMetrics get() = domainMetrics
+    override val service: String get() = "ledger"
 
     @Scheduled(
         every = "\${openbank.outbox.poll-interval:5s}",

--- a/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/integration/LedgerOutboxDispatchFailureIT.kt
+++ b/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/integration/LedgerOutboxDispatchFailureIT.kt
@@ -94,7 +94,12 @@ class LedgerOutboxDispatchFailureIT {
         val failingPublisher = mockk<KafkaLedgerOutboxEventPublisher>()
         coEvery { failingPublisher.publish(any<OutboxEntry>()) } throws RuntimeException("simulated broker outage")
         // Construct directly with dispatchEnabled=true so the guard does not suppress the tick.
-        val dispatcher = LedgerOutboxDispatcher(repository, failingPublisher, dispatchEnabled = true)
+        val dispatcher = LedgerOutboxDispatcher(
+            repository,
+            failingPublisher,
+            domainMetrics = mockk(relaxed = true),
+            dispatchEnabled = true,
+        )
 
         val msg = OutboxMessage(
             eventId = UUID.randomUUID(),

--- a/openbank-libs-domain/src/main/kotlin/com/openbank/libs/persistence/outbox/OutboxDispatch.kt
+++ b/openbank-libs-domain/src/main/kotlin/com/openbank/libs/persistence/outbox/OutboxDispatch.kt
@@ -90,6 +90,7 @@ object OutboxDispatch {
     suspend fun dispatchOnce(
         repository: OutboxRepository,
         batchSize: Int = DEFAULT_BATCH_SIZE,
+        observer: OutboxDispatchObserver = OutboxDispatchObserver.NOOP,
         publish: suspend (entry: OutboxEntry) -> Unit,
     ) {
         val claimed = runCatching { repository.claimProcessable(batchSize) }
@@ -100,6 +101,7 @@ object OutboxDispatch {
             try {
                 publish(entry)
                 repository.markSent(entry.eventId)
+                observer.onDispatched(entry)
             } catch (ex: Exception) {
                 if (isTransportUnavailable(ex)) {
                     log.log(

--- a/openbank-libs-domain/src/main/kotlin/com/openbank/libs/persistence/outbox/OutboxDispatchObserver.kt
+++ b/openbank-libs-domain/src/main/kotlin/com/openbank/libs/persistence/outbox/OutboxDispatchObserver.kt
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.libs.persistence.outbox
+
+/**
+ * Framework-free observation hook for [OutboxDispatch.dispatchOnce] (issue #5091 phase 1).
+ *
+ * This module has zero framework imports by design (ADR-0002/ADR-0122, `check-domain-purity.py`),
+ * so it cannot call `DomainMetrics` (openbank-libs-runtime, depends on Micrometer) directly. This
+ * interface is the port: `dispatchOnce` calls it on every dispatch outcome it can see, and the
+ * runtime-side [AbstractOutboxDispatcher] implements it by delegating to `DomainMetrics` — the
+ * only place in this module's call graph allowed to know a metrics library exists.
+ *
+ * A single abstract method by design (`fun interface`, SAM-convertible) — callers construct one
+ * inline as a lambda: `OutboxDispatchObserver { entry -> metrics.outboxDispatched(...) }`.
+ * [NOOP] is the explicit "observe nothing" implementation, not a default method body, since a
+ * `fun interface`'s one method cannot itself carry a default (it would no longer be a single
+ * abstract member and SAM conversion would stop working). Adding a genuinely new observation
+ * point later (e.g. once phase 2 makes `onDead` possible) means a new interface, not a new method
+ * on this one — see `DomainMetrics`'s own file header for why growing an existing single-method
+ * contract is avoided here.
+ *
+ * **Deliberately does NOT have an `onDead` callback.** `OutboxRepository.markFailed` returns
+ * `Unit` today, so `dispatchOnce` has no way to know whether a given failure was the one that
+ * tipped a row into terminal `DEAD` versus just incremented its attempt counter — emitting a dead
+ * signal from here now would be a guess, not an observation. That needs `markFailed`'s signature
+ * to change across all ~31 `OutboxRepository` implementations first (issue #5091 phase 2,
+ * deliberately scoped separately — a much larger and more invasive change than this one).
+ */
+fun interface OutboxDispatchObserver {
+    /** Called after [OutboxRepository.markSent] succeeds for [entry] — a real, confirmed dispatch. */
+    fun onDispatched(entry: OutboxEntry)
+
+    companion object {
+        val NOOP: OutboxDispatchObserver = OutboxDispatchObserver { }
+    }
+}

--- a/openbank-libs-domain/src/test/kotlin/com/openbank/libs/persistence/outbox/OutboxDispatchTest.kt
+++ b/openbank-libs-domain/src/test/kotlin/com/openbank/libs/persistence/outbox/OutboxDispatchTest.kt
@@ -126,6 +126,64 @@ class OutboxDispatchTest {
         assertThat(repo.sent).containsExactly(rows[1].eventId)
     }
 
+    // Issue #5091 phase 1: OutboxDispatchObserver.onDispatched is the port that lets a
+    // framework-touching layer (this module has none, ADR-0002/ADR-0122) observe real dispatches.
+    @Test
+    fun `notifies the observer once per successfully dispatched row, with the full entry`() {
+        val rows = listOf(entry("a.created"), entry("b.created"))
+        val repo = FakeRepo(rows)
+        val observed = mutableListOf<OutboxEntry>()
+
+        runBlocking {
+            OutboxDispatch.dispatchOnce(repo, observer = OutboxDispatchObserver { e -> observed += e }) { }
+        }
+
+        assertThat(observed).containsExactlyElementsOf(rows)
+    }
+
+    @Test
+    fun `does not notify the observer for a row that fails to publish`() {
+        val row = entry("boom")
+        val repo = FakeRepo(listOf(row))
+        val observed = mutableListOf<OutboxEntry>()
+
+        runBlocking {
+            OutboxDispatch.dispatchOnce(repo, observer = OutboxDispatchObserver { e -> observed += e }) {
+                throw IllegalStateException("kafka down")
+            }
+        }
+
+        assertThat(observed).isEmpty()
+    }
+
+    @Test
+    fun `does not notify the observer when the batch is abandoned on a breaker-open`() {
+        val rows = listOf(entry("a.created"), entry("b.created"))
+        val repo = FakeRepo(rows)
+        val observed = mutableListOf<OutboxEntry>()
+
+        runBlocking {
+            OutboxDispatch.dispatchOnce(repo, observer = OutboxDispatchObserver { e -> observed += e }) {
+                throw breakerOpen()
+            }
+        }
+
+        assertThat(observed).isEmpty()
+    }
+
+    @Test
+    fun `dispatchOnce with the default (NOOP) observer behaves exactly as before -- no crash, no calls`() {
+        val rows = listOf(entry("a.created"))
+        val repo = FakeRepo(rows)
+
+        // No observer argument at all -- the pre-existing call shape from every current caller.
+        runBlocking {
+            OutboxDispatch.dispatchOnce(repo) { }
+        }
+
+        assertThat(repo.sent).containsExactly(rows[0].eventId)
+    }
+
     @Test
     fun `a timeout is NOT treated as transport-unavailable`() {
         // A @Timeout can fire after the record already reached the broker, so it must keep

--- a/openbank-libs-runtime/src/main/kotlin/com/openbank/libs/persistence/outbox/AbstractOutboxDispatcher.kt
+++ b/openbank-libs-runtime/src/main/kotlin/com/openbank/libs/persistence/outbox/AbstractOutboxDispatcher.kt
@@ -4,6 +4,7 @@
 
 package com.openbank.libs.persistence.outbox
 
+import com.openbank.libs.observability.DomainMetrics
 import org.jboss.logging.Logger
 
 /**
@@ -48,11 +49,30 @@ import org.jboss.logging.Logger
  * Resilience interceptors must instead be triggered via CDI injection of the concrete bean
  * itself — callers of [dispatchScheduledBatch] should be annotated `@Scheduled` methods on
  * the concrete bean, which already goes through the proxy.
+ *
+ * ### Metrics (issue #5091 phase 1)
+ * [metrics] and [service] are `open` with `null` defaults, not `abstract` — every existing
+ * concrete dispatcher across the fleet compiles unchanged. A subclass opts in to
+ * `openbank_outbox_dispatched_total` by overriding both:
+ * ```
+ * override val metrics: DomainMetrics get() = domainMetrics   // inject it in the constructor
+ * override val service: String get() = "ledger"
+ * ```
+ * With either left `null` (the default), dispatch behaves exactly as before — no metric, no
+ * behaviour change. This is deliberately NOT the same "every subclass must implement" shape as
+ * [outboxRepository]/[outboxEventPublisher]: those are load-bearing to dispatch AT ALL, these two
+ * are purely observational, and forcing every one of the ~30 existing dispatchers to add them in
+ * the same change that introduces the mechanism would turn a scoped, verified rollout into a
+ * fleet-wide breaking change reviewed all at once. Remaining services are tracked as a checklist
+ * in issue #5091 — adding metrics/service to one is a two-line, low-risk follow-up once this
+ * mechanism has proven itself live on the first services that opt in.
  */
 abstract class AbstractOutboxDispatcher {
 
     protected abstract val outboxRepository: OutboxRepository
     protected abstract val outboxEventPublisher: OutboxEventPublisher
+    protected open val metrics: DomainMetrics? = null
+    protected open val service: String? = null
 
     /**
      * Core dispatch loop. Call this from the concrete subclass's `@Scheduled` method.
@@ -63,7 +83,14 @@ abstract class AbstractOutboxDispatcher {
      */
 
     protected open suspend fun dispatchScheduledBatch() {
-        OutboxDispatch.dispatchOnce(outboxRepository) { entry ->
+        val m = metrics
+        val svc = service
+        val observer = if (m != null && svc != null) {
+            OutboxDispatchObserver { entry -> m.outboxDispatched(svc, entry.eventType) }
+        } else {
+            OutboxDispatchObserver.NOOP
+        }
+        OutboxDispatch.dispatchOnce(outboxRepository, observer = observer) { entry ->
             publishWithResilience(entry)
         }
     }

--- a/openbank-libs-runtime/src/test/kotlin/com/openbank/libs/persistence/outbox/AbstractOutboxDispatcherTest.kt
+++ b/openbank-libs-runtime/src/test/kotlin/com/openbank/libs/persistence/outbox/AbstractOutboxDispatcherTest.kt
@@ -4,6 +4,11 @@
 
 package com.openbank.libs.persistence.outbox
 
+import com.openbank.libs.observability.DomainMetrics
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import io.mockk.every
+import io.mockk.mockk
+import jakarta.enterprise.inject.Instance
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -128,5 +133,80 @@ class AbstractOutboxDispatcherTest {
         // and it delegated to publisher
         assertThat(publisher.published).containsExactly(row)
         assertThat(repo.sent).containsExactly(row.eventId)
+    }
+
+    private fun domainMetrics(reg: SimpleMeterRegistry): DomainMetrics {
+        val inst = mockk<Instance<io.micrometer.core.instrument.MeterRegistry>>()
+        every { inst.isResolvable } returns true
+        every { inst.get() } returns reg
+        return DomainMetrics().apply { registryInstance = inst }
+    }
+
+    // Issue #5091 phase 1: metrics/service default to null so every existing dispatcher across
+    // the fleet compiles and behaves unchanged; a concrete subclass opts in by overriding both.
+    @Test
+    fun `does not touch DomainMetrics when metrics and service are left at their null defaults`() {
+        val rows = listOf(entry("account.created"))
+        val repo = FakeRepo(rows)
+        val publisher = FakePublisher()
+        // TestOutboxDispatcher (above) overrides neither metrics nor service.
+        val dispatcher = TestOutboxDispatcher(repo, publisher)
+
+        runBlocking { dispatcher.runBatch() }
+
+        // No crash, no NPE, dispatch behaves exactly as it did before this feature existed.
+        assertThat(repo.sent).containsExactly(rows[0].eventId)
+    }
+
+    @Test
+    fun `records openbank_outbox_dispatched_total, tagged by service and eventType, when opted in`() {
+        val rows = listOf(entry("account.created"), entry("account.closed"))
+        val repo = FakeRepo(rows)
+        val publisher = FakePublisher()
+        val reg = SimpleMeterRegistry()
+        val dm = domainMetrics(reg)
+
+        class MeteredDispatcher(
+            override val outboxRepository: OutboxRepository,
+            override val outboxEventPublisher: OutboxEventPublisher,
+        ) : AbstractOutboxDispatcher() {
+            override val metrics: DomainMetrics get() = dm
+            override val service: String get() = "account"
+            suspend fun runBatch() = dispatchScheduledBatch()
+        }
+
+        runBlocking { MeteredDispatcher(repo, publisher).runBatch() }
+
+        assertThat(
+            reg.find("openbank.outbox.dispatched").tag("service", "account").tag("topic", "account.created")
+                .counter()?.count(),
+        ).isEqualTo(1.0)
+        assertThat(
+            reg.find("openbank.outbox.dispatched").tag("service", "account").tag("topic", "account.closed")
+                .counter()?.count(),
+        ).isEqualTo(1.0)
+    }
+
+    @Test
+    fun `does not record a dispatched metric for a row that fails to publish`() {
+        val row = entry("payment.failed")
+        val repo = FakeRepo(listOf(row))
+        val publisher = FakePublisher()
+        publisher.publishErrors[row.eventId] = IllegalStateException("kafka timeout")
+        val reg = SimpleMeterRegistry()
+        val dm = domainMetrics(reg)
+
+        class MeteredDispatcher(
+            override val outboxRepository: OutboxRepository,
+            override val outboxEventPublisher: OutboxEventPublisher,
+        ) : AbstractOutboxDispatcher() {
+            override val metrics: DomainMetrics get() = dm
+            override val service: String get() = "payments"
+            suspend fun runBatch() = dispatchScheduledBatch()
+        }
+
+        runBlocking { MeteredDispatcher(repo, publisher).runBatch() }
+
+        assertThat(reg.find("openbank.outbox.dispatched").counter()).isNull()
     }
 }


### PR DESCRIPTION
## What

Phase 1 of #5091: `openbank_outbox_dispatched_total` wired fleet-wide (mechanism) and live on two services (ledger, account). `openbank_outbox_dead_total` is deliberately **not** in this PR — see below.

## Why this couldn't be a same-module call

`OutboxDispatch.dispatchOnce` lives in `openbank-libs-domain`, which has **zero framework imports by design** (ADR-0002/ADR-0122, `check-domain-purity.py`). `DomainMetrics` (`openbank-libs-runtime`) depends on Micrometer — `dispatchOnce` cannot call it directly without breaking the domain/runtime split this repo has its own CI gate for.

Added the port instead: `OutboxDispatchObserver`, a `fun interface` single-method callback. `dispatchOnce` invokes it right after every confirmed `markSent`. `AbstractOutboxDispatcher` (runtime side, has framework access) implements it by delegating to `DomainMetrics` — the only place in this call graph allowed to know a metrics library exists.

```kotlin
fun interface OutboxDispatchObserver {
    fun onDispatched(entry: OutboxEntry)
    companion object { val NOOP: OutboxDispatchObserver = OutboxDispatchObserver { } }
}
```

`check-domain-purity.py`: **0 new violations**.

## Why `outboxDead` isn't in this PR

`OutboxRepository.markFailed(eventId, error)` returns `Unit`. It internally computes `OutboxFailurePolicy.statusAfterFailure(attemptCount)` and applies it, but the dispatch loop has no way to observe whether *this* call was the one that tipped a row into terminal `DEAD` versus just incremented `attempt_count`. Getting that right needs `markFailed`'s signature to change across **all ~31 `OutboxRepository` implementations** — a much larger, separately-reviewable change. Tracked as phase 2 in #5091, not attempted here.

## Why `metrics`/`service` are optional, not required

```kotlin
protected open val metrics: DomainMetrics? = null
protected open val service: String? = null
```

`open` with `null` defaults, not `abstract`. Every one of the ~30 existing concrete `AbstractOutboxDispatcher` subclasses across the fleet **compiles and behaves unchanged** without touching them. Making these `abstract` would force every dispatcher to be edited in the same PR that introduces the mechanism — turning a scoped, verified rollout into one enormous fleet-wide diff reviewed all at once, which is exactly the shape #5091 was written to avoid.

```kotlin
protected open suspend fun dispatchScheduledBatch() {
    val m = metrics; val svc = service
    val observer = if (m != null && svc != null) {
        OutboxDispatchObserver { entry -> m.outboxDispatched(svc, entry.eventType) }
    } else {
        OutboxDispatchObserver.NOOP
    }
    OutboxDispatch.dispatchOnce(outboxRepository, observer = observer) { entry -> publishWithResilience(entry) }
}
```

## Wired live on two services — proof, not just compilation

`ledger` (money-path) and `account`. Both needed `DomainMetrics` added to their `*OutboxDispatcher`'s constructor, which wasn't there before:

```kotlin
class LedgerOutboxDispatcher(
    private val repo: LedgerOutboxRepositoryImpl,
    private val publisher: KafkaLedgerOutboxEventPublisher,
    private val domainMetrics: DomainMetrics,
    @ConfigProperty(...) private val dispatchEnabled: Boolean,
) : AbstractOutboxDispatcher() {
    override val metrics: DomainMetrics get() = domainMetrics
    override val service: String get() = "ledger"
    ...
}
```

## Tests

`OutboxDispatchTest` (libs-domain) and `AbstractOutboxDispatcherTest` (libs-runtime) — existing suites unchanged and still green, plus new cases:
- observer notified once per real dispatch, with the full entry
- **not** notified on a publish failure
- **not** notified when a batch is abandoned on breaker-open (#4005's no-attempt-consumed rule)
- the default call shape (no `observer` argument) behaves exactly as every existing caller already uses it
- `AbstractOutboxDispatcherTest`: null `metrics`/`service` ⇒ zero `DomainMetrics` interaction, no crash; an opted-in dispatcher records `openbank_outbox_dispatched_total` tagged by `service` **and** `eventType`, asserted against a real `SimpleMeterRegistry` — not a mock verification.

## Verified

- `openbank-libs-domain`/`openbank-libs-runtime` suites: **10/10**, **6/6**.
- `ledger-service`: **303 tests, 0 failures**. `account-service`: **244 tests, 0 failures**.
- `ktlintCheck`, `detekt` — clean on all four touched modules.
- `quarkusBuild` — green on both services. Confirms `DomainMetrics` resolves through the new constructor parameter (the CDI/ArC class of failure unit tests can't see).
- `check-domain-purity.py`: 0 new violations.
- **Live baseline recorded before merge**: `count({__name__="openbank_outbox_dispatched_total"})` = **0** in Prometheus right now. Will check it lights up with real traffic after this deploys — the same live-verification discipline as every other PR in this sweep, not "the code compiles so it must work."
- Local `run-gates.py --all`: **150/151** (the one failure, `api-contract-gate`, needs `sudo` locally and reproduces on a clean `origin/main` worktree).

## Follow-up

Remaining ~28 services are a two-line mechanical addition each (inject `DomainMetrics`, override `metrics`/`service`) — tracked as a checklist in #5091, not attempted here. `outboxDead` (phase 2, the `markFailed` signature change) is also tracked there, separately.

## Review note

`ledger-service` is `money_path_services` — 2 approvals. No trust-boundary change (no new listener/port/auth key — this is metrics-only), so `threat-model-updated-on-trust-boundary-change` correctly doesn't fire.

Refs #5091
