### PR TITLE
fix(admin-ui): clarify expandable card state

### DIFF
--- a/openbank-admin-ui/src/app/audit/page.tsx
+++ b/openbank-admin-ui/src/app/audit/page.tsx
@@ -120,7 +120,7 @@ export default function AuditPage() {
             <tbody>
               {entries.map(e => (
                 <>
-                  <tr key={e.id} tabIndex={0} aria-expanded={expanded === e.id} aria-label={t('Rozbalit auditní událost', 'Expand audit event')} style={{ cursor: 'pointer' }} onClick={() => setExpanded(expanded === e.id ? null : e.id)}
+                  <tr key={e.id} tabIndex={0} aria-expanded={expanded === e.id} aria-label={expanded === e.id ? t('Sbalit auditní událost', 'Collapse audit event') : t('Rozbalit auditní událost', 'Expand audit event')} style={{ cursor: 'pointer' }} onClick={() => setExpanded(expanded === e.id ? null : e.id)}
                     onKeyDown={event => { if (event.key === 'Enter' || event.key === ' ') { event.preventDefault(); setExpanded(expanded === e.id ? null : e.id) } }}>
                     <td>
                       <span className="pill" style={{ background: `${EVENT_COLOR[e.eventType] ?? 'var(--text-muted)'}22`, color: EVENT_COLOR[e.eventType] ?? 'var(--text-muted)' }}>

--- a/openbank-admin-ui/src/app/docs/cluster/page.tsx
+++ b/openbank-admin-ui/src/app/docs/cluster/page.tsx
@@ -275,8 +275,11 @@ export default function ClusterDossierPage() {
             const LI = ICONS[l.icon] ?? Shield
             const on = activeLayer === l.id
             return (
-              <div key={l.id} onClick={() => setActiveLayer(l.id)} className="card" style={{ padding: 14, cursor: 'pointer', borderLeft: `3px solid ${STATUS[l.status].color}`, boxShadow: on ? '0 0 0 1px var(--accent)' : undefined }}>
-                <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: on ? 8 : 0 }}>
+              <div key={l.id} className="card" style={{ padding: 14, borderLeft: `3px solid ${STATUS[l.status].color}`, boxShadow: on ? '0 0 0 1px var(--accent)' : undefined }}>
+                <div role="button" tabIndex={0} aria-expanded={on} aria-label={`${l.label} — ${on ? t('Sbalit vrstvu', 'Collapse layer') : t('Rozbalit vrstvu', 'Expand layer')}`}
+                  onClick={() => setActiveLayer(current => current === l.id ? null : l.id)}
+                  onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); setActiveLayer(current => current === l.id ? null : l.id) } }}
+                  style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: on ? 8 : 0, cursor: 'pointer' }}>
                   <span style={{ fontFamily: 'var(--font-mono,monospace)', fontSize: 11, color: 'var(--text-tertiary)', width: 18 }}>{i + 1}</span>
                   <LI size={16} style={{ color: K8S_BLUE }} />
                   <span style={{ fontSize: 14, fontWeight: 700, color: 'var(--text-primary)', flex: 1 }}>{l.label}</span>

--- a/openbank-admin-ui/src/test/card-state-a11y.guard.test.ts
+++ b/openbank-admin-ui/src/test/card-state-a11y.guard.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+import fs from 'node:fs'
+import path from 'node:path'
+
+const root = path.resolve(process.cwd(), 'src')
+const read = (file: string) => fs.readFileSync(path.join(root, file), 'utf8')
+
+describe('card and row state accessibility contract', () => {
+  it('keeps expandable documentation layers and audit rows truthful', () => {
+    const cluster = read('app/docs/cluster/page.tsx')
+    const audit = read('app/audit/page.tsx')
+    expect(cluster).toContain('role="button" tabIndex={0} aria-expanded={on}')
+    expect(cluster).toContain("e.key === 'Enter'")
+    expect(cluster).toContain("e.key === ' '")
+    expect(cluster).toContain('setActiveLayer(current => current === l.id ? null : l.id)')
+    expect(audit).toContain("expanded === e.id ? t('Sbalit auditní událost'")
+    expect(audit).toContain("expanded === e.id ? null : e.id")
+  })
+})


### PR DESCRIPTION
## Summary
- make cluster security layer headers keyboard-expandable without swallowing nested detail links
- expose truthful expand/collapse labels for audit rows
- add regression guard

## Validation
- focused Vitest guard
- npm run type-check
- git diff --check

## Linked issues

N/A — focused accessibility hardening found during the admin UI fleet audit.