### PR TITLE
fix(admin-ui): align party links with backend roles

### DIFF
--- a/openbank-admin-ui/src/app/kyc/page.tsx
+++ b/openbank-admin-ui/src/app/kyc/page.tsx
@@ -11,6 +11,7 @@ import { DataUnavailable, type UnavailableKind } from '@/components/feedback/Dat
 import { ShieldCheck, Search, RefreshCw, ChevronRight } from 'lucide-react'
 import Link from 'next/link'
 import { PageHeader, StatusBadge } from '@/components/ui'
+import { Can } from '@/components/auth/AuthGuard'
 
 const KYC_SERVICE = '/api/svc/kyc-service'
 
@@ -134,7 +135,7 @@ export default function KycPage() {
               <tr key={c.id}>
                 <td style={{ fontFamily: 'var(--font-mono)', fontSize: '11px' }}>{c.id.slice(0, 8)}…</td>
                 <td style={{ fontFamily: 'var(--font-mono)', fontSize: '11px' }}>
-                  <Link href={`/parties/${c.partyId}`} style={{ color: 'var(--accent)', textDecoration: 'none' }}>{c.partyId.slice(0, 8)}…</Link>
+                  <Can permission="parties:view"><Link href={`/parties/${c.partyId}`} style={{ color: 'var(--accent)', textDecoration: 'none' }}>{c.partyId.slice(0, 8)}…</Link></Can>
                 </td>
                 <td>
                   <StatusBadge status={c.status} />
@@ -149,9 +150,9 @@ export default function KycPage() {
                 <td style={{ color: 'var(--text-muted)', fontSize: '12px' }}>{c.reviewedBy ?? '—'}</td>
                 <td style={{ color: 'var(--text-muted)', fontSize: '12px' }}>{new Date(c.updatedAt).toLocaleDateString(dateLocale)}</td>
                 <td>
-                  <Link href={`/parties/${c.partyId}`} style={{ color: 'var(--accent)', display: 'flex', alignItems: 'center', gap: '2px', fontSize: '12px', textDecoration: 'none' }}>
+                  <Can permission="parties:view"><Link href={`/parties/${c.partyId}`} style={{ color: 'var(--accent)', display: 'flex', alignItems: 'center', gap: '2px', fontSize: '12px', textDecoration: 'none' }}>
                     {t('Klient', 'Party')} <ChevronRight size={12} />
-                  </Link>
+                  </Link></Can>
                 </td>
               </tr>
             ))}

--- a/openbank-admin-ui/src/app/onboarding/page.tsx
+++ b/openbank-admin-ui/src/app/onboarding/page.tsx
@@ -11,6 +11,7 @@ import { DataUnavailable, type UnavailableKind } from '@/components/feedback/Dat
 import { ClipboardList, RefreshCw, ChevronRight, X, TrendingUp } from 'lucide-react'
 import Link from 'next/link'
 import { PageHeader } from '@/components/ui'
+import { Can } from '@/components/auth/AuthGuard'
 
 const SVC = 'onboarding-service'
 
@@ -400,13 +401,15 @@ function RecordDrawer({
 
         {/* Links */}
         <div style={{ marginTop: '24px', display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
-          <Link
-            href={`/parties/${record.partyId}`}
-            className="btn btn-secondary"
-            style={{ textDecoration: 'none', fontSize: '12px' }}
-          >
-            {t('Otevřít party →', 'Open party →')}
-          </Link>
+          <Can permission="parties:view">
+            <Link
+              href={`/parties/${record.partyId}`}
+              className="btn btn-secondary"
+              style={{ textDecoration: 'none', fontSize: '12px' }}
+            >
+              {t('Otevřít party →', 'Open party →')}
+            </Link>
+          </Can>
           {record.kycCaseId && (
             <Link
               href={`/kyc`}

--- a/openbank-admin-ui/src/app/pid/page.tsx
+++ b/openbank-admin-ui/src/app/pid/page.tsx
@@ -10,7 +10,7 @@ import { Map, Plus, Search, RefreshCw, Fingerprint, Clock, CheckCircle2, AlertTr
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { classifyBffFailure } from '@/lib/services/bff'
 import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
-import { AuthGuard } from '@/components/auth/AuthGuard'
+import { AuthGuard, Can } from '@/components/auth/AuthGuard'
 import { PageHeader } from '@/components/ui/PageHeader'
 
 const PID_SERVICE = '/api/svc/pid-service'
@@ -205,9 +205,11 @@ export default function PidPage() {
               <button className="btn btn-secondary" onClick={() => setShowNewForm(true)}>
                 {t('Rychlé vytvoření', 'Quick Create')}
               </button>
-              <Link href="/parties/new" className="btn btn-primary" style={{ display: 'flex', alignItems: 'center', gap: '6px', textDecoration: 'none' }}>
-                <Plus size={13} /> {t('Nový záznam', 'New Record')}
-              </Link>
+              <Can permission="parties:create">
+                <Link href="/parties/new" className="btn btn-primary" style={{ display: 'flex', alignItems: 'center', gap: '6px', textDecoration: 'none' }}>
+                  <Plus size={13} aria-hidden="true" /> {t('Nový záznam', 'New Record')}
+                </Link>
+              </Can>
             </div>
             <div style={{ fontSize: '11px', color: 'var(--text-secondary)', textAlign: 'right' }}>
               {t('Chcete vytvořit záznam rychle?', 'Want to create quickly?')}
@@ -529,9 +531,11 @@ export default function PidPage() {
                   <td style={{ fontWeight: 600, fontFamily: 'var(--font-mono)' }}>{r.identifierValue}</td>
                   <td style={{ color: 'var(--text-secondary)' }}>{r.issuingCountry}</td>
                   <td style={{ fontFamily: 'var(--font-mono)', fontSize: '12px' }}>
-                    <Link href={`/parties/${r.personId}`} style={{ color: 'var(--accent)', textDecoration: 'none' }}>
-                      {r.personId?.slice(0, 8) || r.personId}...
-                    </Link>
+                    <Can permission="parties:view">
+                      <Link href={`/parties/${r.personId}`} style={{ color: 'var(--accent)', textDecoration: 'none' }}>
+                        {r.personId?.slice(0, 8) || r.personId}...
+                      </Link>
+                    </Can>
                   </td>
                   <td>
                     <span className="pill" style={{ background: `${STATUS_COLORS[r.status] ?? 'var(--text-muted)'}22`, color: STATUS_COLORS[r.status] ?? 'var(--text-muted)' }}>

--- a/openbank-admin-ui/src/components/entities/EntityChip.tsx
+++ b/openbank-admin-ui/src/components/entities/EntityChip.tsx
@@ -13,6 +13,8 @@ import { useEffect, useState } from 'react'
 import Link from 'next/link'
 import { CreditCard, User } from 'lucide-react'
 import { svcUrl } from '@/lib/services/bff'
+import { useSession } from 'next-auth/react'
+import { hasPermission } from '@/lib/auth/roles'
 
 export type EntityChipType = 'party' | 'account'
 
@@ -45,36 +47,41 @@ function shortId(id: string): string {
 }
 
 export function EntityChip({ type, id, label, sublabel }: Props) {
+  const { data: session } = useSession()
+  const canOpenParty = type !== 'party' || hasPermission(session?.user?.roles ?? [], 'parties:view')
   const [resolved, setResolved] = useState<string | undefined>(label)
   const Icon = type === 'party' ? User : CreditCard
 
   useEffect(() => {
     if (label) { setResolved(label); return }
+    if (!canOpenParty) { setResolved(undefined); return }
     const ctrl = new AbortController()
     fetch(RESOLVER[type].url(id), { signal: ctrl.signal, cache: 'no-store' })
       .then(r => (r.ok ? r.json() : null))
       .then(d => { if (d) setResolved(RESOLVER[type].pick(d) ?? shortId(id)) })
       .catch(() => setResolved(shortId(id)))
     return () => ctrl.abort()
-  }, [type, id, label])
+  }, [type, id, label, canOpenParty])
 
-  return (
-    <Link
-      href={ROUTE[type](id)}
-      title={`${type}: ${id}`}
-      style={{
-        display: 'inline-flex', alignItems: 'center', gap: '6px',
-        padding: '3px 8px', borderRadius: '8px', textDecoration: 'none',
-        background: 'var(--surface-3)', border: '1px solid var(--border)',
-        color: 'var(--accent)', fontSize: '12px', fontWeight: 600,
-        maxWidth: '280px',
-      }}
-    >
-      <Icon size={12} style={{ flexShrink: 0 }} />
+  const content = (
+    <>
+      <Icon size={12} aria-hidden="true" style={{ flexShrink: 0 }} />
       <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
         {resolved ?? shortId(id)}
       </span>
       {sublabel && <span style={{ color: 'var(--text-tertiary)', fontWeight: 400 }}>{sublabel}</span>}
-    </Link>
+    </>
+  )
+  const style = {
+    display: 'inline-flex', alignItems: 'center', gap: '6px',
+    padding: '3px 8px', borderRadius: '8px', textDecoration: 'none',
+    background: 'var(--surface-3)', border: '1px solid var(--border)',
+    color: 'var(--accent)', fontSize: '12px', fontWeight: 600,
+    maxWidth: '280px',
+  }
+  return canOpenParty ? (
+    <Link href={ROUTE[type](id)} title={`${type}: ${id}`} style={style}>{content}</Link>
+  ) : (
+    <span title={`${type}: ${id}`} style={{ ...style, color: 'var(--text-secondary)' }}>{content}</span>
   )
 }

--- a/openbank-admin-ui/src/lib/auth/roles.ts
+++ b/openbank-admin-ui/src/lib/auth/roles.ts
@@ -63,10 +63,11 @@ export const PERMISSIONS = {
   "catalog:read":         [ROLES.ADMIN, ROLES.OPERATOR, ROLES.CATALOG_READ, ROLES.CATALOG_AUTHOR, ROLES.CATALOG_PUBLISH],
   "catalog:author":       [ROLES.ADMIN, ROLES.OPERATOR, ROLES.CATALOG_AUTHOR],
   "catalog:publish":      [ROLES.ADMIN, ROLES.OPERATOR, ROLES.CATALOG_PUBLISH],
-  // Parties / KYC / Onboarding — KYC_OPENER may NOT approve (four-eyes, ADR-0116);
-  // KYC_REVIEWER may NOT open. The UI mirrors the backend @RolesAllowed split so a
-  // holder of only one KYC role gets exactly their half of the workflow.
-  "parties:view":         [ROLES.ADMIN, ROLES.OPERATOR, ROLES.VIEWER, ROLES.COMPLIANCE, ROLES.KYC, ROLES.KYC_OPENER, ROLES.KYC_REVIEWER],
+  // Parties / KYC / Onboarding — party-service's list/search/detail GETs accept
+  // VIEWER/OPERATOR/ADMIN/KYC only (PartyResource.kt). Compliance and the
+  // split KYC opener/reviewer roles use their own case endpoints and must not
+  // receive a PII party directory link that the backend will 403.
+  "parties:view":         [ROLES.ADMIN, ROLES.OPERATOR, ROLES.VIEWER, ROLES.KYC],
   // Mirrors party-service POST /api/v1/parties: a viewer may inspect parties but
   // must never be offered a customer-creation workflow.
   "parties:create":       [ROLES.ADMIN, ROLES.OPERATOR, ROLES.KYC],

--- a/openbank-admin-ui/src/test/delegation-counterparty-name.test.tsx
+++ b/openbank-admin-ui/src/test/delegation-counterparty-name.test.tsx
@@ -14,8 +14,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import React from 'react'
 import { render, screen, cleanup, waitFor } from '@testing-library/react'
+import { SessionProvider } from 'next-auth/react'
 import { EntityChip } from '@/components/entities/EntityChip'
 import { counterpartyLabel } from '@/components/delegations/GrantView'
+import { ROLES } from '@/lib/auth/roles'
 
 const PARTY_ID = '33333333-3333-4333-8333-333333333333'
 
@@ -44,8 +46,12 @@ describe('counterpartyLabel', () => {
 })
 
 describe('delegation counterparty chip', () => {
+  const renderChip = (roles: string[], chip: React.ReactElement) => render(
+    <SessionProvider session={{ user: { roles } } as never}>{chip}</SessionProvider>,
+  )
+
   it('shows the snapshotted name and asks no service for it', async () => {
-    render(<EntityChip type="party" id={PARTY_ID} label={counterpartyLabel('Alice Testerova')} />)
+    renderChip([ROLES.OPERATOR], <EntityChip type="party" id={PARTY_ID} label={counterpartyLabel('Alice Testerova')} />)
 
     expect(await screen.findByText('Alice Testerova')).toBeTruthy()
     // The regression this guards: the id must not be what the human reads.
@@ -55,8 +61,15 @@ describe('delegation counterparty chip', () => {
 
   it('falls back to a shortened id, never a blank, when the grant carries no name', async () => {
     // A grant offered before #3604: party-service answers, but with nothing usable as a label.
-    render(<EntityChip type="party" id={PARTY_ID} label={counterpartyLabel(null)} />)
+    renderChip([ROLES.OPERATOR], <EntityChip type="party" id={PARTY_ID} label={counterpartyLabel(null)} />)
 
     await waitFor(() => expect(screen.getByText('33333333…')).toBeTruthy())
+  })
+
+  it('keeps a party snapshot visible but non-linking for a role denied party PII', () => {
+    renderChip([ROLES.COMPLIANCE], <EntityChip type="party" id={PARTY_ID} label={counterpartyLabel('Alice Testerova')} />)
+    expect(screen.getByText('Alice Testerova')).toBeTruthy()
+    expect(screen.queryByRole('link')).toBeNull()
+    expect(vi.mocked(global.fetch)).not.toHaveBeenCalled()
   })
 })

--- a/openbank-admin-ui/src/test/entity-chip.test.tsx
+++ b/openbank-admin-ui/src/test/entity-chip.test.tsx
@@ -7,13 +7,20 @@
 // always deep-links to the entity.
 
 import { render, screen, waitFor } from '@testing-library/react'
+import type { ReactElement } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { SessionProvider } from 'next-auth/react'
 import { EntityChip } from '@/components/entities/EntityChip'
+import { ROLES } from '@/lib/auth/roles'
 
 const PARTY_ID = 'b7c1a2d3-1111-4000-8000-0000000000aa'
 const ACCOUNT_ID = 'c8d2b3e4-2222-4000-8000-0000000000bb'
 
 describe('EntityChip (ADR-0231 D3)', () => {
+  const renderChip = (chip: ReactElement) => render(
+    <SessionProvider session={{ user: { roles: [ROLES.VIEWER] } } as never}>{chip}</SessionProvider>,
+  )
+
   beforeEach(() => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
       new Response(JSON.stringify({ legalName: 'Jan Novák' }), { status: 200 }),
@@ -24,7 +31,7 @@ describe('EntityChip (ADR-0231 D3)', () => {
   })
 
   it('renders a pre-resolved label as a deep-link without fetching', () => {
-    render(<EntityChip type="party" id={PARTY_ID} label="Jan Novák" />)
+    renderChip(<EntityChip type="party" id={PARTY_ID} label="Jan Novák" />)
     const link = screen.getByRole('link')
     expect(link.getAttribute('href')).toBe(`/parties/${PARTY_ID}`)
     expect(link.textContent).toContain('Jan Novák')
@@ -32,7 +39,7 @@ describe('EntityChip (ADR-0231 D3)', () => {
   })
 
   it('resolves the label through the BFF when only the id is known', async () => {
-    render(<EntityChip type="party" id={PARTY_ID} />)
+    renderChip(<EntityChip type="party" id={PARTY_ID} />)
     await waitFor(() => expect(screen.getByText('Jan Novák')).toBeTruthy())
     const [url] = vi.mocked(fetch).mock.calls[0] as [string]
     expect(url).toContain(`/api/v1/parties/${PARTY_ID}`)
@@ -42,14 +49,14 @@ describe('EntityChip (ADR-0231 D3)', () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
       new Response(JSON.stringify({ accountNumber: '192000145399/0800' }), { status: 200 }),
     ))
-    render(<EntityChip type="account" id={ACCOUNT_ID} />)
+    renderChip(<EntityChip type="account" id={ACCOUNT_ID} />)
     await waitFor(() => expect(screen.getByText('192000145399/0800')).toBeTruthy())
     expect(screen.getByRole('link').getAttribute('href')).toBe(`/accounts/${ACCOUNT_ID}`)
   })
 
   it('falls back to a shortened UUID when resolution fails', async () => {
     vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('down')))
-    render(<EntityChip type="party" id={PARTY_ID} />)
+    renderChip(<EntityChip type="party" id={PARTY_ID} />)
     await waitFor(() => expect(screen.getByRole('link').textContent).toContain('b7c1a2d3…'))
   })
 })

--- a/openbank-admin-ui/src/test/party-rbac-alignment.guard.test.ts
+++ b/openbank-admin-ui/src/test/party-rbac-alignment.guard.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const root = resolve(__dirname, '..')
+const read = (file: string) => readFileSync(resolve(root, file), 'utf8')
+
+describe('party PII links respect the party-service role boundary', () => {
+  it('keeps route roles aligned with PartyResource and gates cross-page links', () => {
+    const roles = read('lib/auth/roles.ts')
+    expect(roles).toContain('"parties:view":         [ROLES.ADMIN, ROLES.OPERATOR, ROLES.VIEWER, ROLES.KYC]')
+    expect(read('app/kyc/page.tsx')).toMatch(/<Can permission="parties:view">[\s\S]*href=\{`\/parties\//)
+    expect(read('app/onboarding/page.tsx')).toMatch(/<Can permission="parties:view">[\s\S]*href=\{`\/parties\//)
+    expect(read('app/pid/page.tsx')).toMatch(/<Can permission="parties:create">[\s\S]*href="\/parties\/new"/)
+    expect(read('components/entities/EntityChip.tsx')).toContain("'parties:view'")
+    expect(read('components/entities/EntityChip.tsx')).toContain('canOpenParty')
+  })
+})

--- a/openbank-admin-ui/src/test/roles.test.ts
+++ b/openbank-admin-ui/src/test/roles.test.ts
@@ -39,6 +39,16 @@ describe('hasPermission', () => {
     expect(hasPermission([ROLES.KYC_OPENER], 'kyc:approve')).toBe(false)
   })
 
+  it('matches party-service PII read roles without widening the backend gate', () => {
+    expect(hasPermission([ROLES.ADMIN], 'parties:view')).toBe(true)
+    expect(hasPermission([ROLES.OPERATOR], 'parties:view')).toBe(true)
+    expect(hasPermission([ROLES.VIEWER], 'parties:view')).toBe(true)
+    expect(hasPermission([ROLES.KYC], 'parties:view')).toBe(true)
+    expect(hasPermission([ROLES.COMPLIANCE], 'parties:view')).toBe(false)
+    expect(hasPermission([ROLES.KYC_OPENER], 'parties:view')).toBe(false)
+    expect(hasPermission([ROLES.KYC_REVIEWER], 'parties:view')).toBe(false)
+  })
+
   it('admits the supervisor to payment approval and audit reading, not to creation', () => {
     expect(hasPermission([ROLES.SUPERVISOR], 'payments:approve')).toBe(true)
     expect(hasPermission([ROLES.SUPERVISOR], 'audit:view')).toBe(true)


### PR DESCRIPTION
## Summary
- align parties:view with PartyResource list/search/detail roles
- hide party deep-links and create links when the session cannot open them
- add role/link regression coverage

Closes #66

## Verification
- targeted Vitest: 23/23
- npm run type-check
- git diff --check