### PR TITLE
perf(admin-ui): stabilize cloud diagram renders

### DIFF
--- a/openbank-admin-ui/src/app/docs/cloud-architecture/page.tsx
+++ b/openbank-admin-ui/src/app/docs/cloud-architecture/page.tsx
@@ -157,6 +157,29 @@ function StatusDot({ status }: { status: Status }) {
   return <m.Icon size={13} style={{ color: m.color, flexShrink: 0 }} />
 }
 
+type CloudNodeBoxProps = { n: Node; selectedId: string | null; liveStatus: Record<string, InfraStatusResult> | null; t: (cs: string, en: string) => string; onSelect: (node: Node) => void }
+
+function CloudNodeBox({ n, selectedId, liveStatus, t, onSelect }: CloudNodeBoxProps) {
+  const m = STATUS_META[n.status]
+  const active = selectedId === n.id
+  const probeId = INFRA_PROBE_MAP[n.id]
+  const probe = probeId && liveStatus ? liveStatus[probeId] : null
+  const pm = probe ? PROBE_META[probe.status] : null
+  return <button onClick={() => onSelect(n)} title={t(...n.desc)} style={{ display: 'flex', alignItems: 'center', gap: '6px', padding: '6px 10px', borderRadius: '8px', cursor: 'pointer', background: m.bg, border: `1px solid ${active ? m.color : m.border}`, boxShadow: active ? `0 0 0 2px ${m.color}55` : 'none', color: 'var(--text-primary)', fontSize: '12px', fontWeight: 600, fontFamily: 'inherit', textAlign: 'left' }}>
+    <StatusDot status={n.status} />
+    {t(...n.name)}
+    {pm && <span style={{ display: 'inline-flex', alignItems: 'center', gap: '2px', marginLeft: '4px', padding: '1px 5px', borderRadius: '10px', background: pm.bg, border: `1px solid ${pm.color}44`, fontSize: '10px', fontWeight: 700, color: pm.color }}><pm.Icon size={9} aria-hidden="true" />{pm.label}</span>}
+  </button>
+}
+
+function ArchitectureZone({ title, subtitle, accent, children }: { title: string; subtitle?: string; accent: string; children: React.ReactNode }) {
+  return <div style={{ border: `1.5px solid ${accent}`, borderRadius: '12px', padding: '14px 16px', background: `${accent}08` }}><div style={{ display: 'flex', alignItems: 'baseline', gap: '10px', marginBottom: '10px', flexWrap: 'wrap' }}><span style={{ fontSize: '11px', fontWeight: 800, letterSpacing: '0.06em', color: accent, textTransform: 'uppercase' }}>{title}</span>{subtitle && <span style={{ fontSize: '11px', color: 'var(--text-secondary)' }}>{subtitle}</span>}</div>{children}</div>
+}
+
+function ArchitectureArrow({ label }: { label?: string }) {
+  return <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', margin: '2px 0' }}><div aria-hidden="true" style={{ width: 0, height: 0, borderLeft: '6px solid transparent', borderRight: '6px solid transparent', borderTop: '8px solid var(--border)' }} />{label && <span style={{ fontSize: '10px', color: 'var(--text-secondary)', marginTop: '-2px' }}>{label}</span>}</div>
+}
+
 export default function CloudArchitecturePage() {
   const { t, language } = useLanguage()
   const dateLocale = language === 'cs' ? 'cs-CZ' : 'en-GB'
@@ -183,60 +206,8 @@ export default function CloudArchitecturePage() {
 
   useEffect(() => { void fetchStatus() }, [fetchStatus])
 
-  const Box = ({ n }: { n: Node }) => {
-    const m = STATUS_META[n.status]
-    const active = selected?.id === n.id
-    const probeId = INFRA_PROBE_MAP[n.id]
-    const probe = probeId && liveStatus ? liveStatus[probeId] : null
-    const pm = probe ? PROBE_META[probe.status] : null
-    return (
-      <button
-        onClick={() => setSelected(active ? null : n)}
-        title={t(...n.desc)}
-        style={{
-          display: 'flex', alignItems: 'center', gap: '6px',
-          padding: '6px 10px', borderRadius: '8px', cursor: 'pointer',
-          background: m.bg, border: `1px solid ${active ? m.color : m.border}`,
-          boxShadow: active ? `0 0 0 2px ${m.color}55` : 'none',
-          color: 'var(--text-primary)', fontSize: '12px', fontWeight: 600,
-          fontFamily: 'inherit', textAlign: 'left',
-        }}
-      >
-        <StatusDot status={n.status} />
-        {t(...n.name)}
-        {pm && (
-          <span style={{
-            display: 'inline-flex', alignItems: 'center', gap: '2px',
-            marginLeft: '4px', padding: '1px 5px', borderRadius: '10px',
-            background: pm.bg, border: `1px solid ${pm.color}44`,
-            fontSize: '10px', fontWeight: 700, color: pm.color,
-          }}>
-            <pm.Icon size={9} />
-            {pm.label}
-          </span>
-        )}
-      </button>
-    )
-  }
-
-  const Zone = ({ title, subtitle, accent, children }: { title: string; subtitle?: string; accent: string; children: React.ReactNode }) => (
-    <div style={{ border: `1.5px solid ${accent}`, borderRadius: '12px', padding: '14px 16px', background: `${accent}08` }}>
-      <div style={{ display: 'flex', alignItems: 'baseline', gap: '10px', marginBottom: '10px', flexWrap: 'wrap' }}>
-        <span style={{ fontSize: '11px', fontWeight: 800, letterSpacing: '0.06em', color: accent, textTransform: 'uppercase' }}>{title}</span>
-        {subtitle && <span style={{ fontSize: '11px', color: 'var(--text-secondary)' }}>{subtitle}</span>}
-      </div>
-      {children}
-    </div>
-  )
-
-  const Arrow = ({ label }: { label?: string }) => (
-    <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', margin: '2px 0' }}>
-      <div style={{ width: 0, height: 0, borderLeft: '6px solid transparent', borderRight: '6px solid transparent', borderTop: '8px solid var(--border)' }} />
-      {label && <span style={{ fontSize: '10px', color: 'var(--text-secondary)', marginTop: '-2px' }}>{label}</span>}
-    </div>
-  )
-
   const wrap = { display: 'flex', flexWrap: 'wrap' as const, gap: '8px' }
+  const selectNode = useCallback((n: Node) => setSelected(current => current?.id === n.id ? null : n), [])
 
   return (
     <div>
@@ -285,24 +256,24 @@ export default function CloudArchitecturePage() {
 
       <div style={{ display: 'grid', gridTemplateColumns: selected ? '1fr 320px' : '1fr', gap: '16px', alignItems: 'start' }}>
         <div style={{ display: 'flex', flexDirection: 'column', gap: '0' }}>
-          <Zone title={t('Internet / Edge', 'Internet / Edge')} subtitle={t('Edge vrstva ADR-0027 — zatím neprovisionováno', 'ADR-0027 edge tier — not provisioned yet')} accent="#0ea5e9">
-            <div style={wrap}>{EDGE.map(n => <Box key={n.id} n={n} />)}</div>
-          </Zone>
+          <ArchitectureZone title={t('Internet / Edge', 'Internet / Edge')} subtitle={t('Edge vrstva ADR-0027 — zatím neprovisionováno', 'ADR-0027 edge tier — not provisioned yet')} accent="#0ea5e9">
+            <div style={wrap}>{EDGE.map(n => <CloudNodeBox key={n.id} n={n} selectedId={selected?.id ?? null} liveStatus={liveStatus} t={t} onSelect={selectNode} />)}</div>
+          </ArchitectureZone>
 
-          <Arrow label={t('TLS (ACM)', 'TLS (ACM)')} />
+          <ArchitectureArrow label={t('TLS (ACM)', 'TLS (ACM)')} />
 
-          <Zone title={t('AWS substrate', 'AWS substrate')} subtitle={t('účet 265175468565 · eu-north-1 · jediná AWS-managed vrstva', 'account 265175468565 · eu-north-1 · the only AWS-managed layer')} accent="#f59e0b">
-            <div style={wrap}>{SUBSTRATE.map(n => <Box key={n.id} n={n} />)}</div>
-          </Zone>
+          <ArchitectureZone title={t('AWS substrate', 'AWS substrate')} subtitle={t('účet 265175468565 · eu-north-1 · jediná AWS-managed vrstva', 'account 265175468565 · eu-north-1 · the only AWS-managed layer')} accent="#f59e0b">
+            <div style={wrap}>{SUBSTRATE.map(n => <CloudNodeBox key={n.id} n={n} selectedId={selected?.id ?? null} liveStatus={liveStatus} t={t} onSelect={selectNode} />)}</div>
+          </ArchitectureZone>
 
-          <Arrow />
+          <ArchitectureArrow />
 
-          <Zone title={t('EKS cluster — openbank-sandbox', 'EKS cluster — openbank-sandbox')} subtitle={t('k8s 1.35 · Karpenter Graviton/Spot autoscaling', 'k8s 1.35 · Karpenter Graviton/Spot autoscaling')} accent="#7c3aed">
+          <ArchitectureZone title={t('EKS cluster — openbank-sandbox', 'EKS cluster — openbank-sandbox')} subtitle={t('k8s 1.35 · Karpenter Graviton/Spot autoscaling', 'k8s 1.35 · Karpenter Graviton/Spot autoscaling')} accent="#7c3aed">
             <div style={{ marginBottom: '12px' }}>
               <div style={{ fontSize: '11px', fontWeight: 700, color: 'var(--text-secondary)', marginBottom: '6px' }}>
                 {t('Platform bootstrap (sandbox-platform → seeduje GitOps)', 'Platform bootstrap (sandbox-platform → seeds GitOps)')}
               </div>
-              <div style={wrap}>{BOOTSTRAP.map(n => <Box key={n.id} n={n} />)}</div>
+              <div style={wrap}>{BOOTSTRAP.map(n => <CloudNodeBox key={n.id} n={n} selectedId={selected?.id ?? null} liveStatus={liveStatus} t={t} onSelect={selectNode} />)}</div>
             </div>
             <div style={{ display: 'flex', flexDirection: 'column', gap: '10px' }}>
               {NAMESPACES.map(ns => (
@@ -311,19 +282,19 @@ export default function CloudArchitecturePage() {
                     <span style={{ fontSize: '12px', fontWeight: 700, color: 'var(--text-primary)', fontFamily: 'monospace' }}>{ns.label}</span>
                     {ns.note && <span style={{ fontSize: '10px', color: 'var(--text-secondary)' }}>{t(...ns.note)}</span>}
                   </div>
-                  <div style={wrap}>{ns.nodes.map(n => <Box key={n.id} n={n} />)}</div>
+                  <div style={wrap}>{ns.nodes.map(n => <CloudNodeBox key={n.id} n={n} selectedId={selected?.id ?? null} liveStatus={liveStatus} t={t} onSelect={selectNode} />)}</div>
                 </div>
               ))}
             </div>
-          </Zone>
+          </ArchitectureZone>
 
-          <Arrow label={t('pull (read-only deploy key)', 'pull (read-only deploy key)')} />
+          <ArchitectureArrow label={t('pull (read-only deploy key)', 'pull (read-only deploy key)')} />
 
-          <Zone title={t('Git (jediný zdroj pravdy)', 'Git (single source of truth)')} accent="#059669">
+          <ArchitectureZone title={t('Git (jediný zdroj pravdy)', 'Git (single source of truth)')} accent="#059669">
             <div style={wrap}>
-              <Box n={node('git', ['Git repo — openbank monorepo', 'Git repo — openbank monorepo'], 'live', ['IaC + k8s manifesty + app-of-apps. ArgoCD odsud pulluje desired state přes read-only SSH deploy key. Proti tomuto repu cluster rekonciluje.', 'IaC + k8s manifests + app-of-apps. ArgoCD pulls desired state from here via a read-only SSH deploy key. This repo is what the cluster reconciles against.'])} />
+              <CloudNodeBox n={node('git', ['Git repo — openbank monorepo', 'Git repo — openbank monorepo'], 'live', ['IaC + k8s manifesty + app-of-apps. ArgoCD odsud pulluje desired state přes read-only SSH deploy key. Proti tomuto repu cluster rekonciluje.', 'IaC + k8s manifests + app-of-apps. ArgoCD pulls desired state from here via a read-only SSH deploy key. This repo is what the cluster reconciles against.'])} selectedId={selected?.id ?? null} liveStatus={liveStatus} t={t} onSelect={selectNode} />
             </div>
-          </Zone>
+          </ArchitectureZone>
         </div>
 
         {selected && (

--- a/openbank-admin-ui/src/test/cloud-architecture-render.guard.test.ts
+++ b/openbank-admin-ui/src/test/cloud-architecture-render.guard.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+import fs from 'node:fs'
+import path from 'node:path'
+
+const file = path.resolve(process.cwd(), 'src/app/docs/cloud-architecture/page.tsx')
+
+describe('cloud architecture render performance contract', () => {
+  it('keeps reusable diagram primitives outside the page render', () => {
+    const source = fs.readFileSync(file, 'utf8')
+    expect(source).toContain('function CloudNodeBox(')
+    expect(source).toContain('function ArchitectureZone(')
+    expect(source).toContain('function ArchitectureArrow(')
+    expect(source).not.toContain('const Box = ({ n }')
+    expect(source).not.toContain('const Zone = ({ title')
+    expect(source).not.toContain('const Arrow = ({ label')
+    expect(source).toContain('const selectNode = useCallback(')
+  })
+})


### PR DESCRIPTION
## Summary
- move cloud diagram primitives out of the page render to avoid remounting on status/selection updates
- preserve node selection and live probe overlays
- add a render-performance regression guard

## Validation
- focused Vitest guard
- npm run type-check
- git diff --check

## Linked issues

N/A — performance hardening found during the admin UI fleet audit.