### PR TITLE
feat(audit): subscribe to openbank.sca.events for SCA enrollment audit trail

### DIFF
--- a/openbank-audit-service/src/main/kotlin/com/openbank/audit/application/EventAttribution.kt
+++ b/openbank-audit-service/src/main/kotlin/com/openbank/audit/application/EventAttribution.kt
@@ -80,6 +80,14 @@ object TopicAttribution {
         "openbank.documents.document.event" to "document-service",
         "openbank.payments.swift.event" to "swift-service",
         "openbank.lending.events" to "lending-service",
+        // Issue #5338: audit-service was not subscribed to this topic at all (absent from both
+        // this table and application.yaml's topics list), so SCA device enrollment
+        // (DEVICE_ENROLLED) was never audited — a real PSD2/SCA gap, since sca-service is
+        // money-path. PR #5337 adds "sourceService" to the enroll payload so this row resolves
+        // AttributionSource.EVENT rather than TOPIC once it merges; until then the topic-derived
+        // value below is still correct (ScaService.kt's outbox payload sets no source field yet,
+        // and "sca-service" is what it will say when it does).
+        "openbank.sca.events" to "sca-service",
     )
 
     /** Topics with a verified producer entry. Visible for the coverage test. */

--- a/openbank-audit-service/src/main/resources/application.yaml
+++ b/openbank-audit-service/src/main/resources/application.yaml
@@ -142,7 +142,13 @@ mp:
         # directly rather than assuming from the port/publisher shape alone). #1035's AML-case
         # design for this topic is a SEPARATE, additional consumer with real business logic
         # (case-opening criteria) — this audit-trail consumer does not replace or block that work.
-        topics: openbank.accounts.account.created,openbank.transactions.transaction.initiated,openbank.balance.events,openbank.party.events,openbank.kyc.events,openbank.consent.events,openbank.customer.audit,openbank.clearing.batch.event,openbank.security.ict.incident,openbank.cards.events,openbank.dispute.events,openbank.domestic.payment.events,openbank.sepa.payment.events,openbank.statement.event,openbank.sanctions.screening.event,openbank.sepa.instant.events,openbank.fx.conversion.completed,openbank.documents.document.event,openbank.payments.swift.event,openbank.lending.events
+        # openbank.sca.events (issue #5338): sca-service's own DEVICE_ENROLLED producer
+        # (ScaService.enroll, KafkaScaOutboxEventPublisher) is a genuine outbox-row write, not
+        # a stub — verified directly in ScaService.kt rather than assumed from the port shape
+        # alone (#1034's lesson). audit-service was the only one of the topic's two documented
+        # consumers (the other being onboarding-service's projection, #4353) that had never
+        # subscribed.
+        topics: openbank.accounts.account.created,openbank.transactions.transaction.initiated,openbank.balance.events,openbank.party.events,openbank.kyc.events,openbank.consent.events,openbank.customer.audit,openbank.clearing.batch.event,openbank.security.ict.incident,openbank.cards.events,openbank.dispute.events,openbank.domestic.payment.events,openbank.sepa.payment.events,openbank.statement.event,openbank.sanctions.screening.event,openbank.sepa.instant.events,openbank.fx.conversion.completed,openbank.documents.document.event,openbank.payments.swift.event,openbank.lending.events,openbank.sca.events
         value.deserializer: org.apache.kafka.common.serialization.StringDeserializer
 "%dev":
   quarkus:

--- a/openbank-audit-service/src/test/kotlin/com/openbank/audit/integration/ScaEnrollmentAuditIT.kt
+++ b/openbank-audit-service/src/test/kotlin/com/openbank/audit/integration/ScaEnrollmentAuditIT.kt
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+package com.openbank.audit.integration
+
+import com.openbank.audit.application.AuditConsumer
+import com.openbank.audit.domain.model.AttributionSource
+import com.openbank.audit.infrastructure.persistence.AuditRepository
+import com.openbank.audit.it.PostgresTestResource
+import com.openbank.libs.persistence.outbox.OutboxKafkaHeaders
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.vertx.VertxContextSupport
+import io.smallrye.mutiny.coroutines.uni
+import io.smallrye.reactive.messaging.kafka.api.IncomingKafkaRecordMetadata
+import jakarta.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.apache.kafka.common.header.internals.RecordHeader
+import org.apache.kafka.common.header.internals.RecordHeaders
+import org.apache.kafka.common.record.RecordBatch
+import org.apache.kafka.common.record.TimestampType
+import org.assertj.core.api.Assertions.assertThat
+import org.eclipse.microprofile.reactive.messaging.Message
+import org.eclipse.microprofile.reactive.messaging.Metadata
+import org.junit.jupiter.api.Test
+import java.nio.charset.StandardCharsets
+import java.time.OffsetDateTime
+import java.util.UUID
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionStage
+import java.util.function.Supplier
+
+/**
+ * Issue #5338: audit-service was not subscribed to `openbank.sca.events` at all — absent from
+ * both [com.openbank.audit.application.TopicAttribution] and `application.yaml`'s
+ * `audit-events-in` topics list — so SCA device enrollment (`DEVICE_ENROLLED`) was never recorded
+ * in the audit trail, a real PSD2/SCA compliance gap (sca-service is money-path).
+ *
+ * **Why this drives the real bean against a real database, not a mocked repository.** Every
+ * existing attribution test in this module ([com.openbank.audit.application.AuditAttributionTest])
+ * mocks [AuditRepository] — correct for pinning `resolveSourceService`'s logic in isolation, but
+ * it cannot prove the topic is actually wired end-to-end: a mock happily "saves" a row for a topic
+ * this service was never subscribed to. This test instead injects the REAL [AuditConsumer] bean
+ * (CDI-managed, not `mockk`) against a real Testcontainers Postgres (the module's established
+ * pattern — [AuditChainRoundTripIT]) and reads the persisted row back with a real JDBC query, so a
+ * regression that removes `openbank.sca.events` from `TopicAttribution` or from the `topics:` list
+ * — the exact defect this issue fixes — fails here, not silently.
+ *
+ * **What it does and does not prove.** There is no Kafka Testcontainers usage anywhere in this
+ * repo (verified before writing this), so this does not drive a literal Kafka broker end to end.
+ * What it DOES exercise is the real production code path: a [Message] carrying a genuine
+ * [IncomingKafkaRecordMetadata] (topic `openbank.sca.events`, `ce-type` header `DEVICE_ENROLLED`,
+ * matching what a real Kafka `ConsumerRecord` delivers) is handed to the actual
+ * `@Incoming("audit-events-in") suspend fun consume(message: Message<String>)` entrypoint — the
+ * same method SmallRye Kafka would invoke for a real delivery — with the EXACT payload shape
+ * `ScaService.enroll` constructs (`ScaService.kt`, read directly rather than guessed), so
+ * `TopicAttribution`'s new `openbank.sca.events -> "sca-service"` entry, `application.yaml`'s
+ * topics list, and `AuditConsumer.resolveSourceService`/`inferAggregateType` all get exercised
+ * together, against a real database write.
+ */
+@QuarkusTest
+@QuarkusTestResource(PostgresTestResource::class)
+class ScaEnrollmentAuditIT {
+
+    @Inject
+    lateinit var consumer: AuditConsumer
+
+    @Inject
+    lateinit var repository: AuditRepository
+
+    private fun <T> onEventLoop(block: suspend () -> T): T =
+        VertxContextSupport.subscribeAndAwait { uni(CoroutineScope(Dispatchers.Unconfined)) { block() } }
+
+    /**
+     * The exact payload shape `ScaService.enroll` writes to the outbox (`ScaService.kt`), read
+     * from that class directly rather than assumed. `sourceService` is PR #5337's field — this
+     * test includes it so the strongest (EVENT) attribution path is exercised too; see the
+     * companion test below for the TOPIC-derived path a pre-#5337 payload takes.
+     */
+    private fun enrollPayload(
+        partyId: UUID,
+        deviceId: UUID,
+        occurredAt: OffsetDateTime,
+        includeSourceService: Boolean,
+    ): String {
+        val sourceServiceField = if (includeSourceService) ""","sourceService":"sca-service"""" else ""
+        return """
+            {
+              "eventType":"DEVICE_ENROLLED",
+              "deviceId":"$deviceId",
+              "partyId":"$partyId",
+              "credentialId":"cred-$deviceId",
+              "algorithm":"ES256",
+              "occurredAt":"$occurredAt"$sourceServiceField
+            }
+        """.trimIndent()
+    }
+
+    private fun kafkaMessage(payload: String): Message<String> {
+        val headers = RecordHeaders()
+        headers.add(
+            RecordHeader(
+                OutboxKafkaHeaders.HEADER_EVENT_TYPE,
+                "DEVICE_ENROLLED".toByteArray(StandardCharsets.UTF_8),
+            ),
+        )
+        val record = ConsumerRecord(
+            "openbank.sca.events",
+            0,
+            0L,
+            RecordBatch.NO_TIMESTAMP,
+            TimestampType.NO_TIMESTAMP_TYPE,
+            ConsumerRecord.NULL_SIZE,
+            ConsumerRecord.NULL_SIZE,
+            null as String?,
+            payload,
+            headers,
+            java.util.Optional.empty(),
+        )
+        val metadata = IncomingKafkaRecordMetadata(record, "audit-events-in")
+        return Message.of(
+            payload,
+            Metadata.of(metadata),
+            Supplier<CompletionStage<Void>> { CompletableFuture.completedFuture(null) },
+        )
+    }
+
+    @Test
+    fun `a real SCA enrollment event delivered on openbank sca events lands in audit_entries`(): Unit = runBlocking {
+        val partyId = UUID.randomUUID()
+        val deviceId = UUID.randomUUID()
+        val occurredAt = OffsetDateTime.now()
+        val message = kafkaMessage(enrollPayload(partyId, deviceId, occurredAt, includeSourceService = true))
+
+        onEventLoop { consumer.consume(message) }
+
+        val stored = onEventLoop { repository.findByAggregateId(partyId.toString()) }.single()
+        assertThat(stored.eventType).isEqualTo("DEVICE_ENROLLED")
+        assertThat(stored.aggregateType).isEqualTo("PARTY")
+        assertThat(stored.aggregateId).isEqualTo(partyId.toString())
+        // The producer's own claim (PR #5337) wins over the topic-derived attribution, and is
+        // marked as the producer's own (AttributionSource.EVENT) — never silently folded into the
+        // weaker TOPIC provenance.
+        assertThat(stored.sourceService).isEqualTo("sca-service")
+        assertThat(stored.sourceServiceSource).isEqualTo(AttributionSource.EVENT)
+    }
+
+    @Test
+    fun `before PR 5337's sourceService field, the topic alone still attributes sca-service`(): Unit = runBlocking {
+        // Guards the TopicAttribution table entry independently of #5337's payload change — the
+        // two PRs are independent deployables, and this repo has been bitten before by a
+        // dependency silently required in the wrong direction.
+        val partyId = UUID.randomUUID()
+        val deviceId = UUID.randomUUID()
+        val occurredAt = OffsetDateTime.now()
+        val message = kafkaMessage(
+            enrollPayload(partyId, deviceId, occurredAt, includeSourceService = false),
+        )
+
+        onEventLoop { consumer.consume(message) }
+
+        val stored = onEventLoop { repository.findByAggregateId(partyId.toString()) }.single()
+        assertThat(stored.sourceService).isEqualTo("sca-service")
+        assertThat(stored.sourceServiceSource).isEqualTo(AttributionSource.TOPIC)
+    }
+}

--- a/openbank-infra/gitops/components/audit/kafka-audit-mtls.yaml
+++ b/openbank-infra/gitops/components/audit/kafka-audit-mtls.yaml
@@ -167,6 +167,18 @@ spec:
           patternType: literal
         operations: [Read, Describe]
         host: "*"
+      # Issue #5338: audit-service did not subscribe to this topic at all, so SCA device
+      # enrollment (DEVICE_ENROLLED) was never recorded in the audit trail -- a real PSD2/SCA
+      # compliance gap (sca-service is money-path, strong customer authentication). The
+      # KafkaTopic resource already exists (owned by onboarding, its other consumer,
+      # components/onboarding/kafka-topics.yaml) -- this is only the Read grant this
+      # KafkaUser needs.
+      - resource:
+          type: topic
+          name: openbank.sca.events
+          patternType: literal
+        operations: [Read, Describe]
+        host: "*"
       - resource:
           type: group
           name: audit-service


### PR DESCRIPTION
## Summary

- `audit-service` was not subscribed to `openbank.sca.events` at all — absent from both
  `TopicAttribution`/`EventAttribution.kt` and the `audit-events-in` consumed-topics list in
  `application.yaml`. SCA device enrollment (`DEVICE_ENROLLED`) was therefore never recorded in
  the audit trail — a real PSD2/SCA compliance gap, since sca-service is money-path (strong
  customer authentication).
- Wires the subscription the same way every other topic in `audit-events-in` was verified:
  `ScaService.enroll` (openbank-sca-service) writes a genuine outbox row on every enrollment
  (`KafkaScaOutboxEventPublisher`, topic `openbank.sca.events`) — a real producer, not a stub.
  Adds the topic to `application.yaml`'s `topics:` list and a `TopicAttribution` entry mapping it
  to `"sca-service"`.
- Grants the `audit-service` KafkaUser `Read`+`Describe` on `openbank.sca.events` in
  `kafka-audit-mtls.yaml` (the cluster is deny-by-default). The `KafkaTopic` resource itself
  already exists under `components/onboarding` — the topic's other, pre-existing consumer — so no
  new `KafkaTopic` manifest is needed here.

## Dependency on #5337

This PR was written against `openbank-sca-service/src/main/kotlin/.../ScaService.kt`'s CURRENT
enroll payload shape (`eventType`, `deviceId`, `partyId`, `credentialId`, `algorithm`,
`occurredAt`). PR #5337 (still open at the time of this PR) adds a `sourceService: "sca-service"`
field to that same payload for `AuditConsumer`'s strongest (`AttributionSource.EVENT`)
attribution path.

Neither PR depends on the other to be *correct* — this one's `TopicAttribution` entry gives every
`DEVICE_ENROLLED` event decent (`AttributionSource.TOPIC`) attribution today, with or without
#5337. Once #5337 merges, the same events upgrade to `AttributionSource.EVENT` automatically, with
no further change needed on this side. `ScaEnrollmentAuditIT` (below) proves both paths
independently, so this PR does not block on #5337 merging first.

Refs #5337

## What was verified before wiring this (not assumed)

- `ScaService.enroll`'s outbox write, read directly rather than guessed from the port/publisher
  shape (`ScaService.kt`): a real `outboxRepository.save(OutboxMessage(...))` call on every
  enrollment, not a stub.
- The topic name (`openbank.sca.events`) and its `KafkaTopic` ownership
  (`components/onboarding/kafka-topics.yaml`, since onboarding-service is the topic's other
  subscriber).
- `AuditConsumer`'s existing `inferAggregateType`/`inferAggregateId` chain already has a
  `"partyId" -> "PARTY"` entry, and the enroll payload's aggregate id
  (`device.partyId`, the outbox row's `aggregateId`) is that same `partyId` field — so no consumer
  code change was needed to parse this payload correctly, only the topic subscription itself.

## Test plan

- [x] New `ScaEnrollmentAuditIT` (`openbank-audit-service`): drives the REAL `AuditConsumer` bean
      (CDI-injected, not mocked) against a real Testcontainers Postgres, with a `Message<String>`
      carrying a genuine `IncomingKafkaRecordMetadata` (topic `openbank.sca.events`, `ce-type`
      header `DEVICE_ENROLLED`) and the exact payload shape `ScaService.enroll` constructs. Two
      cases: with `sourceService` present (post-#5337 shape, asserts `AttributionSource.EVENT`)
      and without it (today's shape, asserts the `AttributionSource.TOPIC` fallback via the new
      `TopicAttribution` entry). Both read the persisted row back with a real JDBC query via
      `AuditRepository.findByAggregateId`, so a regression that removes the topic from
      `TopicAttribution` or from `application.yaml`'s `topics:` list — the exact defect this PR
      fixes — fails here, not silently. There is no Kafka Testcontainers usage anywhere in this
      repo (verified before writing this test), so this does not drive a literal Kafka broker
      round-trip; it does exercise the real `@Incoming("audit-events-in")` entrypoint with
      realistic broker metadata, same as every other `AuditConsumer` code path it touches.
- [x] `TopicAttributionCoverageTest` (existing, unmodified) — passes, confirming the new topic is
      both subscribed and mapped (its whole point is to fail on exactly that mismatch).
- [x] `./gradlew :openbank-audit-service:ktlintCheck :openbank-audit-service:detekt` — clean.
- [x] `./gradlew :openbank-audit-service:test` — full suite green, including the new IT (ran, not
      skipped — verified via the JUnit XML report).

## Money-path note

`audit-service` itself is not a money-path service, but this closes a real compliance gap for
`sca-service`, which is money-path (strong customer authentication, PSD2). No 2-approval/threat-model
requirement applies to this PR directly (the change is entirely in `audit-service`), but reviewers
should weigh it against sca-service's money-path status when prioritizing review.

Closes #5338

🤖 Generated with [Claude Code](https://claude.com/claude-code)
