### PR TITLE
fix(admin-ui): unify documentation page headers

### DIFF
--- a/openbank-admin-ui/src/app/docs/adr/[slug]/page.tsx
+++ b/openbank-admin-ui/src/app/docs/adr/[slug]/page.tsx
@@ -12,6 +12,7 @@ import { ChevronLeft, ScrollText, Calendar, User } from 'lucide-react'
 import { MarkdownView } from '@/components/docs/MarkdownView'
 import { MermaidEnhancer } from '@/components/docs/MermaidEnhancer'
 import { loadAdr, type AdrStatus } from '@/lib/governance/docs'
+import { DocsPageHeader } from '@/components/docs/DocsPageHeader'
 
 export const dynamic = 'force-dynamic'
 
@@ -46,26 +47,22 @@ export default async function AdrDetailPage({ params }: PageProps) {
 
   return (
     <div>
-      <div className="page-header">
-        <div>
-          <div className="breadcrumb">
+      <DocsPageHeader
+        crumbs={<>
             <span>OpenBank</span><span className="breadcrumb-sep">/</span>
             <Link href="/docs" style={{ color: 'inherit', textDecoration: 'none' }}>Docs</Link>
             <span className="breadcrumb-sep">/</span>
             <Link href="/docs/adr" style={{ color: 'inherit', textDecoration: 'none' }}>ADR</Link>
             <span className="breadcrumb-sep">/</span>
             <span className="breadcrumb-current">{adr ? adr.numberLabel : slug}</span>
-          </div>
-          <h1 className="page-title" style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-            <ScrollText size={18} style={{ color: 'var(--accent)' }} />
-            {adr ? `ADR-${adr.numberLabel} — ${adr.title}` : t('Rozhodnutí nenalezeno', 'Decision not found')}
-          </h1>
-        </div>
-        <Link href="/docs/adr" className="btn btn-secondary" style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+          </>}
+        title={adr ? `ADR-${adr.numberLabel} — ${adr.title}` : t('Rozhodnutí nenalezeno', 'Decision not found')}
+        icon={<ScrollText aria-hidden="true" size={18} style={{ color: 'var(--accent)' }} />}
+        actions={<Link href="/docs/adr" className="btn btn-secondary" style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
           <ChevronLeft size={14} />
           {t('Zpět na registr', 'Back to registry')}
-        </Link>
-      </div>
+        </Link>}
+      />
 
       <div className="card" style={{ padding: '24px' }}>
         {!adr ? (

--- a/openbank-admin-ui/src/app/docs/adr/page.tsx
+++ b/openbank-admin-ui/src/app/docs/adr/page.tsx
@@ -10,6 +10,7 @@ import Link from 'next/link'
 import { cookies } from 'next/headers'
 import { ChevronLeft, ScrollText, FileText } from 'lucide-react'
 import { loadAdrIndex, type AdrMeta, type AdrStatus } from '@/lib/governance/docs'
+import { DocsPageHeader } from '@/components/docs/DocsPageHeader'
 
 export const dynamic = 'force-dynamic'
 
@@ -49,30 +50,24 @@ export default async function AdrRegistryPage() {
 
   return (
     <div>
-      <div className="page-header">
-        <div>
-          <div className="breadcrumb">
+      <DocsPageHeader
+        crumbs={<>
             <span>OpenBank</span><span className="breadcrumb-sep">/</span>
             <Link href="/docs" style={{ color: 'inherit', textDecoration: 'none' }}>Docs</Link>
             <span className="breadcrumb-sep">/</span>
             <span className="breadcrumb-current">{t('Architektonická rozhodnutí', 'Architecture Decisions')}</span>
-          </div>
-          <h1 className="page-title" style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-            <ScrollText size={18} style={{ color: 'var(--accent)' }} />
-            {t('Registr architektonických rozhodnutí (ADR)', 'Architecture Decision Records (ADR)')}
-          </h1>
-          <p className="page-subtitle">
-            {t(
+          </>}
+        title={t('Registr architektonických rozhodnutí (ADR)', 'Architecture Decision Records (ADR)')}
+        subtitle={t(
               `${adrs.length} rozhodnutí — proč je systém postavený tak, jak je. Každé ADR má kontext, rozhodnutí a důsledky.`,
               `${adrs.length} decisions — why the system is built the way it is. Each ADR records context, decision and consequences.`,
             )}
-          </p>
-        </div>
-        <Link href="/docs" className="btn btn-secondary" style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+        icon={<ScrollText aria-hidden="true" size={18} style={{ color: 'var(--accent)' }} />}
+        actions={<Link href="/docs" className="btn btn-secondary" style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
           <ChevronLeft size={14} />
           {t('Zpět na dokumentaci', 'Back to docs')}
-        </Link>
-      </div>
+        </Link>}
+      />
 
       {adrs.length === 0 ? (
         <div className="card" style={{ padding: '24px' }}>

--- a/openbank-admin-ui/src/app/docs/api/page.tsx
+++ b/openbank-admin-ui/src/app/docs/api/page.tsx
@@ -7,6 +7,7 @@ import { useEffect, useState, useCallback } from 'react'
 import { FileCode, RefreshCw, CheckCircle2, XCircle, MinusCircle, ChevronDown, ChevronRight, Zap } from 'lucide-react'
 import { svcUrl } from '@/lib/services/bff'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
+import { DocsPageHeader } from '@/components/docs/DocsPageHeader'
 
 // UI short-id → Kubernetes Deployment/Service name (the BFF's canonical key).
 // All but `catalog` carry a `specId` of the form `openbank-<k8s-name>`, so we
@@ -551,26 +552,20 @@ export default function ApiCatalogPage() {
 
   return (
     <div>
-      <div className="page-header">
-        <div>
-          <div className="breadcrumb">
+      <DocsPageHeader
+        crumbs={<>
             <span>OpenBank</span><span className="breadcrumb-sep">/</span>
             <span>{t('Dokumentace', 'Docs')}</span><span className="breadcrumb-sep">/</span>
             <span className="breadcrumb-current">{t('API Katalog', 'API Catalog')}</span>
-          </div>
-          <h1 className="page-title" style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-            <FileCode size={18} style={{ color: 'var(--accent)' }} />
-            {t('API Katalog', 'API Catalog')}
-          </h1>
-          <p className="page-subtitle">{t(`Swagger/OpenAPI dokumentace ${allServices.length} služeb · live status · proklik na Swagger UI`, `Swagger/OpenAPI documentation for ${allServices.length} services · live status · link to Swagger UI`)}</p>
-        </div>
-        <div style={{ display: 'flex', gap: '8px' }}>
-          <button className="btn btn-secondary" onClick={load} disabled={loading}>
+          </>}
+        title={t('API Katalog', 'API Catalog')}
+        subtitle={t(`Swagger/OpenAPI dokumentace ${allServices.length} služeb · live status · proklik na Swagger UI`, `Swagger/OpenAPI documentation for ${allServices.length} services · live status · link to Swagger UI`)}
+        icon={<FileCode aria-hidden="true" size={18} style={{ color: 'var(--accent)' }} />}
+        actions={<button className="btn btn-secondary" onClick={load} disabled={loading}>
             <RefreshCw size={13} className={loading ? 'animate-spin' : ''} />
             {t('Obnovit', 'Refresh')}
-          </button>
-        </div>
-      </div>
+          </button>}
+      />
 
       {/* Tabs */}
       <div style={{ display: 'flex', gap: '4px', marginBottom: '16px', borderBottom: '1px solid var(--border)', paddingBottom: '0' }}>

--- a/openbank-admin-ui/src/app/docs/bcp/page.tsx
+++ b/openbank-admin-ui/src/app/docs/bcp/page.tsx
@@ -6,6 +6,7 @@
 import { useState, useEffect } from 'react'
 import { ShieldAlert, CheckCircle2, XCircle, Clock, AlertTriangle, RefreshCw, ChevronDown, ChevronRight, Server, Database, Lock, Zap, CreditCard, Eye, BookOpen } from 'lucide-react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
+import { DocsPageHeader } from '@/components/docs/DocsPageHeader'
 import { CatalogDriftBanner } from '@/components/governance/CatalogDriftBanner'
 
 type Bilingual = [cs: string, en: string]
@@ -301,24 +302,18 @@ export default function BcpPage() {
 
   return (
     <div>
-      <div className="page-header">
-        <div>
-          <div className="breadcrumb">
+      <DocsPageHeader
+        crumbs={<>
             <span>OpenBank</span>
             <span className="breadcrumb-sep">/</span>
             <span>{t('Dokumentace', 'Documentation')}</span>
             <span className="breadcrumb-sep">/</span>
             <span className="breadcrumb-current">{t('Plán kontinuity provozu', 'Business Continuity Plan')}</span>
-          </div>
-          <h1 className="page-title" style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-            <ShieldAlert size={18} style={{ color: '#dc2626' }} />
-            {t('Plán kontinuity provozu', 'Business Continuity Plan')}
-          </h1>
-          <p className="page-subtitle">
-            {t('Prioritizovaný plán obnovy dle DORA Art. 11-12, CNB § 20d, EBA ICT Risk Guidelines', 'Prioritized recovery plan per DORA Art. 11-12, CNB § 20d, EBA ICT Risk Guidelines')}
-          </p>
-        </div>
-        <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
+          </>}
+        title={t('Plán kontinuity provozu', 'Business Continuity Plan')}
+        subtitle={t('Prioritizovaný plán obnovy dle DORA Art. 11-12, CNB § 20d, EBA ICT Risk Guidelines', 'Prioritized recovery plan per DORA Art. 11-12, CNB § 20d, EBA ICT Risk Guidelines')}
+        icon={<ShieldAlert aria-hidden="true" size={18} style={{ color: '#dc2626' }} />}
+        actions={<div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
           {lastRefresh && (
             <span style={{ fontSize: '12px', color: 'var(--text-secondary)' }}>
               {t('Aktualizováno:', 'Updated:')} {lastRefresh.toLocaleTimeString('cs-CZ')}
@@ -337,8 +332,8 @@ export default function BcpPage() {
             <RefreshCw size={13} style={{ animation: loading ? 'spin 1s linear infinite' : 'none' }} />
             {t('Obnovit', 'Refresh')}
           </button>
-        </div>
-      </div>
+        </div>}
+      />
 
       {/* Summary stats */}
       <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: '12px', marginBottom: '24px' }}>

--- a/openbank-admin-ui/src/app/docs/changelog/[service]/page.tsx
+++ b/openbank-admin-ui/src/app/docs/changelog/[service]/page.tsx
@@ -14,6 +14,7 @@ import { MermaidEnhancer } from '@/components/docs/MermaidEnhancer'
 import { fetchChangelog, SERVICE_RE } from '@/lib/docs/releases'
 import { prettyLabel } from '@/lib/discovery'
 import { LANG_COOKIE } from '@/lib/i18n/LanguageContext'
+import { DocsPageHeader } from '@/components/docs/DocsPageHeader'
 
 interface PageProps {
   params: Promise<{ service: string }>
@@ -30,30 +31,24 @@ export default async function ChangelogPage({ params }: PageProps) {
 
   return (
     <div>
-      <div className="page-header">
-        <div>
-          <div className="breadcrumb">
+      <DocsPageHeader
+        crumbs={<>
             <span>OpenBank</span><span className="breadcrumb-sep">/</span>
             <Link href="/docs/api" style={{ color: 'inherit', textDecoration: 'none' }}>Docs</Link>
             <span className="breadcrumb-sep">/</span>
             <span className="breadcrumb-current">{t('Changelog', 'Changelog')}</span>
-          </div>
-          <h1 className="page-title" style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-            <FileText size={18} style={{ color: 'var(--accent)' }} />
-            {label} — Changelog
-          </h1>
-          <p className="page-subtitle">
-            {t(
+          </>}
+        title={`${label} — Changelog`}
+        subtitle={t(
               'Historie verzí generovaná z Conventional Commits (release-please).',
               'Version history generated from Conventional Commits (release-please).',
             )}
-          </p>
-        </div>
-        <Link href="/docs/api" className="btn btn-secondary" style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+        icon={<FileText aria-hidden="true" size={18} style={{ color: 'var(--accent)' }} />}
+        actions={<Link href="/docs/api" className="btn btn-secondary" style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
           <ChevronLeft size={14} />
           {t('Zpět na API katalog', 'Back to API catalog')}
-        </Link>
-      </div>
+        </Link>}
+      />
 
       <div className="card" style={{ padding: '24px' }}>
         {!valid ? (

--- a/openbank-admin-ui/src/app/docs/cloud-architecture/page.tsx
+++ b/openbank-admin-ui/src/app/docs/cloud-architecture/page.tsx
@@ -7,6 +7,7 @@ import { useState, useEffect, useCallback } from 'react'
 import { Cloud, Info, CheckCircle2, CircleDashed, Circle, X, RefreshCw, Wifi, WifiOff, Minus } from 'lucide-react'
 import type { InfraStatusResult } from '@/lib/infra/probes'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
+import { DocsPageHeader } from '@/components/docs/DocsPageHeader'
 
 // Bilingual string tuple: [Czech, English] — spread into t(cs, en) at render.
 type Bilingual = [string, string]
@@ -238,22 +239,16 @@ export default function CloudArchitecturePage() {
 
   return (
     <div>
-      <div className="page-header">
-        <div>
-          <div className="breadcrumb">
+      <DocsPageHeader
+        crumbs={<>
             <span>OpenBank</span><span className="breadcrumb-sep">/</span>
             <span>{t('Dokumentace', 'Docs')}</span><span className="breadcrumb-sep">/</span>
             <span className="breadcrumb-current">{t('Cloud architektura', 'Cloud Architecture')}</span>
-          </div>
-          <h1 className="page-title" style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-            <Cloud size={18} style={{ color: 'var(--accent)' }} />
-            {t('Cloud architektura (AWS)', 'Cloud Architecture (AWS)')}
-          </h1>
-          <p className="page-subtitle">
-            {t('Cílový stav dle ADR-0027 se status overlay z živého clusteru openbank-sandbox · klikni na prvek pro detail', 'Target state per ADR-0027 with a status overlay from the live openbank-sandbox cluster · click an element for detail')}
-          </p>
-        </div>
-      </div>
+          </>}
+        title={t('Cloud architektura (AWS)', 'Cloud Architecture (AWS)')}
+        subtitle={t('Cílový stav dle ADR-0027 se status overlay z živého clusteru openbank-sandbox · klikni na prvek pro detail', 'Target state per ADR-0027 with a status overlay from the live openbank-sandbox cluster · click an element for detail')}
+        icon={<Cloud aria-hidden="true" size={18} style={{ color: 'var(--accent)' }} />}
+      />
 
       {/* Legend + honesty note */}
       <div className="card" style={{ padding: '12px 16px', marginBottom: '16px', display: 'flex', alignItems: 'center', gap: '20px', flexWrap: 'wrap' }}>

--- a/openbank-admin-ui/src/app/docs/cluster/page.tsx
+++ b/openbank-admin-ui/src/app/docs/cluster/page.tsx
@@ -11,6 +11,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
+import { DocsPageHeader } from '@/components/docs/DocsPageHeader'
 import {
   Boxes, Box, Lock, Network, Cpu, Globe, Shield, Key, CheckCircle2, CircleDashed, Circle,
   ChevronRight, RefreshCw, FileText, BadgeCheck, AlertTriangle, Building2, Server,
@@ -173,28 +174,22 @@ export default function ClusterDossierPage() {
 
   return (
     <div>
-      <div className="page-header">
-        <div>
-          <div className="breadcrumb">
+      <DocsPageHeader
+        crumbs={<>
             <span>OpenBank</span><span className="breadcrumb-sep">/</span>
             <span>{t('Dokumentace', 'Docs')}</span><span className="breadcrumb-sep">/</span>
             <span className="breadcrumb-current">{t('Cluster & kontejner', 'Cluster & container')}</span>
-          </div>
-          <h1 className="page-title" style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
-            <Boxes size={20} style={{ color: K8S_BLUE }} />
-            {t('Cluster & kontejner — topologie a hardening', 'Cluster & container — topology and hardening')}
-          </h1>
-          <p className="page-subtitle">
-            {t(
+          </>}
+        title={t('Cluster & kontejner — topologie a hardening', 'Cluster & container — topology and hardening')}
+        subtitle={t(
               'Jak je platforma rozdělená po namespaces, jak je zabezpečená (obrana do hloubky) a jak je poskládaný a zabezpečený výchozí image — plán vs. realita, odvozeno z GitOpsu (ADR-0081).',
               'How the platform is split across namespaces, how it is secured (defense in depth), and how the default service image is built and hardened — plan vs reality, derived from GitOps (ADR-0081).',
             )}
-          </p>
-        </div>
-        <button onClick={load} disabled={loading} className="btn btn-secondary" style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 12 }}>
+        icon={<Boxes aria-hidden="true" size={20} style={{ color: K8S_BLUE }} />}
+        actions={<button onClick={load} disabled={loading} className="btn btn-secondary" style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 12 }}>
           <RefreshCw size={14} className={loading ? 'animate-spin' : ''} /> {t('Obnovit', 'Refresh')}
-        </button>
-      </div>
+        </button>}
+      />
 
       {/* derived counts */}
       <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit,minmax(150px,1fr))', gap: 12, marginBottom: 26 }}>

--- a/openbank-admin-ui/src/app/docs/compliance/page.tsx
+++ b/openbank-admin-ui/src/app/docs/compliance/page.tsx
@@ -5,6 +5,7 @@
 'use client'
 import { Shield, CheckCircle2, AlertTriangle, XCircle, Info } from 'lucide-react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
+import { DocsPageHeader } from '@/components/docs/DocsPageHeader'
 
 // Bilingual string tuple: [Czech, English] — spread into t(cs, en) at render.
 type Bilingual = [string, string]
@@ -138,20 +139,16 @@ export default function CompliancePage() {
 
   return (
     <div>
-      <div className="page-header">
-        <div>
-          <div className="breadcrumb">
+      <DocsPageHeader
+        crumbs={<>
             <span>OpenBank</span><span className="breadcrumb-sep">/</span>
             <span>{t('Dokumentace', 'Docs')}</span><span className="breadcrumb-sep">/</span>
             <span className="breadcrumb-current">{t('Report compliance', 'Compliance Report')}</span>
-          </div>
-          <h1 className="page-title" style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-            <Shield size={18} style={{ color: 'var(--accent)' }} />
-            {t('Report compliance', 'Compliance Report')}
-          </h1>
-          <p className="page-subtitle">{t('EBA · ČNB · PSD2 · GDPR · AML 5AMLD/6AMLD · FATCA/CRS · připravenost na audit', 'EBA · CNB · PSD2 · GDPR · AML 5AMLD/6AMLD · FATCA/CRS · audit readiness')}</p>
-        </div>
-      </div>
+          </>}
+        title={t('Report compliance', 'Compliance Report')}
+        subtitle={t('EBA · ČNB · PSD2 · GDPR · AML 5AMLD/6AMLD · FATCA/CRS · připravenost na audit', 'EBA · CNB · PSD2 · GDPR · AML 5AMLD/6AMLD · FATCA/CRS · audit readiness')}
+        icon={<Shield aria-hidden="true" size={18} style={{ color: 'var(--accent)' }} />}
+      />
 
       {/* Summary */}
       <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(180px, 1fr))', gap: '12px', marginBottom: '24px' }}>

--- a/openbank-admin-ui/src/app/docs/control-tower/page.tsx
+++ b/openbank-admin-ui/src/app/docs/control-tower/page.tsx
@@ -12,6 +12,7 @@ import Link from 'next/link'
 import { cookies } from 'next/headers'
 import { ChevronLeft, ShieldCheck, Radio, FileText } from 'lucide-react'
 import { loadComplianceCatalog, type ControlStatus, type ComplianceControl } from '@/lib/governance/compliance'
+import { DocsPageHeader } from '@/components/docs/DocsPageHeader'
 
 export const dynamic = 'force-dynamic'
 
@@ -40,20 +41,16 @@ export default async function ControlTowerPage() {
   if (!catalog) {
     return (
       <div>
-        <div className="page-header">
-          <div>
-            <div className="breadcrumb">
+        <DocsPageHeader
+          crumbs={<>
               <span>OpenBank</span><span className="breadcrumb-sep">/</span>
               <Link href="/docs" style={{ color: 'inherit', textDecoration: 'none' }}>Docs</Link>
               <span className="breadcrumb-sep">/</span>
               <span className="breadcrumb-current">{t('Control Tower', 'Control Tower')}</span>
-            </div>
-            <h1 className="page-title" style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-              <ShieldCheck size={18} style={{ color: 'var(--accent)' }} />
-              {t('Compliance Control Tower', 'Compliance Control Tower')}
-            </h1>
-          </div>
-        </div>
+          </>}
+          title={t('Compliance Control Tower', 'Compliance Control Tower')}
+          icon={<ShieldCheck aria-hidden="true" size={18} style={{ color: 'var(--accent)' }} />}
+        />
         <div className="card" style={{ padding: '24px' }}>
           <p style={{ fontSize: '13px', color: 'var(--text-secondary)' }}>
             {t(
@@ -80,30 +77,24 @@ export default async function ControlTowerPage() {
 
   return (
     <div>
-      <div className="page-header">
-        <div>
-          <div className="breadcrumb">
+      <DocsPageHeader
+        crumbs={<>
             <span>OpenBank</span><span className="breadcrumb-sep">/</span>
             <Link href="/docs" style={{ color: 'inherit', textDecoration: 'none' }}>Docs</Link>
             <span className="breadcrumb-sep">/</span>
             <span className="breadcrumb-current">{t('Control Tower', 'Control Tower')}</span>
-          </div>
-          <h1 className="page-title" style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-            <ShieldCheck size={18} style={{ color: 'var(--accent)' }} />
-            {t('Compliance Control Tower', 'Compliance Control Tower')}
-          </h1>
-          <p className="page-subtitle">
-            {t(
+          </>}
+        title={t('Compliance Control Tower', 'Compliance Control Tower')}
+        subtitle={t(
               `Regulace → kontrola → důkaz. ${totalEnforced}/${catalog.controls.length} kontrol vynuceno. Kontroly s odznakem LIVE čtou stav z reálných manifestů, ne z tvrzení.`,
               `Regulation → control → evidence. ${totalEnforced}/${catalog.controls.length} controls enforced. Controls badged LIVE read their status from real manifests, not from a claim.`,
             )}
-          </p>
-        </div>
-        <Link href="/docs" className="btn btn-secondary" style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+        icon={<ShieldCheck aria-hidden="true" size={18} style={{ color: 'var(--accent)' }} />}
+        actions={<Link href="/docs" className="btn btn-secondary" style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
           <ChevronLeft size={14} />
           {t('Zpět na dokumentaci', 'Back to docs')}
-        </Link>
-      </div>
+        </Link>}
+      />
 
       {/* Per-framework coverage */}
       <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(180px, 1fr))', gap: '10px', marginBottom: '24px' }}>

--- a/openbank-admin-ui/src/app/docs/customer-app/page.tsx
+++ b/openbank-admin-ui/src/app/docs/customer-app/page.tsx
@@ -16,6 +16,7 @@
 // from code is why this page cannot repeat that drift.
 
 import { useEffect, useMemo, useState } from 'react'
+import { DocsPageHeader } from '@/components/docs/DocsPageHeader'
 import Link from 'next/link'
 import {
   Smartphone, ChevronLeft, CheckCircle2, CircleDashed, Circle,
@@ -112,27 +113,21 @@ export default function CustomerAppDossierPage() {
 
   return (
     <div>
-      <div className="page-header">
-        <div>
-          <div className="breadcrumb">
+      <DocsPageHeader
+        crumbs={<>
             <Link href="/docs" style={{ display: 'inline-flex', alignItems: 'center', gap: 4, textDecoration: 'none', color: 'inherit' }}>
               <ChevronLeft size={13} /> {t('Dokumentace', 'Documentation')}
             </Link>
             <span className="breadcrumb-sep">/</span>
             <span className="breadcrumb-current">{t('Aplikace', 'Customer App')}</span>
-          </div>
-          <h1 className="page-title" style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-            <Smartphone size={18} style={{ color: 'var(--accent)' }} />
-            {t('Aplikace — plán vs realita', 'Customer App — plan vs reality')}
-          </h1>
-          <p className="page-subtitle">
-            {t(
+          </>}
+        title={t('Aplikace — plán vs realita', 'Customer App — plan vs reality')}
+        subtitle={t(
               'Jak je zákaznická aplikace (KMP/Compose) tvořena, integrována a zabezpečena — pohledem governance, technologií a bezpečnosti. Fakta odvozená z kódu, ne přepsaná ručně (ADR-0074).',
               'How the customer app (KMP/Compose) is built, integrated and secured — through the governance, technology and security lenses. Facts derived from code, not hand-transcribed (ADR-0074).',
             )}
-          </p>
-        </div>
-      </div>
+        icon={<Smartphone aria-hidden="true" size={18} style={{ color: 'var(--accent)' }} />}
+      />
 
       {loading && <div className="card" style={{ padding: 24, color: 'var(--text-secondary)' }}>{t('Načítám…', 'Loading…')}</div>}
 

--- a/openbank-admin-ui/src/app/docs/document-management/page.tsx
+++ b/openbank-admin-ui/src/app/docs/document-management/page.tsx
@@ -9,6 +9,7 @@ import {
   FileText, ShieldAlert, Info,
 } from 'lucide-react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
+import { DocsPageHeader } from '@/components/docs/DocsPageHeader'
 
 const ACCENT = '#6366f1'
 const INK = 'var(--text-primary)'
@@ -19,23 +20,19 @@ export default function DocumentManagementDocsPage() {
 
   return (
     <div>
-      <div className="page-header">
-        <div className="breadcrumb">
+      <DocsPageHeader
+        crumbs={<>
           <span>OpenBank</span><span className="breadcrumb-sep">/</span>
           <span>{t('Dokumentace', 'Docs')}</span><span className="breadcrumb-sep">/</span>
           <span className="breadcrumb-current">{t('Správa dokumentů', 'Document Management')}</span>
-        </div>
-        <h1 className="page-title" style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-          <FileSignature size={18} style={{ color: ACCENT }} />
-          {t('Správa dokumentů, šablon a e-podpisu', 'Document Management, Templating & E-Signature')}
-        </h1>
-        <p className="page-subtitle">
-          {t(
+        </>}
+        title={t('Správa dokumentů, šablon a e-podpisu', 'Document Management, Templating & E-Signature')}
+        subtitle={t(
             'Nová hraniční doména (openbank-document-service): šablony → generování PDF → uložení → podpisová ceremonie → audit → downstream konzumenti.',
             'A new bounded context (openbank-document-service): templates → PDF generation → storage → signature ceremony → audit → downstream consumers.',
           )}
-        </p>
-      </div>
+        icon={<FileSignature aria-hidden="true" size={18} style={{ color: ACCENT }} />}
+      />
 
       {/* Status strip */}
       <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', marginBottom: 16 }}>

--- a/openbank-admin-ui/src/app/docs/flags/page.tsx
+++ b/openbank-admin-ui/src/app/docs/flags/page.tsx
@@ -12,6 +12,7 @@ import Link from 'next/link'
 import { cookies } from 'next/headers'
 import { ChevronLeft, Flag, ShieldAlert } from 'lucide-react'
 import { loadFlagCatalog, type FlagMeta } from '@/lib/governance/flags'
+import { DocsPageHeader } from '@/components/docs/DocsPageHeader'
 
 export const dynamic = 'force-dynamic'
 
@@ -39,28 +40,23 @@ export default async function FlagsRegistryPage() {
 
   return (
     <div>
-      <div className="page-header">
-        <div>
-          <div className="breadcrumb">
+      <DocsPageHeader
+        crumbs={<>
             <span>OpenBank</span><span className="breadcrumb-sep">/</span>
             <Link href="/docs" style={{ color: 'inherit', textDecoration: 'none' }}>Docs</Link>
             <span className="breadcrumb-sep">/</span>
             <span className="breadcrumb-current">{t('Feature flagy', 'Feature Flags')}</span>
-          </div>
-          <h1 className="page-title" style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-            <Flag size={20} /> {t('Registr feature flagů', 'Feature Flag Registry')}
-          </h1>
-          <p className="page-subtitle">
-            {t(
+          </>}
+        title={t('Registr feature flagů', 'Feature Flag Registry')}
+        subtitle={t(
               'Flagy na všech službách, odvozené z flag-as-code v GitOpsu (ADR-0067). Zdroj pravdy je git; přepínání je změna v gitu, ne zápis z UI.',
               'Flags across the fleet, derived from flag-as-code in GitOps (ADR-0067). Git is the source of truth; flipping is a git change, not a UI write.',
             )}
-          </p>
-        </div>
-        <Link href="/docs" className="btn btn-secondary btn-sm" style={{ display: 'inline-flex', alignItems: 'center', gap: '4px' }}>
+        icon={<Flag aria-hidden="true" size={20} />}
+        actions={<Link href="/docs" className="btn btn-secondary btn-sm" style={{ display: 'inline-flex', alignItems: 'center', gap: '4px' }}>
           <ChevronLeft size={14} /> {t('Zpět', 'Back')}
-        </Link>
-      </div>
+        </Link>}
+      />
 
       {flags.length === 0 ? (
         <div className="card" style={{ padding: '24px', color: 'var(--text-secondary)' }}>

--- a/openbank-admin-ui/src/app/docs/identity-dedup/page.tsx
+++ b/openbank-admin-ui/src/app/docs/identity-dedup/page.tsx
@@ -6,6 +6,7 @@
 
 import { Fingerprint, ShieldCheck, GitMerge, KeyRound, Layers, AlertTriangle, Lock, ArrowRight } from 'lucide-react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
+import { DocsPageHeader } from '@/components/docs/DocsPageHeader'
 
 // Status pill mirrored from the docs status vocabulary (live / partial / planned).
 function Status({ kind, t }: { kind: 'live' | 'partial' | 'planned'; t: (cs: string, en: string) => string }) {
@@ -112,27 +113,21 @@ export default function IdentityDedupPage() {
 
   return (
     <div>
-      <div className="page-header">
-        <div>
-          <div className="breadcrumb">
+      <DocsPageHeader
+        crumbs={<>
             <span>OpenBank</span>
             <span className="breadcrumb-sep">/</span>
             <span>{t('Dokumentace', 'Docs')}</span>
             <span className="breadcrumb-sep">/</span>
             <span className="breadcrumb-current">{t('Identita a deduplikace', 'Identity & Deduplication')}</span>
-          </div>
-          <h1 className="page-title" style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-            <Fingerprint size={18} style={{ color: 'var(--accent)' }} />
-            {t('Identita a deduplikace', 'Identity & Deduplication')}
-          </h1>
-          <p className="page-subtitle">
-            {t(
+          </>}
+        title={t('Identita a deduplikace', 'Identity & Deduplication')}
+        subtitle={t(
               'Jak je moderně postavená jednotná identita klienta: principy, privacy-preserving deduplikace, tříúrovňový resolver a konkrétní ukázka (ADR-0072, ADR-0094)',
               'How unified customer identity is built the modern way: principles, privacy-preserving deduplication, a three-tier resolver and a worked example (ADR-0072, ADR-0094)',
             )}
-          </p>
-        </div>
-      </div>
+        icon={<Fingerprint aria-hidden="true" size={18} style={{ color: 'var(--accent)' }} />}
+      />
 
       {/* ---- TL;DR banner ---- */}
       <div className="card" style={{ padding: '18px 22px', marginBottom: '20px', borderLeft: '3px solid var(--accent)', display: 'flex', gap: '14px', alignItems: 'flex-start' }}>

--- a/openbank-admin-ui/src/app/docs/lineage/page.tsx
+++ b/openbank-admin-ui/src/app/docs/lineage/page.tsx
@@ -6,6 +6,7 @@
 import { useState, useEffect } from 'react'
 import { Network, RefreshCw, Play, Pause, ArrowRight, ArrowLeft, BookOpen } from 'lucide-react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
+import { DocsPageHeader } from '@/components/docs/DocsPageHeader'
 import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
 import { edgeGeometry, mixHex, pathId } from '@/components/topology/geometry'
 import { FlowParticle } from '@/components/topology/FlowParticle'
@@ -130,23 +131,17 @@ export default function LineageFlowPage() {
 
   return (
     <div style={{ padding: '28px 32px', maxWidth: '1400px' }}>
-      <div className="page-header">
-        <div>
-          <div className="breadcrumb">
+      <DocsPageHeader
+        crumbs={<>
             <span>OpenBank</span><span className="breadcrumb-sep">/</span>
             <span>{t('Dokumentace', 'Docs')}</span><span className="breadcrumb-sep">/</span>
             <span className="breadcrumb-current">{t('Datová lineage', 'Data Lineage')}</span>
-          </div>
-          <h1 className="page-title" style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-            <Network size={18} style={{ color: 'var(--accent)' }} />
-            {t('Tok datové lineage', 'Data Lineage Flow')}
-          </h1>
-          <p className="page-subtitle">
-            {t('Kdo produkuje data pro koho — deklarovaná governance lineage (ADR-0071), odvozená z governance.yaml každé služby, animovaná jako tok producent → konzument.',
+          </>}
+        title={t('Tok datové lineage', 'Data Lineage Flow')}
+        subtitle={t('Kdo produkuje data pro koho — deklarovaná governance lineage (ADR-0071), odvozená z governance.yaml každé služby, animovaná jako tok producent → konzument.',
                'Who produces data for whom — the declared data-governance lineage (ADR-0071), derived from each service’s governance.yaml, animated as producer → consumer flow.')}
-          </p>
-        </div>
-      </div>
+        icon={<Network aria-hidden="true" size={18} style={{ color: 'var(--accent)' }} />}
+      />
 
       {unavailable ? (
         <DataUnavailable kind={unavailable.kind} service="governance" feature={t('datová lineage', 'data lineage')} dense />

--- a/openbank-admin-ui/src/app/docs/page.tsx
+++ b/openbank-admin-ui/src/app/docs/page.tsx
@@ -6,6 +6,7 @@
 import Link from 'next/link'
 import { GitBranch, BookOpen, Network, FileCode, Shield, ShieldAlert, Cloud, ScrollText, ShieldCheck, LayoutGrid, Smartphone, Bluetooth, Fingerprint, FileSignature } from 'lucide-react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
+import { DocsPageHeader } from '@/components/docs/DocsPageHeader'
 
 // Each section's title/desc is a [cs, en] tuple, spread into t(...) at render.
 const sections: {
@@ -176,20 +177,16 @@ export default function DocsPage() {
   const { t } = useLanguage()
   return (
     <div>
-      <div className="page-header">
-        <div>
-          <div className="breadcrumb">
+      <DocsPageHeader
+        crumbs={<>
             <span>OpenBank</span>
             <span className="breadcrumb-sep">/</span>
             <span className="breadcrumb-current">{t('Dokumentace', 'Documentation')}</span>
-          </div>
-          <h1 className="page-title" style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-            <BookOpen size={18} style={{ color: 'var(--accent)' }} />
-            {t('Dokumentační portál OpenBank', 'OpenBank Documentation Portal')}
-          </h1>
-          <p className="page-subtitle">{t('Architektura, business procesy, API dokumentace a compliance přehled', 'Architecture, business processes, API documentation and compliance overview')}</p>
-        </div>
-      </div>
+          </>}
+        title={t('Dokumentační portál OpenBank', 'OpenBank Documentation Portal')}
+        subtitle={t('Architektura, business procesy, API dokumentace a compliance přehled', 'Architecture, business processes, API documentation and compliance overview')}
+        icon={<BookOpen aria-hidden="true" size={18} style={{ color: 'var(--accent)' }} />}
+      />
 
       <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(320px, 1fr))', gap: '16px' }}>
         {sections.map(s => (

--- a/openbank-admin-ui/src/app/docs/qrlesspay-readiness/page.tsx
+++ b/openbank-admin-ui/src/app/docs/qrlesspay-readiness/page.tsx
@@ -6,6 +6,7 @@
 import Link from 'next/link'
 import { ShieldCheck, ScrollText, Scale, Lock, Landmark, ListOrdered, Info } from 'lucide-react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
+import { DocsPageHeader } from '@/components/docs/DocsPageHeader'
 
 const ACCENT = '#6366f1'
 const INK = 'var(--text-primary)'
@@ -102,25 +103,21 @@ export default function QrlessPayReadinessPage() {
 
   return (
     <div>
-      <div className="page-header">
-        <div className="breadcrumb">
+      <DocsPageHeader
+        crumbs={<>
           <span>OpenBank</span><span className="breadcrumb-sep">/</span>
           <span>{t('Dokumentace', 'Docs')}</span><span className="breadcrumb-sep">/</span>
           <Link href="/docs/qrlesspay" style={{ color: 'inherit' }}>QRlessPay</Link>
           <span className="breadcrumb-sep">/</span>
           <span className="breadcrumb-current">{t('Připravenost', 'Readiness')}</span>
-        </div>
-        <h1 className="page-title" style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-          <ScrollText size={18} style={{ color: ACCENT }} />
-          {t('QRlessPay — posouzení připravenosti', 'QRlessPay — readiness assessment')}
-        </h1>
-        <p className="page-subtitle">
-          {t(
+        </>}
+        title={t('QRlessPay — posouzení připravenosti', 'QRlessPay — readiness assessment')}
+        subtitle={t(
             'Co se zeptá bezpečnost, compliance a právníci — včetně otázek, které bychom raději neslyšeli. Sebehodnocení implementačního týmu, ne schválení.',
             'What security, compliance and counsel will each ask — including the questions we would rather they did not. A self-assessment by the implementing team, not an approval.',
           )}
-        </p>
-      </div>
+        icon={<ScrollText aria-hidden="true" size={18} style={{ color: ACCENT }} />}
+      />
 
       <div className="card" style={{ padding: 14, marginBottom: 16, background: 'var(--accent-bg)', border: '1px solid var(--accent-border)', display: 'flex', gap: 10 }}>
         <Info size={16} style={{ color: ACCENT, flexShrink: 0, marginTop: 1 }} />

--- a/openbank-admin-ui/src/app/docs/qrlesspay/page.tsx
+++ b/openbank-admin-ui/src/app/docs/qrlesspay/page.tsx
@@ -6,6 +6,7 @@
 import Link from 'next/link'
 import { Bluetooth, ShieldCheck, Radio, KeyRound, ScanLine, Info, Circle, CheckCircle, ArrowLeftRight, EyeOff, Hash, ScrollText } from 'lucide-react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
+import { DocsPageHeader } from '@/components/docs/DocsPageHeader'
 
 const ACCENT = '#6366f1'
 const RECV = '#6366f1' // payee / bank A
@@ -18,23 +19,19 @@ export default function QrlessPayPage() {
 
   return (
     <div>
-      <div className="page-header">
-        <div className="breadcrumb">
+      <DocsPageHeader
+        crumbs={<>
           <span>OpenBank</span><span className="breadcrumb-sep">/</span>
           <span>{t('Dokumentace', 'Docs')}</span><span className="breadcrumb-sep">/</span>
           <span className="breadcrumb-current">QRlessPay</span>
-        </div>
-        <h1 className="page-title" style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-          <Bluetooth size={18} style={{ color: ACCENT }} />
-          {t('QRlessPay — platba poblíž bez QR', 'QRlessPay — QR-less proximity pay')}
-        </h1>
-        <p className="page-subtitle">
-          {t(
+        </>}
+        title={t('QRlessPay — platba poblíž bez QR', 'QRlessPay — QR-less proximity pay')}
+        subtitle={t(
             'Otevřený BLE profil pro platbu telefon-telefon bez skenování. Banka-agnostický, backend volitelný — cíl je standard (ČBA/EPC).',
             'Open BLE phone-to-phone profile for scan-less pay. Bank-agnostic, backend-optional — aimed at becoming a standard (ČBA/EPC).',
           )}
-        </p>
-      </div>
+        icon={<Bluetooth aria-hidden="true" size={18} style={{ color: ACCENT }} />}
+      />
 
       {/* Status strip */}
       <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', marginBottom: 16 }}>

--- a/openbank-admin-ui/src/app/docs/release-notes/[service]/page.tsx
+++ b/openbank-admin-ui/src/app/docs/release-notes/[service]/page.tsx
@@ -15,6 +15,7 @@ import { fetchReleaseNotes, SERVICE_RE } from '@/lib/docs/releases'
 import { prettyLabel } from '@/lib/discovery'
 import { LANG_COOKIE } from '@/lib/i18n/LanguageContext'
 import styles from './ReleaseNotes.module.css'
+import { DocsPageHeader } from '@/components/docs/DocsPageHeader'
 
 interface PageProps {
   params: Promise<{ service: string }>
@@ -43,30 +44,24 @@ export default async function ReleaseNotesPage({ params }: PageProps) {
 
   return (
     <div>
-      <div className="page-header">
-        <div>
-          <div className="breadcrumb">
+      <DocsPageHeader
+        crumbs={<>
             <span>OpenBank</span><span className="breadcrumb-sep">/</span>
             <Link href="/docs/api" style={{ color: 'inherit', textDecoration: 'none' }}>Docs</Link>
             <span className="breadcrumb-sep">/</span>
             <span className="breadcrumb-current">{t('Poznámky k vydání', 'Release Notes')}</span>
-          </div>
-          <h1 className="page-title" style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-            <Tag size={18} style={{ color: 'var(--accent)' }} />
-            {label} — {t('Poznámky k vydání', 'Release Notes')}
-          </h1>
-          <p className="page-subtitle">
-            {t(
+          </>}
+        title={`${label} — ${t('Poznámky k vydání', 'Release Notes')}`}
+        subtitle={t(
               'Publikovaná vydání služby (release-please / GitHub Releases).',
               'Published service releases (release-please / GitHub Releases).',
             )}
-          </p>
-        </div>
-        <Link href="/docs/api" className="btn btn-secondary" style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+        icon={<Tag aria-hidden="true" size={18} style={{ color: 'var(--accent)' }} />}
+        actions={<Link href="/docs/api" className="btn btn-secondary" style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
           <ChevronLeft size={14} />
           {t('Zpět na API katalog', 'Back to API catalog')}
-        </Link>
-      </div>
+        </Link>}
+      />
 
       {!valid ? (
         <div className="card" style={{ padding: '24px' }}>

--- a/openbank-admin-ui/src/app/docs/service-map/page.tsx
+++ b/openbank-admin-ui/src/app/docs/service-map/page.tsx
@@ -9,6 +9,7 @@ import type { GovernanceManifestEntry } from '@/lib/governance/manifest'
 import { svcUrl } from '@/lib/services/bff'
 import { CatalogDriftBanner } from '@/components/governance/CatalogDriftBanner'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
+import { DocsPageHeader } from '@/components/docs/DocsPageHeader'
 import { edgeGeometry, mixHex, pathId, type Pt, type Half } from '@/components/topology/geometry'
 import { FlowParticle } from '@/components/topology/FlowParticle'
 import { useFlowAnimation } from '@/components/topology/useFlowAnimation'
@@ -554,20 +555,16 @@ export default function ServiceMapPage() {
 
   return (
     <div>
-      <div className="page-header">
-        <div>
-          <div className="breadcrumb">
+      <DocsPageHeader
+        crumbs={<>
             <span>OpenBank</span><span className="breadcrumb-sep">/</span>
             <span>{t('Dokumentace', 'Docs')}</span><span className="breadcrumb-sep">/</span>
             <span className="breadcrumb-current">{t('Mapa služeb', 'Service Map')}</span>
-          </div>
-          <h1 className="page-title" style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-            <Network size={18} style={{ color: 'var(--accent)' }} />
-            {t('Mapa architektury služeb', 'Service Architecture Map')}
-          </h1>
-          <p className="page-subtitle">{t(`Animovaná mapa toku dat napříč ${SERVICES.length} službami, infrastrukturou a 3. stranami · sync i async · najeďte myší na uzel pro zvýraznění cesty`, `Animated data-flow map across ${SERVICES.length} services, infrastructure and 3rd parties · sync and async · hover a node to highlight its path`)}</p>
-        </div>
-      </div>
+          </>}
+        title={t('Mapa architektury služeb', 'Service Architecture Map')}
+        subtitle={t(`Animovaná mapa toku dat napříč ${SERVICES.length} službami, infrastrukturou a 3. stranami · sync i async · najeďte myší na uzel pro zvýraznění cesty`, `Animated data-flow map across ${SERVICES.length} services, infrastructure and 3rd parties · sync and async · hover a node to highlight its path`)}
+        icon={<Network aria-hidden="true" size={18} style={{ color: 'var(--accent)' }} />}
+      />
 
       <CatalogDriftBanner present={CATALOG_PRESENT} />
 

--- a/openbank-admin-ui/src/app/docs/threat-models/[service]/page.tsx
+++ b/openbank-admin-ui/src/app/docs/threat-models/[service]/page.tsx
@@ -11,6 +11,7 @@ import { ChevronLeft, ShieldAlert } from 'lucide-react'
 import { MarkdownView } from '@/components/docs/MarkdownView'
 import { MermaidEnhancer } from '@/components/docs/MermaidEnhancer'
 import { loadThreatModel } from '@/lib/governance/docs'
+import { DocsPageHeader } from '@/components/docs/DocsPageHeader'
 
 export const dynamic = 'force-dynamic'
 
@@ -27,19 +28,16 @@ export default async function ThreatModelDetailPage({ params }: PageProps) {
 
   return (
     <div>
-      <div className="page-header">
-        <div>
-          <div className="breadcrumb">
+      <DocsPageHeader
+        crumbs={<>
             <span>OpenBank</span><span className="breadcrumb-sep">/</span>
             <Link href="/docs" style={{ color: 'inherit', textDecoration: 'none' }}>Docs</Link>
             <span className="breadcrumb-sep">/</span>
             <Link href="/docs/threat-models" style={{ color: 'inherit', textDecoration: 'none' }}>{t('Threat modely', 'Threat models')}</Link>
             <span className="breadcrumb-sep">/</span>
             <span className="breadcrumb-current">{service}</span>
-          </div>
-          <h1 className="page-title" style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-            <ShieldAlert size={18} style={{ color: 'var(--accent)' }} />
-            {t('Threat model', 'Threat model')} — {service}
+          </>}
+        title={<>{t('Threat model', 'Threat model')} — {service}
             {model?.moneyPath && (
               <span style={{
                 fontSize: '11px', fontWeight: 700, padding: '2px 8px', borderRadius: '20px',
@@ -49,13 +47,13 @@ export default async function ThreatModelDetailPage({ params }: PageProps) {
                 {t('Peněžní cesta', 'Money path')}
               </span>
             )}
-          </h1>
-        </div>
-        <Link href="/docs/threat-models" className="btn btn-secondary" style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+          </>}
+        icon={<ShieldAlert aria-hidden="true" size={18} style={{ color: 'var(--accent)' }} />}
+        actions={<Link href="/docs/threat-models" className="btn btn-secondary" style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
           <ChevronLeft size={14} />
           {t('Zpět na registr', 'Back to registry')}
-        </Link>
-      </div>
+        </Link>}
+      />
 
       <div className="card" style={{ padding: '24px' }}>
         {!model ? (

--- a/openbank-admin-ui/src/app/docs/threat-models/page.tsx
+++ b/openbank-admin-ui/src/app/docs/threat-models/page.tsx
@@ -12,6 +12,7 @@ import Link from 'next/link'
 import { cookies } from 'next/headers'
 import { ChevronLeft, ShieldAlert, ShieldCheck, AlertTriangle, FileText } from 'lucide-react'
 import { loadThreatModelIndex, missingThreatModels } from '@/lib/governance/docs'
+import { DocsPageHeader } from '@/components/docs/DocsPageHeader'
 
 export const dynamic = 'force-dynamic'
 
@@ -25,30 +26,24 @@ export default async function ThreatModelRegistryPage() {
 
   return (
     <div>
-      <div className="page-header">
-        <div>
-          <div className="breadcrumb">
+      <DocsPageHeader
+        crumbs={<>
             <span>OpenBank</span><span className="breadcrumb-sep">/</span>
             <Link href="/docs" style={{ color: 'inherit', textDecoration: 'none' }}>Docs</Link>
             <span className="breadcrumb-sep">/</span>
             <span className="breadcrumb-current">{t('Threat modely', 'Threat models')}</span>
-          </div>
-          <h1 className="page-title" style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-            <ShieldAlert size={18} style={{ color: 'var(--accent)' }} />
-            {t('Registr threat modelů', 'Threat Model Registry')}
-          </h1>
-          <p className="page-subtitle">
-            {t(
+          </>}
+        title={t('Registr threat modelů', 'Threat Model Registry')}
+        subtitle={t(
               `STRIDE threat modely pro služby na peněžní cestě (ADR-0030). Pokrytí money-path: ${moneyPathCovered}/${moneyPathTotal}.`,
               `STRIDE threat models for money-path services (ADR-0030). Money-path coverage: ${moneyPathCovered}/${moneyPathTotal}.`,
             )}
-          </p>
-        </div>
-        <Link href="/docs" className="btn btn-secondary" style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+        icon={<ShieldAlert aria-hidden="true" size={18} style={{ color: 'var(--accent)' }} />}
+        actions={<Link href="/docs" className="btn btn-secondary" style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
           <ChevronLeft size={14} />
           {t('Zpět na dokumentaci', 'Back to docs')}
-        </Link>
-      </div>
+        </Link>}
+      />
 
       {/* Coverage gap — money-path services without a threat model yet */}
       {missing.length > 0 && (

--- a/openbank-admin-ui/src/app/docs/zero-trust/page.tsx
+++ b/openbank-admin-ui/src/app/docs/zero-trust/page.tsx
@@ -16,6 +16,7 @@ import {
   AlertTriangle, Ban, CheckCircle2, Globe,
 } from 'lucide-react'
 import { loadSecurityPosture } from '@/lib/governance/security'
+import { DocsPageHeader } from '@/components/docs/DocsPageHeader'
 
 export const dynamic = 'force-dynamic'
 
@@ -45,20 +46,16 @@ export default async function ZeroTrustPage() {
   if (!posture) {
     return (
       <div>
-        <div className="page-header">
-          <div>
-            <div className="breadcrumb">
+        <DocsPageHeader
+          crumbs={<>
               <span>OpenBank</span><span className="breadcrumb-sep">/</span>
               <Link href="/docs" style={{ color: 'inherit', textDecoration: 'none' }}>Docs</Link>
               <span className="breadcrumb-sep">/</span>
               <span className="breadcrumb-current">{t('Zero-Trust mapa', 'Zero-Trust map')}</span>
-            </div>
-            <h1 className="page-title" style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-              <ShieldCheck size={18} style={{ color: 'var(--accent)' }} />
-              {t('Zero-Trust bezpečnostní mapa', 'Zero-Trust Security Map')}
-            </h1>
-          </div>
-        </div>
+          </>}
+          title={t('Zero-Trust bezpečnostní mapa', 'Zero-Trust Security Map')}
+          icon={<ShieldCheck aria-hidden="true" size={18} style={{ color: 'var(--accent)' }} />}
+        />
         <div className="card" style={{ padding: '24px' }}>
           <p style={{ fontSize: '13px', color: 'var(--text-secondary)' }}>
             {t(
@@ -222,30 +219,24 @@ export default async function ZeroTrustPage() {
 
   return (
     <div>
-      <div className="page-header">
-        <div>
-          <div className="breadcrumb">
+      <DocsPageHeader
+        crumbs={<>
             <span>OpenBank</span><span className="breadcrumb-sep">/</span>
             <Link href="/docs" style={{ color: 'inherit', textDecoration: 'none' }}>Docs</Link>
             <span className="breadcrumb-sep">/</span>
             <span className="breadcrumb-current">{t('Zero-Trust mapa', 'Zero-Trust map')}</span>
-          </div>
-          <h1 className="page-title" style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-            <ShieldCheck size={18} style={{ color: 'var(--accent)' }} />
-            {t('Zero-Trust bezpečnostní mapa', 'Zero-Trust Security Map')}
-          </h1>
-          <p className="page-subtitle">
-            {t(
+          </>}
+        title={t('Zero-Trust bezpečnostní mapa', 'Zero-Trust Security Map')}
+        subtitle={t(
               'Obrana do hloubky odvozená z reálných, gitops-nasazených manifestů (NetworkPolicy, Kyverno). Žádný service mesh v sandboxu neběží — mTLS/JWT/L7 řádky níže to říkají otevřeně, ne jako "vynuceno".',
               'Defense in depth derived from the real, gitops-deployed manifests (NetworkPolicy, Kyverno). No service mesh runs in the sandbox — the mTLS/JWT/L7 rows below say so plainly, not "enforced".',
             )}
-          </p>
-        </div>
-        <Link href="/docs" className="btn btn-secondary" style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+        icon={<ShieldCheck aria-hidden="true" size={18} style={{ color: 'var(--accent)' }} />}
+        actions={<Link href="/docs" className="btn btn-secondary" style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
           <ChevronLeft size={14} />
           {t('Zpět na dokumentaci', 'Back to docs')}
-        </Link>
-      </div>
+        </Link>}
+      />
 
       <div style={{ display: 'grid', gridTemplateColumns: 'minmax(0, 1.6fr) minmax(0, 1fr)', gap: '20px', alignItems: 'start' }}>
         {/* Left: nested perimeters */}

--- a/openbank-admin-ui/src/components/docs/BpmnView.tsx
+++ b/openbank-admin-ui/src/components/docs/BpmnView.tsx
@@ -22,6 +22,7 @@
 import { useState } from 'react'
 import { GitBranch, RefreshCw, CheckCircle2, XCircle, AlertCircle } from 'lucide-react'
 import type { BpmnProcess, BpmnStep } from '@/lib/docs/bpmn/schema'
+import { DocsPageHeader } from '@/components/docs/DocsPageHeader'
 
 const LANE_BG: Record<string, string> = {
   compliance: '#fef2f2', core: '#eff6ff', psd2: '#fffbeb', payment: '#faf5ff',
@@ -287,20 +288,16 @@ export function BpmnView({ processes }: { processes: BpmnProcess[] }) {
 
   return (
     <div>
-      <div className="page-header">
-        <div>
-          <div className="breadcrumb">
+      <DocsPageHeader
+        crumbs={<>
             <span>OpenBank</span><span className="breadcrumb-sep">/</span>
             <span>Docs</span><span className="breadcrumb-sep">/</span>
             <span className="breadcrumb-current">Business Processes</span>
-          </div>
-          <h1 className="page-title" style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-            <GitBranch size={18} style={{ color: 'var(--accent)' }} />
-            Business Process Diagrams (BPMN 2.0)
-          </h1>
-          <p className="page-subtitle">Klíčové bankovní procesy vizualizované pro business, compliance a IT týmy</p>
-        </div>
-      </div>
+          </>}
+        title="Business Process Diagrams (BPMN 2.0)"
+        subtitle="Klíčové bankovní procesy vizualizované pro business, compliance a IT týmy"
+        icon={<GitBranch aria-hidden="true" size={18} style={{ color: 'var(--accent)' }} />}
+      />
 
       {/* Process tabs */}
       <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap', marginBottom: '20px' }}>

--- a/openbank-admin-ui/src/components/docs/DocsPageHeader.tsx
+++ b/openbank-admin-ui/src/components/docs/DocsPageHeader.tsx
@@ -1,0 +1,27 @@
+import type { ReactNode } from 'react'
+import { PageHeader } from '@/components/ui/PageHeader'
+
+type DocsPageHeaderProps = {
+  title: ReactNode
+  subtitle?: ReactNode
+  icon?: ReactNode
+  /** Breadcrumb items, without the surrounding `.breadcrumb` landmark styling. */
+  crumbs: ReactNode
+  actions?: ReactNode
+}
+
+/**
+ * Documentation-specific wrapper around the shared header. Keeping the breadcrumb wrapper here
+ * prevents the 20+ server/client docs routes from drifting back to hand-rolled hierarchy markup.
+ */
+export function DocsPageHeader({ title, subtitle, icon, crumbs, actions }: DocsPageHeaderProps) {
+  return (
+    <PageHeader
+      breadcrumb={<div className="breadcrumb">{crumbs}</div>}
+      title={title}
+      subtitle={subtitle}
+      icon={icon}
+      actions={actions}
+    />
+  )
+}

--- a/openbank-admin-ui/src/components/docs/ProcessView.tsx
+++ b/openbank-admin-ui/src/components/docs/ProcessView.tsx
@@ -16,6 +16,7 @@ import { useState } from 'react'
 import type { ElementType } from 'react'
 import { ShieldCheck, Info, CheckCircle2, CircleDashed, Circle, X } from 'lucide-react'
 import { Mermaid } from '@/components/docs/Mermaid'
+import { DocsPageHeader } from '@/components/docs/DocsPageHeader'
 import { overallScore, type Process, type Status, type TechNode } from '@/lib/docs/process/schema'
 
 type Mode = 'reality' | 'target'
@@ -59,20 +60,16 @@ export function ProcessView({ proc }: { proc: Process }) {
 
   return (
     <div>
-      <div className="page-header">
-        <div>
-          <div className="breadcrumb">
+      <DocsPageHeader
+        crumbs={<>
             <span>OpenBank</span><span className="breadcrumb-sep">/</span>
             <span>Docs</span><span className="breadcrumb-sep">/</span>
             <span className="breadcrumb-current">{proc.title}</span>
-          </div>
-          <h1 className="page-title" style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-            <TitleIcon size={18} style={{ color: 'var(--accent)' }} />
-            {proc.title}
-          </h1>
-          <p className="page-subtitle">{proc.subtitle}</p>
-        </div>
-      </div>
+          </>}
+        title={proc.title}
+        subtitle={proc.subtitle}
+        icon={<TitleIcon aria-hidden="true" size={18} style={{ color: 'var(--accent)' }} />}
+      />
 
       {/* Honesty banner + reality/target toggle */}
       <div className="card" style={{ padding: '12px 16px', marginBottom: '16px', display: 'flex', alignItems: 'center', gap: '16px', flexWrap: 'wrap' }}>

--- a/openbank-admin-ui/src/components/layout/Sidebar.tsx
+++ b/openbank-admin-ui/src/components/layout/Sidebar.tsx
@@ -245,7 +245,7 @@ export function Sidebar() {
 
       {/* Footer */}
       <div className={styles.footer}>
-        <div className={styles.footerVersion}>OpenBank v2.0</div>
+        <div className={styles.footerVersion}>{t('OpenBank Admin portál', 'OpenBank Admin Portal')}</div>
         <div className={styles.footerScope}>EBA · PSD2 · CNB · GDPR</div>
       </div>
     </aside>

--- a/openbank-admin-ui/src/components/ui/PageHeader.tsx
+++ b/openbank-admin-ui/src/components/ui/PageHeader.tsx
@@ -6,8 +6,8 @@ import type { ReactNode } from 'react'
 import { cn } from '@/lib/utils'
 
 type PageHeaderProps = {
-  title: string
-  subtitle?: string
+  title: ReactNode
+  subtitle?: ReactNode
   /** Leading icon beside the title. */
   icon?: ReactNode
   /** Optional hierarchy label rendered above the title. */

--- a/openbank-admin-ui/src/test/docs-page-header.guard.test.ts
+++ b/openbank-admin-ui/src/test/docs-page-header.guard.test.ts
@@ -1,0 +1,52 @@
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const docsRoot = path.resolve(__dirname, '../app/docs')
+const pages = [
+  'page.tsx',
+  'adr/page.tsx',
+  'adr/[slug]/page.tsx',
+  'api/page.tsx',
+  'bcp/page.tsx',
+  'changelog/[service]/page.tsx',
+  'cloud-architecture/page.tsx',
+  'cluster/page.tsx',
+  'compliance/page.tsx',
+  'control-tower/page.tsx',
+  'customer-app/page.tsx',
+  'document-management/page.tsx',
+  'flags/page.tsx',
+  'identity-dedup/page.tsx',
+  'lineage/page.tsx',
+  'qrlesspay/page.tsx',
+  'qrlesspay-readiness/page.tsx',
+  'release-notes/[service]/page.tsx',
+  'service-map/page.tsx',
+  'threat-models/page.tsx',
+  'threat-models/[service]/page.tsx',
+  'zero-trust/page.tsx',
+].map(file => readFileSync(path.join(docsRoot, file), 'utf8'))
+
+const sharedHeader = readFileSync(path.resolve(__dirname, '../components/docs/DocsPageHeader.tsx'), 'utf8')
+const processView = readFileSync(path.resolve(__dirname, '../components/docs/ProcessView.tsx'), 'utf8')
+const bpmnView = readFileSync(path.resolve(__dirname, '../components/docs/BpmnView.tsx'), 'utf8')
+
+describe('documentation header contract', () => {
+  it('routes use the shared docs header and no legacy page-header markup', () => {
+    for (const page of pages) {
+      expect(page).toContain('DocsPageHeader')
+      expect(page).not.toContain('className="page-header"')
+    }
+    expect(processView).toContain('<DocsPageHeader')
+    expect(bpmnView).toContain('<DocsPageHeader')
+    expect(sharedHeader).toContain('className="breadcrumb"')
+  })
+
+  it('keeps a single accessible icon contract in the shared wrapper', () => {
+    expect(sharedHeader).toContain('breadcrumb={<div className="breadcrumb">')
+    for (const source of [...pages, processView, bpmnView]) {
+      if (source.includes('icon={<')) expect(source).toContain('aria-hidden="true"')
+    }
+  })
+})

--- a/openbank-admin-ui/src/test/sidebar-branding.guard.test.ts
+++ b/openbank-admin-ui/src/test/sidebar-branding.guard.test.ts
@@ -1,0 +1,13 @@
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const sidebar = readFileSync(path.resolve(__dirname, '../components/layout/Sidebar.tsx'), 'utf8')
+
+describe('sidebar product branding contract', () => {
+  it('does not advertise a stale hard-coded platform version', () => {
+    expect(sidebar).not.toContain('OpenBank v2.0')
+    expect(sidebar).toContain("OpenBank Admin Portal")
+    expect(sidebar).toContain("OpenBank Admin portál")
+  })
+})


### PR DESCRIPTION
Closes #5333

## Summary
- replace duplicated legacy docs headers with the shared `DocsPageHeader`/`PageHeader` contract across every documentation route and process view
- preserve all live governance/API/cluster data, filters, links, and honest plan-vs-reality copy
- make rich subtitles and dynamic title badges first-class without losing accessibility semantics
- add an exhaustive docs header regression guard

## Verification
- npm test -- --run src/test/docs-page-header.guard.test.ts route-permissions.test.ts
- npm run type-check
- git diff --check