### PR TITLE
feat(flaky-test-hunter): wire AI-attributed audit + adapter contract proof for the GitHub PR path

### DIFF
--- a/openbank-flaky-test-hunter/src/main/kotlin/com/openbank/flakytest/application/workflow/DiagnoseAndProposeActivityImpl.kt
+++ b/openbank-flaky-test-hunter/src/main/kotlin/com/openbank/flakytest/application/workflow/DiagnoseAndProposeActivityImpl.kt
@@ -10,6 +10,10 @@ import com.openbank.flakytest.application.port.out.GitHubProposalPort
 import com.openbank.flakytest.application.port.out.LlmDiagnosisPort
 import com.openbank.flakytest.domain.model.FindingStatus
 import com.openbank.flakytest.domain.model.FlakyTestFinding
+import com.openbank.flakytest.infrastructure.config.FlakyTestHunterConfig
+import com.openbank.libs.audit.AuditEvent
+import com.openbank.libs.audit.AuditEventPublisher
+import com.openbank.libs.audit.AuditResult
 import io.quarkus.vertx.VertxContextSupport
 import io.smallrye.mutiny.coroutines.asUni
 import jakarta.enterprise.context.ApplicationScoped
@@ -19,11 +23,21 @@ import kotlinx.coroutines.async
 import org.jboss.logging.Logger
 import java.time.Instant
 
+/**
+ * ADR-0031 D9 phase-3: every disposition this development agent reaches for a finding —
+ * whether it results in a real GitHub PR or falls back to the ticket-only path — is recorded as
+ * AI-attributed audit (D5) before returning. `actorType = AI_AGENT` and `policy_decision` mirror
+ * the same envelope shape `AgentPolicyGate` uses for MCP tool calls; this activity is the
+ * equivalent enforcement point for the Temporal-workflow action surface, since flaky-test-hunter
+ * never calls MCP tools directly.
+ */
 @ApplicationScoped
 open class DiagnoseAndProposeActivityImpl(
     private val llm: LlmDiagnosisPort,
     private val githubProposal: GitHubProposalPort,
     private val findingRepository: FindingRepository,
+    private val auditPublisher: AuditEventPublisher,
+    private val config: FlakyTestHunterConfig,
 ) : DiagnoseAndProposeActivity {
 
     private val log = Logger.getLogger(DiagnoseAndProposeActivityImpl::class.java)
@@ -68,11 +82,46 @@ open class DiagnoseAndProposeActivityImpl(
                 proposedAt = Instant.now(),
             )
         }
+        auditProposal(finding, fixDiff, proposed.proposalUrl)
         findingRepository.update(proposed)
+    }
+
+    /**
+     * One AI-attributed [AuditEvent] per disposition, regardless of outcome — a refusal is exactly
+     * as auditable as an opened PR (D5, ADR-0031). `policy_decision` is `ALLOW` only when this
+     * capability's own fail-closed write path (`GitHubProposalPort.openProposalPr`) actually
+     * produced a PR; every other outcome — no mechanical fix, a missing/invalid token, an
+     * ineligible finding, or a GitHub API failure — is `DENY` and falls back to the ticket-only
+     * path. No human approver is known yet at proposal time (that is [FindingStatus.APPROVED],
+     * recorded separately once a human disposes the finding through the HITL queue).
+     */
+    private suspend fun auditProposal(finding: FlakyTestFinding, fixDiff: String?, proposalUrl: String?) {
+        val prOpened = fixDiff != null && proposalUrl != null
+        auditPublisher.publish(
+            AuditEvent(
+                actorId = AGENT_ID,
+                actorType = "AI_AGENT",
+                operation = if (prOpened) "$AGENT_ID.github.pr_opened" else "$AGENT_ID.github.ticket_opened",
+                resourceType = "flaky_test_finding",
+                resourceId = finding.id,
+                result = if (proposalUrl != null) AuditResult.SUCCESS else AuditResult.DENIED,
+                payload = mapOf(
+                    "model_id" to config.modelId(),
+                    "flaky_test_check_type_impacted" to finding.checkType.name,
+                    "policy_decision" to if (prOpened) "ALLOW" else "DENY",
+                    "proposal_url" to proposalUrl,
+                    "human_approved_by" to null,
+                ),
+            ),
+        )
     }
 
     @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
     protected open fun <T> runOnVertxContext(block: suspend () -> T): T = VertxContextSupport.subscribeAndAwait {
         CoroutineScope(Dispatchers.Unconfined).async { block() }.asUni()
+    }
+
+    private companion object {
+        const val AGENT_ID = "flaky-test-hunter"
     }
 }

--- a/openbank-flaky-test-hunter/src/test/kotlin/com/openbank/flakytest/application/workflow/DiagnoseAndProposeActivityImplTest.kt
+++ b/openbank-flaky-test-hunter/src/test/kotlin/com/openbank/flakytest/application/workflow/DiagnoseAndProposeActivityImplTest.kt
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+
+package com.openbank.flakytest.application.workflow
+
+import com.openbank.flakytest.application.port.out.FindingRepository
+import com.openbank.flakytest.application.port.out.GitHubProposalPort
+import com.openbank.flakytest.application.port.out.LlmDiagnosisPort
+import com.openbank.flakytest.domain.model.FindingSeverity
+import com.openbank.flakytest.domain.model.FlakyTestCheckType
+import com.openbank.flakytest.domain.model.FlakyTestFinding
+import com.openbank.flakytest.infrastructure.config.FlakyTestHunterConfig
+import com.openbank.libs.audit.AuditEvent
+import com.openbank.libs.audit.AuditEventPublisher
+import com.openbank.libs.audit.AuditResult
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.Instant
+import java.util.Optional
+
+/**
+ * ADR-0031 D9 phase-3 / D5: proves the AI-attributed [AuditEvent] fires for BOTH dispositions this
+ * capability can reach — a real GitHub PR, and the ticket-only fallback — not only the success path.
+ * `runOnVertxContext` is overridden with `runBlocking` (the established fleet pattern, see
+ * `openbank-governance-auditor`'s `DetectViolationsActivityImplTest`) since a live Vert.x duplicated
+ * context is not available to a plain unit test.
+ */
+class DiagnoseAndProposeActivityImplTest {
+
+    private val llm = mockk<LlmDiagnosisPort>()
+    private val githubProposal = mockk<GitHubProposalPort>()
+    private val findingRepository = mockk<FindingRepository>()
+    private val auditPublisher = mockk<AuditEventPublisher>(relaxed = true)
+    private val config = mockk<FlakyTestHunterConfig> {
+        every { modelId() } returns "deepseek-ai/DeepSeek-V3.2"
+        every { githubApiUrl() } returns "https://api.github.com"
+        every { githubRepo() } returns "JiRaska/open-bank-oss"
+        every { githubToken() } returns Optional.empty()
+        every { llmGatewayUrl() } returns "http://litellm.ai-platform:4000"
+        every { checkCron() } returns "0 30 6 ? * SUN"
+        every { repoRoot() } returns "."
+    }
+
+    private val activity = object : DiagnoseAndProposeActivityImpl(
+        llm,
+        githubProposal,
+        findingRepository,
+        auditPublisher,
+        config,
+    ) {
+        override fun <T> runOnVertxContext(block: suspend () -> T): T = runBlocking { block() }
+    }
+
+    private fun aFinding() = FlakyTestFinding(
+        id = "finding-1",
+        checkType = FlakyTestCheckType.RUNBLOCKING_UNIT_MISSING,
+        severity = FindingSeverity.CRITICAL,
+        detectedAt = Instant.now(),
+        title = "SomeTest.kt:12 uses the unsafe '= runBlocking {' form without ': Unit'",
+        component = "openbank-flaky-test-hunter/src/test/kotlin/.../SomeTest.kt",
+        filePath = "openbank-flaky-test-hunter/src/test/kotlin/.../SomeTest.kt",
+        rawMetricValue = BigDecimal.ONE,
+        threshold = BigDecimal.ZERO,
+        rootCause = "expression-body runBlocking with no explicit Unit return type",
+    )
+
+    @Test
+    fun `a real PR opened records an ALLOW policy decision and SUCCESS result`() {
+        val finding = aFinding()
+        coEvery { llm.proposeFixDiff(finding, finding.rootCause!!) } returns "add-explicit-unit-return-type"
+        coEvery {
+            githubProposal.openProposalPr(finding, "add-explicit-unit-return-type")
+        } returns "https://github.com/JiRaska/open-bank-oss/pull/9001"
+        coEvery { findingRepository.update(any()) } answers { firstArg() }
+
+        val result = activity.propose(finding)
+
+        assertThat(result.proposalUrl).isEqualTo("https://github.com/JiRaska/open-bank-oss/pull/9001")
+        val captured = slot<AuditEvent>()
+        coVerify(exactly = 1) { auditPublisher.publish(capture(captured)) }
+        val event = captured.captured
+        assertThat(event.actorType).isEqualTo("AI_AGENT")
+        assertThat(event.actorId).isEqualTo("flaky-test-hunter")
+        assertThat(event.operation).isEqualTo("flaky-test-hunter.github.pr_opened")
+        assertThat(event.resourceType).isEqualTo("flaky_test_finding")
+        assertThat(event.resourceId).isEqualTo("finding-1")
+        assertThat(event.result).isEqualTo(AuditResult.SUCCESS)
+        assertThat(event.payload["policy_decision"]).isEqualTo("ALLOW")
+        assertThat(event.payload["model_id"]).isEqualTo("deepseek-ai/DeepSeek-V3.2")
+        assertThat(event.payload["proposal_url"]).isEqualTo("https://github.com/JiRaska/open-bank-oss/pull/9001")
+    }
+
+    @Test
+    fun `no mechanical fix falls back to the ticket path and records a DENY policy decision`() {
+        val finding = aFinding()
+        coEvery { llm.proposeFixDiff(finding, finding.rootCause!!) } returns null
+        coEvery { githubProposal.openTicket(finding, finding.rootCause!!) } returns null
+        coEvery { findingRepository.update(any()) } answers { firstArg() }
+
+        val result = activity.propose(finding)
+
+        assertThat(result.proposalUrl).isNull()
+        val captured = slot<AuditEvent>()
+        coVerify(exactly = 1) { auditPublisher.publish(capture(captured)) }
+        val event = captured.captured
+        assertThat(event.operation).isEqualTo("flaky-test-hunter.github.ticket_opened")
+        assertThat(event.result).isEqualTo(AuditResult.DENIED)
+        assertThat(event.payload["policy_decision"]).isEqualTo("DENY")
+        assertThat(event.payload["proposal_url"]).isNull()
+    }
+
+    @Test
+    fun `a fix diff exists but the GitHub write is refused still records DENY, never a fabricated ALLOW`() {
+        val finding = aFinding()
+        coEvery { llm.proposeFixDiff(finding, finding.rootCause!!) } returns "add-explicit-unit-return-type"
+        // Fail-closed adapter refusal (no token, ineligible finding, or a failed GitHub call) — null,
+        // never an exception and never a fabricated URL.
+        coEvery { githubProposal.openProposalPr(finding, "add-explicit-unit-return-type") } returns null
+        coEvery { githubProposal.openTicket(finding, finding.rootCause!!) } returns null
+        coEvery { findingRepository.update(any()) } answers { firstArg() }
+
+        activity.propose(finding)
+
+        val captured = slot<AuditEvent>()
+        coVerify(exactly = 1) { auditPublisher.publish(capture(captured)) }
+        assertThat(captured.captured.payload["policy_decision"]).isEqualTo("DENY")
+        assertThat(captured.captured.result).isEqualTo(AuditResult.DENIED)
+    }
+}

--- a/openbank-flaky-test-hunter/src/test/kotlin/com/openbank/flakytest/infrastructure/adapter/GitHubProposalAdapterTest.kt
+++ b/openbank-flaky-test-hunter/src/test/kotlin/com/openbank/flakytest/infrastructure/adapter/GitHubProposalAdapterTest.kt
@@ -1,0 +1,236 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+
+package com.openbank.flakytest.infrastructure.adapter
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.flakytest.domain.model.FindingSeverity
+import com.openbank.flakytest.domain.model.FlakyTestCheckType
+import com.openbank.flakytest.domain.model.FlakyTestFinding
+import com.openbank.flakytest.infrastructure.config.FlakyTestHunterConfig
+import com.sun.net.httpserver.HttpExchange
+import com.sun.net.httpserver.HttpServer
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.net.InetSocketAddress
+import java.nio.charset.StandardCharsets
+import java.time.Instant
+import java.util.Base64
+import java.util.Optional
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * ADR-0031 D9 phase-3 proof: [GitHubProposalAdapter] round-tripped against a real in-JVM GitHub
+ * REST stub (com.sun HttpServer, the fleet's established idiom — see
+ * `OpenAiCompatibleLlmGatewayClientTest`) so the actual GitHub Contents/Refs/Pulls API shape is
+ * exercised, not a hand-waved interface mock. Two proofs the issue requires explicitly:
+ * 1. an eligible finding opens a real PR with the right branch/title/body/diff scope;
+ * 2. an unconfigured (no-token) adapter refuses cleanly — no exception, no fabricated success, and
+ *    it makes zero network calls (the fail-closed contract, not merely a null return).
+ */
+class GitHubProposalAdapterTest {
+
+    private var server: HttpServer? = null
+    private val requestsSeen = AtomicInteger(0)
+    private var lastPullRequestBody: String? = null
+    private var lastCommitRequestBody: String? = null
+    private var lastBranchRequestBody: String? = null
+    private val objectMapper = ObjectMapper()
+
+    @AfterEach
+    fun stop() {
+        server?.stop(0)
+    }
+
+    private val eligibleFinding = FlakyTestFinding(
+        id = "abcdef1234567890",
+        checkType = FlakyTestCheckType.RUNBLOCKING_UNIT_MISSING,
+        severity = FindingSeverity.CRITICAL,
+        detectedAt = Instant.now(),
+        title = "SomeTest.kt:12 uses the unsafe '= runBlocking {' form without ': Unit'",
+        component = "openbank-flaky-test-hunter/src/test/kotlin/com/openbank/flakytest/SomeTest.kt",
+        filePath = "openbank-flaky-test-hunter/src/test/kotlin/com/openbank/flakytest/SomeTest.kt",
+        rawMetricValue = BigDecimal.ONE,
+        threshold = BigDecimal.ZERO,
+    )
+
+    // Built via interpolation, not a literal 'fun ... = runBlocking {' substring in this file — see
+    // TestScanAdapterTest's fixture comment: that exact shape written literally under
+    // src/test/**/*.kt would itself trip check-test-runblocking-unit.sh.
+    private val runBlockingBuilder = "runBlocking"
+    private val sourceWithOneRepairableFunction = """
+        package com.openbank.flakytest
+        class SomeTest {
+            fun lostTest() = $runBlockingBuilder { assertTrue(true) }
+        }
+    """.trimIndent()
+
+    /** Starts a minimal but contract-faithful GitHub REST API stub covering the five endpoints
+     * the adapter calls in sequence for an eligible finding. */
+    private fun startGitHubStub(): String {
+        val srv = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
+        srv.createContext("/repos/test-owner/test-repo/git/ref/heads/main") { ex: HttpExchange ->
+            requestsSeen.incrementAndGet()
+            respond(ex, 200, """{"object":{"sha":"base-sha-123"}}""")
+        }
+        srv.createContext("/repos/test-owner/test-repo/contents/") { ex: HttpExchange ->
+            requestsSeen.incrementAndGet()
+            when (ex.requestMethod) {
+                "GET" -> {
+                    val encoded = Base64.getEncoder().encodeToString(
+                        sourceWithOneRepairableFunction.toByteArray(StandardCharsets.UTF_8),
+                    )
+                    respond(ex, 200, """{"sha":"file-sha-456","content":"$encoded"}""")
+                }
+                "PUT" -> {
+                    lastCommitRequestBody = ex.requestBody.readBytes().toString(StandardCharsets.UTF_8)
+                    respond(ex, 200, """{"content":{"sha":"new-file-sha"}}""")
+                }
+                else -> respond(ex, 405, "{}")
+            }
+        }
+        srv.createContext("/repos/test-owner/test-repo/git/refs") { ex: HttpExchange ->
+            requestsSeen.incrementAndGet()
+            lastBranchRequestBody = ex.requestBody.readBytes().toString(StandardCharsets.UTF_8)
+            respond(ex, 201, """{"ref":"refs/heads/branch"}""")
+        }
+        srv.createContext("/repos/test-owner/test-repo/pulls") { ex: HttpExchange ->
+            requestsSeen.incrementAndGet()
+            lastPullRequestBody = ex.requestBody.readBytes().toString(StandardCharsets.UTF_8)
+            respond(
+                ex,
+                201,
+                """{"html_url":"https://github.com/test-owner/test-repo/pull/9001"}""",
+            )
+        }
+        srv.start()
+        server = srv
+        return "http://127.0.0.1:${srv.address.port}"
+    }
+
+    private fun respond(ex: HttpExchange, status: Int, body: String) {
+        val bytes = body.toByteArray(StandardCharsets.UTF_8)
+        ex.sendResponseHeaders(status, bytes.size.toLong())
+        ex.responseBody.use { it.write(bytes) }
+    }
+
+    private fun configWithToken(baseUrl: String, token: Optional<String>): FlakyTestHunterConfig = mockk {
+        every { githubApiUrl() } returns baseUrl
+        every { githubRepo() } returns "test-owner/test-repo"
+        every { githubToken() } returns token
+    }
+
+    private fun adapterFor(config: FlakyTestHunterConfig): GitHubProposalAdapter {
+        val adapter = GitHubProposalAdapter(config)
+        adapter.objectMapper = objectMapper
+        return adapter
+    }
+
+    @Test
+    fun `an eligible finding with a token opens a real PR with the right branch, title, body and diff scope`() {
+        val baseUrl = startGitHubStub()
+        val adapter = adapterFor(configWithToken(baseUrl, Optional.of("fine-grained-test-token")))
+
+        val prUrl = runBlocking { adapter.openProposalPr(eligibleFinding, "add-explicit-unit-return-type") }
+
+        assertThat(prUrl).isEqualTo("https://github.com/test-owner/test-repo/pull/9001")
+        // GET contents, GET ref/heads/main, POST git/refs, PUT contents, POST pulls — exactly once each.
+        assertThat(requestsSeen.get()).isEqualTo(5)
+
+        val branchRequest = objectMapper.readTree(lastBranchRequestBody)
+        assertThat(branchRequest.path("ref").asText()).isEqualTo("refs/heads/flaky-test-hunter/unit-return-abcdef12")
+        assertThat(branchRequest.path("sha").asText()).isEqualTo("base-sha-123")
+
+        val commitRequest = objectMapper.readTree(lastCommitRequestBody)
+        assertThat(commitRequest.path("branch").asText()).isEqualTo("flaky-test-hunter/unit-return-abcdef12")
+        val decodedContent = String(
+            Base64.getDecoder().decode(commitRequest.path("content").asText()),
+            StandardCharsets.UTF_8,
+        )
+        assertThat(decodedContent).contains("fun lostTest(): Unit = runBlocking { assertTrue(true) }")
+
+        val pullRequest = objectMapper.readTree(lastPullRequestBody)
+        assertThat(pullRequest.path("title").asText()).isEqualTo("fix(flaky-test-hunter): restore JUnit test execution")
+        assertThat(pullRequest.path("head").asText()).isEqualTo("flaky-test-hunter/unit-return-abcdef12")
+        assertThat(pullRequest.path("base").asText()).isEqualTo("main")
+        assertThat(pullRequest.path("body").asText())
+            .contains(eligibleFinding.filePath)
+            .contains("did not modify production code, approve, or merge")
+            .contains("#5281")
+    }
+
+    @Test
+    fun `no token configured refuses cleanly with no exception, no fabricated success, and no network call`() {
+        var stubHit = false
+        val srv = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
+        srv.createContext("/") { ex: HttpExchange ->
+            stubHit = true
+            respond(ex, 500, "{}")
+        }
+        srv.start()
+        server = srv
+        val baseUrl = "http://127.0.0.1:${srv.address.port}"
+        val adapter = adapterFor(configWithToken(baseUrl, Optional.empty()))
+
+        val prUrl = runBlocking { adapter.openProposalPr(eligibleFinding, "add-explicit-unit-return-type") }
+
+        assertThat(prUrl).isNull()
+        assertThat(stubHit)
+            .describedAs("a missing token must fail closed before any GitHub API call is attempted")
+            .isFalse()
+    }
+
+    @Test
+    fun `a blank token is treated identically to a missing one`() {
+        var stubHit = false
+        val srv = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
+        srv.createContext("/") { ex: HttpExchange ->
+            stubHit = true
+            respond(ex, 500, "{}")
+        }
+        srv.start()
+        server = srv
+        val baseUrl = "http://127.0.0.1:${srv.address.port}"
+        val adapter = adapterFor(configWithToken(baseUrl, Optional.of("   ")))
+
+        val prUrl = runBlocking { adapter.openProposalPr(eligibleFinding, "add-explicit-unit-return-type") }
+
+        assertThat(prUrl).isNull()
+        assertThat(stubHit).isFalse()
+    }
+
+    @Test
+    fun `an ineligible finding (outside own test source) is refused before any network call`() {
+        val baseUrl = startGitHubStub()
+        val adapter = adapterFor(configWithToken(baseUrl, Optional.of("fine-grained-test-token")))
+        val outOfScope = eligibleFinding.copy(
+            filePath = "openbank-ledger-service/src/test/kotlin/com/openbank/ledger/SomeTest.kt",
+            component = "openbank-ledger-service/src/test/kotlin/com/openbank/ledger/SomeTest.kt",
+        )
+
+        val prUrl = runBlocking { adapter.openProposalPr(outOfScope, "add-explicit-unit-return-type") }
+
+        assertThat(prUrl).isNull()
+        assertThat(requestsSeen.get())
+            .describedAs("a money-path/other-service path must never even reach the GitHub API")
+            .isEqualTo(0)
+    }
+
+    @Test
+    fun `an unrecognized fix marker is refused before any network call`() {
+        val baseUrl = startGitHubStub()
+        val adapter = adapterFor(configWithToken(baseUrl, Optional.of("fine-grained-test-token")))
+
+        val prUrl = runBlocking { adapter.openProposalPr(eligibleFinding, "some-model-generated-diff") }
+
+        assertThat(prUrl).isNull()
+        assertThat(requestsSeen.get()).isEqualTo(0)
+    }
+}


### PR DESCRIPTION
Refs #5281, ADR-0031 D9 phase 3.

## Context

Issue #5281 was already closed by #5289 (merged 2026-08-17), which replaced
`GitHubProposalAdapter`'s placeholder with the real, token-backed, fail-closed
implementation: fine-grained-token check, GitHub Contents/Refs/Pulls calls, a
mechanically-verifiable one-file/one-function repair shape, and a GitOps
`ExternalSecret` binding. Re-reading that PR and the adapter against the issue's
own explicit checklist found two items #5289 did not cover, which this PR closes:

1. **No test exercised the adapter's actual HTTP behavior.** The committed tests
   (`ExplicitUnitReturnTypeTest`) only cover the pure string transformer and the
   path-safety check — nothing drove `GitHubProposalAdapter.openProposalPr`
   itself, so neither "a real PR gets opened with the right shape" nor "no token
   ⇒ clean refusal" had contract/integration proof, as the issue requires.
2. **No AI-attributed audit event fired for this capability's actions.** D5 says
   `AuditEvent` should be emitted with `actorType = AI_AGENT` for every agent
   action; `DiagnoseAndProposeActivityImpl.propose()` (the code path that decides
   whether a finding gets a real PR or falls back to a ticket) called
   `GitHubProposalPort` but never published anything to `AuditEventPublisher`.
   That gap isn't unique to flaky-test-hunter — none of its sibling development
   agents (release-steward, governance-auditor, docs-truth-agent,
   authz-policy-auditor) wire `AuditEventPublisher` either — but this issue's own
   scope is specifically this capability, so this PR wires it here only. The
   fleet-wide gap is a separate, larger sweep and is out of scope for this PR.

## What this PR adds

- `DiagnoseAndProposeActivityImpl` now takes `AuditEventPublisher` +
  `FlakyTestHunterConfig` and publishes one `AuditEvent` per disposition
  (`actorType=AI_AGENT`, `actorId=flaky-test-hunter`), regardless of outcome — a
  refused write is exactly as auditable as an opened PR. `policy_decision` is
  `ALLOW` only when a real PR was opened; every other outcome (no mechanical fix,
  missing/blank token, an ineligible finding, or a failed GitHub call) is `DENY`
  and the `AuditResult` is `DENIED`. Uses the repo's existing `AuditEvent` /
  `AuditEventPublisher` (`openbank-libs-domain`/`-runtime`, ADR-0031 D5) — no new
  audit mechanism.
- `GitHubProposalAdapterTest`: rounds the adapter against a real in-JVM GitHub
  REST stub (`com.sun.net.httpserver.HttpServer`, the fleet's established idiom
  — see `OpenAiCompatibleLlmGatewayClientTest`), proving:
  - an eligible finding + a valid token opens a real PR with the exact branch
    (`flaky-test-hunter/unit-return-<id8>`), title, base (`main`), and body
    (references the changed file, "did not modify production code, approve, or
    merge", and `#5281`), and the diff scope is exactly the one `: Unit`
    insertion;
  - **no token configured refuses cleanly**: `null` return, no exception, and
    the stub records **zero** HTTP hits — the adapter never reaches the network,
    which is the fail-closed contract, not merely "returns null";
  - a blank token is treated identically to a missing one;
  - a finding outside `openbank-flaky-test-hunter/src/test/kotlin/` (the one
    allowed non-money-path service/path scope) and an unrecognized fix marker
    are both refused before any network call.
- `DiagnoseAndProposeActivityImplTest`: proves the audit event fires with the
  right `policy_decision`/`result` for the PR-opened path, the no-mechanical-fix
  ticket fallback, and the "fix exists but the GitHub write was refused" case
  (proving the activity never fabricates an `ALLOW` when the adapter itself
  denied the write).

## Explicitly NOT changed

- **The allowed target service is unchanged: `openbank-flaky-test-hunter` only**,
  and only its own `src/test/kotlin/` tree — enforced mechanically by
  `BoundedTestPath.isSafe` (path prefix + no `..`/encoded-path/leading-slash
  bypass) in the adapter, not by a prompt instruction. Confirmed
  `openbank-flaky-test-hunter` is **not** in `rules.yaml: money_path_services`.
- **No rollout-status flag is flipped.** `agents.yaml`'s `flaky-test-hunter`
  charter and ADR-0031's D9 phasing table are untouched — the ADR's own
  delivery note already lists D9 phase 3 as this issue's scope without claiming
  it "live" anywhere, and this PR does not add such a claim. Per the issue: that
  step needs a human to actually merge a PR this pipeline opened first, which
  cannot happen inside this task. This PR does not close #5281 (it's already
  closed) — it closes the residual gap found by re-checking the issue's
  checklist against what #5289 shipped.
- No merge/approval capability exists anywhere in this path — `GitHubProposalPort`
  has no merge or approve method, and the PR body text says so explicitly.

## Deployment evidence (from #5289, verified still present)

- `openbank-infra/gitops/components/flaky-test-hunter/model-externalsecret.yaml`:
  a fine-grained-token `ExternalSecret` scoped to `contents:write` +
  `pull_requests:write` on this repository only, sourced from OpenBao
  (`vault-kv` `ClusterSecretStore`), seeded by a separate operator action
  (`bao kv patch openbank/flaky-test-hunter GITHUB_TOKEN=<token>`) — distinct
  from every other agent's credential, so revoking it disables only this one
  capability.
- **What still needs a human step, unchanged from #5289's own PR body:** an
  operator must actually seed that OpenBao value in a real environment, and a
  human must merge at least one PR this pipeline opens, before D9 phase 3 is
  promoted from "capability exists, fail-closed, gated" to "in active use."
  This PR adds proof the capability behaves correctly under test; it does not
  and cannot supply that human step.

## Verification

- `./gradlew :openbank-flaky-test-hunter:test` — full module suite green,
  including the 5 new `GitHubProposalAdapterTest` cases and 3 new
  `DiagnoseAndProposeActivityImplTest` cases (0 failures/skipped/errors).
- `./gradlew :openbank-flaky-test-hunter:ktlintCheck :openbank-flaky-test-hunter:detekt` — clean.
- `./gradlew :openbank-flaky-test-hunter:quarkusBuild` — CDI wiring for the two
  new constructor dependencies resolves at build time (ArC augmentation), not
  just at the unit-test level.
- `.github/scripts/check-test-runblocking-unit.sh openbank-flaky-test-hunter` —
  clean (the new test fixtures use the established string-interpolation trick
  so the guard doesn't trip on its own literal test text).
- `check-agent-model-parity.py`, `check-prompt-registry.py`,
  `check-agent-charter-registry.sh` — all green, no drift (agents.yaml untouched).

Never merge, never `--admin` — human review required per D4.
