### PR TITLE
refactor(admin-ui): unify legacy headers

### DIFF
--- a/openbank-admin-ui/src/app/finops/allocation/page.tsx
+++ b/openbank-admin-ui/src/app/finops/allocation/page.tsx
@@ -13,6 +13,7 @@ import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { AuthGuard } from '@/components/auth/AuthGuard'
 import { DataUnavailable } from '@/components/feedback/DataUnavailable'
 import type { UnavailableKind } from '@/components/feedback/DataUnavailable'
+import { PageHeader } from '@/components/ui/PageHeader'
 
 // Cost-allocation (showback) view — ADR-0062. Reads /api/finops/allocation, which joins the AWS
 // cost snapshot with build-time resource footprints and rolls spend up service -> domain -> flow.
@@ -131,25 +132,12 @@ function AllocationContent() {
 
   return (
     <div style={{ padding: '28px 32px', maxWidth: '1400px', animation: 'fadeIn 0.2s ease-out' }}>
-      <div style={{ marginBottom: '24px', display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between' }}>
-        <div>
-          <div className="breadcrumb">
-            <span>OpenBank</span><span className="breadcrumb-sep">/</span>
-            <Link href="/finops" style={{ color: 'inherit', textDecoration: 'none' }}>FinOps</Link>
-            <span className="breadcrumb-sep">/</span>
-            <span className="breadcrumb-current">{t('Rozpad nákladů', 'Cost Allocation')}</span>
-          </div>
-          <h1 style={{ fontSize: '24px', fontWeight: 800, color: 'var(--text-primary)', margin: '8px 0 4px', letterSpacing: '-0.03em' }}>
-            {t('Rozpad nákladů', 'Cost Allocation')}
-          </h1>
-          <p style={{ fontSize: '13px', color: 'var(--text-secondary)', margin: 0 }}>
-            {t(
-              'Cloud útraty rozpočítané po službě, doméně a business procesu — showback dle požadovaných zdrojů (ADR-0062)',
-              'Cloud spend split by service, domain and business flow — requests-weighted showback (ADR-0062)',
-            )}
-          </p>
-        </div>
-        <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
+      <PageHeader
+        breadcrumb={<div className="breadcrumb"><span>OpenBank</span><span className="breadcrumb-sep">/</span><Link href="/finops" style={{ color: 'inherit', textDecoration: 'none' }}>FinOps</Link><span className="breadcrumb-sep">/</span><span className="breadcrumb-current">{t('Rozpad nákladů', 'Cost Allocation')}</span></div>}
+        icon={<DollarSign size={20} aria-hidden="true" />}
+        title={t('Rozpad nákladů', 'Cost Allocation')}
+        subtitle={t('Cloud útraty rozpočítané po službě, doméně a business procesu — showback dle požadovaných zdrojů (ADR-0062)', 'Cloud spend split by service, domain and business flow — requests-weighted showback (ADR-0062)')}
+        actions={<div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
           <Link href="/finops" style={{ display: 'flex', alignItems: 'center', gap: '6px', padding: '7px 14px',
             borderRadius: '8px', border: '1px solid var(--border)', background: 'var(--surface)',
             color: 'var(--text-secondary)', fontSize: '12px', textDecoration: 'none' }}>
@@ -162,8 +150,8 @@ function AllocationContent() {
             <RefreshCw size={13} style={{ animation: loading ? 'spin 0.8s linear infinite' : 'none' }} />
             {t('Obnovit', 'Refresh')}
           </button>
-        </div>
-      </div>
+        </div>}
+      />
 
       {loading && !data ? (
         <div style={{ display: 'flex', alignItems: 'center', gap: '10px', padding: '40px', color: 'var(--text-tertiary)' }}>

--- a/openbank-admin-ui/src/app/observability/stack/page.tsx
+++ b/openbank-admin-ui/src/app/observability/stack/page.tsx
@@ -10,6 +10,7 @@ import {
   Globe, Bot,
 } from 'lucide-react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
+import { PageHeader } from '@/components/ui/PageHeader'
 
 // Static explainer — the LGTM(P) + GlitchTip correlation layer (ADR-0087), extended with
 // SLO-as-code, on-call, durable S3 retention and mobile RUM (ADR-0088 / ADR-0089). No backend
@@ -115,19 +116,12 @@ export default function ObservabilityStackPage() {
 
   return (
     <div style={{ maxWidth: '1200px', margin: '0 auto' }}>
-      {/* Title */}
-      <div style={{ marginBottom: '24px' }}>
-        <div style={{ fontSize: '11px', fontWeight: 700, letterSpacing: '0.08em', textTransform: 'uppercase', color: 'var(--text-secondary)', marginBottom: '6px' }}>
-          {t('Observability · ADR-0087 / 0088 / 0089', 'Observability · ADR-0087 / 0088 / 0089')}
-        </div>
-        <h1 style={{ fontSize: '24px', fontWeight: 800, letterSpacing: '-0.02em', margin: 0 }}>
-          {t('Jak funguje náš observability stack', 'How our observability stack works')}
-        </h1>
-        <p style={{ fontSize: '14px', color: 'var(--text-secondary)', marginTop: '8px', lineHeight: 1.6 }}>
-          {t('Čtyři pilíře (metriky, logy, traces, profily) + mobilní pády se sbíhají do jednoho plátna v Grafaně; na to navazuje SLO-as-code (Pyrra), on-call s eskalací (GoAlert → ntfy), trvanlivé úložiště v S3, mobilní RUM, syntetické proby zvenčí (blackbox + k6) a AI root-cause analýza nad alerty (HolmesGPT). Páteří je trace_id a X-Correlation-ID — z každého bodu se proklikneš do souvisejícího kontextu. Vše čistě open-source, self-hosted, ve VPC.',
-             'Four pillars (metrics, logs, traces, profiles) + mobile crashes converge into one pane in Grafana; on top sit SLO-as-code (Pyrra), on-call with escalation (GoAlert → ntfy), durable S3 storage, mobile RUM, external synthetic probes (blackbox + k6) and AI root-cause analysis over alerts (HolmesGPT). The spine is trace_id and X-Correlation-ID — from any point you click through to the related context. All pure OSS, self-hosted, in-VPC.')}
-        </p>
-      </div>
+      <PageHeader
+        breadcrumb={<div className="breadcrumb"><span>OpenBank</span><span className="breadcrumb-sep">/</span><span className="breadcrumb-current">{t('Observabilita', 'Observability')}</span></div>}
+        icon={<Globe size={20} aria-hidden="true" />}
+        title={t('Jak funguje náš observability stack', 'How our observability stack works')}
+        subtitle={t('Čtyři pilíře (metriky, logy, traces, profily) + mobilní pády se sbíhají do jednoho plátna v Grafaně; na to navazuje SLO-as-code (Pyrra), on-call s eskalací (GoAlert → ntfy), trvanlivé úložiště v S3, mobilní RUM, syntetické proby zvenčí (blackbox + k6) a AI root-cause analýza nad alerty (HolmesGPT). Páteří je trace_id a X-Correlation-ID — z každého bodu se proklikneš do souvisejícího kontextu. Vše čistě open-source, self-hosted, ve VPC.', 'Four pillars (metrics, logs, traces, profiles) + mobile crashes converge into one pane in Grafana; on top sit SLO-as-code (Pyrra), on-call with escalation (GoAlert → ntfy), durable S3 storage, mobile RUM, external synthetic probes (blackbox + k6) and AI root-cause analysis over alerts (HolmesGPT). The spine is trace_id and X-Correlation-ID — from any point you click through to the related context. All pure OSS, self-hosted, in-VPC.')}
+      />
 
       {/* Pillar cards */}
       <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(240px, 1fr))', gap: '14px', marginBottom: '28px' }}>

--- a/openbank-admin-ui/src/test/legacy-header.guard.test.ts
+++ b/openbank-admin-ui/src/test/legacy-header.guard.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+import fs from 'node:fs'
+import path from 'node:path'
+
+describe('legacy operational pages use the shared PageHeader contract', () => {
+  it('keeps a single structured header with breadcrumb and decorative icon', () => {
+    for (const file of ['finops/allocation/page.tsx', 'observability/stack/page.tsx']) {
+      const source = fs.readFileSync(path.join(process.cwd(), 'src/app', file), 'utf8')
+      expect(source).toContain('PageHeader')
+      expect(source).toContain('className="breadcrumb"')
+      expect(source).toContain('aria-hidden="true"')
+      expect(source).not.toMatch(/<h1\b/)
+    }
+  })
+})


### PR DESCRIPTION
## Summary
Unifies FinOps Cost Allocation and Observability Stack on the shared PageHeader contract with structured breadcrumbs and decorative icons. Adds a regression guard. Data links and read-only behavior are unchanged.

## Linked issues
N/A — presentation and accessibility maintenance; no separate issue.