### PR TITLE
feat(admin-ui): unify party operations workspace

### DIFF
--- a/openbank-admin-ui/src/app/parties/[id]/page.tsx
+++ b/openbank-admin-ui/src/app/parties/[id]/page.tsx
@@ -15,6 +15,7 @@ import { AuthGuard } from '@/components/auth/AuthGuard'
 import { svcUrl, classifyBffFailure } from '@/lib/services/bff'
 import { EntityChip } from '@/components/entities/EntityChip'
 import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
+import { PageHeader } from '@/components/ui/PageHeader'
 import { opsMessageApi, OPERATOR_MESSAGE_TEMPLATE_VARS, type OperatorMessageTemplate, type ComposeMessageRequest } from '@/lib/api'
 
 const PAGE_SIZE = 25
@@ -109,27 +110,18 @@ function PartyDetailPage() {
 
   return (
     <div>
-      <div className="page-header">
-        <div>
-          <div className="breadcrumb">
-            <span>OpenBank</span><span className="breadcrumb-sep">/</span>
-            <Link href="/parties" style={{ color: 'var(--text-secondary)', textDecoration: 'none' }}>{t('Subjekty', 'Parties')}</Link>
-            <span className="breadcrumb-sep">/</span>
-            <span className="breadcrumb-current">{party.legalName}</span>
-          </div>
-          <h1 className="page-title" style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-            <Users size={18} style={{ color: 'var(--accent)' }} />
-            {party.legalName}
-          </h1>
-          <p className="page-subtitle" style={{ fontFamily: 'var(--font-mono)', fontSize: '12px' }}>{party.id}</p>
-        </div>
-        <div style={{ display: 'flex', gap: '8px' }}>
-          <button className="btn btn-secondary" onClick={load}><RefreshCw size={13} /> {t('Obnovit', 'Refresh')}</button>
+      <PageHeader
+        icon={<Users size={18} aria-hidden="true" />}
+        title={party.legalName}
+        subtitle={party.id}
+        breadcrumb={<div className="breadcrumb"><span>OpenBank</span><span className="breadcrumb-sep">/</span><Link href="/parties" style={{ color: 'var(--text-secondary)', textDecoration: 'none' }}>{t('Subjekty', 'Parties')}</Link><span className="breadcrumb-sep">/</span><span className="breadcrumb-current">{party.legalName}</span></div>}
+        actions={<div style={{ display: 'flex', gap: '8px' }}>
+          <button className="btn btn-secondary" onClick={load}><RefreshCw size={13} aria-hidden="true" /> {t('Obnovit', 'Refresh')}</button>
           <Link href="/parties" className="btn btn-secondary" style={{ textDecoration: 'none', display: 'flex', alignItems: 'center', gap: '6px' }}>
-            <ArrowLeft size={13} /> {t('Zpět', 'Back')}
+            <ArrowLeft size={13} aria-hidden="true" /> {t('Zpět', 'Back')}
           </Link>
-        </div>
-      </div>
+        </div>}
+      />
 
       {/* Loop var is `item`, never `t` — a callback param named `t` shadows the translation
           function (see openbank-admin-ui/CLAUDE.md rule #4; sanctions/page.tsx does this). */}

--- a/openbank-admin-ui/src/app/parties/new/page.tsx
+++ b/openbank-admin-ui/src/app/parties/new/page.tsx
@@ -9,6 +9,7 @@ import { useRouter } from 'next/navigation'
 import Link from 'next/link'
 import { Users, ArrowLeft, Save } from 'lucide-react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
+import { PageHeader } from '@/components/ui/PageHeader'
 
 const PARTY_SERVICE = '/api/svc/party-service'
 
@@ -66,24 +67,13 @@ export default function NewPartyPage() {
 
   return (
     <div>
-      <div className="page-header">
-        <div>
-          <div className="breadcrumb">
-            <span>OpenBank</span><span className="breadcrumb-sep">/</span>
-            <Link href="/parties" style={{ color: 'var(--text-secondary)', textDecoration: 'none' }}>Parties</Link>
-            <span className="breadcrumb-sep">/</span>
-            <span className="breadcrumb-current">{t('Nový subjekt', 'New Party')}</span>
-          </div>
-          <h1 className="page-title" style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-            <Users size={18} style={{ color: 'var(--accent)' }} />
-            {t('Registrovat nový subjekt', 'Register New Party')}
-          </h1>
-          <p className="page-subtitle">{t('Vytvořte nového zákazníka nebo společnost v platformě', 'Create a new customer or company in the platform')}</p>
-        </div>
-        <Link href="/parties" className="btn btn-secondary" style={{ textDecoration: 'none', display: 'flex', alignItems: 'center', gap: '6px' }}>
-          <ArrowLeft size={13} /> {t('Zpět', 'Back')}
-        </Link>
-      </div>
+      <PageHeader
+        icon={<Users size={18} aria-hidden="true" />}
+        title={t('Registrovat nový subjekt', 'Register New Party')}
+        subtitle={t('Vytvořte nového zákazníka nebo společnost v platformě', 'Create a new customer or company in the platform')}
+        breadcrumb={<div className="breadcrumb"><span>OpenBank</span><span className="breadcrumb-sep">/</span><Link href="/parties" style={{ color: 'var(--text-secondary)', textDecoration: 'none' }}>{t('Subjekty', 'Parties')}</Link><span className="breadcrumb-sep">/</span><span className="breadcrumb-current">{t('Nový subjekt', 'New Party')}</span></div>}
+        actions={<Link href="/parties" className="btn btn-secondary" style={{ textDecoration: 'none', display: 'flex', alignItems: 'center', gap: '6px' }}><ArrowLeft size={13} aria-hidden="true" /> {t('Zpět', 'Back')}</Link>}
+      />
 
       <form onSubmit={submit}>
         <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '16px' }}>

--- a/openbank-admin-ui/src/app/parties/page.tsx
+++ b/openbank-admin-ui/src/app/parties/page.tsx
@@ -10,6 +10,7 @@ import { Users, Plus, Search, RefreshCw, ChevronRight, ChevronDown } from 'lucid
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { classifyBffFailure, svcUrl } from '@/lib/services/bff'
 import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
+import { PageHeader } from '@/components/ui/PageHeader'
 
 const PAGE_SIZE = 25
 
@@ -144,28 +145,21 @@ export default function PartiesPage() {
 
   return (
     <div>
-      <div className="page-header">
-        <div>
-          <div className="breadcrumb">
-            <span>OpenBank</span><span className="breadcrumb-sep">/</span>
-            <span className="breadcrumb-current">{t('Subjekty', 'Parties')}</span>
-          </div>
-          <h1 className="page-title" style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-            <Users size={18} style={{ color: 'var(--accent)' }} />
-            {t('Subjekty', 'Parties')}
-          </h1>
-          <p className="page-subtitle">{t('Zákazníci a společnosti registrované v platformě', 'Customers and companies registered in the platform')}</p>
-        </div>
-        <div style={{ display: 'flex', gap: '8px' }}>
+      <PageHeader
+        icon={<Users size={18} aria-hidden="true" />}
+        title={t('Subjekty', 'Parties')}
+        subtitle={t('Zákazníci a společnosti registrované v platformě', 'Customers and companies registered in the platform')}
+        breadcrumb={<div className="breadcrumb"><span>OpenBank</span><span className="breadcrumb-sep">/</span><span className="breadcrumb-current">{t('Subjekty', 'Parties')}</span></div>}
+        actions={<div style={{ display: 'flex', gap: '8px' }}>
           <button className="btn btn-secondary" onClick={load} disabled={loading || inSearchMode}>
-            <RefreshCw size={13} style={{ animation: loading ? 'spin 1s linear infinite' : 'none' }} />
+            <RefreshCw size={13} aria-hidden="true" style={{ animation: loading ? 'spin 1s linear infinite' : 'none' }} />
             {t('Obnovit', 'Refresh')}
           </button>
           <Link href="/parties/new" className="btn btn-primary" style={{ display: 'flex', alignItems: 'center', gap: '6px', textDecoration: 'none' }}>
-            <Plus size={13} /> {t('Nový subjekt', 'New Party')}
+            <Plus size={13} aria-hidden="true" /> {t('Nový subjekt', 'New Party')}
           </Link>
-        </div>
-      </div>
+        </div>}
+      />
 
       {/* Search toolbar */}
       <div style={{ display: 'flex', gap: '10px', marginBottom: '16px', alignItems: 'center' }}>


### PR DESCRIPTION
## Summary\n- unify the party list, creation, and detail flow on the shared PageHeader pattern\n- preserve existing BFF calls, validation, permissions, and actions\n- improve semantic icon accessibility without changing data or authorization paths\n\n## Validation\n- npm test -- route-permissions ui-tone render-smoke\n- npm run type-check\n\nRefs #4599