### PR TITLE
fix(admin-ui): improve account search accessibility

### DIFF
--- a/openbank-admin-ui/src/app/accounts/page.tsx
+++ b/openbank-admin-ui/src/app/accounts/page.tsx
@@ -44,6 +44,7 @@ function classifyQuery(raw: string): QueryKind {
 
 export default function AccountsPage() {
   const { t, language } = useLanguage()
+  const numberLocale = language === 'cs' ? 'cs-CZ' : 'en-GB'
   const [query, setQuery]               = useState('')
   const [statusFilter, setStatusFilter] = useState('')
   const [typeFilter, setTypeFilter]     = useState('')
@@ -136,6 +137,7 @@ export default function AccountsPage() {
 
   const visible = filtered.slice(0, visibleCount)
   const hasMore = filtered.length > visibleCount
+  const queryHelpVisible = !ibanHint && !result && !unavailable
 
   return (
     <div>
@@ -160,10 +162,14 @@ export default function AccountsPage() {
         }}>
           <div style={{ display: 'flex', flexWrap: 'wrap', gap: '8px', alignItems: 'center' }}>
             <div style={{ position: 'relative', flex: '1', minWidth: '260px' }}>
-              <Search size={13} style={{ position: 'absolute', left: '10px', top: '50%', transform: 'translateY(-50%)', color: 'var(--text-tertiary)' }} />
+              <Search size={13} aria-hidden="true" style={{ position: 'absolute', left: '10px', top: '50%', transform: 'translateY(-50%)', color: 'var(--text-tertiary)' }} />
               <input
+                id="accounts-query"
                 className="input"
                 style={{ paddingLeft: '30px', width: '100%', ...(ibanHint ? { borderColor: 'var(--danger)' } : {}) }}
+                aria-label={t('Vyhledat účet podle čísla, IBANu nebo Party ID', 'Search accounts by number, IBAN, or Party ID')}
+                aria-describedby={ibanHint ? 'accounts-query-error' : queryHelpVisible ? 'accounts-query-help' : undefined}
+                aria-invalid={Boolean(ibanHint)}
                 placeholder={t('Fragment čísla účtu, IBAN nebo Party ID (UUID)…', 'Account-number fragment, IBAN, or Party ID (UUID)…')}
                 value={query}
                 onChange={e => { setQuery(e.target.value); if (ibanHint) setIbanHint(null) }}
@@ -171,6 +177,7 @@ export default function AccountsPage() {
               />
             </div>
             <select
+              aria-label={t('Filtrovat podle stavu účtu', 'Filter by account status')}
               className="input"
               style={{ width: '150px' }}
               value={statusFilter}
@@ -183,6 +190,7 @@ export default function AccountsPage() {
               <option value="CLOSED">{t('Uzavřený', 'Closed')}</option>
             </select>
             <select
+              aria-label={t('Filtrovat podle typu účtu', 'Filter by account type')}
               className="input"
               style={{ width: '140px' }}
               value={typeFilter}
@@ -197,7 +205,7 @@ export default function AccountsPage() {
               onClick={search}
               disabled={loading || !canSearch}
             >
-              <Search size={13} />
+              <Search size={13} aria-hidden="true" />
               {loading ? t('Hledám…', 'Searching…') : t('Hledat', 'Search')}
             </button>
             <button
@@ -209,17 +217,17 @@ export default function AccountsPage() {
             </button>
             {result && (
               <span style={{ fontSize: '12px', color: 'var(--text-tertiary)', marginLeft: 'auto' }}>
-                <Filter size={11} style={{ display: 'inline', marginRight: '4px' }} />
+                <Filter size={11} aria-hidden="true" style={{ display: 'inline', marginRight: '4px' }} />
                 {t(`${filtered.length} výsledků`, `${filtered.length} result${filtered.length !== 1 ? 's' : ''}`)}
               </span>
             )}
           </div>
           {/* Inline hints — never a raw backend error. */}
           {ibanHint && (
-            <span style={{ fontSize: '11px', color: 'var(--danger)' }}>{ibanHint}</span>
+            <span id="accounts-query-error" role="alert" style={{ fontSize: '11px', color: 'var(--danger)' }}>{ibanHint}</span>
           )}
-          {!ibanHint && !result && !unavailable && (
-            <span style={{ fontSize: '11px', color: 'var(--text-tertiary)' }}>
+          {queryHelpVisible && (
+            <span id="accounts-query-help" style={{ fontSize: '11px', color: 'var(--text-tertiary)' }}>
               {t(
                 'Hledejte podle fragmentu čísla účtu (trigram, ≥2 znaky), přesného IBANu nebo Party ID (UUID). Vyhledávání podle jména/příjmení/rodného čísla vyžaduje party-service (v přípravě, #66–68).',
                 'Search by an account-number fragment (trigram, ≥2 chars), an exact IBAN, or a Party ID (UUID). Search by name / surname / birth number needs party-service (coming soon, #66–68).',
@@ -294,7 +302,7 @@ export default function AccountsPage() {
                     <td><span className="tag">{a.currencyCode}</span></td>
                     <td><StatusBadge status={a.status} /></td>
                     <td><span className="mono" style={{ fontSize: '11px', color: 'var(--text-tertiary)' }}>{a.partyId}</span></td>
-                    <td><span style={{ fontSize: '12px', color: 'var(--text-secondary)' }}>{new Date(a.openedAt).toLocaleDateString('en-GB')}</span></td>
+                    <td><span style={{ fontSize: '12px', color: 'var(--text-secondary)' }}>{new Date(a.openedAt).toLocaleDateString(numberLocale)}</span></td>
                     <td style={{ textAlign: 'right' }}>
                       <Link href={`/accounts/${a.id}`} className="btn btn-ghost" style={{ padding: '4px 10px', fontSize: '12px' }}>
                         {t('Detail', 'View')} →

--- a/openbank-admin-ui/src/test/accounts-list-usability.guard.test.ts
+++ b/openbank-admin-ui/src/test/accounts-list-usability.guard.test.ts
@@ -1,0 +1,22 @@
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const page = readFileSync(path.resolve(__dirname, '../app/accounts/page.tsx'), 'utf8')
+
+describe('accounts list usability', () => {
+  it('keeps the search and filters named, with actionable query feedback', () => {
+    expect(page).toContain("const numberLocale = language === 'cs' ? 'cs-CZ' : 'en-GB'")
+    expect(page).toContain('id="accounts-query"')
+    expect(page).toContain('aria-label={t(')
+    expect(page).toContain('const queryHelpVisible = !ibanHint && !result && !unavailable')
+    expect(page).toContain("aria-describedby={ibanHint ? 'accounts-query-error' : queryHelpVisible ? 'accounts-query-help' : undefined}")
+    expect(page).toContain('id="accounts-query-error" role="alert"')
+  })
+
+  it('uses the active operator locale for account dates and hides decorative icons', () => {
+    expect(page).toContain('toLocaleDateString(numberLocale)')
+    expect(page).toContain('<Search size={13} aria-hidden="true"')
+    expect(page).toContain('<Filter size={11} aria-hidden="true"')
+  })
+})

--- a/openbank-admin-ui/src/test/accounts-list-usability.test.tsx
+++ b/openbank-admin-ui/src/test/accounts-list-usability.test.tsx
@@ -1,0 +1,35 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import React from 'react'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { LanguageProvider } from '@/lib/i18n/LanguageContext'
+import AccountsPage from '@/app/accounts/page'
+
+vi.mock('@/components/auth/AuthGuard', () => ({ Can: ({ children }: { children: React.ReactNode }) => <>{children}</> }))
+
+const account = {
+  id: 'account-1', accountNumber: '1234567890', accountType: 'CURRENT', currencyCode: 'CZK',
+  status: 'ACTIVE', partyId: 'party-1', openedAt: '2026-08-01T12:00:00Z',
+}
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+})
+
+describe('account search accessibility', () => {
+  it('does not leave a dangling help reference after results replace the search guidance', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({ data: [account], pagination: {} }), {
+      status: 200, headers: { 'content-type': 'application/json' },
+    })))
+    render(React.createElement(LanguageProvider, null, React.createElement(AccountsPage)))
+
+    const query = screen.getByLabelText('Search accounts by number, IBAN, or Party ID')
+    expect(query).toHaveAttribute('aria-describedby', 'accounts-query-help')
+    fireEvent.change(query, { target: { value: '12' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Search' }))
+
+    await screen.findByText('1234567890')
+    expect(query).not.toHaveAttribute('aria-describedby')
+    expect(document.getElementById('accounts-query-help')).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary
- Name account-search and filter controls, expose IBAN guidance and errors to assistive technology, and localize rendered account dates.
- Keep account query classification, BFF URLs, pagination, RBAC and account lifecycle actions unchanged.
- Add a focused regression guard.

## Verification
- `npm test -- accounts-list-usability.guard accounts-new-accessibility.guard route-permissions`
- `npm run type-check`
- `git diff --check`

## Linked issues
N/A — isolated UX/accessibility correction in the existing read-only account-search workflow.