### PR TITLE
fix(sca): add sourceService to DEVICE_ENROLLED for audit attribution

### DIFF
--- a/openbank-sca-service/src/main/kotlin/com/openbank/sca/application/usecase/ScaService.kt
+++ b/openbank-sca-service/src/main/kotlin/com/openbank/sca/application/usecase/ScaService.kt
@@ -282,6 +282,7 @@ class ScaService(
                         "credentialId" to device.credentialId,
                         "algorithm" to device.algorithm.name,
                         "occurredAt" to device.createdAt.toString(),
+                        "sourceService" to SOURCE_SERVICE,
                     ),
                 ),
             ),
@@ -446,6 +447,19 @@ private fun ScaChallenge.isReplayable(now: OffsetDateTime): Boolean =
  * reaches onboarding-service.
  */
 private const val DEVICE_ENROLLED_EVENT_TYPE = "DEVICE_ENROLLED"
+
+/**
+ * Producing service, read by `AuditConsumer.resolveSourceService` as the strongest
+ * (EVENT-sourced) attribution — issue #3994/#5256. `eventType` ("DEVICE_ENROLLED") is unchanged
+ * (load-bearing for onboarding-service's `OnboardingEventConsumer`, and customer-edge already
+ * writes its own distinct "SCA_DEVICE_ENROLLED" eventType for a different event on a different
+ * topic, so there is no fleet-wide collision to worry about). `sourceService` has no consumer
+ * today, so it is safe to add net-new. Value matches the fleet's audit convention: the module
+ * directory without the `openbank-` prefix — audit-service does not currently subscribe to
+ * `openbank.sca.events` at all (absent from both `TopicAttribution` and its consumed-topics
+ * list), so this field is forward-looking rather than fixing a live "unknown" row today.
+ */
+private const val SOURCE_SERVICE = "sca-service"
 
 private fun Throwable.causedByUniqueViolation(): Boolean {
     var t: Throwable? = this

--- a/openbank-sca-service/src/test/kotlin/com/openbank/sca/application/usecase/ScaServiceTest.kt
+++ b/openbank-sca-service/src/test/kotlin/com/openbank/sca/application/usecase/ScaServiceTest.kt
@@ -634,6 +634,28 @@ class ScaServiceTest {
         assertThat(body.path("credentialId").asText()).isEqualTo("cred-wire")
     }
 
+    /**
+     * Serialization round-trip for `AuditConsumer` attribution (issue #3994/#5256, fleet
+     * follow-up to #5255/#5267/#5329). Before `sourceService` existed on the DEVICE_ENROLLED
+     * payload body, an audit consumer reading this event's wire body had no EVENT-sourced claim
+     * to fall back on — and today's `TopicAttribution` table has no entry for
+     * `openbank.sca.events` at all, so this field is what an audit consumer subscribed to that
+     * topic in the future would read as its strongest signal.
+     */
+    @Test
+    fun `enroll publishes sourceService in the payload body for AuditConsumer attribution`(): Unit = runBlocking {
+        val partyId = UUID.randomUUID()
+        coEvery { enrolledDeviceRepository.findByCredentialId("cred-attribution") } returns null
+        coEvery { enrolledDeviceRepository.save(any()) } answers { firstArg() }
+        val captured = slot<OutboxMessage>()
+        coEvery { outboxRepository.save(capture(captured)) } just runs
+
+        service.enroll(EnrollDeviceCommand(partyId, "cred-attribution", "pk", SignatureAlgorithm.ES256))
+
+        val body = objectMapper.readTree(captured.captured.payload)
+        assertThat(body.path("sourceService").asText()).isEqualTo("sca-service")
+    }
+
     @Test
     fun `enroll returns existing device idempotently for same-party re-enroll`(): Unit = runBlocking {
         val partyId = UUID.randomUUID()


### PR DESCRIPTION
## Summary

Bounded slice of #5256 (fleet-wide follow-up to #3994), sibling of #5255 (domestic-payment),
#5267 (account/party), #5329 (transaction-service): sca-service's only Kafka-emitted domain
event, `DEVICE_ENROLLED`, carried no `sourceService` in its wire body.

- `ScaService.enroll()`'s hand-built `OutboxMessage` payload now carries
  `"sourceService" to SOURCE_SERVICE` (`"sca-service"`) alongside the existing `"eventType"` key
  (added in #4353, itself a fix for the same class of bug — the discriminator missing from the
  payload body).
- `eventType` (`"DEVICE_ENROLLED"`) is **unchanged** — verified load-bearing for
  onboarding-service's `OnboardingEventConsumer` (`consumeScaEvent`, per #4353's own regression
  test). `sourceService` has no consumer today, so it is safe to add net-new.
- Fleet-wide check: `sca-service`'s scope is a single hand-built map in `ScaService.kt` — there
  is no separate domain-event class file for this service (unlike kyc/account/transaction).
  Grepped for `"DEVICE_ENROLLED"` and `"SCA_DEVICE_ENROLLED"` fleet-wide; the latter is a
  *different*, unrelated event customer-edge itself emits on a different topic, so no naming
  collision.
- `ScaServiceTest.kt`: added a round-trip test mirroring the existing sibling test for `eventType`
  (`enroll publishes eventType in the payload body...`) — asserts the real serialized
  `OutboxMessage.payload` contains `sourceService`, not just that the field compiles.

**Finding, not fixed here (flagged for a separate follow-up):** audit-service does not currently
subscribe to `openbank.sca.events` at all — the topic is absent from both `EventAttribution.kt`'s
`TopicAttribution` table and audit-service's `application.yaml` consumed-topics list. So unlike
the domestic-payment/account/party/transaction-service siblings, this field is **forward-looking**
rather than fixing a live "unknown"-attributed row today; no `AuditAttributionTest` case was added
here because there is no real `AuditConsumer` code path that currently receives this event. Wiring
audit-service onto `openbank.sca.events` is a separate, larger change (new topic subscription +
`TopicAttribution` entry + coverage-test update) and is out of scope for this bounded PR.

**Money-path:** sca-service **is** in `rules.yaml: money_path_services` (four-eyes assessed, not
wired — see the entry's own note: `device.enroll` and `scaChallenge.consume` have a confirmed M2M
automated caller). This PR needs **2 approvals** per the money-path rule.

## Test plan

- [x] `./gradlew :openbank-sca-service:ktlintCheck :openbank-sca-service:detekt` — clean
- [x] `./gradlew :openbank-sca-service:test --tests "com.openbank.sca.application.usecase.ScaServiceTest"` — green (existing `enroll` tests + new round-trip test)
- [x] `./gradlew :openbank-sca-service:test --tests "com.openbank.sca.contract.ScaPactFolderProviderVerificationTest"` — green in isolation (a full-module concurrent run hit an unrelated port collision from another local Quarkus process; confirmed environmental, not caused by this diff)

Refs #5256

🤖 Generated with [Claude Code](https://claude.com/claude-code)
