### PR TITLE
fix(audit): publish a percentile histogram for the chain-verify timer

### DIFF
--- a/openbank-audit-service/src/main/kotlin/com/openbank/audit/infrastructure/observability/AuditChainIntegrityGauge.kt
+++ b/openbank-audit-service/src/main/kotlin/com/openbank/audit/infrastructure/observability/AuditChainIntegrityGauge.kt
@@ -6,6 +6,7 @@ package com.openbank.audit.infrastructure.observability
 import com.openbank.audit.infrastructure.persistence.AuditRepository
 import io.micrometer.core.instrument.Gauge
 import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.Timer
 import io.quarkus.runtime.Startup
 import io.quarkus.scheduler.Scheduled
 import jakarta.annotation.PostConstruct
@@ -82,8 +83,19 @@ class AuditChainIntegrityGauge {
     private val unverifiableLegacy = AtomicLong(0)
     private val lastVerifiedEpochSeconds = AtomicLong(0)
 
+    // Registered once, up front, rather than via registry.timer(name) inside verify() (#5049): the
+    // implicit-registration form returns a Timer with NO histogram config, so it publishes only
+    // _count/_sum/_max — the Business KPIs dashboard's histogram_quantile() panel over
+    // openbank_audit_chain_verify_duration_seconds_bucket had nothing to read despite this control
+    // running hourly since #3505. publishPercentileHistogram() is what emits the _bucket series.
+    private lateinit var verifyDurationTimer: Timer
+
     @PostConstruct
     fun register() {
+        verifyDurationTimer = Timer.builder("openbank.audit.chain.verify.duration")
+            .description("Duration of a full audit hash-chain verification walk")
+            .publishPercentileHistogram()
+            .register(registry)
         Gauge.builder("openbank.audit.chain.intact") { intact.get().toDouble() }
             .description("1 when every audit hash-chain link recomputed correctly on the last run, 0 when broken")
             .strongReference(true)
@@ -143,8 +155,7 @@ class AuditChainIntegrityGauge {
             log.errorf(ex, "audit chain verification failed to run — leaving previous gauge values in place")
             return
         }
-        registry.timer("openbank.audit.chain.verify.duration")
-            .record(System.nanoTime() - startedAt, java.util.concurrent.TimeUnit.NANOSECONDS)
+        verifyDurationTimer.record(System.nanoTime() - startedAt, java.util.concurrent.TimeUnit.NANOSECONDS)
 
         intact.set(if (result.intact) 1 else 0)
         checked.set(result.checked)

--- a/openbank-audit-service/src/test/kotlin/com/openbank/audit/infrastructure/observability/AuditChainIntegrityGaugeTest.kt
+++ b/openbank-audit-service/src/test/kotlin/com/openbank/audit/infrastructure/observability/AuditChainIntegrityGaugeTest.kt
@@ -6,6 +6,8 @@ package com.openbank.audit.infrastructure.observability
 import com.openbank.audit.infrastructure.persistence.AuditRepository
 import com.openbank.audit.infrastructure.persistence.ChainVerification
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import io.micrometer.prometheus.PrometheusConfig
+import io.micrometer.prometheus.PrometheusMeterRegistry
 import io.mockk.coEvery
 import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
@@ -126,5 +128,29 @@ class AuditChainIntegrityGaugeTest {
         // reporting a confident, permanent "intact".
         assertThat(registry.gaugeValue("openbank.audit.chain.last.verified.timestamp.seconds"))
             .isEqualTo(0.0)
+    }
+
+    // #5049: openbank_audit_chain_verify_duration_seconds_bucket read as empty on the Business KPIs
+    // dashboard because registry.timer(name) — the implicit-registration form previously used — never
+    // configures a histogram, so it publishes only _count/_sum/_max. SimpleMeterRegistry can't show
+    // this (it isn't Prometheus-shaped), so this test uses the same PrometheusMeterRegistry the
+    // dashboard actually scrapes and asserts a real _bucket sample exists, not just that the timer
+    // has a count.
+    @Test
+    fun `verify duration timer publishes a percentile histogram, so the dashboard's histogram_quantile panel has data`() {
+        val repo = mockk<AuditRepository>()
+        coEvery { repo.verifyChain(any()) } returns
+            ChainVerification(intact = true, checked = 3, unchained = 0, firstBrokenEntryId = null)
+        val registry = PrometheusMeterRegistry(PrometheusConfig.DEFAULT)
+        val g = AuditChainIntegrityGauge()
+        g.registry = registry
+        g.auditRepository = repo
+        g.enabled = true
+        g.register()
+
+        runBlocking { g.verify() }
+
+        val scraped = registry.scrape()
+        assertThat(scraped).contains("openbank_audit_chain_verify_duration_seconds_bucket")
     }
 }


### PR DESCRIPTION
## What

Refs #5049 — fixes the last real gap in the 16-metric sweep: `openbank_audit_chain_verify_duration_seconds_bucket`.

## Investigation

The other 15 metrics in #5049 turned out to already be wired (payments, sanctions, outbox — fixed in #5068/#5079/#5071/#5144; accounts/parties/kyc/sca confirmed already emitting via `DomainMetrics`, no code change needed, issue tracking was stale). This one metric is the exception: the underlying event **is** instrumented — `AuditChainIntegrityGauge.verify()` has timed the chain walk since #3505 — but the timer was never configured to publish a histogram, so the dashboard's `histogram_quantile()` panel had nothing to read.

## Root cause

```kotlin
registry.timer("openbank.audit.chain.verify.duration")
    .record(System.nanoTime() - startedAt, TimeUnit.NANOSECONDS)
```

`registry.timer(name)` is the implicit-registration form — it returns a `Timer` with no histogram configuration, so it publishes only `_count`/`_sum`/`_max`. No `_bucket` series exists to query, and the panel has been empty since the control shipped.

## Fix

Register the timer explicitly in `@PostConstruct`, held in a field the same way the four existing gauges already are (Micrometer only weakly references a gauge's source object; the existing code already documents why a strong-referenced field matters):

```kotlin
verifyDurationTimer = Timer.builder("openbank.audit.chain.verify.duration")
    .description("Duration of a full audit hash-chain verification walk")
    .publishPercentileHistogram()
    .register(registry)
```

`verify()` now records into that instance instead of re-resolving by name every run.

## Tests

Added a test using a real `PrometheusMeterRegistry` — the fleet's actual scrape backend — asserting the scraped payload contains `openbank_audit_chain_verify_duration_seconds_bucket`. `SimpleMeterRegistry` (used by the file's other tests) can't distinguish this class of bug; it isn't Prometheus-shaped, so a timer with no histogram config and one with `publishPercentileHistogram()` look identical through it.

`AuditChainIntegrityGaugeTest`: 6/6 passing (was 5, +1 new).

## Note

Small, audit-service-only, observability-only change — no behavior change to the chain-verify logic itself, same values recorded, just a different registration call.
