### PR TITLE
feat(card-issuance): re-encrypt batch job for rotated OpenBao DEK (ADR-0262 follow-up)

### DIFF
--- a/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/application/port/out/CardPorts.kt
+++ b/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/application/port/out/CardPorts.kt
@@ -58,4 +58,28 @@ interface CardRepository {
      * a card that already has a credential.
      */
     suspend fun storePanCredentialIfAbsent(cardId: UUID, panEncrypted: String, cvvEncrypted: String): Boolean
+
+    /**
+     * Every card carrying a stored PAN credential (`pan_encrypted IS NOT NULL`), including
+     * terminal ones. Feeds `CardPanKeyReencrypt` (ADR-0262 follow-up): a KEK rotation must retire
+     * the OLD DEK everywhere, and a terminal card's row still needs migrating even though the
+     * vault backfill above would never mint it a NEW credential — unlike that backfill, this is
+     * re-encrypting an EXISTING number, not choosing a new one, so a dead card's row is not exempt.
+     */
+    suspend fun findWithPanCredential(): List<Card>
+
+    /**
+     * Compare-and-swap: writes the re-encrypted PAN/CVV only if the row still holds exactly
+     * [expectedPanEncrypted] (the ciphertext the caller successfully decrypted under the OLD key a
+     * moment earlier). Returns true when the row was written. The guard is what makes a re-encrypt
+     * pass safe to race against a concurrent card-detail read/write elsewhere, or a second replica
+     * running the same pass: if the row changed underneath us, this update is a no-op rather than
+     * clobbering fresher data with a re-encryption of a value that is no longer current.
+     */
+    suspend fun updatePanCredentialIfMatches(
+        cardId: UUID,
+        expectedPanEncrypted: String,
+        newPanEncrypted: String,
+        newCvvEncrypted: String,
+    ): Boolean
 }

--- a/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/application/usecase/CardPanKeyReencrypt.kt
+++ b/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/application/usecase/CardPanKeyReencrypt.kt
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.cardissuance.application.usecase
+
+import com.openbank.cardissuance.application.port.out.CardRepository
+import com.openbank.cardissuance.application.port.out.CardSecretCipher
+import com.openbank.cardissuance.domain.model.Card
+import com.openbank.cardissuance.infrastructure.crypto.AesGcmCardSecretCipher
+import com.openbank.cardissuance.infrastructure.crypto.OpenBaoTransitDekUnwrapper
+import jakarta.enterprise.context.ApplicationScoped
+import org.jboss.logging.Logger
+import java.util.Base64
+import java.util.Optional
+
+/** Outcome of one re-encrypt pass. Counts only — never a card number, never a ciphertext. */
+data class CardPanReencryptResult(
+    val migrated: Int,
+    val alreadyCurrent: Int,
+    val skippedConcurrentWrite: Int,
+    val unmigrable: Int,
+) {
+    val isEmpty: Boolean get() = migrated == 0 && alreadyCurrent == 0 && skippedConcurrentWrite == 0 && unmigrable == 0
+}
+
+/**
+ * Re-encrypts every stored PAN/CVV from a PREVIOUS OpenBao Transit DEK to the CURRENT one
+ * (ADR-0262 follow-up, the batch job that ADR's Decision section calls out as separate work).
+ *
+ * A KEK rotation (`vault write -f transit/keys/<kek-name>/rotate`) does not, by itself, touch a
+ * single row: `OpenBaoEnvelopeCardSecretCipher` keeps decrypting existing rows fine because Transit
+ * retains prior key versions, and every NEW row is encrypted under the new DEK from the moment the
+ * operator switches `openbank.card.envelope.wrapped-dek` to the freshly-wrapped one. What is left
+ * outstanding after that switch is every row written BEFORE it — this job is how those catch up, so
+ * the old DEK can eventually be retired from Transit for good.
+ *
+ * **No row metadata says which DEK encrypted it** — the wire format
+ * (`base64(IV ‖ ciphertext ‖ tag)`) carries no key identifier (see `AesGcmCardSecretCipher`'s own
+ * doc on why: the whole point of envelope encryption is that Transit's OWN versioned ciphertext is
+ * the source of truth for that, not a scheme this service reinvents). So this job discovers a row's
+ * key the only way possible: try the CURRENT cipher first (cheap, no OpenBao call — already
+ * migrated rows are the common case after the first pass), and only on failure try the OLD one
+ * (unwrapped once via [unwrapper], not per row).
+ *
+ * Idempotent by construction, the same shape as [CardPanVaultBackfill]: a row that decrypts under
+ * the current cipher needs no action, and the write itself is a compare-and-swap on the ciphertext
+ * it read ([CardRepository.updatePanCredentialIfMatches]) — a second pass, a second replica, or a
+ * card that changed underneath the job all land as a no-op rather than a clobber.
+ */
+@ApplicationScoped
+class CardPanKeyReencrypt(
+    private val repo: CardRepository,
+    private val currentCipher: CardSecretCipher,
+    private val unwrapper: OpenBaoTransitDekUnwrapper,
+) {
+
+    /**
+     * Unwraps [previousWrappedDek] once, then walks every card with a stored credential. Logs one
+     * summary line. **No PAN, CVV, or ciphertext is ever logged**, here or in the failure path —
+     * only the reason a row could not be migrated, by card id.
+     */
+    suspend fun run(previousWrappedDek: String): CardPanReencryptResult {
+        // Lazy: unwrapping is the one OpenBao call this job makes, and it must happen at most
+        // once — never per row — but also NOT at all if every row turns out to already be on the
+        // current DEK (a re-run after a completed migration is exactly that case).
+        val oldCipher = lazy {
+            AesGcmCardSecretCipher(
+                Optional.of(Base64.getEncoder().encodeToString(unwrapper.unwrap(previousWrappedDek))),
+                false,
+            )
+        }
+
+        val candidates = repo.findWithPanCredential()
+        var migrated = 0
+        var alreadyCurrent = 0
+        var skippedConcurrentWrite = 0
+        var unmigrable = 0
+        for (card in candidates) {
+            when (migrateOne(card, oldCipher)) {
+                Outcome.ALREADY_CURRENT -> alreadyCurrent++
+                Outcome.MIGRATED -> migrated++
+                Outcome.SKIPPED_CONCURRENT_WRITE -> skippedConcurrentWrite++
+                Outcome.UNMIGRABLE -> unmigrable++
+            }
+        }
+        log.infof(
+            "[pan-key-reencrypt] %d card(s) with a stored credential: %d already on the current " +
+                "DEK, %d migrated, %d skipped (changed concurrently, will retry next pass), " +
+                "%d unmigrable (neither the current nor the given previous DEK decrypts them)",
+            candidates.size,
+            alreadyCurrent,
+            migrated,
+            skippedConcurrentWrite,
+            unmigrable,
+        )
+        return CardPanReencryptResult(migrated, alreadyCurrent, skippedConcurrentWrite, unmigrable)
+    }
+
+    private suspend fun migrateOne(card: Card, oldCipher: Lazy<AesGcmCardSecretCipher>): Outcome {
+        val panEncrypted = card.panEncrypted ?: return Outcome.UNMIGRABLE
+        val cvvEncrypted = card.cvvEncrypted ?: return Outcome.UNMIGRABLE
+
+        if (runCatching { currentCipher.decrypt(panEncrypted) }.isSuccess) return Outcome.ALREADY_CURRENT
+
+        val oldPan = runCatching { oldCipher.value.decrypt(panEncrypted) }.getOrNull()
+        val oldCvv = runCatching { oldCipher.value.decrypt(cvvEncrypted) }.getOrNull()
+        if (oldPan == null || oldCvv == null) {
+            log.warnf(
+                "[pan-key-reencrypt] card %s: neither the current DEK nor the given previous one " +
+                    "decrypts this row — leaving it untouched",
+                card.id,
+            )
+            return Outcome.UNMIGRABLE
+        }
+
+        val written = repo.updatePanCredentialIfMatches(
+            card.id,
+            panEncrypted,
+            currentCipher.encrypt(oldPan),
+            currentCipher.encrypt(oldCvv),
+        )
+        return if (written) Outcome.MIGRATED else Outcome.SKIPPED_CONCURRENT_WRITE
+    }
+
+    private enum class Outcome { ALREADY_CURRENT, MIGRATED, SKIPPED_CONCURRENT_WRITE, UNMIGRABLE }
+
+    private companion object {
+        val log: Logger = Logger.getLogger(CardPanKeyReencrypt::class.java)
+    }
+}

--- a/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/infrastructure/crypto/OpenBaoEnvelopeCardSecretCipher.kt
+++ b/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/infrastructure/crypto/OpenBaoEnvelopeCardSecretCipher.kt
@@ -4,21 +4,12 @@
 
 package com.openbank.cardissuance.infrastructure.crypto
 
-import com.fasterxml.jackson.databind.ObjectMapper
 import com.openbank.cardissuance.application.port.out.CardSecretCipher
 import io.quarkus.arc.properties.IfBuildProperty
 import io.quarkus.runtime.Startup
 import jakarta.enterprise.context.ApplicationScoped
 import org.eclipse.microprofile.config.inject.ConfigProperty
 import org.jboss.logging.Logger
-import java.net.URI
-import java.net.http.HttpClient
-import java.net.http.HttpRequest
-import java.net.http.HttpRequest.BodyPublishers
-import java.net.http.HttpResponse.BodyHandlers
-import java.nio.file.Files
-import java.nio.file.Path
-import java.time.Duration
 import java.util.Base64
 import java.util.Optional
 
@@ -28,15 +19,15 @@ import java.util.Optional
  * living as a flat 32-byte secret in a Kubernetes Secret, the way [AesGcmCardSecretCipher] reads
  * it today. All actual PAN/CVV encrypt/decrypt work stays local and unchanged — delegated to an
  * [AesGcmCardSecretCipher] instance constructed with the unwrapped DEK — so this class only ever
- * talks to OpenBao once, at boot, to unwrap the DEK. No per-value network call, no change to the
- * encrypt/decrypt hot path.
+ * talks to OpenBao once, at boot, to unwrap the DEK (via [OpenBaoTransitDekUnwrapper]). No
+ * per-value network call, no change to the encrypt/decrypt hot path.
  *
  * **Rotation** (the gap this ADR closes): `vault write -f transit/keys/<kek-name>/rotate` bumps
  * the KEK version. OpenBao Transit retains prior key versions, so a wrapped DEK produced under an
  * older version still unwraps after rotation — nothing here needs to change to keep decrypting
  * existing rows. Minting a *new* DEK under the new KEK version and re-encrypting existing PAN/CVV
- * rows from the old DEK to the new one is a separate, follow-up batch job (mirrors
- * [com.openbank.cardissuance.application.usecase.CardPanVaultBackfill]'s idempotent,
+ * rows from the old DEK to the new one is `CardPanKeyReencrypt` — a separate, follow-up batch job
+ * (mirrors [com.openbank.cardissuance.application.usecase.CardPanVaultBackfill]'s idempotent,
  * count-only-logging shape) — not part of this adapter, which only ever unwraps whatever DEK it is
  * configured with at boot.
  *
@@ -51,45 +42,20 @@ import java.util.Optional
  * because a local integration test has no Transit engine to unwrap against, and should not need
  * one to exercise PAN encryption.
  *
- * **Test seam is two constructor-defaulted lambdas, not `open`/override.** [delegate] is loaded
+ * **Test seam is a constructor-defaulted lambda, not `open`/override.** [delegate] is loaded
  * eagerly (see below) as part of THIS class's own constructor, and in Kotlin a superclass's eager
  * property initializers run before a subclass's constructor parameters are assigned — so an
  * `open fun` overridden by a test subclass would be invoked while the subclass's own stub fields
- * are still null. Defaulted constructor parameters don't have that ordering problem: [loginFn] and
- * [unwrapDekFn] are bound before [delegate]'s initializer runs, in normal top-to-bottom order
- * within one constructor. CDI never sees these parameters (no matching injectable type for a
- * `() -> String` / `(String, String) -> ByteArray`), so `@Inject`ion is unaffected in production.
- *
- * **Retries with backoff around both OpenBao calls.** OpenBao today is a single replica (no raft
- * HA) — a login/unwrap attempt landing during a brief unavailability window (a restart, a leader
- * election) must not fail the whole pod boot on the first hiccup. [withRetry] retries only
- * transient failures (network errors, non-200 responses) with exponential backoff, bounded well
- * inside the Deployment's `startupProbe` budget (30 attempts × 5s). It does NOT retry the
- * DEK-length `require()` in [loadDelegate] — that is a configuration/data error, not a transient
- * one, and retrying it would just repeat the same wrong answer.
+ * are still null. A defaulted constructor parameter doesn't have that ordering problem: [unwrapFn]
+ * is bound before [delegate]'s initializer runs, in normal top-to-bottom order within one
+ * constructor. CDI never sees it (no matching injectable type for a `(String) -> ByteArray`), so
+ * `@Inject`ion is unaffected in production.
  */
 @IfBuildProperty(name = "openbank.card.key-source", stringValue = "openbao-transit")
 @Startup
 @ApplicationScoped
-@Suppress("LongParameterList")
 class OpenBaoEnvelopeCardSecretCipher(
-    @ConfigProperty(name = "openbank.card.envelope.bao-addr", defaultValue = "http://openbao.vault.svc:8200")
-    private val baoAddr: String,
-
-    @ConfigProperty(name = "openbank.card.envelope.role", defaultValue = "card-issuance-pan-dek")
-    private val role: String,
-
-    @ConfigProperty(name = "openbank.card.envelope.transit-mount", defaultValue = "transit")
-    private val transitMount: String,
-
-    @ConfigProperty(name = "openbank.card.envelope.kek-name", defaultValue = "card-pan")
-    private val kekName: String,
-
-    @ConfigProperty(
-        name = "openbank.card.envelope.sa-token-path",
-        defaultValue = "/var/run/secrets/kubernetes.io/serviceaccount/token",
-    )
-    private val saTokenPath: String,
+    private val unwrapper: OpenBaoTransitDekUnwrapper,
 
     // The OpenBao Transit ciphertext for the DEK ("vault:v<N>:...", produced once by an operator
     // via `vault write transit/encrypt/<kek-name> plaintext=$(head -c32 /dev/urandom | base64)`,
@@ -105,20 +71,13 @@ class OpenBaoEnvelopeCardSecretCipher(
     @ConfigProperty(name = "openbank.card.allow-ephemeral-pan-key", defaultValue = "false")
     private val allowEphemeralKey: Boolean,
 
-    private val objectMapper: ObjectMapper,
-
-    // Test-only seams (see class doc). CDI never satisfies a bare function-type constructor
-    // parameter via @Inject, so these always take their real-HTTP default in every deployed build;
-    // only a directly-constructed test instance ever passes a non-default value.
-    private val loginFn: (() -> String)? = null,
-    private val unwrapDekFn: ((String, String) -> ByteArray)? = null,
+    // Test-only seam (see class doc). CDI never satisfies a bare function-type constructor
+    // parameter via @Inject, so this always takes its real-unwrapper default in every deployed
+    // build; only a directly-constructed test instance ever passes a non-default value.
+    private val unwrapFn: ((String) -> ByteArray)? = null,
 ) : CardSecretCipher {
 
     private val log = Logger.getLogger(OpenBaoEnvelopeCardSecretCipher::class.java)
-
-    private val httpClient: HttpClient = HttpClient.newBuilder()
-        .connectTimeout(Duration.ofSeconds(CONNECT_TIMEOUT_SECONDS))
-        .build()
 
     // Eager, NOT `by lazy`: combined with @Startup this makes a bad KEK/DEK a boot failure, never
     // a surprise on the first card issued — same reasoning as AesGcmCardSecretCipher's own `key`.
@@ -143,91 +102,14 @@ class OpenBaoEnvelopeCardSecretCipher(
             )
             return AesGcmCardSecretCipher(Optional.empty(), true)
         }
-        val token = withRetry("OpenBao kubernetes-auth login", loginFn ?: ::login)
-        val dek =
-            withRetry("OpenBao transit decrypt for key '$kekName'") { (unwrapDekFn ?: ::unwrapDek)(token, wrapped) }
+        val dek = (unwrapFn ?: unwrapper::unwrap)(wrapped)
         require(dek.size == DEK_LENGTH_BYTES) {
-            "OpenBao transit key '$kekName' unwrapped a DEK of ${dek.size} bytes, expected " +
-                "$DEK_LENGTH_BYTES (AES-256)"
+            "OpenBao envelope key unwrapped a DEK of ${dek.size} bytes, expected $DEK_LENGTH_BYTES (AES-256)"
         }
         return AesGcmCardSecretCipher(Optional.of(Base64.getEncoder().encodeToString(dek)), false)
     }
 
-    /**
-     * OpenBao Kubernetes-auth login — same flow as
-     * `OpenBaoClientSignatureAdapter` (document-service) uses for its own PKI issuance, against a
-     * dedicated role scoped to this Transit key rather than a PKI mount.
-     */
-    private fun login(): String {
-        val jwt = Files.readString(Path.of(saTokenPath)).trim()
-        val body = objectMapper.writeValueAsString(mapOf("role" to role, "jwt" to jwt))
-        val request = HttpRequest.newBuilder()
-            .uri(URI.create("$baoAddr/v1/auth/kubernetes/login"))
-            .timeout(Duration.ofSeconds(REQUEST_TIMEOUT_SECONDS))
-            .header("Content-Type", "application/json")
-            .POST(BodyPublishers.ofString(body))
-            .build()
-        val response = httpClient.send(request, BodyHandlers.ofString())
-        check(response.statusCode() == HTTP_OK) {
-            "OpenBao kubernetes-auth login failed: HTTP ${response.statusCode()}"
-        }
-        return objectMapper.readTree(response.body())["auth"]["client_token"].asText()
-    }
-
-    /**
-     * Retries [block] on any exception (connection refused/timeout, or the `check()`-thrown
-     * `IllegalStateException` for a non-200 response) with exponential backoff, up to
-     * [MAX_ATTEMPTS] total tries. Blocking `Thread.sleep` is fine here: this only ever runs once,
-     * synchronously, inside `@Startup` bean construction — the same place the eager HTTP call
-     * itself already blocks.
-     */
-    @Suppress("TooGenericExceptionCaught")
-    private fun <T> withRetry(description: String, block: () -> T): T {
-        var delay = INITIAL_BACKOFF
-        var lastError: Exception? = null
-        repeat(MAX_ATTEMPTS) { attempt ->
-            try {
-                return block()
-            } catch (e: Exception) {
-                lastError = e
-                if (attempt < MAX_ATTEMPTS - 1) {
-                    log.warn(
-                        "$description failed (attempt ${attempt + 1}/$MAX_ATTEMPTS: " +
-                            "${e.javaClass.simpleName}), retrying in ${delay.toMillis()}ms",
-                    )
-                    Thread.sleep(delay.toMillis())
-                    delay = delay.multipliedBy(BACKOFF_MULTIPLIER)
-                }
-            }
-        }
-        throw lastError ?: error("$description failed with no recorded exception")
-    }
-
-    /** Unwraps [wrapped] (an OpenBao Transit ciphertext, `vault:v<N>:...`) via Transit `decrypt`. */
-    private fun unwrapDek(token: String, wrapped: String): ByteArray {
-        val body = objectMapper.writeValueAsString(mapOf("ciphertext" to wrapped))
-        val request = HttpRequest.newBuilder()
-            .uri(URI.create("$baoAddr/v1/$transitMount/decrypt/$kekName"))
-            .timeout(Duration.ofSeconds(REQUEST_TIMEOUT_SECONDS))
-            .header("Content-Type", "application/json")
-            .header("X-Vault-Token", token)
-            .POST(BodyPublishers.ofString(body))
-            .build()
-        val response = httpClient.send(request, BodyHandlers.ofString())
-        check(response.statusCode() == HTTP_OK) {
-            "OpenBao transit decrypt failed for key '$kekName': HTTP ${response.statusCode()}"
-        }
-        val plaintextBase64 = objectMapper.readTree(response.body())["data"]["plaintext"].asText()
-        return Base64.getDecoder().decode(plaintextBase64)
-    }
-
     private companion object {
-        const val CONNECT_TIMEOUT_SECONDS = 5L
-        const val REQUEST_TIMEOUT_SECONDS = 10L
-        const val HTTP_OK = 200
         const val DEK_LENGTH_BYTES = 32
-        const val MAX_ATTEMPTS = 4
-        const val BACKOFF_MULTIPLIER = 2L
-        val INITIAL_BACKOFF: Duration = Duration.ofMillis(500)
     }
 }

--- a/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/infrastructure/crypto/OpenBaoTransitDekUnwrapper.kt
+++ b/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/infrastructure/crypto/OpenBaoTransitDekUnwrapper.kt
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.cardissuance.infrastructure.crypto
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import jakarta.enterprise.context.ApplicationScoped
+import org.eclipse.microprofile.config.inject.ConfigProperty
+import org.jboss.logging.Logger
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpRequest.BodyPublishers
+import java.net.http.HttpResponse.BodyHandlers
+import java.nio.file.Files
+import java.nio.file.Path
+import java.time.Duration
+import java.util.Base64
+
+/**
+ * Unwraps an OpenBao Transit ciphertext (`vault:v<N>:...`) into raw key bytes (ADR-0262). Shared by
+ * two callers with different lifecycles:
+ *
+ * - [OpenBaoEnvelopeCardSecretCipher] unwraps the CURRENT DEK once, eagerly, at `@Startup`.
+ * - `CardPanKeyReencrypt` unwraps a PREVIOUS DEK on demand, only when an operator has configured
+ *   `openbank.card.envelope.previous-wrapped-dek` after rotating the KEK — most boots never call
+ *   [unwrap] at all.
+ *
+ * Deliberately NOT `@Startup` and does no eager work itself: unlike the cipher, this bean's own
+ * construction must never touch OpenBao, since it exists in every build (there is no
+ * `@IfBuildProperty` gate here — both callers already gate their OWN OpenBao usage).
+ *
+ * Retries the whole (login, decrypt) pair together, restarting from a fresh login each attempt —
+ * a token that logged in fine but then failed decrypt (e.g. it expired between the two calls)
+ * should not be reused on retry.
+ *
+ * **`open`, with `protected open` [login]/[unwrapDek], instead of a constructor-defaulted lambda
+ * test seam.** Unlike [OpenBaoEnvelopeCardSecretCipher] (injected everywhere via the
+ * `CardSecretCipher` interface), this class is injected by CALLERS using its own concrete type —
+ * and empirically, Quarkus ArC fails `@ApplicationScoped` bean discovery for a Kotlin class with a
+ * defaulted function-typed constructor parameter the moment something else injects it by concrete
+ * type (`UnsatisfiedResolutionException: ... does not declare a valid bean constructor`), even
+ * though the identical pattern is fine for an interface-injected bean. Subclassing carries none of
+ * the Kotlin-init-ordering risk documented elsewhere in this package (that trap is specifically
+ * about an EAGER property initializer invoking an open member during construction —
+ * [OpenBaoEnvelopeCardSecretCipher]'s own `delegate`); [login] and [unwrapDek] are only ever
+ * called on demand, from [unwrap], never from this class's own init.
+ */
+@ApplicationScoped
+@Suppress("LongParameterList")
+open class OpenBaoTransitDekUnwrapper(
+    @ConfigProperty(name = "openbank.card.envelope.bao-addr", defaultValue = "http://openbao.vault.svc:8200")
+    private val baoAddr: String,
+
+    @ConfigProperty(name = "openbank.card.envelope.role", defaultValue = "card-issuance-pan-dek")
+    private val role: String,
+
+    @ConfigProperty(name = "openbank.card.envelope.transit-mount", defaultValue = "transit")
+    private val transitMount: String,
+
+    @ConfigProperty(name = "openbank.card.envelope.kek-name", defaultValue = "card-pan")
+    private val kekName: String,
+
+    @ConfigProperty(
+        name = "openbank.card.envelope.sa-token-path",
+        defaultValue = "/var/run/secrets/kubernetes.io/serviceaccount/token",
+    )
+    private val saTokenPath: String,
+
+    private val objectMapper: ObjectMapper,
+) {
+
+    private val log = Logger.getLogger(OpenBaoTransitDekUnwrapper::class.java)
+
+    private val httpClient: HttpClient = HttpClient.newBuilder()
+        .connectTimeout(Duration.ofSeconds(CONNECT_TIMEOUT_SECONDS))
+        .build()
+
+    /** Unwraps [wrapped] into raw key bytes. Retries transient failures with exponential backoff. */
+    fun unwrap(wrapped: String): ByteArray = withRetry("OpenBao transit decrypt for key '$kekName'") {
+        val token = login()
+        unwrapDek(token, wrapped)
+    }
+
+    /**
+     * OpenBao Kubernetes-auth login — same flow as
+     * `OpenBaoClientSignatureAdapter` (document-service) uses for its own PKI issuance, against a
+     * dedicated role scoped to this Transit key rather than a PKI mount.
+     */
+    protected open fun login(): String {
+        val jwt = Files.readString(Path.of(saTokenPath)).trim()
+        val body = objectMapper.writeValueAsString(mapOf("role" to role, "jwt" to jwt))
+        val request = HttpRequest.newBuilder()
+            .uri(URI.create("$baoAddr/v1/auth/kubernetes/login"))
+            .timeout(Duration.ofSeconds(REQUEST_TIMEOUT_SECONDS))
+            .header("Content-Type", "application/json")
+            .POST(BodyPublishers.ofString(body))
+            .build()
+        val response = httpClient.send(request, BodyHandlers.ofString())
+        check(response.statusCode() == HTTP_OK) {
+            "OpenBao kubernetes-auth login failed: HTTP ${response.statusCode()}"
+        }
+        return objectMapper.readTree(response.body())["auth"]["client_token"].asText()
+    }
+
+    /** Unwraps [wrapped] (an OpenBao Transit ciphertext, `vault:v<N>:...`) via Transit `decrypt`. */
+    protected open fun unwrapDek(token: String, wrapped: String): ByteArray {
+        val body = objectMapper.writeValueAsString(mapOf("ciphertext" to wrapped))
+        val request = HttpRequest.newBuilder()
+            .uri(URI.create("$baoAddr/v1/$transitMount/decrypt/$kekName"))
+            .timeout(Duration.ofSeconds(REQUEST_TIMEOUT_SECONDS))
+            .header("Content-Type", "application/json")
+            .header("X-Vault-Token", token)
+            .POST(BodyPublishers.ofString(body))
+            .build()
+        val response = httpClient.send(request, BodyHandlers.ofString())
+        check(response.statusCode() == HTTP_OK) {
+            "OpenBao transit decrypt failed for key '$kekName': HTTP ${response.statusCode()}"
+        }
+        val plaintextBase64 = objectMapper.readTree(response.body())["data"]["plaintext"].asText()
+        return Base64.getDecoder().decode(plaintextBase64)
+    }
+
+    /**
+     * Retries [block] on any exception (connection refused/timeout, or the `check()`-thrown
+     * `IllegalStateException` for a non-200 response) with exponential backoff, up to
+     * [MAX_ATTEMPTS] total tries. Blocking `Thread.sleep` is fine here: both callers already run
+     * this synchronously (one at `@Startup`, the other inside a batch job that is not on any
+     * request hot path).
+     */
+    @Suppress("TooGenericExceptionCaught")
+    private fun <T> withRetry(description: String, block: () -> T): T {
+        var delay = INITIAL_BACKOFF
+        var lastError: Exception? = null
+        repeat(MAX_ATTEMPTS) { attempt ->
+            try {
+                return block()
+            } catch (e: Exception) {
+                lastError = e
+                if (attempt < MAX_ATTEMPTS - 1) {
+                    log.warn(
+                        "$description failed (attempt ${attempt + 1}/$MAX_ATTEMPTS: " +
+                            "${e.javaClass.simpleName}), retrying in ${delay.toMillis()}ms",
+                    )
+                    Thread.sleep(delay.toMillis())
+                    delay = delay.multipliedBy(BACKOFF_MULTIPLIER)
+                }
+            }
+        }
+        throw lastError ?: error("$description failed with no recorded exception")
+    }
+
+    private companion object {
+        const val CONNECT_TIMEOUT_SECONDS = 5L
+        const val REQUEST_TIMEOUT_SECONDS = 10L
+        const val HTTP_OK = 200
+        const val MAX_ATTEMPTS = 4
+        const val BACKOFF_MULTIPLIER = 2L
+        val INITIAL_BACKOFF: Duration = Duration.ofMillis(500)
+    }
+}

--- a/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/infrastructure/persistence/repository/CardRepositoryImpl.kt
+++ b/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/infrastructure/persistence/repository/CardRepositoryImpl.kt
@@ -101,6 +101,30 @@ class CardRepositoryImpl(private val outboxRepository: CardOutboxRepositoryImpl)
         )
     }.awaitSuspending() == 1
 
+    override suspend fun findWithPanCredential(): List<Card> = Panache.withSession {
+        find("panEncrypted IS NOT NULL").list()
+    }.awaitSuspending().map { it.toDomain() }
+
+    /**
+     * Compare-and-swap on the OLD ciphertext, not a plain "update by id": the `expectedPanEncrypted`
+     * predicate is part of the *write*, so a row that changed between the caller's decrypt and this
+     * write (a re-issue, a concurrent re-encrypt pass) is left untouched instead of being clobbered.
+     */
+    override suspend fun updatePanCredentialIfMatches(
+        cardId: UUID,
+        expectedPanEncrypted: String,
+        newPanEncrypted: String,
+        newCvvEncrypted: String,
+    ): Boolean = Panache.withTransaction {
+        update(
+            "panEncrypted = ?1, cvvEncrypted = ?2 WHERE id = ?3 AND panEncrypted = ?4",
+            newPanEncrypted,
+            newCvvEncrypted,
+            cardId,
+            expectedPanEncrypted,
+        )
+    }.awaitSuspending() == 1
+
     private companion object {
         /** `status` is persisted as its enum NAME (see CardMapper), so the query compares strings. */
         val TERMINAL_STATUS_NAMES = Card.TERMINAL_STATUSES.map { it.name }

--- a/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/infrastructure/startup/CardPanKeyReencryptStarter.kt
+++ b/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/infrastructure/startup/CardPanKeyReencryptStarter.kt
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.cardissuance.infrastructure.startup
+
+import com.openbank.cardissuance.application.usecase.CardPanKeyReencrypt
+import io.quarkus.runtime.Startup
+import io.quarkus.vertx.VertxContextSupport
+import io.smallrye.mutiny.coroutines.uni
+import jakarta.annotation.PostConstruct
+import jakarta.enterprise.context.ApplicationScoped
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import org.eclipse.microprofile.config.inject.ConfigProperty
+import org.jboss.logging.Logger
+import java.util.Optional
+
+/**
+ * Runs [CardPanKeyReencrypt] once per boot — but only when an operator has actually configured
+ * [previousWrappedDek] (ADR-0262 follow-up). Absent, the overwhelming common case, this does
+ * nothing: no config read beyond the one Optional, no repository query, no OpenBao call. Safe to
+ * leave wired permanently rather than something an operator has to remember to disable: once every
+ * row has migrated, a further pass just decrypts everything under the current cipher on the first
+ * try and reports zero migrated (`CardPanKeyReencrypt`'s own fast path).
+ *
+ * Same two deliberate properties as [CardPanVaultBackfillStarter], and for the same reasons — see
+ * that class's doc: runs on a Vert.x duplicated context ([VertxContextSupport]), and never blocks
+ * or fails the boot (fire-and-forget, every failure caught and logged loudly). A rotation that
+ * hasn't finished migrating yet is not an outage; a card-issuance pod that won't start is.
+ */
+@Startup
+@ApplicationScoped
+class CardPanKeyReencryptStarter(
+    private val reencrypt: CardPanKeyReencrypt,
+    @ConfigProperty(name = "openbank.card.envelope.previous-wrapped-dek")
+    private val previousWrappedDek: Optional<String>,
+) {
+
+    // TooGenericExceptionCaught: this IS the loud-log-and-carry-on boundary, same as the backfill
+    // starter's identical suppression.
+    @PostConstruct
+    @Suppress("TooGenericExceptionCaught")
+    fun onStartup() {
+        val wrapped = previousWrappedDek.orElse("")
+        if (wrapped.isBlank()) {
+            return
+        }
+        try {
+            VertxContextSupport.subscribe(
+                { uni(CoroutineScope(Dispatchers.Unconfined)) { reencrypt.run(wrapped) }.toMulti() },
+                { subscription -> subscription.with({ }, { failure -> logFailure(failure) }) },
+            )
+        } catch (e: Throwable) {
+            logFailure(e)
+        }
+    }
+
+    private fun logFailure(failure: Throwable) {
+        log.error(
+            "[pan-key-reencrypt] failed; the service is starting anyway. Rows still on the previous " +
+                "DEK stay migrated on a later boot — Transit still serves that key version, so " +
+                "nothing is unreadable in the meantime.",
+            failure,
+        )
+    }
+
+    private companion object {
+        val log: Logger = Logger.getLogger(CardPanKeyReencryptStarter::class.java)
+    }
+}

--- a/openbank-card-issuance-service/src/main/resources/application.yaml
+++ b/openbank-card-issuance-service/src/main/resources/application.yaml
@@ -219,6 +219,12 @@ openbank:
     # is unwrapped once at boot from openbank.card.envelope.wrapped-dek via an OpenBao Transit key.
     # Deliberately not set here for the same reason pan-encryption-key is absent: this is a
     # per-environment opt-in, not a repo default.
+    #
+    # envelope.previous-wrapped-dek: set ONLY while migrating off a rotated-out DEK
+    # (CardPanKeyReencrypt). Absent (the default) means the re-encrypt starter does nothing on
+    # boot — no config read beyond the Optional check, no OpenBao call. An operator sets this to
+    # the OLD wrapped-dek value right after rotating envelope.wrapped-dek to a freshly-wrapped one,
+    # leaves it set until a boot's log line reports 0 remaining, then unsets it.
   outbox:
     dispatch-enabled: true
   rate-limit:

--- a/openbank-card-issuance-service/src/test/kotlin/com/openbank/cardissuance/application/usecase/CardPanKeyReencryptTest.kt
+++ b/openbank-card-issuance-service/src/test/kotlin/com/openbank/cardissuance/application/usecase/CardPanKeyReencryptTest.kt
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.cardissuance.application.usecase
+
+import com.openbank.cardissuance.application.port.out.CardRepository
+import com.openbank.cardissuance.application.port.out.CardSecretCipher
+import com.openbank.cardissuance.domain.model.Card
+import com.openbank.cardissuance.domain.model.CardNetwork
+import com.openbank.cardissuance.domain.model.CardStatus
+import com.openbank.cardissuance.domain.model.CardType
+import com.openbank.cardissuance.infrastructure.crypto.AesGcmCardSecretCipher
+import com.openbank.cardissuance.infrastructure.crypto.OpenBaoTransitDekUnwrapper
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.time.LocalDate
+import java.util.Base64
+import java.util.Optional
+import java.util.UUID
+
+private const val WRAPPED_OLD_DEK = "vault:v1:old-not-a-real-wrapped-value"
+
+/**
+ * The re-encrypt batch job (ADR-0262 follow-up): migrates rows off a rotated-out DEK, the same
+ * way [CardPanVaultBackfillTest] exercises the sibling backfill.
+ */
+class CardPanKeyReencryptTest {
+
+    private lateinit var repo: CardRepository
+    private lateinit var unwrapper: OpenBaoTransitDekUnwrapper
+    private lateinit var reencrypt: CardPanKeyReencrypt
+
+    // Real ciphers, as in CardPanVaultBackfillTest: the round-trip (and the deliberate MISMATCH
+    // between them) is part of the behaviour under test. TEST ONLY keys, built in code rather than
+    // pasted as base64 literals.
+    private val currentCipher: CardSecretCipher =
+        AesGcmCardSecretCipher(Optional.of(Base64.getEncoder().encodeToString(ByteArray(32) { it.toByte() })), false)
+    private val oldDekBytes = ByteArray(32) { (it + 1).toByte() }
+    private val oldCipher = AesGcmCardSecretCipher(Optional.of(Base64.getEncoder().encodeToString(oldDekBytes)), false)
+
+    @BeforeEach
+    fun setUp() {
+        repo = mockk()
+        unwrapper = mockk()
+        every { unwrapper.unwrap(WRAPPED_OLD_DEK) } returns oldDekBytes
+        reencrypt = CardPanKeyReencrypt(repo, currentCipher, unwrapper)
+    }
+
+    @Test fun `migrates a row encrypted under the old DEK to the current one`(): Unit = runBlocking {
+        val oldPan = oldCipher.encrypt("4111111234567893")
+        val oldCvv = oldCipher.encrypt("123")
+        val card = card(panEncrypted = oldPan, cvvEncrypted = oldCvv)
+        coEvery { repo.findWithPanCredential() } returns listOf(card)
+        val newPan = slot<String>()
+        val newCvv = slot<String>()
+        coEvery {
+            repo.updatePanCredentialIfMatches(card.id, oldPan, capture(newPan), capture(newCvv))
+        } returns true
+
+        val result = reencrypt.run(WRAPPED_OLD_DEK)
+
+        assertThat(
+            result,
+        ).isEqualTo(
+            CardPanReencryptResult(migrated = 1, alreadyCurrent = 0, skippedConcurrentWrite = 0, unmigrable = 0),
+        )
+        assertThat(currentCipher.decrypt(newPan.captured)).isEqualTo("4111111234567893")
+        assertThat(currentCipher.decrypt(newCvv.captured)).isEqualTo("123")
+    }
+
+    @Test fun `a row already on the current DEK is left untouched`(): Unit = runBlocking {
+        val card =
+            card(panEncrypted = currentCipher.encrypt("4111111234567893"), cvvEncrypted = currentCipher.encrypt("123"))
+        coEvery { repo.findWithPanCredential() } returns listOf(card)
+
+        val result = reencrypt.run(WRAPPED_OLD_DEK)
+
+        assertThat(
+            result,
+        ).isEqualTo(
+            CardPanReencryptResult(migrated = 0, alreadyCurrent = 1, skippedConcurrentWrite = 0, unmigrable = 0),
+        )
+        coVerify(exactly = 0) { repo.updatePanCredentialIfMatches(any(), any(), any(), any()) }
+        // The fast path never needed the old cipher at all — confirms "try current first" is
+        // actually cheap (no OpenBao call), not just documented as such.
+        verify(exactly = 0) { unwrapper.unwrap(any()) }
+    }
+
+    @Test fun `a row under neither key is left untouched and counted unmigrable`(): Unit = runBlocking {
+        val thirdKeyBytes = ByteArray(32) { (it + 2).toByte() }
+        val thirdCipher = AesGcmCardSecretCipher(Optional.of(Base64.getEncoder().encodeToString(thirdKeyBytes)), false)
+        val card =
+            card(panEncrypted = thirdCipher.encrypt("4111111234567893"), cvvEncrypted = thirdCipher.encrypt("123"))
+        coEvery { repo.findWithPanCredential() } returns listOf(card)
+
+        val result = reencrypt.run(WRAPPED_OLD_DEK)
+
+        assertThat(
+            result,
+        ).isEqualTo(
+            CardPanReencryptResult(migrated = 0, alreadyCurrent = 0, skippedConcurrentWrite = 0, unmigrable = 1),
+        )
+        coVerify(exactly = 0) { repo.updatePanCredentialIfMatches(any(), any(), any(), any()) }
+    }
+
+    // Idempotence's second layer, same shape as the backfill: the CAS write loses to a row that
+    // changed between the read and the write, and that is a SKIP, never a clobber.
+    @Test fun `a row that changed concurrently is skipped, not overwritten`(): Unit = runBlocking {
+        val oldPan = oldCipher.encrypt("4111111234567893")
+        val card = card(panEncrypted = oldPan, cvvEncrypted = oldCipher.encrypt("123"))
+        coEvery { repo.findWithPanCredential() } returns listOf(card)
+        coEvery { repo.updatePanCredentialIfMatches(card.id, oldPan, any(), any()) } returns false
+
+        val result = reencrypt.run(WRAPPED_OLD_DEK)
+
+        assertThat(
+            result,
+        ).isEqualTo(
+            CardPanReencryptResult(migrated = 0, alreadyCurrent = 0, skippedConcurrentWrite = 1, unmigrable = 0),
+        )
+    }
+
+    @Test fun `a second pass is a no-op once every row has migrated`(): Unit = runBlocking {
+        val oldPan = oldCipher.encrypt("4111111234567893")
+        val card = card(panEncrypted = oldPan, cvvEncrypted = oldCipher.encrypt("123"))
+        var stored = card
+        coEvery { repo.findWithPanCredential() } answers { listOf(stored) }
+        coEvery { repo.updatePanCredentialIfMatches(card.id, oldPan, any(), any()) } answers {
+            stored = stored.copy(panEncrypted = thirdArg(), cvvEncrypted = arg(3))
+            true
+        }
+
+        assertThat(reencrypt.run(WRAPPED_OLD_DEK).migrated).isEqualTo(1)
+        assertThat(reencrypt.run(WRAPPED_OLD_DEK)).isEqualTo(
+            CardPanReencryptResult(migrated = 0, alreadyCurrent = 1, skippedConcurrentWrite = 0, unmigrable = 0),
+        )
+    }
+
+    @Test fun `no candidates is an empty, not-unmigrable result`(): Unit = runBlocking {
+        coEvery { repo.findWithPanCredential() } returns emptyList()
+
+        val result = reencrypt.run(WRAPPED_OLD_DEK)
+
+        assertThat(result.isEmpty).isTrue()
+    }
+
+    private fun card(
+        panEncrypted: String,
+        cvvEncrypted: String,
+        id: UUID = UUID.fromString("11111111-1111-1111-1111-111111111111"),
+    ) = Card(
+        id = id,
+        idempotencyKey = "idem-$id",
+        partyId = UUID.fromString("22222222-2222-2222-2222-222222222222"),
+        accountId = UUID.fromString("33333333-3333-3333-3333-333333333333"),
+        productCode = "CARD-001",
+        cardType = CardType.VIRTUAL,
+        network = CardNetwork.VISA,
+        maskedPan = "**** **** **** 7893",
+        cardholderName = "Jane Doe",
+        embossedName = "JANE DOE",
+        expiryDate = LocalDate.of(2030, 12, 31),
+        status = CardStatus.ACTIVE,
+        dailyLimitMinorUnits = 100_00,
+        monthlyLimitMinorUnits = 1_000_00,
+        currency = "EUR",
+        deliveryAddress = null,
+        activatedAt = null,
+        blockedAt = null,
+        blockedReason = null,
+        createdAt = Instant.parse("2026-01-01T00:00:00Z"),
+        updatedAt = Instant.parse("2026-01-01T00:00:00Z"),
+        panEncrypted = panEncrypted,
+        cvvEncrypted = cvvEncrypted,
+    )
+}

--- a/openbank-card-issuance-service/src/test/kotlin/com/openbank/cardissuance/infrastructure/crypto/OpenBaoEnvelopeCardSecretCipherTest.kt
+++ b/openbank-card-issuance-service/src/test/kotlin/com/openbank/cardissuance/infrastructure/crypto/OpenBaoEnvelopeCardSecretCipherTest.kt
@@ -4,7 +4,7 @@
 
 package com.openbank.cardissuance.infrastructure.crypto
 
-import com.fasterxml.jackson.databind.ObjectMapper
+import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
@@ -12,7 +12,6 @@ import java.security.SecureRandom
 import java.util.Optional
 
 private const val WRAPPED_DEK_FIXTURE = "vault:v1:not-a-real-wrapped-value"
-private const val LOGIN_TOKEN_FIXTURE = "stub-token"
 
 // Shared, not one per call: these are unrelated test fixtures, not real key material, so reusing
 // one generator is both fine and what CodeQL's "Random object created and used only once" wants.
@@ -20,61 +19,56 @@ private val testRandom = SecureRandom()
 
 private fun randomDek(size: Int = 32): ByteArray = ByteArray(size).also { testRandom.nextBytes(it) }
 
-/** Builds a cipher with the two OpenBao HTTP seams stubbed (see the class doc on why lambdas, not subclassing). */
+// Never actually invoked by any test here — real HTTP calls to OpenBao live in
+// OpenBaoTransitDekUnwrapper and are exercised in that class's own test. This cipher test only
+// cares that it calls unwrapFn (or the injected unwrapper, wired but never reached when unwrapFn
+// is set) with the configured wrapped DEK and uses the result.
+private val unusedUnwrapper = mockk<OpenBaoTransitDekUnwrapper>()
+
+/** Builds a cipher with [OpenBaoTransitDekUnwrapper.unwrap] stubbed via the lambda test seam. */
 private fun cipher(
     wrapped: Optional<String>,
     allowEphemeral: Boolean,
-    loginFn: (() -> String)? = { LOGIN_TOKEN_FIXTURE },
-    unwrapDekFn: ((String, String) -> ByteArray)? = { _, _ -> randomDek() },
+    unwrapFn: ((String) -> ByteArray)? = { randomDek() },
 ) = OpenBaoEnvelopeCardSecretCipher(
-    baoAddr = "http://openbao.invalid:8200",
-    role = "card-issuance-pan-dek",
-    transitMount = "transit",
-    kekName = "card-pan",
-    saTokenPath = "/nonexistent/token",
+    unwrapper = unusedUnwrapper,
     wrappedDek = wrapped,
     allowEphemeralKey = allowEphemeral,
-    objectMapper = ObjectMapper(),
-    loginFn = loginFn,
-    unwrapDekFn = unwrapDekFn,
+    unwrapFn = unwrapFn,
 )
 
 class OpenBaoEnvelopeCardSecretCipherTest {
 
     @Test fun `round trips a PAN through the unwrapped DEK`() {
         val dek = randomDek()
-        val c = cipher(Optional.of(WRAPPED_DEK_FIXTURE), allowEphemeral = false, unwrapDekFn = { _, _ -> dek })
+        val c = cipher(Optional.of(WRAPPED_DEK_FIXTURE), allowEphemeral = false, unwrapFn = { dek })
         val pan = "4111111234567893"
 
         assertThat(c.decrypt(c.encrypt(pan))).isEqualTo(pan)
     }
 
-    @Test fun `logs in and unwraps with the configured wrapped DEK and derived token`() {
-        var seenToken: String? = null
+    @Test fun `unwraps with the configured wrapped DEK`() {
         var seenWrapped: String? = null
         val c = cipher(
             wrapped = Optional.of(WRAPPED_DEK_FIXTURE),
             allowEphemeral = false,
-            unwrapDekFn = { token, wrapped ->
-                seenToken = token
+            unwrapFn = { wrapped ->
                 seenWrapped = wrapped
                 randomDek()
             },
         )
         c.encrypt("4111111234567893")
 
-        assertThat(seenToken).isEqualTo(LOGIN_TOKEN_FIXTURE)
         assertThat(seenWrapped).isEqualTo(WRAPPED_DEK_FIXTURE)
     }
 
-    @Test fun `never calls OpenBao when no wrapped DEK is configured and ephemeral is allowed`() {
-        // If loadDelegate() called either seam here, these would throw — proving the ephemeral path
+    @Test fun `never unwraps when no wrapped DEK is configured and ephemeral is allowed`() {
+        // If loadDelegate() called unwrapFn here, this would throw — proving the ephemeral path
         // never reaches OpenBao when no wrapped DEK is configured.
         val c = cipher(
             wrapped = Optional.empty(),
             allowEphemeral = true,
-            loginFn = { error("must not be called: no wrapped DEK configured") },
-            unwrapDekFn = { _, _ -> error("must not be called: no wrapped DEK configured") },
+            unwrapFn = { error("must not be called: no wrapped DEK configured") },
         )
 
         assertThat(c.decrypt(c.encrypt("4111111111111111"))).isEqualTo("4111111111111111")
@@ -93,12 +87,12 @@ class OpenBaoEnvelopeCardSecretCipherTest {
             .hasMessageContaining("openbank.card.envelope.wrapped-dek is not set")
     }
 
-    @Test fun `refuses to start when Transit unwraps a DEK of the wrong length`() {
+    @Test fun `refuses to start when the unwrapped DEK has the wrong length`() {
         assertThatThrownBy {
             cipher(
                 wrapped = Optional.of(WRAPPED_DEK_FIXTURE),
                 allowEphemeral = false,
-                unwrapDekFn = { _, _ -> randomDek(size = 16) },
+                unwrapFn = { randomDek(size = 16) },
             )
         }.isInstanceOf(IllegalArgumentException::class.java)
             .hasMessageContaining("unwrapped a DEK of 16 bytes, expected 32 (AES-256)")
@@ -108,24 +102,24 @@ class OpenBaoEnvelopeCardSecretCipherTest {
         val sealed = cipher(
             wrapped = Optional.of(WRAPPED_DEK_FIXTURE),
             allowEphemeral = false,
-            unwrapDekFn = { _, _ -> randomDek() },
+            unwrapFn = { randomDek() },
         ).encrypt("4111111234567893")
 
         val otherCipher = cipher(
             wrapped = Optional.of(WRAPPED_DEK_FIXTURE),
             allowEphemeral = false,
-            unwrapDekFn = { _, _ -> randomDek() },
+            unwrapFn = { randomDek() },
         )
 
         assertThatThrownBy { otherCipher.decrypt(sealed) }.isInstanceOf(Exception::class.java)
     }
 
-    @Test fun `propagates a login failure instead of falling back silently`() {
+    @Test fun `propagates an unwrap failure instead of falling back silently`() {
         assertThatThrownBy {
             cipher(
                 wrapped = Optional.of(WRAPPED_DEK_FIXTURE),
                 allowEphemeral = false,
-                loginFn = { error("OpenBao kubernetes-auth login failed: HTTP 403") },
+                unwrapFn = { error("OpenBao transit decrypt failed for key 'card-pan': HTTP 403") },
             )
         }.isInstanceOf(Exception::class.java)
     }

--- a/openbank-card-issuance-service/src/test/kotlin/com/openbank/cardissuance/infrastructure/crypto/OpenBaoTransitDekUnwrapperTest.kt
+++ b/openbank-card-issuance-service/src/test/kotlin/com/openbank/cardissuance/infrastructure/crypto/OpenBaoTransitDekUnwrapperTest.kt
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.cardissuance.infrastructure.crypto
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import java.security.SecureRandom
+
+private const val WRAPPED_DEK_FIXTURE = "vault:v1:not-a-real-wrapped-value"
+private const val LOGIN_TOKEN_FIXTURE = "stub-token"
+
+private val testRandom = SecureRandom()
+private fun randomDek(size: Int = 32): ByteArray = ByteArray(size).also { testRandom.nextBytes(it) }
+
+/**
+ * Stubs the two HTTP seams by subclassing (see the production class's own doc for why: this
+ * class is injected by concrete type, which rules out the constructor-defaulted-lambda seam used
+ * elsewhere in this package). Safe here — [login]/[unwrapDek] are only ever called on demand from
+ * [OpenBaoTransitDekUnwrapper.unwrap], never from this class's own `init`, so there is no
+ * Kotlin superclass-init-order risk.
+ */
+private open class StubUnwrapper(
+    private val onLogin: () -> String = { LOGIN_TOKEN_FIXTURE },
+    private val onUnwrap: (String, String) -> ByteArray = { _, _ -> randomDek() },
+) : OpenBaoTransitDekUnwrapper(
+    baoAddr = "http://openbao.invalid:8200",
+    role = "card-issuance-pan-dek",
+    transitMount = "transit",
+    kekName = "card-pan",
+    saTokenPath = "/nonexistent/token",
+    objectMapper = ObjectMapper(),
+) {
+    override fun login(): String = onLogin()
+
+    override fun unwrapDek(token: String, wrapped: String): ByteArray = onUnwrap(token, wrapped)
+}
+
+class OpenBaoTransitDekUnwrapperTest {
+
+    @Test fun `logs in and unwraps with the given wrapped DEK and derived token`() {
+        var seenToken: String? = null
+        var seenWrapped: String? = null
+        val dek = randomDek()
+        val u = StubUnwrapper(
+            onUnwrap = { token, wrapped ->
+                seenToken = token
+                seenWrapped = wrapped
+                dek
+            },
+        )
+
+        assertThat(u.unwrap(WRAPPED_DEK_FIXTURE)).isEqualTo(dek)
+        assertThat(seenToken).isEqualTo(LOGIN_TOKEN_FIXTURE)
+        assertThat(seenWrapped).isEqualTo(WRAPPED_DEK_FIXTURE)
+    }
+
+    @Test fun `retries a transient login failure and succeeds on a later attempt`() {
+        var attempts = 0
+        val dek = randomDek()
+        val u = StubUnwrapper(
+            onLogin = {
+                attempts++
+                if (attempts < 2) error("connection refused") else LOGIN_TOKEN_FIXTURE
+            },
+            onUnwrap = { _, _ -> dek },
+        )
+
+        assertThat(u.unwrap(WRAPPED_DEK_FIXTURE)).isEqualTo(dek)
+        assertThat(attempts).isEqualTo(2)
+    }
+
+    @Test fun `retries a transient decrypt failure, logging in again each attempt`() {
+        var loginAttempts = 0
+        var decryptAttempts = 0
+        val dek = randomDek()
+        val u = StubUnwrapper(
+            onLogin = {
+                loginAttempts++
+                "token-$loginAttempts"
+            },
+            onUnwrap = { token, _ ->
+                decryptAttempts++
+                if (decryptAttempts < 3) {
+                    error("HTTP 503")
+                } else {
+                    // The retry restarts from a fresh login each attempt — never reuses a token
+                    // from an earlier failed pass.
+                    assertThat(token).isEqualTo("token-3")
+                    dek
+                }
+            },
+        )
+
+        assertThat(u.unwrap(WRAPPED_DEK_FIXTURE)).isEqualTo(dek)
+        assertThat(loginAttempts).isEqualTo(3)
+    }
+
+    @Test fun `gives up and throws after exhausting all attempts`() {
+        var attempts = 0
+        val u = StubUnwrapper(onLogin = {
+            attempts++
+            error("OpenBao unreachable")
+        })
+
+        assertThatThrownBy { u.unwrap(WRAPPED_DEK_FIXTURE) }.isInstanceOf(Exception::class.java)
+        assertThat(attempts).isEqualTo(4)
+    }
+}


### PR DESCRIPTION
## Summary
- Implements the re-encrypt batch job ADR-0262 called out as a follow-up: `CardPanKeyReencrypt` migrates every stored PAN/CVV off a rotated-out OpenBao Transit DEK to the current one.
- Fast path: tries the current cipher first — no OpenBao call, and this is the outcome for every row once migration is done. Falls back to unwrapping the given previous DEK (once, lazily, only if at least one row needs it) only when the current cipher fails.
- Write is a compare-and-swap on the OLD ciphertext (`CardRepository.updatePanCredentialIfMatches`) — a row that changed concurrently (re-issue, another replica running the same pass) is skipped, never clobbered. Same idempotent shape as `CardPanVaultBackfill`.
- Wired at boot via `CardPanKeyReencryptStarter`, gated on `openbank.card.envelope.previous-wrapped-dek` (absent by default — no config read beyond the Optional check, no repository query, no OpenBao call on a normal boot).
- Refactor: extracted `OpenBaoTransitDekUnwrapper` out of `OpenBaoEnvelopeCardSecretCipher` so the eager current-DEK unwrap (at `@Startup`) and this on-demand previous-DEK unwrap share one login/retry implementation instead of two copies.
- New `CardRepository` port methods: `findWithPanCredential` (all cards with a stored credential, including terminal — unlike the vault backfill, re-encrypting an existing number is harmless for a dead card) and `updatePanCredentialIfMatches`.

## Linked issues
N/A — implements the follow-up batch job ADR-0262 itself already called out (ADR-0052: ADRs aren't tracked as backlog issues).

## A CDI gotcha worth flagging for review
`OpenBaoTransitDekUnwrapper` is injected by its own CONCRETE type (not an interface) into two other beans. Quarkus ArC failed bean discovery (`does not declare a valid bean constructor`) as long as its constructor carried ANY defaulted function-typed test-seam parameter — even just one — despite the identical pattern working fine on `OpenBaoEnvelopeCardSecretCipher` (which is only ever injected via the `CardSecretCipher` interface). Bisected empirically (see the class's own doc comment). Fix: no default constructor params on this class at all; the test seam is `protected open fun login()/unwrapDek()` overridden by a subclass in the test — safe here since neither is called from this class's own `init`, unlike the Kotlin superclass-init-order trap that ruled out subclassing for the cipher itself.

## Test plan
- [x] `./gradlew :openbank-card-issuance-service:test` — full suite, green (new: `CardPanKeyReencryptTest`, `OpenBaoTransitDekUnwrapperTest`; updated: `OpenBaoEnvelopeCardSecretCipherTest`)
- [x] `./gradlew :openbank-card-issuance-service:ktlintCheck :openbank-card-issuance-service:detekt` — clean
- [x] `./gradlew :openbank-card-issuance-service:quarkusBuild -x test` (flat-key) and `-Dopenbank.card.key-source=openbao-transit` — both green, confirms the CDI fix above
- [x] `python3 .github/scripts/check-asvs-l3.py --baseline .github/asvs-l3-baseline.txt --enforce` and `check-network-policy-code-edges.py` — both clean, no new plaintext-HTTP or cross-namespace findings (reuses the already-declared `openbank.card.envelope.bao-addr` egress)
- [ ] Real OpenBao Transit integration test (needs a live Transit engine) — not run here, same limitation as the base ADR-0262 PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
