### PR TITLE
test(account): close #5049's negative-case gap for accounts_created/accounts_closed

### DIFF
--- a/openbank-account-service/src/test/kotlin/com/openbank/account/application/usecase/AccountServiceLifecycleTest.kt
+++ b/openbank-account-service/src/test/kotlin/com/openbank/account/application/usecase/AccountServiceLifecycleTest.kt
@@ -38,6 +38,7 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
 import io.mockk.slot
+import io.mockk.verify
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
@@ -363,6 +364,8 @@ class AccountServiceLifecycleTest {
         }.isInstanceOf(AccountNotEmptyException::class.java)
 
         coVerify(exactly = 0) { accountRepository.update(any()) }
+        // #4348 hazard: a refused close must never share the accountClosed count with a real one.
+        verify(exactly = 0) { metrics.accountClosed(any(), any()) }
     }
 
     @Test

--- a/openbank-account-service/src/test/kotlin/com/openbank/account/application/usecase/AccountServiceTest.kt
+++ b/openbank-account-service/src/test/kotlin/com/openbank/account/application/usecase/AccountServiceTest.kt
@@ -253,6 +253,8 @@ class AccountServiceTest {
             .isInstanceOf(AccountOpeningBlockedByScreeningException::class.java)
 
         coVerify(exactly = 0) { accountRepository.saveNewAccount(any(), any(), any()) }
+        // #4348 hazard: a blocked open must never share the accountCreated count with a real one.
+        verify(exactly = 0) { metrics.accountCreated(any(), any()) }
     }
 
     @Test
@@ -267,6 +269,7 @@ class AccountServiceTest {
             .isInstanceOf(AccountOpeningBlockedByScreeningException::class.java)
 
         coVerify(exactly = 0) { accountRepository.saveNewAccount(any(), any(), any()) }
+        verify(exactly = 0) { metrics.accountCreated(any(), any()) }
     }
 
     @Test
@@ -281,6 +284,7 @@ class AccountServiceTest {
             .isInstanceOf(AccountScreeningUnavailableException::class.java)
 
         coVerify(exactly = 0) { accountRepository.saveNewAccount(any(), any(), any()) }
+        verify(exactly = 0) { metrics.accountCreated(any(), any()) }
     }
 
     @Test


### PR DESCRIPTION
## What

Refs #5049.

Investigated the account-service portion of #5049
(`openbank_accounts_created_total` / `openbank_accounts_closed_total`) and found it was
**already fixed on main** before this issue was filed:

- `DomainMetrics.accountCreated(productType, currency)` →
  `counter("openbank.accounts.created", "product_type", ..., "currency", ...)`
- `DomainMetrics.accountClosed(productType, reason)` →
  `counter("openbank.accounts.closed", "product_type", ..., "reason", ...)`
- Both are wired into `AccountService.openAccount()` / `closeAccount()`, called only
  *after* the transaction commits and the domain event publishes — never on a rejected
  or exception path, so the metric can't double as a "no-op counted as success" trap
  (the #4348 hazard this repo has a documented incident about).
- Positive-path tests already existed (`AccountServiceTest`: "open account counts
  accountCreated...", "close account counts accountClosed...").

So there is no missing instrumentation here — verified the counter registers under
`Counter.builder(...).increment()` (not just `.register()`, which was the historical
bug class per this file's own comment), and confirmed via `git log -S` that both the
counter methods and their call sites predate the 2026-08-16 audit that filed #5049 by
weeks. The issue's "0 hits" grep for account-service was a false negative — likely a
naming-pattern miss in the audit script, not a real gap.

## What this PR actually does

Closes the one real gap: there was **no negative-case coverage** proving the counters
stay untouched on a rejected attempt (the same #4348 shape — a skipped/rejected outcome
must never share a count with a real success). Added `verify(exactly = 0)` assertions
to:

- `AccountServiceTest`: sanctions HIT / REVIEW / unavailable → `openAccount` throws →
  `metrics.accountCreated` must not fire.
- `AccountServiceLifecycleTest`: `closeAccount` refused because the account still holds
  money → `metrics.accountClosed` must not fire.

No production code changed — `AccountService.kt` and `DomainMetrics.kt` are untouched.

## Money-path

`openbank-account-service` is on `rules.yaml: money_path_services` — flagging for the
2-approval requirement (ADR-0030) even though this PR is test-only and does not change
`src/main`.

## Test plan

- [x] `./gradlew :openbank-account-service:test --tests
      "com.openbank.account.application.usecase.AccountServiceTest" --tests
      "com.openbank.account.application.usecase.AccountServiceLifecycleTest"` — green,
      including the new negative assertions.
- [x] `./gradlew :openbank-account-service:ktlintCheck :openbank-account-service:detekt`
      — green.
- [x] No `DomainMetrics.kt` / `openbank-libs-runtime` changes, so no libs-runtime test
      run needed.
