### PR TITLE
chore(security): allowlist LLM model name false positive in gitleaks

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -168,4 +168,12 @@ regexes = [
   # / openapi.yaml, since refactored into src/test), so a full-history scan
   # (--log-opts=--all) still trips the bare-number rod-cislo heuristic on those blobs.
   '''2000145399''',
+  # LLM model identifier (Groq's `llama-3.3-70b-versatile`), named in agents.yaml's
+  # gateway-provider comments and config values (ADR-0175). The version-number-plus-size
+  # shape reads as high-entropy to the default generic-api-key rule; it is a public model
+  # name, not a credential — the actual Groq API key never appears in this repo (it is
+  # OpenBao/ESO-projected, same as every other service secret). A full-history scan
+  # (--log-opts=--all) trips on the comment form in a since-superseded commit
+  # (df37ca6f, openbank-libs/governance/agents.yaml:121).
+  '''llama-3\.3-70b-versatile\.?''',
 ]


### PR DESCRIPTION
## Summary
- Public-readiness audit (`.github/scripts/public-readiness-audit.sh`) found 1 failure: a full-history gitleaks scan (`--log-opts=--all`) flagged `llama-3.3-70b-versatile` (a Groq LLM model identifier named in `agents.yaml`'s gateway-provider comments) as a `generic-api-key` match.
- Confirmed false positive: it's a public model name in a comment, not a credential — the actual Groq API key is OpenBao/ESO-projected like every other service secret and never appears in the repo.
- Adds a scoped regex allowlist entry to `.gitleaks.toml` (same pattern as the existing IBAN/PAN/rodné-číslo entries in that file).
- Re-ran the full audit after the fix: 15/15 passed, `PUBLIC-READY`.

## Linked issues
N/A — routine gitleaks false-positive fix found during a repo-hygiene pass, not tracked as a backlog item.

## Test plan
- [x] `gitleaks detect --log-opts=--all --report-path /tmp/gl2.json --no-banner --config .gitleaks.toml` — 0 findings (was 1)
- [x] `bash .github/scripts/public-readiness-audit.sh` — 15 passed, 0 failed, PUBLIC-READY
