### PR TITLE
feat(admin-ui): add weekly approval-rate trend to agent outcomes (#4462)

### DIFF
--- a/openbank-admin-ui/src/components/agent/AgentOutcomes.tsx
+++ b/openbank-admin-ui/src/components/agent/AgentOutcomes.tsx
@@ -8,6 +8,7 @@ import { Sparkles } from 'lucide-react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import {
   deriveAgentOutcomes,
+  deriveWeeklyOutcomes,
   formatLatency,
   MIN_DECIDED_FOR_RATE,
   PROPOSAL_PAGE_CAP,
@@ -36,6 +37,37 @@ function Figure({ label, value, sub }: { label: string; value: string; sub: stri
       <div style={{ fontSize: '10px', textTransform: 'uppercase', letterSpacing: '0.04em', color: 'var(--text-tertiary)' }}>{label}</div>
       <div style={{ fontSize: '22px', fontWeight: 700, color: 'var(--text-primary)', lineHeight: 1.3 }}>{value}</div>
       <div style={{ fontSize: '11px', color: 'var(--text-tertiary)' }}>{sub}</div>
+    </div>
+  )
+}
+
+// ── Weekly trend (#4462: "per week") ────────────────────────────────────────
+// Most weeks will legitimately read "insufficient data" — the queue is thin. Each row
+// still states its own decided count, so a reader can see WHY a week is blank rather
+// than wondering if the week rendered a zero.
+function WeeklyTrend({ items }: { items: ProposalOutcomeInput[] }) {
+  const { t } = useLanguage()
+  const weeks = deriveWeeklyOutcomes(items)
+
+  if (weeks.length === 0) return null
+
+  return (
+    <div style={{ marginTop: '14px', paddingTop: '12px', borderTop: '1px solid var(--border)' }}>
+      <div style={{ fontSize: '10px', textTransform: 'uppercase', letterSpacing: '0.04em', color: 'var(--text-tertiary)', marginBottom: '8px' }}>
+        {t('Míra schválení podle týdne', 'Approval rate by week')}
+      </div>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
+        {weeks.map(w => (
+          <div key={w.weekStart} style={{ display: 'flex', justifyContent: 'space-between', fontSize: '11px', color: 'var(--text-secondary)' }}>
+            <span>{w.weekStart}</span>
+            <span>
+              {w.insufficientData
+                ? t(`nedostatek dat (${w.decided} rozhodnuto)`, `insufficient data (${w.decided} decided)`)
+                : t(`${Math.round((w.approvalRate as number) * 100)}% (${w.approved} z ${w.decided})`, `${Math.round((w.approvalRate as number) * 100)}% (${w.approved} of ${w.decided})`)}
+            </span>
+          </div>
+        ))}
+      </div>
     </div>
   )
 }
@@ -116,6 +148,8 @@ export function OutcomeMetricsCard({ items }: { items: ProposalOutcomeInput[] })
               </div>
             )}
           </div>
+
+          <WeeklyTrend items={items} />
         </>
       )}
     </Card>

--- a/openbank-admin-ui/src/lib/governance/agentOutcomes.ts
+++ b/openbank-admin-ui/src/lib/governance/agentOutcomes.ts
@@ -136,6 +136,68 @@ export function deriveAgentOutcomes(proposals: ProposalOutcomeInput[]): AgentOut
   }
 }
 
+// ── Weekly trend (issue #4462: "per week") ─────────────────────────────────
+// The queue is thin — 41 decided proposals across two charters over ~10 weeks in the
+// measurement that motivated this file — so most weekly buckets will legitimately read
+// "insufficient data". That is not a bug to work around: a week with 2 decisions saying
+// "67%" would be exactly the misleading-100%-on-a-thin-sample failure this file exists
+// to prevent, just at a finer grain. Reuse [MIN_DECIDED_FOR_RATE] rather than inventing a
+// second, smaller threshold — a per-week rate is a rate over the same kind of event
+// (a decided proposal) as the overall one, and a lower bar here would let a week assert
+// more confidence per-sample than the aggregate does.
+
+export interface WeeklyOutcome {
+  /** Monday 00:00 UTC of the ISO week, e.g. "2026-06-08". Weeks with zero decisions are omitted. */
+  weekStart: string
+  decided: number
+  approved: number
+  /** approved / decided, or null when [decided] < [MIN_DECIDED_FOR_RATE]. */
+  approvalRate: number | null
+  insufficientData: boolean
+}
+
+/** Monday 00:00 UTC of the ISO week containing `ms`. */
+function isoWeekStartMs(ms: number): number {
+  const d = new Date(ms)
+  const day = d.getUTCDay() // 0 = Sunday .. 6 = Saturday
+  const diffToMonday = day === 0 ? -6 : 1 - day
+  return Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate() + diffToMonday)
+}
+
+/**
+ * Approval rate bucketed by the ISO week of `decidedAt`. A decided proposal whose
+ * `decidedAt` is missing or unparseable is excluded from every bucket — it cannot be
+ * dated, so folding it into "this week" or "some week" would misattribute it — the same
+ * exclude-rather-than-guess rule [deriveAgentOutcomes] applies to latency.
+ */
+export function deriveWeeklyOutcomes(proposals: ProposalOutcomeInput[]): WeeklyOutcome[] {
+  const buckets = new Map<number, { decided: number; approved: number }>()
+
+  for (const p of proposals) {
+    if (p.state !== 'APPROVED' && p.state !== 'REJECTED') continue
+    const decidedMs = parseInstant(p.decidedAt)
+    if (decidedMs === null) continue
+    const weekMs = isoWeekStartMs(decidedMs)
+    const bucket = buckets.get(weekMs) ?? { decided: 0, approved: 0 }
+    bucket.decided += 1
+    if (p.state === 'APPROVED') bucket.approved += 1
+    buckets.set(weekMs, bucket)
+  }
+
+  return [...buckets.entries()]
+    .sort(([a], [b]) => a - b)
+    .map(([weekMs, { decided, approved }]) => {
+      const insufficientData = decided < MIN_DECIDED_FOR_RATE
+      return {
+        weekStart: new Date(weekMs).toISOString().slice(0, 10),
+        decided,
+        approved,
+        approvalRate: insufficientData ? null : approved / decided,
+        insufficientData,
+      }
+    })
+}
+
 /** "2 d 12 h" / "3 h 5 m" / "45 s" — a latency a reviewer can read without dividing. */
 export function formatLatency(seconds: number): string {
   if (seconds < 60) return `${Math.round(seconds)} s`

--- a/openbank-admin-ui/src/test/agent-outcomes-card.test.tsx
+++ b/openbank-admin-ui/src/test/agent-outcomes-card.test.tsx
@@ -73,4 +73,19 @@ describe('OutcomeMetricsCard', () => {
     expect(screen.queryByText(/Coverage:/)).toBeNull()
     expect(screen.queryByText('0%')).toBeNull()
   })
+
+  it('renders a weekly rate once a week has enough decisions, and "insufficient data" when it does not', () => {
+    // Week of 2026-06-08: 5 decided, 3 approved -> a real rate.
+    renderCard(<OutcomeMetricsCard items={decided(3, 2)} />)
+
+    expect(screen.getByText('2026-06-08')).toBeTruthy()
+    expect(screen.getByText('60% (3 of 5)')).toBeTruthy()
+  })
+
+  it('shows the weekly insufficient-data label with its own count, not the overall one', () => {
+    // 2 decided this week; the overall coverage line and the weekly line are different claims.
+    renderCard(<OutcomeMetricsCard items={decided(2, 0)} />)
+
+    expect(screen.getByText('insufficient data (2 decided)')).toBeTruthy()
+  })
 })

--- a/openbank-admin-ui/src/test/agent-outcomes.test.ts
+++ b/openbank-admin-ui/src/test/agent-outcomes.test.ts
@@ -5,6 +5,7 @@
 import { describe, it, expect } from 'vitest'
 import {
   deriveAgentOutcomes,
+  deriveWeeklyOutcomes,
   formatLatency,
   MIN_DECIDED_FOR_RATE,
   PROPOSAL_PAGE_CAP,
@@ -145,6 +146,74 @@ describe('deriveAgentOutcomes — truncation', () => {
 
     expect(uncapped.truncated).toBe(false)
     expect(capped.truncated).toBe(true)
+  })
+})
+
+describe('deriveWeeklyOutcomes — per-week rate with its own small-sample guard', () => {
+  it('has no decided proposals and returns no weeks, rather than a fabricated empty one', () => {
+    expect(deriveWeeklyOutcomes([])).toEqual([])
+    expect(deriveWeeklyOutcomes([proposal('PROPOSED', '2026-06-10T12:00:00Z')])).toEqual([])
+  })
+
+  it('reports a 100% week only once decided count reaches the threshold — all approved', () => {
+    // Wed 2026-06-10 .. all decided the same week, all approved.
+    const rows = decidedSet(MIN_DECIDED_FOR_RATE, 0)
+
+    const weeks = deriveWeeklyOutcomes(rows)
+
+    expect(weeks).toHaveLength(1)
+    expect(weeks[0]).toMatchObject({ decided: MIN_DECIDED_FOR_RATE, approved: MIN_DECIDED_FOR_RATE, approvalRate: 1, insufficientData: false })
+    // 2026-06-10 is a Wednesday; the ISO week starts Monday 2026-06-08.
+    expect(weeks[0].weekStart).toBe('2026-06-08')
+  })
+
+  it('mixes approvals and rejections within a week and rates only the decided total', () => {
+    const rows = decidedSet(3, 2) // 5 decided, same week, 3 approved
+
+    const weeks = deriveWeeklyOutcomes(rows)
+
+    expect(weeks).toHaveLength(1)
+    expect(weeks[0]).toMatchObject({ decided: 5, approved: 3, approvalRate: 3 / 5, insufficientData: false })
+  })
+
+  it('is insufficient at N-1 decided in a week and crosses to a real rate at exactly N', () => {
+    const thin = deriveWeeklyOutcomes(decidedSet(MIN_DECIDED_FOR_RATE - 1, 0))
+    const enough = deriveWeeklyOutcomes(decidedSet(MIN_DECIDED_FOR_RATE, 0))
+
+    expect(thin).toHaveLength(1)
+    expect(thin[0].insufficientData).toBe(true)
+    expect(thin[0].approvalRate).toBeNull()
+    expect(thin[0].decided).toBe(MIN_DECIDED_FOR_RATE - 1)
+
+    expect(enough).toHaveLength(1)
+    expect(enough[0].insufficientData).toBe(false)
+    expect(enough[0].approvalRate).toBe(1)
+  })
+
+  it('buckets by the week of decidedAt, not proposedAt, and sorts weeks ascending', () => {
+    const rows = [
+      // Proposed in week 1, decided in week 3 — must land in week 3's bucket.
+      proposal('APPROVED', '2026-06-01T09:00:00Z', '2026-06-22T09:00:00Z'),
+      ...decidedSet(MIN_DECIDED_FOR_RATE, 0), // week of 2026-06-08
+    ]
+
+    const weeks = deriveWeeklyOutcomes(rows)
+
+    expect(weeks.map(w => w.weekStart)).toEqual(['2026-06-08', '2026-06-22'])
+    expect(weeks[1]).toMatchObject({ decided: 1, insufficientData: true })
+  })
+
+  it('excludes a decided row with an unparseable or missing decidedAt instead of misdating it', () => {
+    const rows = [
+      ...decidedSet(MIN_DECIDED_FOR_RATE, 0),
+      proposal('REJECTED', '2026-06-10T12:00:00Z', 'not-a-date'),
+      proposal('APPROVED', '2026-06-10T12:00:00Z', null),
+    ]
+
+    const weeks = deriveWeeklyOutcomes(rows)
+
+    expect(weeks).toHaveLength(1)
+    expect(weeks[0].decided).toBe(MIN_DECIDED_FOR_RATE)
   })
 })
 


### PR DESCRIPTION
## What

Adds a **per-week approval-rate trend** to the outcome metrics panel shipped by #4749, on
`/iaops/agents/<id>`. That is the one buildable piece of issue #4462 not yet delivered.

Refs #4462 (stays open — see "What remains blocked" below; this PR does not claim to close it).

## Where this picks up

#4462 already shipped, in #4749 (merged 2026-08-14):
- charter-level **approval rate** (built as a proxy for "approved without modification" —
  see below for why the literal wording isn't representable)
- **review latency**, median and p95, per charter
- the coverage line (decided/total/pending) beside every figure
- the "insufficient data" guard at `MIN_DECIDED_FOR_RATE = 5` decided proposals
- displayed per-charter (each `/iaops/agents/<id>` page is one charter), no `agents.yaml` change

This PR adds the "per week" clause of item 1, which #4749 didn't cover.

## What's new: weekly trend

`deriveWeeklyOutcomes()` (`openbank-admin-ui/src/lib/governance/agentOutcomes.ts`) buckets
**decided** proposals by the ISO week (Monday 00:00 UTC) of `decidedAt`, and reports
`approved`/`decided`/`approvalRate` per week.

It reuses `MIN_DECIDED_FOR_RATE` (5) as the per-week threshold rather than inventing a
smaller one — a per-week rate is a rate over the same kind of event (a decided proposal) as
the fleet-wide one, and a lower bar would let one week claim more confidence per sample than
the aggregate does. I checked for existing small-sample-threshold precedent elsewhere in
admin-ui governance/finops code before picking a number; there is none (the FinOps anomaly
gate uses a z-score, not a sample count), so 5 is inherited from the sibling gate in this
same file, not invented fresh.

**Given how thin the queue is — 41 decided proposals across two charters over roughly ten
weeks, per the measurement in #4749 — most weekly buckets will legitimately render
"insufficient data (N decided)" rather than a percentage.** That is not a bug to design
around: a 2-decision week reading "67%" would be exactly the misleading-small-sample
failure this whole feature exists to prevent, one level finer-grained. Rendering it that way
was a deliberate choice, not an oversight — flagging it here so it doesn't read as "the
feature doesn't work yet."

A decided row whose `decidedAt` is missing or unparseable is excluded from every weekly
bucket (it can't be dated) — same exclude-rather-than-misattribute rule the latency
computation already applies.

## What remains blocked, and why (unchanged from #4749, re-verified this session)

**"approved *without modification*" (issue item 1, literal wording).** Re-checked
`openbank-agent-service/src/main/kotlin/com/openbank/agent/domain/proposal/AgentProposal.kt`:
`ProposalState` is `{ PROPOSED, APPROVED, REJECTED }` — three values, no `MODIFIED` state, no
diff-from-original field, on the entity or the `V1__agent_proposals.sql` table. There is no
concept of "the human edited this before deciding" anywhere in the schema. Capturing it would
mean adding a new field written at decision time — a new write path, which this issue's own
acceptance criteria exclude ("no new write path"). Approval rate is delivered as the honest,
buildable substitute (as #4749 already did); the literal clause cannot be satisfied without
violating the issue's own constraint, so it stays permanently out of scope as specified.

**Post-merge incident correlation (issue item 3).** Re-verified this session: `agent_proposal`
has no PR-number or incident-id column. The closest existing artifact is
`openbank-governance-auditor`'s `findings` table
(`V1__init_govaudit.sql`, columns `pr_number`, `pr_url`, `proposal_url`, `proposed_fix_diff`,
`status`) — but it belongs to a separate, still-stubbed pipeline
(`DiagnoseAndProposeActivityImpl.kt`, `GitHubProposalAdapter.kt`, TODO(ADR-0164)) and carries
no foreign key to `agent_proposal.id`. No table named `compliance_incident` or
`proposal_pr_link` exists anywhere in the repo. Building the correlation would require both a
new link (proposal → merged PR) and wiring the governance-auditor findings pipeline to
completion — two new write paths, excluded by the same acceptance criterion. Left for a
follow-up that would need to be scoped as its own issue (a schema change + a still-unbuilt
pipeline), not as an admin-ui change.

Since both remaining gaps are structural — not effort, not a missed API, but "the field this
would read from doesn't exist and creating it is out of this issue's stated scope" — #4462
probably shouldn't stay open indefinitely waiting on them. I'm leaving that call to whoever
triages the issue rather than closing it myself in a PR whose acceptance criteria I partly
can't meet.

## Acceptance criteria (issue #4462)

- [x] Metrics computed from an existing store — no new write path (unchanged: still the
      `agent_proposal` store #4749 used; this PR adds no new data source)
- [x] Displayed per-charter in the admin-ui governance view
- [x] Per-week breakdown (this PR)
- [x] `<5` decided (overall, and now per-week) renders "insufficient data" with its count,
      never a misleading rate
- [x] No change to `agents.yaml` or the prompt registry
- [ ] "approved without modification" — not representable in the current schema; approval
      rate delivered as the substitute (blocked, see above)
- [ ] Post-merge incident correlation — no data link exists; building one is a new write path
      (blocked, see above)

## Verification

- `npm test`: **114 files, 1331 tests, all pass** — 8 new (6 unit tests for
  `deriveWeeklyOutcomes`, 2 component tests for the weekly-trend render).
- Falsified before trusting: swapped the per-week threshold check from
  `decided < MIN_DECIDED_FOR_RATE` to `decided < 1` — 3 of 22 tests in the two touched files
  go red (the N-1/N boundary tests), confirming they actually discriminate the boundary and
  aren't just checking the function compiles. Restored, green again.
- `npx tsc --noEmit`: clean.
- `npm run lint`: 0 errors, 96 warnings — identical to the pre-existing baseline on this
  branch's parent commit (verified by diffing lint output with and without this change); no
  new warnings introduced.

## Files changed

- `openbank-admin-ui/src/lib/governance/agentOutcomes.ts` — `deriveWeeklyOutcomes()`,
  `WeeklyOutcome` type
- `openbank-admin-ui/src/components/agent/AgentOutcomes.tsx` — `WeeklyTrend` render, wired
  into `OutcomeMetricsCard`
- `openbank-admin-ui/src/test/agent-outcomes.test.ts` — unit tests (empty, all-approved,
  mixed, N-1/N boundary, week-of-decidedAt-not-proposedAt, unparseable-`decidedAt` exclusion)
- `openbank-admin-ui/src/test/agent-outcomes-card.test.tsx` — render tests for the weekly rate
  and the weekly insufficient-data label
