### PR TITLE
fix(admin-ui): expose campaign brief state

### DIFF
--- a/openbank-admin-ui/src/app/campaigns/new/page.tsx
+++ b/openbank-admin-ui/src/app/campaigns/new/page.tsx
@@ -575,6 +575,7 @@ export default function NewCampaignPage() {
           </div>
           <input
             id="c-name"
+            aria-label={t('Název kampaně', 'Campaign name')}
             className="input w-full"
             style={{ fontSize: '1.5rem', fontWeight: 600, padding: '0.7rem 0.9rem' }}
             placeholder={t('Pojmenujte kampaň', 'Name this campaign')}
@@ -583,6 +584,7 @@ export default function NewCampaignPage() {
           />
           <input
             id="c-goal"
+            aria-label={t('Cíl kampaně', 'Campaign goal')}
             className="input w-full"
             style={{ marginTop: '0.75rem' }}
             placeholder={t(
@@ -609,6 +611,8 @@ export default function NewCampaignPage() {
                   type="button"
                   data-segment={ref}
                   data-selected={active ? 'true' : 'false'}
+                  aria-pressed={active}
+                  aria-label={t(`Vybrat publikum ${s.name}`, `Select ${s.name} audience`)}
                   onClick={() => {
                     setSegment(ref)
                     previewReach(ref)
@@ -662,6 +666,7 @@ export default function NewCampaignPage() {
               type="button"
               data-entry-pick="MANUAL"
               data-selected={entryMode === 'MANUAL' ? 'true' : 'false'}
+              aria-pressed={entryMode === 'MANUAL'}
               onClick={() => chooseEntryMode('MANUAL')}
               className="rounded-lg border p-3 text-left text-sm"
               style={entryMode === 'MANUAL' ? { borderColor: 'var(--accent)', boxShadow: '0 0 0 1px var(--accent)' } : undefined}
@@ -675,6 +680,7 @@ export default function NewCampaignPage() {
               type="button"
               data-entry-pick="SCHEDULE"
               data-selected={entryMode === 'SCHEDULE' ? 'true' : 'false'}
+              aria-pressed={entryMode === 'SCHEDULE'}
               onClick={() => chooseEntryMode('SCHEDULE')}
               disabled={cadences.length === 0}
               className="rounded-lg border p-3 text-left text-sm disabled:opacity-40"
@@ -689,6 +695,7 @@ export default function NewCampaignPage() {
               type="button"
               data-entry-pick="TRIGGER"
               data-selected={entryMode === 'TRIGGER' ? 'true' : 'false'}
+              aria-pressed={entryMode === 'TRIGGER'}
               onClick={() => chooseEntryMode('TRIGGER')}
               disabled={triggers.length === 0}
               className="rounded-lg border p-3 text-left text-sm disabled:opacity-40"

--- a/openbank-admin-ui/src/test/campaign-brief-a11y.guard.test.ts
+++ b/openbank-admin-ui/src/test/campaign-brief-a11y.guard.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+describe('campaign brief accessibility', () => {
+  it('names brief fields and exposes pressed state for choice tiles', () => {
+    const page = readFileSync(resolve(__dirname, '../app/campaigns/new/page.tsx'), 'utf8')
+    expect(page).toContain('id="c-name"')
+    expect(page).toContain("aria-label={t('Název kampaně', 'Campaign name')}")
+    expect(page).toContain('id="c-goal"')
+    expect(page).toContain("aria-label={t('Cíl kampaně', 'Campaign goal')}")
+    expect(page).toContain('aria-pressed={active}')
+    expect(page).toContain("data-entry-pick=\"SCHEDULE\"")
+    expect(page).toContain("aria-pressed={entryMode === 'SCHEDULE'}")
+    expect(page).toContain("aria-pressed={entryMode === 'TRIGGER'}")
+    expect(page).toContain("aria-pressed={entryMode === 'MANUAL'}")
+  })
+})


### PR DESCRIPTION
## Summary
- name campaign brief fields for assistive technology
- expose pressed state for audience and entry-mode choices
- preserve campaign validation and submission behavior

Refs #5333