### PR TITLE
fix(admin-ui): improve operations table accessibility

### DIFF
--- a/openbank-admin-ui/src/app/aml/page.tsx
+++ b/openbank-admin-ui/src/app/aml/page.tsx
@@ -26,6 +26,7 @@ interface AmlCase {
 
 export default function AmlPage() {
   const { t, language } = useLanguage()
+  const numberLocale = language === 'cs' ? 'cs-CZ' : 'en-GB'
   const [scanning, setScanning] = useState(false)
   const [search, setSearch] = useState('')
   const { data, loading, unavailable, waking, reload } = useServiceResource<AmlCase[]>(
@@ -113,8 +114,9 @@ export default function AmlPage() {
         <div className="card">
           <div style={{ padding: '16px 20px', borderBottom: '1px solid var(--border)', display: 'flex', gap: '10px', alignItems: 'center' }}>
             <div style={{ position: 'relative', flex: 1 }}>
-              <Search size={13} style={{ position: 'absolute', left: '10px', top: '50%', transform: 'translateY(-50%)', color: 'var(--text-tertiary)' }} />
+              <Search size={13} aria-hidden="true" style={{ position: 'absolute', left: '10px', top: '50%', transform: 'translateY(-50%)', color: 'var(--text-tertiary)' }} />
               <input value={search} onChange={e => setSearch(e.target.value)} placeholder={t('Hledat jméno klienta, status, úroveň rizika…', 'Search customer name, status, risk level…')}
+                aria-label={t('Hledat AML případy', 'Search AML cases')}
                 style={{ width: '100%', paddingLeft: '30px', paddingRight: '12px', height: '32px', borderRadius: '6px',
                   border: '1px solid var(--border)', fontSize: '13px', background: 'var(--surface-2)', color: 'var(--text-primary)', outline: 'none' }} />
             </div>
@@ -171,7 +173,7 @@ export default function AmlPage() {
                     <td style={{ padding: '12px 16px' }}>
                       <StatusBadge status={c.status} label={c.status.replace('_', ' ')} />
                     </td>
-                    <td style={{ padding: '12px 16px', fontSize: '12px', color: 'var(--text-tertiary)' }}>{c.timestamp ? new Date(c.timestamp).toLocaleString('cs-CZ') : '—'}</td>
+                    <td style={{ padding: '12px 16px', fontSize: '12px', color: 'var(--text-tertiary)' }}>{c.timestamp ? new Date(c.timestamp).toLocaleString(numberLocale) : '—'}</td>
                   </tr>
                 )
               })}</tbody>

--- a/openbank-admin-ui/src/app/clearing/page.tsx
+++ b/openbank-admin-ui/src/app/clearing/page.tsx
@@ -22,6 +22,7 @@ interface ClearingBatch {
 
 export default function ClearingPage() {
   const { t, language } = useLanguage()
+  const numberLocale = language === 'cs' ? 'cs-CZ' : 'en-GB'
   const [search, setSearch] = useState('')
   const { data, loading, unavailable, waking } = useServiceResource<ClearingBatch[]>(
     svcUrl('clearing-service', '/api/v1/clearing/batches'),
@@ -62,18 +63,19 @@ export default function ClearingPage() {
 
         <div className="grid-4" style={{ marginBottom: '24px' }}>
           {[
-            { label: t('Dávky celkem', 'Total batches'), value: batches.length, icon: <Layers size={16} /> },
-            { label: t('Vypořádáno', 'Settled'), value: settled.length, icon: <CheckCircle2 size={16} />, tone: 'success' as const },
-            { label: t('Čeká / Zpracovává', 'Pending / Processing'), value: pending.length, icon: <Clock size={16} />, tone: 'warning' as const },
-            { label: t('Objem (EUR)', 'Volume (EUR)'), value: totalVolume.toLocaleString('cs-CZ', { maximumFractionDigits: 0 }), icon: <Banknote size={16} /> },
+            { label: t('Dávky celkem', 'Total batches'), value: batches.length, icon: <Layers size={16} aria-hidden="true" /> },
+            { label: t('Vypořádáno', 'Settled'), value: settled.length, icon: <CheckCircle2 size={16} aria-hidden="true" />, tone: 'success' as const },
+            { label: t('Čeká / Zpracovává', 'Pending / Processing'), value: pending.length, icon: <Clock size={16} aria-hidden="true" />, tone: 'warning' as const },
+            { label: t('Objem (EUR)', 'Volume (EUR)'), value: totalVolume.toLocaleString(numberLocale, { maximumFractionDigits: 0 }), icon: <Banknote size={16} aria-hidden="true" /> },
           ].map(k => <StatCard key={k.label} label={k.label} value={k.value} icon={k.icon} tone={k.tone} />)}
         </div>
 
         <div className="card">
           <div style={{ padding: '16px 20px', borderBottom: '1px solid var(--border)', display: 'flex', gap: '10px', alignItems: 'center' }}>
             <div style={{ position: 'relative', flex: 1 }}>
-              <Search size={13} style={{ position: 'absolute', left: '10px', top: '50%', transform: 'translateY(-50%)', color: 'var(--text-tertiary)' }} />
+              <Search size={13} aria-hidden="true" style={{ position: 'absolute', left: '10px', top: '50%', transform: 'translateY(-50%)', color: 'var(--text-tertiary)' }} />
               <input value={search} onChange={e => setSearch(e.target.value)} placeholder={t('Hledat referenci, rail, status…', 'Search reference, rail, status…')}
+                aria-label={t('Hledat clearing dávky', 'Search clearing batches')}
                 style={{ width: '100%', paddingLeft: '30px', paddingRight: '12px', height: '32px', borderRadius: '6px',
                   border: '1px solid var(--border)', fontSize: '13px', background: 'var(--surface-2)', color: 'var(--text-primary)', outline: 'none' }} />
             </div>
@@ -104,10 +106,10 @@ export default function ClearingPage() {
                     <td style={{ padding: '12px 16px', fontSize: '13px', fontWeight: 600, color: 'var(--text-primary)', fontFamily: 'var(--font-mono)' }}>{b.batchReference}</td>
                     <td style={{ padding: '12px 16px', fontSize: '12px', color: 'var(--text-secondary)' }}>{b.paymentRail}</td>
                     <td style={{ padding: '12px 16px', fontSize: '13px', color: 'var(--text-primary)' }}>{b.itemCount}</td>
-                    <td style={{ padding: '12px 16px', fontSize: '13px', fontWeight: 600, color: 'var(--text-primary)' }}>{(b.totalAmount ?? 0).toLocaleString('cs-CZ', { minimumFractionDigits: 2 })}</td>
+                    <td style={{ padding: '12px 16px', fontSize: '13px', fontWeight: 600, color: 'var(--text-primary)' }}>{(b.totalAmount ?? 0).toLocaleString(numberLocale, { minimumFractionDigits: 2 })}</td>
                     <td style={{ padding: '12px 16px', fontSize: '12px', color: 'var(--text-secondary)' }}>{b.currency}</td>
                     <td style={{ padding: '12px 16px' }}><StatusBadge status={b.status} tone={b.status === 'FAILED' ? 'danger' : b.status === 'SETTLED' ? 'success' : 'warning'} /></td>
-                    <td style={{ padding: '12px 16px', fontSize: '12px', color: 'var(--text-tertiary)' }}>{b.createdAt ? new Date(b.createdAt).toLocaleString('cs-CZ') : '—'}</td>
+                    <td style={{ padding: '12px 16px', fontSize: '12px', color: 'var(--text-tertiary)' }}>{b.createdAt ? new Date(b.createdAt).toLocaleString(numberLocale) : '—'}</td>
                   </tr>
                 )
               })}</tbody>

--- a/openbank-admin-ui/src/app/disputes/page.tsx
+++ b/openbank-admin-ui/src/app/disputes/page.tsx
@@ -21,6 +21,7 @@ interface Dispute {
 
 export default function DisputesPage() {
   const { t, language } = useLanguage()
+  const numberLocale = language === 'cs' ? 'cs-CZ' : 'en-GB'
   const [search, setSearch] = useState('')
   const { data, loading, unavailable, waking } = useServiceResource<Dispute[]>(
     svcUrl('dispute-service', '/api/v1/disputes'),
@@ -95,8 +96,8 @@ export default function DisputesPage() {
         <div className="card">
           <div style={{ padding: '16px 20px', borderBottom: '1px solid var(--border)', display: 'flex', gap: '10px', alignItems: 'center' }}>
             <div style={{ position: 'relative', flex: 1 }}>
-              <Search size={13} style={{ position: 'absolute', left: '10px', top: '50%', transform: 'translateY(-50%)', color: 'var(--text-tertiary)' }} />
-              <input value={search} onChange={e => setSearch(e.target.value)} placeholder={t('Hledat referenci, typ, status…', 'Search reference, type, status…')} className="input" style={{ paddingLeft: '30px', height: '32px' }} />
+              <Search size={13} aria-hidden="true" style={{ position: 'absolute', left: '10px', top: '50%', transform: 'translateY(-50%)', color: 'var(--text-tertiary)' }} />
+              <input value={search} onChange={e => setSearch(e.target.value)} placeholder={t('Hledat referenci, typ, status…', 'Search reference, type, status…')} aria-label={t('Hledat spory', 'Search disputes')} className="input" style={{ paddingLeft: '30px', height: '32px' }} />
             </div>
           </div>
           {loading ? (
@@ -124,13 +125,13 @@ export default function DisputesPage() {
                     <td style={{ color: 'var(--text-secondary)' }}>{d.disputeType}</td>
                     <td className="mono" style={{ fontSize: '11px', color: 'var(--text-tertiary)' }}>{d.transactionId?.slice(0, 8)}…</td>
                     <td style={{ fontWeight: 600 }}>
-                      {(d.amount ?? 0).toLocaleString('cs-CZ', { minimumFractionDigits: 2 })} {d.currency}
+                      {(d.amount ?? 0).toLocaleString(numberLocale, { minimumFractionDigits: 2 })} {d.currency}
                     </td>
                     <td>
                       <StatusBadge status={d.status} />
                     </td>
                     <td>{slaStatus(d.slaDeadline, d.status)}</td>
-                    <td style={{ color: 'var(--text-tertiary)' }}>{d.createdAt ? new Date(d.createdAt).toLocaleString('cs-CZ') : '—'}</td>
+                    <td style={{ color: 'var(--text-tertiary)' }}>{d.createdAt ? new Date(d.createdAt).toLocaleString(numberLocale) : '—'}</td>
                   </tr>
                 ))}</tbody>
               </table>

--- a/openbank-admin-ui/src/app/fees/page.tsx
+++ b/openbank-admin-ui/src/app/fees/page.tsx
@@ -44,6 +44,7 @@ const STATUS_COLOR: Record<string, string> = {
 
 export default function FeesPage() {
   const { t, language } = useLanguage()
+  const numberLocale = language === 'cs' ? 'cs-CZ' : 'en-GB'
   const [fees, setFees] = useState<FeeScheduleItem[]>([])
   const [loading, setLoading] = useState(true)
   // Typed unavailable reason → renders the calm <DataUnavailable> panel instead
@@ -113,7 +114,7 @@ export default function FeesPage() {
           subtitle={t('Ceník poplatků ze service product-catalog', 'Fee schedule served by the product-catalog service')}
           actions={<div className="flex gap-2">
             <button className="btn btn-secondary" onClick={() => void load()} disabled={loading}>
-              <RefreshCw size={14} style={loading ? { animation: 'spin 1s linear infinite' } : undefined} />
+              <RefreshCw size={14} aria-hidden="true" style={loading ? { animation: 'spin 1s linear infinite' } : undefined} />
               {t('Obnovit', 'Refresh')}
             </button>
           </div>}
@@ -127,18 +128,19 @@ export default function FeesPage() {
 
         <div style={{ display: 'flex', gap: '10px', marginBottom: '16px', flexWrap: 'wrap' }}>
           <div style={{ position: 'relative', flex: 1, minWidth: '250px', maxWidth: '320px' }}>
-            <Search size={14} style={{ position: 'absolute', left: '10px', top: '50%', transform: 'translateY(-50%)', color: 'var(--text-muted)' }} />
+            <Search size={14} aria-hidden="true" style={{ position: 'absolute', left: '10px', top: '50%', transform: 'translateY(-50%)', color: 'var(--text-muted)' }} />
             <input
               className="input"
               style={{ paddingLeft: '32px', width: '100%' }}
               placeholder={t('Hledat kód, název, produkt…', 'Search code, name, product…')}
+              aria-label={t('Hledat v ceníku poplatků', 'Search fee schedule')}
               value={search}
               onChange={e => setSearch(e.target.value)}
             />
           </div>
           <div style={{ display: 'flex', gap: '4px', alignItems: 'center' }}>
             <span style={{ fontSize: '12px', color: 'var(--text-muted)', marginRight: '4px' }}>{t('Typ', 'Type')}:</span>
-            <select className="input" style={{ width: 'auto', padding: '6px 12px' }} value={typeFilter} onChange={(e) => setTypeFilter(e.target.value)}>
+            <select className="input" aria-label={t('Typ poplatku', 'Fee type')} style={{ width: 'auto', padding: '6px 12px' }} value={typeFilter} onChange={(e) => setTypeFilter(e.target.value)}>
               <option value="ALL">{t('Všechny', 'All')}</option>
               {uniqueTypes.map(typ => <option key={typ} value={typ}>{typ}</option>)}
             </select>
@@ -208,7 +210,7 @@ export default function FeesPage() {
                   </td>
                   <td><span className="tag" style={{ color: 'var(--accent)' }}>{fee.type}</span></td>
                   <td style={{ fontFamily: 'var(--font-mono)' }}>
-                    {fee.amount.toLocaleString('cs-CZ', { minimumFractionDigits: 2 })}
+                    {fee.amount.toLocaleString(numberLocale, { minimumFractionDigits: 2 })}
                   </td>
                   <td style={{ fontFamily: 'var(--font-mono)', fontSize: '12px' }}>{fee.currency}</td>
                   <td style={{ fontSize: '12px', color: 'var(--text-muted)' }}>{fee.frequency}</td>

--- a/openbank-admin-ui/src/app/standing-orders/page.tsx
+++ b/openbank-admin-ui/src/app/standing-orders/page.tsx
@@ -25,6 +25,7 @@ const FREQ_LABELS: Record<string, string> = {
 
 export default function StandingOrdersPage() {
   const { t, language } = useLanguage()
+  const numberLocale = language === 'cs' ? 'cs-CZ' : 'en-GB'
   const [search, setSearch] = useState('')
   // standing-order-service is on the FinOps off-hours scaledown allowlist, so it
   // legitimately sits at zero replicas overnight/weekends. Route through the BFF
@@ -67,10 +68,10 @@ export default function StandingOrdersPage() {
 
         <div className="grid-4" style={{ marginBottom: '24px' }}>
           {[
-            { label: t('Celkem příkazů', 'Total orders'), value: orders.length, icon: <Repeat size={16} />, color: 'var(--accent)' },
-            { label: t('Aktivní', 'Active'), value: orders.filter(o => o.status === 'ACTIVE').length, icon: <CheckCircle2 size={16} />, color: 'var(--success)' },
-            { label: t('Pozastavené', 'Suspended'), value: orders.filter(o => o.status === 'SUSPENDED').length, icon: <Clock size={16} />, color: 'var(--warning)' },
-            { label: t('Zrušené', 'Cancelled'), value: orders.filter(o => o.status === 'CANCELLED').length, icon: <XCircle size={16} />, color: 'var(--danger)' },
+            { label: t('Celkem příkazů', 'Total orders'), value: orders.length, icon: <Repeat size={16} aria-hidden="true" />, color: 'var(--accent)' },
+            { label: t('Aktivní', 'Active'), value: orders.filter(o => o.status === 'ACTIVE').length, icon: <CheckCircle2 size={16} aria-hidden="true" />, color: 'var(--success)' },
+            { label: t('Pozastavené', 'Suspended'), value: orders.filter(o => o.status === 'SUSPENDED').length, icon: <Clock size={16} aria-hidden="true" />, color: 'var(--warning)' },
+            { label: t('Zrušené', 'Cancelled'), value: orders.filter(o => o.status === 'CANCELLED').length, icon: <XCircle size={16} aria-hidden="true" />, color: 'var(--danger)' },
           ].map(k => (
             <div key={k.label} className="stat-card">
               <div style={{ width: '32px', height: '32px', borderRadius: '8px', background: `${k.color}18`,
@@ -84,8 +85,9 @@ export default function StandingOrdersPage() {
         <div className="card">
           <div style={{ padding: '16px 20px', borderBottom: '1px solid var(--border)', display: 'flex', gap: '10px', alignItems: 'center' }}>
             <div style={{ position: 'relative', flex: 1 }}>
-              <Search size={13} style={{ position: 'absolute', left: '10px', top: '50%', transform: 'translateY(-50%)', color: 'var(--text-tertiary)' }} />
+              <Search size={13} aria-hidden="true" style={{ position: 'absolute', left: '10px', top: '50%', transform: 'translateY(-50%)', color: 'var(--text-tertiary)' }} />
               <input value={search} onChange={e => setSearch(e.target.value)} placeholder={t('Hledat příkazy…', 'Search orders…')}
+                aria-label={t('Hledat trvalé příkazy', 'Search standing orders')}
                 style={{ width: '100%', paddingLeft: '30px', paddingRight: '12px', height: '32px', borderRadius: '6px',
                   border: '1px solid var(--border)', fontSize: '13px', background: 'var(--surface-2)', color: 'var(--text-primary)', outline: 'none' }} />
             </div>
@@ -114,12 +116,12 @@ export default function StandingOrdersPage() {
                   onMouseLeave={e => (e.currentTarget.style.background = '')}>
                   <td style={{ padding: '12px 16px', fontSize: '13px', fontWeight: 500, color: 'var(--text-primary)' }}>{o.creditorName}</td>
                   <td style={{ padding: '12px 16px', fontFamily: 'var(--font-mono)', fontSize: '13px', color: 'var(--text-primary)' }}>
-                    {o.amount?.toLocaleString('cs-CZ', { minimumFractionDigits: 2 })} {o.currency}
+                    {o.amount?.toLocaleString(numberLocale, { minimumFractionDigits: 2 })} {o.currency}
                   </td>
                   <td style={{ padding: '12px 16px', fontSize: '12px', color: 'var(--text-secondary)' }}>{t(FREQ_LABELS[o.frequency] ?? o.frequency, o.frequency)}</td>
                   <td style={{ padding: '12px 16px', fontSize: '12px', color: 'var(--text-secondary)', display: 'flex', alignItems: 'center', gap: '5px' }}>
-                    <Calendar size={11} style={{ color: 'var(--text-tertiary)' }} />
-                    {o.nextExecutionDate ? new Date(o.nextExecutionDate).toLocaleDateString('cs-CZ') : '—'}
+                    <Calendar size={11} aria-hidden="true" style={{ color: 'var(--text-tertiary)' }} />
+                    {o.nextExecutionDate ? new Date(o.nextExecutionDate).toLocaleDateString(numberLocale) : '—'}
                   </td>
                   <td style={{ padding: '12px 16px' }}>
                     <span style={{ padding: '2px 8px', borderRadius: '10px', fontSize: '11px', fontWeight: 600,

--- a/openbank-admin-ui/src/test/operations-table-accessibility.guard.test.ts
+++ b/openbank-admin-ui/src/test/operations-table-accessibility.guard.test.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const app = path.resolve(__dirname, '../app')
+const routes = ['aml', 'disputes', 'clearing', 'fees', 'standing-orders']
+
+describe('read-only operations tables', () => {
+  it('names their search controls and formats displayed values in the active locale', () => {
+    for (const route of routes) {
+      const page = readFileSync(path.join(app, route, 'page.tsx'), 'utf8')
+      expect(page, route).toContain("const numberLocale = language === 'cs' ? 'cs-CZ' : 'en-GB'")
+      expect(page, route).toContain('aria-label={t(')
+      expect(page, route).toContain('toLocaleString(numberLocale')
+    }
+  })
+
+  it('keeps search illustrations out of the accessibility tree', () => {
+    for (const route of routes) {
+      const page = readFileSync(path.join(app, route, 'page.tsx'), 'utf8')
+      expect(page, route).toContain('<Search size=')
+      expect(page, route).toContain('aria-hidden="true"')
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- format read-only operations tables in the active operator locale
- give search and filtering controls accessible names
- remove decorative icons from the accessibility tree

## Validation
- npm test -- operations-table-accessibility.guard
- npm run type-check
- git diff --check

## Issue
N/A — focused correctness and accessibility maintenance; no workflow, BFF, or RBAC change.