### PR TITLE
fix(customer-edge): announce the single-replica assumption behind PaymentSessionStore

### DIFF
--- a/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/PaymentSessionReplicaAssumptionAnnouncer.kt
+++ b/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/PaymentSessionReplicaAssumptionAnnouncer.kt
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.customeredge.infrastructure.rest
+
+import io.quarkus.runtime.Startup
+import jakarta.annotation.PostConstruct
+import jakarta.enterprise.context.ApplicationScoped
+import org.jboss.logging.Logger
+
+/**
+ * Announce, once at boot, that [PaymentSessionStore] depends on `customer-edge` running
+ * `replicas: 1` (issue #4728).
+ *
+ * [PaymentSessionStore] itself already documents the tradeoff in its class doc — "In-memory is
+ * acceptable because the loss mode is benign… For multi-replica edge the token would need a
+ * shared TTL cache (Redis) — tracked as a follow-up; single-replica sandbox is fine." That
+ * follow-up is issue #4728, and #3806 proposes raising exactly the replica counts this depends
+ * on. What was missing is not the reasoning — it is anything a person changing `replicas` would
+ * actually encounter. A doc comment on a class nobody opens before editing gitops is silent in
+ * exactly the way that matters.
+ *
+ * **This is a declared assumption, not a live check.** A pod has no way to learn its own current
+ * replica count from inside the process: there is no Kubernetes downward-API field for it (it is
+ * a property of the parent Rollout/Deployment, not the pod), `customer-edge` carries no
+ * Kubernetes API client to read the `Rollout` object, and nothing in this fleet does either
+ * (checked before writing this). So this warning fires on **every** boot, regardless of the live
+ * replica count — it cannot conditionally fire only when the assumption is actually violated.
+ * Building a fake conditional check would be worse than an honest unconditional one: it would
+ * look like verification and would not be.
+ *
+ * `@Startup` is load-bearing, not decoration, per the same reasoning as
+ * `AuthzModeAnnouncer`/`PdfBoxPadesSealAdapter`: `@ApplicationScoped` is lazy, so a
+ * `@PostConstruct` that exists purely to state a boot-time fact never runs until something else
+ * touches the bean — for a bean nothing injects, that is never (#1299).
+ *
+ * Deliberately WARN, not ERROR: no service in this fleet logs `.error` from a `@Startup` bean
+ * (checked before writing this), and `replicas: 1` is the CORRECT, intended state today — this is
+ * a standing reminder for whoever changes it next, not a report of something already wrong.
+ *
+ * Does not fail boot. A hard crash here would be a worse outage than the latent correctness risk
+ * it guards against — `customer-edge` is money-path (nearby-pay creates a real payment
+ * instruction) and this store's failure mode even under N replicas is a benign 404 + re-share,
+ * never a wrong or duplicate payment.
+ */
+@Startup
+@ApplicationScoped
+class PaymentSessionReplicaAssumptionAnnouncer {
+
+    @PostConstruct
+    fun announce() {
+        log.warn(
+            "PaymentSessionStore (nearby-pay sessions) keeps its state in a per-pod, non-shared " +
+                "ConcurrentHashMap with no cross-replica propagation and no durable row — it is " +
+                "correct ONLY while customer-edge runs replicas: 1 " +
+                "(openbank-infra/gitops/components/customer-edge/customer-edge.yaml). This message " +
+                "cannot detect the live replica count from inside the pod, so it logs on every " +
+                "boot regardless — it is a standing reminder, not a violation report. Before " +
+                "raising customer-edge above 1 replica (see #3806), move PaymentSessionStore to a " +
+                "shared TTL cache — this service already runs the Redis it would need, for " +
+                "ChallengeStore/DeviceSessionStore/PendingOnboardingStore/ThemePreferenceStore — " +
+                "or a token created on one pod will 404 on resolve whenever the payer's request " +
+                "lands on a different pod (issue #4728).",
+        )
+    }
+
+    private companion object {
+        val log: Logger = Logger.getLogger(PaymentSessionReplicaAssumptionAnnouncer::class.java)
+    }
+}

--- a/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/infrastructure/rest/PaymentSessionReplicaAssumptionAnnouncerTest.kt
+++ b/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/infrastructure/rest/PaymentSessionReplicaAssumptionAnnouncerTest.kt
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.customeredge.infrastructure.rest
+
+import io.quarkus.runtime.Startup
+import jakarta.annotation.PostConstruct
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * The thing worth protecting here is `@Startup`, not the log text.
+ *
+ * `@ApplicationScoped` is lazy — without `@Startup` the bean is only constructed on first
+ * injection, nothing injects this one, and the announcement never runs: the class would look
+ * completely correct and produce nothing, forever (same failure shape as #1299 /
+ * `PdfBoxPadesSealAdapter`, and the same fix as `AuthzModeAnnouncer`). A test that only called
+ * `announce()` directly would pass against exactly that bug, because the direct call supplies the
+ * instantiation the container would otherwise skip — so assert the annotations themselves, not
+ * just the method's behavior.
+ */
+class PaymentSessionReplicaAssumptionAnnouncerTest {
+
+    @Test
+    fun `carries @Startup, without which the announcement never runs`() {
+        assertThat(PaymentSessionReplicaAssumptionAnnouncer::class.java.isAnnotationPresent(Startup::class.java))
+            .`as`("@ApplicationScoped is lazy — @Startup is what makes a boot-time statement happen at boot")
+            .isTrue()
+    }
+
+    @Test
+    fun `the announcement is a @PostConstruct callback, so the container invokes it`() {
+        val method = PaymentSessionReplicaAssumptionAnnouncer::class.java.declaredMethods.single {
+            it.name == "announce"
+        }
+        assertThat(method.isAnnotationPresent(PostConstruct::class.java)).isTrue()
+    }
+
+    @Test
+    fun `announce runs unconditionally without throwing`() {
+        // No replica count is available inside the pod (no downward-API field, no Kubernetes
+        // client in this fleet) — the announcement cannot be conditional on it, so this must
+        // simply not fail on every boot.
+        PaymentSessionReplicaAssumptionAnnouncer().announce()
+    }
+}


### PR DESCRIPTION
## Summary

Adds a boot-time `@Startup` announcer for `PaymentSessionStore` (`openbank-customer-edge`) that
logs a WARN naming the store, the risk, and the shared cache it would need — the same idiom as
`AuthzModeAnnouncer` / `PdfBoxPadesSealAdapter`. No persistence layer, Redis wiring, or new
detection mechanism is added; this is deliberately the smallest safe slice of #4728.

## Why the scope narrowed from 4 sites to 1

#4728 originally named 5 sites (excluding `AgentSvidVerifier`, out of scope here as a security
replay control per its own framing — left untouched, no comment added). Before writing code I
re-checked the other 3 non-excluded sites against `origin/main` and the issue's own follow-up
comment (2026-08-15, same author), and each turned out **not** to need this treatment:

- **`IctIncidentService` (security-scanner)** — still an in-memory `ConcurrentHashMap` on
  `origin/main`, but **PR #4939 is already open** giving it a real durable row (Postgres +
  `IctIncidentRepository`, migration `V5__create_ict_incidents.sql`). Adding a boot-time guard
  here would be redundant work heading for deletion the moment #4939 merges, and risks a
  needless conflict on the same file. Left alone; #4939 is the actual fix.
- **`InMemoryProposalStore` (analytics-sink)** — confirmed **not the deployed binding**.
  `ClickHouseProposalStore` (`@Alternative @Priority(100)`, `@IfBuildProperty(openbank.analytics.
  sink.type=clickhouse)`) is selected because `auto-deploy.yml:480` sets
  `ANALYTICS_SINK_TYPE: clickhouse` on the *Build fast-jars* step (a build-time property,
  `@IfBuildProperty` resolves at augmentation — the runtime env var alone couldn't reach it).
  `InMemoryProposalStore` is the offline/test `@Default`. Guarding a class that isn't what runs in
  production would be misleading, not loud-and-honest. Left alone.
- **`SecurityScannerService.lastResults`** — verified it is a genuine cache: every entry is
  re-derived by `scanAll()`/`scanService()` from live HTTP probes of other services, with an
  explicit `// Cache last scan results` comment on the field. A restart costs at most one scan
  cycle of staleness on a read-only report; there is no decision or business record lost. Adding a
  loud guard here would be flagging a working-as-intended cache as a latent risk it isn't. Left
  alone.

That leaves **`PaymentSessionStore`** as the only site where the guard is honest: it is the one
`ConcurrentHashMap` in the original five still (a) actually deployed as the binding in use, (b) not
already covered by an open fix, and (c) not simply a re-derivable cache — a nearby-pay session lost
on restart is a real (if benign — payer just re-shares) instruction-level artifact, and it runs on
customer-edge's Argo **Rollout**, the only one of the five workloads that `#3806`'s replica-raise
proposal actually touches.

## What the guard does, and its real limit

`PaymentSessionReplicaAssumptionAnnouncer` is `@Startup @ApplicationScoped` with a `@PostConstruct`
that logs a WARN naming `PaymentSessionStore`, the `replicas: 1` dependency, the gitops file where
that's declared, and the Redis this service already runs for its sibling stores (`ChallengeStore`,
`DeviceSessionStore`, `PendingOnboardingStore`, `ThemePreferenceStore` — all confirmed
`RedisDataSource`-backed) as the documented follow-up path.

**This is a declared assumption, not a live check.** Before writing it I confirmed, fleet-wide,
that no pod can read its own current replica count from inside the process:
- No Kubernetes downward-API field exposes a workload's live replica count to its own pod (that's
  a property of the parent `Rollout`/`Deployment`, not the pod) — checked every `fieldRef`/
  `resourceFieldRef` across `openbank-infra/gitops/components/**`; all of them inject
  namespace/metadata, never replica count.
- No service's application code carries a Kubernetes/Argo API client (no fabric8/kubernetes-client
  dependency anywhere in `src/main`) that could read the `Rollout` object at runtime.
- The only place replica counts are read/written is external `kubectl scale` from a CronJob
  (`finops-scaledown`) with its own RBAC — not something an app pod does to itself.

So the log fires on **every** boot, regardless of the actual live replica count — it cannot be
conditional on the thing it's warning about. Building a fake conditional (e.g. inferring
"multi-replica" from something that happens to correlate today) would look like verification and
would not be one; an honest unconditional WARN is the correct fallback per the issue's own
acceptance criterion ("records the single-replica dependency somewhere a person changing `replicas`
encounters it").

Deliberately WARN, not ERROR or a hard crash:
- No `@Startup` bean anywhere in this fleet logs `.error()` — WARN is the established ceiling for
  "flag, don't crash" (checked `AuthzModeAnnouncer`, `DataResidencyValidator`, and every other
  `@Startup`/`@Observes StartupEvent` sanity-check bean before writing this).
- `replicas: 1` is customer-edge's live, correct state today — this is a standing reminder for
  whoever changes it next, not a report that something is currently wrong.
- customer-edge is money-path; a hard crash here would be a worse outage than the latent
  correctness risk it guards against, and the loss mode even under N replicas stays benign (a 404 +
  re-share, never a wrong or duplicate payment).

## Explicitly out of scope (unchanged from #4728's own framing)

- **No Redis wiring, DB table, or any new persistence layer added.** The issue calls its own
  suggested shape "a suggestion, not a decision" — that decision stays open here.
- **`AgentSvidVerifier.seenNonces` (agent-service) is untouched, including no comment added to
  it.** The issue flags it specifically as a security replay control ("a replayed PoP simply needs
  to land on a different pod to be accepted... a security property that silently weakens in
  proportion to replica count"), not a correctness nicety, and that needs a security review before
  any code change — not a unilateral PR.
- **`IctIncidentService`** — tracked by #4939 (open), not duplicated here.
- **`InMemoryProposalStore`** and **`SecurityScannerService.lastResults`** — verdict is "no fix
  needed" per the analysis above; not closing #4728 since that verdict, and the agent-service
  decision, both remain to be recorded/acted on there.

## Verification

- `./gradlew :openbank-customer-edge:test --tests "*PaymentSessionReplicaAssumptionAnnouncerTest*"`
  — exit 0; JUnit XML: `tests="3" failures="0" errors="0" skipped="0"`.
- `./gradlew :openbank-customer-edge:test` (full module) — exit 0; aggregated JUnit XML across the
  module: `tests=376 failures=0 errors=0 skipped=1` (the 1 skip is the pre-existing
  `CustomerEdgeContractBrokerProviderVerificationTest`, gated on `pactbroker.url` outside CI —
  unrelated to this change).
- `./gradlew :openbank-customer-edge:ktlintCheck :openbank-customer-edge:detekt` — exit 0, clean.
- `./gradlew :openbank-customer-edge:quarkusBuild -x test` — exit 0 (CDI/ArC augmentation
  succeeds — this is the check that would have caught a wiring mistake ktlint/unit tests can't
  see, per this repo's own CLAUDE.md note on `@Startup`/CDI).
- Falsification of the test itself: `PaymentSessionReplicaAssumptionAnnouncerTest` asserts the
  `@Startup` and `@PostConstruct` annotations directly (not just that `announce()` runs cleanly
  when called by hand) — the same shape as `AuthzModeAnnouncerTest`, because a direct call would
  pass even if `@Startup` were accidentally removed and the announcement never actually ran in a
  booted container.

Refs #4728
