### PR TITLE
fix(admin-ui): localize operator timestamps

### DIFF
--- a/openbank-admin-ui/src/app/approvals/page.tsx
+++ b/openbank-admin-ui/src/app/approvals/page.tsx
@@ -46,7 +46,8 @@ const STATE_META: Record<string, { color: string; bg: string; border: string; Ic
 }
 
 export default function ApprovalsPage() {
-  const { t } = useLanguage()
+  const { t, language } = useLanguage()
+  const dateLocale = language === 'cs' ? 'cs-CZ' : 'en-GB'
   const { data: session } = useSession()
   const decidedBy = session?.user?.email || session?.user?.name || 'operator'
 
@@ -166,7 +167,7 @@ export default function ApprovalsPage() {
               <div style={{ fontSize: 11, color: 'var(--text-tertiary)', marginTop: 2 }}>
                 {item.resourceId && <span style={{ fontFamily: 'var(--font-mono)' }}>{item.resourceId} · </span>}
                 {item.maker && <span>{t('navrhl', 'by')} {item.maker}</span>}
-                {item.proposedAt && <span> · {new Date(item.proposedAt).toLocaleString()}</span>}
+                {item.proposedAt && <span> · {new Date(item.proposedAt).toLocaleString(dateLocale)}</span>}
               </div>
             </div>
             <span style={{ fontSize: 10, fontWeight: 700, color: '#d97706', background: '#fffbeb', border: '1px solid #fcd34d', padding: '2px 7px', borderRadius: 20, textTransform: 'uppercase', flexShrink: 0 }}>
@@ -217,7 +218,7 @@ export default function ApprovalsPage() {
                 <span style={{ fontWeight: 700 }}>{t('Navrhovaná akce: ', 'Suggested action: ')}</span>{p.suggestedAction}
               </div>
               <div style={{ fontSize: 11, color: 'var(--text-tertiary)', marginBottom: 10 }}>
-                {t('Navrhl', 'Proposed by')} <b>{p.proposedBy}</b> · {new Date(p.proposedAt).toLocaleString('cs-CZ')}
+                {t('Navrhl', 'Proposed by')} <b>{p.proposedBy}</b> · {new Date(p.proposedAt).toLocaleString(dateLocale)}
               </div>
               <div style={{ display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap' }}>
                 <input

--- a/openbank-admin-ui/src/app/audit/page.tsx
+++ b/openbank-admin-ui/src/app/audit/page.tsx
@@ -27,6 +27,7 @@ const EVENT_COLOR: Record<string, string> = {
 
 export default function AuditPage() {
   const { t, language } = useLanguage()
+  const dateLocale = language === 'cs' ? 'cs-CZ' : 'en-GB'
   const [entries, setEntries]   = useState<AuditEntry[]>([])
   const [loading, setLoading]   = useState(false)
   // Instead of a raw "HTTP 404" string, hold a typed reason that renders as a
@@ -130,7 +131,7 @@ export default function AuditPage() {
                       {e.actorId ? `${e.actorType ?? 'USER'}:${e.actorId.slice(0, 8)}…` : 'system'}
                     </td>
                     <td style={{ fontSize: '12px', color: 'var(--text-muted)', fontFamily: 'var(--font-mono)' }}>
-                      {new Date(e.occurredAt).toLocaleString()}
+                      {new Date(e.occurredAt).toLocaleString(dateLocale)}
                     </td>
                     <td style={{ color: 'var(--accent)', fontSize: '12px' }}>{expanded === e.id ? '▲' : '▼'}</td>
                   </tr>

--- a/openbank-admin-ui/src/app/notifications/page.tsx
+++ b/openbank-admin-ui/src/app/notifications/page.tsx
@@ -31,6 +31,7 @@ const STATUS_COLOR: Record<string, string> = {
 
 export default function NotificationsPage() {
   const { t, language } = useLanguage()
+  const dateLocale = language === 'cs' ? 'cs-CZ' : 'en-GB'
   const { roles } = useAuth()
   const canApprove = hasPermission(roles, 'opsmessage:approve')
   const [items, setItems]     = useState<Notification[]>([])
@@ -148,7 +149,7 @@ export default function NotificationsPage() {
                     </span>
                   </td>
                   <td style={{ fontSize: '12px', color: 'var(--text-muted)' }}>
-                    {n.sentAt ? new Date(n.sentAt).toLocaleString() : '—'}
+                    {n.sentAt ? new Date(n.sentAt).toLocaleString(dateLocale) : '—'}
                   </td>
                 </tr>
               )

--- a/openbank-admin-ui/src/test/ops-locale.guard.test.ts
+++ b/openbank-admin-ui/src/test/ops-locale.guard.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+import fs from 'node:fs'
+import path from 'node:path'
+
+const root = path.resolve(process.cwd(), 'src/app')
+
+describe('operator surfaces use the active locale for timestamps', () => {
+  it('does not leave implicit or fixed-locale date formatting in approvals, notifications, or audit', () => {
+    for (const file of ['approvals/page.tsx', 'notifications/page.tsx', 'audit/page.tsx']) {
+      const source = fs.readFileSync(path.join(root, file), 'utf8')
+      expect(source).toContain("const dateLocale = language === 'cs' ? 'cs-CZ' : 'en-GB'")
+      expect(source).not.toMatch(/toLocaleString\(\)/)
+      expect(source).not.toMatch(/toLocaleString\(['"]cs-CZ['"]\)/)
+      expect(source).not.toMatch(/toLocaleString\(['"]en-GB['"]\)/)
+      expect(source).toMatch(/toLocaleString\(dateLocale\)/)
+    }
+  })
+})


### PR DESCRIPTION
## Summary
Aligns Approvals, Notifications, and Audit timestamps with the active Czech/English locale. Adds a regression guard for implicit or fixed-locale formatting. No BFF, RBAC, or mutation flow changes.

## Linked issues
N/A — localized presentation-only maintenance; no separate issue.