### PR TITLE
fix(admin-ui): load next ledger journal page

### DIFF
--- a/openbank-admin-ui/src/app/ledger/page.tsx
+++ b/openbank-admin-ui/src/app/ledger/page.tsx
@@ -25,28 +25,52 @@ export default function LedgerPage() {
   const [toDate, setToDate]     = useState(() => new Date().toISOString().slice(0, 10))
   const [result, setResult]     = useState<CursorPage<JournalEntry> | null>(null)
   const [loading, setLoading]   = useState(false)
+  const [loadingMore, setLoadingMore] = useState(false)
   // Typed unavailable reason → renders the calm <DataUnavailable> panel instead
   // of a raw "HTTP 500" leak (admin-ui graceful-state rule).
   const [unavailable, setUnavailable] = useState<{ kind: UnavailableKind } | null>(null)
   const [expanded, setExpanded] = useState<string | null>(null)
+  const [moreError, setMoreError] = useState<string | null>(null)
 
-  async function search() {
-    setLoading(true); setUnavailable(null)
+  async function loadPage(cursor?: string) {
     try {
-      const res = await fetch(svcUrl('ledger-service', '/api/v1/journals', { fromDate, toDate }), {
+      const res = await fetch(svcUrl('ledger-service', '/api/v1/journals', { fromDate, toDate, limit: '20', ...(cursor ? { cursor } : {}) }), {
         signal: AbortSignal.timeout(8000),
       })
       if (!res.ok) {
-        setResult(null)
-        setUnavailable({ kind: await classifyBffFailure(res) })
-        return
+        throw new Error(await classifyBffFailure(res))
       }
-      setResult(await res.json() as CursorPage<JournalEntry>)
-    } catch {
+      return await res.json() as CursorPage<JournalEntry>
+    } catch (error) {
+      throw error instanceof Error ? error : new Error('unreachable')
+    }
+  }
+
+  async function search() {
+    setLoading(true); setUnavailable(null); setMoreError(null); setExpanded(null)
+    try {
+      setResult(await loadPage())
+    } catch (error) {
       // Timeout / abort / network — the BFF or ledger-service didn't answer.
       setResult(null)
-      setUnavailable({ kind: 'unreachable' })
+      setUnavailable({ kind: (error as Error).message as UnavailableKind || 'unreachable' })
     } finally { setLoading(false) }
+  }
+
+  async function loadMore() {
+    const cursor = result?.pagination.nextCursor
+    if (!cursor) return
+    setLoadingMore(true); setMoreError(null)
+    try {
+      const next = await loadPage(cursor)
+      setResult(previous => previous ? {
+        data: [...previous.data, ...next.data],
+        pagination: next.pagination,
+      } : next)
+    } catch {
+      // Keep already-read ledger records visible; a failed next page must not erase evidence.
+      setMoreError(t('Další stránku se nepodařilo načíst. Zkuste to znovu.', 'The next page could not be loaded. Try again.'))
+    } finally { setLoadingMore(false) }
   }
 
   return (
@@ -203,7 +227,10 @@ export default function LedgerPage() {
 
         {result?.pagination.hasNextPage && (
           <div style={{ padding: '12px 16px', borderTop: '1px solid var(--border)', textAlign: 'center' }}>
-            <button className="btn btn-secondary" style={{ fontSize: '12px' }}>{t('Načíst další', 'Load more')}</button>
+            {moreError && <p role="alert" style={{ margin: '0 0 8px', fontSize: '12px', color: 'var(--danger-text)' }}>{moreError}</p>}
+            <button className="btn btn-secondary" style={{ fontSize: '12px' }} onClick={loadMore} disabled={loadingMore}>
+              {loadingMore ? t('Načítám…', 'Loading…') : t('Načíst další', 'Load more')}
+            </button>
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary\n- make the General Ledger ‘Load more’ control follow the API cursor\n- retain already-read journal evidence if fetching the next page fails\n- distinguish initial-query availability failures from pagination failures\n\n## Verification\n- npm test -- render-smoke route-permissions graceful-states.guard\n- npm run type-check\n\nRefs #4599