### PR TITLE
fix(standing-order): route DOMESTIC/INTERNAL orders, don't complete before they run (#889)

### DIFF
--- a/docs/threat-models/openbank-standing-order-service.md
+++ b/docs/threat-models/openbank-standing-order-service.md
@@ -15,8 +15,11 @@ sweeps for due orders (`StandingOrderExecutionScheduler`), writes a transactiona
 due order, and dispatches `standing-order.due.v1` to Kafka. `StandingOrderDueConsumer` (#889)
 picks each due event up and, for a `SEPA_CREDIT` order, initiates the real credit transfer via
 `openbank-sepa-payment`'s `POST /api/v1/sepa-payments` — a gated money-path service that owns the
-irreversible debit (sanctions/AML gate, Temporal workflow, ledger booking). `DOMESTIC`/`INTERNAL`
-rails are not wired yet and are recorded as failures, never silently dropped.
+irreversible debit (sanctions/AML gate, Temporal workflow, ledger booking). For `DOMESTIC`/
+`INTERNAL` orders, a creditor IBAN resolving to an account of the SAME party books directly via
+`openbank-transaction-service` as a same-day `TRANSFER` (own-account move, no screening gap — see
+§4); any other outcome (a different party's account, or no resolvable account) is recorded as a
+failure, never silently dropped or mis-routed.
 
 The service is **money-path-adjacent**: it authorises and schedules the instruction and triggers
 the transfer, but the fund movement itself lives downstream — the same class as
@@ -31,14 +34,19 @@ openbank-sdd-service.
                                            |---> [outbox -> Kafka: standing-order.due.v1 / standing-order.failed.v1]
                                            |
                      SEPA execution   -----|---> [openbank-sepa-payment] (SCT, money-path)
+                     DOMESTIC/INTERNAL -----|---> [openbank-account-service] (IBAN -> accountId/partyId lookup)
+                     (own-account only) ----|---> [openbank-transaction-service] (TRANSFER, money-path)
                      outcome           --- |---> [confirmExecution / recordFailure -> order state + outbox]
 ```
 
 - **External entities:** customer-edge (authenticated customer), admin-UI (ROLE_OPERATOR),
-  sepa-payment (M2M callee).
+  sepa-payment / account-service / transaction-service (M2M callees).
 - **Trust boundaries:** edge → service (OIDC + OPA sidecar, currently AUTHZ_ENFORCE=false
   advisory); service → Kafka (mTLS via Strimzi); service → sepa-payment (OIDC client credentials,
-  `openbank-services` client, ROLE_OPERATOR accepted by sepa-payment's createPayment).
+  `openbank-services` client, ROLE_OPERATOR accepted by sepa-payment's createPayment); service →
+  account-service (same client, ROLE_OPERATOR accepted by `account.read`, read-only IBAN lookup,
+  new — #889 follow-up); service → transaction-service (same client, ROLE_OPERATOR accepted by
+  `transaction.create`, new — #889 follow-up, see §4 for why this path is scope-limited).
 - **Assets:** standing-order instructions (debtor/creditor IBAN, BIC, amount, currency, schedule,
   remittance info), execution history, idempotency keys.
 
@@ -75,23 +83,46 @@ openbank-sdd-service.
 | **T**ampering | Alter amount or creditor IBAN on the stored instruction or in flight | Order mutations go through the authenticated REST surface with `@RolesAllowed`; TLS in transit; amount is carried in minor units with currency-explicit conversion (`CurrencyCode.defaultFractionDigits`) — no float path |
 | **R**epudiation | Customer denies creating or amending the order | AuditEvent per order action; outbox-backed execution history (confirmExecution / recordFailure) ties every transfer attempt to the order and its deterministic `so-exec-{orderId}-{executionDate}` key |
 | **I**nfo disclosure | Leak creditor/debtor IBANs via logs, errors, or metrics | Consumer logs truncate payloads (`%.300s`) and never log full request bodies; error bodies carry codes only; metrics are low-cardinality (ADR-0077/0079) |
-| **D**oS | Duplicate execution from Kafka redelivery or scheduler re-run; poison-pill event wedges the group | Deterministic idempotency key `so-exec-{orderId}-{executionDate}` reused as sepa-payment's `Idempotency-Key` — a redelivery replays the cached 201 instead of double-paying; consumer swallows and acks any failure (parse, rail, DB) so one bad event cannot wedge the group |
-| **E**oP | Abuse an operator role to redirect a standing order to an attacker's IBAN | Order amendment is an authenticated write on the customer's own order (customer) or a logged operator action; the money-moving step re-runs sepa-payment's sanctions/AML screening on every execution, so a redirected creditor is screened at debit time, not only at order-creation time |
+| **D**oS | Duplicate execution from Kafka redelivery or scheduler re-run; poison-pill event wedges the group | Deterministic idempotency key `so-exec-{orderId}-{executionDate}` reused as sepa-payment's `Idempotency-Key` (SEPA) and as `InitiateTransactionRequest.idempotencyKey` (own-account transfer, #889 follow-up) — a redelivery replays the same outcome instead of double-paying either way; consumer swallows and acks any failure (parse, rail, DB) so one bad event cannot wedge the group |
+| **E**oP | Abuse an operator role to redirect a standing order to an attacker's IBAN | Order amendment is an authenticated write on the customer's own order (customer) or a logged operator action; the SEPA execution step re-runs sepa-payment's sanctions/AML screening on every execution, so a redirected creditor is screened at debit time, not only at order-creation time. **The own-account transfer path (DOMESTIC/INTERNAL, #889 follow-up) has no screening of its own** — `transaction-service`'s raw TRANSFER carries none — so it is deliberately restricted to creditor accounts belonging to the SAME party as the order (`resolveOwnAccountCreditor` compares `creditorPartyId` from the account-service lookup against the order's own `partyId`); a creditor resolving to a DIFFERENT party is refused rather than silently auto-routed around the screening `domestic-payment`'s `INTERNAL_CLIENT` scope would otherwise apply |
 
 ## 5. Residual risks / assumptions
 
 - **Advisory authz:** `AUTHZ_ENFORCE=false` means the OPA sidecar logs but does not block; RBAC
   (`@RolesAllowed`) is the only enforced fine-grained gate until the enforce flip (tracked in the
   #3679 cohort).
-- **Unwired rails:** `DOMESTIC`/`INTERNAL` orders record an execution failure each due day until
-  the rail clients land — visible as repeated failure events, never silent; tracked as a #889
-  follow-up.
+- **Partially-wired rails (#889):** `DOMESTIC`/`INTERNAL` orders now execute when the creditor IBAN
+  resolves to an account of the SAME party as the order (own-account move, transaction-service
+  `TRANSFER`, no screening needed — the same case `domestic-payment` itself skips AML/sanctions for).
+  A creditor IBAN that resolves to a DIFFERENT party, or to no internal account at all (genuinely
+  external CZ payment), still records a failure each due day rather than being wired — the former
+  because it would bypass `domestic-payment`'s `INTERNAL_CLIENT` screening, the latter because the
+  external CZ clearing rail needs an IBAN→BBAN conversion this service does not implement. Both are
+  visible as repeated failure events, never silent; tracked as a #889 follow-up.
 - **Scheduler single-writer:** the daily sweep relies on the outbox claim protocol
   (`StandingOrderOutboxClaimIT`) to avoid double-dispatch across replicas; idempotency at
   sepa-payment is the backstop if that ever regresses.
 
 ## 6. Change log
 
+- **2026-08-17** — DOMESTIC/INTERNAL execution routing + premature-completion fix (#889).
+  **New trust boundaries added to §2:** service → account-service (`AccountServiceClient`,
+  read-only IBAN lookup) and service → transaction-service (`TransactionServiceClient`, `TRANSFER`).
+  Before this, every real standing order (the app only ever sends `DOMESTIC`/`INTERNAL`) fell to
+  the unrouted `else` branch and failed on every due date, forever — accepted, shown ACTIVE,
+  silently dead. Now: a creditor IBAN resolving to an account of the SAME party as the order books
+  as a same-day `TRANSFER` (own-account move, no AML/sanctions gap — see §4 EoP row for why the
+  same-party check is load-bearing, not incidental). A different party, or no resolvable account,
+  still fails cleanly — the former needs `domestic-payment`'s screened `INTERNAL_CLIENT` path, the
+  latter needs a BBAN-clearing rail this change does not build; neither is silently mis-routed.
+  Independently, `StandingOrder.recordExecution` no longer completes a `ONCE` order at scheduling
+  time (before the payment is even attempted) — only `confirmExecution` does, once the payment is
+  actually confirmed, closing a gap where a failed one-off payment ended up `COMPLETED` with zero
+  money moved and no failure ever recorded (`recordFailure`'s `ACTIVE`-only guard threw and was
+  swallowed). Updated §2 (DFD, trust boundaries), §4 (DoS/EoP rows), §5 (residual risk reworded from
+  "unwired" to "partially wired, and why the remaining gap is deliberate"). Rollback: revert the
+  commit — the consumer falls back to recording a failure for every DOMESTIC/INTERNAL order, same
+  as before this change, not a partial or inconsistent state.
 - **2026-08-09** — `standingOrder.pause` narrowed from a role-only grant to an identity-scoped
   one (GHSA-58jq-9hq3-66jr, issue #4228): added `m2m-standing-order-pause` pinned to
   `service-account-openbank-edge`, then the `not startswith(input.principal.id,

--- a/openbank-infra/gitops/components/payments/payments-services.yaml
+++ b/openbank-infra/gitops/components/payments/payments-services.yaml
@@ -1768,6 +1768,17 @@ spec:
             # dialled a name that does not exist, on a port that belongs to another service.
             - name: SEPA_PAYMENT_SERVICE_URL
               value: http://sepa-payment.payments.svc:8115
+            # #889 follow-up: DOMESTIC/INTERNAL routing. The app only ever sends these two payment
+            # types, so before this every real standing order was accepted, shown ACTIVE, and
+            # silently failed on every due date — no rail existed for either. A creditor IBAN that
+            # resolves through account-service never leaves the bank, so it books straight through
+            # transaction-service as a same-day TRANSFER. Verified Service name/port against the
+            # live cluster (account-service.accounts.svc:8100, transaction-service.payments.svc:8102)
+            # rather than assumed, per the SEPA_PAYMENT_SERVICE_URL lesson two lines above.
+            - name: ACCOUNT_SERVICE_URL
+              value: http://account-service.accounts.svc:8100
+            - name: TRANSACTION_SERVICE_URL
+              value: http://transaction-service.payments.svc:8102
             - name: QUARKUS_REDIS_HOSTS
               value: redis://redis.payments.svc:6379
             - name: QUARKUS_OTEL_EXPORTER_OTLP_ENDPOINT

--- a/openbank-standing-order-service/src/main/kotlin/com/openbank/standingorder/application/usecase/StandingOrderService.kt
+++ b/openbank-standing-order-service/src/main/kotlin/com/openbank/standingorder/application/usecase/StandingOrderService.kt
@@ -5,8 +5,8 @@
 package com.openbank.standingorder.application.usecase
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.openbank.libs.persistence.outbox.OutboxMessage
 import com.openbank.libs.domain.identifiers.Ids
+import com.openbank.libs.persistence.outbox.OutboxMessage
 import com.openbank.standingorder.application.port.`in`.CreateStandingOrderCommand
 import com.openbank.standingorder.application.port.`in`.StandingOrderUseCase
 import com.openbank.standingorder.application.port.out.StandingOrderRepository
@@ -76,6 +76,12 @@ class StandingOrderService(
                     payload = objectMapper.writeValueAsString(
                         mapOf(
                             "orderId" to order.id,
+                            // The consumer's internal-transfer route only auto-books when the
+                            // resolved creditor belongs to THIS party (own-account move) — a
+                            // standing order paying a different customer needs the screened
+                            // domestic-payment path, not a bare transaction-service TRANSFER,
+                            // which carries no AML/sanctions check of its own.
+                            "partyId" to order.partyId,
                             "paymentType" to order.paymentType,
                             "debitAccountId" to order.debitAccountId,
                             "debtorIban" to order.debtorIban,

--- a/openbank-standing-order-service/src/main/kotlin/com/openbank/standingorder/domain/model/StandingOrder.kt
+++ b/openbank-standing-order-service/src/main/kotlin/com/openbank/standingorder/domain/model/StandingOrder.kt
@@ -64,9 +64,15 @@ data class StandingOrder(
         nextExecutionDate = nextDate,
         executionCount = executionCount + 1,
         updatedAt = now,
-        // A ONCE order is spent after its single execution; a recurring order completes only once
-        // it runs past its (optional) endDate.
-        status = if (frequency == Frequency.ONCE || (endDate != null && nextDate.isAfter(endDate))) {
+        // A recurring order past its (optional) endDate has nothing left to execute regardless of
+        // today's outcome, so it completes here. A ONCE order does NOT: this method runs BEFORE the
+        // payment is even attempted, and completing it here meant a ONCE order that failed its
+        // single execution ended up COMPLETED with zero money moved — recordFailure requires
+        // status==ACTIVE, so the consumer's failure report silently threw and was swallowed. It
+        // stays ACTIVE (so it is re-picked and retried on the next sweep, and can still reach
+        // FAILED after MAX_CONSECUTIVE_FAILURES) until [confirmExecution] proves the payment
+        // actually went through.
+        status = if (frequency != Frequency.ONCE && endDate != null && nextDate.isAfter(endDate)) {
             StandingOrderStatus.COMPLETED
         } else {
             status
@@ -74,8 +80,8 @@ data class StandingOrder(
     )
 
     fun calculateNextDate(from: LocalDate): LocalDate = when (frequency) {
-        // ONCE never recurs (recordExecution completes it); the returned date is unused, so keep it
-        // unchanged rather than inventing a future occurrence.
+        // ONCE never recurs (confirmExecution completes it once the payment is confirmed); the
+        // returned date is unused, so keep it unchanged rather than inventing a future occurrence.
         Frequency.ONCE -> from
         Frequency.DAILY -> from.plusDays(1)
         Frequency.WEEKLY -> from.plusWeeks(1)
@@ -97,7 +103,13 @@ data class StandingOrder(
 
     fun confirmExecution(now: Instant): StandingOrder {
         require(status == StandingOrderStatus.ACTIVE) { "Cannot confirm execution for $status order" }
-        return copy(failureCount = 0, updatedAt = now)
+        // A ONCE order is spent once its single execution is actually confirmed — see the note on
+        // recordExecution for why that used to happen too early.
+        return copy(
+            failureCount = 0,
+            updatedAt = now,
+            status = if (frequency == Frequency.ONCE) StandingOrderStatus.COMPLETED else status,
+        )
     }
 
     companion object {

--- a/openbank-standing-order-service/src/main/kotlin/com/openbank/standingorder/infrastructure/client/AccountServiceClient.kt
+++ b/openbank-standing-order-service/src/main/kotlin/com/openbank/standingorder/infrastructure/client/AccountServiceClient.kt
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.standingorder.infrastructure.client
+
+import io.smallrye.mutiny.Uni
+import jakarta.ws.rs.GET
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.PathParam
+import jakarta.ws.rs.Produces
+import jakarta.ws.rs.core.MediaType
+import jakarta.ws.rs.core.Response
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient
+
+/**
+ * Resolves a `creditorIban` to an internal `accountId` (`GET /api/v1/accounts/iban/{iban}`) — the
+ * same lookup `openbank-domestic-payment`'s `AccountServiceClient` uses to tell an in-house payee
+ * from a genuinely external one. A `DOMESTIC`/`INTERNAL` standing order whose creditor resolves
+ * here never leaves the bank, so [StandingOrderDueConsumer] routes it straight to
+ * transaction-service instead of the CZ clearing rail — the same rule
+ * `com.openbank.libs.domain.payment.SettlementScope` encodes for same-day booking.
+ *
+ * `Uni<Response>`, not a typed 404-throws-exception client, to match this file's own
+ * [SepaPaymentClient] style: 404 (no such IBAN, or genuinely a different bank) is read as a normal
+ * answer here, not an error — resolved to `null`, not retried or logged loud.
+ */
+@RegisterRestClient(configKey = "account-service")
+@RegisterProvider(io.quarkus.oidc.client.reactive.filter.OidcClientRequestReactiveFilter::class)
+@Path("/api/v1/accounts")
+@Produces(MediaType.APPLICATION_JSON)
+interface AccountServiceClient {
+    @GET
+    @Path("/iban/{iban}")
+    fun getByIban(@PathParam("iban") iban: String): Uni<Response>
+}

--- a/openbank-standing-order-service/src/main/kotlin/com/openbank/standingorder/infrastructure/client/TransactionServiceClient.kt
+++ b/openbank-standing-order-service/src/main/kotlin/com/openbank/standingorder/infrastructure/client/TransactionServiceClient.kt
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.standingorder.infrastructure.client
+
+import io.smallrye.mutiny.Uni
+import jakarta.ws.rs.Consumes
+import jakarta.ws.rs.POST
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.Produces
+import jakarta.ws.rs.core.MediaType
+import jakarta.ws.rs.core.Response
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient
+import java.math.BigDecimal
+import java.util.UUID
+
+/**
+ * REST client for transaction-service's `POST /api/v1/transactions` (#889 follow-up). A
+ * `DOMESTIC`/`INTERNAL` order whose creditor IBAN resolves to an account of ours
+ * ([AccountServiceClient]) is an own-account or same-bank move, so it books here as `type=TRANSFER`
+ * with no `rail` — exactly the signal `com.openbank.libs.domain.payment.SettlementScope` reads as
+ * "stays in the bank", giving it same-day value/booking (transaction-service's own fix, #5225)
+ * rather than the CERTIS cutoff/calendar a genuinely external CZ payment needs.
+ *
+ * Idempotency is body-based here (`InitiateTransactionRequest.idempotencyKey`), not a header —
+ * `TransactionResource.initiateTransaction` has no `Idempotency-Key` header param, unlike
+ * sepa-payment's create endpoint.
+ */
+@RegisterRestClient(configKey = "transaction-service")
+@RegisterProvider(io.quarkus.oidc.client.reactive.filter.OidcClientRequestReactiveFilter::class)
+interface TransactionServiceClient {
+
+    @POST
+    @Path("/api/v1/transactions")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    fun initiate(request: InitiateTransactionRequest): Uni<Response>
+}
+
+data class InitiateTransactionRequest(
+    val idempotencyKey: String,
+    val type: String,
+    val sourceAccountId: UUID?,
+    val targetAccountId: UUID?,
+    val amount: BigDecimal,
+    val currencyCode: String,
+    val description: String?,
+    val valueDate: String,
+)

--- a/openbank-standing-order-service/src/main/kotlin/com/openbank/standingorder/infrastructure/kafka/StandingOrderDueConsumer.kt
+++ b/openbank-standing-order-service/src/main/kotlin/com/openbank/standingorder/infrastructure/kafka/StandingOrderDueConsumer.kt
@@ -35,11 +35,13 @@ import java.util.UUID
  *    non-2xx ⇒ [StandingOrderUseCase.recordFailure].
  *  - `DOMESTIC` / `INTERNAL` → the app only ever sends these two, so this used to mean "every real
  *    standing order fails on every due date" (#3931-class defect: accepted, shown ACTIVE, silently
- *    dead). Resolves `creditorIban` via account-service; a hit means the payee never leaves the
- *    bank, so it books straight through transaction-service as a same-day `TRANSFER`
- *    ([SettlementScope], #5225). A miss is a genuinely external CZ payment, which still needs the
- *    BBAN-based `domestic-payment` rail this change does not build — recorded as a clear failure,
- *    same as before, not a silent one.
+ *    dead). Resolves `creditorIban` via account-service; when it resolves to an account **of the
+ *    same party** as the order, that is an own-account move — the one case `domestic-payment`
+ *    itself skips AML/sanctions screening for — so it books straight through transaction-service
+ *    as a same-day `TRANSFER` ([SettlementScope], #5225). A creditor belonging to a DIFFERENT
+ *    party, or an IBAN that resolves to no account at all (genuinely external CZ payment), both
+ *    still need `domestic-payment`'s screened / BBAN-clearing paths this change does not build —
+ *    recorded as a clear failure, same as before, never a silently unscreened success.
  *
  * Idempotency: the payment call reuses the event's deterministic `so-exec-{orderId}-{executionDate}`
  * key, so a Kafka redelivery replays the same payment (sepa-payment returns the cached 201) instead of
@@ -139,14 +141,20 @@ class StandingOrderDueConsumer(
      * types; `SEPA_CREDIT` is unreachable from it) was accepted, shown ACTIVE, and silently failed
      * on every due date until it auto-suspended (#3931-class defect).
      *
-     * The fix routes the case this consumer CAN handle correctly without inventing new CZ-clearing
-     * plumbing: if the creditor IBAN resolves to an account of ours, this is an own-account or
-     * same-bank move and transaction-service can book it directly as a `TRANSFER` — same-day, no
-     * rail, no clearing calendar (`SettlementScope`, #5225). A creditor IBAN that does NOT resolve
-     * is a genuinely external CZ payment (a different bank's BBAN) that needs the CERTIS-clearing
-     * `domestic-payment` rail; that integration needs an IBAN→BBAN conversion this change does not
-     * attempt, and is a tracked follow-up — it still records a clear failure, same as today, rather
-     * than a wrong one.
+     * The fix routes only the case this consumer can handle both correctly AND safely: an
+     * **own-account** move, where the resolved creditor belongs to the SAME party as the order.
+     * That is exactly `domestic-payment`'s own `OWN_ACCOUNTS` scope — the one case its own
+     * screening logic already skips AML/sanctions checks for — so booking it as a bare
+     * transaction-service `TRANSFER` (same-day, no rail, no clearing calendar; `SettlementScope`,
+     * #5225) carries no screening gap. transaction-service itself has NO screening client of its
+     * own, so routing a payment to a DIFFERENT party this way would silently skip the check
+     * `domestic-payment` runs for its `INTERNAL_CLIENT` scope — that case still needs the real
+     * screened path and is deliberately left recording a failure, not wrongly auto-booked.
+     *
+     * A creditor IBAN that resolves to no account at all is a genuinely external CZ payment (a
+     * different bank's BBAN) needing the CERTIS-clearing `domestic-payment` rail; that needs an
+     * IBAN→BBAN conversion this change does not attempt. Both gaps record a clear failure, same as
+     * before this fix, rather than a wrong success.
      */
     private suspend fun executeDomesticOrInternal(orderId: UUID, node: com.fasterxml.jackson.databind.JsonNode) {
         val creditorIban = node.path("creditorIban").asText(null)?.takeIf { it.isNotBlank() }
@@ -155,22 +163,8 @@ class StandingOrderDueConsumer(
             recordFailureSafely(orderId)
             return
         }
-        val lookup = runCatching { accountClient.getByIban(creditorIban).awaitSuspending() }
-        val response = lookup.getOrNull()
-        if (response == null || response.statusInfo.family != Response.Status.Family.SUCCESSFUL) {
-            log.infof(
-                "[standing-order-exec] order %s creditor IBAN does not resolve to an internal account " +
-                    "— external CZ clearing rail is not wired yet (#889 follow-up), recording failure",
-                orderId,
-            )
-            recordFailureSafely(orderId)
-            return
-        }
-        val targetAccountId = runCatching {
-            objectMapper.readTree(response.readEntity(String::class.java)).path("id").asText().let(UUID::fromString)
-        }.getOrNull()
+        val targetAccountId = resolveOwnAccountCreditor(orderId, node, creditorIban)
         if (targetAccountId == null) {
-            log.warnf("[standing-order-exec] order %s: could not parse account lookup response", orderId)
             recordFailureSafely(orderId)
             return
         }
@@ -200,6 +194,49 @@ class StandingOrderDueConsumer(
             )
             recordFailureSafely(orderId)
         }
+    }
+
+    /**
+     * Resolves [creditorIban] and returns its accountId ONLY when it belongs to the same party as
+     * the order — the safety boundary [executeDomesticOrInternal]'s KDoc explains. Returns null
+     * (and logs why) for every other outcome: no account, an unparseable response, or a different
+     * party's account. The caller records failure uniformly on null; only the reason differs.
+     */
+    private suspend fun resolveOwnAccountCreditor(
+        orderId: UUID,
+        node: com.fasterxml.jackson.databind.JsonNode,
+        creditorIban: String,
+    ): UUID? {
+        val lookup = runCatching { accountClient.getByIban(creditorIban).awaitSuspending() }
+        val response = lookup.getOrNull()
+        if (response == null || response.statusInfo.family != Response.Status.Family.SUCCESSFUL) {
+            log.infof(
+                "[standing-order-exec] order %s creditor IBAN does not resolve to an internal account " +
+                    "— external CZ clearing rail is not wired yet (#889 follow-up), recording failure",
+                orderId,
+            )
+            return null
+        }
+        val lookupJson = runCatching { objectMapper.readTree(response.readEntity(String::class.java)) }.getOrNull()
+        val targetAccountId = lookupJson?.path("id")?.asText(null)?.let {
+            runCatching { UUID.fromString(it) }.getOrNull()
+        }
+        val creditorPartyId = lookupJson?.path("partyId")?.asText(null)
+        if (targetAccountId == null || creditorPartyId == null) {
+            log.warnf("[standing-order-exec] order %s: could not parse account lookup response", orderId)
+            return null
+        }
+        val orderPartyId = node.path("partyId").asText(null)
+        if (orderPartyId == null || creditorPartyId != orderPartyId) {
+            log.infof(
+                "[standing-order-exec] order %s pays a different party's account — that needs " +
+                    "domestic-payment's screened INTERNAL_CLIENT path, not a bare transaction-service " +
+                    "TRANSFER (which carries no AML/sanctions check of its own); recording failure",
+                orderId,
+            )
+            return null
+        }
+        return targetAccountId
     }
 
     // Minor units (e.g. 220000 "cents") → major units (2200.00) using the currency's fraction digits.

--- a/openbank-standing-order-service/src/main/kotlin/com/openbank/standingorder/infrastructure/kafka/StandingOrderDueConsumer.kt
+++ b/openbank-standing-order-service/src/main/kotlin/com/openbank/standingorder/infrastructure/kafka/StandingOrderDueConsumer.kt
@@ -7,8 +7,11 @@ package com.openbank.standingorder.infrastructure.kafka
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.openbank.libs.domain.money.CurrencyCode
 import com.openbank.standingorder.application.port.`in`.StandingOrderUseCase
+import com.openbank.standingorder.infrastructure.client.AccountServiceClient
 import com.openbank.standingorder.infrastructure.client.CreateSepaPaymentRequest
+import com.openbank.standingorder.infrastructure.client.InitiateTransactionRequest
 import com.openbank.standingorder.infrastructure.client.SepaPaymentClient
+import com.openbank.standingorder.infrastructure.client.TransactionServiceClient
 import io.smallrye.mutiny.coroutines.awaitSuspending
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.ws.rs.core.Response
@@ -16,6 +19,8 @@ import org.eclipse.microprofile.reactive.messaging.Incoming
 import org.eclipse.microprofile.rest.client.inject.RestClient
 import org.jboss.logging.Logger
 import java.math.BigDecimal
+import java.time.Clock
+import java.time.LocalDate
 import java.util.UUID
 
 /**
@@ -28,9 +33,13 @@ import java.util.UUID
  *
  *  - `SEPA_CREDIT` → POST sepa-payment `/api/v1/sepa-payments` (SCT). 2xx ⇒ [StandingOrderUseCase.confirmExecution];
  *    non-2xx ⇒ [StandingOrderUseCase.recordFailure].
- *  - `DOMESTIC` / `INTERNAL` → not wired yet (the CZK/internal rails need a different request shape than
- *    the order carries). Recorded as a failure with a clear log line rather than silently dropped, and
- *    tracked as a follow-up. Until then only SEPA standing orders actually move money.
+ *  - `DOMESTIC` / `INTERNAL` → the app only ever sends these two, so this used to mean "every real
+ *    standing order fails on every due date" (#3931-class defect: accepted, shown ACTIVE, silently
+ *    dead). Resolves `creditorIban` via account-service; a hit means the payee never leaves the
+ *    bank, so it books straight through transaction-service as a same-day `TRANSFER`
+ *    ([SettlementScope], #5225). A miss is a genuinely external CZ payment, which still needs the
+ *    BBAN-based `domestic-payment` rail this change does not build — recorded as a clear failure,
+ *    same as before, not a silent one.
  *
  * Idempotency: the payment call reuses the event's deterministic `so-exec-{orderId}-{executionDate}`
  * key, so a Kafka redelivery replays the same payment (sepa-payment returns the cached 201) instead of
@@ -45,6 +54,9 @@ class StandingOrderDueConsumer(
     private val useCase: StandingOrderUseCase,
     private val objectMapper: ObjectMapper,
     @RestClient private val sepaClient: SepaPaymentClient,
+    @RestClient private val accountClient: AccountServiceClient,
+    @RestClient private val transactionClient: TransactionServiceClient,
+    private val clock: Clock,
 ) {
     private val log = Logger.getLogger(StandingOrderDueConsumer::class.java)
 
@@ -64,10 +76,10 @@ class StandingOrderDueConsumer(
                 }
             when (val paymentType = node.path("paymentType").asText()) {
                 "SEPA_CREDIT" -> executeSepa(orderId, node)
+                "DOMESTIC", "INTERNAL" -> executeDomesticOrInternal(orderId, node)
                 else -> {
                     log.warnf(
-                        "[standing-order-exec] order %s paymentType %s is not yet wired to a rail (#889 follow-up) " +
-                            "— recording failure",
+                        "[standing-order-exec] order %s has unrecognised paymentType %s — recording failure",
                         orderId,
                         paymentType,
                     )
@@ -116,6 +128,75 @@ class StandingOrderDueConsumer(
                 "[standing-order-exec] order %s SEPA transfer rejected (HTTP %d) — recording failure",
                 orderId,
                 status,
+            )
+            recordFailureSafely(orderId)
+        }
+    }
+
+    /**
+     * `DOMESTIC` and `INTERNAL` orders used to fall straight to [recordFailureSafely] — no rail
+     * existed for either, so every real standing order (the app only ever sends these two payment
+     * types; `SEPA_CREDIT` is unreachable from it) was accepted, shown ACTIVE, and silently failed
+     * on every due date until it auto-suspended (#3931-class defect).
+     *
+     * The fix routes the case this consumer CAN handle correctly without inventing new CZ-clearing
+     * plumbing: if the creditor IBAN resolves to an account of ours, this is an own-account or
+     * same-bank move and transaction-service can book it directly as a `TRANSFER` — same-day, no
+     * rail, no clearing calendar (`SettlementScope`, #5225). A creditor IBAN that does NOT resolve
+     * is a genuinely external CZ payment (a different bank's BBAN) that needs the CERTIS-clearing
+     * `domestic-payment` rail; that integration needs an IBAN→BBAN conversion this change does not
+     * attempt, and is a tracked follow-up — it still records a clear failure, same as today, rather
+     * than a wrong one.
+     */
+    private suspend fun executeDomesticOrInternal(orderId: UUID, node: com.fasterxml.jackson.databind.JsonNode) {
+        val creditorIban = node.path("creditorIban").asText(null)?.takeIf { it.isNotBlank() }
+        if (creditorIban == null) {
+            log.warnf("[standing-order-exec] order %s has no creditorIban — recording failure", orderId)
+            recordFailureSafely(orderId)
+            return
+        }
+        val lookup = runCatching { accountClient.getByIban(creditorIban).awaitSuspending() }
+        val response = lookup.getOrNull()
+        if (response == null || response.statusInfo.family != Response.Status.Family.SUCCESSFUL) {
+            log.infof(
+                "[standing-order-exec] order %s creditor IBAN does not resolve to an internal account " +
+                    "— external CZ clearing rail is not wired yet (#889 follow-up), recording failure",
+                orderId,
+            )
+            recordFailureSafely(orderId)
+            return
+        }
+        val targetAccountId = runCatching {
+            objectMapper.readTree(response.readEntity(String::class.java)).path("id").asText().let(UUID::fromString)
+        }.getOrNull()
+        if (targetAccountId == null) {
+            log.warnf("[standing-order-exec] order %s: could not parse account lookup response", orderId)
+            recordFailureSafely(orderId)
+            return
+        }
+
+        val currency = node.path("currency").asText()
+        val idempotencyKey = node.path("idempotencyKey").asText()
+        val request = InitiateTransactionRequest(
+            idempotencyKey = idempotencyKey,
+            type = "TRANSFER",
+            sourceAccountId = UUID.fromString(node.path("debitAccountId").asText()),
+            targetAccountId = targetAccountId,
+            amount = toMajorUnits(node.path("amountMinorUnits").asLong(), currency),
+            currencyCode = currency,
+            description = node.path("remittanceInfo").asText(null)?.takeIf { it.isNotBlank() },
+            valueDate = LocalDate.now(clock).toString(),
+        )
+        val txResponse = transactionClient.initiate(request).awaitSuspending()
+        if (txResponse.statusInfo.family == Response.Status.Family.SUCCESSFUL) {
+            log.infof("[standing-order-exec] order %s internal transfer accepted (HTTP %d)", orderId, txResponse.status)
+            runCatching { useCase.confirmExecution(orderId) }
+                .onFailure { log.warnf(it, "[standing-order-exec] confirmExecution failed for order %s", orderId) }
+        } else {
+            log.warnf(
+                "[standing-order-exec] order %s internal transfer rejected (HTTP %d) — recording failure",
+                orderId,
+                txResponse.status,
             )
             recordFailureSafely(orderId)
         }

--- a/openbank-standing-order-service/src/main/resources/application.yaml
+++ b/openbank-standing-order-service/src/main/resources/application.yaml
@@ -62,6 +62,14 @@ quarkus:
     sepa-payment-service:
       url: ${SEPA_PAYMENT_SERVICE_URL:http://localhost:8115}
       scope: jakarta.inject.Singleton
+    # DOMESTIC/INTERNAL routing (#889 follow-up): resolve the creditor IBAN, then book the
+    # transfer directly when it is one of ours.
+    account-service:
+      url: ${ACCOUNT_SERVICE_URL:http://account-service.accounts.svc:8100}
+      scope: jakarta.inject.Singleton
+    transaction-service:
+      url: ${TRANSACTION_SERVICE_URL:http://transaction-service.payments.svc:8102}
+      scope: jakarta.inject.Singleton
   redis:
     hosts: redis://localhost:6379
   smallrye-reactive-messaging:

--- a/openbank-standing-order-service/src/test/kotlin/com/openbank/standingorder/domain/model/StandingOrderTest.kt
+++ b/openbank-standing-order-service/src/test/kotlin/com/openbank/standingorder/domain/model/StandingOrderTest.kt
@@ -120,8 +120,15 @@ class StandingOrderTest {
         assertThat(updated.status).isEqualTo(StandingOrderStatus.ACTIVE)
     }
 
+    /**
+     * Regression coverage for the #3931-class defect this pair of tests guards: `recordExecution`
+     * runs at SCHEDULING time, before the payment is even attempted. Completing a ONCE order here
+     * meant a one-off payment that then failed left the order COMPLETED with zero money moved —
+     * `recordFailure`'s `status == ACTIVE` guard threw on the already-COMPLETED order, and the
+     * consumer's `runCatching` swallowed it. A ONCE order must stay ACTIVE through scheduling.
+     */
     @Test
-    fun `recordExecution completes a ONCE order after its single execution`() {
+    fun `recordExecution does NOT complete a ONCE order — only schedules the attempt`() {
         val order = standingOrder(
             frequency = Frequency.ONCE,
             startDate = LocalDate.of(2026, 6, 1),
@@ -130,10 +137,45 @@ class StandingOrderTest {
             status = StandingOrderStatus.ACTIVE,
         )
 
-        val executed = order.recordExecution(order.calculateNextDate(order.nextExecutionDate), FIXED_NOW)
+        val scheduled = order.recordExecution(order.calculateNextDate(order.nextExecutionDate), FIXED_NOW)
 
-        assertThat(executed.status).isEqualTo(StandingOrderStatus.COMPLETED)
-        assertThat(executed.executionCount).isEqualTo(order.executionCount + 1)
+        assertThat(scheduled.status).isEqualTo(StandingOrderStatus.ACTIVE)
+        assertThat(scheduled.executionCount).isEqualTo(order.executionCount + 1)
+    }
+
+    /** The other half: only [StandingOrder.confirmExecution] — the real success signal — completes it. */
+    @Test
+    fun `confirmExecution completes a ONCE order once the payment is actually confirmed`() {
+        val order = standingOrder(frequency = Frequency.ONCE, status = StandingOrderStatus.ACTIVE)
+
+        val confirmed = order.confirmExecution(FIXED_NOW)
+
+        assertThat(confirmed.status).isEqualTo(StandingOrderStatus.COMPLETED)
+    }
+
+    /** confirmExecution must not complete a still-recurring order — only ONCE is spent by one run. */
+    @Test
+    fun `confirmExecution leaves a recurring order ACTIVE`() {
+        val order = standingOrder(frequency = Frequency.MONTHLY, status = StandingOrderStatus.ACTIVE)
+
+        val confirmed = order.confirmExecution(FIXED_NOW)
+
+        assertThat(confirmed.status).isEqualTo(StandingOrderStatus.ACTIVE)
+    }
+
+    /**
+     * A failed ONCE execution must be recordable at all — before this fix it threw (`recordFailure`
+     * requires ACTIVE, but the order was already COMPLETED by the time it failed).
+     */
+    @Test
+    fun `a failed ONCE execution can still be recorded, and retried until it hits the failure cap`() {
+        val order = standingOrder(frequency = Frequency.ONCE, status = StandingOrderStatus.ACTIVE, failureCount = 0)
+        val scheduled = order.recordExecution(order.calculateNextDate(order.nextExecutionDate), FIXED_NOW)
+
+        val failed = scheduled.recordFailure(FIXED_NOW)
+
+        assertThat(failed.status).isEqualTo(StandingOrderStatus.ACTIVE)
+        assertThat(failed.failureCount).isEqualTo(1)
     }
 
     private fun standingOrder(
@@ -203,7 +245,7 @@ class StandingOrderTest {
 
         @JvmStatic
         fun frequencyNextDateCases(): Stream<Arguments> = Stream.of(
-            // ONCE never advances — the returned date is unused (recordExecution completes it).
+            // ONCE never advances — the returned date is unused (confirmExecution completes it).
             Arguments.of(Frequency.ONCE, LocalDate.of(2026, 1, 1), LocalDate.of(2026, 1, 1)),
             Arguments.of(Frequency.DAILY, LocalDate.of(2026, 1, 1), LocalDate.of(2026, 1, 2)),
             Arguments.of(Frequency.WEEKLY, LocalDate.of(2026, 1, 1), LocalDate.of(2026, 1, 8)),

--- a/openbank-standing-order-service/src/test/kotlin/com/openbank/standingorder/infrastructure/kafka/StandingOrderDueConsumerTest.kt
+++ b/openbank-standing-order-service/src/test/kotlin/com/openbank/standingorder/infrastructure/kafka/StandingOrderDueConsumerTest.kt
@@ -38,6 +38,7 @@ class StandingOrderDueConsumerTest {
         StandingOrderDueConsumer(useCase, mapper, sepaClient, accountClient, transactionClient, clock)
 
     private val orderId = UUID.fromString("00000000-0000-0000-0000-0000000000d1")
+    private val partyId = UUID.fromString("00000000-0000-0000-0000-0000000000d9")
 
     private fun dueEvent(
         paymentType: String = "SEPA_CREDIT",
@@ -45,9 +46,11 @@ class StandingOrderDueConsumerTest {
         debtorName: String? = "Debtor",
         amountMinorUnits: Long = 220000L,
         currency: String = "CZK",
+        orderPartyId: UUID? = partyId,
     ): String {
         val payload = mutableMapOf<String, Any?>(
             "orderId" to orderId,
+            "partyId" to orderPartyId,
             "paymentType" to paymentType,
             "debitAccountId" to UUID.fromString("00000000-0000-0000-0000-0000000000d2"),
             "debtorIban" to debtorIban,
@@ -112,28 +115,33 @@ class StandingOrderDueConsumerTest {
      * every real standing order failed on every due date, forever.
      */
     @Test
-    fun `DOMESTIC order whose creditor resolves to an internal account is booked as a TRANSFER`(): Unit = runBlocking {
-        val targetAccountId = UUID.fromString("00000000-0000-0000-0000-0000000000d3")
-        val lookupBody = mapper.writeValueAsString(mapOf("id" to targetAccountId, "partyId" to UUID.randomUUID()))
-        every { accountClient.getByIban("DE89370400440532013000") } returns
-            Uni.createFrom().item(Response.ok(lookupBody).build())
-        val req = slot<InitiateTransactionRequest>()
-        every { transactionClient.initiate(capture(req)) } returns
-            Uni.createFrom().item(Response.status(201).build())
-        coEvery { useCase.confirmExecution(orderId) } returns mockk(relaxed = true)
+    fun `DOMESTIC order whose creditor resolves to the SAME party's account is booked as a TRANSFER`(): Unit =
+        runBlocking {
+            val targetAccountId = UUID.fromString("00000000-0000-0000-0000-0000000000d3")
+            // Same partyId as the order — an own-account move, the one case domestic-payment itself
+            // skips AML/sanctions screening for. A different party's account must NOT auto-route this
+            // way (see the two tests below) — a bare transaction-service TRANSFER carries no screening
+            // of its own.
+            val lookupBody = mapper.writeValueAsString(mapOf("id" to targetAccountId, "partyId" to partyId))
+            every { accountClient.getByIban("DE89370400440532013000") } returns
+                Uni.createFrom().item(Response.ok(lookupBody).build())
+            val req = slot<InitiateTransactionRequest>()
+            every { transactionClient.initiate(capture(req)) } returns
+                Uni.createFrom().item(Response.status(201).build())
+            coEvery { useCase.confirmExecution(orderId) } returns mockk(relaxed = true)
 
-        consumer.consume(dueEvent(paymentType = "DOMESTIC"))
+            consumer.consume(dueEvent(paymentType = "DOMESTIC"))
 
-        assertThat(req.captured.type).isEqualTo("TRANSFER")
-        assertThat(req.captured.targetAccountId).isEqualTo(targetAccountId)
-        assertThat(req.captured.sourceAccountId)
-            .isEqualTo(UUID.fromString("00000000-0000-0000-0000-0000000000d2"))
-        assertThat(req.captured.amount).isEqualByComparingTo("2200.00")
-        assertThat(req.captured.idempotencyKey).isEqualTo("so-exec-$orderId-2026-07-13")
-        coVerify(exactly = 1) { useCase.confirmExecution(orderId) }
-        coVerify(exactly = 0) { useCase.recordFailure(any()) }
-        coVerify(exactly = 0) { sepaClient.createPayment(any(), any()) }
-    }
+            assertThat(req.captured.type).isEqualTo("TRANSFER")
+            assertThat(req.captured.targetAccountId).isEqualTo(targetAccountId)
+            assertThat(req.captured.sourceAccountId)
+                .isEqualTo(UUID.fromString("00000000-0000-0000-0000-0000000000d2"))
+            assertThat(req.captured.amount).isEqualByComparingTo("2200.00")
+            assertThat(req.captured.idempotencyKey).isEqualTo("so-exec-$orderId-2026-07-13")
+            coVerify(exactly = 1) { useCase.confirmExecution(orderId) }
+            coVerify(exactly = 0) { useCase.recordFailure(any()) }
+            coVerify(exactly = 0) { sepaClient.createPayment(any(), any()) }
+        }
 
     @Test
     fun `INTERNAL order whose creditor does NOT resolve to an internal account records a failure`(): Unit =
@@ -148,10 +156,50 @@ class StandingOrderDueConsumerTest {
             coVerify(exactly = 0) { transactionClient.initiate(any()) }
         }
 
+    /**
+     * The security-relevant boundary: resolving to SOME internal account is not enough. Paying a
+     * different party's account this way would silently skip the AML/sanctions screening
+     * `domestic-payment` runs for its `INTERNAL_CLIENT` scope — transaction-service's raw TRANSFER
+     * has no screening client of its own.
+     */
+    @Test
+    fun `INTERNAL order whose creditor resolves to a DIFFERENT party's account records a failure`(): Unit =
+        runBlocking {
+            val lookupBody = mapper.writeValueAsString(
+                mapOf(
+                    "id" to UUID.fromString("00000000-0000-0000-0000-0000000000d3"),
+                    "partyId" to UUID.fromString("00000000-0000-0000-0000-0000000000dd"),
+                ),
+            )
+            every { accountClient.getByIban("DE89370400440532013000") } returns
+                Uni.createFrom().item(Response.ok(lookupBody).build())
+            coEvery { useCase.recordFailure(orderId) } returns mockk(relaxed = true)
+
+            consumer.consume(dueEvent(paymentType = "INTERNAL"))
+
+            coVerify(exactly = 1) { useCase.recordFailure(orderId) }
+            coVerify(exactly = 0) { transactionClient.initiate(any()) }
+        }
+
+    @Test
+    fun `an order with no partyId on the event never auto-routes, even to a resolvable account`(): Unit = runBlocking {
+        val lookupBody = mapper.writeValueAsString(
+            mapOf("id" to UUID.fromString("00000000-0000-0000-0000-0000000000d3"), "partyId" to partyId),
+        )
+        every { accountClient.getByIban("DE89370400440532013000") } returns
+            Uni.createFrom().item(Response.ok(lookupBody).build())
+        coEvery { useCase.recordFailure(orderId) } returns mockk(relaxed = true)
+
+        consumer.consume(dueEvent(paymentType = "INTERNAL", orderPartyId = null))
+
+        coVerify(exactly = 1) { useCase.recordFailure(orderId) }
+        coVerify(exactly = 0) { transactionClient.initiate(any()) }
+    }
+
     @Test
     fun `a rejected internal transfer records a failure, not a confirmed execution`(): Unit = runBlocking {
         val lookupBody = mapper.writeValueAsString(
-            mapOf("id" to UUID.fromString("00000000-0000-0000-0000-0000000000d3"), "partyId" to UUID.randomUUID()),
+            mapOf("id" to UUID.fromString("00000000-0000-0000-0000-0000000000d3"), "partyId" to partyId),
         )
         every { accountClient.getByIban(any()) } returns Uni.createFrom().item(Response.ok(lookupBody).build())
         every { transactionClient.initiate(any()) } returns Uni.createFrom().item(Response.status(422).build())

--- a/openbank-standing-order-service/src/test/kotlin/com/openbank/standingorder/infrastructure/kafka/StandingOrderDueConsumerTest.kt
+++ b/openbank-standing-order-service/src/test/kotlin/com/openbank/standingorder/infrastructure/kafka/StandingOrderDueConsumerTest.kt
@@ -6,8 +6,11 @@ package com.openbank.standingorder.infrastructure.kafka
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.openbank.standingorder.application.port.`in`.StandingOrderUseCase
+import com.openbank.standingorder.infrastructure.client.AccountServiceClient
 import com.openbank.standingorder.infrastructure.client.CreateSepaPaymentRequest
+import com.openbank.standingorder.infrastructure.client.InitiateTransactionRequest
 import com.openbank.standingorder.infrastructure.client.SepaPaymentClient
+import com.openbank.standingorder.infrastructure.client.TransactionServiceClient
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -18,14 +21,21 @@ import jakarta.ws.rs.core.Response
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
 import java.util.UUID
 
 class StandingOrderDueConsumerTest {
 
     private val useCase = mockk<StandingOrderUseCase>()
     private val sepaClient = mockk<SepaPaymentClient>()
+    private val accountClient = mockk<AccountServiceClient>()
+    private val transactionClient = mockk<TransactionServiceClient>()
     private val mapper = jacksonObjectMapper()
-    private val consumer = StandingOrderDueConsumer(useCase, mapper, sepaClient)
+    private val clock = Clock.fixed(Instant.parse("2026-07-13T10:00:00Z"), ZoneOffset.UTC)
+    private val consumer =
+        StandingOrderDueConsumer(useCase, mapper, sepaClient, accountClient, transactionClient, clock)
 
     private val orderId = UUID.fromString("00000000-0000-0000-0000-0000000000d1")
 
@@ -96,14 +106,84 @@ class StandingOrderDueConsumerTest {
         coVerify(exactly = 0) { sepaClient.createPayment(any(), any()) }
     }
 
+    /**
+     * The #3931-class defect this whole class of tests guards: before the fix, DOMESTIC/INTERNAL
+     * fell straight to `else -> recordFailureSafely`, and the app only ever sends these two — so
+     * every real standing order failed on every due date, forever.
+     */
     @Test
-    fun `DOMESTIC order is not yet wired to a rail and records a failure`(): Unit = runBlocking {
+    fun `DOMESTIC order whose creditor resolves to an internal account is booked as a TRANSFER`(): Unit = runBlocking {
+        val targetAccountId = UUID.fromString("00000000-0000-0000-0000-0000000000d3")
+        val lookupBody = mapper.writeValueAsString(mapOf("id" to targetAccountId, "partyId" to UUID.randomUUID()))
+        every { accountClient.getByIban("DE89370400440532013000") } returns
+            Uni.createFrom().item(Response.ok(lookupBody).build())
+        val req = slot<InitiateTransactionRequest>()
+        every { transactionClient.initiate(capture(req)) } returns
+            Uni.createFrom().item(Response.status(201).build())
+        coEvery { useCase.confirmExecution(orderId) } returns mockk(relaxed = true)
+
+        consumer.consume(dueEvent(paymentType = "DOMESTIC"))
+
+        assertThat(req.captured.type).isEqualTo("TRANSFER")
+        assertThat(req.captured.targetAccountId).isEqualTo(targetAccountId)
+        assertThat(req.captured.sourceAccountId)
+            .isEqualTo(UUID.fromString("00000000-0000-0000-0000-0000000000d2"))
+        assertThat(req.captured.amount).isEqualByComparingTo("2200.00")
+        assertThat(req.captured.idempotencyKey).isEqualTo("so-exec-$orderId-2026-07-13")
+        coVerify(exactly = 1) { useCase.confirmExecution(orderId) }
+        coVerify(exactly = 0) { useCase.recordFailure(any()) }
+        coVerify(exactly = 0) { sepaClient.createPayment(any(), any()) }
+    }
+
+    @Test
+    fun `INTERNAL order whose creditor does NOT resolve to an internal account records a failure`(): Unit =
+        runBlocking {
+            every { accountClient.getByIban("DE89370400440532013000") } returns
+                Uni.createFrom().item(Response.status(404).build())
+            coEvery { useCase.recordFailure(orderId) } returns mockk(relaxed = true)
+
+            consumer.consume(dueEvent(paymentType = "INTERNAL"))
+
+            coVerify(exactly = 1) { useCase.recordFailure(orderId) }
+            coVerify(exactly = 0) { transactionClient.initiate(any()) }
+        }
+
+    @Test
+    fun `a rejected internal transfer records a failure, not a confirmed execution`(): Unit = runBlocking {
+        val lookupBody = mapper.writeValueAsString(
+            mapOf("id" to UUID.fromString("00000000-0000-0000-0000-0000000000d3"), "partyId" to UUID.randomUUID()),
+        )
+        every { accountClient.getByIban(any()) } returns Uni.createFrom().item(Response.ok(lookupBody).build())
+        every { transactionClient.initiate(any()) } returns Uni.createFrom().item(Response.status(422).build())
         coEvery { useCase.recordFailure(orderId) } returns mockk(relaxed = true)
 
         consumer.consume(dueEvent(paymentType = "DOMESTIC"))
 
         coVerify(exactly = 1) { useCase.recordFailure(orderId) }
-        coVerify(exactly = 0) { sepaClient.createPayment(any(), any()) }
+        coVerify(exactly = 0) { useCase.confirmExecution(any()) }
+    }
+
+    @Test
+    fun `DOMESTIC order with no creditorIban records a failure without calling account-service`(): Unit = runBlocking {
+        coEvery { useCase.recordFailure(orderId) } returns mockk(relaxed = true)
+        val payload = mapper.writeValueAsString(
+            mapOf(
+                "orderId" to orderId,
+                "paymentType" to "DOMESTIC",
+                "debitAccountId" to UUID.fromString("00000000-0000-0000-0000-0000000000d2"),
+                "creditorIban" to null,
+                "creditorName" to "Creditor",
+                "amountMinorUnits" to 220000L,
+                "currency" to "CZK",
+                "idempotencyKey" to "so-exec-$orderId-2026-07-13",
+                "executionDate" to "2026-07-13",
+            ),
+        )
+
+        consumer.consume(payload)
+
+        coVerify(exactly = 1) { useCase.recordFailure(orderId) }
+        coVerify(exactly = 0) { accountClient.getByIban(any()) }
     }
 
     @Test

--- a/openbank-standing-order-service/src/test/kotlin/com/openbank/standingorder/integration/StandingOrderExecutionSweepIT.kt
+++ b/openbank-standing-order-service/src/test/kotlin/com/openbank/standingorder/integration/StandingOrderExecutionSweepIT.kt
@@ -145,8 +145,14 @@ class StandingOrderExecutionSweepIT {
             .describedAs("the due order must be executed exactly once by the sweep")
             .isEqualTo(1)
         assertThat(reloaded.status)
-            .describedAs("a ONCE order is COMPLETED after its single execution")
-            .isEqualTo(StandingOrderStatus.COMPLETED)
+            .describedAs(
+                "the sweep only SCHEDULES the attempt — dispatch is off in this profile, so the " +
+                    "payment was never actually confirmed. Staying ACTIVE (not COMPLETED) here is " +
+                    "the fix for the #3931-class defect where a ONCE order completed before its " +
+                    "payment was even attempted, so a failed one-off silently ended up COMPLETED " +
+                    "with zero money moved.",
+            )
+            .isEqualTo(StandingOrderStatus.ACTIVE)
         assertThat(reloaded.lastExecutionDate)
             .describedAs("the execution is stamped with the date it was due")
             .isEqualTo(today)


### PR DESCRIPTION
## Every real standing order was failing on every due date, forever

`StandingOrderDueConsumer` routed only `"SEPA_CREDIT"` to a rail:

```kotlin
when (val paymentType = node.path("paymentType").asText()) {
    "SEPA_CREDIT" -> executeSepa(orderId, node)
    else -> { /* record failure */ }
}
```

The app only ever sends `DOMESTIC` (recurring orders, `StandingOrderScreen.kt`) or `INTERNAL` (scheduled one-offs, `PaymentDetailScreen.kt`) — `SEPA_CREDIT` appears nowhere outside this service's own demo fixtures. **100% of customer-created standing orders took the failure branch**: accepted with 201, shown `ACTIVE`, silently dead from the first due date, auto-suspending after 3 consecutive failures with no visible sign anything was wrong in the meantime.

## A second, independent defect compounded it for one-off payments

`StandingOrder.recordExecution` ran at **scheduling** time — before the payment was even attempted — and completed a `ONCE` order right there. A `ONCE` order whose single execution then failed was already `COMPLETED` by the time the consumer tried `recordFailure` (which requires `status==ACTIVE`), so the domain guard threw and the consumer's `runCatching` swallowed it silently.

**Net: a scheduled payment that failed still ended up `COMPLETED` with zero money moved, and nothing ever recorded that it had failed.**

## The fix

**Routing.** `DOMESTIC`/`INTERNAL` now resolve the creditor IBAN against account-service:
- **Resolves** (payee is one of our own accounts) → books straight through transaction-service as a same-day `TRANSFER`, no rail — exactly what `SettlementScope` (#5225) reads as "stays in the bank."
- **Doesn't resolve** (genuinely external CZ bank) → this needs the BBAN-based `domestic-payment` rail, which needs an IBAN→BBAN conversion. **No such converter exists anywhere in this codebase**, and getting the Czech check-digit math wrong silently misroutes real money — far worse than a clean, logged failure. Still fails, same as before, but now correctly scoped to only the case this consumer genuinely can't route.

**Premature completion.** `recordExecution` no longer completes a `ONCE` order; only `confirmExecution` does, once the payment is actually confirmed. A `ONCE` order now stays `ACTIVE` through scheduling, gets re-picked and retried by the next sweep on failure, and can still reach `FAILED` after 3 consecutive failures — the same closed loop `DAILY`/`MONTHLY`/etc. orders already had.

**Bonus catch.** `StandingOrderExecutionSweepIT` asserted `COMPLETED` immediately after scheduling (dispatch is disabled in that test profile, so the payment is never actually attempted) — that assertion was itself exercising the exact bug this PR fixes. Corrected to assert `ACTIVE`, with the reasoning inline.

## Not in this PR

The BBAN-routed external-CZ-payment case, tracked as a follow-up — needs a correctly-verified IBAN→BBAN converter, which is its own piece of work.

## Testing

- `StandingOrderDueConsumerTest` — resolved-internal-payee path (booked as `TRANSFER`, confirms execution), unresolved-external path (records failure, no transaction-service call), a rejected transfer, and no `creditorIban`.
- `StandingOrderTest` — `recordExecution` no longer completes `ONCE`; `confirmExecution` completes it instead; `confirmExecution` leaves a recurring order untouched; a failed `ONCE` execution is recordable and retryable instead of throwing.
- `:openbank-standing-order-service:test` (including the real-threading `StandingOrderExecutionSweepIT`), `detekt`, `ktlintCheck` all green.

Gitops: `ACCOUNT_SERVICE_URL`/`TRANSACTION_SERVICE_URL` verified against the live cluster's actual Service names/ports (`kubectl get svc`) rather than assumed — the comment directly above this addition explains why that verification step is non-negotiable here.

## Merge

Per repo convention, money-path PRs are left for a human to merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)