### PR TITLE
fix(admin-ui): modernize operational page headers

### DIFF
--- a/openbank-admin-ui/src/app/infrastructure/topology/page.tsx
+++ b/openbank-admin-ui/src/app/infrastructure/topology/page.tsx
@@ -14,6 +14,7 @@ import { FlowParticle } from '@/components/topology/FlowParticle'
 import { useFlowAnimation } from '@/components/topology/useFlowAnimation'
 import { NodeShadow, ArrowMarker } from '@/components/topology/TopologyDefs'
 import { layoutBands } from '@/components/topology/layout'
+import { PageHeader } from '@/components/ui/PageHeader'
 
 // ---------------------------------------------------------------------------
 // Infrastructure topology (ADR-0027/0029). A companion to the code-derived
@@ -233,23 +234,13 @@ export default function InfraTopologyPage() {
 
   return (
     <div style={{ padding: '28px 32px', maxWidth: '1400px' }}>
-      <div className="page-header">
-        <div>
-          <div className="breadcrumb">
-            <span>OpenBank</span><span className="breadcrumb-sep">/</span>
-            <span>{t('Infrastruktura', 'Infrastructure')}</span><span className="breadcrumb-sep">/</span>
-            <span className="breadcrumb-current">{t('Topologie', 'Topology')}</span>
-          </div>
-          <h1 className="page-title" style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-            <Network size={18} style={{ color: 'var(--accent)' }} />
-            {t('Topologie infrastruktury', 'Infrastructure Topology')}
-          </h1>
-          <p className="page-subtitle">
-            {t('Jak jsou platformní komponenty zapojené — architektura toku dat s živým stavem. Hrany jsou zdokumentovaná architektura (ne odvozená data); uzly nesou živý stav z prób.',
-               'How the platform components are wired — a data-flow architecture with live status. Edges are the documented architecture (not derived data); nodes carry live probe status.')}
-          </p>
-        </div>
-      </div>
+      <PageHeader
+        icon={<Network size={18} aria-hidden="true" />}
+        title={t('Topologie infrastruktury', 'Infrastructure Topology')}
+        subtitle={t('Jak jsou platformní komponenty zapojené — architektura toku dat s živým stavem. Hrany jsou zdokumentovaná architektura (ne odvozená data); uzly nesou živý stav z prób.',
+          'How the platform components are wired — a data-flow architecture with live status. Edges are the documented architecture (not derived data); nodes carry live probe status.')}
+        breadcrumb={<div className="breadcrumb"><span>OpenBank</span><span className="breadcrumb-sep">/</span><span>{t('Infrastruktura', 'Infrastructure')}</span><span className="breadcrumb-sep">/</span><span className="breadcrumb-current">{t('Topologie', 'Topology')}</span></div>}
+      />
 
       {/* Controls */}
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '16px', flexWrap: 'wrap', gap: '12px' }}>

--- a/openbank-admin-ui/src/app/observability/traces/page.tsx
+++ b/openbank-admin-ui/src/app/observability/traces/page.tsx
@@ -15,6 +15,7 @@ import { Activity, RefreshCw, GitBranch, Clock, ChevronRight } from 'lucide-reac
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { AuthGuard } from '@/components/auth/AuthGuard'
 import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
+import { PageHeader } from '@/components/ui/PageHeader'
 
 interface TraceSummary {
   traceID: string
@@ -137,29 +138,16 @@ export default function TraceExplorerPage() {
   return (
     <AuthGuard permission="system:view">
       <div>
-        <div className="page-header">
-          <div>
-            <div className="breadcrumb">
-              <span>OpenBank</span><span className="breadcrumb-sep">/</span>
-              <span className="breadcrumb-current">{t('Trasování', 'Tracing')}</span>
-            </div>
-            <h1 className="page-title" style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-              <GitBranch size={18} style={{ color: 'var(--accent)' }} />
-              {t('Trace Explorer', 'Trace Explorer')}
-            </h1>
-            <p className="page-subtitle">
-              {t(
-                'Sleduj jeden požadavek napříč službami — distribuované trasy z Tempa s časováním každého spanu.',
-                'Watch a single request hop across services — distributed traces from Tempo with per-span timing.',
-              )}
-            </p>
-          </div>
-          <button onClick={loadTraces} className="btn btn-secondary" disabled={loading}
-            style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
-            <RefreshCw size={14} className={loading ? 'spin' : undefined} />
+        <PageHeader
+          icon={<GitBranch size={18} aria-hidden="true" />}
+          title={t('Trace Explorer', 'Trace Explorer')}
+          subtitle={t('Sleduj jeden požadavek napříč službami — distribuované trasy z Tempa s časováním každého spanu.', 'Watch a single request hop across services — distributed traces from Tempo with per-span timing.')}
+          breadcrumb={<div className="breadcrumb"><span>OpenBank</span><span className="breadcrumb-sep">/</span><span className="breadcrumb-current">{t('Trasování', 'Tracing')}</span></div>}
+          actions={<button onClick={loadTraces} className="btn btn-secondary" disabled={loading} style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+            <RefreshCw size={14} aria-hidden="true" className={loading ? 'spin' : undefined} />
             {t('Obnovit', 'Refresh')}
-          </button>
-        </div>
+          </button>}
+        />
 
         {unavailable && !traces?.length ? (
           <DataUnavailable

--- a/openbank-admin-ui/src/app/onboarding/analytics/page.tsx
+++ b/openbank-admin-ui/src/app/onboarding/analytics/page.tsx
@@ -20,6 +20,7 @@ import {
   LineChart, Line, PieChart, Pie, Legend,
 } from 'recharts'
 import type { FunnelAnalytics } from '@/app/api/onboarding/funnel-analytics/route'
+import { PageHeader } from '@/components/ui/PageHeader'
 
 // ── Step labels (contract order WELCOME→SIGN) ─────────────────────────────────
 
@@ -112,27 +113,12 @@ export default function OnboardingAnalyticsPage() {
 
   return (
     <div>
-      {/* Page header */}
-      <div className="page-header">
-        <div>
-          <div className="breadcrumb">
-            <span>OpenBank</span><span className="breadcrumb-sep">/</span>
-            <Link href="/onboarding" style={{ color: 'inherit', textDecoration: 'none' }}>
-              {t('Onboarding', 'Onboarding')}
-            </Link>
-            <span className="breadcrumb-sep">/</span>
-            <span className="breadcrumb-current">{t('Konverze', 'Conversion')}</span>
-          </div>
-          <h1 className="page-title" style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-            <TrendingUp size={18} style={{ color: 'var(--accent)' }} />
-            {t('Konverze onboardingu', 'Onboarding Conversion')}
-          </h1>
-          <p className="page-subtitle">
-            {t('Historická analýza funnelu — krok po kroku, kde a proč prospekti odpadají',
-               'Historical funnel analysis — where and why prospects drop off, step by step')}
-          </p>
-        </div>
-        <div style={{ display: 'flex', alignItems: 'flex-end', gap: '8px' }}>
+      <PageHeader
+        icon={<TrendingUp size={18} aria-hidden="true" />}
+        title={t('Konverze onboardingu', 'Onboarding Conversion')}
+        subtitle={t('Historická analýza funnelu — krok po kroku, kde a proč prospekti odpadají', 'Historical funnel analysis — where and why prospects drop off, step by step')}
+        breadcrumb={<div className="breadcrumb"><span>OpenBank</span><span className="breadcrumb-sep">/</span><Link href="/onboarding" style={{ color: 'inherit', textDecoration: 'none' }}>{t('Onboarding', 'Onboarding')}</Link><span className="breadcrumb-sep">/</span><span className="breadcrumb-current">{t('Konverze', 'Conversion')}</span></div>}
+        actions={<div style={{ display: 'flex', alignItems: 'flex-end', gap: '8px' }}>
           <label style={{ display: 'flex', flexDirection: 'column', gap: '2px', fontSize: '11px', color: 'var(--text-muted)' }}>
             {t('Od', 'From')}
             <input type="date" value={from} max={to} onChange={e => setFrom(e.target.value)}
@@ -144,11 +130,11 @@ export default function OnboardingAnalyticsPage() {
               className="input" style={{ padding: '5px 8px', fontSize: '12px' }} />
           </label>
           <button className="btn btn-secondary" onClick={load} disabled={loading}>
-            <RefreshCw size={13} style={{ animation: loading ? 'spin 1s linear infinite' : 'none' }} />
+            <RefreshCw size={13} aria-hidden="true" style={{ animation: loading ? 'spin 1s linear infinite' : 'none' }} />
             {t('Obnovit', 'Refresh')}
           </button>
-        </div>
-      </div>
+        </div>}
+      />
 
       <div style={{ marginBottom: '16px' }}>
         <Link href="/onboarding" className="btn btn-secondary" style={{ textDecoration: 'none', fontSize: '12px' }}>

--- a/openbank-admin-ui/src/app/swift/[id]/page.tsx
+++ b/openbank-admin-ui/src/app/swift/[id]/page.tsx
@@ -12,6 +12,7 @@ import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { svcUrl, classifyBffFailure } from '@/lib/services/bff'
 import { readStashedRow } from '@/lib/services/rowHandoff'
 import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
+import { PageHeader } from '@/components/ui/PageHeader'
 
 interface SwiftMessage {
   id: string
@@ -67,32 +68,18 @@ export default function SwiftDetailPage() {
 
   return (
     <div>
-      <div className="page-header">
-        <div>
-          <div className="breadcrumb">
-            <span>OpenBank</span>
-            <span className="breadcrumb-sep">/</span>
-            <Link href="/swift" style={{ color: 'var(--text-tertiary)', textDecoration: 'none' }}>{t('SWIFT zprávy', 'SWIFT')}</Link>
-            <span className="breadcrumb-sep">/</span>
-            <span className="breadcrumb-current mono" style={{ fontSize: '12px' }}>{id.slice(0, 12)}…</span>
-          </div>
-          <h1 className="page-title" style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
-            {message?.messageType && <span className="mono" style={{ fontSize: '18px', color: 'var(--accent)' }}>{message.messageType}</span>}
-            {message?.status && (
-              <span className="pill" style={{ background: `${STATUS_COLOR[message.status] ?? 'var(--text-muted)'}22`, color: STATUS_COLOR[message.status] ?? 'var(--text-muted)' }}>
-                {message.status}
-              </span>
-            )}
-          </h1>
-          <p className="page-subtitle">{t('Detail SWIFT zprávy — ISO 20022', 'SWIFT message detail — ISO 20022')}</p>
-        </div>
-        <div style={{ display: 'flex', gap: '8px' }}>
-          <Link href="/swift" className="btn btn-secondary"><ArrowLeft size={13} /> {t('Zpět', 'Back')}</Link>
+      <PageHeader
+        title={message?.messageType ?? t('SWIFT zpráva', 'SWIFT message')}
+        subtitle={t('Detail SWIFT zprávy — ISO 20022', 'SWIFT message detail — ISO 20022')}
+        breadcrumb={<div className="breadcrumb"><span>OpenBank</span><span className="breadcrumb-sep">/</span><Link href="/swift" style={{ color: 'var(--text-tertiary)', textDecoration: 'none' }}>{t('SWIFT zprávy', 'SWIFT')}</Link><span className="breadcrumb-sep">/</span><span className="breadcrumb-current mono" style={{ fontSize: '12px' }}>{id.slice(0, 12)}…</span></div>}
+        actions={<div style={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
+          {message?.status && <span className="pill" style={{ background: `${STATUS_COLOR[message.status] ?? 'var(--text-muted)'}22`, color: STATUS_COLOR[message.status] ?? 'var(--text-muted)' }}>{message.status}</span>}
+          <Link href="/swift" className="btn btn-secondary"><ArrowLeft size={13} aria-hidden="true" /> {t('Zpět', 'Back')}</Link>
           <button className="btn btn-secondary" onClick={load} disabled={loading}>
-            <RefreshCw size={13} className={loading ? 'animate-spin' : ''} /> {t('Obnovit', 'Refresh')}
+            <RefreshCw size={13} aria-hidden="true" className={loading ? 'animate-spin' : ''} /> {t('Obnovit', 'Refresh')}
           </button>
-        </div>
-      </div>
+        </div>}
+      />
 
       {loading && !message ? (
         <div style={{ padding: '40px 0', color: 'var(--text-tertiary)', fontSize: '13px', display: 'flex', alignItems: 'center', gap: '8px' }}>

--- a/openbank-admin-ui/src/test/operational-page-header.guard.test.ts
+++ b/openbank-admin-ui/src/test/operational-page-header.guard.test.ts
@@ -1,0 +1,27 @@
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const pages = [
+  'infrastructure/topology/page.tsx',
+  'observability/traces/page.tsx',
+  'onboarding/analytics/page.tsx',
+  'swift/[id]/page.tsx',
+].map(file => readFileSync(path.resolve(__dirname, '../app', file), 'utf8'))
+
+describe('operational page header contract', () => {
+  it('uses the shared header and valid breadcrumb wrapper on every migrated page', () => {
+    for (const page of pages) {
+      expect(page).toContain('<PageHeader')
+      expect(page).toContain('breadcrumb={<div className="breadcrumb">')
+      expect(page).not.toContain('className="page-header"')
+    }
+  })
+
+  it('marks relocated decorative icons hidden while preserving native controls', () => {
+    for (const page of pages) expect(page).toContain('aria-hidden="true"')
+    expect(pages[1]).toContain('onClick={loadTraces}')
+    expect(pages[2]).toContain('onClick={load}')
+    expect(pages[3]).toContain('href="/swift"')
+  })
+})


### PR DESCRIPTION
Closes #5308

## What
- migrate infrastructure topology, observability traces, onboarding conversion analytics and SWIFT detail to shared PageHeader
- preserve existing data flows and native controls
- add breadcrumb/icon regression guard

## Verification
- npm test -- operational-page-header route-permissions roles (17/17)
- npm run type-check
- git diff --check