### PR TITLE
fix(security-scanner): add sourceService to ICT incident events

### DIFF
--- a/openbank-audit-service/src/test/kotlin/com/openbank/audit/application/AuditAttributionTest.kt
+++ b/openbank-audit-service/src/test/kotlin/com/openbank/audit/application/AuditAttributionTest.kt
@@ -69,6 +69,27 @@ class AuditAttributionTest {
     }
 
     @Test
+    fun `security-scanner's own sourceService wins, no longer falling to the topic table`(): Unit = runBlocking {
+        // Issue #3994/#5256's security-scanner fix: IctIncidentService's hand-built
+        // ict-incident-events-out payload (its ONLY live event producer — the outbox apparatus
+        // was deleted entirely by #4709/#4940) now carries "sourceService". Before this,
+        // EventAttribution's `openbank.security.ict.incident` -> `security-scanner` entry
+        // already resolved these rows correctly, but as TOPIC-sourced rather than the producer's
+        // own claim — and this topic IS in audit-service's consumed-topics list today, so this
+        // is a live attribution upgrade.
+        val entry = capturingSave()
+
+        consumer.consume(
+            """{"eventType":"ICT_INCIDENT_REPORTED","sourceService":"security-scanner"}""",
+            EventAddress(topic = "openbank.security.ict.incident"),
+        )
+
+        assertThat(entry.captured.eventType).isEqualTo("ICT_INCIDENT_REPORTED")
+        assertThat(entry.captured.sourceService).isEqualTo("security-scanner")
+        assertThat(entry.captured.sourceServiceSource).isEqualTo(AttributionSource.EVENT)
+    }
+
+    @Test
     fun `the topic names the producing service when the producer does not`(): Unit = runBlocking {
         // 1353 of 1774 live rows are here: every producer except customer-edge omits sourceService.
         // RED against the old code, which stored "unknown" with ABSENT-equivalent silence.

--- a/openbank-security-scanner/src/main/kotlin/com/openbank/securityscanner/application/IctIncidentService.kt
+++ b/openbank-security-scanner/src/main/kotlin/com/openbank/securityscanner/application/IctIncidentService.kt
@@ -123,8 +123,28 @@ class IctIncidentService(
 
     private fun publishEvent(eventType: String, incident: IctIncident) {
         val payload = objectMapper.writeValueAsString(
-            mapOf("eventType" to eventType, "incident" to incident, "occurredAt" to Instant.now(clock)),
+            mapOf(
+                "eventType" to eventType,
+                "incident" to incident,
+                "occurredAt" to Instant.now(clock),
+                "sourceService" to SOURCE_SERVICE,
+            ),
         )
         emitter.send(Record.of(incident.id.toString(), payload))
+    }
+
+    companion object {
+        /**
+         * Producing service, read by `AuditConsumer.resolveSourceService` (audit-service) as the
+         * strongest (EVENT-sourced) attribution — issue #3994/#5256. Before this field,
+         * `TopicAttribution` already resolved `openbank.security.ict.incident` ->
+         * `security-scanner` correctly, but only as TOPIC-sourced, not the producer's own claim —
+         * and audit-service DOES subscribe to this topic today (it is in `application.yaml`'s
+         * consumed-topics list), so this is a live attribution improvement, not a
+         * forward-looking one. Value matches the fleet's audit convention: the module directory
+         * without the `openbank-` prefix, the same spelling `TopicAttribution` already maps this
+         * topic to.
+         */
+        internal const val SOURCE_SERVICE = "security-scanner"
     }
 }

--- a/openbank-security-scanner/src/test/kotlin/com/openbank/securityscanner/application/IctIncidentServiceTest.kt
+++ b/openbank-security-scanner/src/test/kotlin/com/openbank/securityscanner/application/IctIncidentServiceTest.kt
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.securityscanner.application
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.security.application.port.out.IctIncidentRepository
+import com.openbank.securityscanner.domain.IncidentCategory
+import com.openbank.securityscanner.domain.IncidentSeverity
+import com.openbank.securityscanner.domain.IncidentStatus
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.smallrye.reactive.messaging.kafka.Record
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.eclipse.microprofile.reactive.messaging.Emitter
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+import java.util.UUID
+import java.util.concurrent.CompletableFuture
+
+/**
+ * Issue #3994/#5256: `IctIncidentService` is security-scanner's only live event producer (its
+ * outbox apparatus was deleted entirely by #4709/#4940 — `V4__drop_security_outbox.sql`). It
+ * publishes a hand-built map, not a serialised data class, straight to
+ * `ict-incident-events-out` (`openbank.security.ict.incident`), so `sourceService` has to be
+ * added at the map-construction call site rather than on a domain event type.
+ *
+ * `TopicAttribution` already resolves `openbank.security.ict.incident` -> `security-scanner`
+ * correctly, but only as TOPIC-sourced — and audit-service DOES subscribe to this topic today
+ * (it is in `application.yaml`'s consumed-topics list), so this is a live attribution
+ * improvement, not a forward-looking one.
+ */
+class IctIncidentServiceTest {
+
+    private val fixedClock: Clock = Clock.fixed(Instant.parse("2026-08-16T10:00:00Z"), ZoneOffset.UTC)
+    private val objectMapper = ObjectMapper().findAndRegisterModules()
+    private val repository = mockk<IctIncidentRepository>()
+
+    @Suppress("UNCHECKED_CAST")
+    private fun mockEmitter(): Emitter<Record<String, String>> = mockk<Emitter<Record<String, String>>> {
+        every { send(any()) } returns CompletableFuture.completedFuture(null)
+    }
+
+    @Test
+    fun `reportIncident publishes sourceService on the ICT_INCIDENT_REPORTED event`(): Unit = runBlocking {
+        val emitter = mockEmitter()
+        val recordSlot = slot<Record<String, String>>()
+        every { emitter.send(capture(recordSlot)) } returns CompletableFuture.completedFuture(null)
+        coEvery { repository.save(any()) } answers { firstArg() }
+        val service = IctIncidentService(emitter, objectMapper, fixedClock, repository)
+
+        service.reportIncident(
+            ReportIncidentCommand(
+                title = "Core banking outage",
+                description = "Ledger writes failing fleet-wide",
+                category = IncidentCategory.AVAILABILITY,
+                severity = IncidentSeverity.P1_CRITICAL,
+                affectedServices = listOf("ledger-service"),
+                detectedAt = Instant.now(fixedClock),
+                assignedTo = null,
+            ),
+        )
+
+        val payload = objectMapper.readTree(recordSlot.captured.value())
+        assertThat(payload.get("eventType").asText()).isEqualTo("ICT_INCIDENT_REPORTED")
+        assertThat(payload.get("sourceService").asText()).isEqualTo("security-scanner")
+    }
+
+    @Test
+    fun `updateStatus publishes sourceService on the ICT_INCIDENT_STATUS_CHANGED event`(): Unit = runBlocking {
+        val emitter = mockEmitter()
+        val recordSlot = slot<Record<String, String>>()
+        every { emitter.send(capture(recordSlot)) } returns CompletableFuture.completedFuture(null)
+        val incidentId = UUID.randomUUID()
+        val existing = existingIncident(incidentId)
+        coEvery { repository.findIncident(incidentId) } returns existing
+        coEvery { repository.save(any()) } answers { firstArg() }
+        val service = IctIncidentService(emitter, objectMapper, fixedClock, repository)
+
+        service.updateStatus(
+            id = incidentId,
+            status = IncidentStatus.CONTAINED,
+            containedAt = Instant.now(fixedClock),
+            resolvedAt = null,
+            rtoMinutes = null,
+            rpoMinutes = null,
+        )
+
+        val payload = objectMapper.readTree(recordSlot.captured.value())
+        assertThat(payload.get("eventType").asText()).isEqualTo("ICT_INCIDENT_STATUS_CHANGED")
+        assertThat(payload.get("sourceService").asText()).isEqualTo("security-scanner")
+    }
+
+    private fun existingIncident(id: UUID) = com.openbank.securityscanner.domain.IctIncident(
+        id = id,
+        title = "Core banking outage",
+        description = "Ledger writes failing fleet-wide",
+        category = IncidentCategory.AVAILABILITY,
+        severity = IncidentSeverity.P1_CRITICAL,
+        status = IncidentStatus.OPEN,
+        affectedServices = listOf("ledger-service"),
+        detectedAt = Instant.now(fixedClock),
+        reportedAt = Instant.now(fixedClock),
+        containedAt = null,
+        resolvedAt = null,
+        rtoMinutes = null,
+        rpoMinutes = null,
+        reportedToRegulator = false,
+        regulatoryReportId = null,
+        assignedTo = null,
+        createdAt = Instant.now(fixedClock),
+        updatedAt = Instant.now(fixedClock),
+    )
+}


### PR DESCRIPTION
## Summary

Bounded slice of #5256 (fleet-wide follow-up to #3994) for security-scanner: add `sourceService`
to its only live event producer's payload so audit-service's `AuditConsumer` resolves it as the
strongest (EVENT-sourced) attribution.

- security-scanner's outbox apparatus was deleted entirely earlier this session (#4709/#4940 —
  `V4__drop_security_outbox.sql`). Verified: `IctIncidentService` (direct `@Channel` publish to
  `ict-incident-events-out` / `openbank.security.ict.incident`) is the ONLY live event producer
  left in the service. No outbox code was touched or resurrected.
- Its idiom is a hand-built map (`objectMapper.writeValueAsString(mapOf(...))`), not a serialised
  data class, so `sourceService` is added at the map-construction call site
  (`IctIncidentService.publishEvent`), value `"security-scanner"`.
- `TopicAttribution` (`openbank-audit-service/.../EventAttribution.kt`) already maps
  `openbank.security.ict.incident` -> `security-scanner`, and audit-service's
  `application.yaml` consumed-topics list already includes this topic today — so this is a live
  attribution upgrade (rows move from TOPIC-sourced to EVENT-sourced), not a forward-looking fix.
  No `AuditConsumer` wiring changes needed.
- `eventType` values (`ICT_INCIDENT_REPORTED` / `ICT_INCIDENT_STATUS_CHANGED` /
  `ICT_INCIDENT_REPORTED_TO_REGULATOR`) are untouched — only `sourceService` is added, per the
  fleet convention of never renaming an existing field.

## Changes

- `openbank-security-scanner/.../application/IctIncidentService.kt`: `publishEvent` now includes
  `"sourceService" to SOURCE_SERVICE` (`= "security-scanner"`) in the payload map.
- `openbank-security-scanner/.../application/IctIncidentServiceTest.kt` (new): unit tests
  asserting `sourceService` on the wire for both `reportIncident` and `updateStatus`.
- `openbank-audit-service/.../AuditAttributionTest.kt`: one new case,
  `security-scanner's own sourceService wins, no longer falling to the topic table`, driven
  through the real `AuditConsumer.consume` — a live attribution upgrade, matching the shape of
  the sibling PRs (#5255, #5267, #5329, #5336, #5337, #5343, #5344, #5349, #5351, #5369, #5374,
  #5376).

## Money-path

security-scanner is not in `rules.yaml: money_path_services` — standard single-approval review.

## Test plan

- [x] `./gradlew :openbank-security-scanner:ktlintMainSourceSetCheck
      :openbank-security-scanner:ktlintTestSourceSetCheck :openbank-security-scanner:detekt`
- [x] `./gradlew :openbank-audit-service:ktlintMainSourceSetCheck
      :openbank-audit-service:ktlintTestSourceSetCheck :openbank-audit-service:detekt`
- [x] `./gradlew :openbank-security-scanner:test --tests "*IctIncidentServiceTest*"` — 2/2 green
- [x] `./gradlew :openbank-audit-service:test --tests "*AuditAttributionTest*"` — 8/8 green

Refs #5256

🤖 Generated with [Claude Code](https://claude.com/claude-code)
