### PR TITLE
test(admin-ui): cover ledger cursor pagination

### DIFF
--- a/openbank-admin-ui/src/test/ledger-pagination.test.tsx
+++ b/openbank-admin-ui/src/test/ledger-pagination.test.tsx
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import React from 'react'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { LanguageProvider } from '@/lib/i18n/LanguageContext'
+import LedgerPage from '@/app/ledger/page'
+
+const firstPage = {
+  data: [{ id: 'entry-1', transactionId: 'transaction-1', entryDate: '2026-08-01', valueDate: '2026-08-01', status: 'POSTED', lines: [], description: 'First page' }],
+  pagination: { limit: 20, hasNextPage: true, nextCursor: 'cursor-1' },
+}
+const secondPage = {
+  data: [{ id: 'entry-2', transactionId: 'transaction-2', entryDate: '2026-08-02', valueDate: '2026-08-02', status: 'POSTED', lines: [], description: 'Second page' }],
+  pagination: { limit: 20, hasNextPage: false },
+}
+
+function renderPage() {
+  return render(React.createElement(LanguageProvider, null, React.createElement(LedgerPage)))
+}
+
+function response(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } })
+}
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+})
+
+describe('General Ledger pagination', () => {
+  it('forwards the server cursor and appends the next journal page', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(response(firstPage))
+      .mockResolvedValueOnce(response(secondPage))
+    vi.stubGlobal('fetch', fetchMock)
+    renderPage()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Load Entries' }))
+    await screen.findByText('First page')
+    fireEvent.click(screen.getByRole('button', { name: 'Load more' }))
+
+    await screen.findByText('Second page')
+    expect(screen.getByText('First page')).toBeTruthy()
+    expect(String(fetchMock.mock.calls[1]?.[0])).toContain('cursor=cursor-1')
+    expect(String(fetchMock.mock.calls[1]?.[0])).toContain('limit=20')
+  })
+
+  it('keeps the first page visible and explains a next-page failure', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(response(firstPage))
+      .mockRejectedValueOnce(new TypeError('network down'))
+    vi.stubGlobal('fetch', fetchMock)
+    renderPage()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Load Entries' }))
+    await screen.findByText('First page')
+    fireEvent.click(screen.getByRole('button', { name: 'Load more' }))
+
+    await waitFor(() => expect(screen.getByRole('alert').textContent).toContain('next page could not be loaded'))
+    expect(screen.getByText('First page')).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Load more' })).toBeTruthy()
+  })
+})


### PR DESCRIPTION
## Summary\n- prove that the ledger UI forwards the opaque server cursor\n- prove page results append rather than replace the accounting evidence\n- prove a failed subsequent page keeps the prior page visible and offers retry\n\n## Verification\n- npm test -- ledger-pagination\n- npm run type-check\n\nFollow-up for #5171 review finding.