### PR TITLE
chore(sepa-instant): drop vestigial outbox table, correct threat-model docs

### DIFF
--- a/docs/threat-models/openbank-sepa-instant.md
+++ b/docs/threat-models/openbank-sepa-instant.md
@@ -19,7 +19,7 @@ above batch SEPA.
 ```
 [Channels/Operators] --> (REST /api/v1/sepa-instant) --> [sepa-instant-service] --> [(Postgres: sct_inst payments)]
                                                                 |
-                                                                +--> [(sct_inst_outbox)] --> [Kafka events] --> clearing/scheme
+                                                                +--> [Kafka events] (direct emit via KafkaSctInstEventPublisher) --> clearing/scheme
                                                                 |
                                                                 +--> [fraud-service] (shadow, OIDC CC / mTLS, fail-open)
    recall <-- (POST /{paymentId}/recall)
@@ -42,7 +42,6 @@ above batch SEPA.
 | **T**ampering | Amount/beneficiary change before send | Server-validated, immutable once accepted; audit |
 | **R**epudiation | Deny initiating an instant payment | AuditEvent + SCA evidence + correlation id |
 | **I**nfo disclosure | Debtor payment history (`/debtor/{id}`) leak | AuthZ scoping to owner/role |
-| **I**nfo disclosure | Domain metrics leak PII / enable per-payment inference via high-cardinality labels | `DomainMetrics` low-cardinality contract (ADR-0077 / ADR-0079): the outbox-backlog gauge `openbank.outbox.backlog` is tagged **only** by `service="sepa-instant"` — never a payment id, end-to-end id, debtor/creditor IBAN, amount, or any PII. The gauge value is a read-only `COUNT(*)` of PENDING+FAILED outbox rows, refreshed off a scheduled tick (not on the Prometheus scrape thread); `/q/metrics` is cluster-internal |
 | **D**oS | Flood to exhaust instant-rail capacity | Rate limit; idempotency |
 | **E**oP | Unauthorized recall to claw back funds | Recall gated by distinct authority; audit; reason required |
 
@@ -96,6 +95,9 @@ not change any existing request's outcome until explicitly flipped.
   payment id, IBAN, amount, or PII (low-cardinality contract). **Risk class = confidentiality / metric
   cardinality** (bounded to a single per-service series). Mitigated by `SctInstOutboxBacklogGaugeTest`
   (supplier tracks the refreshed cache). No DB change; rollback = revert the commit.
+  **Superseded — see the 2026-08-17 entry below**: this gauge, `countProcessable()`, and the outbox
+  pipeline it measured were removed as dead code (PR #1364); the corresponding STRIDE row above no
+  longer applies and has been removed from §4.
 - **2026-06-17** — ADR-0084 fraud shadow scoring (observe-only). New outbound trust boundary:
   `sepa-instant → fraud-service (POST /api/v1/fraud/score, OIDC client-credentials)`.
   **Shadow = fail-open and never-enforce**: `SctInstPaymentService.scoreFraudShadow()` wraps the call
@@ -119,3 +121,16 @@ not change any existing request's outcome until explicitly flipped.
   defaults `false` — no behavior change to any existing request in this PR; flipping it is a
   tracked follow-up. No DB schema change (Redis, TTL-bounded); rollback = revert the commit (or
   leave `authz.four-eyes.enforce=false`, its default).
+- **2026-08-17** — Doc correction (issue #5127), no behavior change. PR #1364 (2026-07-17) had
+  already removed the dead transactional-outbox pipeline —
+  `SctInstOutboxPort`/`SctInstOutboxDispatcher`/`KafkaSctInstOutboxEventPublisher`/the
+  outbox-backlog gauge — after confirming nothing ever wrote to it: `KafkaSctInstEventPublisher`
+  (a direct, synchronous emitter) was always the pipeline actually in use (issue #1034). This
+  entry corrects §2's DFD (the `sct_inst_outbox` node is replaced with the direct
+  `KafkaSctInstEventPublisher` edge that was always the real path) and removes the now-void
+  metric-cardinality row from §4 STRIDE, and lands alongside a Flyway migration
+  (`V4__drop_sct_inst_outbox.sql`) dropping the vestigial `sct_inst_outbox` table and
+  `sct_inst_outbox_seq` sequence that PR #1364 left behind (0 rows, unused since #1034).
+  **Risk class = none** — this is a documentation and dead-schema cleanup only; the live pipeline
+  (direct Kafka emitter) and every trust boundary above are unchanged. Rollback: revert this doc
+  commit; the migration's own rollback is stated in `V4__drop_sct_inst_outbox.sql`.

--- a/openbank-sepa-instant/detekt-baseline.xml
+++ b/openbank-sepa-instant/detekt-baseline.xml
@@ -7,8 +7,6 @@
     <ID>MagicNumber:ExceptionMappers.kt$BadRequestMapper$400</ID>
     <ID>MagicNumber:ExceptionMappers.kt$NotFoundMapper$404</ID>
     <ID>MagicNumber:SanctionsScreeningAdapter.kt$SanctionsScreeningAdapter$5_000</ID>
-    <ID>MagicNumber:SctInstOutboxRepositoryImpl.kt$SctInstOutboxRepositoryImpl$4000</ID>
-    <ID>TooManyFunctions:SctInstOutboxRepositoryImpl.kt$SctInstOutboxRepositoryImpl : SctInstOutboxRepositoryPanacheRepository</ID>
     <ID>TooManyFunctions:SctInstPaymentService.kt$SctInstPaymentService : SubmitSctInstPaymentUseCaseGetSctInstPaymentUseCaseRecallSctInstPaymentUseCase</ID>
   </CurrentIssues>
 </SmellBaseline>

--- a/openbank-sepa-instant/ktlint-baseline.xml
+++ b/openbank-sepa-instant/ktlint-baseline.xml
@@ -7,65 +7,12 @@
     <file name="src/main/kotlin/com/openbank/sepainstant/application/port/out/ScreeningPorts.kt">
         <error line="39" column="31" source="standard:trailing-comma-on-declaration-site" />
     </file>
-    <file name="src/main/kotlin/com/openbank/sepainstant/application/port/out/SctInstOutboxPort.kt">
-        <error line="22" column="43" source="standard:trailing-comma-on-declaration-site" />
-        <error line="36" column="27" source="standard:trailing-comma-on-declaration-site" />
-    </file>
-    <file name="src/main/kotlin/com/openbank/sepainstant/application/usecase/SctInstPaymentService.kt">
-        <error line="8" column="1" source="standard:no-wildcard-imports" />
-        <error line="16" column="1" source="standard:no-wildcard-imports" />
-        <error line="40" column="37" source="standard:trailing-comma-on-declaration-site" />
-        <error line="41" column="34" source="standard:class-signature" />
-        <error line="41" column="60" source="standard:class-signature" />
-        <error line="84" column="47" source="standard:trailing-comma-on-call-site" />
-        <error line="106" column="40" source="standard:function-literal" />
-        <error line="106" column="84" source="standard:binary-expression-wrapping" />
-        <error line="106" column="97" source="standard:binary-expression-wrapping" />
-        <error line="106" column="121" source="standard:max-line-length" />
-        <error line="106" column="131" source="standard:function-literal" />
-        <error line="117" column="82" source="standard:trailing-comma-on-call-site" />
-        <error line="127" column="50" source="standard:trailing-comma-on-call-site" />
-        <error line="128" column="18" source="standard:trailing-comma-on-call-site" />
-        <error line="138" column="34" source="standard:trailing-comma-on-call-site" />
-        <error line="142" column="26" source="standard:function-literal" />
-        <error line="142" column="46" source="standard:argument-list-wrapping" />
-        <error line="142" column="69" source="standard:argument-list-wrapping" />
-        <error line="142" column="98" source="standard:argument-list-wrapping" />
-        <error line="142" column="121" source="standard:max-line-length" />
-        <error line="142" column="126" source="standard:argument-list-wrapping" />
-        <error line="142" column="127" source="standard:argument-list-wrapping" />
-        <error line="142" column="129" source="standard:function-literal" />
-        <error line="157" column="25" source="standard:trailing-comma-on-declaration-site" />
-        <error line="171" column="25" source="standard:trailing-comma-on-declaration-site" />
-        <error line="172" column="19" source="standard:function-signature" />
-        <error line="182" column="40" source="standard:trailing-comma-on-call-site" />
-        <error line="183" column="14" source="standard:trailing-comma-on-call-site" />
-        <error line="197" column="65" source="standard:function-signature" />
-        <error line="201" column="56" source="standard:function-signature" />
-        <error line="207" column="80" source="standard:function-signature" />
-        <error line="212" column="21" source="standard:multiline-if-else" />
-        <error line="215" column="26" source="standard:function-literal" />
-        <error line="215" column="35" source="standard:argument-list-wrapping" />
-        <error line="215" column="68" source="standard:argument-list-wrapping" />
-        <error line="215" column="103" source="standard:argument-list-wrapping" />
-        <error line="215" column="121" source="standard:max-line-length" />
-        <error line="215" column="124" source="standard:argument-list-wrapping" />
-        <error line="215" column="126" source="standard:function-literal" />
-    </file>
-    <file name="src/main/kotlin/com/openbank/sepainstant/domain/event/SctInstEvents.kt">
-        <error line="23" column="67" source="standard:trailing-comma-on-declaration-site" />
-        <error line="29" column="67" source="standard:trailing-comma-on-declaration-site" />
-        <error line="35" column="67" source="standard:trailing-comma-on-declaration-site" />
-        <error line="40" column="67" source="standard:trailing-comma-on-declaration-site" />
-        <error line="46" column="67" source="standard:trailing-comma-on-declaration-site" />
-    </file>
     <file name="src/main/kotlin/com/openbank/sepainstant/domain/model/SctInstPayment.kt">
         <error line="12" column="14" source="standard:enum-wrapping" />
         <error line="12" column="26" source="standard:enum-wrapping" />
         <error line="12" column="35" source="standard:enum-wrapping" />
         <error line="12" column="45" source="standard:enum-wrapping" />
         <error line="12" column="54" source="standard:enum-wrapping" />
-        <error line="38" column="57" source="standard:trailing-comma-on-declaration-site" />
     </file>
     <file name="src/main/kotlin/com/openbank/sepainstant/domain/screening/ScreeningPolicy.kt">
         <error line="22" column="31" source="standard:trailing-comma-on-declaration-site" />
@@ -113,17 +60,6 @@
         <error line="26" column="45" source="standard:trailing-comma-on-call-site" />
         <error line="27" column="9" source="standard:wrapping" />
         <error line="27" column="10" source="standard:wrapping" />
-    </file>
-    <file name="src/main/kotlin/com/openbank/sepainstant/infrastructure/kafka/KafkaSctInstOutboxEventPublisher.kt">
-        <error line="14" column="5" source="standard:class-signature" />
-        <error line="14" column="79" source="standard:class-signature" />
-        <error line="14" column="79" source="standard:trailing-comma-on-declaration-site" />
-        <error line="15" column="5" source="standard:class-signature" />
-    </file>
-    <file name="src/main/kotlin/com/openbank/sepainstant/infrastructure/outbox/SctInstOutboxDispatcher.kt">
-        <error line="18" column="79" source="standard:trailing-comma-on-declaration-site" />
-        <error line="23" column="65" source="standard:trailing-comma-on-call-site" />
-        <error line="25" column="46" source="standard:function-signature" />
     </file>
     <file name="src/main/kotlin/com/openbank/sepainstant/infrastructure/persistence/entity/SctInstPaymentEntity.kt">
         <error line="7" column="1" source="standard:no-wildcard-imports" />
@@ -191,67 +127,6 @@
         <error line="35" column="39" source="standard:statement-wrapping" />
         <error line="35" column="66" source="standard:statement-wrapping" />
     </file>
-    <file name="src/main/kotlin/com/openbank/sepainstant/infrastructure/persistence/repository/SctInstOutboxRepositoryImpl.kt">
-        <error line="6" column="1" source="standard:import-ordering" />
-        <error line="20" column="37" source="standard:class-signature" />
-        <error line="20" column="62" source="standard:class-signature" />
-        <error line="22" column="62" source="standard:function-signature" />
-        <error line="25" column="81" source="standard:function-signature" />
-        <error line="30" column="48" source="standard:trailing-comma-on-call-site" />
-        <error line="34" column="52" source="standard:function-signature" />
-        <error line="85" column="30" source="standard:trailing-comma-on-call-site" />
-        <error line="88" column="72" source="standard:function-signature" />
-        <error line="93" column="48" source="standard:trailing-comma-on-call-site" />
-        <error line="102" column="43" source="standard:function-signature" />
-        <error line="107" column="48" source="standard:trailing-comma-on-call-site" />
-        <error line="111" column="48" source="standard:function-signature" />
-        <error line="124" column="65" source="standard:function-signature" />
-    </file>
-    <file name="src/main/kotlin/com/openbank/sepainstant/infrastructure/persistence/repository/SctInstPaymentRepositoryImpl.kt">
-        <error line="24" column="38" source="standard:trailing-comma-on-declaration-site" />
-        <error line="34" column="74" source="standard:function-signature" />
-        <error line="41" column="75" source="standard:function-signature" />
-        <error line="48" column="56" source="standard:function-signature" />
-        <error line="50" column="27" source="standard:argument-list-wrapping" />
-        <error line="50" column="80" source="standard:argument-list-wrapping" />
-        <error line="50" column="112" source="standard:argument-list-wrapping" />
-        <error line="50" column="121" source="standard:max-line-length" />
-        <error line="56" column="27" source="standard:argument-list-wrapping" />
-        <error line="56" column="107" source="standard:argument-list-wrapping" />
-        <error line="56" column="121" source="standard:max-line-length" />
-        <error line="56" column="139" source="standard:argument-list-wrapping" />
-        <error line="61" column="82" source="standard:function-signature" />
-        <error line="64" column="31" source="standard:argument-list-wrapping" />
-        <error line="64" column="36" source="standard:argument-list-wrapping" />
-        <error line="64" column="47" source="standard:argument-list-wrapping" />
-        <error line="64" column="62" source="standard:argument-list-wrapping" />
-        <error line="64" column="69" source="standard:argument-list-wrapping" />
-        <error line="64" column="89" source="standard:argument-list-wrapping" />
-        <error line="64" column="104" source="standard:argument-list-wrapping" />
-        <error line="64" column="110" source="standard:argument-list-wrapping" />
-        <error line="64" column="119" source="standard:argument-list-wrapping" />
-        <error line="64" column="121" source="standard:max-line-length" />
-        <error line="68" column="61" source="standard:function-signature" />
-        <error line="70" column="27" source="standard:argument-list-wrapping" />
-        <error line="70" column="121" source="standard:max-line-length" />
-        <error line="70" column="146" source="standard:argument-list-wrapping" />
-        <error line="70" column="178" source="standard:argument-list-wrapping" />
-    </file>
-    <file name="src/main/kotlin/com/openbank/sepainstant/infrastructure/rest/ExceptionMappers.kt">
-        <error line="7" column="1" source="standard:import-ordering" />
-    </file>
-    <file name="src/main/kotlin/com/openbank/sepainstant/infrastructure/rest/SctInstResource.kt">
-        <error line="7" column="1" source="standard:import-ordering" />
-        <error line="7" column="1" source="standard:no-wildcard-imports" />
-        <error line="8" column="1" source="standard:no-wildcard-imports" />
-        <error line="13" column="1" source="standard:no-wildcard-imports" />
-        <error line="27" column="59" source="standard:trailing-comma-on-declaration-site" />
-        <error line="33" column="35" source="standard:function-signature" />
-        <error line="54" column="41" source="standard:trailing-comma-on-call-site" />
-        <error line="75" column="58" source="standard:trailing-comma-on-declaration-site" />
-        <error line="76" column="23" source="standard:function-signature" />
-        <error line="93" column="100" source="standard:trailing-comma-on-call-site" />
-    </file>
     <file name="src/main/kotlin/com/openbank/sepainstant/infrastructure/rest/dto/SctInstDtos.kt">
         <error line="22" column="27" source="standard:trailing-comma-on-declaration-site" />
         <error line="37" column="34" source="standard:trailing-comma-on-declaration-site" />
@@ -259,110 +134,6 @@
     <file name="src/test/kotlin/com/openbank/governance/HibernateSequenceGuardTest.kt">
         <error line="54" column="33" source="standard:trailing-comma-on-call-site" />
         <error line="68" column="36" source="standard:trailing-comma-on-call-site" />
-    </file>
-    <file name="src/test/kotlin/com/openbank/sepainstant/application/usecase/SctInstPaymentServiceTest.kt">
-        <error line="24" column="1" source="standard:no-wildcard-imports" />
-        <error line="42" column="26" source="standard:property-wrapping" />
-        <error line="42" column="49" source="standard:argument-list-wrapping" />
-        <error line="42" column="55" source="standard:argument-list-wrapping" />
-        <error line="42" column="66" source="standard:argument-list-wrapping" />
-        <error line="42" column="81" source="standard:argument-list-wrapping" />
-        <error line="42" column="94" source="standard:argument-list-wrapping" />
-        <error line="42" column="103" source="standard:argument-list-wrapping" />
-        <error line="42" column="121" source="standard:max-line-length" />
-        <error line="42" column="123" source="standard:argument-list-wrapping" />
-        <error line="54" column="35" source="standard:argument-list-wrapping" />
-        <error line="54" column="51" source="standard:argument-list-wrapping" />
-        <error line="54" column="67" source="standard:argument-list-wrapping" />
-        <error line="54" column="89" source="standard:argument-list-wrapping" />
-        <error line="54" column="117" source="standard:argument-list-wrapping" />
-        <error line="54" column="121" source="standard:max-line-length" />
-        <error line="54" column="122" source="standard:argument-list-wrapping" />
-        <error line="54" column="126" source="standard:argument-list-wrapping" />
-        <error line="54" column="127" source="standard:argument-list-wrapping" />
-        <error line="56" column="35" source="standard:argument-list-wrapping" />
-        <error line="56" column="51" source="standard:argument-list-wrapping" />
-        <error line="56" column="67" source="standard:argument-list-wrapping" />
-        <error line="56" column="91" source="standard:argument-list-wrapping" />
-        <error line="56" column="119" source="standard:argument-list-wrapping" />
-        <error line="56" column="121" source="standard:max-line-length" />
-        <error line="56" column="124" source="standard:argument-list-wrapping" />
-        <error line="56" column="128" source="standard:argument-list-wrapping" />
-        <error line="56" column="129" source="standard:argument-list-wrapping" />
-        <error line="112" column="35" source="standard:argument-list-wrapping" />
-        <error line="112" column="51" source="standard:argument-list-wrapping" />
-        <error line="112" column="67" source="standard:argument-list-wrapping" />
-        <error line="112" column="89" source="standard:argument-list-wrapping" />
-        <error line="112" column="117" source="standard:argument-list-wrapping" />
-        <error line="112" column="121" source="standard:max-line-length" />
-        <error line="112" column="122" source="standard:argument-list-wrapping" />
-        <error line="112" column="126" source="standard:argument-list-wrapping" />
-        <error line="112" column="127" source="standard:argument-list-wrapping" />
-        <error line="114" column="35" source="standard:argument-list-wrapping" />
-        <error line="114" column="51" source="standard:argument-list-wrapping" />
-        <error line="114" column="67" source="standard:argument-list-wrapping" />
-        <error line="114" column="91" source="standard:argument-list-wrapping" />
-        <error line="114" column="117" source="standard:argument-list-wrapping" />
-        <error line="114" column="121" source="standard:max-line-length" />
-        <error line="114" column="123" source="standard:argument-list-wrapping" />
-        <error line="114" column="144" source="standard:argument-list-wrapping" />
-        <error line="114" column="145" source="standard:argument-list-wrapping" />
-        <error line="126" column="18" source="standard:trailing-comma-on-call-site" />
-        <error line="139" column="35" source="standard:argument-list-wrapping" />
-        <error line="139" column="51" source="standard:argument-list-wrapping" />
-        <error line="139" column="67" source="standard:argument-list-wrapping" />
-        <error line="139" column="89" source="standard:argument-list-wrapping" />
-        <error line="139" column="117" source="standard:argument-list-wrapping" />
-        <error line="139" column="121" source="standard:max-line-length" />
-        <error line="139" column="122" source="standard:argument-list-wrapping" />
-        <error line="139" column="126" source="standard:argument-list-wrapping" />
-        <error line="139" column="127" source="standard:argument-list-wrapping" />
-        <error line="141" column="35" source="standard:argument-list-wrapping" />
-        <error line="141" column="51" source="standard:argument-list-wrapping" />
-        <error line="141" column="67" source="standard:argument-list-wrapping" />
-        <error line="141" column="91" source="standard:argument-list-wrapping" />
-        <error line="141" column="121" source="standard:max-line-length" />
-        <error line="141" column="127" source="standard:argument-list-wrapping" />
-        <error line="141" column="133" source="standard:argument-list-wrapping" />
-        <error line="141" column="146" source="standard:argument-list-wrapping" />
-        <error line="141" column="147" source="standard:argument-list-wrapping" />
-        <error line="148" column="114" source="standard:trailing-comma-on-call-site" />
-        <error line="167" column="43" source="standard:function-literal" />
-        <error line="167" column="87" source="standard:binary-expression-wrapping" />
-        <error line="167" column="103" source="standard:binary-expression-wrapping" />
-        <error line="167" column="121" source="standard:max-line-length" />
-        <error line="167" column="128" source="standard:function-literal" />
-        <error line="167" column="129" source="standard:trailing-comma-on-call-site" />
-        <error line="177" column="15" source="standard:function-literal" />
-        <error line="177" column="16" source="standard:wrapping" />
-        <error line="177" column="38" source="standard:argument-list-wrapping" />
-        <error line="177" column="47" source="standard:argument-list-wrapping" />
-        <error line="177" column="49" source="standard:function-literal" />
-        <error line="177" column="58" source="standard:binary-expression-wrapping" />
-        <error line="177" column="81" source="standard:argument-list-wrapping" />
-        <error line="177" column="89" source="standard:argument-list-wrapping" />
-        <error line="177" column="120" source="standard:max-line-length" />
-        <error line="177" column="124" source="standard:argument-list-wrapping" />
-        <error line="177" column="145" source="standard:argument-list-wrapping" />
-        <error line="177" column="146" source="standard:argument-list-wrapping" />
-        <error line="195" column="15" source="standard:function-literal" />
-        <error line="195" column="16" source="standard:binary-expression-wrapping" />
-        <error line="195" column="16" source="standard:wrapping" />
-        <error line="195" column="35" source="standard:argument-list-wrapping" />
-        <error line="195" column="65" source="standard:function-literal" />
-        <error line="195" column="66" source="standard:wrapping" />
-        <error line="195" column="95" source="standard:binary-expression-wrapping" />
-        <error line="195" column="114" source="standard:binary-expression-wrapping" />
-        <error line="195" column="121" source="standard:max-line-length" />
-        <error line="195" column="136" source="standard:function-literal" />
-        <error line="195" column="137" source="standard:argument-list-wrapping" />
-        <error line="195" column="139" source="standard:binary-expression-wrapping" />
-        <error line="195" column="139" source="standard:function-literal" />
-        <error line="195" column="148" source="standard:binary-expression-wrapping" />
-        <error line="220" column="39" source="standard:trailing-comma-on-declaration-site" />
-        <error line="232" column="32" source="standard:trailing-comma-on-call-site" />
-        <error line="237" column="82" source="standard:trailing-comma-on-declaration-site" />
-        <error line="261" column="65" source="standard:trailing-comma-on-call-site" />
     </file>
     <file name="src/test/kotlin/com/openbank/sepainstant/domain/model/SctInstPaymentTest.kt">
         <error line="44" column="28" source="standard:trailing-comma-on-call-site" />

--- a/openbank-sepa-instant/src/main/resources/db/migration/V4__drop_sct_inst_outbox.sql
+++ b/openbank-sepa-instant/src/main/resources/db/migration/V4__drop_sct_inst_outbox.sql
@@ -1,0 +1,15 @@
+-- PR #1364 (2026-07-17) removed the sct_inst_outbox transactional-outbox pipeline
+-- (SctInstOutboxPort/SctInstOutboxDispatcher/KafkaSctInstOutboxEventPublisher) after confirming
+-- it was never wired to any real call site: KafkaSctInstEventPublisher (a direct, synchronous
+-- emitter) was always the pipeline actually in use (issue #1034). That PR could not drop the
+-- table itself — needs its own migration, this one — and left it behind at 0 rows (issue #5127).
+-- Rollback: CREATE TABLE sct_inst_outbox (id BIGSERIAL PRIMARY KEY, event_id UUID NOT NULL UNIQUE,
+--   aggregate_id UUID NOT NULL, event_type VARCHAR(128) NOT NULL, payload TEXT NOT NULL,
+--   status VARCHAR(16) NOT NULL, attempt_count INTEGER NOT NULL DEFAULT 0, sent_at TIMESTAMPTZ,
+--   last_error TEXT, created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(), updated_at TIMESTAMPTZ NOT NULL
+--   DEFAULT NOW()); CREATE INDEX idx_sct_inst_outbox_status_created_at ON
+--   sct_inst_outbox(status, created_at ASC); CREATE INDEX idx_sct_inst_outbox_aggregate_id ON
+--   sct_inst_outbox(aggregate_id); CREATE SEQUENCE IF NOT EXISTS sct_inst_outbox_seq INCREMENT BY 50;
+
+DROP TABLE IF EXISTS sct_inst_outbox;
+DROP SEQUENCE IF EXISTS sct_inst_outbox_seq;

--- a/openbank-sepa-instant/src/main/resources/docs/02-architecture.en.md
+++ b/openbank-sepa-instant/src/main/resources/docs/02-architecture.en.md
@@ -13,9 +13,8 @@ The service follows the hexagonal (ports & adapters) architecture mandated by [A
         │       │                   ├─► SanctionsScreeningPort ─────────►│──► sanctions-service
         │       │                   ├─► AmlCasePort ────────────────────►│──► aml-service
         │       │                   ├─► SctInstPaymentRepository ───────►│──► PostgreSQL
-        │       │                   └─► SctInstEventPublisher / outbox ─►│
-        │       │                                                        │
-        │  OutboxDispatcher (@Scheduled 5s) ──► Kafka emitter ──────────►│──► openbank.sepa.instant.events
+        │       │                   └─► SctInstEventPublisher ──────────►│──► openbank.sepa.instant.events
+        │       │                       (direct Kafka emitter, no outbox)│
         └──────────────────────────────────────────────────────────────┘
 ```
 

--- a/openbank-sepa-instant/src/main/resources/docs/04-data.cs.md
+++ b/openbank-sepa-instant/src/main/resources/docs/04-data.cs.md
@@ -41,36 +41,24 @@ Platební agregát. Jeden řádek na SCT Inst příkaz.
 
 Indexy: `idx_sct_inst_status(status)`, `idx_sct_inst_debtor(debtor_account_id)`, `idx_sct_inst_created(created_at DESC)` a parciální `idx_sct_inst_timeout(execution_timeout_at) WHERE status = 'PROCESSING'` (pohání watchdog provedení / `findTimedOut`).
 
-### `sct_inst_outbox` (V2)
+### `sct_inst_outbox` — ODSTRANĚNO (V2 vytvořeno, V4 zrušeno)
 
-Transakční outbox pro at-least-once publikování událostí.
-
-| Sloupec | Typ | Poznámka |
-|---|---|---|
-| `id` | BIGSERIAL PK | |
-| `event_id` | UUID UNIQUE | dedup klíč |
-| `aggregate_id` | UUID | `payment_id` |
-| `event_type` | VARCHAR(128) | např. `SctInstPaymentSubmitted` |
-| `payload` | TEXT | serializovaný JSON události |
-| `status` | VARCHAR(16) | NEW / SENT / FAILED |
-| `attempt_count` | INTEGER | čítač retry |
-| `sent_at` | TIMESTAMPTZ | nullable |
-| `last_error` | TEXT | nullable |
-| `created_at` / `updated_at` | TIMESTAMPTZ | výchozí `NOW()` |
-
-Indexy: `idx_sct_inst_outbox_status_created_at(status, created_at ASC)` (pořadí odeslání), `idx_sct_inst_outbox_aggregate_id(aggregate_id)`.
-
-### Sekvence (V3)
-
-`CREATE SEQUENCE IF NOT EXISTS sct_inst_outbox_seq INCREMENT BY 50` — Hibernate Reactive + Panache alokují id ze sekvence `<table>_seq` (allocationSize 50), kterou samotný BIGSERIAL neposkytuje. Bez ní inserty selžou za běhu s `relation "sct_inst_outbox_seq" does not exist`. Konvence repa: bez uvozovek, lowercase, `INCREMENT BY 50`.
+Transakční outbox pro at-least-once publikování událostí byl vytvořen ve V2, ale nikdy nebyl
+napojen na žádné reálné volání — publikace událostí vždy šla přímo přes synchronní
+`KafkaSctInstEventPublisher` (issue #1034). PR #1364 odstranil mrtvý kód
+`SctInstOutboxPort`/`SctInstOutboxDispatcher`; samotná tabulka (0 řádků) a její sekvence
+`sct_inst_outbox_seq` (přidaná ve V3 kvůli konvenci alokace id Hibernate Reactive/Panache) byly
+zrušeny ve V4 (issue #5127). Ponecháno zde jen jako poznámka k historii schématu — na této službě
+už žádná živá outbox tabulka není.
 
 ## Flyway migrace
 
 | Verze | Soubor | Účel | Poznámka k rollbacku |
 |---|---|---|---|
 | V1 | `V1__create_sct_inst_payments.sql` | tabulka plateb + 4 indexy | `DROP TABLE sct_inst_payments;` |
-| V2 | `V2__create_sct_inst_outbox.sql` | tabulka outbox + 2 indexy | `DROP TABLE sct_inst_outbox;` |
-| V3 | `V3__hibernate_sequences.sql` | `sct_inst_outbox_seq` | `DROP SEQUENCE sct_inst_outbox_seq;` (uvedeno v migraci) |
+| V2 | `V2__create_sct_inst_outbox.sql` | tabulka outbox + 2 indexy (odstraněno, viz V4) | `DROP TABLE sct_inst_outbox;` |
+| V3 | `V3__hibernate_sequences.sql` | `sct_inst_outbox_seq` (odstraněno, viz V4) | `DROP SEQUENCE sct_inst_outbox_seq;` (uvedeno v migraci) |
+| V4 | `V4__drop_sct_inst_outbox.sql` | zrušení vestigiální tabulky `sct_inst_outbox` + sekvence `sct_inst_outbox_seq` ponechané po PR #1364 | znovuvytvoří tabulku + sekvenci z V2/V3 (uvedeno v migraci) |
 
 `flyway.migrate-at-start = true` s 10 connect retries (interval 2 s). **Nikdy nepřepisuj migraci poté, co byla aplikována na živou DB** (checksum mismatch → pád startu; gotcha repa).
 

--- a/openbank-sepa-instant/src/main/resources/docs/04-data.en.md
+++ b/openbank-sepa-instant/src/main/resources/docs/04-data.en.md
@@ -41,36 +41,24 @@ The payment aggregate. One row per SCT Inst instruction.
 
 Indexes: `idx_sct_inst_status(status)`, `idx_sct_inst_debtor(debtor_account_id)`, `idx_sct_inst_created(created_at DESC)`, and a partial `idx_sct_inst_timeout(execution_timeout_at) WHERE status = 'PROCESSING'` (powers the execution watchdog / `findTimedOut`).
 
-### `sct_inst_outbox` (V2)
+### `sct_inst_outbox` — REMOVED (V2 created, V4 dropped)
 
-Transactional outbox for at-least-once event publishing.
-
-| Column | Type | Notes |
-|---|---|---|
-| `id` | BIGSERIAL PK | |
-| `event_id` | UUID UNIQUE | dedup key |
-| `aggregate_id` | UUID | the `payment_id` |
-| `event_type` | VARCHAR(128) | e.g. `SctInstPaymentSubmitted` |
-| `payload` | TEXT | serialized event JSON |
-| `status` | VARCHAR(16) | NEW / SENT / FAILED |
-| `attempt_count` | INTEGER | retry counter |
-| `sent_at` | TIMESTAMPTZ | nullable |
-| `last_error` | TEXT | nullable |
-| `created_at` / `updated_at` | TIMESTAMPTZ | default `NOW()` |
-
-Indexes: `idx_sct_inst_outbox_status_created_at(status, created_at ASC)` (dispatch order), `idx_sct_inst_outbox_aggregate_id(aggregate_id)`.
-
-### Sequence (V3)
-
-`CREATE SEQUENCE IF NOT EXISTS sct_inst_outbox_seq INCREMENT BY 50` — Hibernate Reactive + Panache allocate ids from a `<table>_seq` (allocationSize 50), which BIGSERIAL alone does not provide. Without this, inserts fail at runtime with `relation "sct_inst_outbox_seq" does not exist`. Repo convention: unquoted, lowercase, `INCREMENT BY 50`.
+A transactional outbox for at-least-once event publishing was created in V2 but never wired to
+any real call site — event publishing has always gone through the direct, synchronous
+`KafkaSctInstEventPublisher` instead (issue #1034). PR #1364 removed the dead
+`SctInstOutboxPort`/`SctInstOutboxDispatcher` code; the table itself (0 rows) and its
+`sct_inst_outbox_seq` sequence (added in V3 for the Hibernate Reactive/Panache id-allocation
+convention) were dropped in V4 (issue #5127). Kept here only as a schema-history note — there is
+no live outbox table on this service.
 
 ## Flyway migrations
 
 | Version | File | Purpose | Rollback note |
 |---|---|---|---|
 | V1 | `V1__create_sct_inst_payments.sql` | payments table + 4 indexes | `DROP TABLE sct_inst_payments;` |
-| V2 | `V2__create_sct_inst_outbox.sql` | outbox table + 2 indexes | `DROP TABLE sct_inst_outbox;` |
-| V3 | `V3__hibernate_sequences.sql` | `sct_inst_outbox_seq` | `DROP SEQUENCE sct_inst_outbox_seq;` (stated in the migration) |
+| V2 | `V2__create_sct_inst_outbox.sql` | outbox table + 2 indexes (removed, see V4) | `DROP TABLE sct_inst_outbox;` |
+| V3 | `V3__hibernate_sequences.sql` | `sct_inst_outbox_seq` (removed, see V4) | `DROP SEQUENCE sct_inst_outbox_seq;` (stated in the migration) |
+| V4 | `V4__drop_sct_inst_outbox.sql` | drops the vestigial `sct_inst_outbox` table + `sct_inst_outbox_seq` sequence left behind by PR #1364 | recreates the V2/V3 table + sequence (stated in the migration) |
 
 `flyway.migrate-at-start = true` with 10 connect retries (2 s interval). **Never rewrite a migration after it is applied to a live DB** (checksum mismatch → startup fail; repo gotcha).
 

--- a/openbank-sepa-instant/src/main/resources/docs/05-operations.cs.md
+++ b/openbank-sepa-instant/src/main/resources/docs/05-operations.cs.md
@@ -70,8 +70,8 @@ Tajemství (`POSTGRES_PASSWORD`, `OIDC_CLIENT_SECRET`) přicházejí z prostřed
 ### Platby uvízlé v PENDING
 Nárůst `PENDING` znamená, že sankční brána platby drží — buď skutečné REVIEW výstupy, nebo pravděpodobněji **sanctions-service je nedostupná** (fail-closed, ADR-0032 §C). Zkontroluj health sanctions-service a stav circuit-breakeru. Každá podržená platba má otevřený AML případ (`AML_HOLD` nebo `SCREENING_UNAVAILABLE`); řeš přes aml-service / compliance ops. Platby jsou uloženy, nikdy ztraceny.
 
-### Backlog outboxu
-Zaostává-li `openbank.sepa.instant.events`, zkontroluj `sct_inst_outbox` na řádky s `status != SENT` a rostoucím `attempt_count` / `last_error`. Dispatcher běží každých 5 s (dávka 25, `concurrentExecution = SKIP`). Zkontroluj health Kafka emitteru / brokeru.
+### Zpoždění publikace událostí
+Události se publikují přímo a synchronně ze `SctInstPaymentService` přes `KafkaSctInstEventPublisher` — na této cestě není žádný outbox ani dispatcher (dřívější outbox pipeline byla odstraněna jako mrtvý kód, issue #1034). Zaostává-li `openbank.sepa.instant.events`, zkontroluj health Kafka emitteru / brokeru a logy na straně producenta u samotného volání publikace; signálem je zaseknutý přechod stavu platby, ne zaseknutá backlog tabulka.
 
 ### Flyway checksum mismatch při startu
 Způsobeno přepsanou aplikovanou migrací. Dočasná oprava: nastav `QUARKUS_FLYWAY_REPAIR_AT_START=true` v GitOps env, pak odeber, jakmile se DB ustálí. Nikdy nepřepisuj aplikovanou migraci.

--- a/openbank-sepa-instant/src/main/resources/docs/05-operations.en.md
+++ b/openbank-sepa-instant/src/main/resources/docs/05-operations.en.md
@@ -70,8 +70,8 @@ Secrets (`POSTGRES_PASSWORD`, `OIDC_CLIENT_SECRET`) come from the environment; t
 ### Payments stuck in PENDING
 A surge of `PENDING` means the screening gate is holding payments — either genuine REVIEW outcomes or, more likely, **sanctions-service is unreachable** (fail-closed, ADR-0032 §C). Check sanctions-service health and the circuit-breaker state. Each held payment has an open AML case (`AML_HOLD` or `SCREENING_UNAVAILABLE`); resolve via aml-service / compliance ops. Payments are persisted, never lost.
 
-### Outbox backlog
-If `openbank.sepa.instant.events` lags, inspect `sct_inst_outbox` for rows with `status != SENT` and rising `attempt_count` / `last_error`. The dispatcher runs every 5 s (batch 25, `concurrentExecution = SKIP`). Check the Kafka emitter / broker health.
+### Event publish lag
+Events publish directly and synchronously from `SctInstPaymentService` via `KafkaSctInstEventPublisher` — there is no outbox or dispatcher on this path (an earlier outbox pipeline was removed as dead code, issue #1034). If `openbank.sepa.instant.events` lags, check the Kafka emitter / broker health and producer-side logs on the publish call itself; a stuck payment transition (rather than a stuck backlog table) is the signal to look for.
 
 ### Flyway checksum mismatch on startup
 Caused by a rewritten applied migration. Temporary fix: set `QUARKUS_FLYWAY_REPAIR_AT_START=true` in the GitOps env, then remove once the DB is settled. Never rewrite an applied migration.

--- a/openbank-sepa-instant/src/main/resources/docs/README.cs.md
+++ b/openbank-sepa-instant/src/main/resources/docs/README.cs.md
@@ -9,7 +9,7 @@ Tato dokumentace je publikována přímo službou na management endpointu `/q/op
 | Sekce | Publikum | Co tam najdete |
 |---|---|---|
 | [01 — Přehled](./01-overview.md) | Produkt, audit, management | Co služba dělá, kdo ji volá, kde sídlí v doméně |
-| [02 — Architektura](./02-architecture.md) | Inženýři, tech leadi | C4 diagramy, hexagonální vrstvy, sankční brána, outbox tok |
+| [02 — Architektura](./02-architecture.md) | Inženýři, tech leadi | C4 diagramy, hexagonální vrstvy, sankční brána, přímá publikace událostí |
 | [03 — API](./03-api.md) | Vývojáři služeb, integrátoři | REST kontrakt, idempotence, model chyb |
 | [04 — Data](./04-data.md) | Data, analytika, DBA | Schéma, migrace, retence, PII pole |
 | [05 — Provoz](./05-operations.md) | DevOps, SRE, release inženýři | Build, deploy, runbooky, SLO |
@@ -19,8 +19,8 @@ Tato dokumentace je publikována přímo službou na management endpointu `/q/op
 
 - **Tech stack:** Kotlin / Quarkus 3.x / Hibernate Reactive (Panache) + reaktivní PostgreSQL / SmallRye Reactive Messaging (Kafka) — sestaveno přes konvenční plugin `openbank.quarkus-service`
 - **Port:** 8127 (app), 8085 (management — `/q`)
-- **Persistence:** dedikovaná databáze `openbank_sepa_instant`, deklarované schéma `sepa_instant_schema`, Flyway migrace V1..V3
-- **Outbox:** `sct_inst_outbox` → Kafka topic `openbank.sepa.instant.events` (polling po 5 s, dávka 25)
+- **Persistence:** dedikovaná databáze `openbank_sepa_instant`, deklarované schéma `sepa_instant_schema`, Flyway migrace V1..V4
+- **Události:** přímá, synchronní publikace ze `SctInstPaymentService` při každém přechodu stavu přes `KafkaSctInstEventPublisher` → Kafka topic `openbank.sepa.instant.events` (nejde o transakční outbox — dřívější outbox pipeline byla postavena, ale nikdy napojena na žádné reálné volání, a byla odstraněna, issue #1034)
 - **Idempotence:** hlavička `Idempotency-Key` (fallback na pole v těle) → unique constraint na `sct_inst_payments.idempotency_key`
 - **Auth:** Keycloak OIDC (klient `openbank-services`); OPA autorizace (ADR-0034) ve výchozím stavu advisory; `@Authorize` na recallu
 - **Money-path:** ANO — uvedeno v `rules.yaml: money_path_services`; ADR-0057 tier **T0 (always-on)**; threat model v `docs/threat-models/openbank-sepa-instant.md`

--- a/openbank-sepa-instant/src/main/resources/docs/README.en.md
+++ b/openbank-sepa-instant/src/main/resources/docs/README.en.md
@@ -9,7 +9,7 @@ This documentation is published directly by the service at the management endpoi
 | Section | Audience | What you'll find |
 |---|---|---|
 | [01 — Overview](./01-overview.md) | Product, audit, management | What the service does, who calls it, where it sits in the domain |
-| [02 — Architecture](./02-architecture.md) | Engineering, tech leads | C4 diagrams, hexagonal layers, screening gate, outbox flow |
+| [02 — Architecture](./02-architecture.md) | Engineering, tech leads | C4 diagrams, hexagonal layers, screening gate, direct event-publish flow |
 | [03 — API](./03-api.md) | Service developers, integrators | REST contract, idempotency, error model |
 | [04 — Data](./04-data.md) | Data, analytics, DBA | Schema, migrations, retention, PII fields |
 | [05 — Operations](./05-operations.md) | DevOps, SRE, release engineers | Build, deploy, runbooks, SLO |
@@ -19,8 +19,8 @@ This documentation is published directly by the service at the management endpoi
 
 - **Tech stack:** Kotlin / Quarkus 3.x / Hibernate Reactive (Panache) + Reactive PostgreSQL / SmallRye Reactive Messaging (Kafka) — built via the `openbank.quarkus-service` convention plugin
 - **Port:** 8127 (app), 8085 (management — `/q`)
-- **Persistence:** dedicated database `openbank_sepa_instant`, schema declared `sepa_instant_schema`, Flyway migrations V1..V3
-- **Outbox:** `sct_inst_outbox` → Kafka topic `openbank.sepa.instant.events` (polled every 5 s, batch 25)
+- **Persistence:** dedicated database `openbank_sepa_instant`, schema declared `sepa_instant_schema`, Flyway migrations V1..V4
+- **Events:** direct, synchronous publish from `SctInstPaymentService` at each lifecycle transition via `KafkaSctInstEventPublisher` → Kafka topic `openbank.sepa.instant.events` (not a transactional outbox — an earlier outbox pipeline was built but never wired to a real call site and was removed, issue #1034)
 - **Idempotency:** `Idempotency-Key` header (falls back to body field) → unique constraint on `sct_inst_payments.idempotency_key`
 - **Auth:** Keycloak OIDC (client `openbank-services`); OPA authz (ADR-0034) advisory by default; `@Authorize` on recall
 - **Money-path:** YES — listed in `rules.yaml: money_path_services`; ADR-0057 tier **T0 (always-on)**; threat model at `docs/threat-models/openbank-sepa-instant.md`


### PR DESCRIPTION
## Summary

PR #1364 (2026-07-17, closing #1034) deliberately removed sepa-instant's dead
`SctInstOutboxPort` transactional-outbox pipeline — `SctInstOutboxPort`,
`SctInstOutboxDispatcher`, `KafkaSctInstOutboxEventPublisher`, the
outbox-backlog gauge and its Panache repository — after confirming nothing
ever wrote to it and that `KafkaSctInstEventPublisher` (a direct, synchronous
emitter) "was always the pipeline actually in use."

Two things were left behind, and #5127 flags them:

1. The `sct_inst_outbox` DB table (and its `sct_inst_outbox_seq` sequence)
   stayed in place, at 0 rows, because dropping a table needs its own Flyway
   migration — code removal alone can't do it.
2. `docs/threat-models/openbank-sepa-instant.md`'s DFD and its 2026-06-11
   changelog entry still described the removed backlog gauge and
   `countProcessable()` as if they were live.

**Decision (repo owner, on #5127): accept #1364's removal rather than
reverse it.** `KafkaSctInstEventPublisher` remains the sole, already-verified
event-publishing pipeline for this service — there is nothing to restore.

## What this PR does

- **`V4__drop_sct_inst_outbox.sql`** — a new, additive-only Flyway migration
  (never edits V1–V3) that drops the vestigial `sct_inst_outbox` table and
  `sct_inst_outbox_seq` sequence. Carries a `-- Rollback:` comment per
  `rules.yaml: db_change`.
- **`docs/threat-models/openbank-sepa-instant.md`** — corrects §2's DFD (the
  `sct_inst_outbox` node is replaced with the direct
  `KafkaSctInstEventPublisher` edge that was always the real path), removes
  the now-void metric-cardinality STRIDE row from §4, and appends a new
  2026-08-17 changelog entry documenting this correction. The 2026-06-11
  entry is annotated as **superseded**, not rewritten — the file's own
  convention is append-only, correction-by-new-entry.
- **Service docs (en+cs)** — a repo-wide grep for `SctInstOutbox`/
  `sct_inst_outbox` turned up more drift than the threat model alone:
  - `02-architecture.en.md`'s C4 diagram still showed
    `SctInstEventPublisher / outbox` and `OutboxDispatcher (@Scheduled 5s)`.
    #1364 had already fixed the **`.cs.md` sibling** (`přímý Kafka emitter,
    bez outboxu`) but missed the English one — this brings them back in sync.
  - `README.en.md`/`README.cs.md` advertised an `Outbox:` TL;DR bullet
    describing a 5 s poll/dispatch that no longer exists.
  - `05-operations.en.md`/`.cs.md` had an **"Outbox backlog" runbook**
    telling an on-call responder to inspect `sct_inst_outbox` for stuck
    rows — actively misleading once the table is gone. Replaced with the
    real signal to check (Kafka emitter/broker health, producer-side logs).
  - `04-data.en.md`/`.cs.md`'s schema section is corrected to describe the
    table as historical/removed and the migration table now lists V4.
- **`detekt-baseline.xml` / `ktlint-baseline.xml`** (sepa-instant) —
  regenerated via `./gradlew :openbank-sepa-instant:detektBaseline
  :openbank-sepa-instant:ktlintGenerateBaseline`. Both still carried ratchet
  entries for the four Kotlin files #1364 deleted
  (`SctInstOutboxRepositoryImpl.kt`, `SctInstOutboxPort.kt`,
  `KafkaSctInstOutboxEventPublisher.kt`, `SctInstOutboxDispatcher.kt`) —
  inert, but stale.

**Not touched, on purpose:** `openbank-sepa-instant/CHANGELOG.md` (release-please-
generated history, left as-is) and a comment in
`openbank-audit-service/src/main/resources/application.yaml` that references
`SctInstOutboxPort` as a past investigation note, not a live mechanism for
that service.

## Money-path note

`openbank-sepa-instant` is in `rules.yaml: money_path_services`, so this PR
needs **2 approvals** per the repo's money-path rule — even though it is pure
cleanup (dropping an already-dead, 0-row table + correcting docs) with no new
trust surface. Confirmed against `check-threat-model-diff.py --enforce`: no
trust-boundary change is flagged, so the existing threat-model correction is
sufficient and no new STRIDE analysis is required.

## Verification

- `python3 openbank-infra/scripts/check-db-migration.py --base origin/main --enforce`
  → `1 migration change(s) checked — all forward-only, all with a rollback note.`
- `python3 openbank-infra/scripts/check-threat-model-diff.py --base origin/main --enforce`
  → `no money-path trust-boundary change without a threat-model update.`
- `python3 .github/scripts/check-flyway-default-datasource.py --enforce` → clean.
- `./gradlew :openbank-sepa-instant:ktlintCheck :openbank-sepa-instant:detekt` → `BUILD SUCCESSFUL`.

Closes #5127
Refs #1364, #1034
