### PR TITLE
refactor(admin-ui): unify operations headers

### DIFF
--- a/openbank-admin-ui/src/app/infrastructure/page.tsx
+++ b/openbank-admin-ui/src/app/infrastructure/page.tsx
@@ -13,6 +13,7 @@ import {
 } from 'lucide-react'
 import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
 import { LifecycleStrip, type CompLifecycle } from '@/components/infra/LifecycleStrip'
+import { PageHeader } from '@/components/ui/PageHeader'
 
 type InfraStatus = 'UP' | 'DOWN' | 'UNKNOWN'
 
@@ -91,6 +92,7 @@ function StatusBadge({ status }: { status: InfraStatus }) {
 
 export default function InfrastructurePage() {
   const { t, language } = useLanguage()
+  const dateLocale = language === 'cs' ? 'cs-CZ' : 'en-GB'
   const [statuses, setStatuses] = useState<Record<string, StatusResult>>({})
   const [unavailable, setUnavailable] = useState<{ kind: UnavailableKind } | null>(null)
   const [loading, setLoading] = useState(true)
@@ -172,19 +174,15 @@ export default function InfrastructurePage() {
 
   return (
     <div style={{ padding: '28px 32px', maxWidth: '1400px', animation: 'fadeIn 0.2s ease-out' }}>
-      <div style={{ marginBottom: '28px', display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between' }}>
-        <div>
-          <h1 style={{ fontSize: '24px', fontWeight: 800, color: 'var(--text-primary)', letterSpacing: '-0.03em', marginBottom: '4px' }}>
-            {t('Infrastruktura', 'Infrastructure')}
-          </h1>
-          <p style={{ fontSize: '13px', color: 'var(--text-secondary)' }}>
-            {t('Zdraví, životní cyklus a zranitelnosti komponent platformy — patch & EoL evidence (ADR-0079, DORA)', 'Component health, lifecycle & vulnerabilities — patch & EoL evidence (ADR-0079, DORA)')}
-          </p>
-        </div>
-        <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
+      <PageHeader
+        breadcrumb={<div className="breadcrumb"><span>OpenBank</span><span className="breadcrumb-sep">/</span><span className="breadcrumb-current">{t('Platforma', 'Platform')}</span></div>}
+        icon={<Server size={20} aria-hidden="true" />}
+        title={t('Infrastruktura', 'Infrastructure')}
+        subtitle={t('Zdraví, životní cyklus a zranitelnosti komponent platformy — patch & EoL evidence (ADR-0079, DORA)', 'Component health, lifecycle & vulnerabilities — patch & EoL evidence (ADR-0079, DORA)')}
+        actions={<div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
           {lastRefresh && (
             <span style={{ fontSize: '11px', color: 'var(--text-tertiary)' }}>
-              {t('Aktualizováno', 'Updated')} {lastRefresh.toLocaleTimeString()}
+              {t('Aktualizováno', 'Updated')} {lastRefresh.toLocaleTimeString(dateLocale)}
             </span>
           )}
           {!loading && !unavailable && (
@@ -206,8 +204,8 @@ export default function InfrastructurePage() {
             <RefreshCw size={13} style={{ animation: loading ? 'spin 0.8s linear infinite' : 'none' }} />
             {t('Obnovit', 'Refresh')}
           </button>
-        </div>
-      </div>
+        </div>}
+      />
 
       {unavailable && (
         <div style={{
@@ -277,7 +275,7 @@ export default function InfrastructurePage() {
                             {t('Ověřeno', 'Checked')}
                           </div>
                           <div style={{ fontSize: '11px', color: 'var(--text-secondary)', fontFamily: 'monospace' }}>
-                            {new Date(st.checkedAt).toLocaleTimeString()}
+                            {new Date(st.checkedAt).toLocaleTimeString(dateLocale)}
                           </div>
                         </div>
                       )}

--- a/openbank-admin-ui/src/app/swift/page.tsx
+++ b/openbank-admin-ui/src/app/swift/page.tsx
@@ -13,6 +13,7 @@ import { useServiceResource } from '@/lib/services/useServiceResource'
 import { stashRow } from '@/lib/services/rowHandoff'
 import { DataUnavailable } from '@/components/feedback/DataUnavailable'
 import { ServiceStatusBadge } from '@/components/feedback/ServiceStatusBadge'
+import { PageHeader } from '@/components/ui/PageHeader'
 
 interface SwiftMessage {
   id: string; messageType: string; senderBic: string; receiverBic: string
@@ -28,6 +29,8 @@ const STATUS_COLORS: Record<string, { bg: string; text: string; border: string }
 
 export default function SwiftPage() {
   const { t, language } = useLanguage()
+  const dateLocale = language === 'cs' ? 'cs-CZ' : 'en-GB'
+  const numberLocale = dateLocale
   const router = useRouter()
   const [search, setSearch] = useState('')
   const { data, loading, unavailable, waking } = useServiceResource<SwiftMessage[]>(
@@ -46,16 +49,12 @@ export default function SwiftPage() {
   return (
     <AuthGuard>
       <div style={{ padding: '28px 32px', maxWidth: '1400px', animation: 'fadeIn 0.2s ease-out' }}>
-        <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', marginBottom: '28px' }}>
-          <div>
-            <h1 style={{ fontSize: '24px', fontWeight: 800, color: 'var(--text-primary)', letterSpacing: '-0.03em', marginBottom: '4px' }}>
-              {t('SWIFT zprávy', 'SWIFT Messaging')}
-            </h1>
-            <p style={{ fontSize: '13px', color: 'var(--text-secondary)' }}>
-              {t('Mezinárodní platby a SWIFT MT/MX zprávy — ISO 20022', 'International payments and SWIFT MT/MX messages — ISO 20022')}
-            </p>
-          </div>
-          <div style={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
+        <PageHeader
+          breadcrumb={<div className="breadcrumb"><span>OpenBank</span><span className="breadcrumb-sep">/</span><span className="breadcrumb-current">{t('SWIFT', 'SWIFT')}</span></div>}
+          icon={<Globe size={20} aria-hidden="true" />}
+          title={t('SWIFT zprávy', 'SWIFT Messaging')}
+          subtitle={t('Mezinárodní platby a SWIFT MT/MX zprávy — ISO 20022', 'International payments and SWIFT MT/MX messages — ISO 20022')}
+          actions={<div style={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
             <ServiceStatusBadge
               label="swift-service :8122"
               loading={loading}
@@ -71,8 +70,8 @@ export default function SwiftPage() {
             <span role="status" style={{ padding: '5px 9px', borderRadius: '6px', border: '1px solid var(--warning-border)', background: 'var(--warning-bg)', color: 'var(--warning-text)', fontSize: '11px', fontWeight: 600 }}>
               {t('Odeslání zprávy není připojeno', 'Message submission is not connected')}
             </span>
-          </div>
-        </div>
+          </div>}
+        />
 
         <div className="grid-4" style={{ marginBottom: '24px' }}>
           {[
@@ -130,14 +129,14 @@ export default function SwiftPage() {
                     <td style={{ padding: '12px 16px', fontFamily: 'var(--font-mono)', fontSize: '12px', color: 'var(--text-primary)' }}>{m.senderBic}</td>
                     <td style={{ padding: '12px 16px', fontFamily: 'var(--font-mono)', fontSize: '12px', color: 'var(--text-primary)' }}>{m.receiverBic}</td>
                     <td style={{ padding: '12px 16px', fontFamily: 'var(--font-mono)', fontSize: '13px', color: 'var(--text-primary)' }}>
-                      {m.amount?.toLocaleString('cs-CZ', { minimumFractionDigits: 2 })} {m.currency}
+                      {m.amount?.toLocaleString(numberLocale, { minimumFractionDigits: 2 })} {m.currency}
                     </td>
                     <td style={{ padding: '12px 16px', fontFamily: 'var(--font-mono)', fontSize: '11px', color: 'var(--text-tertiary)' }}>{m.reference}</td>
                     <td style={{ padding: '12px 16px' }}>
                       <span style={{ padding: '2px 8px', borderRadius: '10px', fontSize: '11px', fontWeight: 600,
                         background: sc.bg, color: sc.text, border: `1px solid ${sc.border}` }}>{m.status}</span>
                     </td>
-                    <td style={{ padding: '12px 16px', fontSize: '12px', color: 'var(--text-tertiary)' }}>{m.createdAt ? new Date(m.createdAt).toLocaleDateString('cs-CZ') : '—'}</td>
+                    <td style={{ padding: '12px 16px', fontSize: '12px', color: 'var(--text-tertiary)' }}>{m.createdAt ? new Date(m.createdAt).toLocaleDateString(dateLocale) : '—'}</td>
                     <td style={{ padding: '12px 8px', textAlign: 'right' }}><ChevronRight size={14} style={{ color: 'var(--text-tertiary)' }} /></td>
                   </tr>
                 )

--- a/openbank-admin-ui/src/app/system/inventory/page.tsx
+++ b/openbank-admin-ui/src/app/system/inventory/page.tsx
@@ -10,6 +10,7 @@ import { fetchAllServiceSnapshots } from '@/lib/api'
 import type { ServiceSnapshot, ServiceStack } from '@/types'
 import { Package, RefreshCw, CheckCircle2, AlertTriangle, XCircle, Clock, ShieldAlert } from 'lucide-react'
 import { SbomViewer } from '@/components/sbom/SbomViewer'
+import { PageHeader } from '@/components/ui/PageHeader'
 
 const POLL = 30_000
 
@@ -117,7 +118,8 @@ function aggregate(snapshots: ServiceSnapshot[]): ComponentAggregate[] {
 }
 
 export default function TechInventoryPage() {
-  const { t } = useLanguage()
+  const { t, language } = useLanguage()
+  const dateLocale = language === 'cs' ? 'cs-CZ' : 'en-GB'
   const [snapshots, setSnapshots] = useState<ServiceSnapshot[]>([])
   const [loading, setLoading] = useState(true)
   const [lastRefreshed, setLastRefreshed] = useState<Date | null>(null)
@@ -163,22 +165,16 @@ export default function TechInventoryPage() {
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
-      {/* Page header */}
-      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-        <div>
-          <h1 style={{ fontSize: '24px', fontWeight: 300, color: 'var(--text-primary)', letterSpacing: '-0.02em', margin: 0 }}>
-            <Package size={20} style={{ display: 'inline', marginRight: '8px', verticalAlign: '-2px' }} />
-            {t('Tech Inventory', 'Tech Inventory')}
-          </h1>
-          <div style={{ fontSize: '12px', color: 'var(--text-tertiary)', marginTop: '4px' }}>
-            {t('Verze runtime stacku napříč všemi službami. Generuje se z /api/v1/info každé služby.',
-               'Runtime stack versions across all services. Sourced from each service\'s /api/v1/info.')}
-          </div>
-        </div>
-        <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
+      <PageHeader
+        breadcrumb={<div className="breadcrumb"><span>OpenBank</span><span className="breadcrumb-sep">/</span><span className="breadcrumb-current">{t('Systém', 'System')}</span></div>}
+        icon={<Package size={20} aria-hidden="true" />}
+        title={t('Tech Inventory', 'Tech Inventory')}
+        subtitle={t('Verze runtime stacku napříč všemi službami. Generuje se z /api/v1/info každé služby.',
+          'Runtime stack versions across all services. Sourced from each service\'s /api/v1/info.')}
+        actions={<div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
           {lastRefreshed && (
             <span style={{ fontSize: '11px', color: 'var(--text-tertiary)', display: 'flex', alignItems: 'center', gap: '4px' }}>
-              <Clock size={11} /> {lastRefreshed.toLocaleTimeString()}
+              <Clock size={11} aria-hidden="true" /> {lastRefreshed.toLocaleTimeString(dateLocale)}
             </span>
           )}
           <button
@@ -193,8 +189,8 @@ export default function TechInventoryPage() {
             <RefreshCw size={12} style={{ animation: refreshing ? 'spin 1s linear infinite' : undefined }} />
             {t('Obnovit', 'Refresh')}
           </button>
-        </div>
-      </div>
+        </div>}
+      />
 
       {/* Summary cards */}
       <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: '12px' }}>

--- a/openbank-admin-ui/src/test/ops-header-locale.guard.test.ts
+++ b/openbank-admin-ui/src/test/ops-header-locale.guard.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import fs from 'node:fs'
+import path from 'node:path'
+
+describe('legacy operator surfaces use the shared header and active locale', () => {
+  it('migrates the three pages without implicit or fixed locale timestamps', () => {
+    for (const file of ['swift/page.tsx', 'infrastructure/page.tsx', 'system/inventory/page.tsx']) {
+      const source = fs.readFileSync(path.join(process.cwd(), 'src/app', file), 'utf8')
+      expect(source).toContain('PageHeader')
+      expect(source).toContain("const dateLocale = language === 'cs' ? 'cs-CZ' : 'en-GB'")
+      expect(source).not.toMatch(/toLocaleTimeString\(\)/)
+      expect(source).not.toMatch(/toLocaleTimeString\(['"](?:cs-CZ|en-US|en-GB)['"]\)/)
+      expect(source).not.toMatch(/toLocaleDateString\(\)/)
+      expect(source).not.toMatch(/toLocaleDateString\(['"](?:cs-CZ|en-US|en-GB)['"]\)/)
+      expect(source).not.toMatch(/toLocaleString\(['"](?:cs-CZ|en-US|en-GB)['"]\)/)
+    }
+    const swift = fs.readFileSync(path.join(process.cwd(), 'src/app/swift/page.tsx'), 'utf8')
+    expect(swift).toContain('const numberLocale = dateLocale')
+    expect(swift).toMatch(/toLocaleString\(numberLocale/)
+    expect(swift).toMatch(/toLocaleDateString\(dateLocale\)/)
+  })
+})


### PR DESCRIPTION
## Summary
Unifies the legacy Swift, Infrastructure, and Tech Inventory surfaces on PageHeader and applies active Czech/English timestamp formatting. Adds a regression guard for the shared header/locale contract. Data reads, BFF paths, RBAC, and actions are unchanged.

## Linked issues
N/A — presentation and accessibility maintenance; no separate issue.