### PR TITLE
feat(admin-ui): resolve party when opening account

### DIFF
--- a/openbank-admin-ui/src/app/accounts/new/page.tsx
+++ b/openbank-admin-ui/src/app/accounts/new/page.tsx
@@ -12,6 +12,7 @@ import { accountApi } from '@/lib/api'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { PageHeader } from '@/components/ui/PageHeader'
 import { AuthGuard } from '@/components/auth/AuthGuard'
+import { PartySearch, partyDisplayName, type PartyHit } from '@/components/party/PartySearch'
 
 
 const ACCOUNT_TYPES = ['CURRENT', 'SAVINGS', 'NOSTRO', 'GL_ASSET', 'GL_LIABILITY', 'GL_INCOME', 'GL_EXPENSE']
@@ -39,6 +40,18 @@ export default function NewAccountPage() {
     else if (!/^[0-9a-f-]{36}$/i.test(form.productId.trim())) e.productId = t('Musí být platné UUID', 'Must be a valid UUID')
     if (!form.legalName.trim()) e.legalName = t('Právní název je povinný pro sankční screening', 'Legal name is required for sanctions screening')
     return e
+  }
+
+  function selectParty(party: PartyHit) {
+    setForm(prev => ({
+      ...prev,
+      partyId: party.id,
+      // The selected party is the source of truth for sanctions screening. Keep
+      // the field editable for exceptional legal-name corrections, but never
+      // make an operator retype a name after selecting an existing party.
+      ...(party.legalName || party.tradingName ? { legalName: partyDisplayName(party) } : {}),
+    }))
+    setErrors(prev => ({ ...prev, partyId: '', legalName: '' }))
   }
 
   async function submit(e: React.FormEvent) {
@@ -77,6 +90,12 @@ export default function NewAccountPage() {
       />
 
       <div style={{ maxWidth: '560px' }}>
+        <PartySearch
+          onSelect={selectParty}
+          selectedId={form.partyId || undefined}
+          busy={submitting}
+          placeholder={t('Vyhledejte existující party podle jména nebo UUID', 'Find an existing party by name or UUID')}
+        />
         <form onSubmit={submit}>
           <div className="card">
             <div className="card-header"><span className="card-header-title">{t('Detaily účtu', 'Account Details')}</span></div>

--- a/openbank-admin-ui/src/test/accounts-new-accessibility.guard.test.ts
+++ b/openbank-admin-ui/src/test/accounts-new-accessibility.guard.test.ts
@@ -24,4 +24,15 @@ describe('new account form accessibility', () => {
   it('requires account-creation permission before rendering the form', () => {
     expect(page).toContain('<AuthGuard permission="accounts:create">')
   })
+
+  it('resolves an existing party before the money-path submit', () => {
+    expect(page).toContain("import { PartySearch, partyDisplayName, type PartyHit } from '@/components/party/PartySearch'")
+    expect(page).toContain('<PartySearch')
+    expect(page).toContain('onSelect={selectParty}')
+    expect(page).toContain('partyId: party.id')
+    expect(page).toContain('legalName: partyDisplayName(party)')
+    expect(page).toContain('accountApi.open({')
+    expect(page).toContain('partyId:     form.partyId.trim()')
+    expect(page).toContain('legalName:   form.legalName.trim()')
+  })
 })


### PR DESCRIPTION
## Summary
- add the shared party-service name/UUID resolver to account opening
- on selection, fill the exact party UUID and sanctions-screening legal name
- preserve the existing POST payload, idempotency key, and server-side sanctions gate

Refs #66

## Verification
- targeted resolver/accessibility tests: 10/10
- npm run type-check
- git diff --check