### PR TITLE
fix(admin-ui): add shell skip navigation

### DIFF
--- a/openbank-admin-ui/src/app/dashboard/page.tsx
+++ b/openbank-admin-ui/src/app/dashboard/page.tsx
@@ -150,7 +150,7 @@ export default function DashboardPage() {
   const groups = ['core', 'payments', 'compliance', 'identity', 'open-banking', 'platform']
 
   return (
-    <main className={styles.dashboard}>
+    <div className={styles.dashboard}>
       <PageHeader
         title={t('Můj pracovní prostor', 'My workspace')}
         subtitle={`${personaLabel(persona, personaLanguage)} · ${t('Prioritní pracovní fronty a aktuální stav platformy.', 'Priority work queues and the current platform state.')}`}
@@ -308,6 +308,6 @@ export default function DashboardPage() {
           ))}
         </div>
       </section>
-    </main>
+    </div>
   )
 }

--- a/openbank-admin-ui/src/app/globals.css
+++ b/openbank-admin-ui/src/app/globals.css
@@ -144,6 +144,23 @@ main {
   animation: fadeIn 0.4s ease-out;
 }
 
+.ob-skip-link {
+  position: fixed;
+  z-index: 100;
+  top: .75rem;
+  left: .75rem;
+  transform: translateY(-180%);
+  padding: .6rem .8rem;
+  border-radius: .5rem;
+  background: var(--accent);
+  color: #fff;
+  font-size: .875rem;
+  font-weight: 700;
+  text-decoration: none;
+  transition: transform .15s ease-out;
+}
+.ob-skip-link:focus { transform: translateY(0); outline: 3px solid var(--focus-ring); outline-offset: 2px; }
+
 /* ── Operator application shell ── */
 .ob-app-shell {
   display: flex;

--- a/openbank-admin-ui/src/app/globals.css
+++ b/openbank-admin-ui/src/app/globals.css
@@ -159,7 +159,7 @@ main {
   text-decoration: none;
   transition: transform .15s ease-out;
 }
-.ob-skip-link:focus { transform: translateY(0); outline: 3px solid var(--focus-ring); outline-offset: 2px; }
+.ob-skip-link:focus { transform: translateY(0); outline: 3px solid rgba(255, 255, 255, .9); outline-offset: 2px; }
 
 /* ── Operator application shell ── */
 .ob-app-shell {

--- a/openbank-admin-ui/src/app/services/[name]/docs/[[...slug]]/page.tsx
+++ b/openbank-admin-ui/src/app/services/[name]/docs/[[...slug]]/page.tsx
@@ -193,7 +193,7 @@ export default async function ServiceDocsPage({ params, searchParams }: PageProp
         )}
       </aside>
 
-      <main style={{
+      <div style={{
         background: 'var(--surface)',
         border: '1px solid var(--border)',
         borderRadius: 'var(--r-lg)',
@@ -253,7 +253,7 @@ export default async function ServiceDocsPage({ params, searchParams }: PageProp
             <MarkdownView markdown={doc.markdown} serviceName={name} />
           </MermaidEnhancer>
         )}
-      </main>
+      </div>
     </div>
   )
 }

--- a/openbank-admin-ui/src/components/layout/AppShell.tsx
+++ b/openbank-admin-ui/src/components/layout/AppShell.tsx
@@ -16,10 +16,11 @@ import { Sidebar } from '@/components/layout/Sidebar'
 export function AppShell({ children }: { children: ReactNode }) {
   return (
     <div className="ob-app-shell">
+      <a className="ob-skip-link" href="#main-content">Skip to main content</a>
       <Sidebar />
       <div className="ob-app-frame">
         <Header />
-        <main className="ob-app-content">{children}</main>
+        <main id="main-content" className="ob-app-content" tabIndex={-1}>{children}</main>
       </div>
     </div>
   )

--- a/openbank-admin-ui/src/components/layout/AppShell.tsx
+++ b/openbank-admin-ui/src/components/layout/AppShell.tsx
@@ -5,6 +5,7 @@
 import type { ReactNode } from 'react'
 import { Header } from '@/components/layout/Header'
 import { Sidebar } from '@/components/layout/Sidebar'
+import { SkipLink } from '@/components/layout/SkipLink'
 
 /**
  * The single authenticated operator shell.
@@ -16,7 +17,7 @@ import { Sidebar } from '@/components/layout/Sidebar'
 export function AppShell({ children }: { children: ReactNode }) {
   return (
     <div className="ob-app-shell">
-      <a className="ob-skip-link" href="#main-content">Skip to main content</a>
+      <SkipLink />
       <Sidebar />
       <div className="ob-app-frame">
         <Header />

--- a/openbank-admin-ui/src/components/layout/SkipLink.tsx
+++ b/openbank-admin-ui/src/components/layout/SkipLink.tsx
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+'use client'
+
+import { useLanguage } from '@/lib/i18n/LanguageContext'
+
+export function SkipLink() {
+  const { t } = useLanguage()
+
+  return (
+    <a className="ob-skip-link" href="#main-content">
+      {t('Přeskočit na hlavní obsah', 'Skip to main content')}
+    </a>
+  )
+}

--- a/openbank-admin-ui/src/test/layout-shell.guard.test.ts
+++ b/openbank-admin-ui/src/test/layout-shell.guard.test.ts
@@ -88,6 +88,12 @@ describe('admin-ui app-shell rule', () => {
     expect(shell).toMatch(/<Header\s*\/>/)
   })
 
+  it('provides a keyboard skip link to the shared main landmark', () => {
+    const shell = readFileSync(path.resolve(__dirname, '../components/layout/AppShell.tsx'), 'utf8')
+    expect(shell).toMatch(/href="#main-content"/)
+    expect(shell).toMatch(/<main id="main-content"[^>]*tabIndex=\{-1\}/)
+  })
+
   it('keeps the reusable operator layout as the only owner of the shell composition', () => {
     const layout = readFileSync(path.resolve(__dirname, '../components/layout/OperatorLayout.tsx'), 'utf8')
     expect(layout).toMatch(/<AppShell>\{children\}<\/AppShell>/)

--- a/openbank-admin-ui/src/test/layout-shell.guard.test.ts
+++ b/openbank-admin-ui/src/test/layout-shell.guard.test.ts
@@ -90,7 +90,9 @@ describe('admin-ui app-shell rule', () => {
 
   it('provides a keyboard skip link to the shared main landmark', () => {
     const shell = readFileSync(path.resolve(__dirname, '../components/layout/AppShell.tsx'), 'utf8')
-    expect(shell).toMatch(/href="#main-content"/)
+    const skipLink = readFileSync(path.resolve(__dirname, '../components/layout/SkipLink.tsx'), 'utf8')
+    expect(shell).toMatch(/<SkipLink\s*\/>/)
+    expect(skipLink).toMatch(/href="#main-content"/)
     expect(shell).toMatch(/<main id="main-content"[^>]*tabIndex=\{-1\}/)
   })
 
@@ -111,6 +113,14 @@ describe('admin-ui app-shell rule', () => {
 
   it('discovers page files', () => {
     expect(pages.length).toBeGreaterThan(10)
+  })
+
+  it('keeps the shared shell as the only main landmark on operator pages', () => {
+    for (const file of pages) {
+      const rel = path.relative(APP_DIR, file).split(path.sep).join('/')
+      if (EXEMPT.has(rel) || !hasShellLayoutInChain(file)) continue
+      expect(readFileSync(file, 'utf8'), rel).not.toMatch(/<main\b/)
+    }
   })
 
   for (const file of pages) {


### PR DESCRIPTION
## Summary\n- add a keyboard skip link to the single admin content landmark\n- make the destination programmatically focusable\n- guard the shell contract against regression\n\n## Verification\n- npm test -- layout-shell.guard render-smoke\n- npm run type-check\n\nRefs #4599