### PR TITLE
fix(admin-ui): name shared operator inputs

### DIFF
--- a/openbank-admin-ui/src/components/agent/AgentDock.tsx
+++ b/openbank-admin-ui/src/components/agent/AgentDock.tsx
@@ -106,6 +106,7 @@ export function AgentDock() {
               <select
                 value={model}
                 onChange={e => setModel(e.target.value)}
+                aria-label={t('Model asistenta', 'Assistant model')}
                 style={{ fontSize: 11, padding: '3px 6px', borderRadius: 6, border: '1px solid var(--border)', background: 'var(--surface-2)', color: 'var(--text-secondary)' }}
               >
                 {models.map(m => <option key={m.id} value={m.id}>{m.id}</option>)}

--- a/openbank-admin-ui/src/components/party/PartySearch.tsx
+++ b/openbank-admin-ui/src/components/party/PartySearch.tsx
@@ -110,6 +110,7 @@ export function PartySearch({ onSelect, selectedId, busy = false, placeholder, l
             onChange={e => setTerm(e.target.value)}
             onKeyDown={e => { if (e.key === 'Enter') run() }}
             placeholder={placeholder ?? t('Jméno nebo název firmy (nebo UUID party)', 'Name or company name (or party UUID)')}
+            aria-label={t('Vyhledat stranu', 'Search parties')}
             style={{
               flex: '1 1 340px', padding: '8px 12px', borderRadius: '8px', border: '1px solid var(--border)',
               background: 'var(--surface)', color: 'var(--text-primary)', fontSize: '13px',

--- a/openbank-admin-ui/src/components/sbom/SbomViewer.tsx
+++ b/openbank-admin-ui/src/components/sbom/SbomViewer.tsx
@@ -237,6 +237,7 @@ export function SbomViewer({ serviceName }: Props) {
                   <input
                     type="text"
                     placeholder="filter…"
+                    aria-label={t('Filtro komponent SBOM', 'Filter SBOM components')}
                     value={filter}
                     onChange={e => setFilter(e.target.value)}
                     style={{

--- a/openbank-admin-ui/src/test/shared-input-a11y.guard.test.ts
+++ b/openbank-admin-ui/src/test/shared-input-a11y.guard.test.ts
@@ -1,0 +1,16 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const root = path.join(process.cwd(), 'src', 'components')
+
+describe('shared inputs have accessible names', () => {
+  it('names the SBOM filter, party resolver and assistant model selector', () => {
+    const sbom = fs.readFileSync(path.join(root, 'sbom/SbomViewer.tsx'), 'utf8')
+    const party = fs.readFileSync(path.join(root, 'party/PartySearch.tsx'), 'utf8')
+    const agent = fs.readFileSync(path.join(root, 'agent/AgentDock.tsx'), 'utf8')
+    expect(sbom).toContain("aria-label={t('Filtro komponent SBOM', 'Filter SBOM components')}")
+    expect(party).toContain("aria-label={t('Vyhledat stranu', 'Search parties')}")
+    expect(agent).toContain("aria-label={t('Model asistenta', 'Assistant model')}")
+  })
+})


### PR DESCRIPTION
## Summary

Add localized accessible names to the SBOM filter, shared party resolver, and assistant model selector.

## Verification

- npm test -- --run src/test/shared-input-a11y.guard.test.ts --reporter=dot
- npm run type-check
- git diff --check

## Linked issues
N/A - shared operator input accessibility hardening.