### PR TITLE
fix(admin-ui): name operator search controls

### DIFF
--- a/openbank-admin-ui/src/app/audit/page.tsx
+++ b/openbank-admin-ui/src/app/audit/page.tsx
@@ -75,6 +75,7 @@ export default function AuditPage() {
               className="input"
               style={{ paddingLeft: '32px', width: '100%', fontFamily: 'var(--font-mono)', fontSize: '12px' }}
               placeholder="Aggregate ID (account UUID, party UUID, transaction UUID…)"
+              aria-label={t('ID agregátu', 'Aggregate ID')}
               value={aggregateId}
               onChange={e => setAggregateId(e.target.value)}
               onKeyDown={e => e.key === 'Enter' && search()}

--- a/openbank-admin-ui/src/app/pid/page.tsx
+++ b/openbank-admin-ui/src/app/pid/page.tsx
@@ -461,6 +461,7 @@ export default function PidPage() {
               className="input"
               style={{ paddingLeft: '32px', width: '100%' }}
               placeholder={t('Hledat hodnotu, ID osoby...', 'Search value, person ID...')}
+              aria-label={t('Hledat PID případy', 'Search PID cases')}
               value={search}
               onChange={e => setSearch(e.target.value)}
             />

--- a/openbank-admin-ui/src/app/product-catalog/page.tsx
+++ b/openbank-admin-ui/src/app/product-catalog/page.tsx
@@ -608,7 +608,7 @@ export default function ProductCatalogPage() {
           <div style={{ display: 'flex', gap: '8px', marginBottom: '16px', flexWrap: 'wrap', alignItems: 'center' }}>
             <div style={{ position: 'relative', flex: 1, minWidth: '220px', maxWidth: '300px' }}>
               <Search size={13} style={{ position: 'absolute', left: '10px', top: '50%', transform: 'translateY(-50%)', color: 'var(--text-tertiary)' }} />
-              <input className="input" style={{ paddingLeft: '30px', width: '100%' }} placeholder={t('Kód, název, štítek…', 'Code, name, tag…')} value={search} onChange={e => setSearch(e.target.value)} />
+              <input className="input" style={{ paddingLeft: '30px', width: '100%' }} placeholder={t('Kód, název, štítek…', 'Code, name, tag…')} aria-label={t('Hledat v katalogu produktů', 'Search product catalog')} value={search} onChange={e => setSearch(e.target.value)} />
             </div>
             {[
               { label: t('Typ', 'Type'), value: typeFilter, set: setTypeFilter, options: [['ALL', t('Všechny typy', 'All types')], ...uniqueTypes.map(v => [v, v])] },

--- a/openbank-admin-ui/src/app/sanctions/page.tsx
+++ b/openbank-admin-ui/src/app/sanctions/page.tsx
@@ -538,7 +538,7 @@ export default function SanctionsPage() {
               <div style={{ padding: '12px 16px', borderBottom: '1px solid var(--border)', display: 'flex', gap: '8px', alignItems: 'center' }}>
                 <div style={{ position: 'relative', flex: 1 }}>
                   <Search size={13} style={{ position: 'absolute', left: '10px', top: '50%', transform: 'translateY(-50%)', color: 'var(--text-tertiary)' }} />
-                  <input value={search} onChange={e => setSearch(e.target.value)} placeholder={t('Hledat jméno, status, seznam…', 'Search name, status, list…')}
+                  <input value={search} onChange={e => setSearch(e.target.value)} placeholder={t('Hledat jméno, status, seznam…', 'Search name, status, list…')} aria-label={t('Hledat sankční kontroly', 'Search sanctions checks')}
                     style={{ width: '100%', paddingLeft: '30px', paddingRight: '12px', height: '32px', borderRadius: '6px',
                       border: '1px solid var(--border)', fontSize: '13px', background: 'var(--surface-2)', color: 'var(--text-primary)', outline: 'none' }} />
                 </div>

--- a/openbank-admin-ui/src/app/swift/page.tsx
+++ b/openbank-admin-ui/src/app/swift/page.tsx
@@ -94,7 +94,7 @@ export default function SwiftPage() {
           <div style={{ padding: '16px 20px', borderBottom: '1px solid var(--border)', display: 'flex', gap: '10px', alignItems: 'center' }}>
             <div style={{ position: 'relative', flex: 1 }}>
               <Search size={13} style={{ position: 'absolute', left: '10px', top: '50%', transform: 'translateY(-50%)', color: 'var(--text-tertiary)' }} />
-              <input value={search} onChange={e => setSearch(e.target.value)} placeholder={t('Hledat BIC, referenci, typ zprávy…', 'Search BIC, reference, message type…')}
+              <input value={search} onChange={e => setSearch(e.target.value)} placeholder={t('Hledat BIC, referenci, typ zprávy…', 'Search BIC, reference, message type…')} aria-label={t('Hledat SWIFT zprávy', 'Search SWIFT messages')}
                 style={{ width: '100%', paddingLeft: '30px', paddingRight: '12px', height: '32px', borderRadius: '6px',
                   border: '1px solid var(--border)', fontSize: '13px', background: 'var(--surface-2)', color: 'var(--text-primary)', outline: 'none' }} />
             </div>

--- a/openbank-admin-ui/src/test/search-controls-a11y-pack.guard.test.ts
+++ b/openbank-admin-ui/src/test/search-controls-a11y-pack.guard.test.ts
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'fs'
+import path from 'path'
+
+const page = (name: string) => readFileSync(path.resolve(__dirname, `../app/${name}/page.tsx`), 'utf8')
+
+describe('operator search accessibility contract', () => {
+  it('gives every migrated search field a localized accessible name', () => {
+    const expected: Record<string, string> = {
+      swift: 'Hledat SWIFT zprávy',
+      sanctions: 'Hledat sankční kontroly',
+      'product-catalog': 'Hledat v katalogu produktů',
+      audit: 'ID agregátu',
+      pid: 'Hledat PID případy',
+    }
+    for (const [route, label] of Object.entries(expected)) {
+      expect(page(route)).toContain(`aria-label={t('${label}'`)
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- add localized accessible names to operator search fields across audit, PID, sanctions, SWIFT, and product catalog
- add a source guard covering the migrated controls

## Verification
- npm test -- --run src/test/search-controls-a11y-pack.guard.test.ts
- npm run type-check
- git diff --check

Refs #5403