### PR TITLE
perf(admin-ui): parallelize dashboard health reads

### DIFF
--- a/openbank-admin-ui/src/app/dashboard/page.tsx
+++ b/openbank-admin-ui/src/app/dashboard/page.tsx
@@ -74,22 +74,27 @@ export default function DashboardPage() {
     if (loadingRef.current) return
     loadingRef.current = true
     setLoading(true)
+    // Governance and live health are independent reads. Start them together so a
+    // slow health probe cannot delay the canonical roster (and vice versa).
+    const governanceRequest = fetch('/api/services/governance', { cache: 'no-store' }).catch(() => null)
+    const healthRequest = fetch('/api/services/health', { signal: AbortSignal.timeout(10000), cache: 'no-store' }).catch(() => null)
+    const [govRes, res] = await Promise.all([governanceRequest, healthRequest])
+
     // Canonical fleet from the code-derived governance manifest (ADR-0071).
     let fleet: { name: string; group: string }[] = []
-    try {
-      const govRes = await fetch('/api/services/governance', { cache: 'no-store' })
-      if (govRes.ok) {
+    if (govRes?.ok) {
+      try {
         const g = await govRes.json() as { items?: { serviceName: string; dataDomain: string }[] }
         fleet = (g.items ?? []).map(e => ({ name: e.serviceName, group: e.dataDomain }))
-      }
-    } catch { /* fleet stays empty → roster degrades calmly, no blank crash */ }
+      } catch { /* fleet stays empty → roster degrades calmly, no blank crash */ }
+    }
+
     try {
-      const res = await fetch('/api/services/health', { signal: AbortSignal.timeout(10000), cache: 'no-store' })
       // Live discovery (ADR-0051) keyed by bare deployment name. Empty on failure —
       // the fleet still renders, every member simply shows as not-deployed rather
       // than the page going blank.
       const discovered = new Map<string, HealthEntry>()
-      if (res.ok) {
+      if (res?.ok) {
         const data = await res.json() as { services: HealthEntry[] }
         for (const e of (data.services ?? [])) discovered.set(e.name, e)
       }

--- a/openbank-admin-ui/src/test/dashboard-parallel-load.guard.test.ts
+++ b/openbank-admin-ui/src/test/dashboard-parallel-load.guard.test.ts
@@ -1,0 +1,13 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+describe('dashboard health loading', () => {
+  it('starts governance and live health requests concurrently', () => {
+    const source = fs.readFileSync(path.join(process.cwd(), 'src/app/dashboard/page.tsx'), 'utf8')
+    expect(source).toContain("const governanceRequest = fetch('/api/services/governance'")
+    expect(source).toContain("const healthRequest = fetch('/api/services/health'")
+    expect(source).toContain('const [govRes, res] = await Promise.all([governanceRequest, healthRequest])')
+    expect(source).toContain(".catch(() => null)")
+  })
+})


### PR DESCRIPTION
## Summary

Start dashboard governance and live health reads concurrently while preserving graceful fallback behavior.

## Linked issues
N/A - dashboard performance hardening.