### PR TITLE
fix(admin-ui): name oversight inputs

### DIFF
--- a/openbank-admin-ui/src/app/approvals/page.tsx
+++ b/openbank-admin-ui/src/app/approvals/page.tsx
@@ -221,6 +221,7 @@ export default function ApprovalsPage() {
               </div>
               <div style={{ display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap' }}>
                 <input
+                  aria-label={t('Důvod rozhodnutí návrhu', 'Proposal decision reason')}
                   placeholder={t('Důvod rozhodnutí (volitelné)', 'Decision reason (optional)')}
                   value={reasons[p.id] || ''}
                   onChange={e => setReasons(r => ({ ...r, [p.id]: e.target.value }))}

--- a/openbank-admin-ui/src/app/iaops/page.tsx
+++ b/openbank-admin-ui/src/app/iaops/page.tsx
@@ -688,6 +688,7 @@ function IAOpsContent() {
             </SectionTitle>
             <div style={{ display: 'flex', gap: '8px', marginBottom: '12px' }}>
               <textarea
+                aria-label={t('Popis alertu pro RCA', 'Alert description for RCA')}
                 value={rcaAsk}
                 onChange={e => setRcaAsk(e.target.value)}
                 disabled={rcaLoading}

--- a/openbank-admin-ui/src/app/notifications/page.tsx
+++ b/openbank-admin-ui/src/app/notifications/page.tsx
@@ -215,7 +215,7 @@ function OperatorMessageApprovals() {
         </span>
         <div style={{ display: 'flex', gap: '8px', alignItems: 'center', flexWrap: 'wrap' }}>
           <input
-            aria-label={t('Důvod rozhodnutí notifikace', 'Notification decision reason')}
+            aria-label={t('ID schválení notifikace', 'Notification approval ID')}
             className="input"
             style={{ flex: 1, minWidth: '240px', fontFamily: 'var(--font-mono)' }}
             value={approvalId}

--- a/openbank-admin-ui/src/app/notifications/page.tsx
+++ b/openbank-admin-ui/src/app/notifications/page.tsx
@@ -215,6 +215,7 @@ function OperatorMessageApprovals() {
         </span>
         <div style={{ display: 'flex', gap: '8px', alignItems: 'center', flexWrap: 'wrap' }}>
           <input
+            aria-label={t('Důvod rozhodnutí notifikace', 'Notification decision reason')}
             className="input"
             style={{ flex: 1, minWidth: '240px', fontFamily: 'var(--font-mono)' }}
             value={approvalId}

--- a/openbank-admin-ui/src/app/system/agent/page.tsx
+++ b/openbank-admin-ui/src/app/system/agent/page.tsx
@@ -379,6 +379,7 @@ function ToolCard({ tool, expanded, onToggle }: { tool: ToolDef; expanded: boole
                     <span style={{ color: 'var(--text-tertiary)', fontWeight: 400 }}>— {prop.description}</span>
                   </label>
                   <input
+                    aria-label={t(`${name} parametr`, `${name} parameter`)}
                     className="input"
                     type="text"
                     value={args[name] ?? ''}

--- a/openbank-admin-ui/src/test/oversight-form-a11y.guard.test.ts
+++ b/openbank-admin-ui/src/test/oversight-form-a11y.guard.test.ts
@@ -8,7 +8,7 @@ const page = (name: string) => readFileSync(path.resolve(__dirname, `../app/${na
 
 describe('oversight form accessibility contract', () => {
   it('names operator decision and investigation inputs', () => {
-    expect(page('notifications')).toContain("aria-label={t('Důvod rozhodnutí notifikace'")
+    expect(page('notifications')).toContain("aria-label={t('ID schválení notifikace'")
     expect(page('approvals')).toContain("aria-label={t('Důvod rozhodnutí návrhu'")
     expect(page('system/agent')).toContain('aria-label={t(`${name} parametr`')
     expect(page('iaops')).toContain("aria-label={t('Popis alertu pro RCA'")

--- a/openbank-admin-ui/src/test/oversight-form-a11y.guard.test.ts
+++ b/openbank-admin-ui/src/test/oversight-form-a11y.guard.test.ts
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'fs'
+import path from 'path'
+
+const page = (name: string) => readFileSync(path.resolve(__dirname, `../app/${name}/page.tsx`), 'utf8')
+
+describe('oversight form accessibility contract', () => {
+  it('names operator decision and investigation inputs', () => {
+    expect(page('notifications')).toContain("aria-label={t('Důvod rozhodnutí notifikace'")
+    expect(page('approvals')).toContain("aria-label={t('Důvod rozhodnutí návrhu'")
+    expect(page('system/agent')).toContain('aria-label={t(`${name} parametr`')
+    expect(page('iaops')).toContain("aria-label={t('Popis alertu pro RCA'")
+  })
+})


### PR DESCRIPTION
## Summary
- add localized accessible names to notification/proposal decision, agent parameter, and RCA inputs
- add source guard for oversight controls

## Verification
- npm test -- --run src/test/oversight-form-a11y.guard.test.ts
- npm run type-check
- git diff --check

Refs #5410