### PR TITLE
fix(admin-ui): announce active navigation route

### DIFF
--- a/openbank-admin-ui/src/components/layout/Sidebar.tsx
+++ b/openbank-admin-ui/src/components/layout/Sidebar.tsx
@@ -297,9 +297,9 @@ function NavSection({ items, pathname, isLocked }: { items: NavItem[]; pathname:
         // next/link would client-side navigate and 404 (ADR-0234). Plain <a>,
         // same origin, so the session cookie reaches the edge gate.
         return item.external ? (
-          <a key={item.href} href={item.href} style={{ textDecoration: 'none' }}>{row}</a>
+          <a key={item.href} href={item.href} aria-current={active ? 'page' : undefined} style={{ textDecoration: 'none' }}>{row}</a>
         ) : (
-          <Link key={item.href} href={item.href} style={{ textDecoration: 'none' }}>{row}</Link>
+          <Link key={item.href} href={item.href} aria-current={active ? 'page' : undefined} style={{ textDecoration: 'none' }}>{row}</Link>
         )
       })}
     </>

--- a/openbank-admin-ui/src/test/sidebar-navigation-a11y.guard.test.ts
+++ b/openbank-admin-ui/src/test/sidebar-navigation-a11y.guard.test.ts
@@ -1,0 +1,13 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const source = readFileSync(resolve(__dirname, '../components/layout/Sidebar.tsx'), 'utf8')
+
+describe('sidebar navigation accessibility contract', () => {
+  it('announces the active route on both internal and same-origin external links', () => {
+    expect(source).toContain("aria-current={active ? 'page' : undefined}")
+    expect(source).toMatch(/<a key=\{item\.href\}[^>]*aria-current=\{active \? 'page' : undefined\}/)
+    expect(source).toMatch(/<Link key=\{item\.href\}[^>]*aria-current=\{active \? 'page' : undefined\}/)
+  })
+})


### PR DESCRIPTION
## Summary

Expose the active route to assistive technology while preserving navigation behavior.

## Verification

- vitest run src/test/sidebar-navigation-a11y.guard.test.ts
- npm run type-check
- git diff --check

## Linked issues
N/A - shared navigation accessibility hardening.