### PR TITLE
fix(admin-ui): remove fake IAOPS analysis trigger

### DIFF
--- a/openbank-admin-ui/src/app/iaops/page.tsx
+++ b/openbank-admin-ui/src/app/iaops/page.tsx
@@ -536,10 +536,9 @@ function IAOpsContent() {
                           {t('Citlivé kroky schvaluje člověk', 'Human approval for sensitive steps')}
                         </span>
                         {isFinopsAgent && (
-                          <button onClick={e => { e.stopPropagation(); alert(t('Funkce přijde v P4 (HITL backend)', 'Feature coming in P4 (HITL backend)')) }}
-                            style={{ fontSize: '10px', fontWeight: 700, padding: '3px 8px', borderRadius: '8px', border: '1px solid #6366f1', background: 'transparent', color: '#6366f1', cursor: 'pointer' }}>
-                            {t('Spustit analýzu', 'Trigger Analysis')}
-                          </button>
+                          <span role="status" style={{ fontSize: '10px', fontWeight: 650, padding: '3px 8px', borderRadius: '8px', border: '1px solid var(--border)', background: 'var(--surface)', color: 'var(--text-secondary)' }}>
+                            {t('Analýza zatím není připojená k HITL backendu', 'Analysis is not connected to the HITL backend yet')}
+                          </span>
                         )}
                       </div>
 

--- a/openbank-admin-ui/src/test/iaops-agent-card.test.tsx
+++ b/openbank-admin-ui/src/test/iaops-agent-card.test.tsx
@@ -70,8 +70,6 @@ describe('AIOps agent card interactions', () => {
       }
       return response({ anomalies: [] })
     }))
-    const alertSpy = vi.fn()
-    vi.stubGlobal('alert', alertSpy)
     const user = userEvent.setup()
 
     render(<IAOpsPage />)
@@ -95,12 +93,8 @@ describe('AIOps agent card interactions', () => {
     await user.keyboard('{Enter}')
     expect(linkClick).not.toHaveBeenCalled()
 
-    const trigger = screen.getByRole('button', { name: 'Trigger Analysis' })
-    trigger.focus()
-    await user.keyboard('{Enter}')
-    expect(alertSpy).toHaveBeenCalledOnce()
+    const analysisStatus = screen.getByText('Analysis is not connected to the HITL backend yet')
+    expect(analysisStatus).toBeVisible()
     expect(linkClick).not.toHaveBeenCalled()
-
-    await waitFor(() => expect(document.activeElement).toBe(trigger))
   })
 })

--- a/openbank-admin-ui/src/test/iaops-truthfulness.guard.test.ts
+++ b/openbank-admin-ui/src/test/iaops-truthfulness.guard.test.ts
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'fs'
+import path from 'path'
+
+describe('IAOps agent capability truthfulness', () => {
+  it('does not expose a fake interactive HITL trigger', () => {
+    const source = readFileSync(path.resolve(__dirname, '../app/iaops/page.tsx'), 'utf8')
+
+    expect(source).toContain('Analysis is not connected to the HITL backend yet')
+    expect(source).toContain('Analýza zatím není připojená k HITL backendu')
+    expect(source).not.toContain("alert(t('Funkce přijde v P4 (HITL backend)'")
+    expect(source).not.toContain("{t('Spustit analýzu', 'Trigger Analysis')}")
+  })
+})


### PR DESCRIPTION
## Summary
- replace the IAOPS FinOps agent fake browser-alert action with an honest localized read-only status
- preserve the real RCA POST flow and all existing governance/RBAC behavior
- add render and source guards against reintroducing a non-functional trigger

## Verification
- focused tests: 13/13
- npm run type-check
- git diff --check

Refs #5413