### PR TITLE
feat(admin-ui): modernize delegation and feedback headers

### DIFF
--- a/openbank-admin-ui/src/app/delegations/[id]/page.tsx
+++ b/openbank-admin-ui/src/app/delegations/[id]/page.tsx
@@ -21,6 +21,7 @@ import { ArrowLeft, ShieldQuestion, Lock } from 'lucide-react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { classifyBffFailure } from '@/lib/services/bff'
 import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
+import { PageHeader } from '@/components/ui/PageHeader'
 import { EntityChip } from '@/components/entities/EntityChip'
 import {
   DelegationStatusBadge,
@@ -57,18 +58,13 @@ export default function DelegationDetailPage() {
 
   return (
     <div>
-      <Link href="/delegations" className="btn btn-secondary" style={{ marginBottom: '16px', fontSize: '12px' }}>
-        <ArrowLeft size={14} />
-        {t('Zpět na delegace', 'Back to delegations')}
-      </Link>
-
-      <h1 className="page-title">{t('Detail delegace', 'Delegation detail')}</h1>
-      <p className="page-subtitle">
-        {t(
-          'Udělená práva, stropy a časová osa stavu (ADR-0232).',
-          'Granted rights, ceilings and status timeline (ADR-0232).',
-        )}
-      </p>
+      <PageHeader
+        icon={<ShieldQuestion size={18} aria-hidden="true" />}
+        breadcrumb={<div className="breadcrumb"><Link href="/delegations">{t('Delegace', 'Delegations')}</Link><span className="breadcrumb-sep">/</span><span className="breadcrumb-current">{t('Detail', 'Detail')}</span></div>}
+        title={t('Detail delegace', 'Delegation detail')}
+        subtitle={t('Udělená práva, stropy a časová osa stavu (ADR-0232).', 'Granted rights, ceilings and status timeline (ADR-0232).')}
+        actions={<Link href="/delegations" className="btn btn-secondary"><ArrowLeft size={14} aria-hidden="true" />{t('Zpět na delegace', 'Back to delegations')}</Link>}
+      />
 
       {unavail && (
         <DataUnavailable

--- a/openbank-admin-ui/src/app/feedback/page.tsx
+++ b/openbank-admin-ui/src/app/feedback/page.tsx
@@ -19,6 +19,7 @@ import { useState, useEffect, useCallback } from 'react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { DataUnavailable } from '@/components/feedback/DataUnavailable'
 import { MessageSquare, RefreshCw } from 'lucide-react'
+import { PageHeader } from '@/components/ui/PageHeader'
 import {
   ResponsiveContainer, BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend,
 } from 'recharts'
@@ -63,7 +64,7 @@ export default function ScreenFeedbackPage() {
   if (!data?.available) {
     return (
       <div className="page">
-        <h1><MessageSquare size={20} /> {cs ? 'Zpětná vazba k obrazovkám' : 'Screen feedback'}</h1>
+        <PageHeader icon={<MessageSquare size={18} aria-hidden="true" />} title={cs ? 'Zpětná vazba k obrazovkám' : 'Screen feedback'} subtitle={cs ? 'Kvalitativní signály z operátorských obrazovek.' : 'Qualitative signals from operator screens.'} />
         <DataUnavailable
           kind={data?.error ? 'unreachable' : 'no_data'}
           service="ClickHouse"
@@ -83,12 +84,14 @@ export default function ScreenFeedbackPage() {
 
   return (
     <div className="page">
-      <header style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-        <h1><MessageSquare size={20} /> {cs ? 'Zpětná vazba k obrazovkám' : 'Screen feedback'}</h1>
-        <button className="btn btn-secondary" onClick={() => void load()}>
-          <RefreshCw size={16} /> {cs ? 'Obnovit' : 'Refresh'}
-        </button>
-      </header>
+      <PageHeader
+        icon={<MessageSquare size={18} aria-hidden="true" />}
+        title={cs ? 'Zpětná vazba k obrazovkám' : 'Screen feedback'}
+        subtitle={cs ? 'Kvalitativní signály z operátorských obrazovek.' : 'Qualitative signals from operator screens.'}
+        actions={<button className="btn btn-secondary" onClick={() => void load()}>
+          <RefreshCw size={16} aria-hidden="true" /> {cs ? 'Obnovit' : 'Refresh'}
+        </button>}
+      />
 
       <section>
         <h2>{cs ? 'Které obrazovky bolí' : 'Which screens hurt'}</h2>

--- a/openbank-admin-ui/src/test/legacy-shell-header.guard.test.ts
+++ b/openbank-admin-ui/src/test/legacy-shell-header.guard.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+import fs from 'node:fs'
+import path from 'node:path'
+
+describe('legacy shell pages use the shared header contract', () => {
+  it('keeps one structured title and decorative icons', () => {
+    for (const file of ['delegations/[id]/page.tsx', 'feedback/page.tsx']) {
+      const source = fs.readFileSync(path.join(process.cwd(), 'src/app', file), 'utf8')
+      expect(source).toContain('PageHeader')
+      expect(source).toContain('aria-hidden="true"')
+      expect(source).not.toMatch(/<h1\b/)
+    }
+
+    const detail = fs.readFileSync(path.join(process.cwd(), 'src/app/delegations/[id]/page.tsx'), 'utf8')
+    expect(detail).toContain('className="breadcrumb"')
+    expect(detail).toContain("fetch('/api/delegations/check'")
+  })
+})


### PR DESCRIPTION
## Summary
- migrate delegation detail and screen feedback to shared PageHeader
- preserve read/probe flows, privacy boundary, and RBAC
- add regression guard for shell header contract

Closes #5477