### PR TITLE
fix(admin-ui): hide operator decorative icons

### DIFF
--- a/openbank-admin-ui/src/app/lending/compliance-packs/page.tsx
+++ b/openbank-admin-ui/src/app/lending/compliance-packs/page.tsx
@@ -191,7 +191,7 @@ export default function CompliancePacksPage() {
           'Jurisdictional credit compliance packs (ADR-0212 D4). A maker proposes, a DIFFERENT compliance principal decides. An activated pack takes effect immediately — no service release.',
         )}
         actions={<button onClick={() => void load()} disabled={loading} className="btn btn-secondary" style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 12 }}>
-          <RefreshCw size={14} className={loading ? 'animate-spin' : ''} /> {t('Obnovit', 'Refresh')}
+          <RefreshCw aria-hidden="true" size={14} className={loading ? 'animate-spin' : ''} /> {t('Obnovit', 'Refresh')}
         </button>}
       />
       {actor && (
@@ -202,7 +202,7 @@ export default function CompliancePacksPage() {
 
       {degraded.length > 0 && (
         <div className="card" data-testid="degraded" style={{ padding: 12, marginBottom: 16, borderLeft: '3px solid var(--warning)', fontSize: 13, display: 'flex', alignItems: 'center', gap: 6 }}>
-          <AlertTriangle size={14} />
+          <AlertTriangle aria-hidden="true" size={14} />
           {t(
             `Nepřečteno (403 / nedostupné): ${degraded.join(', ')} — prázdný seznam NEZNAMENÁ, že nic nečeká.`,
             `Not read (403 / unavailable): ${degraded.join(', ')} — an empty list does NOT mean nothing is pending.`,
@@ -221,7 +221,7 @@ export default function CompliancePacksPage() {
       )}
 
       <div className="section-title" style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
-        <CheckCircle2 size={15} /> {t('Aktivní packy', 'Active packs')} ({active.length})
+        <CheckCircle2 aria-hidden="true" size={15} /> {t('Aktivní packy', 'Active packs')} ({active.length})
       </div>
       <div className="card" style={{ padding: 0, overflow: 'hidden', marginBottom: 24 }}>
         <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 13 }}>
@@ -259,7 +259,7 @@ export default function CompliancePacksPage() {
       </div>
 
       <div className="section-title" style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
-        <Clock size={15} /> {t('Čeká na druhý pár očí', 'Awaiting a checker')} ({pending.length})
+        <Clock aria-hidden="true" size={15} /> {t('Čeká na druhý pár očí', 'Awaiting a checker')} ({pending.length})
       </div>
       <div className="card" style={{ padding: 0, overflow: 'hidden', marginBottom: 24 }}>
         {pending.map(p => (
@@ -304,7 +304,7 @@ export default function CompliancePacksPage() {
       </div>
 
       <div className="section-title" style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
-        <ScrollText size={15} /> {t('Navrhnout pack (maker)', 'Propose a pack (maker)')}
+        <ScrollText aria-hidden="true" size={15} /> {t('Navrhnout pack (maker)', 'Propose a pack (maker)')}
       </div>
       <div className="card" style={{ padding: 14 }}>
         <p style={{ fontSize: 12, color: 'var(--text-tertiary)', marginTop: 0 }}>

--- a/openbank-admin-ui/src/app/notifications/page.tsx
+++ b/openbank-admin-ui/src/app/notifications/page.tsx
@@ -75,7 +75,7 @@ export default function NotificationsPage() {
         title={t('Oznámení', 'Notifications')}
         subtitle={t('Odchozí oznámení — e-maily, upozornění, webhooky', 'Outbound notification log — emails, alerts, webhooks')}
         actions={<button className="btn btn-secondary" onClick={load} disabled={loading}>
-          <RefreshCw size={13} style={{ animation: loading ? 'spin 1s linear infinite' : 'none' }} />
+          <RefreshCw aria-hidden="true" size={13} style={{ animation: loading ? 'spin 1s linear infinite' : 'none' }} />
           {t('Obnovit', 'Refresh')}
         </button>}
       />
@@ -139,7 +139,7 @@ export default function NotificationsPage() {
               const Icon = TYPE_ICON[n.type] ?? Bell
               return (
                 <tr key={n.id}>
-                  <td><div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}><Icon size={13} style={{ color: 'var(--accent)' }} /><span className="tag">{n.type}</span></div></td>
+                  <td><div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}><Icon aria-hidden="true" size={13} style={{ color: 'var(--accent)' }} /><span className="tag">{n.type}</span></div></td>
                   <td><span className="tag">{n.channel}</span></td>
                   <td style={{ fontSize: '12px', fontFamily: 'var(--font-mono)' }}>{n.recipient}</td>
                   <td style={{ fontSize: '13px', color: 'var(--text-secondary)' }}>{n.subject ?? '—'}</td>
@@ -202,7 +202,7 @@ function OperatorMessageApprovals() {
   return (
     <div className="card" style={{ overflow: 'hidden', marginBottom: '16px' }}>
       <div style={{ display: 'flex', alignItems: 'center', gap: '8px', padding: '16px 20px', borderBottom: '1px solid var(--border)' }}>
-        <Clock size={15} style={{ color: 'var(--yellow)' }} />
+        <Clock aria-hidden="true" size={15} style={{ color: 'var(--yellow)' }} />
         <span style={{ fontWeight: 600, fontSize: '13px' }}>
           {t('Schválení zpráv (princip čtyř očí)', 'Message approvals (four-eyes)')}
         </span>
@@ -229,7 +229,7 @@ function OperatorMessageApprovals() {
             onClick={() => decide(true)}
             disabled={busy || !approvalId.trim()}
           >
-            <Check size={13} /> {t('Schválit', 'Approve')}
+            <Check aria-hidden="true" size={13} /> {t('Schválit', 'Approve')}
           </button>
           <button
             className="btn btn-secondary"
@@ -237,7 +237,7 @@ function OperatorMessageApprovals() {
             onClick={() => decide(false)}
             disabled={busy || !approvalId.trim()}
           >
-            <X size={13} /> {t('Zamítnout', 'Reject')}
+            <X aria-hidden="true" size={13} /> {t('Zamítnout', 'Reject')}
           </button>
         </div>
         {result && (

--- a/openbank-admin-ui/src/test/ops-icons-a11y.guard.test.ts
+++ b/openbank-admin-ui/src/test/ops-icons-a11y.guard.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+import fs from 'node:fs'
+import path from 'node:path'
+
+const read = (file: string) => fs.readFileSync(path.resolve(process.cwd(), file), 'utf8')
+
+describe('operator surface decorative icon contract', () => {
+  it('hides sized icons that accompany visible operational labels', () => {
+    for (const file of [
+      'src/app/notifications/page.tsx',
+      'src/app/lending/compliance-packs/page.tsx',
+    ]) {
+      const source = read(file)
+      expect(source).not.toMatch(/<[A-Z][A-Za-z0-9]*(?=[^>]*\bsize=\{)(?![^>]*\baria-hidden\b)[^>]*\/>/)
+    }
+  })
+})


### PR DESCRIPTION
Marks sized decorative icons aria-hidden on notifications and lending compliance-pack surfaces. Adds a source guard; no endpoint, action, RBAC, maker-checker, or data-flow changes.\n\nRefs #5500