### PR TITLE
fix(admin-ui): modernize compliance pack header

### DIFF
--- a/openbank-admin-ui/src/app/lending/compliance-packs/page.tsx
+++ b/openbank-admin-ui/src/app/lending/compliance-packs/page.tsx
@@ -22,6 +22,7 @@ import { useSession } from 'next-auth/react'
 import { CheckCircle2, Clock, RefreshCw, ShieldCheck, ScrollText, AlertTriangle } from 'lucide-react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { svcUrl } from '@/lib/services/bff'
+import { PageHeader } from '@/components/ui/PageHeader'
 
 /** Mirrors lending-service `PackActivationView`. `listActive()` synthesises id = all-zero UUID for
  *  every row (it projects the in-memory registry, not a workflow row) — never key a list on it. */
@@ -177,34 +178,27 @@ export default function CompliancePacksPage() {
 
   return (
     <div>
-      <div className="page-header">
-        <div>
-          <div className="breadcrumb">
+      <PageHeader
+        breadcrumb={<div className="breadcrumb">
             <span>OpenBank</span><span className="breadcrumb-sep">/</span>
             <span>{t('Úvěry', 'Lending')}</span><span className="breadcrumb-sep">/</span>
             <span className="breadcrumb-current">{t('Compliance packy', 'Compliance packs')}</span>
-          </div>
-          <h1 className="page-title" style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-            <ShieldCheck size={18} style={{ color: 'var(--accent)' }} />
-            {t('Aktivace compliance packů', 'Compliance pack activation')}
-          </h1>
-          <p className="page-subtitle">
-            {t(
-              'Jurisdikční úvěrové compliance packy (ADR-0212 D4). Maker navrhne, JINÝ compliance principál rozhodne. Aktivovaný pack platí okamžitě — bez release služby.',
-              'Jurisdictional credit compliance packs (ADR-0212 D4). A maker proposes, a DIFFERENT compliance principal decides. An activated pack takes effect immediately — no service release.',
-            )}
-          </p>
-          {actor && (
-            <p className="page-subtitle" data-testid="acting-as">
-              {t('Jednáte jako', 'Acting as')}: <strong>{actor}</strong>
-            </p>
-          )}
-        </div>
-        <button onClick={() => void load()} disabled={loading} className="btn btn-secondary" style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 12 }}>
+          </div>}
+        title={t('Aktivace compliance packů', 'Compliance pack activation')}
+        icon={<ShieldCheck aria-hidden="true" size={18} style={{ color: 'var(--accent)' }} />}
+        subtitle={t(
+          'Jurisdikční úvěrové compliance packy (ADR-0212 D4). Maker navrhne, JINÝ compliance principál rozhodne. Aktivovaný pack platí okamžitě — bez release služby.',
+          'Jurisdictional credit compliance packs (ADR-0212 D4). A maker proposes, a DIFFERENT compliance principal decides. An activated pack takes effect immediately — no service release.',
+        )}
+        actions={<button onClick={() => void load()} disabled={loading} className="btn btn-secondary" style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 12 }}>
           <RefreshCw size={14} className={loading ? 'animate-spin' : ''} /> {t('Obnovit', 'Refresh')}
-        </button>
-      </div>
-
+        </button>}
+      />
+      {actor && (
+        <p className="page-subtitle" data-testid="acting-as">
+          {t('Jednáte jako', 'Acting as')}: <strong>{actor}</strong>
+        </p>
+      )}
       {degraded.length > 0 && (
         <div className="card" data-testid="degraded" style={{ padding: 12, marginBottom: 16, borderLeft: '3px solid var(--warning)', fontSize: 13, display: 'flex', alignItems: 'center', gap: 6 }}>
           <AlertTriangle size={14} />

--- a/openbank-admin-ui/src/test/lending-compliance-page-header.guard.test.ts
+++ b/openbank-admin-ui/src/test/lending-compliance-page-header.guard.test.ts
@@ -1,0 +1,20 @@
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const page = readFileSync(path.resolve(__dirname, '../app/lending/compliance-packs/page.tsx'), 'utf8')
+
+describe('lending compliance page header contract', () => {
+  it('uses the shared header and preserves the compliance breadcrumb', () => {
+    expect(page).toContain('<PageHeader')
+    expect(page).toContain('breadcrumb={<div className="breadcrumb">')
+    expect(page).not.toContain('className="page-header"')
+  })
+
+  it('keeps the maker-checker actions and decorative icon semantics', () => {
+    expect(page).toContain('aria-hidden="true"')
+    expect(page).toContain('PACKS_BASE}/proposals')
+    expect(page).toContain('PACKS_BASE}/proposals/${id}/decide')
+    expect(page).toContain('onClick={() => void load()}')
+  })
+})


### PR DESCRIPTION
Closes #5319

## Summary
- migrate the ADR-0212 lending compliance-pack console to the shared PageHeader
- preserve maker-checker proposal/decision flows, refresh behavior, and compliance role routing
- add source guard coverage for header, breadcrumb, icon, and endpoint contracts

## Verification
- npm test -- --run src/test/lending-compliance-page-header.guard.test.ts route-permissions.test.ts
- npm run type-check
- git diff --check