### PR TITLE
fix(admin-ui): remove dead pid detail action

### DIFF
--- a/openbank-admin-ui/src/app/pid/page.tsx
+++ b/openbank-admin-ui/src/app/pid/page.tsx
@@ -6,7 +6,7 @@
 
 import { useState, useEffect, useCallback } from 'react'
 import Link from 'next/link'
-import { Map, Plus, Search, RefreshCw, ChevronRight, Fingerprint, Clock, CheckCircle2, AlertTriangle, ShieldCheck } from 'lucide-react'
+import { Map, Plus, Search, RefreshCw, Fingerprint, Clock, CheckCircle2, AlertTriangle, ShieldCheck } from 'lucide-react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { classifyBffFailure } from '@/lib/services/bff'
 import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
@@ -543,9 +543,9 @@ export default function PidPage() {
                   </td>
                   <td style={{ color: 'var(--text-muted)', fontSize: '12px' }}>{new Date(r.createdAt).toLocaleDateString(dateLocale)}</td>
                   <td>
-                    <button style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--accent)', display: 'flex', alignItems: 'center', gap: '2px', fontSize: '12px', textDecoration: 'none' }}>
-                      {t('Detail', 'View')} <ChevronRight size={12} />
-                    </button>
+                    <span role="status" style={{ color: 'var(--text-tertiary)', fontSize: '12px' }}>
+                      {t('Detail není dostupný', 'Details unavailable')}
+                    </span>
                   </td>
                 </tr>
               ))}

--- a/openbank-admin-ui/src/test/pid-truthfulness.guard.test.ts
+++ b/openbank-admin-ui/src/test/pid-truthfulness.guard.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+describe('PID list truthfulness', () => {
+  it('does not render a dead detail button when no detail route exists', () => {
+    const source = readFileSync(resolve(process.cwd(), 'src/app/pid/page.tsx'), 'utf8')
+    expect(source).not.toMatch(/<button[^>]*>\s*\{t\(\[['"]Detail/)
+    expect(source).toMatch(/role="status"[\s\S]*Details unavailable/)
+    expect(source).toMatch(/toLocaleDateString\(dateLocale\)/)
+  })
+})


### PR DESCRIPTION
Replace the non-functional PID Detail button with an explicit unavailable state. Preserve the existing read-only PID flow and locale-aware dates. Add a regression guard for truthful action semantics.

## Linked issues

N/A - small truthfulness cleanup; no existing issue covers this dead UI action.

## Validation

- PID truthfulness guard
- type-check
