### PR TITLE
fix(admin-ui): label unwired payment actions

### DIFF
--- a/openbank-admin-ui/src/app/standing-orders/page.tsx
+++ b/openbank-admin-ui/src/app/standing-orders/page.tsx
@@ -4,7 +4,7 @@
 
 'use client'
 import { useState } from 'react'
-import { Repeat, Plus, Search, CheckCircle2, XCircle, Clock, RefreshCw, Calendar } from 'lucide-react'
+import { Repeat, Search, CheckCircle2, XCircle, Clock, RefreshCw, Calendar } from 'lucide-react'
 import { AuthGuard } from '@/components/auth/AuthGuard'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { svcUrl } from '@/lib/services/bff'
@@ -60,7 +60,9 @@ export default function StandingOrdersPage() {
                 checking: t('Zjišťuji stav služby…', 'Checking service…'),
               }}
             />
-            <button className="btn btn-primary btn-sm"><Plus size={13} /> {t('Nový příkaz', 'New Order')}</button>
+            <span role="status" style={{ padding: '5px 9px', borderRadius: '6px', border: '1px solid var(--warning-border)', background: 'var(--warning-bg)', color: 'var(--warning-text)', fontSize: '11px', fontWeight: 600 }}>
+              {t('Založení příkazu není připojeno', 'Order creation is not connected')}
+            </span>
           </div>} />
 
         <div className="grid-4" style={{ marginBottom: '24px' }}>

--- a/openbank-admin-ui/src/app/swift/page.tsx
+++ b/openbank-admin-ui/src/app/swift/page.tsx
@@ -5,7 +5,7 @@
 'use client'
 import { useState } from 'react'
 import { useRouter } from 'next/navigation'
-import { Globe, Send, Search, CheckCircle2, Clock, RefreshCw, AlertTriangle, ChevronRight } from 'lucide-react'
+import { Globe, Search, CheckCircle2, Clock, RefreshCw, AlertTriangle, ChevronRight } from 'lucide-react'
 import { AuthGuard } from '@/components/auth/AuthGuard'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { svcUrl } from '@/lib/services/bff'
@@ -68,7 +68,9 @@ export default function SwiftPage() {
                 checking: t('Zjišťuji stav služby…', 'Checking service…'),
               }}
             />
-            <button className="btn btn-primary btn-sm"><Send size={13} /> {t('Nová zpráva', 'New Message')}</button>
+            <span role="status" style={{ padding: '5px 9px', borderRadius: '6px', border: '1px solid var(--warning-border)', background: 'var(--warning-bg)', color: 'var(--warning-text)', fontSize: '11px', fontWeight: 600 }}>
+              {t('Odeslání zprávy není připojeno', 'Message submission is not connected')}
+            </span>
           </div>
         </div>
 


### PR DESCRIPTION
## Summary\n- replace no-op SWIFT and standing-order creation buttons with explicit workflow status\n- avoid implying that a money-movement action was started when no supported UI flow exists\n- do not change service APIs, RBAC or payment execution\n\n## Verification\n- npm test -- render-smoke route-permissions ui-tone\n- npm run type-check\n\nRefs #4599