### PR TITLE
fix(admin-ui): localize fraud review queue

### DIFF
--- a/openbank-admin-ui/src/app/fraud/page.tsx
+++ b/openbank-admin-ui/src/app/fraud/page.tsx
@@ -36,6 +36,7 @@ function scoreTone(score: number): Tone {
 
 export default function FraudPage() {
   const { t, language } = useLanguage()
+  const numberLocale = language === 'cs' ? 'cs-CZ' : 'en-GB'
   const [rows, setRows] = useState<ScoredRecord[]>([])
   const [loading, setLoading] = useState(true)
   const [unavailable, setUnavailable] = useState<{ kind: UnavailableKind } | null>(null)
@@ -71,9 +72,9 @@ export default function FraudPage() {
           'Platby označené enginem jako REVIEW. Rozhodnutí zůstává ve čtyřočkovém compliance toku.',
           'Payments flagged REVIEW by the engine. Resolution remains in the four-eyes compliance flow.',
         )}
-        icon={<ShieldAlert size={20} style={{ color: 'var(--accent)' }} />}
+        icon={<ShieldAlert size={20} aria-hidden="true" style={{ color: 'var(--accent)' }} />}
         actions={<button onClick={load} disabled={loading} className="btn btn-secondary btn-sm">
-          <RefreshCw size={14} className={loading ? 'animate-spin' : ''} /> {t('Obnovit', 'Refresh')}
+          <RefreshCw size={14} aria-hidden="true" className={loading ? 'animate-spin' : ''} /> {t('Obnovit', 'Refresh')}
         </button>}
       />
 
@@ -102,7 +103,7 @@ export default function FraudPage() {
               return (
                 <tr key={r.scoreId} style={{ borderTop: '1px solid var(--border)' }}>
                   <td style={{ padding: '10px 14px', fontWeight: 700 }}>
-                    {r.amount.toLocaleString('cs-CZ')} {r.currency}
+                    {r.amount.toLocaleString(numberLocale)} {r.currency}
                   </td>
                   <td style={{ padding: '10px 14px' }}><span className="pill">{r.rail}</span></td>
                   <td style={{ padding: '10px 14px', fontFamily: 'var(--font-mono)', fontSize: 11, color: 'var(--text-secondary)' }}>
@@ -115,7 +116,7 @@ export default function FraudPage() {
                     {r.ruleVersion}
                   </td>
                   <td style={{ padding: '10px 14px', color: 'var(--text-tertiary)', fontSize: 12 }}>
-                    {new Date(r.createdAt).toLocaleString()}
+                    {new Date(r.createdAt).toLocaleString(numberLocale)}
                   </td>
                 </tr>
               )

--- a/openbank-admin-ui/src/test/fraud-localization-a11y.guard.test.ts
+++ b/openbank-admin-ui/src/test/fraud-localization-a11y.guard.test.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const page = readFileSync(path.resolve(__dirname, '../app/fraud/page.tsx'), 'utf8')
+
+describe('fraud queue presentation', () => {
+  it('uses the active operator locale for money and timestamps', () => {
+    expect(page).toContain("const numberLocale = language === 'cs' ? 'cs-CZ' : 'en-GB'")
+    expect(page).toContain('r.amount.toLocaleString(numberLocale)')
+    expect(page).toContain('new Date(r.createdAt).toLocaleString(numberLocale)')
+  })
+
+  it('hides decorative icons while retaining their button text', () => {
+    expect(page).toContain('<ShieldAlert size={20} aria-hidden="true"')
+    expect(page).toContain('<RefreshCw size={14} aria-hidden="true"')
+  })
+})


### PR DESCRIPTION
## Summary
- format fraud queue amounts and timestamps in the active operator locale
- hide decorative header/action icons from assistive technology
- add a focused regression guard

## Validation
- npm test -- fraud-localization-a11y.guard
- npm run type-check
- git diff --check

## Issue
N/A — focused correctness and accessibility maintenance for an existing read-only compliance view.