### PR TITLE
fix(admin-ui): keyboard-enable inline navigation

### DIFF
--- a/openbank-admin-ui/src/app/docs/lineage/page.tsx
+++ b/openbank-admin-ui/src/app/docs/lineage/page.tsx
@@ -295,7 +295,11 @@ export default function LineageFlowPage() {
                       <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
                         {selectedSvc.lineage!.upstream!.map((u, i) => (
                           <div key={i} style={{ display: 'flex', justifyContent: 'space-between', gap: '6px', fontSize: '12px', background: 'var(--surface)', padding: '4px 8px', borderRadius: '4px', border: '1px solid var(--border)' }}>
-                            <span style={{ fontWeight: 500, color: 'var(--text-secondary)', cursor: 'pointer' }} onClick={() => known.has(u.serviceName) && setSelected(u.serviceName)}>{prettyName(u.serviceName)}</span>
+                            <button type="button" disabled={!known.has(u.serviceName)} aria-label={known.has(u.serviceName)
+                              ? t(`Vybrat ${prettyName(u.serviceName)}`, `Select ${prettyName(u.serviceName)}`)
+                              : t(`${prettyName(u.serviceName)} není načtená`, `${prettyName(u.serviceName)} is not loaded`)}
+                              style={{ fontWeight: 500, color: 'var(--text-secondary)', cursor: known.has(u.serviceName) ? 'pointer' : 'default', opacity: known.has(u.serviceName) ? 1 : 0.7, background: 'none', border: 0, padding: 0, font: 'inherit', textAlign: 'left' }}
+                              onClick={() => known.has(u.serviceName) && setSelected(u.serviceName)}>{prettyName(u.serviceName)}</button>
                             <span style={{ fontSize: '10px', color: REL_COLOR[u.relationType] }}>{relLabel(u.relationType, t)}</span>
                           </div>
                         ))}
@@ -308,7 +312,11 @@ export default function LineageFlowPage() {
                       <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
                         {selectedSvc.lineage!.downstream!.map((dn, i) => (
                           <div key={i} style={{ display: 'flex', justifyContent: 'space-between', gap: '6px', fontSize: '12px', background: 'var(--surface)', padding: '4px 8px', borderRadius: '4px', border: '1px solid var(--border)' }}>
-                            <span style={{ fontWeight: 500, color: 'var(--text-secondary)', cursor: 'pointer' }} onClick={() => known.has(dn.serviceName) && setSelected(dn.serviceName)}>{prettyName(dn.serviceName)}</span>
+                            <button type="button" disabled={!known.has(dn.serviceName)} aria-label={known.has(dn.serviceName)
+                              ? t(`Vybrat ${prettyName(dn.serviceName)}`, `Select ${prettyName(dn.serviceName)}`)
+                              : t(`${prettyName(dn.serviceName)} není načtená`, `${prettyName(dn.serviceName)} is not loaded`)}
+                              style={{ fontWeight: 500, color: 'var(--text-secondary)', cursor: known.has(dn.serviceName) ? 'pointer' : 'default', opacity: known.has(dn.serviceName) ? 1 : 0.7, background: 'none', border: 0, padding: 0, font: 'inherit', textAlign: 'left' }}
+                              onClick={() => known.has(dn.serviceName) && setSelected(dn.serviceName)}>{prettyName(dn.serviceName)}</button>
                             <span style={{ fontSize: '10px', color: REL_COLOR[dn.relationType] }}>{relLabel(dn.relationType, t)}</span>
                           </div>
                         ))}

--- a/openbank-admin-ui/src/app/regulatory/page.tsx
+++ b/openbank-admin-ui/src/app/regulatory/page.tsx
@@ -432,8 +432,11 @@ export default function RegulatoryPage() {
           const isSelected = selected === report.id
           return (
             <div key={report.id} className="card" style={{ overflow: 'hidden', borderLeft: `3px solid ${cfg.color}` }}>
-              <div style={{ padding: '14px 16px', display: 'flex', alignItems: 'center', gap: '12px', cursor: 'pointer', flexWrap: 'wrap' }}
-                onClick={() => setSelected(s => s === report.id ? null : report.id)}>
+              <div role="button" tabIndex={0} aria-expanded={isSelected}
+                aria-label={`${report.name} — ${isSelected ? t('Sbalit detail', 'Collapse details') : t('Rozbalit detail', 'Expand details')}`}
+                style={{ padding: '14px 16px', display: 'flex', alignItems: 'center', gap: '12px', cursor: 'pointer', flexWrap: 'wrap' }}
+                onClick={() => setSelected(s => s === report.id ? null : report.id)}
+                onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); setSelected(s => s === report.id ? null : report.id) } }}>
                 {/* Status */}
                 <span style={{ color: cfg.color, flexShrink: 0 }}>{cfg.icon}</span>
 

--- a/openbank-admin-ui/src/test/inline-navigation-keyboard-a11y.guard.test.ts
+++ b/openbank-admin-ui/src/test/inline-navigation-keyboard-a11y.guard.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import fs from 'node:fs'
+import path from 'node:path'
+
+const root = path.resolve(process.cwd(), 'src')
+const read = (file: string) => fs.readFileSync(path.join(root, file), 'utf8')
+
+describe('inline navigation keyboard contract', () => {
+  it('keeps custom expandable rows and lineage links keyboard accessible', () => {
+    const regulatory = read('app/regulatory/page.tsx')
+    const lineage = read('app/docs/lineage/page.tsx')
+    expect(regulatory).toContain('role="button" tabIndex={0} aria-expanded={isSelected}')
+    expect(regulatory).toContain("e.key === 'Enter'")
+    expect(regulatory).toContain("e.key === ' '")
+    expect(lineage).toContain('<button type="button" disabled={!known.has(')
+    expect(lineage).toContain('disabled={!known.has(')
+    expect(lineage).toContain('is not loaded')
+    expect(lineage).toContain('background: \'none\', border: 0')
+  })
+})


### PR DESCRIPTION
## Summary

- make regulatory report rows keyboard expandable with truthful state labels
- replace lineage click-only service names with labelled native buttons
- add regression guard for keyboard semantics

## Validation

- focused Vitest guard
- `npm run type-check`
- `git diff --check`

## Linked issues

N/A — focused accessibility hardening found during the admin UI fleet audit.
