### PR TITLE
fix(admin-ui): keyboard-enable table rows

### DIFF
--- a/openbank-admin-ui/src/app/audit/page.tsx
+++ b/openbank-admin-ui/src/app/audit/page.tsx
@@ -120,7 +120,8 @@ export default function AuditPage() {
             <tbody>
               {entries.map(e => (
                 <>
-                  <tr key={e.id} style={{ cursor: 'pointer' }} onClick={() => setExpanded(expanded === e.id ? null : e.id)}>
+                  <tr key={e.id} tabIndex={0} aria-expanded={expanded === e.id} aria-label={t('Rozbalit auditní událost', 'Expand audit event')} style={{ cursor: 'pointer' }} onClick={() => setExpanded(expanded === e.id ? null : e.id)}
+                    onKeyDown={event => { if (event.key === 'Enter' || event.key === ' ') { event.preventDefault(); setExpanded(expanded === e.id ? null : e.id) } }}>
                     <td>
                       <span className="pill" style={{ background: `${EVENT_COLOR[e.eventType] ?? 'var(--text-muted)'}22`, color: EVENT_COLOR[e.eventType] ?? 'var(--text-muted)' }}>
                         {e.eventType}

--- a/openbank-admin-ui/src/app/onboarding/page.tsx
+++ b/openbank-admin-ui/src/app/onboarding/page.tsx
@@ -275,7 +275,8 @@ export default function OnboardingPage() {
                 </tr>
               )}
               {!loading && records.map(r => (
-                <tr key={r.partyId} style={{ cursor: 'pointer' }} onClick={() => setSelected(r)}>
+                <tr key={r.partyId} tabIndex={0} aria-label={t(`Vybrat onboarding subjekt ${r.legalName ?? r.partyId}`, `Select onboarding party ${r.legalName ?? r.partyId}`)} style={{ cursor: 'pointer' }} onClick={() => setSelected(r)}
+                  onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); setSelected(r) } }}>
                   <td style={{ fontWeight: 500 }}>{r.legalName ?? <span style={{ color: 'var(--text-muted)', fontStyle: 'italic' }}>—</span>}</td>
                   <td style={{ fontFamily: 'var(--font-mono)', fontSize: '12px', color: 'var(--text-secondary)' }}>{r.email ?? '—'}</td>
                   <td>

--- a/openbank-admin-ui/src/app/payments/page.tsx
+++ b/openbank-admin-ui/src/app/payments/page.tsx
@@ -919,7 +919,10 @@ function PaymentsContent() {
                 {!loading && filtered.map(p => (
                   <tr key={`${p.type}-${p.id}`} style={{ cursor: 'pointer' }}
                     title={t('Zobrazit detail platby', 'View payment detail')}
-                    onClick={() => { stashRow('payments', p.id, p); router.push(`/payments/${p.id}?type=${p.type}`) }}>
+                    tabIndex={0}
+                    aria-label={t(`Otevřít detail platby ${p.id.slice(0, 8)}`, `Open payment ${p.id.slice(0, 8)} detail`)}
+                    onClick={() => { stashRow('payments', p.id, p); router.push(`/payments/${p.id}?type=${p.type}`) }}
+                    onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); stashRow('payments', p.id, p); router.push(`/payments/${p.id}?type=${p.type}`) } }}>
                     <td style={{ fontFamily: 'var(--font-mono)', fontSize: '11px' }}>{p.id.slice(0, 8)}…</td>
                     <td><span className="tag" style={{ color: p.type === 'SEPA' ? 'var(--accent)' : 'var(--green)' }}>{p.type}</span></td>
                     <td>

--- a/openbank-admin-ui/src/app/security/page.tsx
+++ b/openbank-admin-ui/src/app/security/page.tsx
@@ -301,7 +301,8 @@ export default function SecurityPage() {
                     {filteredResults.map((r, i) => {
                       const isSelected = selected?.serviceName === r.serviceName
                       return (
-                        <tr key={`${r.serviceName}-${i}`} onClick={() => setSelected(r)}
+                        <tr key={`${r.serviceName}-${i}`} tabIndex={0} aria-label={t(`Vybrat službu ${r.serviceName}`, `Select service ${r.serviceName}`)} onClick={() => setSelected(r)}
+                          onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); setSelected(r) } }}
                           style={{ borderBottom: '1px solid var(--border)', cursor: 'pointer',
                             background: isSelected ? 'var(--accent-light)' : 'transparent',
                             transition: 'background 0.15s' }}

--- a/openbank-admin-ui/src/app/swift/page.tsx
+++ b/openbank-admin-ui/src/app/swift/page.tsx
@@ -121,7 +121,10 @@ export default function SwiftPage() {
                 const sc = STATUS_COLORS[m.status] ?? STATUS_COLORS.PENDING
                 return (
                   <tr key={m.id} style={{ borderBottom: '1px solid var(--border)', cursor: 'pointer' }}
+                    tabIndex={0}
+                    aria-label={t(`Otevřít detail zprávy ${m.messageType}`, `Open ${m.messageType} message detail`)}
                     onClick={() => { stashRow('swift', m.id, m); router.push(`/swift/${m.id}`) }}
+                    onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); stashRow('swift', m.id, m); router.push(`/swift/${m.id}`) } }}
                     title={t('Zobrazit detail zprávy', 'View message detail')}
                     onMouseEnter={e => (e.currentTarget.style.background = 'var(--surface-2)')}
                     onMouseLeave={e => (e.currentTarget.style.background = '')}>

--- a/openbank-admin-ui/src/test/table-keyboard-a11y.guard.test.ts
+++ b/openbank-admin-ui/src/test/table-keyboard-a11y.guard.test.ts
@@ -1,0 +1,22 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const files = [
+  'src/app/payments/page.tsx',
+  'src/app/swift/page.tsx',
+  'src/app/security/page.tsx',
+  'src/app/audit/page.tsx',
+  'src/app/onboarding/page.tsx',
+]
+
+describe('interactive table keyboard guard', () => {
+  it('keeps click-to-open rows keyboard reachable', () => {
+    for (const file of files) {
+      const source = readFileSync(resolve(process.cwd(), file), 'utf8')
+      expect(source).toContain('tabIndex={0}')
+      expect(source).toContain('onKeyDown=')
+      expect(source).toMatch(/(?:e|event)\.key === 'Enter' \|\| (?:e|event)\.key === ' '/)
+    }
+  })
+})


### PR DESCRIPTION
Make the interactive payment, SWIFT, security, audit and onboarding table rows keyboard reachable. Enter/Space now performs the same action as click, with localized accessible row names and audit expansion state. No data, navigation or authorization contract changes.

## Linked issues

N/A - focused accessibility cleanup for existing click-to-open table rows.

## Validation

- table keyboard accessibility guard
- type-check
- git diff --check
