### PR TITLE
feat(admin-ui): unify account operations workspace

### DIFF
--- a/openbank-admin-ui/src/app/accounts/[id]/page.tsx
+++ b/openbank-admin-ui/src/app/accounts/[id]/page.tsx
@@ -11,6 +11,7 @@ import { ArrowLeft, RefreshCw, Lock, Unlock, XCircle, AlertCircle } from 'lucide
 import { accountApi } from '@/lib/api'
 import { EntityChip } from '@/components/entities/EntityChip'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
+import { PageHeader } from '@/components/ui/PageHeader'
 import type { Account, AccountBalance } from '@/types'
 
 const STATUS_PILL: Record<string, string> = {
@@ -87,31 +88,21 @@ export default function AccountDetailPage() {
 
   return (
     <div>
-      <div className="page-header">
-        <div>
-          <div className="breadcrumb">
-            <span>OpenBank</span>
-            <span className="breadcrumb-sep">/</span>
-            <Link href="/accounts" style={{ color: 'var(--text-tertiary)', textDecoration: 'none' }}>{t('Účty', 'Accounts')}</Link>
-            <span className="breadcrumb-sep">/</span>
-            <span className="breadcrumb-current mono" style={{ fontSize: '12px' }}>{account.accountNumber}</span>
-          </div>
-          <h1 className="page-title" style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
-            <span className="mono">{account.accountNumber}</span>
-            <span className={STATUS_PILL[account.status] ?? 'pill pill-neutral'}>{account.status}</span>
-          </h1>
-          <p className="page-subtitle">{account.accountType} · {account.currencyCode}</p>
-        </div>
-        <div style={{ display: 'flex', gap: '8px' }}>
-          <Link href="/accounts" className="btn btn-secondary"><ArrowLeft size={13}/> {t('Zpět', 'Back')}</Link>
+      <PageHeader
+        title={account.accountNumber}
+        subtitle={`${account.accountType} · ${account.currencyCode}`}
+        breadcrumb={<div className="breadcrumb"><span>OpenBank</span><span className="breadcrumb-sep">/</span><Link href="/accounts" style={{ color: 'var(--text-tertiary)', textDecoration: 'none' }}>{t('Účty', 'Accounts')}</Link><span className="breadcrumb-sep">/</span><span className="breadcrumb-current mono" style={{ fontSize: '12px' }}>{account.accountNumber}</span></div>}
+        actions={<div style={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
+          <span className={STATUS_PILL[account.status] ?? 'pill pill-neutral'}>{account.status}</span>
+          <Link href="/accounts" className="btn btn-secondary"><ArrowLeft size={13} aria-hidden="true"/> {t('Zpět', 'Back')}</Link>
           {account.status === 'ACTIVE' && (
             <button className="btn btn-secondary" onClick={() => doAction('freeze')} disabled={acting}>
-              <Lock size={13}/> {t('Zmrazit', 'Freeze')}
+              <Lock size={13} aria-hidden="true"/> {t('Zmrazit', 'Freeze')}
             </button>
           )}
           {account.status === 'FROZEN' && (
             <button className="btn btn-secondary" onClick={() => doAction('unfreeze')} disabled={acting}>
-              <Unlock size={13}/> {t('Odzmrazit', 'Unfreeze')}
+              <Unlock size={13} aria-hidden="true"/> {t('Odzmrazit', 'Unfreeze')}
             </button>
           )}
           {account.status !== 'CLOSED' && (
@@ -121,11 +112,11 @@ export default function AccountDetailPage() {
               disabled={acting}
               style={{ color: 'var(--danger)', borderColor: 'var(--danger-border)' }}
             >
-              <XCircle size={13}/> {t('Zrušit účet', 'Close')}
+              <XCircle size={13} aria-hidden="true"/> {t('Zrušit účet', 'Close')}
             </button>
           )}
-        </div>
-      </div>
+        </div>}
+      />
 
       {actionError && (
         <div

--- a/openbank-admin-ui/src/app/accounts/new/page.tsx
+++ b/openbank-admin-ui/src/app/accounts/new/page.tsx
@@ -10,6 +10,7 @@ import Link from 'next/link'
 import { ArrowLeft, Save, AlertCircle } from 'lucide-react'
 import { accountApi } from '@/lib/api'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
+import { PageHeader } from '@/components/ui/PageHeader'
 
 
 const ACCOUNT_TYPES = ['CURRENT', 'SAVINGS', 'NOSTRO', 'GL_ASSET', 'GL_LIABILITY', 'GL_INCOME', 'GL_EXPENSE']
@@ -66,22 +67,12 @@ export default function NewAccountPage() {
 
   return (
     <div>
-      <div className="page-header">
-        <div>
-          <div className="breadcrumb">
-            <span>OpenBank</span>
-            <span className="breadcrumb-sep">/</span>
-            <Link href="/accounts" style={{ color: 'var(--text-tertiary)', textDecoration: 'none' }}>{t('Účty', 'Accounts')}</Link>
-            <span className="breadcrumb-sep">/</span>
-            <span className="breadcrumb-current">{t('Otevřít účet', 'Open Account')}</span>
-          </div>
-          <h1 className="page-title">{t('Otevřít nový účet', 'Open New Account')}</h1>
-          <p className="page-subtitle">{t('Vytvořte nový bankovní účet pro zákazníka', 'Create a new bank account for a customer party')}</p>
-        </div>
-        <Link href="/accounts" className="btn btn-secondary">
-          <ArrowLeft size={13}/> {t('Zpět', 'Back')}
-        </Link>
-      </div>
+      <PageHeader
+        title={t('Otevřít nový účet', 'Open New Account')}
+        subtitle={t('Vytvořte nový bankovní účet pro zákazníka', 'Create a new bank account for a customer party')}
+        breadcrumb={<div className="breadcrumb"><span>OpenBank</span><span className="breadcrumb-sep">/</span><Link href="/accounts" style={{ color: 'var(--text-tertiary)', textDecoration: 'none' }}>{t('Účty', 'Accounts')}</Link><span className="breadcrumb-sep">/</span><span className="breadcrumb-current">{t('Otevřít účet', 'Open Account')}</span></div>}
+        actions={<Link href="/accounts" className="btn btn-secondary"><ArrowLeft size={13} aria-hidden="true"/> {t('Zpět', 'Back')}</Link>}
+      />
 
       <div style={{ maxWidth: '560px' }}>
         <form onSubmit={submit}>


### PR DESCRIPTION
## Summary\n- unify account detail and account opening on the shared PageHeader pattern\n- preserve account lifecycle controls, validation, idempotency, and BFF behavior\n- retain semantic navigation and visible native actions\n\n## Validation\n- npm test -- accounts route-permissions ui-tone render-smoke\n- npm run type-check\n\nRefs #4599