### PR TITLE
feat(admin-ui): add governance document PDF export

### DIFF
--- a/openbank-admin-ui/src/app/docs/bcp/page.tsx
+++ b/openbank-admin-ui/src/app/docs/bcp/page.tsx
@@ -7,6 +7,7 @@ import { useState, useEffect } from 'react'
 import { ShieldAlert, CheckCircle2, XCircle, Clock, AlertTriangle, RefreshCw, ChevronDown, ChevronRight, Server, Database, Lock, Zap, CreditCard, Eye, BookOpen } from 'lucide-react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { DocsPageHeader } from '@/components/docs/DocsPageHeader'
+import { PrintDocumentButton } from '@/components/docs/PrintDocumentButton'
 import { CatalogDriftBanner } from '@/components/governance/CatalogDriftBanner'
 
 type Bilingual = [cs: string, en: string]
@@ -302,7 +303,7 @@ export default function BcpPage() {
   }
 
   return (
-    <div>
+    <div className="docs-printable">
       <DocsPageHeader
         crumbs={<>
             <span>OpenBank</span>
@@ -314,13 +315,15 @@ export default function BcpPage() {
         title={t('Plán kontinuity provozu', 'Business Continuity Plan')}
         subtitle={t('Prioritizovaný plán obnovy dle DORA Art. 11-12, CNB § 20d, EBA ICT Risk Guidelines', 'Prioritized recovery plan per DORA Art. 11-12, CNB § 20d, EBA ICT Risk Guidelines')}
         icon={<ShieldAlert aria-hidden="true" size={18} style={{ color: '#dc2626' }} />}
-        actions={<div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
+        actions={<div className="docs-header-actions" style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
           {lastRefresh && (
             <span style={{ fontSize: '12px', color: 'var(--text-secondary)' }}>
               {t('Aktualizováno:', 'Updated:')} {lastRefresh.toLocaleTimeString(dateLocale)}
             </span>
           )}
+          <PrintDocumentButton />
           <button
+            className="btn"
             onClick={fetchHealth}
             disabled={loading}
             style={{

--- a/openbank-admin-ui/src/app/docs/zero-trust/page.tsx
+++ b/openbank-admin-ui/src/app/docs/zero-trust/page.tsx
@@ -17,6 +17,7 @@ import {
 } from 'lucide-react'
 import { loadSecurityPosture } from '@/lib/governance/security'
 import { DocsPageHeader } from '@/components/docs/DocsPageHeader'
+import { PrintDocumentButton } from '@/components/docs/PrintDocumentButton'
 
 export const dynamic = 'force-dynamic'
 
@@ -45,7 +46,7 @@ export default async function ZeroTrustPage() {
 
   if (!posture) {
     return (
-      <div>
+      <div className="docs-printable">
         <DocsPageHeader
           crumbs={<>
               <span>OpenBank</span><span className="breadcrumb-sep">/</span>
@@ -55,6 +56,7 @@ export default async function ZeroTrustPage() {
           </>}
           title={t('Zero-Trust bezpečnostní mapa', 'Zero-Trust Security Map')}
           icon={<ShieldCheck aria-hidden="true" size={18} style={{ color: 'var(--accent)' }} />}
+          actions={<PrintDocumentButton />}
         />
         <div className="card" style={{ padding: '24px' }}>
           <p style={{ fontSize: '13px', color: 'var(--text-secondary)' }}>
@@ -218,7 +220,7 @@ export default async function ZeroTrustPage() {
   ]
 
   return (
-    <div>
+    <div className="docs-printable">
       <DocsPageHeader
         crumbs={<>
             <span>OpenBank</span><span className="breadcrumb-sep">/</span>
@@ -232,10 +234,13 @@ export default async function ZeroTrustPage() {
               'Defense in depth derived from the real, gitops-deployed manifests (NetworkPolicy, Kyverno). No service mesh runs in the sandbox — the mTLS/JWT/L7 rows below say so plainly, not "enforced".',
             )}
         icon={<ShieldCheck aria-hidden="true" size={18} style={{ color: 'var(--accent)' }} />}
-        actions={<Link href="/docs" className="btn btn-secondary" style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
-          <ChevronLeft size={14} />
-          {t('Zpět na dokumentaci', 'Back to docs')}
-        </Link>}
+        actions={<div className="docs-header-actions" style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+          <PrintDocumentButton />
+          <Link href="/docs" className="btn btn-secondary" style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+            <ChevronLeft size={14} aria-hidden="true" />
+            {t('Zpět na dokumentaci', 'Back to docs')}
+          </Link>
+        </div>}
       />
 
       <div style={{ display: 'grid', gridTemplateColumns: 'minmax(0, 1.6fr) minmax(0, 1fr)', gap: '20px', alignItems: 'start' }}>

--- a/openbank-admin-ui/src/test/docs-pdf-export.guard.test.ts
+++ b/openbank-admin-ui/src/test/docs-pdf-export.guard.test.ts
@@ -14,13 +14,18 @@ describe('long-form documentation PDF export contract', () => {
     const compliance = read('app/docs/compliance/page.tsx')
     const documentManagement = read('app/docs/document-management/page.tsx')
     const identityDedup = read('app/docs/identity-dedup/page.tsx')
+    const bcp = read('app/docs/bcp/page.tsx')
+    const zeroTrust = read('app/docs/zero-trust/page.tsx')
     const css = read('app/globals.css')
     expect(button).toContain('window.print()')
     expect(button).toContain("t('Exportovat PDF', 'Export PDF')")
-    for (const source of [readiness, threat, adr, compliance, documentManagement, identityDedup]) {
+    for (const source of [readiness, threat, adr, compliance, documentManagement, identityDedup, bcp, zeroTrust]) {
       expect(source).toContain('PrintDocumentButton')
       expect(source).toContain('className="docs-printable"')
     }
+    expect(bcp).toContain('className="docs-header-actions"')
+    expect(bcp).toContain('className="btn"')
+    expect(zeroTrust).toContain('className="docs-header-actions"')
     expect(css).toContain('.docs-printable .card')
   })
 })


### PR DESCRIPTION
Adds native print-to-PDF export to the review-oriented BCP and Zero-Trust governance documents. Extends the existing PDF contract guard; no API, RBAC, or data-flow changes.\n\nRefs #5500