### PR TITLE
feat(admin-ui): modernize legacy detail headers

### DIFF
--- a/openbank-admin-ui/src/app/iaops/agents/[agentId]/page.tsx
+++ b/openbank-admin-ui/src/app/iaops/agents/[agentId]/page.tsx
@@ -16,6 +16,7 @@ import { AgentPortrait, getAgentPersona } from '@/components/agent/AgentIdentity
 import { AgentBodyAnalysis, AgentMeshMap } from '@/components/agent/AgentDiagnostics'
 import type { AgentDiagnostic, AgentMeshSummary } from '@/lib/governance/agentDiagnostics'
 import { OutcomeMetricsCard } from '@/components/agent/AgentOutcomes'
+import { PageHeader } from '@/components/ui/PageHeader'
 
 // ── Types (mirror /api/iaops/agents/[agentId]) ─────────────────────────────
 interface Schedule { daily: string | null; reactive: string | null }
@@ -177,18 +178,13 @@ function AgentDetailContent() {
 
   return (
     <div style={{ padding: '28px 32px', maxWidth: '1100px', animation: 'fadeIn 0.2s ease-out' }}>
-      <div style={{ marginBottom: '20px' }}>
-        <div className="breadcrumb">
-          <span>OpenBank</span><span className="breadcrumb-sep">/</span>
-          <Link href="/iaops" className="breadcrumb-current" style={{ textDecoration: 'none' }}>{t('IAOps', 'IAOps')}</Link>
-          <span className="breadcrumb-sep">/</span>
-          <span className="breadcrumb-current">{agentId}</span>
-        </div>
-        <Link href="/iaops" style={{ display: 'inline-flex', alignItems: 'center', gap: '6px', marginTop: '10px',
-          fontSize: '12px', color: 'var(--text-secondary)', textDecoration: 'none' }}>
-          <ArrowLeft size={13} /> {t('Zpět na přehled agentů', 'Back to agent roster')}
-        </Link>
-      </div>
+      <PageHeader
+        breadcrumb={<div className="breadcrumb"><span>OpenBank</span><span className="breadcrumb-sep">/</span><Link href="/iaops" className="breadcrumb-current" style={{ textDecoration: 'none' }}>{t('IAOps', 'IAOps')}</Link><span className="breadcrumb-sep">/</span><span className="breadcrumb-current">{agentId}</span></div>}
+        icon={<Users size={20} aria-hidden="true" />}
+        title={persona.name}
+        subtitle={persona.role}
+        actions={<Link href="/iaops" className="btn btn-secondary btn-sm"><ArrowLeft size={13} aria-hidden="true" /> {t('Zpět na přehled agentů', 'Back to agent roster')}</Link>}
+      />
 
       {loading && !data ? (
         <div style={{ display: 'flex', alignItems: 'center', gap: '10px', padding: '40px', color: 'var(--text-tertiary)' }}>
@@ -201,9 +197,6 @@ function AgentDetailContent() {
           <div style={{ display: 'flex', alignItems: 'center', gap: '18px', marginBottom: '20px', flexWrap: 'wrap' }}>
             <AgentPortrait agentId={agentId} />
             <div style={{ flex: 1, minWidth: '200px' }}>
-              <h1 style={{ fontSize: '25px', fontWeight: 850, color: 'var(--text-primary)', margin: 0, letterSpacing: '-0.03em' }}>
-                {persona.name}
-              </h1>
               <p style={{ fontSize: '13px', fontWeight: 750, color: 'var(--text-primary)', margin: '1px 0 3px' }}>
                 {persona.role}
               </p>

--- a/openbank-admin-ui/src/app/iaops/cases/[caseId]/page.tsx
+++ b/openbank-admin-ui/src/app/iaops/cases/[caseId]/page.tsx
@@ -14,6 +14,7 @@ import type { UnavailableKind } from '@/components/feedback/DataUnavailable'
 import { deriveCaseDecisionBrief } from '@/lib/governance/caseDecisionBrief'
 import { caseStatusPresentation } from '@/lib/governance/caseStatusPresentation'
 import type { CaseStatus } from '@/lib/governance/caseStatusPresentation'
+import { PageHeader } from '@/components/ui/PageHeader'
 
 type EntryType = 'CASE_OPENED' | 'CONTRIBUTION' | 'PROPOSAL_EMITTED'
 
@@ -110,19 +111,13 @@ export default function IaopsCaseThreadPage() {
 
   return (
     <div style={{ padding: '28px 32px', maxWidth: '900px', animation: 'fadeIn 0.2s ease-out' }}>
-      <div style={{ marginBottom: '20px' }}>
-        <div className="breadcrumb">
-          <span>OpenBank</span><span className="breadcrumb-sep">/</span>
-          <Link href="/iaops" className="breadcrumb-current" style={{ textDecoration: 'none' }}>{t('IAOps', 'IAOps')}</Link>
-          <span className="breadcrumb-sep">/</span>
-          <Link href="/iaops/cases" className="breadcrumb-current" style={{ textDecoration: 'none' }}>{t('Swarm case', 'Swarm cases')}</Link>
-          <span className="breadcrumb-sep">/</span>
-          <span className="breadcrumb-current">{caseId}</span>
-        </div>
-        <Link href="/iaops/cases" style={{ display: 'inline-flex', alignItems: 'center', gap: '6px', marginTop: '10px', fontSize: '12px', color: 'var(--text-secondary)', textDecoration: 'none' }}>
-          <ArrowLeft size={13} /> {t('Zpět na seznam case', 'Back to case list')}
-        </Link>
-      </div>
+      <PageHeader
+        breadcrumb={<div className="breadcrumb"><span>OpenBank</span><span className="breadcrumb-sep">/</span><Link href="/iaops" className="breadcrumb-current" style={{ textDecoration: 'none' }}>{t('IAOps', 'IAOps')}</Link><span className="breadcrumb-sep">/</span><Link href="/iaops/cases" className="breadcrumb-current" style={{ textDecoration: 'none' }}>{t('Swarm case', 'Swarm cases')}</Link><span className="breadcrumb-sep">/</span><span className="breadcrumb-current">{caseId}</span></div>}
+        icon={<GitMerge size={20} aria-hidden="true" />}
+        title={caseId}
+        subtitle={t('Detail sdíleného case vlákna; data jsou pouze pro čtení.', 'Shared case thread detail; data is read-only.')}
+        actions={<Link href="/iaops/cases" className="btn btn-secondary btn-sm"><ArrowLeft size={13} aria-hidden="true" /> {t('Zpět na seznam case', 'Back to case list')}</Link>}
+      />
 
       {loading && !thread ? (
         <div style={{ display: 'flex', alignItems: 'center', gap: '10px', padding: '40px', color: 'var(--text-tertiary)' }}>
@@ -132,9 +127,6 @@ export default function IaopsCaseThreadPage() {
       ) : thread ? (
         <>
           <div style={{ display: 'flex', alignItems: 'center', gap: '12px', marginBottom: '16px', flexWrap: 'wrap' }}>
-            <h1 style={{ fontFamily: 'var(--font-mono)', fontSize: '18px', fontWeight: 800, color: 'var(--text-primary)', margin: 0 }}>
-              {thread.caseId}
-            </h1>
             {(() => {
               const visual = statusVisual(thread.status)
               const Icon = visual.icon

--- a/openbank-admin-ui/src/app/temporal/page.tsx
+++ b/openbank-admin-ui/src/app/temporal/page.tsx
@@ -9,6 +9,7 @@ import { RefreshCw, CheckCircle, Clock, AlertTriangle, Zap, Database, Shield, Gi
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { MONEY_WORKFLOWS } from '@/lib/temporal/workflows'
 import { AuthGuard } from '@/components/auth/AuthGuard'
+import { PageHeader } from '@/components/ui/PageHeader'
 
 // ─── types ───────────────────────────────────────────────────────────────────
 
@@ -256,6 +257,7 @@ function PhaseRow({ phase, t }: { phase: typeof PHASES[0]; t: (cs: string, en: s
 
 export default function TemporalPage() {
   const { t, language } = useLanguage()
+  const dateLocale = language === 'cs' ? 'cs-CZ' : 'en-GB'
   const [tab, setTab] = useState<Tab>('overview')
   const [status, setStatus] = useState<StatusData | null>(null)
   const [loading, setLoading] = useState(true)
@@ -296,36 +298,12 @@ export default function TemporalPage() {
     <AuthGuard permission="system:view">
       <div style={{ maxWidth: '1200px', margin: '0 auto' }}>
 
-        {/* Header */}
-        <div style={{ marginBottom: '24px' }}>
-          <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: '16px', flexWrap: 'wrap' }}>
-            <div>
-              <div style={{ display: 'flex', alignItems: 'center', gap: '12px', marginBottom: '6px' }}>
-                <div style={{
-                  width: '40px', height: '40px', borderRadius: '12px',
-                  background: 'linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%)',
-                  display: 'flex', alignItems: 'center', justifyContent: 'center',
-                  boxShadow: '0 4px 12px rgba(99,102,241,0.3)',
-                }}>
-                  <Zap size={20} color="white" />
-                </div>
-                <h1 style={{ fontSize: '24px', fontWeight: 800, color: 'var(--text)', margin: 0 }}>
-                  Temporal
-                </h1>
-                <span style={{
-                  fontSize: '11px', fontWeight: 700, padding: '3px 10px', borderRadius: '20px',
-                  background: 'rgba(99,102,241,0.15)', color: '#818cf8',
-                  border: '1px solid rgba(99,102,241,0.3)',
-                }}>ADR-0101</span>
-              </div>
-              <p style={{ fontSize: '14px', color: 'var(--text-muted)', margin: 0, maxWidth: '600px' }}>
-                {t(
-                  'Durable execution engine pro money-path workflows — challenger model nahrazující ruční outbox sagu',
-                  'Durable execution engine for money-path workflows — challenger model replacing hand-rolled outbox saga',
-                )}
-              </p>
-            </div>
-            <div style={{ display: 'flex', alignItems: 'center', gap: '12px', flexShrink: 0 }}>
+        <PageHeader
+          breadcrumb={<div className="breadcrumb"><span>OpenBank</span><span className="breadcrumb-sep">/</span><span className="breadcrumb-current">Temporal</span></div>}
+          icon={<Zap size={20} aria-hidden="true" />}
+          title="Temporal"
+          subtitle={t('Durable execution engine pro money-path workflows — challenger model nahrazující ruční outbox sagu', 'Durable execution engine for money-path workflows — challenger model replacing hand-rolled outbox saga')}
+          actions={<div style={{ display: 'flex', alignItems: 'center', gap: '12px', flexShrink: 0 }}>
               {status && (
                 <div style={{
                   display: 'flex', alignItems: 'center', gap: '6px',
@@ -359,14 +337,9 @@ export default function TemporalPage() {
                 <RefreshCw size={14} style={{ animation: loading ? 'spin 1s linear infinite' : 'none' }} />
                 {t('Obnovit', 'Refresh')}
               </button>
-            </div>
-          </div>
-          {lastRefresh && (
-            <div style={{ fontSize: '12px', color: 'var(--text-muted)', marginTop: '8px' }}>
-              {t('Aktualizováno', 'Updated')}: {lastRefresh.toLocaleTimeString()}
-            </div>
-          )}
-        </div>
+          </div>}
+        />
+        {lastRefresh && <div style={{ fontSize: '12px', color: 'var(--text-muted)', margin: '8px 0 16px' }}>{t('Aktualizováno', 'Updated')}: {lastRefresh.toLocaleTimeString(dateLocale)}</div>}
 
         {/* Tabs */}
         <div style={{ display: 'flex', gap: '4px', marginBottom: '24px', borderBottom: '1px solid var(--border)', paddingBottom: '0' }}>

--- a/openbank-admin-ui/src/test/legacy-detail-header.guard.test.ts
+++ b/openbank-admin-ui/src/test/legacy-detail-header.guard.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import fs from 'node:fs'
+import path from 'node:path'
+
+describe('legacy detail pages use shared PageHeader', () => {
+  it('keeps structured breadcrumbs and a single semantic title', () => {
+    for (const file of [
+      'iaops/cases/[caseId]/page.tsx',
+      'iaops/agents/[agentId]/page.tsx',
+      'temporal/page.tsx',
+    ]) {
+      const source = fs.readFileSync(path.join(process.cwd(), 'src/app', file), 'utf8')
+      expect(source).toContain('PageHeader')
+      expect(source).toContain('className="breadcrumb"')
+      expect(source).toContain('aria-hidden="true"')
+      expect(source).not.toMatch(/<h1\b/)
+    }
+
+    const temporal = fs.readFileSync(path.join(process.cwd(), 'src/app/temporal/page.tsx'), 'utf8')
+    expect(temporal).toContain("const dateLocale = language === 'cs' ? 'cs-CZ' : 'en-GB'")
+    expect(temporal).not.toMatch(/toLocaleTimeString\(\)/)
+  })
+})


### PR DESCRIPTION
## Summary
- migrate IAOps case/agent detail and Temporal overview to shared PageHeader
- remove duplicate local h1 headings while preserving read-only data and actions
- localize Temporal refresh timestamps and add regression guard

## Verification
- npx vitest run src/test/legacy-detail-header.guard.test.ts
- npm run type-check

Issue: N/A — presentation and accessibility maintenance; no separate issue.