### PR TITLE
fix(libs-runtime): rename outboxDispatched's topic tag to event_type

### DIFF
--- a/openbank-libs-runtime/src/main/kotlin/com/openbank/libs/observability/DomainMetrics.kt
+++ b/openbank-libs-runtime/src/main/kotlin/com/openbank/libs/observability/DomainMetrics.kt
@@ -327,11 +327,16 @@ class DomainMetrics {
     /**
      * Increment each time the outbox dispatcher successfully publishes an event.
      *
-     * @param service  service name (e.g. `sepa-payment`, `ledger`)
-     * @param topic    Kafka topic
+     * @param service   service name (e.g. `sepa-payment`, `ledger`)
+     * @param eventType the outbox entry's domain event type (e.g. `PARTY_ERASED`), **not** the
+     *                  Kafka topic — every publisher in this fleet sends to one fixed topic per
+     *                  service, so a `topic` tag would be constant per `service` and add nothing;
+     *                  `eventType` is the actual per-row granularity this counter measures
+     *                  (issue #5128 finding 1). If a service ever fans out to more than one topic,
+     *                  add a separate `topic` parameter rather than overloading this one.
      */
-    fun outboxDispatched(service: String, topic: String) {
-        counter("openbank.outbox.dispatched", "service", service, "topic", topic)
+    fun outboxDispatched(service: String, eventType: String) {
+        counter("openbank.outbox.dispatched", "service", service, "event_type", eventType)
     }
 
     /**

--- a/openbank-libs-runtime/src/test/kotlin/com/openbank/libs/persistence/outbox/AbstractOutboxDispatcherTest.kt
+++ b/openbank-libs-runtime/src/test/kotlin/com/openbank/libs/persistence/outbox/AbstractOutboxDispatcherTest.kt
@@ -173,7 +173,8 @@ class AbstractOutboxDispatcherTest {
 
         // Falsifying assertion: a no-op wiring (metrics never called) or a wiring that fires once
         // per BATCH instead of once per ROW both fail this — it must be exactly 2, tagged with
-        // each row's own eventType as the topic label, not a shared/hardcoded one.
+        // each row's own eventType as the event_type label (#5128 finding 1), not a
+        // shared/hardcoded one.
         verify(exactly = 1) { metrics.outboxDispatched("widget", "account.created") }
         verify(exactly = 1) { metrics.outboxDispatched("widget", "payment.sent") }
         verify(exactly = 0) { metrics.outboxDead(any()) }


### PR DESCRIPTION
## What

`DomainMetrics.outboxDispatched`'s `topic` parameter was documented `@param topic Kafka topic`,
but its only caller (`AbstractOutboxDispatcher.dispatchScheduledBatch`) passes
`outcome.entry.eventType` — a domain value like `PARTY_ERASED`, not a Kafka topic. Every
publisher in this fleet sends to one fixed Kafka channel per service, so a `topic` tag carrying
the real topic name would be constant per `service` and add nothing; the value actually being
recorded is per-event-type granularity, which is a more useful signal for a dashboard anyway.

This renames the parameter and the emitted Prometheus tag from `topic` to `event_type` (truthful
label) rather than plumbing in the real Kafka topic name, per the issue's own recommendation
(option a — the metric has exactly one caller today, so nothing depends on the old semantics).

## Why not option (b) — pass the real topic

No dispatcher currently has easy access to its own Kafka channel/topic name at the point this
metric fires (`OutboxEventPublisher.publish` owns that, not the dispatch loop), and a `topic`
tag would be redundant with `service` for every fleet publisher (one topic per service). Inventing
that plumbing for no dashboard benefit isn't justified — flagged explicitly in the issue as
probably not worth it.

## Verified no dashboard/alert config depends on the old tag name

Checked `openbank-infra/gitops/components/observability/*.yaml` for anything querying
`openbank_outbox_dispatched_total` — the three panels that do (`dashboard-openbank-event-bus.yaml`,
`dashboard-openbank-ledger-integrity.yaml`, `dashboard-openbank-payments.yaml`) all aggregate with
`sum by (service) (...)` or `sum(...)`, never filtering or grouping by `topic`. No dashboard change
needed.

## Testing

- `./gradlew :openbank-libs-runtime:ktlintCheck :openbank-libs-runtime:detekt :openbank-libs-runtime:test` — green.
- Grepped every `outboxDispatched(` call site fleet-wide — the sole non-test caller passes
  positional args, so the rename doesn't break any named-argument caller.

Refs #5128 (finding 1 of 4 in scope for this follow-up; findings 2-4 land as separate PRs).
