### PR TITLE
fix(admin-ui): localize operator dates

### DIFF
--- a/openbank-admin-ui/src/app/kyc/page.tsx
+++ b/openbank-admin-ui/src/app/kyc/page.tsx
@@ -23,6 +23,7 @@ interface KycCase {
 export default function KycPage() {
   const [cases, setCases]     = useState<KycCase[]>([])
   const { t, language } = useLanguage()
+  const dateLocale = language === 'cs' ? 'cs-CZ' : 'en-GB'
   const [loading, setLoading] = useState(true)
   // Typed unavailable reason → renders the calm <DataUnavailable> panel instead
   // of leaking a raw "HTTP 404" string (admin-ui graceful-state rule).
@@ -146,7 +147,7 @@ export default function KycPage() {
                   </div>
                 </td>
                 <td style={{ color: 'var(--text-muted)', fontSize: '12px' }}>{c.reviewedBy ?? '—'}</td>
-                <td style={{ color: 'var(--text-muted)', fontSize: '12px' }}>{new Date(c.updatedAt).toLocaleDateString()}</td>
+                <td style={{ color: 'var(--text-muted)', fontSize: '12px' }}>{new Date(c.updatedAt).toLocaleDateString(dateLocale)}</td>
                 <td>
                   <Link href={`/parties/${c.partyId}`} style={{ color: 'var(--accent)', display: 'flex', alignItems: 'center', gap: '2px', fontSize: '12px', textDecoration: 'none' }}>
                     {t('Klient', 'Party')} <ChevronRight size={12} />

--- a/openbank-admin-ui/src/app/onboarding/page.tsx
+++ b/openbank-admin-ui/src/app/onboarding/page.tsx
@@ -89,6 +89,7 @@ const STAGE_COLOR: Record<Stage, string> = {
 
 export default function OnboardingPage() {
   const { t, language } = useLanguage()
+  const dateLocale = language === 'cs' ? 'cs-CZ' : 'en-GB'
 
   // funnel KPI
   const [counts, setCounts] = useState<FunnelCounts>({})
@@ -293,7 +294,7 @@ export default function OnboardingPage() {
                       ? <span style={{ color: 'var(--green)', fontSize: '12px' }}>✓ {r.deviceCount}</span>
                       : <span style={{ color: 'var(--text-muted)', fontSize: '12px' }}>—</span>}
                   </td>
-                  <td style={{ color: 'var(--text-muted)', fontSize: '12px' }}>{new Date(r.updatedAt).toLocaleDateString()}</td>
+                  <td style={{ color: 'var(--text-muted)', fontSize: '12px' }}>{new Date(r.updatedAt).toLocaleDateString(dateLocale)}</td>
                   <td>
                     <span style={{ color: 'var(--accent)', display: 'flex', alignItems: 'center', gap: '2px', fontSize: '12px' }}>
                       {t('Detail', 'Detail')} <ChevronRight size={12} />
@@ -342,6 +343,8 @@ function RecordDrawer({
   stageLabel: (s: string) => string
   t: (cs: string, en: string) => string
 }) {
+  const { language } = useLanguage()
+  const dateLocale = language === 'cs' ? 'cs-CZ' : 'en-GB'
   const stageColor = STAGE_COLOR[record.funnelStage as Stage] ?? 'var(--text-muted)'
 
   return (
@@ -390,8 +393,8 @@ function RecordDrawer({
           <DrawerRow label={t('Stav KYC', 'KYC status')} value={record.kycStatus?.replace('_', ' ') ?? '—'} />
           <DrawerRow label={t('KYC případ', 'KYC case ID')} value={record.kycCaseId ? record.kycCaseId.slice(0, 8) + '…' : '—'} mono />
           <DrawerRow label={t('SCA zapsáno', 'SCA enrolled')} value={record.scaEnrolled ? `✓ (${record.deviceCount} ${t('zařízení', 'device(s)')})` : '—'} />
-          <DrawerRow label={t('Vytvořeno', 'Created')} value={new Date(record.createdAt).toLocaleString()} />
-          <DrawerRow label={t('Aktualizováno', 'Updated')} value={new Date(record.updatedAt).toLocaleString()} />
+          <DrawerRow label={t('Vytvořeno', 'Created')} value={new Date(record.createdAt).toLocaleString(dateLocale)} />
+          <DrawerRow label={t('Aktualizováno', 'Updated')} value={new Date(record.updatedAt).toLocaleString(dateLocale)} />
         </div>
 
         {/* Links */}

--- a/openbank-admin-ui/src/app/parties/page.tsx
+++ b/openbank-admin-ui/src/app/parties/page.tsx
@@ -48,6 +48,7 @@ const STATUS_COLORS: Record<string, string> = {
 
 export default function PartiesPage() {
   const { t, language } = useLanguage()
+  const dateLocale = language === 'cs' ? 'cs-CZ' : 'en-GB'
 
   // ── list mode (no search term) ──────────────────────────────────────────────
   const [parties, setParties]         = useState<Party[]>([])
@@ -258,7 +259,7 @@ export default function PartiesPage() {
                       {p.kycStatus?.replace('_', ' ')}
                     </span>
                   </td>
-                  <td style={{ color: 'var(--text-muted)', fontSize: '12px' }}>{new Date(p.createdAt).toLocaleDateString()}</td>
+                  <td style={{ color: 'var(--text-muted)', fontSize: '12px' }}>{new Date(p.createdAt).toLocaleDateString(dateLocale)}</td>
                   <td>
                     <Link href={`/parties/${p.id}`} style={{ color: 'var(--accent)', display: 'flex', alignItems: 'center', gap: '2px', fontSize: '12px', textDecoration: 'none' }}>
                       {t('Detail', 'View')} <ChevronRight size={12} />

--- a/openbank-admin-ui/src/test/dates-locale.guard.test.ts
+++ b/openbank-admin-ui/src/test/dates-locale.guard.test.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+describe('operator date locale consistency', () => {
+  it('uses the active language on KYC, onboarding and parties lists', () => {
+    for (const route of ['kyc', 'onboarding', 'parties']) {
+      const source = readFileSync(resolve(process.cwd(), `src/app/${route}/page.tsx`), 'utf8')
+      expect(source).toContain("const dateLocale = language === 'cs' ? 'cs-CZ' : 'en-GB'")
+      expect(source).toMatch(/toLocaleDateString\(dateLocale\)|toLocaleString\(dateLocale\)/)
+      expect(source).not.toMatch(/toLocale(?:DateString|String)\(\)/)
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- use the active operator locale for KYC, onboarding and parties timestamps
- add a regression guard for date formatting consistency

## Verification
- dates locale guard: 1/1
- npm run type-check

## Linked issues
N/A — focused UX localization correction with no new product scope.