### PR TITLE
fix(security-scanner): wire outboxDispatched into SecurityOutboxDispatcher

### DIFF
--- a/openbank-security-scanner/src/main/kotlin/com/openbank/security/infrastructure/outbox/SecurityOutboxDispatcher.kt
+++ b/openbank-security-scanner/src/main/kotlin/com/openbank/security/infrastructure/outbox/SecurityOutboxDispatcher.kt
@@ -4,6 +4,7 @@
 package com.openbank.security.infrastructure.outbox
 
 import com.openbank.libs.domain.identifiers.Ids
+import com.openbank.libs.observability.DomainMetrics
 import com.openbank.security.infrastructure.persistence.repository.SecurityOutboxRepositoryImpl
 import io.quarkus.scheduler.Scheduled
 import io.smallrye.mutiny.Multi
@@ -13,46 +14,66 @@ import jakarta.enterprise.context.ApplicationScoped
 import org.eclipse.microprofile.reactive.messaging.Channel
 import org.eclipse.microprofile.reactive.messaging.Emitter
 
+/**
+ * Bespoke Mutiny/reactive outbox dispatcher — does **not** extend
+ * [com.openbank.libs.persistence.outbox.AbstractOutboxDispatcher] (that base class is
+ * suspend-fun/coroutine shaped; this service's whole outbox surface is reactive Panache, see
+ * [SecurityOutboxRepositoryImpl]), so it was unreachable by #5049's dispatched/dead metrics
+ * wiring and reported a permanent false "never dispatches" reading next to
+ * [SecurityOutboxBacklogGauge]'s real backlog data (#5128 finding 4). Wires
+ * [DomainMetrics.outboxDispatched] manually into the reactive chain below, constructor-injected
+ * like [SecurityOutboxBacklogGauge] already is.
+ *
+ * No call to `DomainMetrics.outboxDead` here: [SecurityOutboxStatus] has no `DEAD`/terminal
+ * state at all — [markFailedUni][SecurityOutboxRepositoryImpl.markFailedUni] always sets
+ * `FAILED`, which [listProcessableUni][SecurityOutboxRepositoryImpl.listProcessableUni] re-picks
+ * up on the next tick forever, so nothing in this service's outbox is ever "dead" in the sense
+ * that metric means elsewhere in the fleet.
+ */
 @ApplicationScoped
 class SecurityOutboxDispatcher(
     private val outboxRepository: SecurityOutboxRepositoryImpl,
-    @Channel("security-events-out") private val emitter: Emitter<Record<String, String>>
+    @Channel("security-events-out") private val emitter: Emitter<Record<String, String>>,
+    private val metrics: DomainMetrics,
 ) {
     @Scheduled(
         every = "5s",
         delayed = "5s",
-        concurrentExecution = Scheduled.ConcurrentExecution.SKIP
+        concurrentExecution = Scheduled.ConcurrentExecution.SKIP,
     )
-    fun dispatchScheduledBatch(): Uni<Void> =
-        outboxRepository.listProcessableUni(BATCH_SIZE)
-            .onItem().transformToMulti { Multi.createFrom().iterable(it) }
-            .onItem().transformToUniAndConcatenate { event ->
-                // `completionStage`, NOT `item`. `Emitter.send` returns a CompletionStage that
-                // completes when the broker ACKS; wrapping it with `item { }` made the Uni's VALUE
-                // that CompletionStage and completed the Uni the instant `send` RETURNED. So the
-                // chain below ran unconditionally and marked the row SENT for a publish that had
-                // not happened yet — and could still fail. A broker denial, an unreachable broker
-                // or a serialisation error all lost the event silently, with the outbox reporting
-                // success. `onFailure` could only ever see a synchronous throw from `send` itself,
-                // which is the one case that does not happen.
-                //
-                // Measured while fixing #3393: security-scanner is refused by the broker as
-                // ANONYMOUS on every publish, and its outbox would have recorded every one of
-                // those as SENT. Verify a publish on the BROKER, never on outbox status.
-                Uni.createFrom().completionStage {
-                    emitter.send(
-                        Record.of(Ids.randomId().toString(), event.payload),
-                    )
-                }
-                    .chain { _ -> outboxRepository.markSentUni(event.eventId) }
-                    .onFailure().recoverWithUni { ex ->
-                        outboxRepository.markFailedUni(event.eventId, ex.message ?: ex.javaClass.simpleName)
-                    }
+    fun dispatchScheduledBatch(): Uni<Void> = outboxRepository.listProcessableUni(BATCH_SIZE)
+        .onItem().transformToMulti { Multi.createFrom().iterable(it) }
+        .onItem().transformToUniAndConcatenate { event ->
+            // `completionStage`, NOT `item`. `Emitter.send` returns a CompletionStage that
+            // completes when the broker ACKS; wrapping it with `item { }` made the Uni's VALUE
+            // that CompletionStage and completed the Uni the instant `send` RETURNED. So the
+            // chain below ran unconditionally and marked the row SENT for a publish that had
+            // not happened yet — and could still fail. A broker denial, an unreachable broker
+            // or a serialisation error all lost the event silently, with the outbox reporting
+            // success. `onFailure` could only ever see a synchronous throw from `send` itself,
+            // which is the one case that does not happen.
+            //
+            // Measured while fixing #3393: security-scanner is refused by the broker as
+            // ANONYMOUS on every publish, and its outbox would have recorded every one of
+            // those as SENT. Verify a publish on the BROKER, never on outbox status.
+            Uni.createFrom().completionStage {
+                emitter.send(
+                    Record.of(Ids.randomId().toString(), event.payload),
+                )
             }
-            .collect().asList()
-            .replaceWithVoid()
+                .chain { _ -> outboxRepository.markSentUni(event.eventId) }
+                .invoke { _: Void? -> metrics.outboxDispatched(SERVICE, event.eventType) }
+                .onFailure().recoverWithUni { ex ->
+                    outboxRepository.markFailedUni(event.eventId, ex.message ?: ex.javaClass.simpleName)
+                }
+        }
+        .collect().asList()
+        .replaceWithVoid()
 
     companion object {
         private const val BATCH_SIZE = 25
+
+        /** Matches [SecurityOutboxBacklogGauge.service] so both panels share one label. */
+        private const val SERVICE = "security-scanner"
     }
 }

--- a/openbank-security-scanner/src/main/resources/application.yaml
+++ b/openbank-security-scanner/src/main/resources/application.yaml
@@ -125,6 +125,9 @@ mp:
 
 openbank:
   outbox:
+    # Every service with an outbox entity must flip this explicitly — it defaults to false, and a
+    # service that forgets ships an outbox that fills forever with no error anywhere.
+    dispatch-enabled: true
     poll-interval: 5s
     initial-delay: 5s
   security-scanner:

--- a/openbank-security-scanner/src/test/kotlin/com/openbank/security/infrastructure/outbox/SecurityOutboxDispatcherTest.kt
+++ b/openbank-security-scanner/src/test/kotlin/com/openbank/security/infrastructure/outbox/SecurityOutboxDispatcherTest.kt
@@ -3,6 +3,7 @@
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 package com.openbank.security.infrastructure.outbox
 
+import com.openbank.libs.observability.DomainMetrics
 import com.openbank.security.application.port.out.SecurityOutboxEntry
 import com.openbank.security.application.port.out.SecurityOutboxStatus
 import com.openbank.security.infrastructure.persistence.repository.SecurityOutboxRepositoryImpl
@@ -54,10 +55,11 @@ class SecurityOutboxDispatcherTest {
     private fun dispatcherFor(
         repo: SecurityOutboxRepositoryImpl,
         sendResult: CompletionStage<Void>,
+        metrics: DomainMetrics = mockk(relaxed = true),
     ): SecurityOutboxDispatcher {
         val emitter = mockk<Emitter<Record<String, String>>>()
         every { emitter.send(any<Record<String, String>>()) } returns sendResult
-        return SecurityOutboxDispatcher(repo, emitter)
+        return SecurityOutboxDispatcher(repo, emitter, metrics)
     }
 
     @Test
@@ -67,16 +69,19 @@ class SecurityOutboxDispatcherTest {
         every { repo.listProcessableUni(any()) } returns Uni.createFrom().item(listOf(row))
         every { repo.markSentUni(any(), any()) } returns Uni.createFrom().voidItem()
         every { repo.markFailedUni(any(), any(), any()) } returns Uni.createFrom().voidItem()
+        val metrics = mockk<DomainMetrics>(relaxed = true)
 
         val refused = CompletableFuture<Void>().apply {
             completeExceptionally(IllegalStateException("Not authorized to access topics"))
         }
 
-        dispatcherFor(repo, refused).dispatchScheduledBatch().await().indefinitely()
+        dispatcherFor(repo, refused, metrics).dispatchScheduledBatch().await().indefinitely()
 
         // The assertion that would have caught #3393's silent loss.
         verify(exactly = 0) { repo.markSentUni(row.eventId, any()) }
         verify(exactly = 1) { repo.markFailedUni(row.eventId, any(), any()) }
+        // #5128 finding 4: a rejected publish must never be counted as dispatched.
+        verify(exactly = 0) { metrics.outboxDispatched(any(), any()) }
     }
 
     @Test
@@ -86,11 +91,14 @@ class SecurityOutboxDispatcherTest {
         every { repo.listProcessableUni(any()) } returns Uni.createFrom().item(listOf(row))
         every { repo.markSentUni(any(), any()) } returns Uni.createFrom().voidItem()
         every { repo.markFailedUni(any(), any(), any()) } returns Uni.createFrom().voidItem()
+        val metrics = mockk<DomainMetrics>(relaxed = true)
 
-        dispatcherFor(repo, CompletableFuture.completedFuture(null)).dispatchScheduledBatch()
+        dispatcherFor(repo, CompletableFuture.completedFuture(null), metrics).dispatchScheduledBatch()
             .await().indefinitely()
 
         verify(exactly = 1) { repo.markSentUni(row.eventId, any()) }
         verify(exactly = 0) { repo.markFailedUni(row.eventId, any(), any()) }
+        // #5128 finding 4: dispatched metric fires once, tagged with this row's own eventType.
+        verify(exactly = 1) { metrics.outboxDispatched("security-scanner", row.eventType) }
     }
 }


### PR DESCRIPTION
## What

`SecurityOutboxDispatcher` is a bespoke Mutiny/reactive class that does **not** extend
`AbstractOutboxDispatcher` (its whole outbox surface — `SecurityOutboxRepositoryImpl` — is
reactive Panache, not the suspend-fun shape the abstract base expects), so it was unreachable by
#5071's `outboxDispatched`/`outboxDead` metrics wiring. `SecurityOutboxBacklogGauge` already
reports real, live backlog data for the same service, so an operator's dashboard shows a live
backlog panel next to a permanently-zero dispatched panel for security-scanner — reading as
"never dispatches" rather than "not instrumented" (#5128 finding 4).

This constructor-injects `DomainMetrics` (matching `SecurityOutboxBacklogGauge`'s existing
pattern) and calls `outboxDispatched(service, eventType)` manually inside the reactive chain,
only after `markSentUni` confirms the row is durably recorded `SENT` — never on a publish that
merely returned, per the class's own #3393 history of counting a broker-refused publish as
success.

## Why no `outboxDead` call

`SecurityOutboxStatus` has exactly three values — `PENDING`, `SENT`, `FAILED` — no `DEAD`/terminal
state. `markFailedUni` always sets `FAILED`, and `listProcessableUni` re-selects `PENDING` +
`FAILED` rows on every subsequent 5s tick, forever. So nothing in this service's outbox is ever
"dead" in the sense the metric means elsewhere in the fleet (a row that has exhausted retries and
stopped being retried). Wiring `outboxDead` here would misrepresent a row that is still being
retried as permanently failed. Documented directly in the class's KDoc so the omission reads as a
deliberate decision, not a missed spot.

## #4940 status (checked live, not from memory)

Finding 4's issue text says to check whether #4940 (proposed deletion of security-scanner's whole
outbox apparatus) had already merged, which would make this finding moot. Re-verified against
`gh pr view 4940 --json state,mergedAt` at the time of this PR: **`state: OPEN`, `mergedAt: null`**
— unmerged. The apparatus this finding refers to still exists on `main`, so the fix is live work,
not moot. If #4940 lands first, this PR will need reconciling (or dropping) — noted for reviewers.

## Testing

- `./gradlew :openbank-security-scanner:ktlintCheck :openbank-security-scanner:detekt :openbank-security-scanner:test` — green.
- Updated both existing `SecurityOutboxDispatcherTest` cases to assert the new metric: a
  broker-rejected publish records **zero** `outboxDispatched` calls; an accepted publish records
  **exactly one**, tagged with the row's own `eventType`.
- Ran only the module's own build — did not re-run `ktlintFormat` module-wide after the first
  attempt rewrote ~9 unrelated pre-existing-debt files (a known path-scoped-lint pitfall in this
  repo); those were reverted so this diff stays scoped to the two files above.

Refs #5128 (finding 4 of 4 in scope for this follow-up round; findings 1-3 are separate PRs).
