### PR TITLE
fix(libs-domain): read markFailed's persisted status instead of predicting it

### DIFF
--- a/openbank-account-service/src/main/kotlin/com/openbank/account/infrastructure/persistence/repository/AccountOutboxRepositoryImpl.kt
+++ b/openbank-account-service/src/main/kotlin/com/openbank/account/infrastructure/persistence/repository/AccountOutboxRepositoryImpl.kt
@@ -87,18 +87,23 @@ class AccountOutboxRepositoryImpl(private val clock: Clock) :
         }.awaitSuspending()
     }
 
-    override suspend fun markFailed(eventId: UUID, error: String, failedAt: Instant) {
+    override suspend fun markFailed(eventId: UUID, error: String, failedAt: Instant): OutboxStatus =
         Panache.withTransaction {
-            find("eventId", eventId).firstResult().invoke { e ->
+            find("eventId", eventId).firstResult().map { e ->
                 if (e != null) {
                     e.attemptCount += 1
                     e.status = OutboxFailurePolicy.statusAfterFailure(e.attemptCount).name
                     e.lastError = error.take(OutboxFailurePolicy.MAX_ERROR_LEN)
                     e.updatedAt = failedAt
+                    OutboxStatus.valueOf(e.status)
+                } else {
+                    // Row not found -- unreachable in practice (the dispatcher only calls
+                    // markFailed on a row it just claimed), but degrade gracefully rather than
+                    // throw out of a batch that is otherwise mid-flight (#5128 finding 3).
+                    OutboxStatus.FAILED
                 }
-            }.replaceWithVoid()
+            }
         }.awaitSuspending()
-    }
 
     private fun OutboxMessage.toEntity() = AccountOutboxEntity().also {
         it.eventId = eventId

--- a/openbank-aml-service/src/main/kotlin/com/openbank/aml/infrastructure/persistence/repository/AmlOutboxRepositoryImpl.kt
+++ b/openbank-aml-service/src/main/kotlin/com/openbank/aml/infrastructure/persistence/repository/AmlOutboxRepositoryImpl.kt
@@ -94,17 +94,21 @@ class AmlOutboxRepositoryImpl(private val clock: Clock) :
         }.replaceWith(Unit)
     }
 
-    override suspend fun markFailed(eventId: UUID, error: String, failedAt: Instant) {
+    override suspend fun markFailed(eventId: UUID, error: String, failedAt: Instant): OutboxStatus =
         markFailedUni(eventId, error, failedAt).awaitSuspending()
-    }
 
-    fun markFailedUni(eventId: UUID, error: String, failedAt: Instant = Instant.now(clock)): Uni<Unit> =
+    fun markFailedUni(eventId: UUID, error: String, failedAt: Instant = Instant.now(clock)): Uni<OutboxStatus> =
         Panache.withTransaction {
-            find("eventId", eventId).firstResult().invoke { e ->
+            find("eventId", eventId).firstResult().map { e ->
                 if (e != null) {
                     applyFailure(e, error, failedAt)
+                } else {
+                    // Row not found -- unreachable in practice (the dispatcher only calls
+                    // markFailed on a row it just claimed), but degrade gracefully rather than
+                    // throw out of a batch that is otherwise mid-flight (#5128 finding 3).
+                    OutboxStatus.FAILED
                 }
-            }.replaceWith(Unit)
+            }
         }
 
     /**
@@ -112,7 +116,7 @@ class AmlOutboxRepositoryImpl(private val clock: Clock) :
      * configured cap is reached, parks the row in the terminal DEAD state and emits a WARN an
      * operator alert can hook — so a poison row can neither be retried forever nor starve the batch.
      */
-    private fun applyFailure(e: AmlOutboxEntity, error: String, at: Instant = Instant.now(clock)) {
+    private fun applyFailure(e: AmlOutboxEntity, error: String, at: Instant = Instant.now(clock)): OutboxStatus {
         e.attemptCount += 1
         e.lastError = error.take(OutboxFailurePolicy.MAX_ERROR_LEN)
         e.updatedAt = at
@@ -128,6 +132,7 @@ class AmlOutboxRepositoryImpl(private val clock: Clock) :
                 e.lastError,
             )
         }
+        return next
     }
 
     private fun OutboxMessage.toEntity() = AmlOutboxEntity().also {

--- a/openbank-audit-service/src/main/kotlin/com/openbank/audit/infrastructure/persistence/repository/AuditOutboxRepositoryImpl.kt
+++ b/openbank-audit-service/src/main/kotlin/com/openbank/audit/infrastructure/persistence/repository/AuditOutboxRepositoryImpl.kt
@@ -86,18 +86,23 @@ class AuditOutboxRepositoryImpl(private val clock: Clock) :
         }.awaitSuspending()
     }
 
-    override suspend fun markFailed(eventId: UUID, error: String, failedAt: Instant) {
+    override suspend fun markFailed(eventId: UUID, error: String, failedAt: Instant): OutboxStatus =
         Panache.withTransaction {
-            find("eventId", eventId).firstResult().invoke { e ->
+            find("eventId", eventId).firstResult().map { e ->
                 if (e != null) {
                     e.attemptCount += 1
                     e.status = OutboxFailurePolicy.statusAfterFailure(e.attemptCount).name
                     e.lastError = error.take(OutboxFailurePolicy.MAX_ERROR_LEN)
                     e.updatedAt = failedAt
+                    OutboxStatus.valueOf(e.status)
+                } else {
+                    // Row not found -- unreachable in practice (the dispatcher only calls
+                    // markFailed on a row it just claimed), but degrade gracefully rather than
+                    // throw out of a batch that is otherwise mid-flight (#5128 finding 3).
+                    OutboxStatus.FAILED
                 }
-            }.replaceWithVoid()
+            }
         }.awaitSuspending()
-    }
 
     private fun OutboxMessage.toEntity() = AuditOutboxEntity().also {
         it.eventId = eventId

--- a/openbank-balance-service/src/main/kotlin/com/openbank/balance/infrastructure/persistence/repository/BalanceOutboxRepositoryImpl.kt
+++ b/openbank-balance-service/src/main/kotlin/com/openbank/balance/infrastructure/persistence/repository/BalanceOutboxRepositoryImpl.kt
@@ -87,18 +87,23 @@ class BalanceOutboxRepositoryImpl(private val clock: Clock) :
         }.awaitSuspending()
     }
 
-    override suspend fun markFailed(eventId: UUID, error: String, failedAt: Instant) {
+    override suspend fun markFailed(eventId: UUID, error: String, failedAt: Instant): OutboxStatus =
         Panache.withTransaction {
-            find("eventId", eventId).firstResult().invoke { e ->
+            find("eventId", eventId).firstResult().map { e ->
                 if (e != null) {
                     e.attemptCount += 1
                     e.status = OutboxFailurePolicy.statusAfterFailure(e.attemptCount).name
                     e.lastError = error.take(OutboxFailurePolicy.MAX_ERROR_LEN)
                     e.updatedAt = failedAt
+                    OutboxStatus.valueOf(e.status)
+                } else {
+                    // Row not found -- unreachable in practice (the dispatcher only calls
+                    // markFailed on a row it just claimed), but degrade gracefully rather than
+                    // throw out of a batch that is otherwise mid-flight (#5128 finding 3).
+                    OutboxStatus.FAILED
                 }
-            }.replaceWith(Unit)
+            }
         }.awaitSuspending()
-    }
 
     private fun OutboxMessage.toEntity() = BalanceOutboxEntity().also {
         it.eventId = eventId

--- a/openbank-billing-service/src/main/kotlin/com/openbank/billing/infrastructure/outbox/BillingOutboxRepositoryImpl.kt
+++ b/openbank-billing-service/src/main/kotlin/com/openbank/billing/infrastructure/outbox/BillingOutboxRepositoryImpl.kt
@@ -96,18 +96,22 @@ class BillingOutboxRepositoryImpl(private val assessments: BillingAssessmentRepo
         }.awaitSuspending()
     }
 
-    override suspend fun markFailed(eventId: UUID, error: String, failedAt: Instant) {
-        val deadRow: Uni<DeadRow?> = Panache.withTransaction {
+    override suspend fun markFailed(eventId: UUID, error: String, failedAt: Instant): OutboxStatus {
+        val outcome: Uni<FailureOutcome> = Panache.withTransaction {
             find("eventId", eventId).firstResult().map { e ->
                 if (e == null) {
-                    null
+                    // Row not found -- unreachable in practice (the dispatcher only calls
+                    // markFailed on a row it just claimed), but degrade gracefully rather than
+                    // throw out of a batch that is otherwise mid-flight (#5128 finding 3).
+                    FailureOutcome(OutboxStatus.FAILED, null)
                 } else {
-                    applyFailure(e, error, failedAt)
-                    if (e.status == OutboxStatus.DEAD.name) {
+                    val status = applyFailure(e, error, failedAt)
+                    val dead = if (status == OutboxStatus.DEAD) {
                         DeadRow(e.eventType, extractIdempotencyKey(e.eventType, e.payload))
                     } else {
                         null
                     }
+                    FailureOutcome(status, dead)
                 }
             }
         }
@@ -115,19 +119,21 @@ class BillingOutboxRepositoryImpl(private val assessments: BillingAssessmentRepo
         // separate aggregate from the outbox row; both updates are individually durable, and a
         // crash between them just means the fee catches up to FAILED on a later markFailed retry
         // or is visible as "PENDING forever" — never silently POSTED).
-        val dead = deadRow.awaitSuspending() ?: return
+        val result = outcome.awaitSuspending()
+        val dead = result.dead ?: return result.status
         if (dead.eventType == ANNUAL_FEE_SUMMARY_EVENT_TYPE) {
             // ADR-0248: not a fee-posting event — there is no AssessedFee row to flip. A DEAD
             // annual-summary row is operator-visible via the `billing.outbox.dead` log line above
             // and the outbox backlog gauge; nothing on the fee side needs (or can) be updated.
-            return
+            return result.status
         }
-        val idempotencyKey = dead.idempotencyKey ?: return
+        val idempotencyKey = dead.idempotencyKey ?: return result.status
         if (dead.eventType == REVERSAL_INTENT_EVENT_TYPE) {
             assessments.markReversalFailed(idempotencyKey)
         } else {
             assessments.markFailed(idempotencyKey)
         }
+        return result.status
     }
 
     /**
@@ -154,8 +160,12 @@ class BillingOutboxRepositoryImpl(private val assessments: BillingAssessmentRepo
 
     private data class DeadRow(val eventType: String, val idempotencyKey: String?)
 
+    /** [markFailed]'s per-row result: the status the row was actually persisted with, plus the
+     * fee-side follow-up data only populated when that status is terminal DEAD. */
+    private data class FailureOutcome(val status: OutboxStatus, val dead: DeadRow?)
+
     /** Record a publish failure (ADR-0050 N5) — same policy every service's outbox repo applies. */
-    private fun applyFailure(e: BillingOutboxEntity, error: String, at: Instant) {
+    private fun applyFailure(e: BillingOutboxEntity, error: String, at: Instant): OutboxStatus {
         e.attemptCount += 1
         e.lastError = error.take(OutboxFailurePolicy.MAX_ERROR_LEN)
         e.updatedAt = at
@@ -171,6 +181,7 @@ class BillingOutboxRepositoryImpl(private val assessments: BillingAssessmentRepo
                 e.lastError,
             )
         }
+        return next
     }
 
     companion object {

--- a/openbank-billing-service/src/test/kotlin/com/openbank/billing/BillingOutboxDispatcherTest.kt
+++ b/openbank-billing-service/src/test/kotlin/com/openbank/billing/BillingOutboxDispatcherTest.kt
@@ -84,7 +84,7 @@ class BillingOutboxDispatcherTest {
         val poisoned = entry()
         coEvery { repo.claimProcessable(any(), any()) } returns listOf(poisoned)
         coEvery { publisher.publish(poisoned) } throws IllegalStateException("ledger unavailable")
-        coJustRun { repo.markFailed(any(), any(), any()) }
+        coEvery { repo.markFailed(any(), any(), any()) } returns OutboxStatus.FAILED
 
         BillingOutboxDispatcher(repo, publisher, dispatchEnabled = true).dispatch()
 

--- a/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/infrastructure/persistence/repository/CardOutboxRepositoryImpl.kt
+++ b/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/infrastructure/persistence/repository/CardOutboxRepositoryImpl.kt
@@ -88,9 +88,9 @@ class CardOutboxRepositoryImpl(private val clock: Clock) :
         }.awaitSuspending()
     }
 
-    override suspend fun markFailed(eventId: UUID, error: String, failedAt: Instant) {
+    override suspend fun markFailed(eventId: UUID, error: String, failedAt: Instant): OutboxStatus =
         Panache.withTransaction {
-            find("eventId", eventId).firstResult().invoke { e ->
+            find("eventId", eventId).firstResult().map { e ->
                 if (e != null) {
                     e.attemptCount += 1
                     e.status = OutboxFailurePolicy.statusAfterFailure(e.attemptCount).name
@@ -106,10 +106,15 @@ class CardOutboxRepositoryImpl(private val clock: Clock) :
                             e.lastError,
                         )
                     }
+                    OutboxStatus.valueOf(e.status)
+                } else {
+                    // Row not found -- unreachable in practice (the dispatcher only calls
+                    // markFailed on a row it just claimed), but degrade gracefully rather than
+                    // throw out of a batch that is otherwise mid-flight (#5128 finding 3).
+                    OutboxStatus.FAILED
                 }
-            }.replaceWithVoid()
+            }
         }.awaitSuspending()
-    }
 
     private fun OutboxMessage.toEntity() = CardOutboxEntity().also {
         it.eventId = eventId

--- a/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/infrastructure/persistence/CaseOutboxRepositoryImpl.kt
+++ b/openbank-case-coordinator-agent/src/main/kotlin/com/openbank/casecoordinator/infrastructure/persistence/CaseOutboxRepositoryImpl.kt
@@ -71,18 +71,23 @@ class CaseOutboxRepositoryImpl(private val clock: Clock) :
         }.awaitSuspending()
     }
 
-    override suspend fun markFailed(eventId: UUID, error: String, failedAt: Instant) {
+    override suspend fun markFailed(eventId: UUID, error: String, failedAt: Instant): OutboxStatus =
         Panache.withTransaction {
-            find("eventId", eventId).firstResult().invoke { e ->
+            find("eventId", eventId).firstResult().map { e ->
                 if (e != null) {
                     e.attemptCount += 1
                     e.status = OutboxFailurePolicy.statusAfterFailure(e.attemptCount).name
                     e.lastError = error.take(OutboxFailurePolicy.MAX_ERROR_LEN)
                     e.updatedAt = failedAt
+                    OutboxStatus.valueOf(e.status)
+                } else {
+                    // Row not found -- unreachable in practice (the dispatcher only calls
+                    // markFailed on a row it just claimed), but degrade gracefully rather than
+                    // throw out of a batch that is otherwise mid-flight (#5128 finding 3).
+                    OutboxStatus.FAILED
                 }
-            }.replaceWithVoid()
+            }
         }.awaitSuspending()
-    }
 
     private companion object {
         @Suppress("MaxLineLength")

--- a/openbank-clearing-service/src/main/kotlin/com/openbank/clearing/infrastructure/persistence/repository/ClearingOutboxRepositoryImpl.kt
+++ b/openbank-clearing-service/src/main/kotlin/com/openbank/clearing/infrastructure/persistence/repository/ClearingOutboxRepositoryImpl.kt
@@ -87,18 +87,23 @@ class ClearingOutboxRepositoryImpl(private val clock: Clock) :
         }.awaitSuspending()
     }
 
-    override suspend fun markFailed(eventId: UUID, error: String, failedAt: Instant) {
+    override suspend fun markFailed(eventId: UUID, error: String, failedAt: Instant): OutboxStatus =
         Panache.withTransaction {
-            find("eventId", eventId).firstResult().invoke { e ->
+            find("eventId", eventId).firstResult().map { e ->
                 if (e != null) {
                     e.attemptCount += 1
                     e.status = OutboxFailurePolicy.statusAfterFailure(e.attemptCount).name
                     e.lastError = error.take(OutboxFailurePolicy.MAX_ERROR_LEN)
                     e.updatedAt = failedAt
+                    OutboxStatus.valueOf(e.status)
+                } else {
+                    // Row not found -- unreachable in practice (the dispatcher only calls
+                    // markFailed on a row it just claimed), but degrade gracefully rather than
+                    // throw out of a batch that is otherwise mid-flight (#5128 finding 3).
+                    OutboxStatus.FAILED
                 }
-            }.replaceWith(Unit)
+            }
         }.awaitSuspending()
-    }
 
     private fun OutboxMessage.toEntity() = ClearingOutboxEntity().also {
         it.eventId = eventId

--- a/openbank-consent-service/src/main/kotlin/com/openbank/consent/infrastructure/persistence/repository/ConsentOutboxRepositoryImpl.kt
+++ b/openbank-consent-service/src/main/kotlin/com/openbank/consent/infrastructure/persistence/repository/ConsentOutboxRepositoryImpl.kt
@@ -87,18 +87,23 @@ class ConsentOutboxRepositoryImpl(private val clock: Clock) :
         }.awaitSuspending()
     }
 
-    override suspend fun markFailed(eventId: UUID, error: String, failedAt: Instant) {
+    override suspend fun markFailed(eventId: UUID, error: String, failedAt: Instant): OutboxStatus =
         Panache.withTransaction {
-            find("eventId", eventId).firstResult().invoke { e ->
+            find("eventId", eventId).firstResult().map { e ->
                 if (e != null) {
                     e.attemptCount += 1
                     e.status = OutboxFailurePolicy.statusAfterFailure(e.attemptCount).name
                     e.lastError = error.take(OutboxFailurePolicy.MAX_ERROR_LEN)
                     e.updatedAt = failedAt
+                    OutboxStatus.valueOf(e.status)
+                } else {
+                    // Row not found -- unreachable in practice (the dispatcher only calls
+                    // markFailed on a row it just claimed), but degrade gracefully rather than
+                    // throw out of a batch that is otherwise mid-flight (#5128 finding 3).
+                    OutboxStatus.FAILED
                 }
-            }.replaceWith(Unit)
+            }
         }.awaitSuspending()
-    }
 
     private fun OutboxMessage.toEntity() = ConsentOutboxEntity().also {
         it.eventId = eventId

--- a/openbank-delegation-service/src/main/kotlin/com/openbank/delegation/infrastructure/persistence/repository/DelegationOutboxRepositoryImpl.kt
+++ b/openbank-delegation-service/src/main/kotlin/com/openbank/delegation/infrastructure/persistence/repository/DelegationOutboxRepositoryImpl.kt
@@ -78,18 +78,23 @@ class DelegationOutboxRepositoryImpl(private val clock: Clock) :
         }.awaitSuspending()
     }
 
-    override suspend fun markFailed(eventId: UUID, error: String, failedAt: Instant) {
+    override suspend fun markFailed(eventId: UUID, error: String, failedAt: Instant): OutboxStatus =
         Panache.withTransaction {
-            find("eventId", eventId).firstResult().invoke { e ->
+            find("eventId", eventId).firstResult().map { e ->
                 if (e != null) {
                     e.attemptCount += 1
                     e.status = OutboxFailurePolicy.statusAfterFailure(e.attemptCount).name
                     e.lastError = error.take(OutboxFailurePolicy.MAX_ERROR_LEN)
                     e.updatedAt = failedAt
+                    OutboxStatus.valueOf(e.status)
+                } else {
+                    // Row not found -- unreachable in practice (the dispatcher only calls
+                    // markFailed on a row it just claimed), but degrade gracefully rather than
+                    // throw out of a batch that is otherwise mid-flight (#5128 finding 3).
+                    OutboxStatus.FAILED
                 }
-            }.replaceWith(Unit)
+            }
         }.awaitSuspending()
-    }
 
     private fun OutboxMessage.toEntity() = DelegationOutboxEntity().also {
         it.eventId = eventId

--- a/openbank-dispute-service/src/main/kotlin/com/openbank/dispute/infrastructure/persistence/repository/DisputeOutboxRepositoryImpl.kt
+++ b/openbank-dispute-service/src/main/kotlin/com/openbank/dispute/infrastructure/persistence/repository/DisputeOutboxRepositoryImpl.kt
@@ -57,18 +57,23 @@ class DisputeOutboxRepositoryImpl(private val clock: Clock) :
         }.awaitSuspending()
     }
 
-    override suspend fun markFailed(eventId: UUID, error: String, failedAt: Instant) {
+    override suspend fun markFailed(eventId: UUID, error: String, failedAt: Instant): OutboxStatus =
         Panache.withTransaction {
-            find("eventId", eventId).firstResult().invoke { e ->
+            find("eventId", eventId).firstResult().map { e ->
                 if (e != null) {
                     e.attemptCount += 1
                     e.status = OutboxFailurePolicy.statusAfterFailure(e.attemptCount).name
                     e.lastError = error.take(OutboxFailurePolicy.MAX_ERROR_LEN)
                     e.updatedAt = failedAt
+                    OutboxStatus.valueOf(e.status)
+                } else {
+                    // Row not found -- unreachable in practice (the dispatcher only calls
+                    // markFailed on a row it just claimed), but degrade gracefully rather than
+                    // throw out of a batch that is otherwise mid-flight (#5128 finding 3).
+                    OutboxStatus.FAILED
                 }
-            }.replaceWithVoid()
+            }
         }.awaitSuspending()
-    }
 
     /**
      * Reference implementation for the [OutboxRepository.claimProcessable] atomic-claim

--- a/openbank-document-service/src/main/kotlin/com/openbank/document/infrastructure/persistence/repository/DocumentOutboxRepositoryImpl.kt
+++ b/openbank-document-service/src/main/kotlin/com/openbank/document/infrastructure/persistence/repository/DocumentOutboxRepositoryImpl.kt
@@ -87,18 +87,23 @@ class DocumentOutboxRepositoryImpl(private val clock: Clock) :
         }.awaitSuspending()
     }
 
-    override suspend fun markFailed(eventId: UUID, error: String, failedAt: Instant) {
+    override suspend fun markFailed(eventId: UUID, error: String, failedAt: Instant): OutboxStatus =
         Panache.withTransaction {
-            find("eventId", eventId).firstResult().invoke { e ->
+            find("eventId", eventId).firstResult().map { e ->
                 if (e != null) {
                     e.attemptCount += 1
                     e.status = OutboxFailurePolicy.statusAfterFailure(e.attemptCount).name
                     e.lastError = error.take(OutboxFailurePolicy.MAX_ERROR_LEN)
                     e.updatedAt = failedAt
+                    OutboxStatus.valueOf(e.status)
+                } else {
+                    // Row not found -- unreachable in practice (the dispatcher only calls
+                    // markFailed on a row it just claimed), but degrade gracefully rather than
+                    // throw out of a batch that is otherwise mid-flight (#5128 finding 3).
+                    OutboxStatus.FAILED
                 }
-            }.replaceWith(Unit)
+            }
         }.awaitSuspending()
-    }
 
     private fun OutboxMessage.toEntity() = DocumentOutboxEntity().also {
         it.eventId = eventId

--- a/openbank-domestic-payment/src/main/kotlin/com/openbank/domestic/infrastructure/persistence/repository/DomesticPaymentOutboxRepositoryImpl.kt
+++ b/openbank-domestic-payment/src/main/kotlin/com/openbank/domestic/infrastructure/persistence/repository/DomesticPaymentOutboxRepositoryImpl.kt
@@ -91,20 +91,24 @@ class DomesticPaymentOutboxRepositoryImpl(private val clock: Clock) :
         }.awaitSuspending()
     }
 
-    override suspend fun markFailed(eventId: UUID, error: String, failedAt: Instant) {
+    override suspend fun markFailed(eventId: UUID, error: String, failedAt: Instant): OutboxStatus =
         Panache.withTransaction {
             find("eventId", eventId).firstResult()
-                .invoke { entity ->
+                .map { entity ->
                     if (entity != null) {
                         entity.attemptCount += 1
                         entity.status = OutboxFailurePolicy.statusAfterFailure(entity.attemptCount).name
                         entity.lastError = error.take(OutboxFailurePolicy.MAX_ERROR_LEN)
                         entity.updatedAt = failedAt
+                        OutboxStatus.valueOf(entity.status)
+                    } else {
+                        // Row not found -- unreachable in practice (the dispatcher only calls
+                        // markFailed on a row it just claimed), but degrade gracefully rather than
+                        // throw out of a batch that is otherwise mid-flight (#5128 finding 3).
+                        OutboxStatus.FAILED
                     }
                 }
-                .replaceWith(Unit)
         }.awaitSuspending()
-    }
 
     private fun OutboxMessage.toEntity() = DomesticPaymentOutboxEntity().also {
         it.eventId = eventId

--- a/openbank-domestic-payment/src/test/kotlin/com/openbank/domestic/infrastructure/outbox/DomesticPaymentOutboxDispatcherTest.kt
+++ b/openbank-domestic-payment/src/test/kotlin/com/openbank/domestic/infrastructure/outbox/DomesticPaymentOutboxDispatcherTest.kt
@@ -70,7 +70,7 @@ class DomesticPaymentOutboxDispatcherTest {
         coEvery { eventPublisher.publish(failing) } throws RuntimeException("kafka down")
         coJustRun { eventPublisher.publish(healthy) }
         coJustRun { outboxRepository.markSent(any(), any()) }
-        coJustRun { outboxRepository.markFailed(any(), any(), any()) }
+        coEvery { outboxRepository.markFailed(any(), any(), any()) } returns OutboxStatus.FAILED
 
         dispatcher().dispatch()
 

--- a/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/infrastructure/persistence/repository/EngagementOutboxRepositoryImpl.kt
+++ b/openbank-engagement-service/src/main/kotlin/com/openbank/engagement/infrastructure/persistence/repository/EngagementOutboxRepositoryImpl.kt
@@ -79,17 +79,21 @@ class EngagementOutboxRepositoryImpl(private val clock: Clock) :
         }.awaitSuspending()
     }
 
-    override suspend fun markFailed(eventId: UUID, error: String, failedAt: Instant) {
+    override suspend fun markFailed(eventId: UUID, error: String, failedAt: Instant): OutboxStatus =
         Panache.withTransaction {
-            find("eventId", eventId).firstResult().invoke { e ->
+            find("eventId", eventId).firstResult().map { e ->
                 if (e != null) {
                     applyFailure(e, error, failedAt)
+                } else {
+                    // Row not found -- unreachable in practice (the dispatcher only calls
+                    // markFailed on a row it just claimed), but degrade gracefully rather than
+                    // throw out of a batch that is otherwise mid-flight (#5128 finding 3).
+                    OutboxStatus.FAILED
                 }
-            }.replaceWith(Unit)
+            }
         }.awaitSuspending()
-    }
 
-    private fun applyFailure(e: EngagementOutboxEntity, error: String, at: Instant = Instant.now(clock)) {
+    private fun applyFailure(e: EngagementOutboxEntity, error: String, at: Instant = Instant.now(clock)): OutboxStatus {
         e.attemptCount += 1
         e.lastError = error.take(OutboxFailurePolicy.MAX_ERROR_LEN)
         e.updatedAt = at
@@ -105,6 +109,7 @@ class EngagementOutboxRepositoryImpl(private val clock: Clock) :
                 e.lastError,
             )
         }
+        return next
     }
 
     private fun OutboxMessage.toEntity() = EngagementOutboxEntity().also {

--- a/openbank-fraud-service/src/main/kotlin/com/openbank/fraud/infrastructure/persistence/FraudOutboxRepositoryImpl.kt
+++ b/openbank-fraud-service/src/main/kotlin/com/openbank/fraud/infrastructure/persistence/FraudOutboxRepositoryImpl.kt
@@ -79,17 +79,21 @@ class FraudOutboxRepositoryImpl(private val clock: Clock) :
         }.awaitSuspending()
     }
 
-    override suspend fun markFailed(eventId: UUID, error: String, failedAt: Instant) {
+    override suspend fun markFailed(eventId: UUID, error: String, failedAt: Instant): OutboxStatus =
         Panache.withTransaction {
-            find("eventId", eventId).firstResult().invoke { e ->
+            find("eventId", eventId).firstResult().map { e ->
                 if (e != null) {
                     applyFailure(e, error, failedAt)
+                } else {
+                    // Row not found -- unreachable in practice (the dispatcher only calls
+                    // markFailed on a row it just claimed), but degrade gracefully rather than
+                    // throw out of a batch that is otherwise mid-flight (#5128 finding 3).
+                    OutboxStatus.FAILED
                 }
-            }.replaceWith(Unit)
+            }
         }.awaitSuspending()
-    }
 
-    private fun applyFailure(e: FraudOutboxEntity, error: String, at: Instant = Instant.now(clock)) {
+    private fun applyFailure(e: FraudOutboxEntity, error: String, at: Instant = Instant.now(clock)): OutboxStatus {
         e.attemptCount += 1
         e.lastError = error.take(OutboxFailurePolicy.MAX_ERROR_LEN)
         e.updatedAt = at
@@ -105,6 +109,7 @@ class FraudOutboxRepositoryImpl(private val clock: Clock) :
                 e.lastError,
             )
         }
+        return next
     }
 
     private fun OutboxMessage.toEntity() = FraudOutboxEntity().also {

--- a/openbank-fx-service/src/main/kotlin/com/openbank/fx/infrastructure/persistence/repository/FxOutboxRepositoryImpl.kt
+++ b/openbank-fx-service/src/main/kotlin/com/openbank/fx/infrastructure/persistence/repository/FxOutboxRepositoryImpl.kt
@@ -87,18 +87,23 @@ class FxOutboxRepositoryImpl(private val clock: Clock) :
         }.awaitSuspending()
     }
 
-    override suspend fun markFailed(eventId: UUID, error: String, failedAt: Instant) {
+    override suspend fun markFailed(eventId: UUID, error: String, failedAt: Instant): OutboxStatus =
         Panache.withTransaction {
-            find("eventId", eventId).firstResult().invoke { e ->
+            find("eventId", eventId).firstResult().map { e ->
                 if (e != null) {
                     e.attemptCount += 1
                     e.status = OutboxFailurePolicy.statusAfterFailure(e.attemptCount).name
                     e.lastError = error.take(OutboxFailurePolicy.MAX_ERROR_LEN)
                     e.updatedAt = failedAt
+                    OutboxStatus.valueOf(e.status)
+                } else {
+                    // Row not found -- unreachable in practice (the dispatcher only calls
+                    // markFailed on a row it just claimed), but degrade gracefully rather than
+                    // throw out of a batch that is otherwise mid-flight (#5128 finding 3).
+                    OutboxStatus.FAILED
                 }
-            }.replaceWithVoid()
+            }
         }.awaitSuspending()
-    }
 
     private fun OutboxMessage.toEntity() = FxOutboxEntity().also {
         it.eventId = eventId

--- a/openbank-interest-service/src/main/kotlin/com/openbank/interest/infrastructure/persistence/repository/InterestOutboxRepositoryImpl.kt
+++ b/openbank-interest-service/src/main/kotlin/com/openbank/interest/infrastructure/persistence/repository/InterestOutboxRepositoryImpl.kt
@@ -82,15 +82,19 @@ class InterestOutboxRepositoryImpl(private val clock: Clock) :
         }.awaitSuspending()
     }
 
-    override suspend fun markFailed(eventId: UUID, error: String, failedAt: Instant) {
+    override suspend fun markFailed(eventId: UUID, error: String, failedAt: Instant): OutboxStatus =
         Panache.withTransaction {
-            find("eventId", eventId).firstResult().invoke { e ->
+            find("eventId", eventId).firstResult().map { e ->
                 if (e != null) {
                     applyFailure(e, error, failedAt)
+                } else {
+                    // Row not found -- unreachable in practice (the dispatcher only calls
+                    // markFailed on a row it just claimed), but degrade gracefully rather than
+                    // throw out of a batch that is otherwise mid-flight (#5128 finding 3).
+                    OutboxStatus.FAILED
                 }
-            }.replaceWith(Unit)
+            }
         }.awaitSuspending()
-    }
 
     private fun OutboxMessage.toEntity() = InterestOutboxEntity().also {
         it.eventId = eventId
@@ -122,7 +126,7 @@ class InterestOutboxRepositoryImpl(private val clock: Clock) :
      * an operator alert can hook — so a poison row can neither be retried forever nor starve the
      * batch.
      */
-    private fun applyFailure(e: InterestOutboxEntity, error: String, at: Instant) {
+    private fun applyFailure(e: InterestOutboxEntity, error: String, at: Instant): OutboxStatus {
         e.attemptCount += 1
         e.lastError = error.take(OutboxFailurePolicy.MAX_ERROR_LEN)
         e.updatedAt = at
@@ -138,6 +142,7 @@ class InterestOutboxRepositoryImpl(private val clock: Clock) :
                 e.lastError,
             )
         }
+        return next
     }
 
     companion object {

--- a/openbank-kyc-service/src/main/kotlin/com/openbank/kyc/infrastructure/persistence/repository/KycOutboxRepositoryImpl.kt
+++ b/openbank-kyc-service/src/main/kotlin/com/openbank/kyc/infrastructure/persistence/repository/KycOutboxRepositoryImpl.kt
@@ -87,18 +87,23 @@ class KycOutboxRepositoryImpl(private val clock: Clock) :
         }.awaitSuspending()
     }
 
-    override suspend fun markFailed(eventId: UUID, error: String, failedAt: Instant) {
+    override suspend fun markFailed(eventId: UUID, error: String, failedAt: Instant): OutboxStatus =
         Panache.withTransaction {
-            find("eventId", eventId).firstResult().invoke { e ->
+            find("eventId", eventId).firstResult().map { e ->
                 if (e != null) {
                     e.attemptCount += 1
                     e.status = OutboxFailurePolicy.statusAfterFailure(e.attemptCount).name
                     e.lastError = error.take(OutboxFailurePolicy.MAX_ERROR_LEN)
                     e.updatedAt = failedAt
+                    OutboxStatus.valueOf(e.status)
+                } else {
+                    // Row not found -- unreachable in practice (the dispatcher only calls
+                    // markFailed on a row it just claimed), but degrade gracefully rather than
+                    // throw out of a batch that is otherwise mid-flight (#5128 finding 3).
+                    OutboxStatus.FAILED
                 }
-            }.replaceWith(Unit)
+            }
         }.awaitSuspending()
-    }
 
     private fun OutboxMessage.toEntity() = KycOutboxEntity().also {
         it.eventId = eventId

--- a/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/persistence/repository/LedgerOutboxRepositoryImpl.kt
+++ b/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/persistence/repository/LedgerOutboxRepositoryImpl.kt
@@ -105,15 +105,19 @@ class LedgerOutboxRepositoryImpl(private val clock: Clock) :
         }.awaitSuspending()
     }
 
-    override suspend fun markFailed(eventId: UUID, error: String, failedAt: Instant) {
+    override suspend fun markFailed(eventId: UUID, error: String, failedAt: Instant): OutboxStatus =
         Panache.withTransaction {
-            find("eventId", eventId).firstResult().invoke { e ->
+            find("eventId", eventId).firstResult().map { e ->
                 if (e != null) {
                     applyFailure(e, error, failedAt)
+                } else {
+                    // Row not found -- unreachable in practice (the dispatcher only calls
+                    // markFailed on a row it just claimed), but degrade gracefully rather than
+                    // throw out of a batch that is otherwise mid-flight (#5128 finding 3).
+                    OutboxStatus.FAILED
                 }
-            }.replaceWith(Unit)
+            }
         }.awaitSuspending()
-    }
 
     /**
      * Record a publish failure (ADR-0050 N5). Increments the attempt counter and, once the
@@ -121,7 +125,7 @@ class LedgerOutboxRepositoryImpl(private val clock: Clock) :
      * WARN an operator alert can hook — so a poison row can neither be retried forever nor
      * starve the batch.
      */
-    private fun applyFailure(e: LedgerOutboxEntity, error: String, at: Instant = Instant.now(clock)) {
+    private fun applyFailure(e: LedgerOutboxEntity, error: String, at: Instant = Instant.now(clock)): OutboxStatus {
         e.attemptCount += 1
         e.lastError = error.take(OutboxFailurePolicy.MAX_ERROR_LEN)
         e.updatedAt = at
@@ -137,6 +141,7 @@ class LedgerOutboxRepositoryImpl(private val clock: Clock) :
                 e.lastError,
             )
         }
+        return next
     }
 
     private fun OutboxMessage.toEntity() = LedgerOutboxEntity().also {

--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/infrastructure/persistence/repository/LendingOutboxRepositoryImpl.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/infrastructure/persistence/repository/LendingOutboxRepositoryImpl.kt
@@ -94,18 +94,23 @@ class LendingOutboxRepositoryImpl(private val clock: Clock) :
         }.awaitSuspending()
     }
 
-    override suspend fun markFailed(eventId: UUID, error: String, failedAt: Instant) {
+    override suspend fun markFailed(eventId: UUID, error: String, failedAt: Instant): OutboxStatus =
         Panache.withTransaction {
-            find("eventId", eventId).firstResult().invoke { e ->
+            find("eventId", eventId).firstResult().map { e ->
                 if (e != null) {
                     e.attemptCount += 1
                     e.status = OutboxFailurePolicy.statusAfterFailure(e.attemptCount).name
                     e.lastError = error.take(OutboxFailurePolicy.MAX_ERROR_LEN)
                     e.updatedAt = failedAt
+                    OutboxStatus.valueOf(e.status)
+                } else {
+                    // Row not found -- unreachable in practice (the dispatcher only calls
+                    // markFailed on a row it just claimed), but degrade gracefully rather than
+                    // throw out of a batch that is otherwise mid-flight (#5128 finding 3).
+                    OutboxStatus.FAILED
                 }
-            }.replaceWith(Unit)
+            }
         }.awaitSuspending()
-    }
 
     private fun LendingOutboxMessage.toEntity() = LendingOutboxEntity().also {
         it.eventId = eventId

--- a/openbank-lending-service/src/test/kotlin/com/openbank/lending/infrastructure/outbox/LendingOutboxDispatcherTest.kt
+++ b/openbank-lending-service/src/test/kotlin/com/openbank/lending/infrastructure/outbox/LendingOutboxDispatcherTest.kt
@@ -77,7 +77,7 @@ class LendingOutboxDispatcherTest {
         val poisoned = entry()
         coEvery { repo.claimProcessable(any(), any()) } returns listOf(poisoned)
         coEvery { publisher.publish(poisoned) } throws IllegalStateException("broker unavailable")
-        coJustRun { repo.markFailed(any(), any(), any()) }
+        coEvery { repo.markFailed(any(), any(), any()) } returns OutboxStatus.FAILED
 
         LendingOutboxDispatcher(repo, publisher, dispatchEnabled = true).dispatch()
 

--- a/openbank-libs-domain/src/main/kotlin/com/openbank/libs/persistence/outbox/OutboxDispatch.kt
+++ b/openbank-libs-domain/src/main/kotlin/com/openbank/libs/persistence/outbox/OutboxDispatch.kt
@@ -25,11 +25,11 @@ package com.openbank.libs.persistence.outbox
  * real-but-retryable failure from a terminal DEAD row, so a runtime-layer caller (see
  * `AbstractOutboxDispatcher.dispatchScheduledBatch`) can attribute
  * `DomainMetrics.outboxDispatched`/`.outboxDead` correctly without duplicating
- * [OutboxFailurePolicy]'s terminal-vs-retry decision. [Failed.terminal] mirrors exactly what the
- * row's own `markFailed` independently computes — both read the SAME
- * [OutboxFailurePolicy.statusAfterFailure] over the entry's pre-failure `attemptCount + 1`, so
- * this can never disagree with the status a repository implementation actually persists (see
- * every `<Service>OutboxRepositoryImpl.applyFailure`, which does the identical computation).
+ * [OutboxFailurePolicy]'s terminal-vs-retry decision. [Failed.terminal] is read directly from the
+ * [OutboxStatus] [OutboxRepository.markFailed] returns — the status the repository actually
+ * persisted — rather than independently recomputed by this class (#5128 finding 3: recomputing it
+ * here could only ever agree with a repository's own write by convention, never by the type
+ * system).
  */
 sealed class OutboxDispatchOutcome {
     abstract val entry: OutboxEntry
@@ -147,12 +147,15 @@ object OutboxDispatch {
                     )
                     return OutboxDispatchResult(outcomes)
                 }
-                repository.markFailed(entry.eventId, ex.message ?: ex.javaClass.simpleName)
-                // Same computation `markFailed` applies internally (see the class doc on
-                // OutboxDispatchOutcome) — attemptCount BEFORE this failure was recorded, so the
-                // post-failure count is entry.attemptCount + 1.
-                val terminal = OutboxFailurePolicy.statusAfterFailure(entry.attemptCount + 1) == OutboxStatus.DEAD
-                outcomes += OutboxDispatchOutcome.Failed(entry, terminal)
+                // Read back what markFailed actually persisted rather than independently
+                // recomputing OutboxFailurePolicy.statusAfterFailure over entry.attemptCount + 1
+                // (#5128 finding 3) — the two could only ever agree by convention (every
+                // <Service>OutboxRepositoryImpl.markFailed happening to apply the identical
+                // policy with the same maxAttempts), never by the type system, and a future repo
+                // impl with different backoff/maxAttempts would silently desync this metric from
+                // the DB's real row status.
+                val persistedStatus = repository.markFailed(entry.eventId, ex.message ?: ex.javaClass.simpleName)
+                outcomes += OutboxDispatchOutcome.Failed(entry, terminal = persistedStatus == OutboxStatus.DEAD)
             }
         }
         return OutboxDispatchResult(outcomes)

--- a/openbank-libs-domain/src/main/kotlin/com/openbank/libs/persistence/outbox/OutboxPorts.kt
+++ b/openbank-libs-domain/src/main/kotlin/com/openbank/libs/persistence/outbox/OutboxPorts.kt
@@ -63,8 +63,15 @@ interface OutboxRepository {
      * passes none, and it lands in `updated_at` — which the dead-letter janitor prunes on
      * (`status = DEAD and updatedAt < threshold`). At 1970 every DEAD row is instantly older than
      * any retention window (#3272).
+     *
+     * @return the status this row was actually persisted with ([OutboxStatus.FAILED] or
+     * [OutboxStatus.DEAD]) — the caller (see `OutboxDispatch.dispatchOnce`) uses this to attribute
+     * `DomainMetrics.outboxDead` correctly instead of independently recomputing
+     * [OutboxFailurePolicy.statusAfterFailure] and hoping it agrees with what this call actually
+     * wrote (#5128 finding 3). Every implementation must return the status it persisted, not a
+     * value predicted before the write.
      */
-    suspend fun markFailed(eventId: UUID, error: String, failedAt: Instant = Instant.now())
+    suspend fun markFailed(eventId: UUID, error: String, failedAt: Instant = Instant.now()): OutboxStatus
 }
 
 interface OutboxEventPublisher {

--- a/openbank-libs-domain/src/test/kotlin/com/openbank/libs/persistence/outbox/OutboxCountProcessableTest.kt
+++ b/openbank-libs-domain/src/test/kotlin/com/openbank/libs/persistence/outbox/OutboxCountProcessableTest.kt
@@ -26,7 +26,7 @@ class OutboxCountProcessableTest {
             return rows.take(limit)
         }
         override suspend fun markSent(eventId: UUID, sentAt: Instant) = Unit
-        override suspend fun markFailed(eventId: UUID, error: String, failedAt: Instant) = Unit
+        override suspend fun markFailed(eventId: UUID, error: String, failedAt: Instant) = OutboxStatus.FAILED
     }
 
     private fun entry() = OutboxEntry(

--- a/openbank-libs-domain/src/test/kotlin/com/openbank/libs/persistence/outbox/OutboxDispatchTest.kt
+++ b/openbank-libs-domain/src/test/kotlin/com/openbank/libs/persistence/outbox/OutboxDispatchTest.kt
@@ -12,7 +12,12 @@ import java.util.UUID
 
 class OutboxDispatchTest {
 
-    /** Minimal in-memory repository recording the dispatcher's bookkeeping calls. */
+    /** Minimal in-memory repository recording the dispatcher's bookkeeping calls.
+     *
+     * `markFailed` computes and RETURNS the resulting [OutboxStatus] the same way every real
+     * `<Service>OutboxRepositoryImpl` does — [OutboxFailurePolicy.statusAfterFailure] over the
+     * row's pre-failure `attemptCount + 1` — so these tests exercise [OutboxDispatch] reading that
+     * return value back, not a value it recomputed itself (#5128 finding 3). */
     private class FakeRepo(private val rows: List<OutboxEntry>) : OutboxRepository {
         val sent = mutableListOf<UUID>()
         val failed = mutableListOf<Pair<UUID, String>>()
@@ -20,8 +25,10 @@ class OutboxDispatchTest {
         override suspend fun markSent(eventId: UUID, sentAt: Instant) {
             sent += eventId
         }
-        override suspend fun markFailed(eventId: UUID, error: String, failedAt: Instant) {
+        override suspend fun markFailed(eventId: UUID, error: String, failedAt: Instant): OutboxStatus {
             failed += eventId to error
+            val entry = rows.first { it.eventId == eventId }
+            return OutboxFailurePolicy.statusAfterFailure(entry.attemptCount + 1)
         }
     }
 
@@ -204,6 +211,34 @@ class OutboxDispatchTest {
         assertThat(
             result.outcomes.filterIsInstance<OutboxDispatchOutcome.Failed>().count { !it.terminal },
         ).isEqualTo(1)
+    }
+
+    @Test
+    fun `terminal is read from markFailed's return value, not recomputed independently`() {
+        // Falsifying test for #5128 finding 3: a repository whose markFailed applies a DIFFERENT
+        // policy than OutboxFailurePolicy.statusAfterFailure(attemptCount + 1) -- e.g. a lower
+        // maxAttempts -- must have that DISAGREEMENT show up in the outcome. Before the fix,
+        // OutboxDispatch recomputed the terminal flag itself and this test would report
+        // `terminal = false` (attemptCount + 1 = 1, nowhere near DEFAULT_MAX_ATTEMPTS) even though
+        // the repository just persisted DEAD.
+        val row = entry("low-tolerance", attemptCount = 0)
+        val repo = object : OutboxRepository {
+            override suspend fun listProcessable(limit: Int) = listOf(row)
+            override suspend fun markSent(eventId: UUID, sentAt: Instant) = Unit
+            override suspend fun markFailed(eventId: UUID, error: String, failedAt: Instant): OutboxStatus =
+                // This repository's own policy parks a row DEAD after just ONE failure -- nothing
+                // OutboxDispatch could derive from entry.attemptCount + 1 under the shared default
+                // policy.
+                OutboxStatus.DEAD
+        }
+
+        val result = runBlocking { OutboxDispatch.dispatchOnce(repo) { error("poison") } }
+
+        val outcome = result.outcomes.single() as OutboxDispatchOutcome.Failed
+        assertThat(outcome.terminal)
+            .describedAs("must reflect the DEAD status markFailed actually returned")
+            .isTrue()
+        assertThat(result.deadCount).isEqualTo(1)
     }
 
     @Test

--- a/openbank-libs-runtime/src/test/kotlin/com/openbank/libs/persistence/outbox/AbstractOutboxDispatcherTest.kt
+++ b/openbank-libs-runtime/src/test/kotlin/com/openbank/libs/persistence/outbox/AbstractOutboxDispatcherTest.kt
@@ -23,8 +23,10 @@ class AbstractOutboxDispatcherTest {
         override suspend fun markSent(eventId: UUID, sentAt: Instant) {
             sent += eventId
         }
-        override suspend fun markFailed(eventId: UUID, error: String, failedAt: Instant) {
+        override suspend fun markFailed(eventId: UUID, error: String, failedAt: Instant): OutboxStatus {
             failed += eventId to error
+            val entry = rows.first { it.eventId == eventId }
+            return OutboxFailurePolicy.statusAfterFailure(entry.attemptCount + 1)
         }
     }
 

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/infrastructure/persistence/repository/NotificationOutboxRepositoryImpl.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/infrastructure/persistence/repository/NotificationOutboxRepositoryImpl.kt
@@ -87,18 +87,23 @@ class NotificationOutboxRepositoryImpl(private val clock: Clock) :
         }.awaitSuspending()
     }
 
-    override suspend fun markFailed(eventId: UUID, error: String, failedAt: Instant) {
+    override suspend fun markFailed(eventId: UUID, error: String, failedAt: Instant): OutboxStatus =
         Panache.withTransaction {
-            find("eventId", eventId).firstResult().invoke { e ->
+            find("eventId", eventId).firstResult().map { e ->
                 if (e != null) {
                     e.attemptCount += 1
                     e.status = OutboxFailurePolicy.statusAfterFailure(e.attemptCount).name
                     e.lastError = error.take(OutboxFailurePolicy.MAX_ERROR_LEN)
                     e.updatedAt = failedAt
+                    OutboxStatus.valueOf(e.status)
+                } else {
+                    // Row not found -- unreachable in practice (the dispatcher only calls
+                    // markFailed on a row it just claimed), but degrade gracefully rather than
+                    // throw out of a batch that is otherwise mid-flight (#5128 finding 3).
+                    OutboxStatus.FAILED
                 }
-            }.replaceWithVoid()
+            }
         }.awaitSuspending()
-    }
 
     override fun purgeDeadBefore(threshold: Instant): Uni<Long> = Panache.withTransaction {
         delete("status = ?1 and updatedAt < ?2", OutboxStatus.DEAD.name, threshold)

--- a/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/persistence/repository/PartyOutboxRepositoryImpl.kt
+++ b/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/persistence/repository/PartyOutboxRepositoryImpl.kt
@@ -88,18 +88,23 @@ class PartyOutboxRepositoryImpl(private val clock: Clock) :
         }.awaitSuspending()
     }
 
-    override suspend fun markFailed(eventId: UUID, error: String, failedAt: Instant) {
+    override suspend fun markFailed(eventId: UUID, error: String, failedAt: Instant): OutboxStatus =
         Panache.withTransaction {
-            find("eventId", eventId).firstResult().invoke { e ->
+            find("eventId", eventId).firstResult().map { e ->
                 if (e != null) {
                     e.attemptCount += 1
                     e.status = OutboxFailurePolicy.statusAfterFailure(e.attemptCount).name
                     e.lastError = error.take(OutboxFailurePolicy.MAX_ERROR_LEN)
                     e.updatedAt = failedAt
+                    OutboxStatus.valueOf(e.status)
+                } else {
+                    // Row not found -- unreachable in practice (the dispatcher only calls
+                    // markFailed on a row it just claimed), but degrade gracefully rather than
+                    // throw out of a batch that is otherwise mid-flight (#5128 finding 3).
+                    OutboxStatus.FAILED
                 }
-            }.replaceWith(Unit)
+            }
         }.awaitSuspending()
-    }
 
     private fun OutboxMessage.toEntity() = PartyOutboxEntity().also {
         it.eventId = eventId

--- a/openbank-pid-service/src/main/kotlin/com/openbank/pid/infrastructure/persistence/repository/PidOutboxRepositoryImpl.kt
+++ b/openbank-pid-service/src/main/kotlin/com/openbank/pid/infrastructure/persistence/repository/PidOutboxRepositoryImpl.kt
@@ -87,18 +87,23 @@ class PidOutboxRepositoryImpl(private val clock: Clock) :
         }.awaitSuspending()
     }
 
-    override suspend fun markFailed(eventId: UUID, error: String, failedAt: Instant) {
+    override suspend fun markFailed(eventId: UUID, error: String, failedAt: Instant): OutboxStatus =
         Panache.withTransaction {
-            find("eventId", eventId).firstResult().invoke { e ->
+            find("eventId", eventId).firstResult().map { e ->
                 if (e != null) {
                     e.attemptCount += 1
                     e.status = OutboxFailurePolicy.statusAfterFailure(e.attemptCount).name
                     e.lastError = error.take(OutboxFailurePolicy.MAX_ERROR_LEN)
                     e.updatedAt = failedAt
+                    OutboxStatus.valueOf(e.status)
+                } else {
+                    // Row not found -- unreachable in practice (the dispatcher only calls
+                    // markFailed on a row it just claimed), but degrade gracefully rather than
+                    // throw out of a batch that is otherwise mid-flight (#5128 finding 3).
+                    OutboxStatus.FAILED
                 }
-            }.replaceWith(Unit)
+            }
         }.awaitSuspending()
-    }
 
     private fun OutboxMessage.toEntity() = PidOutboxEntity().also {
         it.eventId = eventId

--- a/openbank-psd2-service/src/main/kotlin/com/openbank/psd2/infrastructure/persistence/repository/Psd2OutboxRepositoryImpl.kt
+++ b/openbank-psd2-service/src/main/kotlin/com/openbank/psd2/infrastructure/persistence/repository/Psd2OutboxRepositoryImpl.kt
@@ -86,18 +86,23 @@ class Psd2OutboxRepositoryImpl(private val clock: Clock) :
         }.awaitSuspending()
     }
 
-    override suspend fun markFailed(eventId: UUID, error: String, failedAt: Instant) {
+    override suspend fun markFailed(eventId: UUID, error: String, failedAt: Instant): OutboxStatus =
         Panache.withTransaction {
-            find("eventId", eventId).firstResult().invoke { e ->
+            find("eventId", eventId).firstResult().map { e ->
                 if (e != null) {
                     e.attemptCount += 1
                     e.status = OutboxFailurePolicy.statusAfterFailure(e.attemptCount).name
                     e.lastError = error.take(OutboxFailurePolicy.MAX_ERROR_LEN)
                     e.updatedAt = failedAt
+                    OutboxStatus.valueOf(e.status)
+                } else {
+                    // Row not found -- unreachable in practice (the dispatcher only calls
+                    // markFailed on a row it just claimed), but degrade gracefully rather than
+                    // throw out of a batch that is otherwise mid-flight (#5128 finding 3).
+                    OutboxStatus.FAILED
                 }
-            }.replaceWith(Unit)
+            }
         }.awaitSuspending()
-    }
 
     private fun OutboxMessage.toEntity() = Psd2OutboxEntity().also {
         it.eventId = eventId

--- a/openbank-psd2-service/src/test/kotlin/com/openbank/psd2/infrastructure/outbox/Psd2OutboxDispatcherTest.kt
+++ b/openbank-psd2-service/src/test/kotlin/com/openbank/psd2/infrastructure/outbox/Psd2OutboxDispatcherTest.kt
@@ -75,7 +75,7 @@ class Psd2OutboxDispatcherTest {
         val entry = sampleEntry()
         coEvery { repo.claimProcessable(any(), any()) } returns listOf(entry)
         coEvery { publisher.publish(entry) } throws RuntimeException("kafka unavailable")
-        coEvery { repo.markFailed(any(), any(), any()) } returns Unit
+        coEvery { repo.markFailed(any(), any(), any()) } returns OutboxStatus.FAILED
 
         val dispatcher = Psd2OutboxDispatcher(repo, publisher, dispatchEnabled = true)
 

--- a/openbank-sanctions-service/src/main/kotlin/com/openbank/sanctions/infrastructure/persistence/repository/SanctionsOutboxRepositoryImpl.kt
+++ b/openbank-sanctions-service/src/main/kotlin/com/openbank/sanctions/infrastructure/persistence/repository/SanctionsOutboxRepositoryImpl.kt
@@ -87,18 +87,23 @@ class SanctionsOutboxRepositoryImpl(private val clock: Clock) :
         }.awaitSuspending()
     }
 
-    override suspend fun markFailed(eventId: UUID, error: String, failedAt: Instant) {
+    override suspend fun markFailed(eventId: UUID, error: String, failedAt: Instant): OutboxStatus =
         Panache.withTransaction {
-            find("eventId", eventId).firstResult().invoke { e ->
+            find("eventId", eventId).firstResult().map { e ->
                 if (e != null) {
                     e.attemptCount += 1
                     e.status = OutboxFailurePolicy.statusAfterFailure(e.attemptCount).name
                     e.lastError = error.take(OutboxFailurePolicy.MAX_ERROR_LEN)
                     e.updatedAt = failedAt
+                    OutboxStatus.valueOf(e.status)
+                } else {
+                    // Row not found -- unreachable in practice (the dispatcher only calls
+                    // markFailed on a row it just claimed), but degrade gracefully rather than
+                    // throw out of a batch that is otherwise mid-flight (#5128 finding 3).
+                    OutboxStatus.FAILED
                 }
-            }.replaceWithVoid()
+            }
         }.awaitSuspending()
-    }
 
     private fun OutboxMessage.toEntity() = SanctionsOutboxEntity().also {
         it.eventId = eventId

--- a/openbank-sca-service/src/main/kotlin/com/openbank/sca/infrastructure/persistence/repository/ScaOutboxRepositoryImpl.kt
+++ b/openbank-sca-service/src/main/kotlin/com/openbank/sca/infrastructure/persistence/repository/ScaOutboxRepositoryImpl.kt
@@ -84,18 +84,23 @@ class ScaOutboxRepositoryImpl(private val clock: Clock) :
         }.awaitSuspending()
     }
 
-    override suspend fun markFailed(eventId: UUID, error: String, failedAt: Instant) {
+    override suspend fun markFailed(eventId: UUID, error: String, failedAt: Instant): OutboxStatus =
         Panache.withTransaction {
-            find("eventId", eventId).firstResult().invoke { e ->
+            find("eventId", eventId).firstResult().map { e ->
                 if (e != null) {
                     e.attemptCount += 1
                     e.status = OutboxFailurePolicy.statusAfterFailure(e.attemptCount).name
                     e.lastError = error.take(OutboxFailurePolicy.MAX_ERROR_LEN)
                     e.updatedAt = failedAt
+                    OutboxStatus.valueOf(e.status)
+                } else {
+                    // Row not found -- unreachable in practice (the dispatcher only calls
+                    // markFailed on a row it just claimed), but degrade gracefully rather than
+                    // throw out of a batch that is otherwise mid-flight (#5128 finding 3).
+                    OutboxStatus.FAILED
                 }
-            }.replaceWith(Unit)
+            }
         }.awaitSuspending()
-    }
 
     override suspend fun save(message: OutboxMessage) {
         Panache.withTransaction { persistAndFlush(message.toEntity()) }.awaitSuspending()

--- a/openbank-sdd-service/src/main/kotlin/com/openbank/sdd/infrastructure/persistence/repository/SddOutboxRepositoryImpl.kt
+++ b/openbank-sdd-service/src/main/kotlin/com/openbank/sdd/infrastructure/persistence/repository/SddOutboxRepositoryImpl.kt
@@ -73,18 +73,23 @@ class SddOutboxRepositoryImpl(private val clock: Clock) :
         }.awaitSuspending()
     }
 
-    override suspend fun markFailed(eventId: UUID, error: String, failedAt: Instant) {
+    override suspend fun markFailed(eventId: UUID, error: String, failedAt: Instant): OutboxStatus =
         Panache.withTransaction {
-            find("eventId", eventId).firstResult().invoke { e ->
+            find("eventId", eventId).firstResult().map { e ->
                 if (e != null) {
                     e.attemptCount += 1
                     e.status = OutboxFailurePolicy.statusAfterFailure(e.attemptCount).name
                     e.lastError = error.take(OutboxFailurePolicy.MAX_ERROR_LEN)
                     e.updatedAt = failedAt
+                    OutboxStatus.valueOf(e.status)
+                } else {
+                    // Row not found -- unreachable in practice (the dispatcher only calls
+                    // markFailed on a row it just claimed), but degrade gracefully rather than
+                    // throw out of a batch that is otherwise mid-flight (#5128 finding 3).
+                    OutboxStatus.FAILED
                 }
-            }.replaceWithVoid()
+            }
         }.awaitSuspending()
-    }
 
     /**
      * Reference implementation for the [OutboxRepository.claimProcessable] atomic-claim

--- a/openbank-sepa-payment/src/main/kotlin/com/openbank/sepa/infrastructure/persistence/repository/SepaPaymentOutboxRepositoryImpl.kt
+++ b/openbank-sepa-payment/src/main/kotlin/com/openbank/sepa/infrastructure/persistence/repository/SepaPaymentOutboxRepositoryImpl.kt
@@ -91,20 +91,24 @@ class SepaPaymentOutboxRepositoryImpl(private val clock: Clock) :
         }.awaitSuspending()
     }
 
-    override suspend fun markFailed(eventId: UUID, error: String, failedAt: Instant) {
+    override suspend fun markFailed(eventId: UUID, error: String, failedAt: Instant): OutboxStatus =
         Panache.withTransaction {
             find("eventId", eventId).firstResult()
-                .invoke { entity ->
+                .map { entity ->
                     if (entity != null) {
                         entity.attemptCount += 1
                         entity.status = OutboxFailurePolicy.statusAfterFailure(entity.attemptCount).name
                         entity.lastError = error.take(OutboxFailurePolicy.MAX_ERROR_LEN)
                         entity.updatedAt = failedAt
+                        OutboxStatus.valueOf(entity.status)
+                    } else {
+                        // Row not found -- unreachable in practice (the dispatcher only calls
+                        // markFailed on a row it just claimed), but degrade gracefully rather than
+                        // throw out of a batch that is otherwise mid-flight (#5128 finding 3).
+                        OutboxStatus.FAILED
                     }
                 }
-                .replaceWith(Unit)
         }.awaitSuspending()
-    }
 
     private fun SepaPaymentOutboxMessage.toEntity() = SepaPaymentOutboxEntity().also {
         it.eventId = eventId

--- a/openbank-sepa-payment/src/test/kotlin/com/openbank/sepa/infrastructure/outbox/SepaPaymentOutboxDispatcherTest.kt
+++ b/openbank-sepa-payment/src/test/kotlin/com/openbank/sepa/infrastructure/outbox/SepaPaymentOutboxDispatcherTest.kt
@@ -76,7 +76,7 @@ class SepaPaymentOutboxDispatcherTest {
         coEvery { eventPublisher.publish(failing) } throws RuntimeException("broker down")
         coJustRun { eventPublisher.publish(ok) }
         coJustRun { outboxRepository.markSent(any(), any()) }
-        coJustRun { outboxRepository.markFailed(any(), any(), any()) }
+        coEvery { outboxRepository.markFailed(any(), any(), any()) } returns OutboxStatus.FAILED
 
         dispatcher.dispatch()
 

--- a/openbank-standing-order-service/src/main/kotlin/com/openbank/standingorder/infrastructure/persistence/repository/StandingOrderOutboxRepositoryImpl.kt
+++ b/openbank-standing-order-service/src/main/kotlin/com/openbank/standingorder/infrastructure/persistence/repository/StandingOrderOutboxRepositoryImpl.kt
@@ -87,18 +87,23 @@ class StandingOrderOutboxRepositoryImpl(private val clock: Clock) :
         }.awaitSuspending()
     }
 
-    override suspend fun markFailed(eventId: UUID, error: String, failedAt: Instant) {
+    override suspend fun markFailed(eventId: UUID, error: String, failedAt: Instant): OutboxStatus =
         Panache.withTransaction {
-            find("eventId", eventId).firstResult().invoke { e ->
+            find("eventId", eventId).firstResult().map { e ->
                 if (e != null) {
                     e.attemptCount += 1
                     e.status = OutboxFailurePolicy.statusAfterFailure(e.attemptCount).name
                     e.lastError = error.take(OutboxFailurePolicy.MAX_ERROR_LEN)
                     e.updatedAt = failedAt
+                    OutboxStatus.valueOf(e.status)
+                } else {
+                    // Row not found -- unreachable in practice (the dispatcher only calls
+                    // markFailed on a row it just claimed), but degrade gracefully rather than
+                    // throw out of a batch that is otherwise mid-flight (#5128 finding 3).
+                    OutboxStatus.FAILED
                 }
-            }.replaceWith(Unit)
+            }
         }.awaitSuspending()
-    }
 
     private fun OutboxMessage.toEntity() = StandingOrderOutboxEntity().also {
         it.eventId = eventId

--- a/openbank-statement-service/src/main/kotlin/com/openbank/statement/infrastructure/persistence/repository/StatementOutboxRepositoryImpl.kt
+++ b/openbank-statement-service/src/main/kotlin/com/openbank/statement/infrastructure/persistence/repository/StatementOutboxRepositoryImpl.kt
@@ -100,18 +100,23 @@ class StatementOutboxRepositoryImpl(private val clock: Clock) :
         }.awaitSuspending()
     }
 
-    override suspend fun markFailed(eventId: UUID, error: String, failedAt: Instant) {
+    override suspend fun markFailed(eventId: UUID, error: String, failedAt: Instant): OutboxStatus =
         Panache.withTransaction {
-            find("eventId", eventId).firstResult().invoke { e ->
+            find("eventId", eventId).firstResult().map { e ->
                 if (e != null) {
                     e.attemptCount += 1
                     e.status = OutboxFailurePolicy.statusAfterFailure(e.attemptCount).name
                     e.lastError = error.take(OutboxFailurePolicy.MAX_ERROR_LEN)
                     e.updatedAt = failedAt
+                    OutboxStatus.valueOf(e.status)
+                } else {
+                    // Row not found -- unreachable in practice (the dispatcher only calls
+                    // markFailed on a row it just claimed), but degrade gracefully rather than
+                    // throw out of a batch that is otherwise mid-flight (#5128 finding 3).
+                    OutboxStatus.FAILED
                 }
-            }.replaceWithVoid()
+            }
         }.awaitSuspending()
-    }
 
     companion object {
         @Suppress("MaxLineLength")

--- a/openbank-swift-service/src/main/kotlin/com/openbank/swift/infrastructure/persistence/repository/SwiftOutboxRepositoryImpl.kt
+++ b/openbank-swift-service/src/main/kotlin/com/openbank/swift/infrastructure/persistence/repository/SwiftOutboxRepositoryImpl.kt
@@ -92,18 +92,23 @@ class SwiftOutboxRepositoryImpl(private val clock: Clock) :
         }.awaitSuspending()
     }
 
-    override suspend fun markFailed(eventId: UUID, error: String, failedAt: Instant) {
+    override suspend fun markFailed(eventId: UUID, error: String, failedAt: Instant): OutboxStatus =
         Panache.withTransaction {
-            find("eventId", eventId).firstResult().invoke { e ->
+            find("eventId", eventId).firstResult().map { e ->
                 if (e != null) {
                     e.attemptCount += 1
                     e.status = OutboxFailurePolicy.statusAfterFailure(e.attemptCount).name
                     e.lastError = error.take(OutboxFailurePolicy.MAX_ERROR_LEN)
                     e.updatedAt = failedAt
+                    OutboxStatus.valueOf(e.status)
+                } else {
+                    // Row not found -- unreachable in practice (the dispatcher only calls
+                    // markFailed on a row it just claimed), but degrade gracefully rather than
+                    // throw out of a batch that is otherwise mid-flight (#5128 finding 3).
+                    OutboxStatus.FAILED
                 }
-            }.replaceWith(Unit)
+            }
         }.awaitSuspending()
-    }
 
     private fun SwiftOutboxMessage.toEntity() = SwiftOutboxEntity().also {
         it.eventId = eventId

--- a/openbank-tpp-registry-service/src/main/kotlin/com/openbank/tpp/infrastructure/persistence/repository/TppOutboxRepositoryImpl.kt
+++ b/openbank-tpp-registry-service/src/main/kotlin/com/openbank/tpp/infrastructure/persistence/repository/TppOutboxRepositoryImpl.kt
@@ -87,18 +87,23 @@ class TppOutboxRepositoryImpl(private val clock: Clock) :
         }.awaitSuspending()
     }
 
-    override suspend fun markFailed(eventId: UUID, error: String, failedAt: Instant) {
+    override suspend fun markFailed(eventId: UUID, error: String, failedAt: Instant): OutboxStatus =
         Panache.withTransaction {
-            find("eventId", eventId).firstResult().invoke { e ->
+            find("eventId", eventId).firstResult().map { e ->
                 if (e != null) {
                     e.attemptCount += 1
                     e.status = OutboxFailurePolicy.statusAfterFailure(e.attemptCount).name
                     e.lastError = error.take(OutboxFailurePolicy.MAX_ERROR_LEN)
                     e.updatedAt = failedAt
+                    OutboxStatus.valueOf(e.status)
+                } else {
+                    // Row not found -- unreachable in practice (the dispatcher only calls
+                    // markFailed on a row it just claimed), but degrade gracefully rather than
+                    // throw out of a batch that is otherwise mid-flight (#5128 finding 3).
+                    OutboxStatus.FAILED
                 }
-            }.replaceWith(Unit)
+            }
         }.awaitSuspending()
-    }
 
     private fun OutboxMessage.toEntity() = TppOutboxEntity().also {
         it.eventId = eventId

--- a/openbank-transaction-service/src/main/kotlin/com/openbank/transaction/infrastructure/persistence/repository/TransactionOutboxRepositoryImpl.kt
+++ b/openbank-transaction-service/src/main/kotlin/com/openbank/transaction/infrastructure/persistence/repository/TransactionOutboxRepositoryImpl.kt
@@ -94,20 +94,24 @@ class TransactionOutboxRepositoryImpl(private val clock: Clock) :
         }.awaitSuspending()
     }
 
-    override suspend fun markFailed(eventId: UUID, error: String, failedAt: Instant) {
+    override suspend fun markFailed(eventId: UUID, error: String, failedAt: Instant): OutboxStatus =
         Panache.withTransaction {
             find("eventId", eventId).firstResult()
-                .invoke { entity ->
+                .map { entity ->
                     if (entity != null) {
                         entity.attemptCount += 1
                         entity.status = OutboxFailurePolicy.statusAfterFailure(entity.attemptCount).name
                         entity.lastError = error.take(OutboxFailurePolicy.MAX_ERROR_LEN)
                         entity.updatedAt = failedAt
+                        OutboxStatus.valueOf(entity.status)
+                    } else {
+                        // Row not found -- unreachable in practice (the dispatcher only calls
+                        // markFailed on a row it just claimed), but degrade gracefully rather than
+                        // throw out of a batch that is otherwise mid-flight (#5128 finding 3).
+                        OutboxStatus.FAILED
                     }
                 }
-                .replaceWith(Unit)
         }.awaitSuspending()
-    }
 
     private fun OutboxMessage.toEntity() = TransactionOutboxEntity().also {
         it.eventId = eventId


### PR DESCRIPTION
## What

`OutboxDispatch.dispatchOnce` independently recomputed
`OutboxFailurePolicy.statusAfterFailure(entry.attemptCount + 1)` to decide whether a failed row's
`Failed.terminal` flag should be true, instead of reading what `repository.markFailed(...)` actually
persisted. Correctness depended on every `<Service>OutboxRepositoryImpl.markFailed` applying the
identical computation with the same default `maxAttempts` — true today (verified across the fleet),
but enforced only by convention, not the type system. A future repo impl with different
backoff/`maxAttempts` would silently desync the `outboxDead` metric from the DB's real row status,
and no existing test (they all mock the repository) could catch it (#5128 finding 3).

`OutboxRepository.markFailed` now returns the `OutboxStatus` it actually persisted (`FAILED` or
`DEAD`). `OutboxDispatch.dispatchOnce` reads that return value directly instead of recomputing it.

## Why this is its own PR

Explicitly scoped separately per the issue's own guidance: bundling this with finding 2's
constructor-injection sweep (#5199) would have doubled the blast radius of a single PR touching
every outbox-bearing service, for two independently risky mechanical changes. Splitting keeps each
PR revertible on its own.

## Fleet sweep — 33 implementations, not uniform

- **26 "bucket A" repos** (account, audit, balance, case-coordinator, clearing, consent,
  delegation, dispute, document, domestic-payment, fx, kyc, lending, notification, party, pid,
  psd2, sanctions, sca, sdd, sepa-payment, standing-order, statement, swift, tpp-registry,
  transaction) share one reactive-Panache shape — now return the mapped `OutboxStatus` instead of
  `Unit`, falling back to `FAILED` on the (practically unreachable) row-not-found path.
- **5 repos with a shared `applyFailure` helper** (aml, engagement, fraud, interest, ledger)
  already computed the resulting status locally as `next` — that helper now returns it instead of
  discarding it.
- **card-issuance** has its own inline DEAD-state log line; same shape as bucket A, log preserved.
- **billing** is the one genuinely different implementation: `markFailed` also flips an
  `AssessedFee`'s `posting_status` when the outbox row goes DEAD, via several early-return
  branches. Restructured with a small internal `FailureOutcome(status, dead)` so the persisted
  `OutboxStatus` is captured on *every* path — including the two early returns that previously
  discarded it entirely, not only the branch that also had fee-side work to do.

`openbank-security-scanner`'s `SecurityOutboxRepositoryImpl` implements a bespoke, unrelated port
(no `DEAD` state at all — see #5195, finding 4) and is untouched here.

## Test fallout

Six test doubles/mocks stubbed the old `Unit`-returning signature and would not have compiled
otherwise:
- `OutboxDispatchTest.FakeRepo` and `AbstractOutboxDispatcherTest.FakeRepo` now compute the
  returned `OutboxStatus` the same way a real repo does (`OutboxFailurePolicy.statusAfterFailure`
  over the row's own `attemptCount + 1`) — so these tests exercise `OutboxDispatch` reading the
  return value back, not a value it recomputed itself.
- `OutboxCountProcessableTest`'s stub returns a fixed `OutboxStatus.FAILED` (unrelated to what it
  tests).
- Four `*OutboxDispatcherTest` mockk stubs (billing, domestic-payment, lending, sepa-payment,
  psd2) changed `coJustRun`/`returns Unit` to `coEvery { ... } returns OutboxStatus.FAILED`.

**New falsifying test** in `OutboxDispatchTest`: a repository whose `markFailed` applies a
*different* policy than the shared default (parks DEAD after one failure, not ten) — before this
fix, `OutboxDispatch`'s own recomputation would have reported that row as non-terminal even though
the repository just persisted DEAD. This is the regression the whole finding is about.

## Testing

- `ktlintCheck` + `detekt` clean on all 35 touched modules (33 repo-impl modules + libs-domain +
  libs-runtime).
- `compileKotlin` + `compileTestKotlin` clean on all 33 service modules.
- Full `./gradlew :<module>:test` green on libs-domain, libs-runtime, and every module with
  dispatcher-level test coverage: billing, consent, domestic-payment, fraud, fx, ledger, lending,
  psd2, sepa-payment, swift, card-issuance, party, document — including
  `LedgerOutboxDispatchFailureIT`, which drives a real row through
  `PENDING -> FAILED -> ... -> DEAD` against a live Postgres and is the one test in the fleet that
  would actually have caught a drift between `markFailed`'s write and `OutboxDispatch`'s
  prediction.
- Two runs (`fraud-service`, `sepa-payment` on the sibling PRs) hit an unrelated
  `Failed to start quarkus` Testcontainers/Docker port-contention flake from a concurrently running
  Gradle test JVM; re-ran each in isolation and they passed — the outbox-dispatcher tests
  themselves were green on every run.

## Money-path note

`ledger`, `transaction`, `account`, `balance`, `sepa-payment`, `domestic-payment`, `clearing`,
`swift`, `fx`, `lending`, `sdd`, `interest` and `sca` (`rules.yaml: money_path_services`) are all
among the touched repositories. Business logic is unchanged (same `OutboxFailurePolicy`, same
fields written) — only which layer reports the resulting status — but per `rules.yaml` money-path
services still require **2 approvals**.

Refs #5128 (finding 3 of 4 in scope for this follow-up round; findings 1, 2 and 4 are #5194, #5199
and #5195 respectively).
