### PR TITLE
fix(admin-ui): align card operations with RBAC

### DIFF
--- a/openbank-admin-ui/src/app/cards/[id]/page.tsx
+++ b/openbank-admin-ui/src/app/cards/[id]/page.tsx
@@ -23,10 +23,12 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useParams } from 'next/navigation'
 import Link from 'next/link'
+import { useSession } from 'next-auth/react'
 import {
   ArrowLeft, CreditCard, Info, RefreshCw, ShieldCheck, Clock, User, Landmark,
 } from 'lucide-react'
 import { AuthGuard } from '@/components/auth/AuthGuard'
+import { hasPermission } from '@/lib/auth/roles'
 import { DataUnavailable } from '@/components/feedback/DataUnavailable'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { classifyBffFailure, svcUrl } from '@/lib/services/bff'
@@ -73,7 +75,10 @@ function Panel({ icon, title, children, span }: { icon: React.ReactNode; title: 
 export default function CardDetailPage() {
   const { id } = useParams<{ id: string }>()
   const { t, language } = useLanguage()
+  const { data: session } = useSession()
   const locale = language === 'cs' ? 'cs-CZ' : 'en-US'
+  const canManage = hasPermission(session?.user?.roles ?? [], 'cards:manage')
+  const canBlock = hasPermission(session?.user?.roles ?? [], 'cards:block')
 
   const { data: card, loading, unavailable, waking, reload } = useServiceResource<Card>(
     id ? svcUrl('card-issuance-service', `/api/v1/cards/${id}`) : null,
@@ -157,7 +162,7 @@ export default function CardDetailPage() {
   }
 
   return (
-    <AuthGuard>
+    <AuthGuard permission="cards:view">
       <div style={{ padding: '28px 32px', maxWidth: '1400px', animation: 'fadeIn 0.2s ease-out' }}>
         <div style={{ marginBottom: '18px' }}>
           <Link href="/cards" className="btn btn-ghost btn-sm" style={{ textDecoration: 'none' }}>
@@ -187,7 +192,7 @@ export default function CardDetailPage() {
               subtitle={[card.cardType, card.productCode, card.currency].filter(Boolean).join(' · ')}
               actions={<div style={{ display: 'flex', gap: '8px', alignItems: 'center', flexWrap: 'wrap' }}>
                 <CardStatusChip status={card.status} current />
-                <CardTransitionButtons card={card} busy={ops.busy} onSelect={onSelectTransition} />
+                {(canManage || canBlock) && <CardTransitionButtons card={card} busy={ops.busy} canManage={canManage} canBlock={canBlock} onSelect={onSelectTransition} />}
                 <button className="btn btn-ghost btn-sm" onClick={reload} disabled={ops.busy !== null}>
                   <RefreshCw size={12} aria-hidden="true" /> {t('Obnovit', 'Refresh')}
                 </button>
@@ -285,18 +290,22 @@ export default function CardDetailPage() {
               {/* The `key` carries the server's own values: when the service hands
                   back a changed card the editor remounts on the new truth instead
                   of keeping a stale draft alive. */}
-              <CardLimitsPanel
-                key={`limits-${card.dailyLimitMinorUnits}-${card.monthlyLimitMinorUnits}-${card.status}`}
-                card={card}
-                busy={ops.busy}
-                onSave={(daily, monthly) => ops.saveLimits(card, daily, monthly)}
-              />
-              <CardControlsPanel
-                key={`controls-${card.contactlessEnabled}-${card.onlineEnabled}-${card.atmEnabled}-${card.abroadEnabled}-${card.status}`}
-                card={card}
-                busy={ops.busy}
-                onSave={controls => ops.saveControls(card, controls)}
-              />
+              {canManage && (
+                <>
+                  <CardLimitsPanel
+                    key={`limits-${card.dailyLimitMinorUnits}-${card.monthlyLimitMinorUnits}-${card.status}`}
+                    card={card}
+                    busy={ops.busy}
+                    onSave={(daily, monthly) => ops.saveLimits(card, daily, monthly)}
+                  />
+                  <CardControlsPanel
+                    key={`controls-${card.contactlessEnabled}-${card.onlineEnabled}-${card.atmEnabled}-${card.abroadEnabled}-${card.status}`}
+                    card={card}
+                    busy={ops.busy}
+                    onSave={controls => ops.saveControls(card, controls)}
+                  />
+                </>
+              )}
 
               {/* ── audit trail ─────────────────────────────────────────── */}
               <Panel icon={<Clock size={15} style={{ color: 'var(--accent)' }} />} title={t('Časová osa', 'Timeline')}>

--- a/openbank-admin-ui/src/app/cards/page.tsx
+++ b/openbank-admin-ui/src/app/cards/page.tsx
@@ -6,11 +6,13 @@
 import { useCallback, useMemo, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import Link from 'next/link'
+import { useSession } from 'next-auth/react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import {
   CreditCard, Search, RefreshCw, CheckCircle2, XCircle, Clock, ChevronRight, Plus, ShieldCheck,
 } from 'lucide-react'
 import { AuthGuard } from '@/components/auth/AuthGuard'
+import { hasPermission } from '@/lib/auth/roles'
 import { svcUrl } from '@/lib/services/bff'
 import { useServiceResource } from '@/lib/services/useServiceResource'
 import { DataUnavailable } from '@/components/feedback/DataUnavailable'
@@ -38,6 +40,10 @@ const ALL = '__ALL__'
 export default function CardsPage() {
   const { t, language } = useLanguage()
   const router = useRouter()
+  const { data: session } = useSession()
+  const canIssue = hasPermission(session?.user?.roles ?? [], 'cards:issue')
+  const canManage = hasPermission(session?.user?.roles ?? [], 'cards:manage')
+  const canBlock = hasPermission(session?.user?.roles ?? [], 'cards:block')
   const [search, setSearch] = useState('')
   const [statusFilter, setStatusFilter] = useState<string>(ALL)
   const [typeFilter, setTypeFilter] = useState<string>(ALL)
@@ -97,7 +103,7 @@ export default function CardsPage() {
   })
 
   return (
-    <AuthGuard>
+    <AuthGuard permission="cards:view">
       <div style={{ padding: '28px 32px', maxWidth: '1400px', animation: 'fadeIn 0.2s ease-out' }}>
         <PageHeader
           icon={<CreditCard size={20} aria-hidden="true" />}
@@ -116,9 +122,11 @@ export default function CardsPage() {
                 checking: t('Zjišťuji stav služby…', 'Checking service…'),
               }}
             />
-            <button className="btn btn-primary btn-sm" onClick={() => { ops.setFeedback(null); setIssuing(true) }}>
-              <Plus size={13} /> {t('Vydat kartu', 'Issue a card')}
-            </button>
+            {canIssue && (
+              <button className="btn btn-primary btn-sm" onClick={() => { ops.setFeedback(null); setIssuing(true) }}>
+                <Plus size={13} aria-hidden="true" /> {t('Vydat kartu', 'Issue a card')}
+              </button>
+            )}
             <button className="btn btn-ghost btn-sm" onClick={reload} disabled={loading}>
               <RefreshCw size={13} /> {t('Obnovit', 'Refresh')}
             </button>
@@ -239,7 +247,7 @@ export default function CardsPage() {
                         <td style={{ padding: '12px 16px', fontSize: '12px', color: 'var(--text-secondary)' }}>{c.cardholderName || '—'}</td>
                         <td style={{ padding: '12px 16px', fontSize: '12px', color: 'var(--text-tertiary)' }}>{c.createdAt ? new Date(c.createdAt).toLocaleDateString(language === 'cs' ? 'cs-CZ' : 'en-US') : '—'}</td>
                         <td style={{ padding: '10px 16px' }} onClick={e => e.stopPropagation()}>
-                          <CardTransitionButtons card={c} busy={ops.busy} onSelect={tr => onSelectTransition(c, tr)} />
+                          {(canManage || canBlock) && <CardTransitionButtons card={c} busy={ops.busy} canManage={canManage} canBlock={canBlock} onSelect={tr => onSelectTransition(c, tr)} />}
                         </td>
                         <td style={{ padding: '10px 12px', color: 'var(--text-tertiary)' }}><ChevronRight size={14} /></td>
                       </tr>

--- a/openbank-admin-ui/src/components/cards/CardTransitionButtons.tsx
+++ b/openbank-admin-ui/src/components/cards/CardTransitionButtons.tsx
@@ -24,15 +24,21 @@ const ACTION_ICON: Record<CardAction, React.ElementType> = {
 }
 
 export function CardTransitionButtons({
-  card, busy, onSelect,
+  card, busy, canManage, canBlock, onSelect,
 }: {
   card: Card
   /** `${cardId}:${action}` of the in-flight write, or null. */
   busy: string | null
+  /** activate, suspend and resume are ROLE_OPERATOR/ROLE_ADMIN only. */
+  canManage: boolean
+  /** block and cancel also admit the service-authorized ROLE_COMPLIANCE emergency role. */
+  canBlock: boolean
   onSelect: (transition: CardTransition) => void
 }) {
   const { t } = useLanguage()
-  const transitions = legalTransitions(card.status)
+  const transitions = legalTransitions(card.status).filter(tr =>
+    tr.action === 'block' || tr.action === 'cancel' ? canBlock : canManage,
+  )
 
   if (transitions.length === 0) {
     return (

--- a/openbank-admin-ui/src/components/layout/Sidebar.tsx
+++ b/openbank-admin-ui/src/components/layout/Sidebar.tsx
@@ -67,7 +67,7 @@ const paymentsNav: NavItem[] = [
   { nameCs: 'Inkasa (SDD)',      nameEn: 'Direct Debits',    href: '/sdd',               icon: Repeat,    permission: 'payments:view' },
   { nameCs: 'FX',                nameEn: 'FX',               href: '/fx',                icon: DollarSign,permission: 'payments:view' },
   { nameCs: 'SWIFT',             nameEn: 'SWIFT',            href: '/swift',             icon: Globe,     permission: 'payments:view' },
-  { nameCs: 'Karty',             nameEn: 'Cards',            href: '/cards',             icon: CreditCard,permission: 'payments:view' },
+  { nameCs: 'Karty',             nameEn: 'Cards',            href: '/cards',             icon: CreditCard,permission: 'cards:view' },
   { nameCs: 'Clearing',          nameEn: 'Clearing',         href: '/clearing',          icon: Layers,    permission: 'payments:view' },
   { nameCs: 'Úroky',             nameEn: 'Interest',         href: '/interest',          icon: TrendingUp,permission: 'payments:view' },
   { nameCs: 'Šablony dokumentů', nameEn: 'Document Templates', href: '/document-templates', icon: FileSignature, permission: 'templates:view' },

--- a/openbank-admin-ui/src/lib/auth/roles.ts
+++ b/openbank-admin-ui/src/lib/auth/roles.ts
@@ -49,6 +49,15 @@ export const PERMISSIONS = {
   "payments:view":        [ROLES.ADMIN, ROLES.OPERATOR, ROLES.VIEWER, ROLES.PAYMENTS, ROLES.SUPERVISOR],
   "payments:create":      [ROLES.ADMIN, ROLES.OPERATOR, ROLES.PAYMENTS],
   "payments:approve":     [ROLES.ADMIN, ROLES.PAYMENTS, ROLES.SUPERVISOR],
+  // Card-issuance deliberately has a narrower read role than the wider payments
+  // workspace: its GET endpoints accept only VIEWER/OPERATOR/ADMIN, and every
+  // lifecycle writes except block/cancel accept only OPERATOR/ADMIN. Compliance
+  // retains the service-authorized emergency block/cancel pair, not limit or
+  // channel-control changes. Keep the console's controls aligned with that split.
+  "cards:view":            [ROLES.ADMIN, ROLES.OPERATOR, ROLES.VIEWER],
+  "cards:issue":           [ROLES.ADMIN, ROLES.OPERATOR],
+  "cards:manage":          [ROLES.ADMIN, ROLES.OPERATOR],
+  "cards:block":           [ROLES.ADMIN, ROLES.OPERATOR, ROLES.COMPLIANCE],
   // Generic Product Studio. Scope-derived roles make the same UI usable with a provider-neutral
   // standalone OIDC issuer; OpenBank OPERATOR/ADMIN remain compatible personas.
   "catalog:read":         [ROLES.ADMIN, ROLES.OPERATOR, ROLES.CATALOG_READ, ROLES.CATALOG_AUTHOR, ROLES.CATALOG_PUBLISH],
@@ -176,9 +185,10 @@ const ROUTE_PREFIXES: ReadonlyArray<readonly [Permission, readonly string[]]> = 
   ['transactions:view', ['/transactions']],
   ['accounts:create', ['/accounts/new']],
   ['accounts:view', ['/accounts', '/ledger', '/day-end']],
+  ['cards:view', ['/cards']],
   ['payments:view', [
     '/payments', '/product-catalog', '/standing-orders', '/sdd', '/sepa-instant', '/clearing',
-    '/fx', '/swift', '/cards', '/interest', '/pid', '/fees', '/lending',
+    '/fx', '/swift', '/interest', '/pid', '/fees', '/lending',
   ]],
   ['compliance:view', [
     '/aml', '/fraud', '/sanctions', '/disputes', '/consents', '/customer-360', '/campaigns',

--- a/openbank-admin-ui/src/test/cards-rbac.guard.test.ts
+++ b/openbank-admin-ui/src/test/cards-rbac.guard.test.ts
@@ -1,0 +1,45 @@
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const roles = readFileSync(path.resolve(__dirname, '../lib/auth/roles.ts'), 'utf8')
+const sidebar = readFileSync(path.resolve(__dirname, '../components/layout/Sidebar.tsx'), 'utf8')
+const listPage = readFileSync(path.resolve(__dirname, '../app/cards/page.tsx'), 'utf8')
+const detailPage = readFileSync(path.resolve(__dirname, '../app/cards/[id]/page.tsx'), 'utf8')
+
+describe('card issuance access boundary', () => {
+  it('keeps the card route aligned with the card-issuance GET roles', () => {
+    expect(roles).toContain('"cards:view":            [ROLES.ADMIN, ROLES.OPERATOR, ROLES.VIEWER]')
+    expect(roles).toContain("['cards:view', ['/cards']]")
+    expect(sidebar).toContain("href: '/cards',             icon: CreditCard,permission: 'cards:view'")
+    expect(listPage).toContain('<AuthGuard permission="cards:view">')
+    expect(detailPage).toContain('<AuthGuard permission="cards:view">')
+  })
+
+  it('does not offer issuance or operator-only lifecycle writes to a read-only card viewer', () => {
+    expect(roles).toContain('"cards:issue":           [ROLES.ADMIN, ROLES.OPERATOR]')
+    expect(roles).toContain('"cards:manage":          [ROLES.ADMIN, ROLES.OPERATOR]')
+    expect(roles).toContain('"cards:block":           [ROLES.ADMIN, ROLES.OPERATOR, ROLES.COMPLIANCE]')
+    expect(listPage).toContain("hasPermission(session?.user?.roles ?? [], 'cards:issue')")
+    expect(listPage).toContain("hasPermission(session?.user?.roles ?? [], 'cards:manage')")
+    expect(listPage).toContain('{canIssue && (')
+    expect(listPage).toContain("hasPermission(session?.user?.roles ?? [], 'cards:block')")
+    expect(listPage).toContain('{(canManage || canBlock) && <CardTransitionButtons')
+    expect(detailPage).toContain("hasPermission(session?.user?.roles ?? [], 'cards:manage')")
+    expect(detailPage).toContain("hasPermission(session?.user?.roles ?? [], 'cards:block')")
+    expect(detailPage).toContain('{(canManage || canBlock) && <CardTransitionButtons')
+    expect(detailPage).toContain('{canManage && (')
+  })
+
+  it('keeps the emergency compliance actions separate from operator-only transitions', () => {
+    const transitions = readFileSync(path.resolve(__dirname, '../components/cards/CardTransitionButtons.tsx'), 'utf8')
+    expect(transitions).toContain("tr.action === 'block' || tr.action === 'cancel' ? canBlock : canManage")
+    expect(transitions).toContain('canBlock: boolean')
+  })
+
+  it('preserves PCI-safe card presentation and the idempotent issue flow', () => {
+    expect(listPage).toContain('full card number and CVV are not available here (PCI DSS)')
+    expect(readFileSync(path.resolve(__dirname, '../lib/cards/useCardOperations.ts'), 'utf8'))
+      .toContain("headers: { 'Idempotency-Key': idempotencyKey }")
+  })
+})

--- a/openbank-admin-ui/src/test/route-permissions.test.ts
+++ b/openbank-admin-ui/src/test/route-permissions.test.ts
@@ -32,6 +32,7 @@ describe('route permission projection (ADR-0229 D3)', () => {
   it('uses the most specific matching prefix', () => {
     expect(permissionForPath('/dashboard')).toBe('dashboard:view')
     expect(permissionForPath('/accounts/new')).toBe('accounts:create')
+    expect(permissionForPath('/cards/sample')).toBe('cards:view')
     expect(permissionForPath('/lending/compliance-packs')).toBe('compliance:view')
     expect(permissionForPath('/system/config')).toBe('system:config')
   })


### PR DESCRIPTION
Closes #5297

## What
- map /cards to the exact card-issuance read roles
- hide issue, lifecycle, limit and channel-control writes from read-only users
- add route and access-boundary regression tests

## Verification
- npm test -- cards-rbac route-permissions roles (18/18)
- npm run type-check
- git diff --check

The backend remains the authority; this aligns the UI and edge-route projection with its existing @RolesAllowed contract.