### PR TITLE
fix(billing): provision Kafka mTLS identity for the annual-fee-summary publisher (does not fix #4701's dead rows — see #5642)

### DIFF
--- a/docs/threat-models/openbank-billing-service.md
+++ b/docs/threat-models/openbank-billing-service.md
@@ -185,13 +185,25 @@ first departure from "every trust boundary here is OIDC+mTLS REST".
   (sandbox) yet.** All verification so far is unit/integration-level (Testcontainers Postgres +
   Redis) and the DST harness (pure-JVM, in-memory). Sandbox e2e verification of a charged, a
   waived, and a reversed fee all reconciling to the ledger is a required go-live gate.
-- **Annual fee-summary (ADR-0248, new — not yet deployed or sandbox-verified):** disabled by
-  default (`openbank.billing.annual-fee-summary.scheduler.enabled=false`) for the same reason the
+- **Annual fee-summary (ADR-0248, scheduler-disabled, now credentialed but still
+  sandbox-unverified):** the scheduler is disabled by default
+  (`openbank.billing.annual-fee-summary.scheduler.enabled=false`) for the same reason the
   discovered cycle sweep is double-gated — an accidental fire publishes a real PAD Art. 5 push-duty
   event per active account, with no cheap way to retract it once document-service's consumer has
   acted. Residual risks distinct from the charge path above:
   - This is billing-service's **first outbound Kafka publish** — a new class of trust boundary
-    (message broker, not OIDC+mTLS REST) that nothing else in this service's data flow uses.
+    (message broker, not OIDC+mTLS REST) that nothing else in this service's data flow uses. The
+    boundary was *designed* 2026-08-07 (ADR-0248) but its runtime identity was never provisioned —
+    the Deployment carried no `KAFKA_*` env vars, `KafkaUser`, or cert `Secret` at all, so
+    `application.yaml`'s config had nowhere to connect (readiness probe: reactive-messaging channel
+    `DOWN`, `Connection to node -1 (localhost/127.0.0.1:9092) could not be established`). Closed
+    2026-08-19 (see change log) by provisioning the `billing-service` `KafkaUser` (Write+Describe on
+    `openbank.billing.fee.event` only) and the matching mTLS cert projection. **This gap did not
+    cause the 2 `billing.fee.post-intent.v1` rows dead-lettered in #4701** — that event type is
+    dispatched via `LedgerOutboxEventPublisher.publishCharge`, a REST call to ledger-service that
+    never touches this Kafka channel at all; #4701's actual cause was malformed JSON from
+    unescaped fee names (fixed separately, #5642). The scheduler itself is still off, so this
+    channel carries no live traffic yet.
     Delivery is at-least-once (standard outbox semantics); document-service's consumer is
     responsible for its own idempotent handling of `(accountId, year)` — billing only guarantees
     it appends the outbox row at most once per `(accountId, year)` (deterministic `aggregateId`
@@ -214,6 +226,7 @@ first departure from "every trust boundary here is OIDC+mTLS REST".
 
 | Date | Change |
 |---|---|
+| 2026-08-19 | Operationalizes the 2026-08-07 entry below: `KafkaUser billing-service` (Write+Describe on `openbank.billing.fee.event` only, no incoming channels) + `ExternalSecret`-projected mTLS keystore/truststore + the matching `KAFKA_*` env vars on the Deployment (#4701 investigation). The trust boundary itself was already documented; nothing about its shape changed, only that it now has a live identity instead of falling through to `localhost:9092`. Does **not** address #4701's dead-lettered `billing.fee.post-intent.v1` rows — that path is REST-to-ledger, not Kafka; see the corrected §5 bullet and #5642. |
 | 2026-08-07 | Trust-boundary change (ADR-0248, Refs #4109): new outbound Kafka publisher — billing-service's first — for the `billing.annual-fee-summary.ready` event (topic `openbank.billing.fee.event`, PAD Art. 5 annual statement of fees, consumed by document-service). New `AnnualFeeSummaryScheduler` (disabled by default), `AnnualFeeSummaryService` use case, and `AccountPartyLookupPort` (a second read of the already-trusted `account-service GET /api/v1/accounts/{id}` response, no new boundary). See §2 step 7 and the new §5 residual-risk bullet: `interestRate` is always `null` (no source in this service's domain) and `AnnualFeeSummaryLine.category` reuses the fee name pending the PAD Annex II taxonomy mapping ADR-0248 itself flags as an open item. |
 | 2026-08-05 | Trust-boundary change (#3734): `operator-billing-write` now excludes `service-account-*` principals, and a new `prohibited` veto closes all three billing writes (`post`, `reverse`, `approval.decide`) to `service-account-openbank-edge` — the role_action_matrix grants all three to ROLE_OPERATOR and matrix-allows bypasses rule-level exclusions. Billing has no in-repo M2M caller at all (verified 2026-08-05: no edge URL, no backend REST client; account-service's billing-discovery read is INBOUND from billing), so no identity-scoped grant needed preserving. Ext moved from generator heredoc to standalone `billing_rest_ext.rego` with an 8-test opa suite. |
 

--- a/openbank-infra/gitops/apps/billing.yaml
+++ b/openbank-infra/gitops/apps/billing.yaml
@@ -1,7 +1,10 @@
 # ArgoCD app for billing-service (ADR-0143 phase 2c: runtime fee assessment).
-# Postgres-backed (billing-db.yaml, single-owner CNPG cluster) — no Kafka. Reads
-# product, account, and balance state via REST to compute fee assessments; ledger
-# posting (outbox) is the phase 2c-ii follow-up gated behind a four-eyes OPA decision.
+# Postgres-backed (billing-db.yaml, single-owner CNPG cluster). Reads product, account,
+# and balance state via REST to compute fee assessments; publishes
+# billing.fee.post-intent.v1 to its own openbank.billing.fee.event Kafka topic via a
+# transactional outbox (ADR-0248) — kafka-billing-mtls.yaml provisions that identity
+# (issue #4701; the topic existed before this app's Deployment ever supplied the
+# connection to reach it).
 # The OIDC_CLIENT_SECRET Secret is delivered by ESO (billing-service-oidc).
 apiVersion: argoproj.io/v1alpha1
 kind: Application

--- a/openbank-infra/gitops/components/billing/billing-service.yaml
+++ b/openbank-infra/gitops/components/billing/billing-service.yaml
@@ -106,6 +106,32 @@ spec:
               value: http://tempo.observability.svc:4317
             - name: OTEL_TRACES_SAMPLER_ARG
               value: "0.1"
+            # Kafka producer -> Strimzi tls:9093 (mTLS, issue #4701). Wires the env vars
+            # billing-service's own application.yaml has read since ADR-0248 shipped the
+            # outbox producer -- this Deployment never supplied them, so every publish
+            # attempt fell through SmallRye's connector default of localhost:9092.
+            - name: KAFKA_BOOTSTRAP_SERVERS
+              value: openbank-cluster-kafka-bootstrap.messaging.svc:9093
+            - name: KAFKA_SECURITY_PROTOCOL
+              value: SSL
+            - name: KAFKA_SSL_KEYSTORE_LOCATION
+              value: /mnt/kafka/keystore/user.p12
+            - name: KAFKA_SSL_KEYSTORE_TYPE
+              value: PKCS12
+            - name: KAFKA_SSL_KEYSTORE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: billing-service-kafka-keystore
+                  key: user.password
+            - name: KAFKA_SSL_TRUSTSTORE_LOCATION
+              value: /mnt/kafka/truststore/ca.p12
+            - name: KAFKA_SSL_TRUSTSTORE_TYPE
+              value: PKCS12
+            - name: KAFKA_SSL_TRUSTSTORE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: kafka-cluster-ca-truststore
+                  key: ca.password
             # OPA sidecar is deployed (ADR-0034 Phase 5, issue #266). AUTHZ_ENFORCE=true
             # enables the @Authorize HTTP interceptor to enforce decisions from
             # data.openbank.rest.allow. RBAC via OIDC remains the outer gate; OPA is the
@@ -140,6 +166,12 @@ spec:
           volumeMounts:
             - name: tmp
               mountPath: /tmp
+            - name: kafka-keystore
+              mountPath: /mnt/kafka/keystore
+              readOnly: true
+            - name: kafka-truststore
+              mountPath: /mnt/kafka/truststore
+              readOnly: true
           resources:
             requests:
               cpu: 100m
@@ -229,6 +261,12 @@ spec:
         - name: opa-bundle
           configMap:
             name: billing-opa-bundle
+        - name: kafka-keystore
+          secret:
+            secretName: billing-service-kafka-keystore
+        - name: kafka-truststore
+          secret:
+            secretName: kafka-cluster-ca-truststore
 ---
 apiVersion: v1
 kind: Service

--- a/openbank-infra/gitops/components/billing/kafka-billing-mtls.yaml
+++ b/openbank-infra/gitops/components/billing/kafka-billing-mtls.yaml
@@ -1,0 +1,89 @@
+# Kafka mTLS identity + cert projection for billing-service (issue #4701).
+#
+# Pattern mirrors components/ledger/kafka-ledger-mtls.yaml. billing-service's
+# application.yaml (ADR-0248) has read KAFKA_BOOTSTRAP_SERVERS / KAFKA_SECURITY_PROTOCOL /
+# KAFKA_SSL_* since the outbox producer shipped, but this Deployment never supplied them —
+# no env vars, no KafkaUser, no cert Secret at all. Every publish attempt fell through
+# SmallRye's connector default of localhost:9092, which billing-service's own readiness
+# probe already reported (SmallRye Reactive Messaging readiness check DOWN,
+# "Connection to node -1 (localhost/127.0.0.1:9092) could not be established") — this
+# had been failing since the topic was introduced, not a new regression. Confirmed live
+# 2026-08-18: billing_outbox carries 2 DEAD rows, both last_error "circuit breaker is
+# open" — the dispatcher's own resilience wrapper giving up on a target that was never
+# going to answer, not a broker or payload problem (the "why they died" question #4701
+# asked). KafkaUser minted in `messaging` (where Strimzi User Operator watches); the
+# Strimzi User Operator writes a Secret of the same name there with user.crt/key/p12 +
+# password. The ExternalSecrets below project that secret from `messaging` into `billing`
+# via the shared `kafka-messaging-certs` ClusterSecretStore, same as every other service.
+#
+# Topic model:
+#   billing-service WRITES openbank.billing.fee.event → Write+Describe ACL on that topic.
+#   No incoming channels (billing has no @Incoming Kafka consumer).
+#   No consumer-group ACL needed.
+#
+# Gate: allow.everyone.if.no.acl.found=true until all ~33 clients are migrated (issue #2665).
+# This identity is provisioned ahead of the eventual deny-by-default flip, same as ledger's.
+---
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaUser
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "-2"
+  name: billing-service
+  namespace: messaging
+  labels:
+    strimzi.io/cluster: openbank-cluster
+spec:
+  authentication:
+    type: tls
+  authorization:
+    type: simple
+    acls:
+      - resource:
+          type: topic
+          name: openbank.billing.fee.event
+          patternType: literal
+        operations: [Write, Describe]
+        host: "*"
+---
+# Project the billing-service keystore from `messaging` into `billing` namespace.
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+  name: billing-service-kafka-keystore
+  namespace: billing
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: kafka-messaging-certs
+  target:
+    name: billing-service-kafka-keystore
+    creationPolicy: Owner
+    deletionPolicy: Retain
+  dataFrom:
+    - extract:
+        key: billing-service
+---
+# Shared cluster-CA truststore for all Kafka clients in `billing`.
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+  name: kafka-cluster-ca-truststore
+  namespace: billing
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: kafka-messaging-certs
+  target:
+    name: kafka-cluster-ca-truststore
+    creationPolicy: Owner
+    deletionPolicy: Retain
+  dataFrom:
+    - extract:
+        key: openbank-cluster-cluster-ca-cert

--- a/openbank-infra/gitops/components/kafka/network-policies.yaml
+++ b/openbank-infra/gitops/components/kafka/network-policies.yaml
@@ -62,6 +62,9 @@ spec:
               kubernetes.io/metadata.name: balances
         - namespaceSelector:
             matchLabels:
+              kubernetes.io/metadata.name: billing
+        - namespaceSelector:
+            matchLabels:
               kubernetes.io/metadata.name: campaign
         - namespaceSelector:
             matchLabels:

--- a/openbank-infra/gitops/components/payments/kafka-scheme-accepted-acl.yaml
+++ b/openbank-infra/gitops/components/payments/kafka-scheme-accepted-acl.yaml
@@ -437,6 +437,7 @@ rules:
       - security-scanner                # issue #3393: last fleet workload without a KafkaUser — scan-event + ICT-incident producer, ns security-scanner (first ESO client there)
       - kafka-ui                        # issue #3393: the cluster-browsing console, and the only workload that was actually SPEAKING on :9092 — every DESCRIBE denied as User:ANONYMOUS. Unusually, it runs IN `messaging`, so this projection does not cross a namespace; it goes through ESO anyway to stay in this inventory (see components/kafka/kafka-ui-mtls.yaml)
       - case-coordinator                # ADR-0244: proposal-events producer (case_outbox), ns platform — third ESO Kafka client there after agent-service and copilot-service, sharing that namespace's kafka-cluster-ca-truststore
+      - billing-service                 # issue #4701: fee-event outbox producer, ns billing (first ESO client there); had been failing since the topic was introduced (SmallRye default localhost:9092, no KafkaUser/cert ever provisioned)
       - openbank-cluster-cluster-ca-cert
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
## What

Provisions the missing Kafka mTLS identity for `billing-service`'s outbound Kafka publisher
(`billing.annual-fee-summary.ready`, ADR-0248) — designed 2026-08-07 but never operationalized:
the Deployment carried no `KAFKA_*` env vars, `KafkaUser`, or cert `Secret`, so `application.yaml`'s
config had nowhere to connect (readiness probe: reactive-messaging channel `DOWN`,
`Connection to node -1 (localhost/127.0.0.1:9092) could not be established`).

## Live evidence (2026-08-18)

- `billing-service`'s readiness probe reports the reactive-messaging channel `DOWN` right now.
- `billing_outbox` has 2 `DEAD` rows (`last_error: "circuit breaker is open"`), both
  `billing.fee.post-intent.v1`.

## Correction (2026-08-19) — this does NOT root-cause #4701's 2 dead rows

Traced the actual dispatch path: `billing.fee.post-intent.v1` and `billing.fee.reversal-intent.v1`
are handled by `LedgerOutboxEventPublisher.publishCharge`/`publishReversal`, which call
ledger-service over **REST** — they never touch Kafka. Only `billing.annual-fee-summary.ready`
uses the Kafka emitter this PR provisions credentials for, and that scheduler is (and remains)
disabled by default, so this channel carries no traffic either before or after this PR.

`BillingOutboxDispatcher`'s own KDoc says its outer `@CircuitBreaker` wraps
"a failure anywhere in `LedgerOutboxEventPublisher.publish` (**deserialization**, the ledger call,
or the `markPosted` write)" for the whole `publish()` call — so the `"circuit breaker is open"`
`last_error` on the 2 dead rows is far better explained by **#5642** (malformed JSON from
unescaped fee names → `mapper.readValue` throws before the ledger call is ever reached) than by
this PR's Kafka gap, which the dead rows' event type never routes through in the first place.

**This PR is still worth merging on its own merits** — the Kafka boundary genuinely was designed
and never deployed, and that's a real gap closed here — but it should not be credited with fixing
#4701's dead-lettered rows. See #5642 for that, and the corrected residual-risk bullet + change-log
entry in `docs/threat-models/openbank-billing-service.md` (pushed to this branch) for the full
trace.

## Fix

Mirrors `components/ledger/kafka-ledger-mtls.yaml` exactly:

- New `kafka-billing-mtls.yaml`: a `KafkaUser` in `messaging` (Write+Describe ACL on the one topic
  billing publishes; no incoming channels to grant), and two `ExternalSecret`s projecting the
  Strimzi-minted keystore + shared cluster-CA truststore into `billing` via the existing
  `kafka-messaging-certs` `ClusterSecretStore`.
- `billing-service.yaml`: the matching `KAFKA_*` env vars, `volumeMounts`, `volumes` on the
  Deployment.
- `apps/billing.yaml`: fixed the header comment, which still said "no Kafka" — already live
  (ADR-0248), the comment just never caught up.
- `docs/threat-models/openbank-billing-service.md`: threat-model-diff gate (ADR-0030 D2) update
  for the trust-boundary change, with the causation correction above.

## Verified

`kubectl apply --dry-run=client -f ...` against the live sandbox API server for all three gitops
files — clean, no admission errors. Local `check-threat-model-diff.py --enforce` — passes.

## Money-path — corrected

`rules.yaml: money_path_services` **does** list `openbank-billing-service` (it posts debit/credit
journals to the ledger). The 2-approval gate applies; the earlier claim that it didn't was wrong.

## Not attempted (left for #4701 to track)

- Replaying the 2 existing `DEAD` rows — #4701 itself calls this "a data decision, not a code one."
- A `DEAD`-row-count alert (#4701's still-open question 2).

Refs #4701
