### PR TITLE
fix(admin-ui): align AIOps enforcement copy

### DIFF
--- a/openbank-admin-ui/src/app/iaops/page.tsx
+++ b/openbank-admin-ui/src/app/iaops/page.tsx
@@ -798,8 +798,8 @@ function IAOpsContent() {
             </div>
             <p style={{ fontSize: '10px', color: 'var(--text-tertiary)', margin: '12px 0 0', lineHeight: 1.5 }}>
               {t(
-                'Pozn.: Fáze 1 je advisory + audit-only — kontroly jsou zavedené, ale enforcement (OPA block) ještě neběží. EU AI Act se klasifikuje per agent; oversight/dev agenti jsou proposal-only (pravděpodobně limited risk). Žádný agent se nedotýká scoringu úvěruschopnosti.',
-                'Note: Phase 1 is advisory + audit-only — controls are in place but enforcement (OPA block) is not yet live. EU AI Act is classified per agent; oversight/dev agents are proposal-only (likely limited risk). No agent touches creditworthiness scoring.',
+                'Pozn.: Fáze 1 je vynucovaná, je-li PDP dostupný: policy gate je deny-by-default a OPA blokuje nepovolené volání nástrojů. Při výpadku PDP se režim degraduje na advisory. Fáze 2 zůstává read-only a proposal-only — každý návrh rozhoduje člověk. EU AI Act se klasifikuje per agent; žádný agent se nedotýká scoringu úvěruschopnosti.',
+                'Note: Phase 1 is enforced while the PDP is available: the policy gate is deny-by-default and OPA blocks disallowed tool calls. A PDP outage degrades the gate to advisory. Phase 2 remains read-only and proposal-only — a human decides every proposal. EU AI Act is classified per agent; no agent touches creditworthiness scoring.',
               )}
             </p>
           </Card>

--- a/openbank-admin-ui/src/test/iaops-agent-card.test.tsx
+++ b/openbank-admin-ui/src/test/iaops-agent-card.test.tsx
@@ -23,8 +23,8 @@ const FINOPS_AGENT = {
 }
 
 const GOVERNANCE = {
-  adrRef: 'ADR-0031', adrStatus: 'accepted', phase: 1, totalPhases: 4, phaseLabel: 'Advisory',
-  enforcement: 'audit-only', policyDefault: 'deny', agentsActing: 1, chartersAvailable: true,
+  adrRef: 'ADR-0031', adrStatus: 'accepted', phase: 2, totalPhases: 5, phaseLabel: 'Read-only oversight active',
+  enforcement: 'block', policyDefault: 'deny', agentsActing: 0, chartersAvailable: true,
   agentCount: 1, agents: [FINOPS_AGENT], toolTiers: {}, decisions: [],
   decisionSummary: { built: 0, partial: 0, planned: 0, total: 0 }, compliance: [],
   auditTrail: { capture: [], pipeline: [], live: [], planned: [] },
@@ -45,6 +45,17 @@ afterEach(() => {
 })
 
 describe('AIOps agent card interactions', () => {
+  it('describes the enforced policy gate without overstating phase 2 autonomy', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => response(GOVERNANCE)))
+
+    render(<IAOpsPage />)
+
+    expect(await screen.findByText(/Phase 1 is enforced while the PDP is available/i)).toBeVisible()
+    expect(screen.getByText(/A PDP outage degrades the gate to advisory/i)).toBeVisible()
+    expect(screen.getByText(/Phase 2 remains read-only and proposal-only/i)).toBeVisible()
+    expect(screen.queryByText(/enforcement \(OPA block\) is not yet live/i)).not.toBeInTheDocument()
+  })
+
   it.each(['ai-swarm', 'ai-mesh', 'agent-roster'])('scrolls to the %s fragment after governance data loads', async fragment => {
     const scrollIntoView = vi.fn()
     Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', { configurable: true, value: scrollIntoView })


### PR DESCRIPTION
Summary: align the compliance note with the policy gate enforced while the PDP is available; disclose the advisory fallback during a PDP outage; keep phase 2 accurately read-only and proposal-only; add focused rendered-copy regression coverage.

Verification: npm test -- --run src/test/iaops-agent-card.test.tsx (5 passed); npm run type-check; independent review approved.

Closes #5606