### PR TITLE
fix(audit): follow merged_into at read time for a party's history

### DIFF
--- a/openbank-audit-service/src/main/kotlin/com/openbank/audit/application/AuditConsumer.kt
+++ b/openbank-audit-service/src/main/kotlin/com/openbank/audit/application/AuditConsumer.kt
@@ -11,6 +11,7 @@ import com.openbank.audit.domain.model.AttributionSource
 import com.openbank.audit.domain.model.AuditEntry
 import com.openbank.audit.domain.model.OccurredAtSource
 import com.openbank.audit.infrastructure.persistence.AuditRepository
+import com.openbank.audit.infrastructure.persistence.PartyMergeIndexRepository
 import com.openbank.libs.persistence.outbox.OutboxKafkaHeaders
 import io.micrometer.core.instrument.MeterRegistry
 import io.smallrye.mutiny.Uni
@@ -29,6 +30,12 @@ import java.util.UUID
 class AuditConsumer {
 
     @Inject lateinit var repo: AuditRepository
+
+    // ADR-0179 / issue #1984: the write side of `merged_into` adoption. Optional in tests the
+    // same way meterRegistry is below — a unit test that never sets it just skips the index
+    // write, it does not crash (most tests never send a PARTY_MERGED payload, but at least one,
+    // AuditAttributionTest, deliberately does — for its own unrelated attribution assertion).
+    @Inject lateinit var mergeIndex: PartyMergeIndexRepository
 
     @Inject lateinit var objectMapper: ObjectMapper
 
@@ -167,6 +174,9 @@ class AuditConsumer {
                 countMissingAttribution(entry.sourceService, entry.sourceServiceSource)
             }
             repo.save(entry)
+            if (entry.eventType == "PARTY_MERGED" && ::mergeIndex.isInitialized) {
+                recordPartyMergeIndex(mergeIndex, log, node, entry.occurredAt)
+            }
         } catch (e: Exception) {
             log.errorf(e, "Failed to record audit entry: %s", payload.take(200))
         }
@@ -481,3 +491,39 @@ internal fun actorProvenance(actorId: String?, actorType: String?): ActorProvena
  */
 private fun JsonNode.textOrNull(field: String): String? =
     this[field]?.takeIf { !it.isNull }?.asText()?.takeIf { it.isNotBlank() }
+
+/**
+ * ADR-0179 / issue #1984: records the `retired -> survivor` edge from a `PARTY_MERGED` event
+ * (`PartyEvents.merged`'s exact field names: `partyId` is the retired duplicate,
+ * `mergedIntoPartyId` the survivor) so [AuditRepository.findByAggregateId] can follow it at read
+ * time — `audit_entries` itself cannot be rewritten (V2's append-only RULEs; see V15's migration
+ * comment for why this is a read-time fix and not a write-time one).
+ *
+ * Free-standing, not a member, for the same reason as [resolveActor]/[resolveChannel]:
+ * [AuditConsumer] is already at detekt's function-count threshold, which fires AT the threshold.
+ *
+ * Its own try/catch, deliberately separate from the one around [AuditConsumer.consume]'s call
+ * site: by the time this runs, the audit row FOR the `PARTY_MERGED` event itself is already
+ * saved. A failure here must not be logged as "failed to record audit entry" (untrue — it did)
+ * and must not stop the message ack; it only means one history query stays retired-id-only until
+ * the next `PARTY_MERGED` delivery is processed, not that the merge went unrecorded as an event.
+ */
+// Deliberately broad: a DB hiccup here must never propagate to consume()'s own catch and be
+// misreported as "failed to record audit entry" — the audit row is already safely saved by then.
+@Suppress("TooGenericExceptionCaught")
+private suspend fun recordPartyMergeIndex(
+    mergeIndex: PartyMergeIndexRepository,
+    log: Logger,
+    node: JsonNode,
+    occurredAt: Instant,
+) {
+    val retired = node.textOrNull("partyId")?.let { runCatching { UUID.fromString(it) }.getOrNull() } ?: return
+    val survivor = node.textOrNull("mergedIntoPartyId")
+        ?.let { runCatching { UUID.fromString(it) }.getOrNull() }
+        ?: return
+    try {
+        mergeIndex.recordMerge(retired, survivor, occurredAt)
+    } catch (e: Exception) {
+        log.errorf(e, "Failed to record party-merge index entry for %s -> %s", retired, survivor)
+    }
+}

--- a/openbank-audit-service/src/main/kotlin/com/openbank/audit/infrastructure/persistence/AuditRepository.kt
+++ b/openbank-audit-service/src/main/kotlin/com/openbank/audit/infrastructure/persistence/AuditRepository.kt
@@ -12,6 +12,7 @@ import io.quarkus.hibernate.reactive.panache.kotlin.PanacheEntity
 import io.quarkus.hibernate.reactive.panache.kotlin.PanacheRepository
 import io.smallrye.mutiny.coroutines.awaitSuspending
 import jakarta.enterprise.context.ApplicationScoped
+import jakarta.inject.Inject
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.Table
@@ -142,6 +143,13 @@ class AuditEntryEntity : PanacheEntity() {
 
 @ApplicationScoped
 class AuditRepository : PanacheRepository<AuditEntryEntity> {
+
+    // ADR-0179 / issue #1984: follows `merged_into` at read time so a party-history query does
+    // not stop at the retired id (see PartyMergeIndexRepository and findByAggregateId below).
+    // Optional in tests the same way meterRegistry is elsewhere in this service — a unit test
+    // that constructs this repo by hand and never sets it gets today's un-merge-aware behaviour,
+    // not a crash.
+    @Inject lateinit var mergeIndex: PartyMergeIndexRepository
 
     // Chain writes are serialised in-process: the consumer group has a single member
     // (group.id=audit-service, 1 replica), so a mutex is sufficient — and much simpler than
@@ -326,9 +334,29 @@ class AuditRepository : PanacheRepository<AuditEntryEntity> {
             }
         }.awaitSuspending()
 
-    suspend fun findByAggregateId(aggregateId: String, limit: Int = 100): List<AuditEntry> = Panache.withSession {
-        find("aggregateId = ?1 ORDER BY occurredAt DESC", aggregateId).page(0, limit).list()
-    }.awaitSuspending().map { it.toDomain() }
+    /**
+     * The audit trail for [aggregateId] — and, for a party, its full history: ADR-0179 /
+     * issue #1984. A party merge retires the duplicate (`PartyStatus.MERGED` + `merged_into`) and
+     * moves nothing else, so the rows recorded under the retired id before the merge would
+     * otherwise be invisible to a query for the survivor — exactly the gap #3901 closed for
+     * customer-edge's JWT resolution, on the read side here instead of the write side, because
+     * `audit_entries` cannot be rewritten (see V15's migration comment).
+     *
+     * [PartyMergeIndexRepository.ancestorsOf] is a safe no-op for every [aggregateId] this is not
+     * true of: an id that never had anything merged into it (the common case, and every non-party
+     * aggregate) resolves to just itself, so this is unconditionally correct to call for both
+     * callers of this method — the auditor investigator route AND the customer's own access log.
+     */
+    suspend fun findByAggregateId(aggregateId: String, limit: Int = 100): List<AuditEntry> {
+        val ids = if (::mergeIndex.isInitialized) mergeIndex.ancestorsOf(aggregateId) else listOf(aggregateId)
+        return Panache.withSession {
+            if (ids.size == 1) {
+                find("aggregateId = ?1 ORDER BY occurredAt DESC", aggregateId).page(0, limit).list()
+            } else {
+                find("aggregateId in ?1 ORDER BY occurredAt DESC", ids).page(0, limit).list()
+            }
+        }.awaitSuspending().map { it.toDomain() }
+    }
 
     /**
      * Person-across-channels query (ADR-0226 D3): every entry an actor produced, optionally

--- a/openbank-audit-service/src/main/kotlin/com/openbank/audit/infrastructure/persistence/PartyMergeIndexRepository.kt
+++ b/openbank-audit-service/src/main/kotlin/com/openbank/audit/infrastructure/persistence/PartyMergeIndexRepository.kt
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.audit.infrastructure.persistence
+
+import io.quarkus.hibernate.reactive.panache.Panache
+import io.quarkus.hibernate.reactive.panache.kotlin.PanacheEntity
+import io.quarkus.hibernate.reactive.panache.kotlin.PanacheRepository
+import io.smallrye.mutiny.coroutines.awaitSuspending
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Table
+import java.time.Instant
+import java.util.UUID
+
+@Entity
+@Table(name = "party_merge_index")
+class PartyMergeIndexEntity : PanacheEntity() {
+    @Column(name = "retired_party_id", nullable = false, unique = true)
+    lateinit var retiredPartyId: UUID
+
+    @Column(name = "survivor_party_id", nullable = false)
+    lateinit var survivorPartyId: UUID
+
+    @Column(name = "recorded_at", nullable = false)
+    lateinit var recordedAt: Instant
+}
+
+/**
+ * ADR-0179 / issue #1984: the read-side half of `merged_into` adoption in openbank-audit-service.
+ *
+ * `audit_entries` cannot be rewritten (V2's append-only RULEs, see V15's migration comment), so a
+ * merge is adopted at READ time instead: this repository records the `retired -> survivor` edge
+ * from each `PARTY_MERGED` event, and [ancestorsOf] walks it BACKWARD from a survivor to recover
+ * every id that was, transitively, merged into it. [AuditRepository.findByAggregateId] is the one
+ * caller — both auditor-facing routes (`/entries/{aggregateId}`, the investigator query, and
+ * `/customer/{partyId}`, the customer's own access log) go through it, so fixing that one
+ * chokepoint fixes both, the same shape as customer-edge's `PartyMergeResolver` (#3901) at its
+ * chokepoint.
+ *
+ * This table is NOT audit evidence. It carries no hash chain and no append-only RULE — it is an
+ * ordinary, mutable lookup projection that exists purely to make a query answer completely. The
+ * `PARTY_MERGED` event that grounds each row is itself stored as a normal, tamper-evident
+ * `audit_entries` row exactly as it always was; nothing about that path changes.
+ */
+@ApplicationScoped
+class PartyMergeIndexRepository : PanacheRepository<PartyMergeIndexEntity> {
+
+    /**
+     * Records that [retiredPartyId] was merged into [survivorPartyId].
+     *
+     * Idempotent via a plain check-then-insert, not a database-level upsert: `retired_party_id`
+     * carries a UNIQUE constraint as a backstop, but the real invariant is upstream —
+     * party-service's `mergeParty` rejects merging a party that is already `MERGED`
+     * (`PartyService.kt`), so a given retired id can be the source of at most one merge ever, and
+     * this consumer group has a single member (mirrors [AuditRepository]'s own chain-write note),
+     * so there is no concurrent writer to race against. A redelivery of the same `PARTY_MERGED`
+     * message therefore finds the row already there and does nothing.
+     */
+    suspend fun recordMerge(retiredPartyId: UUID, survivorPartyId: UUID, recordedAt: Instant) {
+        val exists = Panache.withSession {
+            find("retiredPartyId", retiredPartyId).firstResult()
+        }.awaitSuspending() != null
+        if (exists) return
+        val e = PartyMergeIndexEntity().also {
+            it.retiredPartyId = retiredPartyId
+            it.survivorPartyId = survivorPartyId
+            it.recordedAt = recordedAt
+        }
+        Panache.withTransaction { persist(e) }.awaitSuspending()
+    }
+
+    /**
+     * [aggregateId] plus every id that was, transitively, merged into it — the full set of
+     * aggregate ids whose `audit_entries` rows belong to the same party history as [aggregateId].
+     *
+     * Returns just `[aggregateId]` when it does not parse as a UUID, or when nothing was ever
+     * recorded as merged into it — which is every non-party aggregate id (account, transaction,
+     * …) and every party that was never on the receiving end of a merge. Calling this
+     * unconditionally from [AuditRepository.findByAggregateId] is therefore a safe no-op for
+     * every aggregate type this service was not written to reason about.
+     *
+     * Bounded to [MAX_HOPS] hops with a visited set, the same ceiling and the same reason as
+     * customer-edge's `PartyMergeResolver` (#3901): real chains are 0-1 hops (A merged into B is
+     * the overwhelming case), but a merge can chain over time — party-service's guard only
+     * refuses merging INTO an already-merged target *at merge time*; it does not prevent that
+     * target from itself being merged elsewhere later (A -> B, then afterwards B -> C) — and a
+     * corrupted or cyclic edge in this table must not turn a read into an unbounded query.
+     */
+    suspend fun ancestorsOf(aggregateId: String): List<String> {
+        val start = runCatching { UUID.fromString(aggregateId) }.getOrNull() ?: return listOf(aggregateId)
+        val visited = linkedSetOf(start)
+        var frontier = listOf(start)
+        var hop = 0
+        while (frontier.isNotEmpty() && hop < MAX_HOPS) {
+            val next = Panache.withSession {
+                find("survivorPartyId in ?1", frontier).list()
+            }.awaitSuspending().map { it.retiredPartyId }.filter { visited.add(it) }
+            frontier = next
+            hop++
+        }
+        return visited.map { it.toString() }
+    }
+
+    private companion object {
+        const val MAX_HOPS = 5
+    }
+}

--- a/openbank-audit-service/src/main/resources/db/migration/V15__party_merge_index.sql
+++ b/openbank-audit-service/src/main/resources/db/migration/V15__party_merge_index.sql
@@ -1,0 +1,45 @@
+-- ADR-0179 / issue #1984 (consumer adoption of `merged_into`): openbank-audit-service.
+--
+-- `audit_entries` is append-only at the DATABASE level (V2's `no_update_audit`/`no_delete_audit`
+-- RULEs, `DO INSTEAD NOTHING`), so a party merge can never be handled by rewriting `aggregate_id`
+-- on the historical rows recorded under the retired party's id — that write would silently no-op,
+-- and even if it did not, a tamper-evident row is not a row this service may rewrite. Those rows
+-- stay exactly as they were recorded, forever.
+--
+-- This table is not the audit trail and carries none of its guarantees. It is a small, ordinary
+-- (mutable) lookup projection, consulted only at READ time, that lets a history query follow the
+-- `merged_into` pointer BACKWARD — from a survivor to every id that was, transitively, merged
+-- into it — without touching a single existing `audit_entries` row. See PartyMergeIndexRepository.
+--
+-- One row per merge. party-service's `mergeParty` use case rejects merging a party that is
+-- already MERGED (`PartyService.kt`: "Party ... is already merged into ..."), so a given
+-- `retired_party_id` can be the SOURCE of at most one merge ever — which is what makes it a safe
+-- natural idempotency key for a Kafka redelivery of the same PARTY_MERGED event (see
+-- PartyMergeIndexRepository.recordMerge). It does not, and need not, prevent the SURVIVOR from
+-- later itself being merged elsewhere — that is exactly the chained case
+-- (A -> B, then later B -> C) the reverse walk is written to follow.
+--
+-- Rollback: DROP TABLE IF EXISTS party_merge_index; DROP SEQUENCE IF EXISTS party_merge_index_seq;
+CREATE TABLE IF NOT EXISTS party_merge_index (
+    id                 BIGSERIAL   PRIMARY KEY,
+    retired_party_id   UUID        NOT NULL UNIQUE,
+    survivor_party_id  UUID        NOT NULL,
+    recorded_at        TIMESTAMPTZ NOT NULL,
+    created_at         TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- The direction a history query actually needs: "which retired ids point AT this survivor",
+-- the reverse of how the pointer is written (retired -> survivor).
+CREATE INDEX IF NOT EXISTS idx_party_merge_index_survivor ON party_merge_index(survivor_party_id);
+
+-- PanacheEntity allocates ids from a sequence named "<table>_seq" (allocationSize 50, repo
+-- convention per V4/V7) — a plain BIGSERIAL alone only creates "<table>_id_seq", which Hibernate
+-- never looks at.
+CREATE SEQUENCE IF NOT EXISTS party_merge_index_seq INCREMENT BY 50;
+
+COMMENT ON TABLE party_merge_index IS
+    'ADR-0179 read-side projection: retired party id -> the survivor it was merged into. Deliberately mutable and NOT covered by the audit_entries immutability RULEs — it is a lookup index, never evidence in its own right (the PARTY_MERGED event itself is the evidence, and it is stored as an ordinary audit_entries row exactly as before).';
+
+GRANT ALL ON party_merge_index TO openbank;
+GRANT ALL ON SEQUENCE party_merge_index_seq TO openbank;
+GRANT ALL ON SEQUENCE party_merge_index_id_seq TO openbank;

--- a/openbank-audit-service/src/test/kotlin/com/openbank/audit/integration/PartyMergeAuditAdoptionIT.kt
+++ b/openbank-audit-service/src/test/kotlin/com/openbank/audit/integration/PartyMergeAuditAdoptionIT.kt
@@ -1,0 +1,232 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+package com.openbank.audit.integration
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.openbank.audit.application.AuditConsumer
+import com.openbank.audit.infrastructure.persistence.AuditRepository
+import com.openbank.audit.infrastructure.persistence.PartyMergeIndexRepository
+import com.openbank.audit.it.PostgresTestResource
+import io.quarkus.hibernate.reactive.panache.Panache
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.vertx.VertxContextSupport
+import io.smallrye.mutiny.coroutines.awaitSuspending
+import io.smallrye.mutiny.coroutines.uni
+import jakarta.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.util.UUID
+
+/**
+ * ADR-0179 / issue #1984 ("consumer adoption of `merged_into`"), the audit-service slice.
+ *
+ * `audit_entries` is append-only at the database level (V2's `no_update_audit`/`no_delete_audit`
+ * RULEs), so unlike #3901's write-time fix at customer-edge's identity chokepoint, this cannot
+ * rewrite the `aggregate_id` of rows recorded before a merge — those rows correctly stay exactly
+ * as they were. The fix is at READ time instead: [PartyMergeIndexRepository] records each merge's
+ * `retired -> survivor` edge, and [AuditRepository.findByAggregateId] — the one method behind
+ * both `GET /api/v1/audit/entries/{aggregateId}` (the auditor investigator query) and
+ * `GET /api/v1/audit/customer/{partyId}` (the customer's own access log) — follows it backward so
+ * a query for the survivor returns the WHOLE history, not just what was recorded after the merge.
+ *
+ * Falsifiability, in the same test as the fix rather than by reverting code: [AuditEntryEntity]'s
+ * own literal-match finder (`aggregateId = ?1`, no merge awareness — precisely
+ * `findByAggregateId`'s shape before this PR) is run alongside [AuditRepository.findByAggregateId]
+ * against the identical rows. The literal query is incomplete; the fixed one is not. That is the
+ * defect and the fix, both demonstrated, not merely asserted.
+ */
+@QuarkusTest
+@QuarkusTestResource(PostgresTestResource::class)
+class PartyMergeAuditAdoptionIT {
+
+    @Inject
+    lateinit var repository: AuditRepository
+
+    @Inject
+    lateinit var mergeIndex: PartyMergeIndexRepository
+
+    private val consumer = AuditConsumer()
+
+    private fun <T> onEventLoop(block: suspend () -> T): T =
+        VertxContextSupport.subscribeAndAwait { uni(CoroutineScope(Dispatchers.Unconfined)) { block() } }
+
+    private fun consumerFor(): AuditConsumer = consumer.also {
+        it.repo = repository
+        it.mergeIndex = mergeIndex
+        it.objectMapper = jacksonObjectMapper().findAndRegisterModules()
+        it.clock = Clock.systemUTC()
+    }
+
+    /** Matches `PartyEvents.lifecycle`'s exact flat envelope for a pre-merge lifecycle event. */
+    private fun partyLifecycleEvent(eventType: String, partyId: UUID, at: String) = """
+        {
+          "eventType": "$eventType",
+          "partyId": "$partyId",
+          "partyType": "INDIVIDUAL",
+          "status": "ACTIVE",
+          "kycStatus": "VERIFIED",
+          "occurredAt": "$at"
+        }
+    """.trimIndent()
+
+    /** Matches `PartyEvents.merged`'s exact flat envelope — the field names this fix depends on. */
+    private fun partyMergedEvent(retired: UUID, survivor: UUID, at: String) = """
+        {
+          "eventType": "PARTY_MERGED",
+          "partyId": "$retired",
+          "mergedIntoPartyId": "$survivor",
+          "status": "MERGED",
+          "occurredAt": "$at",
+          "actorId": "operator-1",
+          "actorType": "HUMAN"
+        }
+    """.trimIndent()
+
+    /** The literal, merge-UNAWARE query — exactly [AuditRepository.findByAggregateId]'s shape before this fix. */
+    private fun literalAggregateIdMatch(aggregateId: String) = onEventLoop {
+        Panache.withSession {
+            repository.find("aggregateId = ?1 ORDER BY occurredAt DESC", aggregateId).list()
+        }.awaitSuspending()
+    }
+
+    // ── the headline: a survivor's history includes what happened to the party before it merged ──
+
+    @Test
+    fun `a survivor's history includes rows recorded under the retired party before the merge`() {
+        val retired = UUID.randomUUID()
+        val survivor = UUID.randomUUID()
+
+        onEventLoop {
+            val c = consumerFor()
+            // Before the merge: two lifecycle events under the RETIRED id.
+            c.consume(partyLifecycleEvent("PARTY_CREATED", retired, "2026-01-01T09:00:00Z"))
+            c.consume(partyLifecycleEvent("KYC_STATUS_CHANGED", retired, "2026-01-02T09:00:00Z"))
+            // The merge itself.
+            c.consume(partyMergedEvent(retired, survivor, "2026-01-03T09:00:00Z"))
+            // After the merge: one event under the SURVIVOR id.
+            c.consume(partyLifecycleEvent("KYC_STATUS_CHANGED", survivor, "2026-01-04T09:00:00Z"))
+        }
+
+        // FALSIFICATION: the literal, merge-unaware match sees only what was ever recorded under
+        // the survivor's own id — the pre-merge history is invisible to it.
+        val literal = literalAggregateIdMatch(survivor.toString())
+        assertThat(literal).hasSize(1)
+        assertThat(literal.single().eventType).isEqualTo("KYC_STATUS_CHANGED")
+
+        // THE FIX: findByAggregateId follows merged_into backward and returns all four rows —
+        // the two pre-merge, the merge event itself, and the one post-merge — newest first.
+        val full = onEventLoop { repository.findByAggregateId(survivor.toString()) }
+        assertThat(full).hasSize(4)
+        assertThat(full.map { it.eventType }).containsExactly(
+            "KYC_STATUS_CHANGED", // 01-04, post-merge, under survivor
+            "PARTY_MERGED", // 01-03
+            "KYC_STATUS_CHANGED", // 01-02, pre-merge, under retired
+            "PARTY_CREATED", // 01-01, pre-merge, under retired
+        )
+        assertThat(full.map { it.occurredAt }).isSortedAccordingTo(Comparator.reverseOrder())
+    }
+
+    /**
+     * The other direction must stay untouched: querying the RETIRED id (which nothing does in
+     * production once #3901's edge resolver is in the loop, but the auditor route accepts any id)
+     * returns only what was recorded under it — never the survivor's post-merge activity. The
+     * pointer resolves backward (survivor -> its retired predecessors), never forward.
+     */
+    @Test
+    fun `querying the retired id itself is unaffected — only the survivor's query gains history`() {
+        val retired = UUID.randomUUID()
+        val survivor = UUID.randomUUID()
+
+        onEventLoop {
+            val c = consumerFor()
+            c.consume(partyLifecycleEvent("PARTY_CREATED", retired, "2026-01-01T09:00:00Z"))
+            c.consume(partyMergedEvent(retired, survivor, "2026-01-02T09:00:00Z"))
+            c.consume(partyLifecycleEvent("KYC_STATUS_CHANGED", survivor, "2026-01-03T09:00:00Z"))
+        }
+
+        val retiredHistory = onEventLoop { repository.findByAggregateId(retired.toString()) }
+        assertThat(retiredHistory.map { it.eventType }).containsExactly("PARTY_MERGED", "PARTY_CREATED")
+    }
+
+    /**
+     * Merges chain over time: party-service's guard only refuses merging INTO an
+     * already-merged target, at merge time — it does not stop that target from later itself being
+     * merged elsewhere (A -> B, then afterwards B -> C). A history query for the FINAL survivor
+     * must walk the whole chain, not just one hop.
+     */
+    @Test
+    fun `a chain of merges is followed to its end, recovering the whole history`() {
+        val a = UUID.randomUUID()
+        val b = UUID.randomUUID()
+        val c = UUID.randomUUID()
+
+        onEventLoop {
+            val consumer = consumerFor()
+            consumer.consume(partyLifecycleEvent("PARTY_CREATED", a, "2026-01-01T09:00:00Z"))
+            consumer.consume(partyMergedEvent(a, b, "2026-01-02T09:00:00Z"))
+            consumer.consume(partyLifecycleEvent("PARTY_CREATED", b, "2026-01-02T10:00:00Z"))
+            consumer.consume(partyMergedEvent(b, c, "2026-01-03T09:00:00Z"))
+            consumer.consume(partyLifecycleEvent("KYC_STATUS_CHANGED", c, "2026-01-04T09:00:00Z"))
+        }
+
+        // FALSIFICATION: the literal match at the final survivor still sees only its own row.
+        assertThat(literalAggregateIdMatch(c.toString())).hasSize(1)
+
+        val full = onEventLoop { repository.findByAggregateId(c.toString()) }
+        assertThat(full.map { it.eventType }).containsExactlyInAnyOrder(
+            "PARTY_CREATED", // A's own creation
+            "PARTY_MERGED", // A -> B
+            "PARTY_CREATED", // B's own creation
+            "PARTY_MERGED", // B -> C
+            "KYC_STATUS_CHANGED", // C, post-chain
+        )
+    }
+
+    /**
+     * A Kafka redelivery of the same `PARTY_MERGED` message must not fail, and must not double
+     * the retired party's rows in a history query — the natural idempotency key is the retired
+     * party id itself (party-service's `mergeParty` rejects merging an already-MERGED party, so a
+     * given retired id is the source of at most one real merge, ever).
+     */
+    @Test
+    fun `redelivering the same PARTY_MERGED event is idempotent`() {
+        val retired = UUID.randomUUID()
+        val survivor = UUID.randomUUID()
+
+        onEventLoop {
+            val c = consumerFor()
+            c.consume(partyLifecycleEvent("PARTY_CREATED", retired, "2026-01-01T09:00:00Z"))
+            val mergedPayload = partyMergedEvent(retired, survivor, "2026-01-02T09:00:00Z")
+            c.consume(mergedPayload)
+            c.consume(mergedPayload) // redelivery
+        }
+
+        // Each delivery still lands its own audit_entries row (append-only, by design) — but the
+        // merge-index resolution set is not doubled.
+        val ancestors = onEventLoop { mergeIndex.ancestorsOf(survivor.toString()) }
+        assertThat(ancestors).containsExactlyInAnyOrder(survivor.toString(), retired.toString())
+
+        // Not containsExactly: the two PARTY_MERGED rows share an identical occurredAt (same
+        // payload, redelivered), so their relative order under `ORDER BY occurredAt DESC` alone
+        // is not guaranteed — only the total shape (both merges, plus the one pre-merge row) is.
+        val full = onEventLoop { repository.findByAggregateId(survivor.toString()) }
+        assertThat(full.map { it.eventType }).containsExactlyInAnyOrder("PARTY_MERGED", "PARTY_MERGED", "PARTY_CREATED")
+    }
+
+    /** An id nothing was ever merged into behaves exactly as before — the common case. */
+    @Test
+    fun `a party that was never merged sees only its own rows`() {
+        val party = UUID.randomUUID()
+        onEventLoop {
+            consumerFor().consume(partyLifecycleEvent("PARTY_CREATED", party, "2026-01-01T09:00:00Z"))
+        }
+
+        assertThat(onEventLoop { repository.findByAggregateId(party.toString()) }).hasSize(1)
+        assertThat(onEventLoop { mergeIndex.ancestorsOf(party.toString()) }).containsExactly(party.toString())
+    }
+}


### PR DESCRIPTION
## What #1984 says, and where audit-service sits in it

Issue #1984's "consumer adoption of `merged_into`" checklist item names nine services still
treating a merged party as two separate identities: account, aml, analytics-sink, **audit**,
card-issuance, copilot, kyc, notification, onboarding. #3901 fixed the highest-value single
placement — customer-edge's identity chokepoint, resolving the JWT `party_id` forward at write
time (well, request time) so ~86 customer routes see the survivor. This PR is the audit-service
slice of the fleet sweep #1984 asks for next.

The gap in one sentence: party-service sets `PartyStatus.MERGED` + `merged_into` on a retired
duplicate and emits `PARTY_MERGED`, but nothing in audit-service ever followed that pointer, so an
investigator pulling a survivor's full history via `GET /api/v1/audit/entries/{aggregateId}` (the
auditor route) or a customer reading their own trail via `GET /api/v1/audit/customer/{partyId}`
(proxied by customer-edge, which since #3901 already sends the survivor's id) got only what was
recorded *after* the merge. Everything that happened under the retired party before the merge —
account opening, KYC status changes, whatever else — was invisible.

## Why this is a read-time fix, not #3901's write-time shape

`audit_entries` is append-only at the **database** level: V2's migration installs
`no_update_audit`/`no_delete_audit` RULEs (`DO INSTEAD NOTHING`), confirmed by reading the schema
before assuming the shape of the fix, per this task's own instruction. So rewriting the
`aggregate_id` of a historical row from the retired id to the survivor's is not available — the
UPDATE would silently no-op — and even if it somehow worked, a tamper-evident row is not something
this service is entitled to rewrite. `DelegatedActionAuditChainIT` already demonstrates the RULE
live (an UPDATE affecting zero rows), and this PR does not touch it.

The fix is at read time. Three pieces:

1. **`party_merge_index`** (new table, `V15__party_merge_index.sql`) — an ordinary, mutable lookup
   projection: `retired_party_id -> survivor_party_id`. It carries **no** hash chain and **no**
   append-only RULE; it is explicitly NOT audit evidence. The `PARTY_MERGED` event that grounds
   each row is still stored as a normal, tamper-evident `audit_entries` row exactly as before —
   nothing about that path changes.
2. **`AuditConsumer`** now also records that edge when it sees `eventType == "PARTY_MERGED"`,
   reading `PartyEvents.merged`'s exact field names (`partyId` = retired, `mergedIntoPartyId` =
   survivor) verified from party-service's own event builder. This is additive and wrapped in its
   own try/catch — a failure here does not affect the audit row for the merge event itself (already
   saved by then) and does not stall the ack.
3. **`AuditRepository.findByAggregateId`** — the one method behind both the auditor route and the
   customer route — now resolves `[aggregateId] + every id transitively merged into it` before
   querying, walking `party_merge_index` backward, hop-bounded at 5 with a visited set (same
   ceiling and the same reason as #3901's `PartyMergeResolver`: chains are 0-1 hops in practice,
   but party-service's merge guard only refuses merging INTO an already-merged target *at merge
   time* — it does not stop that target from itself being merged elsewhere later, so A -> B -> C is
   possible over time and is exercised in the tests below).

An id nothing was ever merged into — every account, every transaction, and every party that was
never on the receiving end of a merge — resolves to itself, so this is a safe no-op everywhere it
doesn't apply. Fixing the one chokepoint fixes both read routes, the same shape as #3901.

## Evidence

`PartyMergeAuditAdoptionIT` (real Postgres via Testcontainers, not mocks):

- a survivor's history includes rows recorded under the retired party before the merge
- querying the retired id itself is unaffected (the pointer resolves backward only)
- a chain of merges (A -> B -> C) is followed to its end
- a redelivered `PARTY_MERGED` message is idempotent (no duplicate index row)
- a party that was never merged sees only its own rows (no regression)

**Falsifiability, measured, not assumed.** I temporarily reverted
`AuditRepository.findByAggregateId` to its pre-fix literal `aggregateId = ?1` match and re-ran the
suite: exactly the 3 tests that depend on merge resolution went red (the headline test, the chain
test, and the idempotency test's history assertion); the other 2 (retired-id and never-merged)
stayed green, as expected since they don't exercise the fix. Restored, re-ran, all 5 green again.
The full `openbank-audit-service` suite (118 tests) is green with 0 failures, 0 errors, 0 skipped
— read from the JUnit XML, not the console tail.

`ktlintCheck`, `detekt`, and `quarkusBuild` (new CDI bean, `PartyMergeIndexRepository`) all pass —
`quarkusBuild` specifically because a unit test cannot see an ArC wiring failure.

## What this does NOT solve

- **No admin-UI change.** Item 4 of #1984 (the merge/close action) is untouched by this PR.
- **The other eight services #1984 names are unaffected** — account, aml, analytics-sink,
  card-issuance, copilot, kyc, notification, onboarding all still treat a merged party as two
  identities. This PR does not close #1984; it is one slice of the sweep. `Refs #1984`, not
  `Closes`.
- **Chained merges are tested against real Postgres, not live traffic.** The A -> B -> C case
  passes in `PartyMergeAuditAdoptionIT`, but no chain longer than two hops has ever been exercised
  against a running cluster (the issue's own live-state note records exactly one real merge in the
  sandbox to date, a single hop).
- **No four-eyes interaction.** #1984 separately tracks that `party.merge` carries a four-eyes
  gate that is coded but not enforced (`AUTHZ_FOUR_EYES_ENFORCE=false`). That is a party-service
  deployment question, orthogonal to this PR — audit-service adopts whatever `PARTY_MERGED` events
  actually arrive, gated or not.
- **party-service's own 409 message still names a nonexistent "ledger ADJUSTMENT journal"** for
  the balance-sweep escape hatch — a separate, already-filed docs fix (#4753), unrelated to this
  service.

## Files

- `openbank-audit-service/src/main/resources/db/migration/V15__party_merge_index.sql` (new table)
- `openbank-audit-service/src/main/kotlin/com/openbank/audit/infrastructure/persistence/PartyMergeIndexRepository.kt` (new)
- `openbank-audit-service/src/main/kotlin/com/openbank/audit/infrastructure/persistence/AuditRepository.kt` (`findByAggregateId` now merge-aware)
- `openbank-audit-service/src/main/kotlin/com/openbank/audit/application/AuditConsumer.kt` (records the merge edge)
- `openbank-audit-service/src/test/kotlin/com/openbank/audit/integration/PartyMergeAuditAdoptionIT.kt` (new)

Refs #1984
