### PR TITLE
feat(admin-ui): extend static docs PDF export

### DIFF
--- a/openbank-admin-ui/src/app/docs/compliance/page.tsx
+++ b/openbank-admin-ui/src/app/docs/compliance/page.tsx
@@ -6,6 +6,7 @@
 import { Shield, CheckCircle2, AlertTriangle, XCircle, Info } from 'lucide-react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { DocsPageHeader } from '@/components/docs/DocsPageHeader'
+import { PrintDocumentButton } from '@/components/docs/PrintDocumentButton'
 
 // Bilingual string tuple: [Czech, English] — spread into t(cs, en) at render.
 type Bilingual = [string, string]
@@ -138,7 +139,7 @@ export default function CompliancePage() {
   const warnItems = COMPLIANCE_AREAS.flatMap(a => a.items).filter(i => i.status === 'warn').length
 
   return (
-    <div>
+    <div className="docs-printable">
       <DocsPageHeader
         crumbs={<>
             <span>OpenBank</span><span className="breadcrumb-sep">/</span>
@@ -148,6 +149,7 @@ export default function CompliancePage() {
         title={t('Report compliance', 'Compliance Report')}
         subtitle={t('EBA · ČNB · PSD2 · GDPR · AML 5AMLD/6AMLD · FATCA/CRS · připravenost na audit', 'EBA · CNB · PSD2 · GDPR · AML 5AMLD/6AMLD · FATCA/CRS · audit readiness')}
         icon={<Shield aria-hidden="true" size={18} style={{ color: 'var(--accent)' }} />}
+        actions={<PrintDocumentButton />}
       />
 
       {/* Summary */}

--- a/openbank-admin-ui/src/app/docs/document-management/page.tsx
+++ b/openbank-admin-ui/src/app/docs/document-management/page.tsx
@@ -10,6 +10,7 @@ import {
 } from 'lucide-react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { DocsPageHeader } from '@/components/docs/DocsPageHeader'
+import { PrintDocumentButton } from '@/components/docs/PrintDocumentButton'
 
 const ACCENT = '#6366f1'
 const INK = 'var(--text-primary)'
@@ -19,7 +20,7 @@ export default function DocumentManagementDocsPage() {
   const { t } = useLanguage()
 
   return (
-    <div>
+    <div className="docs-printable">
       <DocsPageHeader
         crumbs={<>
           <span>OpenBank</span><span className="breadcrumb-sep">/</span>
@@ -32,6 +33,7 @@ export default function DocumentManagementDocsPage() {
             'A new bounded context (openbank-document-service): templates → PDF generation → storage → signature ceremony → audit → downstream consumers.',
           )}
         icon={<FileSignature aria-hidden="true" size={18} style={{ color: ACCENT }} />}
+        actions={<PrintDocumentButton />}
       />
 
       {/* Status strip */}

--- a/openbank-admin-ui/src/app/docs/identity-dedup/page.tsx
+++ b/openbank-admin-ui/src/app/docs/identity-dedup/page.tsx
@@ -7,6 +7,7 @@
 import { Fingerprint, ShieldCheck, GitMerge, KeyRound, Layers, AlertTriangle, Lock, ArrowRight } from 'lucide-react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { DocsPageHeader } from '@/components/docs/DocsPageHeader'
+import { PrintDocumentButton } from '@/components/docs/PrintDocumentButton'
 
 // Status pill mirrored from the docs status vocabulary (live / partial / planned).
 function Status({ kind, t }: { kind: 'live' | 'partial' | 'planned'; t: (cs: string, en: string) => string }) {
@@ -112,7 +113,7 @@ export default function IdentityDedupPage() {
   const sub = 'var(--text-secondary)'
 
   return (
-    <div>
+    <div className="docs-printable">
       <DocsPageHeader
         crumbs={<>
             <span>OpenBank</span>
@@ -127,6 +128,7 @@ export default function IdentityDedupPage() {
               'How unified customer identity is built the modern way: principles, privacy-preserving deduplication, a three-tier resolver and a worked example (ADR-0072, ADR-0094)',
             )}
         icon={<Fingerprint aria-hidden="true" size={18} style={{ color: 'var(--accent)' }} />}
+        actions={<PrintDocumentButton />}
       />
 
       {/* ---- TL;DR banner ---- */}

--- a/openbank-admin-ui/src/test/docs-pdf-export.guard.test.ts
+++ b/openbank-admin-ui/src/test/docs-pdf-export.guard.test.ts
@@ -11,10 +11,13 @@ describe('long-form documentation PDF export contract', () => {
     const readiness = read('app/docs/qrlesspay-readiness/page.tsx')
     const threat = read('app/docs/threat-models/[service]/page.tsx')
     const adr = read('app/docs/adr/[slug]/page.tsx')
+    const compliance = read('app/docs/compliance/page.tsx')
+    const documentManagement = read('app/docs/document-management/page.tsx')
+    const identityDedup = read('app/docs/identity-dedup/page.tsx')
     const css = read('app/globals.css')
     expect(button).toContain('window.print()')
     expect(button).toContain("t('Exportovat PDF', 'Export PDF')")
-    for (const source of [readiness, threat, adr]) {
+    for (const source of [readiness, threat, adr, compliance, documentManagement, identityDedup]) {
       expect(source).toContain('PrintDocumentButton')
       expect(source).toContain('className="docs-printable"')
     }


### PR DESCRIPTION
## Summary
- extend the shared localized print-to-PDF action to compliance, document-management, and identity/dedup documentation
- keep live cloud architecture overlays out until snapshot semantics are explicit
- retain browser-native print pipeline and existing docs shell behavior

## Verification
- docs PDF + i18n guards: 168/168
- npm run type-check
- git diff --check

Related: #5502