### PR TITLE
fix(admin-ui): localize account detail values

### DIFF
--- a/openbank-admin-ui/src/app/accounts/[id]/page.tsx
+++ b/openbank-admin-ui/src/app/accounts/[id]/page.tsx
@@ -24,7 +24,8 @@ const STATUS_PILL: Record<string, string> = {
 
 export default function AccountDetailPage() {
   const { id } = useParams<{ id: string }>()
-  const { t } = useLanguage()
+  const { t, language } = useLanguage()
+  const numberLocale = language === 'cs' ? 'cs-CZ' : 'en-GB'
   const [account, setAccount]   = useState<Account | null>(null)
   const [balance, setBalance]   = useState<AccountBalance | null>(null)
   const [loading, setLoading]   = useState(true)
@@ -196,8 +197,8 @@ export default function AccountDetailPage() {
               { label: t('Typ', 'Type'),                   value: account.accountType },
               { label: t('Měna', 'Currency'),              value: account.currencyCode },
               { label: t('Stav', 'Status'),                value: account.status },
-              { label: t('Otevřen', 'Opened'),             value: new Date(account.openedAt).toLocaleString('en-GB') },
-              ...(account.closedAt ? [{ label: t('Uzavřen', 'Closed'), value: new Date(account.closedAt).toLocaleString('en-GB') }] : []),
+              { label: t('Otevřen', 'Opened'),             value: new Date(account.openedAt).toLocaleString(numberLocale) },
+              ...(account.closedAt ? [{ label: t('Uzavřen', 'Closed'), value: new Date(account.closedAt).toLocaleString(numberLocale) }] : []),
             ].map((row, i, arr) => (
               <div key={row.label} style={{
                 display: 'flex', justifyContent: 'space-between', alignItems: 'center',
@@ -245,13 +246,13 @@ export default function AccountDetailPage() {
                     color: row.highlight ? 'var(--accent)' : 'var(--text-primary)',
                     fontFamily: 'JetBrains Mono, monospace',
                   }}>
-                    {Number(row.value).toLocaleString('en-US', { minimumFractionDigits: 2 })} {balance.currencyCode}
+                    {Number(row.value).toLocaleString(numberLocale, { minimumFractionDigits: 2 })} {balance.currencyCode}
                   </span>
                 </div>
               ))}
               <div style={{ padding: '10px 18px', borderTop: '1px solid var(--border)' }}>
                 <span style={{ fontSize: '11px', color: 'var(--text-tertiary)' }}>
-                  {t('Naposledy aktualizováno:', 'Last updated:')} {new Date(balance.lastUpdatedAt).toLocaleString('en-GB')}
+                  {t('Naposledy aktualizováno:', 'Last updated:')} {new Date(balance.lastUpdatedAt).toLocaleString(numberLocale)}
                 </span>
               </div>
             </div>

--- a/openbank-admin-ui/src/test/accounts-detail-locale.guard.test.ts
+++ b/openbank-admin-ui/src/test/accounts-detail-locale.guard.test.ts
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'fs'
+import path from 'path'
+
+describe('account detail locale contract', () => {
+  it('uses the active UI locale for dates and monetary values', () => {
+    const source = readFileSync(path.resolve(__dirname, '../app/accounts/[id]/page.tsx'), 'utf8')
+
+    expect(source).toContain("const numberLocale = language === 'cs' ? 'cs-CZ' : 'en-GB'")
+    expect(source).toContain('toLocaleString(numberLocale)')
+    expect(source).toContain('toLocaleString(numberLocale, { minimumFractionDigits: 2 })')
+    expect(source).not.toContain("toLocaleString('en-US'")
+    expect(source).not.toContain("toLocaleString('en-GB'")
+  })
+})


### PR DESCRIPTION
## Summary
- format account detail timestamps and balances using the active Czech/English locale
- add a regression guard against hard-coded en-US/en-GB formatting
- preserve account reads, lifecycle actions, API contracts and RBAC

## Verification
- focused tests: 3/3
- npm run type-check
- git diff --check

Refs #5413