### PR TITLE
chore(infra): drop ecr:CreateRepository from the CI deploy role

### DIFF
--- a/openbank-infra/aws/envs/sandbox-platform/arc-runners.tf
+++ b/openbank-infra/aws/envs/sandbox-platform/arc-runners.tf
@@ -673,27 +673,29 @@ data "aws_iam_policy_document" "arc_deploy_ecr" {
       "arn:aws:ecr:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:repository/openbank-*"
     ]
   }
-  # A new service's ECR repository is declared nowhere — every one of the ~32 existing repos was
-  # created by hand — so the first build of a new service compiles, runs the whole cold-cache
-  # Gradle build, and dies at the push with `name unknown` (issue #3423, measured on
-  # openbank-delegation-service). Nothing upstream can see it: the drift declaration checks only
-  # the pin's SHAPE, and the attestation gate reports the image as ABSENT, which is the correct
-  # state for a first registration.
+  # CreateRepository REMOVED (#3661, point 2 of #3477): every openbank-* repository this role
+  # could have created is now declared in ecr-service-repositories.tf and, as of that PR's apply,
+  # imported into Terraform state — a build job that can create registry namespaces is exactly
+  # the thing declaring them was meant to remove the need for (#3423's original hole). Verified
+  # before removing, not assumed: `aws ecr describe-repositories` against the live account, diffed
+  # against the file's own for_each derivation (gitops image pins + the CI runner image), showed
+  # zero repositories the declaration does not already cover.
   #
-  # Scoped to openbank-* deliberately. CreateRepository already exists on this role for
-  # repository/docker-hub/* (the pull-through cache); widening it to `*` would let a build create
-  # anything in the registry, and the naming prefix is the whole boundary.
+  # Describe STAYS. It answers a question CreateRepository never did: whether a missing repository
+  # is a real drift (Terraform's declaration and the account have diverged — someone deleted a
+  # repository outside Terraform, or a new service's gitops manifest landed without its
+  # ecr-service-repositories.tf entry in the same PR) versus this role simply lacking permission
+  # to see it. Collapsing that distinction is what made #3444 fail builds for repositories that
+  # already existed (reverted by #3453) — the same failure mode Create's removal must not
+  # reintroduce from the opposite direction. ensure-ecr-repository.sh's fail-open path (#3492)
+  # keeps working unchanged: it can still observe and still fails open, it just never creates.
   #
-  # Describe is here for a reason of its own: without it the caller cannot tell
-  # RepositoryNotFoundException from AccessDenied, and reading the latter as the former is what
-  # made #3444 fail builds for repositories that already existed (reverted by #3453).
-  # ensure-ecr-repository.sh now fails OPEN when it cannot observe the registry, so it is inert
-  # until this statement applies rather than dependent on it.
+  # sid renamed from EcrCreateServiceRepository — the old name asserted a capability this
+  # statement no longer grants.
   statement {
-    sid = "EcrCreateServiceRepository"
+    sid = "EcrDescribeServiceRepository"
     actions = [
       "ecr:DescribeRepositories",
-      "ecr:CreateRepository",
     ]
     resources = [
       "arn:aws:ecr:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:repository/openbank-*"


### PR DESCRIPTION
## What, and why it's a draft

Item 2 of #3661 — dropping `ecr:CreateRepository` from the CI deploy role's `EcrCreateServiceRepository` statement, now `EcrDescribeServiceRepository` (Describe-only). **Opened as DRAFT deliberately: do not mark ready or merge until item 1 (`tofu apply` importing all 63 `openbank-*` repos) has landed and a fresh `tofu plan` shows 0 import lines remaining.** Merging this first restores #3423's original failure with no fallback — `ensure-ecr-repository.sh` needs `CreateRepository` to auto-create a missing repo, and that path is only safe to retire once nothing is actually missing.

## What was verified before writing any code

**Fresh registry comparison, not the stale Aug-3 plan.** Reproduced `ecr-service-repositories.tf`'s own derivation logic (regex over every gitops manifest for `<account>.dkr.ecr.<region>.amazonaws.com/(openbank-*)[:@]`, plus the CI runner image) and diffed against `aws ecr describe-repositories` on the live account:

```
derived set:  63 (was 61 at #3659's original plan — 2 services added since)
live account: 136 repositories total
  63 openbank-* match exactly, zero missing either direction
  73 are ECR pull-through-cache namespaces (docker-hub/*, ghcr/*, quay/*, ecr-public/*, k8s/*) —
     correctly out of this file's scope, untouched by it
```

So the apply this depends on is a **pure import**: 0 create, 0 destroy, 63 existing repositories brought under Terraform state. Nothing is created by it, and after it lands nothing legitimate is left for this grant to create either.

**Two `ecr:CreateRepository` grants exist on this role, only one of which is in scope.** The other (`EcrPullThroughReadAndImport`) is required for the pull-through-cache mechanism (`docker-hub/*` etc.) and is untouched — confirmed by reading both statements in full before editing, not grepping-and-deleting the first match.

**`ecr:DescribeRepositories` stays**, deliberately — it's what lets `ensure-ecr-repository.sh` (#3492) tell a real drift (repository deleted outside Terraform, or a new service's gitops manifest landing without its `ecr-service-repositories.tf` entry in the same PR) apart from a plain `AccessDenied`. That distinction is exactly what #3444/#3453 were about; collapsing it again from the other direction would reopen the same failure class.

## FinOps — checked explicitly, zero impact

- **State import**: Terraform state operations carry no AWS cost.
- **Tag reconciliation** (`default_tags` reaching hand-created repos): free.
- **`scan_on_push: false -> true` on 9 repos**: confirmed `scan_type = "BASIC"` in `ecr-image-scanning.tf` — AWS's native, no-charge scan, not Inspector/Enhanced. The account-level `aws_ecr_registry_scanning_configuration` already applies `SCAN_ON_PUSH` to all `openbank-*` by wildcard regardless of this PR; the per-repo setting is stated redundancy ("belt-and-braces" per that file's own comment), not a new cost driver.
- **This PR's own change** (IAM policy document): zero cost, reduces blast radius.

## What was deliberately NOT run

`tofu plan`/`validate` against the real backend — even read-only, that acquires an S3 state lock (`use_lockfile=true`), which is touching shared infrastructure. The verification above (live registry vs. the file's own derivation) establishes the same facts without needing it. `tofu fmt -check`: clean.

Refs #3661, #3477, #3423, #3492

🤖 Generated with [Claude Code](https://claude.com/claude-code)
