### PR TITLE
fix(admin-ui): honor active locale in ops docs

### DIFF
--- a/openbank-admin-ui/src/app/docs/bcp/page.tsx
+++ b/openbank-admin-ui/src/app/docs/bcp/page.tsx
@@ -170,7 +170,8 @@ const CATALOG_PRESENT = TIERS.flatMap(tier => tier.services.map(s => s.name))
   .filter(n => n.endsWith('-service') || n.endsWith('-payment') || n.endsWith('-instant'))
 
 export default function BcpPage() {
-  const { t } = useLanguage()
+  const { t, language } = useLanguage()
+  const dateLocale = language === 'cs' ? 'cs-CZ' : 'en-GB'
   const [health, setHealth] = useState<ServiceHealth>({})
   const [loading, setLoading] = useState(true)
   const [lastRefresh, setLastRefresh] = useState<Date | null>(null)
@@ -316,7 +317,7 @@ export default function BcpPage() {
         actions={<div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
           {lastRefresh && (
             <span style={{ fontSize: '12px', color: 'var(--text-secondary)' }}>
-              {t('Aktualizováno:', 'Updated:')} {lastRefresh.toLocaleTimeString('cs-CZ')}
+              {t('Aktualizováno:', 'Updated:')} {lastRefresh.toLocaleTimeString(dateLocale)}
             </span>
           )}
           <button

--- a/openbank-admin-ui/src/app/docs/cloud-architecture/page.tsx
+++ b/openbank-admin-ui/src/app/docs/cloud-architecture/page.tsx
@@ -158,7 +158,8 @@ function StatusDot({ status }: { status: Status }) {
 }
 
 export default function CloudArchitecturePage() {
-  const { t } = useLanguage()
+  const { t, language } = useLanguage()
+  const dateLocale = language === 'cs' ? 'cs-CZ' : 'en-GB'
   const [selected, setSelected] = useState<Node | null>(null)
   const [liveStatus, setLiveStatus] = useState<Record<string, InfraStatusResult> | null>(null)
   const [checkedAt, setCheckedAt] = useState<string | null>(null)
@@ -171,14 +172,14 @@ export default function CloudArchitecturePage() {
       if (res.ok) {
         const data: Record<string, InfraStatusResult> = await res.json()
         setLiveStatus(data)
-        setCheckedAt(new Date().toLocaleTimeString('cs-CZ'))
+        setCheckedAt(new Date().toLocaleTimeString(dateLocale))
       }
     } catch {
       // graceful degradation — static statuses remain visible
     } finally {
       setRefreshing(false)
     }
-  }, [])
+  }, [dateLocale])
 
   useEffect(() => { void fetchStatus() }, [fetchStatus])
 

--- a/openbank-admin-ui/src/app/sanctions/page.tsx
+++ b/openbank-admin-ui/src/app/sanctions/page.tsx
@@ -125,7 +125,9 @@ function ListCard({ list, onToggle, onRefresh, onSave }: {
   onRefresh: (listType: string) => void
   onSave: (id: string, patch: Partial<SanctionsList>) => void
 }) {
-  const { t } = useLanguage()
+  const { t, language } = useLanguage()
+  const numberLocale = language === 'cs' ? 'cs-CZ' : 'en-GB'
+  const dateLocale = numberLocale
   const [expanded, setExpanded] = useState(false)
   const [refreshing, setRefreshing] = useState(false)
 
@@ -148,8 +150,8 @@ function ListCard({ list, onToggle, onRefresh, onSave }: {
         <div style={{ textAlign: 'right', fontSize: '11px', color: 'var(--text-tertiary)' }}>
           {list.lastUpdatedAt ? (
             <>
-              <div style={{ color: 'var(--success-text)', fontWeight: 600 }}>{list.lastEntryCount?.toLocaleString()} {t('záznamů', 'entries')}</div>
-              <div>{new Date(list.lastUpdatedAt).toLocaleString('cs-CZ')}</div>
+              <div style={{ color: 'var(--success-text)', fontWeight: 600 }}>{list.lastEntryCount?.toLocaleString(numberLocale)} {t('záznamů', 'entries')}</div>
+              <div>{new Date(list.lastUpdatedAt).toLocaleString(dateLocale)}</div>
             </>
           ) : <div>{t('Nikdy nestaženo', 'Never downloaded')}</div>}
         </div>
@@ -182,6 +184,8 @@ function ListCard({ list, onToggle, onRefresh, onSave }: {
 
 export default function SanctionsPage() {
   const { t, language } = useLanguage()
+  const numberLocale = language === 'cs' ? 'cs-CZ' : 'en-GB'
+  const dateLocale = numberLocale
   const [tab, setTab] = useState<'checks'|'search'|'lists'>('checks')
   const [checks, setChecks] = useState<SanctionCheck[]>([])
   const [lists, setLists] = useState<SanctionsList[]>([])
@@ -599,7 +603,7 @@ export default function SanctionsPage() {
                           </span>
                         </td>
                         <td style={{ padding: '12px 16px', fontSize: '12px', color: 'var(--text-tertiary)' }}>
-                          {c.checkedAt ? new Date(c.checkedAt).toLocaleString('cs-CZ') : '—'}
+                          {c.checkedAt ? new Date(c.checkedAt).toLocaleString(dateLocale) : '—'}
                         </td>
                         <td style={{ padding: '12px 16px', fontSize: '12px' }}>
                           {c.reviewedBy ? (
@@ -731,7 +735,7 @@ export default function SanctionsPage() {
                               {a.action}{a.makerId ? ` — ${t('žádá', 'asked by')} ${a.makerId}` : ''}
                             </div>
                             <div style={{ fontSize: '11px', color: 'var(--text-tertiary)', fontFamily: 'var(--font-mono)', wordBreak: 'break-all' }}>
-                              {a.id}{a.createdAt ? ` · ${new Date(a.createdAt).toLocaleString('cs-CZ')}` : ''}
+                              {a.id}{a.createdAt ? ` · ${new Date(a.createdAt).toLocaleString(dateLocale)}` : ''}
                             </div>
                           </div>
                           <button onClick={() => setDecideId(a.id)}
@@ -843,7 +847,7 @@ export default function SanctionsPage() {
                                 {!lst.enabled && <span style={{ fontSize: '9px', fontWeight: 700, color: 'var(--text-tertiary)', background: 'var(--surface-4)', padding: '1px 4px', borderRadius: '3px' }}>{t('vyp.', 'off')}</span>}
                               </div>
                               <div style={{ fontSize: '10px', color: 'var(--text-tertiary)', fontFamily: 'var(--font-mono)', marginTop: '2px' }}>
-                                {lst.lastEntryCount ? `${lst.lastEntryCount.toLocaleString()} ${t('zázn.', 'entries')}` : t('nestaženo', 'not synced')}
+                                {lst.lastEntryCount ? `${lst.lastEntryCount.toLocaleString(numberLocale)} ${t('zázn.', 'entries')}` : t('nestaženo', 'not synced')}
                               </div>
                             </div>
                           </label>

--- a/openbank-admin-ui/src/test/sanctions-bcp-cloud-locale.guard.test.ts
+++ b/openbank-admin-ui/src/test/sanctions-bcp-cloud-locale.guard.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import fs from 'node:fs'
+import path from 'node:path'
+
+const root = path.resolve(process.cwd(), 'src')
+const read = (file: string) => fs.readFileSync(path.join(root, file), 'utf8')
+
+describe('operator locale consistency for sanctions and continuity docs', () => {
+  it('uses the active locale for all visible date/time and count formatting', () => {
+    const sanctions = read('app/sanctions/page.tsx')
+    const bcp = read('app/docs/bcp/page.tsx')
+    const cloud = read('app/docs/cloud-architecture/page.tsx')
+
+    for (const source of [sanctions, bcp, cloud]) {
+      expect(source).not.toMatch(/toLocale(?:String|DateString|TimeString)\(['"](?:cs-CZ|en-US|en-GB)['"]\)/)
+      expect(source).not.toMatch(/toLocale(?:String|DateString|TimeString)\(\)/)
+    }
+    expect(sanctions).toContain('toLocaleString(numberLocale)')
+    expect(sanctions).toContain('toLocaleString(dateLocale)')
+    expect(bcp).toContain('toLocaleTimeString(dateLocale)')
+    expect(cloud).toContain('toLocaleTimeString(dateLocale)')
+  })
+})


### PR DESCRIPTION
## Summary
- use the active operator locale for sanctions dates/counts and continuity/cloud refresh timestamps
- add a regression guard for fixed or implicit locale formatting
- preserve all BFF, RBAC, mutation, and live-status behavior

## Verification
- locale and adjacent guards: 3/3
- npm run type-check
- git diff --check

Related: #5510