### PR TITLE
fix(admin-ui): localize fx values

### DIFF
--- a/openbank-admin-ui/src/app/fx/page.tsx
+++ b/openbank-admin-ui/src/app/fx/page.tsx
@@ -135,6 +135,7 @@ function MidCell({ mid, symbol }: { mid: number; symbol?: string }) {
 
 export default function FxPage() {
   const { t, language } = useLanguage()
+  const numberLocale = language === 'cs' ? 'cs-CZ' : 'en-GB'
   const [loading, setLoading] = useState(true)
   const [refreshing, setRefreshing] = useState<string | null>(null)
   // Typed unavailable reason for a failed aggregate fetch → renders the calm
@@ -375,7 +376,7 @@ export default function FxPage() {
             { label: t('CNB Páry', 'CNB Pairs'), value: cnbRates.length, icon: <Banknote size={16} />, color: 'var(--accent)' },
             { label: t('ECB Páry', 'ECB Pairs'), value: ecbRates.length, icon: <Globe size={16} />, color: 'var(--info)' },
             { label: t('Publikované měny', 'Published Currencies'), value: Object.values(overrides).filter(o => o.published).length, icon: <Eye size={16} />, color: 'var(--success)' },
-            { label: t('Objem (EUR)', 'Volume (EUR)'), value: totalVolume > 0 ? totalVolume.toLocaleString('cs-CZ', { maximumFractionDigits: 0 }) : '—', icon: <TrendingUp size={16} />, color: 'var(--warning)' },
+            { label: t('Objem (EUR)', 'Volume (EUR)'), value: totalVolume > 0 ? totalVolume.toLocaleString(numberLocale, { maximumFractionDigits: 0 }) : '—', icon: <TrendingUp size={16} />, color: 'var(--warning)' },
           ].map(k => (
             <div key={k.label} className="stat-card">
               <div style={{ width: '32px', height: '32px', borderRadius: '8px', background: `${k.color}18`, display: 'flex', alignItems: 'center', justifyContent: 'center', color: k.color, marginBottom: '10px' }}>{k.icon}</div>
@@ -399,7 +400,7 @@ export default function FxPage() {
               <div style={{ padding: '10px 20px', borderBottom: '1px solid var(--border)', display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
                 <span style={{ fontSize: '11px', color: 'var(--text-tertiary)' }}>
                   {t('Střed kurzu z ČNB · Nákup/Prodej = střed ±', 'CNB mid rate · Buy/Sell = mid ±')} {cnbSpread}% {t('(orientační)', '(indicative)')}
-                  {cnbSyncedAt && ` · ${t('Synchronizace', 'Sync')}: ${new Date(cnbSyncedAt).toLocaleTimeString(language === 'cs' ? 'cs-CZ' : 'en-US')}`}
+                  {cnbSyncedAt && ` · ${t('Synchronizace', 'Sync')}: ${new Date(cnbSyncedAt).toLocaleTimeString(numberLocale)}`}
                   {cnbError && <span style={{ color: 'var(--red)', marginLeft: '8px' }}>⚠ {cnbError}</span>}
                 </span>
                 <button onClick={() => manualRefresh('cnb')} disabled={!!refreshing || loading} style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--accent)', display: 'flex', alignItems: 'center', gap: '4px', fontSize: '11px' }}>
@@ -448,7 +449,7 @@ export default function FxPage() {
               <div style={{ padding: '10px 20px', borderBottom: '1px solid var(--border)', display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
                 <span style={{ fontSize: '11px', color: 'var(--text-tertiary)' }}>
                   {t('ECB referenční kurzy (EUR base) · Nákup/Prodej = střed ±', 'ECB reference rates (EUR base) · Buy/Sell = mid ±')} {margin.buyPct}%/{margin.sellPct}%
-                  {ecbSyncedAt && ` · ${t('Synchronizace', 'Sync')}: ${new Date(ecbSyncedAt).toLocaleTimeString(language === 'cs' ? 'cs-CZ' : 'en-US')}`}
+                  {ecbSyncedAt && ` · ${t('Synchronizace', 'Sync')}: ${new Date(ecbSyncedAt).toLocaleTimeString(numberLocale)}`}
                   {ecbError && <span style={{ color: 'var(--red)', marginLeft: '8px' }}>⚠ {ecbError}</span>}
                 </span>
                 <button onClick={() => manualRefresh('ecb')} disabled={!!refreshing || loading} style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--info)', display: 'flex', alignItems: 'center', gap: '4px', fontSize: '11px' }}>
@@ -649,7 +650,7 @@ export default function FxPage() {
                   </div>
                   <div style={{ textAlign: 'right', minWidth: '110px' }}>
                     <div style={{ fontSize: '11px', color: 'var(--text-tertiary)' }}>{t('Poslední spuštění', 'Last run')}</div>
-                    <div style={{ fontSize: '12px', color: 'var(--text-secondary)' }}>{s.lastRun ? new Date(s.lastRun).toLocaleTimeString('cs-CZ') : '—'}</div>
+                    <div style={{ fontSize: '12px', color: 'var(--text-secondary)' }}>{s.lastRun ? new Date(s.lastRun).toLocaleTimeString(numberLocale) : '—'}</div>
                   </div>
                   <div style={{ minWidth: '80px', textAlign: 'center' }}>
                     {s.lastStatus === 'ok' && (
@@ -748,7 +749,7 @@ export default function FxPage() {
                 <tbody>
                   {history.map((h, i) => (
                     <tr key={i} style={{ borderBottom: '1px solid var(--border)' }}>
-                      <td style={{ padding: '6px 16px', fontSize: '11px', color: 'var(--text-secondary)' }}>{new Date(h.timestamp).toLocaleTimeString('cs-CZ')}</td>
+                      <td style={{ padding: '6px 16px', fontSize: '11px', color: 'var(--text-secondary)' }}>{new Date(h.timestamp).toLocaleTimeString(numberLocale)}</td>
                       <td style={{ padding: '6px 16px', fontSize: '11px', fontWeight: 600 }}>
                         <span style={{ padding: '2px 6px', borderRadius: '4px', background: h.source === 'CNB' ? 'var(--accent)' : h.source.includes('Override') ? 'var(--warning)' : h.source.includes('Margin') ? 'var(--info)' : 'var(--info)', color: '#fff', opacity: 0.85 }}>{h.source}</span>
                       </td>
@@ -787,7 +788,7 @@ export default function FxPage() {
                     <tr key={c.id} style={{ borderBottom: '1px solid var(--border)' }}
                       onMouseEnter={e => (e.currentTarget.style.background = 'var(--surface-2)')}
                       onMouseLeave={e => (e.currentTarget.style.background = '')}>
-                      <td style={{ padding: '10px 16px', fontSize: '12px', color: 'var(--text-secondary)' }}>{c.createdAt ? new Date(c.createdAt).toLocaleString('cs-CZ') : '—'}</td>
+                      <td style={{ padding: '10px 16px', fontSize: '12px', color: 'var(--text-secondary)' }}>{c.createdAt ? new Date(c.createdAt).toLocaleString(numberLocale) : '—'}</td>
                       <td style={{ padding: '10px 16px' }}>
                         <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
                           <span style={{ fontSize: '14px' }}>{CURRENCY_META[c.fromCurrency]?.flag ?? '🏳️'}</span>
@@ -797,8 +798,8 @@ export default function FxPage() {
                           <span style={{ fontFamily: 'var(--font-mono)', fontSize: '12px', fontWeight: 600 }}>{c.toCurrency}</span>
                         </div>
                       </td>
-                      <td style={{ padding: '10px 16px', fontSize: '12px', color: 'var(--text-secondary)' }}>{c.fromAmount?.toLocaleString('cs-CZ')}</td>
-                      <td style={{ padding: '10px 16px', fontSize: '12px', color: 'var(--text-primary)', fontWeight: 600 }}>{c.toAmount?.toLocaleString('cs-CZ')}</td>
+                      <td style={{ padding: '10px 16px', fontSize: '12px', color: 'var(--text-secondary)' }}>{c.fromAmount?.toLocaleString(numberLocale)}</td>
+                      <td style={{ padding: '10px 16px', fontSize: '12px', color: 'var(--text-primary)', fontWeight: 600 }}>{c.toAmount?.toLocaleString(numberLocale)}</td>
                       <td style={{ padding: '10px 16px' }}>
                         <span style={{ padding: '2px 8px', borderRadius: '10px', fontSize: '11px', fontWeight: 600,
                           background: c.status === 'COMPLETED' ? 'var(--success-bg)' : 'var(--warning-bg)',

--- a/openbank-admin-ui/src/test/fx-locale.guard.test.ts
+++ b/openbank-admin-ui/src/test/fx-locale.guard.test.ts
@@ -1,0 +1,13 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+describe('fx locale formatting', () => {
+  it('uses the active language for volumes and quotes', () => {
+    const source = readFileSync(resolve(process.cwd(), 'src/app/fx/page.tsx'), 'utf8')
+    expect(source).toContain("const numberLocale = language === 'cs' ? 'cs-CZ' : 'en-GB'")
+    expect(source).toContain('toLocaleString(numberLocale)')
+    expect(source).toContain('toLocaleTimeString(numberLocale)')
+    expect(source).not.toMatch(/toLocale(?:String|TimeString|DateString)\([^)]*['\"](?:cs-CZ|en-US)['\"]/)
+  })
+})


### PR DESCRIPTION
## Summary
- format FX volumes, timestamps and quote values using the active operator locale
- add a focused regression guard

## Verification
- FX locale guard: 1/1
- npm run type-check

## Linked issues
N/A — focused UX localization correction with no new product scope.