### PR TITLE
fix(admin-ui): modernize PID and regulatory headers

### DIFF
--- a/openbank-admin-ui/src/app/pid/page.tsx
+++ b/openbank-admin-ui/src/app/pid/page.tsx
@@ -11,6 +11,7 @@ import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { classifyBffFailure } from '@/lib/services/bff'
 import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
 import { AuthGuard } from '@/components/auth/AuthGuard'
+import { PageHeader } from '@/components/ui/PageHeader'
 
 const PID_SERVICE = '/api/svc/pid-service'
 
@@ -189,24 +190,15 @@ export default function PidPage() {
   return (
     <AuthGuard>
       <div style={{ animation: 'fadeIn 0.2s ease-out', maxWidth: '1400px', margin: '0 auto' }}>
-        <div className="page-header">
-          <div>
-            <div className="breadcrumb">
-              <span>OpenBank</span><span className="breadcrumb-sep">/</span>
-              <span className="breadcrumb-current">PID</span>
-            </div>
-            <h1 className="page-title" style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-              <Map size={18} style={{ color: 'var(--accent)' }} />
-              {t('Osobní identifikační údaje (PID)', 'Personal Identification Data (PID)')}
-            </h1>
-            <p className="page-subtitle">
-              {t('Správa identit, dokladů a identifikátorů klientů', 'Management of identities, documents, and client identifiers')}
-            </p>
-          </div>
-          <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: '4px' }}>
+        <PageHeader
+          icon={<Map size={18} aria-hidden="true" />}
+          title={t('Osobní identifikační údaje (PID)', 'Personal Identification Data (PID)')}
+          subtitle={t('Správa identit, dokladů a identifikátorů klientů', 'Management of identities, documents, and client identifiers')}
+          breadcrumb={<div className="breadcrumb"><span>OpenBank</span><span className="breadcrumb-sep">/</span><span className="breadcrumb-current">PID</span></div>}
+          actions={<div style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: '4px' }}>
             <div style={{ display: 'flex', gap: '8px' }}>
               <button className="btn btn-secondary" onClick={load} disabled={loading}>
-                <RefreshCw size={13} style={{ animation: loading ? 'spin 1s linear infinite' : 'none' }} />
+                <RefreshCw size={13} aria-hidden="true" style={{ animation: loading ? 'spin 1s linear infinite' : 'none' }} />
                 {t('Obnovit', 'Refresh')}
               </button>
               <button className="btn btn-secondary" onClick={() => setShowNewForm(true)}>
@@ -219,8 +211,8 @@ export default function PidPage() {
             <div style={{ fontSize: '11px', color: 'var(--text-secondary)', textAlign: 'right' }}>
               {t('Chcete vytvořit záznam rychle?', 'Want to create quickly?')}
             </div>
-          </div>
-        </div>
+          </div>}
+        />
 
         <div className="grid-4" style={{ marginBottom: '24px' }}>
           {[

--- a/openbank-admin-ui/src/app/regulatory/page.tsx
+++ b/openbank-admin-ui/src/app/regulatory/page.tsx
@@ -9,6 +9,7 @@ import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { classifyBffFailure, svcUrl, type BffFailure } from '@/lib/services/bff'
 import { DataUnavailable } from '@/components/feedback/DataUnavailable'
 import { FileText, CheckCircle2, AlertTriangle, ExternalLink, Calendar, Check, Eye, X, Table as TableIcon, FileJson, FileSpreadsheet, RefreshCw } from 'lucide-react'
+import { PageHeader } from '@/components/ui/PageHeader'
 
 type Report = (typeof REPORTS)[number]
 
@@ -332,23 +333,16 @@ export default function RegulatoryPage() {
 
   return (
     <div>
-      <div className="page-header">
-        <div>
-          <div className="breadcrumb">
-            <span>OpenBank</span><span className="breadcrumb-sep">/</span>
-            <span className="breadcrumb-current">{t('Regulatorní výkaznictví', 'Regulatory Reporting')}</span>
-          </div>
-          <h1 className="page-title" style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-            <FileText size={18} style={{ color: 'var(--accent)' }} />
-            {t('Regulatorní výkaznictví', 'Regulatory Reporting')}
-          </h1>
-          <p className="page-subtitle">{t('CNB SDAT · FAÚ · COREP/FINREP · ECB · FATCA/CRS · DORA ICT incidenty', 'CNB SDAT · FAÚ · COREP/FINREP · ECB · FATCA/CRS · DORA ICT incidents')}</p>
-        </div>
-        <a href="https://www.cnb.cz/cs/dohled-financni-trh/vykaznictvi/" target="_blank" rel="noreferrer" className="btn btn-secondary">
-          <ExternalLink size={13} />
+      <PageHeader
+        icon={<FileText size={18} aria-hidden="true" />}
+        title={t('Regulatorní výkaznictví', 'Regulatory Reporting')}
+        subtitle={t('CNB SDAT · FAÚ · COREP/FINREP · ECB · FATCA/CRS · DORA ICT incidenty', 'CNB SDAT · FAÚ · COREP/FINREP · ECB · FATCA/CRS · DORA ICT incidents')}
+        breadcrumb={<div className="breadcrumb"><span>OpenBank</span><span className="breadcrumb-sep">/</span><span className="breadcrumb-current">{t('Regulatorní výkaznictví', 'Regulatory Reporting')}</span></div>}
+        actions={<a href="https://www.cnb.cz/cs/dohled-financni-trh/vykaznictvi/" target="_blank" rel="noreferrer" className="btn btn-secondary">
+          <ExternalLink size={13} aria-hidden="true" />
           {t('CNB Výkaznictví', 'CNB Reporting')}
-        </a>
-      </div>
+        </a>}
+      />
 
       {/* Summary */}
       <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(150px, 1fr))', gap: '12px', marginBottom: '20px' }}>

--- a/openbank-admin-ui/src/test/pid-regulatory-page-header.guard.test.ts
+++ b/openbank-admin-ui/src/test/pid-regulatory-page-header.guard.test.ts
@@ -1,0 +1,23 @@
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const pid = readFileSync(path.resolve(__dirname, '../app/pid/page.tsx'), 'utf8')
+const regulatory = readFileSync(path.resolve(__dirname, '../app/regulatory/page.tsx'), 'utf8')
+
+describe('operator page header contract', () => {
+  it('uses the shared header with a real breadcrumb and accessible decorative icons', () => {
+    for (const page of [pid, regulatory]) {
+      expect(page).toContain('<PageHeader')
+      expect(page).toContain('breadcrumb={<div className="breadcrumb">')
+      expect(page).toContain('aria-hidden="true"')
+      expect(page).not.toContain('className="page-header"')
+    }
+  })
+
+  it('keeps PID and regulatory actions as native controls/links', () => {
+    expect(pid).toContain('onClick={load}')
+    expect(pid).toContain('href="/parties/new"')
+    expect(regulatory).toContain('href="https://www.cnb.cz/cs/dohled-financni-trh/vykaznictvi/"')
+  })
+})


### PR DESCRIPTION
Closes #5306

## What
- migrate PID and regulatory reporting pages to shared PageHeader
- preserve existing actions, external links and data flows
- add source guard for breadcrumb and decorative icon semantics

## Verification
- npm test -- pid-regulatory-page-header route-permissions roles (17/17)
- npm run type-check
- git diff --check