### PR TITLE
fix(libs-runtime): outbox-dispatch-metrics review follow-ups (findings 6/7/8)

### DIFF
--- a/openbank-libs-domain/src/main/kotlin/com/openbank/libs/persistence/outbox/OutboxDispatch.kt
+++ b/openbank-libs-domain/src/main/kotlin/com/openbank/libs/persistence/outbox/OutboxDispatch.kt
@@ -47,13 +47,7 @@ sealed class OutboxDispatchOutcome {
  * [OutboxDispatch.isTransportUnavailable]) is simply absent — not a synthetic `Failed`, since no
  * attempt was made against it.
  */
-data class OutboxDispatchResult(val outcomes: List<OutboxDispatchOutcome> = emptyList()) {
-    /** Count of rows this batch delivered successfully. */
-    val dispatchedCount: Int get() = outcomes.count { it is OutboxDispatchOutcome.Dispatched }
-
-    /** Count of rows this batch parked as terminal DEAD (ADR-0050 N5). */
-    val deadCount: Int get() = outcomes.count { it is OutboxDispatchOutcome.Failed && it.terminal }
-}
+data class OutboxDispatchResult(val outcomes: List<OutboxDispatchOutcome> = emptyList())
 
 object OutboxDispatch {
     // JDK System.Logger, not org.jboss.logging.Logger — this module must stay framework-free

--- a/openbank-libs-domain/src/test/kotlin/com/openbank/libs/persistence/outbox/OutboxDispatchTest.kt
+++ b/openbank-libs-domain/src/test/kotlin/com/openbank/libs/persistence/outbox/OutboxDispatchTest.kt
@@ -156,8 +156,8 @@ class OutboxDispatchTest {
 
         val result = runBlocking { OutboxDispatch.dispatchOnce(repo) { } }
 
-        assertThat(result.dispatchedCount).isEqualTo(2)
-        assertThat(result.deadCount).isZero()
+        assertThat(result.outcomes.count { it is OutboxDispatchOutcome.Dispatched }).isEqualTo(2)
+        assertThat(result.outcomes.count { it is OutboxDispatchOutcome.Failed && it.terminal }).isZero()
         assertThat(result.outcomes).allMatch { it is OutboxDispatchOutcome.Dispatched }
         assertThat(result.outcomes.map { it.entry.eventId }).containsExactly(rows[0].eventId, rows[1].eventId)
     }
@@ -170,8 +170,8 @@ class OutboxDispatchTest {
 
         val result = runBlocking { OutboxDispatch.dispatchOnce(repo) { error("kafka down") } }
 
-        assertThat(result.dispatchedCount).isZero()
-        assertThat(result.deadCount).isZero()
+        assertThat(result.outcomes.count { it is OutboxDispatchOutcome.Dispatched }).isZero()
+        assertThat(result.outcomes.count { it is OutboxDispatchOutcome.Failed && it.terminal }).isZero()
         val outcome = result.outcomes.single() as OutboxDispatchOutcome.Failed
         assertThat(outcome.terminal).isFalse()
     }
@@ -184,8 +184,8 @@ class OutboxDispatchTest {
 
         val result = runBlocking { OutboxDispatch.dispatchOnce(repo) { error("still failing") } }
 
-        assertThat(result.dispatchedCount).isZero()
-        assertThat(result.deadCount).isEqualTo(1)
+        assertThat(result.outcomes.count { it is OutboxDispatchOutcome.Dispatched }).isZero()
+        assertThat(result.outcomes.count { it is OutboxDispatchOutcome.Failed && it.terminal }).isEqualTo(1)
         val outcome = result.outcomes.single() as OutboxDispatchOutcome.Failed
         assertThat(outcome.terminal).isTrue()
     }
@@ -205,8 +205,8 @@ class OutboxDispatchTest {
 
         // This is the falsifying assertion: a no-op/wrong wiring that always reports
         // dispatchedCount == claimed.size, or deadCount == failedCount, would fail here.
-        assertThat(result.dispatchedCount).isEqualTo(1)
-        assertThat(result.deadCount).isEqualTo(1)
+        assertThat(result.outcomes.count { it is OutboxDispatchOutcome.Dispatched }).isEqualTo(1)
+        assertThat(result.outcomes.count { it is OutboxDispatchOutcome.Failed && it.terminal }).isEqualTo(1)
         assertThat(result.outcomes.filterIsInstance<OutboxDispatchOutcome.Failed>()).hasSize(2)
         assertThat(
             result.outcomes.filterIsInstance<OutboxDispatchOutcome.Failed>().count { !it.terminal },
@@ -238,7 +238,7 @@ class OutboxDispatchTest {
         assertThat(outcome.terminal)
             .describedAs("must reflect the DEAD status markFailed actually returned")
             .isTrue()
-        assertThat(result.deadCount).isEqualTo(1)
+        assertThat(result.outcomes.count { it is OutboxDispatchOutcome.Failed && it.terminal }).isEqualTo(1)
     }
 
     @Test
@@ -253,7 +253,7 @@ class OutboxDispatchTest {
         // The breaker aborts before the first row's publish is even attempted (#4005) — no
         // outcome at all, not a Failed(terminal = false).
         assertThat(result.outcomes).isEmpty()
-        assertThat(result.dispatchedCount).isZero()
-        assertThat(result.deadCount).isZero()
+        assertThat(result.outcomes.count { it is OutboxDispatchOutcome.Dispatched }).isZero()
+        assertThat(result.outcomes.count { it is OutboxDispatchOutcome.Failed && it.terminal }).isZero()
     }
 }

--- a/openbank-libs-runtime/src/main/kotlin/com/openbank/libs/persistence/outbox/AbstractOutboxDispatcher.kt
+++ b/openbank-libs-runtime/src/main/kotlin/com/openbank/libs/persistence/outbox/AbstractOutboxDispatcher.kt
@@ -59,14 +59,22 @@ abstract class AbstractOutboxDispatcher {
     /**
      * `service` tag for [DomainMetrics.outboxDispatched] / `.outboxDead` (#5049). Defaults to a
      * kebab-case derivation of the concrete class's simple name — `PartyOutboxDispatcher`
-     * becomes `party` — which was verified (2026-08-16) to reproduce the `service` string every
-     * one of the 31 sibling [AbstractOutboxBacklogGauge] subclasses already hardcodes, so the
-     * outbox-dispatch and outbox-backlog panels of the same dashboard share one label
-     * vocabulary. Three dispatchers whose derivation would silently disagree with their own
-     * gauge override it explicitly: `CardOutboxDispatcher` (`card-issuance`, not `card`),
-     * `TppOutboxDispatcher` (`tpp-registry`, not `tpp`), `DomesticPaymentOutboxDispatcher`
-     * (`domestic`, not `domestic-payment`). A new dispatcher whose class name does not already
-     * match its own gauge's `service` must override this the same way.
+     * becomes `party` — chosen (2026-08-16) to reproduce the `service` string most sibling
+     * [AbstractOutboxBacklogGauge] subclasses already hardcode, so the outbox-dispatch and
+     * outbox-backlog panels of the same dashboard share one label vocabulary. Three dispatchers
+     * whose derivation would silently disagree with their own gauge override it explicitly:
+     * `CardOutboxDispatcher` (`card-issuance`, not `card`), `TppOutboxDispatcher`
+     * (`tpp-registry`, not `tpp`), `DomesticPaymentOutboxDispatcher` (`domestic`, not
+     * `domestic-payment`). A new dispatcher whose class name does not already match its own
+     * gauge's `service` must override this the same way.
+     *
+     * **Not CI-enforced (#5128 finding 5/8).** Nothing compares this derivation against the
+     * fleet's actual gauge labels, so agreement rests on the 3 overrides above staying complete
+     * and correct by hand — a prior version of this comment claimed a specific verified count of
+     * sibling gauges, which itself went stale (grep patterns for a hand-written class hierarchy
+     * are fragile across formatting styles). Verify directly instead of trusting a number here:
+     * `grep -rl ': AbstractOutboxBacklogGauge' --include='*.kt' .` for the gauge side,
+     * [deriveServiceName] for the dispatcher side.
      *
      * **`this::class.java.simpleName` is NOT the class you wrote (issue #5143).** This getter is
      * inherited from the abstract base, so `this` at the call site is Quarkus Arc's generated
@@ -82,7 +90,14 @@ abstract class AbstractOutboxDispatcher {
      * immune only by coincidence (they exist for a naming disagreement, not this). See
      * [deriveServiceName] for the fix.
      */
-    protected open val service: String get() = deriveServiceName(this::class.java.simpleName)
+    // Lazy, not a plain val: it must still read `this::class.java.simpleName` at first access
+    // (Arc's proxy is only fully constructed by then), but every subsequent outbox row on every
+    // scheduled tick reuses the cached result instead of recompiling deriveServiceName's Regex
+    // and re-walking the class name (#5128 finding 6) — the value cannot change for the life of
+    // the bean, so recomputing it per-row was pure waste on a fleet-wide hot path.
+    protected open val service: String by lazy(LazyThreadSafetyMode.PUBLICATION) {
+        deriveServiceName(this::class.java.simpleName)
+    }
 
     /**
      * Metrics facade, deliberately **field**-injected rather than threaded through the


### PR DESCRIPTION
## What

3 of the 8 findings from #5128 (post-merge review of #5071, `feat(libs-runtime): wire outboxDispatched/outboxDead metrics into AbstractOutboxDispatcher`).

## Status of all 8

| # | Finding | Status |
|---|---|---|
| 1 | `topic` tag mislabeled | Already fixed on main — `eventType` param, KDoc explicitly cites "issue #5128 finding 1" |
| 2 | Untested CDI field-injection | Open — needs a real `@QuarkusTest` IT, out of scope here |
| 3 | `outboxDead` terminal flag predicted not read back | Already fixed on main — `OutboxDispatch.dispatchOnce` now reads `repository.markFailed`'s return, KDoc cites "finding 3" |
| **4** | **security-scanner has no dispatch/dead metrics** | **Open — a parallel worktree is actively touching `SecurityOutboxDispatcher` right now, left alone** |
| **5** | **`service` derivation has no CI drift enforcement** | **Open — needs a new gate, out of scope here** |
| **6** | **Regex + Counter rebuilt per row** | **Fixed here (the `service` half — see below)** |
| **7** | **`dispatchedCount`/`deadCount` dead code** | **Fixed here** |
| **8** | **KDoc overclaims verification coverage** | **Fixed here** |

## Finding 6 (perf)

`service` was a plain `get()` re-invoking `deriveServiceName` — recompiling its `Regex` and re-walking the class name — on every claimed outbox row, on every scheduled tick, across ~34 services. The value cannot change for the bean's lifetime, so this was pure waste on a fleet-wide hot path.

```kotlin
protected open val service: String by lazy(LazyThreadSafetyMode.PUBLICATION) {
    deriveServiceName(this::class.java.simpleName)
}
```

Deliberately scoped to just this: `DomainMetrics.counter()`'s per-call `Counter.builder(...).register()` is shared by every metric type in the fleet, not just outbox — caching that is a separate, larger change than this issue's finding covers.

## Finding 7 (dead code)

`OutboxDispatchResult.dispatchedCount`/`.deadCount` had zero production call sites — `dispatchScheduledBatch` iterates `.outcomes` directly. Removed; rewrote the 11 test assertions in `OutboxDispatchTest` that used them to count `.outcomes` inline, so no coverage was lost.

## Finding 8 (KDoc overclaim)

The `service`-derivation KDoc asserted a specific verified count of sibling `AbstractOutboxBacklogGauge` subclasses ("31"). Re-checking with a few grep patterns returned different numbers depending on formatting style (single-line `class Foo : AbstractOutboxBacklogGauge()` vs wrapped) — the claim was already fragile in practice, which is exactly finding 5's point (nothing enforces this derivation against the real gauge labels). Reworded to not assert an unenforced number and point at how to verify it directly instead.

## Tests

`OutboxDispatchTest`: 12/12. `AbstractOutboxDispatcherTest`: 8/8. `ktlintCheck` + `detekt` clean on both `openbank-libs-domain` and `openbank-libs-runtime`.

Refs #5128
