### PR TITLE
fix(ci): treat 'already running' as success in spot-kill auto-retry

### DIFF
--- a/.github/workflows/auto-retry-cancelled.yml
+++ b/.github/workflows/auto-retry-cancelled.yml
@@ -148,8 +148,21 @@ jobs:
           # Note what that failure was NOT: not "never triggered" and not "never detected" —
           # 3 of 10 sampled runs the same day issued a real re-run that landed as attempt 2.
           # Only 5xx / 429 / a transport error are retried. A 403/404/422 is a real answer
-          # (run too old, already re-running, no permission); retrying those just burns the
-          # budget and delays the alarm, so they fail immediately.
+          # (run too old, no permission); retrying those just burns the budget and delays the
+          # alarm, so they fail immediately.
+          #
+          # "ALREADY RUNNING" IS NOT ONE OF THOSE (issue #5489). Measured on run 32100417490:
+          # attempt 1 hit `HTTP 502: Server Error` (a transient loss, retried per the rule
+          # above); by attempt 2 the run had already started re-running — a race with GitHub's
+          # own retry of the first, lost call, or with a duplicate trigger — and `gh` answered
+          #   run 32100417490 cannot be rerun; This workflow is already running
+          # Treating that as a hard failure was wrong: the substance this workflow exists to
+          # achieve (the reclaimed run gets a fresh attempt) had ALREADY happened by the time
+          # attempt 2 asked. Filing #5489 for it escalates a no-op as if it were the #4595
+          # case (the API call losing 3/3), which it structurally cannot be — a losing call
+          # never gets to "already running", it gets HTTP 5xx/429/timeout every time. So this
+          # is matched and returned as a distinct success, not folded into the transient-retry
+          # loop above and not falling to the non-transient catch-all.
           rerun_with_retry() {
             # Written with `if ... fi`, never `[ x ] && cmd`, because a trailing AND-list that
             # evaluates false is a FAILING last command and `set -e` would exit the whole step
@@ -166,6 +179,13 @@ jobs:
               fi
               echo "gh run rerun attempt ${attempt}/3 failed: ${out}"
               case "${out}" in
+                *"already running"*)
+                  # Not an error to retry and not an error to escalate: the run is already
+                  # retrying, so there is nothing left for this step to do. Matched BEFORE the
+                  # transient-vs-non-transient case below so it can never fall into either —
+                  # it is neither.
+                  echo "gh run rerun attempt ${attempt}/3: ${RUN_URL} is already running (race with a prior attempt or GitHub's own mechanism) — nothing to do, treating as success"
+                  return 0 ;;
                 *"HTTP 5"*|*"HTTP 429"*|*"Server Error"*|*"connection reset"*|*"EOF"*|*"timeout"*) ;;
                 *) echo "::error title=spot-kill auto-retry::Non-transient error from gh run rerun; not retrying: ${out}"
                    return 1 ;;


### PR DESCRIPTION
## Summary

`auto-retry-cancelled.yml`'s `rerun_with_retry()` treated `gh run rerun`'s
"cannot be rerun; This workflow is already running" answer as a
non-transient hard failure and escalated it to the `raise-issue` job
(#5489). It isn't one — it means the retry this workflow exists to
perform had already happened by another path, so there is nothing
left to do; escalating turns a no-op success into a filed issue.

- Confirmed live on run **32100417490** (auto-retry run 32110103205,
  the run that filed #5489). Attempt 1 hit a transient `HTTP 502:
  Server Error` and was correctly retried per the #4595 rule; by
  attempt 2 the run had already started re-running (a race with a
  prior attempt, or GitHub's own retry), so `gh` answered:

  ```
  run 32100417490 cannot be rerun; This workflow is already running
  ```

  (log lines 163–165 of run 32110103205, step "Re-run only if the
  runner was reclaimed")

- Added a `case` arm matching `*"already running"*` **before** the
  transient/non-transient split, returning success with a clear log
  line instead of falling into the `*)` catch-all. A genuine
  non-transient error (403/404/422 — wrong permissions, run too old)
  is unaffected and still escalates.

## Test plan

This script is inline shell in the workflow YAML with no existing
fixture harness, so I extracted `rerun_with_retry()` verbatim (via
`yaml.safe_load` on the step's `run:` block, not a hand-retyped copy)
and drove it through a stubbed `gh` covering three cases:

- [x] transient `HTTP 502` on attempt 1, success on attempt 2 → still
      retries, returns success
- [x] genuine non-transient `HTTP 403` → still escalates (return 1)
- [x] the real 32100417490 sequence (502 then "already running") →
      now returns success instead of escalating

- [x] Falsified the harness itself: ran the same three-case driver
      against the **pre-fix** function extracted from `origin/main`.
      The 403 and 5xx cases behave identically; the "already running"
      case fails there (`rc=1`, escalates) — confirming the test
      actually discriminates the fix from the bug, not just green
      either way.
- [x] `actionlint .github/workflows/auto-retry-cancelled.yml` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
