### PR TITLE
fix(admin-ui): localize banking record dates

### DIFF
--- a/openbank-admin-ui/src/app/cards/page.tsx
+++ b/openbank-admin-ui/src/app/cards/page.tsx
@@ -39,6 +39,7 @@ const ALL = '__ALL__'
 
 export default function CardsPage() {
   const { t, language } = useLanguage()
+  const dateLocale = language === 'cs' ? 'cs-CZ' : 'en-GB'
   const router = useRouter()
   const { data: session } = useSession()
   const canIssue = hasPermission(session?.user?.roles ?? [], 'cards:issue')
@@ -245,7 +246,7 @@ export default function CardsPage() {
                         </td>
                         <td style={{ padding: '12px 16px', fontSize: '12px', color: 'var(--text-secondary)' }}>{c.expiryDate}</td>
                         <td style={{ padding: '12px 16px', fontSize: '12px', color: 'var(--text-secondary)' }}>{c.cardholderName || '—'}</td>
-                        <td style={{ padding: '12px 16px', fontSize: '12px', color: 'var(--text-tertiary)' }}>{c.createdAt ? new Date(c.createdAt).toLocaleDateString(language === 'cs' ? 'cs-CZ' : 'en-US') : '—'}</td>
+                        <td style={{ padding: '12px 16px', fontSize: '12px', color: 'var(--text-tertiary)' }}>{c.createdAt ? new Date(c.createdAt).toLocaleDateString(dateLocale) : '—'}</td>
                         <td style={{ padding: '10px 16px' }} onClick={e => e.stopPropagation()}>
                           {(canManage || canBlock) && <CardTransitionButtons card={c} busy={ops.busy} canManage={canManage} canBlock={canBlock} onSelect={tr => onSelectTransition(c, tr)} />}
                         </td>

--- a/openbank-admin-ui/src/app/docs/cluster/page.tsx
+++ b/openbank-admin-ui/src/app/docs/cluster/page.tsx
@@ -148,6 +148,7 @@ function ContainerAnatomy({ anatomy, lang }: { anatomy: Topology['imageAnatomy']
 
 export default function ClusterDossierPage() {
   const { t, language } = useLanguage()
+  const dateLocale = language === 'cs' ? 'cs-CZ' : 'en-GB'
   const [topo, setTopo] = useState<Topology | null>(null)
   const [loading, setLoading] = useState(true)
   const [activeLayer, setActiveLayer] = useState<string | null>(null)
@@ -336,7 +337,7 @@ export default function ClusterDossierPage() {
       <p style={{ fontSize: 11, color: 'var(--text-tertiary)', display: 'flex', alignItems: 'center', gap: 6 }}>
         <FileText size={12} />
         {t('Odvozeno z GitOpsu + reprezentativního Dockerfile při buildu (ADR-0081). Žádná data ručně — gapy se zobrazují poctivě.', 'Derived from GitOps + a representative Dockerfile at build (ADR-0081). No hand-typed data — gaps shown honestly.')}
-        {topo?.generatedAt && <span> · {new Date(topo.generatedAt).toLocaleString(language === 'cs' ? 'cs-CZ' : 'en-US')}</span>}
+        {topo?.generatedAt && <span> · {new Date(topo.generatedAt).toLocaleString(dateLocale)}</span>}
       </p>
     </div>
   )

--- a/openbank-admin-ui/src/app/parties/[id]/page.tsx
+++ b/openbank-admin-ui/src/app/parties/[id]/page.tsx
@@ -53,6 +53,7 @@ function PartyDetailPage() {
   const { id } = useParams<{ id: string }>()
   const router = useRouter()
   const { t, language } = useLanguage()
+  const dateLocale = language === 'cs' ? 'cs-CZ' : 'en-GB'
   const { roles } = useAuth()
   const [party, setParty]     = useState<Party | null>(null)
   const [kyc, setKyc]         = useState<KycCase | null>(null)
@@ -170,8 +171,8 @@ function PartyDetailPage() {
                 [t('Reg. číslo', 'Reg. Number'),          party.registrationNumber ?? '—'],
                 [t('Státní příslušnost', 'Nationality'),  party.nationality ?? '—'],
                 [t('Datum narození', 'Date of Birth'),    party.dateOfBirth ?? '—'],
-                [t('Vytvořeno', 'Created'),               new Date(party.createdAt).toLocaleString()],
-                [t('Aktualizováno', 'Updated'),           new Date(party.updatedAt).toLocaleString()],
+                [t('Vytvořeno', 'Created'),               new Date(party.createdAt).toLocaleString(dateLocale)],
+                [t('Aktualizováno', 'Updated'),           new Date(party.updatedAt).toLocaleString(dateLocale)],
               ].map(([label, value]) => (
                 <div key={label} style={{ display: 'flex', justifyContent: 'space-between', fontSize: '13px', borderBottom: '1px solid var(--border)', paddingBottom: '8px' }}>
                   <span style={{ color: 'var(--text-muted)' }}>{label}</span>
@@ -298,6 +299,7 @@ function MessagesTab({ partyId, partyEmail, roles }: { partyId: string; partyEma
   // A helper component outside the page needs its own language context (all admin-ui pages
   // are 'use client') — never reference the page's `t` out of scope (CLAUDE.md rule #4).
   const { t, language } = useLanguage()
+  const dateLocale = language === 'cs' ? 'cs-CZ' : 'en-GB'
   const [rows, setRows] = useState<NotificationSummary[]>([])
   const [total, setTotal] = useState(0)
   const [page, setPage] = useState(0)
@@ -554,8 +556,8 @@ function MessagesTab({ partyId, partyEmail, roles }: { partyId: string; partyEma
                     {row.status}
                   </span>
                 </td>
-                <td style={{ fontSize: '12px', color: 'var(--text-muted)' }}>{row.sentAt ? new Date(row.sentAt).toLocaleString() : '—'}</td>
-                <td style={{ fontSize: '12px', color: 'var(--text-muted)' }}>{row.readAt ? new Date(row.readAt).toLocaleString() : '—'}</td>
+                <td style={{ fontSize: '12px', color: 'var(--text-muted)' }}>{row.sentAt ? new Date(row.sentAt).toLocaleString(dateLocale) : '—'}</td>
+                <td style={{ fontSize: '12px', color: 'var(--text-muted)' }}>{row.readAt ? new Date(row.readAt).toLocaleString(dateLocale) : '—'}</td>
               </tr>
             ))}
           </tbody>

--- a/openbank-admin-ui/src/app/payments/[id]/page.tsx
+++ b/openbank-admin-ui/src/app/payments/[id]/page.tsx
@@ -58,6 +58,7 @@ function PaymentDetailContent() {
   const params = useSearchParams()
   const type = (params.get('type') ?? '').toUpperCase()
   const { t, language } = useLanguage()
+  const numberLocale = language === 'cs' ? 'cs-CZ' : 'en-GB'
 
   const [payment, setPayment] = useState<Payment | null>(null)
   const [loading, setLoading] = useState(true)
@@ -130,9 +131,9 @@ function PaymentDetailContent() {
               { label: t('ID platby', 'Payment ID'), value: payment.id, mono: true },
               { label: t('Typ', 'Type'), value: payment.type ?? '—' },
               { label: t('Stav', 'Status'), value: payment.status ?? '—' },
-              { label: t('Částka', 'Amount'), value: payment.amount != null ? `${Number(payment.amount).toLocaleString(language === 'cs' ? 'cs-CZ' : 'en-US', { minimumFractionDigits: 2 })} ${payment.currency ?? ''}` : '—' },
+              { label: t('Částka', 'Amount'), value: payment.amount != null ? `${Number(payment.amount).toLocaleString(numberLocale, { minimumFractionDigits: 2 })} ${payment.currency ?? ''}` : '—' },
               { label: 'End-to-End ID', value: (payment.endToEndId as string) ?? '—', mono: true },
-              { label: t('Vytvořeno', 'Created'), value: payment.createdAt ? new Date(payment.createdAt).toLocaleString(language === 'cs' ? 'cs-CZ' : 'en-GB') : '—' },
+              { label: t('Vytvořeno', 'Created'), value: payment.createdAt ? new Date(payment.createdAt).toLocaleString(numberLocale) : '—' },
             ]} />
           </div>
           <div className="card">

--- a/openbank-admin-ui/src/app/pid/page.tsx
+++ b/openbank-admin-ui/src/app/pid/page.tsx
@@ -36,6 +36,7 @@ const STATUS_COLORS: Record<string, string> = {
 
 export default function PidPage() {
   const { t, language } = useLanguage()
+  const dateLocale = language === 'cs' ? 'cs-CZ' : 'en-GB'
   const [records, setRecords] = useState<PidRecord[]>([])
   const [loading, setLoading] = useState(true)
   // Inline error is reserved for user-initiated writes (the quick-create form);
@@ -540,7 +541,7 @@ export default function PidPage() {
                   <td>
                     {r.verified ? <CheckCircle2 size={14} color="var(--success)" /> : <Clock size={14} color="var(--warning)" />}
                   </td>
-                  <td style={{ color: 'var(--text-muted)', fontSize: '12px' }}>{new Date(r.createdAt).toLocaleDateString()}</td>
+                  <td style={{ color: 'var(--text-muted)', fontSize: '12px' }}>{new Date(r.createdAt).toLocaleDateString(dateLocale)}</td>
                   <td>
                     <button style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--accent)', display: 'flex', alignItems: 'center', gap: '2px', fontSize: '12px', textDecoration: 'none' }}>
                       {t('Detail', 'View')} <ChevronRight size={12} />

--- a/openbank-admin-ui/src/app/sdd/page.tsx
+++ b/openbank-admin-ui/src/app/sdd/page.tsx
@@ -31,6 +31,7 @@ const STATUSES = ['', 'PENDING_CONFIRMATION', 'ACTIVE', 'SUSPENDED', 'CANCELLED'
 
 export default function SddPage() {
   const { t, language } = useLanguage()
+  const dateLocale = language === 'cs' ? 'cs-CZ' : 'en-GB'
   const [status, setStatus] = useState('')
   const [rows, setRows] = useState<Mandate[]>([])
   const [loading, setLoading] = useState(true)
@@ -108,7 +109,7 @@ export default function SddPage() {
                     <StatusBadge status={m.status} />
                   </td>
                   <td style={{ padding: '10px 14px', color: 'var(--text-tertiary)', fontSize: 12 }}>
-                    {m.createdAt ? new Date(m.createdAt).toLocaleString() : '—'}
+                    {m.createdAt ? new Date(m.createdAt).toLocaleString(dateLocale) : '—'}
                   </td>
                 </tr>
               )

--- a/openbank-admin-ui/src/test/record-locale.guard.test.ts
+++ b/openbank-admin-ui/src/test/record-locale.guard.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const source = (route: string) => readFileSync(resolve(process.cwd(), 'src/app', route, 'page.tsx'), 'utf8')
+
+describe('banking record dates use active locale', () => {
+  it('does not expose browser-dependent date formatting', () => {
+    const routes = ['sdd', 'pid', 'cards', 'parties/[id]', 'payments/[id]', 'docs/cluster']
+    for (const route of routes) {
+      const file = source(route)
+      expect(file).not.toMatch(/toLocale(?:String|DateString|TimeString)\(\)/)
+      expect(file).toMatch(/(?:dateLocale|numberLocale)/)
+    }
+    expect(source('parties/[id]')).toMatch(/row\.sentAt[\s\S]*toLocaleString\(dateLocale\)/)
+    expect(source('parties/[id]')).toMatch(/row\.readAt[\s\S]*toLocaleString\(dateLocale\)/)
+  })
+})


### PR DESCRIPTION
## Summary
- use active cs-CZ/en-GB locale for banking record timestamps and payment amounts
- cover SDD, PID, cards, parties, payments and cluster docs
- add a regression guard against implicit browser-locale formatting

## Verification
- npm test -- --run src/test/record-locale.guard.test.ts
- npm run type-check
- git diff --check

Refs #5514