### PR TITLE
fix(admin-ui): modernize system operation headers

### DIFF
--- a/openbank-admin-ui/src/app/system/agent/page.tsx
+++ b/openbank-admin-ui/src/app/system/agent/page.tsx
@@ -9,6 +9,7 @@ import { Bot, Play, ChevronDown, ChevronRight, Zap, CheckCircle2, XCircle, Refre
 import { cn } from '@/lib/utils'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { DataUnavailable } from '@/components/feedback/DataUnavailable'
+import { PageHeader } from '@/components/ui/PageHeader'
 
 interface ToolDef {
   name: string
@@ -76,26 +77,22 @@ export default function AgentPage() {
 
   return (
     <div>
-      <div className="page-header">
-        <div>
-          <div className="breadcrumb">
+      <PageHeader
+        breadcrumb={<div className="breadcrumb">
             <span>OpenBank</span>
             <span className="breadcrumb-sep">/</span>
             <span>{t('Systém', 'System')}</span>
             <span className="breadcrumb-sep">/</span>
             <span className="breadcrumb-current">Agent (MCP)</span>
-          </div>
-          <h1 className="page-title" style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-            <Bot size={18} style={{ color: 'var(--accent)' }} />
-            {t('Agent služba', 'Agent Service')}
-          </h1>
-          <p className="page-subtitle">{t('MCP server zpřístupňující nástroje OpenBank AI agentům · JSON-RPC 2.0 přes HTTP', 'MCP server exposing OpenBank tools to AI agents · JSON-RPC 2.0 over HTTP')}</p>
-        </div>
-        <button className="btn btn-secondary" onClick={loadTools} disabled={loading}>
+          </div>}
+        title={t('Agent služba', 'Agent Service')}
+        subtitle={t('MCP server zpřístupňující nástroje OpenBank AI agentům · JSON-RPC 2.0 přes HTTP', 'MCP server exposing OpenBank tools to AI agents · JSON-RPC 2.0 over HTTP')}
+        icon={<Bot aria-hidden="true" size={18} style={{ color: 'var(--accent)' }} />}
+        actions={<button className="btn btn-secondary" onClick={loadTools} disabled={loading}>
           <RefreshCw size={13} className={cn(loading && 'animate-spin')} />
           {t('Obnovit', 'Refresh')}
-        </button>
-      </div>
+        </button>}
+      />
 
       {/* Server info chips */}
       {serverInfo && (

--- a/openbank-admin-ui/src/app/system/config/page.tsx
+++ b/openbank-admin-ui/src/app/system/config/page.tsx
@@ -9,6 +9,7 @@ import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { Shield, RefreshCw, Clock, Zap, ChevronDown, ChevronRight, Info, Circle, Loader2 } from 'lucide-react'
 import { fetchAllServiceConfigSnapshots } from '@/lib/api'
 import type { ServiceConfigSnapshot } from '@/types'
+import { PageHeader } from '@/components/ui/PageHeader'
 
 const POLL_INTERVAL = 15_000
 
@@ -50,24 +51,18 @@ export default function ServiceConfigPage() {
 
   return (
     <div>
-      {/* Page header */}
-      <div className="page-header">
-        <div>
-          <div className="breadcrumb">
+      <PageHeader
+        breadcrumb={<div className="breadcrumb">
             <span>OpenBank</span>
             <span className="breadcrumb-sep">/</span>
             <span>{t('Systém', 'System')}</span>
             <span className="breadcrumb-sep">/</span>
             <span className="breadcrumb-current">{t('Konfigurace', 'Configuration')}</span>
-          </div>
-          <h1 className="page-title">{t('Konfigurace služeb', 'Service Configuration')}</h1>
-          <p className="page-subtitle">
-            {t('Živé resilience politiky načtené z každé služby přes', 'Live resilience policies fetched from each service via')}{' '}
-            <code style={{ fontFamily: 'JetBrains Mono, monospace', fontSize: '12px', background: 'var(--surface-3)', padding: '1px 5px', borderRadius: '3px', border: '1px solid var(--border)' }}>/api/v1/config</code>.
-            {' '}{t('Automatická obnova každých', 'Auto-refreshes every')} {POLL_INTERVAL / 1000}s.
-          </p>
-        </div>
-        <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
+          </div>}
+        title={t('Konfigurace služeb', 'Service Configuration')}
+        icon={<Shield aria-hidden="true" size={18} style={{ color: 'var(--accent)' }} />}
+        subtitle={t('Živé resilience politiky načtené z každé služby přes', 'Live resilience policies fetched from each service via') + ' /api/v1/config. ' + t('Automatická obnova každých', 'Auto-refreshes every') + ` ${POLL_INTERVAL / 1000}s.`}
+        actions={<div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
           {lastRefresh && (
             <span style={{ fontSize: '11px', color: 'var(--text-tertiary)' }}>
               {lastRefresh.toLocaleTimeString()}
@@ -85,9 +80,8 @@ export default function ServiceConfigPage() {
             <RefreshCw size={12} className={loading ? 'spinning' : ''} />
             {t('Obnovit', 'Refresh')}
           </button>
-        </div>
-      </div>
-
+        </div>}
+      />
       {/* Status summary */}
       <div style={{ display: 'flex', gap: '10px', marginBottom: '16px' }}>
         <StatusPill color="#059669" bg="#ecfdf5" count={upCount} label={t('V pořádku', 'Healthy')} />

--- a/openbank-admin-ui/src/app/temporal/flow/page.tsx
+++ b/openbank-admin-ui/src/app/temporal/flow/page.tsx
@@ -10,6 +10,7 @@ import { FlowParticle } from '@/components/topology/FlowParticle'
 import { useFlowAnimation } from '@/components/topology/useFlowAnimation'
 import { ArrowMarker } from '@/components/topology/TopologyDefs'
 import { MONEY_WORKFLOWS } from '@/lib/temporal/workflows'
+import { PageHeader } from '@/components/ui/PageHeader'
 
 // ---------------------------------------------------------------------------
 // Temporal workflow flow (ADR-0100). The third animated topology view: each
@@ -68,24 +69,17 @@ export default function TemporalFlowPage() {
 
   return (
     <div style={{ padding: '28px 32px', maxWidth: '1400px' }}>
-      <div className="page-header">
-        <div>
-          <div className="breadcrumb">
+      <PageHeader
+        breadcrumb={<div className="breadcrumb">
             <span>OpenBank</span><span className="breadcrumb-sep">/</span>
             <span>Temporal</span><span className="breadcrumb-sep">/</span>
             <span className="breadcrumb-current">{t('Tok workflow', 'Workflow Flow')}</span>
-          </div>
-          <h1 className="page-title" style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-            <Workflow size={18} style={{ color: 'var(--accent)' }} />
-            {t('Tok Temporal workflow', 'Temporal Workflow Flow')}
-          </h1>
-          <p className="page-subtitle">
-            {t('Money-path ságy jako animované řetězce kroků (krok → krok → kompenzace). Kroky jsou zdokumentované definice ság; metriky jsou živé, ale agregátní za namespace (ne přehrání jednotlivých běhů).',
+          </div>}
+        title={t('Tok Temporal workflow', 'Temporal Workflow Flow')}
+        icon={<Workflow aria-hidden="true" size={18} style={{ color: 'var(--accent)' }} />}
+        subtitle={t('Money-path ságy jako animované řetězce kroků (krok → krok → kompenzace). Kroky jsou zdokumentované definice ság; metriky jsou živé, ale agregátní za namespace (ne přehrání jednotlivých běhů).',
                'Money-path sagas as animated step-chains (step → step → compensation). The steps are the documented saga definitions; the metrics are live but namespace-aggregate (not per-run replay).')}
-          </p>
-        </div>
-      </div>
-
+      />
       {/* Controls */}
       <div style={{ display: 'flex', justifyContent: 'flex-end', alignItems: 'center', marginBottom: '14px', gap: '8px' }}>
         <button onClick={() => setFlow(v => !v)} aria-pressed={flow} title={t('Přepnout tok', 'Toggle flow')}

--- a/openbank-admin-ui/src/test/system-operations-page-header.guard.test.ts
+++ b/openbank-admin-ui/src/test/system-operations-page-header.guard.test.ts
@@ -1,0 +1,26 @@
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const pages = [
+  'system/agent/page.tsx',
+  'system/config/page.tsx',
+  'temporal/flow/page.tsx',
+].map(file => readFileSync(path.resolve(__dirname, '../app', file), 'utf8'))
+
+describe('system operations page header contract', () => {
+  it('uses the shared header and valid breadcrumb wrapper', () => {
+    for (const page of pages) {
+      expect(page).toContain('<PageHeader')
+      expect(page).toContain('breadcrumb={<div className="breadcrumb">')
+      expect(page).not.toContain('className="page-header"')
+    }
+  })
+
+  it('keeps decorative icons hidden and native refresh controls wired', () => {
+    for (const page of pages) expect(page).toContain('aria-hidden="true"')
+    expect(pages[0]).toContain('onClick={loadTools}')
+    expect(pages[1]).toContain('fetchAllServiceConfigSnapshots')
+    expect(pages[2]).toContain('onClick={load}')
+  })
+})


### PR DESCRIPTION
Closes #5315

## Summary
- migrate system agent, service configuration, and Temporal workflow pages to the shared PageHeader
- preserve existing fetch, refresh, flow toggle, and live snapshot behavior
- add source guard coverage for breadcrumb/icon/control contracts

## Verification
- npm test -- --run src/test/system-operations-page-header.guard.test.ts route-permissions.test.ts
- npm run type-check
- git diff --check