### PR TITLE
fix(admin-ui): label payment form controls

### DIFF
--- a/openbank-admin-ui/src/app/payments/page.tsx
+++ b/openbank-admin-ui/src/app/payments/page.tsx
@@ -187,7 +187,8 @@ function VopSection({ formData, setFormData }: { formData: SepaFormData; setForm
         )}
       </div>
       <div style={{ display: 'flex', gap: '8px', alignItems: 'center', marginBottom: '6px' }}>
-        <input className="input" style={{ flex: 1 }} placeholder={t('Jméno příjemce pro ověření', 'Payee name to verify')}
+        <label className="sr-only" htmlFor="sepa-vop-payee-name">{t('Jméno příjemce pro ověření', 'Payee name to verify')}</label>
+        <input id="sepa-vop-payee-name" className="input" style={{ flex: 1 }} placeholder={t('Jméno příjemce pro ověření', 'Payee name to verify')}
           value={formData.creditorName} onChange={e => setFormData({ ...formData, vopStatus: 'idle', vopResult: null, creditorName: e.target.value })} />
         <button type="button" className="btn btn-secondary btn-sm" disabled={!formData.creditorIban || !formData.creditorName || formData.vopStatus === 'loading'}
           onClick={async () => {
@@ -528,12 +529,13 @@ function PaymentsContent() {
             <div style={{ padding: '16px 20px', borderBottom: '1px solid var(--border)', display: 'flex', gap: '10px', alignItems: 'center' }}>
               <div style={{ position: 'relative', flex: 1, maxWidth: '320px' }}>
                 <Search size={13} style={{ position: 'absolute', left: '10px', top: '50%', transform: 'translateY(-50%)', color: 'var(--text-tertiary)' }} />
-                <input value={sctSearch} onChange={e => setSctSearch(e.target.value)}
+                <label className="sr-only" htmlFor="payments-sct-search">{t('Hledat SCT platby', 'Search SCT payments')}</label>
+                <input id="payments-sct-search" value={sctSearch} onChange={e => setSctSearch(e.target.value)}
                   placeholder={t('Hledat IBAN, end-to-end ID, status…', 'Search IBAN, end-to-end ID, status…')}
                   style={{ width: '100%', paddingLeft: '30px', paddingRight: '12px', height: '32px', borderRadius: '6px',
                     border: '1px solid var(--border)', fontSize: '13px', background: 'var(--surface-2)', color: 'var(--text-primary)', outline: 'none' }} />
               </div>
-              <button className="btn btn-secondary btn-sm" onClick={loadSct} disabled={sctLoading}>
+              <button aria-label={t('Obnovit SCT platby', 'Refresh SCT payments')} className="btn btn-secondary btn-sm" onClick={loadSct} disabled={sctLoading}>
                 <RefreshCw size={12} style={{ animation: sctLoading ? 'spin 0.8s linear infinite' : 'none' }} />
               </button>
             </div>
@@ -658,8 +660,8 @@ function PaymentsContent() {
               <form onSubmit={handleDomesticCreate} style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
                 <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '12px' }}>
                   <div>
-                    <label className="stat-label" style={{ display: 'block', marginBottom: '4px' }}>{t('Typ převodu', 'Transfer Scope')}</label>
-                    <select className="input" style={{ width: '100%' }} value={domesticForm.transferScope}
+                    <label htmlFor="domestic-transfer-scope" className="stat-label" style={{ display: 'block', marginBottom: '4px' }}>{t('Typ převodu', 'Transfer Scope')}</label>
+                    <select id="domestic-transfer-scope" className="input" style={{ width: '100%' }} value={domesticForm.transferScope}
                       onChange={e => setDomesticForm({ ...domesticForm, transferScope: e.target.value })}>
                       <option value="OWN_ACCOUNTS">{t('Vlastní účty', 'Own Accounts')}</option>
                       <option value="INTERNAL_CLIENT">{t('Interní klient', 'Internal Client')}</option>
@@ -668,100 +670,100 @@ function PaymentsContent() {
                   </div>
                   {domesticForm.transferScope === 'TECHNICAL_ACCOUNT' && (
                     <div>
-                      <label className="stat-label" style={{ display: 'block', marginBottom: '4px' }}>{t('Kód technického účtu', 'Technical Account Code')}</label>
-                      <input className="input" style={{ width: '100%' }} value={domesticForm.technicalAccountCode}
+                      <label htmlFor="domestic-technical-account-code" className="stat-label" style={{ display: 'block', marginBottom: '4px' }}>{t('Kód technického účtu', 'Technical Account Code')}</label>
+                      <input id="domestic-technical-account-code" className="input" style={{ width: '100%' }} value={domesticForm.technicalAccountCode}
                         onChange={e => setDomesticForm({ ...domesticForm, technicalAccountCode: e.target.value })} required />
                     </div>
                   )}
                 </div>
                 <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '12px' }}>
                   <div>
-                    <label className="stat-label" style={{ display: 'block', marginBottom: '4px' }}>{t('Účet plátce (ID)', 'Debtor Account ID')}</label>
-                    <input className="input" style={{ width: '100%' }} value={domesticForm.debtorAccountId}
+                    <label htmlFor="domestic-debtor-account-id" className="stat-label" style={{ display: 'block', marginBottom: '4px' }}>{t('Účet plátce (ID)', 'Debtor Account ID')}</label>
+                    <input id="domestic-debtor-account-id" className="input" style={{ width: '100%' }} value={domesticForm.debtorAccountId}
                       onChange={e => setDomesticForm({ ...domesticForm, debtorAccountId: e.target.value })} required />
                   </div>
                   <div>
-                    <label className="stat-label" style={{ display: 'block', marginBottom: '4px' }}>{t('Číslo účtu plátce', 'Debtor Account No.')}</label>
+                    <label htmlFor="domestic-debtor-account-number" className="stat-label" style={{ display: 'block', marginBottom: '4px' }}>{t('Číslo účtu plátce', 'Debtor Account No.')}</label>
                     <div style={{ display: 'flex', gap: '8px' }}>
-                      <input className="input" style={{ flex: 2 }} placeholder="1234567890" value={domesticForm.debtorAccountNumber}
+                      <input id="domestic-debtor-account-number" className="input" style={{ flex: 2 }} placeholder="1234567890" value={domesticForm.debtorAccountNumber}
                         onChange={e => setDomesticForm({ ...domesticForm, debtorAccountNumber: e.target.value })} required />
                       <span style={{ display: 'flex', alignItems: 'center' }}>/</span>
-                      <input className="input" style={{ flex: 1 }} placeholder="0100" value={domesticForm.debtorBankCode}
+                      <input id="domestic-debtor-bank-code" aria-label={t('Kód banky plátce', 'Debtor bank code')} className="input" style={{ flex: 1 }} placeholder="0100" value={domesticForm.debtorBankCode}
                         onChange={e => setDomesticForm({ ...domesticForm, debtorBankCode: e.target.value })} required />
                     </div>
                   </div>
                   <div>
-                    <label className="stat-label" style={{ display: 'block', marginBottom: '4px' }}>{t('Jméno plátce', 'Debtor Name')}</label>
-                    <input className="input" style={{ width: '100%' }} value={domesticForm.debtorName}
+                    <label htmlFor="domestic-debtor-name" className="stat-label" style={{ display: 'block', marginBottom: '4px' }}>{t('Jméno plátce', 'Debtor Name')}</label>
+                    <input id="domestic-debtor-name" className="input" style={{ width: '100%' }} value={domesticForm.debtorName}
                       onChange={e => setDomesticForm({ ...domesticForm, debtorName: e.target.value })} required />
                   </div>
                 </div>
                 <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '12px' }}>
                   <div>
-                    <label className="stat-label" style={{ display: 'block', marginBottom: '4px' }}>{t('Číslo účtu příjemce', 'Creditor Account No.')}</label>
+                    <label htmlFor="domestic-creditor-account-number" className="stat-label" style={{ display: 'block', marginBottom: '4px' }}>{t('Číslo účtu příjemce', 'Creditor Account No.')}</label>
                     <div style={{ display: 'flex', gap: '8px' }}>
-                      <input className="input" style={{ flex: 2 }} placeholder="0987654321" value={domesticForm.creditorAccountNumber}
+                      <input id="domestic-creditor-account-number" className="input" style={{ flex: 2 }} placeholder="0987654321" value={domesticForm.creditorAccountNumber}
                         onChange={e => setDomesticForm({ ...domesticForm, creditorAccountNumber: e.target.value })} required />
                       <span style={{ display: 'flex', alignItems: 'center' }}>/</span>
-                      <input className="input" style={{ flex: 1 }} placeholder="0100" value={domesticForm.creditorBankCode}
+                      <input id="domestic-creditor-bank-code" aria-label={t('Kód banky příjemce', 'Creditor bank code')} className="input" style={{ flex: 1 }} placeholder="0100" value={domesticForm.creditorBankCode}
                         onChange={e => setDomesticForm({ ...domesticForm, creditorBankCode: e.target.value })} required />
                     </div>
                   </div>
                   <div>
-                    <label className="stat-label" style={{ display: 'block', marginBottom: '4px' }}>{t('Jméno příjemce', 'Creditor Name')}</label>
-                    <input className="input" style={{ width: '100%' }} value={domesticForm.creditorName}
+                    <label htmlFor="domestic-creditor-name" className="stat-label" style={{ display: 'block', marginBottom: '4px' }}>{t('Jméno příjemce', 'Creditor Name')}</label>
+                    <input id="domestic-creditor-name" className="input" style={{ width: '100%' }} value={domesticForm.creditorName}
                       onChange={e => setDomesticForm({ ...domesticForm, creditorName: e.target.value })} required />
                   </div>
                 </div>
                 <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '12px' }}>
                   <div>
-                    <label className="stat-label" style={{ display: 'block', marginBottom: '4px' }}>{t('Částka', 'Amount')}</label>
+                    <label htmlFor="domestic-amount" className="stat-label" style={{ display: 'block', marginBottom: '4px' }}>{t('Částka', 'Amount')}</label>
                     <div style={{ display: 'flex', gap: '8px' }}>
-                      <input type="number" step="0.01" min="0.01" max="2500000" className="input" style={{ flex: 1 }} value={domesticForm.amount}
+                      <input id="domestic-amount" type="number" step="0.01" min="0.01" max="2500000" className="input" style={{ flex: 1 }} value={domesticForm.amount}
                         onChange={e => setDomesticForm({ ...domesticForm, amount: e.target.value })} required />
                       <span className="input" style={{ width: '80px', border: '1px solid var(--border)', display: 'flex', alignItems: 'center', justifyContent: 'center', background: 'var(--surface-2)' }}>CZK</span>
                     </div>
                   </div>
                   <div>
-                    <label className="stat-label" style={{ display: 'block', marginBottom: '4px' }}>{t('Zpráva pro příjemce', 'Message for Payee')}</label>
-                    <input className="input" style={{ width: '100%' }} value={domesticForm.messageForPayee}
+                    <label htmlFor="domestic-message" className="stat-label" style={{ display: 'block', marginBottom: '4px' }}>{t('Zpráva pro příjemce', 'Message for Payee')}</label>
+                    <input id="domestic-message" className="input" style={{ width: '100%' }} value={domesticForm.messageForPayee}
                       onChange={e => setDomesticForm({ ...domesticForm, messageForPayee: e.target.value })} />
                   </div>
                 </div>
                 <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr', gap: '12px' }}>
                   <div>
-                    <label className="stat-label" style={{ display: 'block', marginBottom: '4px' }}>{t('Variabilní symbol', 'Variable Symbol')}</label>
-                    <input className="input" style={{ width: '100%' }} value={domesticForm.variableSymbol}
+                    <label htmlFor="domestic-variable-symbol" className="stat-label" style={{ display: 'block', marginBottom: '4px' }}>{t('Variabilní symbol', 'Variable Symbol')}</label>
+                    <input id="domestic-variable-symbol" className="input" style={{ width: '100%' }} value={domesticForm.variableSymbol}
                       onChange={e => setDomesticForm({ ...domesticForm, variableSymbol: e.target.value })} />
                   </div>
                   <div>
-                    <label className="stat-label" style={{ display: 'block', marginBottom: '4px' }}>{t('Specifický symbol', 'Specific Symbol')}</label>
-                    <input className="input" style={{ width: '100%' }} value={domesticForm.specificSymbol}
+                    <label htmlFor="domestic-specific-symbol" className="stat-label" style={{ display: 'block', marginBottom: '4px' }}>{t('Specifický symbol', 'Specific Symbol')}</label>
+                    <input id="domestic-specific-symbol" className="input" style={{ width: '100%' }} value={domesticForm.specificSymbol}
                       onChange={e => setDomesticForm({ ...domesticForm, specificSymbol: e.target.value })} />
                   </div>
                   <div>
-                    <label className="stat-label" style={{ display: 'block', marginBottom: '4px' }}>{t('Konstantní symbol', 'Constant Symbol')}</label>
-                    <input className="input" style={{ width: '100%' }} value={domesticForm.constantSymbol}
+                    <label htmlFor="domestic-constant-symbol" className="stat-label" style={{ display: 'block', marginBottom: '4px' }}>{t('Konstantní symbol', 'Constant Symbol')}</label>
+                    <input id="domestic-constant-symbol" className="input" style={{ width: '100%' }} value={domesticForm.constantSymbol}
                       onChange={e => setDomesticForm({ ...domesticForm, constantSymbol: e.target.value })} />
                   </div>
                 </div>
                 <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr', gap: '12px' }}>
                   <div>
-                    <label className="stat-label" style={{ display: 'block', marginBottom: '4px' }}>{t('Priorita', 'Priority')}</label>
-                    <select className="input" style={{ width: '100%' }} value={domesticForm.priority}
+                    <label htmlFor="domestic-priority" className="stat-label" style={{ display: 'block', marginBottom: '4px' }}>{t('Priorita', 'Priority')}</label>
+                    <select id="domestic-priority" className="input" style={{ width: '100%' }} value={domesticForm.priority}
                       onChange={e => setDomesticForm({ ...domesticForm, priority: e.target.value })}>
                       <option value="STANDARD">{t('Standardní', 'Standard')}</option>
                       <option value="URGENT">{t('Urgentní', 'Urgent')}</option>
                     </select>
                   </div>
                   <div>
-                    <label className="stat-label" style={{ display: 'block', marginBottom: '4px' }}>{t('End-To-End ID', 'End-To-End ID')}</label>
-                    <input className="input" style={{ width: '100%' }} value={domesticForm.endToEndId}
+                    <label htmlFor="domestic-end-to-end" className="stat-label" style={{ display: 'block', marginBottom: '4px' }}>{t('End-To-End ID', 'End-To-End ID')}</label>
+                    <input id="domestic-end-to-end" className="input" style={{ width: '100%' }} value={domesticForm.endToEndId}
                       onChange={e => setDomesticForm({ ...domesticForm, endToEndId: e.target.value })} />
                   </div>
                   <div>
-                    <label className="stat-label" style={{ display: 'block', marginBottom: '4px' }}>{t('Označení výpisu', 'Statement Label')}</label>
-                    <input className="input" style={{ width: '100%' }} value={domesticForm.statementLabel}
+                    <label htmlFor="domestic-statement-label" className="stat-label" style={{ display: 'block', marginBottom: '4px' }}>{t('Označení výpisu', 'Statement Label')}</label>
+                    <input id="domestic-statement-label" className="input" style={{ width: '100%' }} value={domesticForm.statementLabel}
                       onChange={e => setDomesticForm({ ...domesticForm, statementLabel: e.target.value })} />
                   </div>
                 </div>
@@ -795,51 +797,51 @@ function PaymentsContent() {
               <form onSubmit={handleSepaCreate} style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
                 <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '12px' }}>
                   <div>
-                    <label className="stat-label" style={{ display: 'block', marginBottom: '4px' }}>{t('IBAN plátce', 'Debtor IBAN')}</label>
-                    <input className="input" style={{ width: '100%', fontFamily: 'var(--font-mono)' }}
+                    <label htmlFor="sepa-debtor-iban" className="stat-label" style={{ display: 'block', marginBottom: '4px' }}>{t('IBAN plátce', 'Debtor IBAN')}</label>
+                    <input id="sepa-debtor-iban" className="input" style={{ width: '100%', fontFamily: 'var(--font-mono)' }}
                       placeholder="CZ65 0800 0000 1920 0014 5399" value={sepaForm.debtorIban}
                       onChange={e => setSepaForm({ ...sepaForm, debtorIban: e.target.value })} required />
                   </div>
                   <div>
-                    <label className="stat-label" style={{ display: 'block', marginBottom: '4px' }}>{t('IBAN příjemce', 'Creditor IBAN')}</label>
-                    <input className="input" style={{ width: '100%', fontFamily: 'var(--font-mono)' }}
+                    <label htmlFor="sepa-creditor-iban" className="stat-label" style={{ display: 'block', marginBottom: '4px' }}>{t('IBAN příjemce', 'Creditor IBAN')}</label>
+                    <input id="sepa-creditor-iban" className="input" style={{ width: '100%', fontFamily: 'var(--font-mono)' }}
                       placeholder="CZ65 0800 0000 1920 0014 5399" value={sepaForm.creditorIban}
                       onChange={e => setSepaForm({ ...sepaForm, creditorIban: e.target.value })} required />
                   </div>
                 </div>
                 <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '12px' }}>
                   <div>
-                    <label className="stat-label" style={{ display: 'block', marginBottom: '4px' }}>{t('Jméno příjemce', 'Creditor Name')}</label>
-                    <input className="input" style={{ width: '100%' }} placeholder="John Doe" value={sepaForm.creditorName}
+                    <label htmlFor="sepa-creditor-name" className="stat-label" style={{ display: 'block', marginBottom: '4px' }}>{t('Jméno příjemce', 'Creditor Name')}</label>
+                    <input id="sepa-creditor-name" className="input" style={{ width: '100%' }} placeholder="John Doe" value={sepaForm.creditorName}
                       onChange={e => setSepaForm({ ...sepaForm, creditorName: e.target.value })} required />
                     <div style={{ fontSize: '10px', color: 'var(--text-tertiary)', marginTop: '3px' }}>
                       {t('Max 70 znaků. SWIFT charset: A-Z, 0-9, / - ? : ( ) . , \' + (bez diakritiky)', 'Max 70 chars. SWIFT charset: A-Z, 0-9, / - ? : ( ) . , \' + (no diacritics)')}
                     </div>
                   </div>
                   <div>
-                    <label className="stat-label" style={{ display: 'block', marginBottom: '4px' }}>{t('Částka (EUR)', 'Amount (EUR)')}</label>
-                    <input type="number" step="0.01" min="0.01" className="input" style={{ width: '100%' }} placeholder="100.00"
+                    <label htmlFor="sepa-amount" className="stat-label" style={{ display: 'block', marginBottom: '4px' }}>{t('Částka (EUR)', 'Amount (EUR)')}</label>
+                    <input id="sepa-amount" type="number" step="0.01" min="0.01" className="input" style={{ width: '100%' }} placeholder="100.00"
                       value={sepaForm.amount} onChange={e => setSepaForm({ ...sepaForm, amount: e.target.value })} required />
                   </div>
                 </div>
                 <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '12px' }}>
                   <div>
-                    <label className="stat-label" style={{ display: 'block', marginBottom: '4px' }}>{t('BIC (nepovinný)', 'BIC (optional)')}</label>
-                    <input className="input" style={{ width: '100%', fontFamily: 'var(--font-mono)' }} placeholder="KOMBCZPP"
+                    <label htmlFor="sepa-bic" className="stat-label" style={{ display: 'block', marginBottom: '4px' }}>{t('BIC (nepovinný)', 'BIC (optional)')}</label>
+                    <input id="sepa-bic" className="input" style={{ width: '100%', fontFamily: 'var(--font-mono)' }} placeholder="KOMBCZPP"
                       value={sepaForm.bic} onChange={e => setSepaForm({ ...sepaForm, bic: e.target.value })} />
                     <div style={{ fontSize: '10px', color: 'var(--text-tertiary)', marginTop: '3px' }}>
                       {t('Odvodit z IBAN — nepovinné', 'Derivable from IBAN — optional')}
                     </div>
                   </div>
                   <div>
-                    <label className="stat-label" style={{ display: 'block', marginBottom: '4px' }}>{t('End-to-End ID (nepovinný)', 'End-to-End ID (optional)')}</label>
-                    <input className="input" style={{ width: '100%', fontFamily: 'var(--font-mono)' }} placeholder="Max 35 znaků"
+                    <label htmlFor="sepa-end-to-end" className="stat-label" style={{ display: 'block', marginBottom: '4px' }}>{t('End-to-End ID (nepovinný)', 'End-to-End ID (optional)')}</label>
+                    <input id="sepa-end-to-end" className="input" style={{ width: '100%', fontFamily: 'var(--font-mono)' }} placeholder="Max 35 znaků"
                       value={sepaForm.endToEndId} onChange={e => setSepaForm({ ...sepaForm, endToEndId: e.target.value })} />
                   </div>
                 </div>
                 <div>
-                  <label className="stat-label" style={{ display: 'block', marginBottom: '4px' }}>{t('Zpráva pro příjemce (nepovinná)', 'Remittance Info (optional)')}</label>
-                  <input className="input" style={{ width: '100%' }} placeholder={t('Max 140 znaků, free-form', 'Max 140 chars, free-form')}
+                  <label htmlFor="sepa-remittance" className="stat-label" style={{ display: 'block', marginBottom: '4px' }}>{t('Zpráva pro příjemce (nepovinná)', 'Remittance Info (optional)')}</label>
+                  <input id="sepa-remittance" className="input" style={{ width: '100%' }} placeholder={t('Max 140 znaků, free-form', 'Max 140 chars, free-form')}
                     maxLength={140} value={sepaForm.remittanceInfo}
                     onChange={e => setSepaForm({ ...sepaForm, remittanceInfo: e.target.value })} />
                   <div style={{ fontSize: '10px', color: 'var(--text-tertiary)', marginTop: '3px' }}>
@@ -868,7 +870,8 @@ function PaymentsContent() {
           <div style={{ display: 'flex', gap: '10px', marginBottom: '16px' }}>
             <div style={{ position: 'relative', flex: 1, maxWidth: '320px' }}>
               <Search size={14} style={{ position: 'absolute', left: '10px', top: '50%', transform: 'translateY(-50%)', color: 'var(--text-muted)' }} />
-              <input className="input" style={{ paddingLeft: '32px', width: '100%' }}
+              <label className="sr-only" htmlFor="payments-search">{t('Hledat platby', 'Search payments')}</label>
+              <input id="payments-search" className="input" style={{ paddingLeft: '32px', width: '100%' }}
                 placeholder={t('Hledat podle ID, IBAN, příjemce…', 'Search by ID, IBAN, creditor…')}
                 value={search} onChange={e => setSearch(e.target.value)} />
             </div>

--- a/openbank-admin-ui/src/test/payments-form-a11y.guard.test.ts
+++ b/openbank-admin-ui/src/test/payments-form-a11y.guard.test.ts
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'fs'
+import path from 'path'
+
+const page = readFileSync(path.resolve(__dirname, '../app/payments/page.tsx'), 'utf8')
+
+describe('payments money-path form accessibility contract', () => {
+  it('associates domestic and SEPA labels with every visible control', () => {
+    const ids = [
+      'domestic-transfer-scope', 'domestic-technical-account-code', 'domestic-debtor-account-id',
+      'domestic-debtor-account-number', 'domestic-debtor-name', 'domestic-creditor-account-number',
+      'domestic-creditor-name', 'domestic-amount', 'domestic-message', 'domestic-variable-symbol',
+      'domestic-specific-symbol', 'domestic-constant-symbol', 'domestic-priority', 'domestic-end-to-end',
+      'domestic-statement-label', 'sepa-debtor-iban', 'sepa-creditor-iban', 'sepa-creditor-name',
+      'sepa-amount', 'sepa-bic', 'sepa-end-to-end', 'sepa-remittance', 'sepa-vop-payee-name',
+      'payments-sct-search', 'payments-search',
+    ]
+    for (const id of ids) {
+      expect(page).toContain(`id="${id}"`)
+      expect(page).toContain(`htmlFor="${id}"`)
+    }
+    expect(page).toContain("id=\"domestic-debtor-bank-code\" aria-label={t('Kód banky plátce', 'Debtor bank code')}")
+    expect(page).toContain("id=\"domestic-creditor-bank-code\" aria-label={t('Kód banky příjemce', 'Creditor bank code')}")
+  })
+})


### PR DESCRIPTION
Associate every domestic and SEPA money-path form control with an accessible name, including VoP and search controls. No payment payload, validation, endpoint, idempotency or RBAC behavior changes.

Refs #85