### PR TITLE
fix(transaction): a payee of ours settles same-day, whatever the rail says

### DIFF
--- a/openbank-libs-domain/src/main/kotlin/com/openbank/libs/domain/payment/SettlementScope.kt
+++ b/openbank-libs-domain/src/main/kotlin/com/openbank/libs/domain/payment/SettlementScope.kt
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+package com.openbank.libs.domain.payment
+
+/**
+ * Whether a booking's money actually crosses the bank's boundary — the single question that decides
+ * if a clearing calendar may touch its value date.
+ *
+ * A cutoff time and a business-day roll describe a *scheme's* behaviour: CERTIS closes at 16:00,
+ * SWIFT does not run on Sunday. Applied to money that never reaches a scheme, they are pure
+ * invention, and an expensive one — a future value date makes the credit leg
+ * `notYetEffectiveCredit`, which suppresses `effectiveAvailableAmount`, which makes the next hold
+ * fail. That is how an own-account transfer came to be silently refused for weeks (#4869), and the
+ * same rule was still being applied to in-house domestic payments, welcome bonuses and reversals.
+ *
+ * **The discriminator is the payee leg, not the rail.** `targetAccountId` is set only when there is
+ * an account of ours to credit — domestic-payment resolves it for in-house transfers and leaves it
+ * null when "the money genuinely leaves the bank" (its own words), and sepa-payment, swift-service
+ * and sepa-instant never set it at all. Rail is deliberately *not* trusted here: it arrives as a
+ * free-form string parsed with `PaymentRail.valueOf(...)` inside a swallowing `runCatching`, and
+ * three services currently send values that are not members (`SCT_INST`, `SEPA`, `FX`) and land as
+ * null. A guard keyed on `rail == null` would therefore hand same-day booking to genuinely external
+ * SEPA payments.
+ */
+object SettlementScope {
+
+    /**
+     * Rails that are internal by definition, whatever else is on the booking. Listed so that
+     * stamping a rail honestly can never re-introduce the bug: before this, the only guard was
+     * `rail == null`, so the day someone set `rail = INTERNAL` on an own-account transfer — the
+     * correct thing to do under ADR-0103 — it would have started rolling again.
+     */
+    private val ALWAYS_IN_HOUSE = setOf(PaymentRail.INTERNAL, PaymentRail.FEE, PaymentRail.INTEREST)
+
+    /**
+     * True when this booking credits an account of ours, or rides a rail that never leaves the
+     * bank. Such a booking settles the moment it is made: there is no scheme to wait for, so there
+     * is no calendar to roll against.
+     *
+     * [hasInternalPayee] is `targetAccountId != null` at the call site.
+     */
+    fun staysInTheBank(rail: PaymentRail?, hasInternalPayee: Boolean): Boolean =
+        hasInternalPayee || (rail != null && rail in ALWAYS_IN_HOUSE)
+}

--- a/openbank-libs-domain/src/test/kotlin/com/openbank/libs/domain/payment/SettlementScopeTest.kt
+++ b/openbank-libs-domain/src/test/kotlin/com/openbank/libs/domain/payment/SettlementScopeTest.kt
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+package com.openbank.libs.domain.payment
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class SettlementScopeTest {
+
+    @Test
+    fun `an internal payee leg stays in the bank whatever the rail`() {
+        assertThat(SettlementScope.staysInTheBank(PaymentRail.DOMESTIC, hasInternalPayee = true)).isTrue()
+        assertThat(SettlementScope.staysInTheBank(null, hasInternalPayee = true)).isTrue()
+    }
+
+    @Test
+    fun `INTERNAL, FEE and INTEREST rails stay in the bank even with no resolved payee`() {
+        for (rail in listOf(PaymentRail.INTERNAL, PaymentRail.FEE, PaymentRail.INTEREST)) {
+            assertThat(SettlementScope.staysInTheBank(rail, hasInternalPayee = false))
+                .describedAs(rail.name)
+                .isTrue()
+        }
+    }
+
+    @Test
+    fun `a real external rail with no resolved payee leaves the bank`() {
+        for (rail in listOf(PaymentRail.SEPA_CT, PaymentRail.SEPA_INST, PaymentRail.SWIFT, PaymentRail.DOMESTIC)) {
+            assertThat(SettlementScope.staysInTheBank(rail, hasInternalPayee = false))
+                .describedAs(rail.name)
+                .isFalse()
+        }
+    }
+
+    @Test
+    fun `no rail and no resolved payee leaves the bank`() {
+        // The honest "we don't know" case must not be treated as internal by default.
+        assertThat(SettlementScope.staysInTheBank(null, hasInternalPayee = false)).isFalse()
+    }
+}

--- a/openbank-transaction-service/src/main/kotlin/com/openbank/transaction/application/usecase/TransactionService.kt
+++ b/openbank-transaction-service/src/main/kotlin/com/openbank/transaction/application/usecase/TransactionService.kt
@@ -9,6 +9,7 @@ import com.openbank.libs.api.pagination.CursorPage
 import com.openbank.libs.api.pagination.PageInfo
 import com.openbank.libs.domain.money.CurrencyCode
 import com.openbank.libs.domain.money.Money
+import com.openbank.libs.domain.payment.SettlementScope
 import com.openbank.libs.persistence.outbox.OutboxMessage
 import com.openbank.libs.temporal.TemporalConfig
 import com.openbank.transaction.application.port.`in`.GetTransactionQuery
@@ -127,7 +128,17 @@ class TransactionService(
         // own-account move carries no rail -- customer-edge sets none on any of its three TRANSFER
         // payloads -- so the pair (TRANSFER, no rail) is what "never leaves the ledger" actually
         // means here.
-        val dates = if (command.type == TransactionType.TRANSFER && command.rail == null) {
+        // Money that never reaches a scheme must not be dated by one. The original guard here only
+        // covered (TRANSFER, no rail), which left every other in-house booking rolling against the
+        // CERTIS calendar: an openbank-to-openbank domestic payment (rail=DOMESTIC, but with an
+        // internal payee leg), the welcome bonus (type=CREDIT), and reversals. Verified in the
+        // sandbox ledger — a bonus granted 08:31 on a Saturday booked on the Monday, and in-house
+        // "Interní převod" debits made after 16:00 booked the next business day, on a clearing
+        // calendar the money never touched. See [SettlementScope] for why the payee leg, and not
+        // the rail, is what decides this.
+        val staysInTheBank = (command.type == TransactionType.TRANSFER && command.rail == null) ||
+            SettlementScope.staysInTheBank(command.rail, hasInternalPayee = command.targetAccountId != null)
+        val dates = if (staysInTheBank) {
             val today = Instant.now(clock).atZone(SettlementDateResolver.BANK_ZONE).toLocalDate()
             SettlementDates(bookingDate = today, valueDate = today)
         } else {

--- a/openbank-transaction-service/src/test/kotlin/com/openbank/transaction/application/usecase/TransactionServiceTest.kt
+++ b/openbank-transaction-service/src/test/kotlin/com/openbank/transaction/application/usecase/TransactionServiceTest.kt
@@ -191,7 +191,10 @@ class TransactionServiceTest {
     fun `a SEPA settlement booked as TRANSFER still honours the requested value date`(): Unit = runBlocking {
         val today = Instant.now(clock).atZone(SettlementDateResolver.BANK_ZONE).toLocalDate()
         val requested = today.plusMonths(1)
-        val command = initiateCommand().copy(valueDate = requested, rail = PaymentRail.SEPA_CT)
+        // sepa-payment's real settlement request carries no targetAccountId (it never resolves an
+        // internal payee) — the fixture must match that, or this test cannot tell "external SEPA"
+        // apart from "internal transfer that happens to be tagged SEPA_CT".
+        val command = initiateCommand().copy(valueDate = requested, rail = PaymentRail.SEPA_CT, targetAccountId = null)
 
         coEvery { transactionRepository.findByIdempotencyKey(command.idempotencyKey) } returns null
         every { eventPublisher.initiatedPayload(any()) } returns "{}"
@@ -204,6 +207,115 @@ class TransactionServiceTest {
             .describedAs("a railed TRANSFER must keep going through SettlementDateResolver")
             .isNotEqualTo(today)
         assertThat(result.valueDate).isEqualTo(requested)
+    }
+
+    /**
+     * The original guard (`type == TRANSFER && rail == null`) covered an own-account transfer but
+     * missed everything else that also never leaves the bank. domestic-payment books its in-house
+     * settlement leg as **type=DEBIT, rail=DOMESTIC** — the rail is real (a scheme exists), but a
+     * `targetAccountId` is set because the payee is one of our own accounts, per its own comment:
+     * "External transfers keep a null target (the money genuinely leaves the bank)."
+     *
+     * Verified live in the sandbox ledger before this fix: an in-house "Interní převod" debit at
+     * 21:11 on a Thursday booked value_date the next day, and one made on a Saturday booked two
+     * days out — on a CERTIS calendar the money never touched.
+     */
+    @Test
+    fun `an in-house domestic payment with a resolved payee books same-day despite rail=DOMESTIC`(): Unit =
+        runBlocking {
+            val today = Instant.now(clock).atZone(SettlementDateResolver.BANK_ZONE).toLocalDate()
+            val command = initiateCommand().copy(
+                type = TransactionType.DEBIT,
+                rail = PaymentRail.DOMESTIC,
+                valueDate = today.plusMonths(1),
+            )
+
+            coEvery { transactionRepository.findByIdempotencyKey(command.idempotencyKey) } returns null
+            every { eventPublisher.initiatedPayload(any()) } returns "{}"
+            stubWorkflowCommitted(TransactionStatus.COMPLETED)
+            every { workflowStub.execute(any()) } returns SagaState.COMPLETED
+
+            val result = service.initiateTransaction(command)
+
+            assertThat(result.valueDate).isEqualTo(today)
+            assertThat(result.bookingDate).isEqualTo(today)
+        }
+
+    /**
+     * The counterpart: a domestic DEBIT with no resolved payee (the ordinary case — money genuinely
+     * leaving the bank) must keep going through the resolver. Proves the discriminator is the payee
+     * leg, not the transaction type.
+     */
+    @Test
+    fun `a domestic payment leaving the bank still honours the resolver`(): Unit = runBlocking {
+        val today = Instant.now(clock).atZone(SettlementDateResolver.BANK_ZONE).toLocalDate()
+        val requested = today.plusMonths(1)
+        val command = initiateCommand().copy(
+            type = TransactionType.DEBIT,
+            rail = PaymentRail.DOMESTIC,
+            targetAccountId = null,
+            valueDate = requested,
+        )
+
+        coEvery { transactionRepository.findByIdempotencyKey(command.idempotencyKey) } returns null
+        every { eventPublisher.initiatedPayload(any()) } returns "{}"
+        stubWorkflowCommitted(TransactionStatus.COMPLETED)
+        every { workflowStub.execute(any()) } returns SagaState.COMPLETED
+
+        val result = service.initiateTransaction(command)
+
+        assertThat(result.valueDate)
+            .describedAs("a domestic payment with no internal payee must keep going through the resolver")
+            .isNotEqualTo(today)
+        assertThat(result.valueDate).isEqualTo(requested)
+    }
+
+    /**
+     * The welcome bonus (account-service, `type=CREDIT`, no rail) and a reversal credit both hit
+     * this same shape: a payee of ours, no rail. Verified live — a bonus granted 08:31 on a Saturday
+     * booked on the Monday.
+     */
+    @Test
+    fun `a welcome-bonus-shaped credit with no rail books same-day`(): Unit = runBlocking {
+        val today = Instant.now(clock).atZone(SettlementDateResolver.BANK_ZONE).toLocalDate()
+        val command = initiateCommand().copy(
+            type = TransactionType.CREDIT,
+            sourceAccountId = null,
+            rail = null,
+            valueDate = today.plusMonths(1),
+        )
+
+        coEvery { transactionRepository.findByIdempotencyKey(command.idempotencyKey) } returns null
+        every { eventPublisher.initiatedPayload(any()) } returns "{}"
+        stubWorkflowCommitted(TransactionStatus.COMPLETED)
+        every { workflowStub.execute(any()) } returns SagaState.COMPLETED
+
+        val result = service.initiateTransaction(command)
+
+        assertThat(result.valueDate).isEqualTo(today)
+        assertThat(result.bookingDate).isEqualTo(today)
+    }
+
+    /**
+     * A rail honestly stamped INTERNAL, FEE or INTEREST must never roll, whatever the type — this is
+     * the guard against the exact regression the audit warned about: the old check was keyed on
+     * `rail == null`, so stamping rail correctly on an own-account move would have silently
+     * re-introduced the bug it fixed.
+     */
+    @Test
+    fun `a rail honestly stamped INTERNAL never rolls`(): Unit = runBlocking {
+        val today = Instant.now(clock).atZone(SettlementDateResolver.BANK_ZONE).toLocalDate()
+        val command = initiateCommand().copy(rail = PaymentRail.INTERNAL, valueDate = today.plusMonths(1))
+
+        coEvery { transactionRepository.findByIdempotencyKey(command.idempotencyKey) } returns null
+        every { eventPublisher.initiatedPayload(any()) } returns "{}"
+        stubWorkflowCommitted(TransactionStatus.COMPLETED)
+        every { workflowStub.execute(any()) } returns SagaState.COMPLETED
+
+        val result = service.initiateTransaction(command)
+
+        assertThat(result.valueDate).isEqualTo(today)
+        assertThat(result.bookingDate).isEqualTo(today)
     }
 
     @Test


### PR DESCRIPTION
## Background

#4869 fixed own-account transfers (`type=TRANSFER, rail=null`) being value-dated against the CERTIS calendar. That guard was keyed on exactly that one pair and missed every other booking that also never leaves the bank.

## Verified live, in the sandbox ledger, before this fix

| initiated (Prague) | day | booked | roll |
|---|---|---|---|
| Thu 21:11 (after 16:00 cutoff) | in-house DOMESTIC debit | next day | +1 |
| Sat 17:35 | in-house DOMESTIC debit | +2 days | **+2** |
| Sun 15:49 | in-house DOMESTIC debit | next day | +1 |
| Sat 08:31 | welcome bonus (CREDIT) | Monday | **+2** |

- **In-house domestic payments.** `domestic-payment` books its settlement leg as `type=DEBIT, rail=DOMESTIC` — a real rail, because it resolves the payee's own account and asks transaction-service for a two-sided journal. Its own comment already states the right test: *"External transfers keep a null target (the money genuinely leaves the bank)."* That test just wasn't applied to the date.
- **Welcome bonus.** `account-service` posts `type=CREDIT`, no rail. A customer who signs up over a weekend gets a push saying money arrived while the app shows zero spendable for up to two days.
- **Reversals.** `type=REVERSAL`, no rail — a payment corrected by the bank's own hand sits future-dated while the original debit already left instantly.

## The fix

`SettlementScope.staysInTheBank(rail, hasInternalPayee)` — true when `targetAccountId` resolves to an account of ours, **or** the rail is `INTERNAL`/`FEE`/`INTEREST` (internal by definition, listed explicitly so honestly stamping a rail can never regress this — the old guard was keyed on `rail == null`, so the day someone correctly set `rail = INTERNAL` on an own-account move under ADR-0103, it would have silently started rolling again).

**Rail alone is deliberately not the signal.** It arrives as a free string through `PaymentRail.valueOf(...)` inside a swallowing `runCatching`, and three services currently send values that aren't enum members (`SCT_INST`, `SEPA`, `FX`) and land as `null` today. A guard keyed on `rail == null` would hand same-day booking to genuinely external SEPA payments the moment that parsing gets fixed.

## Testing

- `an in-house domestic payment with a resolved payee books same-day despite rail=DOMESTIC`
- `a domestic payment leaving the bank still honours the resolver` (the counterpart — proves the discriminator is the payee leg, not the type)
- `a welcome-bonus-shaped credit with no rail books same-day`
- `a rail honestly stamped INTERNAL never rolls` — the regression guard described above
- `SettlementScopeTest` — standalone four-quadrant truth table

`:openbank-transaction-service:test` and `:openbank-libs-domain:test` green. `detekt` + `ktlintCheck` on both modules pass. One pre-existing flaky test (`DomesticPaymentResourceAuthzTest`) was red on first run and green on rerun with no diff touching that module — confirmed flaky on `origin/main` too, unrelated.

## Not in this PR

Two siblings the same audit found, tracked separately:
- Standing orders route only `SEPA_CREDIT`; the app only ever sends `DOMESTIC`/`INTERNAL`, so every real standing order silently fails after 3 attempts.
- Lending disbursement journal has no `subAccountId`, so a loan is booked with nothing ever credited to the borrower.

## Merge

Per repo convention, money-path PRs are left for a human to merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)