### PR TITLE
fix(admin-ui): keyboard-enable architecture maps

### DIFF
--- a/openbank-admin-ui/src/app/docs/cluster/page.tsx
+++ b/openbank-admin-ui/src/app/docs/cluster/page.tsx
@@ -72,13 +72,16 @@ function DefenseRings({ layers, active, onPick, lang }: { layers: Layer[]; activ
   const size = 260
   const cx = size / 2
   return (
-    <svg viewBox={`0 0 ${size} ${size}`} style={{ width: 240, height: 240, flexShrink: 0 }} role="img" aria-label={lang === 'cs' ? 'Obrana do hloubky' : 'Defense in depth'}>
+    <svg viewBox={`0 0 ${size} ${size}`} style={{ width: 240, height: 240, flexShrink: 0 }} role="group" aria-label={lang === 'cs' ? 'Obrana do hloubky' : 'Defense in depth'}>
       {layers.map((l, i) => {
         const r = (cx - 6) * (1 - i / n)
         const m = STATUS[l.status]
         const on = active === l.id
         return (
-          <g key={l.id} onClick={() => onPick(l.id)} style={{ cursor: 'pointer' }}>
+          <g key={l.id} role="button" tabIndex={0} aria-label={l.label}
+            onClick={() => onPick(l.id)}
+            onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onPick(l.id) } }}
+            onFocus={() => onPick(l.id)} style={{ cursor: 'pointer' }}>
             <circle cx={cx} cy={cx} r={r} fill={on ? m.bg : 'transparent'} stroke={m.color} strokeWidth={on ? 3 : 2} opacity={on ? 1 : 0.55} />
           </g>
         )

--- a/openbank-admin-ui/src/app/docs/service-map/page.tsx
+++ b/openbank-admin-ui/src/app/docs/service-map/page.tsx
@@ -323,8 +323,11 @@ function TierChip({ pos, color, label, active, dim, faded, onClick, onEnter, onL
   const { cx, cy, w } = pos
   const x = cx - w / 2, y = cy - CHIP_H / 2
   return (
-    <g opacity={dim ? 0.25 : 1} style={{ cursor: 'pointer', transition: 'opacity 0.15s' }}
-      onClick={onClick} onMouseEnter={onEnter} onMouseLeave={onLeave}>
+    <g role="button" tabIndex={0} aria-label={label} opacity={dim ? 0.25 : 1}
+      style={{ cursor: 'pointer', transition: 'opacity 0.15s' }}
+      onClick={onClick}
+      onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onClick() } }}
+      onFocus={onEnter} onMouseEnter={onEnter} onMouseLeave={onLeave}>
       <rect x={x} y={y} width={w} height={CHIP_H} rx={CHIP_H / 2}
         fill={active ? color : 'var(--surface)'} stroke={color} strokeWidth={active ? 1.8 : 1.3}
         strokeDasharray={faded ? '4,3' : undefined} opacity={faded ? 0.75 : 1} filter="url(#node-shadow)" />
@@ -732,10 +735,12 @@ export default function ServiceMapPage() {
                     const label = svc.name.replace(/ Service$/, '')
                     const { w: bw, h: bh } = brickSize(degrees[svc.id] ?? 0)
                     return (
-                      <g key={svc.id}
+                      <g key={svc.id} role="button" tabIndex={0} aria-label={label}
                         style={{ cursor: 'pointer', transition: 'opacity 0.15s' }}
                         opacity={emphasized ? 1 : 0.25}
                         onClick={() => setSelected(s => s === svc.id ? null : svc.id)}
+                        onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); setSelected(s => s === svc.id ? null : svc.id) } }}
+                        onFocus={() => setHovered(svc.id)}
                         onMouseEnter={() => setHovered(svc.id)}
                         onMouseLeave={() => setHovered(h => h === svc.id ? null : h)}>
                         <LegoBrick cx={p.cx} cy={p.cy} color={svc.color} degree={degrees[svc.id] ?? 0} selected={isSelected} />

--- a/openbank-admin-ui/src/app/infrastructure/topology/page.tsx
+++ b/openbank-admin-ui/src/app/infrastructure/topology/page.tsx
@@ -340,8 +340,11 @@ export default function InfraTopologyPage() {
               const st = statusOf(n.id)
               const x = p.cx - p.w / 2, y = p.cy - PILL_H / 2
               return (
-                <g key={n.id} style={{ cursor: 'pointer', transition: 'opacity 0.15s' }} opacity={emphasized ? 1 : 0.25}
+                <g key={n.id} role="button" tabIndex={0} aria-label={n.label}
+                  style={{ cursor: 'pointer', transition: 'opacity 0.15s' }} opacity={emphasized ? 1 : 0.25}
                   onClick={() => setSelected(s => s === n.id ? null : n.id)}
+                  onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); setSelected(s => s === n.id ? null : n.id) } }}
+                  onFocus={() => setHovered(n.id)}
                   onMouseEnter={() => setHovered(n.id)} onMouseLeave={() => setHovered(h => h === n.id ? null : h)}>
                   <rect x={x} y={y} width={p.w} height={PILL_H} rx={PILL_H / 2}
                     fill={isSel ? meta.color : 'var(--surface)'} stroke={meta.color} strokeWidth={isSel ? 1.9 : 1.3}

--- a/openbank-admin-ui/src/test/visual-map-keyboard-a11y.guard.test.ts
+++ b/openbank-admin-ui/src/test/visual-map-keyboard-a11y.guard.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import fs from 'node:fs'
+import path from 'node:path'
+
+const root = path.resolve(process.cwd(), 'src')
+const read = (file: string) => fs.readFileSync(path.join(root, file), 'utf8')
+
+describe('interactive architecture maps keyboard contract', () => {
+  it('keeps SVG and custom map nodes reachable and activatable', () => {
+    const sources = [
+      read('app/docs/cluster/page.tsx'),
+      read('app/docs/service-map/page.tsx'),
+      read('app/infrastructure/topology/page.tsx'),
+    ]
+    for (const source of sources) {
+      expect(source).toContain('role="button"')
+      expect(source).toContain('tabIndex={0}')
+      expect(source).toContain("e.key === 'Enter'")
+      expect(source).toContain("e.key === ' '")
+    }
+    expect(sources[0]).toContain('aria-label={l.label}')
+    expect(sources[0]).toContain('role="group" aria-label={lang')
+    expect(sources[0]).not.toContain('role="img" aria-label={lang')
+    expect(sources[1]).toContain('aria-label={label}')
+    expect(sources[2]).toContain('aria-label={n.label}')
+  })
+})


### PR DESCRIPTION
## Summary

- make SVG architecture and topology nodes keyboard reachable
- preserve existing selection/hover behavior for Enter and Space
- add a source guard for keyboard activation semantics

## Validation

- focused Vitest guard
- `npm run type-check`
- `git diff --check`

Closes #5545
