### PR TITLE
feat(admin-ui): show registered devices on Customer 360

### DIFF
--- a/openbank-admin-ui/src/app/customer-360/page.tsx
+++ b/openbank-admin-ui/src/app/customer-360/page.tsx
@@ -12,6 +12,7 @@ import { PageHeader, StatCard, StatusBadge } from '@/components/ui'
 import type { Customer360 } from '@/app/api/customer-360/[partyId]/route'
 import { PartySearch, partyDisplayName, type PartyHit } from '@/components/party/PartySearch'
 import { AdverseStatePanel } from '@/components/party/AdverseStatePanel'
+import { DevicesPanel } from '@/components/party/DevicesPanel'
 
 // ADR-0210: a lookup over the analytics silver layer, not a customer list. There is no
 // crm-service and no "list all customers" surface here — party-service owns that.
@@ -90,6 +91,7 @@ export default function Customer360Page() {
           projected events must not hide an active fraud hold. Those are independent sources and the
           page now degrades independently for each. */}
       {selected && <AdverseStatePanel key={selected.id} partyId={selected.id} />}
+      {selected && <DevicesPanel key={selected.id} partyId={selected.id} />}
 
       {loading && (
         <div style={{ color: 'var(--text-secondary)', padding: '40px', textAlign: 'center' }}>

--- a/openbank-admin-ui/src/components/party/DevicesPanel.tsx
+++ b/openbank-admin-ui/src/components/party/DevicesPanel.tsx
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+'use client'
+
+import { useEffect, useState } from 'react'
+import { Smartphone, HelpCircle } from 'lucide-react'
+import { useLanguage } from '@/lib/i18n/LanguageContext'
+import { StatusBadge } from '@/components/ui'
+import { svcUrl, classifyBffFailure, type BffFailure } from '@/lib/services/bff'
+
+// Reads notification-service's `GET /api/v1/devices?partyId=` (DeviceResource, ROLE_VIEWER-readable)
+// through the ADR-0056 BFF proxy — same operator-token relay + backend RBAC as AdverseStatePanel, no
+// new BFF route needed since notification-service is already in the proxy's SERVICE_MAP.
+//
+// DeviceResource deliberately never returns the push token itself (PII-adjacent, write-only) — only
+// platform/appVersion/osVersion/status and three timestamps. There is no "last login" anywhere in the
+// fleet (no session/auth tracking service); `refreshedAt` is the closest proxy — it advances on every
+// foreground token refresh (ADR-0135 §2), so it reads as "last time the app was open", not a login event.
+// The panel says so rather than labelling it "last login".
+
+interface DeviceView {
+  id: string
+  platform: string
+  appInstance: string
+  appVersion: string | null
+  osVersion: string | null
+  status: string
+  registeredAt: string
+  refreshedAt: string | null
+  lastUsedAt: string | null
+}
+
+interface DevicesResponse {
+  items: DeviceView[]
+  total: number
+}
+
+type State =
+  | { kind: 'loading' }
+  | { kind: 'ok'; devices: DeviceView[] }
+  | { kind: 'unknown'; why: BffFailure }
+
+export function DevicesPanel({ partyId }: { partyId: string }) {
+  const { t, language } = useLanguage()
+  const [state, setState] = useState<State>({ kind: 'loading' })
+
+  // No loading reset here either — same reasoning as AdverseStatePanel: the parent mounts this with
+  // `key={partyId}`, so a new selection is a fresh component already starting from `loading`.
+  useEffect(() => {
+    let live = true
+    ;(async () => {
+      try {
+        const res = await fetch(svcUrl('notification-service', '/api/v1/devices', { partyId }), {
+          cache: 'no-store',
+        })
+        if (!res.ok) {
+          const why = await classifyBffFailure(res)
+          if (live) setState({ kind: 'unknown', why })
+          return
+        }
+        const body = (await res.json()) as DevicesResponse
+        if (live) setState({ kind: 'ok', devices: body.items ?? [] })
+      } catch {
+        if (live) setState({ kind: 'unknown', why: 'unreachable' })
+      }
+    })()
+    return () => {
+      live = false
+    }
+  }, [partyId])
+
+  const fmt = (iso: string | null) =>
+    iso
+      ? new Intl.DateTimeFormat(language === 'cs' ? 'cs-CZ' : 'en-GB', { dateStyle: 'medium', timeStyle: 'short' })
+          .format(new Date(iso.replace(' ', 'T') + (iso.endsWith('Z') ? '' : 'Z')))
+      : t('nikdy', 'never')
+
+  return (
+    <div className="card" style={{ padding: '16px 20px', marginBottom: '20px' }}>
+      <h2 className="section-title" style={{ marginBottom: '4px' }}>
+        {t('Zařízení', 'Devices')}
+      </h2>
+      <p style={{ margin: '0 0 12px', fontSize: '11px', color: 'var(--text-secondary)' }}>
+        {t(
+          'Zdroj: notification-service, registr push tokenů. Token samotný se nikdy nevrací. „Naposledy aktivní“ je čas posledního obnovení tokenu appkou na popředí — appka nemusí evidovat přihlášení, jde o nejbližší dostupný signál, ne o skutečné přihlášení.',
+          'Source: notification-service push-token registry. The token itself is never returned. "Last active" is the last foreground token refresh — there is no login/session tracking anywhere in the fleet, this is the closest available signal, not a real login event.',
+        )}
+      </p>
+
+      {state.kind === 'loading' && (
+        <span style={{ fontSize: '12px', color: 'var(--text-secondary)' }}>{t('Načítám…', 'Loading…')}</span>
+      )}
+
+      {state.kind === 'ok' && state.devices.length === 0 && (
+        <div style={{ display: 'flex', alignItems: 'center', gap: '8px', fontSize: '13px', color: 'var(--text-secondary)' }}>
+          <Smartphone size={16} />
+          <span>{t('Žádná registrovaná zařízení', 'No registered devices')}</span>
+        </div>
+      )}
+
+      {state.kind === 'ok' && state.devices.length > 0 && (
+        <div style={{ overflowX: 'auto' }}>
+          <table className="table">
+            <thead>
+              <tr>
+                <th>{t('Platforma', 'Platform')}</th>
+                <th>{t('Aplikace', 'App')}</th>
+                <th>{t('Stav', 'Status')}</th>
+                <th>{t('Registrováno', 'Registered')}</th>
+                <th>{t('Naposledy aktivní', 'Last active')}</th>
+              </tr>
+            </thead>
+            <tbody>
+              {state.devices.map(d => (
+                <tr key={d.id}>
+                  <td style={{ fontWeight: 600 }}>{d.platform}</td>
+                  <td style={{ fontSize: '11px' }}>
+                    {d.appVersion ?? '—'}{d.osVersion ? ` · ${d.osVersion}` : ''}
+                  </td>
+                  <td><StatusBadge status={d.status} withDot /></td>
+                  <td>{fmt(d.registeredAt)}</td>
+                  <td>{fmt(d.refreshedAt ?? d.lastUsedAt)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {state.kind === 'unknown' && (
+        <div style={{ display: 'flex', alignItems: 'center', gap: '8px', fontSize: '13px', color: 'var(--text-secondary)' }}>
+          <HelpCircle size={16} />
+          <span>
+            {t(
+              `Zařízení nelze zjistit (notification-service: ${state.why}).`,
+              `Devices unavailable (notification-service: ${state.why}).`,
+            )}
+          </span>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/openbank-admin-ui/src/test/customer-360-devices.test.tsx
+++ b/openbank-admin-ui/src/test/customer-360-devices.test.tsx
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+// An operator on Customer 360 asked to see a party's registered push devices and last-active time
+// (there is no login/session tracking anywhere in the fleet — see notification-service DeviceResource).
+//
+// Same reasoning as customer-360-adverse-state.test.tsx: the failure path is the one worth pinning,
+// so an unreachable notification-service never renders as "no devices" — those read identically to
+// an operator unless the failure state is explicit. The BFF URL is pinned as a LITERAL, not derived
+// from svcUrl(), so the assertion can actually catch the component pointing at a dead route.
+
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import React from 'react'
+import { render, screen, cleanup, waitFor } from '@testing-library/react'
+import { LanguageProvider } from '@/lib/i18n/LanguageContext'
+import { DevicesPanel } from '@/components/party/DevicesPanel'
+
+const PARTY = '55555555-5555-5555-5555-555555555555'
+
+function json(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } })
+}
+
+function renderPanel() {
+  return render(
+    <LanguageProvider>
+      <DevicesPanel partyId={PARTY} />
+    </LanguageProvider>,
+  )
+}
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+})
+
+describe('Customer 360 devices panel', () => {
+  it('asks notification-service through the BFF proxy, on the path DeviceResource serves', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => json({ items: [], total: 0 })))
+    renderPanel()
+    await waitFor(() => expect(fetch).toHaveBeenCalled())
+    const url = String((fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0])
+    expect(url).toBe(`/api/svc/notification-service/api/v1/devices?partyId=${PARTY}`)
+  })
+
+  it('renders a row per device with status and last-active, never the push token', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => json({
+      items: [{
+        id: 'd1',
+        platform: 'IOS',
+        appInstance: 'inst-1',
+        appVersion: '2.3.0',
+        osVersion: '18.1',
+        status: 'ACTIVE',
+        registeredAt: '2026-07-17 10:00:00',
+        refreshedAt: '2026-08-15 09:30:00',
+        lastUsedAt: '2026-08-15 09:30:00',
+      }],
+      total: 1,
+    })))
+    renderPanel()
+
+    await waitFor(() => expect(screen.getByText('IOS')).toBeTruthy())
+    expect(screen.getByText(/2\.3\.0/)).toBeTruthy()
+    // The response contract omits `token` entirely, so the JSON value itself can never leak; this
+    // guards against a future column accidentally rendering a raw token verbatim on the page.
+    expect(screen.queryByText(/^[A-Za-z0-9+/]{40,}$/)).toBeNull()
+  })
+
+  it('states an empty result as measured, not unknown', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => json({ items: [], total: 0 })))
+    renderPanel()
+    await waitFor(() => expect(screen.getByText(/No registered devices/i)).toBeTruthy())
+  })
+
+  // THE load-bearing one — same shape as the adverse-state panel's.
+  it('never reports an unreachable notification-service as "no devices"', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => json({ error: 'Unknown service: notification-service' }, 404)))
+    renderPanel()
+
+    await waitFor(() => expect(screen.getByText(/Devices unavailable/i)).toBeTruthy())
+    expect(screen.queryByText(/No registered devices/i)).toBeNull()
+  })
+
+  it('treats a scaled-to-zero backend the same way — unknown, not empty', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => json({ error: 'scaled_to_zero' }, 503)))
+    renderPanel()
+
+    await waitFor(() => expect(screen.getByText(/scaled_to_zero/i)).toBeTruthy())
+    expect(screen.queryByText(/No registered devices/i)).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary
- Add `DevicesPanel` to Customer 360, showing a party's registered push devices (platform, app version, status, registered/last-active) from notification-service's existing `GET /api/v1/devices?partyId=` — a ROLE_VIEWER-readable endpoint that no UI currently calls.
- No new BFF route: notification-service is already registered in the generic `/api/svc` proxy's `SERVICE_MAP`, which does the bearer relay.
- Panel follows `AdverseStatePanel`'s exact pattern: an explicit `unknown` state so an unreachable notification-service never renders as "no devices".
- No login/session tracking exists anywhere in the fleet — the panel surfaces the closest available signal (last token refresh) and says so, rather than labelling it "last login".

## Test plan
- [x] `npm test` — full suite, 1330/1330 passing, including the new `customer-360-devices.test.tsx` and the i18n/graceful-state/layout-shell/service-registry guards
- [x] `npm run type-check` — clean
- [x] `npx eslint` on changed files — clean
- [ ] Not visually verified in a running preview (no local Keycloak/ClickHouse/notification-service stack available in this environment) — component and BFF wiring mirror the already-verified `AdverseStatePanel`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Linked issues
N/A — follow-up from an operator conversation, no tracked issue.
