### PR TITLE
fix(flaky-test-hunter): map GITHUB_TOKEN env into the config the adapter reads

### DIFF
--- a/openbank-flaky-test-hunter/src/main/resources/application.yaml
+++ b/openbank-flaky-test-hunter/src/main/resources/application.yaml
@@ -111,6 +111,9 @@ openbank:
     check-cron: ${FLAKY_TEST_HUNTER_CHECK_CRON:0 30 6 ? * SUN}
     github-api-url: ${GITHUB_API_URL:https://api.github.com}
     github-repo: ${GITHUB_REPO:JiRaska/open-bank-oss}
+    # Optional (Optional<String>, no default): absent until openbank/flaky-test-hunter is seeded in
+    # OpenBao, and the writer fails closed on a blank value (see GitHubProposalAdapter).
+    github-token: ${FLAKY_TEST_HUNTER_GITHUB_TOKEN:}
     llm-gateway-url: ${LLM_GATEWAY_URL:http://litellm.ai-platform:4000}
     # Filesystem path to the monorepo checkout this agent reads */src/test/kotlin/**/*.kt,
     # .github/scripts/*.sh CI guard scripts, and */build/test-results/test/*.xml JUnit reports

--- a/openbank-infra/scripts/seed-flaky-test-hunter-github-token.sh
+++ b/openbank-infra/scripts/seed-flaky-test-hunter-github-token.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Uloží fine-grained GitHub PAT do OpenBao KV pro flaky-test-hunter a vynutí refresh
+# ExternalSecretu flaky-test-hunter-secrets (phase-3 activation, ADR-0168).
+#
+# Usage:
+#   VAULT_TOKEN=hvs.xxx FLAKY_TEST_HUNTER_GITHUB_TOKEN=github_pat_xxx \
+#     ./openbank-infra/scripts/seed-flaky-test-hunter-github-token.sh
+#
+# Vyžaduje:
+#   - kubectl nakonfigurovaný na sandbox cluster (aws eks update-kubeconfig --name openbank-sandbox)
+#   - VAULT_TOKEN: operator token s write na openbank/* (AWS Secrets Manager
+#     openbank/openbao/break-glass, klic root_token)
+#   - FLAKY_TEST_HUNTER_GITHUB_TOKEN: fine-grained PAT scoped na JiRaska/open-bank-oss,
+#     Contents: write + Pull requests: write (bounded agentni PR path, ADR-0168)
+set -euo pipefail
+
+: "${VAULT_TOKEN:?Set VAULT_TOKEN to an operator token with write access to openbank/*}"
+: "${FLAKY_TEST_HUNTER_GITHUB_TOKEN:?Set FLAKY_TEST_HUNTER_GITHUB_TOKEN to a fine-grained PAT (Contents+Pull requests: write) for JiRaska/open-bank-oss}"
+
+vault_kv_patch() {
+  kubectl -n vault exec -i openbao-0 -- \
+    env VAULT_TOKEN="$VAULT_TOKEN" VAULT_ADDR=http://127.0.0.1:8200 \
+    vault kv patch "$@" >/dev/null
+}
+
+echo "[1/2] Ukladam GITHUB_TOKEN do openbank/flaky-test-hunter..."
+vault_kv_patch openbank/flaky-test-hunter GITHUB_TOKEN="$FLAKY_TEST_HUNTER_GITHUB_TOKEN"
+echo "      OK"
+
+echo "[2/2] Vynucuji refresh ExternalSecret flaky-test-hunter/flaky-test-hunter-secrets..."
+kubectl -n flaky-test-hunter annotate externalsecret flaky-test-hunter-secrets \
+  force-sync="$(date +%s)" --overwrite 2>/dev/null || true
+echo "      OK"
+
+echo ""
+echo "Overeni:"
+echo "  kubectl -n flaky-test-hunter get externalsecret flaky-test-hunter-secrets"
+echo "  kubectl -n flaky-test-hunter get secret flaky-test-hunter-secrets"


### PR DESCRIPTION
## Summary
- `openbank-flaky-test-hunter/src/main/resources/application.yaml` never mapped `github-token` under the `openbank.flaky-test-hunter` prefix, so `FlakyTestHunterConfig.githubToken()` stayed empty even after the `FLAKY_TEST_HUNTER_GITHUB_TOKEN` env var / `flaky-test-hunter-secrets` ExternalSecret is populated.
- Every sibling key in that block (`check-cron`, `github-api-url`, `github-repo`, `llm-gateway-url`, `repo-root`) already carries the explicit `${ENV_VAR:default}` mapping; `github-token` was the one gap.
- Without this, `GitHubProposalAdapter.openProposalPr` would keep fail-closing (`config.githubToken().orElse("").isBlank()`) regardless of what's seeded in OpenBao — ADR-0031 D9 phase-3 activation was blocked on this in addition to the missing OpenBao value.

## Test plan
- [x] `:openbank-flaky-test-hunter:quarkusBuild` green (config mapping validated at boot)
- [ ] After merge + deploy: seed `openbank/flaky-test-hunter` `GITHUB_TOKEN` in OpenBao, force-sync the ExternalSecret, confirm the pod picks up a non-blank `config.githubToken()`

Refs ADR-0031 D9, ADR-0168.


## Linked issues

N/A — infra config-mapping fix + tooling script, discovered while operating OpenBao credential provisioning, no tracked issue.

