### PR TITLE
feat(product-catalog): expose immutable revision lookup

### DIFF
--- a/openbank-product-catalog/src/main/kotlin/com/openbank/productcatalog/infrastructure/rest/GenericCatalogResource.kt
+++ b/openbank-product-catalog/src/main/kotlin/com/openbank/productcatalog/infrastructure/rest/GenericCatalogResource.kt
@@ -177,6 +177,13 @@ class GenericCatalogResource(
         return Response.ok(revisionResponse(found)).tag(EntityTag(found.revision.toString())).build()
     }
 
+    @RolesAllowed(Roles.OPERATOR, Roles.ADMIN, CatalogRoles.READ)
+    @Authorize(action = "catalog.read", resource = "#id")
+    override suspend fun getRevisionV2(id: UUID): Response {
+        val found = service.findRevision(id)
+        return Response.ok(revisionResponse(found)).tag(EntityTag(found.revision.toString())).build()
+    }
+
     @RolesAllowed(Roles.OPERATOR, Roles.ADMIN, CatalogRoles.AUTHOR)
     @Authorize(action = "catalog.author", resource = "#offeringId")
     override suspend fun replaceOfferingRevisionV2(

--- a/openbank-product-catalog/src/main/resources/openapi.yaml
+++ b/openbank-product-catalog/src/main/resources/openapi.yaml
@@ -4,7 +4,7 @@ openapi: 3.1.0
 info:
   title: Product Catalog API
   # API-contract version is independent of version.txt (ADR-0048); newest URL major is /api/v2.
-  version: 2.1.0
+  version: 2.2.0
   description: >-
     Industry-neutral, schema-governed catalog API with immutable four-eyes publication,
     exact decimal pricing, effective-dated reads and transactional audit/outbox. The

--- a/openbank-product-catalog/src/main/resources/openapi.yaml
+++ b/openbank-product-catalog/src/main/resources/openapi.yaml
@@ -541,6 +541,28 @@ paths:
         '428': { $ref: '#/components/responses/PreconditionRequired' }
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
+  /api/v2/revisions/{id}:
+    get:
+      tags: [Catalog V2]
+      summary: Get one immutable revision by its durable identifier
+      description: >-
+        Consumer-facing lookup for a revision referenced by the durable catalog change stream.
+        The response preserves the offering identity, schema reference, effective interval and
+        approved content required to materialize an independent effective-dated snapshot.
+      operationId: getRevisionV2
+      parameters:
+        - { name: id, in: path, required: true, schema: { type: string, format: uuid } }
+      responses:
+        '200':
+          description: Revision
+          headers:
+            ETag: { $ref: '#/components/headers/RevisionETag' }
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ProductRevision' }
+        '404': { $ref: '#/components/responses/CatalogNotFound' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
   /api/v2/offerings/{offeringId}/revisions/{revisionId}/publish:
     post:
       tags: [Catalog V2]

--- a/openbank-product-catalog/src/test/kotlin/com/openbank/productcatalog/CatalogPlatformResourceTest.kt
+++ b/openbank-product-catalog/src/test/kotlin/com/openbank/productcatalog/CatalogPlatformResourceTest.kt
@@ -114,6 +114,17 @@ class CatalogPlatformResourceTest {
             body("state", equalTo("PUBLISHED"))
             body("content.attributes.interest.dayCount", equalTo("ACT_365"))
         }
+
+        Given { this } When {
+            get("/api/v2/revisions/$revisionId")
+        } Then {
+            statusCode(200)
+            header("ETag", equalTo("\"1\""))
+            body("id", equalTo(revisionId.toString()))
+            body("offeringId", equalTo(offeringId.toString()))
+            body("state", equalTo("PUBLISHED"))
+            body("content.attributes.interest.annualRate", equalTo("0.0425"))
+        }
     }
 
     @Test


### PR DESCRIPTION
## What
- Adds an authenticated generated GET /api/v2/revisions/{id} operation.
- Returns the immutable revision, strong ETag, offering identity, effective interval and approved content.
- Exercises the route against real PostgreSQL after independent publication.

## Why
The durable catalog event identifies a revision. A downstream effective-dated snapshot consumer must read that exact immutable revision rather than query the latest product state.

## Validation
- CatalogPlatformResourceTest: 12 tests, 0 failures.
- git diff --check.

Refs #668