### PR TITLE
fix(admin-ui): guard party creation workflow

### DIFF
--- a/openbank-admin-ui/src/app/parties/new/page.tsx
+++ b/openbank-admin-ui/src/app/parties/new/page.tsx
@@ -10,6 +10,7 @@ import Link from 'next/link'
 import { Users, ArrowLeft, Save } from 'lucide-react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { PageHeader } from '@/components/ui/PageHeader'
+import { AuthGuard } from '@/components/auth/AuthGuard'
 
 const PARTY_SERVICE = '/api/svc/party-service'
 
@@ -66,6 +67,7 @@ export default function NewPartyPage() {
   }
 
   return (
+    <AuthGuard permission="parties:create">
     <div>
       <PageHeader
         icon={<Users size={18} aria-hidden="true" />}
@@ -81,37 +83,37 @@ export default function NewPartyPage() {
           <div className="card" style={{ padding: '20px' }}>
             <div style={{ fontWeight: 600, fontSize: '13px', marginBottom: '16px' }}>{t('Identita', 'Identity')}</div>
             <div className="field">
-              <label className="field-label">{t('Typ subjektu *', 'Party Type *')}</label>
-              <select className="input" value={form.partyType} onChange={e => set('partyType', e.target.value)}>
+              <label className="field-label" htmlFor="party-type">{t('Typ subjektu *', 'Party Type *')}</label>
+              <select id="party-type" className="input" value={form.partyType} onChange={e => set('partyType', e.target.value)}>
                 <option value="INDIVIDUAL">{t('Fyzická osoba', 'Individual')}</option>
                 <option value="COMPANY">{t('Společnost', 'Company')}</option>
                 <option value="SOLE_TRADER">{t('Živnostník', 'Sole Trader')}</option>
               </select>
             </div>
             <div className="field">
-              <label className="field-label">{t('Obchodní jméno *', 'Legal Name *')}</label>
-              <input className="input" required value={form.legalName} onChange={e => set('legalName', e.target.value)} placeholder={t('Celé právní jméno', 'Full legal name')} />
+              <label className="field-label" htmlFor="party-legal-name">{t('Obchodní jméno *', 'Legal Name *')}</label>
+              <input id="party-legal-name" className="input" required value={form.legalName} onChange={e => set('legalName', e.target.value)} placeholder={t('Celé právní jméno', 'Full legal name')} />
             </div>
             <div className="field">
-              <label className="field-label">{t('Obchodní název', 'Trading Name')}</label>
-              <input className="input" value={form.tradingName} onChange={e => set('tradingName', e.target.value)} placeholder={t('Nepovinné', 'Optional')} />
+              <label className="field-label" htmlFor="party-trading-name">{t('Obchodní název', 'Trading Name')}</label>
+              <input id="party-trading-name" className="input" value={form.tradingName} onChange={e => set('tradingName', e.target.value)} placeholder={t('Nepovinné', 'Optional')} />
             </div>
             <div className="field">
-              <label className="field-label">{t('DIČ', 'Tax ID')}</label>
-              <input className="input" value={form.taxId} onChange={e => set('taxId', e.target.value)} placeholder="e.g. CZ12345678" />
+              <label className="field-label" htmlFor="party-tax-id">{t('DIČ', 'Tax ID')}</label>
+              <input id="party-tax-id" className="input" value={form.taxId} onChange={e => set('taxId', e.target.value)} placeholder="e.g. CZ12345678" />
             </div>
             <div className="field">
-              <label className="field-label">{t('Registrační číslo', 'Registration Number')}</label>
-              <input className="input" value={form.registrationNumber} onChange={e => set('registrationNumber', e.target.value)} placeholder={t('IČO firmy', 'Company reg. number')} />
+              <label className="field-label" htmlFor="party-registration-number">{t('Registrační číslo', 'Registration Number')}</label>
+              <input id="party-registration-number" className="input" value={form.registrationNumber} onChange={e => set('registrationNumber', e.target.value)} placeholder={t('IČO firmy', 'Company reg. number')} />
             </div>
             {form.partyType === 'INDIVIDUAL' && <>
               <div className="field">
-                <label className="field-label">{t('Státní příslušnost', 'Nationality')}</label>
-                <input className="input" value={form.nationality} onChange={e => set('nationality', e.target.value)} placeholder="e.g. CZ" maxLength={2} />
+                <label className="field-label" htmlFor="party-nationality">{t('Státní příslušnost', 'Nationality')}</label>
+                <input id="party-nationality" className="input" value={form.nationality} onChange={e => set('nationality', e.target.value)} placeholder="e.g. CZ" maxLength={2} />
               </div>
               <div className="field">
-                <label className="field-label">{t('Datum narození', 'Date of Birth')}</label>
-                <input className="input" type="date" value={form.dateOfBirth} onChange={e => set('dateOfBirth', e.target.value)} />
+                <label className="field-label" htmlFor="party-date-of-birth">{t('Datum narození', 'Date of Birth')}</label>
+                <input id="party-date-of-birth" className="input" type="date" value={form.dateOfBirth} onChange={e => set('dateOfBirth', e.target.value)} />
               </div>
             </>}
           </div>
@@ -121,41 +123,41 @@ export default function NewPartyPage() {
             <div className="card" style={{ padding: '20px' }}>
               <div style={{ fontWeight: 600, fontSize: '13px', marginBottom: '16px' }}>{t('Kontakt', 'Contact')}</div>
               <div className="field">
-                <label className="field-label">{t('E-mail *', 'Email *')}</label>
-                <input className="input" type="email" required value={form.email} onChange={e => set('email', e.target.value)} placeholder="email@example.com" />
+                <label className="field-label" htmlFor="party-email">{t('E-mail *', 'Email *')}</label>
+                <input id="party-email" className="input" type="email" required value={form.email} onChange={e => set('email', e.target.value)} placeholder="email@example.com" />
               </div>
               <div className="field">
-                <label className="field-label">{t('Telefon', 'Phone')}</label>
-                <input className="input" value={form.phone} onChange={e => set('phone', e.target.value)} placeholder="+420 123 456 789" />
+                <label className="field-label" htmlFor="party-phone">{t('Telefon', 'Phone')}</label>
+                <input id="party-phone" className="input" value={form.phone} onChange={e => set('phone', e.target.value)} placeholder="+420 123 456 789" />
               </div>
             </div>
 
             <div className="card" style={{ padding: '20px' }}>
               <div style={{ fontWeight: 600, fontSize: '13px', marginBottom: '16px' }}>{t('Adresa', 'Address')}</div>
               <div className="field">
-                <label className="field-label">{t('Ulice', 'Street')}</label>
-                <input className="input" value={form.addressLine1} onChange={e => set('addressLine1', e.target.value)} placeholder={t('Ulice a číslo popisné', 'Street and number')} />
+                <label className="field-label" htmlFor="party-address-line1">{t('Ulice', 'Street')}</label>
+                <input id="party-address-line1" className="input" value={form.addressLine1} onChange={e => set('addressLine1', e.target.value)} placeholder={t('Ulice a číslo popisné', 'Street and number')} />
               </div>
               <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '10px' }}>
                 <div className="field">
-                  <label className="field-label">{t('Město', 'City')}</label>
-                  <input className="input" value={form.addressCity} onChange={e => set('addressCity', e.target.value)} />
+                  <label className="field-label" htmlFor="party-address-city">{t('Město', 'City')}</label>
+                  <input id="party-address-city" className="input" value={form.addressCity} onChange={e => set('addressCity', e.target.value)} />
                 </div>
                 <div className="field">
-                  <label className="field-label">{t('PSČ', 'Postal Code')}</label>
-                  <input className="input" value={form.addressPostal} onChange={e => set('addressPostal', e.target.value)} />
+                  <label className="field-label" htmlFor="party-address-postal">{t('PSČ', 'Postal Code')}</label>
+                  <input id="party-address-postal" className="input" value={form.addressPostal} onChange={e => set('addressPostal', e.target.value)} />
                 </div>
               </div>
               <div className="field">
-                <label className="field-label">{t('Kód země', 'Country Code')}</label>
-                <input className="input" value={form.addressCountry} onChange={e => set('addressCountry', e.target.value)} maxLength={2} placeholder="CZ" />
+                <label className="field-label" htmlFor="party-address-country">{t('Kód země', 'Country Code')}</label>
+                <input id="party-address-country" className="input" value={form.addressCountry} onChange={e => set('addressCountry', e.target.value)} maxLength={2} placeholder="CZ" />
               </div>
             </div>
           </div>
         </div>
 
         {error && (
-          <div className="card" style={{ padding: '12px 16px', color: 'var(--red)', marginTop: '16px', fontSize: '13px' }}>
+          <div className="card" role="alert" style={{ padding: '12px 16px', color: 'var(--red)', marginTop: '16px', fontSize: '13px' }}>
             {error}
           </div>
         )}
@@ -165,11 +167,12 @@ export default function NewPartyPage() {
             {t('Zrušit', 'Cancel')}
           </Link>
           <button type="submit" className="btn btn-primary" disabled={saving}>
-            <Save size={13} />
+            <Save size={13} aria-hidden="true" />
             {saving ? t('Vytvářím…', 'Creating…') : t('Vytvořit subjekt', 'Create Party')}
           </button>
         </div>
       </form>
     </div>
+    </AuthGuard>
   )
 }

--- a/openbank-admin-ui/src/app/parties/page.tsx
+++ b/openbank-admin-ui/src/app/parties/page.tsx
@@ -11,6 +11,7 @@ import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { classifyBffFailure, svcUrl } from '@/lib/services/bff'
 import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
 import { PageHeader } from '@/components/ui/PageHeader'
+import { Can } from '@/components/auth/AuthGuard'
 
 const PAGE_SIZE = 25
 
@@ -155,18 +156,22 @@ export default function PartiesPage() {
             <RefreshCw size={13} aria-hidden="true" style={{ animation: loading ? 'spin 1s linear infinite' : 'none' }} />
             {t('Obnovit', 'Refresh')}
           </button>
-          <Link href="/parties/new" className="btn btn-primary" style={{ display: 'flex', alignItems: 'center', gap: '6px', textDecoration: 'none' }}>
-            <Plus size={13} aria-hidden="true" /> {t('Nový subjekt', 'New Party')}
-          </Link>
+          <Can permission="parties:create">
+            <Link href="/parties/new" className="btn btn-primary" style={{ display: 'flex', alignItems: 'center', gap: '6px', textDecoration: 'none' }}>
+              <Plus size={13} aria-hidden="true" /> {t('Nový subjekt', 'New Party')}
+            </Link>
+          </Can>
         </div>}
       />
 
       {/* Search toolbar */}
       <div style={{ display: 'flex', gap: '10px', marginBottom: '16px', alignItems: 'center' }}>
         <div style={{ position: 'relative', flex: 1, maxWidth: '360px' }}>
-          <Search size={14} style={{ position: 'absolute', left: '10px', top: '50%', transform: 'translateY(-50%)', color: 'var(--text-muted)' }} />
+          <Search size={14} aria-hidden="true" style={{ position: 'absolute', left: '10px', top: '50%', transform: 'translateY(-50%)', color: 'var(--text-muted)' }} />
           <input
+            id="party-search"
             className="input"
+            aria-label={t('Vyhledat subjekt podle jména', 'Search parties by name')}
             style={{ paddingLeft: '32px', width: '100%' }}
             placeholder={t('Hledat podle jména (min. 2 znaky)…', 'Search by name (min. 2 chars)…')}
             value={search}

--- a/openbank-admin-ui/src/lib/auth/roles.ts
+++ b/openbank-admin-ui/src/lib/auth/roles.ts
@@ -58,6 +58,9 @@ export const PERMISSIONS = {
   // KYC_REVIEWER may NOT open. The UI mirrors the backend @RolesAllowed split so a
   // holder of only one KYC role gets exactly their half of the workflow.
   "parties:view":         [ROLES.ADMIN, ROLES.OPERATOR, ROLES.VIEWER, ROLES.COMPLIANCE, ROLES.KYC, ROLES.KYC_OPENER, ROLES.KYC_REVIEWER],
+  // Mirrors party-service POST /api/v1/parties: a viewer may inspect parties but
+  // must never be offered a customer-creation workflow.
+  "parties:create":       [ROLES.ADMIN, ROLES.OPERATOR, ROLES.KYC],
   "parties:edit":         [ROLES.ADMIN, ROLES.OPERATOR, ROLES.COMPLIANCE],
   "kyc:view":             [ROLES.ADMIN, ROLES.OPERATOR, ROLES.COMPLIANCE, ROLES.KYC, ROLES.KYC_OPENER, ROLES.KYC_REVIEWER],
   "kyc:approve":          [ROLES.ADMIN, ROLES.COMPLIANCE, ROLES.KYC_REVIEWER],
@@ -168,6 +171,7 @@ const ROUTE_PREFIXES: ReadonlyArray<readonly [Permission, readonly string[]]> = 
   ['audit:view', ['/audit']],
   ['kyc:view', ['/kyc']],
   ['onboarding:view', ['/onboarding', '/identity-cases']],
+  ['parties:create', ['/parties/new']],
   ['parties:view', ['/parties']],
   ['transactions:view', ['/transactions']],
   ['accounts:create', ['/accounts/new']],

--- a/openbank-admin-ui/src/test/parties-create-accessibility.guard.test.ts
+++ b/openbank-admin-ui/src/test/parties-create-accessibility.guard.test.ts
@@ -1,0 +1,29 @@
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const form = readFileSync(path.resolve(__dirname, '../app/parties/new/page.tsx'), 'utf8')
+const list = readFileSync(path.resolve(__dirname, '../app/parties/page.tsx'), 'utf8')
+const roles = readFileSync(path.resolve(__dirname, '../lib/auth/roles.ts'), 'utf8')
+
+describe('party creation UI', () => {
+  it('matches the party-service creator roles with a specific route and client guard', () => {
+    expect(roles).toContain('"parties:create":       [ROLES.ADMIN, ROLES.OPERATOR, ROLES.KYC]')
+    expect(roles).toContain("['parties:create', ['/parties/new']]")
+    expect(form).toContain('<AuthGuard permission="parties:create">')
+    expect(list).toContain('<Can permission="parties:create">')
+  })
+
+  it('binds all inputs to labels and announces failed submissions', () => {
+    for (const id of [
+      'party-type', 'party-legal-name', 'party-trading-name', 'party-tax-id',
+      'party-registration-number', 'party-nationality', 'party-date-of-birth', 'party-email',
+      'party-phone', 'party-address-line1', 'party-address-city', 'party-address-postal', 'party-address-country',
+    ]) {
+      expect(form).toContain(`htmlFor="${id}"`)
+      expect(form).toContain(`id="${id}"`)
+    }
+    expect(form).toContain('role="alert"')
+    expect(form).toContain('<Save size={13} aria-hidden="true"')
+  })
+})


### PR DESCRIPTION
## Summary\n\nAligns the admin party-creation UI with the exact creator roles enforced by `party-service`, and makes the form accessible to assistive technology.\n\n## Linked issues\n\nCloses #5286\n\n## Verification\n\n- `npm test -- parties-create-accessibility route-permissions roles` — 17/17\n- `npm run type-check`