### PR TITLE
fix(analytics-sink): close lost-update race in reload proposal decisions

### DIFF
--- a/openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/application/SensitiveReloadService.kt
+++ b/openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/application/SensitiveReloadService.kt
@@ -4,6 +4,7 @@
 
 package com.openbank.analytics.application
 
+import com.openbank.analytics.application.port.out.ProposalDecisionPhase
 import com.openbank.analytics.application.port.out.ProposalStore
 import com.openbank.libs.analytics.BackfillRequest
 import com.openbank.libs.analytics.MakerCheckerViolation
@@ -63,7 +64,12 @@ class SensitiveReloadService {
 
     suspend fun approve(id: String, checker: String, reason: String?): Proposal<BackfillRequest> {
         val proposal = require(id)
+        // Compute the transition first: it is pure (validates PROPOSED + four-eyes, no I/O), so an
+        // invalid call (wrong state, self-approval) throws here and never touches the claim below —
+        // it must not burn the one claim a later, legitimate decision needs. Only a proposal that
+        // WOULD be validly approved right now goes on to contend for the claim.
         val approved = proposal.approve(checker, Instant.now(clock), reason)
+        claimOrThrow(id, ProposalDecisionPhase.DECIDE)
         store.save(approved)
         log.infof(
             "reload approved id=%s by=%s (proposer=%s)",
@@ -75,7 +81,9 @@ class SensitiveReloadService {
     }
 
     suspend fun reject(id: String, checker: String, reason: String?): Proposal<BackfillRequest> {
-        val rejected = require(id).reject(checker, Instant.now(clock), reason)
+        val proposal = require(id)
+        val rejected = proposal.reject(checker, Instant.now(clock), reason)
+        claimOrThrow(id, ProposalDecisionPhase.DECIDE)
         store.save(rejected)
         log.infof("reload rejected id=%s by=%s", id.sanitizeForLog(), checker.sanitizeForLog())
         return rejected
@@ -83,12 +91,16 @@ class SensitiveReloadService {
 
     /**
      * Executes an APPROVED proposal: runs the actual reload, then marks it EXECUTED so it cannot run
-     * twice. The maker-checker invariant is upheld by [Proposal.markExecuted] (only APPROVED → EXECUTED).
+     * twice. The maker-checker invariant is upheld by [Proposal.markExecuted] (only APPROVED → EXECUTED)
+     * plus the [ProposalDecisionPhase.EXECUTE] claim, which is won BEFORE [BackfillService.run] so two
+     * concurrent callers cannot both trigger the (expensive, side-effecting) backfill itself — only
+     * the claim's winner ever reaches [BackfillService.run].
      */
     suspend fun execute(id: String): BackfillReport {
         val proposal = require(id)
-        // Transition first (fails fast if not APPROVED), persist, then load.
+        // Pure transition first — fails fast (and claims nothing) if not APPROVED.
         val executing = proposal.markExecuted(Instant.now(clock))
+        claimOrThrow(id, ProposalDecisionPhase.EXECUTE)
         val report = backfill.run(proposal.action)
         store.save(executing)
         log.infof(
@@ -105,4 +117,18 @@ class SensitiveReloadService {
 
     private suspend fun require(id: String): Proposal<BackfillRequest> =
         store.get(id) ?: throw MakerCheckerViolation("no such proposal: $id")
+
+    /**
+     * The compare-and-set gate a decision/execution must win before it is persisted (or, for
+     * [ProposalDecisionPhase.EXECUTE], before the real backfill runs). See [ProposalStore.claim]'s
+     * KDoc: without this, two concurrent calls can both observe the same pre-transition state, both
+     * pass [Proposal]'s own state check, and both write — a lost update on this four-eyes control
+     * (ADR-0023 F3). Called only AFTER the pure domain transition has already validated the call, so
+     * an invalid call never consumes the claim a legitimate later call would need.
+     */
+    private suspend fun claimOrThrow(id: String, phase: ProposalDecisionPhase) {
+        if (!store.claim(id, phase)) {
+            throw MakerCheckerViolation("proposal '$id' $phase was already claimed by another decision")
+        }
+    }
 }

--- a/openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/application/port/out/ProposalStore.kt
+++ b/openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/application/port/out/ProposalStore.kt
@@ -18,8 +18,27 @@ import com.openbank.libs.analytics.Proposal
  * them in a map so the service is offline-buildable; a ClickHouse/Postgres-free durable adapter (e.g.
  * the audit service or an object store) is the documented follow-up.
  */
+/**
+ * The two phases a [Proposal] transition must be claimed for before it is computed and persisted.
+ * [DECIDE] covers approve/reject (mutually exclusive — only one decision may ever win a proposal);
+ * [EXECUTE] covers the one-time backfill run.
+ */
+enum class ProposalDecisionPhase { DECIDE, EXECUTE }
+
 interface ProposalStore {
     suspend fun save(proposal: Proposal<BackfillRequest>)
     suspend fun get(id: String): Proposal<BackfillRequest>?
     suspend fun list(): List<Proposal<BackfillRequest>>
+
+    /**
+     * Atomically claims [phase] for the proposal at [id]. The first caller for a given (id, phase)
+     * pair wins (`true`); every other concurrent — or later — caller for the same pair loses
+     * (`false`) and must treat that as a refusal with no side effect.
+     *
+     * This is the compare-and-set primitive maker-checker relies on. A `get`-then-`save` pair is
+     * NOT enough: two concurrent decisions can both observe [com.openbank.libs.analytics.ProposalState.PROPOSED],
+     * both pass the domain's state check, and both write — a lost update on a segregation-of-duties
+     * control. Callers MUST call [claim] before computing the transition, not after.
+     */
+    suspend fun claim(id: String, phase: ProposalDecisionPhase): Boolean
 }

--- a/openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/infrastructure/proposal/ClickHouseProposalStore.kt
+++ b/openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/infrastructure/proposal/ClickHouseProposalStore.kt
@@ -6,6 +6,7 @@ package com.openbank.analytics.infrastructure.proposal
 
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.analytics.application.port.out.ProposalDecisionPhase
 import com.openbank.analytics.application.port.out.ProposalStore
 import com.openbank.analytics.infrastructure.clickhouse.ClickHouseClient
 import com.openbank.libs.analytics.BackfillRequest
@@ -22,6 +23,7 @@ import java.time.Instant
 import java.time.LocalDateTime
 import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
+import java.util.concurrent.ConcurrentHashMap
 
 /**
  * ClickHouse-backed [ProposalStore]: the durable maker-checker decision trail (ADR-0023, F3).
@@ -29,8 +31,9 @@ import java.time.format.DateTimeFormatter
  * Each state transition is written as a new row into `reload_proposals`; the table's
  * `ReplacingMergeTree(updated_at)` keeps the latest transition, and reads use `FINAL` so a proposal's
  * **current** state (and full lineage of who proposed / approved / executed) survives a restart and
- * is queryable as audit evidence. This makes F3 fully GREEN: the segregation-of-duties *logic* was
- * already real (the Proposal state machine), and now the trail is durable rather than in-memory.
+ * is queryable as audit evidence. The segregation-of-duties *logic* lives in the [Proposal] state
+ * machine and the atomic [claim] below; this class makes the resulting trail durable rather than
+ * in-memory. See [claim]'s KDoc for exactly what its compare-and-set does and does not cover.
  *
  * It is the `@Alternative @Priority(100)` binding behind the `@Default` [InMemoryProposalStore],
  * gated at build time by `openbank.analytics.sink.type=clickhouse`. Row building and parsing are pure
@@ -51,9 +54,42 @@ open class ClickHouseProposalStore : ProposalStore {
     @Inject
     lateinit var clock: Clock
 
+    /**
+     * The compare-and-set primitive for [claim], scoped to THIS POD.
+     *
+     * ClickHouse's `ReplacingMergeTree` (what `reload_proposals` uses, see below) has no conditional
+     * write: an `INSERT` is always accepted, and `FINAL`/the ReplacingMergeTree merge only decide
+     * which row wins *after the fact*, by `updated_at` — so a `get`-then-`save` pair here has the
+     * exact race this class exists to close (two concurrent decisions both read `PROPOSED`, both
+     * pass the domain's state check, both `save`). `ALTER TABLE ... UPDATE ... WHERE state = :from`
+     * (the Postgres pattern `CompliancePackActivationRepository.compareAndSetDecision` uses) is not
+     * an answer either: ClickHouse mutations are asynchronous background jobs with no synchronous
+     * "rows affected" result, so a caller cannot learn whether it won.
+     *
+     * The one primitive that WOULD give a true, cross-replica compare-and-set — the `KeeperMap`
+     * table engine, backed by ClickHouse Keeper — needs a Keeper ensemble this deployment does not
+     * have: `clickhouse.yaml` runs a single, unreplicated ClickHouse node and says so explicitly
+     * ("production would run a replicated ClickHouse (Keeper + shards)"). Verified directly against
+     * that same image (`clickhouse/clickhouse-server:24.8-alpine`) before writing this comment:
+     * `CREATE TABLE ... ENGINE = KeeperMap(...)` fails with `KeeperMap is disabled because
+     * 'keeper_map_path_prefix' config is not defined` — the engine is not merely undocumented here,
+     * it is actively unavailable, so depending on it would ship a claim that silently never works.
+     *
+     * What IS true today, and is what this closes: `analytics-sink` runs a single replica
+     * (`analytics-sink.yaml`, `replicas: 1`), so a JVM-local claim — the same
+     * `ConcurrentHashMap`-backed compare-and-set [InMemoryProposalStore] uses — closes the race for
+     * every decision this deployment can actually receive. It does NOT protect a decision race split
+     * across multiple pods; scaling this deployment beyond one replica needs a durable claim first
+     * (KeeperMap once ClickHouse Keeper is deployed, or an equivalent). Track that as a precondition
+     * of raising `replicas`, not as something this class already provides.
+     */
+    private val claims = ConcurrentHashMap.newKeySet<String>()
+
     override suspend fun save(proposal: Proposal<BackfillRequest>) {
         clickhouse.insert("reload_proposals", rowJson(proposal, Instant.now(clock)))
     }
+
+    override suspend fun claim(id: String, phase: ProposalDecisionPhase): Boolean = claims.add("$id:$phase")
 
     override suspend fun get(id: String): Proposal<BackfillRequest>? {
         val sql = "SELECT $COLUMNS FROM reload_proposals FINAL WHERE proposal_id = '${escape(id)}' FORMAT JSONEachRow"

--- a/openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/infrastructure/proposal/InMemoryProposalStore.kt
+++ b/openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/infrastructure/proposal/InMemoryProposalStore.kt
@@ -4,6 +4,7 @@
 
 package com.openbank.analytics.infrastructure.proposal
 
+import com.openbank.analytics.application.port.out.ProposalDecisionPhase
 import com.openbank.analytics.application.port.out.ProposalStore
 import com.openbank.libs.analytics.BackfillRequest
 import com.openbank.libs.analytics.Proposal
@@ -21,6 +22,11 @@ class InMemoryProposalStore : ProposalStore {
 
     private val store = ConcurrentHashMap<String, Proposal<BackfillRequest>>()
 
+    // A concurrent set, not a per-proposal flag on the stored Proposal: Set.add() is the atomic
+    // primitive (JDK-guaranteed, no external locking) that turns "claim (id, phase)" into a true
+    // compare-and-set — exactly one caller for a given key ever gets `true` back.
+    private val claims = ConcurrentHashMap.newKeySet<String>()
+
     override suspend fun save(proposal: Proposal<BackfillRequest>) {
         store[proposal.id] = proposal
     }
@@ -28,4 +34,6 @@ class InMemoryProposalStore : ProposalStore {
     override suspend fun get(id: String): Proposal<BackfillRequest>? = store[id]
 
     override suspend fun list(): List<Proposal<BackfillRequest>> = store.values.sortedBy { it.proposedAt }
+
+    override suspend fun claim(id: String, phase: ProposalDecisionPhase): Boolean = claims.add("$id:$phase")
 }

--- a/openbank-analytics-sink/src/test/kotlin/com/openbank/analytics/application/SensitiveReloadServiceConcurrentDecideTest.kt
+++ b/openbank-analytics-sink/src/test/kotlin/com/openbank/analytics/application/SensitiveReloadServiceConcurrentDecideTest.kt
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.analytics.application
+
+import com.openbank.analytics.infrastructure.proposal.InMemoryProposalStore
+import com.openbank.libs.analytics.BackfillRequest
+import com.openbank.libs.analytics.IngestSource
+import com.openbank.libs.analytics.ProposalState
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.time.Instant
+import java.util.concurrent.Callable
+import java.util.concurrent.CyclicBarrier
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+
+/**
+ * The four-eyes decision on an analytics reload proposal (ADR-0023, F3) must be applied AT MOST
+ * ONCE, mirroring `openbank-lending-service`'s `CompliancePackConcurrentDecideIT` for the
+ * compliance-pack four-eyes flow.
+ *
+ * WHY THIS IS NOT COVERED BY [RecoveryFlowsTest]
+ *
+ * That test drives propose -> approve -> execute sequentially, so [SensitiveReloadService]'s
+ * `require(id)` always sees the committed result of the previous call and any bug in the
+ * read-then-write window is invisible. Before [ProposalStore.claim] existed, `approve`/`reject`
+ * read the proposal, decided against that in-memory snapshot, and wrote back — two decisions
+ * arriving together would both observe `PROPOSED`, both pass [com.openbank.libs.analytics.Proposal]'s
+ * own state check, and both write: a lost update on a segregation-of-duties control.
+ *
+ * WHAT THIS TEST DOES
+ *
+ * It races a real `approve` against a real `reject` on the same proposal, over real concurrent
+ * threads, [ROUNDS] times with a fresh proposal each round, and asserts that exactly one of the two
+ * ever succeeds, with the persisted state agreeing with whichever one won. Runs against the
+ * in-memory store (the default, offline-buildable binding) — no container needed, since the
+ * compare-and-set primitive under test ([InMemoryProposalStore.claim]) is a plain JVM data
+ * structure, the same one every binding of [com.openbank.analytics.application.port.out.ProposalStore]
+ * uses for the phase-claim gate (see [com.openbank.analytics.infrastructure.proposal.ClickHouseProposalStore]'s
+ * KDoc for why the ClickHouse binding's claim is scoped the same way).
+ *
+ * Like the lending test, this is a timing test and is honest about being probabilistic: it can only
+ * fail when the race actually interleaves, so it runs [ROUNDS] rounds rather than trusting one. It
+ * cannot produce a false RED — two accepted decisions on one proposal is a defect however the
+ * threads landed.
+ */
+class SensitiveReloadServiceConcurrentDecideTest {
+
+    private companion object {
+        const val ROUNDS = 20
+        const val BARRIER_TIMEOUT_SECONDS = 10L
+    }
+
+    private fun newService(): SensitiveReloadService = SensitiveReloadService().apply {
+        store = InMemoryProposalStore()
+        clock = Clock.systemUTC()
+        backfill = BackfillService()
+    }
+
+    @Test
+    fun `a concurrent approve and reject cannot both be applied to one proposal`() {
+        val service = newService()
+        val pool = Executors.newFixedThreadPool(2)
+        val violations = mutableListOf<String>()
+        try {
+            repeat(ROUNDS) { round ->
+                val proposal = runBlocking {
+                    service.propose(
+                        BackfillRequest(
+                            source = IngestSource.CORRECTION,
+                            from = Instant.parse("2026-01-01T00:00:00Z"),
+                            to = Instant.parse("2026-01-02T00:00:00Z"),
+                            reason = "race probe $round",
+                            requestedBy = "alice",
+                        ),
+                    )
+                }
+                val barrier = CyclicBarrier(2)
+
+                val approve = pool.submit(
+                    decideTask(barrier) {
+                        runBlocking { service.approve(proposal.id, "bob", "race") }
+                    },
+                )
+                val reject = pool.submit(
+                    decideTask(barrier) { runBlocking { service.reject(proposal.id, "carol", "race") } },
+                )
+                val outcomes = listOf(approve.get(), reject.get())
+
+                val wins = outcomes.count { it }
+                if (wins != 1) {
+                    violations += "proposal ${proposal.id}: expected exactly 1 winner, got $wins (outcomes=$outcomes)"
+                }
+
+                val state = runBlocking { service.get(proposal.id) }?.state
+                val expected = when {
+                    outcomes[0] -> ProposalState.APPROVED
+                    outcomes[1] -> ProposalState.REJECTED
+                    else -> null
+                }
+                if (expected != null && state != expected) {
+                    violations += "proposal ${proposal.id}: winner implies $expected but stored state is $state"
+                }
+            }
+        } finally {
+            pool.shutdownNow()
+        }
+
+        assertThat(violations)
+            .describedAs("four-eyes decisions applied more than once, or a stored state disagreeing with the winner")
+            .isEmpty()
+    }
+
+    private fun decideTask(barrier: CyclicBarrier, decide: () -> Unit) = Callable {
+        barrier.await(BARRIER_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        runCatching(decide).isSuccess
+    }
+}

--- a/openbank-analytics-sink/src/test/kotlin/com/openbank/analytics/infrastructure/clickhouse/ClickHouseAdaptersTest.kt
+++ b/openbank-analytics-sink/src/test/kotlin/com/openbank/analytics/infrastructure/clickhouse/ClickHouseAdaptersTest.kt
@@ -6,6 +6,7 @@ package com.openbank.analytics.infrastructure.clickhouse
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.openbank.analytics.application.port.out.IntegrityAnchor
+import com.openbank.analytics.application.port.out.ProposalDecisionPhase
 import com.openbank.analytics.infrastructure.proposal.ClickHouseProposalStore
 import com.openbank.analytics.infrastructure.reconcile.ClickHouseWarehouseStateReader
 import com.openbank.analytics.infrastructure.worm.ClickHouseWormArchive
@@ -268,5 +269,23 @@ class ClickHouseAdaptersTest {
         assertThat(fetched.id).isEqualTo("prop-1")
         assertThat(fetched.action.aggregateId).isEqualTo("acc-1")
         assertThat(client.lastQuery).contains("FINAL").contains("prop-1")
+    }
+
+    @Test
+    fun `claim wins exactly once per (id, phase) and never touches ClickHouse`() = runBlocking<Unit> {
+        val client = FakeClickHouseClient()
+        val store = ClickHouseProposalStore().apply { clickhouse = client }
+
+        assertThat(store.claim("prop-1", ProposalDecisionPhase.DECIDE)).isTrue()
+        // Same (id, phase) again — the negative case: a second claim on an already-claimed phase
+        // must be refused, not silently accepted.
+        assertThat(store.claim("prop-1", ProposalDecisionPhase.DECIDE)).isFalse()
+        // A different phase on the same proposal is independent.
+        assertThat(store.claim("prop-1", ProposalDecisionPhase.EXECUTE)).isTrue()
+        // A different proposal is independent too.
+        assertThat(store.claim("prop-2", ProposalDecisionPhase.DECIDE)).isTrue()
+
+        assertThat(client.lastInsertTable).isNull()
+        assertThat(client.lastQuery).isNull()
     }
 }


### PR DESCRIPTION
## Summary

- `SensitiveReloadService.approve()`/`reject()`/`execute()` did read-then-blind-write against
  `ProposalStore`: two concurrent decisions on the same proposal could both observe `PROPOSED`,
  both pass the `Proposal` state machine's check, and both write — a lost update on the reload
  maker-checker control (ADR-0023, finding F3).
- Added `ProposalStore.claim(id, phase)`: an atomic compare-and-set, won *after* the pure domain
  transition validates (so an invalid call never burns a claim) but *before* the decision is
  persisted — and, for `execute`, before the real backfill runs, so two racing executes can't both
  trigger the reload.
- `InMemoryProposalStore` and `ClickHouseProposalStore` both implement `claim` with a JVM-local
  `ConcurrentHashMap` set. This fully closes the race for `analytics-sink`'s actual deployed
  topology (`replicas: 1`, per `openbank-infra/gitops/components/analytics/analytics-sink.yaml`).
- `ClickHouseProposalStore`'s KDoc documents why a cross-replica CAS isn't available today:
  `ReplacingMergeTree` has no conditional write, and `KeeperMap` (ClickHouse's real CAS primitive)
  needs a Keeper ensemble the sandbox ClickHouse doesn't run — verified directly against the same
  image this deployment uses (`clickhouse/clickhouse-server:24.8-alpine`), which fails table
  creation with `KeeperMap is disabled because 'keeper_map_path_prefix' config is not defined`.
  Scaling `analytics-sink` beyond one replica needs a durable claim primitive first.

Neither `openbank-analytics-sink` nor `openbank-agent-service` is money-path per `rules.yaml`, but
this is a real correctness gap in a compliance control. Found while investigating #4728 (a
different, already-addressed durability concern for the same store).

## Test plan

- [x] `SensitiveReloadServiceConcurrentDecideTest` — races a real `approve` against a real `reject`
      on the same proposal over 20 rounds, asserts exactly one winner and that the persisted state
      agrees with the winner.
- [x] Verified the test actually catches the bug: reverted the `claim` calls, reran — test went red;
      restored, reran — green.
- [x] `ClickHouseAdaptersTest` — new case proving `claim` wins exactly once per `(id, phase)` and
      never touches ClickHouse.
- [x] `./gradlew :openbank-analytics-sink:ktlintCheck :openbank-analytics-sink:detekt :openbank-analytics-sink:test` green.
