### PR TITLE
fix(agent): back the PoP nonce replay guard with a shared Redis store

### DIFF
--- a/.github/workflows/auto-deploy.yml
+++ b/.github/workflows/auto-deploy.yml
@@ -478,6 +478,11 @@ jobs:
         # looks perfectly healthy. Harmless for the other services: only this module reads it.
         env:
           ANALYTICS_SINK_TYPE: clickhouse
+          # agent-service selects its NonceStore binding with @IfBuildProperty (same trap as
+          # analytics-sink above — resolved at AUGMENTATION time, so a runtime env var cannot
+          # reach it). Without this the image ships the @Default InMemoryNonceStore, and the PoP
+          # replay guard silently weakens to per-pod once replicas > 1 (issue #4728).
+          AGENT_SVID_NONCE_STORE: redis
         run: |
           set -euo pipefail
           SERVICES='${{ needs.changes.outputs.services }}'

--- a/openbank-agent-service/build.gradle.kts
+++ b/openbank-agent-service/build.gradle.kts
@@ -28,6 +28,10 @@ dependencies {
     implementation(libs.quarkus.smallrye.fault.tolerance)
     implementation(libs.quarkus.scheduler)
     implementation(libs.quarkus.smallrye.kafka)
+    // Cross-replica PoP nonce replay guard (issue #4728) — same shared TTL-cache mechanism
+    // already deployed for ~30 services fleet-wide (RedisIdempotencyStore/RedisApprovalStore
+    // in openbank-libs-runtime are the closest siblings). See RedisNonceStore.
+    implementation(libs.quarkus.redis.client)
 
     implementation(libs.kotlinx.coroutines.core)
     implementation(libs.kotlinx.coroutines.reactive)

--- a/openbank-agent-service/src/main/kotlin/com/openbank/agent/application/AgentSvidVerifier.kt
+++ b/openbank-agent-service/src/main/kotlin/com/openbank/agent/application/AgentSvidVerifier.kt
@@ -5,7 +5,9 @@
 
 package com.openbank.agent.application
 
+import com.openbank.agent.application.port.out.NonceStore
 import jakarta.enterprise.context.ApplicationScoped
+import kotlinx.coroutines.runBlocking
 import org.eclipse.microprofile.config.inject.ConfigProperty
 import org.jboss.logging.Logger
 import java.io.ByteArrayInputStream
@@ -17,7 +19,6 @@ import java.time.Instant
 import java.util.Base64
 import java.util.Date
 import java.util.Optional
-import java.util.concurrent.ConcurrentHashMap
 
 /**
  * ADR-0031 D3b (verify side): verifies a proof-of-possession over a short-TTL OpenBao-issued client
@@ -46,14 +47,17 @@ class AgentSvidVerifier(
     caCertPem: Optional<String>,
     @ConfigProperty(name = "agent.identity.svid.max-skew-seconds", defaultValue = "60")
     private val maxSkewSeconds: Long,
+    /**
+     * Single-use nonce claim, injected so replay protection can be backed by a store the whole
+     * fleet's replicas share (issue #4728) rather than this class's own per-pod map. See
+     * [NonceStore]'s KDoc for the durability rationale and the two bindings.
+     */
+    private val nonceStore: NonceStore,
 ) {
     private val log = Logger.getLogger(AgentSvidVerifier::class.java)
 
     /** Trust anchor: the pki-agent CA. Blank/unparseable config → SVID disabled (fail to header binding). */
     private val caCert: X509Certificate? = parseCaOrNull(caCertPem.orElse(""))
-
-    /** Single-use nonce cache; each entry expires after the max time a PoP can stay fresh. */
-    private val seenNonces = ConcurrentHashMap<String, Instant>()
 
     val enabled: Boolean get() = caCert != null
 
@@ -89,7 +93,7 @@ class AgentSvidVerifier(
         if (!popVerifies(leaf, popB64, "$ts.$nonce")) return SvidResult.Rejected("PoP signature does not verify")
         // Resolve the CN before consuming the nonce, so a no-CN cert doesn't burn a nonce.
         val agentId = cnOf(leaf) ?: return SvidResult.Rejected("certificate has no CN")
-        if (!consumeNonce(nonce, now)) return SvidResult.Rejected("replayed nonce")
+        if (!consumeNonce(nonce)) return SvidResult.Rejected("replayed nonce")
         return SvidResult.Verified(agentId)
     }
 
@@ -113,12 +117,14 @@ class AgentSvidVerifier(
         }.getOrDefault(false)
     }
 
-    /** Atomically claim [nonce]; false when already seen (replay). Evicts expired entries lazily. */
-    private fun consumeNonce(nonce: String, now: Instant): Boolean {
-        if (seenNonces.size > MAX_NONCES) seenNonces.values.removeIf { it.isBefore(now) }
-        val expiry = now.plusSeconds(maxSkewSeconds * NONCE_TTL_MULTIPLIER)
-        return seenNonces.putIfAbsent(nonce, expiry) == null
-    }
+    /**
+     * Atomically claim [nonce]; false when already seen (replay). Bridges to the suspend
+     * [NonceStore] port from this class's synchronous API — the same `runBlocking` bridge this
+     * service already uses at its MCP entry point (`McpEndpoint.handle`) for the equally
+     * synchronous JAX-RS/`@Blocking`-worker-thread call path.
+     */
+    private fun consumeNonce(nonce: String): Boolean =
+        runBlocking { nonceStore.claim(nonce, maxSkewSeconds * NONCE_TTL_MULTIPLIER) }
 
     private fun cnOf(cert: X509Certificate): String? =
         CN_PATTERN.find(cert.subjectX500Principal.name)?.groupValues?.get(1)?.trim()?.takeIf { it.isNotEmpty() }
@@ -150,7 +156,6 @@ class AgentSvidVerifier(
     }
 
     private companion object {
-        const val MAX_NONCES = 10_000
         const val NONCE_TTL_MULTIPLIER = 2L
         const val PEM_MARKER = "BEGIN CERTIFICATE"
         val CN_PATTERN = Regex("CN=([^,]+)")

--- a/openbank-agent-service/src/main/kotlin/com/openbank/agent/application/port/out/NonceStore.kt
+++ b/openbank-agent-service/src/main/kotlin/com/openbank/agent/application/port/out/NonceStore.kt
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+
+package com.openbank.agent.application.port.out
+
+/**
+ * Single-use claim for a [AgentSvidVerifier][com.openbank.agent.application.AgentSvidVerifier]
+ * PoP nonce (ADR-0031 D3b, issue #4728).
+ *
+ * The replay guard's entire security property is that a nonce can be claimed **once**: under N
+ * replicas, a store whose state is per-pod (a bare `ConcurrentHashMap`) lets a replayed PoP
+ * succeed simply by landing on a different pod — the guard weakens in proportion to replica
+ * count rather than failing loudly. [claim] must therefore be atomic and, in any deployment with
+ * more than one replica, backed by a store all replicas share.
+ *
+ * The default binding [com.openbank.agent.infrastructure.security.InMemoryNonceStore] keeps the
+ * service offline-buildable/testable with zero infra (correct only at `replicas: 1`, which is
+ * what every environment runs today). The durable, cross-replica binding is
+ * [com.openbank.agent.infrastructure.security.RedisNonceStore], the same
+ * `quarkus-redis-client` + per-service `@Produces`-free `@Alternative` mechanism already used
+ * fleet-wide for TTL-bounded shared state (`RedisIdempotencyStore`, `RedisApprovalStore` in
+ * `openbank-libs-runtime`), activated by `agent.identity.svid.nonce-store=redis`.
+ */
+interface NonceStore {
+    /**
+     * Atomically claims [nonce] for [ttlSeconds]. Returns `true` the first time a given [nonce]
+     * is claimed (the caller may proceed), `false` on every subsequent claim within [ttlSeconds]
+     * (a replay — the caller must reject).
+     */
+    suspend fun claim(nonce: String, ttlSeconds: Long): Boolean
+}

--- a/openbank-agent-service/src/main/kotlin/com/openbank/agent/infrastructure/security/InMemoryNonceStore.kt
+++ b/openbank-agent-service/src/main/kotlin/com/openbank/agent/infrastructure/security/InMemoryNonceStore.kt
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+
+package com.openbank.agent.infrastructure.security
+
+import com.openbank.agent.application.port.out.NonceStore
+import jakarta.enterprise.context.ApplicationScoped
+import java.time.Instant
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Default [NonceStore]: a per-pod concurrent map. Keeps the service offline-buildable/testable
+ * with zero infra, and is correct as long as `replicas: 1` (every environment today). It is NOT
+ * safe across replicas — see [NonceStore]'s KDoc — which is why the deployed image instead binds
+ * [RedisNonceStore] via `agent.identity.svid.nonce-store=redis` (issue #4728).
+ */
+@ApplicationScoped
+class InMemoryNonceStore : NonceStore {
+
+    private val seen = ConcurrentHashMap<String, Instant>()
+
+    override suspend fun claim(nonce: String, ttlSeconds: Long): Boolean {
+        val now = Instant.now()
+        if (seen.size > MAX_NONCES) seen.values.removeIf { it.isBefore(now) }
+        val expiry = now.plusSeconds(ttlSeconds)
+        return seen.putIfAbsent(nonce, expiry) == null
+    }
+
+    private companion object {
+        const val MAX_NONCES = 10_000
+    }
+}

--- a/openbank-agent-service/src/main/kotlin/com/openbank/agent/infrastructure/security/RedisNonceStore.kt
+++ b/openbank-agent-service/src/main/kotlin/com/openbank/agent/infrastructure/security/RedisNonceStore.kt
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+
+package com.openbank.agent.infrastructure.security
+
+import com.openbank.agent.application.port.out.NonceStore
+import io.quarkus.arc.properties.IfBuildProperty
+import io.quarkus.redis.datasource.ReactiveRedisDataSource
+import io.quarkus.redis.datasource.value.SetArgs
+import io.smallrye.mutiny.coroutines.awaitSuspending
+import jakarta.annotation.Priority
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.enterprise.inject.Alternative
+import jakarta.inject.Inject
+
+/**
+ * Redis/Valkey-backed [NonceStore]: the durable, cross-replica PoP replay guard (issue #4728).
+ *
+ * Reuses the exact `quarkus-redis-client` mechanism already deployed for ~30 other services in
+ * this fleet (`RedisIdempotencyStore`, `RedisApprovalStore` in `openbank-libs-runtime` are the
+ * closest siblings — a TTL-bounded value keyed by a caller-supplied token) rather than
+ * introducing a new caching technology. `SET key value NX EX ttl GET` is a single atomic Redis
+ * command: it claims the key only if absent, and reports whether it was already present via the
+ * returned (old) value — exactly the compare-and-swap a replay guard needs, with no separate
+ * lock, version column or two-step SETNX+EXPIRE race.
+ *
+ * It is the `@Alternative @Priority(100)` binding behind the `@Default` [InMemoryNonceStore],
+ * gated at BUILD time by `agent.identity.svid.nonce-store=redis` — same convention as
+ * `openbank-analytics-sink`'s `ClickHouseProposalStore` (`openbank.analytics.sink.type=clickhouse`).
+ */
+@ApplicationScoped
+@Alternative
+@Priority(RedisNonceStore.ALTERNATIVE_PRIORITY)
+@IfBuildProperty(name = "agent.identity.svid.nonce-store", stringValue = "redis")
+open class RedisNonceStore : NonceStore {
+
+    @Inject
+    lateinit var redis: ReactiveRedisDataSource
+
+    private val valueCommands by lazy { redis.value(String::class.java) }
+
+    override suspend fun claim(nonce: String, ttlSeconds: Long): Boolean {
+        val previous = valueCommands
+            .setGet("$KEY_PREFIX$nonce", CLAIMED, SetArgs().nx().ex(ttlSeconds))
+            .awaitSuspending()
+        return previous == null
+    }
+
+    companion object {
+        // Matches ClickHouseProposalStore's @Alternative priority in openbank-analytics-sink —
+        // no cross-bean ordering depends on the exact value, only on outranking @Default (1).
+        const val ALTERNATIVE_PRIORITY = 100
+        private const val KEY_PREFIX = "agent-svid-nonce:"
+        private const val CLAIMED = "1"
+    }
+}

--- a/openbank-agent-service/src/main/resources/application.yaml
+++ b/openbank-agent-service/src/main/resources/application.yaml
@@ -135,6 +135,13 @@ quarkus:
     migrate-at-start: true
     connect-retries: 10
 
+  # Cross-replica PoP nonce replay guard (issue #4728) — only consulted by RedisNonceStore,
+  # which is only bound when agent.identity.svid.nonce-store=redis (a build-time flag CI sets).
+  # An in-cluster deploy overrides this with QUARKUS_REDIS_HOSTS, same pattern as every other
+  # Redis-consuming service (redis.<namespace>.svc — a per-namespace Deployment, not shared).
+  redis:
+    hosts: redis://localhost:6379
+
 "%dev":
   quarkus:
     oidc:
@@ -237,6 +244,12 @@ agent:
       ca-cert: ${AGENT_IDENTITY_SVID_CA_CERT:}
       enforced: ${AGENT_IDENTITY_SVID_ENFORCED:false}
       max-skew-seconds: ${AGENT_IDENTITY_SVID_MAX_SKEW_SECONDS:60}
+      # BUILD-TIME (Quarkus @IfBuildProperty — resolved at augmentation, a runtime env var
+      # cannot reach it, same trap the analytics-sink ANALYTICS_SINK_TYPE comment documents).
+      # Empty/default -> the offline-buildable InMemoryNonceStore (correct only at replicas: 1).
+      # `redis` -> the cross-replica RedisNonceStore (issue #4728); set via AGENT_SVID_NONCE_STORE
+      # in the CI build step (auto-deploy.yml), never here, so local/dev builds stay infra-free.
+      nonce-store: ${AGENT_SVID_NONCE_STORE:}
   # D2 (ADR-0031): per-agent charter limits enforced by CharterRateLimiter. Mirrors the canonical
   # values in openbank-libs/governance/agents.yaml; code reads from config so no YAML parsing at
   # runtime. Adding an agent = one entry here + the charter entry in agents.yaml.

--- a/openbank-agent-service/src/test/kotlin/com/openbank/agent/application/AgentSvidVerifierTest.kt
+++ b/openbank-agent-service/src/test/kotlin/com/openbank/agent/application/AgentSvidVerifierTest.kt
@@ -5,6 +5,7 @@
 
 package com.openbank.agent.application
 
+import com.openbank.agent.infrastructure.security.InMemoryNonceStore
 import org.assertj.core.api.Assertions.assertThat
 import org.bouncycastle.asn1.x500.X500Name
 import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter
@@ -91,7 +92,7 @@ class AgentSvidVerifierTest {
     @Test
     fun `a valid cert and PoP yield the CN as the agent id`() {
         val p = pki("ui-assistant")
-        val v = AgentSvidVerifier(Optional.of(p.caPem), skew)
+        val v = AgentSvidVerifier(Optional.of(p.caPem), skew, InMemoryNonceStore())
         val t = ts()
         assertThat(v.verify(p.leafPem, pop(p.leafKey, t, "n1"), t, "n1", now))
             .isEqualTo(SvidResult.Verified("ui-assistant"))
@@ -99,14 +100,14 @@ class AgentSvidVerifierTest {
 
     @Test
     fun `no CA configured disables SVID`() {
-        val result = AgentSvidVerifier(Optional.empty(), skew).verify("c", "s", ts(), "n", now)
+        val result = AgentSvidVerifier(Optional.empty(), skew, InMemoryNonceStore()).verify("c", "s", ts(), "n", now)
         assertThat(result).isEqualTo(SvidResult.Disabled)
     }
 
     @Test
     fun `CA configured but no cert presented is Disabled, not Rejected (staged rollout fallback)`() {
         val p = pki("ui-assistant")
-        val v = AgentSvidVerifier(Optional.of(p.caPem), skew)
+        val v = AgentSvidVerifier(Optional.of(p.caPem), skew, InMemoryNonceStore())
         // No SVID headers at all → caller falls back to the D3a binding (svid.enforced decides), so a
         // CA being configured must not hard-reject callers that don't yet present certs (PR5b-2).
         assertThat(v.verify(null, null, null, null, now)).isEqualTo(SvidResult.Disabled)
@@ -115,14 +116,14 @@ class AgentSvidVerifierTest {
     @Test
     fun `a present cert with missing PoP headers is rejected`() {
         val p = pki("ui-assistant")
-        val v = AgentSvidVerifier(Optional.of(p.caPem), skew)
+        val v = AgentSvidVerifier(Optional.of(p.caPem), skew, InMemoryNonceStore())
         assertThat(v.verify(p.leafPem, null, ts(), "n", now)).isInstanceOf(SvidResult.Rejected::class.java)
     }
 
     @Test
     fun `a tampered PoP signature is rejected`() {
         val p = pki("ui-assistant")
-        val v = AgentSvidVerifier(Optional.of(p.caPem), skew)
+        val v = AgentSvidVerifier(Optional.of(p.caPem), skew, InMemoryNonceStore())
         val t = ts()
         val tampered = pop(p.leafKey, t, "n1").dropLast(4) + "AAAA"
         assertThat(v.verify(p.leafPem, tampered, t, "n1", now))
@@ -132,7 +133,7 @@ class AgentSvidVerifierTest {
     @Test
     fun `a PoP signed over a different nonce is rejected`() {
         val p = pki("ui-assistant")
-        val v = AgentSvidVerifier(Optional.of(p.caPem), skew)
+        val v = AgentSvidVerifier(Optional.of(p.caPem), skew, InMemoryNonceStore())
         val t = ts()
         val sigForN1 = pop(p.leafKey, t, "n1")
         assertThat(v.verify(p.leafPem, sigForN1, t, "n2", now))
@@ -143,7 +144,7 @@ class AgentSvidVerifierTest {
     fun `a cert from an untrusted CA is rejected`() {
         val trusted = pki("ui-assistant")
         val other = pki("ui-assistant")
-        val v = AgentSvidVerifier(Optional.of(trusted.caPem), skew)
+        val v = AgentSvidVerifier(Optional.of(trusted.caPem), skew, InMemoryNonceStore())
         val t = ts()
         assertThat(v.verify(other.leafPem, pop(other.leafKey, t, "n"), t, "n", now))
             .isEqualTo(SvidResult.Rejected("certificate not issued by the trusted agent CA"))
@@ -152,7 +153,7 @@ class AgentSvidVerifierTest {
     @Test
     fun `an expired cert is rejected`() {
         val p = pki("ui-assistant", ttl = Duration.ofMinutes(5))
-        val v = AgentSvidVerifier(Optional.of(p.caPem), skew)
+        val v = AgentSvidVerifier(Optional.of(p.caPem), skew, InMemoryNonceStore())
         val later = now.plus(Duration.ofMinutes(10))
         val t = ts(later)
         assertThat(v.verify(p.leafPem, pop(p.leafKey, t, "n"), t, "n", later))
@@ -162,7 +163,7 @@ class AgentSvidVerifierTest {
     @Test
     fun `a stale timestamp is rejected`() {
         val p = pki("ui-assistant")
-        val v = AgentSvidVerifier(Optional.of(p.caPem), skew)
+        val v = AgentSvidVerifier(Optional.of(p.caPem), skew, InMemoryNonceStore())
         val staleTs = ts(now.minusSeconds(120))
         assertThat(v.verify(p.leafPem, pop(p.leafKey, staleTs, "n"), staleTs, "n", now))
             .isEqualTo(SvidResult.Rejected("stale or future timestamp"))
@@ -171,7 +172,7 @@ class AgentSvidVerifierTest {
     @Test
     fun `a replayed nonce is rejected on second use`() {
         val p = pki("ui-assistant")
-        val v = AgentSvidVerifier(Optional.of(p.caPem), skew)
+        val v = AgentSvidVerifier(Optional.of(p.caPem), skew, InMemoryNonceStore())
         val t = ts()
         val sig = pop(p.leafKey, t, "n1")
         assertThat(v.verify(p.leafPem, sig, t, "n1", now)).isEqualTo(SvidResult.Verified("ui-assistant"))
@@ -182,7 +183,7 @@ class AgentSvidVerifierTest {
     fun `a base64-encoded cert and CA verify the same as raw PEM (on-the-wire transport)`() {
         val p = pki("ui-assistant")
         val b64 = { s: String -> Base64.getEncoder().encodeToString(s.toByteArray(Charsets.UTF_8)) }
-        val v = AgentSvidVerifier(Optional.of(b64(p.caPem)), skew)
+        val v = AgentSvidVerifier(Optional.of(b64(p.caPem)), skew, InMemoryNonceStore())
         val t = ts()
         assertThat(v.verify(b64(p.leafPem), pop(p.leafKey, t, "n1"), t, "n1", now))
             .isEqualTo(SvidResult.Verified("ui-assistant"))

--- a/openbank-agent-service/src/test/kotlin/com/openbank/agent/infrastructure/mcp/McpEndpointIdentityTest.kt
+++ b/openbank-agent-service/src/test/kotlin/com/openbank/agent/infrastructure/mcp/McpEndpointIdentityTest.kt
@@ -20,6 +20,7 @@ import com.openbank.agent.domain.policy.AgentIdentity
 import com.openbank.agent.domain.policy.EnforcementMode
 import com.openbank.agent.domain.policy.GateOutcome
 import com.openbank.agent.domain.policy.PolicyDecision
+import com.openbank.agent.infrastructure.security.InMemoryNonceStore
 import com.openbank.libs.audit.AuditEvent
 import com.openbank.libs.audit.AuditEventPublisher
 import io.mockk.coVerify
@@ -100,7 +101,7 @@ class McpEndpointIdentityTest {
             this.auditPublisher = this@McpEndpointIdentityTest.auditPublisher
             this.svid = if (svidResult == SvidResult.Disabled) {
                 // Use the real disabled verifier for the existing D3a tests (unchanged).
-                AgentSvidVerifier(caCertPem = Optional.empty(), maxSkewSeconds = 60)
+                AgentSvidVerifier(caCertPem = Optional.empty(), maxSkewSeconds = 60, nonceStore = InMemoryNonceStore())
             } else {
                 svidMock
             }
@@ -273,7 +274,8 @@ class McpEndpointIdentityTest {
                         Principal { "op" }
                 }
             this.auditPublisher = this@McpEndpointIdentityTest.auditPublisher
-            this.svid = AgentSvidVerifier(caCertPem = Optional.empty(), maxSkewSeconds = 60)
+            this.svid =
+                AgentSvidVerifier(caCertPem = Optional.empty(), maxSkewSeconds = 60, nonceStore = InMemoryNonceStore())
             this.svidEnforced = false
             this.headers =
                 mockk {

--- a/openbank-agent-service/src/test/kotlin/com/openbank/agent/infrastructure/security/NonceStoreCrossReplicaTest.kt
+++ b/openbank-agent-service/src/test/kotlin/com/openbank/agent/infrastructure/security/NonceStoreCrossReplicaTest.kt
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+
+package com.openbank.agent.infrastructure.security
+
+import com.openbank.agent.application.port.out.NonceStore
+import io.mockk.every
+import io.mockk.mockk
+import io.quarkus.redis.datasource.ReactiveRedisDataSource
+import io.quarkus.redis.datasource.value.ReactiveValueCommands
+import io.quarkus.redis.datasource.value.SetArgs
+import io.smallrye.mutiny.Uni
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * Proves the cross-replica half of issue #4728: a nonce claimed on one pod must be visible to a
+ * sibling pod so a replayed PoP is rejected everywhere, not just on the pod that saw it first.
+ *
+ * WHAT THIS TEST IS SIMULATING
+ *
+ * Two independently-constructed [NonceStore] instances stand in for two `AgentSvidVerifier`
+ * beans running in two different pods. Real infra (a shared Redis/Valkey `Deployment` per
+ * namespace — `openbank-infra/gitops/components/agent/redis.yaml`) is stood in for by a single
+ * `backing` map that both [RedisNonceStore] instances read and write, exactly the way both pods
+ * would really talk to the one Redis instance. A Testcontainers Redis would prove the same thing
+ * with a live network hop, but not exercise the wiring any more than this does — the property
+ * under test is "two instances observe the same underlying store", and a mocked
+ * [ReactiveRedisDataSource] backed by a real shared map demonstrates exactly that (the same
+ * technique `RedisApprovalStoreTest`/`RedisIdempotencyStoreTest` in `openbank-libs-runtime` use
+ * to avoid a Docker dependency for the only test of a security invariant).
+ *
+ * RED ON [InMemoryNonceStore]
+ *
+ * Swap [newRedisStore] for two *separate* [InMemoryNonceStore] instances in the first test and it
+ * goes red — each pod's `ConcurrentHashMap` only ever sees its own claims, so pod B accepts the
+ * exact nonce pod A already consumed. That is the bug this issue describes; the second test pins
+ * it down explicitly as the contrasting case.
+ */
+class NonceStoreCrossReplicaTest {
+
+    private fun newRedisStore(backing: MutableMap<String, String>): NonceStore {
+        val values = mockk<ReactiveValueCommands<String, String>>()
+        every { values.setGet(any<String>(), any<String>(), any<SetArgs>()) } answers {
+            val key = firstArg<String>()
+            val value = secondArg<String>()
+            val previous = backing[key]
+            if (previous == null) backing[key] = value
+            Uni.createFrom().item(previous)
+        }
+        val redisDataSource = mockk<ReactiveRedisDataSource>()
+        every { redisDataSource.value(String::class.java) } returns values
+        return RedisNonceStore().apply { redis = redisDataSource }
+    }
+
+    @Test
+    fun `a nonce claimed on pod A is rejected as a replay on pod B (shared Redis)`() {
+        val sharedRedis = mutableMapOf<String, String>()
+        val podA = newRedisStore(sharedRedis)
+        val podB = newRedisStore(sharedRedis)
+
+        val firstClaim = runBlocking { podA.claim("nonce-1", 60L) }
+        val secondClaim = runBlocking { podB.claim("nonce-1", 60L) }
+
+        assertThat(firstClaim).describedAs("pod A sees this nonce for the first time").isTrue()
+        assertThat(secondClaim)
+            .describedAs(
+                "pod B must see pod A's claim through the shared store and refuse the replay — " +
+                    "on the old per-pod ConcurrentHashMap this would wrongly be true (#4728)",
+            )
+            .isFalse()
+    }
+
+    @Test
+    fun `contrast — two UNSHARED in-memory stores each accept the same nonce (the bug this replaces)`() {
+        val podA: NonceStore = InMemoryNonceStore()
+        val podB: NonceStore = InMemoryNonceStore()
+
+        val firstClaim = runBlocking { podA.claim("nonce-1", 60L) }
+        val secondClaim = runBlocking { podB.claim("nonce-1", 60L) }
+
+        assertThat(firstClaim).isTrue()
+        assertThat(secondClaim)
+            .describedAs(
+                "each pod's in-memory map is independent, so pod B wrongly accepts a nonce pod A " +
+                    "already consumed — exactly the weakened replay guard #4728 describes, and why " +
+                    "InMemoryNonceStore is only the offline-buildable default, never the deployed binding",
+            )
+            .isTrue()
+    }
+}

--- a/openbank-infra/gitops/components/agent/agent-service.yaml
+++ b/openbank-infra/gitops/components/agent/agent-service.yaml
@@ -152,6 +152,12 @@ spec:
               valueFrom: { secretKeyRef: { name: agent-db-app, key: username } }
             - name: QUARKUS_DATASOURCE_PASSWORD
               valueFrom: { secretKeyRef: { name: agent-db-app, key: password } }
+            # Cross-replica PoP nonce replay guard (ADR-0031 D3b, issue #4728): RedisNonceStore,
+            # bound only when agent.identity.svid.nonce-store=redis (build-time, set below in the
+            # image build step). Named agent-redis (not the bare per-ns `redis`) because
+            # `platform` is a shared namespace — see redis.yaml.
+            - name: QUARKUS_REDIS_HOSTS
+              value: redis://agent-redis.platform.svc:6379
             - name: QUARKUS_OTEL_EXPORTER_OTLP_ENDPOINT
               value: "http://tempo.observability.svc:4317"
             - name: OTEL_TRACES_SAMPLER_ARG

--- a/openbank-infra/gitops/components/agent/network-policies.yaml
+++ b/openbank-infra/gitops/components/agent/network-policies.yaml
@@ -27,6 +27,24 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
+  name: agent-redis-ingress-allow-list
+  namespace: platform
+  labels:
+    app.kubernetes.io/part-of: platform
+    openbank.io/derived: gen-network-policies
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: agent-redis
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector: {}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
   name: agent-service-ingress-allow-list
   namespace: platform
   labels:

--- a/openbank-infra/gitops/components/agent/redis.yaml
+++ b/openbank-infra/gitops/components/agent/redis.yaml
@@ -1,0 +1,96 @@
+# Cross-replica PoP nonce replay guard for agent-service (ADR-0031 D3b, issue #4728).
+# RedisNonceStore backs AgentSvidVerifier's single-use nonce claim so a replayed PoP is
+# rejected on every replica, not just the one that first saw it — same shape as the fleet's
+# other TTL-bounded shared caches (RedisIdempotencyStore/RedisApprovalStore in
+# openbank-libs-runtime). Ephemeral on purpose — persistence is disabled (--save ""
+# --appendonly no); a restart just clears in-flight nonce claims, which only re-opens the
+# same replay window a fresh pod already has, not a new one. Prod should use an
+# operator-managed HA Redis. Named agent-redis (not the bare per-ns `redis`) because
+# `platform` is a shared namespace (copilot-service already owns `copilot-redis` there).
+# Pinned to the valkey uid 999/gid 1000 for PSS restricted; /data is a writable emptyDir so
+# the root fs can stay read-only.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: agent-redis
+  namespace: platform
+  labels:
+    app.kubernetes.io/name: agent-redis
+    app.kubernetes.io/part-of: agent-service
+spec:
+  replicas: 1
+  # Terminate-first, deliberately (#3545). This is a single-writer cache on an emptyDir
+  # behind one ClusterIP Service: a SURGED second pod would answer half the traffic from an
+  # empty keyspace, so surge is not a property worth keeping here. It also makes the roll
+  # possible at all when the cluster has no room for two pods.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: agent-redis
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: agent-redis
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 999
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: redis
+          image: docker.io/valkey/valkey:8-alpine
+          args: ["--save", "", "--appendonly", "no"]
+          ports:
+            - name: redis
+              containerPort: 6379
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: data
+              mountPath: /data
+          readinessProbe:
+            tcpSocket:
+              port: redis
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: redis
+            initialDelaySeconds: 15
+            periodSeconds: 15
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 500m
+              memory: 192Mi
+      volumes:
+        - name: data
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: agent-redis
+  namespace: platform
+  labels:
+    app.kubernetes.io/name: agent-redis
+spec:
+  selector:
+    app.kubernetes.io/name: agent-redis
+  ports:
+    - name: redis
+      port: 6379
+      targetPort: redis


### PR DESCRIPTION
## Summary

Fixes the `openbank-agent-service` half of issue #4728: `AgentSvidVerifier.seenNonces` was a
per-pod `ConcurrentHashMap<String, Instant>` guarding single-use PoP (proof-of-possession) nonces
for the ADR-0031 D3b SVID identity mechanism. Under N replicas a nonce claimed on pod A was
invisible to pod B, so a replayed PoP simply needed to land on a different pod to be accepted — a
security control (single-use replay protection) that silently weakens in proportion to replica
count, not a caching nit. Latent today only because every canary Rollout runs `replicas: 1`;
#3806 proposes raising exactly that.

Reuses existing fleet infrastructure rather than introducing anything new: `quarkus-redis-client`
is already deployed for ~30 services (`RedisIdempotencyStore`/`RedisApprovalStore` in
`openbank-libs-runtime` are the closest siblings — a TTL-bounded value keyed by a caller token),
and each namespace runs its own small Valkey `Deployment` (`redis.yaml` per component, e.g.
`accounts/redis.yaml`, `copilot/redis.yaml`). `agent-service` had none of this wired yet; this PR
adds it, scoped to the nonce store only.

## What changed

- New port `NonceStore` (`application/port/out/NonceStore.kt`) — `suspend fun claim(nonce, ttl): Boolean`.
- `InMemoryNonceStore` (`infrastructure/security/`) — the `@Default` binding, the exact same
  `ConcurrentHashMap` logic `AgentSvidVerifier` used to inline. Offline-buildable/testable, correct
  only at `replicas: 1` — same role `InMemoryProposalStore` plays in `analytics-sink`.
- `RedisNonceStore` (`infrastructure/security/`) — `@Alternative @Priority(100)`, gated at BUILD
  time by `agent.identity.svid.nonce-store=redis`, exactly the pattern `analytics-sink`'s
  `ClickHouseProposalStore` uses for `openbank.analytics.sink.type=clickhouse`. Uses a single
  atomic `SET key value NX EX ttl GET` (`ReactiveValueCommands.setGet` + `SetArgs().nx().ex(ttl)`)
  — claims the key only if absent and reports the prior value in one round trip, so there's no
  separate SETNX+EXPIRE race.
- `AgentSvidVerifier` now takes an injected `NonceStore` instead of owning the map; `consumeNonce`
  bridges to the suspend port via `runBlocking`, the same bridge this service's `McpEndpoint`
  already uses for `auditPublisher.publish(...)` from its synchronous JAX-RS/`@Blocking`-worker
  call path.
- `build.gradle.kts`: added `quarkus-redis-client`.
- `application.yaml`: `agent.identity.svid.nonce-store` (empty by default; env `AGENT_SVID_NONCE_STORE`)
  and a `quarkus.redis.hosts` local default (docker-compose already wired `QUARKUS_REDIS_HOSTS` for
  this service, unused until now).
- `openbank-infra/gitops/components/agent/redis.yaml`: new `agent-redis` Deployment+Service in the
  `platform` namespace (shared with `copilot-service`, which already owns `copilot-redis` there —
  same naming convention). Ephemeral (`--save "" --appendonly no`) like every other per-namespace
  Redis in this fleet — a restart just clears in-flight nonce claims, reopening the same replay
  window a fresh pod already has, not a new one.
- `agent-service.yaml`: wires `QUARKUS_REDIS_HOSTS=redis://agent-redis.platform.svc:6379`.
- `.github/workflows/auto-deploy.yml`: sets `AGENT_SVID_NONCE_STORE=redis` for the agent-service
  build step, mirroring `ANALYTICS_SINK_TYPE=clickhouse` right above it (same `@IfBuildProperty`
  augmentation-time trap — a runtime env var cannot reach it).

## Tests

- `NonceStoreCrossReplicaTest` (new): two independently-constructed `RedisNonceStore` instances
  sharing one mocked backing map (standing in for two pod replicas talking to the same Redis —
  same mockk-backed-by-a-real-map technique `RedisApprovalStoreTest`/`RedisIdempotencyStoreTest`
  use to avoid a Docker dependency for a security-invariant test) prove a nonce claimed by "pod A"
  is rejected as a replay by "pod B". A second test pins down the contrasting case explicitly: two
  *unshared* `InMemoryNonceStore` instances each wrongly accept the same nonce — the exact bug this
  PR fixes, and why `InMemoryNonceStore` stays the offline default but is never the deployed binding.
- `AgentSvidVerifierTest` / `McpEndpointIdentityTest`: updated call sites (constructor now takes a
  `NonceStore`), behavior unchanged — all 9 + 6 existing cases still pass, including the existing
  same-pod replay test.
- `McpEndpointRoutingIT` / `ProposalApiIT` (existing `@QuarkusTest` boot ITs): re-ran to confirm the
  new `quarkus-redis-client` dependency doesn't break service boot when Redis isn't reachable in the
  test profile (it doesn't — the client connects lazily, and `nonce-store` stays unset/in-memory in
  `%test`).

## Money-path / review

`openbank-agent-service` is not in `rules.yaml: money_path_services`. Standard review applies.

## What's out of scope for this PR (rest of #4728)

- `openbank-security-scanner`'s `IctIncidentService` and `SecurityScannerService` — being handled
  by #4939/#4940 (both open as of this writing); this PR does not touch that service.
- `openbank-customer-edge/.../PaymentSessionStore.kt` — the issue itself notes this one already
  carries an honest comment marking it a deliberate, tracked follow-up; not touched here.
- `openbank-analytics-sink/.../InMemoryProposalStore.kt` — investigated as part of this same task
  and found to be a NON-issue: `openbank-analytics-sink` already ships a durable, cross-replica
  `ClickHouseProposalStore` (`@Alternative @Priority(100)`, gated by
  `openbank.analytics.sink.type=clickhouse`), and that binding is what `auto-deploy.yml` actually
  builds (`ANALYTICS_SINK_TYPE: clickhouse`) — `InMemoryProposalStore` is only the offline-buildable
  `@Default` for local dev/tests, matching this exact service's convention for every other adapter
  (`AnalyticsSink`, `WormArchive`, `WarehouseStateReader`). No code change needed there; #4728's
  table should be corrected. Separately (found while verifying this, not itself a durability gap):
  `SensitiveReloadService.approve()/reject()` do a read-then-blind-write against `ProposalStore`
  with no compare-and-set, so two concurrent decisions on the same proposal can both win — the same
  class of lost-update bug `CompliancePackActivationRepository.compareAndSetDecision` fixed for the
  lending-service four-eyes flow. Flagged as a follow-up, not fixed in this PR (out of scope: a
  different bug from #4728's durability concern).

Refs #4728
