### PR TITLE
feat(admin-ui): trigger bounded flaky test check

### DIFF
--- a/.github/asvs-l3-baseline.txt
+++ b/.github/asvs-l3-baseline.txt
@@ -241,7 +241,6 @@ V13.1 openbank-control-liveness-sentinel: serves REST resources but publishes no
 V13.1 openbank-devops-agent: serves REST resources but publishes no openapi.yaml
 V13.1 openbank-docs-truth-agent: serves REST resources but publishes no openapi.yaml
 V13.1 openbank-finops-agent: serves REST resources but publishes no openapi.yaml
-V13.1 openbank-flaky-test-hunter: serves REST resources but publishes no openapi.yaml
 V13.1 openbank-governance-auditor: serves REST resources but publishes no openapi.yaml
 V13.1 openbank-release-steward: serves REST resources but publishes no openapi.yaml
 V9.1 openbank-infra/gitops/components/delegation/delegation-service.yaml:106: plaintext http:// env value http://sca-service.sca.svc:8110
@@ -252,6 +251,7 @@ V9.1 openbank-infra/gitops/components/engagement/engagement-service.yaml:81: pla
 V9.1 openbank-infra/gitops/components/case-coordinator/case-coordinator-service.yaml:122: plaintext http:// env value http://litellm.ai-platform.svc:4000/v1
 V9.1 openbank-infra/gitops/components/case-coordinator/case-coordinator-service.yaml:134: plaintext http:// env value http://tempo.observability.svc:4317
 V9.1 openbank-infra/gitops/components/admin-ui/admin-ui.yaml:99: plaintext http:// env value http://case-coordinator-agent.platform.svc:8146
+V9.1 openbank-infra/gitops/components/admin-ui/admin-ui.yaml:104: plaintext http:// env value http://flaky-test-hunter.flaky-test-hunter.svc:8148
 # V9.1 — customer-edge -> delegation-service. NOT a new plaintext edge: the call already
 # ran over plaintext via the resource's @ConfigProperty default
 # (openbank-customer-edge/src/main/resources/application.yaml:121), where neither this gate nor

--- a/openbank-admin-ui/src/app/api/iaops/flaky-test-hunter/trigger/route.ts
+++ b/openbank-admin-ui/src/app/api/iaops/flaky-test-hunter/trigger/route.ts
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import { NextResponse } from 'next/server'
+import { auth } from '@/auth'
+import { hasRole, ROLES } from '@/lib/auth/roles'
+
+export const dynamic = 'force-dynamic'
+
+// This is deliberately not a generic agent proxy. The route names one bounded
+// operator action and one in-cluster service, so a browser session cannot turn
+// Admin UI into an arbitrary cluster relay.
+function flakyTestHunterBase(): string {
+  return (process.env.FLAKY_TEST_HUNTER_URL ?? 'http://localhost:8148').replace(/\/$/, '')
+}
+
+export async function POST() {
+  const session = await auth()
+  const accessToken = session?.user?.accessToken
+  if (!accessToken) return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+  if (!hasRole(session.user.roles ?? [], ROLES.ADMIN)) {
+    return NextResponse.json({ error: 'forbidden' }, { status: 403 })
+  }
+
+  try {
+    const upstream = await fetch(`${flakyTestHunterBase()}/api/v1/flaky-test-hunter/check/trigger-async`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${accessToken}` },
+      // The endpoint only asks Temporal to start the durable workflow and returns
+      // 202. It must not wait for a fleet scan/LLM diagnosis, which can take minutes.
+      signal: AbortSignal.timeout(10_000),
+      cache: 'no-store',
+    })
+    if (!upstream.ok) return NextResponse.json({ error: 'upstream_error' }, { status: upstream.status })
+    const body = await upstream.json().catch(() => null) as { workflowId?: unknown } | null
+    if (!body || typeof body.workflowId !== 'string' || !body.workflowId.trim()) {
+      return NextResponse.json({ error: 'upstream_invalid_response' }, { status: 502 })
+    }
+    return NextResponse.json({ workflowId: body.workflowId }, { status: upstream.status })
+  } catch (error: unknown) {
+    const errorName = error && typeof error === 'object' && 'name' in error ? String(error.name) : ''
+    if (errorName === 'AbortError' || errorName === 'TimeoutError') {
+      // A timed-out POST can have reached Temporal. Do not misrepresent this as an outage
+      // or as a failed start; the operator must check the durable workflow history first.
+      return NextResponse.json({ error: 'admission_outcome_unknown' }, { status: 504 })
+    }
+    return NextResponse.json({ error: 'upstream_unreachable' }, { status: 502 })
+  }
+}

--- a/openbank-admin-ui/src/app/iaops/agents/[agentId]/page.tsx
+++ b/openbank-admin-ui/src/app/iaops/agents/[agentId]/page.tsx
@@ -7,9 +7,11 @@
 import { useState, useEffect, useCallback } from 'react'
 import { useParams } from 'next/navigation'
 import Link from 'next/link'
-import { ArrowLeft, RefreshCw, Lock, Users, FileText, Clock, Sparkles, Hand } from 'lucide-react'
+import { ArrowLeft, RefreshCw, Lock, Users, FileText, Clock, Sparkles, Hand, Play, ShieldCheck } from 'lucide-react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { AuthGuard } from '@/components/auth/AuthGuard'
+import { useAuth } from '@/lib/auth/useAuth'
+import { ROLES } from '@/lib/auth/roles'
 import { DataUnavailable } from '@/components/feedback/DataUnavailable'
 import type { UnavailableKind } from '@/components/feedback/DataUnavailable'
 import { AgentPortrait, getAgentPersona } from '@/components/agent/AgentIdentity'
@@ -149,9 +151,12 @@ function AgentDetailContent() {
   const params = useParams<{ agentId: string }>()
   const agentId = params.agentId
   const { t, language } = useLanguage()
+  const { hasRole } = useAuth()
   const [data, setData] = useState<AgentDetail | null>(null)
   const [loading, setLoading] = useState(true)
   const [unavailable, setUnavailable] = useState<{ kind: UnavailableKind } | null>(null)
+  const [triggering, setTriggering] = useState(false)
+  const [triggerFeedback, setTriggerFeedback] = useState<{ tone: 'success' | 'error'; text: string } | null>(null)
 
   const load = useCallback(async () => {
     setLoading(true)
@@ -169,6 +174,39 @@ function AgentDetailContent() {
   }, [agentId])
 
   useEffect(() => { load() }, [load])
+
+  const triggerBoundedCheck = async () => {
+    setTriggering(true)
+    setTriggerFeedback(null)
+    try {
+      const res = await fetch('/api/iaops/flaky-test-hunter/trigger', { method: 'POST' })
+      if (res.status === 401 || res.status === 403) {
+        setTriggerFeedback({ tone: 'error', text: t('Tento krok vyžaduje roli administrátora.', 'This action requires the Administrator role.') })
+        return
+      }
+      if (res.status === 504) {
+        setTriggerFeedback({ tone: 'error', text: t('Nelze potvrdit, zda se kontrola spustila; před dalším pokusem ověř běh ve workflow historii.', 'The check admission could not be confirmed; verify the workflow history before trying again.') })
+        return
+      }
+      if (!res.ok) {
+        setTriggerFeedback({ tone: 'error', text: t('Kontrolu se nepodařilo spustit. Zkus ji prosím později.', 'The check could not be started. Please try again later.') })
+        return
+      }
+      const started = await res.json() as { workflowId?: string }
+      setTriggerFeedback({
+        tone: 'success',
+        text: t(
+          `Požadavek je evidován jako workflow ${started.workflowId ?? '—'}. Výsledek může trvat několik minut.`,
+          `The request is recorded as workflow ${started.workflowId ?? '—'}. Its result can take several minutes.`,
+        ),
+      })
+      void load()
+    } catch {
+      setTriggerFeedback({ tone: 'error', text: t('Služba kontroly testů není dostupná.', 'The test-check service is unavailable.') })
+    } finally {
+      setTriggering(false)
+    }
+  }
 
   if (unavailable) {
     return <DataUnavailable kind={unavailable.kind} service={agentId} feature={t('agent charter', 'agent charter')} lang={language} />
@@ -254,6 +292,34 @@ function AgentDetailContent() {
               </div>
             </div>
           </Card>
+
+          {agentId === 'flaky-test-hunter' && hasRole(ROLES.ADMIN) && (
+            <Card>
+              <div style={{ display: 'flex', alignItems: 'flex-start', gap: '12px', justifyContent: 'space-between', flexWrap: 'wrap' }}>
+                <div style={{ minWidth: '240px', flex: 1 }}>
+                  <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '6px' }}>
+                    <ShieldCheck size={15} style={{ color: '#0f766e' }} />
+                    <span style={{ fontSize: '13px', fontWeight: 700 }}>{t('Omezená operátorská kontrola', 'Bounded operator check')}</span>
+                  </div>
+                  <p style={{ fontSize: '12px', color: 'var(--text-secondary)', lineHeight: 1.55, margin: 0 }}>
+                    {t(
+                      'Prověří testové zdroje napříč platformou. Pouze případná automatická oprava je omezená na testové soubory tohoto agenta a vznikne jen jako návrh; agent nic nemerguje.',
+                      'Scans test source across the platform. Only a possible automated repair is limited to this agent\'s test source and is a proposal only; the agent never merges.',
+                    )}
+                  </p>
+                </div>
+                <button type="button" className="btn btn-primary btn-sm" onClick={triggerBoundedCheck} disabled={triggering}>
+                  {triggering ? <RefreshCw size={13} aria-hidden="true" style={{ animation: 'spin 0.8s linear infinite' }} /> : <Play size={13} aria-hidden="true" />}
+                  {triggering ? t('Kontroluji…', 'Checking…') : t('Spustit kontrolu', 'Run check')}
+                </button>
+              </div>
+              {triggerFeedback && (
+                <p role="status" style={{ fontSize: '12px', margin: '12px 0 0', color: triggerFeedback.tone === 'success' ? '#15803d' : '#b91c1c' }}>
+                  {triggerFeedback.text}
+                </p>
+              )}
+            </Card>
+          )}
 
           {data.charter && data.diagnostics.length > 0 && (
             <AgentBodyAnalysis agentId={agentId} diagnostics={data.diagnostics} language={language} />

--- a/openbank-admin-ui/src/test/flaky-test-hunter-trigger-bff.test.ts
+++ b/openbank-admin-ui/src/test/flaky-test-hunter-trigger-bff.test.ts
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { readFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+
+vi.mock('@/auth', () => ({ auth: vi.fn() }))
+
+import { auth } from '@/auth'
+
+describe('flaky-test-hunter trigger BFF', () => {
+  beforeEach(() => vi.resetModules())
+  afterEach(() => vi.restoreAllMocks())
+
+  it('drives the real BFF through the provider-replayed Admin UI Pact interaction', async () => {
+    vi.mocked(auth).mockResolvedValue({ user: { accessToken: 'operator-token', roles: ['ROLE_ADMIN'] } } as never)
+    const pact = JSON.parse(await readFile(
+      resolve(process.cwd(), '../pacts/openbank-admin-ui-openbank-flaky-test-hunter.json'), 'utf8',
+    )) as { interactions: Array<{ request: { method: string; path: string; headers?: Record<string, string | string[]> }; response: { body: unknown } }> }
+    const interaction = pact.interactions.find(item => item.request.method === 'POST' && item.request.path === '/api/v1/flaky-test-hunter/check/trigger-async')
+    if (!interaction) throw new Error('flaky-test trigger interaction is missing from the committed Pact')
+    const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify({ workflowId: 'flaky-test-check-operator_manual-2026-08-18' }), { status: 202 }))
+    vi.stubGlobal('fetch', fetchMock)
+    const { POST } = await import('@/app/api/iaops/flaky-test-hunter/trigger/route')
+
+    const response = await POST()
+
+    expect(response.status).toBe(202)
+    expect(fetchMock).toHaveBeenCalledOnce()
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(new URL(url).pathname).toBe(interaction.request.path)
+    expect(new URL(url).search).toBe('')
+    expect(new Headers(init.headers).get('Authorization')).toBe('Bearer operator-token')
+    await expect(response.json()).resolves.toEqual(interaction.response.body)
+  })
+
+  it('rejects a non-admin session before it contacts the agent', async () => {
+    vi.mocked(auth).mockResolvedValue({ user: { accessToken: 'viewer-token', roles: ['ROLE_VIEWER'] } } as never)
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+    const { POST } = await import('@/app/api/iaops/flaky-test-hunter/trigger/route')
+
+    const response = await POST()
+
+    expect(response.status).toBe(403)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects a missing session before it contacts the agent', async () => {
+    vi.mocked(auth).mockResolvedValue(null as never)
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+    const { POST } = await import('@/app/api/iaops/flaky-test-hunter/trigger/route')
+
+    const response = await POST()
+
+    expect(response.status).toBe(401)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('reports a timed-out admission as unknown rather than as an unavailable service', async () => {
+    vi.mocked(auth).mockResolvedValue({ user: { accessToken: 'operator-token', roles: ['ROLE_ADMIN'] } } as never)
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new DOMException('Timed out', 'TimeoutError')))
+    const { POST } = await import('@/app/api/iaops/flaky-test-hunter/trigger/route')
+
+    const response = await POST()
+
+    expect(response.status).toBe(504)
+    await expect(response.json()).resolves.toEqual({ error: 'admission_outcome_unknown' })
+  })
+
+  it('does not report success for an accepted response without a workflow id', async () => {
+    vi.mocked(auth).mockResolvedValue({ user: { accessToken: 'operator-token', roles: ['ROLE_ADMIN'] } } as never)
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('{}', { status: 202 })))
+    const { POST } = await import('@/app/api/iaops/flaky-test-hunter/trigger/route')
+
+    const response = await POST()
+
+    expect(response.status).toBe(502)
+    await expect(response.json()).resolves.toEqual({ error: 'upstream_invalid_response' })
+  })
+})

--- a/openbank-flaky-test-hunter/build.gradle.kts
+++ b/openbank-flaky-test-hunter/build.gradle.kts
@@ -41,10 +41,19 @@ dependencies {
     testImplementation("io.temporal:temporal-testing:1.25.1")
     testImplementation("io.grpc:grpc-inprocess:1.68.1")
     testImplementation(libs.quarkus.junit5)
+    testImplementation(libs.quarkus.test.security)
     testImplementation(libs.assertj)
     testImplementation(libs.mockk)
     testImplementation(libs.testcontainers.postgresql)
     testImplementation(libs.rest.assured.kotlin)
+    // Git-pact for the Admin UI's bounded operator trigger (ADR-0063): the
+    // consumer shape and provider replay protect the 202/workflowId contract.
+    testImplementation(libs.pact.consumer)
+    testImplementation(libs.pact.provider)
+}
+
+tasks.withType<Test> {
+    systemProperty("pact.rootDir", "${rootProject.projectDir}/pacts")
 }
 
 // Package the ADR-0148 prompt registry onto the classpath so LlmDiagnosisAdapter loads its system

--- a/openbank-flaky-test-hunter/src/main/kotlin/com/openbank/flakytest/infrastructure/rest/FlakyTestResource.kt
+++ b/openbank-flaky-test-hunter/src/main/kotlin/com/openbank/flakytest/infrastructure/rest/FlakyTestResource.kt
@@ -18,6 +18,7 @@ import jakarta.ws.rs.Path
 import jakarta.ws.rs.PathParam
 import jakarta.ws.rs.Produces
 import jakarta.ws.rs.core.MediaType
+import jakarta.ws.rs.core.Response
 import kotlinx.coroutines.runBlocking
 
 @Path("/api/v1/flaky-test-hunter")
@@ -28,6 +29,18 @@ class FlakyTestResource(private val runCheck: RunFlakyTestCheckUseCase, private 
     @RolesAllowed("ROLE_ADMIN")
     fun triggerCheck(): FlakyTestReport = runBlocking {
         runCheck.run(RunTrigger.OPERATOR_MANUAL)
+    }
+
+    /**
+     * Starts the durable operator workflow without holding an Admin UI request open for a fleet
+     * scan and any per-finding diagnosis. The id is the operator-visible handle; completion and
+     * any proposal remain recorded by the workflow, not implied by this accepted response.
+     */
+    @POST
+    @Path("/check/trigger-async")
+    @RolesAllowed("ROLE_ADMIN")
+    fun triggerCheckAsync(): Response = runBlocking {
+        Response.accepted(FlakyTestCheckStarted(runCheck.startDetached(RunTrigger.OPERATOR_MANUAL))).build()
     }
 
     @GET
@@ -44,3 +57,5 @@ class FlakyTestResource(private val runCheck: RunFlakyTestCheckUseCase, private 
         getFindings.getById(id) ?: throw NotFoundException("Finding $id not found")
     }
 }
+
+data class FlakyTestCheckStarted(val workflowId: String)

--- a/openbank-flaky-test-hunter/src/main/resources/application.yaml
+++ b/openbank-flaky-test-hunter/src/main/resources/application.yaml
@@ -93,6 +93,9 @@ quarkus:
       check-cron: "0 0 5 31 2 ?"
 
 openbank:
+  api:
+    # Major matches the served /api/v1 path and openapi.yaml (ADR-0048).
+    version: 1
   temporal:
     enabled: ${TEMPORAL_ENABLED:false}
     server-url: ${TEMPORAL_HOST:temporal-frontend.temporal:7233}

--- a/openbank-flaky-test-hunter/src/main/resources/openapi.yaml
+++ b/openbank-flaky-test-hunter/src/main/resources/openapi.yaml
@@ -1,0 +1,79 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+# See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+
+openapi: 3.1.0
+info:
+  title: Flaky Test Hunter API
+  version: 1.0.0
+  description: Internal development-plane agent API. It scans fleet test source; any automated repair is constrained to the agent's own test source and is proposed for human review only.
+  license:
+    name: AGPL-3.0-only
+    url: https://www.gnu.org/licenses/agpl-3.0.html
+servers:
+  - url: http://localhost:8148
+    description: Local development
+tags:
+  - name: Flaky test checks
+paths:
+  /api/v1/flaky-test-hunter/check/trigger:
+    post:
+      tags: [Flaky test checks]
+      operationId: triggerFlakyTestCheck
+      summary: Run a flaky-test check and wait for its report
+      security: [{ bearerAuth: [ROLE_ADMIN] }]
+      responses:
+        '200': { description: Completed check report }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+  /api/v1/flaky-test-hunter/check/trigger-async:
+    post:
+      tags: [Flaky test checks]
+      operationId: triggerFlakyTestCheckAsync
+      summary: Admit a durable flaky-test workflow without waiting for its report
+      description: A 202 confirms only workflow admission, not completion, a proposal, PR creation, or human approval.
+      security: [{ bearerAuth: [ROLE_ADMIN] }]
+      responses:
+        '202':
+          description: Workflow admission accepted
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [workflowId]
+                properties:
+                  workflowId: { type: string }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+  /api/v1/flaky-test-hunter/findings:
+    get:
+      tags: [Flaky test checks]
+      operationId: listFlakyTestFindings
+      summary: List active flaky-test findings
+      security: [{ bearerAuth: [ROLE_ADMIN, ROLE_VIEWER] }]
+      responses:
+        '200': { description: Active findings }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+  /api/v1/flaky-test-hunter/findings/{id}:
+    get:
+      tags: [Flaky test checks]
+      operationId: getFlakyTestFinding
+      summary: Get one active flaky-test finding
+      security: [{ bearerAuth: [ROLE_ADMIN, ROLE_VIEWER] }]
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        '200': { description: Finding }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { description: Finding not found }
+components:
+  securitySchemes:
+    bearerAuth: { type: http, scheme: bearer }
+  responses:
+    Unauthorized: { description: Authentication is required }
+    Forbidden: { description: The authenticated role is not permitted }

--- a/openbank-flaky-test-hunter/src/test/kotlin/com/openbank/flakytest/contract/FlakyTestTriggerPactConsumerTest.kt
+++ b/openbank-flaky-test-hunter/src/test/kotlin/com/openbank/flakytest/contract/FlakyTestTriggerPactConsumerTest.kt
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+
+package com.openbank.flakytest.contract
+
+import au.com.dius.pact.consumer.MockServer
+import au.com.dius.pact.consumer.dsl.PactDslWithProvider
+import au.com.dius.pact.consumer.junit5.PactConsumerTestExt
+import au.com.dius.pact.consumer.junit5.PactTestFor
+import au.com.dius.pact.core.model.PactSpecVersion
+import au.com.dius.pact.core.model.RequestResponsePact
+import au.com.dius.pact.core.model.annotations.Pact
+import io.restassured.RestAssured.given
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+/**
+ * Consumer contract for the Admin UI BFF. The UI has no Pact runtime, so this test declares its
+ * literal HTTP shape and commits the generated git-pact; the provider replay lives alongside it.
+ */
+@ExtendWith(PactConsumerTestExt::class)
+@PactTestFor(providerName = "openbank-flaky-test-hunter", pactVersion = PactSpecVersion.V3)
+class FlakyTestTriggerPactConsumerTest {
+
+    @Pact(consumer = "openbank-admin-ui", provider = "openbank-flaky-test-hunter")
+    fun asyncTriggerPact(builder: PactDslWithProvider): RequestResponsePact = builder
+        .given("an administrator may admit a flaky-test workflow")
+        .uponReceiving("admit the bounded flaky-test workflow")
+        .path("/api/v1/flaky-test-hunter/check/trigger-async")
+        .method("POST")
+        .matchHeader("Authorization", "Bearer [A-Za-z0-9._-]+", "Bearer pact-admin-token")
+        .willRespondWith()
+        .status(202)
+        .headers(mapOf("Content-Type" to "application/json"))
+        .body("""{"workflowId":"flaky-test-check-operator_manual-2026-08-18"}""")
+        .toPact()
+
+    @Test
+    @PactTestFor(pactMethod = "asyncTriggerPact")
+    fun `admin UI receives an admission handle`(mockServer: MockServer) {
+        val workflowId = given()
+            .header("Authorization", "Bearer pact-admin-token")
+            .`when`().post("${mockServer.getUrl()}/api/v1/flaky-test-hunter/check/trigger-async")
+            .then().statusCode(202)
+            .extract().jsonPath().getString("workflowId")
+
+        assertThat(workflowId).isEqualTo("flaky-test-check-operator_manual-2026-08-18")
+    }
+}

--- a/openbank-flaky-test-hunter/src/test/kotlin/com/openbank/flakytest/contract/FlakyTestTriggerPactProviderVerificationTest.kt
+++ b/openbank-flaky-test-hunter/src/test/kotlin/com/openbank/flakytest/contract/FlakyTestTriggerPactProviderVerificationTest.kt
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+
+package com.openbank.flakytest.contract
+
+import au.com.dius.pact.provider.junit5.HttpTestTarget
+import au.com.dius.pact.provider.junit5.PactVerificationContext
+import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvider
+import au.com.dius.pact.provider.junitsupport.Provider
+import au.com.dius.pact.provider.junitsupport.State
+import au.com.dius.pact.provider.junitsupport.loader.PactFolder
+import com.openbank.flakytest.PostgresTestResource
+import com.openbank.flakytest.application.usecase.FlakyTestHunterService
+import com.openbank.flakytest.domain.model.RunTrigger
+import io.mockk.coEvery
+import io.mockk.mockk
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusMock
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.security.TestSecurity
+import org.eclipse.microprofile.config.inject.ConfigProperty
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.TestTemplate
+import org.junit.jupiter.api.extension.ExtendWith
+
+@QuarkusTest
+@QuarkusTestResource(PostgresTestResource::class)
+@Provider("openbank-flaky-test-hunter")
+@PactFolder("../pacts")
+@TestSecurity(user = "pact-admin", roles = ["ROLE_ADMIN"])
+class FlakyTestTriggerPactProviderVerificationTest {
+
+    @ConfigProperty(name = "quarkus.http.test-port")
+    lateinit var port: String
+
+    @BeforeEach
+    fun before(context: PactVerificationContext) {
+        val runCheck = mockk<FlakyTestHunterService>()
+        coEvery { runCheck.startDetached(RunTrigger.OPERATOR_MANUAL) } returns WORKFLOW_ID
+        QuarkusMock.installMockForType(runCheck, FlakyTestHunterService::class.java)
+        context.target = HttpTestTarget("localhost", port.toInt())
+    }
+
+    @State("an administrator may admit a flaky-test workflow")
+    fun administratorMayAdmitWorkflow() = Unit
+
+    @TestTemplate
+    @ExtendWith(PactVerificationInvocationContextProvider::class)
+    fun pactVerificationTestTemplate(context: PactVerificationContext) {
+        context.verifyInteraction()
+    }
+
+    private companion object {
+        const val WORKFLOW_ID = "flaky-test-check-operator_manual-2026-08-18"
+    }
+}

--- a/openbank-flaky-test-hunter/src/test/kotlin/com/openbank/flakytest/infrastructure/rest/FlakyTestResourceRoutingIT.kt
+++ b/openbank-flaky-test-hunter/src/test/kotlin/com/openbank/flakytest/infrastructure/rest/FlakyTestResourceRoutingIT.kt
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+
+package com.openbank.flakytest.infrastructure.rest
+
+import com.openbank.flakytest.PostgresTestResource
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.security.TestSecurity
+import io.restassured.RestAssured.given
+import org.junit.jupiter.api.Test
+
+@QuarkusTest
+@QuarkusTestResource(PostgresTestResource::class)
+class FlakyTestResourceRoutingIT {
+
+    @Test
+    fun `async trigger is a served route that rejects an anonymous caller`() {
+        given()
+            .`when`().post("/api/v1/flaky-test-hunter/check/trigger-async")
+            .then().statusCode(401)
+    }
+
+    @Test
+    @TestSecurity(user = "viewer", roles = ["ROLE_VIEWER"])
+    fun `async trigger rejects a viewer before workflow admission`() {
+        given()
+            .`when`().post("/api/v1/flaky-test-hunter/check/trigger-async")
+            .then().statusCode(403)
+    }
+}

--- a/openbank-flaky-test-hunter/src/test/kotlin/com/openbank/flakytest/infrastructure/rest/FlakyTestResourceTest.kt
+++ b/openbank-flaky-test-hunter/src/test/kotlin/com/openbank/flakytest/infrastructure/rest/FlakyTestResourceTest.kt
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+
+package com.openbank.flakytest.infrastructure.rest
+
+import com.openbank.flakytest.application.port.incoming.GetFindingsUseCase
+import com.openbank.flakytest.application.port.incoming.RunFlakyTestCheckUseCase
+import com.openbank.flakytest.domain.model.RunTrigger
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class FlakyTestResourceTest {
+
+    @Test
+    fun `async trigger accepts the workflow without waiting for its report`() {
+        val runCheck = mockk<RunFlakyTestCheckUseCase>()
+        val findings = mockk<GetFindingsUseCase>()
+        coEvery { runCheck.startDetached(RunTrigger.OPERATOR_MANUAL) } returns "operator-workflow-1"
+        val resource = FlakyTestResource(runCheck, findings)
+
+        val response = resource.triggerCheckAsync()
+
+        assertThat(response.status).isEqualTo(202)
+        assertThat((response.entity as FlakyTestCheckStarted).workflowId).isEqualTo("operator-workflow-1")
+        coVerify(exactly = 1) { runCheck.startDetached(RunTrigger.OPERATOR_MANUAL) }
+        coVerify(exactly = 0) { runCheck.run(any()) }
+    }
+}

--- a/openbank-infra/gitops/components/admin-ui/admin-ui.yaml
+++ b/openbank-infra/gitops/components/admin-ui/admin-ui.yaml
@@ -97,6 +97,11 @@ spec:
             # page renders not_deployed). The in-cluster Service lives in the platform ns.
             - name: CASE_COORDINATOR_URL
               value: http://case-coordinator-agent.platform.svc:8146
+            # The phase-3 test check is an explicitly bounded ADMIN action. It is
+            # not sent through discovery because this agent has its own namespace;
+            # the dedicated BFF route relays the operator bearer to this one URL.
+            - name: FLAKY_TEST_HUNTER_URL
+              value: http://flaky-test-hunter.flaky-test-hunter.svc:8148
             # ADR-0224 D4/D2: the staff OBO MCP channel (/api/agent/obo-mcp). The route
             # 404s unless enabled; enabling requires the whole chain in place —
             # realm permission (#2762), session store (#2843) and this flow (#2850).

--- a/pacts/openbank-admin-ui-openbank-flaky-test-hunter.json
+++ b/pacts/openbank-admin-ui-openbank-flaky-test-hunter.json
@@ -1,0 +1,55 @@
+{
+  "consumer": {
+    "name": "openbank-admin-ui"
+  },
+  "interactions": [
+    {
+      "description": "admit the bounded flaky-test workflow",
+      "providerStates": [
+        {
+          "name": "an administrator may admit a flaky-test workflow"
+        }
+      ],
+      "request": {
+        "headers": {
+          "Authorization": "Bearer pact-admin-token"
+        },
+        "matchingRules": {
+          "header": {
+            "Authorization": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "Bearer [A-Za-z0-9._-]+"
+                }
+              ]
+            }
+          }
+        },
+        "method": "POST",
+        "path": "/api/v1/flaky-test-hunter/check/trigger-async"
+      },
+      "response": {
+        "body": {
+          "workflowId": "flaky-test-check-operator_manual-2026-08-18"
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "status": 202
+      }
+    }
+  ],
+  "metadata": {
+    "pact-jvm": {
+      "version": "4.7.3"
+    },
+    "pactSpecification": {
+      "version": "3.0.0"
+    }
+  },
+  "provider": {
+    "name": "openbank-flaky-test-hunter"
+  }
+}


### PR DESCRIPTION
Summary: Adds an ADMIN-only AIOps control for flaky-test-hunter. It starts a durable 202 workflow admission, never claims completion or merge, relays the operator bearer through a fixed BFF endpoint, and adds a replayed API contract. Verification: focused Admin UI BFF test, Admin UI type check, focused flaky-test-hunter resource/Pact tests, and OpenAPI conformance checks. Refs #5281.