### PR TITLE
fix(admin-ui): complete shell menu accessibility

### DIFF
--- a/openbank-admin-ui/src/components/layout/Header.tsx
+++ b/openbank-admin-ui/src/components/layout/Header.tsx
@@ -20,6 +20,9 @@ export function Header({ mobileNavOpen, onMenuToggle }: { mobileNavOpen?: boolea
   const [menuOpen, setMenuOpen] = useState(false)
   const [paletteOpen, setPaletteOpen] = useState(false)
   const mobileMenuRef = useRef<HTMLButtonElement>(null)
+  const userMenuButtonRef = useRef<HTMLButtonElement>(null)
+  const userMenuRef = useRef<HTMLDivElement>(null)
+  const wasUserMenuOpen = useRef(false)
   const wasMobileNavOpen = useRef(false)
   const { language, setLanguage, t } = useLanguage()
   const [build, setBuild] = useState<BuildInfo | null>(null)
@@ -28,6 +31,34 @@ export function Header({ mobileNavOpen, onMenuToggle }: { mobileNavOpen?: boolea
     if (wasMobileNavOpen.current && !mobileNavOpen) mobileMenuRef.current?.focus()
     wasMobileNavOpen.current = Boolean(mobileNavOpen)
   }, [mobileNavOpen])
+
+  // Keep the small account menu keyboard-complete: focus enters the menu,
+  // Escape/outside click closes it, and focus returns to the opener. Without
+  // this, keyboard users can land behind the menu and lose their place.
+  useEffect(() => {
+    if (menuOpen) {
+      wasUserMenuOpen.current = true
+      const frame = requestAnimationFrame(() => userMenuRef.current?.querySelector<HTMLElement>('[role="menuitem"]')?.focus())
+      const onKeyDown = (event: KeyboardEvent) => {
+        if (event.key === 'Escape') {
+          event.preventDefault()
+          setMenuOpen(false)
+        }
+      }
+      const onPointerDown = (event: PointerEvent) => {
+        if (!userMenuRef.current?.contains(event.target as Node) && !userMenuButtonRef.current?.contains(event.target as Node)) setMenuOpen(false)
+      }
+      window.addEventListener('keydown', onKeyDown)
+      document.addEventListener('pointerdown', onPointerDown)
+      return () => {
+        cancelAnimationFrame(frame)
+        window.removeEventListener('keydown', onKeyDown)
+        document.removeEventListener('pointerdown', onPointerDown)
+      }
+    }
+    if (wasUserMenuOpen.current) userMenuButtonRef.current?.focus()
+    wasUserMenuOpen.current = menuOpen
+  }, [menuOpen])
 
   useEffect(() => {
     let mounted = true
@@ -77,11 +108,12 @@ export function Header({ mobileNavOpen, onMenuToggle }: { mobileNavOpen?: boolea
       </button>
       {/* Search — ADR-0228 D3: the painted placeholder is now a real palette. */}
       <button
+        type="button"
         onClick={() => setPaletteOpen(true)}
         aria-label={t('Rychlé hledání (⌘K)', 'Quick search (⌘K)')}
         className={styles.searchTrigger}
       >
-        <Search size={14} />
+        <Search size={14} aria-hidden="true" />
         <span style={{ fontSize: '13px' }}>{t('Rychlé hledání…', 'Quick search…')}</span>
         <kbd style={{
           fontSize: '10px', padding: '1px 5px',
@@ -127,6 +159,9 @@ export function Header({ mobileNavOpen, onMenuToggle }: { mobileNavOpen?: boolea
           </Link>
         )}
         <button
+          type="button"
+          aria-label={t('Přepnout na angličtinu', 'Switch to Czech')}
+          title={t('Přepnout jazyk', 'Switch language')}
           onClick={() => setLanguage(language === 'en' ? 'cs' : 'en')}
           style={{
             width: '32px', height: '32px', display: 'flex', alignItems: 'center', justifyContent: 'center',
@@ -139,17 +174,19 @@ export function Header({ mobileNavOpen, onMenuToggle }: { mobileNavOpen?: boolea
         >
           {language.toUpperCase()}
         </button>
-        {canReadDocs && <HeaderLink href="/docs" label={t('Nápověda a dokumentace', 'Help and documentation')}><HelpCircle size={15} /></HeaderLink>}
-        {canViewApprovals && <HeaderLink href="/approvals" label={t('Schvalování', 'Approvals')}><Bell size={15} /></HeaderLink>}
+        {canReadDocs && <HeaderLink href="/docs" label={t('Nápověda a dokumentace', 'Help and documentation')}><HelpCircle size={15} aria-hidden="true" /></HeaderLink>}
+        {canViewApprovals && <HeaderLink href="/approvals" label={t('Schvalování', 'Approvals')}><Bell size={15} aria-hidden="true" /></HeaderLink>}
         <div style={{ width: '1px', height: '20px', background: 'var(--border)', margin: '0 6px' }} />
 
         {/* User menu */}
         <div style={{ position: 'relative' }}>
           <button
             type="button"
+            ref={userMenuButtonRef}
             onClick={() => setMenuOpen(v => !v)}
             aria-expanded={menuOpen}
             aria-haspopup="menu"
+            aria-controls={menuOpen ? 'admin-user-menu' : undefined}
             aria-label={t('Otevřít uživatelskou nabídku', 'Open user menu')}
             style={{
               display: 'flex', alignItems: 'center', gap: '8px',
@@ -179,12 +216,12 @@ export function Header({ mobileNavOpen, onMenuToggle }: { mobileNavOpen?: boolea
                 </span>
               )}
             </div>
-            <ChevronDown size={12} style={{ color: 'var(--text-tertiary)', marginLeft: '2px' }} />
+            <ChevronDown aria-hidden="true" size={12} style={{ color: 'var(--text-tertiary)', marginLeft: '2px' }} />
           </button>
 
           {/* Dropdown */}
           {menuOpen && (
-            <div role="menu" aria-label={t('Uživatelská nabídka', 'User menu')} style={{
+            <div id="admin-user-menu" ref={userMenuRef} role="menu" aria-label={t('Uživatelská nabídka', 'User menu')} style={{
               position: 'absolute', top: 'calc(100% + 6px)', right: 0,
               width: '240px', background: 'var(--surface)', border: '1px solid var(--border)',
               borderRadius: '10px', boxShadow: 'var(--shadow-lg)', padding: '8px',
@@ -217,6 +254,8 @@ export function Header({ mobileNavOpen, onMenuToggle }: { mobileNavOpen?: boolea
               {/* Sign out — federated (ADR-0080 P1 / F-AUTH-04): clear the local session AND
                   the Keycloak SSO session, otherwise navigating Back silently re-authenticates. */}
               <button
+                type="button"
+                role="menuitem"
                 onClick={async () => {
                   setMenuOpen(false)
                   let kcLogoutUrl: string | null = null
@@ -236,7 +275,7 @@ export function Header({ mobileNavOpen, onMenuToggle }: { mobileNavOpen?: boolea
                 onMouseEnter={e => (e.currentTarget.style.background = '#fef2f2')}
                 onMouseLeave={e => (e.currentTarget.style.background = 'transparent')}
               >
-                <LogOut size={14} />
+                <LogOut size={14} aria-hidden="true" />
                 {t('Odhlásit se', 'Sign out')}
               </button>
             </div>

--- a/openbank-admin-ui/src/components/layout/Sidebar.tsx
+++ b/openbank-admin-ui/src/components/layout/Sidebar.tsx
@@ -208,7 +208,7 @@ export function Sidebar({ mobileOpen, onClose }: { mobileOpen?: boolean; onClose
       <div className={styles.brand}>
         <div className={styles.brandLockup}>
           <div className={styles.brandMark}>
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="white" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+            <svg aria-hidden="true" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="white" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
               <rect x="3" y="3" width="18" height="18" rx="3"/><path d="M3 9h18M9 21V9"/>
             </svg>
           </div>
@@ -276,16 +276,16 @@ function NavSection({ items, pathname, isLocked }: { items: NavItem[]; pathname:
         if (locked) {
           return (
             <div key={item.href} title={language === 'cs' ? 'Přístup není povolen pro demo účet' : 'Not available for demo account'} className={`${styles.navItem} ${styles.locked}`}>
-              <Icon size={16} className={styles.navIcon} />
+              <Icon aria-hidden="true" size={16} className={styles.navIcon} />
               <span className={styles.navLabel}>{displayName}</span>
-              <Lock size={11} className={styles.lockIcon} />
+              <Lock aria-hidden="true" size={11} className={styles.lockIcon} />
             </div>
           )
         }
 
         const row = (
             <div className={`${styles.navItem} ${active ? styles.active : ''}`}>
-              <Icon size={16} className={styles.navIcon} />
+              <Icon aria-hidden="true" size={16} className={styles.navIcon} />
               <span className={styles.navLabel}>{displayName}</span>
               {item.badge && (
                 <span className={styles.navBadge}>{item.badge}</span>

--- a/openbank-admin-ui/src/test/shell-ux-a11y.guard.test.ts
+++ b/openbank-admin-ui/src/test/shell-ux-a11y.guard.test.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const header = readFileSync(resolve(__dirname, '../components/layout/Header.tsx'), 'utf8')
+const sidebar = readFileSync(resolve(__dirname, '../components/layout/Sidebar.tsx'), 'utf8')
+
+describe('shared shell interaction and icon accessibility contract', () => {
+  it('keeps the account menu connected to its opener and keyboard-dismissible', () => {
+    expect(header).toContain('userMenuButtonRef')
+    expect(header).toContain('userMenuRef')
+    expect(header).toContain("aria-controls={menuOpen ? 'admin-user-menu' : undefined}")
+    expect(header).toContain('id="admin-user-menu"')
+    expect(header).toContain("event.key === 'Escape'")
+    expect(header).toContain("role=\"menuitem\"")
+    expect(header).toContain('userMenuButtonRef.current?.focus()')
+  })
+
+  it('names the language action and hides shell decoration from assistive tech', () => {
+    expect(header).toContain('Přepnout na angličtinu')
+    expect(header).toContain('Switch to Czech')
+    expect(header).toMatch(/<Search[^>]*aria-hidden="true"/)
+    expect(header).toMatch(/<LogOut[^>]*aria-hidden="true"/)
+    expect(sidebar).toMatch(/<svg aria-hidden="true"/)
+    expect(sidebar).toMatch(/<Icon aria-hidden="true" size=\{16\}/)
+    expect(sidebar).toMatch(/<Lock aria-hidden="true"/)
+  })
+})


### PR DESCRIPTION
## Summary
- make the account menu keyboard-complete with focus entry/restoration, Escape and outside-click close
- label the language action and hide decorative shell icons from assistive technology
- add a source guard for the shared shell contract

## Verification
- `vitest run src/test/shell-ux-a11y.guard.test.ts` (2/2)
- `npm run type-check`
- independent release review: no blocker

## Linked issues
N/A — shared admin-shell accessibility hardening tracked as part of the ongoing admin UI modernization follow-through.