### PR TITLE
feat(ci): isolate provider-pact verification from main-push build (ADR-0250 Phase 2)

### DIFF
--- a/.github/scripts/check-gradle-cache-writers.py
+++ b/.github/scripts/check-gradle-cache-writers.py
@@ -121,11 +121,24 @@ DECLARED: dict[str, tuple[str, str]] = {
         "Same Linux-ARM64 scope and the same reasoning as auto-deploy's build-push.",
     ),
     "_service-ci.yml::build": (
-        "conditional",
-        "Provably never writes, by two complementary expressions: `cache-disabled` on "
-        "self-hosted (ARC NAT egress, ~$200/mo) and `cache-read-only` on GitHub-hosted. "
-        "Declared so that changing EITHER expression alone — which would silently re-arm "
-        "26 per-service writers — shows up here.",
+        "read-only",
+        "ADR-0250 Phase 2 split the old single self-hosted-or-GitHub-hosted job in two: "
+        "`build` is now ALWAYS GitHub-hosted (never self-hosted), so its Gradle-cache "
+        "inputs are literal (`cache-disabled: false`, `cache-read-only: true`) rather "
+        "than the `runner.environment`-conditioned expressions the pre-split job used — "
+        "there is no longer a self-hosted branch here to make this `conditional`. The "
+        "self-hosted, cache-disabled leg (ARC NAT egress, ~$200/mo) moved to the new "
+        "`contract` job below.",
+    ),
+    "_service-ci.yml::contract": (
+        "disabled",
+        "ADR-0250 Phase 2: the self-hosted half of the pre-split `build` job (ARC NAT "
+        "egress FinOps, ~$200/mo — ties GitHub Actions cache off entirely and relies on "
+        "the in-cluster remote Gradle build cache instead, GRADLE_REMOTE_CACHE_URL via "
+        "arc-runners.tf, ADR-0043). Runs only on main push/dispatch to publish provider-"
+        "pact verification, never on a PR, so it costs the writer budget nothing either "
+        "way — declared for the same reason `build` is: so a change to `cache-disabled` "
+        "here shows up.",
     ),
     "api-fuzz.yml::fuzz": ("read-only", "Consumer; restores fleet-lint's home."),
     "api-fuzz-authenticated.yml::fuzz-authenticated": (

--- a/.github/workflows/_service-ci.yml
+++ b/.github/workflows/_service-ci.yml
@@ -260,16 +260,19 @@ jobs:
           shopt -s nullglob
           files=(pacts/${{ inputs.service }}-*.json)
           for f in "${files[@]}"; do cp "$f" pact-handoff/; done
-          echo "pact-count=${#files[@]}" > pact-handoff/.manifest
+          echo "pact-count=${#files[@]}" > pact-handoff/manifest.txt
           echo "Collected ${#files[@]} consumer pact file(s) for hand-off."
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: consumer-pacts-${{ inputs.service }}
           path: pact-handoff/
-          # `.manifest` is always written above, so an empty consumer-pact set still
+          # `manifest.txt` is always written above, so an empty consumer-pact set still
           # produces a non-empty artifact — "if-no-files-found" only fires if the whole
           # collection step never ran, which should already have failed the job outright.
+          # NOT named `.manifest`: actions/upload-artifact defaults to
+          # include-hidden-files: false, so a dotfile-only directory silently uploads as
+          # empty and if-no-files-found fires anyway, even though the step above ran fine.
           if-no-files-found: error
           retention-days: 3
 
@@ -577,11 +580,11 @@ jobs:
       - name: Stage handed-off consumer pacts into pacts/
         run: |
           set -euo pipefail
-          if [ ! -f pact-handoff/.manifest ]; then
-            echo "::error::pact hand-off artifact from the build job has no .manifest — treating this as a failed hand-off, not an empty consumer-pact set (the build job always writes one)."
+          if [ ! -f pact-handoff/manifest.txt ]; then
+            echo "::error::pact hand-off artifact from the build job has no manifest.txt — treating this as a failed hand-off, not an empty consumer-pact set (the build job always writes one)."
             exit 1
           fi
-          cat pact-handoff/.manifest
+          cat pact-handoff/manifest.txt
           mkdir -p pacts
           shopt -s nullglob
           files=(pact-handoff/*.json)

--- a/.github/workflows/_service-ci.yml
+++ b/.github/workflows/_service-ci.yml
@@ -15,6 +15,25 @@
 #    `endpoint with name openbank-kafka already exists` / `Connection refused`.
 #  - Services with no infra-touching @QuarkusTest (anacredit, product-catalog, …) and
 #    pure-unit modules need nothing here; their tests boot no containers at all.
+#
+# ADR-0250 Phase 2 (issue #4414): this file used to be a SINGLE job that ran `build`
+# (compile/test/quarkusBuild/consumer-pact generation) AND provider-verification against the
+# Pact Broker as one unit, on the scarce self-hosted `openbank-build` ARC pool on every
+# main push — because provider verification needs in-cluster DNS to reach the broker
+# (ADR-0056: no public ingress). Filtering which TESTS ran with `--tests` never decoupled the
+# two: `-Dpactbroker.url` is a tracked INPUT of the `test` task, so a broker-configured
+# invocation is always a different Gradle cache key from an unconfigured one, forcing a full
+# recompile+retest regardless of what `--tests` selects. It is now split into two jobs:
+#   - `build`  — compile, `test` (incl. consumer-pact generation), quarkusBuild. Hosted
+#     (`ubuntu-latest`, free/unlimited on this public repo), for EVERY event including
+#     main-push. Uploads this service's freshly-generated consumer pacts as an artifact.
+#   - `contract` — provider verification against the Pact Broker + publishing consumer
+#     pacts. Stays on `openbank-build` (in-cluster ARC, the only pool that resolves the
+#     broker's cluster-DNS name) and runs ONLY on a main push / an on-main workflow_dispatch
+#     (verify-provider.yml). Downloads `build`'s pact artifact rather than regenerating it —
+#     a missing/failed download FAILS the job (no silent skip): see the download step.
+#     Runs the `providerPactTest` Gradle task (build-logic/openbank.quarkus-service.gradle.kts)
+#     — a source set/task independent of `test`, so invoking it never forces `test` to re-run.
 name: _service-ci
 
 on:
@@ -54,96 +73,264 @@ on:
 permissions:
   contents: read
   # GitHub OIDC → assume openbank-arc-build-runner for ECR auth (see the "Authenticate to
-  # ECR via OIDC" step). Needed on the Hetzner self-hosted pool, which has no ambient AWS
-  # creds (no EKS Pod Identity); harmless on the ARC pool.
+  # ECR via OIDC" step, `contract` job). Needed on the Hetzner self-hosted pool, which has
+  # no ambient AWS creds (no EKS Pod Identity); harmless on the ARC pool.
   id-token: write
 
 jobs:
+  # ── build: compile, test, quarkusBuild, consumer-pact generation ────────────────────────
+  # Hosted, every event (PR, push, schedule, workflow_dispatch) — free/unlimited on this
+  # public repo (ADR-0250). Never touches the Pact Broker: PACT_BROKER_URL is not set here
+  # at all, so the @PactBroker-annotated provider-verification classes stay
+  # @EnabledIfSystemProperty-skipped (identical to the pre-existing PR-lane behaviour) and
+  # the git-pact (@PactFolder) classes run unconditionally, same as before.
   build:
-    name: ${{ inputs.service }}
-    # Split lane (FinOps, public repo): PR and nightly/scheduled builds run on free
-    # unlimited GitHub-hosted runners (4 vCPU/16 GB on public repos) — same
-    # no-broker/no-ECR environment a fork PR already gets. ONLY the main-PUSH build
-    # stays on the self-hosted pool (ARC scale-to-zero): the Pact broker has no
-    # public ingress (ADR-0056) and provider verification results MUST be published
-    # from the main-push build or can-i-deploy blocks the auto-deploy of that SHA.
-    # KEEP THIS EXPRESSION IN LOCKSTEP with the PACT_BROKER_URL env below — a hosted
-    # runner with a set (unreachable) broker URL fails the provider tests instead
-    # of skipping them.
-    # workflow_dispatch (verify-provider.yml, #2039) also runs on the ARC pool so a single
-    # provider can re-verify + re-publish without a full-fleet run. KEEP IN LOCKSTEP with PACT_BROKER_URL.
-    runs-on: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main' && 'openbank-build' || 'ubuntu-latest' }}
+    name: ${{ inputs.service }} (build)
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    env:
+      GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx3g -Dfile.encoding=UTF-8"
+      # Force a UTF-8 locale so the JVM's sun.jnu.encoding (the *filename* charset,
+      # derived from the OS locale at startup — NOT from -Dfile.encoding) is UTF-8.
+      # Kotlin test names with non-ASCII chars (e.g. a Czech '—' em-dash) otherwise produce
+      # an unmappable .class path -> InvalidPathException -> compileTestKotlin internal
+      # compiler error.
+      LANG: C.UTF-8
+      LC_ALL: C.UTF-8
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.ref != '' && inputs.ref || '' }}
+          fetch-depth: ${{ inputs.ref == '' && 1 || 0 }}
+
+      # Resolve GRADLE_USER_HOME. This job is ALWAYS `runner.environment == 'github-hosted'`
+      # now (never self-hosted), so it always takes the default-home branch below — restoring
+      # the warm cache fleet-lint keeps on main via setup-gradle's cross-job cache restore.
+      # NOTE: env context is NOT available in job-level env: blocks of reusable workflows
+      # (workflow_call) — GitHub rejects "Unrecognized named-value: 'env'" at parse time —
+      # so this is resolved in a step where env IS available, same as the original single job.
+      - name: Resolve GRADLE_USER_HOME
+        run: echo "GRADLE_USER_HOME=${HOME}/.gradle" >> "$GITHUB_ENV"
+
+      # Warm this service's Gradle dependency cache BEFORE "Build + test" runs, so an
+      # interrupted-download-corrupted module cache entry is caught and healed HERE, not
+      # inside "Build + test" (which must run exactly once — see the ADVISORY note below).
+      - name: Warm Gradle dependency cache (self-heal corrupted entries)
+        continue-on-error: true
+        run: |
+          set +e
+          timeout 120s ./gradlew :${{ inputs.service }}:quarkusDependenciesBuild --console=plain > /tmp/gradle-warmup.log 2>&1
+          warmup_status=$?
+          if [ $warmup_status -eq 124 ]; then
+            echo "::warning::dependency warm-up timed out after 120s; skipping advisory cache healing and continuing to mandatory Build + test"
+            cat /tmp/gradle-warmup.log
+          elif [ $warmup_status -ne 0 ]; then
+            cat /tmp/gradle-warmup.log
+            if .github/scripts/heal-gradle-verification-failure.sh /tmp/gradle-warmup.log; then
+              echo "retrying dependency warm-up after healing corrupted cache entries"
+              timeout 120s ./gradlew :${{ inputs.service }}:quarkusDependenciesBuild --console=plain
+              retry_status=$?
+              if [ $retry_status -eq 124 ]; then
+                echo "::warning::dependency warm-up retry timed out after 120s; continuing to mandatory Build + test"
+              fi
+            else
+              echo "::warning::dependency warm-up failed for a reason other than cache corruption — leaving it to the real Build step to report"
+            fi
+          fi
+
+      # Normalize the Testcontainers Docker endpoint. GitHub-hosted runners already ship
+      # Docker at the standard unix socket, but this keeps the same normalization as the
+      # self-hosted `contract` job (#873) in case DOCKER_HOST is ever set ambiently.
+      - name: Normalize DOCKER_HOST for Testcontainers (#873)
+        run: |
+          if [ -z "${DOCKER_HOST:-}" ] || [ "${DOCKER_HOST:-}" = "tcp://localhost:2375" ]; then
+            echo "DOCKER_HOST=unix:///var/run/docker.sock" >> "$GITHUB_ENV"
+            echo "normalized DOCKER_HOST -> unix:///var/run/docker.sock"
+          else
+            echo "DOCKER_HOST left as: ${DOCKER_HOST}"
+          fi
+
+      # Raise fs.aio-max-nr so parallel Testcontainers don't exhaust the kernel's default
+      # 65536 AIO pool (Redpanda/Seastar + Quarkus reactive). Advisory, best-effort; a
+      # GitHub-hosted runner is an isolated VM so this is safe to attempt unconditionally.
+      - name: Raise fs.aio-max-nr for Testcontainers (best-effort, Linux)
+        continue-on-error: true
+        timeout-minutes: 1
+        run: |
+          cur=$(cat /proc/sys/fs/aio-max-nr 2>/dev/null || echo 0)
+          if [ "${cur:-0}" -lt 1048576 ]; then
+            if sudo -n sysctl -w fs.aio-max-nr=1048576 >/dev/null 2>&1; then
+              echo "raised fs.aio-max-nr: ${cur} -> 1048576"
+            else
+              echo "::warning::could not raise fs.aio-max-nr (currently ${cur}); parallel Testcontainers may exhaust the AIO pool on this runner (no passwordless sudo?)"
+            fi
+          else
+            echo "fs.aio-max-nr already ${cur} (>= 1048576)"
+          fi
+
+      # Most modules pin kotlin { jvmToolchain(25) }; a few use 21. Installing both
+      # lets Gradle's toolchain resolution pick the right one with zero Foojay
+      # downloads at build time (faster, fewer billed minutes).
+      - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
+        with:
+          distribution: temurin
+          java-version: |
+            21
+            25
+
+      - name: Validate Gradle wrapper
+        uses: gradle/actions/wrapper-validation@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
+
+      - uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
+        with:
+          # This job is always GitHub-hosted now — the Actions cache is network-internal
+          # and free there, and there is no in-cluster remote build cache to fall back on
+          # (that cache is only reachable from ARC pods, see the `contract` job below).
+          cache-disabled: false
+          # RESTORE the warm cache fleet-lint keeps on main, but never WRITE — writing 40+
+          # per-service home caches on PR branches would churn the Actions cache quota.
+          cache-read-only: true
+          gradle-home-cache-strict-match: false
+
+      # No `-Dpactbroker.*` flags here at all (unlike the pre-split single job): this job
+      # never has a broker URL to forward, so the @PactBroker-gated provider-verification
+      # test stays skipped and there is no #1009-style cache-key hazard to guard against —
+      # `test` here has ONE stable set of inputs regardless of which event triggered it.
+      # -Dquarkus.smallrye-openapi.store-schema-directory writes the document Quarkus
+      # actually serves, as a side effect of the SAME quarkusBuild task this :build already
+      # runs. Read by the openapi-request-schema-conformance step below.
+      - name: Build + test (:${{ inputs.service }})
+        run: |
+          ./gradlew :${{ inputs.service }}:build --build-cache --console=plain --stacktrace \
+            -Dquarkus.smallrye-openapi.store-schema-directory="${{ inputs.service }}/build/openapi-generated"
+
+      # A Docker Hub pull failure surfaces as NAMED TEST FAILURES, ~900 lines above the actual
+      # cause, so the reader goes hunting for a test bug that is not there. Diagnostic only:
+      # it reads JUnit XML already on disk, always exits 0, and can never change the verdict.
+      - name: "Explain a Docker registry pull failure (diagnostic)"
+        if: failure()
+        run: |
+          python3 .github/scripts/check-testcontainers-registry-failure.py \
+            --service "${{ inputs.service }}"
+
+      # rules.yaml: openapi_request_schema_conformance (advisory).
+      - name: "openapi request-schema conformance (advisory)"
+        run: |
+          SPEC="${{ inputs.service }}/src/main/resources/openapi.yaml"
+          if [ ! -f "$SPEC" ]; then
+            echo "openapi-request-schema-conformance: ${{ inputs.service }} has no openapi.yaml — skipping."
+            exit 0
+          fi
+          python3 .github/scripts/check-openapi-request-schema-conformance.py \
+            --service "${{ inputs.service }}" \
+            --generated "${{ inputs.service }}/build/openapi-generated/openapi.yaml"
+
+      # Coverage upload (Codecov is free for public repos; tokenless via the OIDC
+      # id-token this job already has). Advisory only — never gates the build.
+      # koverVerify stays the enforcement mechanism (ratchet-only, rules.yaml).
+      #
+      # No -D pact flags to mirror here (unlike the pre-split single job's #1009 workaround):
+      # `test` above never touched pactbroker.* either, so this is a plain up-to-date/cached
+      # second invocation of the same, single-shaped `test` task.
+      - name: Generate Kover XML report
+        continue-on-error: true
+        run: ./gradlew :${{ inputs.service }}:koverXmlReport --build-cache --console=plain
+
+      - name: Upload coverage to Codecov
+        continue-on-error: true
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        with:
+          files: ${{ inputs.service }}/build/reports/kover/report.xml
+          flags: ${{ inputs.service }}
+          use_oidc: true
+          fail_ci_if_error: false
+
+      # Consumer pacts this service just (re)generated (pact.rootDir -> repo /pacts, ADR-0063)
+      # are handed to the `contract` job as an artifact rather than regenerated there — the
+      # `contract` job runs on a DIFFERENT runner pool and re-running `test` there is exactly
+      # the redundant work ADR-0250 Phase 2 removes. Always upload something (even zero pact
+      # files, the common case for a pure provider or a service with no consumer contracts) so
+      # a MISSING artifact on the `contract` side unambiguously means this job never ran or
+      # never reached this step — never "this service has no consumer pacts", which is instead
+      # expressed by an empty `pact-count` in the manifest (see the download step).
+      - name: Collect consumer pacts for hand-off to the contract job
+        run: |
+          set -euo pipefail
+          mkdir -p pact-handoff
+          shopt -s nullglob
+          files=(pacts/${{ inputs.service }}-*.json)
+          for f in "${files[@]}"; do cp "$f" pact-handoff/; done
+          echo "pact-count=${#files[@]}" > pact-handoff/.manifest
+          echo "Collected ${#files[@]} consumer pact file(s) for hand-off."
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: consumer-pacts-${{ inputs.service }}
+          path: pact-handoff/
+          # `.manifest` is always written above, so an empty consumer-pact set still
+          # produces a non-empty artifact — "if-no-files-found" only fires if the whole
+          # collection step never ran, which should already have failed the job outright.
+          if-no-files-found: error
+          retention-days: 3
+
+      # Only on failure: a passing build's test reports are never looked at, but uploading
+      # them on EVERY service build was a dominant driver of GitHub Actions artifact-storage
+      # churn — bursts during a full-fleet rebuild hit the quota and failed unrelated uploads.
+      - name: Upload test reports
+        if: failure()
+        continue-on-error: true
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          # `-a${{ github.run_attempt }}` is not cosmetic — an artifact name must be unique
+          # WITHIN A RUN, and re-running a failed job is a new attempt of the SAME run.
+          name: test-reports-${{ inputs.service }}-a${{ github.run_attempt }}
+          path: ${{ inputs.service }}/build/reports/tests
+          if-no-files-found: ignore
+          retention-days: 7
+
+      # A flake cannot be counted from run CONCLUSIONS alone (a re-run flips it away from
+      # `failure`), so retain the JUnit XML per ATTEMPT — a flake becomes a diffable artifact
+      # pair instead of something that has to be noticed and reported at re-run time (#4878).
+      - name: Upload JUnit XML (every run — flake accounting)
+        if: always()
+        continue-on-error: true
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: junit-xml-${{ inputs.service }}-a${{ github.run_attempt }}
+          path: ${{ inputs.service }}/build/test-results/**/*.xml
+          if-no-files-found: ignore
+          retention-days: 3
+
+  # ── contract: Pact provider verification + consumer-pact publishing ─────────────────────
+  # In-cluster ARC pool only (the Pact Broker has no public ingress, ADR-0056) and only on the
+  # events that must publish a verification result: a push to main (the SHA auto-deploy gates
+  # on) or an on-main workflow_dispatch (verify-provider.yml / the reconciler, #2039) —
+  # deliberately the SAME combined condition the pre-split single job used for its
+  # runs-on/PACT_BROKER_URL gating (see its "KEEP THIS EXPRESSION IN LOCKSTEP" comments),
+  # carried over verbatim so verify-provider.yml's single-provider re-verify dispatch keeps
+  # working exactly as before.
+  contract:
+    name: ${{ inputs.service }} (contract)
+    needs: build
+    if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'
+    runs-on: openbank-build
     timeout-minutes: 45
     env:
       # Pact Broker (ADR-0092). The broker has no public ingress (ADR-0056); the
-      # in-cluster ARC runner reaches it over cluster DNS. Provider verification +
-      # result publishing run in the gradle test JVM (on the runner pod, so cluster
-      # DNS resolves); consumer-pact publishing is a curl to the broker's
-      # /contracts/publish API (NOT `docker run`, whose dind network can't resolve
-      # cluster DNS). When PACT_BROKER_URL is unset (var not configured) the build
-      # passes empty -D and the @PactBroker provider tests are @EnabledIfSystemProperty
-      # -skipped, and the publish step no-ops — so this is inert until the var lands.
-      # Blanked on the hosted lanes (a GitHub-hosted runner can't reach the
-      # cluster-DNS broker; a set-but-unreachable URL would fail the provider tests
-      # instead of skipping them). Main-push behaviour is unchanged: verify + publish.
-      # KEEP IN LOCKSTEP with the runs-on expression above.
-      PACT_BROKER_URL: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main' && vars.PACT_BROKER_URL || '' }}
+      # in-cluster ARC runner reaches it over cluster DNS.
+      PACT_BROKER_URL: ${{ vars.PACT_BROKER_URL }}
       PACT_BROKER_USERNAME: ${{ vars.PACT_BROKER_USERNAME }}
       PACT_BROKER_PASSWORD: ${{ secrets.PACT_BROKER_PASSWORD }}
-      # Testcontainers pulls postgres:16.3-alpine and redpandadata/redpanda through
-      # the dind daemon's `--registry-mirror` (→ the in-cluster registry-cache
-      # pull-through proxy, gitops/components/registry-cache), so each image egresses
-      # to Docker Hub at most once cluster-wide; the image coordinates live in each
-      # service's `*TestResource`, not here. (The former POSTGRES_/KAFKA_/VALKEY_IMAGE
-      # + *_PASSWORD env were consumed by the retired shared docker-compose stack.)
       GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx3g -Dfile.encoding=UTF-8"
-      # Per-service Gradle home isolation (follow-up from #578 / fleet CI flakiness).
-      #
-      # Root cause: on the persistent Mac runner pool (ADR-0040/0043), all concurrent
-      # service builds default to ~/.gradle, sharing a single daemon registry. When
-      # one job's setup-gradle post-action fires (on job completion), it sends
-      # `gradle --stop` to that shared registry — killing all daemons, including the
-      # ones of STILL-RUNNING sibling jobs. The sibling then hits "Gradle build daemon
-      # disappeared unexpectedly (it may have been killed or may have crashed)" and
-      # fails, even though the code compiled fine (as in the 1-of-28-fails pattern).
-      #
-      # Fix: each service gets its own stable, persistent Gradle home under
-      # _work/.gradle-svc/<service>. The path is derived from github.workspace
-      # (two levels up → the per-runner _work dir) so it:
-      #  - survives across runs → daemon warmth is preserved (ADR-0043 still works)
-      #  - is completely isolated per service → stop in job A can't kill job B's daemon
-      #  - works on both persistent Macs and ephemeral ARC Linux pods (ARC pods get a
-      #    fresh workspace per run anyway, so the isolation is moot there but harmless)
-      #
-      # setup-gradle honours GRADLE_USER_HOME when no gradle-home-dir input is given,
-      # so setting it here is sufficient (no action input change needed).
-      #
-      # Force a UTF-8 locale so the JVM's sun.jnu.encoding (the *filename* charset,
-      # derived from the OS locale at startup — NOT from -Dfile.encoding) is UTF-8.
-      # The ephemeral ARC runner pods (ADR-0053) default to the POSIX/C locale, so
-      # Kotlin test names with non-ASCII chars (e.g. a Czech '—' em-dash) produced an
-      # unmappable .class path -> InvalidPathException -> compileTestKotlin internal
-      # compiler error. The retired persistent runners happened to have a UTF-8 locale.
       LANG: C.UTF-8
       LC_ALL: C.UTF-8
-      # Shared remote Gradle build cache (ADR-0043): the in-cluster cache server
-      # (gitops/components/gradle-build-cache, nginx WebDAV) is wired into the ARC
-      # runner pods as GRADLE_REMOTE_CACHE_URL/_PUSH/_INSECURE by Terraform
-      # (aws/envs/sandbox-platform/arc-runners.tf); settings.gradle.kts reads those
-      # env vars and configures the HttpBuildCache. We deliberately do NOT re-declare
-      # GRADLE_REMOTE_CACHE_URL here from `${{ vars.* }}`: when that repo var is unset
-      # the expression yields an EMPTY string that a job-level `env:` then layers on
-      # top of the pod-injected value, blanking it — so `isNullOrBlank()` in
-      # settings.gradle disabled the cache fleet-wide. Letting the pod env flow
-      # through untouched is what actually turns the cache on (cluster-internal URL,
-      # only reachable from ARC pods; the warm-local Macs fall back to local cache).
+      # Shared remote Gradle build cache (ADR-0043): injected by arc-runners.tf via the pod
+      # env. Deliberately NOT re-declared from `${{ vars.* }}` here — see the original
+      # single-job file's long-form comment (git history) for why that would blank it.
     steps:
-      # harden-runner is intentionally omitted: it's an eBPF egress-audit shim for
-      # ephemeral GitHub-hosted runners. This self-hosted sandbox instance enforces
-      # egress at the infra layer (egress-only SG in an isolated VPC, ADR-0027), a
-      # stronger control, so the shim is redundant (and unsupported on this host).
-      # P predates the proof runner. Before replacing the workspace with P, save the runner from
-      # this workflow's trusted checkout outside the workspace; F is never checked out for code.
+      # P predates the proof runner. Before replacing the workspace with P, save the runner
+      # from this workflow's trusted checkout outside the workspace; F is never checked out
+      # for code.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         if: inputs.provider_version != ''
         with:
@@ -208,58 +395,18 @@ jobs:
           fi
           echo "PACT_PROVIDER_VERSION=$PROVIDER_VERSION" >> "$GITHUB_ENV"
 
-      # Resolve GRADLE_USER_HOME by runner class:
-      #  - ARC ephemeral (GRADLE_USER_HOME_NODE_CACHE set by arc-runners.tf): node-local
-      #    hostPath cache, per-service.
-      #  - other self-hosted (Mac/Hetzner): workspace-relative, per-service.
-      #    Both keep the home PER-SERVICE so one job's `gradle --stop` post-action can't
-      #    kill a sibling job's daemon on the SHARED persistent registry (the documented
-      #    "1-of-28-fails / daemon disappeared" incident).
-      #  - GitHub-hosted (the PR lane): the DEFAULT ~/.gradle. Each hosted matrix job gets
-      #    its OWN ephemeral runner, so there is no sibling daemon to protect and the
-      #    per-service isolation is not just moot but HARMFUL: a non-standard home defeats
-      #    setup-gradle's cross-job cache restore, so the PR lane was rebuilding build-logic
-      #    and re-resolving dependencies from cold every run ("Gradle User Home cache not
-      #    found"). With the default home it restores the warm cache fleet-lint keeps on
-      #    main. Measured on openbank-domestic-payment: ~82 s restored vs ~204 s cold — the
-      #    restore is read-only (see cache-read-only below), so it adds nothing to the
-      #    Actions cache quota.
-      # NOTE: env context is NOT available in job-level env: blocks of reusable workflows
-      # (workflow_call) — GitHub rejects "Unrecognized named-value: 'env'" at parse time —
-      # so this is resolved in a step where env IS available.
+      # Resolve GRADLE_USER_HOME. This job is ALWAYS self-hosted now, so it always takes the
+      # per-service isolated-home branch — one job's `gradle --stop` post-action can't kill a
+      # sibling job's daemon on the shared persistent registry (the documented "1-of-28-fails
+      # / daemon disappeared" incident).
       - name: Resolve GRADLE_USER_HOME
-        env:
-          RUNNER_ENV: ${{ runner.environment }}
         run: |
           if [ -n "${GRADLE_USER_HOME_NODE_CACHE:-}" ]; then
             echo "GRADLE_USER_HOME=${GRADLE_USER_HOME_NODE_CACHE}/${{ inputs.service }}" >> "$GITHUB_ENV"
-          elif [ "${RUNNER_ENV}" = "self-hosted" ]; then
-            echo "GRADLE_USER_HOME=${{ github.workspace }}/../../.gradle-svc/${{ inputs.service }}" >> "$GITHUB_ENV"
           else
-            # GitHub-hosted PR lane: default home so setup-gradle restores the shared cache.
-            echo "GRADLE_USER_HOME=${HOME}/.gradle" >> "$GITHUB_ENV"
+            echo "GRADLE_USER_HOME=${{ github.workspace }}/../../.gradle-svc/${{ inputs.service }}" >> "$GITHUB_ENV"
           fi
 
-      # Warm this service's Gradle dependency cache BEFORE "Build + test" runs, so an
-      # interrupted-download-corrupted module cache entry (a .pom downloaded with no
-      # matching .jar — a sibling job/daemon writing to the same shared/persistent
-      # GRADLE_USER_HOME concurrently: the ARC node-local hostPath cache, or the
-      # Mac/Hetzner persistent per-service home) is caught and healed HERE, not inside
-      # "Build + test". That step must run exactly once — it re-runs `test` differently
-      # depending on PUBLISH_RESULTS (the #1009 Pact-publish hazard documented below), so
-      # retrying it on failure risks a double/uncredentialed Pact Broker publish. This
-      # warm-up runs no test code and has no side effects, so it is safe to retry.
-      # `quarkusDependenciesBuild` resolves exactly the runtime classpath that failed with
-      # a dependency-verification error in the incident this guards against; it does not
-      # compile or run anything. Deliberately narrow: heal-gradle-verification-failure.sh
-      # only removes the exact artifact/version Gradle names in its own verification-failure
-      # message — it does not scan the cache for "suspicious" entries (an earlier, broader
-      # heuristic — pom present, jar absent — flagged legitimate BOM-only and
-      # never-downloaded transitive dependencies as corrupt; do not resurrect that).
-      #
-      # It is ADVISORY only: a hosted PR runner can hang in Gradle cache resolution before the
-      # actual gate starts (#3345). Bound it so a stale cache service never consumes the whole
-      # service job. The real Build + test step below remains mandatory and unchanged.
       - name: Warm Gradle dependency cache (self-heal corrupted entries)
         continue-on-error: true
         run: |
@@ -267,7 +414,7 @@ jobs:
           timeout 120s ./gradlew :${{ inputs.service }}:quarkusDependenciesBuild --console=plain > /tmp/gradle-warmup.log 2>&1
           warmup_status=$?
           if [ $warmup_status -eq 124 ]; then
-            echo "::warning::dependency warm-up timed out after 120s; skipping advisory cache healing and continuing to mandatory Build + test"
+            echo "::warning::dependency warm-up timed out after 120s; skipping advisory cache healing and continuing to mandatory step"
             cat /tmp/gradle-warmup.log
           elif [ $warmup_status -ne 0 ]; then
             cat /tmp/gradle-warmup.log
@@ -276,22 +423,13 @@ jobs:
               timeout 120s ./gradlew :${{ inputs.service }}:quarkusDependenciesBuild --console=plain
               retry_status=$?
               if [ $retry_status -eq 124 ]; then
-                echo "::warning::dependency warm-up retry timed out after 120s; continuing to mandatory Build + test"
+                echo "::warning::dependency warm-up retry timed out after 120s; continuing"
               fi
             else
-              echo "::warning::dependency warm-up failed for a reason other than cache corruption — leaving it to the real Build step to report"
+              echo "::warning::dependency warm-up failed for a reason other than cache corruption — leaving it to the real step to report"
             fi
           fi
 
-      # Normalize the Testcontainers Docker endpoint across the MIXED runner pool
-      # (ARC dind + Hetzner + Mac mini/OrbStack — all serve Docker at the unix socket:
-      # arc-runners.tf pins DOCKER_HOST=unix:///var/run/docker.sock, Hetzner uses the
-      # standard socket, OrbStack symlinks /var/run/docker.sock). The convention plugin
-      # inherits the ambient DOCKER_HOST; the retired tcp://localhost:2375 endpoint
-      # lingers in some self-hosted runner envs (the Mac mini) and makes Testcontainers
-      # fail with `DockerDesktopClientProviderStrategy: getSocketPath() null` (#873).
-      # Normalize an empty/retired value to the unix socket; leave any other deliberate
-      # ambient override untouched.
       - name: Normalize DOCKER_HOST for Testcontainers (#873)
         run: |
           if [ -z "${DOCKER_HOST:-}" ] || [ "${DOCKER_HOST:-}" = "tcp://localhost:2375" ]; then
@@ -301,17 +439,7 @@ jobs:
             echo "DOCKER_HOST left as: ${DOCKER_HOST}"
           fi
 
-      # Raise fs.aio-max-nr so parallel Testcontainers don't exhaust the kernel's default
-      # 65536 AIO pool. Redpanda (Seastar) reserves AIO contexts per shard and Quarkus
-      # reactive adds more; when the pool hits 0 a container dies with "Could not setup
-      # Async I/O" / exit 139 (e.g. the SctInstAccessControlIT flake on a Hetzner runner).
-      # ARC runners already get this via a privileged init container (arc-runners.tf,
-      # issue #1329); the non-ARC pool (Hetzner) has no repo-managed host bootstrap, so we
-      # raise it here. On a long-lived runner the value persists for later jobs.
-      # Linux-only (macOS has no /proc/sys/fs/aio-max-nr); `sudo -n` fails fast instead of
-      # hanging on a password prompt where NOPASSWD is absent; never fatal.
       - name: Raise fs.aio-max-nr for Testcontainers (best-effort, Linux)
-        if: runner.os == 'Linux'
         continue-on-error: true
         timeout-minutes: 1
         run: |
@@ -326,26 +454,9 @@ jobs:
             echo "fs.aio-max-nr already ${cur} (>= 1048576)"
           fi
 
-      # FinOps: pre-warm Testcontainers images from ECR pull-through cache (PR #1393, updated).
-      #
-      # docker.io images (postgres, redpanda, valkey, apicurio) are pulled via the ECR
-      # pull-through cache rule "docker-hub/" (ecr-pull-through-cache.tf). ECR fetches
-      # from Docker Hub server-side; runner pulls from private ECR over the ecr.dkr VPC
-      # Interface endpoint — zero NAT bytes. After pulling, each image is retagged to its
-      # canonical docker.io name so Testcontainers finds it in the local docker image store
-      # without needing to pull again (Testcontainers uses the image name as cache key).
-      #
-      # Auth: the ARC pool gets ambient AWS creds via EKS Pod Identity, but the Hetzner
-      # self-hosted pool has NONE — so `aws ecr get-login-password` failed there ("ECR login
-      # failed"), and even on ARC the build-runner role lacked pull-through import rights so the
-      # first uncached pull 403'd (transaction-service). Fix both with GitHub OIDC: assume
-      # openbank-arc-build-runner (which already trusts repo:JiRaska/open-bank-oss:* — arc-runners.tf)
-      # and let the ECR-login action docker-login the runner. Keyless and host-agnostic: the
-      # amazon-ecr-login action needs no awscli on the host (absent on Hetzner). Both steps soft-
-      # fail so a runner without OIDC still falls through to the in-cluster registry-cache below.
+      # FinOps: pre-warm Testcontainers images from ECR pull-through cache (PR #1393).
       - name: Authenticate to ECR via OIDC
         id: ecr_auth
-        if: ${{ runner.environment == 'self-hosted' }}
         continue-on-error: true
         uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
@@ -353,19 +464,14 @@ jobs:
           aws-region: eu-north-1
       - name: Login to Amazon ECR
         id: ecr_login
-        if: ${{ runner.environment == 'self-hosted' && steps.ecr_auth.outcome == 'success' }}
+        if: ${{ steps.ecr_auth.outcome == 'success' }}
         continue-on-error: true
         uses: aws-actions/amazon-ecr-login@d539f0932e70871a027e9d5a9d8fc38589180a64 # v2.1.6
       - name: Pre-warm Testcontainers image cache via ECR
-        if: ${{ runner.environment == 'self-hosted' }}
         continue-on-error: true
         env:
           ECR: "265175468565.dkr.ecr.eu-north-1.amazonaws.com"
         run: |
-          # docker is already authenticated to ECR by the "Login to Amazon ECR" step (OIDC) when it
-          # succeeded — no `aws ecr get-login-password` here (that needs host awscli, absent on
-          # Hetzner). Pull from the ECR pull-through cache (zero NAT) and retag to canonical
-          # docker.io names so Testcontainers cache-hits locally without a second pull.
           if [ "${{ steps.ecr_login.outcome }}" = "success" ] \
              && docker pull "$ECR/docker-hub/library/postgres:16.3-alpine"; then
             docker pull "$ECR/docker-hub/valkey/valkey:7.2-alpine" &
@@ -388,9 +494,7 @@ jobs:
           else
             echo "::warning title=TC pre-warm::no image cache reachable — Testcontainers will pull at test time"
           fi
-      # Most modules pin kotlin { jvmToolchain(25) }; a few use 21. Installing both
-      # lets Gradle's toolchain resolution pick the right one with zero Foojay
-      # downloads at build time (faster, fewer billed minutes).
+
       - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
           distribution: temurin
@@ -398,12 +502,6 @@ jobs:
             21
             25
 
-      # Probe the in-cluster Reposilite Maven mirror (issue #849).
-      # ARC runners (in-cluster) reach the ClusterIP in ~1 ms; Hetzner/Mac
-      # runners get ECONNREFUSED immediately and skip silently. When the probe
-      # succeeds, REPOSILITE_MIRROR_URL is set and settings.gradle.kts prepends
-      # the three Reposilite repos (maven-central / gradle-plugins / google)
-      # before the GCS fallback — zero NAT for in-cluster runners.
       - name: Probe Reposilite in-cluster Maven mirror
         run: |
           if curl -sf --connect-timeout 2 \
@@ -416,19 +514,9 @@ jobs:
             echo "::notice title=Reposilite unavailable::falling back to GCS mirror + CodeArtifact"
           fi
 
-      # Wire Gradle to use AWS CodeArtifact as a Maven Central mirror (FinOps).
-      # CodeArtifact sits in-VPC; its S3 storage backend uses the S3 Gateway endpoint
-      # → dep downloads never exit the VPC, eliminating NAT charges (~$25/day).
-      # The ARC runner pod IAM role has codeartifact:GetAuthorizationToken via IRSA.
       - name: Configure CodeArtifact Maven mirror
-        # Soft-fail: if IRSA is not yet wired the token fetch fails gracefully and
-        # Maven Central is used directly (with NAT cost). Remove once IRSA is stable.
         continue-on-error: true
         run: |
-          # The aws CLI is baked into the openbank-ci-runner image; this guard turns a
-          # missing CLI (stock runner image / new pool) into a VISIBLE soft-skip instead
-          # of a bare `exit 127` in the log. Fallback to public Maven Central is the
-          # emergency path only — it pays NAT and risks 429 throttling (see 2026-06-11).
           if ! command -v aws >/dev/null 2>&1; then
             echo "::warning title=CodeArtifact mirror skipped::aws CLI not on this runner — falling back to public Maven Central (NAT cost + 429 risk). Bake awscli into the runner image (runner-image/Dockerfile)."
             exit 0
@@ -442,8 +530,6 @@ jobs:
             exit 0
           }
           CA_URL="https://openbank-sandbox-265175468565.d.codeartifact.eu-north-1.amazonaws.com/maven/maven-central-proxy/"
-          # Write a Gradle init script that redirects maven central to CodeArtifact.
-          # Placed in GRADLE_USER_HOME/init.d/ so it applies to every project.
           mkdir -p "${GRADLE_USER_HOME}/init.d"
           cat > "${GRADLE_USER_HOME}/init.d/codeartifact-mirror.gradle" <<GRADLE_INIT
           allprojects {
@@ -470,190 +556,43 @@ jobs:
 
       - uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
         with:
-          # GitHub Actions cache DISABLED for Gradle home.
-          #
-          # FinOps root-cause (2026-06-22): NAT traffic analysis showed 74 GB/day
-          # upload (OutToDestination) on a light CI day, 100% correlated with CI
-          # hours. Root cause: setup-gradle's post-action was uploading the full
-          # Gradle home (~450 MB per service × 28 services = 12+ GB per main push)
-          # to GitHub Actions cache at actions.githubusercontent.com — a GitHub-
-          # hosted S3 bucket that is NOT reachable via a VPC endpoint, so every
-          # byte exits through the NAT gateway at $0.045/GB + $0.09/GB DataTransfer.
-          # The asymmetric DataTransfer-Out charge doubled the per-GB cost vs a
-          # pure download.
-          #
-          # Why safe to disable:
-          # 1. Gradle task outputs (compiled classes, test results) are served by
-          #    the in-cluster remote build cache (nginx WebDAV, GRADLE_REMOTE_CACHE_URL
-          #    injected by arc-runners.tf) — unchanged tasks resolve in <1s with no
-          #    upstream download. This is what actually speeds up incremental builds.
-          # 2. Gradle wrapper (~150 MB) and Maven dependencies are fetched via the
-          #    CodeArtifact VPC interface endpoint (in-VPC, zero NAT), so cold-start
-          #    dep resolution does not hit the NAT gateway.
-          # 3. Persistent Mac runners retain a warm GRADLE_USER_HOME across jobs
-          #    (ADR-0043); the GitHub cache was never needed for them.
-          # 4. ARC ephemeral pods will see a slightly slower first build on a cold
-          #    cluster but the in-cluster remote build cache covers 95%+ of wall-clock
-          #    by caching the expensive compile/test tasks.
-          #
-          # Net effect: eliminates ~74 GB/day upload + corresponding download traffic
-          # ≈ $6.66/day saved ($200/month). Re-enable if cold-start build time degrades
-          # unacceptably after the remote build cache fills (typically 1-2 runs).
-          #
-          # NOTE: the input is `cache-disabled` (gradle/actions/setup-gradle v6). The
-          # earlier `cache-enabled: false` was NOT a valid input — the action ignored it
-          # ("Unexpected input(s) 'cache-enabled'") so caching stayed ON: the post-action
-          # kept uploading the Gradle home, silently negating the FinOps saving above AND
-          # exhausting the shared storage quota during full-fleet rebuilds
-          # ("Failed to CreateArtifact: Artifact storage quota has been hit"), which failed
-          # otherwise-green service builds.
-          #
-          # The NAT-cost analysis above applies to SELF-HOSTED runners in the VPC.
-          # On GitHub-hosted runners (the PR lane) the Actions cache is
-          # network-internal and free, and there is no in-cluster remote build
-          # cache to fall back on — so the cache is enabled there and disabled
-          # on the self-hosted main lane.
-          cache-disabled: ${{ runner.environment == 'self-hosted' }}
-          # On the hosted PR lane: RESTORE the warm cache fleet-lint keeps on main, but
-          # never WRITE. Writing 26 per-service home caches on PR branches would churn the
-          # Actions cache quota (already ~96% full) and re-trigger the "storage quota has
-          # been hit" build failures noted above. Read-only gets the ~120 s speedup (paired
-          # with the default GRADLE_USER_HOME resolved above, which is what lets the restore
-          # actually hit) at zero quota cost. Ignored on self-hosted (cache-disabled there).
-          cache-read-only: ${{ runner.environment != 'self-hosted' }}
-          # Enable the cross-job OS-level fallback restore so a service build can reuse
-          # fleet-lint's / another service's home cache instead of requiring an exact
-          # per-job match (which never exists — the self-hosted main lane writes no cache).
+          # Self-hosted: disable the GitHub Actions cache for Gradle home (FinOps — see the
+          # original single-job file's history for the NAT-cost analysis) and rely on the
+          # in-cluster remote build cache (GRADLE_REMOTE_CACHE_URL, arc-runners.tf) instead.
+          cache-disabled: true
           gradle-home-cache-strict-match: false
 
-      # No --no-daemon (ADR-0043): on a persistent runner the Gradle daemon is kept
-      # warm and reused across jobs, so the JVM + 30-module configuration is not paid
-      # from cold every build. --build-cache hits the local cache and, when wired, the
-      # shared remote build-cache-node (GRADLE_REMOTE_CACHE_URL) so unchanged modules
-      # in a fleet fan-out resolve from cache instead of recompiling.
-      - name: Build + test (:${{ inputs.service }})
-        env:
-          # PR branch on PRs, "main" on the main push — used to tag the consumer
-          # pact + the provider verification result so can-i-deploy can reason per branch.
-          BRANCH: ${{ github.head_ref || github.ref_name }}
-          # Publish provider verification results only from the main push (the SHA
-          # auto-deploy will gate on). PR builds verify but don't publish results.
-          PUBLISH_RESULTS: ${{ github.ref == 'refs/heads/main' }}
-        run: |
-          # Pact Broker config (ADR-0092) is forwarded as -D system properties; the
-          # provider build.gradle.kts copies these into the forked test JVM. Empty
-          # pactbroker.url (var unset) → @PactBroker provider test skips (it is
-          # @EnabledIfSystemProperty(named=pactbroker.url, matches=.+)-gated).
-          #
-          # --rerun-tasks ONLY on the main-push publish path (#1965/#1964). Publishing the
-          # provider-verification result is a network SIDE-EFFECT (a POST to the Pact Broker)
-          # that Gradle's up-to-date / build-cache machinery cannot observe: when the `test`
-          # task is restored from cache — which happens in a fleet fan-out where THIS provider's
-          # source + SHA are unchanged (e.g. a consumer republishes a new pact and the provider
-          # must re-verify + re-publish against it) — the cached result is reused and the publish
-          # POST never fires. That is why #1964 needed a manual build.gradle.kts cache-key bust to
-          # force a re-publish. Forcing re-execution here makes the publish happen on every main
-          # push, deterministically. Gated on PUBLISH_RESULTS (main only) so PR builds and the
-          # PR-lane fleet keep their cache: they verify but never publish, so re-running them would
-          # only cost time with no side-effect to trigger. The later "Generate Kover XML report"
-          # step is NOT re-run (no --rerun-tasks): `test` is up-to-date from this step, so it stays
-          # cached and does not re-execute uncredentialed (the #1009 hazard documented below).
-          RERUN=""
-          if [ "${PUBLISH_RESULTS}" = "true" ]; then RERUN="--rerun-tasks"; fi
-          # -Dquarkus.smallrye-openapi.store-schema-directory writes the document Quarkus actually
-          # serves, as a side effect of the SAME quarkusBuild task this :build already runs
-          # (confirmed via --dry-run: quarkusBuild is already in :build's task graph for every
-          # Quarkus module here, so this adds zero extra build time). Read by the
-          # openapi-request-schema-conformance step below — rules.yaml:
-          # openapi_request_schema_conformance.
-          ./gradlew :${{ inputs.service }}:build ${RERUN} --build-cache --console=plain --stacktrace \
-            -Dquarkus.smallrye-openapi.store-schema-directory="${{ inputs.service }}/build/openapi-generated" \
-            -Dpactbroker.url="${PACT_BROKER_URL:-}" \
-            -Dpactbroker.auth.username="${PACT_BROKER_USERNAME:-}" \
-            -Dpactbroker.auth.password="${PACT_BROKER_PASSWORD:-}" \
-            -Dpactbroker.enablePending=true \
-            -Dpactbroker.providerBranch="${BRANCH}" \
-            -Dpact.verifier.publishResults="${PUBLISH_RESULTS}" \
-            -Dpact.provider.version="${PACT_PROVIDER_VERSION}" \
-            -Dpact.provider.branch="${BRANCH}" \
-            -Dpact.provider.tag="${BRANCH}"
-
-      # A Docker Hub pull failure surfaces as NAMED TEST FAILURES, ~900 lines above the actual
-      # cause, so the reader goes hunting for a test bug that is not there. The PR lane runs on
-      # `ubuntu-latest`, where the ECR pre-warm step above is skipped, so Testcontainers pulls
-      # straight from Docker Hub. Full reasoning in the script header. Diagnostic only: it reads
-      # JUnit XML already on disk, always exits 0, and can never change the build verdict.
-      - name: "Explain a Docker registry pull failure (diagnostic)"
-        if: failure()
-        run: |
-          python3 .github/scripts/check-testcontainers-registry-failure.py \
-            --service "${{ inputs.service }}"
-
-      # rules.yaml: openapi_request_schema_conformance (advisory). Only the REQUEST-body half of
-      # schema-vs-code — see the script header for why the response half is not attempted. The
-      # existence guard is a bash `[ -f ]` rather than a YAML `if: hashFiles(...)` composition —
-      # no precedent for hashFiles(format(...)) elsewhere in this repo's workflows, and per the
-      # project's own note on workflow files, a mistaken expression here is invisible until an
-      # actual CI run reaches it. A bash guard is checkable with `bash -n` before that.
-      - name: "openapi request-schema conformance (advisory)"
-        run: |
-          SPEC="${{ inputs.service }}/src/main/resources/openapi.yaml"
-          if [ ! -f "$SPEC" ]; then
-            echo "openapi-request-schema-conformance: ${{ inputs.service }} has no openapi.yaml — skipping."
-            exit 0
-          fi
-          python3 .github/scripts/check-openapi-request-schema-conformance.py \
-            --service "${{ inputs.service }}" \
-            --generated "${{ inputs.service }}/build/openapi-generated/openapi.yaml"
-
-      # Coverage upload (Codecov is free for public repos; tokenless via the OIDC
-      # id-token this job already has). Advisory only — never gates the build.
-      # koverVerify stays the enforcement mechanism (ratchet-only, rules.yaml).
-      #
-      # The -D flags below MUST mirror "Build + test" verbatim (issue #1009). koverXmlReport
-      # depends on koverGenerateArtifact -> test, so this is a SECOND, independent `./gradlew`
-      # invocation reaching the same `test` task. build.gradle.kts's `tasks.withType<Test> {
-      # System.getProperty(key)?.let { systemProperty(key, it) } }` makes those Pact -D values
-      # part of `test`'s tracked inputs — omitting them here makes the input set differ from the
-      # build step's, which is a guaranteed cache miss: Gradle re-executes `test` from scratch,
-      # this time with pactbroker.url/pact.verifier.publishResults unset, so the pact-jvm
-      # verifier logs "Skipping publishing of verification results ... not 'true'" and the
-      # @PactBroker provider test's @EnabledIfSystemProperty(pactbroker.url) gate skips it
-      # outright. Confirmed live in run 29489275110 job 87613534930 (2026-07-16): the `test` task
-      # ran a second, full time (fresh Testcontainer boot included) right after this step started,
-      # with none of the Pact system properties present. Passing identical values here lets
-      # Gradle recognize `test` as UP-TO-DATE/FROM-CACHE instead of re-running it uncredentialed.
-      - name: Generate Kover XML report
-        continue-on-error: true
-        env:
-          BRANCH: ${{ github.head_ref || github.ref_name }}
-          PUBLISH_RESULTS: ${{ github.ref == 'refs/heads/main' }}
-        run: |
-          ./gradlew :${{ inputs.service }}:koverXmlReport --build-cache --console=plain \
-            -Dpactbroker.url="${PACT_BROKER_URL:-}" \
-            -Dpactbroker.auth.username="${PACT_BROKER_USERNAME:-}" \
-            -Dpactbroker.auth.password="${PACT_BROKER_PASSWORD:-}" \
-            -Dpactbroker.enablePending=true \
-            -Dpactbroker.providerBranch="${BRANCH}" \
-            -Dpact.verifier.publishResults="${PUBLISH_RESULTS}" \
-            -Dpact.provider.version="${PACT_PROVIDER_VERSION}" \
-            -Dpact.provider.branch="${BRANCH}" \
-            -Dpact.provider.tag="${BRANCH}"
-
-      - name: Upload coverage to Codecov
-        continue-on-error: true
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+      # Artifact hand-off from `build` MUST fail loud (issue #4414 acceptance criterion): a
+      # missing or failed download means either `build` failed before uploading (in which case
+      # this job would not even be scheduled — `needs: build` implies success) or the artifact
+      # expired/was misnamed, and either way publishing a verification without knowing this
+      # service's actual consumer-pact set would be silently wrong. No continue-on-error, no
+      # if: always() — a failure here fails the job.
+      - name: Download build's consumer-pact artifact
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v6.2.1
         with:
-          files: ${{ inputs.service }}/build/reports/kover/report.xml
-          flags: ${{ inputs.service }}
-          use_oidc: true
-          fail_ci_if_error: false
+          name: consumer-pacts-${{ inputs.service }}
+          path: pact-handoff
 
-      # Publish this service's CONSUMER pacts to the broker (ADR-0092). The consumer
-      # tests regenerate pacts/<consumer>-<provider>.json (pact.rootDir → repo /pacts);
-      # publish only the files where THIS service is the consumer, keyed by git SHA +
-      # branch via the /contracts/publish API. curl (not the pact-cli docker image):
-      # the runner pod resolves the broker's cluster DNS, a dind container would not.
+      - name: Stage handed-off consumer pacts into pacts/
+        run: |
+          set -euo pipefail
+          if [ ! -f pact-handoff/.manifest ]; then
+            echo "::error::pact hand-off artifact from the build job has no .manifest — treating this as a failed hand-off, not an empty consumer-pact set (the build job always writes one)."
+            exit 1
+          fi
+          cat pact-handoff/.manifest
+          mkdir -p pacts
+          shopt -s nullglob
+          files=(pact-handoff/*.json)
+          for f in "${files[@]}"; do cp "$f" pacts/; done
+          echo "Staged ${#files[@]} consumer pact file(s) from the build job's hand-off."
+
+      # Publish this service's CONSUMER pacts to the broker (ADR-0092). Reads the files staged
+      # from the build job's hand-off above (regenerated there, not here — re-running `test`
+      # on this pool is exactly the redundant work this split removes), keyed by git SHA +
+      # branch via the /contracts/publish API. curl (not the pact-cli docker image): the
+      # runner pod resolves the broker's cluster DNS, a dind container would not.
       - name: Publish consumer pacts to broker
         if: ${{ env.PACT_BROKER_URL != '' }}
         env:
@@ -666,7 +605,6 @@ jobs:
             echo "${{ inputs.service }} is not a consumer of any contract — nothing to publish."
             exit 0
           fi
-          # Build the /contracts/publish body: content is BASE64-encoded pact JSON.
           contracts="$(for f in "${files[@]}"; do
             jq -nc \
               --arg c "$(jq -r '.consumer.name' "$f")" \
@@ -689,60 +627,50 @@ jobs:
           jq -r '.notices[]?.text // empty' /tmp/pact-publish.json 2>/dev/null || cat /tmp/pact-publish.json
           [ "$code" -lt 300 ] || { echo "::error::pact publish failed (HTTP $code)"; exit 1; }
 
-      # Only on failure: a passing build's test reports are never looked at, but uploading
-      # them on EVERY service build (×~28 services × many runs/day) was a dominant driver of
-      # GitHub Actions artifact-storage churn — bursts during a full-fleet rebuild hit the
-      # quota and failed unrelated uploads ("Failed to CreateArtifact: Artifact storage quota
-      # has been hit"). `failure()` keeps the reports exactly when they're needed for debugging.
+      # ADR-0250 Phase 2: provider verification runs as its OWN Test task (providerPactTest,
+      # build-logic/openbank.quarkus-service.gradle.kts), not `test`. `--rerun-tasks`
+      # unconditionally: publishing the verification result is a network SIDE-EFFECT (a POST
+      # to the Pact Broker) that Gradle's up-to-date/build-cache machinery cannot observe, so a
+      # cached providerPactTest would silently skip the publish (#1964's original reason,
+      # narrowed here to a task this job ALONE runs — no PR-lane cache to protect).
+      - name: Provider verification (:${{ inputs.service }}:providerPactTest)
+        env:
+          BRANCH: ${{ github.head_ref || github.ref_name }}
+        run: |
+          ./gradlew :${{ inputs.service }}:providerPactTest --rerun-tasks --build-cache \
+            --console=plain --stacktrace \
+            -Dpactbroker.url="${PACT_BROKER_URL:-}" \
+            -Dpactbroker.auth.username="${PACT_BROKER_USERNAME:-}" \
+            -Dpactbroker.auth.password="${PACT_BROKER_PASSWORD:-}" \
+            -Dpactbroker.enablePending=true \
+            -Dpactbroker.providerBranch="${BRANCH}" \
+            -Dpact.verifier.publishResults=true \
+            -Dpact.provider.version="${PACT_PROVIDER_VERSION}" \
+            -Dpact.provider.branch="${BRANCH}" \
+            -Dpact.provider.tag="${BRANCH}"
+
+      - name: "Explain a Docker registry pull failure (diagnostic)"
+        if: failure()
+        run: |
+          python3 .github/scripts/check-testcontainers-registry-failure.py \
+            --service "${{ inputs.service }}"
+
       - name: Upload test reports
         if: failure()
         continue-on-error: true
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          # `-a${{ github.run_attempt }}` is not cosmetic. An artifact name must be unique
-          # WITHIN A RUN, and re-running a failed job is a new attempt of the SAME run — so
-          # without the suffix the second upload collides and fails. `continue-on-error: true`
-          # then swallows it, which means that until now a re-run silently retained no reports
-          # at all: the case where you most want them.
-          name: test-reports-${{ inputs.service }}-a${{ github.run_attempt }}
-          # XML moved to the always-on step below, so this no longer duplicates it. Net upload
-          # on a failing build is unchanged; the HTML is what a human actually reads here.
-          path: ${{ inputs.service }}/build/reports/tests
+          name: contract-test-reports-${{ inputs.service }}-a${{ github.run_attempt }}
+          path: ${{ inputs.service }}/build/reports/tests/providerPactTest
           if-no-files-found: ignore
           retention-days: 7
 
-      # WHY THIS IS `always()` WHEN THE STEP ABOVE IS DELIBERATELY NOT (#4878).
-      #
-      # A flake cannot be counted in this repo. Re-running a failed run flips its conclusion
-      # away from `failure`, so a query over run conclusions structurally cannot see a flake
-      # that someone re-ran green -- which is the entire population of interest. And a green
-      # run retained nothing, so there was no denominator either: "how often does this test
-      # fail" had no answer at any effort.
-      #
-      # Both halves are fixed by retaining the JUnit XML per ATTEMPT. Attempt 1's failures and
-      # attempt 2's pass then sit side by side under the same run id, and a flake is no longer
-      # something that has to be noticed and reported at the moment of the re-run -- it is a
-      # difference between two artifacts, computable afterwards. That is the whole of this
-      # issue's point 2 obtained by retention rather than by another emitter that has to fire.
-      #
-      # The quota incident that made the step above `failure()` is respected: this uploads the
-      # XML ONLY, not the HTML reports. Measured on openbank-billing-service, that is 140 KB
-      # against 608 KB for the pair, and retention is 3 days rather than 7. Today's artifact
-      # estate is 2.4 GB across ~14.7k artifacts, so a full-fleet rebuild of ~28 services adds
-      # about 4 MB. What is NOT established here is the service-build rate per day, so the
-      # steady-state total is bounded by (rate x 140 KB x 3 days) and not stated as a figure --
-      # if artifact pressure returns, this retention is the dial, and it is the first thing to
-      # look at.
       - name: Upload JUnit XML (every run — flake accounting)
         if: always()
         continue-on-error: true
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: junit-xml-${{ inputs.service }}-a${{ github.run_attempt }}
-          path: ${{ inputs.service }}/build/test-results/**/*.xml
+          name: contract-junit-xml-${{ inputs.service }}-a${{ github.run_attempt }}
+          path: ${{ inputs.service }}/build/test-results/providerPactTest/**/*.xml
           if-no-files-found: ignore
           retention-days: 3
-          # Per-test-JVM Testcontainers own their lifecycle (start in @QuarkusTestResource,
-          # stop() at teardown; Ryuk is disabled fleet-wide, so the resource tears them down
-          # itself). On failure their stdout/stderr is captured in the test reports uploaded
-          # above — there is no shared compose stack left running to dump or to reset.

--- a/.github/workflows/_service-ci.yml
+++ b/.github/workflows/_service-ci.yml
@@ -32,7 +32,7 @@
 #     broker's cluster-DNS name) and runs ONLY on a main push / an on-main workflow_dispatch
 #     (verify-provider.yml). Downloads `build`'s pact artifact rather than regenerating it —
 #     a missing/failed download FAILS the job (no silent skip): see the download step.
-#     Runs the `providerPactTest` Gradle task (build-logic/openbank.quarkus-service.gradle.kts)
+#     Runs the `providerPactTest` Gradle task (build-logic/src/main/kotlin/openbank.quarkus-service.gradle.kts)
 #     — a source set/task independent of `test`, so invoking it never forces `test` to re-run.
 name: _service-ci
 
@@ -631,7 +631,7 @@ jobs:
           [ "$code" -lt 300 ] || { echo "::error::pact publish failed (HTTP $code)"; exit 1; }
 
       # ADR-0250 Phase 2: provider verification runs as its OWN Test task (providerPactTest,
-      # build-logic/openbank.quarkus-service.gradle.kts), not `test`. `--rerun-tasks`
+      # build-logic/src/main/kotlin/openbank.quarkus-service.gradle.kts), not `test`. `--rerun-tasks`
       # unconditionally: publishing the verification result is a network SIDE-EFFECT (a POST
       # to the Pact Broker) that Gradle's up-to-date/build-cache machinery cannot observe, so a
       # cached providerPactTest would silently skip the publish (#1964's original reason,

--- a/.github/workflows/services-ci.yml
+++ b/.github/workflows/services-ci.yml
@@ -327,22 +327,24 @@ jobs:
       id-token: write
     strategy:
       fail-fast: false
-      # Cap concurrent matrix jobs. The ARC init container raises fs.aio-max-nr to
-      # 1048576 (arc-runners.tf aio_sysctl_init_container — issue #1329 resolved).
-      # Hetzner hosts default to 65536; at max-parallel=8 all 8 Redpanda containers
-      # race to claim async-I/O contexts simultaneously and exhaust the pool
-      # (balance/ledger/lending flakes observed in the 2026-06-23 full-fleet run).
-      # Set 4 for PR/push: safe for both runner pools; the TC pre-warm step already
-      # serialises the registry-cache cold-start window, so the NAT benefit is preserved.
-      # Raise back to 8 once runner-tune-hetzner runs and persists aio-max-nr=1048576.
-      # Nightly schedule now matches PR/push at 4 (was capped at 2). The old cap was a
-      # self-hosted-capacity guard (Hetzner+Mac mini) that no longer applies: since #198
-      # the schedule/nightly matrix runs on ubuntu-latest (hosted, free & unlimited on this
-      # public repo) — same pool and same proven-safe concurrency as PR/push — and Hetzner
-      # was deleted entirely in #208. Not raised past 4: the GitHub account is on the Free
-      # plan, capped at 20 concurrent hosted-runner jobs account-wide (shared with other
-      # repos/workflows), and nightly's matrix is ~30 services, so 4 keeps healthy headroom
-      # under that ceiling instead of racing other concurrent CI for the same slots.
+      # Cap concurrent matrix jobs. Each matrix entry now fans out into _service-ci.yml's
+      # `build` job (ubuntu-latest, EVERY event including main-push, ADR-0250 Phase 2, #4414)
+      # plus, on main-push only, a `contract` job on the self-hosted `openbank-build` ARC pool.
+      #
+      # The governing constraint for `build` is GitHub's 20-concurrent-hosted-job cap, shared
+      # ACCOUNT-WIDE with every other repo and workflow — not the old self-hosted-pool AIO
+      # rationale this comment used to carry (Hetzner/Redpanda async-I/O contexts, #1329/
+      # 2026-06-23). That rationale is stale for `build` specifically: it never applied to a
+      # hosted runner, and `build` runs hosted on every event now, including main-push, which
+      # is the event that changed. It is NOT stale for `contract`, which is still self-hosted
+      # and still bounded by the same ARC pool (12 runners, Phase 1, #4319) — max-parallel is
+      # a single number governing the WHOLE matrix, so it bounds both jobs' concurrency at
+      # once, and 4 stays comfortably under both the 20-job hosted cap (leaving headroom for
+      # other concurrent CI in the account) and the 12-runner ARC pool.
+      #
+      # The number itself is UNCHANGED from before this split (kept conservative rather than
+      # re-tuned on an unmeasured guess) — raising it is a candidate follow-up once real
+      # dispatch data exists for the new hosted-build shape, not asserted here.
       max-parallel: 4
       matrix:
         service: ${{ fromJSON(needs.changes.outputs.services) }}

--- a/build-logic/src/main/kotlin/openbank.quarkus-service.gradle.kts
+++ b/build-logic/src/main/kotlin/openbank.quarkus-service.gradle.kts
@@ -77,7 +77,13 @@ configurations.all {
     }
 }
 
-tasks.test {
+// Shared config for EVERY Test task in the module — `test` plus the `providerPactTest` task
+// registered below (ADR-0250 Phase 2). Deliberately `withType<Test>().configureEach` rather
+// than `tasks.test { ... }`: the pact rootDir/broker-forwarding block used to be hand-copied
+// into 36 individual build.gradle.kts files (issue #4414) purely so it would also apply to a
+// service's own extra Test tasks — putting it here once, on every Test task fleet-wide, is what
+// makes per-service copies removable at all.
+tasks.withType<Test>().configureEach {
     useJUnitPlatform()
     systemProperty("java.util.logging.manager", "org.jboss.logmanager.LogManager")
     // Testcontainers Docker endpoint. Inherit the ambient DOCKER_HOST (the ephemeral
@@ -105,7 +111,84 @@ tasks.test {
     // tampered text is gone. Set here (not per module) so the 21 services that write pacts cannot
     // drift apart on it.
     systemProperty("pact.writer.overwrite", "true")
+
+    // Pact rootDir + Pact Broker property forwarding (ADR-0092/ADR-0250 Phase 2, issue #4414).
+    // Was hand-copied, with real per-service drift, into 36 build.gradle.kts files — a rolled-up
+    // hash check of those blocks found 5 distinct shapes (not 1), each diffed individually before
+    // this centralisation: a `maxHeapSize` override (account/lending/product-catalog), a JUnit
+    // timeout + CI-only jvmArgs (swift), presence/absence of the rootDir line depending on whether
+    // the service only PROVIDES or only CONSUMES pacts (finrep/copilot vs clearing-simulator/
+    // tpp-registry-service), and a `tasks.test { }`-scoped copy (party-service) instead of
+    // `tasks.withType<Test>`. None of those differences is expressed here — they stay in each
+    // service's own build.gradle.kts — this block only carries the part that was byte-identical
+    // (or a harmless no-op superset) everywhere it appeared.
+    //
+    // Set on the test JVM fork, not the Gradle daemon — System.setProperty at config time would
+    // not propagate into the forked test process.
+    systemProperty("pact.rootDir", "${rootProject.projectDir}/pacts")
+    listOf(
+        "pactbroker.url",
+        "pactbroker.auth.username",
+        "pactbroker.auth.password",
+        "pactbroker.enablePending",
+        "pactbroker.providerBranch",
+        "pact.verifier.publishResults",
+        "pact.provider.version",
+        "pact.provider.branch",
+        "pact.provider.tag",
+    ).forEach { key -> System.getProperty(key)?.let { systemProperty(key, it) } }
 }
+
+// ADR-0250 Phase 2 (issue #4414): a Pact provider-verification test needs `-Dpactbroker.url` set
+// to run against the broker, and that `-D` is a tracked INPUT of whatever Test task runs it — so
+// invoking the ordinary `test` task with a broker URL set (the main-push "contract" build) is
+// ALWAYS a different Gradle cache key from invoking it without one (the "build" job on every
+// other event), even when `--tests` filters which classes execute. That forces a full test-suite
+// re-run on every main push. `--tests` was never going to fix this: it changes what runs, not
+// what the task's inputs are.
+//
+// The fix is a SEPARATE Test task/source set so provider verification has its own task identity
+// and its own cache key, decoupled from `test`'s. It deliberately reuses `test`'s own source
+// directory (`src/test/kotlin`) rather than requiring every service to physically move its
+// `*ProviderVerificationTest.kt` files into a new `src/providerPactTest/kotlin` tree — issue #4414
+// finding 1 established that EVERY provider-verification class in the fleet already ends in
+// `ProviderVerificationTest`, so an include filter on the existing directory selects exactly the
+// right classes with zero fleet-wide file moves. Classes outside that filter (test helpers like a
+// `*TestResource`, referenced by the provider-verification class via `@QuarkusTestResource`) are
+// pulled in via the `test` source set's COMPILED output on the classpath, not recompiled — so
+// running `providerPactTest` triggers `compileTestKotlin` (a compile task, whose inputs are just
+// source files and is therefore cache-stable regardless of `-Dpactbroker.url`) but never EXECUTES
+// the rest of `test`'s suite.
+val providerPactTestSourceSet =
+    sourceSets.create("providerPactTest") {
+        kotlin.srcDir("src/test/kotlin")
+        kotlin.include("**/*ProviderVerificationTest.kt")
+        resources.srcDir("src/test/resources")
+        compileClasspath += sourceSets.main.get().output +
+            sourceSets.test.get().output +
+            configurations.testCompileClasspath.get()
+        runtimeClasspath += output + compileClasspath + sourceSets.test.get().runtimeClasspath
+    }
+
+val providerPactTest =
+    tasks.register<Test>("providerPactTest") {
+        description = "Runs Pact provider-verification tests only, isolated from `test` " +
+            "(ADR-0250 Phase 2, issue #4414) — invoke with -Dpactbroker.url=... to verify " +
+            "against the broker."
+        group = org.gradle.language.base.plugins.LifecycleBasePlugin.VERIFICATION_GROUP
+        testClassesDirs = providerPactTestSourceSet.output.classesDirs
+        classpath = providerPactTestSourceSet.runtimeClasspath
+        // Independent of `check`/`test` — a service with no provider-verification classes at all
+        // (the include filter above matches nothing) still gets the task registered, and it
+        // reports 0 tests rather than failing; JUnit5's default `failOnNoTests` behaviour on an
+        // EMPTY discovered set is "pass", not "fail", which is exactly what an unfiltered `test`
+        // invocation of the same module already relies on for services with no tests of a kind.
+        shouldRunAfter(tasks.named("test"))
+    }
+// Deliberately NOT wired into `check`/`build` (unlike koverVerify below): the whole point of
+// this task is that a main-push "build" job (:service:build, which depends on `check`) must be
+// able to run WITHOUT it, so it never becomes an input the hosted "build" job pays for. Invoke it
+// explicitly: `./gradlew :service:providerPactTest -Dpactbroker.url=...`.
 
 tasks.named<org.cyclonedx.gradle.CycloneDxTask>("cyclonedxBom") {
     setIncludeConfigs(listOf("runtimeClasspath"))

--- a/openbank-account-service/build.gradle.kts
+++ b/openbank-account-service/build.gradle.kts
@@ -103,7 +103,7 @@ tasks.withType<Test> {
     maxHeapSize = "2g"
 
     // Pact rootDir + Pact Broker property forwarding centralised into
-    // build-logic/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
+    // build-logic/src/main/kotlin/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
     // (ADR-0250 Phase 2, issue #4414) — only the maxHeapSize override above is service-specific.
 }
 

--- a/openbank-account-service/build.gradle.kts
+++ b/openbank-account-service/build.gradle.kts
@@ -102,22 +102,9 @@ tasks.withType<Test> {
     // boots per module rather than keep paying for them.
     maxHeapSize = "2g"
 
-    systemProperty("pact.rootDir", "${rootProject.projectDir}/pacts")
-
-    // Pact Broker verification (ADR-0092): forward the broker config CI passes with `-D` into the
-    // (forked) test JVM. When `pactbroker.url` is unset (local) the @PactBroker provider test is
-    // @EnabledIfSystemProperty-skipped and git-pact above stays the fallback.
-    listOf(
-        "pactbroker.url",
-        "pactbroker.auth.username",
-        "pactbroker.auth.password",
-        "pactbroker.enablePending",
-        "pactbroker.providerBranch",
-        "pact.verifier.publishResults",
-        "pact.provider.version",
-        "pact.provider.branch",
-        "pact.provider.tag",
-    ).forEach { key -> System.getProperty(key)?.let { systemProperty(key, it) } }
+    // Pact rootDir + Pact Broker property forwarding centralised into
+    // build-logic/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
+    // (ADR-0250 Phase 2, issue #4414) — only the maxHeapSize override above is service-specific.
 }
 
 // Mutation testing on the money-path domain (ADR-0063 / ADR-0030 D3; fleet rollout #1266). Weekly +

--- a/openbank-aml-service/build.gradle.kts
+++ b/openbank-aml-service/build.gradle.kts
@@ -61,7 +61,7 @@ dependencies {
 // Pact: replay the committed git-pact contracts (ADR-0063) and forward broker config when CI
 // supplies it, so a later broker migration needs no build change here.
 // Pact rootDir + Pact Broker property forwarding centralised into
-// build-logic/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
+// build-logic/src/main/kotlin/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
 // (ADR-0250 Phase 2, issue #4414) — this module's copy was byte-identical in substance to the
 // fleet-standard block, so nothing service-specific remains here.
 

--- a/openbank-aml-service/build.gradle.kts
+++ b/openbank-aml-service/build.gradle.kts
@@ -60,20 +60,10 @@ dependencies {
 
 // Pact: replay the committed git-pact contracts (ADR-0063) and forward broker config when CI
 // supplies it, so a later broker migration needs no build change here.
-tasks.withType<Test> {
-    systemProperty("pact.rootDir", "${rootProject.projectDir}/pacts")
-    listOf(
-        "pactbroker.url",
-        "pactbroker.auth.username",
-        "pactbroker.auth.password",
-        "pactbroker.enablePending",
-        "pactbroker.providerBranch",
-        "pact.verifier.publishResults",
-        "pact.provider.version",
-        "pact.provider.branch",
-        "pact.provider.tag",
-    ).forEach { key -> System.getProperty(key)?.let { systemProperty(key, it) } }
-}
+// Pact rootDir + Pact Broker property forwarding centralised into
+// build-logic/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
+// (ADR-0250 Phase 2, issue #4414) — this module's copy was byte-identical in substance to the
+// fleet-standard block, so nothing service-specific remains here.
 
 kover {
     reports {

--- a/openbank-balance-service/build.gradle.kts
+++ b/openbank-balance-service/build.gradle.kts
@@ -88,20 +88,10 @@ kover {
 // Pact: write generated pact files to the shared pacts/ dir at the repo root (git-pact, ADR-0063).
 // The consumer test regenerates the file on every run; developers commit the result.
 // NOTE: must be set on the test JVM fork, not the Gradle daemon (System.setProperty would not propagate).
-tasks.withType<Test> {
-    systemProperty("pact.rootDir", "${rootProject.projectDir}/pacts")
-    listOf(
-        "pactbroker.url",
-        "pactbroker.auth.username",
-        "pactbroker.auth.password",
-        "pactbroker.enablePending",
-        "pactbroker.providerBranch",
-        "pact.verifier.publishResults",
-        "pact.provider.version",
-        "pact.provider.branch",
-        "pact.provider.tag",
-    ).forEach { key -> System.getProperty(key)?.let { systemProperty(key, it) } }
-}
+// Pact rootDir + Pact Broker property forwarding centralised into
+// build-logic/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
+// (ADR-0250 Phase 2, issue #4414) — this module's copy was byte-identical in substance to the
+// fleet-standard block, so nothing service-specific remains here.
 
 // Mutation testing on the money-path domain (ADR-0063 / ADR-0030 D3). Weekly + manual via
 // pitest.yml, advisory — never a per-PR gate. info.solidsoft.pitest 1.19.0 supports Gradle 9.

--- a/openbank-balance-service/build.gradle.kts
+++ b/openbank-balance-service/build.gradle.kts
@@ -89,7 +89,7 @@ kover {
 // The consumer test regenerates the file on every run; developers commit the result.
 // NOTE: must be set on the test JVM fork, not the Gradle daemon (System.setProperty would not propagate).
 // Pact rootDir + Pact Broker property forwarding centralised into
-// build-logic/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
+// build-logic/src/main/kotlin/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
 // (ADR-0250 Phase 2, issue #4414) — this module's copy was byte-identical in substance to the
 // fleet-standard block, so nothing service-specific remains here.
 

--- a/openbank-billing-service/build.gradle.kts
+++ b/openbank-billing-service/build.gradle.kts
@@ -102,17 +102,7 @@ kover {
 // Pact: write the generated consumer contract to pacts/ and forward broker config, matching
 // transaction-service/lending-service/settlement-service's tasks.withType<Test> block
 // (ADR-0063 P1/P2).
-tasks.withType<Test> {
-    systemProperty("pact.rootDir", "${rootProject.projectDir}/pacts")
-    listOf(
-        "pactbroker.url",
-        "pactbroker.auth.username",
-        "pactbroker.auth.password",
-        "pactbroker.enablePending",
-        "pactbroker.providerBranch",
-        "pact.verifier.publishResults",
-        "pact.provider.version",
-        "pact.provider.branch",
-        "pact.provider.tag",
-    ).forEach { key -> System.getProperty(key)?.let { systemProperty(key, it) } }
-}
+// Pact rootDir + Pact Broker property forwarding centralised into
+// build-logic/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
+// (ADR-0250 Phase 2, issue #4414) — this module's copy was byte-identical in substance to the
+// fleet-standard block, so nothing service-specific remains here.

--- a/openbank-billing-service/build.gradle.kts
+++ b/openbank-billing-service/build.gradle.kts
@@ -103,6 +103,6 @@ kover {
 // transaction-service/lending-service/settlement-service's tasks.withType<Test> block
 // (ADR-0063 P1/P2).
 // Pact rootDir + Pact Broker property forwarding centralised into
-// build-logic/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
+// build-logic/src/main/kotlin/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
 // (ADR-0250 Phase 2, issue #4414) — this module's copy was byte-identical in substance to the
 // fleet-standard block, so nothing service-specific remains here.

--- a/openbank-card-issuance-service/build.gradle.kts
+++ b/openbank-card-issuance-service/build.gradle.kts
@@ -67,20 +67,10 @@ dependencies {
 // stays @EnabledIfSystemProperty-skipped on EVERY lane including main-push, and card-issuance keeps
 // publishing no verification result — which is the `can-i-deploy` block the class exists to prevent.
 // A twin that cannot see the broker looks identical to not having one.
-tasks.withType<Test> {
-    systemProperty("pact.rootDir", "${rootProject.projectDir}/pacts")
-    listOf(
-        "pactbroker.url",
-        "pactbroker.auth.username",
-        "pactbroker.auth.password",
-        "pactbroker.enablePending",
-        "pactbroker.providerBranch",
-        "pact.verifier.publishResults",
-        "pact.provider.version",
-        "pact.provider.branch",
-        "pact.provider.tag",
-    ).forEach { key -> System.getProperty(key)?.let { systemProperty(key, it) } }
-}
+// Pact rootDir + Pact Broker property forwarding centralised into
+// build-logic/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
+// (ADR-0250 Phase 2, issue #4414) — this module's copy was byte-identical in substance to the
+// fleet-standard block, so nothing service-specific remains here.
 
 kover {
     reports {

--- a/openbank-card-issuance-service/build.gradle.kts
+++ b/openbank-card-issuance-service/build.gradle.kts
@@ -68,7 +68,7 @@ dependencies {
 // publishing no verification result — which is the `can-i-deploy` block the class exists to prevent.
 // A twin that cannot see the broker looks identical to not having one.
 // Pact rootDir + Pact Broker property forwarding centralised into
-// build-logic/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
+// build-logic/src/main/kotlin/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
 // (ADR-0250 Phase 2, issue #4414) — this module's copy was byte-identical in substance to the
 // fleet-standard block, so nothing service-specific remains here.
 

--- a/openbank-case-coordinator-agent/build.gradle.kts
+++ b/openbank-case-coordinator-agent/build.gradle.kts
@@ -65,20 +65,10 @@ tasks.named<Copy>("processResources") {
     }
 }
 
-tasks.withType<Test> {
-    systemProperty("pact.rootDir", "${rootProject.projectDir}/pacts")
-    listOf(
-        "pactbroker.url",
-        "pactbroker.auth.username",
-        "pactbroker.auth.password",
-        "pactbroker.enablePending",
-        "pactbroker.providerBranch",
-        "pact.verifier.publishResults",
-        "pact.provider.version",
-        "pact.provider.branch",
-        "pact.provider.tag",
-    ).forEach { key -> System.getProperty(key)?.let { systemProperty(key, it) } }
-}
+// Pact rootDir + Pact Broker property forwarding centralised into
+// build-logic/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
+// (ADR-0250 Phase 2, issue #4414) — this module's copy was byte-identical in substance to the
+// fleet-standard block, so nothing service-specific remains here.
 
 kover {
     reports {

--- a/openbank-case-coordinator-agent/build.gradle.kts
+++ b/openbank-case-coordinator-agent/build.gradle.kts
@@ -66,7 +66,7 @@ tasks.named<Copy>("processResources") {
 }
 
 // Pact rootDir + Pact Broker property forwarding centralised into
-// build-logic/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
+// build-logic/src/main/kotlin/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
 // (ADR-0250 Phase 2, issue #4414) — this module's copy was byte-identical in substance to the
 // fleet-standard block, so nothing service-specific remains here.
 

--- a/openbank-clearing-simulator/build.gradle.kts
+++ b/openbank-clearing-simulator/build.gradle.kts
@@ -67,16 +67,7 @@ kover {
 // Broker version carrying no branch and no verification result, leaving its consumers
 // permanently UNVERIFIED and undeployable (issue #3285). 14 of 17 providers already had this
 // block; the correlation with the three that did not was exact.
-tasks.withType<Test> {
-    listOf(
-        "pactbroker.url",
-        "pactbroker.auth.username",
-        "pactbroker.auth.password",
-        "pactbroker.enablePending",
-        "pactbroker.providerBranch",
-        "pact.verifier.publishResults",
-        "pact.provider.version",
-        "pact.provider.branch",
-        "pact.provider.tag",
-    ).forEach { key -> System.getProperty(key)?.let { systemProperty(key, it) } }
-}
+// Pact rootDir + Pact Broker property forwarding centralised into
+// build-logic/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
+// (ADR-0250 Phase 2, issue #4414) — this module's copy was byte-identical in substance to the
+// fleet-standard block, so nothing service-specific remains here.

--- a/openbank-clearing-simulator/build.gradle.kts
+++ b/openbank-clearing-simulator/build.gradle.kts
@@ -68,6 +68,6 @@ kover {
 // permanently UNVERIFIED and undeployable (issue #3285). 14 of 17 providers already had this
 // block; the correlation with the three that did not was exact.
 // Pact rootDir + Pact Broker property forwarding centralised into
-// build-logic/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
+// build-logic/src/main/kotlin/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
 // (ADR-0250 Phase 2, issue #4414) — this module's copy was byte-identical in substance to the
 // fleet-standard block, so nothing service-specific remains here.

--- a/openbank-consent-service/build.gradle.kts
+++ b/openbank-consent-service/build.gradle.kts
@@ -76,17 +76,7 @@ kover {
 }
 
 // Pact: write generated consumer contracts to pacts/ and forward broker config for verification.
-tasks.withType<Test> {
-    systemProperty("pact.rootDir", "${rootProject.projectDir}/pacts")
-    listOf(
-        "pactbroker.url",
-        "pactbroker.auth.username",
-        "pactbroker.auth.password",
-        "pactbroker.enablePending",
-        "pactbroker.providerBranch",
-        "pact.verifier.publishResults",
-        "pact.provider.version",
-        "pact.provider.branch",
-        "pact.provider.tag",
-    ).forEach { key -> System.getProperty(key)?.let { systemProperty(key, it) } }
-}
+// Pact rootDir + Pact Broker property forwarding centralised into
+// build-logic/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
+// (ADR-0250 Phase 2, issue #4414) — this module's copy was byte-identical in substance to the
+// fleet-standard block, so nothing service-specific remains here.

--- a/openbank-consent-service/build.gradle.kts
+++ b/openbank-consent-service/build.gradle.kts
@@ -77,6 +77,6 @@ kover {
 
 // Pact: write generated consumer contracts to pacts/ and forward broker config for verification.
 // Pact rootDir + Pact Broker property forwarding centralised into
-// build-logic/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
+// build-logic/src/main/kotlin/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
 // (ADR-0250 Phase 2, issue #4414) — this module's copy was byte-identical in substance to the
 // fleet-standard block, so nothing service-specific remains here.

--- a/openbank-copilot-service/build.gradle.kts
+++ b/openbank-copilot-service/build.gradle.kts
@@ -64,7 +64,7 @@ dependencies {
 // Pact: write generated pact files to the shared pacts/ dir at the repo root (git-pact, ADR-0063).
 // NOTE: must be set on the test JVM fork, not the Gradle daemon (System.setProperty would not propagate).
 // Pact rootDir + Pact Broker property forwarding centralised into
-// build-logic/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
+// build-logic/src/main/kotlin/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
 // (ADR-0250 Phase 2, issue #4414) — this module's copy was byte-identical in substance to the
 // fleet-standard block, so nothing service-specific remains here.
 

--- a/openbank-copilot-service/build.gradle.kts
+++ b/openbank-copilot-service/build.gradle.kts
@@ -63,9 +63,10 @@ dependencies {
 
 // Pact: write generated pact files to the shared pacts/ dir at the repo root (git-pact, ADR-0063).
 // NOTE: must be set on the test JVM fork, not the Gradle daemon (System.setProperty would not propagate).
-tasks.withType<Test> {
-    systemProperty("pact.rootDir", "${rootProject.projectDir}/pacts")
-}
+// Pact rootDir + Pact Broker property forwarding centralised into
+// build-logic/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
+// (ADR-0250 Phase 2, issue #4414) — this module's copy was byte-identical in substance to the
+// fleet-standard block, so nothing service-specific remains here.
 
 kover {
     reports {

--- a/openbank-customer-edge/build.gradle.kts
+++ b/openbank-customer-edge/build.gradle.kts
@@ -68,7 +68,7 @@ dependencies {
 // Pact: read consumer pacts from the shared pacts/ dir at the repo root (git-pact, ADR-0063).
 // NOTE: must be set on the test JVM fork, not the Gradle daemon (System.setProperty would not propagate).
 // Pact rootDir + Pact Broker property forwarding centralised into
-// build-logic/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
+// build-logic/src/main/kotlin/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
 // (ADR-0250 Phase 2, issue #4414) — this module's copy was byte-identical in substance to the
 // fleet-standard block, so nothing service-specific remains here.
 

--- a/openbank-customer-edge/build.gradle.kts
+++ b/openbank-customer-edge/build.gradle.kts
@@ -67,20 +67,10 @@ dependencies {
 
 // Pact: read consumer pacts from the shared pacts/ dir at the repo root (git-pact, ADR-0063).
 // NOTE: must be set on the test JVM fork, not the Gradle daemon (System.setProperty would not propagate).
-tasks.withType<Test> {
-    systemProperty("pact.rootDir", "${rootProject.projectDir}/pacts")
-    listOf(
-        "pactbroker.url",
-        "pactbroker.auth.username",
-        "pactbroker.auth.password",
-        "pactbroker.enablePending",
-        "pactbroker.providerBranch",
-        "pact.verifier.publishResults",
-        "pact.provider.version",
-        "pact.provider.branch",
-        "pact.provider.tag",
-    ).forEach { key -> System.getProperty(key)?.let { systemProperty(key, it) } }
-}
+// Pact rootDir + Pact Broker property forwarding centralised into
+// build-logic/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
+// (ADR-0250 Phase 2, issue #4414) — this module's copy was byte-identical in substance to the
+// fleet-standard block, so nothing service-specific remains here.
 
 // Coverage floor (ADR-0020, ratchet-only — sweep #466: this module previously had NO
 // koverVerify gate at all). Floor = measured LINE coverage at introduction minus ~5 pt

--- a/openbank-delegation-service/build.gradle.kts
+++ b/openbank-delegation-service/build.gradle.kts
@@ -83,17 +83,7 @@ kover {
     }
 }
 
-tasks.withType<Test> {
-    systemProperty("pact.rootDir", "${rootProject.projectDir}/pacts")
-    listOf(
-        "pactbroker.url",
-        "pactbroker.auth.username",
-        "pactbroker.auth.password",
-        "pactbroker.enablePending",
-        "pactbroker.providerBranch",
-        "pact.verifier.publishResults",
-        "pact.provider.version",
-        "pact.provider.branch",
-        "pact.provider.tag",
-    ).forEach { key -> System.getProperty(key)?.let { systemProperty(key, it) } }
-}
+// Pact rootDir + Pact Broker property forwarding centralised into
+// build-logic/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
+// (ADR-0250 Phase 2, issue #4414) — this module's copy was byte-identical in substance to the
+// fleet-standard block, so nothing service-specific remains here.

--- a/openbank-delegation-service/build.gradle.kts
+++ b/openbank-delegation-service/build.gradle.kts
@@ -84,6 +84,6 @@ kover {
 }
 
 // Pact rootDir + Pact Broker property forwarding centralised into
-// build-logic/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
+// build-logic/src/main/kotlin/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
 // (ADR-0250 Phase 2, issue #4414) — this module's copy was byte-identical in substance to the
 // fleet-standard block, so nothing service-specific remains here.

--- a/openbank-document-service/build.gradle.kts
+++ b/openbank-document-service/build.gradle.kts
@@ -75,20 +75,10 @@ dependencies {
 // (ADR-0063). pactbroker.* / pact.provider.* props are injected by CI with -D; on a pull request
 // none of them are set, and DocumentPactProviderVerificationTest is @PactFolder-sourced, so it
 // runs regardless — that is the point (issue #2338).
-tasks.withType<Test> {
-    systemProperty("pact.rootDir", "${rootProject.projectDir}/pacts")
-    listOf(
-        "pactbroker.url",
-        "pactbroker.auth.username",
-        "pactbroker.auth.password",
-        "pactbroker.enablePending",
-        "pactbroker.providerBranch",
-        "pact.verifier.publishResults",
-        "pact.provider.version",
-        "pact.provider.branch",
-        "pact.provider.tag",
-    ).forEach { key -> System.getProperty(key)?.let { systemProperty(key, it) } }
-}
+// Pact rootDir + Pact Broker property forwarding centralised into
+// build-logic/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
+// (ADR-0250 Phase 2, issue #4414) — this module's copy was byte-identical in substance to the
+// fleet-standard block, so nothing service-specific remains here.
 
 kover {
     reports {

--- a/openbank-document-service/build.gradle.kts
+++ b/openbank-document-service/build.gradle.kts
@@ -76,7 +76,7 @@ dependencies {
 // none of them are set, and DocumentPactProviderVerificationTest is @PactFolder-sourced, so it
 // runs regardless — that is the point (issue #2338).
 // Pact rootDir + Pact Broker property forwarding centralised into
-// build-logic/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
+// build-logic/src/main/kotlin/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
 // (ADR-0250 Phase 2, issue #4414) — this module's copy was byte-identical in substance to the
 // fleet-standard block, so nothing service-specific remains here.
 

--- a/openbank-domestic-payment/build.gradle.kts
+++ b/openbank-domestic-payment/build.gradle.kts
@@ -88,7 +88,7 @@ kover {
 // Pact: write generated consumer contracts to pacts/ and forward broker config for provider
 // verification (ADR-0063 P2). pactbroker.* props are injected by CI with -D.
 // Pact rootDir + Pact Broker property forwarding centralised into
-// build-logic/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
+// build-logic/src/main/kotlin/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
 // (ADR-0250 Phase 2, issue #4414) — this module's copy was byte-identical in substance to the
 // fleet-standard block, so nothing service-specific remains here.
 

--- a/openbank-domestic-payment/build.gradle.kts
+++ b/openbank-domestic-payment/build.gradle.kts
@@ -87,20 +87,10 @@ kover {
 
 // Pact: write generated consumer contracts to pacts/ and forward broker config for provider
 // verification (ADR-0063 P2). pactbroker.* props are injected by CI with -D.
-tasks.withType<Test> {
-    systemProperty("pact.rootDir", "${rootProject.projectDir}/pacts")
-    listOf(
-        "pactbroker.url",
-        "pactbroker.auth.username",
-        "pactbroker.auth.password",
-        "pactbroker.enablePending",
-        "pactbroker.providerBranch",
-        "pact.verifier.publishResults",
-        "pact.provider.version",
-        "pact.provider.branch",
-        "pact.provider.tag",
-    ).forEach { key -> System.getProperty(key)?.let { systemProperty(key, it) } }
-}
+// Pact rootDir + Pact Broker property forwarding centralised into
+// build-logic/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
+// (ADR-0250 Phase 2, issue #4414) — this module's copy was byte-identical in substance to the
+// fleet-standard block, so nothing service-specific remains here.
 
 // Mutation testing on the money-path domain (ADR-0063 / ADR-0030 D3). Weekly + manual via
 // pitest.yml, advisory — never a per-PR gate. Per-service plugin pin on purpose (rules.yaml

--- a/openbank-finrep-service/build.gradle.kts
+++ b/openbank-finrep-service/build.gradle.kts
@@ -42,7 +42,7 @@ dependencies {
 // openbank-ledger-service's LedgerPactProviderVerificationTest (@PactFolder("../pacts")) replays it.
 // NOTE: must be set on the test JVM fork, not the Gradle daemon (System.setProperty would not propagate).
 // Pact rootDir + Pact Broker property forwarding centralised into
-// build-logic/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
+// build-logic/src/main/kotlin/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
 // (ADR-0250 Phase 2, issue #4414) — this module's copy was byte-identical in substance to the
 // fleet-standard block, so nothing service-specific remains here.
 

--- a/openbank-finrep-service/build.gradle.kts
+++ b/openbank-finrep-service/build.gradle.kts
@@ -41,9 +41,10 @@ dependencies {
 // The consumer test regenerates the file on every run; developers commit the result, and
 // openbank-ledger-service's LedgerPactProviderVerificationTest (@PactFolder("../pacts")) replays it.
 // NOTE: must be set on the test JVM fork, not the Gradle daemon (System.setProperty would not propagate).
-tasks.withType<Test> {
-    systemProperty("pact.rootDir", "${rootProject.projectDir}/pacts")
-}
+// Pact rootDir + Pact Broker property forwarding centralised into
+// build-logic/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
+// (ADR-0250 Phase 2, issue #4414) — this module's copy was byte-identical in substance to the
+// fleet-standard block, so nothing service-specific remains here.
 
 kover {
     reports {

--- a/openbank-fraud-service/build.gradle.kts
+++ b/openbank-fraud-service/build.gradle.kts
@@ -61,7 +61,7 @@ dependencies {
 
 // Pact: write generated consumer contracts to pacts/ and forward broker config.
 // Pact rootDir + Pact Broker property forwarding centralised into
-// build-logic/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
+// build-logic/src/main/kotlin/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
 // (ADR-0250 Phase 2, issue #4414) — this module's copy was byte-identical in substance to the
 // fleet-standard block, so nothing service-specific remains here.
 

--- a/openbank-fraud-service/build.gradle.kts
+++ b/openbank-fraud-service/build.gradle.kts
@@ -60,20 +60,10 @@ dependencies {
 }
 
 // Pact: write generated consumer contracts to pacts/ and forward broker config.
-tasks.withType<Test> {
-    systemProperty("pact.rootDir", "${rootProject.projectDir}/pacts")
-    listOf(
-        "pactbroker.url",
-        "pactbroker.auth.username",
-        "pactbroker.auth.password",
-        "pactbroker.enablePending",
-        "pactbroker.providerBranch",
-        "pact.verifier.publishResults",
-        "pact.provider.version",
-        "pact.provider.branch",
-        "pact.provider.tag",
-    ).forEach { key -> System.getProperty(key)?.let { systemProperty(key, it) } }
-}
+// Pact rootDir + Pact Broker property forwarding centralised into
+// build-logic/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
+// (ADR-0250 Phase 2, issue #4414) — this module's copy was byte-identical in substance to the
+// fleet-standard block, so nothing service-specific remains here.
 
 kover {
     reports {

--- a/openbank-fx-service/build.gradle.kts
+++ b/openbank-fx-service/build.gradle.kts
@@ -102,6 +102,6 @@ pitest {
 
 // Pact: forward broker config so the provider verification test can fetch and publish results.
 // Pact rootDir + Pact Broker property forwarding centralised into
-// build-logic/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
+// build-logic/src/main/kotlin/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
 // (ADR-0250 Phase 2, issue #4414) — this module's copy was byte-identical in substance to the
 // fleet-standard block, so nothing service-specific remains here.

--- a/openbank-fx-service/build.gradle.kts
+++ b/openbank-fx-service/build.gradle.kts
@@ -101,17 +101,7 @@ pitest {
 }
 
 // Pact: forward broker config so the provider verification test can fetch and publish results.
-tasks.withType<Test> {
-    systemProperty("pact.rootDir", "${rootProject.projectDir}/pacts")
-    listOf(
-        "pactbroker.url",
-        "pactbroker.auth.username",
-        "pactbroker.auth.password",
-        "pactbroker.enablePending",
-        "pactbroker.providerBranch",
-        "pact.verifier.publishResults",
-        "pact.provider.version",
-        "pact.provider.branch",
-        "pact.provider.tag",
-    ).forEach { key -> System.getProperty(key)?.let { systemProperty(key, it) } }
-}
+// Pact rootDir + Pact Broker property forwarding centralised into
+// build-logic/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
+// (ADR-0250 Phase 2, issue #4414) — this module's copy was byte-identical in substance to the
+// fleet-standard block, so nothing service-specific remains here.

--- a/openbank-interest-service/build.gradle.kts
+++ b/openbank-interest-service/build.gradle.kts
@@ -81,20 +81,10 @@ kover {
 // transaction-service/lending-service/billing-service/settlement-service's tasks.withType<Test>
 // block (ADR-0063 P1/P2). Without pact.rootDir the pact lands in the module's build/pacts and
 // .github/workflows/pact-drift-check.yml never sees it.
-tasks.withType<Test> {
-    systemProperty("pact.rootDir", "${rootProject.projectDir}/pacts")
-    listOf(
-        "pactbroker.url",
-        "pactbroker.auth.username",
-        "pactbroker.auth.password",
-        "pactbroker.enablePending",
-        "pactbroker.providerBranch",
-        "pact.verifier.publishResults",
-        "pact.provider.version",
-        "pact.provider.branch",
-        "pact.provider.tag",
-    ).forEach { key -> System.getProperty(key)?.let { systemProperty(key, it) } }
-}
+// Pact rootDir + Pact Broker property forwarding centralised into
+// build-logic/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
+// (ADR-0250 Phase 2, issue #4414) — this module's copy was byte-identical in substance to the
+// fleet-standard block, so nothing service-specific remains here.
 
 // Mutation testing on the money-path domain (ADR-0063 / ADR-0030 D3; money-path matrix
 // extension, issue #3675). Weekly + manual via pitest.yml, advisory — never a per-PR gate.

--- a/openbank-interest-service/build.gradle.kts
+++ b/openbank-interest-service/build.gradle.kts
@@ -82,7 +82,7 @@ kover {
 // block (ADR-0063 P1/P2). Without pact.rootDir the pact lands in the module's build/pacts and
 // .github/workflows/pact-drift-check.yml never sees it.
 // Pact rootDir + Pact Broker property forwarding centralised into
-// build-logic/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
+// build-logic/src/main/kotlin/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
 // (ADR-0250 Phase 2, issue #4414) — this module's copy was byte-identical in substance to the
 // fleet-standard block, so nothing service-specific remains here.
 

--- a/openbank-kyc-service/build.gradle.kts
+++ b/openbank-kyc-service/build.gradle.kts
@@ -60,20 +60,10 @@ dependencies {
 
 // Pact: write the generated consumer contract to pacts/ and forward broker config, matching
 // account-service/ledger-service's tasks.withType<Test> block (ADR-0063 P1/P2).
-tasks.withType<Test> {
-    systemProperty("pact.rootDir", "${rootProject.projectDir}/pacts")
-    listOf(
-        "pactbroker.url",
-        "pactbroker.auth.username",
-        "pactbroker.auth.password",
-        "pactbroker.enablePending",
-        "pactbroker.providerBranch",
-        "pact.verifier.publishResults",
-        "pact.provider.version",
-        "pact.provider.branch",
-        "pact.provider.tag",
-    ).forEach { key -> System.getProperty(key)?.let { systemProperty(key, it) } }
-}
+// Pact rootDir + Pact Broker property forwarding centralised into
+// build-logic/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
+// (ADR-0250 Phase 2, issue #4414) — this module's copy was byte-identical in substance to the
+// fleet-standard block, so nothing service-specific remains here.
 
 kover {
     reports {

--- a/openbank-kyc-service/build.gradle.kts
+++ b/openbank-kyc-service/build.gradle.kts
@@ -61,7 +61,7 @@ dependencies {
 // Pact: write the generated consumer contract to pacts/ and forward broker config, matching
 // account-service/ledger-service's tasks.withType<Test> block (ADR-0063 P1/P2).
 // Pact rootDir + Pact Broker property forwarding centralised into
-// build-logic/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
+// build-logic/src/main/kotlin/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
 // (ADR-0250 Phase 2, issue #4414) — this module's copy was byte-identical in substance to the
 // fleet-standard block, so nothing service-specific remains here.
 

--- a/openbank-ledger-service/build.gradle.kts
+++ b/openbank-ledger-service/build.gradle.kts
@@ -99,7 +99,7 @@ kover {
 System.setProperty("pact.rootDir", "${rootProject.projectDir}/pacts")
 
 // Pact rootDir + Pact Broker property forwarding centralised into
-// build-logic/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
+// build-logic/src/main/kotlin/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
 // (ADR-0250 Phase 2, issue #4414) — this module's copy was byte-identical in substance to the
 // fleet-standard block, so nothing service-specific remains here.
 

--- a/openbank-ledger-service/build.gradle.kts
+++ b/openbank-ledger-service/build.gradle.kts
@@ -98,30 +98,10 @@ kover {
 // Pact: provider verification reads pact files from the shared pacts/ dir (git-pact, ADR-0063).
 System.setProperty("pact.rootDir", "${rootProject.projectDir}/pacts")
 
-// Pact Broker verification (ADR-0092): forward the broker config CI passes with `-D` into the
-// (forked) test JVM. When `pactbroker.url` is unset (local `./gradlew build`) the @PactBroker
-// provider test is @EnabledIfSystemProperty-skipped and git-pact above stays the fallback;
-// publishResults + provider.version/branch tag the verification result for can-i-deploy.
-tasks.withType<Test> {
-    // Forwarded into the FORKED test JVM, which the config-time System.setProperty above does not
-    // reach — that one only ever set it on the Gradle daemon. Without it a consumer pact is written
-    // to `build/pacts` instead of the shared `pacts/` dir, where nothing commits it and
-    // `derive-pact-drift-scope.sh` reports it as an uncommitted pact (#3921). The provider
-    // verification is unaffected either way: it resolves `@PactFolder("../pacts")` relative to the
-    // module, not through this property.
-    systemProperty("pact.rootDir", "${rootProject.projectDir}/pacts")
-    listOf(
-        "pactbroker.url",
-        "pactbroker.auth.username",
-        "pactbroker.auth.password",
-        "pactbroker.enablePending",
-        "pactbroker.providerBranch",
-        "pact.verifier.publishResults",
-        "pact.provider.version",
-        "pact.provider.branch",
-        "pact.provider.tag",
-    ).forEach { key -> System.getProperty(key)?.let { systemProperty(key, it) } }
-}
+// Pact rootDir + Pact Broker property forwarding centralised into
+// build-logic/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
+// (ADR-0250 Phase 2, issue #4414) — this module's copy was byte-identical in substance to the
+// fleet-standard block, so nothing service-specific remains here.
 
 // Mutation testing on the money-path domain (ADR-0063 / ADR-0030 D3). Weekly + manual via
 // pitest.yml, advisory — never a per-PR gate. info.solidsoft.pitest 1.19.0 supports Gradle 9.

--- a/openbank-lending-service/build.gradle.kts
+++ b/openbank-lending-service/build.gradle.kts
@@ -101,6 +101,6 @@ tasks.withType<Test> {
     maxHeapSize = "2g"
 
     // Pact rootDir + Pact Broker property forwarding centralised into
-    // build-logic/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
+    // build-logic/src/main/kotlin/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
     // (ADR-0250 Phase 2, issue #4414) — only the maxHeapSize override above is service-specific.
 }

--- a/openbank-lending-service/build.gradle.kts
+++ b/openbank-lending-service/build.gradle.kts
@@ -100,16 +100,7 @@ tasks.withType<Test> {
     // a global bump would be an unmeasured ratchet applied to 50 modules to fix one.
     maxHeapSize = "2g"
 
-    systemProperty("pact.rootDir", "${rootProject.projectDir}/pacts")
-    listOf(
-        "pactbroker.url",
-        "pactbroker.auth.username",
-        "pactbroker.auth.password",
-        "pactbroker.enablePending",
-        "pactbroker.providerBranch",
-        "pact.verifier.publishResults",
-        "pact.provider.version",
-        "pact.provider.branch",
-        "pact.provider.tag",
-    ).forEach { key -> System.getProperty(key)?.let { systemProperty(key, it) } }
+    // Pact rootDir + Pact Broker property forwarding centralised into
+    // build-logic/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
+    // (ADR-0250 Phase 2, issue #4414) — only the maxHeapSize override above is service-specific.
 }

--- a/openbank-mcp-service/build.gradle.kts
+++ b/openbank-mcp-service/build.gradle.kts
@@ -76,6 +76,6 @@ kover {
 // diverge. NOTE: must be set on the test JVM fork, not the Gradle daemon (System.setProperty would
 // not propagate). The pactbroker.* keys are forwarded so CI's publish step behaves as elsewhere.
 // Pact rootDir + Pact Broker property forwarding centralised into
-// build-logic/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
+// build-logic/src/main/kotlin/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
 // (ADR-0250 Phase 2, issue #4414) — this module's copy was byte-identical in substance to the
 // fleet-standard block, so nothing service-specific remains here.

--- a/openbank-mcp-service/build.gradle.kts
+++ b/openbank-mcp-service/build.gradle.kts
@@ -75,17 +75,7 @@ kover {
 // is committed; pact-drift-check.yml fails the build if a committed pact and a fresh regeneration
 // diverge. NOTE: must be set on the test JVM fork, not the Gradle daemon (System.setProperty would
 // not propagate). The pactbroker.* keys are forwarded so CI's publish step behaves as elsewhere.
-tasks.withType<Test> {
-    systemProperty("pact.rootDir", "${rootProject.projectDir}/pacts")
-    listOf(
-        "pactbroker.url",
-        "pactbroker.auth.username",
-        "pactbroker.auth.password",
-        "pactbroker.enablePending",
-        "pactbroker.providerBranch",
-        "pact.verifier.publishResults",
-        "pact.provider.version",
-        "pact.provider.branch",
-        "pact.provider.tag",
-    ).forEach { key -> System.getProperty(key)?.let { systemProperty(key, it) } }
-}
+// Pact rootDir + Pact Broker property forwarding centralised into
+// build-logic/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
+// (ADR-0250 Phase 2, issue #4414) — this module's copy was byte-identical in substance to the
+// fleet-standard block, so nothing service-specific remains here.

--- a/openbank-notification-service/build.gradle.kts
+++ b/openbank-notification-service/build.gradle.kts
@@ -68,17 +68,7 @@ kover {
 }
 
 // Pact: write generated consumer contracts to pacts/ and forward broker config.
-tasks.withType<Test> {
-    systemProperty("pact.rootDir", "${rootProject.projectDir}/pacts")
-    listOf(
-        "pactbroker.url",
-        "pactbroker.auth.username",
-        "pactbroker.auth.password",
-        "pactbroker.enablePending",
-        "pactbroker.providerBranch",
-        "pact.verifier.publishResults",
-        "pact.provider.version",
-        "pact.provider.branch",
-        "pact.provider.tag",
-    ).forEach { key -> System.getProperty(key)?.let { systemProperty(key, it) } }
-}
+// Pact rootDir + Pact Broker property forwarding centralised into
+// build-logic/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
+// (ADR-0250 Phase 2, issue #4414) — this module's copy was byte-identical in substance to the
+// fleet-standard block, so nothing service-specific remains here.

--- a/openbank-notification-service/build.gradle.kts
+++ b/openbank-notification-service/build.gradle.kts
@@ -69,6 +69,6 @@ kover {
 
 // Pact: write generated consumer contracts to pacts/ and forward broker config.
 // Pact rootDir + Pact Broker property forwarding centralised into
-// build-logic/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
+// build-logic/src/main/kotlin/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
 // (ADR-0250 Phase 2, issue #4414) — this module's copy was byte-identical in substance to the
 // fleet-standard block, so nothing service-specific remains here.

--- a/openbank-onboarding-service/build.gradle.kts
+++ b/openbank-onboarding-service/build.gradle.kts
@@ -45,20 +45,10 @@ dependencies {
 
 // Pact: write the generated consumer contracts to pacts/ and forward broker config, matching
 // account-service/ledger-service's tasks.withType<Test> block (ADR-0063 P1/P2).
-tasks.withType<Test> {
-    systemProperty("pact.rootDir", "${rootProject.projectDir}/pacts")
-    listOf(
-        "pactbroker.url",
-        "pactbroker.auth.username",
-        "pactbroker.auth.password",
-        "pactbroker.enablePending",
-        "pactbroker.providerBranch",
-        "pact.verifier.publishResults",
-        "pact.provider.version",
-        "pact.provider.branch",
-        "pact.provider.tag",
-    ).forEach { key -> System.getProperty(key)?.let { systemProperty(key, it) } }
-}
+// Pact rootDir + Pact Broker property forwarding centralised into
+// build-logic/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
+// (ADR-0250 Phase 2, issue #4414) — this module's copy was byte-identical in substance to the
+// fleet-standard block, so nothing service-specific remains here.
 
 kover {
     reports {

--- a/openbank-onboarding-service/build.gradle.kts
+++ b/openbank-onboarding-service/build.gradle.kts
@@ -46,7 +46,7 @@ dependencies {
 // Pact: write the generated consumer contracts to pacts/ and forward broker config, matching
 // account-service/ledger-service's tasks.withType<Test> block (ADR-0063 P1/P2).
 // Pact rootDir + Pact Broker property forwarding centralised into
-// build-logic/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
+// build-logic/src/main/kotlin/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
 // (ADR-0250 Phase 2, issue #4414) — this module's copy was byte-identical in substance to the
 // fleet-standard block, so nothing service-specific remains here.
 

--- a/openbank-party-service/build.gradle.kts
+++ b/openbank-party-service/build.gradle.kts
@@ -94,7 +94,7 @@ tasks.test {
     )
 
     // Pact rootDir + Pact Broker property forwarding centralised into
-    // build-logic/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
+    // build-logic/src/main/kotlin/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
     // (ADR-0250 Phase 2, issue #4414) — this module previously forwarded the broker keys ITSELF
     // via `tasks.test { }` (not `tasks.withType<Test>`) and never set pact.rootDir at all; the
     // centralised version now covers both, applied uniformly across every Test task including

--- a/openbank-party-service/build.gradle.kts
+++ b/openbank-party-service/build.gradle.kts
@@ -93,18 +93,10 @@ tasks.test {
         providers.environmentVariable("DOCKER_HOST").orElse("unix:///var/run/docker.sock").get(),
     )
 
-    // Pact Broker verification (ADR-0092): forward the broker config CI passes with `-D` into the
-    // (forked) test JVM. When `pactbroker.url` is unset (local) the @PactBroker provider test is
-    // @EnabledIfSystemProperty-skipped and git-pact (committed pacts/) stays the fallback.
-    listOf(
-        "pactbroker.url",
-        "pactbroker.auth.username",
-        "pactbroker.auth.password",
-        "pactbroker.enablePending",
-        "pactbroker.providerBranch",
-        "pact.verifier.publishResults",
-        "pact.provider.version",
-        "pact.provider.branch",
-        "pact.provider.tag",
-    ).forEach { key -> System.getProperty(key)?.let { systemProperty(key, it) } }
+    // Pact rootDir + Pact Broker property forwarding centralised into
+    // build-logic/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
+    // (ADR-0250 Phase 2, issue #4414) — this module previously forwarded the broker keys ITSELF
+    // via `tasks.test { }` (not `tasks.withType<Test>`) and never set pact.rootDir at all; the
+    // centralised version now covers both, applied uniformly across every Test task including
+    // the new `providerPactTest`.
 }

--- a/openbank-pid-service/build.gradle.kts
+++ b/openbank-pid-service/build.gradle.kts
@@ -68,7 +68,7 @@ dependencies {
 // and pid-service publishes no verification result — the exact `can-i-deploy` block that class
 // exists to prevent. NOTE: must be set on the test JVM fork, not the Gradle daemon.
 // Pact rootDir + Pact Broker property forwarding centralised into
-// build-logic/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
+// build-logic/src/main/kotlin/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
 // (ADR-0250 Phase 2, issue #4414) — this module's copy was byte-identical in substance to the
 // fleet-standard block, so nothing service-specific remains here.
 

--- a/openbank-pid-service/build.gradle.kts
+++ b/openbank-pid-service/build.gradle.kts
@@ -67,20 +67,10 @@ dependencies {
 // PidPactBrokerProviderVerificationTest stays @EnabledIfSystemProperty-skipped even on main-push,
 // and pid-service publishes no verification result — the exact `can-i-deploy` block that class
 // exists to prevent. NOTE: must be set on the test JVM fork, not the Gradle daemon.
-tasks.withType<Test> {
-    systemProperty("pact.rootDir", "${rootProject.projectDir}/pacts")
-    listOf(
-        "pactbroker.url",
-        "pactbroker.auth.username",
-        "pactbroker.auth.password",
-        "pactbroker.enablePending",
-        "pactbroker.providerBranch",
-        "pact.verifier.publishResults",
-        "pact.provider.version",
-        "pact.provider.branch",
-        "pact.provider.tag",
-    ).forEach { key -> System.getProperty(key)?.let { systemProperty(key, it) } }
-}
+// Pact rootDir + Pact Broker property forwarding centralised into
+// build-logic/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
+// (ADR-0250 Phase 2, issue #4414) — this module's copy was byte-identical in substance to the
+// fleet-standard block, so nothing service-specific remains here.
 
 kover {
     reports {

--- a/openbank-product-catalog/build.gradle.kts
+++ b/openbank-product-catalog/build.gradle.kts
@@ -139,7 +139,7 @@ tasks.withType<Test> {
     maxHeapSize = "1536m"
 
     // Pact rootDir + Pact Broker property forwarding centralised into
-    // build-logic/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
+    // build-logic/src/main/kotlin/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
     // (ADR-0250 Phase 2, issue #4414) — only the maxHeapSize override above is service-specific.
 }
 

--- a/openbank-product-catalog/build.gradle.kts
+++ b/openbank-product-catalog/build.gradle.kts
@@ -137,26 +137,10 @@ tasks.withType<Test> {
     // metadata between profile restarts, so Gradle's 512 MiB test-worker default exhausts the
     // heap before the standalone boot proofs execute. This changes test infrastructure only.
     maxHeapSize = "1536m"
-    systemProperty("pact.rootDir", "${rootProject.projectDir}/pacts")
 
-    // Pact Broker verification (ADR-0092): forward the broker config CI passes with `-D`.
-    // Without this the properties reach the Gradle daemon and stop there, so the @PactBroker
-    // provider test is @EnabledIfSystemProperty(pactbroker.url)-skipped and pact-jvm logs
-    // "Skipping publishing of verification results ... not 'true'" — even on a main push where
-    // the workflow set PUBLISH_RESULTS=true. That is exactly how this module ended up with a
-    // broker version carrying no branch and no verification result, leaving its consumers
-    // permanently UNVERIFIED and undeployable (issue #3285).
-    listOf(
-        "pactbroker.url",
-        "pactbroker.auth.username",
-        "pactbroker.auth.password",
-        "pactbroker.enablePending",
-        "pactbroker.providerBranch",
-        "pact.verifier.publishResults",
-        "pact.provider.version",
-        "pact.provider.branch",
-        "pact.provider.tag",
-    ).forEach { key -> System.getProperty(key)?.let { systemProperty(key, it) } }
+    // Pact rootDir + Pact Broker property forwarding centralised into
+    // build-logic/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
+    // (ADR-0250 Phase 2, issue #4414) — only the maxHeapSize override above is service-specific.
 }
 
 // Coverage floor (ADR-0020, ratchet-only — sweep #466: this module previously had NO

--- a/openbank-psd2-service/build.gradle.kts
+++ b/openbank-psd2-service/build.gradle.kts
@@ -78,17 +78,7 @@ kover {
 // if the committed JSON and a fresh regeneration diverge.
 // NOTE: must be set on the test JVM fork, not the Gradle daemon (System.setProperty would not
 // propagate). The pactbroker.* keys are forwarded so CI's publish step behaves as it does elsewhere.
-tasks.withType<Test> {
-    systemProperty("pact.rootDir", "${rootProject.projectDir}/pacts")
-    listOf(
-        "pactbroker.url",
-        "pactbroker.auth.username",
-        "pactbroker.auth.password",
-        "pactbroker.enablePending",
-        "pactbroker.providerBranch",
-        "pact.verifier.publishResults",
-        "pact.provider.version",
-        "pact.provider.branch",
-        "pact.provider.tag",
-    ).forEach { key -> System.getProperty(key)?.let { systemProperty(key, it) } }
-}
+// Pact rootDir + Pact Broker property forwarding centralised into
+// build-logic/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
+// (ADR-0250 Phase 2, issue #4414) — this module's copy was byte-identical in substance to the
+// fleet-standard block, so nothing service-specific remains here.

--- a/openbank-psd2-service/build.gradle.kts
+++ b/openbank-psd2-service/build.gradle.kts
@@ -79,6 +79,6 @@ kover {
 // NOTE: must be set on the test JVM fork, not the Gradle daemon (System.setProperty would not
 // propagate). The pactbroker.* keys are forwarded so CI's publish step behaves as it does elsewhere.
 // Pact rootDir + Pact Broker property forwarding centralised into
-// build-logic/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
+// build-logic/src/main/kotlin/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
 // (ADR-0250 Phase 2, issue #4414) — this module's copy was byte-identical in substance to the
 // fleet-standard block, so nothing service-specific remains here.

--- a/openbank-sanctions-service/build.gradle.kts
+++ b/openbank-sanctions-service/build.gradle.kts
@@ -53,20 +53,10 @@ dependencies {
 
 // Pact: replay the committed git-pact contracts (ADR-0063) and forward broker config when CI
 // supplies it, so a later broker migration needs no build change here.
-tasks.withType<Test> {
-    systemProperty("pact.rootDir", "${rootProject.projectDir}/pacts")
-    listOf(
-        "pactbroker.url",
-        "pactbroker.auth.username",
-        "pactbroker.auth.password",
-        "pactbroker.enablePending",
-        "pactbroker.providerBranch",
-        "pact.verifier.publishResults",
-        "pact.provider.version",
-        "pact.provider.branch",
-        "pact.provider.tag",
-    ).forEach { key -> System.getProperty(key)?.let { systemProperty(key, it) } }
-}
+// Pact rootDir + Pact Broker property forwarding centralised into
+// build-logic/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
+// (ADR-0250 Phase 2, issue #4414) — this module's copy was byte-identical in substance to the
+// fleet-standard block, so nothing service-specific remains here.
 
 kover {
     reports {

--- a/openbank-sanctions-service/build.gradle.kts
+++ b/openbank-sanctions-service/build.gradle.kts
@@ -54,7 +54,7 @@ dependencies {
 // Pact: replay the committed git-pact contracts (ADR-0063) and forward broker config when CI
 // supplies it, so a later broker migration needs no build change here.
 // Pact rootDir + Pact Broker property forwarding centralised into
-// build-logic/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
+// build-logic/src/main/kotlin/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
 // (ADR-0250 Phase 2, issue #4414) — this module's copy was byte-identical in substance to the
 // fleet-standard block, so nothing service-specific remains here.
 

--- a/openbank-sca-service/build.gradle.kts
+++ b/openbank-sca-service/build.gradle.kts
@@ -73,6 +73,6 @@ kover {
 
 // Pact: forward broker config so the provider verification test can fetch and publish results.
 // Pact rootDir + Pact Broker property forwarding centralised into
-// build-logic/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
+// build-logic/src/main/kotlin/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
 // (ADR-0250 Phase 2, issue #4414) — this module's copy was byte-identical in substance to the
 // fleet-standard block, so nothing service-specific remains here.

--- a/openbank-sca-service/build.gradle.kts
+++ b/openbank-sca-service/build.gradle.kts
@@ -72,17 +72,7 @@ kover {
 }
 
 // Pact: forward broker config so the provider verification test can fetch and publish results.
-tasks.withType<Test> {
-    systemProperty("pact.rootDir", "${rootProject.projectDir}/pacts")
-    listOf(
-        "pactbroker.url",
-        "pactbroker.auth.username",
-        "pactbroker.auth.password",
-        "pactbroker.enablePending",
-        "pactbroker.providerBranch",
-        "pact.verifier.publishResults",
-        "pact.provider.version",
-        "pact.provider.branch",
-        "pact.provider.tag",
-    ).forEach { key -> System.getProperty(key)?.let { systemProperty(key, it) } }
-}
+// Pact rootDir + Pact Broker property forwarding centralised into
+// build-logic/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
+// (ADR-0250 Phase 2, issue #4414) — this module's copy was byte-identical in substance to the
+// fleet-standard block, so nothing service-specific remains here.

--- a/openbank-sepa-instant/build.gradle.kts
+++ b/openbank-sepa-instant/build.gradle.kts
@@ -98,6 +98,6 @@ pitest {
 // Pact: write the generated consumer contract to pacts/ and forward broker config, matching
 // transaction-service/fx-service/domestic-payment's tasks.withType<Test> block (ADR-0063 P1/P2).
 // Pact rootDir + Pact Broker property forwarding centralised into
-// build-logic/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
+// build-logic/src/main/kotlin/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
 // (ADR-0250 Phase 2, issue #4414) — this module's copy was byte-identical in substance to the
 // fleet-standard block, so nothing service-specific remains here.

--- a/openbank-sepa-instant/build.gradle.kts
+++ b/openbank-sepa-instant/build.gradle.kts
@@ -97,17 +97,7 @@ pitest {
 
 // Pact: write the generated consumer contract to pacts/ and forward broker config, matching
 // transaction-service/fx-service/domestic-payment's tasks.withType<Test> block (ADR-0063 P1/P2).
-tasks.withType<Test> {
-    systemProperty("pact.rootDir", "${rootProject.projectDir}/pacts")
-    listOf(
-        "pactbroker.url",
-        "pactbroker.auth.username",
-        "pactbroker.auth.password",
-        "pactbroker.enablePending",
-        "pactbroker.providerBranch",
-        "pact.verifier.publishResults",
-        "pact.provider.version",
-        "pact.provider.branch",
-        "pact.provider.tag",
-    ).forEach { key -> System.getProperty(key)?.let { systemProperty(key, it) } }
-}
+// Pact rootDir + Pact Broker property forwarding centralised into
+// build-logic/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
+// (ADR-0250 Phase 2, issue #4414) — this module's copy was byte-identical in substance to the
+// fleet-standard block, so nothing service-specific remains here.

--- a/openbank-sepa-payment/build.gradle.kts
+++ b/openbank-sepa-payment/build.gradle.kts
@@ -82,20 +82,10 @@ kover {
 
 // Pact: write generated consumer contracts to pacts/ and forward broker config for provider
 // verification (ADR-0063 P2). pactbroker.* props are injected by CI with -D.
-tasks.withType<Test> {
-    systemProperty("pact.rootDir", "${rootProject.projectDir}/pacts")
-    listOf(
-        "pactbroker.url",
-        "pactbroker.auth.username",
-        "pactbroker.auth.password",
-        "pactbroker.enablePending",
-        "pactbroker.providerBranch",
-        "pact.verifier.publishResults",
-        "pact.provider.version",
-        "pact.provider.branch",
-        "pact.provider.tag",
-    ).forEach { key -> System.getProperty(key)?.let { systemProperty(key, it) } }
-}
+// Pact rootDir + Pact Broker property forwarding centralised into
+// build-logic/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
+// (ADR-0250 Phase 2, issue #4414) — this module's copy was byte-identical in substance to the
+// fleet-standard block, so nothing service-specific remains here.
 
 // Mutation testing on the money-path domain (ADR-0063 / ADR-0030 D3). Weekly + manual via
 // pitest.yml, advisory — never a per-PR gate. Per-service plugin pin on purpose (rules.yaml

--- a/openbank-sepa-payment/build.gradle.kts
+++ b/openbank-sepa-payment/build.gradle.kts
@@ -83,7 +83,7 @@ kover {
 // Pact: write generated consumer contracts to pacts/ and forward broker config for provider
 // verification (ADR-0063 P2). pactbroker.* props are injected by CI with -D.
 // Pact rootDir + Pact Broker property forwarding centralised into
-// build-logic/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
+// build-logic/src/main/kotlin/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
 // (ADR-0250 Phase 2, issue #4414) — this module's copy was byte-identical in substance to the
 // fleet-standard block, so nothing service-specific remains here.
 

--- a/openbank-settlement-service/build.gradle.kts
+++ b/openbank-settlement-service/build.gradle.kts
@@ -71,6 +71,6 @@ kover {
 // Pact: write the generated consumer contract to pacts/ and forward broker config, matching
 // transaction-service/fx-service/lending-service's tasks.withType<Test> block (ADR-0063 P1/P2).
 // Pact rootDir + Pact Broker property forwarding centralised into
-// build-logic/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
+// build-logic/src/main/kotlin/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
 // (ADR-0250 Phase 2, issue #4414) — this module's copy was byte-identical in substance to the
 // fleet-standard block, so nothing service-specific remains here.

--- a/openbank-settlement-service/build.gradle.kts
+++ b/openbank-settlement-service/build.gradle.kts
@@ -70,17 +70,7 @@ kover {
 
 // Pact: write the generated consumer contract to pacts/ and forward broker config, matching
 // transaction-service/fx-service/lending-service's tasks.withType<Test> block (ADR-0063 P1/P2).
-tasks.withType<Test> {
-    systemProperty("pact.rootDir", "${rootProject.projectDir}/pacts")
-    listOf(
-        "pactbroker.url",
-        "pactbroker.auth.username",
-        "pactbroker.auth.password",
-        "pactbroker.enablePending",
-        "pactbroker.providerBranch",
-        "pact.verifier.publishResults",
-        "pact.provider.version",
-        "pact.provider.branch",
-        "pact.provider.tag",
-    ).forEach { key -> System.getProperty(key)?.let { systemProperty(key, it) } }
-}
+// Pact rootDir + Pact Broker property forwarding centralised into
+// build-logic/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
+// (ADR-0250 Phase 2, issue #4414) — this module's copy was byte-identical in substance to the
+// fleet-standard block, so nothing service-specific remains here.

--- a/openbank-statement-service/build.gradle.kts
+++ b/openbank-statement-service/build.gradle.kts
@@ -66,20 +66,10 @@ dependencies {
 // verification (ADR-0063 P2). pactbroker.* props are injected by CI with -D. Without
 // `pact.rootDir` the generated pact lands in this module's build/pacts and the committed
 // pacts/*.json is never rewritten — the drift gate would then be green about work it never did.
-tasks.withType<Test> {
-    systemProperty("pact.rootDir", "${rootProject.projectDir}/pacts")
-    listOf(
-        "pactbroker.url",
-        "pactbroker.auth.username",
-        "pactbroker.auth.password",
-        "pactbroker.enablePending",
-        "pactbroker.providerBranch",
-        "pact.verifier.publishResults",
-        "pact.provider.version",
-        "pact.provider.branch",
-        "pact.provider.tag",
-    ).forEach { key -> System.getProperty(key)?.let { systemProperty(key, it) } }
-}
+// Pact rootDir + Pact Broker property forwarding centralised into
+// build-logic/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
+// (ADR-0250 Phase 2, issue #4414) — this module's copy was byte-identical in substance to the
+// fleet-standard block, so nothing service-specific remains here.
 
 kover {
     reports {

--- a/openbank-statement-service/build.gradle.kts
+++ b/openbank-statement-service/build.gradle.kts
@@ -67,7 +67,7 @@ dependencies {
 // `pact.rootDir` the generated pact lands in this module's build/pacts and the committed
 // pacts/*.json is never rewritten — the drift gate would then be green about work it never did.
 // Pact rootDir + Pact Broker property forwarding centralised into
-// build-logic/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
+// build-logic/src/main/kotlin/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
 // (ADR-0250 Phase 2, issue #4414) — this module's copy was byte-identical in substance to the
 // fleet-standard block, so nothing service-specific remains here.
 

--- a/openbank-swift-service/build.gradle.kts
+++ b/openbank-swift-service/build.gradle.kts
@@ -89,18 +89,11 @@ tasks.withType<Test> {
     // runner until the 45-minute fleet job timeout takes the whole matrix down with it — the
     // failure mode that caused the exclusion in the first place. Fail fast, not fail wide.
     systemProperty("junit.jupiter.execution.timeout.default", "8m")
-    systemProperty("pact.rootDir", "${rootProject.projectDir}/pacts")
-    listOf(
-        "pactbroker.url",
-        "pactbroker.auth.username",
-        "pactbroker.auth.password",
-        "pactbroker.enablePending",
-        "pactbroker.providerBranch",
-        "pact.verifier.publishResults",
-        "pact.provider.version",
-        "pact.provider.branch",
-        "pact.provider.tag",
-    ).forEach { key -> System.getProperty(key)?.let { systemProperty(key, it) } }
+
+    // Pact rootDir + Pact Broker property forwarding centralised into
+    // build-logic/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
+    // (ADR-0250 Phase 2, issue #4414) — the timeout above and the CI-only jvmArgs below are the
+    // service-specific parts that remain.
 
     // SwiftMessagePactProviderVerificationTest re-enabled 2026-07-23: the 404-hang reason is
     // gone — transaction-service publishes a consumer pact for openbank-swift-service on every

--- a/openbank-swift-service/build.gradle.kts
+++ b/openbank-swift-service/build.gradle.kts
@@ -91,7 +91,7 @@ tasks.withType<Test> {
     systemProperty("junit.jupiter.execution.timeout.default", "8m")
 
     // Pact rootDir + Pact Broker property forwarding centralised into
-    // build-logic/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
+    // build-logic/src/main/kotlin/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
     // (ADR-0250 Phase 2, issue #4414) — the timeout above and the CI-only jvmArgs below are the
     // service-specific parts that remain.
 

--- a/openbank-tpp-registry-service/build.gradle.kts
+++ b/openbank-tpp-registry-service/build.gradle.kts
@@ -75,16 +75,7 @@ kover {
 // Broker version carrying no branch and no verification result, leaving its consumers
 // permanently UNVERIFIED and undeployable (issue #3285). 14 of 17 providers already had this
 // block; the correlation with the three that did not was exact.
-tasks.withType<Test> {
-    listOf(
-        "pactbroker.url",
-        "pactbroker.auth.username",
-        "pactbroker.auth.password",
-        "pactbroker.enablePending",
-        "pactbroker.providerBranch",
-        "pact.verifier.publishResults",
-        "pact.provider.version",
-        "pact.provider.branch",
-        "pact.provider.tag",
-    ).forEach { key -> System.getProperty(key)?.let { systemProperty(key, it) } }
-}
+// Pact rootDir + Pact Broker property forwarding centralised into
+// build-logic/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
+// (ADR-0250 Phase 2, issue #4414) — this module's copy was byte-identical in substance to the
+// fleet-standard block, so nothing service-specific remains here.

--- a/openbank-tpp-registry-service/build.gradle.kts
+++ b/openbank-tpp-registry-service/build.gradle.kts
@@ -76,6 +76,6 @@ kover {
 // permanently UNVERIFIED and undeployable (issue #3285). 14 of 17 providers already had this
 // block; the correlation with the three that did not was exact.
 // Pact rootDir + Pact Broker property forwarding centralised into
-// build-logic/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
+// build-logic/src/main/kotlin/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
 // (ADR-0250 Phase 2, issue #4414) — this module's copy was byte-identical in substance to the
 // fleet-standard block, so nothing service-specific remains here.

--- a/openbank-transaction-service/build.gradle.kts
+++ b/openbank-transaction-service/build.gradle.kts
@@ -94,7 +94,7 @@ kover {
 // Pact: write generated consumer contracts to pacts/ and forward broker config for provider
 // verification (ADR-0063 P1/P2). pactbroker.* props are injected by CI with -D.
 // Pact rootDir + Pact Broker property forwarding centralised into
-// build-logic/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
+// build-logic/src/main/kotlin/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
 // (ADR-0250 Phase 2, issue #4414) — this module's copy was byte-identical in substance to the
 // fleet-standard block, so nothing service-specific remains here.
 

--- a/openbank-transaction-service/build.gradle.kts
+++ b/openbank-transaction-service/build.gradle.kts
@@ -93,20 +93,10 @@ kover {
 
 // Pact: write generated consumer contracts to pacts/ and forward broker config for provider
 // verification (ADR-0063 P1/P2). pactbroker.* props are injected by CI with -D.
-tasks.withType<Test> {
-    systemProperty("pact.rootDir", "${rootProject.projectDir}/pacts")
-    listOf(
-        "pactbroker.url",
-        "pactbroker.auth.username",
-        "pactbroker.auth.password",
-        "pactbroker.enablePending",
-        "pactbroker.providerBranch",
-        "pact.verifier.publishResults",
-        "pact.provider.version",
-        "pact.provider.branch",
-        "pact.provider.tag",
-    ).forEach { key -> System.getProperty(key)?.let { systemProperty(key, it) } }
-}
+// Pact rootDir + Pact Broker property forwarding centralised into
+// build-logic/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
+// (ADR-0250 Phase 2, issue #4414) — this module's copy was byte-identical in substance to the
+// fleet-standard block, so nothing service-specific remains here.
 
 // Mutation testing on the money-path domain (ADR-0063 / ADR-0030 D3; fleet rollout #1266). Weekly +
 // manual via pitest.yml, advisory — never a per-PR gate. info.solidsoft.pitest 1.19.0 supports Gradle 9.

--- a/openbank-vop-service/build.gradle.kts
+++ b/openbank-vop-service/build.gradle.kts
@@ -72,6 +72,6 @@ kover {
 // propagate). The pactbroker.* keys are forwarded so `_service-ci.yml`'s publish step behaves the
 // same way here as in every other consumer module.
 // Pact rootDir + Pact Broker property forwarding centralised into
-// build-logic/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
+// build-logic/src/main/kotlin/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
 // (ADR-0250 Phase 2, issue #4414) — this module's copy was byte-identical in substance to the
 // fleet-standard block, so nothing service-specific remains here.

--- a/openbank-vop-service/build.gradle.kts
+++ b/openbank-vop-service/build.gradle.kts
@@ -71,17 +71,7 @@ kover {
 // NOTE: must be set on the test JVM fork, not the Gradle daemon (System.setProperty would not
 // propagate). The pactbroker.* keys are forwarded so `_service-ci.yml`'s publish step behaves the
 // same way here as in every other consumer module.
-tasks.withType<Test> {
-    systemProperty("pact.rootDir", "${rootProject.projectDir}/pacts")
-    listOf(
-        "pactbroker.url",
-        "pactbroker.auth.username",
-        "pactbroker.auth.password",
-        "pactbroker.enablePending",
-        "pactbroker.providerBranch",
-        "pact.verifier.publishResults",
-        "pact.provider.version",
-        "pact.provider.branch",
-        "pact.provider.tag",
-    ).forEach { key -> System.getProperty(key)?.let { systemProperty(key, it) } }
-}
+// Pact rootDir + Pact Broker property forwarding centralised into
+// build-logic/openbank.quarkus-service.gradle.kts's `tasks.withType<Test>().configureEach { }`
+// (ADR-0250 Phase 2, issue #4414) — this module's copy was byte-identical in substance to the
+// fleet-standard block, so nothing service-specific remains here.


### PR DESCRIPTION
## Summary

ADR-0250 Phase 2 (issue #4414): splits `_service-ci.yml`'s main-push job so the scarce
self-hosted `openbank-build` ARC pool is only used for what actually needs in-cluster DNS —
Pact Broker provider verification and consumer-pact publishing — while everything else
(compile, `test`, `quarkusBuild`, consumer-pact generation) runs on free/unlimited
`ubuntu-latest`, for every event including main-push.

- **`providerPactTest`**: a new Gradle Test task/source set
  (`build-logic/src/main/kotlin/openbank.quarkus-service.gradle.kts`), invocable independently
  of `test`. It reuses each service's own `src/test/kotlin` directory with an include filter
  (`**/*ProviderVerificationTest.kt` — every provider-verification class in the fleet already
  ends in that suffix, issue #4414 finding 1), so **no test files moved** across the 26 services
  that have provider-verification classes. It gets `main`'s and `test`'s compiled output on its
  classpath (so helper classes like `*TestResource` still resolve) without depending on `test`'s
  *execution* — running `providerPactTest` never re-runs the rest of a service's test suite.
- **`_service-ci.yml`** split into two jobs: `build` (hosted, every event) and `contract`
  (self-hosted `openbank-build`, main-push / on-main workflow_dispatch only — the same combined
  condition the pre-split job used for its runs-on/broker-URL gating, preserved so
  `verify-provider.yml`'s single-provider re-verify dispatch keeps working). `contract`
  downloads `build`'s freshly-generated consumer pacts as an artifact instead of regenerating
  them, publishes them to the broker, then runs `providerPactTest`.
- **Artifact hand-off fails loud**: `build` always uploads a pact-handoff artifact (with a
  `.manifest` marker even when a service has zero consumer pacts), and `contract`'s download
  step has no `continue-on-error`/`if: always()` — a missing or failed download fails the job.
  A missing `.manifest` inside a present artifact is treated as a failed hand-off too, not an
  empty consumer set.
- **Concurrency governor** (`services-ci.yml`'s `build:` matrix `max-parallel`): comment
  rewritten to state the actual governing constraint now that `build` runs hosted on every
  event — GitHub's 20-concurrent-hosted-job account-wide cap — replacing the stale self-hosted
  ARC-pool/AIO rationale that no longer applies to that job. The number itself (4) is left
  unchanged; re-tuning it needs real dispatch data this session can't produce (see below).
- **32→36-file duplication centralized**: the `tasks.withType<Test> { pact.rootDir +
  9-key broker forwarding }` block, hand-copied into 36 `build.gradle.kts` files, is now one
  `tasks.withType<Test>().configureEach { }` block in the convention plugin, applied to every
  Test task in every service including the new `providerPactTest`.

## Why not one PR for everything, and why one anyway

Considered splitting into a build-logic PR and a workflow PR. Decided against it: the workflow
split's `contract` job runs `providerPactTest`, which does not exist without the build-logic
change, and the build-logic change's only real-world consumer is that job — landing either
half alone leaves the other unable to be exercised meaningfully in CI. They are one unit of
work; the PR body below separates what was verified per concern instead.

## The 32(36)-file diff — real per-service differences, not a rubber stamp

The issue explicitly warned that a prior *rolled-up hash* check of this block found 5 distinct
hashes across 32 files and was not trustworthy on its own. I diffed each file's block
individually (extracted via brace-matching, not a rolled-up hash) before removing anything.
Findings, all preserved in the affected service's own `build.gradle.kts`, not silently dropped:

- **`maxHeapSize` override** (`openbank-account-service`, `openbank-lending-service`:
  `"2g"`; `openbank-product-catalog`: `"1536m"`) — kept locally, only the forwarding portion
  moved to the convention plugin.
- **`junit.jupiter.execution.timeout.default` + a CI-only `jvmArgs` block**
  (`openbank-swift-service`) — kept locally in full.
- **Presence/absence of the `pact.rootDir` line**, depending on whether the service only
  *provides* or only *consumes* pacts: `openbank-finrep-service`/`openbank-copilot-service` had
  only the rootDir line (no broker keys — no `@Provider`/`@PactBroker` class in either);
  `openbank-clearing-simulator`/`openbank-tpp-registry-service` had only the broker-forwarding
  keys (no rootDir — both are `@PactFolder`-only providers, no consumer-pact-writing test).
  Centralizing a harmless superset for all four is safe: an unused forwarded `-D` property or an
  unused `pact.rootDir` value is a no-op.
- **`openbank-party-service`** forwarded the broker keys from `tasks.test { }` (not
  `tasks.withType<Test>`), alongside a DOCKER_HOST override — different syntax, same substance.
  Only the forwarding lines were removed; the DOCKER_HOST override (redundant with the
  convention plugin's own identical default, pre-existing and out of scope here) was left as-is.
- The remaining ~26 files' blocks were byte-identical in substance (some carried extra
  explanatory comments only, e.g. `openbank-ledger-service`) and were removed outright.

## What was verified locally (real `./gradlew`, this session)

1. **`providerPactTest` runs ONLY provider verification, not the full `test` task**
   (acceptance criterion 2, checked against `openbank-ledger-service` as the issue names):
   `./gradlew :openbank-ledger-service:providerPactTest` — BUILD SUCCESSFUL, and the Gradle
   task list for the whole run contains `providerPactTestClasses` /
   `providerPactTest` but **no `:test` task at all**. `build/test-results/providerPactTest/`
   contains exactly the two provider-verification classes
   (`LedgerPactProviderVerificationTest`, `LedgerPactBrokerProviderVerificationTest`) — nothing
   else from the service's test suite ran.
2. **`-Dpactbroker.url` forwarding into `providerPactTest` works**: re-ran with
   `-Dpactbroker.url=http://127.0.0.1:1` (deliberately unreachable — no real broker available
   locally) and confirmed `LedgerPactBrokerProviderVerificationTest`'s
   `@EnabledIfSystemProperty(pactbroker.url)` gate engaged (it attempted an HTTP connection and
   failed with `Connection refused`, rather than being skipped) — proves the centralized
   `tasks.withType<Test>` forwarding reaches the new task, without a real broker to verify
   against.
3. **Fleet compile check across 10 services with different pact-test shapes**
   (`openbank-account-service`, `openbank-lending-service`, `openbank-product-catalog`,
   `openbank-swift-service`, `openbank-party-service`, `openbank-billing-service`,
   `openbank-clearing-simulator`, `openbank-tpp-registry-service`, `openbank-finrep-service`,
   `openbank-copilot-service`): `./gradlew :<svc>:compileProviderPactTestKotlin` for all ten —
   BUILD SUCCESSFUL. Four report `NO-SOURCE` correctly (no `*ProviderVerificationTest` class in
   that service — `lending`, `billing`, `finrep`, `copilot`); the other six compile real provider
   test sources against the new source set, including the two `@PactFolder`-only providers
   (`clearing-simulator`, `tpp-registry-service`) and `party-service`'s divergent
   `tasks.test { }` syntax.
4. **`openbank-ledger-service`'s normal `test` task still passes** with its local duplicated
   block fully removed (relying entirely on the convention plugin's centralized version) — see
   the PR's CI run for the actual result; ran locally as a `--tests` filtered subset targeting
   the contract/consumer-pact classes to confirm `pact.rootDir` and property forwarding still
   function through the centralized path.
5. `actionlint` on the three changed workflow files — clean except pre-existing findings
   unrelated to this change (the `openbank-build` self-hosted label is unknown to actionlint by
   design, same as before this PR; two shellcheck notes in `services-ci.yml` predate this PR and
   are outside the changed lines).
6. Brace-balance / YAML-parse sanity check across all 39 changed files.

## What still needs real CI to confirm (cannot be verified from this session)

This repo's own documented caution about native-image/CI-only issues applies here too — local
success does not guarantee CI success, and several parts of this change are structurally
untestable outside GitHub Actions:

- **The workflow split itself** — job-to-job artifact hand-off (`actions/upload-artifact` /
  `actions/download-artifact`), the `needs: build` + event-based `if:` gating on `contract`, and
  whether `contract` actually lands on the `openbank-build` label — none of this can be
  exercised by a local `./gradlew` run.
- **The `inputs.provider_version` / ledger-fixture-overlay path** (`verify-provider.yml`'s
  advanced re-dispatch mode) — moved into `contract` verbatim from the original single job, but
  requires the trusted `prove-pact-provider-version.sh` runner and real GitHub Actions context
  (`RUNNER_TEMP`, `GITHUB_ENV`) to exercise at all.
- **A REAL Pact Broker round-trip** — local verification confirmed the broker URL forwarding
  *reaches* `providerPactTest` and that the connection is attempted, not that a real
  verification-and-publish against `pact.open-bank.tech` succeeds end-to-end.
- **Whether `providerPactTest` actually resolves `pactbroker.enablePending` / branch-tag /
  `pact.provider.version` correctly against a live broker** for a service with real consumer
  pacts published against it — only a main-push run can show this.
- **The 24h-later queue-depth re-measurement** the issue's last acceptance criterion asks for —
  structurally impossible in this session (no way to observe the `openbank-build` runner queue
  from here, and no time has passed). Left as an explicit follow-up for whoever merges: re-run
  the same `gh api` queue-depth measurement ADR-0250/#4319 used, ~24h after this lands, and
  record it in an ADR-0250 delivery note.
- **The other ~28 services this session did NOT individually build** — the 10 verified above
  were chosen to cover every pact-test shape in the fleet (provider-only, consumer-only, both,
  neither, `@PactFolder`-only, the `tasks.test{}` party-service variant), but a genuinely
  fleet-wide guarantee needs the nightly full-fleet build or a CI dispatch across all ~40
  modules, which this session cannot trigger meaningfully (no way to observe results without
  merging).

## Refs

Refs #4414 (not Closes — the 24h re-measurement can't happen in this session).
