### PR TITLE
feat(admin-ui): explain swarm case stages

### DIFF
--- a/openbank-admin-ui/src/app/iaops/cases/[caseId]/page.tsx
+++ b/openbank-admin-ui/src/app/iaops/cases/[caseId]/page.tsx
@@ -12,8 +12,9 @@ import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { DataUnavailable } from '@/components/feedback/DataUnavailable'
 import type { UnavailableKind } from '@/components/feedback/DataUnavailable'
 import { deriveCaseDecisionBrief } from '@/lib/governance/caseDecisionBrief'
+import { caseStatusPresentation } from '@/lib/governance/caseStatusPresentation'
+import type { CaseStatus } from '@/lib/governance/caseStatusPresentation'
 
-type CaseStatus = 'OPEN' | 'CONVERGING' | 'CONTESTED' | 'SYNTHESIZED' | 'CLOSED'
 type EntryType = 'CASE_OPENED' | 'CONTRIBUTION' | 'PROPOSAL_EMITTED'
 
 interface ThreadEntry {
@@ -71,19 +72,6 @@ export default function IaopsCaseThreadPage() {
   const fmt = useCallback(
     (epochMs: number) => new Date(epochMs).toLocaleString(locale, { dateStyle: 'short', timeStyle: 'short' }),
     [locale],
-  )
-
-  const statusLabel = useCallback(
-    (status: CaseStatus): string => {
-      switch (status) {
-        case 'OPEN': return t('Otevřený', 'Open')
-        case 'CONVERGING': return t('Konverguje', 'Converging')
-        case 'CONTESTED': return t('Sporný', 'Contested')
-        case 'SYNTHESIZED': return t('Syntetizovaný', 'Synthesized')
-        case 'CLOSED': return t('Uzavřený', 'Closed')
-      }
-    },
-    [t],
   )
 
   const load = useCallback(async () => {
@@ -150,15 +138,19 @@ export default function IaopsCaseThreadPage() {
             {(() => {
               const visual = statusVisual(thread.status)
               const Icon = visual.icon
+              const presentation = caseStatusPresentation(thread.status, language)
               return (
-                <span style={{
-                  display: 'inline-flex', alignItems: 'center', gap: '5px',
-                  fontSize: '11px', fontWeight: 700, padding: '4px 12px', borderRadius: '10px',
-                  background: visual.bg, color: visual.fg,
-                }}>
-                  <Icon size={12} />
-                  {statusLabel(thread.status)}
-                </span>
+                <div>
+                  <span style={{
+                    display: 'inline-flex', alignItems: 'center', gap: '5px',
+                    fontSize: '11px', fontWeight: 700, padding: '4px 12px', borderRadius: '10px',
+                    background: visual.bg, color: visual.fg,
+                  }}>
+                    <Icon size={12} />
+                    {presentation.label}
+                  </span>
+                  <div style={{ marginTop: '4px', fontSize: '11px', color: 'var(--text-tertiary)' }}>{presentation.detail}</div>
+                </div>
               )
             })()}
           </div>

--- a/openbank-admin-ui/src/app/iaops/cases/page.tsx
+++ b/openbank-admin-ui/src/app/iaops/cases/page.tsx
@@ -10,12 +10,11 @@ import { ArrowLeft, CheckCircle2, CircleDot, GitMerge, RefreshCw, Sparkles, Tria
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { DataUnavailable } from '@/components/feedback/DataUnavailable'
 import type { UnavailableKind } from '@/components/feedback/DataUnavailable'
+import { CASE_STATUSES, caseStatusPresentation } from '@/lib/governance/caseStatusPresentation'
+import type { CaseStatus } from '@/lib/governance/caseStatusPresentation'
 
 const PAGE_SIZE = 25
 const MAX_LIMIT = 200
-
-const STATUSES = ['OPEN', 'CONVERGING', 'CONTESTED', 'SYNTHESIZED', 'CLOSED'] as const
-type CaseStatus = (typeof STATUSES)[number]
 
 interface CaseSummary {
   caseId: string
@@ -59,19 +58,6 @@ export default function IaopsCasesPage() {
   const fmt = useCallback(
     (epochMs: number) => new Date(epochMs).toLocaleString(locale, { dateStyle: 'short', timeStyle: 'short' }),
     [locale],
-  )
-
-  const statusLabel = useCallback(
-    (status: CaseStatus): string => {
-      switch (status) {
-        case 'OPEN': return t('Otevřený', 'Open')
-        case 'CONVERGING': return t('Konverguje', 'Converging')
-        case 'CONTESTED': return t('Sporný', 'Contested')
-        case 'SYNTHESIZED': return t('Syntetizovaný', 'Synthesized')
-        case 'CLOSED': return t('Uzavřený', 'Closed')
-      }
-    },
-    [t],
   )
 
   const load = useCallback(async () => {
@@ -151,9 +137,10 @@ export default function IaopsCasesPage() {
         >
           {t('Všechny', 'All')}
         </button>
-        {STATUSES.map((status) => {
+        {CASE_STATUSES.map((status) => {
           const visual = statusVisual(status)
           const active = statusFilter === status
+          const presentation = caseStatusPresentation(status, language)
           return (
             <button
               key={status}
@@ -163,11 +150,12 @@ export default function IaopsCasesPage() {
                 fontSize: '11px', fontWeight: 700, padding: '5px 12px', borderRadius: '14px', cursor: 'pointer',
                 border: `1px solid ${active ? visual.fg : 'var(--border)'}`,
                 background: active ? visual.bg : 'var(--surface)',
-                color: active ? visual.fg : 'var(--text-secondary)',
+              color: active ? visual.fg : 'var(--text-secondary)',
               }}
+              title={presentation.detail}
             >
               <visual.icon size={12} />
-              {statusLabel(status)}
+              {presentation.label}
             </button>
           )
         })}
@@ -200,6 +188,7 @@ export default function IaopsCasesPage() {
             {cases.map((item) => {
               const visual = statusVisual(item.status)
               const Icon = visual.icon
+              const presentation = caseStatusPresentation(item.status, language)
               return (
                 <Link
                   key={item.caseId}
@@ -216,7 +205,7 @@ export default function IaopsCasesPage() {
                       background: visual.bg, color: visual.fg,
                     }}>
                       <Icon size={12} />
-                      {statusLabel(item.status)}
+                      {presentation.label}
                     </span>
                     <span style={{ fontFamily: 'var(--font-mono)', fontSize: '12px', fontWeight: 700, color: 'var(--text-primary)' }}>
                       {item.caseId}
@@ -236,6 +225,7 @@ export default function IaopsCasesPage() {
                     <span>{t('Otevřeno', 'Opened')}: <strong style={{ color: 'var(--text-secondary)' }}>{fmt(item.openedAtEpochMs)}</strong></span>
                     <span>{t('Deadline', 'Deadline')}: <strong style={{ color: 'var(--text-secondary)' }}>{fmt(item.deadlineAtEpochMs)}</strong></span>
                   </div>
+                  <p style={{ margin: '8px 0 0', fontSize: '11px', color: 'var(--text-secondary)', lineHeight: 1.45 }}>{presentation.detail}</p>
                 </Link>
               )
             })}

--- a/openbank-admin-ui/src/lib/governance/caseStatusPresentation.ts
+++ b/openbank-admin-ui/src/lib/governance/caseStatusPresentation.ts
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+export const CASE_STATUSES = ['OPEN', 'CONVERGING', 'CONTESTED', 'SYNTHESIZED', 'CLOSED'] as const
+export type CaseStatus = (typeof CASE_STATUSES)[number]
+
+export interface CaseStatusPresentation {
+  label: string
+  detail: string
+}
+
+// A case status describes only the collaboration thread. In particular, it does
+// not establish delivery of a proposal or a human decision outside the thread.
+export function caseStatusPresentation(status: CaseStatus, language: 'cs' | 'en'): CaseStatusPresentation {
+  const cs = language === 'cs'
+  switch (status) {
+    case 'OPEN':
+      return cs
+        ? { label: 'Sbírají se podklady', detail: 'Specialisté teprve přidávají své pohledy a důkazy.' }
+        : { label: 'Gathering inputs', detail: 'Specialists are still adding their views and evidence.' }
+    case 'CONVERGING':
+      return cs
+        ? { label: 'Porovnávají se podklady', detail: 'Koordinátor porovnává příspěvky v jednom vlákně.' }
+        : { label: 'Comparing inputs', detail: 'The coordinator is comparing contributions in one thread.' }
+    case 'CONTESTED':
+      return cs
+        ? { label: 'Neshoda zůstává viditelná', detail: 'Příspěvky si odporují; systém ji neskrývá ani nepředstírá shodu.' }
+        : { label: 'Dissent remains visible', detail: 'Inputs conflict; the system neither hides it nor pretends there is agreement.' }
+    case 'SYNTHESIZED':
+      return cs
+        ? { label: 'Návrh je ve vlákně', detail: 'Vlákno zaznamenává návrh; stav doručení ani lidského rozhodnutí zde není.' }
+        : { label: 'A proposal is in the thread', detail: 'The thread records a proposal; delivery and the human decision are not shown here.' }
+    case 'CLOSED':
+      return cs
+        ? { label: 'Vlákno je uzavřené', detail: 'Koordinační vlákno už nepřijímá další příspěvky.' }
+        : { label: 'The thread is closed', detail: 'The coordination thread is no longer taking contributions.' }
+  }
+}

--- a/openbank-admin-ui/src/test/case-status-presentation.test.ts
+++ b/openbank-admin-ui/src/test/case-status-presentation.test.ts
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+import { describe, expect, it } from 'vitest'
+import { CASE_STATUSES, caseStatusPresentation } from '@/lib/governance/caseStatusPresentation'
+
+describe('case status presentation', () => {
+  it('turns every technical case status into a business-readable stage', () => {
+    expect(CASE_STATUSES.map(status => caseStatusPresentation(status, 'en').label)).toEqual([
+      'Gathering inputs',
+      'Comparing inputs',
+      'Dissent remains visible',
+      'A proposal is in the thread',
+      'The thread is closed',
+    ])
+  })
+
+  it('keeps a synthesized case truthful about what the thread does not establish', () => {
+    const presentation = caseStatusPresentation('SYNTHESIZED', 'en')
+
+    expect(presentation.detail).toContain('delivery and the human decision are not shown')
+    expect(presentation.detail).not.toContain('approved')
+  })
+})

--- a/openbank-admin-ui/src/test/iaops-case-list-page.test.tsx
+++ b/openbank-admin-ui/src/test/iaops-case-list-page.test.tsx
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import IaopsCasesPage from '@/app/iaops/cases/page'
+
+vi.mock('@/lib/i18n/LanguageContext', () => ({
+  useLanguage: () => ({ language: 'en', t: (_cs: string, en: string) => en }),
+}))
+vi.mock('@/components/feedback/DataUnavailable', () => ({ DataUnavailable: () => null }))
+
+afterEach(() => vi.unstubAllGlobals())
+
+describe('AIOps case list', () => {
+  it('explains a synthesized thread as a recorded proposal, not an approval outcome', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        available: true,
+        cases: [{
+          caseId: 'case-17', caseClass: 'ALERT_REVIEW', dispositionTarget: 'operator', status: 'SYNTHESIZED',
+          openedAtEpochMs: 1_700_000_000_000, deadlineAtEpochMs: 1_700_000_600_000, contestedRate: 0, contributionCount: 2,
+        }],
+      }),
+    }))
+
+    render(<IaopsCasesPage />)
+
+    expect(await screen.findByText('A proposal is in the thread')).toBeInTheDocument()
+    expect(screen.getByText('The thread records a proposal; delivery and the human decision are not shown here.')).toBeInTheDocument()
+    expect(screen.queryByText('Synthesized')).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
Closes #5252

Turns technical swarm case states into one shared business-readable journey in the list and detail. The proposal stage explicitly remains a thread fact, not a delivery or approval claim.