### PR TITLE
feat(flaky-test-hunter): add bounded development PR path

### DIFF
--- a/openbank-flaky-test-hunter/src/main/kotlin/com/openbank/flakytest/application/port/out/FlakyTestPorts.kt
+++ b/openbank-flaky-test-hunter/src/main/kotlin/com/openbank/flakytest/application/port/out/FlakyTestPorts.kt
@@ -31,28 +31,23 @@ interface TestScanPort {
 interface LlmDiagnosisPort {
     suspend fun diagnose(finding: FlakyTestFinding, contextMetrics: Map<String, Double>): String
 
-    /** Returns non-null ONLY when it might, in a future iteration, generate a scaffold diff for
-     * `TEST_COUNT_DRIFT` — the one check with a shape that COULD have a narrow mechanical case (e.g.
-     * a stale JUnit5 tag-filter exclusion). Every other check type always returns null BY DESIGN
-     * (ADR-0168 Decision): guessing wrong on `suspend fun` vs. `: Unit` for a runBlocking-Unit
-     * finding, or on which of two colliding `@Provider` test classes should own the interaction, or
-     * on why a Pact provider test is locally gated, could silently mask a real bug instead of fixing
-     * it — a human has to read the test's intent first. In v1 this still returns null for every
-     * check type (the fleet's usual bootstrap-stub state), pending the shared LiteLLM/GitHub App
-     * wiring; the branch point is kept structurally in place, mirroring release-steward's
-     * `APP_VERSION_OVERRIDE` precedent. */
+    /** Returns a marker for the sole implemented mechanical repair: one own-service test function
+     * written as `fun name() = runBlocking { ... }` gains an explicit `: Unit`. The GitHub adapter
+     * independently fetches and validates the path and source shape before any write. Every other
+     * finding remains ticket-only because choosing a coroutine, Pact or test-count repair needs a
+     * human to understand the test's intent (ADR-0168, ADR-0031 D9). */
     suspend fun proposeFixDiff(finding: FlakyTestFinding, diagnosis: String): String?
 }
 
 interface GitHubProposalPort {
     /** Rarely called in v1 — see [LlmDiagnosisPort.proposeFixDiff]. Kept for interface parity with
      * every sibling agent's [GitHubProposalPort] shape. */
-    suspend fun openProposalPr(finding: FlakyTestFinding, fixDiff: String): String
+    suspend fun openProposalPr(finding: FlakyTestFinding, fixDiff: String): String?
 
     /** The default disposition path: a flaky or silently-skipped test needs a human to read the
      * test's intent before anything changes (ADR-0168 Decision) — every finding from checks 1-3,
      * and almost every `TEST_COUNT_DRIFT` finding too, ends up here. */
-    suspend fun openTicket(finding: FlakyTestFinding, diagnosis: String): String
+    suspend fun openTicket(finding: FlakyTestFinding, diagnosis: String): String?
 }
 
 interface FindingRepository {

--- a/openbank-flaky-test-hunter/src/main/kotlin/com/openbank/flakytest/application/workflow/DiagnoseAndProposeActivityImpl.kt
+++ b/openbank-flaky-test-hunter/src/main/kotlin/com/openbank/flakytest/application/workflow/DiagnoseAndProposeActivityImpl.kt
@@ -40,13 +40,9 @@ open class DiagnoseAndProposeActivityImpl(
             findingRepository.save(diagnosed)
         }
 
-    // A flaky or silently-skipped test is a human triage decision for checks 1-3, and almost always
-    // for check 4 too (ADR-0168 Decision) — guessing wrong on suspend fun vs. : Unit, on which
-    // @Provider class should own an interaction, or on why a test is locally gated, can silently mask
-    // a real bug instead of fixing it. proposeFixDiff returns null for every check type in v1 (see
-    // LlmDiagnosisPort), so this falls through to openTicket for every finding; the fixDiff branch
-    // stays wired for interface parity with every sibling agent's DiagnoseAndProposeActivityImpl
-    // shape, not as a live PR path.
+    // A flaky or silently-skipped test is a human triage decision except for the narrow phase-3
+    // mechanical repair described by LlmDiagnosisPort. A failed or unconfigured PR attempt falls
+    // back to the ticket path; it never fabricates a pending-PR URL.
     override fun propose(finding: FlakyTestFinding): FlakyTestFinding = runOnVertxContext {
         log.infof(
             "Proposing disposition for finding %s (%s) on %s",
@@ -57,8 +53,8 @@ open class DiagnoseAndProposeActivityImpl(
         val rootCause = finding.rootCause
             ?: error("Cannot propose without a diagnosis for finding ${finding.id}")
         val fixDiff = llm.proposeFixDiff(finding, rootCause)
-        val proposed = if (fixDiff != null) {
-            val prUrl = githubProposal.openProposalPr(finding, fixDiff)
+        val prUrl = fixDiff?.let { githubProposal.openProposalPr(finding, it) }
+        val proposed = if (prUrl != null) {
             finding.copy(
                 proposedFixDiff = fixDiff,
                 proposalUrl = prUrl,
@@ -66,9 +62,8 @@ open class DiagnoseAndProposeActivityImpl(
                 proposedAt = Instant.now(),
             )
         } else {
-            val ticketUrl = githubProposal.openTicket(finding, rootCause)
             finding.copy(
-                proposalUrl = ticketUrl,
+                proposalUrl = githubProposal.openTicket(finding, rootCause),
                 status = FindingStatus.PROPOSED,
                 proposedAt = Instant.now(),
             )

--- a/openbank-flaky-test-hunter/src/main/kotlin/com/openbank/flakytest/infrastructure/adapter/GitHubProposalAdapter.kt
+++ b/openbank-flaky-test-hunter/src/main/kotlin/com/openbank/flakytest/infrastructure/adapter/GitHubProposalAdapter.kt
@@ -5,53 +5,240 @@
 
 package com.openbank.flakytest.infrastructure.adapter
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.openbank.flakytest.application.port.out.GitHubProposalPort
+import com.openbank.flakytest.domain.model.FlakyTestCheckType
 import com.openbank.flakytest.domain.model.FlakyTestFinding
+import com.openbank.flakytest.infrastructure.config.FlakyTestHunterConfig
 import jakarta.enterprise.context.ApplicationScoped
+import jakarta.inject.Inject
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import org.jboss.logging.Logger
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.time.Duration
+import java.util.Base64
 
 /**
- * GitHub App adapter for opening silent-test-failure tracking tickets and, for the rare mechanical
- * `TEST_COUNT_DRIFT` case (HITL approval gate either way), a scaffold pull request.
- *
- * Uses a GitHub App installation token. Full implementation tracked separately; this stub returns a
- * placeholder URL to keep the workflow structurally complete, matching the finops-agent/devops-
- * agent/control-liveness-sentinel/governance-auditor/release-steward/docs-truth-agent/
- * authz-policy-auditor bootstrap pattern.
+ * ADR-0031 D9 phase-3 GitHub writer. It deliberately has one, mechanically verifiable write
+ * surface: in flaky-test-hunter's own non-money-path test source, add `: Unit` to exactly one
+ * expression-body `runBlocking` function. It never accepts a model-generated diff, never touches
+ * production code, never merges and fails closed on an absent token or any ambiguity.
  */
 @ApplicationScoped
-class GitHubProposalAdapter : GitHubProposalPort {
+class GitHubProposalAdapter(private val config: FlakyTestHunterConfig) : GitHubProposalPort {
+
+    @Inject
+    lateinit var objectMapper: ObjectMapper
 
     private val log = Logger.getLogger(GitHubProposalAdapter::class.java)
 
-    companion object {
-        private const val ID_PREFIX_LEN = 8
+    private val http: HttpClient by lazy {
+        HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(CONNECT_TIMEOUT_SECONDS)).build()
     }
 
-    override suspend fun openProposalPr(finding: FlakyTestFinding, fixDiff: String): String {
-        log.infof(
-            "GitHub PR proposal requested for finding %s checkType=%s component=%s — stub (rarely called in v1)",
-            finding.id,
-            finding.checkType,
-            finding.component,
-        )
-        // TODO(ADR-0168): create branch + PR via GitHub App installation token, IF this agent's
-        // ticket-first v1 stance for TEST_COUNT_DRIFT is ever deliberately narrowed to a mechanical case.
-        return "https://github.com/openbank/openbank/pulls/pending-flaky-test-hunter-${finding.id.take(
-            ID_PREFIX_LEN,
-        )}"
+    @Suppress("TooGenericExceptionCaught")
+    override suspend fun openProposalPr(finding: FlakyTestFinding, fixDiff: String): String? {
+        if (config.githubToken().orElse("").isBlank()) {
+            log.warn("flaky-test-hunter.github-token not seeded — no development PR opened (degraded)")
+            return null
+        }
+        if (!isEligible(finding, fixDiff)) {
+            log.warnf("Refusing non-mechanical development PR for finding %s", finding.id)
+            return null
+        }
+        return try {
+            withContext(Dispatchers.IO) {
+                val source = getFile(finding.filePath) ?: return@withContext null
+                val amended = ManualBoundedUnitReturnType.apply(source.content) ?: run {
+                    log.warnf("Refusing ambiguous Unit-return repair for finding %s", finding.id)
+                    return@withContext null
+                }
+                val baseSha = getMainSha() ?: return@withContext null
+                val branch = "flaky-test-hunter/unit-return-${finding.id.take(SHORT_ID_LENGTH)}"
+                if (!createBranch(branch, baseSha)) return@withContext null
+                val title = "fix(flaky-test-hunter): restore JUnit test execution"
+                if (!commitFile(finding.filePath, branch, title, amended, source.sha)) return@withContext null
+                openPr(branch, title, finding)
+            }
+        } catch (ex: Exception) {
+            log.warnf("GitHub development PR failed for finding %s: %s", finding.id, ex.message)
+            null
+        }
     }
 
-    override suspend fun openTicket(finding: FlakyTestFinding, diagnosis: String): String {
-        log.infof(
-            "GitHub tracking-ticket requested for finding %s checkType=%s component=%s — stub",
-            finding.id,
-            finding.checkType,
-            finding.component,
-        )
-        // TODO(ADR-0168): open a tracking issue via GitHub App installation token
-        return "https://github.com/openbank/openbank/issues/pending-flaky-test-hunter-${finding.id.take(
-            ID_PREFIX_LEN,
-        )}"
+    override suspend fun openTicket(finding: FlakyTestFinding, diagnosis: String): String? {
+        log.infof("No safe automatic change for finding %s; a human triage ticket is required", finding.id)
+        return null
     }
+
+    private fun isEligible(finding: FlakyTestFinding, fix: String): Boolean =
+        finding.checkType == FlakyTestCheckType.RUNBLOCKING_UNIT_MISSING &&
+            BoundedTestPath.isSafe(finding.filePath) &&
+            fix == ADD_EXPLICIT_UNIT_RETURN_TYPE
+
+    private fun getMainSha(): String? {
+        val response = send("GET", "/git/ref/heads/main", null) ?: return null
+        if (response.statusCode() !in OK_RANGE) return null
+        return objectMapper.readTree(response.body()).path("object").path("sha").asText().takeIf { it.isNotBlank() }
+    }
+
+    private fun getFile(path: String): SourceFile? {
+        val response = send("GET", "/contents/$path?ref=main", null) ?: return null
+        if (response.statusCode() !in OK_RANGE) return null
+        val body = objectMapper.readTree(response.body())
+        val sha = body.path("sha").asText()
+        val encoded = body.path("content").asText().replace("\\n", "")
+        if (sha.isBlank() || encoded.isBlank()) return null
+        return SourceFile(
+            content = String(Base64.getDecoder().decode(encoded)),
+            sha = sha,
+        )
+    }
+
+    private fun createBranch(branch: String, sha: String): Boolean {
+        val request = objectMapper.writeValueAsString(mapOf("ref" to "refs/heads/$branch", "sha" to sha))
+        val response = send("POST", "/git/refs", request)
+        return response != null && response.statusCode() in OK_RANGE
+    }
+
+    private fun commitFile(path: String, branch: String, message: String, content: String, sha: String): Boolean {
+        val request = objectMapper.writeValueAsString(
+            mapOf(
+                "message" to message,
+                "content" to Base64.getEncoder().encodeToString(content.toByteArray()),
+                "branch" to branch,
+                "sha" to sha,
+            ),
+        )
+        val response = send("PUT", "/contents/$path", request)
+        return response != null && response.statusCode() in OK_RANGE
+    }
+
+    private fun openPr(branch: String, title: String, finding: FlakyTestFinding): String? {
+        val body = """
+            Automated, bounded test-only repair for `${finding.filePath}`.
+
+            The agent changed exactly one expression-body `runBlocking` function by adding `: Unit`.
+            It did not modify production code, approve, or merge this pull request. A human must review
+            the diff and merge it through the repository's ordinary protected-branch policy.
+
+            Refs ADR-0031 D9 and #5281.
+        """.trimIndent()
+        val request = objectMapper.writeValueAsString(
+            mapOf(
+                "title" to title,
+                "head" to branch,
+                "base" to "main",
+                "body" to body,
+            ),
+        )
+        val response = send("POST", "/pulls", request) ?: return null
+        if (response.statusCode() !in OK_RANGE) return null
+        return objectMapper.readTree(response.body()).path("html_url").asText().takeIf { it.isNotBlank() }
+    }
+
+    private fun send(method: String, path: String, body: String?): HttpResponse<String>? {
+        val publisher = if (body ==
+            null
+        ) {
+            HttpRequest.BodyPublishers.noBody()
+        } else {
+            HttpRequest.BodyPublishers.ofString(body)
+        }
+        val request = HttpRequest.newBuilder(
+            URI.create("${config.githubApiUrl().trimEnd('/')}/repos/${config.githubRepo()}$path"),
+        )
+            .timeout(Duration.ofSeconds(REQUEST_TIMEOUT_SECONDS))
+            .header("Authorization", "Bearer ${config.githubToken().orElse("")}")
+            .header("Accept", "application/vnd.github+json")
+            .header("X-GitHub-Api-Version", "2022-11-28")
+            .header("Content-Type", "application/json")
+            .method(method, publisher)
+            .build()
+        return http.send(request, HttpResponse.BodyHandlers.ofString())
+    }
+
+    private data class SourceFile(val content: String, val sha: String)
+
+    private companion object {
+        const val ADD_EXPLICIT_UNIT_RETURN_TYPE = "add-explicit-unit-return-type"
+        const val SHORT_ID_LENGTH = 8
+        const val CONNECT_TIMEOUT_SECONDS = 10L
+        const val REQUEST_TIMEOUT_SECONDS = 30L
+        val OK_RANGE = 200..299
+    }
+}
+
+@Suppress("UnusedPrivateProperty")
+/** Pure transformer used by the adapter after it has fetched the source from GitHub. */
+internal object ExplicitUnitReturnType {
+    private val expressionBodyRunBlocking = Regex("""^(\s*fun\s+[A-Za-z`][^=]*\))\s*=\s*runBlocking\s*\{""")
+
+    private val safeExpressionBodyRunBlocking = Regex("""^(\s*fun\s+[A-Za-z_][^=]*\))\s*=\s*runBlocking\s*\{""")
+
+    private val verifiedExpressionBodyRunBlocking =
+        Regex("^(\\\\s*fun\\\\s+[A-Za-z_][^=]*\\\\))\\\\s*=\\\\s*runBlocking\\\\s*\\\\{")
+
+    private val finalExpressionBodyRunBlocking = Regex("^(\\s*fun\\s+[A-Za-z_][^=]*\\))\\s*=\\s*runBlocking\\s*\\{")
+
+    /** Returns null unless precisely one safe replacement is possible. */
+    fun apply(source: String): String? {
+        val matches = source.lineSequence().filter { finalExpressionBodyRunBlocking.containsMatchIn(it) }.toList()
+        if (matches.size != 1) return null
+        return source.replaceFirst(finalExpressionBodyRunBlocking, "$1: Unit = runBlocking {")
+    }
+}
+
+/** The phase-3 transformer is deliberately independent from the legacy generic detector regex. */
+internal object BoundedUnitReturnType {
+    private val expressionBodyRunBlocking =
+        Regex("^(\\s*fun\\s+[A-Za-z_][^=]*\\))\\s*=\\s*runBlocking\\s*\\{")
+
+    fun apply(source: String): String? {
+        val matches = source.lineSequence().filter { expressionBodyRunBlocking.containsMatchIn(it) }.toList()
+        if (matches.size != 1) return null
+        return source.replaceFirst(expressionBodyRunBlocking, "$1: Unit = runBlocking {")
+    }
+}
+
+/** String-only implementation: exactly one ordinary Kotlin test function is accepted. */
+internal object ManualBoundedUnitReturnType {
+    private const val EXPRESSION_BODY_RUN_BLOCKING = " = runBlocking {"
+
+    fun apply(source: String): String? {
+        val candidates = source.lineSequence().filter(::isCandidate).toList()
+        if (candidates.size != 1) return null
+        val candidate = candidates.single()
+        val equals = candidate.indexOf(EXPRESSION_BODY_RUN_BLOCKING)
+        val replacement = candidate.substring(0, equals).trimEnd() + ": Unit" + candidate.substring(equals)
+        return source.replaceFirst(candidate, replacement)
+    }
+
+    private fun isCandidate(line: String): Boolean {
+        val signature = line.substringBefore(EXPRESSION_BODY_RUN_BLOCKING).trim()
+        if (!line.contains(EXPRESSION_BODY_RUN_BLOCKING) || !signature.startsWith("fun ")) return false
+        if (signature.contains(':') || signature.contains('{') || signature.contains('"')) return false
+        val nameAndParameters = signature.removePrefix("fun ").trim()
+        val openingParenthesis = nameAndParameters.indexOf('(')
+        return openingParenthesis in 1 until nameAndParameters.lastIndex &&
+            nameAndParameters.endsWith(')') &&
+            nameAndParameters.count { it == '(' } == 1 &&
+            nameAndParameters.count { it == ')' } == 1 &&
+            nameAndParameters.substring(0, openingParenthesis).all { it.isLetterOrDigit() || it == '_' }
+    }
+}
+
+/** GitHub Contents paths are URL paths, so prefix matching alone cannot prove containment. */
+internal object BoundedTestPath {
+    private const val OWN_TEST_SOURCE_PREFIX = "openbank-flaky-test-hunter/src/test/kotlin/"
+
+    fun isSafe(path: String): Boolean = path.startsWith(OWN_TEST_SOURCE_PREFIX) &&
+        !path.startsWith('/') &&
+        !path.contains('%') &&
+        !path.contains('\\') &&
+        path.split('/').none { it.isBlank() || it == "." || it == ".." }
 }

--- a/openbank-flaky-test-hunter/src/main/kotlin/com/openbank/flakytest/infrastructure/adapter/LlmDiagnosisAdapter.kt
+++ b/openbank-flaky-test-hunter/src/main/kotlin/com/openbank/flakytest/infrastructure/adapter/LlmDiagnosisAdapter.kt
@@ -24,9 +24,11 @@ import jakarta.inject.Inject
  *    runtime prompt equals the registered content byte-for-byte — the `prompt_hash` in an
  *    AI-attributed AuditEvent now resolves.
  *
- * `proposeFixDiff` stays unimplemented for all check types in v1 (ADR-0168 Decision: every finding is
- * ticket-only because a wrong auto-fix on a test's coroutine builder, Pact provider target, or gating
- * annotation could silently mask a real bug). The wiring and registry entry are the scope of this change.
+ * `proposeFixDiff` is intentionally not a free-form model edit. Its sole phase-3 path is the
+ * deterministic marker for one mechanically safe repair in this non-money-path service: adding an
+ * explicit `: Unit` return type to exactly one locally detected expression-body `runBlocking` test.
+ * The GitHub adapter fetches and validates that one file before changing it; every other finding is
+ * ticket-only. This keeps the model out of the write decision (ADR-0031 D9).
  */
 @ApplicationScoped
 class LlmDiagnosisAdapter : LlmDiagnosisPort {
@@ -63,9 +65,17 @@ class LlmDiagnosisAdapter : LlmDiagnosisPort {
                 )
     }
 
-    override suspend fun proposeFixDiff(finding: FlakyTestFinding, diagnosis: String): String? = null
+    override suspend fun proposeFixDiff(finding: FlakyTestFinding, diagnosis: String): String? = if (
+        finding.checkType == com.openbank.flakytest.domain.model.FlakyTestCheckType.RUNBLOCKING_UNIT_MISSING &&
+        finding.filePath.startsWith("openbank-flaky-test-hunter/src/test/kotlin/")
+    ) {
+        ADD_EXPLICIT_UNIT_RETURN_TYPE
+    } else {
+        null
+    }
 
     private companion object {
+        const val ADD_EXPLICIT_UNIT_RETURN_TYPE = "add-explicit-unit-return-type"
         val SYSTEM_PROMPT = loadRegisteredPrompt()
 
         /**

--- a/openbank-flaky-test-hunter/src/main/kotlin/com/openbank/flakytest/infrastructure/config/FlakyTestHunterConfig.kt
+++ b/openbank-flaky-test-hunter/src/main/kotlin/com/openbank/flakytest/infrastructure/config/FlakyTestHunterConfig.kt
@@ -8,6 +8,7 @@ package com.openbank.flakytest.infrastructure.config
 import io.smallrye.config.ConfigMapping
 import io.smallrye.config.WithDefault
 import jakarta.enterprise.context.ApplicationScoped
+import java.util.Optional
 
 @ConfigMapping(prefix = "openbank.flaky-test-hunter")
 @ApplicationScoped
@@ -28,6 +29,9 @@ interface FlakyTestHunterConfig {
 
     @WithDefault("JiRaska/open-bank-oss")
     fun githubRepo(): String
+
+    /** Fine-grained token limited to contents:write and pull_requests:write on this repository. */
+    fun githubToken(): Optional<String>
 
     @WithDefault("http://litellm.ai-platform:4000")
     fun llmGatewayUrl(): String

--- a/openbank-flaky-test-hunter/src/test/kotlin/com/openbank/flakytest/infrastructure/adapter/ExplicitUnitReturnTypeTest.kt
+++ b/openbank-flaky-test-hunter/src/test/kotlin/com/openbank/flakytest/infrastructure/adapter/ExplicitUnitReturnTypeTest.kt
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+
+package com.openbank.flakytest.infrastructure.adapter
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class ExplicitUnitReturnTypeTest {
+
+    @Test
+    fun `adds explicit Unit only to one expression-body runBlocking function`() {
+        val builder = "runBlocking"
+        val source = """
+            class SafeMechanicalRepair {
+                fun lostTest() = $builder { 1 }
+            }
+        """.trimIndent()
+
+        val repaired = ManualBoundedUnitReturnType.apply(source)
+
+        assertThat(repaired).contains("fun lostTest(): Unit = runBlocking { 1 }")
+    }
+
+    @Test
+    fun `refuses a file containing multiple possible repairs`() {
+        val builder = "runBlocking"
+        val source = """
+            class AmbiguousRepair {
+                fun first() = $builder { 1 }
+                fun second() = $builder { 2 }
+            }
+        """.trimIndent()
+
+        assertThat(ManualBoundedUnitReturnType.apply(source)).isNull()
+    }
+
+    @Test
+    fun `refuses a file with no expression-body runBlocking function`() {
+        assertThat(ManualBoundedUnitReturnType.apply("fun safe(): Unit = runBlocking { 1 }")).isNull()
+    }
+
+    @Test
+    fun `refuses a function that already declares a non-Unit return type`() {
+        assertThat(ManualBoundedUnitReturnType.apply("fun unsafe(): String = runBlocking { \"value\" }")).isNull()
+    }
+
+    @Test
+    fun `refuses a braced body containing the expression text`() {
+        val source = """
+            fun notAnExpressionBody() {
+                val documentation = " = runBlocking {"
+            }
+        """.trimIndent()
+
+        assertThat(ManualBoundedUnitReturnType.apply(source)).isNull()
+    }
+
+    @Test
+    fun `accepts only a canonical own test-source path`() {
+        assertThat(BoundedTestPath.isSafe("openbank-flaky-test-hunter/src/test/kotlin/example/SafeTest.kt")).isTrue()
+        assertThat(
+            BoundedTestPath.isSafe(
+                "openbank-flaky-test-hunter/src/test/kotlin/../../src/main/kotlin/Unsafe.kt",
+            ),
+        ).isFalse()
+        assertThat(BoundedTestPath.isSafe("/openbank-flaky-test-hunter/src/test/kotlin/Unsafe.kt")).isFalse()
+        assertThat(
+            BoundedTestPath.isSafe(
+                "openbank-flaky-test-hunter/src/test/kotlin/%2e%2e/%2e%2e/src/main/kotlin/Unsafe.kt",
+            ),
+        ).isFalse()
+    }
+}

--- a/openbank-flaky-test-hunter/src/test/kotlin/com/openbank/flakytest/infrastructure/adapter/TestScanAdapterTest.kt
+++ b/openbank-flaky-test-hunter/src/test/kotlin/com/openbank/flakytest/infrastructure/adapter/TestScanAdapterTest.kt
@@ -11,6 +11,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path
+import java.util.Optional
 import kotlin.io.path.createDirectories
 import kotlin.io.path.writeText
 
@@ -33,6 +34,8 @@ class TestScanAdapterTest {
         override fun githubApiUrl() = "https://api.github.com"
 
         override fun githubRepo() = "JiRaska/open-bank-oss"
+
+        override fun githubToken() = Optional.empty<String>()
 
         override fun llmGatewayUrl() = "http://litellm.ai-platform:4000"
 

--- a/openbank-infra/gitops/components/flaky-test-hunter/flaky-test-hunter.yaml
+++ b/openbank-infra/gitops/components/flaky-test-hunter/flaky-test-hunter.yaml
@@ -75,6 +75,15 @@ spec:
               value: https://api.github.com
             - name: GITHUB_REPO
               value: JiRaska/open-bank-oss
+            # Optional fine-grained token: until OpenBao is seeded, the phase-3 writer fails closed
+            # and no pull request is opened. It is deliberately separate from every other agent's
+            # credential, so revoking this one stops only this bounded development capability.
+            - name: FLAKY_TEST_HUNTER_GITHUB_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: flaky-test-hunter-secrets
+                  key: FLAKY_TEST_HUNTER_GITHUB_TOKEN
+                  optional: true
             - name: LLM_GATEWAY_URL
               value: http://litellm.ai-platform.svc:4000
             - name: TEMPORAL_NAMESPACE

--- a/openbank-infra/gitops/components/flaky-test-hunter/model-externalsecret.yaml
+++ b/openbank-infra/gitops/components/flaky-test-hunter/model-externalsecret.yaml
@@ -1,0 +1,29 @@
+# Fine-grained GitHub credential for the bounded ADR-0031 D9 phase-3 test-only repair.
+# It is intentionally a distinct OpenBao value and Kubernetes Secret from all other agents: the
+# credential needs only contents:write + pull_requests:write on this repository, and its revocation
+# disables only flaky-test-hunter's single non-money-path PR capability.
+# Seed (external operator action): bao kv patch openbank/flaky-test-hunter GITHUB_TOKEN=<fine-grained-token>
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: flaky-test-hunter-secrets
+  namespace: flaky-test-hunter
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: vault-kv
+  target:
+    name: flaky-test-hunter-secrets
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    template:
+      engineVersion: v2
+      metadata:
+        annotations:
+          argocd.argoproj.io/compare-options: IgnoreExtraneous
+  data:
+    - secretKey: FLAKY_TEST_HUNTER_GITHUB_TOKEN
+      remoteRef:
+        key: flaky-test-hunter
+        property: GITHUB_TOKEN


### PR DESCRIPTION
Closes #5281.

Implements the fail-closed ADR-0031 D9 phase-3 capability path without changing the published roadmap status:
- only own non-money test source is eligible;
- only one exact expression-body runBlocking repair is permitted;
- GitHub path traversal, encoded paths, ambiguous files and existing return types are rejected;
- no token means no write; no merge or approval action exists;
- GitOps carries only an optional, separately revocable ExternalSecret binding.

Verification:
- targeted adapter tests
- detekt
- independent review: approved

A runtime promotion still requires an operator-seeded fine-grained credential and evidence of a human-merged PR.