### PR TITLE
fix(admin-ui): clarify FinOps anomaly actions

### DIFF
--- a/openbank-admin-ui/src/app/finops/page.tsx
+++ b/openbank-admin-ui/src/app/finops/page.tsx
@@ -499,8 +499,8 @@ function FinOpsContent() {
           <AgentInsightsPanel
             title={t('FinOps náhledy (AI)', 'FinOps Insights (AI)')}
             subtitle={t(
-              'Aktivní cost anomálie z finops-agenta (D1–D5 detektory z Alertmanageru — ADR-0112). Agent navrhuje, schvaluje člověk (HITL, ADR-0112 P4).',
-              'Active cost anomalies from the finops-agent (D1–D5 detectors via Alertmanager — ADR-0112). The agent proposes; a human approves (HITL, ADR-0112 P4).',
+              'Aktivní cost anomálie z finops-agenta (D1–D5 detektory z Alertmanageru — ADR-0112). Tento přehled je pouze pro čtení: alerty zatím nevytvářejí návrhy ve schvalovací frontě.',
+              'Active cost anomalies from the finops-agent (D1–D5 detectors via Alertmanager — ADR-0112). This view is read-only: alerts do not yet create proposals in the approval queue.',
             )}
             findings={anomalies.map(a => toAgentFinding(a, t))}
             emptyMessage={t(

--- a/openbank-admin-ui/src/app/iaops/page.tsx
+++ b/openbank-admin-ui/src/app/iaops/page.tsx
@@ -595,17 +595,14 @@ function IAOpsContent() {
             icon={<AlertOctagon size={16} />}
             title={t('Cost anomálie', 'Cost Anomalies')}
             subtitle={t(
-              'Aktivní FinOps anomálie z Alertmanageru (D1–D5 detektory, ADR-0112). Agent navrhuje, schvaluje člověk — HITL backend přijde v P4 (tlačítka zatím logují do konzole).',
-              'Active FinOps anomalies from Alertmanager (D1–D5 detectors, ADR-0112). The agent proposes; a human approves — HITL backend arrives in P4 (buttons currently log to console).',
+              'Aktivní FinOps anomálie z Alertmanageru (D1–D5 detektory, ADR-0112). Tento přehled je pouze pro čtení: anomálie zatím nevytvářejí návrhy ve schvalovací frontě.',
+              'Active FinOps anomalies from Alertmanager (D1–D5 detectors, ADR-0112). This view is read-only: anomalies do not yet create proposals in the approval queue.',
             )}
             findings={costAnomalies.map(a => toAgentFinding(a, t))}
             emptyMessage={t(
               'Žádné aktivní cost anomálie — Alertmanager nedosažitelný nebo žádné finops-agent alerty.',
               'No active cost anomalies — Alertmanager unreachable or no finops-agent alerts firing.',
             )}
-            onApprove={id => console.log('HITL approve', id)}
-            onReject={id => console.log('HITL dismiss', id)}
-            decideLabels={{ approve: t('Schválit', 'Approve'), reject: t('Odmítnout', 'Dismiss') }}
           />
 
           {/* ── D. AI audit trail ── */}

--- a/openbank-admin-ui/src/test/finops-anomaly-truthfulness.guard.test.ts
+++ b/openbank-admin-ui/src/test/finops-anomaly-truthfulness.guard.test.ts
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'fs'
+import path from 'path'
+
+const APP = path.resolve(__dirname, '../app')
+
+describe('FinOps anomaly truthfulness', () => {
+  it('does not present Alertmanager alerts as reviewable HITL proposals', () => {
+    for (const page of ['iaops/page.tsx', 'finops/page.tsx']) {
+      const source = readFileSync(path.join(APP, page), 'utf8')
+      expect(source, page).toMatch(/read-only|pouze pro čtení/)
+      expect(source, page).not.toMatch(/console\.log\('HITL/)
+    }
+  })
+})


### PR DESCRIPTION
## Scope
- Removes console-only FinOps approval controls.
- States the actual read-only contract until anomalies create reviewable proposals.

## Verification
- i18n guard and render smoke passed.
- Type-check passed.

## Linked issues
N/A — removes a misleading interaction in the ongoing Admin UI modernization.