### PR TITLE
fix(admin-ui): label search controls

### DIFF
--- a/openbank-admin-ui/src/app/kyc/page.tsx
+++ b/openbank-admin-ui/src/app/kyc/page.tsx
@@ -76,9 +76,11 @@ export default function KycPage() {
       <div style={{ display: 'flex', gap: '10px', marginBottom: '16px' }}>
         <div style={{ position: 'relative', flex: 1, maxWidth: '300px' }}>
           <Search size={14} style={{ position: 'absolute', left: '10px', top: '50%', transform: 'translateY(-50%)', color: 'var(--text-muted)' }} />
-          <input className="input" style={{ paddingLeft: '32px', width: '100%' }} placeholder={t('Hledat podle ID nebo stavu…', 'Search by ID or status…')} value={search} onChange={e => setSearch(e.target.value)} />
+          <label className="sr-only" htmlFor="kyc-search">{t('Hledat KYC případy', 'Search KYC cases')}</label>
+          <input id="kyc-search" className="input" style={{ paddingLeft: '32px', width: '100%' }} placeholder={t('Hledat podle ID nebo stavu…', 'Search by ID or status…')} value={search} onChange={e => setSearch(e.target.value)} />
         </div>
-        <input className="input" style={{ width: '280px', fontFamily: 'var(--font-mono)', fontSize: '12px' }} placeholder={t('Filtrovat podle Party ID (UUID)…', 'Filter by Party ID (UUID)…')} value={partyId} onChange={e => setPartyId(e.target.value)} />
+        <label className="sr-only" htmlFor="kyc-party-id">{t('Filtrovat podle Party ID', 'Filter by Party ID')}</label>
+        <input id="kyc-party-id" className="input" style={{ width: '280px', fontFamily: 'var(--font-mono)', fontSize: '12px' }} placeholder={t('Filtrovat podle Party ID (UUID)…', 'Filter by Party ID (UUID)…')} value={partyId} onChange={e => setPartyId(e.target.value)} />
         <button className="btn btn-secondary" onClick={load}>{t('Hledat', 'Search')}</button>
       </div>
 

--- a/openbank-admin-ui/src/app/transactions/page.tsx
+++ b/openbank-admin-ui/src/app/transactions/page.tsx
@@ -132,19 +132,22 @@ export default function TransactionsPage() {
         <div style={{ padding: '14px 16px', borderBottom: '1px solid var(--border)', background: 'var(--surface-2)', borderRadius: '8px 8px 0 0', display: 'flex', gap: '8px', alignItems: 'center', flexWrap: 'wrap' }}>
           <div style={{ position: 'relative', flex: 1, minWidth: '200px' }}>
             <Search size={13} style={{ position: 'absolute', left: '10px', top: '50%', transform: 'translateY(-50%)', color: 'var(--text-tertiary)' }} />
-            <input className="input" style={{ paddingLeft: '30px', width: '100%' }}
+            <label className="sr-only" htmlFor="transaction-account-id">{t('Hledat podle ID účtu', 'Search by account ID')}</label>
+            <input id="transaction-account-id" className="input" style={{ paddingLeft: '30px', width: '100%' }}
               placeholder={t('ID účtu (UUID)…', 'Account ID (UUID)…')}
               value={accountId} onChange={e => setAccountId(e.target.value)}
               onKeyDown={e => e.key === 'Enter' && search()} />
           </div>
           <div style={{ position: 'relative', flex: 1, minWidth: '180px' }}>
-            <input className="input" style={{ width: '100%' }}
+            <label className="sr-only" htmlFor="transaction-iban">{t('Filtrovat podle IBAN', 'Filter by IBAN')}</label>
+            <input id="transaction-iban" className="input" style={{ width: '100%' }}
               placeholder={t('IBAN (CZ65 0800 …)', 'IBAN (CZ65 0800 …)')}
               value={iban} onChange={e => setIban(e.target.value)}
               onKeyDown={e => e.key === 'Enter' && search()} />
           </div>
           <div style={{ position: 'relative', flex: 1, minWidth: '160px' }}>
-            <input className="input" style={{ width: '100%' }}
+            <label className="sr-only" htmlFor="transaction-bban">{t('Filtrovat podle BBAN', 'Filter by BBAN')}</label>
+            <input id="transaction-bban" className="input" style={{ width: '100%' }}
               placeholder={t('BBAN (123456-1234567890/0800)', 'BBAN (123456-1234567890/0800)')}
               value={bban} onChange={e => setBban(e.target.value)}
               onKeyDown={e => e.key === 'Enter' && search()} />

--- a/openbank-admin-ui/src/test/search-controls-a11y.guard.test.ts
+++ b/openbank-admin-ui/src/test/search-controls-a11y.guard.test.ts
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'fs'
+import path from 'path'
+
+const source = (name: string) => readFileSync(path.resolve(__dirname, `../app/${name}/page.tsx`), 'utf8')
+
+describe('search controls accessibility contract', () => {
+  it('names KYC and transaction primary search inputs', () => {
+    const kyc = source('kyc')
+    for (const id of ['kyc-search', 'kyc-party-id']) {
+      expect(kyc).toContain(`id="${id}"`)
+      expect(kyc).toContain(`htmlFor="${id}"`)
+    }
+    const transactions = source('transactions')
+    for (const id of ['transaction-account-id', 'transaction-iban', 'transaction-bban']) {
+      expect(transactions).toContain(`id="${id}"`)
+      expect(transactions).toContain(`htmlFor="${id}"`)
+    }
+  })
+})


### PR DESCRIPTION
Name KYC and transaction primary search inputs with visible screen-reader labels. No query classification, fetch, pagination, RBAC or money-path mutation behavior changes.

Refs #85