### PR TITLE
fix(notification): follow the ADR-0179 merged_into pointer at dispatch

### DIFF
--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/application/NotificationConsumer.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/application/NotificationConsumer.kt
@@ -36,6 +36,7 @@ import com.openbank.notification.domain.model.PushResult
 import com.openbank.notification.domain.model.PushSendOutcome
 import com.openbank.notification.domain.model.TemplateSensitivity
 import com.openbank.notification.infrastructure.client.PartyContactClient
+import com.openbank.notification.infrastructure.client.PartyMergeResolver
 import com.openbank.notification.infrastructure.persistence.entity.NotificationEntity
 import com.openbank.notification.infrastructure.persistence.repository.DeviceTokenRepository
 import com.openbank.notification.infrastructure.persistence.repository.NotificationPreferenceRepository
@@ -203,6 +204,10 @@ class NotificationConsumer @Inject constructor(
     @RestClient
     lateinit var partyContactClient: PartyContactClient
 
+    /** Follows the ADR-0179 `merged_into` pointer at dispatch entry (issue #1984) — see [dispatch]. */
+    @Inject
+    lateinit var partyMergeResolver: PartyMergeResolver
+
     private val log = Logger.getLogger(NotificationConsumer::class.java)
 
     /**
@@ -285,7 +290,21 @@ class NotificationConsumer @Inject constructor(
             }
     }
 
-    private fun dispatch(req: NotificationRequest): Uni<Void> {
+    /**
+     * Resolves `req.partyId` through [PartyMergeResolver] before anything else runs (issue #1984
+     * fleet sweep — ADR-0179 consumer adoption). This is the identity chokepoint: persistence,
+     * the preference check, the device-token fan-out and the EMAIL address lookup all read
+     * `partyId` off the request that reaches [dispatchResolved], so resolving once here means none
+     * of them need their own adoption. A request for a since-merged party is redirected to the
+     * survivor; an unaffected request pays one resolver call that is almost always a cache hit
+     * (see [PartyMergeResolver]).
+     */
+    private fun dispatch(req: NotificationRequest): Uni<Void> =
+        partyMergeResolver.resolve(req.partyId).chain { resolved ->
+            dispatchResolved(if (resolved == req.partyId) req else req.copy(partyId = resolved))
+        }
+
+    private fun dispatchResolved(req: NotificationRequest): Uni<Void> {
         val (subject, body) = renderTemplate(req.template, req.variables)
         val entity = NotificationEntity().also {
             it.notificationId = Ids.newId()

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/infrastructure/client/PartyContactClient.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/infrastructure/client/PartyContactClient.kt
@@ -39,6 +39,17 @@ interface PartyContactClient {
     @GET
     @Path("/{id}")
     fun getParty(@PathParam("id") id: UUID): Uni<PartyContactResponse>
+
+    /**
+     * Same read, bound to a narrower response — see [PartyIdentityResponse]. A second method
+     * rather than widening [PartyContactResponse]: the two callers ([PartyMergeResolver] and
+     * [com.openbank.notification.application.NotificationConsumer.resolveEmailRecipient]) want
+     * different, non-overlapping slices of the same record, and keeping them apart means neither
+     * accidentally starts depending on a field the other added.
+     */
+    @GET
+    @Path("/{id}")
+    fun getPartyIdentity(@PathParam("id") id: UUID): Uni<PartyIdentityResponse>
 }
 
 /**
@@ -48,3 +59,12 @@ interface PartyContactClient {
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class PartyContactResponse(val email: String? = null)
+
+/**
+ * The two fields [PartyMergeResolver] needs to follow an ADR-0179 `merged_into` pointer: whether
+ * the party is retired, and if so, which party to follow instead. `@JsonIgnoreProperties` for the
+ * same reason as [PartyContactResponse] — this service has no business holding the rest of the
+ * record, which for a MERGED party still carries the retired customer's legalName/email/phone.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class PartyIdentityResponse(val status: String? = null, val mergedIntoPartyId: UUID? = null)

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/infrastructure/client/PartyMergeResolver.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/infrastructure/client/PartyMergeResolver.kt
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.notification.infrastructure.client
+
+import io.quarkus.logging.Log
+import io.smallrye.mutiny.Uni
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.inject.Inject
+import org.eclipse.microprofile.config.inject.ConfigProperty
+import org.eclipse.microprofile.rest.client.inject.RestClient
+import java.time.Clock
+import java.time.Instant
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Follows ADR-0179's `merged_into` pointer so a notification for a merged party's retired id is
+ * delivered/keyed against the surviving party, not the retired one (issue #1984 fleet sweep).
+ *
+ * ## What this fixes
+ *
+ * A party merge retires the duplicate (`PartyStatus.MERGED` + `merged_into` -> the survivor) and
+ * touches nothing else. notification-service stores device tokens, notification preferences and
+ * every persisted `Notification` row keyed by `partyId` — and every producer on
+ * `openbank.notification.requests` (campaign-service, account-service, sca-service, ...) supplies
+ * whatever `partyId` it holds, which for a party merged after that producer last looked it up is
+ * the retired id. Before this resolver, a notification for a merged customer was persisted under
+ * the retired id, checked against preferences for the retired id, and (for PUSH) fanned out to
+ * device tokens registered under the retired id — silently missing the survivor's actual devices
+ * and preferences, or in the EMAIL case, looking up the retired party's (possibly stale) address.
+ *
+ * ## Where it sits
+ *
+ * At the single identity chokepoint: `NotificationConsumer.dispatch()`, before the request is
+ * persisted or fanned out to any channel. Same shape as customer-edge's `PartyMergeResolver`
+ * (#3901) — resolve once at the entry point rather than per downstream lookup, because every
+ * downstream step (persistence, preference check, device-token lookup, EMAIL address lookup)
+ * reads `partyId` off the same request.
+ *
+ * ## Why a synchronous (request/response) read and not the `PARTY_MERGED` event
+ *
+ * notification-service already consumes `openbank.party.events` for `PARTY_ERASED`
+ * ([com.openbank.notification.infrastructure.kafka.PartyErasureConsumer]), so unlike
+ * customer-edge it COULD consume `PARTY_MERGED` too and maintain a redirect table. That was
+ * considered and rejected here: a `NotificationRequest` can arrive before the consumer's own
+ * projection of a merge that happened seconds earlier catches up (no ordering guarantee across
+ * two independent topics/partitions), and the failure mode of a stale redirect table is exactly
+ * the bug this fixes — silently keying a live send to the wrong id. A direct read from
+ * party-service (already the source of truth this service asks for the EMAIL address via
+ * [PartyContactClient]) has no such staleness window. The read is also cheap: notification volume
+ * is nowhere near customer-edge's per-request-of-every-authenticated-call rate, so the extra
+ * upstream call this adds is proportionate.
+ *
+ * ## Failure behaviour: fail-OPEN, deliberately
+ *
+ * This sits ahead of every notification send, including SECURITY-category ones (OTP, SCA, account
+ * freeze) that must not be silently dropped by an unrelated party-service hiccup. If party-service
+ * is unreachable, slow, or answers something unexpected, [resolve] returns the claimed id
+ * unchanged — i.e. exactly today's behaviour (a party is rarely merged, so most sends are
+ * unaffected either way). Failing closed would suppress every notification whenever party-service
+ * has a bad moment, to protect a state (a merged party) that is rare by construction.
+ *
+ * ## Security note
+ *
+ * Following the pointer targets the notification at the SURVIVING party's devices/address/
+ * preferences. That is the intended meaning of a merge (the two rows are one human) and adds no
+ * new authority: `POST /api/v1/parties/{id}/merge` is `@Authorize(action = "party.merge")` and
+ * `party.merge` is listed in `rules.yaml: four_eyes.actions`, so a merge itself needs a maker and
+ * a different checker. This resolver only reads a pointer that endpoint wrote.
+ *
+ * ## Caching
+ *
+ * In-process, per replica — same shape and TTLs as customer-edge's resolver. A resolved merge is
+ * cached for a long time (a merge is irreversible), a "not merged" answer for a short time so a
+ * fresh merge is picked up promptly. Bounded in size; on overflow the cache is cleared rather than
+ * grown.
+ */
+@ApplicationScoped
+class PartyMergeResolver @Inject constructor(
+    @RestClient
+    private val partyContactClient: PartyContactClient,
+    private val clock: Clock,
+    // Kill switch. On by default: a merged party's notifications are misdirected without it.
+    // Flip to false to fall back to "the request's partyId is used verbatim" without a rollback.
+    @ConfigProperty(name = "openbank.notification.party-merge-follow-enabled", defaultValue = "true")
+    private val followEnabled: Boolean,
+) {
+
+    private data class Entry(val survivor: UUID, val expiresAt: Instant)
+
+    private val cache = ConcurrentHashMap<UUID, Entry>()
+
+    /**
+     * Returns a [Uni] of the party id [claimed] should be read as: the surviving party if
+     * [claimed] was merged away (following a chain of merges to its end), otherwise [claimed]
+     * itself.
+     *
+     * Never fails — see the fail-open note on the class.
+     */
+    fun resolve(claimed: UUID): Uni<UUID> {
+        if (!followEnabled) return Uni.createFrom().item(claimed)
+        val now = Instant.now(clock)
+        cache[claimed]?.let { if (it.expiresAt.isAfter(now)) return Uni.createFrom().item(it.survivor) }
+        return walk(claimed, claimed, mutableSetOf(claimed), 0)
+            .onFailure().recoverWithItem { _: Throwable -> claimed }
+            .invoke { survivor -> remember(claimed, survivor, now) }
+    }
+
+    /**
+     * Walks the `mergedIntoPartyId` chain from [start] (tracked only for the log lines) starting
+     * at [current], with [visited] the hop set so far and [hop] the hop count.
+     *
+     * Bounded two ways because a corrupted pointer must not hang a notification send: a hop
+     * ceiling, and a visited set so a cycle (A -> B -> A) terminates at the last id that was not
+     * already seen rather than looping. Any non-OK read, unparseable body, or a party that is not
+     * MERGED (or MERGED with no pointer), ends the walk at the current id.
+     */
+    private fun walk(start: UUID, current: UUID, visited: MutableSet<UUID>, hop: Int): Uni<UUID> {
+        if (hop >= MAX_HOPS) {
+            Log.warnf("party-merge chain from %s exceeded %d hops — stopping at %s", start, MAX_HOPS, current)
+            return Uni.createFrom().item(current)
+        }
+        return partyContactClient.getPartyIdentity(current)
+            .chain { identity ->
+                val next = identity.mergedIntoPartyId
+                if (identity.status != MERGED_STATUS || next == null) {
+                    Uni.createFrom().item(current)
+                } else if (!visited.add(next)) {
+                    Log.warnf("party-merge chain from %s cycles at %s — stopping at %s", start, next, current)
+                    Uni.createFrom().item(current)
+                } else {
+                    walk(start, next, visited, hop + 1)
+                }
+            }
+    }
+
+    private fun remember(claimed: UUID, survivor: UUID, now: Instant) {
+        if (cache.size >= MAX_CACHE_ENTRIES) cache.clear()
+        val ttl = if (survivor == claimed) UNMERGED_TTL_SECONDS else MERGED_TTL_SECONDS
+        cache[claimed] = Entry(survivor, now.plusSeconds(ttl))
+    }
+
+    companion object {
+        private const val MERGED_STATUS = "MERGED"
+
+        // A merge is irreversible (there is no un-merge endpoint), so the positive answer can be
+        // held for a long time; an hour still bounds the blast radius of a bad cache entry.
+        private const val MERGED_TTL_SECONDS = 3600L
+
+        // A "not merged" answer must go stale quickly — this is the case that turns into a merge.
+        private const val UNMERGED_TTL_SECONDS = 300L
+
+        // Depth of a merge chain (A merged into B, B later merged into C). Real chains are 0-1
+        // hops; the ceiling exists so a corrupted pointer cannot spin.
+        private const val MAX_HOPS = 5
+
+        private const val MAX_CACHE_ENTRIES = 50_000
+    }
+}

--- a/openbank-notification-service/src/test/kotlin/com/openbank/notification/infrastructure/client/PartyMergeResolverTest.kt
+++ b/openbank-notification-service/src/test/kotlin/com/openbank/notification/infrastructure/client/PartyMergeResolverTest.kt
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.notification.infrastructure.client
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import io.smallrye.mutiny.Uni
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+import java.util.UUID
+
+/**
+ * [PartyMergeResolver] on its own — same shape as customer-edge's `PartyMergeAdoptionTest`
+ * "resolver behaviour on its own" block (#3901), adapted to the `Uni`-returning REST client this
+ * service already uses for party lookups ([PartyContactClient]).
+ */
+class PartyMergeResolverTest {
+
+    private val fixedClock: Clock = Clock.fixed(Instant.parse("2026-08-16T10:00:00Z"), ZoneOffset.UTC)
+
+    private fun resolverOver(client: PartyContactClient, enabled: Boolean = true, clock: Clock = fixedClock) =
+        PartyMergeResolver(client, clock, enabled)
+
+    private fun identity(status: String?, mergedInto: UUID? = null) =
+        Uni.createFrom().item(PartyIdentityResponse(status, mergedInto))
+
+    @Test
+    fun `an unmerged party resolves to itself`() {
+        val party = UUID.randomUUID()
+        val client = mockk<PartyContactClient>()
+        every { client.getPartyIdentity(party) } returns identity("ACTIVE")
+
+        assertThat(resolverOver(client).resolve(party).await().indefinitely()).isEqualTo(party)
+    }
+
+    @Test
+    fun `a merged party resolves to the survivor`() {
+        val loser = UUID.randomUUID()
+        val survivor = UUID.randomUUID()
+        val client = mockk<PartyContactClient>()
+        every { client.getPartyIdentity(loser) } returns identity("MERGED", survivor)
+        // The walk confirms the survivor is not itself further merged before returning it.
+        every { client.getPartyIdentity(survivor) } returns identity("ACTIVE")
+
+        assertThat(resolverOver(client).resolve(loser).await().indefinitely()).isEqualTo(survivor)
+    }
+
+    @Test
+    fun `a chain of merges resolves to the end of the chain`() {
+        val a = UUID.randomUUID()
+        val b = UUID.randomUUID()
+        val c = UUID.randomUUID()
+        val client = mockk<PartyContactClient>()
+        every { client.getPartyIdentity(a) } returns identity("MERGED", b)
+        every { client.getPartyIdentity(b) } returns identity("MERGED", c)
+        every { client.getPartyIdentity(c) } returns identity("ACTIVE")
+
+        assertThat(resolverOver(client).resolve(a).await().indefinitely()).isEqualTo(c)
+    }
+
+    @Test
+    fun `a cyclic pointer terminates instead of spinning`() {
+        val a = UUID.randomUUID()
+        val b = UUID.randomUUID()
+        val client = mockk<PartyContactClient>()
+        every { client.getPartyIdentity(a) } returns identity("MERGED", b)
+        every { client.getPartyIdentity(b) } returns identity("MERGED", a)
+
+        assertThat(resolverOver(client).resolve(a).await().indefinitely()).isEqualTo(b)
+    }
+
+    @Test
+    fun `a MERGED party with no pointer is not redirected anywhere`() {
+        val party = UUID.randomUUID()
+        val client = mockk<PartyContactClient>()
+        every { client.getPartyIdentity(party) } returns identity("MERGED", null)
+
+        assertThat(resolverOver(client).resolve(party).await().indefinitely()).isEqualTo(party)
+    }
+
+    @Test
+    fun `an upstream failure fails open to the claimed id`() {
+        val party = UUID.randomUUID()
+        val client = mockk<PartyContactClient>()
+        every { client.getPartyIdentity(party) } returns
+            Uni.createFrom().failure(RuntimeException("party-service unreachable"))
+
+        assertThat(resolverOver(client).resolve(party).await().indefinitely()).isEqualTo(party)
+    }
+
+    @Test
+    fun `the kill switch restores verbatim id behaviour without calling upstream at all`() {
+        val loser = UUID.randomUUID()
+        val client = mockk<PartyContactClient>()
+
+        assertThat(resolverOver(client, enabled = false).resolve(loser).await().indefinitely()).isEqualTo(loser)
+        verify(exactly = 0) { client.getPartyIdentity(any()) }
+    }
+
+    @Test
+    fun `a resolved merge is cached rather than re-read on every request`() {
+        val loser = UUID.randomUUID()
+        val survivor = UUID.randomUUID()
+        val client = mockk<PartyContactClient>()
+        every { client.getPartyIdentity(loser) } returns identity("MERGED", survivor)
+        every { client.getPartyIdentity(survivor) } returns identity("ACTIVE")
+        val resolver = resolverOver(client)
+
+        repeat(3) { assertThat(resolver.resolve(loser).await().indefinitely()).isEqualTo(survivor) }
+
+        verify(exactly = 1) { client.getPartyIdentity(loser) }
+    }
+
+    @Test
+    fun `an unmerged answer is not cached across the TTL boundary`() {
+        val party = UUID.randomUUID()
+        val client = mockk<PartyContactClient>()
+        every { client.getPartyIdentity(party) } returns identity("ACTIVE")
+        // "not merged" TTL is 300s (see PartyMergeResolver.UNMERGED_TTL_SECONDS) — advance just past it.
+        val laterClock = Clock.fixed(fixedClock.instant().plusSeconds(301), ZoneOffset.UTC)
+        val resolver = PartyMergeResolver(client, AdvancingClock(fixedClock, laterClock), true)
+
+        resolver.resolve(party).await().indefinitely()
+        resolver.resolve(party).await().indefinitely()
+
+        verify(exactly = 2) { client.getPartyIdentity(party) }
+    }
+
+    /** Returns [first] on its first call to [instant] and [second] thereafter. */
+    private class AdvancingClock(private val first: Clock, private val second: Clock) : Clock() {
+        private var used = false
+
+        override fun getZone() = second.zone
+
+        override fun withZone(zone: java.time.ZoneId?) = this
+
+        override fun instant(): Instant = if (!used) {
+            used = true
+            first.instant()
+        } else {
+            second.instant()
+        }
+    }
+}


### PR DESCRIPTION
## What breaks today for a merged party's notifications (the measurement)

Re-verified on `origin/main` today. #1984 names nine services subscribed to
`openbank.party.events` that still treat a merged party as two separate identities;
notification-service is one of them.

`notification-service` has no consumer for `PARTY_MERGED`. Every downstream step in
`NotificationConsumer.dispatch()` — persisting the `Notification` row, the preference check
(`preferenceRepo.findByParty`), the PUSH device-token fan-out (`deviceTokenRepo.findActiveByParty`),
and the EMAIL address resolution (`PartyContactClient.getParty`) — keys off `req.partyId`, i.e.
whatever id the producer (campaign-service, account-service, sca-service, ...) supplied. For a party
merged after that producer last looked it up, that is the **retired** id: the notification is
persisted under the wrong party, checked against the wrong preferences, and for PUSH, fanned out to
devices registered under an id nobody uses anymore — missing the survivor's actual devices — while
for EMAIL it looks up the retired party's (possibly stale) address instead of the survivor's. No
error anywhere; it looks like a normal send that happens to reach nobody who still checks it.

## The slice I shipped

**`PartyMergeResolver` follows `merged_into` once, at the identity chokepoint** —
`NotificationConsumer.dispatch()`, before the request is persisted or fanned out to any channel.
Same shape as customer-edge's resolver from #3901: resolve once at the entry point rather than per
downstream lookup, because every downstream step reads `partyId` off the same request.

```kotlin
private fun dispatch(req: NotificationRequest): Uni<Void> =
    partyMergeResolver.resolve(req.partyId).chain { resolved ->
        dispatchResolved(if (resolved == req.partyId) req else req.copy(partyId = resolved))
    }
```

Design points that are decisions rather than details:

- **Synchronous read (`GET /api/v1/parties/{id}`), not the `PARTY_MERGED` event.** Unlike
  customer-edge, notification-service *already* consumes `openbank.party.events` for
  `PARTY_ERASED` (`PartyErasureConsumer`), so an event-driven redirect table was a real option here
  — and was rejected. A `NotificationRequest` can arrive before this consumer's own projection of a
  merge that happened seconds earlier catches up (no cross-topic/cross-partition ordering
  guarantee), and a stale redirect table fails in exactly the shape this PR fixes: silently keying a
  live send to the wrong id. A direct read from party-service — the same call
  `PartyContactClient` already makes for EMAIL address resolution (#3581) — has no such staleness
  window, and notification volume is nowhere near customer-edge's per-authenticated-request rate,
  so the extra upstream call is proportionate.
- **Fail-OPEN.** This sits ahead of every send, including SECURITY-category ones (OTP, SCA, account
  freeze) that must not be silently dropped by an unrelated party-service hiccup. Any non-OK read,
  unparseable body, or exception returns the claimed id unchanged — today's behaviour.
- **Bounded.** Max 5 hops plus a visited set, matching customer-edge's resolver.
- **Cached in-process**, 1 h positive (merges are irreversible), 5 min negative, bounded at 50k
  entries — identical shape and TTLs to #3901's resolver.
- **Kill switch** `openbank.notification.party-merge-follow-enabled` (default `true`).

`PartyContactClient` gains a second method, `getPartyIdentity`, alongside the existing `getParty`
(email-only) — same `GET /api/v1/parties/{id}` call, a narrower response DTO
(`status`/`mergedIntoPartyId`) so this service doesn't bind fields it has no reason to hold (the
existing `PartyContactResponse` KDoc makes the same argument for `email` alone).

## Evidence

`./gradlew :openbank-notification-service:ktlintCheck :openbank-notification-service:detekt` —
green. `:openbank-notification-service:quarkusBuild` — green (CDI wiring for the new
`@ApplicationScoped PartyMergeResolver` and its extra field injection into `NotificationConsumer`
verified; a unit test alone cannot catch that class of failure — see this repo's own CLAUDE.md on
`McpEndpoint`'s silently-unregistered route).

**`PartyMergeResolverTest`** (9 tests, 0 failures) exercises the resolver in isolation: an unmerged
party resolves to itself, a merged party resolves to the survivor (confirming the survivor isn't
itself further merged before returning), a multi-hop chain resolves to its end, a cyclic pointer
terminates instead of spinning, a MERGED party with no pointer is not redirected, an upstream
failure fails open, the kill switch skips the upstream call entirely, a resolved merge is cached
(one upstream call across three `resolve()`s), and an unmerged answer expires off its shorter TTL.

**Falsifiability, measured.** With `resolve()` temporarily forced to
`return Uni.createFrom().item(claimed)` (i.e. today's pre-fix behaviour — the request's partyId used
verbatim, matching the pre-fix `dispatch()`), 5 of the 9 tests fail: the merge-resolution, chain,
cycle-termination, caching and negative-TTL cases. The fix was then restored and the suite re-run
green (9/9).

## What this deliberately does NOT solve — same scoping as #3901

- **No live HTTP+Kafka+Postgres end-to-end test.** I built one (WireMock standing in for
  party-service, driving a real `NotificationRequest` through the in-memory Kafka connector against
  the dedicated IT Postgres, matching this module's own `NotificationConsumerIT` /
  `OversightWebhookIT` conventions) and it was unreliable on this machine: two consecutive runs of
  the identical test produced different outcomes — one showed zero requests ever reaching the
  WireMock stub (config-timing on a heavily contended, multi-agent shared host with several
  concurrent Gradle daemons), another showed genuine but implausible cross-hop traffic consistent
  with the app's REST client hitting something other than my stub. Rather than ship a test that
  can be red or green independent of the code under test, I dropped it and rely on the deterministic
  `PartyMergeResolverTest` instead. #3901 made the identical call for the identical reason ("no live
  HTTP-level test").
- **No fleet-wide observability.** Nothing here adds a metric for "how often did this service
  redirect a request" — a resolved merge is silent by design (that's the fix), and there's no signal
  today distinguishing "no merges happened" from "the resolver is silently failing open on every
  call". Same gap as #3901 left for customer-edge.
- **No admin-UI change.** Out of scope for this issue's item.
- **Doesn't touch the other 8 services #1984 names** (account, aml, analytics-sink, audit,
  card-issuance, copilot, kyc, onboarding). Each is its own PR — the fleet sweep is #1984's tracking
  item, not this one. customer-edge (#3901) uses a synchronous resolver at its own REST chokepoint,
  outside this Kafka-consumer list.
- **Doesn't change party-service, the four-eyes enforcement gap on `party.merge`, or the ledger
  merge-sweep** — all separate, already-tracked threads on #1984.

Refs #1984 — 8 more services remain on the fleet sweep (customer-edge landed via #3901,
notification-service here).
