### PR TITLE
fix(libs-runtime): stop Quarkus Arc's generated subclass name leaking into the outbox service tag

### DIFF
--- a/openbank-libs-runtime/src/main/kotlin/com/openbank/libs/persistence/outbox/AbstractOutboxDispatcher.kt
+++ b/openbank-libs-runtime/src/main/kotlin/com/openbank/libs/persistence/outbox/AbstractOutboxDispatcher.kt
@@ -67,6 +67,20 @@ abstract class AbstractOutboxDispatcher {
      * `TppOutboxDispatcher` (`tpp-registry`, not `tpp`), `DomesticPaymentOutboxDispatcher`
      * (`domestic`, not `domestic-payment`). A new dispatcher whose class name does not already
      * match its own gauge's `service` must override this the same way.
+     *
+     * **`this::class.java.simpleName` is NOT the class you wrote (issue #5143).** This getter is
+     * inherited from the abstract base, so `this` at the call site is Quarkus Arc's generated
+     * bean subclass, not the developer's `LedgerOutboxDispatcher` — `simpleName` came back
+     * `"LedgerOutboxDispatcher_Subclass"` in production, confirmed live: the first real dispatch
+     * on `ledger-service` after this mechanism deployed recorded
+     * `openbank_outbox_dispatched_total{service="ledger-outbox-dispatcher_-subclass",...}` while
+     * the sibling `openbank_outbox_backlog` gauge on the SAME dispatcher, same pod, same moment,
+     * correctly read `service="ledger"` — that gauge's `service` is `abstract`, forcing an
+     * explicit value per subclass, which is exactly why it was never exposed to this bug. Not an
+     * edge case: `@ApplicationScoped` is the standard scope every dispatcher in the fleet uses,
+     * so every one relying on the default derivation was affected, and the 3 overrides above were
+     * immune only by coincidence (they exist for a naming disagreement, not this). See
+     * [deriveServiceName] for the fix.
      */
     protected open val service: String get() = deriveServiceName(this::class.java.simpleName)
 
@@ -121,8 +135,21 @@ abstract class AbstractOutboxDispatcher {
         val log: Logger = Logger.getLogger(AbstractOutboxDispatcher::class.java)
         const val DEFAULT_BATCH_SIZE: Int = OutboxDispatch.DEFAULT_BATCH_SIZE
 
-        /** `FooBarOutboxDispatcher` -> `foo-bar`. See [service] for why this exists. */
+        /**
+         * `FooBarOutboxDispatcher` -> `foo-bar`. See [service] for why this exists.
+         *
+         * `substringBefore('_')` strips a Quarkus Arc-generated bean subclass suffix
+         * (`_Subclass`, `_ClientProxy`, ...) BEFORE the kebab-case step — required because
+         * [simpleClassName] is read via `this::class.java.simpleName` from a method inherited
+         * from this abstract class, so at runtime `this` is Arc's generated instance, not the
+         * developer's class (issue #5143). Cutting at the first underscore rather than
+         * enumerating Arc's exact suffix vocabulary is deliberate: no dispatcher class name in
+         * the fleet contains one (`git grep '^class.*OutboxDispatcher'` — none do, and this
+         * repo's naming convention is PascalCase throughout), so it is a safe general strip that
+         * does not need updating if a future Quarkus version generates a different marker.
+         */
         internal fun deriveServiceName(simpleClassName: String): String = simpleClassName
+            .substringBefore('_')
             .removeSuffix("OutboxDispatcher")
             .replace(Regex("(?<!^)(?=[A-Z])"), "-")
             .lowercase()

--- a/openbank-libs-runtime/src/test/kotlin/com/openbank/libs/persistence/outbox/AbstractOutboxDispatcherTest.kt
+++ b/openbank-libs-runtime/src/test/kotlin/com/openbank/libs/persistence/outbox/AbstractOutboxDispatcherTest.kt
@@ -209,4 +209,21 @@ class AbstractOutboxDispatcherTest {
         assertThat(AbstractOutboxDispatcher.deriveServiceName("StandingOrderOutboxDispatcher"))
             .isEqualTo("standing-order")
     }
+
+    // Issue #5143: `this::class.java.simpleName`, read from a method inherited from THIS abstract
+    // class, is Quarkus Arc's generated bean subclass name at runtime, not the developer's class.
+    // Reproduces the exact string observed live in production on the first real dispatch after
+    // this mechanism deployed: openbank_outbox_dispatched_total{service=
+    // "ledger-outbox-dispatcher_-subclass"} where the sibling openbank_outbox_backlog gauge (whose
+    // `service` is `abstract`, not derived) correctly read "ledger" on the same dispatcher, same
+    // pod, same moment. A plain unit-test instantiation (`class Foo(...) : AbstractOutboxDispatcher()`,
+    // as every other case in this file uses) never goes through Arc, so it cannot catch this class
+    // of bug -- this test supplies the exact runtime-observed string directly instead.
+    @Test
+    fun `strips a Quarkus Arc-generated bean subclass suffix before deriving the service name`() {
+        assertThat(AbstractOutboxDispatcher.deriveServiceName("LedgerOutboxDispatcher_Subclass"))
+            .isEqualTo("ledger")
+        assertThat(AbstractOutboxDispatcher.deriveServiceName("PartyOutboxDispatcher_ClientProxy"))
+            .isEqualTo("party")
+    }
 }


### PR DESCRIPTION
## What

Fixes #5143 — found by live verification of #5071 immediately after it deployed (this session's own persistent monitor caught the first real dispatch).

## Live evidence

First real dispatch on `ledger-service` after the outbox-metrics mechanism deployed:

```
openbank_outbox_dispatched_total{service="ledger-outbox-dispatcher_-subclass", topic="AccountingDayTransitioned"} 2
```

Expected `service="ledger"` — confirmed by the sibling gauge on the **exact same dispatcher, same pod, same moment**:

```
openbank_outbox_backlog{service="ledger"} 0
```

## Root cause

```kotlin
protected open val service: String get() = deriveServiceName(this::class.java.simpleName)
```

`dispatchScheduledBatch` (and this getter) is inherited from the abstract base class. Quarkus Arc wraps every `@ApplicationScoped` bean in a generated subclass to support interception, so at runtime `this` is Arc's instance — `this::class.java.simpleName` returns `"LedgerOutboxDispatcher_Subclass"`, not `"LedgerOutboxDispatcher"`.

`removeSuffix("OutboxDispatcher")` does nothing against a string that no longer ends in that suffix; the kebab-case step then runs on the whole synthetic name and produces exactly the garbled tag observed.

**Not an edge case.** `@ApplicationScoped` is the standard scope every dispatcher in the fleet uses — every dispatcher relying on the default derivation was affected. The 3 dispatchers #5071 gave an explicit override (`card-issuance`, `tpp-registry`, `domestic-payment`) were immune only by coincidence, for an unrelated naming disagreement (their derived name would've disagreed with their own gauge's tag even without this bug). `AbstractOutboxBacklogGauge.service` is `abstract` — no derivation, every subclass states it explicitly — which is exactly why the sibling gauge was never exposed to this class of bug.

## Fix

Strip everything from the first underscore before deriving:

```kotlin
internal fun deriveServiceName(simpleClassName: String): String = simpleClassName
    .substringBefore('_')
    .removeSuffix("OutboxDispatcher")
    .replace(Regex("(?<!^)(?=[A-Z])"), "-")
    .lowercase()
```

Cutting at the first `_` rather than enumerating Arc's exact suffix vocabulary (`_Subclass`, `_ClientProxy`, ...) is deliberate: no dispatcher class name in the fleet contains an underscore (`git grep '^class.*OutboxDispatcher'` across the whole tree — zero matches), so this is a safe general strip that doesn't need updating if a future Quarkus version generates a different marker.

## Why the extensive #5071 test suite didn't catch this

Every existing test instantiates the dispatcher directly — `class Foo(...) : AbstractOutboxDispatcher()` — which never goes through Arc, so `this::class.java.simpleName` returns the real class name in every unit test. This bug is invisible to any test that doesn't run through the actual CDI container, which is exactly why it had to be caught live rather than by the (already thorough) test suite #5071 shipped.

## Verified

- Reproduced the exact bug first: a standalone Python re-implementation of the *old* `deriveServiceName` against `"LedgerOutboxDispatcher_Subclass"` produces `"ledger-outbox-dispatcher_-subclass"` — byte-for-byte the string observed in production — before touching the fix.
- New test pins the exact live-observed input: `deriveServiceName("LedgerOutboxDispatcher_Subclass") == "ledger"`.
- `AbstractOutboxDispatcherTest`: **8/8** (was 6, +2 new).
- `ktlintCheck`, `detekt` — clean.
- `quarkusBuild` — green on `ledger-service`.
- Local `run-gates.py --all`: **150/151** (the one failure, `api-contract-gate`, needs `sudo` locally and reproduces on a clean `origin/main` worktree).

## After merge

Once deployed, will re-check `openbank_outbox_dispatched_total{service="ledger"}` on the next real dispatch — same live-verification discipline that caught this in the first place.

Refs #5143, #5071, #5049
