### PR TITLE
feat(product-catalog): add declarative deposit profiles

### DIFF
--- a/openbank-product-catalog/src/main/kotlin/com/openbank/productcatalog/infrastructure/catalog/CatalogPackSeeder.kt
+++ b/openbank-product-catalog/src/main/kotlin/com/openbank/productcatalog/infrastructure/catalog/CatalogPackSeeder.kt
@@ -153,6 +153,7 @@ class CatalogPackSeeder(
         const val STARTUP_PRIORITY_OFFSET = 100
         val PACKS = listOf(
             PackSchema("banking", "org.openbank.banking.deposit", 1, "/catalog-packs/banking/deposit-v1.schema.json"),
+            PackSchema("banking", "org.openbank.banking.deposit", 2, "/catalog-packs/banking/deposit-v2.schema.json"),
             PackSchema(
                 "banking",
                 "org.openbank.banking.legacy-product",

--- a/openbank-product-catalog/src/main/resources/catalog-packs/banking/deposit-v2.schema.json
+++ b/openbank-product-catalog/src/main/resources/catalog-packs/banking/deposit-v2.schema.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:catalog-schema:org.openbank.banking.deposit:2",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["currency", "productType", "interest"],
+  "properties": {
+    "currency": { "type": "string", "pattern": "^[A-Z]{3}$" },
+    "productType": { "type": "string", "enum": ["SAVINGS", "CURRENT", "TERM_DEPOSIT"] },
+    "minimumBalance": { "type": "string", "pattern": "^(0|[1-9][0-9]*)(\\.[0-9]+)?$" },
+    "interest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["rateType", "dayCount", "payoutFrequency"],
+      "properties": {
+        "rateType": { "type": "string", "enum": ["FIXED", "TIERED"] },
+        "dayCount": { "type": "string", "enum": ["ACT_365", "ACT_360", "ACT_ACT", "THIRTY_360"] },
+        "payoutFrequency": { "type": "string", "enum": ["MONTHLY", "QUARTERLY", "ANNUALLY", "AT_MATURITY"] },
+        "annualRate": { "type": "string", "pattern": "^(0|[1-9][0-9]*)(\\.[0-9]+)?$" },
+        "tiers": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["fromBalance", "annualRate"],
+            "properties": {
+              "fromBalance": { "type": "string", "pattern": "^(0|[1-9][0-9]*)(\\.[0-9]+)?$" },
+              "toBalance": { "type": "string", "pattern": "^(0|[1-9][0-9]*)(\\.[0-9]+)?$" },
+              "annualRate": { "type": "string", "pattern": "^(0|[1-9][0-9]*)(\\.[0-9]+)?$" }
+            }
+          }
+        }
+      },
+      "allOf": [
+        {
+          "if": { "properties": { "rateType": { "const": "FIXED" } } },
+          "then": { "required": ["annualRate"] }
+        },
+        {
+          "if": { "properties": { "rateType": { "const": "TIERED" } } },
+          "then": { "required": ["tiers"] }
+        }
+      ]
+    }
+  }
+}

--- a/openbank-product-catalog/src/main/resources/docs/02-architecture.cs.md
+++ b/openbank-product-catalog/src/main/resources/docs/02-architecture.cs.md
@@ -15,7 +15,7 @@ graph LR
 
   admin -- "GET/POST/PUT /products<br/>GET /fees" --> pc
   acc -. "čte definice produktů" .-> pc
-  intr -. "čte deklarované sazby" .-> pc
+  intr -. "čte připnuté snapshoty sazeb" .-> pc
   fx -. "čte FX marže" .-> pc
   card -. "čte konfig karty" .-> pc
 
@@ -24,7 +24,7 @@ graph LR
   classDef svc fill:#dbeafe,stroke:#2563eb
 ```
 
-Katalog je **poskytovatel referenčních dat**. Nemá downstream volání ani účast na peněžní cestě. Publikační důkazy ukládá do trvalého outboxu, ale zatím nemá brokerový transportní adaptér.
+Katalog je **poskytovatel referenčních dat**. Nemá downstream volání ani účast na peněžní cestě. Publikační důkazy ukládá do trvalého outboxu, ale zatím nemá brokerový transportní adaptér. Úrokové zpracování musí číst připnutý snapshot s dobou účinnosti, ne aktuální katalogovou hodnotu během peněžního výpočtu.
 
 ## C4 — Kontejner (vnitřní struktura)
 
@@ -87,6 +87,12 @@ Kořen agregátu je **`Product`** (identita `id`/`code`, `name`, `type`, `curren
 | `savingsConfig` | SAVINGS | úroková pásma, výpovědní lhůta, počet výběrů zdarma, bonusová sazba |
 
 `versionHistory[]` jsou legacy informativní data, nikoli neměnný auditní důkaz. `termsAndConditions[]` nese reference s dobou účinnosti. Autoritativní neměnné revize zavádí v2 dle ADR-0257.
+
+## Banking deposit pack v2
+
+`org.openbank.banking.deposit:2` je deklarativní profil vkladového produktu. Vyžaduje měnu, typ produktu a objekt `interest` s explicitní konvencí počtu dní a frekvencí výplaty. Sazba je buď kanonický desetinný řetězec pro pevnou roční sazbu, nebo neprázdný seznam pásem. Bankovní slovník tak zůstává mimo průmyslově neutrální jádro a přesný profil je součástí neměnné publikované revize.
+
+Nejde záměrně o živé cenové čtení. Budoucí adaptér interest-service musí z publikovaného profilu vytvořit snapshot sazby s dobou účinnosti ještě před výpočtem úroku; čtení nejnovějšího katalogového dokumentu při úročení by zničilo reprodukovatelnost historie.
 
 ## Zploštění sazebníku
 

--- a/openbank-product-catalog/src/main/resources/docs/02-architecture.en.md
+++ b/openbank-product-catalog/src/main/resources/docs/02-architecture.en.md
@@ -15,7 +15,7 @@ graph LR
 
   admin -- "GET/POST/PUT /products<br/>GET /fees" --> pc
   acc -. "read product defs" .-> pc
-  intr -. "read declared rates" .-> pc
+  intr -. "consume pinned rate snapshots" .-> pc
   fx -. "read FX margins" .-> pc
   card -. "read card config" .-> pc
 
@@ -26,6 +26,8 @@ graph LR
 
 The catalog is a **reference-data provider**. It has no downstream calls and no money-path
 involvement. Accepted v2 changes create durable outbox records; no broker adapter is enabled yet.
+Interest processing must consume a pinned, effective-dated snapshot rather than read the latest
+catalog value while accruing money.
 
 ## C4 — Container (internal structure)
 
@@ -106,6 +108,18 @@ This is what `GET /api/v1/fees` serves, so the admin UI renders pricing without 
 attributes, exact decimal prices and effective dates. DRAFT is mutable behind a strong ETag;
 PUBLISHED and SUPERSEDED snapshots are database-enforced immutable. Publication requires a checker
 different from the stored maker.
+
+## Banking deposit pack v2
+
+`org.openbank.banking.deposit:2` is the declarative deposit profile. It requires a currency,
+product type and an `interest` object with an explicit day-count convention and payout frequency.
+The rate is either a canonical decimal-string fixed annual rate or a non-empty tier list. The pack
+keeps this banking vocabulary outside the industry-neutral kernel and makes the exact profile part
+of the immutable published revision.
+
+This is intentionally not a live pricing lookup. A later interest-service adapter must turn a
+published profile into an effective-dated rate snapshot before it is used for accrual; querying the
+latest catalog document during accrual would make historical interest non-reproducible.
 
 ## Events / outbox
 

--- a/openbank-product-catalog/src/test/kotlin/com/openbank/productcatalog/CatalogPlatformResourceTest.kt
+++ b/openbank-product-catalog/src/test/kotlin/com/openbank/productcatalog/CatalogPlatformResourceTest.kt
@@ -72,6 +72,48 @@ class CatalogPlatformResourceTest {
             expectedValid = false,
             schemaVersion = 2,
         )
+
+        validateDeposit(
+            """{"currency":"CZK","productType":"SAVINGS","interest":{"rateType":"FIXED","dayCount":"ACT_365","payoutFrequency":"MONTHLY","annualRate":"0.0425"}}""",
+            expectedValid = true,
+        )
+        validateDeposit(
+            """{"currency":"CZK","productType":"SAVINGS","interest":{"rateType":"TIERED","dayCount":"ACT_365","payoutFrequency":"MONTHLY","tiers":[{"fromBalance":"0","toBalance":"100000","annualRate":"0.03"},{"fromBalance":"100000","annualRate":"0.04"}]}}""",
+            expectedValid = true,
+        )
+        validateDeposit(
+            """{"currency":"CZK","productType":"SAVINGS","interest":{"rateType":"TIERED","dayCount":"ACT_365","payoutFrequency":"MONTHLY"}}""",
+            expectedValid = false,
+        )
+    }
+
+    @Test
+    fun publishesADeclarativeDepositInterestProfile() {
+        val specificationId = createDepositSpecification("SAVINGS_DECLARATIVE_E2E")
+        val offeringId = createOffering(specificationId, "SAVINGS_DECLARATIVE_E2E_CZ")
+        val revisionId = createDepositRevision(offeringId)
+        setMaker(revisionId, "independent-deposit-author")
+
+        Given {
+            contentType("application/json")
+            body("""{"reason":"approved declarative savings profile"}""")
+            header("If-Match", "\"0\"")
+        } When {
+            post("/api/v2/offerings/$offeringId/revisions/$revisionId/publish")
+        } Then {
+            statusCode(200)
+            body("state", equalTo("PUBLISHED"))
+            body("content.attributes.interest.rateType", equalTo("FIXED"))
+            body("content.attributes.interest.annualRate", equalTo("0.0425"))
+        }
+
+        Given { this } When {
+            get("/api/v2/products/$offeringId")
+        } Then {
+            statusCode(200)
+            body("state", equalTo("PUBLISHED"))
+            body("content.attributes.interest.dayCount", equalTo("ACT_365"))
+        }
     }
 
     @Test
@@ -442,6 +484,18 @@ class CatalogPlatformResourceTest {
         }
     }
 
+    private fun validateDeposit(attributes: String, expectedValid: Boolean) {
+        Given {
+            contentType("application/json")
+            body("""{"attributes":$attributes}""")
+        } When {
+            post("/api/v2/product-types/org.openbank.banking.deposit/versions/2/validate")
+        } Then {
+            statusCode(200)
+            body("valid", equalTo(expectedValid))
+        }
+    }
+
     private fun createSpecification(code: String, schemaVersion: Int = 2): UUID = UUID.fromString(
         (
             Given {
@@ -449,6 +503,20 @@ class CatalogPlatformResourceTest {
                 body(
                     """{"code":"$code","schemaRef":{"id":"org.openbank.insurance.term-life","version":$schemaVersion}}""",
                 )
+            } When {
+                post("/api/v2/specifications")
+            } Then {
+                statusCode(201)
+                header("ETag", equalTo("\"0\""))
+            }
+            ).extract().jsonPath().getString("id"),
+    )
+
+    private fun createDepositSpecification(code: String): UUID = UUID.fromString(
+        (
+            Given {
+                contentType("application/json")
+                body("""{"code":"$code","schemaRef":{"id":"org.openbank.banking.deposit","version":2}}""")
             } When {
                 post("/api/v2/specifications")
             } Then {
@@ -485,6 +553,24 @@ class CatalogPlatformResourceTest {
             Given {
                 contentType("application/json")
                 body(revisionPayload(name, relationships, schemaVersion))
+            } When {
+                post("/api/v2/offerings/$offeringId/revisions")
+            } Then {
+                statusCode(201)
+                header("ETag", equalTo("\"0\""))
+                body("state", equalTo("DRAFT"))
+            }
+            ).extract().jsonPath().getString("id"),
+    )
+
+    private fun createDepositRevision(offeringId: UUID): UUID = UUID.fromString(
+        (
+            Given {
+                contentType("application/json")
+                body(
+                    """{"schemaRef":{"id":"org.openbank.banking.deposit","version":2},""" +
+                        """"name":{"en":"Declarative savings"},"attributes":$DEPOSIT_ATTRIBUTES}""",
+                )
             } When {
                 post("/api/v2/offerings/$offeringId/revisions")
             } Then {
@@ -858,5 +944,7 @@ class CatalogPlatformResourceTest {
             """{"coverage":{"amount":"100000.00","currency":"EUR"},"termYears":20,"premiumModel":"CALCULATED"}"""
         const val INSURANCE_ATTRIBUTES =
             """{"coverage":{"amount":"100000.00","currency":"EUR"},"termYears":20,"smokerAccepted":true,"premiumModel":"FIXED","premium":{"amount":"12.3400","currency":"EUR","cadence":"MONTHLY"},"perils":[{"code":"DEATH","description":"Death during the insured term"}],"exclusions":[{"code":"FRAUD","description":"Fraud or deliberate misrepresentation"}],"limits":[{"kind":"PER_EVENT","amount":"100000.00","currency":"EUR"}],"deductibles":[{"kind":"PER_CLAIM","amount":"0","currency":"EUR"}],"underwritingQuestions":[{"id":"smoker","question":"Do you use tobacco?","answerType":"BOOLEAN","required":true}]}"""
+        const val DEPOSIT_ATTRIBUTES =
+            """{"currency":"CZK","productType":"SAVINGS","interest":{"rateType":"FIXED","dayCount":"ACT_365","payoutFrequency":"MONTHLY","annualRate":"0.0425"}}"""
     }
 }


### PR DESCRIPTION
## What changed

Adds `org.openbank.banking.deposit:2`, a versioned declarative deposit profile with exact decimal-string fixed or tiered interest terms, explicit day-count convention, and payout frequency.

The catalog seeds the trusted pack at startup and the PostgreSQL integration test proves validation, maker-checker publication, and published readback.

## Why

This is the first safe vertical slice of #668. It keeps banking terms outside the neutral kernel and avoids a dangerous live interest-rate lookup: a later event consumer must create effective-dated snapshots in interest-service before money accrual uses the profile.

## Validation

- `./gradlew --no-daemon --console=plain :openbank-product-catalog:test --tests com.openbank.productcatalog.CatalogPlatformResourceTest` — 12 tests, 0 failures
- `./gradlew --no-daemon --console=plain :openbank-product-catalog:ktlintCheck :openbank-product-catalog:detekt`
- `git diff --check`

Refs #668