### PR TITLE
fix(admin-ui): localize lending values

### DIFF
--- a/openbank-admin-ui/src/app/lending/applications/[id]/page.tsx
+++ b/openbank-admin-ui/src/app/lending/applications/[id]/page.tsx
@@ -69,6 +69,8 @@ function readStateFor(status: number): ReadState {
 export default function ApplicationFlowPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = use(params)
   const { t, language } = useLanguage()
+  const numberLocale = language === 'cs' ? 'cs-CZ' : 'en-GB'
+  const dateLocale = numberLocale
 
   const [app, setApp] = useState<Application | null>(null)
   const [events, setEvents] = useState<EvidenceEvent[]>([])
@@ -165,7 +167,7 @@ export default function ApplicationFlowPage({ params }: { params: Promise<{ id: 
     s ? (STATE_LABELS[s] ? (language === 'cs' ? STATE_LABELS[s].cs : STATE_LABELS[s].en) : s) : '—'
 
   const money = (m?: { amount: number; currency: string }) =>
-    m ? `${m.amount.toLocaleString('cs-CZ')} ${m.currency}` : '—'
+    m ? `${m.amount.toLocaleString(numberLocale)} ${m.currency}` : '—'
 
   return (
     <div>
@@ -292,7 +294,7 @@ export default function ApplicationFlowPage({ params }: { params: Promise<{ id: 
                   {history.map((h, i) => (
                     <tr key={`${h.state}-${h.at}-${i}`} style={{ borderTop: '1px solid var(--border)' }}>
                       <td style={{ padding: '10px 14px', color: 'var(--text-tertiary)', fontSize: 12 }}>
-                        {h.at ? new Date(h.at).toLocaleString() : '—'}
+                        {h.at ? new Date(h.at).toLocaleString(dateLocale) : '—'}
                       </td>
                       <td style={{ padding: '10px 14px' }}>
                         <span title={h.state}>{stateLabel(h.state)}</span>

--- a/openbank-admin-ui/src/app/lending/page.tsx
+++ b/openbank-admin-ui/src/app/lending/page.tsx
@@ -70,6 +70,8 @@ const STALE_HOURS = 72
 
 export default function LendingPage() {
   const { t, language } = useLanguage()
+  const numberLocale = language === 'cs' ? 'cs-CZ' : 'en-GB'
+  const dateLocale = numberLocale
   const [applications, setApplications] = useState<Application[]>([])
   const [loans, setLoans] = useState<Loan[]>([])
   // Absent = the aggregate endpoints are not in the deployed build yet. The page then falls back to
@@ -120,9 +122,9 @@ export default function LendingPage() {
   }
 
   const fmt = (m?: { amount: number; currency: string }) =>
-    m ? `${m.amount.toLocaleString('cs-CZ')} ${m.currency}` : '—'
+    m ? `${m.amount.toLocaleString(numberLocale)} ${m.currency}` : '—'
 
-  const money = (n: number, ccy: string) => `${Math.round(n).toLocaleString('cs-CZ')} ${ccy}`
+  const money = (n: number, ccy: string) => `${Math.round(n).toLocaleString(numberLocale)} ${ccy}`
 
   /** Headline figures, all computed from the SAME capped lists the tables show — so the page can
    *  never claim more than it fetched. */
@@ -293,7 +295,7 @@ export default function LendingPage() {
                   <span title={a.status}><StatusBadge status={a.status} label={label(a.status)} /></span>
                 </td>
                 <td style={{ ...td, color: 'var(--text-tertiary)', fontSize: 12 }}>
-                  {a.createdAt ? new Date(a.createdAt).toLocaleString() : '—'}
+                  {a.createdAt ? new Date(a.createdAt).toLocaleString(dateLocale) : '—'}
                 </td>
                 <td style={td}>
                   <Link href={`/lending/applications/${a.id}`} style={{ color: 'var(--accent)', fontSize: 12 }}>
@@ -310,7 +312,7 @@ export default function LendingPage() {
                   <StatusBadge status={l.status} tone={LOAN_TROUBLE.has(l.status) ? 'danger' : undefined} />
                 </td>
                 <td style={{ ...td, color: 'var(--text-tertiary)', fontSize: 12 }}>
-                  {l.disbursedAt ? new Date(l.disbursedAt).toLocaleString() : '—'}
+                  {l.disbursedAt ? new Date(l.disbursedAt).toLocaleString(dateLocale) : '—'}
                 </td>
               </tr>
             ))}

--- a/openbank-admin-ui/src/test/console-summary-wiring.test.tsx
+++ b/openbank-admin-ui/src/test/console-summary-wiring.test.tsx
@@ -87,7 +87,9 @@ describe('lending console + aggregates', () => {
     expect(screen.getByText('Active loans').closest('.stat-card')?.textContent).toMatch(/300/)
     // \s, not a literal space: cs-CZ groups thousands with a NON-BREAKING space (U+00A0), so a
     // plain-space regex fails against text that reads identically on screen.
-    expect(screen.getByText('Active loans').closest('.stat-card')?.textContent).toMatch(/7\s100\s000/)
+    expect(screen.getByText('Active loans').closest('.stat-card')?.textContent).toMatch(
+      /7(?:[\s,\u00a0])100(?:[\s,\u00a0])000/,
+    )
     expect(screen.getByText('Loans in trouble').closest('.stat-card')?.textContent).toMatch(/9/)
     // The cap disclosure must be gone: there is nothing truncated to disclose.
     expect(screen.getByTestId('cap-note').textContent).not.toMatch(/NOT in these numbers/)

--- a/openbank-admin-ui/src/test/lending-locale.guard.test.ts
+++ b/openbank-admin-ui/src/test/lending-locale.guard.test.ts
@@ -1,0 +1,15 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+describe('lending locale formatting', () => {
+  it('uses the active language for money and lifecycle timestamps', () => {
+    for (const file of ['src/app/lending/page.tsx', 'src/app/lending/applications/[id]/page.tsx']) {
+      const source = readFileSync(resolve(process.cwd(), file), 'utf8')
+      expect(source).toContain("const numberLocale = language === 'cs' ? 'cs-CZ' : 'en-GB'")
+      expect(source).toContain('toLocaleString(numberLocale)')
+      expect(source).toContain('toLocaleString(dateLocale)')
+      expect(source).not.toContain("toLocaleString('cs-CZ'")
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- format lending amounts and lifecycle timestamps with the active operator locale
- add a regression guard for both lending views

## Verification
- lending locale guard: 1/1
- npm run type-check

## Linked issues
N/A — focused UX localization correction with no new product scope.