### PR TITLE
docs(security): record why micrometer-core CVE-2026-40984 needs a platform bump

### DIFF
--- a/build-logic/src/main/kotlin/openbank.dependency-vulnerability-pins.gradle.kts
+++ b/build-logic/src/main/kotlin/openbank.dependency-vulnerability-pins.gradle.kts
@@ -89,5 +89,18 @@ configurations.all {
         // transitive kafka-clients compression dependency — 1.11.1 is the advisory's patched
         // version and a drop-in patch on the 1.11.x line.
         force("at.yawk.lz4:lz4-java:1.11.1")
+        // micrometer-core GHSA-g3pr-3p32-fp23 / CVE-2026-40984 (HTTP server instrumentation
+        // DoS): NOT forced here, and this is NOT a same-minor patch like the rest of this file
+        // — the advisory's own data has no patched release on the 1.14.x line Quarkus 3.38.0
+        // ships (first_patched_version: null), only 1.15.12+ and 1.16.6+. Tried the same
+        // discipline the OTel entry above documents: forced 1.15.12 (the lowest patched line)
+        // and ran the real @QuarkusTest suite, not just quarkusBuild, for
+        // openbank-account-service. It broke boot on every @QuarkusTest class:
+        // `NoSuchMethodError: 'void io.micrometer.core.instrument.binder.netty4.
+        // NettyEventExecutorMetrics.<init>(java.lang.Iterable, java.lang.Iterable)'` — Micrometer
+        // 1.15 changed that constructor's signature, and Quarkus 3.38.0's micrometer extension
+        // still calls the 1.14.x one. Same shape as the OTel case: needs a Quarkus platform
+        // bump that ships a compatible micrometer, not a bare force onto the advisory's
+        // patched version. Issue #5482.
     }
 }


### PR DESCRIPTION
## Summary
- Documents why `io.micrometer:micrometer-core` CVE-2026-40984 / GHSA-g3pr-3p32-fp23 (HIGH) cannot be fixed with the same `force()` pattern every other entry in `openbank.dependency-vulnerability-pins.gradle.kts` uses.
- The advisory has no patched release on the 1.14.x line Quarkus 3.38.0 ships — only 1.15.12+/1.16.6+, both a minor bump above.
- Tested rather than assumed: forced `micrometer-core:1.15.12` and ran the real `@QuarkusTest` suite for `openbank-account-service`. Every test class failed to boot: `NoSuchMethodError: NettyEventExecutorMetrics.<init>(Iterable, Iterable)` — Micrometer 1.15 changed that constructor's signature and Quarkus 3.38.0's extension still calls the old one. Same shape as the existing OpenTelemetry entry in this file (#1367).
- No `force()` applied — this PR is documentation only, matching the file's existing style for a CVE it explicitly can't safely patch this way.
- Filed [#5482](https://github.com/JiRaska/open-bank-oss/issues/5482) to track the real fix: a Quarkus platform bump to a `quarkus-bom` release that ships a compatible micrometer.

This does **not** clear the `dependency-review` finding on PR #4308 — that PR stays blocked on this CVE until #5482's platform bump lands. This PR only makes sure the next person doesn't repeat the same broken experiment blind.

## Test plan
- [x] `./gradlew :build-logic:compileKotlin` — compiles clean
- [x] Reproduced the failure: forced 1.15.12, ran `openbank-account-service` `@QuarkusTest` suite, confirmed `NoSuchMethodError` on every test class
- [x] Confirmed the fix is reverted (no `force()` in the final diff — comment only)
