### PR TITLE
feat(payees): server-synced saved payees (TOP-10 #5)

### DIFF
--- a/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
+++ b/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
@@ -1402,6 +1402,58 @@ class CustomerEdgeResource(
         )
     }
 
+    // ─── Saved payees (TOP-10 #5) ──────────────────────────────────────────────
+    // Server side of the mobile app's device-local PayeeStore. Same shape as /profile above:
+    // party-scoped by the JWT party — never a client-supplied id — so a customer only ever
+    // reads/writes their own list (no IDOR).
+
+    @GET
+    @Path("/payees")
+    @Authorize(action = "customer.payees.read")
+    @Blocking
+    fun listPayees(): Response {
+        val customer = customer()
+        return upstream.get("$partyServiceUrl/api/v1/parties/${customer.partyId}/payees", customer.partyId.toString())
+    }
+
+    @PUT
+    @Path("/payees")
+    @Authorize(action = "customer.payees.write")
+    @Blocking
+    fun savePayee(body: String): Response {
+        val customer = customer()
+        // Re-serialize through Jackson (not raw string interpolation) — name/iban/bic are
+        // customer-authored free text and must be JSON-escaped, not spliced into a template.
+        val node = runCatching { objectMapper.readTree(body) }.getOrNull() as? ObjectNode
+            ?: return badRequest("Malformed payee request body")
+        val name = node.get("name")?.takeIf { it.isTextual }?.asText()
+            ?: return badRequest("Missing payee name")
+        val iban = node.get("iban")?.takeIf { it.isTextual }?.asText()
+            ?: return badRequest("Missing payee iban")
+        val forwarded = objectMapper.createObjectNode().apply {
+            put("name", name)
+            put("iban", iban)
+            node.get("bic")?.takeIf { it.isTextual }?.let { put("bic", it.asText()) }
+        }
+        return upstream.put(
+            "$partyServiceUrl/api/v1/parties/${customer.partyId}/payees",
+            customer.partyId.toString(),
+            objectMapper.writeValueAsString(forwarded),
+        )
+    }
+
+    @DELETE
+    @Path("/payees/{iban}")
+    @Authorize(action = "customer.payees.write")
+    @Blocking
+    fun deletePayee(@PathParam("iban") iban: String): Response {
+        val customer = customer()
+        return upstream.delete(
+            "$partyServiceUrl/api/v1/parties/${customer.partyId}/payees/$iban",
+            customer.partyId.toString(),
+        )
+    }
+
     /**
      * Pay-to-phone directory lookup. The app sends SHA-256 hashes of phone numbers from the
      * customer's own address book and gets back the subset belonging to parties who opted into

--- a/openbank-customer-edge/src/main/resources/openapi.yaml
+++ b/openbank-customer-edge/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: Customer Edge API
-  version: 1.37.0
+  version: 1.38.0
   description: >-
     Customer-facing edge proxy (ADR-0065). Single internet-facing entry point for the
     retail customer app. Validates JWTs from the openbank-customers Keycloak realm,
@@ -548,6 +548,56 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Profile'
+
+  /payees:
+    get:
+      tags: [Payees]
+      summary: List the authenticated customer's saved payees, newest first
+      operationId: listPayees
+      security:
+        - customerOidc: [accounts:read]
+      responses:
+        '200':
+          description: Saved payees
+          content:
+            application/json:
+              schema:
+                type: array
+                items: {$ref: '#/components/schemas/Payee'}
+    put:
+      tags: [Payees]
+      summary: Save (or update) a payee — upsert by IBAN
+      operationId: savePayee
+      security:
+        - customerOidc: [accounts:write]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: {$ref: '#/components/schemas/SavePayeeRequest'}
+      responses:
+        '200':
+          description: Saved payee
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/Payee'}
+        '400':
+          description: Missing name or iban
+        '422':
+          description: Party already has the maximum of 30 saved payees
+
+  /payees/{iban}:
+    delete:
+      tags: [Payees]
+      summary: Remove a saved payee by IBAN. Idempotent — a missing IBAN is not an error.
+      operationId: deletePayee
+      security:
+        - customerOidc: [accounts:write]
+      parameters:
+        - {name: iban, in: path, required: true, schema: {type: string}}
+      responses:
+        '204':
+          description: Removed (or already absent)
 
   /fx/rates:
     get:
@@ -2232,6 +2282,36 @@ components:
         closedAt:
           type: string
           format: date-time
+
+    # Mirrors com.openbank.party.infrastructure.rest.Payee.toResponse() (openbank-party-service).
+    Payee:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        iban:
+          type: string
+        bic:
+          type: string
+          nullable: true
+        createdAt:
+          type: string
+          format: date-time
+
+    SavePayeeRequest:
+      type: object
+      required: [name, iban]
+      properties:
+        name:
+          type: string
+        iban:
+          type: string
+        bic:
+          type: string
+          nullable: true
 
     # Mirrors the projection returned by openbank-party-service GET /api/v1/parties/{id}
     # (PartyResource.Party.toResponse()). party-service does not declare a response schema for

--- a/openbank-party-service/ktlint-baseline.xml
+++ b/openbank-party-service/ktlint-baseline.xml
@@ -6,58 +6,11 @@
     <file name="src/main/kotlin/com/openbank/party/application/port/in/PartyPort.kt">
         <error line="5" column="9" source="standard:package-name" />
         <error line="8" column="1" source="standard:no-wildcard-imports" />
-        <error line="21" column="26" source="standard:trailing-comma-on-declaration-site" />
-        <error line="37" column="27" source="standard:trailing-comma-on-declaration-site" />
-        <error line="53" column="25" source="standard:trailing-comma-on-declaration-site" />
-        <error line="61" column="29" source="standard:trailing-comma-on-declaration-site" />
-        <error line="69" column="28" source="standard:trailing-comma-on-declaration-site" />
-        <error line="76" column="5" source="standard:class-signature" />
-        <error line="77" column="5" source="standard:class-signature" />
-        <error line="78" column="5" source="standard:class-signature" />
-        <error line="78" column="32" source="standard:class-signature" />
-        <error line="89" column="5" source="standard:spacing-between-declarations-with-comments" />
-        <error line="91" column="5" source="standard:spacing-between-declarations-with-comments" />
-        <error line="98" column="5" source="standard:spacing-between-declarations-with-comments" />
-        <error line="100" column="5" source="standard:spacing-between-declarations-with-comments" />
-        <error line="102" column="5" source="standard:spacing-between-declarations-with-comments" />
-        <error line="104" column="5" source="standard:spacing-between-declarations-with-comments" />
-    </file>
-    <file name="src/main/kotlin/com/openbank/party/application/port/out/PartyPorts.kt">
-        <error line="63" column="5" source="standard:spacing-between-declarations-with-comments" />
-        <error line="65" column="5" source="standard:spacing-between-declarations-with-comments" />
     </file>
     <file name="src/main/kotlin/com/openbank/party/application/usecase/PartyService.kt">
-        <error line="14" column="1" source="standard:no-wildcard-imports" />
         <error line="15" column="1" source="standard:no-wildcard-imports" />
         <error line="16" column="1" source="standard:no-wildcard-imports" />
-        <error line="34" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="35" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="36" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="37" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="101" column="53" source="standard:function-signature" />
-        <error line="111" column="38" source="standard:trailing-comma-on-call-site" />
-        <error line="128" column="38" source="standard:trailing-comma-on-call-site" />
-        <error line="142" column="39" source="standard:function-literal" />
-        <error line="142" column="39" source="standard:wrapping" />
-        <error line="142" column="41" source="standard:statement-wrapping" />
-        <error line="143" column="31" source="standard:argument-list-wrapping" />
-        <error line="143" column="59" source="standard:argument-list-wrapping" />
-        <error line="144" column="45" source="standard:argument-list-wrapping" />
-        <error line="145" column="37" source="standard:argument-list-wrapping" />
-        <error line="145" column="65" source="standard:argument-list-wrapping" />
-        <error line="146" column="13" source="standard:wrapping" />
-        <error line="146" column="14" source="standard:curly-spacing" />
-        <error line="146" column="14" source="standard:statement-wrapping" />
-        <error line="146" column="14" source="standard:function-literal" />
-        <error line="147" column="31" source="standard:argument-list-wrapping" />
-        <error line="147" column="47" source="standard:argument-list-wrapping" />
-        <error line="169" column="40" source="standard:binary-expression-wrapping" />
-        <error line="169" column="85" source="standard:argument-list-wrapping" />
-        <error line="169" column="114" source="standard:argument-list-wrapping" />
-        <error line="169" column="121" source="standard:max-line-length" />
-        <error line="258" column="38" source="standard:trailing-comma-on-call-site" />
-        <error line="265" column="67" source="standard:function-signature" />
-        <error line="277" column="39" source="standard:trailing-comma-on-call-site" />
+        <error line="17" column="1" source="standard:no-wildcard-imports" />
     </file>
     <file name="src/main/kotlin/com/openbank/party/domain/model/Party.kt">
         <error line="43" column="28" source="standard:trailing-comma-on-declaration-site" />
@@ -91,83 +44,6 @@
         <error line="128" column="1" source="standard:spacing-between-declarations-with-annotations" />
         <error line="130" column="1" source="standard:spacing-between-declarations-with-annotations" />
     </file>
-    <file name="src/main/kotlin/com/openbank/party/infrastructure/persistence/repository/PartyRepositoryImpl.kt">
-        <error line="10" column="1" source="standard:no-wildcard-imports" />
-        <error line="22" column="29" source="standard:class-signature" />
-        <error line="22" column="46" source="standard:class-signature" />
-        <error line="40" column="29" source="standard:function-literal" />
-        <error line="40" column="36" source="standard:argument-list-wrapping" />
-        <error line="40" column="46" source="standard:argument-list-wrapping" />
-        <error line="40" column="57" source="standard:argument-list-wrapping" />
-        <error line="40" column="64" source="standard:argument-list-wrapping" />
-        <error line="40" column="70" source="standard:argument-list-wrapping" />
-        <error line="40" column="74" source="standard:argument-list-wrapping" />
-        <error line="40" column="83" source="standard:function-literal" />
-        <error line="40" column="107" source="standard:function-literal" />
-        <error line="40" column="121" source="standard:max-line-length" />
-        <error line="40" column="123" source="standard:function-literal" />
-        <error line="56" column="30" source="standard:argument-list-wrapping" />
-        <error line="68" column="44" source="standard:function-signature" />
-        <error line="99" column="55" source="standard:function-signature" />
-        <error line="126" column="25" source="standard:statement-wrapping" />
-        <error line="126" column="56" source="standard:statement-wrapping" />
-        <error line="127" column="34" source="standard:statement-wrapping" />
-        <error line="127" column="64" source="standard:statement-wrapping" />
-        <error line="128" column="38" source="standard:statement-wrapping" />
-        <error line="128" column="56" source="standard:statement-wrapping" />
-        <error line="129" column="26" source="standard:statement-wrapping" />
-        <error line="129" column="44" source="standard:statement-wrapping" />
-        <error line="131" column="42" source="standard:statement-wrapping" />
-        <error line="132" column="40" source="standard:statement-wrapping" />
-        <error line="134" column="34" source="standard:statement-wrapping" />
-        <error line="145" column="38" source="standard:binary-expression-wrapping" />
-        <error line="145" column="53" source="standard:argument-list-wrapping" />
-        <error line="145" column="69" source="standard:argument-list-wrapping" />
-        <error line="145" column="83" source="standard:argument-list-wrapping" />
-        <error line="145" column="102" source="standard:binary-expression-wrapping" />
-        <error line="145" column="102" source="standard:argument-list-wrapping" />
-        <error line="145" column="120" source="standard:binary-expression-wrapping" />
-        <error line="145" column="121" source="standard:max-line-length" />
-        <error line="145" column="127" source="standard:binary-expression-wrapping" />
-        <error line="145" column="127" source="standard:argument-list-wrapping" />
-        <error line="145" column="146" source="standard:binary-expression-wrapping" />
-        <error line="145" column="151" source="standard:argument-list-wrapping" />
-        <error line="155" column="37" source="standard:class-signature" />
-        <error line="155" column="62" source="standard:class-signature" />
-        <error line="159" column="36" source="standard:statement-wrapping" />
-        <error line="160" column="53" source="standard:statement-wrapping" />
-        <error line="161" column="52" source="standard:statement-wrapping" />
-        <error line="162" column="44" source="standard:statement-wrapping" />
-        <error line="170" column="27" source="standard:wrapping" />
-        <error line="170" column="27" source="standard:argument-list-wrapping" />
-        <error line="170" column="42" source="standard:argument-list-wrapping" />
-        <error line="170" column="54" source="standard:argument-list-wrapping" />
-        <error line="171" column="36" source="standard:argument-list-wrapping" />
-        <error line="171" column="55" source="standard:argument-list-wrapping" />
-        <error line="171" column="70" source="standard:argument-list-wrapping" />
-        <error line="171" column="85" source="standard:argument-list-wrapping" />
-        <error line="171" column="96" source="standard:wrapping" />
-        <error line="171" column="97" source="standard:argument-list-wrapping" />
-        <error line="171" column="97" source="standard:trailing-comma-on-call-site" />
-        <error line="176" column="41" source="standard:class-signature" />
-        <error line="176" column="70" source="standard:class-signature" />
-        <error line="180" column="29" source="standard:statement-wrapping" />
-        <error line="181" column="54" source="standard:statement-wrapping" />
-        <error line="182" column="41" source="standard:statement-wrapping" />
-        <error line="193" column="29" source="standard:function-literal" />
-        <error line="193" column="36" source="standard:argument-list-wrapping" />
-        <error line="193" column="64" source="standard:argument-list-wrapping" />
-        <error line="193" column="68" source="standard:argument-list-wrapping" />
-        <error line="193" column="75" source="standard:argument-list-wrapping" />
-        <error line="193" column="91" source="standard:function-literal" />
-        <error line="193" column="121" source="standard:max-line-length" />
-        <error line="200" column="18" source="standard:argument-list-wrapping" />
-        <error line="200" column="37" source="standard:argument-list-wrapping" />
-        <error line="201" column="30" source="standard:argument-list-wrapping" />
-        <error line="201" column="51" source="standard:argument-list-wrapping" />
-        <error line="201" column="70" source="standard:argument-list-wrapping" />
-        <error line="201" column="93" source="standard:trailing-comma-on-call-site" />
-    </file>
     <file name="src/main/kotlin/com/openbank/party/infrastructure/rest/ExceptionMappers.kt">
         <error line="7" column="1" source="standard:import-ordering" />
         <error line="38" column="17" source="standard:argument-list-wrapping" />
@@ -181,114 +57,6 @@
     </file>
     <file name="src/main/kotlin/com/openbank/party/infrastructure/rest/PartyResource.kt">
         <error line="7" column="1" source="standard:import-ordering" />
-        <error line="7" column="1" source="standard:no-wildcard-imports" />
-        <error line="8" column="1" source="standard:no-unused-imports" />
-        <error line="9" column="1" source="standard:no-unused-imports" />
-        <error line="10" column="1" source="standard:no-wildcard-imports" />
-        <error line="18" column="1" source="standard:no-wildcard-imports" />
-        <error line="39" column="40" source="standard:annotation" />
-        <error line="43" column="16" source="standard:argument-list-wrapping" />
-        <error line="43" column="121" source="standard:max-line-length" />
-        <error line="43" column="126" source="standard:argument-list-wrapping" />
-        <error line="47" column="51" source="standard:trailing-comma-on-declaration-site" />
-        <error line="63" column="16" source="standard:argument-list-wrapping" />
-        <error line="63" column="121" source="standard:max-line-length" />
-        <error line="63" column="126" source="standard:argument-list-wrapping" />
-        <error line="67" column="46" source="standard:trailing-comma-on-declaration-site" />
-        <error line="71" column="102" source="standard:trailing-comma-on-call-site" />
-        <error line="87" column="63" source="standard:function-expression-body" />
-        <error line="97" column="46" source="standard:argument-list-wrapping" />
-        <error line="97" column="65" source="standard:argument-list-wrapping" />
-        <error line="97" column="69" source="standard:argument-list-wrapping" />
-        <error line="97" column="80" source="standard:argument-list-wrapping" />
-        <error line="97" column="91" source="standard:argument-list-wrapping" />
-        <error line="97" column="116" source="standard:argument-list-wrapping" />
-        <error line="97" column="121" source="standard:max-line-length" />
-        <error line="97" column="131" source="standard:argument-list-wrapping" />
-        <error line="97" column="132" source="standard:argument-list-wrapping" />
-        <error line="106" column="44" source="standard:argument-list-wrapping" />
-        <error line="106" column="63" source="standard:argument-list-wrapping" />
-        <error line="106" column="67" source="standard:argument-list-wrapping" />
-        <error line="106" column="88" source="standard:argument-list-wrapping" />
-        <error line="106" column="104" source="standard:argument-list-wrapping" />
-        <error line="106" column="107" source="standard:argument-list-wrapping" />
-        <error line="106" column="121" source="standard:max-line-length" />
-        <error line="106" column="127" source="standard:argument-list-wrapping" />
-        <error line="106" column="147" source="standard:argument-list-wrapping" />
-        <error line="106" column="161" source="standard:argument-list-wrapping" />
-        <error line="106" column="162" source="standard:argument-list-wrapping" />
-        <error line="114" column="68" source="standard:function-expression-body" />
-        <error line="171" column="50" source="standard:trailing-comma-on-call-site" />
-        <error line="172" column="14" source="standard:trailing-comma-on-call-site" />
-        <error line="204" column="39" source="standard:trailing-comma-on-call-site" />
-        <error line="205" column="14" source="standard:trailing-comma-on-call-site" />
-        <error line="207" column="44" source="standard:wrapping" />
-        <error line="208" column="30" source="standard:argument-list-wrapping" />
-        <error line="209" column="50" source="standard:argument-list-wrapping" />
-        <error line="210" column="42" source="standard:argument-list-wrapping" />
-        <error line="210" column="73" source="standard:trailing-comma-on-call-site" />
-        <error line="211" column="9" source="standard:wrapping" />
-        <error line="254" column="86" source="standard:trailing-comma-on-call-site" />
-        <error line="255" column="26" source="standard:trailing-comma-on-call-site" />
-        <error line="264" column="63" source="standard:trailing-comma-on-call-site" />
-        <error line="265" column="26" source="standard:trailing-comma-on-call-site" />
-        <error line="278" column="23" source="standard:parameter-list-spacing" />
-        <error line="278" column="24" source="standard:no-multi-spaces" />
-        <error line="282" column="33" source="standard:trailing-comma-on-declaration-site" />
-        <error line="304" column="28" source="standard:parameter-list-wrapping" />
-        <error line="304" column="28" source="standard:class-signature" />
-        <error line="304" column="51" source="standard:parameter-list-wrapping" />
-        <error line="304" column="51" source="standard:class-signature" />
-        <error line="305" column="31" source="standard:parameter-list-wrapping" />
-        <error line="305" column="31" source="standard:class-signature" />
-        <error line="305" column="57" source="standard:parameter-list-wrapping" />
-        <error line="305" column="57" source="standard:class-signature" />
-        <error line="310" column="38" source="standard:parameter-list-wrapping" />
-        <error line="310" column="38" source="standard:class-signature" />
-        <error line="310" column="58" source="standard:parameter-list-wrapping" />
-        <error line="310" column="58" source="standard:class-signature" />
-        <error line="315" column="27" source="standard:trailing-comma-on-declaration-site" />
-        <error line="319" column="35" source="standard:wrapping" />
-        <error line="321" column="71" source="standard:wrapping" />
-        <error line="321" column="72" source="standard:trailing-comma-on-call-site" />
-        <error line="325" column="31" source="standard:class-signature" />
-        <error line="325" column="51" source="standard:class-signature" />
-        <error line="325" column="71" source="standard:class-signature" />
-        <error line="325" column="97" source="standard:class-signature" />
-        <error line="325" column="120" source="standard:max-line-length" />
-        <error line="325" column="125" source="standard:class-signature" />
-        <error line="326" column="31" source="standard:parameter-list-wrapping" />
-        <error line="326" column="31" source="standard:class-signature" />
-        <error line="326" column="57" source="standard:parameter-list-wrapping" />
-        <error line="326" column="57" source="standard:class-signature" />
-        <error line="326" column="85" source="standard:parameter-list-wrapping" />
-        <error line="326" column="85" source="standard:class-signature" />
-        <error line="326" column="113" source="standard:parameter-list-wrapping" />
-        <error line="326" column="113" source="standard:class-signature" />
-        <error line="326" column="121" source="standard:max-line-length" />
-        <error line="326" column="136" source="standard:parameter-list-wrapping" />
-        <error line="326" column="136" source="standard:class-signature" />
-        <error line="328" column="27" source="standard:parameter-list-wrapping" />
-        <error line="328" column="27" source="standard:class-signature" />
-        <error line="328" column="46" source="standard:parameter-list-wrapping" />
-        <error line="328" column="46" source="standard:class-signature" />
-        <error line="328" column="66" source="standard:parameter-list-wrapping" />
-        <error line="328" column="66" source="standard:class-signature" />
-        <error line="328" column="84" source="standard:parameter-list-wrapping" />
-        <error line="328" column="84" source="standard:class-signature" />
-        <error line="328" column="108" source="standard:parameter-list-wrapping" />
-        <error line="328" column="108" source="standard:class-signature" />
-        <error line="328" column="121" source="standard:max-line-length" />
-        <error line="328" column="131" source="standard:parameter-list-wrapping" />
-        <error line="328" column="131" source="standard:class-signature" />
-        <error line="333" column="17" source="standard:argument-list-wrapping" />
-        <error line="333" column="43" source="standard:argument-list-wrapping" />
-        <error line="333" column="63" source="standard:argument-list-wrapping" />
-        <error line="334" column="35" source="standard:argument-list-wrapping" />
-        <error line="334" column="53" source="standard:argument-list-wrapping" />
-        <error line="334" column="79" source="standard:argument-list-wrapping" />
-        <error line="334" column="103" source="standard:trailing-comma-on-call-site" />
-        <error line="340" column="103" source="standard:trailing-comma-on-call-site" />
     </file>
     <file name="src/test/kotlin/com/openbank/party/application/usecase/PartyServiceTest.kt">
         <error line="7" column="1" source="standard:import-ordering" />

--- a/openbank-party-service/src/main/kotlin/com/openbank/party/application/port/in/PartyPort.kt
+++ b/openbank-party-service/src/main/kotlin/com/openbank/party/application/port/in/PartyPort.kt
@@ -111,6 +111,12 @@ data class AddDocumentCommand(
 
 data class ErasePartyCommand(val id: UUID)
 
+data class SavePayeeCommand(val partyId: UUID, val name: String, val iban: String, val bic: String?)
+
+/** Mirrors the app's own MAX_PAYEES = 30 hard cap (PayeeStore.kt). */
+class PayeeLimitExceededException(partyId: UUID) :
+    RuntimeException("Party $partyId already has the maximum of 30 saved payees")
+
 /** ADR-0055 bounded name search. `q` is normalised via SearchRequest; a blank/`*`/sub-2-char term returns an empty page. */
 data class SearchPartiesQuery(val q: String?, val limit: Int = 20, val cursor: String? = null)
 
@@ -190,6 +196,19 @@ interface PartyUseCase {
      * Used by the GDPR Art. 15 export endpoint to verify subject-access self-service.
      */
     suspend fun getPartyKeycloakSub(id: UUID): String?
+
+    /** Saved payees (TOP-10 #5), newest first — server side of the mobile app's device-local list. */
+    suspend fun listPayees(partyId: UUID): List<Payee>
+
+    /**
+     * Upsert by (partyId, iban). Throws [PayeeLimitExceededException] when [partyId] would exceed
+     * the 30-payee cap AND [iban] is not already one of its existing payees (a re-save of an
+     * existing IBAN is always allowed — it can never itself push the count over the limit).
+     */
+    suspend fun savePayee(cmd: SavePayeeCommand): Payee
+
+    /** No-op (not an error) if no such payee exists — matches the app's own idempotent remove(). */
+    suspend fun deletePayee(partyId: UUID, iban: String)
 }
 
 /**

--- a/openbank-party-service/src/main/kotlin/com/openbank/party/application/port/out/PartyPorts.kt
+++ b/openbank-party-service/src/main/kotlin/com/openbank/party/application/port/out/PartyPorts.kt
@@ -10,6 +10,7 @@ import com.openbank.party.domain.model.PartyDocument
 import com.openbank.party.domain.model.PartyDocumentFile
 import com.openbank.party.domain.model.PartyEvent
 import com.openbank.party.domain.model.PartyStatus
+import com.openbank.party.domain.model.Payee
 import java.time.Instant
 import java.util.UUID
 
@@ -88,6 +89,20 @@ interface PartyDocumentRepository {
     suspend fun save(doc: PartyDocument): PartyDocument
 
     suspend fun findByPartyId(partyId: UUID): List<PartyDocument>
+}
+
+/** Outbound persistence port for saved payees (TOP-10 #5). */
+interface PartyPayeeRepository {
+    /** Upsert by (partyId, normalised iban) — a re-save of an existing IBAN updates that row. */
+    suspend fun save(payee: Payee): Payee
+
+    /** Newest first, matching the app's own display order. */
+    suspend fun findByPartyId(partyId: UUID): List<Payee>
+
+    suspend fun countByPartyId(partyId: UUID): Long
+
+    /** No-op (not an error) if no such payee exists — delete is idempotent. */
+    suspend fun deleteByPartyIdAndIban(partyId: UUID, iban: String)
 }
 
 /** Outbound persistence port for KYC document binary files. */

--- a/openbank-party-service/src/main/kotlin/com/openbank/party/application/usecase/PartyService.kt
+++ b/openbank-party-service/src/main/kotlin/com/openbank/party/application/usecase/PartyService.kt
@@ -8,6 +8,7 @@ import com.openbank.libs.api.pagination.CursorEncoder
 import com.openbank.libs.api.pagination.CursorPage
 import com.openbank.libs.api.pagination.PageInfo
 import com.openbank.libs.api.search.SearchRequest
+import com.openbank.libs.domain.identifiers.Ids
 import com.openbank.libs.identity.BlindIndex
 import com.openbank.libs.identity.RodneCislo
 import com.openbank.libs.observability.DomainMetrics
@@ -39,6 +40,8 @@ class PartyService : PartyUseCase {
     @Inject lateinit var documentRepo: PartyDocumentRepository
 
     @Inject lateinit var documentFileRepo: PartyDocumentFileRepository
+
+    @Inject lateinit var payeeRepo: PartyPayeeRepository
 
     @Inject lateinit var gdprAggregation: GdprAggregationPort
 
@@ -474,7 +477,34 @@ class PartyService : PartyUseCase {
         documentFileRepo.findByIdAndPartyId(fileId, partyId)
 
     override suspend fun getPartyKeycloakSub(id: UUID): String? = partyRepo.findById(id)?.keycloakSub
+
+    override suspend fun listPayees(partyId: UUID): List<Payee> = payeeRepo.findByPartyId(partyId)
+
+    override suspend fun savePayee(cmd: SavePayeeCommand): Payee {
+        val normalizedIban = cmd.iban.filterNot { it.isWhitespace() }.uppercase()
+        val existing = payeeRepo.findByPartyId(cmd.partyId)
+        val alreadySaved = existing.any { it.iban == normalizedIban }
+        if (!alreadySaved && existing.size >= MAX_PAYEES) {
+            throw PayeeLimitExceededException(cmd.partyId)
+        }
+        val payee = Payee(
+            id = existing.firstOrNull { it.iban == normalizedIban }?.id ?: Ids.newId(),
+            partyId = cmd.partyId,
+            name = cmd.name.trim(),
+            iban = normalizedIban,
+            bic = cmd.bic?.trim()?.ifBlank { null },
+            createdAt = Instant.now(clock),
+        )
+        return payeeRepo.save(payee)
+    }
+
+    override suspend fun deletePayee(partyId: UUID, iban: String) {
+        payeeRepo.deleteByPartyIdAndIban(partyId, iban.filterNot { it.isWhitespace() }.uppercase())
+    }
 }
+
+/** Mirrors the app's own PayeeStore.MAX_PAYEES. */
+private const val MAX_PAYEES = 30
 
 /** SHA-256 rendered as lowercase hex. */
 private const val SHA256_HEX_LENGTH = 64

--- a/openbank-party-service/src/main/kotlin/com/openbank/party/domain/model/Party.kt
+++ b/openbank-party-service/src/main/kotlin/com/openbank/party/domain/model/Party.kt
@@ -86,6 +86,24 @@ data class PartyDocument(
     val createdAt: Instant,
 )
 
+/**
+ * A saved payee (uložený příjemce) — a transfer recipient the customer chose to remember so a
+ * future payment can start from a tap instead of re-typing the IBAN. Pure convenience data, NOT
+ * an authorisation input: sending money to it still goes through the paying account-service's
+ * full SCA + Verification-of-Payee path exactly as if the IBAN had been typed fresh. Mirrors the
+ * mobile app's own device-local `Payee`/`SavedPayees` shape and rules field-for-field (name/iban/
+ * bic, dedup-by-normalised-IBAN, cap 30, newest-first) — this is the server side of the SAME
+ * feature (TOP-10 #5, server-synced saved payees), not a new one.
+ */
+data class Payee(
+    val id: UUID,
+    val partyId: UUID,
+    val name: String,
+    val iban: String,
+    val bic: String?,
+    val createdAt: Instant,
+)
+
 data class PartyDocumentFile(
     val id: UUID,
     val partyId: UUID,

--- a/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/persistence/entity/PartyPayeeEntity.kt
+++ b/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/persistence/entity/PartyPayeeEntity.kt
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.party.infrastructure.persistence.entity
+
+import io.quarkus.hibernate.reactive.panache.kotlin.PanacheEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Index
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * Saved-payee row (TOP-10 #5). Panache's own auto Long `id` is the DB PK (unused by the domain,
+ * same convention as [PartyDocumentEntity]'s `documentId`); [payeeId] is the domain-facing UUID.
+ * `partyId` is deliberately NOT unique alone (one party has many payees) — the dedup key is
+ * `(party_id, iban)`, enforced by [UniqueConstraint] so a re-save always finds and updates the
+ * same row rather than the app's own dedup-by-IBAN rule being the only thing standing between a
+ * customer and duplicate rows.
+ */
+@Entity
+@Table(
+    name = "party_payees",
+    indexes = [Index(name = "idx_party_payees_party_id", columnList = "party_id")],
+    uniqueConstraints = [UniqueConstraint(name = "uq_party_payees_party_iban", columnNames = ["party_id", "iban"])],
+)
+class PartyPayeeEntity : PanacheEntity() {
+    @Column(name = "payee_id", nullable = false, unique = true)
+    lateinit var payeeId: UUID
+
+    @Column(name = "party_id", nullable = false)
+    lateinit var partyId: UUID
+
+    @Column(name = "name", nullable = false, length = 120)
+    lateinit var name: String
+
+    @Column(name = "iban", nullable = false, length = 34)
+    lateinit var iban: String
+
+    @Column(name = "bic", length = 11)
+    var bic: String? = null
+
+    @Column(name = "created_at", nullable = false)
+    lateinit var createdAt: Instant
+}

--- a/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/persistence/repository/PartyRepositoryImpl.kt
+++ b/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/persistence/repository/PartyRepositoryImpl.kt
@@ -10,6 +10,7 @@ import com.openbank.libs.persistence.outbox.OutboxMessage
 import com.openbank.party.application.port.out.PartyDocumentFileRepository
 import com.openbank.party.application.port.out.PartyDocumentRepository
 import com.openbank.party.application.port.out.PartyOutboxRepository
+import com.openbank.party.application.port.out.PartyPayeeRepository
 import com.openbank.party.application.port.out.PartyRepository
 import com.openbank.party.domain.model.Address
 import com.openbank.party.domain.model.AmlStatus
@@ -21,12 +22,15 @@ import com.openbank.party.domain.model.PartyDocumentFile
 import com.openbank.party.domain.model.PartyEvent
 import com.openbank.party.domain.model.PartyStatus
 import com.openbank.party.domain.model.PartyType
+import com.openbank.party.domain.model.Payee
 import com.openbank.party.domain.model.PhoneDirectory
 import com.openbank.party.infrastructure.persistence.entity.PartyDocumentEntity
 import com.openbank.party.infrastructure.persistence.entity.PartyDocumentFileEntity
 import com.openbank.party.infrastructure.persistence.entity.PartyEntity
+import com.openbank.party.infrastructure.persistence.entity.PartyPayeeEntity
 import io.quarkus.hibernate.reactive.panache.Panache
 import io.quarkus.hibernate.reactive.panache.kotlin.PanacheRepository
+import io.quarkus.panache.common.Sort
 import io.smallrye.mutiny.Uni
 import io.smallrye.mutiny.coroutines.awaitSuspending
 import jakarta.enterprise.context.ApplicationScoped
@@ -352,5 +356,60 @@ class PartyDocumentFileRepositoryImpl :
         mimeType = mimeType,
         content = content,
         uploadedAt = uploadedAt,
+    )
+}
+
+@ApplicationScoped
+class PartyPayeeRepositoryImpl :
+    PartyPayeeRepository,
+    PanacheRepository<PartyPayeeEntity> {
+
+    // Upsert on (partyId, iban): find-then-update rather than relying on the DB unique
+    // constraint to fail an INSERT and catching that, so a re-save is a normal managed-entity
+    // flush (bumps createdAt, keeps payeeId stable) instead of exception-driven control flow.
+    override suspend fun save(payee: Payee): Payee {
+        Panache.withTransaction {
+            find("partyId = ?1 AND iban = ?2", payee.partyId, payee.iban).firstResult().flatMap { existing ->
+                if (existing != null) {
+                    existing.name = payee.name
+                    existing.bic = payee.bic
+                    existing.createdAt = payee.createdAt
+                    Uni.createFrom().voidItem()
+                } else {
+                    persist(
+                        PartyPayeeEntity().also {
+                            it.payeeId = payee.id
+                            it.partyId = payee.partyId
+                            it.name = payee.name
+                            it.iban = payee.iban
+                            it.bic = payee.bic
+                            it.createdAt = payee.createdAt
+                        },
+                    ).replaceWithVoid()
+                }
+            }
+        }.awaitSuspending()
+        return payee
+    }
+
+    override suspend fun findByPartyId(partyId: UUID): List<Payee> =
+        Panache.withSession { find("partyId", Sort.by("createdAt", Sort.Direction.Descending), partyId).list() }
+            .awaitSuspending()
+            .map { it.toDomain() }
+
+    override suspend fun countByPartyId(partyId: UUID): Long =
+        Panache.withSession { count("partyId", partyId) }.awaitSuspending()
+
+    override suspend fun deleteByPartyIdAndIban(partyId: UUID, iban: String) {
+        Panache.withTransaction { delete("partyId = ?1 AND iban = ?2", partyId, iban) }.awaitSuspending()
+    }
+
+    private fun PartyPayeeEntity.toDomain() = Payee(
+        id = payeeId,
+        partyId = partyId,
+        name = name,
+        iban = iban,
+        bic = bic,
+        createdAt = createdAt,
     )
 }

--- a/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/rest/PartyResource.kt
+++ b/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/rest/PartyResource.kt
@@ -16,7 +16,9 @@ import com.openbank.party.application.port.`in`.CreatePartyCommand
 import com.openbank.party.application.port.`in`.ErasePartyCommand
 import com.openbank.party.application.port.`in`.MergePartyCommand
 import com.openbank.party.application.port.`in`.PartyUseCase
+import com.openbank.party.application.port.`in`.PayeeLimitExceededException
 import com.openbank.party.application.port.`in`.ResolvePartyByRcCommand
+import com.openbank.party.application.port.`in`.SavePayeeCommand
 import com.openbank.party.application.port.`in`.SearchPartiesQuery
 import com.openbank.party.application.port.`in`.SelfRegisterPartyCommand
 import com.openbank.party.application.port.`in`.UpdateMarketingConsentCommand
@@ -29,6 +31,7 @@ import com.openbank.party.domain.model.Party
 import com.openbank.party.domain.model.PartyGdprExport
 import com.openbank.party.domain.model.PartyStatus
 import com.openbank.party.domain.model.PartyType
+import com.openbank.party.domain.model.Payee
 import io.quarkus.security.Authenticated
 import io.quarkus.security.identity.SecurityIdentity
 import jakarta.annotation.security.RolesAllowed
@@ -468,6 +471,48 @@ class PartyResource {
         ).build()
     }
 
+    // ─── Saved payees (TOP-10 #5) ──────────────────────────────────────────────
+    // Server side of the mobile app's device-local PayeeStore. Same trust boundary as
+    // /{id}/consent above: the caller is ALWAYS the customer-edge's M2M service identity, which
+    // has already resolved [id] from the customer's own JWT before calling — never a
+    // client-supplied id the customer chose. No separate ownership check needed here for the
+    // same reason updateConsent doesn't have one: the edge is the trust boundary, not this path.
+
+    @GET
+    @Path("/{id}/payees")
+    @RolesAllowed("ROLE_VIEWER", "ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_KYC", "ROLE_API")
+    @Authorize(action = "party.payees.read", resource = "#id")
+    @Operation(summary = "List a party's saved payees, newest first (mobile)")
+    suspend fun listPayees(@PathParam("id") id: UUID): Response =
+        Response.ok(partyUseCase.listPayees(id).map { it.toResponse() }).build()
+
+    @PUT
+    @Path("/{id}/payees")
+    @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN")
+    @Authorize(action = "party.payees.write", resource = "#id")
+    @Operation(summary = "Save (or update) a payee — upsert by IBAN (mobile)")
+    suspend fun savePayee(@PathParam("id") id: UUID, req: SavePayeeRequest): Response {
+        if (req.name.isBlank() || req.iban.isBlank()) {
+            return Response.status(HTTP_BAD_REQUEST).entity(mapOf("code" to "MISSING_FIELD")).build()
+        }
+        val payee = try {
+            partyUseCase.savePayee(SavePayeeCommand(partyId = id, name = req.name, iban = req.iban, bic = req.bic))
+        } catch (_: PayeeLimitExceededException) {
+            return Response.status(HTTP_UNPROCESSABLE_ENTITY).entity(mapOf("code" to "PAYEE_LIMIT_EXCEEDED")).build()
+        }
+        return Response.ok(payee.toResponse()).build()
+    }
+
+    @DELETE
+    @Path("/{id}/payees/{iban}")
+    @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN")
+    @Authorize(action = "party.payees.write", resource = "#id")
+    @Operation(summary = "Remove a saved payee by IBAN (mobile). Idempotent.")
+    suspend fun deletePayee(@PathParam("id") id: UUID, @PathParam("iban") iban: String): Response {
+        partyUseCase.deletePayee(id, iban)
+        return Response.noContent().build()
+    }
+
     @GET
     @Path("/{id}/documents/{fileId}/content")
     @RolesAllowed("ROLE_VIEWER", "ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_KYC")
@@ -620,6 +665,15 @@ data class AddDocumentRequest(
     val expiryDate: String?,
 )
 data class KycStatusRequest(val kycStatus: String)
+data class SavePayeeRequest(val name: String, val iban: String, val bic: String? = null)
+
+fun Payee.toResponse() = mapOf(
+    "id" to id,
+    "name" to name,
+    "iban" to iban,
+    "bic" to bic,
+    "createdAt" to createdAt,
+)
 data class AddressRequest(
     val line1: String,
     val line2: String?,
@@ -705,3 +759,6 @@ private const val GDPR_EXPORT_SCOPE =
 data class DirectoryLookupRequest(val phoneHashes: List<String> = emptyList())
 
 data class DiscoverableRequest(val discoverable: Boolean = false)
+
+private const val HTTP_BAD_REQUEST = 400
+private const val HTTP_UNPROCESSABLE_ENTITY = 422

--- a/openbank-party-service/src/main/resources/db/migration/V18__party_payees.sql
+++ b/openbank-party-service/src/main/resources/db/migration/V18__party_payees.sql
@@ -1,0 +1,23 @@
+-- Saved payees (TOP-10 #5): server-synced version of the mobile app's device-local payee list.
+-- Rollback:
+--   DROP TABLE party_payees;
+--   DROP SEQUENCE "party_payees_SEQ";
+
+CREATE TABLE party_payees (
+    id         BIGSERIAL PRIMARY KEY,
+    payee_id   UUID NOT NULL UNIQUE,
+    party_id   UUID NOT NULL,
+    name       VARCHAR(120) NOT NULL,
+    iban       VARCHAR(34) NOT NULL,
+    bic        VARCHAR(11),
+    created_at TIMESTAMPTZ NOT NULL
+);
+
+CREATE INDEX idx_party_payees_party_id ON party_payees (party_id);
+
+-- Dedup key: a re-save of the same IBAN updates the existing row (see PartyPayeeRepositoryImpl.save),
+-- matching the app's own "re-add moves it to the front" rule instead of accumulating duplicate rows.
+ALTER TABLE party_payees ADD CONSTRAINT uq_party_payees_party_iban UNIQUE (party_id, iban);
+
+-- Panache's default SEQUENCE id-generation strategy for the entity's surrogate `id`.
+CREATE SEQUENCE IF NOT EXISTS "party_payees_SEQ" INCREMENT BY 50;

--- a/openbank-party-service/src/main/resources/openapi.yaml
+++ b/openbank-party-service/src/main/resources/openapi.yaml
@@ -6,7 +6,7 @@ info:
   # major == openbank.api.version == URL /api/v1 (ADR-0048). Minor bump (1.8 -> 1.9): additive
   # only — a new PATCH /api/v1/parties/approvals/{id} endpoint and an additional 202 response
   # on POST /{id}/merge (ADR-0155 four-eyes). No existing response or schema changed.
-  version: 1.16.0
+  version: 1.17.0
   description: Legal entity and individual party management with document storage.
   license:
     name: Apache-2.0
@@ -252,6 +252,62 @@ paths:
           description: Updated
         '404':
           $ref: '#/components/responses/NotFound'
+
+  /api/v1/parties/{id}/payees:
+    get:
+      tags: [Parties]
+      summary: List a party's saved payees, newest first (TOP-10 #5)
+      operationId: listPayees
+      parameters:
+        - $ref: '#/components/parameters/partyId'
+      responses:
+        '200':
+          description: Saved payees
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Payee'
+    put:
+      tags: [Parties]
+      summary: Save (or update) a payee — upsert by IBAN
+      operationId: savePayee
+      parameters:
+        - $ref: '#/components/parameters/partyId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SavePayeeRequest'
+      responses:
+        '200':
+          description: Saved payee
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Payee'
+        '400':
+          description: Missing name or iban
+        '422':
+          description: Party already has the maximum of 30 saved payees
+
+  /api/v1/parties/{id}/payees/{iban}:
+    delete:
+      tags: [Parties]
+      summary: Remove a saved payee by IBAN. Idempotent — a missing IBAN is not an error.
+      operationId: deletePayee
+      parameters:
+        - $ref: '#/components/parameters/partyId'
+        - name: iban
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Removed (or already absent)
 
   /api/v1/parties/directory/lookup:
     post:
@@ -715,6 +771,34 @@ components:
             Live, revocable marketing-communications preference (mobile app Profile screen).
             Not the onboarding-time consentGdpr snapshot — that isn't Art 6(1)(a) consent and
             has no update path.
+
+    Payee:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        iban:
+          type: string
+        bic:
+          type: string
+          nullable: true
+        createdAt:
+          type: string
+          format: date-time
+    SavePayeeRequest:
+      type: object
+      required: [name, iban]
+      properties:
+        name:
+          type: string
+        iban:
+          type: string
+        bic:
+          type: string
+          nullable: true
 
     AddDocumentRequest:
       type: object

--- a/openbank-party-service/src/test/kotlin/com/openbank/party/application/usecase/PartyServicePayeeTest.kt
+++ b/openbank-party-service/src/test/kotlin/com/openbank/party/application/usecase/PartyServicePayeeTest.kt
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.party.application.usecase
+
+import com.openbank.party.application.port.`in`.PayeeLimitExceededException
+import com.openbank.party.application.port.`in`.SavePayeeCommand
+import com.openbank.party.application.port.out.PartyPayeeRepository
+import com.openbank.party.domain.model.Payee
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+import java.util.UUID
+
+/**
+ * Saved payees (TOP-10 #5) — server side of the mobile app's device-local PayeeStore. Split into
+ * its own class to keep [PartyServiceTest] under detekt's LargeClass threshold.
+ */
+class PartyServicePayeeTest {
+
+    private val now = Instant.parse("2026-08-16T12:00:00Z")
+    private val partyId = UUID.fromString("44444444-4444-4444-4444-444444444444")
+
+    private fun newService(payeeRepo: PartyPayeeRepository) = PartyService().apply {
+        this.payeeRepo = payeeRepo
+        clock = Clock.fixed(now, ZoneOffset.UTC)
+    }
+
+    @Test
+    fun `savePayee normalises the IBAN, trims free text, and stamps createdAt from the clock`(): Unit = runBlocking {
+        val repo = mockk<PartyPayeeRepository>()
+        coEvery { repo.findByPartyId(partyId) } returns emptyList()
+        val saved = slot<Payee>()
+        coEvery { repo.save(capture(saved)) } answers { firstArg() }
+
+        val result = newService(repo).savePayee(
+            SavePayeeCommand(
+                partyId = partyId,
+                name = "  Jana Nováková  ",
+                iban = "cz65 0800 0000 1920 0014 5399",
+                bic = null,
+            ),
+        )
+
+        assertThat(saved.captured.iban).isEqualTo("CZ6508000000192000145399")
+        assertThat(saved.captured.name).isEqualTo("Jana Nováková")
+        assertThat(saved.captured.createdAt).isEqualTo(now)
+        assertThat(result.partyId).isEqualTo(partyId)
+    }
+
+    @Test
+    fun `savePayee reuses the existing id and stays within the 30-payee cap when re-saving the same IBAN`(): Unit =
+        runBlocking {
+            val repo = mockk<PartyPayeeRepository>()
+            val existingId = UUID.randomUUID()
+            val existing = (1..30).map { i ->
+                Payee(
+                    id = if (i == 1) existingId else UUID.randomUUID(),
+                    partyId = partyId,
+                    name = "Payee $i",
+                    iban = if (i == 1) "CZ6508000000192000145399" else "CZ650800000019200014530$i",
+                    bic = null,
+                    createdAt = now.minusSeconds(i.toLong()),
+                )
+            }
+            coEvery { repo.findByPartyId(partyId) } returns existing
+            val saved = slot<Payee>()
+            coEvery { repo.save(capture(saved)) } answers { firstArg() }
+
+            newService(repo).savePayee(
+                SavePayeeCommand(
+                    partyId = partyId,
+                    name = "Jana Nováková",
+                    iban = "CZ6508000000192000145399",
+                    bic = null,
+                ),
+            )
+
+            // A re-save of an already-saved IBAN reuses that payee's id — it never creates a
+            // 31st row, so it cannot itself trip the cap.
+            assertThat(saved.captured.id).isEqualTo(existingId)
+        }
+
+    @Test
+    fun `savePayee refuses a genuinely new payee once the party already has 30`() {
+        val repo = mockk<PartyPayeeRepository>()
+        val existing = (1..30).map { i ->
+            Payee(
+                id = UUID.randomUUID(),
+                partyId = partyId,
+                name = "Payee $i",
+                iban = "CZ650800000019200014530$i",
+                bic = null,
+                createdAt = now.minusSeconds(i.toLong()),
+            )
+        }
+        coEvery { repo.findByPartyId(partyId) } returns existing
+
+        assertThatThrownBy {
+            runBlocking {
+                newService(repo).savePayee(
+                    SavePayeeCommand(
+                        partyId = partyId,
+                        name = "One too many",
+                        iban = "CZ9999999999999999999999",
+                        bic = null,
+                    ),
+                )
+            }
+        }.isInstanceOf(PayeeLimitExceededException::class.java)
+
+        coVerify(exactly = 0) { repo.save(any()) }
+    }
+
+    @Test
+    fun `deletePayee normalises the IBAN the same way savePayee does`(): Unit = runBlocking {
+        val repo = mockk<PartyPayeeRepository>()
+        coEvery { repo.deleteByPartyIdAndIban(partyId, "CZ6508000000192000145399") } returns Unit
+
+        newService(repo).deletePayee(partyId, "cz65 0800 0000 1920 0014 5399")
+
+        coVerify(exactly = 1) { repo.deleteByPartyIdAndIban(partyId, "CZ6508000000192000145399") }
+    }
+}


### PR DESCRIPTION
## Summary
Server side of the mobile app's device-local `PayeeStore` — the last remaining item of the TOP-10 v2 app feature program. New `openbank-party-service` table `party_payees`:

- Dedup by `(party_id, iban)` enforced at the DB level (unique constraint) — a re-save of an existing IBAN updates that row instead of accumulating duplicates, matching the app's own "re-add moves to front" rule.
- 30-payee cap enforced in `PartyService.savePayee`, mirroring the app's `PayeeStore.MAX_PAYEES`.
- `GET/PUT /api/v1/parties/{id}/payees`, `DELETE .../payees/{iban}` — `RolesAllowed(OPERATOR, ADMIN)` + `@Authorize(party.payees.*)`, same trust boundary as the existing `/{id}/consent` endpoint (caller is always customer-edge's M2M identity, which already resolved `{id}` from the real customer JWT — no separate ownership check needed for the same reason `updateConsent` doesn't have one).

**Not money-path**: `openbank-party-service` is absent from `rules.yaml: money_path_services` — no threat-model-doc gate. `AUTHZ_ENFORCE=false` for party-service (advisory only), and the edge's `customer.*` self-action rule already covers `customer.payees.read/write` with zero rego changes needed on either side.

Edge: `GET/PUT /customer/v1/payees`, `DELETE /customer/v1/payees/{iban}`, documented in `openapi.yaml` (bumped 1.37.0 → 1.38.0).

## Test plan
- [x] New unit tests: normalisation/trim/stamp, cap-reuse-on-resave, cap-refusal-on-new, delete normalisation
- [x] ktlint, detekt, `:openbank-party-service:test`, `:openbank-customer-edge:ktlintCheck`, `:openbank-customer-edge:detekt`, `:openbank-customer-edge:test` all green
- [x] `check-openapi-route-conformance.py` run manually — advisory-only, consistent with ~80 pre-existing unpublished-route findings across the fleet (party-service's own internal API isn't documented anywhere today, same as e.g. `PATCH /profile/consent`)

## Linked issues
N/A — self-initiated TOP-10 v2 backlog item (#5, no tracking issue filed).
