### PR TITLE
fix(lending): add sourceService to remaining event types for audit attribution

### DIFF
--- a/openbank-audit-service/src/test/kotlin/com/openbank/audit/application/AuditAttributionTest.kt
+++ b/openbank-audit-service/src/test/kotlin/com/openbank/audit/application/AuditAttributionTest.kt
@@ -107,6 +107,36 @@ class AuditAttributionTest {
     }
 
     @Test
+    fun `lending-service's own sourceService wins, no longer falling to the topic table`(): Unit = runBlocking {
+        // Issue #3994/#5256's lending fix: the six remaining LendingService event types
+        // (loan.disbursed, loan.interest_accrued, loan.written_off, loan.rescheduled,
+        // loan.stage_changed, loan.provisioned — all hand-built payload strings, serialised
+        // verbatim via KafkaLendingOutboxEventPublisher onto the single "lending-events-out"
+        // channel / "openbank.lending.events" topic) now carry "sourceService", joining the three
+        // event types (credit.application.transition, credit.decision.evaluated,
+        // credit.loan.transition) that already had it. Before this, EventAttribution's
+        // `openbank.lending.events` -> `lending-service` entry already resolved these six event
+        // types' rows correctly, but as TOPIC-sourced — and this topic IS in audit-service's
+        // consumed-topics list today, so this is a live attribution upgrade, not a forward-looking
+        // one. lending-service is a money-path service (rules.yaml: money_path_services).
+        //
+        // Note the value is "lending", not "lending-service" — matching the literal the three
+        // already-fixed event types use (a pre-existing choice this PR preserves for
+        // self-consistency across every lending-service event, rather than introducing a second,
+        // different self-reported string). That is deliberately NOT what the topic-fallback table
+        // would say, which is exactly what this test demonstrates: the producer's own claim wins.
+        val entry = capturingSave()
+
+        consumer.consume(
+            """{"loanId":"${UUID.randomUUID()}","eventType":"loan.disbursed","sourceService":"lending"}""",
+            EventAddress(topic = "openbank.lending.events"),
+        )
+
+        assertThat(entry.captured.sourceService).isEqualTo("lending")
+        assertThat(entry.captured.sourceServiceSource).isEqualTo(AttributionSource.EVENT)
+    }
+
+    @Test
     fun `the producer's own claim wins over the topic, and is marked as the producer's`(): Unit = runBlocking {
         // Body-first ordering: this change can only turn a sentinel into a value. It must never
         // re-attribute a row that is already attributed, or customer-edge's 421 correct rows move.

--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/application/usecase/LendingService.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/application/usecase/LendingService.kt
@@ -582,9 +582,19 @@ class LendingService(
                                 eventType = "loan.disbursed",
                                 // #3914: occurredAt is the loan's own `disbursedAt` — the instant the disbursement
                                 // happened on the aggregate — not the serialisation instant.
+                                // Issue #3994/#5256: sourceService is the strongest (EVENT-sourced) attribution
+                                // AuditConsumer.resolveSourceService reads. EventAttribution.TopicAttribution
+                                // already maps openbank.lending.events -> lending-service correctly (TOPIC-sourced),
+                                // and audit-service subscribes to this topic today (openbank-audit-service's
+                                // application.yaml consumed-topics list), so this is a live attribution upgrade.
+                                // Value matches the "lending" literal already used by the 3 previously-fixed
+                                // event types in this file/OriginationDecisionService/TerminationService — not
+                                // "lending-service" as the topic-fallback table would say (a pre-existing,
+                                // self-consistent naming choice this PR preserves rather than introduces).
                                 payload = """{"loanId":"${saved.id.value}","partyId":"${saved.partyId}",""" +
                                     """"principal":"${saved.principal}",""" +
-                                    """"occurredAt":"${saved.disbursedAt.toInstant()}"}""",
+                                    """"occurredAt":"${saved.disbursedAt.toInstant()}",""" +
+                                    """"sourceService":"lending"}""",
                             ),
                         )
                     }
@@ -710,9 +720,11 @@ class LendingService(
                         eventType = "loan.interest_accrued",
                         // #3914: occurredAt is `accruedAt`, the very instant stamped on the installment by
                         // markAccrued above — the recognition event itself, not the emit.
+                        // Issue #3994/#5256: see the loan.disbursed sourceService comment above.
                         payload = """{"loanId":"${installment.loanId.value}","installment":${installment.number},""" +
                             """"interest":"${installment.interest}","dueDate":"${installment.dueDate}",""" +
-                            """"occurredAt":"${accruedAt.toInstant()}"}""",
+                            """"occurredAt":"${accruedAt.toInstant()}",""" +
+                            """"sourceService":"lending"}""",
                     ),
                 )
             }
@@ -757,11 +769,13 @@ class LendingService(
                                 // already used by TerminationService and OriginationDecisionService. Emitted
                                 // once into a local so payload and any future reuse cannot disagree.
                                 val writtenOffAt = clock.instant()
+                                // Issue #3994/#5256: see the loan.disbursed sourceService comment above.
                                 val wPayload = """{"loanId":"${written.id.value}",""" +
                                     """"partyId":"${written.partyId}",""" +
                                     """"writtenOff":"$outstanding",""" +
                                     """"writtenOffBy":"${request.writtenOffBy}",""" +
-                                    """"occurredAt":"$writtenOffAt"}"""
+                                    """"occurredAt":"$writtenOffAt",""" +
+                                    """"sourceService":"lending"}"""
                                 events.emit(
                                     LendingOutboxMessage(
                                         aggregateId = written.id.value,
@@ -1010,12 +1024,14 @@ class LendingService(
                         eventType = "loan.rescheduled",
                         // #3914: no rescheduledAt column on Loan; clock at the completed reschedule, same
                         // house convention as write-off above.
+                        // Issue #3994/#5256: see the loan.disbursed sourceService comment above.
                         payload = """{"loanId":"${updated.id.value}","partyId":"${updated.partyId}",""" +
                             """"newPrincipal":"$newPrincipal",""" +
                             """"newNominalAnnualRate":"${request.newNominalAnnualRate}",""" +
                             """"newTermPeriods":${request.newTermPeriods},""" +
                             """"principalForgiveness":"${request.principalForgiveness}",""" +
-                            """"occurredAt":"${clock.instant()}"}""",
+                            """"occurredAt":"${clock.instant()}",""" +
+                            """"sourceService":"lending"}""",
                     ),
                 ).map { updated }
             }
@@ -1215,14 +1231,7 @@ class LendingService(
                     LendingOutboxMessage(
                         aggregateId = loan.id.value,
                         eventType = "loan.stage_changed",
-                        // partyId added for ADR-0220 D6's arrears exclusion (engagement-service's
-                        // LendingArrearsEventConsumer) — additive field, existing consumers
-                        // (anacredit-service's LoanStageEventConsumer) parse via readTree and
-                        // ignore unknown fields, so this cannot break them.
-                        payload = """{"loanId":"${loan.id.value}","partyId":"${loan.partyId}",""" +
-                            """"previousStage":"${prior!!.stage}","newStage":"${snapshot.stage}",""" +
-                            """"daysPastDue":${snapshot.daysPastDue},"period":"$period",""" +
-                            """"asOf":"${snapshot.asOf}","occurredAt":"${record.createdAt.toInstant()}"}""",
+                        payload = stageChangedPayload(loan, prior!!, snapshot, period, record),
                     ),
                 )
             } else {
@@ -1248,10 +1257,7 @@ class LendingService(
                                 LendingOutboxMessage(
                                     aggregateId = loan.id.value,
                                     eventType = "loan.provisioned",
-                                    payload = """{"loanId":"${loan.id.value}","period":"$period",""" +
-                                        """"stage":"${snapshot.stage}",""" +
-                                        """"expectedCreditLoss":"${snapshot.expectedCreditLoss}",""" +
-                                        """"delta":"$delta","occurredAt":"${record.createdAt.toInstant()}"}""",
+                                    payload = provisionedPayload(loan, period, snapshot, delta, record),
                                 ),
                             )
                         }
@@ -1259,6 +1265,36 @@ class LendingService(
                 }
             }
         }
+
+    /**
+     * partyId added for ADR-0220 D6's arrears exclusion (engagement-service's
+     * LendingArrearsEventConsumer) — additive field, existing consumers (anacredit-service's
+     * LoanStageEventConsumer) parse via readTree and ignore unknown fields, so this cannot break
+     * them. `sourceService` (issue #3994/#5256): see the loan.disbursed sourceService comment above.
+     */
+    private fun stageChangedPayload(
+        loan: Loan,
+        prior: LoanProvisioningRecord,
+        snapshot: ProvisioningSnapshot,
+        period: String,
+        record: LoanProvisioningRecord,
+    ): String = """{"loanId":"${loan.id.value}","partyId":"${loan.partyId}",""" +
+        """"previousStage":"${prior.stage}","newStage":"${snapshot.stage}",""" +
+        """"daysPastDue":${snapshot.daysPastDue},"period":"$period","asOf":"${snapshot.asOf}",""" +
+        """"occurredAt":"${record.createdAt.toInstant()}","sourceService":"lending"}"""
+
+    /** `sourceService` (issue #3994/#5256): see the loan.disbursed sourceService comment above. */
+    private fun provisionedPayload(
+        loan: Loan,
+        period: String,
+        snapshot: ProvisioningSnapshot,
+        delta: Money,
+        record: LoanProvisioningRecord,
+    ): String = """{"loanId":"${loan.id.value}","period":"$period",""" +
+        """"stage":"${snapshot.stage}",""" +
+        """"expectedCreditLoss":"${snapshot.expectedCreditLoss}",""" +
+        """"delta":"$delta","occurredAt":"${record.createdAt.toInstant()}",""" +
+        """"sourceService":"lending"}"""
 
     /** Outstanding principal = opening balance of the first unpaid installment, else fully repaid. */
     private fun outstandingBalance(loan: Loan, schedule: List<LoanInstallment>): Money {

--- a/openbank-lending-service/src/test/kotlin/com/openbank/lending/application/usecase/LendingServiceTest.kt
+++ b/openbank-lending-service/src/test/kotlin/com/openbank/lending/application/usecase/LendingServiceTest.kt
@@ -1893,4 +1893,163 @@ class LendingServiceTest {
         assertThat(occurredAtOf(emitted.single { it.eventType == "loan.provisioned" }))
             .isEqualTo(expectedEventTime)
     }
+
+    // --- sourceService (issue #3994/#5256, fleet follow-up to #5255 and the eighteen prior slices) ---
+    //
+    // `sourceService` is the strongest (EVENT-sourced) attribution `AuditConsumer.resolveSourceService`
+    // reads. `EventAttribution.TopicAttribution` already maps `openbank.lending.events` ->
+    // `lending-service` correctly, but only as TOPIC-sourced — and audit-service subscribes to that
+    // topic today (`openbank-audit-service`'s `application.yaml` consumed-topics list; all nine lending
+    // event types share this single outbox channel/topic, `KafkaLendingOutboxEventPublisher`'s
+    // `lending-events-out` -> `openbank.lending.events`), so this is a live attribution upgrade for
+    // every event type below, not a forward-looking one. lending-service is a money-path service
+    // (`rules.yaml: money_path_services`).
+    //
+    // The literal value is `"lending"`, matching the 3 event types that already carried it before this
+    // PR (`credit.application.transition`, `credit.decision.evaluated`, `credit.loan.transition`) —
+    // not `"lending-service"`, the string `EventAttribution`'s topic-fallback table uses for this
+    // producer. That is a pre-existing inconsistency this PR preserves rather than introduces: every
+    // lending-service event now agrees with every OTHER lending-service event, which is a strictly
+    // better state than adding a second, different self-reported string for these six.
+
+    private fun sourceServiceOf(message: LendingOutboxMessage): String =
+        com.fasterxml.jackson.databind.ObjectMapper().readTree(message.payload).get("sourceService").asText()
+
+    @Test
+    fun `loan disbursed carries sourceService on the wire`() {
+        val app = proposedApplication().copy(status = OriginationState.READY_TO_DISBURSE, decidedBy = "bob")
+        val emitted = mutableListOf<LendingOutboxMessage>()
+        every { applications.findById(app.id) } returns Uni.createFrom().item(app)
+        every { loans.save(any()) } answers { Uni.createFrom().item(firstArg<Loan>()) }
+        every { installments.saveAll(any()) } answers { Uni.createFrom().item(firstArg<List<LoanInstallment>>()) }
+        stubClaim()
+        every { ledger.post(any()) } returns Uni.createFrom().item(Unit)
+        every { events.emit(capture(emitted)) } returns Uni.createFrom().item(Unit)
+        stubBorrowerCreditSucceeds()
+
+        service.disburse(app.id, "dave").await().indefinitely()
+
+        val disbursed = emitted.single { it.eventType == "loan.disbursed" }
+        assertThat(sourceServiceOf(disbursed)).isEqualTo("lending")
+        assertThat(disbursed.payload).contains("\"sourceService\":\"lending\"")
+    }
+
+    @Test
+    fun `loan interest_accrued carries sourceService on the wire`() {
+        val loanId = LoanId.random()
+        val due = listOf(
+            LoanInstallment(
+                loanId = loanId,
+                number = 1,
+                dueDate = firstDue,
+                openingBalance = eur("12000.00"),
+                principal = eur("946.19"),
+                interest = eur("120.00"),
+                payment = eur("1066.19"),
+                closingBalance = eur("11053.81"),
+            ),
+        )
+        val emitted = mutableListOf<LendingOutboxMessage>()
+        every { installments.findAccruable(any(), any()) } returns Uni.createFrom().item(due)
+        every { installments.markAccrued(any(), any()) } returns Uni.createFrom().item(1)
+        every { ledger.post(any()) } returns Uni.createFrom().item(Unit)
+        every { events.emit(capture(emitted)) } returns Uni.createFrom().item(Unit)
+
+        service.accrueDueInterest(LocalDate.parse("2026-08-01"), 500).await().indefinitely()
+
+        assertThat(sourceServiceOf(emitted.single { it.eventType == "loan.interest_accrued" }))
+            .isEqualTo("lending")
+    }
+
+    @Test
+    fun `loan written_off carries sourceService on the wire`() {
+        val loanId = LoanId.random()
+        val loan = activeLoan(loanId)
+        val schedule = listOf(
+            LoanInstallment(
+                loanId = loanId,
+                number = 1,
+                dueDate = firstDue,
+                openingBalance = eur("12000.00"),
+                principal = eur("946.19"),
+                interest = eur("120.00"),
+                payment = eur("1066.19"),
+                closingBalance = eur("11053.81"),
+            ),
+        )
+        val emitted = mutableListOf<LendingOutboxMessage>()
+        every { loans.findById(loanId) } returns Uni.createFrom().item(loan)
+        every { installments.findByLoan(loanId) } returns Uni.createFrom().item(schedule)
+        every { ledger.post(any()) } returns Uni.createFrom().item(Unit)
+        every { loans.update(any()) } answers { Uni.createFrom().item(firstArg<Loan>()) }
+        every { events.emit(capture(emitted)) } returns Uni.createFrom().item(Unit)
+
+        service.writeOff(loanId, WriteOffRequest(writtenOffBy = "carol", reason = "insolvency"))
+            .await().indefinitely()
+
+        assertThat(sourceServiceOf(emitted.single { it.eventType == "loan.written_off" }))
+            .isEqualTo("lending")
+    }
+
+    @Test
+    fun `loan rescheduled carries sourceService on the wire`() {
+        val loanId = LoanId.random()
+        val loan = activeLoan(loanId)
+        val schedule = twoInstallmentSchedule(loanId)
+        mockRescheduleHappyPath(loanId, loan, schedule)
+        val emitted = mutableListOf<LendingOutboxMessage>()
+        every { installments.saveAll(any()) } answers { Uni.createFrom().item(firstArg<List<LoanInstallment>>()) }
+        every { events.emit(capture(emitted)) } returns Uni.createFrom().item(Unit)
+
+        service.reschedule(loanId, rescheduleRequest(), "carol").await().indefinitely()
+
+        assertThat(sourceServiceOf(emitted.single { it.eventType == "loan.rescheduled" }))
+            .isEqualTo("lending")
+    }
+
+    @Test
+    fun `loan stage_changed and loan provisioned carry sourceService on the wire`() {
+        val loanId = LoanId.random()
+        val loan = activeLoan(loanId)
+        val schedule = listOf(
+            LoanInstallment(
+                loanId = loanId,
+                number = 1,
+                dueDate = firstDue,
+                openingBalance = eur("12000.00"),
+                principal = eur("946.19"),
+                interest = eur("120.00"),
+                payment = eur("1066.19"),
+                closingBalance = eur("11053.81"),
+            ),
+        )
+        val asOf = firstDue.plusDays(40)
+        val prior = LoanProvisioningRecord(
+            loanId = loanId,
+            period = "2026-06",
+            asOf = firstDue,
+            outstandingBalance = eur("12000.00"),
+            daysPastDue = 0,
+            bucket = com.openbank.libs.lending.DelinquencyBucket.CURRENT,
+            stage = Ifrs9Stage.STAGE_1,
+            expectedCreditLoss = eur("108.00"),
+            createdAt = fixedNow,
+        )
+        val emitted = mutableListOf<LendingOutboxMessage>()
+        every { loans.findActive(any()) } returns Uni.createFrom().item(listOf(loan))
+        every { installments.findByLoan(loanId) } returns Uni.createFrom().item(schedule)
+        mockRiskParameters(loan, "0.02")
+        every { provisioning.findByLoanAndPeriod(loanId, "2026-07") } returns Uni.createFrom().nullItem()
+        every { provisioning.findLatestBefore(loanId, "2026-07") } returns Uni.createFrom().item(prior)
+        every { ledger.post(any()) } returns Uni.createFrom().item(Unit)
+        every { provisioning.save(any()) } answers { Uni.createFrom().item(firstArg<LoanProvisioningRecord>()) }
+        every { events.emit(capture(emitted)) } returns Uni.createFrom().item(Unit)
+
+        service.runProvisioningCycle("2026-07", asOf, 500).await().indefinitely()
+
+        assertThat(sourceServiceOf(emitted.single { it.eventType == "loan.stage_changed" }))
+            .isEqualTo("lending")
+        assertThat(sourceServiceOf(emitted.single { it.eventType == "loan.provisioned" }))
+            .isEqualTo("lending")
+    }
 }


### PR DESCRIPTION
## Summary

Fleet follow-up to #3994/#5256: lending-service carried `sourceService` on only 3 of its 9
outbox event types. This PR adds it to the remaining 6.

- **Already had it** (unchanged): `credit.application.transition`, `credit.decision.evaluated`,
  `credit.loan.transition` — all built in `LendingService.kt` / `OriginationDecisionService.kt` /
  `TerminationService.kt`.
- **Added in this PR**, all built in `LendingService.kt`: `loan.disbursed`,
  `loan.interest_accrued`, `loan.written_off`, `loan.rescheduled`, `loan.stage_changed`,
  `loan.provisioned`.

All nine event types are hand-built JSON payload strings published verbatim by
`KafkaLendingOutboxEventPublisher` onto the single `lending-events-out` channel /
`openbank.lending.events` topic. `openbank-audit-service`'s `application.yaml` consumed-topics
list already subscribes to this topic, so this is a **live attribution upgrade for all six**, not
a forward-looking one — no follow-up issue needed for a separate unsubscribed topic.

### The `"lending"` vs `"lending-service"` value

The value used is the literal `"lending"`, matching the three event types that already carried
`sourceService` before this PR. This is deliberately **not** `"lending-service"`, the string
`EventAttribution.TopicAttribution`'s topic-fallback table uses for
`openbank.lending.events -> lending-service`. That mismatch pre-exists this change (it shipped
with #4412) — this PR preserves it rather than introduces a new one, so every lending-service
event now agrees with every *other* lending-service event's self-reported value, which is a
strictly better state than adding a second, different literal for these six. Flagging this in case
a separate cleanup to align the topic table (or the three existing event types) is wanted; I did
not make that call unilaterally since it touches already-shipped, already-attributed rows.

### Downstream consumers checked

`grep`ped the fleet for all 6 event-type strings. Two consumers exist:
`anacredit-service`'s `LoanStageEventConsumer` and `engagement-service`'s
`LendingArrearsEventConsumer` (both on `loan.stage_changed`). Both parse via
`ObjectMapper.readTree` and ignore unknown fields (already documented in the existing
`partyId` comment next to the `loan.stage_changed` payload), so adding `sourceService` is
additive-safe. No `eventType` string was renamed.

### Money-path

lending-service is in `rules.yaml: money_path_services` — this PR needs **2 approvals** per
ADR-0030 (no schema/DB change, so no new threat-model entry).

## Test plan

- [x] `LendingServiceTest`: 6 new round-trip tests (`sourceServiceOf` parses the actual JSON
      payload via `ObjectMapper.readTree`, one per newly-fixed event type — same pattern as the
      existing `occurredAtOf` block right above them), plus reused the existing event-emission
      setup for each use case (`disburse`, `accrueDueInterest`, `writeOff`, `reschedule`,
      `runProvisioningCycle`).
- [x] `AuditAttributionTest`: new case demonstrating the producer's own `sourceService: "lending"`
      wins over `EventAttribution`'s topic-fallback `"lending-service"` for
      `openbank.lending.events`.
- [x] `./gradlew :openbank-lending-service:ktlintCheck :openbank-lending-service:detekt
      :openbank-lending-service:test` — green (67/67 `LendingServiceTest` cases, 0 failures).
- [x] `./gradlew :openbank-audit-service:ktlintCheck :openbank-audit-service:detekt
      :openbank-audit-service:test` — green (9/9 `AuditAttributionTest` cases, 0 failures).
- [x] Extracted `stageChangedPayload`/`provisionedPayload` helpers out of
      `postProvisioningDelta` to keep it under detekt's `LongMethod` threshold after the new field.

## Fleet-sweep status (#5256)

With this PR: sepa-payment✓ sepa-instant✓ fx-service✓ document-service✓ statement-service✓
account✓ party✓ transaction✓ kyc✓ consent✓ clearing✓ security-scanner✓ card-issuance✓ dispute✓
sanctions✓ swift✓ balance✓ domestic-payment✓ **lending✓ (this PR)**.

**Not closing #5256 here.** #5337 (sca-service, reopened after being closed by a bot without
explanation) is still open as of this PR — verified fresh (`gh pr view 5337`: state `OPEN`). Once
#5337 and every other PR in that list have merged, #5256 is fully covered; whichever PR merges
last should close it.

Refs #5256
