### PR TITLE
fix(admin-ui): localize operational refresh timestamps

### DIFF
--- a/openbank-admin-ui/src/app/dashboard/page.tsx
+++ b/openbank-admin-ui/src/app/dashboard/page.tsx
@@ -63,6 +63,7 @@ const WORKSPACE_ICONS: Record<string, ElementType> = {
 
 export default function DashboardPage() {
   const { t, language } = useLanguage()
+  const dateLocale = language === 'cs' ? 'cs-CZ' : 'en-GB'
   const { data: session } = useSession()
   const [statuses, setStatuses] = useState<SvcStatus[]>([])
   const [loading, setLoading] = useState(true)
@@ -159,7 +160,7 @@ export default function DashboardPage() {
           <div className={styles.headerActions}>
           {lastRefresh && (
             <span className={styles.lastRefresh}>
-              {t('Aktualizováno', 'Updated')} {lastRefresh.toLocaleTimeString()}
+              {t('Aktualizováno', 'Updated')} {lastRefresh.toLocaleTimeString(dateLocale)}
             </span>
           )}
           <button onClick={load} disabled={loading} className="btn btn-secondary btn-sm">

--- a/openbank-admin-ui/src/app/devops/page.tsx
+++ b/openbank-admin-ui/src/app/devops/page.tsx
@@ -225,6 +225,8 @@ function toAgentFinding(f: DevOpsFinding, t: (cs: string, en: string) => string)
 
 function DevOpsContent() {
   const { t, language } = useLanguage()
+  const dateLocale = language === 'cs' ? 'cs-CZ' : 'en-GB'
+  const numberLocale = dateLocale
   const [dora, setDora] = useState<DoraData | null>(null)
   const [tests, setTests] = useState<TestResultsResponse | null>(null)
   const [findings, setFindings] = useState<DevOpsFinding[]>([])
@@ -330,7 +332,7 @@ function DevOpsContent() {
           )}
           {lastRefresh && (
             <span style={{ fontSize: '11px', color: 'var(--text-tertiary)' }}>
-              {lastRefresh.toLocaleTimeString()}
+              {lastRefresh.toLocaleTimeString(dateLocale)}
             </span>
           )}
           <button
@@ -620,19 +622,19 @@ function DevOpsContent() {
               {[
                 {
                   label: t('Celkem testů', 'Total Tests'),
-                  value: tests.totals.tests.toLocaleString(),
+                  value: tests.totals.tests.toLocaleString(numberLocale),
                   icon: <FlaskConical size={16} />, color: '#6366f1',
                   sub: `${tests.totals.servicesWithTests}/${tests.totals.services} ${t('služeb', 'services')}`,
                 },
                 {
                   label: t('Prošlo', 'Passed'),
-                  value: tests.totals.passed.toLocaleString(),
+                  value: tests.totals.passed.toLocaleString(numberLocale),
                   icon: <CheckCircle2 size={16} />, color: '#16a34a',
                   sub: fleetPassRate !== null ? t(`${fleetPassRate} % úspěšnost`, `${fleetPassRate}% pass rate`) : '—',
                 },
                 {
                   label: t('Selhalo', 'Failed'),
-                  value: (tests.totals.failed).toLocaleString(),
+                  value: (tests.totals.failed).toLocaleString(numberLocale),
                   icon: <XCircle size={16} />, color: tests.totals.failed > 0 ? '#dc2626' : '#16a34a',
                   sub: t('unit + integrační', 'unit + integration'),
                 },

--- a/openbank-admin-ui/src/app/iaops/page.tsx
+++ b/openbank-admin-ui/src/app/iaops/page.tsx
@@ -148,6 +148,7 @@ function Chips({ items, tone }: { items: string[]; tone: 'allow' | 'deny' | 'neu
 // ── Main ────────────────────────────────────────────────────────────────────
 function IAOpsContent() {
   const { t, language } = useLanguage()
+  const dateLocale = language === 'cs' ? 'cs-CZ' : 'en-GB'
   const [data, setData] = useState<GovData | null>(null)
   const [agentCosts, setAgentCosts] = useState<AgentCostEntry[]>([])
   const [costAnomalies, setCostAnomalies] = useState<FinOpsAnomaly[]>([])
@@ -248,7 +249,7 @@ function IAOpsContent() {
         )}
         breadcrumb={<div className="breadcrumb"><span>OpenBank</span><span className="breadcrumb-sep">/</span><span className="breadcrumb-current">IAOps</span></div>}
         actions={<div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
-          {lastRefresh && <span style={{ fontSize: '11px', color: 'var(--text-tertiary)' }}>{lastRefresh.toLocaleTimeString()}</span>}
+          {lastRefresh && <span style={{ fontSize: '11px', color: 'var(--text-tertiary)' }}>{lastRefresh.toLocaleTimeString(dateLocale)}</span>}
           <button onClick={load} disabled={loading}
             style={{ display: 'flex', alignItems: 'center', gap: '6px', padding: '7px 14px', borderRadius: '8px',
               border: '1px solid var(--border)', background: 'var(--surface)', color: 'var(--text-secondary)',

--- a/openbank-admin-ui/src/app/observability/page.tsx
+++ b/openbank-admin-ui/src/app/observability/page.tsx
@@ -28,7 +28,8 @@ interface MetricsData {
 }
 
 export default function ObservabilityPage() {
-  const { t } = useLanguage()
+  const { t, language } = useLanguage()
+  const dateLocale = language === 'cs' ? 'cs-CZ' : 'en-GB'
   const [metrics, setMetrics] = useState<MetricsData | null>(null)
   const [loading, setLoading] = useState(true)
   const [lastRefresh, setLastRefresh] = useState<Date | null>(null)
@@ -146,7 +147,7 @@ export default function ObservabilityPage() {
           )}
           {lastRefresh && (
             <span style={{ fontSize: '11px', color: 'var(--text-tertiary)', marginLeft: '8px' }}>
-              {t('Aktualizováno', 'Updated')} {lastRefresh.toLocaleTimeString()}
+              {t('Aktualizováno', 'Updated')} {lastRefresh.toLocaleTimeString(dateLocale)}
             </span>
           )}
           <Link href="/observability/stack" className="btn btn-secondary btn-sm" style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>

--- a/openbank-admin-ui/src/app/system/config/page.tsx
+++ b/openbank-admin-ui/src/app/system/config/page.tsx
@@ -18,7 +18,8 @@ export default function ServiceConfigPage() {
   const [snapshots, setSnapshots] = useState<ServiceConfigSnapshot[]>([])
   const [loading, setLoading] = useState(true)
   const [lastRefresh, setLastRefresh] = useState<Date | null>(null)
-  const { t } = useLanguage()
+  const { t, language } = useLanguage()
+  const dateLocale = language === 'cs' ? 'cs-CZ' : 'en-GB'
 
   const refresh = useCallback(async () => {
     try {
@@ -65,7 +66,7 @@ export default function ServiceConfigPage() {
         actions={<div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
           {lastRefresh && (
             <span style={{ fontSize: '11px', color: 'var(--text-tertiary)' }}>
-              {lastRefresh.toLocaleTimeString()}
+              {lastRefresh.toLocaleTimeString(dateLocale)}
             </span>
           )}
           <button

--- a/openbank-admin-ui/src/app/system/health/page.tsx
+++ b/openbank-admin-ui/src/app/system/health/page.tsx
@@ -21,7 +21,8 @@ export default function SystemHealthPage() {
   const [configMap, setConfigMap]   = useState<Record<string, ServiceConfigResponse | null>>({})
   const [govMap, setGovMap]         = useState<Record<string, GovernanceManifestEntry>>({})
   const [govTimestamp, setGovTimestamp] = useState<string | null>(null)
-  const { t } = useLanguage()
+  const { t, language } = useLanguage()
+  const dateLocale = language === 'cs' ? 'cs-CZ' : 'en-GB'
   const [loading, setLoading]       = useState(true)
   const [lastRefreshed, setLastRefreshed] = useState<Date | null>(null)
   const [refreshing, setRefreshing] = useState(false)
@@ -88,7 +89,7 @@ export default function SystemHealthPage() {
         actions={<div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
           {lastRefreshed && (
             <span style={{ fontSize: '12px', color: 'var(--text-tertiary)', display: 'flex', alignItems: 'center', gap: '5px' }}>
-              <Clock size={12} /> {lastRefreshed.toLocaleTimeString()}
+              <Clock size={12} aria-hidden="true" /> {lastRefreshed.toLocaleTimeString(dateLocale)}
             </span>
           )}
           <button className="btn btn-secondary" onClick={() => refresh(true)} disabled={refreshing}>
@@ -142,7 +143,8 @@ function SummaryCard({ label, count, total, icon, color, bg, border }: {
 }
 
 function ServiceCard({ snapshot, resilience, governance, govTimestamp }: { snapshot: ServiceSnapshot; resilience: ServiceConfigResponse | null; governance?: GovernanceManifestEntry; govTimestamp?: string | null }) {
-  const { t } = useLanguage()
+  const { t, language } = useLanguage()
+  const dateLocale = language === 'cs' ? 'cs-CZ' : 'en-GB'
   const { name, port, info, health, rateLimitMax, rateLimitRemaining, apiVersion, latencyMs, reachable } = snapshot
 
   const isUp = reachable && health?.status === 'UP'
@@ -237,7 +239,7 @@ function ServiceCard({ snapshot, resilience, governance, govTimestamp }: { snaps
             </div>
             {govTimestamp && (
               <div style={{ fontSize: '9px', color: 'var(--text-tertiary)' }} title="Metadata freshness">
-                {new Date(govTimestamp).toLocaleTimeString()}
+                {new Date(govTimestamp).toLocaleTimeString(dateLocale)}
               </div>
             )}
           </div>

--- a/openbank-admin-ui/src/test/ops-refresh-locale.guard.test.ts
+++ b/openbank-admin-ui/src/test/ops-refresh-locale.guard.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const page = (name: string) => readFileSync(resolve(process.cwd(), 'src/app', name, 'page.tsx'), 'utf8')
+
+describe('operational refresh timestamps use active locale', () => {
+  it('does not fall back to the browser locale for visible refresh/summary values', () => {
+    const files = [
+      'dashboard', 'observability', 'devops', 'iaops', 'system/health', 'system/config',
+    ].map(page)
+    for (const source of files) {
+      expect(source).not.toMatch(/toLocale(?:TimeString|DateString|String)\(\)/)
+      expect(source).toMatch(/dateLocale/)
+    }
+    expect(files[2]).toMatch(/tests\.totals\.tests\.toLocaleString\(numberLocale\)/)
+    expect(files[2]).toMatch(/tests\.totals\.passed\.toLocaleString\(numberLocale\)/)
+    expect(files[2]).toMatch(/tests\.totals\.failed\)\.toLocaleString\(numberLocale\)/)
+  })
+})


### PR DESCRIPTION
## Summary
- use active cs-CZ/en-GB locale for operational refresh timestamps and DevOps totals
- add source regression guard for implicit browser-locale formatting

## Verification
- npm test -- --run src/test/ops-refresh-locale.guard.test.ts
- npm run type-check
- git diff --check

Refs #5514